### PR TITLE
Support linear backoff for hedged executions

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -666,6 +666,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 			return err
 		}
 		log.CtxInfof(ctx, "Dispatched new hedged execution %q for action %q and invocation %q", hedgedExecutionID, downloadString, invocationID)
+		metrics.RemoteExecutionHedgedActions.With(prometheus.Labels{metrics.GroupID: s.getGroupIDForMetrics(ctx)}).Inc()
 	}
 	if mergedExecution {
 		err = action_merger.RecordMergedExecution(ctx, s.rdb, adInstanceDigest, s.getGroupIDForMetrics(ctx))

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -897,6 +897,15 @@ var (
 		GroupID,
 	})
 
+	RemoteExecutionHedgedActions = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "hedged_actions",
+		Help:      "Number of identicial execution request which were merged for which a hedged execution was run in the background.",
+	}, []string{
+		GroupID,
+	})
+
 	RemoteExecutionMergedActionsPerExecution = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",


### PR DESCRIPTION
This PR adds a flag, `remote_execution.action_merging_hedge_delay` which causes the execution server to employ a linear backoff strategy for running hedged executions. IOW, the execution server will run a hedged execution for each client-submitted action that arrives at least `remote_execution.action_merging_hedge_delay` after the last execution (original or hedged), up to `remote_execution.action_merging_hedge_count` times.

It also adds a prometheus counter that counts hedged executions.

**Related issues**: N/A
