### PR TITLE
[FC] Fix OCI tests by enabling SECCOMP

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6936,8 +6936,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
     )
     http_file(
         name = "org_kernel_git_linux_kernel-vmlinux",
-        sha256 = "1b45787fd153c42ed1e64c6ea0f3b6526dd81a31a37a7118f18834be0c08ae6e",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/linux/vmlinux-v5.15-1b45787fd153c42ed1e64c6ea0f3b6526dd81a31a37a7118f18834be0c08ae6e"],
+        sha256 = "3fd19c602f2b11969ad563d4d4855c9147cf13c34238537c1e434097a11aa6b7",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/linux/vmlinux-v5.15-3fd19c602f2b11969ad563d4d4855c9147cf13c34238537c1e434097a11aa6b7"],
         executable = True,
     )
 

--- a/enterprise/vmsupport/kernel/microvm-kernel-x86_64.config
+++ b/enterprise/vmsupport/kernel/microvm-kernel-x86_64.config
@@ -3,8 +3,13 @@
 # Linux/x86 5.10.0 Kernel Configuration
 #
 # Buildbuddy modifications:
+#
+# To support running docker in the VM:
 # * Enabled CONFIG_NETFILTER and related options
 # * Enabled CONFIG_IPV6 and related options
+#
+# To support running OCI in the VM:
+# * Enabled CONFIG_SECCOMP
 #
 CONFIG_CC_VERSION_TEXT="gcc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-17)"
 CONFIG_CC_IS_GCC=y
@@ -651,7 +656,7 @@ CONFIG_ARCH_WANT_COMPAT_IPC_PARSE_VERSION=y
 CONFIG_ARCH_WANT_OLD_COMPAT_IPC=y
 CONFIG_HAVE_ARCH_SECCOMP=y
 CONFIG_HAVE_ARCH_SECCOMP_FILTER=y
-# CONFIG_SECCOMP is not set
+CONFIG_SECCOMP=y
 CONFIG_HAVE_ARCH_STACKLEAK=y
 CONFIG_HAVE_STACKPROTECTOR=y
 CONFIG_STACKPROTECTOR=y


### PR DESCRIPTION
Fix the OCI tests. They run in firecracker containers, and after the kernel config update, started failing with errors like ` create container: {"msg":"prctl: Invalid argument","level":"error","time":"2024-07-26T01:55:10.449777Z"}`. Setting the `CONFIG_SECCOMP=y` kernel option makes them run successfully again.

**Related issues**: N/A
