### PR TITLE
Simplify redundant squeries (which can be slower than necessary)

### DIFF
--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -350,7 +350,6 @@ func NewReQuery(ctx context.Context, q string) (*ReQuery, error) {
 		}
 		squery = "(:and " + squery + " " + clauses + ")"
 	}
-	subLog.Infof("squery: %q", squery)
 
 	req := &ReQuery{
 		ctx:           ctx,


### PR DESCRIPTION
// Skip redundant outer list wrapping
((:and blah)) -> (:and blah)

// Simplify expressions
(:and (expr)) -> (expr)

// Remove redundant subexpressions from :and expressions 
(:and (:all) (expr1) (expr2)) -> (:and (expr1) (expr2))