### PR TITLE
Fix owner/repo linking

### DIFF
--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -291,6 +291,7 @@ func (css *codesearchServer) Search(ctx context.Context, req *srpb.SearchRequest
 		}
 
 		result := &srpb.Result{
+			Owner:       string(doc.Field(ownerField).Contents()),
 			Repo:       string(doc.Field(repoField).Contents()),
 			Filename:   string(doc.Field(filenameField).Contents()),
 			MatchCount: int32(len(dedupedRegions)),

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -291,7 +291,7 @@ func (css *codesearchServer) Search(ctx context.Context, req *srpb.SearchRequest
 		}
 
 		result := &srpb.Result{
-			Owner:       string(doc.Field(ownerField).Contents()),
+			Owner:      string(doc.Field(ownerField).Contents()),
 			Repo:       string(doc.Field(repoField).Contents()),
 			Filename:   string(doc.Field(filenameField).Contents()),
 			MatchCount: int32(len(dedupedRegions)),

--- a/enterprise/app/codesearch/result.tsx
+++ b/enterprise/app/codesearch/result.tsx
@@ -11,7 +11,7 @@ interface SnippetProps {
 
 class SnippetComponent extends React.Component<SnippetProps> {
   getFileAndLineURL(lineNumber: number) {
-    let ownerRepo = this.props.result.repo;
+    let ownerRepo = this.props.result.owner + "/" + this.props.result.repo;
     let filename = this.props.result.filename;
     let parsedQuery = this.props.highlight.source;
     let sha = this.props.result.sha;

--- a/proto/search.proto
+++ b/proto/search.proto
@@ -13,8 +13,11 @@ message Snippet {
   string lines = 1;
 }
 
-// Next tag: 6
+// Next tag: 7
 message Result {
+  // The repository this result came from.
+  string owner = 6;
+
   // The repository this result came from.
   string repo = 1;
 


### PR DESCRIPTION
Return owner + repo in search results, and use both when constructing the link to the code editor.