### PR TITLE
invocation_action_card: handle exception parsing action digest

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -267,7 +267,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
       // execution table lookup.
       const executeResponseDigest = parseActionDigest(executeResponseDigestParam);
       if (!executeResponseDigest) {
-        alert_service.error("Missing execute response digest in URL");
+        alert_service.error("Invalid execute response digest in URL");
         return;
       }
       this.executeResponseRPC = this.fetchExecuteResponseByDigest(executeResponseDigest);

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -108,6 +108,10 @@ export default class InvocationActionCardComponent extends React.Component<Props
       return;
     }
     const digest = parseActionDigest(digestParam);
+    if (!digest) {
+      alert_service.error("Missing action digest URL param");
+      return;
+    }
     const actionUrl = this.props.model.getBytestreamURL(digest);
     rpcService
       .fetchBytestreamFile(actionUrl, this.props.model.getInvocationId(), "arraybuffer")
@@ -212,11 +216,11 @@ export default class InvocationActionCardComponent extends React.Component<Props
    */
   fetchActionResult() {
     let digestParam = this.props.search.get("actionDigest");
-    if (!digestParam) {
+    const digest = parseActionDigest(digestParam ?? "");
+    if (!digest) {
       alert_service.error("Missing action digest in URL");
       return;
     }
-    const digest = parseActionDigest(digestParam);
     const actionResultUrl = this.props.model.getActionCacheURL(digest);
     this.actionResultRPC = rpcService
       .fetchBytestreamFile(actionResultUrl, this.props.model.getInvocationId(), "arraybuffer")
@@ -262,9 +266,17 @@ export default class InvocationActionCardComponent extends React.Component<Props
       // If we have the executeResponseDigest in the URL, we can skip the
       // execution table lookup.
       const executeResponseDigest = parseActionDigest(executeResponseDigestParam);
+      if (!executeResponseDigest) {
+        alert_service.error("Missing execute response digest in URL");
+        return;
+      }
       this.executeResponseRPC = this.fetchExecuteResponseByDigest(executeResponseDigest);
     } else {
       const actionDigest = parseActionDigest(actionDigestParam);
+      if (!actionDigest) {
+        alert_service.error("Missing action digest in URL");
+        return;
+      }
       this.executeResponseRPC = this.fetchExecuteResponseByActionDigest(actionDigest);
     }
     // Whether to fall back to fetching the latest action result.
@@ -916,6 +928,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
 
   render() {
     const digest = parseActionDigest(this.props.search.get("actionDigest") ?? "");
+    if (!digest) return <></>;
     const vmMetadata = this.getFirecrackerVMMetadata();
     const executionId = this.props.search.get("executionId") || this.state.executionId;
 

--- a/app/util/cache.tsx
+++ b/app/util/cache.tsx
@@ -111,10 +111,11 @@ export function getFileDigest(file: build_event_stream.IFile): Digest | undefine
  * Parses an action ID, which may either be a string like "HASH/SIZE"
  * or just a "HASH" (since the SIZE is not required for AC requests).
  */
-export function parseActionDigest(raw: string): Digest {
+export function parseActionDigest(raw: string): Digest | undefined {
   let [hash, rawSize] = raw.split("/");
   if (!hash) {
-    throw new Error(`invalid digest string "${raw}"`);
+    console.error("Failed to parse action digest: ", new Error(`invalid digest string "${raw}"`));
+    return undefined;
   }
   rawSize ??= "1";
   return new Digest({


### PR DESCRIPTION
If user try to navigate to a url such as
`http://app.buildbuddy.io/invocation/<uuid>#action` today, their UI
would crash and unable to recover.

Fix this by returning an alert on the screen instead.
With this, users still see the invocation UI and can navigate away.
