### PR TITLE
Update Bazel protos

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -283,6 +283,7 @@ proto_library(
     srcs = ["spawn.proto"],
     deps = [
         "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
@@ -420,6 +421,14 @@ proto_library(
 proto_library(
     name = "invocation_policy_proto",
     srcs = ["invocation_policy.proto"],
+    deps = [
+        ":strategy_policy_proto",
+    ],
+)
+
+proto_library(
+    name = "strategy_policy_proto",
+    srcs = ["strategy_policy.proto"],
 )
 
 proto_library(
@@ -1251,8 +1260,21 @@ go_proto_library(
         "@io_bazel_rules_go//proto:go_proto",
         "//proto:vtprotobuf_compiler",
     ],
-    importpath = "github.com/buildbuddy-io/buildbuddy/proto/blaze.invocation_policy",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/invocation_policy",
     proto = ":invocation_policy_proto",
+    deps = [
+        ":strategy_policy_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "strategy_policy_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "//proto:vtprotobuf_compiler",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/strategy_policy",
+    proto = ":strategy_policy_proto",
 )
 
 go_proto_library(
@@ -1921,6 +1943,7 @@ ts_proto_library(
         ":duration_ts_proto",
         ":invocation_status_ts_proto",
         ":stat_filter_ts_proto",
+        ":timestamp_ts_proto",
     ],
 )
 
@@ -2087,6 +2110,14 @@ ts_proto_library(
 ts_proto_library(
     name = "invocation_policy_ts_proto",
     proto = ":invocation_policy_proto",
+    deps = [
+        ":strategy_policy_ts_proto",
+    ],
+)
+
+ts_proto_library(
+    name = "strategy_policy_ts_proto",
+    proto = ":strategy_policy_proto",
     deps = [],
 )
 

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -248,11 +248,10 @@ message BuildEventId {
   // Identifier of an event providing convenience symlinks information.
   message ConvenienceSymlinksIdentifiedId {}
 
-  // Identifier of an event signalling that the coverage actions are finished.
-  message CoverageActionsFinishedId {}
-
   // Identifier of an event providing the ExecRequest of a run command.
   message ExecRequestId {}
+
+  reserved 27;
 
   // BUILDBUDDY-SPECIFIC EVENTS BELOW
 
@@ -315,7 +314,6 @@ message BuildEventId {
     WorkspaceConfigId workspace = 23;
     BuildMetadataId build_metadata = 24;
     ConvenienceSymlinksIdentifiedId convenience_symlinks_identified = 25;
-    CoverageActionsFinishedId coverage_actions_finished = 27;
     ExecRequestId exec_request = 28;
 
     // BUILDBUDDY EVENTS BELOW
@@ -336,10 +334,16 @@ message BuildEventId {
 message Progress {
   // The next chunk of stdout that bazel produced since the last progress event
   // or the beginning of the build.
+  // Consumers that need to reason about the relative order of stdout and stderr
+  // can assume that stderr has been emitted before stdout if both are present,
+  // on a best-effort basis.
   string stdout = 1;
 
   // The next chunk of stderr that bazel produced since the last progress event
   // or the beginning of the build.
+  // Consumers that need to reason about the relative order of stdout and stderr
+  // can assume that stderr has been emitted before stdout if both are present,
+  // on a best-effort basis.
   string stderr = 2;
 }
 
@@ -1128,6 +1132,14 @@ message BuildMetrics {
 
   ArtifactMetrics artifact_metrics = 7;
 
+  // Data about the evaluation of Skyfunctions.
+  message EvaluationStat {
+    // Name of the Skyfunction.
+    string skyfunction_name = 1;
+    // How many times a given operation was carried out on a Skyfunction.
+    int64 count = 2;
+  }
+
   // Information about the size and shape of the build graph. Some fields may
   // not be populated if Bazel was able to skip steps due to caching.
   message BuildGraphMetrics {
@@ -1167,6 +1179,56 @@ message BuildMetrics {
     // settings or with Skybuild, and may overestimate if there are nodes from
     // prior evaluations still in the cache.
     int32 post_invocation_skyframe_node_count = 4;
+    // Number of SkyValues that were dirtied during the build. Dirtied nodes are
+    // those that transitively depend on a node that changed by itself (e.g. one
+    // representing a file in the file system)
+    repeated EvaluationStat dirtied_values = 10;
+    // Number of SkyValues that changed by themselves. For example, when a file
+    // on the file system changes, the SkyValue representing it will change.
+    repeated EvaluationStat changed_values = 11;
+    // Number of SkyValues that were built. This means that they were evaluated
+    // and were found to have changed from their previous version.
+    repeated EvaluationStat built_values = 12;
+    // Number of SkyValues that were evaluated and found clean, i.e. equal to
+    // their previous version.
+    repeated EvaluationStat cleaned_values = 13;
+
+    // For SkyKeys in 'done values' where the SkyValue is of type
+    // RuleConfiguredTargetValue, we pull those out separately and report the
+    // ruleClass and action count.
+    message RuleClassCount {
+      // Unique key for the rule class.
+      string key = 1;
+
+      // String name of the rule_class (not guaranteed unique)
+      string rule_class = 2;
+
+      // how many rule instances of this type were seen.
+      uint64 count = 3;
+
+      // how many actions were created by this rule class.
+      uint64 action_count = 4;
+    }
+    repeated RuleClassCount rule_class = 14;
+
+    // For SkyKeys whose function name is ASPECT break out that information
+    message AspectCount {
+      // Unique key for Aspect.
+      string key = 1;
+
+      // usually the same as above, but can differ in some cases.
+      string aspect_name = 2;
+
+      // number of aspects created of this type.
+      uint64 count = 3;
+
+      // number of actions created by aspects of this type.
+      uint64 action_count = 4;
+    }
+    repeated AspectCount aspect = 15;
+
+    // Removed due to overlap with EvaluationStat
+    reserved 16;
   }
 
   BuildGraphMetrics build_graph_metrics = 8;
@@ -1357,9 +1419,8 @@ message ConvenienceSymlink {
   // The operation we are performing on the symlink.
   Action action = 2;
 
-  // If action is CREATE, this is the target path that the symlink should point
-  // to. If the path points underneath the output base, it is relative to the
-  // output base; otherwise it is absolute.
+  // If action is CREATE, this is the target path (relative to the output base)
+  // that the symlink should point to.
   //
   // If action is DELETE, this field is not set.
   string target = 3;

--- a/proto/failure_details.proto
+++ b/proto/failure_details.proto
@@ -228,6 +228,7 @@ message Spawn {
     UNSPECIFIED_EXECUTION_FAILURE = 12 [(metadata) = { exit_code: 1 }];
     FORBIDDEN_INPUT = 13 [(metadata) = { exit_code: 1 }];
     REMOTE_CACHE_EVICTED = 14 [(metadata) = { exit_code: 39 }];
+    SPAWN_LOG_IO_EXCEPTION = 15 [(metadata) = { exit_code: 36 }];
   }
   Code code = 1;
 
@@ -375,6 +376,7 @@ message Skyfocus {
     // The user needs to augment their working set to include the new file(s).
     NON_WORKING_SET_CHANGE = 1 [(metadata) = { exit_code: 2 }];
     CONFIGURATION_CHANGE = 2 [(metadata) = { exit_code: 2 }];
+    DISALLOWED_OPERATION_ON_FOCUSED_GRAPH = 3 [(metadata) = { exit_code: 2 }];
   }
 
   Code code = 1;
@@ -386,6 +388,7 @@ message PackageOptions {
 
     PACKAGE_OPTIONS_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
     PACKAGE_PATH_INVALID = 1 [(metadata) = { exit_code: 2 }];
+    NONSINGLETON_PACKAGE_PATH = 4 [(metadata) = { exit_code: 2 }];
   }
 
   Code code = 1;
@@ -418,6 +421,7 @@ message RemoteExecution {
         [(metadata) = { exit_code: 1 }];
     ILLEGAL_OUTPUT = 15 [(metadata) = { exit_code: 1 }];
     INVALID_EXEC_AND_PLATFORM_PROPERTIES = 16 [(metadata) = { exit_code: 1 }];
+    TOPLEVEL_OUTPUTS_DOWNLOAD_FAILURE = 17 [(metadata) = { exit_code: 34 }];
   }
 
   Code code = 1;
@@ -521,7 +525,7 @@ message Filesystem {
         [(metadata) = { exit_code: 2 }];
     FILESYSTEM_JNI_NOT_AVAILABLE = 8 [(metadata) = { exit_code: 36 }];
 
-    reserved 7;  // For internal use
+    reserved 7, 9, 10;  // For internal use
   }
 
   Code code = 1;
@@ -630,6 +634,8 @@ message BuildConfiguration {
     // command-line error exit code 2.
     INVALID_OUTPUT_DIRECTORY_MNEMONIC = 11 [(metadata) = { exit_code: 2 }];
     CONFIGURATION_DISCARDED_ANALYSIS_CACHE = 12 [(metadata) = { exit_code: 2 }];
+    // Failure modes specific to PROJECT.scl files.
+    INVALID_PROJECT = 13 [(metadata) = { exit_code: 2 }];
   }
 
   Code code = 1;
@@ -1321,6 +1327,7 @@ message ExternalDeps {
     INVALID_REGISTRY_URL = 4 [(metadata) = { exit_code: 48 }];
     ERROR_ACCESSING_REGISTRY = 5 [(metadata) = { exit_code: 32 }];
     INVALID_EXTENSION_IMPORT = 6 [(metadata) = { exit_code: 48 }];
+    BAD_LOCKFILE = 7 [(metadata) = { exit_code: 48 }];
   }
 
   Code code = 1;

--- a/proto/invocation_policy.proto
+++ b/proto/invocation_policy.proto
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 syntax = "proto2";
+
 package blaze.invocation_policy;
+
+import "proto/strategy_policy.proto";
 
 option go_package = "invocation_policy";
 // option java_api_version = 2;
@@ -27,6 +30,8 @@ message InvocationPolicy {
   // requirements, only the final policy on a specific flag will be enforced
   // onto the user's command line.
   repeated FlagPolicy flag_policies = 1;
+
+  optional blaze.strategy_policy.StrategyPolicy strategy_policy = 2;
 }
 
 // A policy for controlling the value of a flag.

--- a/proto/option_filters.proto
+++ b/proto/option_filters.proto
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 syntax = "proto3";
+
 package options;
 
 option go_package = "option_filters";

--- a/proto/spawn.proto
+++ b/proto/spawn.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package tools.protos;
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 
 option java_package = "com.google.devtools.build.lib.exec";
 option java_outer_classname = "Protos";
@@ -111,6 +112,8 @@ message SpawnMetrics {
   int64 memory_bytes_limit = 18;
   // Time limit or 0 if unavailable.
   google.protobuf.Duration time_limit = 19;
+  // Instant when the spawn started to execute.
+  google.protobuf.Timestamp start_time = 20;
 }
 
 // Details of an executed spawn.

--- a/proto/strategy_policy.proto
+++ b/proto/strategy_policy.proto
@@ -1,0 +1,68 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto2";
+
+package blaze.strategy_policy;
+
+option go_package = "strategy_policy";
+option java_multiple_files = true;
+// option java_api_version = 2;
+option java_package = "com.google.devtools.build.lib.runtime.proto";
+
+// Provides control over what strategies (local, remote, etc) may be used.
+//
+// An empty policies (e.g. unset) implies no enforcement, anything is allowed.
+//
+// Policies are enforced against both user-provided values (flags) and
+// application-internal defaults. The latter is useful for guarding against
+// unexpectedly hard-coded defaults.
+//
+// Sample usage to allow everything to execute remotely, while only allowing
+// genrules to execute locally:
+//
+//   strategy_policy {
+//     mnemonic_policy {
+//       default_allowlist: ["remote"]
+//       strategy_allowlist: [
+//         { mnemonic: "Genrule" strategy: ["local"] }
+//       ]
+//     }
+//   }
+message StrategyPolicy {
+  // Controls per-mnemonic policies for regular spawn/action execution. Relevant
+  // command-line flags this controls include --strategy and --genrule_strategy.
+  optional MnemonicPolicy mnemonic_policy = 1;
+
+  // Controls per-mnemonic policies for the remote execution leg of dynamic
+  // execution. Relevant flag is --dynamic_remote_strategy.
+  optional MnemonicPolicy dynamic_remote_policy = 2;
+
+  // Controls per-mnemonic policies for the local execution leg of dynamic
+  // execution. Relevant flag is --dynamic_local_strategy.
+  optional MnemonicPolicy dynamic_local_policy = 3;
+}
+
+message MnemonicPolicy {
+  // Default allowed strategies for mnemonics not present in `strategy` list.
+  repeated string default_allowlist = 1;
+
+  repeated StrategiesForMnemonic strategy_allowlist = 2;
+}
+
+// Per-mnemonic allowlist settings.
+message StrategiesForMnemonic {
+  optional string mnemonic = 1;
+  repeated string strategy = 2;
+}


### PR DESCRIPTION
This PR update the protos from bazel.git to the latest version from

```
> git log -1
commit 5f66ae8032ef84103b34e214153975495f7f5c48 (HEAD -> master, origin/master, origin/HEAD)
Author: Googler <jingwen@google.com>
Date:   Fri Aug 2 07:43:28 2024 -0700

    Add experimental active_directories field to PROJECT.scl.

    .. to support sharding a project's active_directories by name.

    PiperOrigin-RevId: 658787465
    Change-Id: I9685780adef1accafe89a76298d28acdbca6787d
```

https://github.com/bazelbuild/bazel/commit/5f66ae8032ef84103b34e214153975495f7f5c48

This should fix our UI crashing when Bazel fail to write the new compact execution log
with the new Error Code 15.

Some manual adjustment was needed around BUILD configuration for invocation_policy.proto 
and it's newly imported, strategy_policy.proto.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
