### PR TITLE
Fix OCI runtime stats

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -166,7 +166,7 @@ func TestRunUsageStats(t *testing.T) {
 	res := c.Run(ctx, cmd, wd, oci.Credentials{})
 	require.NoError(t, res.Error)
 	require.Equal(t, 0, res.ExitCode)
-	assert.Greater(t, res.UsageStats.GetMemoryBytes(), int64(0), "memory")
+	assert.Greater(t, res.UsageStats.GetPeakMemoryBytes(), int64(0), "memory")
 	assert.Greater(t, res.UsageStats.GetCpuNanos(), int64(0), "CPU")
 }
 


### PR DESCRIPTION
* Fix peak memory getting reported as 0
* Port https://github.com/buildbuddy-io/buildbuddy/pull/7021 to OCI runtime so that we account for the runtime process stats

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3631
