### PR TITLE
invocation_exec_log_card: fix invalid href local runner entries

### DIFF
--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -169,13 +169,13 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
   }
 
   getActionPageLink(entry: tools.protos.ExecLogEntry) {
-    if (entry.spawn?.digest) {
-      const search = new URLSearchParams();
-      search.set("actionDigest", digestToString(entry.spawn.digest));
-      return `/invocation/${this.props.model.getInvocationId()}?${search}#action`;
+    if (!entry.spawn?.digest) {
+      return undefined;
     }
 
-    return undefined;
+    const search = new URLSearchParams();
+    search.set("actionDigest", digestToString(entry.spawn.digest));
+    return `/invocation/${this.props.model.getInvocationId()}?${search}#action`;
   }
 
   render() {

--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -169,12 +169,13 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
   }
 
   getActionPageLink(entry: tools.protos.ExecLogEntry) {
-    const search = new URLSearchParams();
     if (entry.spawn?.digest) {
+      const search = new URLSearchParams();
       search.set("actionDigest", digestToString(entry.spawn.digest));
+      return `/invocation/${this.props.model.getInvocationId()}?${search}#action`;
     }
 
-    return `/invocation/${this.props.model.getInvocationId()}?${search}#action`;
+    return undefined;
   }
 
   render() {


### PR DESCRIPTION
While working on #7166, I discovered that clicking on `local` actions in
the execution log card would crash our UI.

This is because local spawn entry does not have `digest` and thus,
render the entries in the card with `href=/invocation/<uuid>$#action`,
and clicking on it would cause our browser to crash.

Don't render the invalid URL here.

