### PR TITLE
Add histograms for enqueued task sizes

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -414,6 +414,10 @@ func (h *executorHandle) EnqueueTaskReservation(ctx context.Context, req *scpb.E
 	case <-ctx.Done():
 		return nil, status.CanceledErrorf("could not enqueue task reservation %q", req.GetTaskId())
 	case rsp := <-rspCh:
+
+		metrics.RemoteExecutionEnqueuedTaskMilliCPU.Observe(float64(req.GetTaskSize().GetEstimatedMilliCpu()))
+		metrics.RemoteExecutionEnqueuedTaskMemoryBytes.Observe(float64(req.GetTaskSize().GetEstimatedMemoryBytes()))
+
 		return rsp, nil
 	}
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -850,7 +850,7 @@ var (
 		Subsystem: "remote_execution",
 		Name:      "enqueued_task_milli_cpu",
 		Help:      "Milli-CPU prediction of enqueued tasks.",
-		Buckets:   exponentialBucketRange(1, 64_000, 1.2),
+		Buckets:   exponentialBucketRange(1, 128_000, 1.2),
 	})
 
 	RemoteExecutionEnqueuedTaskMemoryBytes = promauto.NewHistogram(prometheus.HistogramOpts{

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -845,6 +845,22 @@ var (
 		StatusHumanReadableLabel,
 	})
 
+	RemoteExecutionEnqueuedTaskMilliCPU = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "enqueued_task_milli_cpu",
+		Help:      "Milli-CPU prediction of enqueued tasks.",
+		Buckets:   exponentialBucketRange(1, 64_000, 1.2),
+	})
+
+	RemoteExecutionEnqueuedTaskMemoryBytes = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "enqueued_task_memory_bytes",
+		Help:      "Memory prediction of enqueued tasks.",
+		Buckets:   exponentialBucketRange(1, 1024*1024*1024*1024 /*1 TB*/, 1.5),
+	})
+
 	RemoteExecutionWaitingExecutionResult = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",


### PR DESCRIPTION
Wound up just doing it per-probe since `adjustTaskSize` incorporates each node's total size, and the adjusted task size is the source of truth for the task size.

**Related issues**: N/A
