### PR TITLE
Sprinkle in some more specificity

### DIFF
--- a/app/components/button/button.css
+++ b/app/components/button/button.css
@@ -122,12 +122,12 @@
   border: 1px solid rgba(20, 20, 20, 0.1);
 }
 
-.outlined-button-group > .outlined-button {
+.outlined-button-group > .outlined-button.outlined-button.outlined-button {
   border: none;
   min-height: 38px; /* = 40px usual min-height - 1px for top + bottom border from parent */
 }
 
-.outlined-button-group > .outlined-button:not(:last-child) {
+.outlined-button-group > .outlined-button.outlined-button:not(:last-child) {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   border-right: 1px solid rgba(20, 20, 20, 0.1);


### PR DESCRIPTION
[This PR](https://github.com/buildbuddy-io/buildbuddy/pull/7170/files) started a battle that `.outlined-button-group` wasn't prepared to fight.

This PR gives `.outlined-button-group` the specificity ammunition to win that battle.

Before:
<img width="167" alt="Screenshot 2024-08-14 at 9 17 15 AM" src="https://github.com/user-attachments/assets/2881ec8d-4a7c-44b9-9f3a-9c7048e4204b">

After:
<img width="176" alt="Screenshot 2024-08-14 at 9 17 02 AM" src="https://github.com/user-attachments/assets/7b64f9f7-c36e-4a1f-80ef-3a43e6e9b8c2">

