### PR TITLE
Enable guest cgroup2 flag by default

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -82,7 +82,7 @@ var workspaceDiskSlackSpaceMB = flag.Int64("executor.firecracker_workspace_disk_
 var healthCheckInterval = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
 var healthCheckTimeout = flag.Duration("executor.firecracker_health_check_timeout", 30*time.Second, "Timeout for VM health check requests.")
 var overprivisionCPUs = flag.Int("executor.firecracker_overprivision_cpus", 3, "Number of CPUs to overprovision for VMs. This allows VMs to more effectively utilize CPU resources on the host machine.")
-var cgroupV2Only = flag.Bool("executor.firecracker_guest_cgroup_v2_only", false, "If true, mount cgroup v2 directly to /sys/fs/cgroup in the guest, instead of a hybrid v1+v2 setup.")
+var cgroupV2Only = flag.Bool("executor.firecracker_guest_cgroup_v2_only", true, "If true, mount cgroup v2 directly to /sys/fs/cgroup in the guest, instead of a hybrid v1+v2 setup.")
 
 var forceRemoteSnapshotting = flag.Bool("debug_force_remote_snapshots", false, "When remote snapshotting is enabled, force remote snapshotting even for tasks which otherwise wouldn't support it.")
 var disableWorkspaceSync = flag.Bool("debug_disable_firecracker_workspace_sync", false, "Do not sync the action workspace to the guest, instead using the existing workspace from the VM snapshot.")


### PR DESCRIPTION
We've had this enabled in prod for a while now.

**Related issues**: N/A
