### PR TITLE
mark packages we used to configure the executor image as auto-installed

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -30,8 +30,8 @@ RUN DOCKER_VERSION="5:26.1.4-1~debian.12~bookworm" && \
     docker-ce-cli=${DOCKER_VERSION} \
     containerd.io=${CONTAINERD_DEB_VERSION} \
     docker-buildx-plugin=${DOCKER_BUILDX_VERSION} && \
-    apt-get remove -y \
-    curl apt-transport-https && \
+    apt-mark auto \
+    curl ca-certificates apt-transport-https && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && apt-get clean && \
     rm \


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
this way, we'll only remove these packages if none of the other stuff we install depends on it--better to explicitly list all the things we manually installed for this purpose.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
