### PR TITLE
Fetch child invocations by run ID to account for retries

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -97,7 +97,8 @@ ts_library(
     deps = [
         "//app/components/link",
         "//app/format",
-        "//proto:build_event_stream_ts_proto",
+        "//proto:invocation_status_ts_proto",
+        "//proto:invocation_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
@@ -109,8 +110,7 @@ ts_library(
     srcs = ["child_invocations.tsx"],
     deps = [
         "//app/invocation:child_invocation_card",
-        "//app/invocation:invocation_model",
-        "//app/util:proto",
+        "//proto:invocation_ts_proto",
         "@npm//@types/react",
         "@npm//react",
     ],

--- a/app/invocation/child_invocations.tsx
+++ b/app/invocation/child_invocations.tsx
@@ -1,61 +1,22 @@
 import React from "react";
-import InvocationModel from "./invocation_model";
-import ChildInvocationCard, { CommandStatus, InvocationMetadata } from "./child_invocation_card";
-import { BazelCommandResult } from "./child_invocation_card";
-import { durationToMillisWithFallback } from "../util/proto";
+import ChildInvocationCard from "./child_invocation_card";
+import { invocation } from "../../proto/invocation_ts_proto";
 
 export type ChildInvocationProps = {
-  model: InvocationModel;
+  childInvocations: invocation.Invocation[];
 };
 
 export default class ChildInvocations extends React.Component<ChildInvocationProps> {
-  private getDurationMillis(invocation: InvocationMetadata): number | undefined {
-    const completedEvent = this.props.model.childInvocationCompletedByInvocationId.get(invocation.invocationId ?? "");
-    if (!completedEvent) return undefined;
-    return durationToMillisWithFallback(completedEvent.duration, +(completedEvent?.durationMillis ?? 0));
-  }
-
   render() {
-    const childInvocationConfiguredEvents = this.props.model.childInvocationsConfigured;
-    let invocations = [];
-    for (let i = 0; i < childInvocationConfiguredEvents.length; i++) {
-      const event = childInvocationConfiguredEvents[i];
-      for (let inv of event.invocation) {
-        invocations.push(inv);
-      }
-    }
-
-    const results: BazelCommandResult[] = [];
-    let inProgressCount = 0;
-    const getStatus = (invocation: InvocationMetadata): CommandStatus => {
-      const completedEvent = this.props.model.childInvocationCompletedByInvocationId.get(invocation.invocationId ?? "");
-      if (completedEvent) {
-        return completedEvent.exitCode === 0 ? "succeeded" : "failed";
-      } else if (this.props.model.finished) {
-        return "not-run";
-      } else if (inProgressCount === 0) {
-        // Only one command should be marked in progress; the rest should be
-        // marked queued.
-        inProgressCount++;
-        return "in-progress";
-      } else {
-        return "queued";
-      }
-    };
-
-    for (const invocation of invocations) {
-      results.push({ invocation, status: getStatus(invocation), durationMillis: this.getDurationMillis(invocation) });
-    }
-
-    if (!results.length) return null;
+    if (!this.props.childInvocations.length) return null;
 
     return (
       <div className="child-invocations-section">
         <h2>Bazel commands</h2>
         <div className="subtitle">Click a command to see results.</div>
         <div className="child-invocations-list">
-          {results.map((result) => (
-            <ChildInvocationCard key={result.invocation.invocationId} result={result} />
+          {this.props.childInvocations.map((result) => (
+            <ChildInvocationCard key={result.invocationId} invocation={result} />
           ))}
         </div>
       </div>

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -60,6 +60,13 @@ interface State {
   runnerExecution?: execution_stats.Execution;
   runnerLastExecuteOperation?: ExecuteOperation;
 
+  /*
+   * We only need to update the child invocation cards right when they've started and ended.
+   * Memoize them on the client, so we don't need to keep fetching them from the
+   * db in the meantime.
+   */
+  childInvocations: invocation.Invocation[];
+
   keyboardShortcutHandle: string;
 }
 
@@ -80,6 +87,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
     inProgress: false,
     error: null,
     keyboardShortcutHandle: "",
+    childInvocations: [],
   };
 
   private timeoutRef: number = 0;
@@ -87,6 +95,9 @@ export default class InvocationComponent extends React.Component<Props, State> {
   private logsSubscription?: Subscription;
   private modelChangedSubscription?: Subscription;
   private runnerExecutionRPC?: CancelablePromise;
+
+  private seenChildInvocationConfiguredIds = new Set<string>();
+  private seenChildInvocationCompletedIds = new Set<string>();
 
   componentWillMount() {
     document.title = `Invocation ${this.props.invocationId} | BuildBuddy`;
@@ -189,9 +200,11 @@ export default class InvocationComponent extends React.Component<Props, State> {
       this.fetchRunnerExecution();
     }
 
+    const fetchChildren = this.shouldFetchChildren(this.state.model);
     let request = new invocation.GetInvocationRequest();
     request.lookup = new invocation.InvocationLookup();
     request.lookup.invocationId = this.props.invocationId;
+    request.lookup.fetchChildInvocations = fetchChildren;
     rpcService.service
       .getInvocation(request)
       .then((response: invocation.GetInvocationResponse) => {
@@ -199,13 +212,17 @@ export default class InvocationComponent extends React.Component<Props, State> {
         if (!response.invocation || response.invocation.length === 0) {
           throw new BuildBuddyError("NotFound", "Invocation not found.");
         }
-        const model = new InvocationModel(response.invocation[0]);
+        const inv = response.invocation[0];
+        const model = new InvocationModel(inv);
         // Only show the in-progress screen if we don't have any events yet.
-        const showInProgressScreen = model.isInProgress() && !response.invocation[0].event?.length;
+        const showInProgressScreen = model.isInProgress() && !inv.event?.length;
+        // Only update the child invocations if we've fetched new updates.
+        const childInvocations = fetchChildren ? inv.childInvocations : this.state.childInvocations;
         this.setState({
           inProgress: showInProgressScreen,
           model: model,
           error: null,
+          childInvocations: childInvocations,
         });
       })
       .catch((error: any) => {
@@ -213,6 +230,30 @@ export default class InvocationComponent extends React.Component<Props, State> {
         this.setState({ error: BuildBuddyError.parse(error) });
       })
       .finally(() => this.setState({ loading: false }));
+  }
+
+  shouldFetchChildren(model: InvocationModel | undefined): boolean {
+    if (!model) return true;
+    const childInvocationConfiguredEvents = model.childInvocationsConfigured;
+    let shouldFetch = false;
+
+    for (const event of childInvocationConfiguredEvents) {
+      for (let inv of event.invocation) {
+        if (!this.seenChildInvocationConfiguredIds.has(inv.invocationId)) {
+          this.seenChildInvocationConfiguredIds.add(inv.invocationId);
+          shouldFetch = true;
+        }
+      }
+    }
+
+    for (const iid of model.childInvocationCompletedByInvocationId.keys()) {
+      if (!this.seenChildInvocationCompletedIds.has(iid)) {
+        this.seenChildInvocationCompletedIds.add(iid);
+        shouldFetch = true;
+      }
+    }
+
+    return shouldFetch;
   }
 
   scheduleRefetch() {
@@ -463,7 +504,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
           )}
           {!isBazelInvocation && (
             <div className="container">
-              <ChildInvocations model={this.state.model} />
+              <ChildInvocations childInvocations={this.state.childInvocations} />
             </div>
           )}
         </div>

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -224,6 +224,12 @@ export default class InvocationComponent extends React.Component<Props, State> {
           error: null,
           childInvocations: childInvocations,
         });
+
+        if (fetchChildren) {
+          for (let child of childInvocations) {
+            this.seenChildInvocationConfiguredIds.add(child.invocationId);
+          }
+        }
       })
       .catch((error: any) => {
         console.error("Failed to fetch invocation:", error);
@@ -240,7 +246,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
     for (const event of childInvocationConfiguredEvents) {
       for (let inv of event.invocation) {
         if (!this.seenChildInvocationConfiguredIds.has(inv.invocationId)) {
-          this.seenChildInvocationConfiguredIds.add(inv.invocationId);
           shouldFetch = true;
         }
       }

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -51,10 +51,7 @@ export default class InvocationModel {
   failedAction?: build_event_stream.BuildEvent;
   workflowConfigured?: build_event_stream.WorkflowConfigured;
   childInvocationsConfigured: build_event_stream.ChildInvocationsConfigured[] = [];
-  childInvocationCompletedByInvocationId = new Map<
-    string,
-    build_event_stream.IChildInvocationCompleted | build_event_stream.IWorkflowCommandCompleted
-  >();
+  childInvocationCompletedByInvocationId = new Map<string, build_event_stream.IChildInvocationCompleted>();
   workspaceStatus?: build_event_stream.WorkspaceStatus;
   configuration?: build_event_stream.Configuration;
   workspaceConfig?: build_event_stream.WorkspaceConfig;
@@ -143,12 +140,6 @@ export default class InvocationModel {
       if (buildEvent.childInvocationsConfigured) {
         this.childInvocationsConfigured.push(
           buildEvent.childInvocationsConfigured as build_event_stream.ChildInvocationsConfigured
-        );
-      }
-      if (buildEvent.workflowCommandCompleted && buildEvent.id?.workflowCommandCompleted?.invocationId) {
-        this.childInvocationCompletedByInvocationId.set(
-          buildEvent.id.workflowCommandCompleted.invocationId,
-          buildEvent.workflowCommandCompleted
         );
       }
       if (buildEvent.childInvocationCompleted && buildEvent.id?.childInvocationCompleted?.invocationId) {

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:eventlog_go_proto",
+        "//proto:execution_stats_go_proto",
         "//proto:git_go_proto",
         "//proto:invocation_go_proto",
         "//proto:remote_execution_go_proto",
@@ -39,6 +40,7 @@ go_library(
         "@com_github_go_git_go_git_v5//plumbing",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_x_sync//errgroup",
         "@org_golang_x_sys//unix",
     ],
 )

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -952,11 +952,6 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		return status.WrapError(err, "failed to get action to run")
 	}
 
-	cic := &bespb.ChildInvocationsConfigured{}
-	cicEvent := &bespb.BuildEvent{
-		Id:      &bespb.BuildEventId{Id: &bespb.BuildEventId_ChildInvocationsConfigured{ChildInvocationsConfigured: &bespb.BuildEventId_ChildInvocationsConfiguredId{}}},
-		Payload: &bespb.BuildEvent_ChildInvocationsConfigured{ChildInvocationsConfigured: cic},
-	}
 	// If the triggering commit merges cleanly with the target branch, the runner
 	// will execute the configured bazel commands. Otherwise, the runner will
 	// exit early without running those commands and does not need to create
@@ -976,19 +971,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 					InvocationId: iid,
 				}},
 			})
-			cic.Invocation = append(cic.Invocation, &bespb.ChildInvocationsConfigured_InvocationMetadata{
-				InvocationId: iid,
-				BazelCommand: bazelCmd,
-			})
-			cicEvent.Children = append(cicEvent.Children, &bespb.BuildEventId{
-				Id: &bespb.BuildEventId_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{
-					InvocationId: iid,
-				}},
-			})
 		}
-	}
-	if err := ar.reporter.Publish(cicEvent); err != nil {
-		return nil
 	}
 
 	if !publishedWorkspaceStatus {
@@ -1090,6 +1073,34 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 	for i, bazelCmd := range action.BazelCommands {
 		cmdStartTime := time.Now()
 
+		if i >= len(wfc.GetInvocation()) {
+			return status.InternalErrorf("No invocation metadata generated for bazel_commands[%d]; this should never happen", i)
+		}
+		iid := wfc.GetInvocation()[i].GetInvocationId()
+
+		cic := &bespb.ChildInvocationsConfigured{
+			Invocation: []*bespb.ChildInvocationsConfigured_InvocationMetadata{
+				{
+					InvocationId: iid,
+					BazelCommand: bazelCmd,
+				},
+			},
+		}
+		cicEvent := &bespb.BuildEvent{
+			Id:      &bespb.BuildEventId{Id: &bespb.BuildEventId_ChildInvocationsConfigured{ChildInvocationsConfigured: &bespb.BuildEventId_ChildInvocationsConfiguredId{}}},
+			Payload: &bespb.BuildEvent_ChildInvocationsConfigured{ChildInvocationsConfigured: cic},
+			Children: []*bespb.BuildEventId{
+				{
+					Id: &bespb.BuildEventId_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{
+						InvocationId: iid,
+					}},
+				},
+			},
+		}
+		if err := ar.reporter.Publish(cicEvent); err != nil {
+			return nil
+		}
+
 		// Publish a TargetConfigured event associated with the bazel command so
 		// that we can render artifacts associated with the "target".
 		targetLabel := fmt.Sprintf("bazel_commands[%d]", i)
@@ -1102,15 +1113,10 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			Payload: &bespb.BuildEvent_Configured{Configured: &bespb.TargetConfigured{}},
 		})
 
-		if i >= len(wfc.GetInvocation()) {
-			return status.InternalErrorf("No invocation metadata generated for bazel_commands[%d]; this should never happen", i)
-		}
-
 		if err := provisionArtifactsDir(ws, i); err != nil {
 			return err
 		}
 
-		iid := wfc.GetInvocation()[i].GetInvocationId()
 		args, err := ws.bazelArgsWithCustomBazelrc(bazelCmd)
 		if err != nil {
 			return status.InvalidArgumentErrorf("failed to parse bazel command: %s", err)

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -193,6 +193,7 @@ var (
 	fallbackToCleanCheckout = flag.Bool("fallback_to_clean_checkout", true, "Fallback to cloning the repo from scratch if sync fails (for testing purposes only).")
 
 	shellCharsRequiringQuote = regexp.MustCompile(`[^\w@%+=:,./-]`)
+	invocationIDRegex        = regexp.MustCompile(`Streaming build results to:\s+.*?/invocation/([a-f0-9-]+)`)
 )
 
 type workspace struct {
@@ -281,6 +282,9 @@ type buildEventReporter struct {
 	startTime             time.Time
 	cancelBackgroundFlush func()
 
+	// Child invocations detected by scanning the build logs
+	childInvocations map[string]struct{}
+
 	mu            sync.Mutex // protects(progressCount)
 	progressCount int32
 }
@@ -310,7 +314,7 @@ func newBuildEventReporter(ctx context.Context, besBackend string, apiKey string
 		uploader = ul
 	}
 
-	return &buildEventReporter{apiKey: apiKey, bep: bep, uploader: uploader, log: newInvocationLog(), invocationID: iid, isWorkflow: isWorkflow}, nil
+	return &buildEventReporter{apiKey: apiKey, bep: bep, uploader: uploader, log: newInvocationLog(), invocationID: iid, isWorkflow: isWorkflow, childInvocations: map[string]struct{}{}}, nil
 }
 
 func (r *buildEventReporter) InvocationID() string {
@@ -428,12 +432,14 @@ func (r *buildEventReporter) Start(startTime time.Time) error {
 		return err
 	}
 
-	// Flush whenever the log buffer fills past a certain threshold.
-	r.log.writeListener = func() {
+	r.log.writeListener = func(b []byte) {
+		r.emitBuildEventsForBazelCommands(b)
+		// Flush whenever the log buffer fills past a certain threshold.
 		if size := r.log.Len(); size >= progressFlushThresholdBytes {
 			r.FlushProgress() // ignore error; it will surface in `bep.Finish()`
 		}
 	}
+
 	stopFlushingProgress := r.startBackgroundProgressFlush()
 	r.cancelBackgroundFlush = stopFlushingProgress
 	return nil
@@ -541,6 +547,65 @@ func (r *buildEventReporter) startBackgroundProgressFlush() func() {
 	}()
 	return func() {
 		stop <- struct{}{}
+	}
+}
+
+// emitBuildEventsForBazelCommands scans command output logs for bazel invocations
+// in order to emit bazel build events.
+//
+// Event publishing errors will be surfaced in the caller func when calling
+// `buildEventPublisher.Finish()`
+//
+// TODO: Emit TargetConfigured and TargetCompleted events to render artifacts
+// for each command
+func (r *buildEventReporter) emitBuildEventsForBazelCommands(b []byte) {
+	output := string(b)
+
+	// Check whether a bazel invocation was invoked
+	iidMatches := invocationIDRegex.FindAllStringSubmatch(output, -1)
+	for _, m := range iidMatches {
+		iid := m[1]
+		_, childStarted := r.childInvocations[iid]
+
+		var buildEvent *bespb.BuildEvent
+		if childStarted {
+			// The `Streaming build results to` log line is printed at the start and
+			// end of a bazel build. If we've already seen it for this invocation,
+			// we know the build has finished.
+			buildEvent = &bespb.BuildEvent{
+				Id: &bespb.BuildEventId{
+					Id: &bespb.BuildEventId_ChildInvocationCompleted{
+						ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{InvocationId: iid},
+					},
+				},
+				Payload: &bespb.BuildEvent_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.ChildInvocationCompleted{}},
+			}
+		} else {
+			r.childInvocations[iid] = struct{}{}
+
+			cic := &bespb.ChildInvocationsConfigured{
+				Invocation: []*bespb.ChildInvocationsConfigured_InvocationMetadata{
+					{
+						InvocationId: iid,
+					},
+				},
+			}
+			buildEvent = &bespb.BuildEvent{
+				Id:      &bespb.BuildEventId{Id: &bespb.BuildEventId_ChildInvocationsConfigured{ChildInvocationsConfigured: &bespb.BuildEventId_ChildInvocationsConfiguredId{}}},
+				Payload: &bespb.BuildEvent_ChildInvocationsConfigured{ChildInvocationsConfigured: cic},
+				Children: []*bespb.BuildEventId{
+					{
+						Id: &bespb.BuildEventId_ChildInvocationCompleted{
+							ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{InvocationId: iid},
+						},
+					},
+				},
+			}
+		}
+
+		if err := r.Publish(buildEvent); err != nil {
+			continue
+		}
 	}
 }
 
@@ -839,18 +904,18 @@ func (r *buildEventReporter) Printf(format string, vals ...interface{}) {
 type invocationLog struct {
 	lockingbuffer.LockingBuffer
 	writer        io.Writer
-	writeListener func()
+	writeListener func(b []byte)
 }
 
 func newInvocationLog() *invocationLog {
-	invLog := &invocationLog{writeListener: func() {}}
+	invLog := &invocationLog{writeListener: func(b []byte) {}}
 	invLog.writer = io.MultiWriter(&invLog.LockingBuffer, os.Stderr)
 	return invLog
 }
 
 func (invLog *invocationLog) Write(b []byte) (int, error) {
+	invLog.writeListener(b)
 	n, err := invLog.writer.Write(b)
-	invLog.writeListener()
 	return n, err
 }
 
@@ -967,9 +1032,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 				BazelCommand: bazelCmd,
 			})
 			wfcEvent.Children = append(wfcEvent.Children, &bespb.BuildEventId{
-				Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{
-					InvocationId: iid,
-				}},
+				Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{}},
 			})
 		}
 	}
