### PR TITLE
[RB] Pass executable args to remote bazel command

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -703,9 +703,14 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		reqArch = *execArch
 	}
 
+	bazelArgs := opts.Args
+	if !*runRemotely {
+		// If we are running the target locally, we append the exec arguments
+		// when we actually run it
+		bazelArgs = arg.GetBazelArgs(opts.Args)
+	}
 	fetchOutputs := false
 	runOutput := false
-	bazelArgs := arg.GetBazelArgs(opts.Args)
 	if len(bazelArgs) > 0 && (bazelArgs[0] == "build" || (bazelArgs[0] == "run" && !*runRemotely)) {
 		fetchOutputs = true
 		if bazelArgs[0] == "run" {


### PR DESCRIPTION
[Here](https://github.com/buildbuddy-io/buildbuddy/blob/master/cli/remotebazel/remotebazel.go#L880) is where we add the executable args if running the target locally

**Related issues**: N/A
