### PR TITLE
Trim space from IP rule input

### DIFF
--- a/enterprise/server/iprules/iprules.go
+++ b/enterprise/server/iprules/iprules.go
@@ -389,6 +389,8 @@ func (s *Service) GetRules(ctx context.Context, req *irpb.GetRulesRequest) (*irp
 }
 
 func validateIPRange(value string) (string, error) {
+	value = strings.TrimSpace(value)
+
 	prefix, err := netip.ParsePrefix(value)
 	if err == nil {
 		if prefix.Addr().Is6() && !*allowIPV6 {


### PR DESCRIPTION
When copying and pasting my IP from Google, it included a space on the left, and I got an error that the IP was invalid

**Related issues**: N/A