@@ -1009,6 +1072,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 
 	// TODO(Maggie): Emit BES events for each bazel command
 	for i, step := range action.Steps {
+		cmdStartTime := time.Now()
 		if err := provisionArtifactsDir(ws, i); err != nil {
 			return err
 		}
@@ -1064,6 +1128,21 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			uploader.UploadDirectory(namedSetID, artifactsDir) // does not return an error
 		}
 
+		duration := time.Since(cmdStartTime)
+		completedEvent := &bespb.BuildEvent{
+			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_WorkflowCommandCompleted{
+				WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{},
+			}},
+			Payload: &bespb.BuildEvent_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.WorkflowCommandCompleted{
+				ExitCode:  int32(exitCode),
+				StartTime: timestamppb.New(cmdStartTime),
+				Duration:  durationpb.New(duration),
+			}},
+		}
+		if err := ar.reporter.Publish(completedEvent); err != nil {
+			break
+		}
+
 		if exitCode != 0 {
 			return runErr
 		}
@@ -1072,34 +1151,10 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 	// TODO(Maggie): Consolidate action.BazelCommands with action.Steps
 	for i, bazelCmd := range action.BazelCommands {
 		cmdStartTime := time.Now()
-
 		if i >= len(wfc.GetInvocation()) {
 			return status.InternalErrorf("No invocation metadata generated for bazel_commands[%d]; this should never happen", i)
 		}
 		iid := wfc.GetInvocation()[i].GetInvocationId()
-
-		cic := &bespb.ChildInvocationsConfigured{
-			Invocation: []*bespb.ChildInvocationsConfigured_InvocationMetadata{
-				{
-					InvocationId: iid,
-					BazelCommand: bazelCmd,
-				},
-			},
-		}
-		cicEvent := &bespb.BuildEvent{
-			Id:      &bespb.BuildEventId{Id: &bespb.BuildEventId_ChildInvocationsConfigured{ChildInvocationsConfigured: &bespb.BuildEventId_ChildInvocationsConfiguredId{}}},
-			Payload: &bespb.BuildEvent_ChildInvocationsConfigured{ChildInvocationsConfigured: cic},
-			Children: []*bespb.BuildEventId{
-				{
-					Id: &bespb.BuildEventId_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{
-						InvocationId: iid,
-					}},
-				},
-			},
-		}
-		if err := ar.reporter.Publish(cicEvent); err != nil {
-			return nil
-		}
 
 		// Publish a TargetConfigured event associated with the bazel command so
 		// that we can render artifacts associated with the "target".
