### PR TITLE
Use the rsc/codesearch DFA for speed

### DIFF
--- a/codesearch/dfa/BUILD
+++ b/codesearch/dfa/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "dfa",
+    srcs = [
+        "copy.go",
+        "dfa.go",
+        "regexp.go",
+        "utf.go",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/dfa",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_google_codesearch//sparse"],
+)

--- a/codesearch/dfa/BUILD
+++ b/codesearch/dfa/BUILD
@@ -10,5 +10,5 @@ go_library(
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/dfa",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_google_codesearch//sparse"],
+    deps = ["//codesearch/sparse"],
 )

--- a/codesearch/dfa/copy.go
+++ b/codesearch/dfa/copy.go
@@ -1,0 +1,223 @@
+// Copyright 2011 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied from Go's regexp/syntax.
+// Formatters edited to handle instByteRange.
+
+package dfa
+
+import (
+	"bytes"
+	"fmt"
+	"regexp/syntax"
+	"sort"
+	"strconv"
+	"unicode"
+)
+
+// cleanClass sorts the ranges (pairs of elements of r),
+// merges them, and eliminates duplicates.
+func cleanClass(rp *[]rune) []rune {
+
+	// Sort by lo increasing, hi decreasing to break ties.
+	sort.Sort(ranges{rp})
+
+	r := *rp
+	if len(r) < 2 {
+		return r
+	}
+
+	// Merge abutting, overlapping.
+	w := 2 // write index
+	for i := 2; i < len(r); i += 2 {
+		lo, hi := r[i], r[i+1]
+		if lo <= r[w-1]+1 {
+			// merge with previous range
+			if hi > r[w-1] {
+				r[w-1] = hi
+			}
+			continue
+		}
+		// new disjoint range
+		r[w] = lo
+		r[w+1] = hi
+		w += 2
+	}
+
+	return r[:w]
+}
+
+// appendRange returns the result of appending the range lo-hi to the class r.
+func appendRange(r []rune, lo, hi rune) []rune {
+	// Expand last range or next to last range if it overlaps or abuts.
+	// Checking two ranges helps when appending case-folded
+	// alphabets, so that one range can be expanding A-Z and the
+	// other expanding a-z.
+	n := len(r)
+	for i := 2; i <= 4; i += 2 { // twice, using i=2, i=4
+		if n >= i {
+			rlo, rhi := r[n-i], r[n-i+1]
+			if lo <= rhi+1 && rlo <= hi+1 {
+				if lo < rlo {
+					r[n-i] = lo
+				}
+				if hi > rhi {
+					r[n-i+1] = hi
+				}
+				return r
+			}
+		}
+	}
+
+	return append(r, lo, hi)
+}
+
+const (
+	// minimum and maximum runes involved in folding.
+	// checked during test.
+	minFold = 0x0041
+	maxFold = 0x1044f
+)
+
+// appendFoldedRange returns the result of appending the range lo-hi
+// and its case folding-equivalent runes to the class r.
+func appendFoldedRange(r []rune, lo, hi rune) []rune {
+	// Optimizations.
+	if lo <= minFold && hi >= maxFold {
+		// Range is full: folding can't add more.
+		return appendRange(r, lo, hi)
+	}
+	if hi < minFold || lo > maxFold {
+		// Range is outside folding possibilities.
+		return appendRange(r, lo, hi)
+	}
+	if lo < minFold {
+		// [lo, minFold-1] needs no folding.
+		r = appendRange(r, lo, minFold-1)
+		lo = minFold
+	}
+	if hi > maxFold {
+		// [maxFold+1, hi] needs no folding.
+		r = appendRange(r, maxFold+1, hi)
+		hi = maxFold
+	}
+
+	// Brute force.  Depend on appendRange to coalesce ranges on the fly.
+	for c := lo; c <= hi; c++ {
+		r = appendRange(r, c, c)
+		f := unicode.SimpleFold(c)
+		for f != c {
+			r = appendRange(r, f, f)
+			f = unicode.SimpleFold(f)
+		}
+	}
+	return r
+}
+
+// ranges implements sort.Interface on a []rune.
+// The choice of receiver type definition is strange
+// but avoids an allocation since we already have
+// a *[]rune.
+type ranges struct {
+	p *[]rune
+}
+
+func (ra ranges) Less(i, j int) bool {
+	p := *ra.p
+	i *= 2
+	j *= 2
+	return p[i] < p[j] || p[i] == p[j] && p[i+1] > p[j+1]
+}
+
+func (ra ranges) Len() int {
+	return len(*ra.p) / 2
+}
+
+func (ra ranges) Swap(i, j int) {
+	p := *ra.p
+	i *= 2
+	j *= 2
+	p[i], p[i+1], p[j], p[j+1] = p[j], p[j+1], p[i], p[i+1]
+}
+
+func progString(p *syntax.Prog) string {
+	var b bytes.Buffer
+	dumpProg(&b, p)
+	return b.String()
+}
+
+func instString(i *syntax.Inst) string {
+	var b bytes.Buffer
+	dumpInst(&b, i)
+	return b.String()
+}
+
+func bw(b *bytes.Buffer, args ...string) {
+	for _, s := range args {
+		b.WriteString(s)
+	}
+}
+
+func dumpProg(b *bytes.Buffer, p *syntax.Prog) {
+	for j := range p.Inst {
+		i := &p.Inst[j]
+		pc := strconv.Itoa(j)
+		if len(pc) < 3 {
+			b.WriteString("   "[len(pc):])
+		}
+		if j == p.Start {
+			pc += "*"
+		}
+		bw(b, pc, "\t")
+		dumpInst(b, i)
+		bw(b, "\n")
+	}
+}
+
+func u32(i uint32) string {
+	return strconv.FormatUint(uint64(i), 10)
+}
+
+func dumpInst(b *bytes.Buffer, i *syntax.Inst) {
+	switch i.Op {
+	case syntax.InstAlt:
+		bw(b, "alt -> ", u32(i.Out), ", ", u32(i.Arg))
+	case syntax.InstAltMatch:
+		bw(b, "altmatch -> ", u32(i.Out), ", ", u32(i.Arg))
+	case syntax.InstCapture:
+		bw(b, "cap ", u32(i.Arg), " -> ", u32(i.Out))
+	case syntax.InstEmptyWidth:
+		bw(b, "empty ", u32(i.Arg), " -> ", u32(i.Out))
+	case syntax.InstMatch:
+		bw(b, "match")
+	case syntax.InstFail:
+		bw(b, "fail")
+	case syntax.InstNop:
+		bw(b, "nop -> ", u32(i.Out))
+	case instByteRange:
+		fmt.Fprintf(b, "byte %02x-%02x", (i.Arg>>8)&0xFF, i.Arg&0xFF)
+		if i.Arg&argFold != 0 {
+			bw(b, "/i")
+		}
+		bw(b, " -> ", u32(i.Out))
+
+	// Should not happen
+	case syntax.InstRune:
+		if i.Rune == nil {
+			// shouldn't happen
+			bw(b, "rune <nil>")
+		}
+		bw(b, "rune ", strconv.QuoteToASCII(string(i.Rune)))
+		if syntax.Flags(i.Arg)&syntax.FoldCase != 0 {
+			bw(b, "/i")
+		}
+		bw(b, " -> ", u32(i.Out))
+	case syntax.InstRune1:
+		bw(b, "rune1 ", strconv.QuoteToASCII(string(i.Rune)), " -> ", u32(i.Out))
+	case syntax.InstRuneAny:
+		bw(b, "any -> ", u32(i.Out))
+	case syntax.InstRuneAnyNotNL:
+		bw(b, "anynotnl -> ", u32(i.Out))
+	}
+}

