### PR TITLE
[raft] do not block leader updates

### DIFF
--- a/enterprise/server/raft/listener/listener.go
+++ b/enterprise/server/raft/listener/listener.go
@@ -56,8 +56,12 @@ func (rl *RaftListener) LeaderUpdated(info raftio.LeaderInfo) {
 	defer rl.mu.Unlock()
 	rl.lastLeaderInfo = &info
 
-	for _, ch := range rl.leaderChangeListeners {
-		ch <- info
+	for id, ch := range rl.leaderChangeListeners {
+		select {
+		case ch <- info:
+		default:
+			log.Warningf("dropping message for %s", id)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When leasekeeper receive quitAll, RemoveLeaderUpdatedListener() can be blocked
waiting for the mutex. The mutex is held by LeaderUpdated(), but itself was
blocked by sending the message to the channel. 
