### PR TITLE
Serve GetTree requests out of the local cache via BatchReadBlobs

### DIFF
--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/digest",
         "//server/util/log",
+        "//server/util/proto",
         "//server/util/status",
         "@org_golang_google_grpc//codes",
     ],

--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/log",
         "//server/util/proto",
+        "//server/util/rpcutil",
         "//server/util/status",
         "@org_golang_google_grpc//codes",
     ],

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -3,12 +3,12 @@ package content_addressable_storage_server_proxy
 import (
 	"context"
 	"fmt"
-	"io"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	"google.golang.org/grpc/codes"
@@ -156,22 +156,30 @@ func (s *CASServerProxy) batchReadBlobsRemote(ctx context.Context, readReq *repb
 }
 
 func (s *CASServerProxy) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
-	// TODO(iain): cache these
-	remoteStream, err := s.remote.GetTree(stream.Context(), req)
-	if err != nil {
-		return err
-	}
-	for {
-		rsp, err := remoteStream.Recv()
-		if err == io.EOF {
-			break
+	ctx := stream.Context()
+	resp := repb.GetTreeResponse{}
+	for dirsToGet := []*repb.Digest{req.RootDigest}; len(dirsToGet) > 0; {
+		brbreq := repb.BatchReadBlobsRequest{
+			InstanceName:   req.InstanceName,
+			Digests:        dirsToGet,
+			DigestFunction: req.DigestFunction,
 		}
+		brbresps, err := s.BatchReadBlobs(ctx, &brbreq)
 		if err != nil {
 			return err
 		}
-		if err = stream.Send(rsp); err != nil {
-			return err
+
+		dirsToGet = []*repb.Digest{}
+		for _, brbresp := range brbresps.Responses {
+			dir := &repb.Directory{}
+			if err := proto.Unmarshal(brbresp.Data, dir); err != nil {
+				return err
+			}
+			resp.Directories = append(resp.Directories, dir)
+			for _, subDir := range dir.Directories {
+				dirsToGet = append(dirsToGet, subDir.Digest)
+			}
 		}
 	}
-	return nil
+	return stream.Send(&resp)
 }

--- a/enterprise/server/remote_execution/dirtools/BUILD
+++ b/enterprise/server/remote_execution/dirtools/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//server/util/fastcopy",
         "//server/util/log",
         "//server/util/proto",
+        "//server/util/rpcutil",
         "//server/util/status",
         "//third_party/singleflight",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -33,7 +33,6 @@ import (
 
 const (
 	uploadBufSizeBytes    = 1000000 // 1MB
-	gRPCMaxSize           = int64(4000000)
 	maxCompressionBufSize = int64(4000000)
 )
 
@@ -610,7 +609,7 @@ func (ul *BatchCASUploader) Upload(d *repb.Digest, rsc io.ReadSeekCloser) error 
 		compressor = repb.Compressor_ZSTD
 	}
 
-	if d.GetSizeBytes() > gRPCMaxSize {
+	if d.GetSizeBytes() > rpcutil.GRPCMaxSizeBytes {
 		resourceName := digest.NewResourceName(d, ul.instanceName, rspb.CacheType_CAS, ul.digestFunction)
 		resourceName.SetCompressor(compressor)
 
@@ -637,7 +636,7 @@ func (ul *BatchCASUploader) Upload(d *repb.Digest, rsc io.ReadSeekCloser) error 
 		b = compression.CompressZstd(nil, b)
 	}
 	additionalSize := int64(len(b))
-	if ul.unsentBatchSize+additionalSize > gRPCMaxSize {
+	if ul.unsentBatchSize+additionalSize > rpcutil.GRPCMaxSizeBytes {
 		ul.flushCurrentBatch()
 	}
 	ul.unsentBatchReq.Requests = append(ul.unsentBatchReq.Requests, &repb.BatchUpdateBlobsRequest_Request{

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/proto",
+        "//server/util/rpcutil",
         "//server/util/status",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_rpc//status",

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,10 +39,7 @@ import (
 	gstatus "google.golang.org/grpc/status"
 )
 
-const (
-	gRPCMaxSize                 = int64(4194304 - 2000)
-	TreeCacheRemoteInstanceName = "_bb_treecache_"
-)
+const TreeCacheRemoteInstanceName = "_bb_treecache_"
 
 var (
 	enableTreeCaching         = flag.Bool("cache.enable_tree_caching", true, "If true, cache GetTree responses (full and partial)")
@@ -532,7 +530,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		rn := digest.ResourceNameFromProto(dirWithDigest.ResourceName)
 		d := rn.GetDigest()
 
-		if rspSizeBytes+d.GetSizeBytes() > gRPCMaxSize {
+		if rspSizeBytes+d.GetSizeBytes() > rpcutil.GRPCMaxSizeBytes {
 			if err := stream.Send(rsp); err != nil {
 				return err
 			}

--- a/server/util/rpcutil/rpcutil.go
+++ b/server/util/rpcutil/rpcutil.go
@@ -7,6 +7,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 )
 
+const GRPCMaxSizeBytes = int64(4 * 1000 * 1000)
+
 type StreamMsg[T proto.Message] struct {
 	Data  T
 	Error error


### PR DESCRIPTION
This is a pretty simple implementation of GetTree. I looked into trying to reuse the implementation in content_addressable_storage_server, but I think that adding support for locally writing remotely read directories will add enough complexity that it's not warranted, at least for now.

I also refactored the three instances of `gRPCMaxSize` out into `rpcutil`, using the lower of the two values defined in the code, rather than adding a fourth redundant definition of this constant.

**Related issues**: N/A
