### PR TITLE
Add tool to bulk-delete keys from Redis

### DIFF
--- a/tools/bulkredis/BUILD
+++ b/tools/bulkredis/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "bulkredis_lib",
+    srcs = ["bulkredis.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/tools/bulkredis",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//server/util/log",
+        "@com_github_go_redis_redis_v8//:redis",
+    ],
+)
+
+go_binary(
+    name = "bulkredis",
+    embed = [":bulkredis_lib"],
+    pure = "on",
+    static = "on",
+    visibility = ["//visibility:public"],
+)

--- a/tools/bulkredis/bulkredis.go
+++ b/tools/bulkredis/bulkredis.go
@@ -1,0 +1,65 @@
+// Tool to run bulk redis operations.
+//
+// List keys matching a pattern:
+// $ bazel run -- tools/bulkredis -match='taskSize/*'
+//
+// Confirm the keys match what you expect, then delete all matching keys with
+// $ bazel run -- tools/bulkredis -match='taskSize/*' -op=delete
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/go-redis/redis/v8"
+)
+
+var (
+	target = flag.String("target", "localhost:6380", "Redis target")
+	match  = flag.String("match", "", "Redis keys to match")
+	op     = flag.String("op", "print", "Bulk operation to perform. Just prints all keys by default.")
+)
+
+func main() {
+	flag.Parse()
+
+	if *match == "" {
+		log.Fatalf("Missing -match arg")
+	}
+
+	c := redis.NewClient(&redis.Options{Addr: *target})
+
+	ctx := context.Background()
+	cursor := uint64(0)
+	for {
+		keys, newCursor, err := c.Scan(ctx, cursor, *match, 100_000).Result()
+		if err != nil {
+			log.Fatalf("Scan failed: %s", err)
+		}
+		if newCursor == 0 {
+			break
+		}
+		cursor = newCursor
+
+		_, err = c.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+			for _, k := range keys {
+				switch *op {
+				case "del", "delete":
+					pipe.Del(ctx, k)
+				default:
+					fmt.Println(k)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			log.Fatalf("Pipeline failed: %s", err)
+		}
+		if *op != "print" {
+			log.Infof("Processed %d keys", len(keys))
+		}
+	}
+}


### PR DESCRIPTION
Starting with just bulk scan + bulk delete for now. This could be useful for other things like computing the size of keys, so eventually it'd be cool to split this up into more unix-like tools like `bulkredis scan 'taskSize/*' | bulkredis delete` or something like that.

Credit to @vadimberezniker for the initial version of this tool in https://github.com/buildbuddy-io/buildbuddy/commit/b5d27e70d545925f3db3d5129fff87bf2d7a8e52

**Related issues**: N/A
