### PR TITLE
Only index lowercase ngrams (still use case in regex match tho).

### DIFF
--- a/codesearch/query/regexp.go
+++ b/codesearch/query/regexp.go
@@ -503,7 +503,8 @@ func analyze(re *syntax.Regexp) (ret regexpInfo) {
 		return emptyString()
 
 	case syntax.OpLiteral:
-		if re.Flags&syntax.FoldCase != 0 {
+		// TBW DISABLE CASE FOLDING IN TRIGRAM GENERATION
+		if re.Flags&syntax.FoldCase != 0 && false {
 			switch len(re.Rune) {
 			case 0:
 				return emptyString()
@@ -535,7 +536,7 @@ func analyze(re *syntax.Regexp) (ret regexpInfo) {
 			}
 			return info
 		}
-		info.exact = stringSet{string(re.Rune)}
+		info.exact = stringSet{strings.ToLower(string(re.Rune))}
 		info.match = allQuery
 
 	case syntax.OpAnyCharNotNL, syntax.OpAnyChar:

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -20,32 +20,28 @@ func TestCaseSensitive(t *testing.T) {
 }
 
 func TestCaseInsensitive(t *testing.T) {
-	q, err := NewReQuery("foo", 1)
+	q, err := NewReQuery("Foo", 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
-	assert.Contains(t, squery, `(:eq * "foo")`)
-	assert.Contains(t, squery, `(:eq * "FOO")`)
-	assert.Contains(t, squery, `(:eq * "fOo")`)
+	assert.Contains(t, squery, `(:eq * foo)`)
 
 	fieldMatchers := q.TestOnlyFieldMatchers()
 	require.Contains(t, fieldMatchers, "content")
-	assert.Contains(t, fieldMatchers["content"].String(), "foo")
+	assert.Contains(t, fieldMatchers["content"].String(), "Foo")
 	assert.Contains(t, fieldMatchers["content"].String(), "(?mi)")
 }
 
 func TestCaseNo(t *testing.T) {
-	q, err := NewReQuery("foo case:no", 1)
+	q, err := NewReQuery("fOO case:no", 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
-	assert.Contains(t, squery, `(:eq * "foo")`)
-	assert.Contains(t, squery, `(:eq * "FOO")`)
-	assert.Contains(t, squery, `(:eq * "fOo")`)
+	assert.Contains(t, squery, `(:eq * foo)`)
 
 	fieldMatchers := q.TestOnlyFieldMatchers()
 	require.Contains(t, fieldMatchers, "content")
-	assert.Contains(t, fieldMatchers["content"].String(), "foo")
+	assert.Contains(t, fieldMatchers["content"].String(), "fOO")
 	assert.Contains(t, fieldMatchers["content"].String(), "(?mi)")
 }
 

--- a/codesearch/query/regexp_test.go
+++ b/codesearch/query/regexp_test.go
@@ -13,7 +13,7 @@ var queryTests = []struct {
 	re string
 	q  string
 }{
-	{`Abcdef`, `"Abc" "bcd" "cde" "def"`},
+	{`Abcdef`, `"abc" "bcd" "cde" "def"`},
 	{`(abc)(def)`, `"abc" "bcd" "cde" "def"`},
 	{`abc.*(def|ghi)`, `"abc" ("def"|"ghi")`},
 	{`abc(def|ghi)`, `"abc" ("bcd" "cde" "def")|("bcg" "cgh" "ghi")`},
@@ -60,14 +60,6 @@ var queryTests = []struct {
 	{`(a|b|c|d)(ef|g|hi|j)`, `+`},
 
 	{`(?s).`, `+`},
-
-	// Expanding case.
-	{`(?i)a~~`, `("A~~"|"a~~")`},
-	{`(?i)ab~`, `("AB~"|"Ab~"|"aB~"|"ab~")`},
-	{`(?i)abc`, `("ABC"|"ABc"|"AbC"|"Abc"|"aBC"|"aBc"|"abC"|"abc")`},
-	{`(?i)abc|def`, `("ABC"|"ABc"|"AbC"|"Abc"|"DEF"|"DEf"|"DeF"|"Def"|"aBC"|"aBc"|"abC"|"abc"|"dEF"|"dEf"|"deF"|"def")`},
-	{`(?i)abcd`, `("ABC"|"ABc"|"AbC"|"Abc"|"aBC"|"aBc"|"abC"|"abc") ("BCD"|"BCd"|"BcD"|"Bcd"|"bCD"|"bCd"|"bcD"|"bcd")`},
-	{`(?i)abc|abc`, `("ABC"|"ABc"|"AbC"|"Abc"|"aBC"|"aBc"|"abC"|"abc")`},
 
 	// Word boundary.
 	{`\b`, `+`},

--- a/codesearch/sparse/BUILD
+++ b/codesearch/sparse/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sparse",
+    srcs = ["set.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/sparse",
+    visibility = ["//visibility:public"],
+)

--- a/codesearch/sparse/set.go
+++ b/codesearch/sparse/set.go
@@ -55,4 +55,3 @@ func (s *Set) Dense() []uint32 {
 func (s *Set) Len() int {
 	return len(s.dense)
 }
-

--- a/codesearch/sparse/set.go
+++ b/codesearch/sparse/set.go
@@ -1,0 +1,58 @@
+package sparse
+
+type Set struct {
+	dense  []uint32
+	sparse []uint32
+}
+
+// This is sparse.Set from:
+// https://github.com/google/codesearch/blob/master/sparse/set.go
+//
+// NewSet returns a new Set with a given maximum size.
+// The set can contain numbers in [0, max-1].
+func NewSet(max uint32) *Set {
+	return &Set{
+		sparse: make([]uint32, max),
+	}
+}
+
+// Init initializes a Set to have a given maximum size.
+// The set can contain numbers in [0, max-1].
+func (s *Set) Init(max uint32) {
+	s.sparse = make([]uint32, max)
+}
+
+// Reset clears (empties) the set.
+func (s *Set) Reset() {
+	s.dense = s.dense[:0]
+}
+
+// Add adds x to the set if it is not already there.
+func (s *Set) Add(x uint32) {
+	v := s.sparse[x]
+	if v < uint32(len(s.dense)) && s.dense[v] == x {
+		return
+	}
+	n := len(s.dense)
+	s.sparse[x] = uint32(n)
+	s.dense = append(s.dense, x)
+}
+
+// Has reports whether x is in the set.
+func (s *Set) Has(x uint32) bool {
+	v := s.sparse[x]
+	return v < uint32(len(s.dense)) && s.dense[v] == x
+}
+
+// Dense returns the values in the set.
+// The values are listed in the order in which they
+// were inserted.
+func (s *Set) Dense() []uint32 {
+	return s.dense
+}
+
+// Len returns the number of values in the set.
+func (s *Set) Len() int {
+	return len(s.dense)
+}
+

--- a/codesearch/token/BUILD
+++ b/codesearch/token/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/token",
     visibility = ["//visibility:public"],
     deps = [
+        "//codesearch/sparse",
         "//codesearch/types",
         "//server/util/status",
     ],
@@ -16,6 +17,7 @@ go_test(
     srcs = ["token_test.go"],
     embed = [":token"],
     deps = [
+        "//codesearch/types",
         "@com_github_roaringbitmap_roaring//:roaring",
         "@com_github_stretchr_testify//assert",
     ],

--- a/codesearch/token/token.go
+++ b/codesearch/token/token.go
@@ -2,71 +2,18 @@ package token
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"hash"
 	"hash/fnv"
 	"io"
 	"strings"
+	"unicode"
 
+	"github.com/buildbuddy-io/buildbuddy/codesearch/sparse"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
-
-type Set struct {
-	dense  []uint32
-	sparse []uint32
-}
-
-// This is sparse.Set from:
-// https://github.com/google/codesearch/blob/master/sparse/set.go
-//
-// NewSet returns a new Set with a given maximum size.
-// The set can contain numbers in [0, max-1].
-func NewSet(max uint32) *Set {
-	return &Set{
-		sparse: make([]uint32, max),
-	}
-}
-
-// Init initializes a Set to have a given maximum size.
-// The set can contain numbers in [0, max-1].
-func (s *Set) Init(max uint32) {
-	s.sparse = make([]uint32, max)
-}
-
-// Reset clears (empties) the set.
-func (s *Set) Reset() {
-	s.dense = s.dense[:0]
-}
-
-// Add adds x to the set if it is not already there.
-func (s *Set) Add(x uint32) {
-	v := s.sparse[x]
-	if v < uint32(len(s.dense)) && s.dense[v] == x {
-		return
-	}
-	n := len(s.dense)
-	s.sparse[x] = uint32(n)
-	s.dense = append(s.dense, x)
-}
-
-// Has reports whether x is in the set.
-func (s *Set) Has(x uint32) bool {
-	v := s.sparse[x]
-	return v < uint32(len(s.dense)) && s.dense[v] == x
-}
-
-// Dense returns the values in the set.
-// The values are listed in the order in which they
-// were inserted.
-func (s *Set) Dense() []uint32 {
-	return s.dense
-}
-
-// Len returns the number of values in the set.
-func (s *Set) Len() int {
-	return len(s.dense)
-}
 
 type byteToken struct {
 	fieldType types.FieldType
@@ -113,7 +60,7 @@ func trigramToBytes(tv uint32) []byte {
 type TrigramTokenizer struct {
 	r io.ByteReader
 
-	trigrams *Set
+	trigrams *sparse.Set
 	buf      []byte
 
 	n  uint64
@@ -122,7 +69,7 @@ type TrigramTokenizer struct {
 
 func NewTrigramTokenizer() *TrigramTokenizer {
 	return &TrigramTokenizer{
-		trigrams: NewSet(1 << 24),
+		trigrams: sparse.NewSet(1 << 24),
 		buf:      make([]byte, 16384),
 	}
 }
@@ -141,10 +88,11 @@ func (tt *TrigramTokenizer) Reset(r io.Reader) {
 
 func (tt *TrigramTokenizer) Next() (types.Token, error) {
 	for {
-		c, err := tt.r.ReadByte()
+		b, err := tt.r.ReadByte()
 		if err != nil {
 			return nil, err
 		}
+		c := unicode.ToLower(rune(b)) // lowercase
 		tt.tv = (tt.tv << 8) & (1<<24 - 1)
 		tt.tv |= uint32(c)
 		if !validUTF8((tt.tv>>8)&0xFF, tt.tv&0xFF) {
@@ -193,13 +141,14 @@ func (wt *WhitespaceTokenizer) Next() (types.Token, error) {
 	}
 
 	for {
-		c, err := wt.r.ReadByte()
+		b, err := wt.r.ReadByte()
 		if err != nil {
 			if wt.sb.Len() > 0 {
 				return currentToken(), nil
 			}
 			return nil, err
 		}
+		c := byte(unicode.ToLower(rune(b)))
 		if c != ' ' {
 			wt.sb.WriteByte(c)
 			wt.n++
@@ -228,6 +177,12 @@ type hashAndPosition struct {
 	pos  int
 }
 
+// maxNgramLength controls how long of ngrams will be emitted by BuildAllNgrams
+// and BuildCoveringNgrams. Increasing this value will result in indexing more
+// ngrams and a bigger index size, but will allow for more selectivity at query
+// time.
+const maxNgramLength = 10
+
 func BuildAllNgrams(s []byte) []string {
 	rv := make([]string, 0)
 
@@ -240,8 +195,9 @@ func BuildAllNgrams(s []byte) []string {
 		for len(st) > 0 && p.hash > st[len(st)-1].hash {
 			start := st[len(st)-1].pos
 			count := i + 2 - start
-			rv = append(rv, string(s[start:start+count]))
-
+			if count <= maxNgramLength {
+				rv = append(rv, string(s[start:start+count]))
+			}
 			for len(st) > 1 && st[len(st)-1].hash == st[len(st)-2].hash {
 				st = st[:len(st)-1]
 			}
@@ -250,7 +206,9 @@ func BuildAllNgrams(s []byte) []string {
 		if len(st) != 0 {
 			start := st[len(st)-1].pos
 			count := i + 2 - start
-			rv = append(rv, string(s[start:start+count]))
+			if count <= maxNgramLength {
+				rv = append(rv, string(s[start:start+count]))
+			}
 		}
 		st = append(st, p)
 	}
@@ -258,7 +216,6 @@ func BuildAllNgrams(s []byte) []string {
 }
 
 func BuildCoveringNgrams(s []byte) []string {
-	const maxNgramLength = 16
 	rv := make([]string, 0)
 
 	st := make([]hashAndPosition, 0)
@@ -307,13 +264,13 @@ func BuildCoveringNgrams(s []byte) []string {
 type SparseNgramTokenizer struct {
 	scanner *bufio.Scanner
 	ngrams  []string
-	seen    *Set
+	seen    *sparse.Set
 	hasher  hash.Hash32
 }
 
 func NewSparseNgramTokenizer() *SparseNgramTokenizer {
 	return &SparseNgramTokenizer{
-		seen:   NewSet(1<<32 - 1),
+		seen:   sparse.NewSet(1<<32 - 1),
 		ngrams: make([]string, 0),
 		hasher: fnv.New32(),
 	}
@@ -333,17 +290,18 @@ func (tt *SparseNgramTokenizer) Next() (types.Token, error) {
 		if err := tt.scanner.Err(); err != nil {
 			return nil, err
 		}
-		line := tt.scanner.Text()
-		if len(line) > 0 {
-			for _, ngram := range BuildAllNgrams([]byte(line)) {
-				ngram = strings.ToLower(ngram)
-				tt.hasher.Reset()
-				tt.hasher.Write([]byte(ngram))
-				ngramID := tt.hasher.Sum32()
-				if alreadySeen := tt.seen.Has(ngramID); !alreadySeen {
-					tt.ngrams = append(tt.ngrams, ngram)
-					tt.seen.Add(ngramID)
-				}
+		line := bytes.ToLower(tt.scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		for _, ngram := range BuildAllNgrams(line) {
+			tt.hasher.Reset()
+			tt.hasher.Write([]byte(ngram))
+			ngramID := tt.hasher.Sum32()
+			if alreadySeen := tt.seen.Has(ngramID); !alreadySeen {
+				tt.ngrams = append(tt.ngrams, ngram)
+				tt.seen.Add(ngramID)
 			}
 		}
 	}


### PR DESCRIPTION
The sparse ngrams are longer than trigrams so I don't want to do case expansion on them (casE, caSe, cAse, Case, caSE...).