### PR TITLE
Revert "[ci_runner] Populate child invocation cards in UI for bazel commands in bash"

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -51,7 +51,10 @@ export default class InvocationModel {
   failedAction?: build_event_stream.BuildEvent;
   workflowConfigured?: build_event_stream.WorkflowConfigured;
   childInvocationsConfigured: build_event_stream.ChildInvocationsConfigured[] = [];
-  childInvocationCompletedByInvocationId = new Map<string, build_event_stream.IChildInvocationCompleted>();
+  childInvocationCompletedByInvocationId = new Map<
+    string,
+    build_event_stream.IChildInvocationCompleted | build_event_stream.IWorkflowCommandCompleted
+  >();
   workspaceStatus?: build_event_stream.WorkspaceStatus;
   configuration?: build_event_stream.Configuration;
   workspaceConfig?: build_event_stream.WorkspaceConfig;
@@ -140,6 +143,12 @@ export default class InvocationModel {
       if (buildEvent.childInvocationsConfigured) {
         this.childInvocationsConfigured.push(
           buildEvent.childInvocationsConfigured as build_event_stream.ChildInvocationsConfigured
+        );
+      }
+      if (buildEvent.workflowCommandCompleted && buildEvent.id?.workflowCommandCompleted?.invocationId) {
+        this.childInvocationCompletedByInvocationId.set(
+          buildEvent.id.workflowCommandCompleted.invocationId,
+          buildEvent.workflowCommandCompleted
         );
       }
       if (buildEvent.childInvocationCompleted && buildEvent.id?.childInvocationCompleted?.invocationId) {

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:eventlog_go_proto",
-        "//proto:execution_stats_go_proto",
         "//proto:git_go_proto",
         "//proto:invocation_go_proto",
         "//proto:remote_execution_go_proto",
@@ -40,7 +39,6 @@ go_library(
         "@com_github_go_git_go_git_v5//plumbing",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//metadata",
-        "@org_golang_x_sync//errgroup",
         "@org_golang_x_sys//unix",
     ],
 )

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -37,14 +37,12 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/metadata"
 
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
-	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	gitpb "github.com/buildbuddy-io/buildbuddy/proto/git"
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -772,6 +770,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 			CommitSha: repoConfig.CommitSHA,
 			Branch:    repoConfig.Ref,
 		},
+		BazelCommand:   strings.Join(bazelArgs, " "),
 		Os:             reqOS,
 		Arch:           reqArch,
 		ContainerImage: *containerImage,
@@ -780,18 +779,6 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		RunRemotely:    *runRemotely,
 	}
 	req.GetRepoState().Patch = append(req.GetRepoState().Patch, repoConfig.Patches...)
-
-	// TODO(Maggie): Clean up after we've migrated fully to use `Steps`
-	stepsMode := os.Getenv("STEPS_MODE") == "1"
-	if stepsMode {
-		req.Steps = []*rnpb.Step{
-			{
-				Run: fmt.Sprintf("bazel %s", strings.Join(bazelArgs, " ")),
-			},
-		}
-	} else {
-		req.BazelCommand = strings.Join(bazelArgs, " ")
-	}
 
 	if *timeout != 0 {
 		req.Timeout = timeout.String()
@@ -837,44 +824,25 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	}
 	isInvocationRunning = false
 
-	eg := errgroup.Group{}
-	var inRsp *inpb.GetInvocationResponse
-	var exRsp *espb.GetExecutionResponse
-	eg.Go(func() error {
-		var err error
-		inRsp, err = bbClient.GetInvocation(ctx, &inpb.GetInvocationRequest{Lookup: &inpb.InvocationLookup{InvocationId: iid}})
-		if err != nil {
-			return fmt.Errorf("could not retrieve invocation: %s", err)
-		}
-		if len(inRsp.GetInvocation()) == 0 {
-			return fmt.Errorf("invocation not found")
-		}
-		return nil
-	})
-	eg.Go(func() error {
-		var err error
-		exRsp, err = bbClient.GetExecution(ctx, &espb.GetExecutionRequest{ExecutionLookup: &espb.ExecutionLookup{
-			InvocationId: iid,
-		}})
-		if err != nil {
-			return fmt.Errorf("could not retrieve ci_runner execution: %s", err)
-		}
-		if len(exRsp.GetExecution()) == 0 {
-			return fmt.Errorf("ci_runner execution not found")
-		}
-		return nil
-	})
-	err = eg.Wait()
+	inRsp, err := bbClient.GetInvocation(ctx, &inpb.GetInvocationRequest{Lookup: &inpb.InvocationLookup{InvocationId: iid}})
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("could not retrieve invocation: %s", err)
+	}
+	if len(inRsp.GetInvocation()) == 0 {
+		return 0, fmt.Errorf("invocation not found")
 	}
 
 	childIID := ""
