### PR TITLE
[raft] set partition usage in usage

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -202,6 +202,11 @@ func (sm *Replica) Usage() (*rfpb.ReplicaUsage, error) {
 	if err != nil {
 		return nil, err
 	}
+	sm.partitionMetadataMu.Lock()
+	for _, pm := range sm.partitionMetadata {
+		ru.Partitions = append(ru.Partitions, pm.CloneVT())
+	}
+	sm.partitionMetadataMu.Unlock()
 	ru.EstimatedDiskBytesUsed = int64(sizeBytes)
 	ru.ReadQps = int64(sm.readQPS.Get())
 	ru.RaftProposeQps = int64(sm.raftProposeQPS.Get())

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -850,6 +850,18 @@ func TestUsage(t *testing.T) {
 		ru, err := repl.Usage()
 		require.NoError(t, err)
 		require.InDelta(t, 2100, ru.GetEstimatedDiskBytesUsed(), 600.0)
+		require.Len(t, ru.GetPartitions(), 2)
+
+		for _, usage := range ru.GetPartitions() {
+			switch usage.GetPartitionId() {
+			case defaultPartition:
+				require.EqualValues(t, 1500, usage.GetSizeBytes())
+				require.EqualValues(t, 2, usage.GetTotalCount())
+			case anotherPartition:
+				require.EqualValues(t, 600, usage.GetSizeBytes())
+				require.EqualValues(t, 3, usage.GetTotalCount())
+			}
+		}
 	}
 
 	// Delete a single record and verify updated usage.
@@ -861,6 +873,17 @@ func TestUsage(t *testing.T) {
 		ru, err := repl.Usage()
 		require.NoError(t, err)
 		require.InDelta(t, 1100, ru.GetEstimatedDiskBytesUsed(), 500.0)
+
+		for _, usage := range ru.GetPartitions() {
+			switch usage.GetPartitionId() {
+			case defaultPartition:
+				require.EqualValues(t, 500, usage.GetSizeBytes())
+				require.EqualValues(t, 1, usage.GetTotalCount())
+			case anotherPartition:
+				require.EqualValues(t, 600, usage.GetSizeBytes())
+				require.EqualValues(t, 3, usage.GetTotalCount())
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3681

We still need to set usage.Partitions.
