### PR TITLE
Revert "[ci_runner] Fetch child invocations from the db instead of BES events"

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -97,8 +97,7 @@ ts_library(
     deps = [
         "//app/components/link",
         "//app/format",
-        "//proto:invocation_status_ts_proto",
-        "//proto:invocation_ts_proto",
+        "//proto:build_event_stream_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
@@ -110,7 +109,8 @@ ts_library(
     srcs = ["child_invocations.tsx"],
     deps = [
         "//app/invocation:child_invocation_card",
-        "//proto:invocation_ts_proto",
+        "//app/invocation:invocation_model",
+        "//app/util:proto",
         "@npm//@types/react",
         "@npm//react",
     ],

--- a/app/invocation/child_invocation_card.tsx
+++ b/app/invocation/child_invocation_card.tsx
@@ -1,49 +1,40 @@
 import React from "react";
 import format from "../format/format";
-import { invocation } from "../../proto/invocation_ts_proto";
-import { CheckCircle, PlayCircle, XCircle, CircleSlash } from "lucide-react";
+import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
+import { CheckCircle, PlayCircle, XCircle, CircleSlash, Timer } from "lucide-react";
 import Link from "../components/link/link";
-import { invocation_status } from "../../proto/invocation_status_ts_proto";
 
-type CommandStatus = "failed" | "succeeded" | "in-progress" | "not-run";
+export type CommandStatus = "failed" | "succeeded" | "in-progress" | "queued" | "not-run";
+
+export type BazelCommandResult = {
+  status: CommandStatus;
+  invocation: InvocationMetadata;
+  durationMillis?: number;
+};
+
+export type InvocationMetadata =
+  | build_event_stream.WorkflowConfigured.IInvocationMetadata
+  | build_event_stream.ChildInvocationsConfigured.IInvocationMetadata;
 
 export type ChildInvocationCardProps = {
-  invocation: invocation.Invocation;
+  result: BazelCommandResult;
 };
 
 export default class ChildInvocationCard extends React.Component<ChildInvocationCardProps> {
-  private getStatus(): CommandStatus {
-    const inv = this.props.invocation;
-    switch (inv.invocationStatus) {
-      case invocation_status.InvocationStatus.COMPLETE_INVOCATION_STATUS:
-      case invocation_status.InvocationStatus.DISCONNECTED_INVOCATION_STATUS:
-        return inv.bazelExitCode == "SUCCESS" ? "succeeded" : "failed";
-      case invocation_status.InvocationStatus.PARTIAL_INVOCATION_STATUS:
-        return "in-progress";
-      default:
-        return "not-run";
-    }
+  private isClickable() {
+    return this.props.result.status !== "queued" && this.props.result.status !== "not-run";
   }
 
-  private isClickable(status: CommandStatus): boolean {
-    return status !== "not-run";
-  }
-
-  private getDurationLabel(status: CommandStatus): string {
-    if (status == "failed" || status == "succeeded") {
-      return format.durationUsec(this.props.invocation.durationUsec);
-    }
-    return "";
-  }
-
-  private renderStatusIcon(status: CommandStatus) {
-    switch (status) {
+  private renderStatusIcon() {
+    switch (this.props.result.status) {
       case "succeeded":
         return <CheckCircle className="icon" />;
       case "failed":
         return <XCircle className="icon" />;
       case "in-progress":
         return <PlayCircle className="icon" />;
+      case "queued":
+        return <Timer className="icon" />;
       case "not-run":
         return <CircleSlash className="icon" />;
       default:
@@ -53,16 +44,15 @@ export default class ChildInvocationCard extends React.Component<ChildInvocation
   }
 
   render() {
-    const status = this.getStatus();
-    const inv = this.props.invocation;
-    const command = `${inv.command} ${inv.pattern.join(" ")}`;
     return (
       <Link
-        className={`child-invocation-card status-${status} ${this.isClickable(status) ? "clickable" : ""}`}
-        href={this.isClickable(status) ? `/invocation/${this.props.invocation.invocationId}` : undefined}>
-        <div className="icon-container">{this.renderStatusIcon(status)}</div>
-        <div className="command">{command}</div>
-        <div className="duration">{this.getDurationLabel(status)}</div>
+        className={`child-invocation-card status-${this.props.result.status} ${this.isClickable() ? "clickable" : ""}`}
+        href={this.isClickable() ? `/invocation/${this.props.result.invocation.invocationId}` : undefined}>
+        <div className="icon-container">{this.renderStatusIcon()}</div>
+        <div className="command">{this.props.result.invocation.bazelCommand}</div>
+        <div className="duration">
+          {this.props.result.durationMillis !== undefined && format.durationMillis(this.props.result.durationMillis)}
+        </div>
       </Link>
     );
   }

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -60,13 +60,6 @@ interface State {
   runnerExecution?: execution_stats.Execution;
   runnerLastExecuteOperation?: ExecuteOperation;
 
-  /*
-   * We only need to update the child invocation cards right when they've started and ended.
-   * Memoize them on the client, so we don't need to keep fetching them from the
-   * db in the meantime.
-   */
-  childInvocations: invocation.Invocation[];
-
   keyboardShortcutHandle: string;
 }
 
@@ -87,7 +80,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
     inProgress: false,
     error: null,
     keyboardShortcutHandle: "",
-    childInvocations: [],
   };
 
   private timeoutRef: number = 0;
@@ -95,9 +87,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
   private logsSubscription?: Subscription;
   private modelChangedSubscription?: Subscription;
   private runnerExecutionRPC?: CancelablePromise;
-
-  private seenChildInvocationConfiguredIds = new Set<string>();
-  private seenChildInvocationCompletedIds = new Set<string>();
 
   componentWillMount() {
     document.title = `Invocation ${this.props.invocationId} | BuildBuddy`;
@@ -200,11 +189,9 @@ export default class InvocationComponent extends React.Component<Props, State> {
       this.fetchRunnerExecution();
     }
 
-    const fetchChildren = this.shouldFetchChildren(this.state.model);
     let request = new invocation.GetInvocationRequest();
     request.lookup = new invocation.InvocationLookup();
     request.lookup.invocationId = this.props.invocationId;
-    request.lookup.fetchChildInvocations = fetchChildren;
     rpcService.service
       .getInvocation(request)
       .then((response: invocation.GetInvocationResponse) => {
@@ -212,17 +199,13 @@ export default class InvocationComponent extends React.Component<Props, State> {
         if (!response.invocation || response.invocation.length === 0) {
           throw new BuildBuddyError("NotFound", "Invocation not found.");
         }
-        const inv = response.invocation[0];
-        const model = new InvocationModel(inv);
+        const model = new InvocationModel(response.invocation[0]);
         // Only show the in-progress screen if we don't have any events yet.
-        const showInProgressScreen = model.isInProgress() && !inv.event?.length;
-        // Only update the child invocations if we've fetched new updates.
-        const childInvocations = fetchChildren ? inv.childInvocations : this.state.childInvocations;
+        const showInProgressScreen = model.isInProgress() && !response.invocation[0].event?.length;
         this.setState({
           inProgress: showInProgressScreen,
           model: model,
           error: null,
-          childInvocations: childInvocations,
         });
       })
       .catch((error: any) => {
@@ -230,30 +213,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
         this.setState({ error: BuildBuddyError.parse(error) });
       })
       .finally(() => this.setState({ loading: false }));
-  }
-
-  shouldFetchChildren(model: InvocationModel | undefined): boolean {
-    if (!model) return true;
-    const childInvocationConfiguredEvents = model.childInvocationsConfigured;
-    let shouldFetch = false;
-
-    for (const event of childInvocationConfiguredEvents) {
-      for (let inv of event.invocation) {
-        if (!this.seenChildInvocationConfiguredIds.has(inv.invocationId)) {
-          this.seenChildInvocationConfiguredIds.add(inv.invocationId);
-          shouldFetch = true;
-        }
-      }
-    }
-
-    for (const iid of model.childInvocationCompletedByInvocationId.keys()) {
-      if (!this.seenChildInvocationCompletedIds.has(iid)) {
-        this.seenChildInvocationCompletedIds.add(iid);
-        shouldFetch = true;
-      }
-    }
-
-    return shouldFetch;
   }
 
   scheduleRefetch() {
@@ -504,7 +463,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
           )}
           {!isBazelInvocation && (
             <div className="container">
-              <ChildInvocations childInvocations={this.state.childInvocations} />
+              <ChildInvocations model={this.state.model} />
             </div>
           )}
         </div>


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#7138

There is a regression from https://github.com/buildbuddy-io/buildbuddy/pull/7138.

We're seeing weird behavior on certain [workflows](https://app.buildbuddy.dev/invocation/536a0418-b197-447c-b73b-14a1fc544e60) where it will link multiple redundant child invocations. I think it may be because the ci_runner execution was disrupted due to an executor restart, so we rescheduled it but we didn't clean up parent_invocation_id on the previous child invocations that were spawned