### PR TITLE
ci_runner: avoid url.*.insteadOf clobbering

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2471,13 +2471,15 @@ func configureGlobalCredentialHelper(ctx context.Context) error {
 // necessarily have any SSH private keys available that we can use to clone
 // repos over SSH.
 func configureGlobalURLRewrites(ctx context.Context) error {
+	flag := "--replace-all"
 	for original, replacement := range map[string]string{
 		"ssh://git@github.com:": "https://github.com/",
 		"git@github.com:":       "https://github.com/",
 	} {
-		if _, err := git(ctx, io.Discard, "config", "--global", "url."+replacement+".insteadOf", original); err != nil {
+		if _, err := git(ctx, io.Discard, "config", "--global", flag, "url."+replacement+".insteadOf", original); err != nil {
 			return err
 		}
+		flag = "--add"
 	}
 	return nil
 }

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2471,6 +2471,7 @@ func configureGlobalCredentialHelper(ctx context.Context) error {
 // necessarily have any SSH private keys available that we can use to clone
 // repos over SSH.
 func configureGlobalURLRewrites(ctx context.Context) error {
+	// Discard any existing rewrites initially, then append.
 	flag := "--replace-all"
 	for original, replacement := range map[string]string{
 		"ssh://git@github.com:": "https://github.com/",


### PR DESCRIPTION
Running
`git config --global url.https://github.com/.insteadOf <original>`
multiple times will replace the previous config value with the new value
of each call.

Instead of doing that, run the very first attempt with `--replace-all`
to wipe all existing values with our new value.  For subsequent runs,
use `--add` to append the new values to existing config.
