### PR TITLE
Track index read performance

### DIFF
--- a/codesearch/cmd/cli/BUILD
+++ b/codesearch/cmd/cli/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//codesearch/index",
+        "//codesearch/performance",
         "//codesearch/query",
         "//codesearch/searcher",
         "//codesearch/types",

--- a/codesearch/cmd/server/server.go
+++ b/codesearch/cmd/server/server.go
@@ -39,6 +39,7 @@ func main() {
 		config.ReloadOnSIGHUP()
 	}
 
+	log.Printf("csIndexDir %s, csScratchDir: %s", *csIndexDir, *csScratchDir)
 	lis, err := net.Listen("tcp", *listen)
 	if err != nil {
 		log.Fatal(err.Error())

--- a/codesearch/index/BUILD
+++ b/codesearch/index/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/index",
     visibility = ["//visibility:public"],
     deps = [
+        "//codesearch/performance",
         "//codesearch/posting",
         "//codesearch/token",
         "//codesearch/types",

--- a/codesearch/kythe/server/BUILD
+++ b/codesearch/kythe/server/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/kythe/server",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/util/flagutil/yaml",
         "@io_kythe//kythe/go/services/filetree",
         "@io_kythe//kythe/go/services/graph",
         "@io_kythe//kythe/go/services/xrefs",

--- a/codesearch/kythe/server/server.go
+++ b/codesearch/kythe/server/server.go
@@ -14,8 +14,13 @@ import (
 	ftsrv "kythe.io/kythe/go/serving/filetree"
 	gsrv "kythe.io/kythe/go/serving/graph"
 	xsrv "kythe.io/kythe/go/serving/xrefs"
+
+	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
+func init() {
+	flagyaml.IgnoreFlagForYAML("experimental_cross_reference_indirection_kinds")
+}
 func New(rootDirectory string) (*kytheServer, error) {
 	db, err := pebble.Open(rootDirectory, nil /*use default options*/)
 	if err != nil {

--- a/codesearch/performance/BUILD
+++ b/codesearch/performance/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "performance",
+    srcs = ["performance.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/performance",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/log",
+        "@org_golang_x_exp//maps",
+    ],
+)

--- a/codesearch/performance/performance.go
+++ b/codesearch/performance/performance.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"sync"
 	"time"
-	
+
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"golang.org/x/exp/maps"
 )
@@ -18,7 +18,7 @@ const (
 
 	DOC_BYTES_READ
 	DOC_KEYS_SCANNED
-	
+
 	QUERY_PARSE_DURATION
 
 	POSTING_LIST_QUERY_DURATION
@@ -66,6 +66,7 @@ func (l label) String() string {
 		return "UNKNOWN_PERFORMANCE_LABEL"
 	}
 }
+
 // I'd like to track:
 //   - how many bytes are read per query
 //   - query parse time
@@ -81,7 +82,7 @@ type Tracker struct {
 
 func NewTracker() *Tracker {
 	return &Tracker{
-		mu: &sync.Mutex{},
+		mu:   &sync.Mutex{},
 		data: make(map[label]int64),
 	}
 }
@@ -108,7 +109,7 @@ func (t *Tracker) Keys() []label {
 	t.mu.Lock()
 	keys := maps.Keys(t.data)
 	t.mu.Unlock()
-	
+
 	slices.Sort(keys)
 	return keys
 }

--- a/codesearch/performance/performance.go
+++ b/codesearch/performance/performance.go
@@ -1,0 +1,148 @@
+package performance
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+	
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"golang.org/x/exp/maps"
+)
+
+type label int
+
+const (
+	INDEX_BYTES_READ label = iota
+	INDEX_KEYS_SCANNED
+
+	DOC_BYTES_READ
+	DOC_KEYS_SCANNED
+	
+	QUERY_PARSE_DURATION
+
+	POSTING_LIST_QUERY_DURATION
+	POSTING_LIST_COUNT
+	POSTING_LIST_DOCIDS_COUNT
+
+	REMOVE_DELETED_DOCS_DURATION
+	REMOVE_DELETED_DOCS_COUNT
+
+	TOTAL_SCORING_DURATION
+	TOTAL_DOCS_SCORED_COUNT
+
+	TOTAL_SEARCH_DURATION
+)
+
+func (l label) String() string {
+	switch l {
+	case INDEX_BYTES_READ:
+		return "INDEX_BYTES_READ"
+	case INDEX_KEYS_SCANNED:
+		return "INDEX_KEYS_SCANNED"
+	case DOC_BYTES_READ:
+		return "DOC_BYTES_READ"
+	case DOC_KEYS_SCANNED:
+		return "DOC_KEYS_SCANNED"
+	case QUERY_PARSE_DURATION:
+		return "QUERY_PARSE_DURATION"
+	case POSTING_LIST_QUERY_DURATION:
+		return "POSTING_LIST_QUERY_DURATION"
+	case POSTING_LIST_COUNT:
+		return "POSTING_LIST_COUNT"
+	case POSTING_LIST_DOCIDS_COUNT:
+		return "POSTING_LIST_DOCIDS_COUNT"
+	case REMOVE_DELETED_DOCS_DURATION:
+		return "REMOVE_DELETED_DOCS_DURATION"
+	case REMOVE_DELETED_DOCS_COUNT:
+		return "REMOVE_DELETED_DOCS_COUNT"
+	case TOTAL_SCORING_DURATION:
+		return "TOTAL_SCORING_DURATION"
+	case TOTAL_DOCS_SCORED_COUNT:
+		return "TOTAL_DOCS_SCORED_COUNT"
+	case TOTAL_SEARCH_DURATION:
+		return "TOTAL_SEARCH_DURATION"
+	default:
+		return "UNKNOWN_PERFORMANCE_LABEL"
+	}
+}
+// I'd like to track:
+//   - how many bytes are read per query
+//   - query parse time
+//   - posting lists query duration
+//   - deletion duration
+//   - scoring duration and number of docs scored
+//   - total search duration
+
+type Tracker struct {
+	mu   *sync.Mutex
+	data map[label]int64
+}
+
+func NewTracker() *Tracker {
+	return &Tracker{
+		mu: &sync.Mutex{},
+		data: make(map[label]int64),
+	}
+}
+
+func (t *Tracker) TrackOnce(key label, value int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if _, ok := t.data[key]; ok {
+		log.Errorf("Attempted overwrite of %s", key)
+	} else {
+		t.data[key] = value
+	}
+}
+
+func (t *Tracker) Add(key label, value int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.data[key] += value
+}
+
+func (t *Tracker) Keys() []label {
+	t.mu.Lock()
+	keys := maps.Keys(t.data)
+	t.mu.Unlock()
+	
+	slices.Sort(keys)
+	return keys
+}
+
+func (t *Tracker) Get(key label) int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.data[key]
+}
+
+func (t *Tracker) PrettyPrint() {
+	indexMB := (float64(t.Get(INDEX_BYTES_READ)) / 1e6)
+	log.Printf("Retrieved %d posting lists in %s [%2.2f MB]", t.Get(POSTING_LIST_COUNT), time.Duration(t.Get(POSTING_LIST_QUERY_DURATION)), indexMB)
+	if t.Get(REMOVE_DELETED_DOCS_COUNT) > 0 {
+		log.Printf("Filtered %d deleted docs in %s", t.Get(REMOVE_DELETED_DOCS_COUNT), time.Duration(t.Get(REMOVE_DELETED_DOCS_DURATION)))
+	}
+	log.Printf("Scored %d docs in %s", t.Get(TOTAL_DOCS_SCORED_COUNT), time.Duration(t.Get(TOTAL_SCORING_DURATION)))
+	log.Printf("Completed search in %s", time.Duration(t.Get(TOTAL_SEARCH_DURATION)))
+}
+
+const trackerContextKey = "x-perf-tracker"
+
+func WrapContext(ctx context.Context) context.Context {
+	if t := TrackerFromContext(ctx); t != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, trackerContextKey, NewTracker())
+}
+
+func TrackerFromContext(ctx context.Context) *Tracker {
+	if v := ctx.Value(trackerContextKey); v != nil {
+		if r, ok := v.(*Tracker); ok {
+			return r
+		}
+	}
+	return nil
+}

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -3,6 +3,7 @@ package query
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/csv"
 	"fmt"
 	"regexp"
@@ -216,6 +217,7 @@ func (h *reHighlighter) Highlight(doc types.Document) []types.HighlightedRegion 
 }
 
 type ReQuery struct {
+	ctx           context.Context
 	log           log.Logger
 	parsed        string
 	squery        []byte
@@ -231,7 +233,7 @@ func expressionToSquery(expr string, fieldName string) (string, error) {
 	return RegexpQuery(syn).SQuery(fieldName), nil
 }
 
-func NewReQuery(q string, numResults int) (*ReQuery, error) {
+func NewReQuery(ctx context.Context, q string, numResults int) (*ReQuery, error) {
 	subLog := log.NamedSubLogger("regexp-query")
 	subLog.Infof("raw query: [%s]", q)
 
@@ -351,6 +353,7 @@ func NewReQuery(q string, numResults int) (*ReQuery, error) {
 	subLog.Infof("squery: %q", squery)
 
 	req := &ReQuery{
+		ctx:           ctx,
 		log:           subLog,
 		squery:        []byte(squery),
 		parsed:        q,

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,8 @@ import (
 )
 
 func TestCaseSensitive(t *testing.T) {
-	q, err := NewReQuery("case:y foo", 1)
+	ctx := context.Background()
+	q, err := NewReQuery(ctx, "case:y foo", 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
@@ -20,7 +22,8 @@ func TestCaseSensitive(t *testing.T) {
 }
 
 func TestCaseInsensitive(t *testing.T) {
-	q, err := NewReQuery("Foo", 1)
+	ctx := context.Background()
+	q, err := NewReQuery(ctx, "Foo", 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
@@ -33,7 +36,8 @@ func TestCaseInsensitive(t *testing.T) {
 }
 
 func TestCaseNo(t *testing.T) {
-	q, err := NewReQuery("fOO case:no", 1)
+	ctx := context.Background()
+	q, err := NewReQuery(ctx, "fOO case:no", 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
@@ -46,7 +50,8 @@ func TestCaseNo(t *testing.T) {
 }
 
 func TestLangAtom(t *testing.T) {
-	q, err := NewReQuery("lang:java foo", 1)
+	ctx := context.Background()
+	q, err := NewReQuery(ctx, "lang:java foo", 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
@@ -58,7 +63,8 @@ func TestLangAtom(t *testing.T) {
 }
 
 func TestFileAtom(t *testing.T) {
-	q, err := NewReQuery("f:foo/bar/baz.a", 1)
+	ctx := context.Background()
+	q, err := NewReQuery(ctx, "f:foo/bar/baz.a", 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
@@ -76,7 +82,8 @@ func TestFileAtom(t *testing.T) {
 }
 
 func TestGroupedTerms(t *testing.T) {
-	q, err := NewReQuery(`"grp trm" case:y`, 1)
+	ctx := context.Background()
+	q, err := NewReQuery(ctx, `"grp trm" case:y`, 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
@@ -88,7 +95,8 @@ func TestGroupedTerms(t *testing.T) {
 }
 
 func TestUngroupedTerms(t *testing.T) {
-	q, err := NewReQuery("grp trm case:y", 1)
+	ctx := context.Background()
+	q, err := NewReQuery(ctx, "grp trm case:y", 1)
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())

--- a/codesearch/searcher/BUILD
+++ b/codesearch/searcher/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/searcher",
     visibility = ["//visibility:public"],
     deps = [
+        "//codesearch/performance",
         "//codesearch/types",
         "//server/util/log",
         "@org_golang_x_sync//errgroup",

--- a/codesearch/server/BUILD
+++ b/codesearch/server/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//codesearch/index",
+        "//codesearch/performance",
         "//codesearch/query",
         "//codesearch/searcher",
         "//codesearch/types",

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -13,7 +13,6 @@ const (
 	SparseNgramField
 
 	DocIDField = "docid"
-	AllFields  = "*"
 )
 
 func (ft FieldType) String() string {


### PR DESCRIPTION
looks about the same as before but now there's more useful data and it can be returned to the client.

```
2024/08/13 12:05:05.257 INF raw query: [(FailedPrecondition|Unknown)Error] name=regexp-query
2024/08/13 12:05:05.257 INF parsed query: [(?mi)((FailedPrecondition|Unknown)Error)] name=regexp-query
2024/08/13 12:05:05.257 INF squery: "(:and (:and (:eq content \"err\") (:eq content \"rror\")) (:or  (:and (:eq content \"cond\") (:eq content \"diti\") (:eq content \"edpr\") (:eq content \"fail\") (:eq content \"iled\") (:eq content \"ion\") (:eq content \"ndi\") (:eq content \"pre\") (:eq content \"reco\") (:eq content \"tio\")) (:and (:eq content \"nkno\") (:eq content \"now\") (:eq content \"own\") (:eq content \"unk\"))) (:or (:eq content \"oner\") (:eq content \"wner\")))" name=regexp-query
2024/08/13 12:05:05.269 INF Retrieved 18 posting lists in 1.165735ms [0.10 MB]
2024/08/13 12:05:05.269 INF Scored 141 docs in 7.103814ms
2024/08/13 12:05:05.269 INF Completed search in 8.563747ms
```