### PR TITLE
OCI runtime: fix some overlayfs bugs

### DIFF
--- a/dockerfiles/test_images/ociruntime_test/env_test_image/Dockerfile
+++ b/dockerfiles/test_images/ociruntime_test/env_test_image/Dockerfile
@@ -1,5 +1,17 @@
 FROM busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
 
+# Test layer ordering: later edit to the file should be reflected
+RUN mkdir -p /test/ && echo 1 > /test/foo
+RUN mkdir -p /test/ && echo 2 > /test/foo
+
+# Test directory whiteouts
+RUN mkdir -p /test/DELETED_DIR/subdir
+RUN rm -rf /test/DELETED_DIR
+
+# Test file whiteouts
+RUN mkdir -p /test/ && touch /test/DELETED_FILE
+RUN rm /test/DELETED_FILE
+
 # Test setting env vars
 ENV TEST_ENV_VAR=foo
 


### PR DESCRIPTION
- Mount `lowerdir` in the correct order
- Respect whiteout files (deleted files/dirs)

**Related issues**: N/A
