### PR TITLE
[raft] fix move graph and range cache hit graph

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -3453,10 +3453,12 @@
                 "type": "prometheus",
                 "uid": "vm"
               },
+              "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(rate(buildbuddy_raft_moves{region=\"${region}\"}[${window}])) by (pod_name)",
+              "expr": "sum(increase(buildbuddy_raft_moves{region=\"${region}\"}[${window}])) by (pod_name)",
               "interval": "",
               "legendFormat": "",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -3505,6 +3507,7 @@
                   "mode": "off"
                 }
               },
+              "decimals": 3,
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
@@ -14064,7 +14067,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 31
       },
       "id": 8,
       "panels": [
@@ -14296,7 +14299,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 32
       },
       "id": 1346,
       "panels": [
@@ -14810,7 +14813,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 33
       },
       "id": 5641,
       "panels": [


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Before this change, the move graph doesn't show the number of moves, and the hit graph shows the value is 100%, but the graph shows movement of the metric
![Screenshot 2024-07-29 at 5 16 40 PM](https://github.com/user-attachments/assets/257fbeca-16b6-4881-b35b-e93a209f6eba)
![Screenshot from 2024-07-29 17-56-19](https://github.com/user-attachments/assets/a50da478-f1bb-4ed0-9601-c68b49817290)

After this change, we can see the number of moves and also the an accurate value in hit graph.
![Screenshot from 2024-07-29 18-00-46](https://github.com/user-attachments/assets/4c0cbe92-1d88-4d45-bb65-f2fa96aceb87)
![Screenshot from 2024-07-29 18-00-25](https://github.com/user-attachments/assets/d6d1d98c-6050-45a9-a5d1-34c8760bcc37)

