### PR TITLE
[raft] only return one kv when we look up range descriptor

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1059,6 +1059,9 @@ func (sm *Replica) scan(db ReplicaReader, req *rfpb.ScanRequest) (*rfpb.ScanResp
 			Key:   k,
 			Value: v,
 		})
+		if req.GetLimit() != 0 && len(rsp.GetKvs()) == int(req.GetLimit()) {
+			break
+		}
 	}
 	return rsp, nil
 }

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -46,6 +46,7 @@ func lookupRangeDescriptor(ctx context.Context, c rfspb.ApiClient, h *rfpb.Heade
 		Start:    keys.RangeMetaKey(key),
 		End:      constants.SystemPrefix,
 		ScanType: rfpb.ScanRequest_SEEKGT_SCAN_TYPE,
+		Limit:    1,
 	}).ToProto()
 	if err != nil {
 		return nil, err

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -172,6 +172,8 @@ message ScanRequest {
     SEEKGT_SCAN_TYPE = 3;
   }
   ScanType scan_type = 3;
+  // The maximum number of results to return. If 0, returns everything.
+  int64 limit = 4;
 }
 
 message ScanResponse {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3626
