### PR TITLE
Set local CAS client in cache_proxy initialization so it doesn't crash.

### DIFF
--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -166,6 +166,7 @@ func startGRPCServers(env *real_environment.RealEnv) error {
 		return status.InternalErrorf("CacheProxy: error starting local bytestream gRPC server: %s", err.Error())
 	}
 	env.SetLocalByteStreamClient(bspb.NewByteStreamClient(conn))
+	env.SetLocalCASClient(repb.NewContentAddressableStorageClient(conn))
 
 	s, err := grpc_server.New(env, grpc_server.GRPCPort(), false, grpcServerConfig)
 	if err != nil {


### PR DESCRIPTION
Forgot to add this in https://github.com/buildbuddy-io/buildbuddy/pull/7076

**Related issues**: N/A
