### PR TITLE
integration/bep: bump test shard to 6

### DIFF
--- a/server/test/integration/build_event_protocol/BUILD
+++ b/server/test/integration/build_event_protocol/BUILD
@@ -4,7 +4,7 @@ go_test(
     name = "build_event_protocol_test",
     size = "small",
     srcs = ["build_event_protocol_test.go"],
-    shard_count = 5,
+    shard_count = 6,
     deps = [
         "//proto:build_event_stream_go_proto",
         "//proto:build_events_go_proto",


### PR DESCRIPTION
We have 6 tests funcs under the target.
Let's try running each one in a separate shard to avoid any concurrency
issue.
