### PR TITLE
Don't mint token objects just to discard them

### DIFF
--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -131,12 +130,7 @@ func getNamespace() string {
 
 func makeDoc(name string) (types.Document, error) {
 	// Open the file and read all contents to memory.
-	f, err := os.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	buf, err := io.ReadAll(f)
+	buf, err := os.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -174,12 +174,8 @@ func (w *Writer) AddDocument(doc types.Document) error {
 		tokenizer := w.tokenizers[field.Type()]
 		tokenizer.Reset(bytes.NewReader(field.Contents()))
 
-		for {
-			tok, err := tokenizer.Next()
-			if err != nil {
-				break
-			}
-			ngram := string(tok.Ngram())
+		for tokenizer.Next() == nil {
+			ngram := string(tokenizer.Ngram())
 			postingLists[ngram] = append(postingLists[ngram], doc.ID())
 		}
 

--- a/codesearch/token/token.go
+++ b/codesearch/token/token.go
@@ -121,7 +121,7 @@ type WhitespaceTokenizer struct {
 	r io.ByteReader
 	n uint64
 
-	sb *strings.Builder
+	sb  *strings.Builder
 	tok string
 }
 
@@ -307,7 +307,6 @@ func (tt *SparseNgramTokenizer) Type() types.FieldType {
 func (tt *SparseNgramTokenizer) Ngram() []byte {
 	return []byte(tt.ngram)
 }
-
 
 func (tt *SparseNgramTokenizer) Next() error {
 	for len(tt.ngrams) == 0 {

--- a/codesearch/token/token_test.go
+++ b/codesearch/token/token_test.go
@@ -77,12 +77,8 @@ func oldTokenize(f io.Reader) []string {
 func tokenizeBuf(buf string, tt types.Tokenizer) []string {
 	tt.Reset(strings.NewReader(buf))
 	tokens := make([]string, 0)
-	for {
-		tok, err := tt.Next()
-		if err != nil {
-			break
-		}
-		tokens = append(tokens, string(tok.Ngram()))
+	for tt.Next() == nil {
+		tokens = append(tokens, string(tt.Ngram()))
 	}
 	return tokens
 }

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -41,11 +41,6 @@ type Document interface {
 	// TODO(tylerw): add Boost() float64
 }
 
-type Token interface {
-	Type() FieldType
-	Ngram() []byte
-}
-
 type Posting interface {
 	Docid() uint64
 	Positions() []uint64
@@ -60,7 +55,10 @@ type DocumentMatch interface {
 
 type Tokenizer interface {
 	Reset(io.Reader)
-	Next() (Token, error)
+	Next() error
+
+	Type() FieldType
+	Ngram() []byte
 }
 
 type IndexWriter interface {


### PR DESCRIPTION
This roughly halves the amount of space allocated (from 12G -> 7G) during an indexing run of the kernel.