### PR TITLE
bzlmod: use googleapis module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,22 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "toolchains_musl", version = "0.1.15")
+bazel_dep(name = "googleapis", version = "0.0.0-20240326-1c8d509c5")
+single_version_override(
+    module_name = "googleapis",
+    patch_strip = 1,
+    patches = [
+        "@@//buildpatches:bzlmod_googleapis.patch",
+    ],
+)
+
+switched_rules = use_extension("//:extensions.bzl", "switched_rules")
+switched_rules.use_languages(
+    cc = True,
+    go = True,
+    grpc = True,
+)
+use_repo(switched_rules, "com_google_googleapis_imports")
 
 # Needed for com_google_protobuf
 bazel_dep(name = "rules_python", version = "0.31.0")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -139,16 +139,19 @@ gazelle_dependencies(
     },
 )
 
+# Version taken from
+# https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/googleapis/0.0.0-20240326-1c8d509c5/source.json
+# So that we can use the same version of googleapis as the one used in bzlmod.
 http_archive(
     name = "googleapis",
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:googleapis.patch",
     ],
-    sha256 = "14d4698e15d7341162363bfaed05995cca692f469c3c4710596aeecbcf44dcf2",
-    strip_prefix = "googleapis-c20f392efc5c9e4f16b37002996607c4cdde4dd3",
+    sha256 = "b854ae17ddb933c249530f743db8d78df80905dfb42681255564a1d1921dfc3c",
+    strip_prefix = "googleapis-1c8d509c574aeab7478be1bfd4f2e8f0931cfead",
     urls = [
-        "https://github.com/googleapis/googleapis/archive/c20f392efc5c9e4f16b37002996607c4cdde4dd3.zip",
+        "https://github.com/googleapis/googleapis/archive/1c8d509c574aeab7478be1bfd4f2e8f0931cfead.tar.gz",
     ],
 )
 

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -24,25 +24,6 @@ load(":deps.bzl", "install_static_dependencies")
 
 install_static_dependencies()
 
-http_archive(
-    name = "googleapis",
-    patch_args = ["-p1"],
-    patches = [
-        "//buildpatches:bzlmod_googleapis.patch",
-    ],
-    sha256 = "14d4698e15d7341162363bfaed05995cca692f469c3c4710596aeecbcf44dcf2",
-    strip_prefix = "googleapis-c20f392efc5c9e4f16b37002996607c4cdde4dd3",
-    urls = [
-        "https://github.com/googleapis/googleapis/archive/c20f392efc5c9e4f16b37002996607c4cdde4dd3.zip",
-    ],
-)
-
-load("@googleapis//:repository_rules.bzl", "switched_rules_by_language")
-
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-)
-
 # Golang staticcheck
 
 http_archive(


### PR DESCRIPTION
Switch to use googleapis module instead of our own.