+	exitCode := -1
 	runfilesRoot := ""
 	var runfiles []*bespb.File
 	var runfileDirectories []*bespb.Tree
 	var defaultRunArgs []string
 	for _, e := range inRsp.GetInvocation()[0].GetEvent() {
+		if cic, ok := e.GetBuildEvent().GetPayload().(*bespb.BuildEvent_ChildInvocationCompleted); ok {
+			childIID = e.GetBuildEvent().GetId().GetChildInvocationCompleted().GetInvocationId()
+			exitCode = int(cic.ChildInvocationCompleted.ExitCode)
+		}
 		if runOutput {
 			if rta, ok := e.GetBuildEvent().GetPayload().(*bespb.BuildEvent_RunTargetAnalyzed); ok {
 				runfilesRoot = rta.RunTargetAnalyzed.GetRunfilesRoot()
@@ -885,7 +853,13 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		}
 	}
 
-	exitCode := int(exRsp.GetExecution()[0].ExitCode)
+	if exitCode == -1 {
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+		return 0, fmt.Errorf("could not determine remote Bazel exit code")
+	}
+
 	if fetchOutputs && exitCode == 0 {
 		conn, err := grpc_client.DialSimple(opts.Server)
 		if err != nil {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -199,7 +199,6 @@ var (
 	fallbackToCleanCheckout = flag.Bool("fallback_to_clean_checkout", true, "Fallback to cloning the repo from scratch if sync fails (for testing purposes only).")
 
 	shellCharsRequiringQuote = regexp.MustCompile(`[^\w@%+=:,./-]`)
-	invocationIDRegex        = regexp.MustCompile(`Streaming build results to:\s+.*?/invocation/([a-f0-9-]+)`)
 )
 
 type workspace struct {
@@ -307,9 +306,6 @@ type buildEventReporter struct {
 	startTime             time.Time
 	cancelBackgroundFlush func()
 
-	// Child invocations detected by scanning the build logs
-	childInvocations map[string]struct{}
-
 	mu            sync.Mutex // protects(progressCount)
 	progressCount int32
 }
@@ -339,7 +335,7 @@ func newBuildEventReporter(ctx context.Context, besBackend string, apiKey string
 		uploader = ul
 	}
 
-	return &buildEventReporter{apiKey: apiKey, bep: bep, uploader: uploader, log: newInvocationLog(), invocationID: iid, isWorkflow: isWorkflow, childInvocations: map[string]struct{}{}}, nil
+	return &buildEventReporter{apiKey: apiKey, bep: bep, uploader: uploader, log: newInvocationLog(), invocationID: iid, isWorkflow: isWorkflow}, nil
 }
 
 func (r *buildEventReporter) InvocationID() string {
@@ -457,14 +453,12 @@ func (r *buildEventReporter) Start(startTime time.Time) error {
 		return err
 	}
 
-	r.log.writeListener = func(b []byte) {
-		r.emitBuildEventsForBazelCommands(b)
-		// Flush whenever the log buffer fills past a certain threshold.
+	// Flush whenever the log buffer fills past a certain threshold.
+	r.log.writeListener = func() {
 		if size := r.log.Len(); size >= progressFlushThresholdBytes {
 			r.FlushProgress() // ignore error; it will surface in `bep.Finish()`
 		}
 	}
-
 	stopFlushingProgress := r.startBackgroundProgressFlush()
 	r.cancelBackgroundFlush = stopFlushingProgress
 	return nil
@@ -572,65 +566,6 @@ func (r *buildEventReporter) startBackgroundProgressFlush() func() {
 	}()
 	return func() {
 		stop <- struct{}{}
-	}
-}
-
-// emitBuildEventsForBazelCommands scans command output logs for bazel invocations
-// in order to emit bazel build events.
-//
-// Event publishing errors will be surfaced in the caller func when calling
-// `buildEventPublisher.Finish()`
-//
-// TODO: Emit TargetConfigured and TargetCompleted events to render artifacts
-// for each command
-func (r *buildEventReporter) emitBuildEventsForBazelCommands(b []byte) {
-	output := string(b)
-
-	// Check whether a bazel invocation was invoked
-	iidMatches := invocationIDRegex.FindAllStringSubmatch(output, -1)
-	for _, m := range iidMatches {
-		iid := m[1]
-		_, childStarted := r.childInvocations[iid]
-
-		var buildEvent *bespb.BuildEvent
-		if childStarted {
-			// The `Streaming build results to` log line is printed at the start and
-			// end of a bazel build. If we've already seen it for this invocation,
-			// we know the build has finished.
-			buildEvent = &bespb.BuildEvent{
-				Id: &bespb.BuildEventId{
-					Id: &bespb.BuildEventId_ChildInvocationCompleted{
-						ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{InvocationId: iid},
-					},
-				},
-				Payload: &bespb.BuildEvent_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.ChildInvocationCompleted{}},
-			}
-		} else {
-			r.childInvocations[iid] = struct{}{}
-
-			cic := &bespb.ChildInvocationsConfigured{
-				Invocation: []*bespb.ChildInvocationsConfigured_InvocationMetadata{
-					{
-						InvocationId: iid,
-					},
-				},
-			}
-			buildEvent = &bespb.BuildEvent{
-				Id:      &bespb.BuildEventId{Id: &bespb.BuildEventId_ChildInvocationsConfigured{ChildInvocationsConfigured: &bespb.BuildEventId_ChildInvocationsConfiguredId{}}},
-				Payload: &bespb.BuildEvent_ChildInvocationsConfigured{ChildInvocationsConfigured: cic},
-				Children: []*bespb.BuildEventId{
-					{
-						Id: &bespb.BuildEventId_ChildInvocationCompleted{
-							ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{InvocationId: iid},
-						},
-					},
-				},
-			}
-		}
-
-		if err := r.Publish(buildEvent); err != nil {
-			continue
-		}
 	}
 }
 
@@ -928,18 +863,18 @@ func (r *buildEventReporter) Printf(format string, vals ...interface{}) {
 type invocationLog struct {
 	lockingbuffer.LockingBuffer
 	writer        io.Writer
-	writeListener func(b []byte)
+	writeListener func()
 }
 
 func newInvocationLog() *invocationLog {
-	invLog := &invocationLog{writeListener: func(b []byte) {}}
+	invLog := &invocationLog{writeListener: func() {}}
 	invLog.writer = io.MultiWriter(&invLog.LockingBuffer, os.Stderr)
 	return invLog
 }
 
 func (invLog *invocationLog) Write(b []byte) (int, error) {
-	invLog.writeListener(b)
 	n, err := invLog.writer.Write(b)
+	invLog.writeListener()
 	return n, err
 }
 
@@ -1056,7 +991,9 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 				BazelCommand: bazelCmd,
 			})
 			wfcEvent.Children = append(wfcEvent.Children, &bespb.BuildEventId{
-				Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{}},
+				Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{
+					InvocationId: iid,
+				}},
 			})
 		}
 	}
