### PR TITLE
Fix bad escape sequences in `post_bazel.py`

### DIFF
--- a/cli/plugins/go-deps/post_bazel.py
+++ b/cli/plugins/go-deps/post_bazel.py
@@ -26,7 +26,7 @@ def main():
             os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
         )
         m = re.search(
-            f'^\\s*(?P<prefix>.*/execroot/|/tmp/bazel-working-directory/)(({workspace_basename}|_main)/)?(?P<src_path>.*?\\.go): import of "(?P<import_url>.*?)"',
+            rf'^\s*(?P<prefix>.*/execroot/|/tmp/bazel-working-directory/)(({workspace_basename}|_main)/)?(?P<src_path>.*?\.go): import of "(?P<import_url>.*?)"',
             line,
         )
         if not m:

--- a/cli/plugins/go-deps/post_bazel.py
+++ b/cli/plugins/go-deps/post_bazel.py
@@ -26,7 +26,7 @@ def main():
             os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
         )
         m = re.search(
-            f'^\s*(?P<prefix>.*/execroot/|/tmp/bazel-working-directory/)(({workspace_basename}|_main)/)?(?P<src_path>.*?\.go): import of "(?P<import_url>.*?)"',
+            f'^\\s*(?P<prefix>.*/execroot/|/tmp/bazel-working-directory/)(({workspace_basename}|_main)/)?(?P<src_path>.*?\\.go): import of "(?P<import_url>.*?)"',
             line,
         )
         if not m:


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

I've been getting

```
/home/zoey/src/bb/buildbuddy/cli/plugins/go-deps/./post_bazel.py:29: SyntaxWarning: invalid escape sequence '\s'
  f'^\s*(?P<prefix>.*/execroot/|/tmp/bazel-working-directory/)(({workspace_basename}|_main)/)?(?P<src_path>.*?\.go): import of "(?P<import_url>.*?)"',
/home/zoey/src/bb/buildbuddy/cli/plugins/go-deps/./post_bazel.py:29: SyntaxWarning: invalid escape sequence '\.'
  f'^\s*(?P<prefix>.*/execroot/|/tmp/bazel-working-directory/)(({workspace_basename}|_main)/)?(?P<src_path>.*?\.go): import of "(?P<import_url>.*?)"',
```

on every build since updating python. This should fix it.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
