### PR TITLE
Revert "Update `soci-snapshotter` version in executor image (#7186)"

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6834,15 +6834,20 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/containerd/stargz-snapshotter/releases/download/v0.11.4/stargz-snapshotter-v0.11.4-linux-amd64.tar.gz"],
     )
 
-    http_archive(
-        name = "com_github_buildbuddy_io_soci_snapshotter-static-linux-amd64",
-        build_file_content = "\n".join([
-            'package(default_visibility = ["//visibility:public"])',
-            'filegroup(name = "soci-store.bin", srcs = ["soci-store"])',
-            'filegroup(name = "soci-store-race.bin", srcs = ["soci-store-race"])',
-        ]),
-        urls = ["https://github.com/buildbuddy-io/soci-snapshotter/releases/download/release%2Fbuildbuddy-v0.7.0/soci-snapshotter-0.7.0-linux-amd64-static.tar.gz"],
-        sha256 = "25d525a709b7dc980dac8c78218193709ea0aea863c00f07d82f9376d30e86bf",
+    http_file(
+        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64",
+        downloaded_file_path = "soci-store",
+        executable = True,
+        sha256 = "0896b1df3dccd97895a5fde4bfbde47f1e533753113e39634261e2e035c9e6a3",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.15-linux-amd64"],
+    )
+
+    http_file(
+        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64-race",
+        downloaded_file_path = "soci-store-race",
+        executable = True,
+        sha256 = "8b420b9e94433f7fe74f71a26a34ee2c0bed6535bdb4c2176a91611e4054d0d0",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.15-linux-amd64-race"],
     )
 
     http_file(

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -202,8 +202,8 @@ container_layer(
         "@platforms//cpu:x86_64": [
             ":firecracker",
             ":jailer",
-            "@com_github_buildbuddy_io_soci_snapshotter-static-linux-amd64//:soci-store.bin",
-            "@com_github_buildbuddy_io_soci_snapshotter-static-linux-amd64//:soci-store-race.bin",
+            "@com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64-race//file:soci-store-race",
+            "@com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64//file:soci-store",
             "@com_github_containers_crun_crun-linux-amd64//file:crun",
         ],
         "@platforms//cpu:aarch64": [


### PR DESCRIPTION
This reverts commit 63c2d0da3a414f92e4fb3f2593e8c6982ae3e11d.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
