### PR TITLE
github/workflows: exclude flaky test

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -9,7 +9,7 @@ on:
       - "*"
 
 jobs:
-  build:
+  "Local-Exec ARM64 Test":
     runs-on: ubuntu-22.04-16cpu-arm64
     if: "!contains(github.event.head_commit.message, 'ci skip')"
 
@@ -46,7 +46,8 @@ jobs:
           )
           bazel test "${BUILD_FLAGS[@]}" --test_tag_filters=-performance,-docker \
             //enterprise/server/remote_execution/... \
-            //enterprise/server/test/integration/remote_execution/...
+            //enterprise/server/test/integration/remote_execution/... \
+            -//enterprise/server/test/integration/remote_execution:remote_execution_test
 
           # Run a separate bazel invocation to invoke tests with the "docker" tag.
           # TODO: improve platform setup so that we can run this whenever the

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -9,7 +9,7 @@ on:
       - "*"
 
 jobs:
-  "Local-Exec ARM64 Test":
+  test:
     runs-on: ubuntu-22.04-16cpu-arm64
     if: "!contains(github.event.head_commit.message, 'ci skip')"
 

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -45,6 +45,7 @@ jobs:
             --color=yes
           )
           bazel test "${BUILD_FLAGS[@]}" --test_tag_filters=-performance,-docker \
+            -- \
             //enterprise/server/remote_execution/... \
             //enterprise/server/test/integration/remote_execution/... \
             -//enterprise/server/test/integration/remote_execution:remote_execution_test


### PR DESCRIPTION
Exclude
//enterprise/server/test/integration/remote_execution:remote_execution_test
from running locally on ARM64.

This constantly fail on ARM64 and create false signals.
