### PR TITLE
add a few more grpc latency buckets for more precise measurement.

### DIFF
--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -117,7 +117,7 @@ func New(env environment.Env, port int, ssl bool, config GRPCServerConfig) (*GRP
 	grpc_prometheus.Register(b.server)
 
 	if *enablePrometheusHistograms {
-		grpc_prometheus.EnableHandlingTimeHistogram()
+		grpc_prometheus.EnableHandlingTimeHistogram(grpc_prometheus.WithHistogramBuckets([]float64{.0005, .001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}))
 	}
 
 	// Register health check service.


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
compare: https://github.com/grpc-ecosystem/go-grpc-middleware/blob/62b7de50cda5a5d633f1013bfbe50e0f38db34ef/providers/prometheus/server_options.go#L37-L48 , which bottoms out at .005s

(`var DefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}`)
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
