### PR TITLE
Implement networking for OCI runtime

### DIFF
--- a/dockerfiles/test_images/net_tools/Dockerfile
+++ b/dockerfiles/test_images/net_tools/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates iproute2 iptables iputils-ping && \
+    update-ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//server/util/disk",
         "//server/util/hash",
         "//server/util/log",
+        "//server/util/networking",
         "//server/util/status",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_opencontainers_runtime_spec//specs-go",
@@ -43,9 +44,9 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:2847b15d47b85fcf3c5af1548b71a08523859c7a0fd4e8277f28f7f9af545602",
         "test.EstimatedComputeUnits": "2",
     },
-    shard_count = 2,
     tags = [
         "no-sandbox",
     ],
@@ -68,6 +69,7 @@ go_test(
         "//server/interfaces",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
+        "//server/testutil/testnetworking",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testnetworking"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -90,6 +91,8 @@ func envTestImage(t *testing.T) string {
 }
 
 func TestRun(t *testing.T) {
+	testnetworking.Setup(t)
+
 	image := manuallyProvisionedBusyboxImage(t)
 
 	ctx := context.Background()
@@ -130,6 +133,8 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunUsageStats(t *testing.T) {
+	testnetworking.Setup(t)
+
 	image := realBusyboxImage(t)
 
 	ctx := context.Background()
@@ -166,6 +171,8 @@ func TestRunUsageStats(t *testing.T) {
 }
 
 func TestRunWithImage(t *testing.T) {
+	testnetworking.Setup(t)
+
 	image := envTestImage(t)
 
 	ctx := context.Background()
@@ -214,6 +221,8 @@ TEST_ENV_VAR=foo
 }
 
 func TestCreateExecRemove(t *testing.T) {
+	testnetworking.Setup(t)
+
 	image := manuallyProvisionedBusyboxImage(t)
 
 	ctx := context.Background()
@@ -256,6 +265,8 @@ func TestCreateExecRemove(t *testing.T) {
 }
 
 func TestExecUsageStats(t *testing.T) {
+	testnetworking.Setup(t)
+
 	image := realBusyboxImage(t)
 
 	ctx := context.Background()
@@ -299,6 +310,8 @@ func TestExecUsageStats(t *testing.T) {
 }
 
 func TestPullCreateExecRemove(t *testing.T) {
+	testnetworking.Setup(t)
+
 	image := envTestImage(t)
 
 	ctx := context.Background()
@@ -377,6 +390,8 @@ TEST_ENV_VAR=foo
 }
 
 func TestCreateExecPauseUnpause(t *testing.T) {
+	testnetworking.Setup(t)
+
 	image := manuallyProvisionedBusyboxImage(t)
 
 	ctx := context.Background()
@@ -420,6 +435,8 @@ func TestCreateExecPauseUnpause(t *testing.T) {
 	`}}
 	res := c.Exec(ctx, cmd, &interfaces.Stdio{})
 	require.NoError(t, res.Error)
+
+	t.Logf("Started update process in container")
 
 	assert.Empty(t, string(res.Stderr))
 	assert.Empty(t, string(res.Stdout))
@@ -476,6 +493,8 @@ func TestCreateExecPauseUnpause(t *testing.T) {
 }
 
 func TestCreateFailureHasStderr(t *testing.T) {
+	testnetworking.Setup(t)
+
 	image := manuallyProvisionedBusyboxImage(t)
 
 	ctx := context.Background()

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1020,21 +1020,6 @@ func (p *pool) newContainer(ctx context.Context, props *platform.Properties, tas
 	}
 
 	isolationType := platform.ContainerType(props.WorkloadIsolationType)
-
-	// For now, fall back to podman or docker if the action requests both OCI
-	// isolation and networking, since we don't yet have networking support
-	// for OCI isolation.
-	if isolationType == platform.OCIContainerType && props.DockerNetwork != "off" {
-		ex := platform.GetExecutorProperties()
-		if ex.SupportsIsolation(platform.PodmanContainerType) {
-			isolationType = platform.PodmanContainerType
-		} else if ex.SupportsIsolation(platform.DockerContainerType) {
-			isolationType = platform.DockerContainerType
-		} else {
-			return nil, status.UnimplementedErrorf("networking is not yet supported for %s isolation", isolationType)
-		}
-	}
-
 	containerProvider, ok := p.containerProviders[isolationType]
 	if !ok {
 		return nil, status.UnimplementedErrorf("no container provider registered for %q isolation", isolationType)

--- a/server/testutil/testnetworking/BUILD
+++ b/server/testutil/testnetworking/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testnetworking",
+    testonly = 1,
+    srcs = ["testnetworking.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testnetworking",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/testutil/testfs",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/testutil/testnetworking/testnetworking.go
+++ b/server/testutil/testnetworking/testnetworking.go
@@ -1,0 +1,41 @@
+package testnetworking
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/stretchr/testify/require"
+)
+
+// Setup sets up the test to be able to call networking functions.
+// If skips the test if the required net tools aren't available.
+func Setup(t *testing.T) {
+	// Ensure ip tools are in PATH
+	os.Setenv("PATH", os.Getenv("PATH")+":/usr/sbin:/sbin")
+
+	// Make sure the 'ip' tool is available and that we have the necessary
+	// permissions to use it.
+	cmd := []string{"ip", "link"}
+	if os.Getuid() != 0 {
+		cmd = append([]string{"sudo", "--non-interactive"}, cmd...)
+	}
+	if b, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput(); err != nil {
+		t.Logf("%s failed: %s: %s", cmd, err, strings.TrimSpace(string(b)))
+		t.Skipf("test requires passwordless sudo for 'ip' command - run ./tools/enable_local_firecracker.sh")
+	}
+
+	// Set up a symlink in PATH so that 'iptables' points to 'iptables-legacy'.
+	// Our Firecracker setup does not yet have nftables enabled and can't use
+	// the newer iptables.
+	iptablesLegacyPath, err := exec.LookPath("iptables-legacy")
+	require.NoError(t, err)
+	overrideBinDir := testfs.MakeTempDir(t)
+	err = os.Symlink(iptablesLegacyPath, filepath.Join(overrideBinDir, "iptables"))
+	require.NoError(t, err)
+	err = os.Setenv("PATH", overrideBinDir+":"+os.Getenv("PATH"))
+	require.NoError(t, err)
+}

--- a/server/testutil/testnetworking/testnetworking.go
+++ b/server/testutil/testnetworking/testnetworking.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Setup sets up the test to be able to call networking functions.
-// If skips the test if the required net tools aren't available.
+// It skips the test if the required net tools aren't available.
 func Setup(t *testing.T) {
 	// Ensure ip tools are in PATH
 	os.Setenv("PATH", os.Getenv("PATH")+":/usr/sbin:/sbin")

--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",
+        "//server/util/uuid",
         "@com_github_vishvananda_netlink//:netlink",
         "@org_golang_x_sys//unix",
     ],
@@ -19,9 +20,15 @@ go_library(
 go_test(
     name = "networking_test",
     srcs = ["networking_test.go"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:2847b15d47b85fcf3c5af1548b71a08523859c7a0fd4e8277f28f7f9af545602",
+        "test.EstimatedComputeUnits": "2",
+    },
     tags = ["no-sandbox"],
     deps = [
         ":networking",
+        "//server/testutil/testnetworking",
         "//server/util/uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
Not much interesting new code is being added here except a new `iptables` rule in `SetupVethPair` to prevent traffic between containers. Everything else is mostly plumbing / tests.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy/pull/7093
