### PR TITLE
invocation_exec_log_card: fix sort direction radio group

### DIFF
--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -268,7 +268,7 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
                       checked={this.state.direction == "desc"}
                       onChange={this.handleSortDirectionChange.bind(this)}
                       value="desc"
-                      name="exec-log-direction"
+                      name="execLogDirection"
                       type="radio"
                     />
                     <label htmlFor="direction-desc">Desc</label>

--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -257,7 +257,7 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
                       checked={this.state.direction == "asc"}
                       onChange={this.handleSortDirectionChange.bind(this)}
                       value="asc"
-                      name="exec-log-direction"
+                      name="execLogDirection"
                       type="radio"
                     />
                     <label htmlFor="direction-asc">Asc</label>

--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -134,12 +134,10 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
     return 0;
   }
 
-  handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const target = event.target;
-    const name = target.name;
+  handleSortDirectionChange(event: React.ChangeEvent<HTMLInputElement>) {
     this.setState({
-      [name]: target.value,
-    } as Record<keyof State, any>);
+      direction: event.target.value as "asc" | "desc",
+    });
   }
 
   handleSortChange(event: React.ChangeEvent<HTMLSelectElement>) {
@@ -257,9 +255,9 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
                     <input
                       id="direction-asc"
                       checked={this.state.direction == "asc"}
-                      onChange={this.handleInputChange.bind(this)}
+                      onChange={this.handleSortDirectionChange.bind(this)}
                       value="asc"
-                      name="direction"
+                      name="exec-log-direction"
                       type="radio"
                     />
                     <label htmlFor="direction-asc">Asc</label>
@@ -268,9 +266,9 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
                     <input
                       id="direction-desc"
                       checked={this.state.direction == "desc"}
-                      onChange={this.handleInputChange.bind(this)}
+                      onChange={this.handleSortDirectionChange.bind(this)}
                       value="desc"
-                      name="direction"
+                      name="exec-log-direction"
                       type="radio"
                     />
                     <label htmlFor="direction-desc">Desc</label>


### PR DESCRIPTION
This was using the same name as the radio buttons for the remote
executions card.
Changing sort direction when both 4 radio buttons are available cause
the checked status to not render correctly.

Rename the radio inputs of exec log.
Also tighten the onChange handler to not rely on the input name to
determine the state.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3587
