### PR TITLE
OCI runtime: fix `run` not respecting context cancellation

### DIFF
--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -311,11 +311,14 @@ func ExitCode(ctx context.Context, cmd *exec.Cmd, err error) (int, error) {
 	// imply that SIGKILL was received.
 
 	if exitCode == KilledExitCode {
+		if ctx.Err() == context.Canceled {
+			return exitCode, status.CanceledErrorf("command was canceled: %s", err.Error())
+		}
 		if dl, ok := ctx.Deadline(); ok && time.Now().After(dl) {
-			return exitCode, status.DeadlineExceededErrorf("Command timed out: %s", err.Error())
+			return exitCode, status.DeadlineExceededErrorf("command timed out: %s", err.Error())
 		}
 		// If the command didn't time out, it was probably killed by the kernel due to OOM.
-		return exitCode, status.ResourceExhaustedErrorf("Command was killed: %s", err.Error())
+		return exitCode, status.ResourceExhaustedErrorf("command was killed: %s", err.Error())
 	}
 
 	return exitCode, nil

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -49,6 +49,9 @@ go_test(
         "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:ac701954d2c522d0d2b5296323127cacaaf77627e69db848a8d6ecb53149d344",
         "test.EstimatedComputeUnits": "2",
     },
+    # NOTE: if testing locally, use --test_sharding_strategy=disabled to work
+    # around the networking package not supporting cross-process locks.
+    shard_count = 4,
     tags = [
         "docker",
         "no-sandbox",
@@ -77,7 +80,10 @@ go_test(
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/testutil/testnetworking",
+        "//server/testutil/testshell",
+        "//server/util/disk",
         "//server/util/proto",
+        "//server/util/status",
         "//server/util/testing/flags",
         "//server/util/uuid",
         "@com_github_stretchr_testify//assert",


### PR DESCRIPTION
Yet another case of `cmd.Run()` getting stuck after the process has terminated.

This is fixed by placing `crun run` inside its own pid namespace, since killing pid 1 in the namespace causes all other processes in the namespace to be killed as well. Before this PR, `crun run` was in the same pid namespace as the executor (and the containerized child processes were in their own namespace). Adding an additional level of pid namespacing simplifies cleanup and ensures that child processes are immediately cleaned up when `crun run` is killed.

I'm not sure why this issue doesn't happen with `crun exec`, but am investigating separately. I tried looking for differences in the output of `ps -eo pid,ppid,pidns,cmd`, but it shows similar output for both `run` and `exec` in terms of the ps tree structure both before and after the context is cancelled. I suspect it has more to do with stdio - will keep digging.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3631