@@ -1225,13 +1280,9 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			}
 		}
 
-		// Publish the status of each command as well as the finish time.
-		// Stop execution early on BEP failure, but ignore error -- it will surface in `bep.Finish()`.
 		duration := time.Since(cmdStartTime)
 		completedEvent := &bespb.BuildEvent{
-			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{
-				InvocationId: iid,
-			}}},
+			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{}}},
 			Payload: &bespb.BuildEvent_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.WorkflowCommandCompleted{
 				ExitCode:  int32(exitCode),
 				StartTime: timestamppb.New(cmdStartTime),
@@ -1239,20 +1290,6 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			}},
 		}
 		if err := ar.reporter.Publish(completedEvent); err != nil {
-			break
-		}
-		duration = time.Since(cmdStartTime)
-		childCompletedEvent := &bespb.BuildEvent{
-			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.BuildEventId_ChildInvocationCompletedId{
-				InvocationId: iid,
-			}}},
-			Payload: &bespb.BuildEvent_ChildInvocationCompleted{ChildInvocationCompleted: &bespb.ChildInvocationCompleted{
-				ExitCode:  int32(exitCode),
-				StartTime: timestamppb.New(cmdStartTime),
-				Duration:  durationpb.New(duration),
-			}},
-		}
-		if err := ar.reporter.Publish(childCompletedEvent); err != nil {
 			break
 		}
 
