### PR TITLE
Temporarily require podman isolation for ci_runner_test

### DIFF
--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -19,6 +19,8 @@ go_test(
     exec_properties = {
         # TODO: remove network dependency.
         "test.dockerNetwork": "bridge",
+        # TODO: fix flakiness on OCI runner.
+        "test.workload-isolation-type": "podman",
     },
     shard_count = 13,
     x_defs = {


### PR DESCRIPTION
In `ci_runner_test > TestArtifactUploads_JVMLog`, Bazel occasionally throws an unexpected "NoClassDefFoundError" instead of the expected "OutOfMemoryError," but only when run inside the OCI runner.

I think we should treat this as a blocker for launching the OCI runner to prod, because it seems likely that whatever's causing this flakiness could also cause some customer actions to flake. But I would like to turn on OCI by default in dev so that we can start testing it much more seriously, so in the meantime this PR should let us do that without the dev tests constantly being flaky.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3631
