### PR TITLE
OCI runtime: make hostname logic more compatible

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -200,7 +200,7 @@ func TestRunWithImage(t *testing.T) {
 	cmd := &repb.Command{
 		Arguments: []string{"sh", "-c", `
 			echo "$GREETING world!"
-			env | grep -v 'HOSTNAME' | sort
+			env | sort
 		`},
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
 			{Name: "GREETING", Value: "Hello"},
@@ -211,6 +211,7 @@ func TestRunWithImage(t *testing.T) {
 	assert.Equal(t, `Hello world!
 GREETING=Hello
 HOME=/root
+HOSTNAME=localhost
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test/bin
 PWD=/buildbuddy-execroot
 SHLVL=1
@@ -356,7 +357,7 @@ func TestPullCreateExecRemove(t *testing.T) {
 		Arguments: []string{"sh", "-ec", `
 			touch /bin/foo.txt
 			pwd
-			env | grep -v HOSTNAME | sort
+			env | sort
 		`},
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
 			{Name: "GREETING", Value: "Hello"},
@@ -371,6 +372,7 @@ func TestPullCreateExecRemove(t *testing.T) {
 	assert.Equal(t, `/buildbuddy-execroot
 GREETING=Hello
 HOME=/root
+HOSTNAME=localhost
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test/bin
 PWD=/buildbuddy-execroot
 SHLVL=1


### PR DESCRIPTION
- `Hostname` field in the OCI config gets set to either `--hostname` if set, or the container name, which defaults to `cid[:12]` if a container name is not set explicitly. We don't allow passing `--hostname` or setting a container name explicitly so just set it to `cid[:12]`.
- `/etc/hostname` just contains `localhost` unless `--hostname` flag is passed, which we don't allow passing. So hard-code this file to `localhost`.
- `$HOSTNAME` env var should match the contents of `/etc/hostname`; hard-code this to `localhost` as well.

**Related issues**: N/A
