### PR TITLE
Allow traffic from default interface to host veth

### DIFF
--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -430,11 +430,12 @@ func SetupVethPair(ctx context.Context, netNamespace string) (_ *VethPair, err e
 	}
 
 	iptablesRules := [][]string{
-		// Allow forwarding traffic from the host side of the veth pair to the
-		// device associated with the configured route prefix (usually the
+		// Allow forwarding traffic between the host side of the veth pair and
+		// the device associated with the configured route prefix (usually the
 		// default route). This is necessary on hosts with default-deny policies
 		// in place.
 		{"FORWARD", "-i", veth1, "-o", device, "-j", "ACCEPT"},
+		{"FORWARD", "-i", device, "-o", veth1, "-j", "ACCEPT"},
 
 		// Drop any traffic from the namespace that is targeting another
 		// namespace.


### PR DESCRIPTION
On my system (ubuntu 22.04), traffic in the FORWARD chain is dropped by default, so I need explicit ACCEPT rules for container networking traffic to be forwarded to/from the host interface. We have the ACCEPT rule in place for forwarding veth => host traffic, but we're missing the rule for the reverse direction (host => veth). This PR fixes that.

I noticed this while trying to run `ping` on my local machine from within an OCI container - no idea why, but this used to work for me before, but stopped working today. (My best guess is that a software update caused it somehow.)

I confirmed with `iptables -L -n -v` that the default-drop policy is what was causing these packets to be dropped, and that adding the ACCEPT rule fixed it.

**Related issues**: N/A
