### PR TITLE
Handle podman SIGKILL / SIGTERM in Run() path

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -409,11 +409,11 @@ func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command,
 		log.CtxInfof(ctx, "podman failed to run command")
 	} else if result.ExitCode == podmanCommandNotFoundExitCode {
 		log.CtxInfof(ctx, "podman failed to find command")
-	} else if res.ExitCode == podmanExecSIGKILLExitCode {
+	} else if result.ExitCode == podmanExecSIGKILLExitCode {
 		log.CtxInfof(ctx, "podman receieved SIGKILL")
 		result.ExitCode = commandutil.KilledExitCode
-		result.Error = commandutil.ErrSIGKILL	
-	} else if res.ExitCode == podmanExecSIGTERMExitCode {
+		result.Error = commandutil.ErrSIGKILL
+	} else if result.ExitCode == podmanExecSIGTERMExitCode {
 		log.CtxInfof(ctx, "podman receieved SIGTERM")
 		result.ExitCode = commandutil.KilledExitCode
 		result.Error = commandutil.ErrSIGKILL

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -409,6 +409,14 @@ func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command,
 		log.CtxInfof(ctx, "podman failed to run command")
 	} else if result.ExitCode == podmanCommandNotFoundExitCode {
 		log.CtxInfof(ctx, "podman failed to find command")
+	} else if res.ExitCode == podmanExecSIGKILLExitCode {
+		log.CtxInfof(ctx, "podman receieved SIGKILL")
+		result.ExitCode = commandutil.KilledExitCode
+		result.Error = commandutil.ErrSIGKILL	
+	} else if res.ExitCode == podmanExecSIGTERMExitCode {
+		log.CtxInfof(ctx, "podman receieved SIGTERM")
+		result.ExitCode = commandutil.KilledExitCode
+		result.Error = commandutil.ErrSIGKILL
 	}
 
 	if err := c.maybeCleanupCorruptedImages(ctx, result); err != nil {


### PR DESCRIPTION
In https://github.com/buildbuddy-io/buildbuddy/pull/7261/files we added this for the `Exec()` path. This PR adds it to the `Run()` path as well. 