### PR TITLE
Fix a bug in digest.Diff() by making it use value equality instead of pointer equality.

### DIFF
--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -583,24 +583,24 @@ func Diff(s1 []*repb.Digest, s2 []*repb.Digest) (missingFromS1 []*repb.Digest, m
 	missingFromS1 = make([]*repb.Digest, 0)
 	missingFromS2 = make([]*repb.Digest, 0)
 
-	s1Set := make(map[Key]*repb.Digest, len(s1))
+	s1Set := make(map[Key]struct{}, len(s1))
 	for _, d := range s1 {
-		s1Set[NewKey(d)] = d
+		s1Set[NewKey(d)] = struct{}{}
 	}
 
-	s2Set := make(map[Key]*repb.Digest, len(s2))
+	s2Set := make(map[Key]struct{}, len(s2))
 	for _, d := range s2 {
 		k := NewKey(d)
-		s2Set[k] = d
+		s2Set[k] = struct{}{}
 
 		if _, inS1 := s1Set[k]; !inS1 {
-			missingFromS1 = append(missingFromS1, d)
+			missingFromS1 = append(missingFromS1, k.ToDigest())
 		}
 	}
 
-	for k, d := range s1Set {
+	for k := range s1Set {
 		if _, inS2 := s2Set[k]; !inS2 {
-			missingFromS2 = append(missingFromS2, d)
+			missingFromS2 = append(missingFromS2, k.ToDigest())
 		}
 	}
 

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -583,22 +583,23 @@ func Diff(s1 []*repb.Digest, s2 []*repb.Digest) (missingFromS1 []*repb.Digest, m
 	missingFromS1 = make([]*repb.Digest, 0)
 	missingFromS2 = make([]*repb.Digest, 0)
 
-	s1Set := make(map[*repb.Digest]struct{}, len(s1))
+	s1Set := make(map[Key]*repb.Digest, len(s1))
 	for _, d := range s1 {
-		s1Set[d] = struct{}{}
+		s1Set[NewKey(d)] = d
 	}
 
-	s2Set := make(map[*repb.Digest]struct{}, len(s2))
+	s2Set := make(map[Key]*repb.Digest, len(s2))
 	for _, d := range s2 {
-		s2Set[d] = struct{}{}
+		k := NewKey(d)
+		s2Set[k] = d
 
-		if _, inS1 := s1Set[d]; !inS1 {
+		if _, inS1 := s1Set[k]; !inS1 {
 			missingFromS1 = append(missingFromS1, d)
 		}
 	}
 
-	for d := range s1Set {
-		if _, inS2 := s2Set[d]; !inS2 {
+	for k, d := range s1Set {
+		if _, inS2 := s2Set[k]; !inS2 {
 			missingFromS2 = append(missingFromS2, d)
 		}
 	}

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -181,7 +181,8 @@ func TestElementsMatch(t *testing.T) {
 func TestDiff(t *testing.T) {
 	d1 := &repb.Digest{Hash: "1234", SizeBytes: 100}
 	d2 := &repb.Digest{Hash: "1111", SizeBytes: 10}
-	d3 := &repb.Digest{Hash: "1234", SizeBytes: 1}
+	d3_1 := &repb.Digest{Hash: "1234", SizeBytes: 1}
+	d3_2 := &repb.Digest{Hash: "1234", SizeBytes: 1}
 
 	cases := []struct {
 		s1 []*repb.Digest
@@ -209,15 +210,15 @@ func TestDiff(t *testing.T) {
 			expectedMissingFromS2: []*repb.Digest{},
 		},
 		{
-			s1:                    []*repb.Digest{d1, d2, d3},
+			s1:                    []*repb.Digest{d1, d2, d3_1},
 			s2:                    []*repb.Digest{d2, d1},
 			expectedMissingFromS1: []*repb.Digest{},
-			expectedMissingFromS2: []*repb.Digest{d3},
+			expectedMissingFromS2: []*repb.Digest{d3_1},
 		},
 		{
 			s1:                    []*repb.Digest{d1, d2},
-			s2:                    []*repb.Digest{d2, d1, d3},
-			expectedMissingFromS1: []*repb.Digest{d3},
+			s2:                    []*repb.Digest{d2, d1, d3_1},
+			expectedMissingFromS1: []*repb.Digest{d3_1},
 			expectedMissingFromS2: []*repb.Digest{},
 		},
 		{
@@ -228,8 +229,14 @@ func TestDiff(t *testing.T) {
 		},
 		{
 			s1:                    []*repb.Digest{d1, d2, d1},
-			s2:                    []*repb.Digest{d2, d1, d3},
-			expectedMissingFromS1: []*repb.Digest{d3},
+			s2:                    []*repb.Digest{d2, d1, d3_1},
+			expectedMissingFromS1: []*repb.Digest{d3_1},
+			expectedMissingFromS2: []*repb.Digest{},
+		},
+		{
+			s1:                    []*repb.Digest{d3_1},
+			s2:                    []*repb.Digest{d3_2},
+			expectedMissingFromS1: []*repb.Digest{},
 			expectedMissingFromS2: []*repb.Digest{},
 		},
 	}


### PR DESCRIPTION
The current implementation of `digest.Diff` uses pointer equality for testing digest equality. This means that it will incorrectly declare two digests to be different if they are pointers to different versions of the same digest, rather than checking their values to determine they are the same.

This is only used in the migration cache and has likely resulted in over-migrating data during the double read phase. From reading the code, it appears the new, correct behavior is desired as it's reading digests from two different backends, so the current implementation will always declare them all to be different, as they'll be pointers into different allocated protos in memory.

I added a new test that demonstrates the bug.

**Related issues**: N/A
