### PR TITLE
Don't uninstall ca-certificates package

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -31,7 +31,7 @@ RUN DOCKER_VERSION="5:26.1.4-1~debian.12~bookworm" && \
     containerd.io=${CONTAINERD_DEB_VERSION} \
     docker-buildx-plugin=${DOCKER_BUILDX_VERSION} && \
     apt-get remove -y \
-    curl ca-certificates apt-transport-https && \
+    curl apt-transport-https && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && apt-get clean && \
     rm \


### PR DESCRIPTION
This has the side effect of uninstalling `docker-credential-ecr-login`

**Related issues**: N/A
