### PR TITLE
CI: no local actions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -320,6 +320,13 @@ use_repo(
 # Note that this is 'rules_nodejs-core'
 # Keep in sync with build_bazel_rules_nodejs in WORKSPACE.bzlmod
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
+single_version_override(
+    module_name = "rules_nodejs",
+    patch_strip = 1,
+    patches = [
+        "@@//buildpatches:build_bazel_rules_nodejs.patch",
+    ],
+)
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 node.toolchain(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,6 +182,20 @@ http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "94070eff79305be05b7699207fbac5d2608054dd53e6109f7d00d923919ff45a",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-5.8.2.tar.gz"],
+    patch_args = ["-p1"],
+    patches = [
+        "//buildpatches:build_bazel_rules_nodejs.patch",
+    ],
+)
+
+http_archive(
+    name = "rules_nodejs",
+    sha256 =  "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
+    patch_args = ["-p1"],
+    patches = [
+        "//buildpatches:build_bazel_rules_nodejs.patch",
+    ],
 )
 
 load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -180,22 +180,22 @@ staticcheck()
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "94070eff79305be05b7699207fbac5d2608054dd53e6109f7d00d923919ff45a",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-5.8.2.tar.gz"],
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:build_bazel_rules_nodejs.patch",
     ],
+    sha256 = "94070eff79305be05b7699207fbac5d2608054dd53e6109f7d00d923919ff45a",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-5.8.2.tar.gz"],
 )
 
 http_archive(
     name = "rules_nodejs",
-    sha256 =  "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:build_bazel_rules_nodejs.patch",
     ],
+    sha256 = "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -41,12 +41,12 @@ http_archive(
 # Since there is no build_bazel_rules_nodejs in BCR, we still want to load it here.
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "94070eff79305be05b7699207fbac5d2608054dd53e6109f7d00d923919ff45a",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-5.8.2.tar.gz"],
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:build_bazel_rules_nodejs.patch",
     ],
+    sha256 = "94070eff79305be05b7699207fbac5d2608054dd53e6109f7d00d923919ff45a",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-5.8.2.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -43,6 +43,10 @@ http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "94070eff79305be05b7699207fbac5d2608054dd53e6109f7d00d923919ff45a",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-5.8.2.tar.gz"],
+    patch_args = ["-p1"],
+    patches = [
+        "//buildpatches:build_bazel_rules_nodejs.patch",
+    ],
 )
 
 load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")

--- a/buildpatches/build_bazel_rules_nodejs.patch
+++ b/buildpatches/build_bazel_rules_nodejs.patch
@@ -1,0 +1,19 @@
+--- a/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_common_private.bzl
++++ b/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_common_private.bzl
+@@ -64,10 +64,10 @@
+     # Sandboxing for this action is wasteful as well since there is a 1:1 mapping of input
+     # file/directory to output file/directory and no room for non-hermetic inputs to sneak in to the
+     # input.
+-    "no-remote": "1",
+-    "no-remote-cache": "1",
+-    "no-remote-exec": "1",
+-    "no-cache": "1",
+-    "no-sandbox": "1",
+-    "local": "1",
++    # "no-remote": "1",
++    # "no-remote-cache": "1",
++    # "no-remote-exec": "1",
++    # "no-cache": "1",
++    # "no-sandbox": "1",
++    # "local": "1",
+ }

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -12,6 +12,6 @@ def sha(name, srcs, **kwargs):
         }
         find $(SRCS) -type f | sort | xargs shasum | normalize_config_paths | shasum | awk '{ print $$1 }' > $@
         """,
-        local = 1,
+        # local = 1,
         **kwargs
     )

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -12,6 +12,5 @@ def sha(name, srcs, **kwargs):
         }
         find $(SRCS) -type f | sort | xargs shasum | normalize_config_paths | shasum | awk '{ print $$1 }' > $@
         """,
-        # local = 1,
         **kwargs
     )

--- a/rules/typescript/index.bzl
+++ b/rules/typescript/index.bzl
@@ -64,7 +64,6 @@ def ts_jasmine_node_test(name, srcs, deps = [], size = "small", **kwargs):
         srcs = [":%s_commonjs.js" % name],
         outs = [":%s_commonjs.test.js" % name],
         cmd_bash = "cp $(SRCS) $@",
-        tags = ["local"],
     )
 
     jasmine_node_test(


### PR DESCRIPTION
This PR attempts to change all the forced-local actions to remote-able actions.
It should improve our Build without the Bytes setup and reduce the amount of artifacts downloaded locally.

After this is applied, we still download a few data from each build:
- Stderr / stdout of each action (including tests)
- Directory tree metadata (no blob)

The remaining data could still be significant in some cases, such as a change that invalidates a lot of tests with large logs.
The fix for these most likely will have to come from Bazel upstream.