### PR TITLE
Reduce cardinality of PSI metrics

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -453,10 +453,6 @@ func observeStageDuration(groupID string, stage string, start *timestamppb.Times
 func observePSI(resourceLabel string, psi *repb.PSI) {
 	metrics.RemoteExecutionTaskPressureStallDurationUsec.With(prometheus.Labels{
 		metrics.PSIResourceLabel:  resourceLabel,
-		metrics.PSIStallTypeLabel: "some",
-	}).Observe(float64(psi.GetSome().GetTotal()))
-	metrics.RemoteExecutionTaskPressureStallDurationUsec.With(prometheus.Labels{
-		metrics.PSIResourceLabel:  resourceLabel,
 		metrics.PSIStallTypeLabel: "full",
 	}).Observe(float64(psi.GetFull().GetTotal()))
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -825,7 +825,7 @@ var (
 		Subsystem: "remote_execution",
 		Name:      "task_pressure_stall_duration_usec",
 		Help:      "Linux PSI metrics for each executed action, in **microseconds**.",
-		Buckets:   durationUsecBuckets(1*time.Microsecond, 10*time.Minute, 1.2),
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*time.Minute, 2),
 	}, []string{
 		PSIResourceLabel,
 		PSIStallTypeLabel,


### PR DESCRIPTION
The high cardinality of this metric seems to be hurting scrape performance.

**Related issues**: N/A
