### PR TITLE
Clean up parent invocation ID on children if the parent is retried

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -55,6 +55,7 @@ go_test(
         "//proto:scheduler_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/tables",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/log",

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -241,6 +241,15 @@ func (d *InvocationDB) FillCounts(ctx context.Context, stat *telpb.TelemetryStat
 	return nil
 }
 
+func (d *InvocationDB) ClearParentInvocationID(ctx context.Context, parentInvocationID string) error {
+	return d.h.NewQuery(ctx, "invocationdb_clear_parent_invocation_id").Raw(`
+		UPDATE "Invocations"
+		SET parent_invocation_id = ''
+		WHERE parent_invocation_id = ?
+	`,
+		parentInvocationID).Exec().Error
+}
+
 func (d *InvocationDB) DeleteInvocation(ctx context.Context, invocationID string) error {
 	return d.deleteInvocation(ctx, d.h, invocationID)
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -416,6 +416,7 @@ type InvocationDB interface {
 	LookupGroupIDFromInvocation(ctx context.Context, invocationID string) (string, error)
 	LookupExpiredInvocations(ctx context.Context, cutoffTime time.Time, limit int) ([]*tables.Invocation, error)
 	LookupChildInvocations(ctx context.Context, parentInvocationID string) ([]*tables.Invocation, error)
+	ClearParentInvocationID(ctx context.Context, parentInvocationID string) error
 	DeleteInvocation(ctx context.Context, invocationID string) error
 	DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *UserInfo, invocationID string) error
 	FillCounts(ctx context.Context, log *telpb.TelemetryStat) error


### PR DESCRIPTION
This refactor https://github.com/buildbuddy-io/buildbuddy/pull/7138 has the UI fetch child invocations for workflows from the DB. I noticed that [some workflows](https://app.buildbuddy.dev/invocation/536a0418-b197-447c-b73b-14a1fc544e60?role=CI_RUNNER) have duplicate child invocations. I think this is happening because the original ci_runner execution was retried due to an executor restart, but the UI is still fetching children from earlier attempts

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
