### PR TITLE
use EstimateDiskUsage in Usage()

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -193,20 +192,15 @@ func (sm *Replica) Usage() (*rfpb.ReplicaUsage, error) {
 		},
 		RangeId: rd.GetRangeId(),
 	}
-
-	var numFileRecords, sizeBytes int64
-	sm.partitionMetadataMu.Lock()
-	for _, pm := range sm.partitionMetadata {
-		ru.Partitions = append(ru.Partitions, pm.CloneVT())
-		numFileRecords += pm.GetTotalCount()
-		sizeBytes += pm.GetSizeBytes()
+	db, err := sm.leaser.DB()
+	if err != nil {
+		return nil, err
 	}
-	sm.partitionMetadataMu.Unlock()
-
-	sort.Slice(ru.Partitions, func(i, j int) bool {
-		return ru.Partitions[i].GetPartitionId() < ru.Partitions[j].GetPartitionId()
-	})
-	ru.EstimatedDiskBytesUsed = sizeBytes
+	sizeBytes, err := db.EstimateDiskUsage(rd.GetStart(), rd.GetEnd())
+	if err != nil {
+		return nil, err
+	}
+	ru.EstimatedDiskBytesUsed = int64(sizeBytes)
 	ru.ReadQps = int64(sm.readQPS.Get())
 	ru.RaftProposeQps = int64(sm.raftProposeQPS.Get())
 

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -196,6 +196,7 @@ func (sm *Replica) Usage() (*rfpb.ReplicaUsage, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer db.Close()
 	sizeBytes, err := db.EstimateDiskUsage(rd.GetStart(), rd.GetEnd())
 	if err != nil {
 		return nil, err

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -169,7 +169,9 @@ func TestAutomaticSplitting(t *testing.T) {
 	sf.StartShard(t, ctx, stores...)
 
 	waitForRangeLease(t, ctx, stores, 2)
-	writeNRecords(ctx, t, s1, 15) // each write is 1000 bytes
+	writeNRecords(ctx, t, s1, 20) // each write is 1000 bytes
+	// EstimateDiskUsage can only estimate after db is flushed.
+	s1.DB().Flush()
 
 	waitForRangeLease(t, ctx, stores, 4)
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3606

Use EstimatedDiskUsage() as a way to calculate the size of a shard; instead of
partition metadata. It's expensive to calculate the accurate size of a partition
in a range post split, because we have to iterate all the keys.
