### PR TITLE
Add prefix to API keys to make them easy to identify by scanners.

### DIFF
--- a/enterprise/app/api_keys/api_keys.css
+++ b/enterprise/app/api_keys/api_keys.css
@@ -99,6 +99,7 @@
 
 .api-keys .api-key-value .display-value {
   margin-right: 4px;
+  width: 200px;
 }
 
 .api-keys .api-key-value button {

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -636,7 +636,7 @@ interface ApiKeyFieldState {
 const ApiKeyFieldDefaultState: ApiKeyFieldState = {
   isCopied: false,
   hideValue: true,
-  displayValue: "••••••••••••••••••••",
+  displayValue: "••••••••••••••••••••••••••",
 };
 
 class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -100,55 +100,60 @@ func TestSessionInsertUpdateDeleteRead(t *testing.T) {
 
 func TestGetAPIKeyGroupFromAPIKey(t *testing.T) {
 	for _, encrypt := range []bool{false, true} {
-		t.Run(fmt.Sprintf("encrypt_%t", encrypt), func(t *testing.T) {
-			if encrypt {
-				key := make([]byte, 32)
-				crand.Read(key)
-				flags.Set(t, "auth.api_key_encryption.key", base64.StdEncoding.EncodeToString(key))
-				flags.Set(t, "auth.api_key_encryption.encrypt_new_keys", true)
-			}
-			ctx := context.Background()
-			env := setupEnv(t)
-			adb := env.GetAuthDB()
+		for _, includePrefix := range []bool{false, true} {
+			t.Run(fmt.Sprintf("encrypt_%t_prefix_%t", encrypt, includePrefix), func(t *testing.T) {
+				if encrypt {
+					key := make([]byte, 32)
+					crand.Read(key)
+					flags.Set(t, "auth.api_key_encryption.key", base64.StdEncoding.EncodeToString(key))
+					flags.Set(t, "auth.api_key_encryption.encrypt_new_keys", true)
+				}
+				if includePrefix {
+					flags.Set(t, "auth.include_api_key_prefix", true)
+				}
+				ctx := context.Background()
+				env := setupEnv(t)
+				adb := env.GetAuthDB()
 
-			keys := createRandomAPIKeys(t, ctx, env)
-			randKey := keys[rand.Intn(len(keys))]
+				keys := createRandomAPIKeys(t, ctx, env)
+				randKey := keys[rand.Intn(len(keys))]
 
-			akg, err := adb.GetAPIKeyGroupFromAPIKey(ctx, randKey.Value)
-			require.NoError(t, err)
+				akg, err := adb.GetAPIKeyGroupFromAPIKey(ctx, randKey.Value)
+				require.NoError(t, err)
 
-			assert.Equal(t, "", akg.GetUserID())
-			assert.Equal(t, randKey.GroupID, akg.GetGroupID())
-			assert.Equal(t, randKey.Capabilities, akg.GetCapabilities())
-			assert.Equal(t, false, akg.GetUseGroupOwnedExecutors())
+				assert.Equal(t, "", akg.GetUserID())
+				assert.Equal(t, randKey.GroupID, akg.GetGroupID())
+				assert.Equal(t, randKey.Capabilities, akg.GetCapabilities())
+				assert.Equal(t, false, akg.GetUseGroupOwnedExecutors())
 
-			// Converting to Claims should produce the expected value
-			c := claims.APIKeyGroupClaims(akg)
-			assert.Equal(t, randKey.GroupID, c.GetGroupID())
-			assert.Equal(t, capabilities.FromInt(randKey.Capabilities), c.GetCapabilities())
-			require.Len(t, c.GetGroupMemberships(), 1)
-			assert.Equal(t, []*interfaces.GroupMembership{
-				{
-					GroupID:      randKey.GroupID,
-					Capabilities: capabilities.FromInt(randKey.Capabilities),
-					// TODO(bduffany): API keys should not have roles - just
-					// capabilities.
-					Role: role.Developer,
-				},
-			}, c.GetGroupMemberships())
+				// Converting to Claims should produce the expected value
+				c := claims.APIKeyGroupClaims(akg)
+				assert.Equal(t, randKey.GroupID, c.GetGroupID())
+				assert.Equal(t, capabilities.FromInt(randKey.Capabilities), c.GetCapabilities())
+				require.Len(t, c.GetGroupMemberships(), 1)
+				assert.Equal(t, []*interfaces.GroupMembership{
+					{
+						GroupID:      randKey.GroupID,
+						Capabilities: capabilities.FromInt(randKey.Capabilities),
+						// TODO(bduffany): API keys should not have roles - just
+						// capabilities.
+						Role: role.Developer,
+					},
+				}, c.GetGroupMemberships())
 
-			// Using an invalid or empty value should produce an error
-			akg, err = adb.GetAPIKeyGroupFromAPIKey(ctx, "")
-			require.Nil(t, akg)
-			require.Truef(
-				t, status.IsUnauthenticatedError(err),
-				"expected Unauthenticated error; got: %v", err)
-			akg, err = adb.GetAPIKeyGroupFromAPIKey(ctx, "INVALID")
-			require.Nil(t, akg)
-			require.Truef(
-				t, status.IsUnauthenticatedError(err),
-				"expected Unauthenticated error; got: %v", err)
-		})
+				// Using an invalid or empty value should produce an error
+				akg, err = adb.GetAPIKeyGroupFromAPIKey(ctx, "")
+				require.Nil(t, akg)
+				require.Truef(
+					t, status.IsUnauthenticatedError(err),
+					"expected Unauthenticated error; got: %v", err)
+				akg, err = adb.GetAPIKeyGroupFromAPIKey(ctx, "INVALID")
+				require.Nil(t, akg)
+				require.Truef(
+					t, status.IsUnauthenticatedError(err),
+					"expected Unauthenticated error; got: %v", err)
+			})
+		}
 	}
 }
 

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	apiKeyRegex = regexp.MustCompile(APIKeyHeader + "=([a-zA-Z0-9]*)")
+	apiKeyRegex = regexp.MustCompile(APIKeyHeader + "=([a-zA-Z0-9_]*)")
 )
 
 // AuthorizeOrgAdmin checks whether the given user has ORG_ADMIN capability

--- a/server/util/authutil/authutil_test.go
+++ b/server/util/authutil/authutil_test.go
@@ -43,6 +43,12 @@ func TestParseAPIKeyFromString(t *testing.T) {
 			want:    "abc456",
 			wantErr: false,
 		},
+		{
+			name:    "key with prefix",
+			input:   "--bes_results_url=http://localhost:8080/invocation/ --remote_header='x-buildbuddy-api-key=bbaki_abc123'",
+			want:    "abc123",
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
My plan is to configure the following prefixes:
 Prod: bbak_
 Dev: bbakd_
 All other: bbaki_

Rollout strategy:
 - First release will accept prefixed API keys but will not yet generate keys with a prefix
 - Second release will start generating new keys with a prefix. Non-prefixed API keys will continue to be accepted.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/3644

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
