### PR TITLE
Fix ping not working in OCI runtime

### DIFF
--- a/dockerfiles/test_images/net_tools/Dockerfile
+++ b/dockerfiles/test_images/net_tools/Dockerfile
@@ -1,7 +1,15 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates iproute2 iptables iputils-ping && \
+    apt-get install -y \
+        ca-certificates \
+        curl \
+        dnsutils \
+        iproute2 \
+        iptables \
+        iputils-ping \
+        net-tools \
+        && \
     update-ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -44,7 +44,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:2847b15d47b85fcf3c5af1548b71a08523859c7a0fd4e8277f28f7f9af545602",
+        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:ac701954d2c522d0d2b5296323127cacaaf77627e69db848a8d6ecb53149d344",
         "test.EstimatedComputeUnits": "2",
     },
     tags = [

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -587,7 +587,9 @@ func (c *ociContainer) createSpec(cmd *repb.Command) (*specs.Spec, error) {
 		Version: ociVersion,
 		Process: &specs.Process{
 			Terminal: false,
-			// TODO: parse USER[:GROUP] from dockerUser
+			// TODO: parse USER[:GROUP] from dockerUser.
+			// Make sure to also update the ping_group_range sysctl below
+			// to match the GID here.
 			User: specs.User{
 				UID:   0,
 				GID:   0,
@@ -707,6 +709,9 @@ func (c *ociContainer) createSpec(cmd *repb.Command) (*specs.Spec, error) {
 			},
 			Seccomp: &seccomp,
 			Devices: []specs.LinuxDevice{},
+			Sysctl: map[string]string{
+				"net.ipv4.ping_group_range": "0 0",
+			},
 			Resources: &specs.LinuxResources{
 				Pids: pids,
 			},

--- a/server/testutil/testnetworking/testnetworking.go
+++ b/server/testutil/testnetworking/testnetworking.go
@@ -28,6 +28,14 @@ func Setup(t *testing.T) {
 		t.Skipf("test requires passwordless sudo for 'ip' command - run ./tools/enable_local_firecracker.sh")
 	}
 
+	// Check whether IP forwarding is enabled
+	b, err := os.ReadFile("/proc/sys/net/ipv4/ip_forward")
+	require.NoError(t, err)
+	if strings.TrimSpace(string(b)) != "1" {
+		os.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1"), 0)
+		require.NoError(t, err, "enable IPv4 forwarding")
+	}
+
 	// Set up a symlink in PATH so that 'iptables' points to 'iptables-legacy'.
 	// Our Firecracker setup does not yet have nftables enabled and can't use
 	// the newer iptables.

--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -22,7 +22,7 @@ go_test(
     srcs = ["networking_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:2847b15d47b85fcf3c5af1548b71a08523859c7a0fd4e8277f28f7f9af545602",
+        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:ac701954d2c522d0d2b5296323127cacaaf77627e69db848a8d6ecb53149d344",
         "test.EstimatedComputeUnits": "2",
     },
     tags = ["no-sandbox"],

--- a/server/util/networking/networking_test.go
+++ b/server/util/networking/networking_test.go
@@ -161,6 +161,9 @@ func TestContainerNetworking(t *testing.T) {
 	netnsExec(t, c1.NetNamespace(), `ping -c 1 -W 3 8.8.8.8`)
 	netnsExec(t, c2.NetNamespace(), `ping -c 1 -W 3 8.8.8.8`)
 
+	// DNS should work from inside the netns.
+	netnsExec(t, c1.NetNamespace(), `ping -c 1 -W 3 example.com`)
+
 	// Containers should not be able to reach each other.
 	netnsExec(t, c1.NetNamespace(), `echo 'Pinging c1' && if ping -c 1 -W 1 `+c2.Network().NamespacedIP()+` ; then exit 1; fi`)
 	netnsExec(t, c2.NetNamespace(), `echo 'Pinging c2' && if ping -c 1 -W 1 `+c1.Network().NamespacedIP()+` ; then exit 1; fi`)


### PR DESCRIPTION
We need the sysctl `net.ipv4.ping_group_range="0 0"` in order for ICMP requests to work without needing `CAP_NET_RAW` capability.

**Related issues**: N/A
