### PR TITLE
Fix `googleapis` module extension usage

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,6 @@ switched_rules.use_languages(
     go = True,
     grpc = True,
 )
-use_repo(switched_rules, "com_google_googleapis_imports")
 
 # Needed for com_google_protobuf
 bazel_dep(name = "rules_python", version = "0.31.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ single_version_override(
     ],
 )
 
-switched_rules = use_extension("//:extensions.bzl", "switched_rules")
+switched_rules = use_extension("@googleapis//:extensions.bzl", "switched_rules")
 switched_rules.use_languages(
     cc = True,
     go = True,

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -13,6 +13,8 @@ actions:
       - test //... --config=linux-workflows --config=race --test_tag_filters=-performance,-docker,-bare
   - name: Test with BzlMod
     container_image: ubuntu-20.04
+    resource_requests:
+      disk: 27GB
     triggers:
       push:
         branches:


### PR DESCRIPTION
This fixes running `bazel mod tidy --enable_bzlmod` in the repo.

Since we do not reference any repos generated by the `switched_rules` extension (otherwise CI would have caught the mistake), we can also drop the `use_repo`.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related PRs**: #7205 
