### PR TITLE
Improve DoNotRecycle logging

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -762,6 +762,8 @@ func run() error {
 // to be called after the current invocation has completed, to avoid blocking
 // the invocation status from being reported.
 func (ws *workspace) prepareRunnerForNextInvocation(ctx context.Context, taskWorkspaceDir string) {
+	log := ws.log
+
 	// After the invocation is complete, ensure that the bazel lock is not
 	// still held. If it is, avoid recycling.
 	if err := ws.checkBazelWorkspaceLock(ctx); err != nil {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -303,6 +303,7 @@ func (r *taskRunner) Run(ctx context.Context) (res *interfaces.CommandResult) {
 		if err != nil {
 			log.CtxWarningf(ctx, "Failed to check existence of %s: %s", doNotRecycleMarkerFile, err)
 		} else if exists {
+			log.CtxInfof(ctx, "Action created %q file in workspace root; not recycling", doNotRecycleMarkerFile)
 			res.DoNotRecycle = true
 		}
 	}()


### PR DESCRIPTION
- In `ci_runner`, make sure logs are sent on the BES stream so that they appear in the workflow invocation logs
- In the executor, log a message when we don't reycle because of the DO_NOT_RECYCLE file

**Related issues**: N/A
