### PR TITLE
Dont try to select "all" filter.

### DIFF
--- a/enterprise/server/test/webdriver/invocation/invocation_test.go
+++ b/enterprise/server/test/webdriver/invocation/invocation_test.go
@@ -211,7 +211,6 @@ func TestAuthenticatedInvocation_PersonalAPIKey_CacheEnabled(t *testing.T) {
 
 	// Make sure we can view the cache section
 	wt.FindByDebugID("cache-sections")
-	wt.FindByDebugID("filter-cache-requests").SendKeys("All")
 	rows := getCacheRequestRows(wt)
 	require.NotEmpty(t, rows, "expected at least one cache request")
 	for _, row := range rows {


### PR DESCRIPTION
We believe it's causing the section to re-render and cause problems with the test. All should already be the default so this should be unnecessary.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
