### PR TITLE
Add logging for CPU usage between Unpause() and Exec()

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -229,6 +229,16 @@ func (s *UsageStats) Reset() {
 	s.peakMemoryUsageBytes = 0
 }
 
+// TODO: remove after debugging stats issue
+func (s *UsageStats) Clone() *UsageStats {
+	clone := *s
+	if s.last != nil {
+		clone.last = s.last.CloneVT()
+	}
+	// Baseline PSI protos are readonly; no need to clone.
+	return &clone
+}
+
 // TaskStats returns the usage stats for an executed task.
 func (s *UsageStats) TaskStats() *repb.UsageStats {
 	if s.last == nil {


### PR DESCRIPTION
If the CPU usage between Unpause() and Exec() is high relative to the exec duration, then this could cause the milli_cpu estimate that we store in Redis to be disproportionately large relative to the task's actual CPU usage. This is because the exec duration only accounts for the time spent in Exec(), not the time between Unpause() and Exec(). So if there is a BG process in the runner and (input_download+pull_image) duration is relatively high, the BG process can be racking up CPU usage which will be misattributed to the exec_duration and inflate the calculated average milli-CPU.

This PR just adds some debug logging to help test this hypothesis, and should not affect scheduling behavior.

**Related issues**: N/A