--- a/codesearch/dfa/dfa.go
+++ b/codesearch/dfa/dfa.go
@@ -9,7 +9,7 @@ import (
 	"regexp/syntax"
 	"sort"
 
-	"github.com/google/codesearch/sparse"
+	"github.com/buildbuddy-io/buildbuddy/codesearch/sparse"
 )
 
 // A matcher holds the state for running regular expression search.

--- a/codesearch/dfa/dfa.go
+++ b/codesearch/dfa/dfa.go
@@ -1,0 +1,344 @@
+// Copyright 2011 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package dfa
+
+import (
+	"encoding/binary"
+	"fmt"
+	"regexp/syntax"
+	"sort"
+
+	"github.com/google/codesearch/sparse"
+)
+
+// A matcher holds the state for running regular expression search.
+type matcher struct {
+	prog      *syntax.Prog       // compiled program
+	dstate    map[string]*dstate // dstate cache
+	start     *dstate            // start state
+	startLine *dstate            // start state for beginning of line
+	z1, z2    nstate             // two temporary nstates
+}
+
+// An nstate corresponds to an NFA state.
+type nstate struct {
+	q       sparse.Set // queue of program instructions
+	partial rune       // partially decoded rune (TODO)
+	flag    flags      // flags (TODO)
+}
+
+// The flags record state about a position between bytes in the text.
+type flags uint32
+
+const (
+	flagBOL  flags = 1 << iota // beginning of line
+	flagEOL                    // end of line
+	flagBOT                    // beginning of text
+	flagEOT                    // end of text
+	flagWord                   // last byte was word byte
+)
+
+// A dstate corresponds to a DFA state.
+type dstate struct {
+	next     [256]*dstate // next state, per byte
+	enc      string       // encoded nstate
+	matchNL  bool         // match when next byte is \n
+	matchEOT bool         // match in this state at end of text
+}
+
+func (z *nstate) String() string {
+	return fmt.Sprintf("%v/%#x+%#x", z.q.Dense(), z.flag, z.partial)
+}
+
+// enc encodes z as a string.
+func (z *nstate) enc() string {
+	var buf []byte
+	var v [10]byte
+	last := ^uint32(0)
+	n := binary.PutUvarint(v[:], uint64(z.partial))
+	buf = append(buf, v[:n]...)
+	n = binary.PutUvarint(v[:], uint64(z.flag))
+	buf = append(buf, v[:n]...)
+	dense := z.q.Dense()
+	ids := make([]int, 0, len(dense))
+	for _, id := range z.q.Dense() {
+		ids = append(ids, int(id))
+	}
+	sort.Ints(ids)
+	for _, id := range ids {
+		n := binary.PutUvarint(v[:], uint64(uint32(id)-last))
+		buf = append(buf, v[:n]...)
+		last = uint32(id)
+	}
+	return string(buf)
+}
+
+// dec decodes the encoding s into z.
+func (z *nstate) dec(s string) {
+	b := []byte(s)
+	i, n := binary.Uvarint(b)
+	if n <= 0 {
+		panic("bug")
+	}
+	b = b[n:]
+	z.partial = rune(i)
+	i, n = binary.Uvarint(b)
+	if n <= 0 {
+		panic("bug")
+	}
+	b = b[n:]
+	z.flag = flags(i)
+	z.q.Reset()
+	last := ^uint32(0)
+	for len(b) > 0 {
+		i, n = binary.Uvarint(b)
+		if n <= 0 {
+			panic("bug")
+		}
+		b = b[n:]
+		last += uint32(i)
+		z.q.Add(last)
+	}
+}
+
+// dmatch is the state we're in when we've seen a match and are just
+// waiting for the end of the line.
+var dmatch = dstate{
+	matchNL:  true,
+	matchEOT: true,
+}
+
+func init() {
+	var z nstate
+	dmatch.enc = z.enc()
+	for i := range dmatch.next {
+		if i != '\n' {
+			dmatch.next[i] = &dmatch
+		}
+	}
+}
+
+// init initializes the matcher.
+func (m *matcher) init(prog *syntax.Prog) error {
+	m.prog = prog
+	m.dstate = make(map[string]*dstate)
+
+	m.z1.q.Init(uint32(len(prog.Inst)))
+	m.z2.q.Init(uint32(len(prog.Inst)))
+
+	m.addq(&m.z1.q, uint32(prog.Start), syntax.EmptyBeginLine|syntax.EmptyBeginText)
+	m.z1.flag = flagBOL | flagBOT
+	m.start = m.cache(&m.z1)
+
+	m.z1.q.Reset()
+	m.addq(&m.z1.q, uint32(prog.Start), syntax.EmptyBeginLine)
+	m.z1.flag = flagBOL
+	m.startLine = m.cache(&m.z1)
+
+	return nil
+}
+
+// stepEmpty steps runq to nextq expanding according to flag.
+func (m *matcher) stepEmpty(runq, nextq *sparse.Set, flag syntax.EmptyOp) {
+	nextq.Reset()
+	for _, id := range runq.Dense() {
+		m.addq(nextq, id, flag)
+	}
+}
+
+// stepByte steps runq to nextq consuming c and then expanding according to flag.
+// It returns true if a match ends immediately before c.
+// c is either an input byte or endText.
+func (m *matcher) stepByte(runq, nextq *sparse.Set, c int, flag syntax.EmptyOp) (match bool) {
+	nextq.Reset()
+	m.addq(nextq, uint32(m.prog.Start), flag)
+	for _, id := range runq.Dense() {
+		i := &m.prog.Inst[id]
+		switch i.Op {
+		default:
+			continue
+		case syntax.InstMatch:
+			match = true
+			continue
+		case instByteRange:
+			if c == endText {
+				break
+			}
+			lo := int((i.Arg >> 8) & 0xFF)
+			hi := int(i.Arg & 0xFF)
+			ch := c
+			if i.Arg&argFold != 0 && 'a' <= ch && ch <= 'z' {
+				ch += 'A' - 'a'
+			}
+			if lo <= ch && ch <= hi {
+				m.addq(nextq, i.Out, flag)
+			}
+		}
+	}
+	return
+}
+
+// addq adds id to the queue, expanding according to flag.
+func (m *matcher) addq(q *sparse.Set, id uint32, flag syntax.EmptyOp) {
+	if q.Has(id) {
+		return
+	}
+	q.Add(id)
+	i := &m.prog.Inst[id]
+	switch i.Op {
+	case syntax.InstCapture, syntax.InstNop:
+		m.addq(q, i.Out, flag)
+	case syntax.InstAlt, syntax.InstAltMatch:
+		m.addq(q, i.Out, flag)
+		m.addq(q, i.Arg, flag)
+	case syntax.InstEmptyWidth:
+		if syntax.EmptyOp(i.Arg)&^flag == 0 {
+			m.addq(q, i.Out, flag)
+		}
+	}
+}
+
+const endText = -1
+
+// computeNext computes the next DFA state if we're in d reading c (an input byte or endText).
+func (m *matcher) computeNext(d *dstate, c int) *dstate {
+	this, next := &m.z1, &m.z2
+	this.dec(d.enc)
+
+	// compute flags in effect before c
+	flag := syntax.EmptyOp(0)
+	if this.flag&flagBOL != 0 {
+		flag |= syntax.EmptyBeginLine
+	}
+	if this.flag&flagBOT != 0 {
+		flag |= syntax.EmptyBeginText
+	}
+	if this.flag&flagWord != 0 {
+		if !isWordByte(c) {
+			flag |= syntax.EmptyWordBoundary
+		} else {
+			flag |= syntax.EmptyNoWordBoundary
+		}
+	} else {
+		if isWordByte(c) {
+			flag |= syntax.EmptyWordBoundary
+		} else {
+			flag |= syntax.EmptyNoWordBoundary
+		}
+	}
+	if c == '\n' {
+		flag |= syntax.EmptyEndLine
+	}
+	if c == endText {
+		flag |= syntax.EmptyEndLine | syntax.EmptyEndText
+	}
+
+	// re-expand queue using new flags.
+	// TODO: only do this when it matters
+	// (something is gating on word boundaries).
+	m.stepEmpty(&this.q, &next.q, flag)
+	this, next = next, this
+
+	// now compute flags after c.
+	flag = 0
+	next.flag = 0
+	if c == '\n' {
+		flag |= syntax.EmptyBeginLine
+		next.flag |= flagBOL
+	}
+	if isWordByte(c) {
+		next.flag |= flagWord
+	}
+
+	// re-add start, process rune + expand according to flags.
+	if m.stepByte(&this.q, &next.q, c, flag) {
+		return &dmatch
+	}
+	return m.cache(next)
+}
+
+func (m *matcher) cache(z *nstate) *dstate {
+	enc := z.enc()
+	d := m.dstate[enc]
+	if d != nil {
+		return d
+	}
+
+	d = &dstate{enc: enc}
+	m.dstate[enc] = d
+	d.matchNL = m.computeNext(d, '\n') == &dmatch
+	d.matchEOT = m.computeNext(d, endText) == &dmatch
+	return d
+}
+
+func (m *matcher) match(b []byte, beginText, endText bool) (end int) {
+	//	fmt.Printf("%v\n", m.prog)
+
+	d := m.startLine
+	if beginText {
+		d = m.start
+	}
+	//	m.z1.dec(d.enc)
+	//	fmt.Printf("%v (%v)\n", &m.z1, d==&dmatch)
+	for i, c := range b {
+		d1 := d.next[c]
+		if d1 == nil {
+			if c == '\n' {
+				if d.matchNL {
+					return i
+				}
+				d1 = m.startLine
+			} else {
+				d1 = m.computeNext(d, int(c))
+			}
+			d.next[c] = d1
+		}
+		d = d1
+		//		m.z1.dec(d.enc)
+		//		fmt.Printf("%#U: %v (%v, %v, %v)\n", c, &m.z1, d==&dmatch, d.matchNL, d.matchEOT)
+	}
+	if d.matchNL || endText && d.matchEOT {
+		return len(b)
+	}
+	return -1
+}
+
+func (m *matcher) matchString(b string, beginText, endText bool) (end int) {
+	d := m.startLine
+	if beginText {
+		d = m.start
+	}
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		d1 := d.next[c]
+		if d1 == nil {
+			if c == '\n' {
+				if d.matchNL {
+					return i
+				}
+				d1 = m.startLine
+			} else {
+				d1 = m.computeNext(d, int(c))
+			}
+			d.next[c] = d1
+		}
+		d = d1
+	}
+	if d.matchNL || endText && d.matchEOT {
+		return len(b)
+	}
+	return -1
+}
+
+// isWordByte reports whether the byte c is a word character: ASCII only.
+// This is used to implement \b and \B.  This is not right for Unicode, but:
+//   - it's hard to get right in a byte-at-a-time matching world
+//     (the DFA has only one-byte lookahead)
+//   - this crude approximation is the same one PCRE uses
+func isWordByte(c int) bool {
+	return 'A' <= c && c <= 'Z' ||
+		'a' <= c && c <= 'z' ||
+		'0' <= c && c <= '9' ||
+		c == '_'
+}

