### PR TITLE
Reduce OCI capabilities set

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -74,15 +74,12 @@ var (
 	// Allowed capabilities.
 	// TODO: allow customizing this (for self-hosted executors).
 	capabilities = []string{
-		"CAP_AUDIT_WRITE",
 		"CAP_CHOWN",
 		"CAP_DAC_OVERRIDE",
 		"CAP_FOWNER",
 		"CAP_FSETID",
 		"CAP_KILL",
-		"CAP_MKNOD",
 		"CAP_NET_BIND_SERVICE",
-		"CAP_NET_RAW",
 		"CAP_SETFCAP",
 		"CAP_SETGID",
 		"CAP_SETPCAP",
@@ -572,7 +569,6 @@ func (c *ociContainer) createSpec(cmd *repb.Command) (*specs.Spec, error) {
 			Env:  env,
 			// TODO: rlimits
 			Rlimits: []specs.POSIXRlimit{},
-			// TODO: audit these
 			Capabilities: &specs.LinuxCapabilities{
 				Bounding:  capabilities,
 				Effective: capabilities,


### PR DESCRIPTION
In our current podman implementation, we are granting fewer capabilities than what's currently in the hard-coded list.

**Related issues**: N/A
