### PR TITLE
Update docker in the executor to pick up recent security fixes

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -7087,32 +7087,3 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         downloaded_file_path = "runc",
         executable = True,
     )
-
-    http_archive(
-        name = "com_github_containerd_containerd-linux-amd64",
-        strip_prefix = "bin",
-        build_file_content = "\n".join([
-            'package(default_visibility = ["//visibility:public"])',
-            'filegroup(name = "containerd.bin", srcs = ["containerd"])',
-            'filegroup(name = "containerd-shim.bin", srcs = ["containerd-shim"])',
-            'filegroup(name = "containerd-shim-runc-v1.bin", srcs = ["containerd-shim-runc-v1"])',
-            'filegroup(name = "containerd-shim-runc-v2.bin", srcs = ["containerd-shim-runc-v2"])',
-            'filegroup(name = "ctr.bin", srcs = ["ctr"])',
-        ]),
-        urls = ["https://github.com/containerd/containerd/releases/download/v1.7.20/containerd-1.7.20-linux-amd64.tar.gz"],
-        sha256 = "e09410787b6f392748959177a84e024424f75d7aff33ea1c5b783f2260edce67",
-    )
-    http_archive(
-        name = "com_github_containerd_containerd-linux-arm64",
-        strip_prefix = "bin",
-        build_file_content = "\n".join([
-            'package(default_visibility = ["//visibility:public"])',
-            'filegroup(name = "containerd.bin", srcs = ["containerd"])',
-            'filegroup(name = "containerd-shim.bin", srcs = ["containerd-shim"])',
-            'filegroup(name = "containerd-shim-runc-v1.bin", srcs = ["containerd-shim-runc-v1"])',
-            'filegroup(name = "containerd-shim-runc-v2.bin", srcs = ["containerd-shim-runc-v2"])',
-            'filegroup(name = "ctr.bin", srcs = ["ctr"])',
-        ]),
-        urls = ["https://github.com/containerd/containerd/releases/download/v1.7.20/containerd-1.7.20-linux-arm64.tar.gz"],
-        sha256 = "cf80cd305f7d1c23aaf0c57bc1c1e37089cad9130d533db6fe968cdebd16c759",
-    )

--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/* && apt-get clean
 
-RUN DOCKER_VERSION="5:26.1.4-1~debian.12~bookworm" && \
-    CONTAINERD_DEB_VERSION="1.7.19-1" && \
-    DOCKER_BUILDX_VERSION="0.15.1-1~debian.12~bookworm" && \
+RUN DOCKER_VERSION="5:27.2.0-1~debian.12~bookworm" && \
+    CONTAINERD_DEB_VERSION="1.7.21-1" && \
+    DOCKER_BUILDX_VERSION="0.16.2-1~debian.12~bookworm" && \
     apt-get update && \
     apt-get install -y \
     curl ca-certificates apt-transport-https && \

--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
 RUN DOCKER_VERSION="5:27.2.0-1~debian.12~bookworm" && \
     CONTAINERD_DEB_VERSION="1.7.21-1" && \
     DOCKER_BUILDX_VERSION="0.16.2-1~debian.12~bookworm" && \
+    DOCKER_COMPOSE_VERSION="2.29.2-1~debian.12~bookworm" && \
     apt-get update && \
     apt-get install -y \
     curl ca-certificates apt-transport-https && \
@@ -29,7 +30,8 @@ RUN DOCKER_VERSION="5:27.2.0-1~debian.12~bookworm" && \
     docker-ce=${DOCKER_VERSION} \
     docker-ce-cli=${DOCKER_VERSION} \
     containerd.io=${CONTAINERD_DEB_VERSION} \
-    docker-buildx-plugin=${DOCKER_BUILDX_VERSION} && \
+    docker-buildx-plugin=${DOCKER_BUILDX_VERSION} \
+    docker-compose-plugin=${DOCKER_COMPOSE_VERSION} && \
     apt-mark auto \
     curl ca-certificates apt-transport-https && \
     apt-get autoremove -y && \
@@ -42,10 +44,4 @@ RUN DOCKER_VERSION="5:27.2.0-1~debian.12~bookworm" && \
     /usr/bin/rootlesskit \
     /usr/bin/rootlesskit-docker-proxy \
     # runc
-    /usr/bin/runc \
-    # containerd
-    /usr/bin/containerd \
-    /usr/bin/containerd-shim \
-    /usr/bin/containerd-shim-runc-v1 \
-    /usr/bin/containerd-shim-runc-v2 \
-    /usr/bin/ctr
+    /usr/bin/runc

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -153,29 +153,6 @@ container_layer(
     tags = ["manual"],
 )
 
-container_layer(
-    name = "containerd_layer",
-    directory = "/usr/bin",
-    files = select({
-        "@platforms//cpu:x86_64": [
-            "@com_github_containerd_containerd-linux-amd64//:containerd.bin",
-            "@com_github_containerd_containerd-linux-amd64//:containerd-shim.bin",
-            "@com_github_containerd_containerd-linux-amd64//:containerd-shim-runc-v1.bin",
-            "@com_github_containerd_containerd-linux-amd64//:containerd-shim-runc-v2.bin",
-            "@com_github_containerd_containerd-linux-amd64//:ctr.bin",
-        ],
-        "@platforms//cpu:arm64": [
-            "@com_github_containerd_containerd-linux-arm64//:containerd.bin",
-            "@com_github_containerd_containerd-linux-arm64//:containerd-shim.bin",
-            "@com_github_containerd_containerd-linux-arm64//:containerd-shim-runc-v1.bin",
-            "@com_github_containerd_containerd-linux-arm64//:containerd-shim-runc-v2.bin",
-            "@com_github_containerd_containerd-linux-arm64//:ctr.bin",
-        ],
-        "//conditions:default": [],
-    }),
-    tags = ["manual"],
-)
-
 # Executor expects "firecracker" and "jailer" binaries in $PATH,
 # and they can't be symlinks (otherwise the VM will not start).
 # Rename the firecracker/jailer binaries so that we can place
@@ -230,7 +207,6 @@ container_image(
         ":docker_credential_gcr_docker_config_layer",
         ":runc_layer",
         ":rootlesskit_layer",
-        ":containerd_layer",
         ":executor_tools_layer",
         ":podman_static_layer",
     ],


### PR DESCRIPTION
- **update docker, docker buildx, and containerd in executor dockerfile**
- **don't have to paste over `containerd` anymore, yay**

Still waiting for a `buildx-plugin` release to fix the last instance of the recent `CRITICAL` CVE, and when `runc` finally releases 1.2.0 we'll want to update `podman-static` again to pick up all the fixes when they [finally upgrade](https://github.com/containers/podman/issues/19795).

Other than that, we have the obvious problem of `docker-credential-gcr` never being updated again. We should probably address that at some point.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