--- a/codesearch/dfa/regexp.go
+++ b/codesearch/dfa/regexp.go
@@ -1,0 +1,72 @@
+// Copyright 2011 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package regexp implements regular expression search tuned for
+// use in grep-like programs.
+package dfa
+
+import "regexp/syntax"
+
+func bug() {
+	panic("codesearch/regexp: internal error")
+}
+
+// Regexp is the representation of a compiled regular expression.
+// A Regexp is NOT SAFE for concurrent use by multiple goroutines.
+type Regexp struct {
+	Syntax *syntax.Regexp
+	expr   string // original expression
+	prog   *syntax.Prog
+	m      matcher
+}
+
+// String returns the source text used to compile the regular expression.
+func (re *Regexp) String() string {
+	return re.expr
+}
+
+// Compile parses a regular expression and returns, if successful,
+// a Regexp object that can be used to match against lines of text.
+func Compile(expr string) (*Regexp, error) {
+	re, err := syntax.Parse(expr, syntax.Perl)
+	if err != nil {
+		return nil, err
+	}
+	sre := re.Simplify()
+	prog, err := syntax.Compile(sre)
+	if err != nil {
+		return nil, err
+	}
+	if err := toByteProg(prog); err != nil {
+		return nil, err
+	}
+	r := &Regexp{
+		Syntax: re,
+		expr:   expr,
+		prog:   prog,
+	}
+	if err := r.m.init(prog); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *Regexp) Clone() *Regexp {
+	r2 := &Regexp{
+		Syntax: r.Syntax,
+		expr:   r.expr,
+		prog:   r.prog,
+		m:      matcher{},
+	}
+	r2.m.init(r.prog)
+	return r2
+}
+
+func (r *Regexp) Match(b []byte, beginText, endText bool) (end int) {
+	return r.m.match(b, beginText, endText)
+}
+
+func (r *Regexp) MatchString(s string, beginText, endText bool) (end int) {
+	return r.m.matchString(s, beginText, endText)
+}