@@ -2151,7 +2188,7 @@ type commandError struct {
 }
 
 func (e *commandError) Error() string {
-	return fmt.Sprintf("%s: %q", e.Err.Error(), e.Output)
+	return e.Err.Error()
 }
 
 func isRemoteAlreadyExists(err error) bool {

--- a/enterprise/server/test/integration/remote_bazel/BUILD
+++ b/enterprise/server/test/integration/remote_bazel/BUILD
@@ -26,6 +26,7 @@ go_test(
     ],
     deps = [
         "//cli/remotebazel",
+        "//enterprise/server/execution_service",
         "//enterprise/server/hostedrunner",
         "//enterprise/server/invocation_search_service",
         "//enterprise/server/test/integration/remote_execution/rbetest",

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/remotebazel"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_search_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest"
@@ -243,6 +244,7 @@ func runLocalServerAndExecutor(t *testing.T, githubToken string) (*rbetest.Env, 
 			keyValStore, err := memory_kvstore.NewMemoryKeyValStore()
 			require.NoError(t, err)
 			e.SetKeyValStore(keyValStore)
+			e.SetExecutionService(execution_service.NewExecutionService(e))
 		},
 	})
 

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -259,20 +259,22 @@ message BuildEventId {
   // run as part of a BuildBuddy workflow.
   message WorkflowConfiguredId {}
 
-  // Identifier of an event providing the status of a completed invocation
+  // Identifier of an event providing the status of a completed step
   // within a BuildBuddy workflow.
   //
-  // A workflow action can specify multiple bazel commands, creating a
-  // "sub-invocation" for each one. There will be one of these events generated
-  // for each of those Bazel commands, where the invocation ID here refers to
-  // the invocation ID of the Bazel command that was completed.
+  // A workflow action can specify multiple steps, each of which is a block of
+  // bash code. This event will be emitted when the entire block has completed.
+  //
+  // For each bazel command invoked in the step, a ChildInvocationsConfigured
+  // and ChildInvocationCompleted event will also be emitted.
+  // TODO(Maggie): Once FE references have been cleaned up, rename to
+  // `RemoteRunnerStepCompleted`
   message WorkflowCommandCompletedId {
-    // Invocation ID of the command that was completed.
-    string invocation_id = 1;
+    reserved 1;
   }
 
-  // Identifier of an event providing a list of commands that are
-  // run as children of this invocation.
+  // Identifier of an event indicating that a child invocation of this
+  // invocation has been invoked.
   message ChildInvocationsConfiguredId {}
 
   // Identifier of an event providing the status of a completed child
@@ -1514,8 +1516,9 @@ message WorkflowConfigured {
   reserved 13;
 }
 
-// Event describing a workflow command that completed.
-// Note: the event ID holds the invocation ID that identifies the command.
+// Event describing a workflow step that completed.
+// This differs from ChildInvocationCompleted because each step can contain
+// multiple child invocations.
 // Next Tag: 6
 message WorkflowCommandCompleted {
   // The overall status of the command. A command was successful if and only if


### PR DESCRIPTION
This PR re-enables two PRs that support showing child invocations in the UI for workflows with bash commands

- Revert "Revert "[ci_runner] Fetch child invocations from the db instead of BES events" (#7305)"
- Revert "Revert "[ci_runner] Populate child invocation cards in UI for bazel commands in bash" (#7298)"

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
