### PR TITLE
Use a configurable fraction of stall time in PSI-adjusted duration

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	useMeasuredSizes = flag.Bool("remote_execution.use_measured_task_sizes", false, "Whether to use measured usage stats to determine task sizes.")
-	modelEnabled     = flag.Bool("remote_execution.task_size_model.enabled", false, "Whether to enable model-based task size prediction.")
+	useMeasuredSizes    = flag.Bool("remote_execution.use_measured_task_sizes", false, "Whether to use measured usage stats to determine task sizes.")
+	modelEnabled        = flag.Bool("remote_execution.task_size_model.enabled", false, "Whether to enable model-based task size prediction.")
+	psiCorrectionFactor = flag.Float64("remote_execution.task_size_psi_correction", 0.75, "What percentage of full-stall time should be subtracted from the execution duration.")
 )
 
 const (
@@ -245,7 +246,12 @@ func computeMilliCPU(ctx context.Context, md *repb.ExecutedActionMetadata) int64
 		ioFullStallDuration = time.Duration(ioStalledUsec) * time.Microsecond
 	}
 	totalFullStallDuration := cpuFullStallDuration + memoryFullStallDuration + ioFullStallDuration
-	activeDuration := execDuration - totalFullStallDuration
+	// Apply a correction factor, since using 100% of the stall duration can
+	// lead to exploding task sizes due to measurement inaccuracies in the case
+	// where the full stall duration is very close to the exec duration.
+	adjustedFullStallDuration := time.Duration(*psiCorrectionFactor * float64(totalFullStallDuration))
+
+	activeDuration := execDuration - adjustedFullStallDuration
 	if activeDuration <= 0 {
 		return 0
 	}
@@ -257,13 +263,14 @@ func computeMilliCPU(ctx context.Context, md *repb.ExecutedActionMetadata) int64
 	// was greater than 0 but less than 1 CPU-millisecond.
 	milliCPU := int64(math.Ceil(milliCPUFloat))
 
-	if milliCPU > 16_000 {
-		log.CtxInfof(
-			ctx,
-			"High computed CPU usage: %d average milli-CPU from %.1f CPU-millis over %s exec duration minus full-stall durations cpu=%s, mem=%s, io=%s",
-			milliCPU, cpuMillisUsed, execDuration, cpuFullStallDuration, memoryFullStallDuration, ioFullStallDuration,
-		)
-	}
+	// Log all task sizing information so that we have a way to assess potential
+	// changes to the formula.
+	log.CtxInfof(
+		ctx,
+		"Computed CPU usage: %d average milli-CPU from %.1f CPU-millis over %s exec duration minus full-stall durations cpu=%s, mem=%s, io=%s",
+		milliCPU, cpuMillisUsed, execDuration, cpuFullStallDuration, memoryFullStallDuration, ioFullStallDuration,
+	)
+
 	return milliCPU
 }
 

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -146,9 +146,9 @@ func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
 			// just returning the default estimates.
 			CpuNanos:        7.13 * 1e9,
 			PeakMemoryBytes: 917 * 1e6,
-			// The *sum* of all of the full-stall total durations should be
-			// subtracted from the execution duration for the purposes of the
-			// milliCPU calculation.
+			// The *sum* of all of the full-stall total durations, multiplied by
+			// the PSI correction factor flag, should be subtracted from the
+			// execution duration for the purposes of the milliCPU calculation.
 			CpuPressure: &repb.PSI{
 				Full: &repb.PSI_Metrics{Total: 0.33 * 1e6 /*usec*/},
 			},
@@ -173,7 +173,7 @@ func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
 		t, int64(917*1e6), ts.GetEstimatedMemoryBytes(),
 		"subsequent mem estimate should equal recorded peak mem usage")
 	assert.Equal(
-		t, int64(math.Ceil(7.13/(2.0-(0.33+0.21+0.07))*1000.0)), ts.GetEstimatedMilliCpu(),
+		t, int64(math.Ceil(7.13/(2.0-0.75*(0.33+0.21+0.07))*1000.0)), ts.GetEstimatedMilliCpu(),
 		"subsequent milliCPU estimate should equal recorded milliCPU")
 }
 


### PR DESCRIPTION
Adds a knob to control the fraction of pressure stall time that we apply as a correction to the execution duration, and adjusts the effective value of the knob from 100% to 75%. This is needed because (for reasons that are still not 100% clear) the PSI stall time is occasionally reported to be very close to the execution duration, resulting in a high computed value for the average milliCPU usage.

Based on analysis of logs, using only 75% of the reported pressure stall time instead of 100% would have fixed all problematic tasks from the last 24h (>16 CPU), putting them under the 30 CPU mark. For non-problematic tasks, this should not affecting task sizes by too much, and preserve enough backpressure to prevent negative feedback loops, since we are still preserving most (75%) of the PSI correction.

Analyzed logs using [this script](https://github.com/buildbuddy-io/buildbuddy/blob/tasksize-parse-logs/parse.py), processing 1600 log entries over the last 24h, where the computed milliCPU was > 16K.

```
millicpu using 0.75*stall_duration:
- min: 2984.2107274066457
- max: 28998.04379154327
- average: 5991.706074873706
- p50: 4686.979561300274
- p90: 8858.734140841832
- p95: 17038.070814486146
- p99: 19499.865554629403

millicpu using 1.00*stall_duration:
- min: 16001.436653717952
- max: 7725139.126009313
- average: 96027.33574049846
- p50: 28856.248638381527
- p90: 140770.50112569623
- p95: 274212.55830794346
- p99: 1238244.4639119518

N=1644
```