@@ -1102,7 +1039,6 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 
 	// TODO(Maggie): Emit BES events for each bazel command
 	for i, step := range action.Steps {
-		cmdStartTime := time.Now()
 		if err := provisionArtifactsDir(ws, i); err != nil {
 			return err
 		}
@@ -1158,21 +1094,6 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			uploader.UploadDirectory(namedSetID, artifactsDir) // does not return an error
 		}
 
-		duration := time.Since(cmdStartTime)
-		completedEvent := &bespb.BuildEvent{
-			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_WorkflowCommandCompleted{
-				WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{},
-			}},
-			Payload: &bespb.BuildEvent_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.WorkflowCommandCompleted{
-				ExitCode:  int32(exitCode),
-				StartTime: timestamppb.New(cmdStartTime),
-				Duration:  durationpb.New(duration),
-			}},
-		}
-		if err := ar.reporter.Publish(completedEvent); err != nil {
-			break
-		}
-
 		if exitCode != 0 {
 			return runErr
 		}
@@ -1181,10 +1102,34 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 	// TODO(Maggie): Consolidate action.BazelCommands with action.Steps
 	for i, bazelCmd := range action.BazelCommands {
 		cmdStartTime := time.Now()
+
 		if i >= len(wfc.GetInvocation()) {
 			return status.InternalErrorf("No invocation metadata generated for bazel_commands[%d]; this should never happen", i)
 		}
 		iid := wfc.GetInvocation()[i].GetInvocationId()
+
+		cic := &bespb.ChildInvocationsConfigured{
+			Invocation: []*bespb.ChildInvocationsConfigured_InvocationMetadata{
+				{
+					InvocationId: iid,
+					BazelCommand: bazelCmd,
+				},
+			},
+		}
+		cicEvent := &bespb.BuildEvent{
+			Id:      &bespb.BuildEventId{Id: &bespb.BuildEventId_ChildInvocationsConfigured{ChildInvocationsConfigured: &bespb.BuildEventId_ChildInvocationsConfiguredId{}}},
+			Payload: &bespb.BuildEvent_ChildInvocationsConfigured{ChildInvocationsConfigured: cic},
+			Children: []*bespb.BuildEventId{
+				{
+					Id: &bespb.BuildEventId_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{
+						InvocationId: iid,
+					}},
+				},
+			},
+		}
+		if err := ar.reporter.Publish(cicEvent); err != nil {
+			return nil
+		}
 
 		// Publish a TargetConfigured event associated with the bazel command so
 		// that we can render artifacts associated with the "target".