--- a/codesearch/dfa/utf.go
+++ b/codesearch/dfa/utf.go
@@ -1,0 +1,267 @@
+// Copyright 2011 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dfa
+
+import (
+	"regexp/syntax"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	instFail      = syntax.InstFail
+	instAlt       = syntax.InstAlt
+	instByteRange = syntax.InstRune | 0x80 // local opcode
+
+	argFold = 1 << 16
+)
+
+func toByteProg(prog *syntax.Prog) error {
+	var b runeBuilder
+	for pc := range prog.Inst {
+		i := &prog.Inst[pc]
+		switch i.Op {
+		case syntax.InstRune, syntax.InstRune1:
+			// General rune range.  PIA.
+			// TODO: Pick off single-byte case.
+			if lo, hi, fold, ok := oneByteRange(i); ok {
+				i.Op = instByteRange
+				i.Arg = uint32(lo)<<8 | uint32(hi)
+				if fold {
+					i.Arg |= argFold
+				}
+				break
+			}
+
+			r := i.Rune
+			if syntax.Flags(i.Arg)&syntax.FoldCase != 0 {
+				// Build folded list.
+				var rr []rune
+				if len(r) == 1 {
+					rr = appendFoldedRange(rr, r[0], r[0])
+				} else {
+					for j := 0; j < len(r); j += 2 {
+						rr = appendFoldedRange(rr, r[j], r[j+1])
+					}
+				}
+				r = rr
+			}
+
+			b.init(prog, uint32(pc), i.Out)
+			if len(r) == 1 {
+				b.addRange(r[0], r[0], false)
+			} else {
+				for j := 0; j < len(r); j += 2 {
+					b.addRange(r[j], r[j+1], false)
+				}
+			}
+
+		case syntax.InstRuneAny, syntax.InstRuneAnyNotNL:
+			// All runes.
+			// AnyNotNL should exclude \n but the line-at-a-time
+			// execution takes care of that for us.
+			b.init(prog, uint32(pc), i.Out)
+			b.addRange(0, unicode.MaxRune, false)
+		}
+	}
+	return nil
+}
+
+func oneByteRange(i *syntax.Inst) (lo, hi byte, fold, ok bool) {
+	if i.Op == syntax.InstRune1 {
+		r := i.Rune[0]
+		if r < utf8.RuneSelf {
+			return byte(r), byte(r), false, true
+		}
+	}
+	if i.Op != syntax.InstRune {
+		return
+	}
+	fold = syntax.Flags(i.Arg)&syntax.FoldCase != 0
+	if len(i.Rune) == 1 || len(i.Rune) == 2 && i.Rune[0] == i.Rune[1] {
+		r := i.Rune[0]
+		if r >= utf8.RuneSelf {
+			return
+		}
+		if fold && !asciiFold(r) {
+			return
+		}
+		return byte(r), byte(r), fold, true
+	}
+	if len(i.Rune) == 2 && i.Rune[1] < utf8.RuneSelf {
+		if fold {
+			for r := i.Rune[0]; r <= i.Rune[1]; r++ {
+				if asciiFold(r) {
+					return
+				}
+			}
+		}
+		return byte(i.Rune[0]), byte(i.Rune[1]), fold, true
+	}
+	if len(i.Rune) == 4 && i.Rune[0] == i.Rune[1] && i.Rune[2] == i.Rune[3] && unicode.SimpleFold(i.Rune[0]) == i.Rune[2] && unicode.SimpleFold(i.Rune[2]) == i.Rune[0] {
+		return byte(i.Rune[0]), byte(i.Rune[0]), true, true
+	}
+
+	return
+}
+
+func asciiFold(r rune) bool {
+	if r >= utf8.RuneSelf {
+		return false
+	}
+	r1 := unicode.SimpleFold(r)
+	if r1 >= utf8.RuneSelf {
+		return false
+	}
+	if r1 == r {
+		return true
+	}
+	return unicode.SimpleFold(r1) == r
+}
+
+func maxRune(n int) rune {
+	b := 0
+	if n == 1 {
+		b = 7
+	} else {
+		b = 8 - (n + 1) + 6*(n-1)
+	}
+	return 1<<uint(b) - 1
+}
+
+type cacheKey struct {
+	lo, hi uint8
+	fold   bool
+	next   uint32
+}
+
+type runeBuilder struct {
+	begin uint32
+	out   uint32
+	cache map[cacheKey]uint32
+	p     *syntax.Prog
+}
+
+func (b *runeBuilder) init(p *syntax.Prog, begin, out uint32) {
+	// We will rewrite p.Inst[begin] to hold the accumulated
+	// machine.  For now, there is no match.
+	p.Inst[begin].Op = instFail
+
+	b.begin = begin
+	b.out = out
+	if b.cache == nil {
+		b.cache = make(map[cacheKey]uint32)
+	}
+	for k := range b.cache {
+		delete(b.cache, k)
+	}
+	b.p = p
+}
+
+func (b *runeBuilder) uncachedSuffix(lo, hi byte, fold bool, next uint32) uint32 {
+	if next == 0 {
+		next = b.out
+	}
+	pc := len(b.p.Inst)
+	i := syntax.Inst{Op: instByteRange, Arg: uint32(lo)<<8 | uint32(hi), Out: next}
+	if fold {
+		i.Arg |= argFold
+	}
+	b.p.Inst = append(b.p.Inst, i)
+	return uint32(pc)
+}
+
+func (b *runeBuilder) suffix(lo, hi byte, fold bool, next uint32) uint32 {
+	if lo < 0x80 || hi > 0xbf {
+		// Not a continuation byte, no need to cache.
+		return b.uncachedSuffix(lo, hi, fold, next)
+	}
+
+	key := cacheKey{lo, hi, fold, next}
+	if pc, ok := b.cache[key]; ok {
+		return pc
+	}
+
+	pc := b.uncachedSuffix(lo, hi, fold, next)
+	b.cache[key] = pc
+	return pc
+}
+
+func (b *runeBuilder) addBranch(pc uint32) {
+	// Add pc to the branch at the beginning.
+	i := &b.p.Inst[b.begin]
+	switch i.Op {
+	case syntax.InstFail:
+		i.Op = syntax.InstNop
+		i.Out = pc
+		return
+	case syntax.InstNop:
+		i.Op = syntax.InstAlt
+		i.Arg = pc
+		return
+	case syntax.InstAlt:
+		apc := uint32(len(b.p.Inst))
+		b.p.Inst = append(b.p.Inst, syntax.Inst{Op: instAlt, Out: i.Arg, Arg: pc})
+		i = &b.p.Inst[b.begin]
+		i.Arg = apc
+		b.begin = apc
+	}
+}
+
+func (b *runeBuilder) addRange(lo, hi rune, fold bool) {
+	if lo > hi {
+		return
+	}
+
+	// TODO: Pick off 80-10FFFF for special handling?
+	//	if lo == 0x80 && hi == 0x10FFFF {}
+
+	// Split range into same-length sized ranges.
+	for i := 1; i < utf8.UTFMax; i++ {
+		max := maxRune(i)
+		if lo <= max && max < hi {
+			b.addRange(lo, max, fold)
+			b.addRange(max+1, hi, fold)
+			return
+		}
+	}
+
+	// ASCII range is special.
+	if hi < utf8.RuneSelf {
+		b.addBranch(b.suffix(byte(lo), byte(hi), fold, 0))
+		return
+	}
+
+	// Split range into sections that agree on leading bytes.
+	for i := 1; i < utf8.UTFMax; i++ {
+		m := rune(1)<<uint(6*i) - 1 // last i bytes of UTF-8 sequence
+		if lo&^m != hi&^m {
+			if lo&m != 0 {
+				b.addRange(lo, lo|m, fold)
+				b.addRange((lo|m)+1, hi, fold)
+				return
+			}
+			if hi&m != m {
+				b.addRange(lo, hi&^m-1, fold)
+				b.addRange(hi&^m, hi, fold)
+				return
+			}
+		}
+	}
+
+	// Finally.  Generate byte matching equivalent for lo-hi.
+	var ulo, uhi [utf8.UTFMax]byte
+	n := utf8.EncodeRune(ulo[:], lo)
+	m := utf8.EncodeRune(uhi[:], hi)
+	if n != m {
+		panic("codesearch/regexp: bad utf-8 math")
+	}
+
+	pc := uint32(0)
+	for i := n - 1; i >= 0; i-- {
+		pc = b.suffix(ulo[i], uhi[i], false, pc)
+	}
+	b.addBranch(pc)
+}

--- a/codesearch/query/BUILD
+++ b/codesearch/query/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/query",
     visibility = ["//visibility:public"],
     deps = [
+        "//codesearch/dfa",
         "//codesearch/token",
         "//codesearch/types",
         "//server/util/log",


### PR DESCRIPTION
for a search like [lang:c failed] on the linux kernel sources, this is about 3x faster.

DFA: 	2024/08/12 19:18:56.695 INF Scoring 12438 docs took 326.02845ms name=searcher
STDLIB: 2024/08/12 19:19:03.823 INF Scoring 12438 docs took 947.251817ms name=searcher

More context on go's relatively slow regex performance here: https://github.com/golang/go/issues/26623