### PR TITLE
Mount /dev/shm in OCI containers

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -588,13 +588,12 @@ func (c *ociContainer) createSpec(cmd *repb.Command) (*specs.Spec, error) {
 				Source:      filepath.Join(c.bundlePath(), "hosts"),
 				Options:     []string{"bind", "rprivate"},
 			},
-			// TODO: shm
-			// {
-			// 		Destination: "/dev/shm",
-			// 		Type:        "bind",
-			// 		Source:      "/run/containers/storage/overlay-containers/99133d16f4f9d0678f87972c01209e308ebafc074f333822805a633620f12507/userdata/shm",
-			// 		Options:     []string{"bind", "rprivate", "nosuid", "noexec", "nodev"},
-			// },
+			{
+				Destination: "/dev/shm",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"rw", "nosuid", "nodev", "noexec", "relatime", "size=64000k", "inode64"},
+			},
 			// TODO: .containerenv
 			// {
 			// 		Destination: "/run/.containerenv",


### PR DESCRIPTION
Not having `/dev/shm/` mounted was causing webdriver tests to fail. When run with `--verbose` mode, Chromium reports failures relating to `/dev/shm`. Confirmed that tests pass on a local executor after enabling this mount.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3631
