### PR TITLE
OCI runtime: fix persistent workers getting stuck on shutdown

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -42,6 +42,7 @@ go_test(
     data = [
         ":busybox",
         ":crun",
+        "//enterprise/server/remote_execution/runner/testworker",
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
@@ -61,17 +62,22 @@ go_test(
     x_defs = {
         "crunRlocationpath": "$(rlocationpath :crun)",
         "busyboxRlocationpath": "$(rlocationpath :busybox)",
+        "testworkerRlocationpath": "$(rlocationpath //enterprise/server/remote_execution/runner/testworker)",
     },
     deps = [
         ":ociruntime",
         "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/persistentworker",
         "//enterprise/server/remote_execution/platform",
+        "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
+        "//proto:worker_go_proto",
         "//server/interfaces",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/testutil/testnetworking",
+        "//server/util/proto",
         "//server/util/testing/flags",
         "//server/util/uuid",
         "@com_github_stretchr_testify//assert",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -491,7 +491,7 @@ func (c *ociContainer) createRootfs(ctx context.Context) error {
 	// manually".
 	// TODO: improve testing setup and get rid of this
 	if c.imageRef == TestBusyboxImageRef {
-		return installBusybox(c.rootfsPath())
+		return installBusybox(ctx, c.rootfsPath())
 	}
 
 	if c.imageRef == "" {
@@ -549,7 +549,7 @@ func (c *ociContainer) createRootfs(ctx context.Context) error {
 	return nil
 }
 
-func installBusybox(path string) error {
+func installBusybox(ctx context.Context, path string) error {
 	busyboxPath, err := exec.LookPath("busybox")
 	if err != nil {
 		return fmt.Errorf("find busybox in PATH: %w", err)
@@ -561,7 +561,7 @@ func installBusybox(path string) error {
 	if err := disk.CopyViaTmpSibling(busyboxPath, filepath.Join(binDir, "busybox")); err != nil {
 		return fmt.Errorf("copy busybox binary: %w", err)
 	}
-	b, err := exec.Command(busyboxPath, "--list").Output()
+	b, err := exec.CommandContext(ctx, busyboxPath, "--list").Output()
 	if err != nil {
 		return fmt.Errorf("list: %w", err)
 	}
@@ -815,7 +815,7 @@ func (c *ociContainer) invokeRuntime(ctx context.Context, command *repb.Command,
 
 	log.CtxDebugf(ctx, "Running %v", runtimeArgs)
 
-	cmd := exec.Command(runtimeArgs[0], runtimeArgs[1:]...)
+	cmd := exec.CommandContext(ctx, runtimeArgs[0], runtimeArgs[1:]...)
 	cmd.Dir = wd
 	var stdout *bytes.Buffer
 	var stderr *bytes.Buffer

--- a/enterprise/server/remote_execution/persistentworker/persistentworker.go
+++ b/enterprise/server/remote_execution/persistentworker/persistentworker.go
@@ -86,9 +86,10 @@ func Start(ctx context.Context, workspace *workspace.Workspace, container contai
 	ctx, cancel := context.WithCancel(ctx)
 	workerTerminated := make(chan struct{})
 	w.stop = func() error {
-		// Canceling the worker context should terminate the worker exec
-		// process.
+		// Canceling the worker context and closing stdin should terminate the
+		// worker exec process.
 		cancel()
+		_ = stdinWriter.Close()
 		// Wait for the worker to terminate. This is needed since canceling the
 		// context doesn't block until the worker is killed. This helps ensure that
 		// the worker is killed if we are shutting down. The shutdown case is also

--- a/enterprise/server/remote_execution/runner/testworker/BUILD
+++ b/enterprise/server/remote_execution/runner/testworker/BUILD
@@ -1,18 +1,18 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-# gazelle:default_visibility //enterprise/server/remote_execution/runner:__subpackages__
-package(default_visibility = [
-    "//enterprise/server/remote_execution/runner:__subpackages__",
-])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "testworker_lib",
     srcs = ["testworker.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner/testworker",
+    visibility = ["//visibility:private"],
     deps = ["//server/util/log"],
 )
 
 go_binary(
     name = "testworker",
     embed = [":testworker_lib"],
+    pure = "on",
+    static = "on",
 )


### PR DESCRIPTION
- Use `CommandContext` for all OCI runtime commands so that they are killed on shutdown.
- Close persistent worker stdin pipe when stopping the persistent worker, otherwise the crun exec command's `cmd.Run()` call never returns, even though the process has been killed.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3631
