### PR TITLE
Fix ociruntime pause/unpause test getting stuck

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6975,3 +6975,19 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         downloaded_file_path = "crun",
         executable = True,
     )
+
+    # busybox static builds (see tools/build_busybox.sh)
+    http_file(
+        name = "net_busybox_busybox-linux-amd64",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/busybox/busybox-1.36.1_linux-amd64"],
+        sha256 = "f1c20582a7efb70382d63ec71fbeb6f422d7338592ff28ffe0bdff55c839a94c",
+        downloaded_file_path = "busybox",
+        executable = True,
+    )
+    http_file(
+        name = "net_busybox_busybox-linux-arm64",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/busybox/busybox-1.36.1_linux-arm64"],
+        sha256 = "19601547c937e9636f64ae2dbd7d2d318dc5bbd58f7d5624bfa452f22cfe33d1",
+        downloaded_file_path = "busybox",
+        executable = True,
+    )

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -37,7 +37,10 @@ go_library(
 go_test(
     name = "ociruntime_test",
     srcs = ["ociruntime_test.go"],
-    data = [":crun"],
+    data = [
+        ":busybox",
+        ":crun",
+    ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
         "test.EstimatedComputeUnits": "2",
@@ -49,6 +52,7 @@ go_test(
     target_compatible_with = ["@platforms//os:linux"],
     x_defs = {
         "crunRlocationpath": "$(rlocationpath :crun)",
+        "busyboxRlocationpath": "$(rlocationpath :busybox)",
     },
     deps = [
         ":ociruntime",
@@ -71,5 +75,13 @@ alias(
     actual = select({
         "@platforms//cpu:x86_64": "@com_github_containers_crun_crun-linux-amd64//file:crun",
         "@platforms//cpu:aarch64": "@com_github_containers_crun_crun-linux-arm64//file:crun",
+    }),
+)
+
+alias(
+    name = "busybox",
+    actual = select({
+        "@platforms//cpu:x86_64": "@net_busybox_busybox-linux-amd64//file:busybox",
+        "@platforms//cpu:aarch64": "@net_busybox_busybox-linux-arm64//file:busybox",
     }),
 )

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -354,9 +354,7 @@ func (c *ociContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *inter
 	args = append(args, c.cid)
 
 	return c.doWithStatsTracking(ctx, func(ctx context.Context) *interfaces.CommandResult {
-		// TODO: Should we specify a non-zero waitDelay so that a process that
-		// spawns children won't block forever?
-		return c.invokeRuntime(ctx, cmd, stdio, 0, args...)
+		return c.invokeRuntime(ctx, cmd, stdio, 1*time.Microsecond, args...)
 	})
 }
 

--- a/tools/build_busybox.sh
+++ b/tools/build_busybox.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${VERSION:=v1.36.1}"
+: "${REPO_DIR:=/tmp/busybox}"
+
+if ! [[ -e "$REPO_DIR" ]]; then
+  mkdir -p "$REPO_DIR"
+  (
+    cd "$REPO_DIR"
+    git init
+    git remote add origin https://git.busybox.net/busybox
+  )
+fi
+cd "$REPO_DIR"
+
+# For version vX.Y.Z the git tag is X_Y_Z
+TAG="$VERSION"
+TAG="${TAG//v/}"
+TAG="${TAG//./_}"
+
+git clean -fdx
+git fetch origin "$TAG" --depth=1
+git checkout "$TAG"
+
+make defconfig
+sed -i 's/# CONFIG_STATIC is not set/CONFIG_STATIC=y/' .config
+make
+
+sha256sum "$REPO_DIR/busybox"
+file "$REPO_DIR/busybox"


### PR DESCRIPTION
It was getting stuck because it spawns a background process, and the unset `WaitDelay` param was causing us to have to wait for the background process to terminate.

Also make sure this test runs on CI by ensuring that `busybox` is available in `PATH`. (I built busybox for amd64 and arm64 and uploaded it to our GCS bucket so that it gets provisioned with Bazel).

**Related issues**: N/A
