### PR TITLE
Return performance metrics to client

### DIFF
--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -275,7 +275,17 @@ func (css *codesearchServer) Search(ctx context.Context, req *srpb.SearchRequest
 		rsp.Results = append(rsp.Results, result)
 	}
 	if t := performance.TrackerFromContext(ctx); t != nil {
-		t.PrettyPrint()
+		keys := t.Keys()
+		performanceMetrics := &srpb.PerformanceMetrics{
+			Metrics: make([]*srpb.Metric, len(keys)),
+		}
+		for i, key := range keys {
+			performanceMetrics.Metrics[i] = &srpb.Metric{
+				Name:  key.String(),
+				Value: t.Get(key),
+			}
+		}
+		rsp.PerformanceMetrics = performanceMetrics
 	}
 	return rsp, nil
 }

--- a/proto/search.proto
+++ b/proto/search.proto
@@ -65,10 +65,21 @@ message ParsedQuery {
   string squery = 3;
 }
 
+message Metric {
+  string name = 1;
+  int64 value = 2;
+}
+
+message PerformanceMetrics {
+  repeated Metric metrics = 1;
+}
+
 message SearchResponse {
   context.ResponseContext response_context = 1;
 
   repeated Result results = 2;
 
   ParsedQuery parsed_query = 3;
+
+  PerformanceMetrics performance_metrics = 4;
 }


### PR DESCRIPTION
```
performance_metrics {
  metrics {
    name: "INDEX_BYTES_READ"
    value: 225999
  }
  metrics {
    name: "INDEX_KEYS_SCANNED"
    value: 18
  }
  metrics {
    name: "DOC_BYTES_READ"
    value: 4573186
  }
  metrics {
    name: "DOC_KEYS_SCANNED"
    value: 3452
  }
  metrics {
    name: "POSTING_LIST_QUERY_DURATION"
    value: 2463906
  }
  metrics {
    name: "POSTING_LIST_COUNT"
    value: 18
  }
  metrics {
    name: "POSTING_LIST_DOCIDS_COUNT"
    value: 23702
  }
  metrics {
    name: "REMOVE_DELETED_DOCS_DURATION"
    value: 5850
  }
  metrics {
    name: "TOTAL_SCORING_DURATION"
    value: 7923278
  }
  metrics {
    name: "TOTAL_DOCS_SCORED_COUNT"
    value: 160
  }
  metrics {
    name: "TOTAL_SEARCH_DURATION"
    value: 10467454
  }
}
```