### PR TITLE
upgrade go-sqlite3 to 1.14.22

### DIFF
--- a/buildpatches/com_github_mattn_go_sqlite3.patch
+++ b/buildpatches/com_github_mattn_go_sqlite3.patch
@@ -1,37 +1,11 @@
-From 7639b60b4d2cb4c62b1c39ed8ff424fa0917cec7 Mon Sep 17 00:00:00 2001
-From: Zoey Greer <zoey@buildbuddy.io>
-Date: Fri, 13 Oct 2023 10:53:13 -0400
-Subject: [PATCH] patch
-
----
- BUILD.bazel | 1 +
- sqlite3.go  | 1 +
- 2 files changed, 2 insertions(+)
-
 diff --git a/BUILD.bazel b/BUILD.bazel
-index fa95473..b8e3848 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -90,6 +90,7 @@ go_library(
+@@ -90,5 +90,6 @@ go_library(
              "-I.",
          ],
          "@io_bazel_rules_go//go/platform:linux": [
 +            "-D_LARGEFILE64_SOURCE",
-             "-DHAVE_PREAD64=1 -DHAVE_PWRITE64=1",
              "-I.",
          ],
-diff --git a/sqlite3.go b/sqlite3.go
-index 5e4e2ff..d87bd31 100644
---- a/sqlite3.go
-+++ b/sqlite3.go
-@@ -21,6 +21,7 @@ package sqlite3
- #cgo CFLAGS: -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1
- #cgo CFLAGS: -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT
- #cgo CFLAGS: -Wno-deprecated-declarations
-+#cgo linux,!android CFLAGS: -D_LARGEFILE64_SOURCE
- #cgo linux,!android CFLAGS: -DHAVE_PREAD64=1 -DHAVE_PWRITE64=1
- #cgo openbsd CFLAGS: -I/usr/local/include
- #cgo openbsd LDFLAGS: -L/usr/local/lib
--- 
-2.30.2
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -3534,8 +3534,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         importpath = "github.com/mattn/go-sqlite3",
         patch_args = ["-p1"],
         patches = ["@{}//buildpatches:com_github_mattn_go_sqlite3.patch".format(workspace_name)],
-        sum = "h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=",
-        version = "v1.14.17",
+        sum = "h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=",
+        version = "v1.14.22",
     )
     go_repository(
         name = "com_github_matttproud_golang_protobuf_extensions",

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/mattn/go-sqlite3 v1.14.17
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/mdlayher/vsock v1.2.1
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9

--- a/go.sum
+++ b/go.sum
@@ -1915,8 +1915,8 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
-github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=


### PR DESCRIPTION
Reduced the patch to minimally needed for building and maintenance.
