### PR TITLE
Add mitigation for kernel bug in PSI calculation

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -297,7 +297,33 @@ func (r *taskRunner) DownloadInputs(ctx context.Context, ioStats *repb.IOStats) 
 
 // Run runs the task that is currently bound to the command runner.
 func (r *taskRunner) Run(ctx context.Context) (res *interfaces.CommandResult) {
+	start := time.Now()
 	defer func() {
+		// Discard nonsensical PSI full-stall durations which are greater
+		// than the execution duration.
+		// See https://bugzilla.kernel.org/show_bug.cgi?id=219194
+		// TL;DR: very rarely, the total stall duration is reported as a number
+		// which is much larger than the actual execution duration, and is
+		// sometimes exactly equal to UINT32_MAX nanoseconds, which is
+		// suspicious and suggests there is a bug in the way this number is
+		// reported.
+		// Also, skip recycling in this case, because the nonsensical result
+		// will persist across tasks.
+		durationUsec := time.Since(start).Microseconds()
+		stats := res.UsageStats
+		if stats.GetCpuPressure().GetFull().GetTotal() > durationUsec {
+			stats.CpuPressure = nil
+			res.DoNotRecycle = true
+		}
+		if stats.GetMemoryPressure().GetFull().GetTotal() > durationUsec {
+			stats.MemoryPressure = nil
+			res.DoNotRecycle = true
+		}
+		if stats.GetIoPressure().GetFull().GetTotal() > durationUsec {
+			stats.IoPressure = nil
+			res.DoNotRecycle = true
+		}
+
 		// Allow tasks to create a special file to skip recycling.
 		exists, err := disk.FileExists(ctx, filepath.Join(r.Workspace.Path(), doNotRecycleMarkerFile))
 		if err != nil {


### PR DESCRIPTION
After investigation, there is strong evidence of a bug somewhere in the kernel [code](https://github.com/torvalds/linux/blob/5be63fc19fcaa4c236b307420483578a56986a37/kernel/sched/psi.c) responsible for reporting PSI durations. I reported a bug here (with more details + small repro program): https://bugzilla.kernel.org/show_bug.cgi?id=219194

If we look at [logs](http://go/bad-cpu-stall) from the last 7d of nonsensical task sizes, almost all of the CPU stall durations for these tasks seem to be about 4.2s, i.e. the suspicious UINT32_MAX nanoseconds number mentioned in the bug report.

At some point, it would be nice to diagnose / fix this bug upstream, but I think it makes sense to add a mitigation for this bug in our code, since any upstream fix would likely to take a long time to develop, get reviewed, be released, and then become available in all environments where the executor is deployed.

**Related issues**: N/A
