### PR TITLE
[raft] make leader updated chan size configurable

### DIFF
--- a/enterprise/server/raft/listener/listener.go
+++ b/enterprise/server/raft/listener/listener.go
@@ -1,10 +1,15 @@
 package listener
 
 import (
+	"flag"
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/lni/dragonboat/v4/raftio"
+)
+
+var (
+	leaderUpdatedChanSize = flag.Int64("cache.raft.leader_updated_chan_size", 200, "The length of the leader updated channel")
 )
 
 type RaftListener struct {
@@ -38,7 +43,7 @@ func (rl *RaftListener) AddLeaderChangeListener(id string) <-chan raftio.LeaderI
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	ch := make(chan raftio.LeaderInfo, 10)
+	ch := make(chan raftio.LeaderInfo, *leaderUpdatedChanSize)
 	rl.leaderChangeListeners[id] = ch
 	if rl.lastLeaderInfo != nil {
 		ch <- *rl.lastLeaderInfo


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When there are 200+ ranges, leaderUpdates chan needs to be bigger; otherwise,
the leader update will be dropped when the server started; and it can cause
decrease range cache hit rate and increased write latency.