@@ -1310,9 +1255,13 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			}
 		}
 
+		// Publish the status of each command as well as the finish time.
+		// Stop execution early on BEP failure, but ignore error -- it will surface in `bep.Finish()`.
 		duration := time.Since(cmdStartTime)
 		completedEvent := &bespb.BuildEvent{
-			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{}}},
+			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{
+				InvocationId: iid,
+			}}},
 			Payload: &bespb.BuildEvent_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.WorkflowCommandCompleted{
 				ExitCode:  int32(exitCode),
 				StartTime: timestamppb.New(cmdStartTime),
@@ -1320,6 +1269,20 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			}},
 		}
 		if err := ar.reporter.Publish(completedEvent); err != nil {
+			break
+		}
+		duration = time.Since(cmdStartTime)
+		childCompletedEvent := &bespb.BuildEvent{
+			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{
+				InvocationId: iid,
+			}}},
+			Payload: &bespb.BuildEvent_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.ChildInvocationCompleted{
+				ExitCode:  int32(exitCode),
+				StartTime: timestamppb.New(cmdStartTime),
+				Duration:  durationpb.New(duration),
+			}},
+		}
+		if err := ar.reporter.Publish(childCompletedEvent); err != nil {
 			break
 		}
 
@@ -2218,7 +2181,7 @@ type commandError struct {
 }
 
 func (e *commandError) Error() string {
-	return e.Err.Error()
+	return fmt.Sprintf("%s: %q", e.Err.Error(), e.Output)
 }
 
 func isRemoteAlreadyExists(err error) bool {

--- a/enterprise/server/test/integration/remote_bazel/BUILD
+++ b/enterprise/server/test/integration/remote_bazel/BUILD
@@ -26,7 +26,6 @@ go_test(
     ],
     deps = [
         "//cli/remotebazel",
-        "//enterprise/server/execution_service",
         "//enterprise/server/hostedrunner",
         "//enterprise/server/invocation_search_service",
         "//enterprise/server/test/integration/remote_execution/rbetest",

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/remotebazel"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_search_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest"
@@ -244,7 +243,6 @@ func runLocalServerAndExecutor(t *testing.T, githubToken string) (*rbetest.Env, 
 			keyValStore, err := memory_kvstore.NewMemoryKeyValStore()
 			require.NoError(t, err)
 			e.SetKeyValStore(keyValStore)
-			e.SetExecutionService(execution_service.NewExecutionService(e))
 		},
 	})
 

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -259,22 +259,20 @@ message BuildEventId {
   // run as part of a BuildBuddy workflow.
   message WorkflowConfiguredId {}
 
-  // Identifier of an event providing the status of a completed step
+  // Identifier of an event providing the status of a completed invocation
   // within a BuildBuddy workflow.
   //
-  // A workflow action can specify multiple steps, each of which is a block of
-  // bash code. This event will be emitted when the entire block has completed.
-  //
-  // For each bazel command invoked in the step, a ChildInvocationsConfigured
-  // and ChildInvocationCompleted event will also be emitted.
-  // TODO(Maggie): Once FE references have been cleaned up, rename to
-  // `RemoteRunnerStepCompleted`
+  // A workflow action can specify multiple bazel commands, creating a
+  // "sub-invocation" for each one. There will be one of these events generated
+  // for each of those Bazel commands, where the invocation ID here refers to
+  // the invocation ID of the Bazel command that was completed.
   message WorkflowCommandCompletedId {
-    reserved 1;
+    // Invocation ID of the command that was completed.
+    string invocation_id = 1;
   }
 
-  // Identifier of an event indicating that a child invocation of this
-  // invocation has been invoked.
+  // Identifier of an event providing a list of commands that are
+  // run as children of this invocation.
   message ChildInvocationsConfiguredId {}
 
   // Identifier of an event providing the status of a completed child
@@ -1516,9 +1514,8 @@ message WorkflowConfigured {
   reserved 13;
 }
 
-// Event describing a workflow step that completed.
-// This differs from ChildInvocationCompleted because each step can contain
-// multiple child invocations.
+// Event describing a workflow command that completed.
+// Note: the event ID holds the invocation ID that identifies the command.
 // Next Tag: 6
 message WorkflowCommandCompleted {
   // The overall status of the command. A command was successful if and only if

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -719,14 +719,6 @@ func isWorkspaceStatusEvent(bazelBuildEvent *build_event_stream.BuildEvent) bool
 	return false
 }
 
-func isChildInvocationsConfiguredEvent(bazelBuildEvent *build_event_stream.BuildEvent) bool {
-	switch bazelBuildEvent.Payload.(type) {
-	case *build_event_stream.BuildEvent_ChildInvocationsConfigured:
-		return true
-	}
-	return false
-}
-
 func readBazelEvent(obe *pepb.OrderedBuildEvent, out *build_event_stream.BuildEvent) error {
 	switch buildEvent := obe.Event.Event.(type) {
 	case *bepb.BuildEvent_BazelEvent:
@@ -1151,11 +1143,11 @@ func (e *EventChannel) processSingleEvent(event *inpb.InvocationEvent, iid strin
 			return err
 		}
 
-		// Small optimization: For certain event types, flush the event stream
-		// immediately to show things to the user faster when fetching status
-		// of an incomplete build.
-		/// Also flush if we haven't in over a minute.
-		if shouldFlushImmediately(event.BuildEvent) || e.pw.TimeSinceLastWrite().Minutes() > 1 {
+		// Small optimization: Flush the event stream after the workspace status event. Most of the
+		// command line options and workspace info has come through by then, so we have
+		// something to show the user. Flushing the proto file here allows that when the
+		// client fetches status for the incomplete build. Also flush if we haven't in over a minute.
+		if isWorkspaceStatusEvent(event.BuildEvent) || e.pw.TimeSinceLastWrite().Minutes() > 1 {
 			if err := e.pw.Flush(e.ctx); err != nil {
 				return err
 			}
@@ -1173,16 +1165,6 @@ func (e *EventChannel) processSingleEvent(event *inpb.InvocationEvent, iid strin
 	}
 
 	return nil
-}
-
-func shouldFlushImmediately(bazelBuildEvent *build_event_stream.BuildEvent) bool {
-	// Workspace status event: Most of the command line options and workspace info
-	// has come through by then, so we have a good amount of info to show the user
-	// about the in-progress build
-	//
-	// Child invocations configured event: If a child invocation starts, flush
-	// the event stream so we can link to the child invocation in the UI
-	return isWorkspaceStatusEvent(bazelBuildEvent) || isChildInvocationsConfiguredEvent(bazelBuildEvent)
 }
 
 const apiFacetsExpiration = 1 * time.Hour


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#7061

There is a regression from https://github.com/buildbuddy-io/buildbuddy/pull/7138.

We're seeing weird behavior on certain [workflows](https://app.buildbuddy.dev/invocation/536a0418-b197-447c-b73b-14a1fc544e60) where it will link multiple redundant child invocations. I think it may be because the ci_runner execution was disrupted due to an executor restart, so we rescheduled it but we didn't clean up parent_invocation_id on the previous child invocations that were spawned

I will revert 7138 as well