### PR TITLE
Fix distributed_test port race flag when running test locally.

### DIFF
--- a/enterprise/server/backends/distributed/BUILD
+++ b/enterprise/server/backends/distributed/BUILD
@@ -41,6 +41,7 @@ go_test(
     srcs = ["distributed_test.go"],
     embed = [":distributed"],
     shard_count = 10,
+    tags = ["block-network"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",


### PR DESCRIPTION
The block-network tag forces each test to run in its own network namespace so there's no issue with port collisions across concurrently running tests.

Part of fixing https://github.com/buildbuddy-io/buildbuddy-internal/issues/3114

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
