### PR TITLE
Cache Proxy: Update remote-cache-atime of locally-accessed cache entries

### DIFF
--- a/enterprise/server/atime_updater/BUILD
+++ b/enterprise/server/atime_updater/BUILD
@@ -31,6 +31,7 @@ go_test(
         "//server/util/log",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/atime_updater/BUILD
+++ b/enterprise/server/atime_updater/BUILD
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "atime_updater",
+    srcs = ["atime_updater.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/atime_updater",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/interfaces",
+        "//server/real_environment",
+        "//server/remote_cache/digest",
+        "//server/util/log",
+    ],
+)
+
+go_test(
+    name = "atime_updater_test",
+    size = "small",
+    srcs = ["atime_updater_test.go"],
+    embed = [":atime_updater"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
+        "//server/interfaces",
+        "//server/remote_cache/digest",
+        "//server/testutil/testauth",
+        "//server/testutil/testenv",
+        "//server/util/log",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -1,0 +1,236 @@
+package atime_updater
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+var (
+	// The maximum gRPC message size is 4MB. Each digest proto is
+	// 64 bytes (hash) + 8 bytes (size) + 2 bytes (tags) = 74 bytes. The
+	// remaining fields in FindMissingBlobsRequest should be small (1kb?), so
+	// we can conceivably fit 4MB / 74bytes = 14.1k of these. Cap it at 10k for
+	// now and we can increase it (or increase the update frequency) if we drop
+	// a lot of updates. Note this also affects memory usage of the proxy!
+	atimeUpdaterMaxDigestsPerUpdate = flag.Int("cache_proxy.remote_atime_max_digests_per_update", 10*1000, "The maximum number of blob digests to send in a single request for updating blob access times in the remote cache.")
+	atimeUpdaterMaxUpdatesPerGroup  = flag.Int("cache_proxy.remote_atime_max_updates_per_group", 25, "The maximum number of FindMissingBlobRequests to accumulate per group for updating blob access times in the remote cache.")
+	atimeUpdaterBatchUpdateInterval = flag.Duration("cache_proxy.remote_atime_update_interval", 30*time.Second, "The time interval to wait between sending access time updates to the remote cache.")
+	atimeUpdaterRpcTimeout          = flag.Duration("cache_proxy.remote_atime_rpc_timeout", 1*time.Second, "RPC timeout to use when updating blob access times in the remote cache.")
+)
+
+// A pending batch of atime updates (basically a FindMissingBlobsRequest).
+type atimeUpdate struct {
+	instanceName   string
+	digests        map[digest.Key]struct{} // stored as a set for de-duping.
+	digestFunction repb.DigestFunction_Value
+}
+
+func (u *atimeUpdate) toProto() *repb.FindMissingBlobsRequest {
+	req := repb.FindMissingBlobsRequest{
+		InstanceName:   u.instanceName,
+		BlobDigests:    []*repb.Digest{},
+		DigestFunction: u.digestFunction,
+	}
+	for d := range u.digests {
+		req.BlobDigests = append(req.BlobDigests, d.ToDigest())
+	}
+	return &req
+}
+
+// The set of pending access time updates to send per group. There should be at
+// most one of these per group, but each contains many atimeUpdate{}s, as
+// there is one per (groupID, instance-name, digest-function) tuple. However,
+// the update will only keep one such atimeUpdate{} and if it gets too big will
+// discard additional digests until it's flushed.
+type atimeUpdates struct {
+	mu      sync.Mutex // protects jwt, updates, and atimeUpdate.digests.
+	jwt     string
+	updates []*atimeUpdate
+}
+
+type atimeUpdater struct {
+	authenticator interfaces.Authenticator
+
+	mu      sync.Mutex               // protects updates
+	updates map[string]*atimeUpdates // pending updates keyed by groupID.
+
+	maxDigestsPerUpdate int
+	maxUpdatesPerGroup  int
+	updateInterval      time.Duration
+	rpcTimeout          time.Duration
+
+	remote repb.ContentAddressableStorageClient
+}
+
+type Opts struct {
+	TickerForTesting <-chan time.Time
+}
+
+func Register(env *real_environment.RealEnv, opts Opts) error {
+	authenticator := env.GetAuthenticator()
+	if authenticator == nil {
+		return fmt.Errorf("An Authenticator is required to enable the AtimeUpdater.")
+	}
+	remote := env.GetContentAddressableStorageClient()
+	if remote == nil {
+		return fmt.Errorf("A remote CAS client is required to enable the AtimeUpdater.")
+	}
+	updater := atimeUpdater{
+		authenticator:       authenticator,
+		updates:             make(map[string]*atimeUpdates),
+		maxDigestsPerUpdate: *atimeUpdaterMaxDigestsPerUpdate,
+		maxUpdatesPerGroup:  *atimeUpdaterMaxUpdatesPerGroup,
+		updateInterval:      *atimeUpdaterBatchUpdateInterval,
+		rpcTimeout:          *atimeUpdaterRpcTimeout,
+		remote:              remote,
+	}
+	go updater.start(opts)
+	env.SetAtimeUpdater(&updater)
+	return nil
+}
+
+func (u *atimeUpdater) groupID(ctx context.Context) string {
+	user, err := u.authenticator.AuthenticatedUser(ctx)
+	if err != nil {
+		return interfaces.AuthAnonymousUser
+	}
+	return user.GetGroupID()
+}
+
+func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests []*repb.Digest, digestFunction repb.DigestFunction_Value) {
+	if len(digests) == 0 {
+		return
+	}
+
+	groupID := u.groupID(ctx)
+	jwt := u.authenticator.TrustedJWTFromAuthContext(ctx)
+	u.mu.Lock()
+	updates, ok := u.updates[groupID]
+	if !ok {
+		updates = &atimeUpdates{}
+		u.updates[groupID] = updates
+	}
+	u.mu.Unlock()
+
+	// Uniqueify the incoming digests. Note this wrecks the order of the
+	// requested updates. Too bad.
+	keys := map[digest.Key]struct{}{}
+	for _, digestProto := range digests {
+		keys[digest.NewKey(digestProto)] = struct{}{}
+	}
+
+	// TODO(iain): this locking may be a bit overzealous. Hopefully not though.
+	updates.mu.Lock()
+	defer updates.mu.Unlock()
+
+	// Always use the most recent JWT for a group for remote atime updates.
+	updates.jwt = jwt
+
+	// First, find the update that the new digests can be merged into, or create
+	// a new one if one doesn't exist.
+	var pendingUpdate *atimeUpdate
+	for _, update := range updates.updates {
+		if update.instanceName == instanceName && update.digestFunction == digestFunction {
+			pendingUpdate = update
+			break
+		}
+	}
+	if pendingUpdate == nil {
+		if len(updates.updates) >= u.maxUpdatesPerGroup {
+			log.CtxInfof(ctx, "Too many pending FindMissingBlobsRequests for updating remote atime for group %s, dropping some pending atime updates", groupID)
+			return
+		}
+		pendingUpdate = &atimeUpdate{
+			instanceName:   instanceName,
+			digests:        map[digest.Key]struct{}{},
+			digestFunction: digestFunction,
+		}
+		updates.updates = append(updates.updates, pendingUpdate)
+	}
+
+	// Now merge the new digests into the update.
+	for key := range keys {
+		if len(pendingUpdate.digests) >= u.maxDigestsPerUpdate {
+			log.CtxInfof(ctx, "FindMissingBlobsRequest for updating remote atime for group %s too large, dropping some pending atime updates", groupID)
+			break
+		}
+		pendingUpdate.digests[key] = struct{}{}
+	}
+}
+
+func (u *atimeUpdater) EnqueueByResourceName(ctx context.Context, downloadString string) {
+	if digest.IsActionCacheResourceName(downloadString) {
+		// ActionCache entries are always read authoritatively, so no need to
+		// enqueue an atime update.
+		return
+	}
+	rn, err := digest.ParseDownloadResourceName(downloadString)
+	if err != nil {
+		log.Warningf("Skipping remote atime update for malformed download resource name: %s [%s]", downloadString, err)
+		return
+	}
+	u.Enqueue(ctx, rn.GetInstanceName(), []*repb.Digest{rn.GetDigest()}, rn.GetDigestFunction())
+}
+
+func (u *atimeUpdater) EnqueueByFindMissingRequest(ctx context.Context, req *repb.FindMissingBlobsRequest) {
+	u.Enqueue(ctx, req.InstanceName, req.BlobDigests, req.DigestFunction)
+}
+
+func (u *atimeUpdater) start(opts Opts) {
+	tickerChan := opts.TickerForTesting
+	if tickerChan == nil {
+		ticker := time.NewTicker(u.updateInterval)
+		tickerChan = ticker.C
+		defer ticker.Stop()
+	}
+
+	for {
+		// Send one update per group every tick. Because the updates are stored
+		// in a per-group array, they will round-robin across instance-names
+		// and digest functions for each group. We could change that approach
+		// to send the biggest update per group each time or something, but
+		// that could starve lesser used instance-names.
+		<-tickerChan
+
+		// Remove updates to send and release the mutex before sending RPCs.
+		updatesToSend := map[string]*atimeUpdate{}
+		jwts := map[string]string{}
+		u.mu.Lock()
+		for groupID, updates := range u.updates {
+			updates.mu.Lock()
+			if len(updates.updates) == 0 {
+				updates.mu.Unlock()
+				continue
+			}
+			updatesToSend[groupID] = updates.updates[0]
+			jwts[groupID] = updates.jwt
+			updates.updates = updates.updates[1:]
+			updates.mu.Unlock()
+		}
+		u.mu.Unlock()
+
+		for groupID, update := range updatesToSend {
+			ctx, cancel := context.WithTimeout(context.Background(), u.rpcTimeout)
+			u.update(ctx, groupID, jwts[groupID], update)
+			cancel()
+		}
+	}
+}
+
+func (u *atimeUpdater) update(ctx context.Context, groupID string, jwt string, update *atimeUpdate) {
+	log.CtxDebugf(ctx, "Asynchronously processing %d atime updates for group %s", len(update.digests), groupID)
+	ctx = u.authenticator.AuthContextFromTrustedJWT(ctx, jwt)
+	if _, err := u.remote.FindMissingBlobs(ctx, update.toProto()); err != nil {
+		log.CtxWarningf(ctx, "Error sending FindMissingBlobs request to update remote atimes for group %s: %s", groupID, err)
+	}
+}

--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -29,6 +29,7 @@ var (
 )
 
 // A pending batch of atime updates (basically a FindMissingBlobsRequest).
+// Stored as a struct so digest keys can be stored in a set for de-duping.
 type atimeUpdate struct {
 	instanceName   string
 	digests        map[digest.Key]struct{} // stored as a set for de-duping.
@@ -38,11 +39,13 @@ type atimeUpdate struct {
 func (u *atimeUpdate) toProto() *repb.FindMissingBlobsRequest {
 	req := repb.FindMissingBlobsRequest{
 		InstanceName:   u.instanceName,
-		BlobDigests:    []*repb.Digest{},
+		BlobDigests:    make([]*repb.Digest, len(u.digests)),
 		DigestFunction: u.digestFunction,
 	}
+	i := 0
 	for d := range u.digests {
-		req.BlobDigests = append(req.BlobDigests, d.ToDigest())
+		req.BlobDigests[i] = d.ToDigest()
+		i++
 	}
 	return &req
 }

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -1,0 +1,543 @@
+package atime_updater
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
+)
+
+const (
+	user1  = "USER1"
+	user2  = "USER2"
+	anon   = "ANON"
+	group1 = "GROUP1"
+	group2 = "GROUP2"
+)
+
+var (
+	aDigest = digestProto(strings.Repeat("a", 64), 3)
+	bDigest = digestProto(strings.Repeat("b", 64), 3)
+	cDigest = digestProto(strings.Repeat("c", 64), 3)
+	dDigest = digestProto(strings.Repeat("d", 64), 3)
+	eDigest = digestProto(strings.Repeat("e", 64), 3)
+	fDigest = digestProto(strings.Repeat("f", 64), 3)
+	gDigest = digestProto(strings.Repeat("g", 64), 3)
+	hDigest = digestProto(strings.Repeat("h", 64), 3)
+	iDigest = digestProto(strings.Repeat("i", 64), 3)
+	jDigest = digestProto(strings.Repeat("j", 64), 3)
+	kDigest = digestProto(strings.Repeat("k", 64), 3)
+)
+
+func digestProto(hash string, sizeBytes int64) *repb.Digest {
+	return &repb.Digest{Hash: hash, SizeBytes: sizeBytes}
+}
+
+type update struct {
+	groupID        string
+	instanceName   string
+	key            digest.Key
+	digestFunction repb.DigestFunction_Value
+}
+
+func updateOf(groupID string, instanceName string, d *repb.Digest, digestFunction repb.DigestFunction_Value) update {
+	return update{
+		groupID:        groupID,
+		instanceName:   instanceName,
+		key:            digest.NewKey(d),
+		digestFunction: digestFunction,
+	}
+}
+
+func (u update) String() string {
+	return fmt.Sprintf("groupID:'%s' instanceName:'%s', key:'%s/%d', digestFunction:%s", u.groupID, u.instanceName, u.key.Hash, u.key.SizeBytes, u.digestFunction)
+}
+
+type fakeCAS struct {
+	t *testing.T
+
+	authenticator interfaces.Authenticator
+
+	mu      sync.Mutex
+	updates []update
+}
+
+func (f *fakeCAS) getUpdates() []update {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.updates
+}
+
+func (f *fakeCAS) clearUpdates() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updates = []update{}
+}
+
+func (f *fakeCAS) FindMissingBlobs(ctx context.Context, req *repb.FindMissingBlobsRequest) (*repb.FindMissingBlobsResponse, error) {
+	log.Debugf("FindMissingBlobs: %s", req)
+
+	groupID := interfaces.AuthAnonymousUser
+	user, err := f.authenticator.AuthenticatedUser(ctx)
+	if err == nil {
+		groupID = user.GetGroupID()
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, d := range req.BlobDigests {
+		f.updates = append(f.updates, updateOf(groupID, req.InstanceName, d, req.DigestFunction))
+	}
+	return &repb.FindMissingBlobsResponse{}, nil
+}
+
+func (f *fakeCAS) BatchUpdateBlobs(ctx context.Context, req *repb.BatchUpdateBlobsRequest) (*repb.BatchUpdateBlobsResponse, error) {
+	f.t.Fatal("Unexpected call to BatchUpdateBlobs")
+	return nil, status.InternalError("Unexpected call to BatchUpdateBlobs")
+}
+
+func (f *fakeCAS) BatchReadBlobs(ctx context.Context, req *repb.BatchReadBlobsRequest) (*repb.BatchReadBlobsResponse, error) {
+	f.t.Fatal("Unexpected call to BatchReadBlobs")
+	return nil, status.InternalError("Unexpected call to BatchReadBlobs")
+}
+
+func (f *fakeCAS) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
+	f.t.Fatal("Unexpected call to GetTree")
+	return status.InternalError("Unexpected call to GetTree")
+}
+
+func runFakeCAS(ctx context.Context, env *testenv.TestEnv, t *testing.T) (*fakeCAS, repb.ContentAddressableStorageClient) {
+	cas := fakeCAS{t: t, authenticator: env.GetAuthenticator(), updates: []update{}}
+	grpcServer, runFunc, lis := testenv.RegisterLocalGRPCServer(t, env)
+	repb.RegisterContentAddressableStorageServer(grpcServer, &cas)
+	go runFunc()
+	conn, err := testenv.LocalGRPCConn(ctx, lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return &cas, repb.NewContentAddressableStorageClient(conn)
+}
+
+func waitExpectingNUpdates(t *testing.T, n int, cas *fakeCAS) {
+	wait := time.Millisecond
+	for i := 0; i < 6; i++ {
+		time.Sleep(wait)
+		wait = wait * 2
+		actual := cas.getUpdates()
+		if len(actual) == n {
+			return
+		}
+	}
+	t.Fatalf("Timed out waiting for expected number of digests. Expected %d, found %d", n, len(cas.getUpdates()))
+}
+
+func waitExpectingUpdates(t *testing.T, expected []update, cas *fakeCAS) {
+	waitExpectingNUpdates(t, len(expected), cas)
+	require.ElementsMatch(t, expected, cas.getUpdates())
+}
+
+func expectNoMoreUpdates(t *testing.T, ticker chan time.Time, cas *fakeCAS) {
+	cas.clearUpdates()
+	for i := 0; i < 100; i++ {
+		ticker <- time.Now()
+	}
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, 0, len(cas.updates))
+}
+
+func setup(t *testing.T) (interfaces.Authenticator, interfaces.AtimeUpdater, *fakeCAS, chan time.Time) {
+	env := testenv.GetTestEnv(t)
+	authenticator := testauth.NewTestAuthenticator(testauth.TestUsers(user1, group1, user2, group2))
+	env.SetAuthenticator(authenticator)
+	cas, casClient := runFakeCAS(context.Background(), env, t)
+	env.SetContentAddressableStorageClient(casClient)
+	ticker := make(chan time.Time)
+	flags.Set(t, "cache_proxy.remote_atime_max_digests_per_update", 5)
+	flags.Set(t, "cache_proxy.remote_atime_max_updates_per_group", 3)
+	require.NoError(t, Register(env, Opts{TickerForTesting: ticker}))
+	updater := env.GetAtimeUpdater()
+	require.NotNil(t, updater)
+	return authenticator, updater, cas, ticker
+}
+
+func TestEnqueue_SimpleBatching(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{aDigest, bDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{cDigest}, repb.DigestFunction_SHA256)
+	require.Equal(t, 0, len(cas.getUpdates()))
+	ticker <- time.Now()
+	waitExpectingUpdates(t,
+		[]update{
+			updateOf(anon, "instance-1", aDigest, repb.DigestFunction_SHA256),
+			updateOf(anon, "instance-1", bDigest, repb.DigestFunction_SHA256),
+			updateOf(anon, "instance-1", cDigest, repb.DigestFunction_SHA256)},
+		cas)
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueue_Deduping(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		updater.Enqueue(ctx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	}
+	require.Equal(t, 0, len(cas.getUpdates()))
+	ticker <- time.Now()
+	waitExpectingUpdates(t, []update{updateOf(anon, "instance-1", aDigest, repb.DigestFunction_SHA256)}, cas)
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueue_InstanceNamesIsolated(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-2", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-3", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	require.Equal(t, 0, len(cas.getUpdates()))
+	ticker <- time.Now()
+	waitExpectingUpdates(t, []update{updateOf(anon, "instance-1", aDigest, repb.DigestFunction_SHA256)}, cas)
+	cas.clearUpdates()
+	ticker <- time.Now()
+	waitExpectingUpdates(t, []update{updateOf(anon, "instance-2", aDigest, repb.DigestFunction_SHA256)}, cas)
+	cas.clearUpdates()
+	ticker <- time.Now()
+	waitExpectingUpdates(t, []update{updateOf(anon, "instance-3", aDigest, repb.DigestFunction_SHA256)}, cas)
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueue_DigestFunctionsIsolated(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_MD5)
+	require.Equal(t, 0, len(cas.getUpdates()))
+	ticker <- time.Now()
+	waitExpectingUpdates(t, []update{updateOf(anon, "instance-1", aDigest, repb.DigestFunction_SHA256)}, cas)
+	cas.clearUpdates()
+	ticker <- time.Now()
+	waitExpectingUpdates(t, []update{updateOf(anon, "instance-1", aDigest, repb.DigestFunction_MD5)}, cas)
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueue_GroupsIsolated(t *testing.T) {
+	authenticator, updater, cas, ticker := setup(t)
+	anonCtx := context.Background()
+	group1Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user1)
+	group2Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user2)
+
+	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(group1Ctx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(group2Ctx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	ticker <- time.Now()
+	waitExpectingUpdates(t,
+		[]update{
+			updateOf(anon, "instance-1", aDigest, repb.DigestFunction_SHA256),
+			updateOf(group1, "instance-1", aDigest, repb.DigestFunction_SHA256),
+			updateOf(group2, "instance-1", aDigest, repb.DigestFunction_SHA256)},
+		cas)
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueue_DedupesToFrontOfLine(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-2", []*repb.Digest{bDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{cDigest}, repb.DigestFunction_SHA256)
+	require.Equal(t, 0, len(cas.getUpdates()))
+	ticker <- time.Now()
+	waitExpectingUpdates(t,
+		[]update{
+			updateOf(anon, "instance-1", aDigest, repb.DigestFunction_SHA256),
+			updateOf(anon, "instance-1", cDigest, repb.DigestFunction_SHA256)},
+		cas)
+	cas.clearUpdates()
+	ticker <- time.Now()
+	waitExpectingUpdates(t, []update{updateOf(anon, "instance-2", bDigest, repb.DigestFunction_SHA256)}, cas)
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueue_DigestsDropped(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	// If the updater accumulates too many digests in an update, it drops them.
+	// setup() sets the value of remote_atime_max_digests_per_update to 5, so
+	// expect that many to be sent, though order is not guaranteed so we don't
+	// know which 5 will be sent.
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{aDigest, bDigest, cDigest, dDigest, eDigest, fDigest, gDigest, hDigest, iDigest, jDigest, kDigest}, repb.DigestFunction_SHA256)
+	for i := 0; i < 100; i++ {
+		ticker <- time.Now()
+	}
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, 5, len(cas.getUpdates()))
+	expectNoMoreUpdates(t, ticker, cas)
+
+	// Make sure there are no more updates sent.
+	cas.clearUpdates()
+	for i := 0; i < 100; i++ {
+		ticker <- time.Now()
+	}
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, 0, len(cas.getUpdates()))
+
+	// Expect the same behavior if they're sent one-by-one.
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{bDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{cDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{dDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{eDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{fDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{gDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{hDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{iDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{jDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(ctx, "instance-1", []*repb.Digest{kDigest}, repb.DigestFunction_SHA256)
+	for i := 0; i < 100; i++ {
+		ticker <- time.Now()
+	}
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, 5, len(cas.getUpdates()))
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueue_UpdatesDropped(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	// If the updater accumulates too many updates, it should start to drop
+	// them. setup() sets the value of remote_atime_max_updates_per_group to
+	// 3, so expect the first 3 to be sent and the others to be dropped.
+	for i := 1; i <= 10; i++ {
+		updater.Enqueue(ctx, fmt.Sprintf("instance-%d", i), []*repb.Digest{aDigest}, repb.DigestFunction_SHA256)
+	}
+	for i := 0; i < 100; i++ {
+		ticker <- time.Now()
+	}
+	waitExpectingUpdates(t,
+		[]update{
+			updateOf(anon, "instance-1", aDigest, repb.DigestFunction_SHA256),
+			updateOf(anon, "instance-2", aDigest, repb.DigestFunction_SHA256),
+			updateOf(anon, "instance-3", aDigest, repb.DigestFunction_SHA256)},
+		cas)
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueue_Fairness(t *testing.T) {
+	authenticator, updater, cas, ticker := setup(t)
+	anonCtx := context.Background()
+	group1Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user1)
+	group2Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user2)
+
+	// Updates (in order of first update in the shard):
+	//   Anon/1/SHA: A, B, C, D, E
+	//   Grp1/1/SHA: A, F, C, G, H, I
+	//   Anon/1/MD5: A, B, C, D, E
+	//   Anon/2/SHA: F, G, H, I, J
+	//   Grp1/2/SHA: A, F
+	//   Grp2/1/SHA: A, G, B, G
+	//   Anon/1/SHA: A, B, I, G, I, A, B, I, C
+	//   Anon/1/SHA: A, A, A, G, B, A, B, C, C
+	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{aDigest, bDigest, cDigest, dDigest, eDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(group1Ctx, "instance-1", []*repb.Digest{aDigest, fDigest, cDigest, gDigest, hDigest, iDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{aDigest, bDigest, cDigest, dDigest, eDigest}, repb.DigestFunction_MD5)
+	updater.Enqueue(anonCtx, "instance-2", []*repb.Digest{fDigest, gDigest, hDigest, iDigest, jDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(group1Ctx, "instance-2", []*repb.Digest{aDigest, fDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(group2Ctx, "instance-1", []*repb.Digest{aDigest, gDigest, bDigest, gDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{aDigest, bDigest, iDigest, gDigest, iDigest, aDigest, bDigest, iDigest, cDigest}, repb.DigestFunction_SHA256)
+	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{aDigest, aDigest, aDigest, gDigest, bDigest, aDigest, bDigest, cDigest, cDigest}, repb.DigestFunction_SHA256)
+	ticker <- time.Now()
+
+	// Expect 5 updates from anon, 5 from group1, and 3 from group2.
+	waitExpectingNUpdates(t, 13, cas)
+	updateCount := map[string]int{anon: 0, group1: 0, group2: 0}
+	for _, update := range cas.getUpdates() {
+		updateCount[update.groupID]++
+	}
+	require.Equal(t, map[string]int{anon: 5, group1: 5, group2: 3}, updateCount)
+
+	// Expect 5 more updates from anon, 2 from group1, and 0 from group2.
+	cas.clearUpdates()
+	ticker <- time.Now()
+	waitExpectingNUpdates(t, 7, cas)
+	updateCount = map[string]int{anon: 0, group1: 0, group2: 0}
+	for _, update := range cas.getUpdates() {
+		updateCount[update.groupID]++
+	}
+	require.Equal(t, map[string]int{anon: 5, group1: 2, group2: 0}, updateCount)
+
+	// Finally, expect 5 more for anon.
+	cas.clearUpdates()
+	ticker <- time.Now()
+	waitExpectingNUpdates(t, 5, cas)
+	updateCount = map[string]int{anon: 0, group1: 0, group2: 0}
+	for _, update := range cas.getUpdates() {
+		updateCount[update.groupID]++
+	}
+	require.Equal(t, map[string]int{anon: 5, group1: 0, group2: 0}, updateCount)
+
+	// Subsequent updates should have been dropped. Because updates are dropped
+	// nondeterministically, we can't assert which were present.
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+// The atimeUpdater code does a lot of stuff with mutexes... This test tries to
+// trip the race detector. Make sure you run with --config=race for debugging.
+func TestEnqueue_Raciness(t *testing.T) {
+	authenticator, updater, _, ticker := setup(t)
+	anonCtx := context.Background()
+	group1Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user1)
+	group2Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user2)
+
+	contexts := []context.Context{anonCtx, group1Ctx, group2Ctx}
+	instances := []string{"instance-1", "instance-2", "instance-3"}
+	batches := [][]*repb.Digest{
+		[]*repb.Digest{aDigest, bDigest, cDigest, dDigest, eDigest},
+		[]*repb.Digest{aDigest, fDigest, cDigest, gDigest, hDigest, iDigest},
+		[]*repb.Digest{aDigest, bDigest, cDigest, dDigest, eDigest},
+		[]*repb.Digest{eDigest, fDigest, aDigest},
+		[]*repb.Digest{aDigest, aDigest, aDigest, aDigest, aDigest, aDigest},
+		[]*repb.Digest{aDigest, bDigest, iDigest, gDigest, iDigest, aDigest, bDigest, iDigest, cDigest},
+		[]*repb.Digest{aDigest},
+	}
+	digestFunctions := []repb.DigestFunction_Value{repb.DigestFunction_SHA256, repb.DigestFunction_MD5}
+
+	for i := 0; i < 3000; i++ {
+		updater.Enqueue(
+			contexts[rand.IntN(len(contexts))],
+			instances[rand.IntN(len(instances))],
+			batches[rand.IntN(len(batches))],
+			digestFunctions[rand.IntN(len(digestFunctions))])
+		if rand.IntN(25) == 0 {
+			ticker <- time.Now()
+		}
+	}
+}
+
+func TestEnqueueByResourceName_ActionCache(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	rn, err := digest.NewResourceName(aDigest, "instance-1", rspb.CacheType_AC, repb.DigestFunction_SHA256).ActionCacheString()
+	require.NoError(t, err)
+	updater.EnqueueByResourceName(ctx, rn)
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func casResourceName(t *testing.T, d *repb.Digest, instanceName string) string {
+	rn, err := digest.NewResourceName(d, instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256).DownloadString()
+	require.NoError(t, err)
+	return rn
+}
+
+func TestEnqueueByResourceName_CAS(t *testing.T) {
+	authenticator, updater, cas, ticker := setup(t)
+	anonCtx := context.Background()
+	group1Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user1)
+	group2Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user2)
+
+	rnA1 := casResourceName(t, aDigest, "instance-1")
+	rnA2 := casResourceName(t, aDigest, "instance-2")
+	rnB1 := casResourceName(t, bDigest, "instance-1")
+	rnB2 := casResourceName(t, bDigest, "instance-2")
+	rnC1 := casResourceName(t, cDigest, "instance-1")
+	rnC2 := casResourceName(t, cDigest, "instance-2")
+	rnD1 := casResourceName(t, dDigest, "instance-1")
+	rnD2 := casResourceName(t, dDigest, "instance-2")
+	rnE1 := casResourceName(t, eDigest, "instance-1")
+	rnF1 := casResourceName(t, fDigest, "instance-1")
+
+	// Updates (in order of first update in the shard):
+	//   Anon/2: B, A, C, D
+	//   Anon/1: A, C, D, B, E, F
+	//   Grp1/1: A
+	//   Grp2/1: C
+	updater.EnqueueByResourceName(anonCtx, rnB2)
+	updater.EnqueueByResourceName(anonCtx, rnA1)
+	updater.EnqueueByResourceName(anonCtx, rnC1)
+	updater.EnqueueByResourceName(anonCtx, rnA2)
+	updater.EnqueueByResourceName(anonCtx, rnB2)
+	updater.EnqueueByResourceName(anonCtx, rnC2)
+	updater.EnqueueByResourceName(anonCtx, rnA1)
+	updater.EnqueueByResourceName(anonCtx, rnD1)
+	updater.EnqueueByResourceName(anonCtx, rnA1)
+	updater.EnqueueByResourceName(group1Ctx, rnA1)
+	updater.EnqueueByResourceName(anonCtx, rnB1)
+	updater.EnqueueByResourceName(anonCtx, rnD2)
+	updater.EnqueueByResourceName(anonCtx, rnE1)
+	updater.EnqueueByResourceName(group2Ctx, rnC1)
+	updater.EnqueueByResourceName(anonCtx, rnF1)
+
+	// First update should be 3 for Anon/2, 1 for Grp1/1, and 1 for Grp2/1
+	ticker <- time.Now()
+	waitExpectingNUpdates(t, 6, cas)
+	updateCount := map[string]int{anon: 0, group1: 0, group2: 0}
+	for _, update := range cas.getUpdates() {
+		updateCount[update.groupID]++
+	}
+	require.Equal(t, map[string]int{anon: 4, group1: 1, group2: 1}, updateCount)
+
+	// Second update should be 5 for Anon/1
+	cas.clearUpdates()
+	ticker <- time.Now()
+	waitExpectingNUpdates(t, 5, cas)
+	updateCount = map[string]int{anon: 0, group1: 0, group2: 0}
+	for _, update := range cas.getUpdates() {
+		updateCount[update.groupID]++
+	}
+	require.Equal(t, map[string]int{anon: 5, group1: 0, group2: 0}, updateCount)
+
+	// One of the 6 Anon/1 updates should be dropped. Because updates are
+	// dropped nondeterministically, we can't figure out which one.
+	cas.clearUpdates()
+	expectNoMoreUpdates(t, ticker, cas)
+}
+
+func TestEnqueueByFindMissing(t *testing.T) {
+	_, updater, cas, ticker := setup(t)
+	ctx := context.Background()
+
+	req := repb.FindMissingBlobsRequest{
+		InstanceName:   "instance-1",
+		BlobDigests:    []*repb.Digest{aDigest, bDigest, cDigest, dDigest},
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	for i := 0; i < 10; i++ {
+		updater.EnqueueByFindMissingRequest(ctx, &req)
+	}
+	require.Equal(t, 0, len(cas.getUpdates()))
+	ticker <- time.Now()
+	waitExpectingUpdates(t,
+		[]update{
+			updateOf(anon, "instance-1", aDigest, repb.DigestFunction_SHA256),
+			updateOf(anon, "instance-1", bDigest, repb.DigestFunction_SHA256),
+			updateOf(anon, "instance-1", cDigest, repb.DigestFunction_SHA256),
+			updateOf(anon, "instance-1", dDigest, repb.DigestFunction_SHA256)},
+		cas)
+	cas.clearUpdates()
+	for i := 0; i < 100; i++ {
+		ticker <- time.Now()
+	}
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, 0, len(cas.getUpdates()))
+}

--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
+        "//server/interfaces",
         "//server/metrics",
         "//server/real_environment",
         "//server/util/log",
@@ -24,6 +25,7 @@ go_test(
     srcs = ["byte_stream_server_proxy_test.go"],
     embed = [":byte_stream_server_proxy"],
     deps = [
+        "//enterprise/server/atime_updater",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/remote_cache/byte_stream_server",

--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -39,6 +39,7 @@ go_test(
         "//server/util/status",
         "//server/util/testing/flags",
         "//server/util/uuid",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/atime_updater"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/byte_stream"
@@ -37,25 +38,68 @@ const (
 	always
 )
 
-func requestCountingInterceptor(count *atomic.Int32) grpc.StreamClientInterceptor {
+// The real AtimeUpdater makes RPCs which may interfere with tests.
+type noOpAtimeUpdater struct{}
+
+func (a *noOpAtimeUpdater) Enqueue(_ context.Context, _ string, _ []*repb.Digest, _ repb.DigestFunction_Value) {
+}
+func (a *noOpAtimeUpdater) EnqueueByResourceName(_ context.Context, _ string) {}
+func (a *noOpAtimeUpdater) EnqueueByFindMissingRequest(_ context.Context, _ *repb.FindMissingBlobsRequest) {
+}
+
+type noOpCAS struct {
+	t *testing.T
+}
+
+func (c *noOpCAS) FindMissingBlobs(ctx context.Context, req *repb.FindMissingBlobsRequest) (*repb.FindMissingBlobsResponse, error) {
+	return &repb.FindMissingBlobsResponse{}, nil
+}
+
+func (c *noOpCAS) BatchUpdateBlobs(ctx context.Context, req *repb.BatchUpdateBlobsRequest) (*repb.BatchUpdateBlobsResponse, error) {
+	c.t.Fatal("Unexpected call to BatchUpdateBlobs")
+	return nil, status.InternalError("Unexpected call to BatchUpdateBlobs")
+}
+
+func (c *noOpCAS) BatchReadBlobs(ctx context.Context, req *repb.BatchReadBlobsRequest) (*repb.BatchReadBlobsResponse, error) {
+	c.t.Fatal("Unexpected call to BatchReadBlobs")
+	return nil, status.InternalError("Unexpected call to BatchReadBlobs")
+}
+
+func (c *noOpCAS) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
+	c.t.Fatal("Unexpected call to GetTree")
+	return status.InternalError("Unexpected call to GetTree")
+}
+
+func requestCountingUnaryInterceptor(count *atomic.Int32) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		count.Add(1)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func requestCountingStreamInterceptor(count *atomic.Int32) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		count.Add(1)
 		return streamer(ctx, desc, cc, method, opts...)
 	}
 }
 
-func runRemoteBSS(ctx context.Context, env *testenv.TestEnv, t *testing.T) (bspb.ByteStreamClient, *atomic.Int32) {
+func runRemoteServices(ctx context.Context, env *testenv.TestEnv, t *testing.T) (bspb.ByteStreamClient, repb.ContentAddressableStorageClient, *atomic.Int32, *atomic.Int32) {
 	server, err := byte_stream_server.NewByteStreamServer(env)
+	cas := noOpCAS{t: t}
 	require.NoError(t, err)
 	grpcServer, runFunc, lis := testenv.RegisterLocalGRPCServer(t, env)
 	bspb.RegisterByteStreamServer(grpcServer, server)
+	repb.RegisterContentAddressableStorageServer(grpcServer, &cas)
 	go runFunc()
+	unaryRequestCounter := atomic.Int32{}
 	streamRequestCounter := atomic.Int32{}
 	conn, err := testenv.LocalGRPCConn(ctx, lis,
-		grpc.WithStreamInterceptor(requestCountingInterceptor(&streamRequestCounter)))
+		grpc.WithUnaryInterceptor(requestCountingUnaryInterceptor(&unaryRequestCounter)),
+		grpc.WithStreamInterceptor(requestCountingStreamInterceptor(&streamRequestCounter)))
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
-	return bspb.NewByteStreamClient(conn), &streamRequestCounter
+	return bspb.NewByteStreamClient(conn), repb.NewContentAddressableStorageClient(conn), &unaryRequestCounter, &streamRequestCounter
 }
 
 func runLocalBSS(ctx context.Context, env *testenv.TestEnv, t *testing.T) bspb.ByteStreamClient {
@@ -71,6 +115,9 @@ func runLocalBSS(ctx context.Context, env *testenv.TestEnv, t *testing.T) bspb.B
 }
 
 func runBSProxy(ctx context.Context, client bspb.ByteStreamClient, env *testenv.TestEnv, t *testing.T) bspb.ByteStreamClient {
+	if env.GetAtimeUpdater() == nil {
+		env.SetAtimeUpdater(&noOpAtimeUpdater{})
+	}
 	env.SetByteStreamClient(client)
 	env.SetLocalByteStreamClient(runLocalBSS(ctx, env, t))
 	byteStreamServer, err := New(env)
@@ -105,9 +152,9 @@ func waitContains(ctx context.Context, env *testenv.TestEnv, rn *rspb.ResourceNa
 func TestRead(t *testing.T) {
 	ctx := context.Background()
 	remoteEnv := testenv.GetTestEnv(t)
-	localEnv := testenv.GetTestEnv(t)
-	bs, requestCounter := runRemoteBSS(ctx, remoteEnv, t)
-	proxy := runBSProxy(ctx, bs, localEnv, t)
+	proxyEnv := testenv.GetTestEnv(t)
+	bs, _, _, requestCounter := runRemoteServices(ctx, remoteEnv, t)
+	proxy := runBSProxy(ctx, bs, proxyEnv, t)
 
 	cases := []struct {
 		wantError error
@@ -153,7 +200,7 @@ func TestRead(t *testing.T) {
 		},
 	}
 
-	ctx, err := prefix.AttachUserPrefixToContext(ctx, localEnv)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, proxyEnv)
 	if err != nil {
 		t.Errorf("error attaching user prefix: %v", err)
 	}
@@ -188,11 +235,58 @@ func TestRead(t *testing.T) {
 
 			// offset and 0-sized reads are not cached in the proxy.
 			if tc.offset == 0 && tc.size > 0 {
-				require.NoError(t, waitContains(ctx, localEnv, rn))
+				require.NoError(t, waitContains(ctx, proxyEnv, rn))
 			}
 		}
 		requestCounter.Store(0)
 	}
+}
+
+func TestRead_RemoteAtimeUpdated(t *testing.T) {
+	rn, blob := testdigest.RandomCompressibleCASResourceBuf(t, 5e4, "" /*instanceName*/)
+	d := rn.Digest
+
+	ctx := context.Background()
+	remoteEnv := testenv.GetTestEnv(t)
+	bs, cas, unaryRequestCounter, streamRequestCounter := runRemoteServices(ctx, remoteEnv, t)
+
+	proxyEnv := testenv.GetTestEnv(t)
+	proxyEnv.SetContentAddressableStorageClient(cas)
+	atimeTicker := make(chan time.Time)
+	require.NoError(t, atime_updater.Register(proxyEnv, atime_updater.Opts{TickerForTesting: atimeTicker}))
+	proxy := runBSProxy(ctx, bs, proxyEnv, t)
+
+	// Upload the test blob to the proxy
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, proxyEnv)
+	require.NoError(t, err)
+	uploadRn := fmt.Sprintf("uploads/%s/blobs/%s/%d", uuid.New(), d.Hash, d.SizeBytes)
+	bazelVersion := "5.0.0"
+	byte_stream.MustUploadChunked(t, ctx, proxy, bazelVersion, uploadRn, blob, true)
+	require.NoError(t, waitContains(ctx, proxyEnv, rn))
+	streamRequestCounter.Store(0)
+
+	// Read the blob back from the proxy
+	downloadBuf := []byte{}
+	downloadRn := fmt.Sprintf("blobs/%s/%d", d.Hash, d.SizeBytes)
+	downloadStream, err := proxy.Read(ctx, &bspb.ReadRequest{ResourceName: downloadRn})
+	require.NoError(t, err)
+	for {
+		res, err := downloadStream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		downloadBuf = append(downloadBuf, res.Data...)
+	}
+	require.Equal(t, blob, downloadBuf)
+	require.Equal(t, int32(0), unaryRequestCounter.Load())
+	require.Equal(t, int32(0), streamRequestCounter.Load())
+
+	// Tick the atime updater and verify a unary FindMissingBlob RPC was sent
+	atimeTicker <- time.Now()
+	time.Sleep(25 * time.Millisecond)
+	require.Equal(t, int32(1), unaryRequestCounter.Load())
+	require.Equal(t, int32(0), streamRequestCounter.Load())
 }
 
 func TestWrite(t *testing.T) {
@@ -244,21 +338,21 @@ func TestWrite(t *testing.T) {
 	for _, tc := range testCases {
 		run := func(t *testing.T) {
 			remoteEnv := testenv.GetTestEnv(t)
-			localEnv := testenv.GetTestEnv(t)
+			proxyEnv := testenv.GetTestEnv(t)
 			ctx := byte_stream.WithBazelVersion(t, context.Background(), tc.bazelVersion)
 
 			// Enable compression
 			flags.Set(t, "cache.zstd_transcoding_enabled", true)
-			localEnv.SetCache(&testcompression.CompressionCache{Cache: localEnv.GetCache()})
+			proxyEnv.SetCache(&testcompression.CompressionCache{Cache: proxyEnv.GetCache()})
 
-			ctx, err := prefix.AttachUserPrefixToContext(ctx, localEnv)
+			ctx, err := prefix.AttachUserPrefixToContext(ctx, proxyEnv)
 			require.NoError(t, err)
-			bs, requestCounter := runRemoteBSS(ctx, remoteEnv, t)
-			proxy := runBSProxy(ctx, bs, localEnv, t)
+			bs, _, _, requestCounter := runRemoteServices(ctx, remoteEnv, t)
+			proxy := runBSProxy(ctx, bs, proxyEnv, t)
 
 			// Upload the blob
 			byte_stream.MustUploadChunked(t, ctx, proxy, tc.bazelVersion, tc.uploadResourceName, tc.uploadBlob, true)
-			require.NoError(t, waitContains(ctx, localEnv, rn))
+			require.NoError(t, waitContains(ctx, proxyEnv, rn))
 
 			// Read back the blob we just uploaded
 			downloadBuf := []byte{}

--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/action_cache_server_proxy",
+        "//enterprise/server/atime_updater",
         "//enterprise/server/backends/configsecrets",
         "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/byte_stream_server_proxy",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -204,7 +204,7 @@ func registerGRPCServices(grpcServer *grpc.Server, env *real_environment.RealEnv
 
 	// The atime updater must be registered after the remote CAS client (which
 	// it depends on), but before the local CAS server (which depends on it).
-	if err := atime_updater.Register(env, atime_updater.Opts{}); err != nil {
+	if err := atime_updater.Register(env); err != nil {
 		log.Fatalf("%v", err)
 	}
 

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/action_cache_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/atime_updater"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
@@ -200,6 +201,12 @@ func registerGRPCServices(grpcServer *grpc.Server, env *real_environment.RealEnv
 	env.SetCapabilitiesClient(repb.NewCapabilitiesClient(conn))
 	env.SetByteStreamClient(bspb.NewByteStreamClient(conn))
 	env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
+
+	// The atime updater must be registered after the remote CAS client (which
+	// it depends on), but before the local CAS server (which depends on it).
+	if err := atime_updater.Register(env, atime_updater.Opts{}); err != nil {
+		log.Fatalf("%v", err)
+	}
 
 	// Configure gRPC services.
 	if err := capabilities_server_proxy.Register(env); err != nil {

--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//server/testutil/cas",
         "//server/testutil/testenv",
         "//server/util/uuid",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",

--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/environment",
+        "//server/interfaces",
         "//server/metrics",
         "//server/real_environment",
         "//server/remote_cache/digest",
@@ -28,6 +29,7 @@ go_test(
     srcs = ["content_addressable_storage_server_proxy_test.go"],
     embed = [":content_addressable_storage_server_proxy"],
     deps = [
+        "//enterprise/server/atime_updater",
         "//enterprise/server/byte_stream_server_proxy",
         "//proto:remote_execution_go_proto",
         "//server/remote_cache/byte_stream_server",

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/atime_updater"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
@@ -30,6 +32,15 @@ const (
 	bazDigest   = "baa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096"
 	quxDigest   = "21f58d27f827d295ffcd860c65045685e3baf1ad4506caa0140113b316647534"
 )
+
+// The real AtimeUpdater makes RPCs which may interfere with tests.
+type noOpAtimeUpdater struct{}
+
+func (a *noOpAtimeUpdater) Enqueue(_ context.Context, _ string, _ []*repb.Digest, _ repb.DigestFunction_Value) {
+}
+func (a *noOpAtimeUpdater) EnqueueByResourceName(_ context.Context, _ string) {}
+func (a *noOpAtimeUpdater) EnqueueByFindMissingRequest(_ context.Context, _ *repb.FindMissingBlobsRequest) {
+}
 
 func requestCountingUnaryInterceptor(count *atomic.Int32) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
@@ -178,10 +189,38 @@ func update(ctx context.Context, client repb.ContentAddressableStorageClient, bl
 	}
 }
 
+func expectAtimeUpdate(t *testing.T, ticker chan time.Time, requestCount *atomic.Int32) {
+	requestCount.Store(0)
+	ticker <- time.Now()
+	wait := time.Millisecond
+	for i := 0; i < 7; i++ {
+		time.Sleep(wait)
+		wait = wait * 2
+		if requestCount.Load() == 1 {
+			requestCount.Store(0)
+			return
+		}
+	}
+	t.Fatal("Timed out waiting for remote atime update")
+}
+
+func expectNoAtimeUpdate(t *testing.T, ticker chan time.Time, requestCount *atomic.Int32) {
+	requestCount.Store(0)
+	for i := 0; i < 10; i++ {
+		ticker <- time.Now()
+	}
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, int32(0), requestCount.Load())
+}
+
 func TestFindMissingBlobs(t *testing.T) {
 	ctx := context.Background()
 	conn, requestCount, _ := runRemoteCASS(ctx, testenv.GetTestEnv(t), t)
-	proxyConn := runCASProxy(ctx, conn, testenv.GetTestEnv(t), t)
+	proxyEnv := testenv.GetTestEnv(t)
+	proxyEnv.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
+	atimeTicker := make(chan time.Time)
+	require.NoError(t, atime_updater.Register(proxyEnv, atime_updater.Opts{TickerForTesting: atimeTicker}))
+	proxyConn := runCASProxy(ctx, conn, proxyEnv, t)
 	proxy := repb.NewContentAddressableStorageClient(proxyConn)
 
 	fooDigestProto := digestProto(fooDigest, 3)
@@ -191,6 +230,7 @@ func TestFindMissingBlobs(t *testing.T) {
 		findMissing(ctx, proxy, []*repb.Digest{fooDigestProto}, []*repb.Digest{fooDigestProto}, t)
 		require.Equal(t, int32(i), requestCount.Load())
 	}
+	expectAtimeUpdate(t, atimeTicker, requestCount)
 
 	update(ctx, proxy, map[*repb.Digest]string{barDigestProto: "bar"}, t)
 
@@ -199,19 +239,25 @@ func TestFindMissingBlobs(t *testing.T) {
 		findMissing(ctx, proxy, []*repb.Digest{barDigestProto}, []*repb.Digest{}, t)
 		require.Equal(t, int32(0), requestCount.Load())
 	}
+	expectAtimeUpdate(t, atimeTicker, requestCount)
 
 	requestCount.Store(0)
 	for i := 1; i < 10; i++ {
 		findMissing(ctx, proxy, []*repb.Digest{fooDigestProto, barDigestProto}, []*repb.Digest{fooDigestProto}, t)
 		require.Equal(t, int32(i), requestCount.Load())
 	}
+	expectAtimeUpdate(t, atimeTicker, requestCount)
 }
 
 func TestReadUpdateBlobs(t *testing.T) {
 	ctx := context.Background()
 	conn, requestCount, _ := runRemoteCASS(ctx, testenv.GetTestEnv(t), t)
 	casClient := repb.NewContentAddressableStorageClient(conn)
-	proxyConn := runCASProxy(ctx, conn, testenv.GetTestEnv(t), t)
+	proxyEnv := testenv.GetTestEnv(t)
+	proxyEnv.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
+	atimeTicker := make(chan time.Time)
+	require.NoError(t, atime_updater.Register(proxyEnv, atime_updater.Opts{TickerForTesting: atimeTicker}))
+	proxyConn := runCASProxy(ctx, conn, proxyEnv, t)
 	proxy := repb.NewContentAddressableStorageClient(proxyConn)
 
 	fooDigestProto := digestProto(fooDigest, 3)
@@ -224,28 +270,37 @@ func TestReadUpdateBlobs(t *testing.T) {
 
 	read(ctx, proxy, []*repb.Digest{fooDigestProto, foofDigestProto, barDigestProto}, map[string]string{}, t)
 	require.Equal(t, int32(1), requestCount.Load())
+	expectNoAtimeUpdate(t, atimeTicker, requestCount)
 
 	update(ctx, proxy, map[*repb.Digest]string{fooDigestProto: "foo"}, t)
-	require.Equal(t, int32(2), requestCount.Load())
+	require.Equal(t, int32(1), requestCount.Load())
+	expectNoAtimeUpdate(t, atimeTicker, requestCount)
 
 	read(ctx, casClient, []*repb.Digest{fooDigestProto}, map[string]string{fooDigest: "foo"}, t)
 	requestCount.Store(0)
 	read(ctx, proxy, []*repb.Digest{fooDigestProto}, map[string]string{fooDigest: "foo"}, t)
 	require.Equal(t, int32(0), requestCount.Load())
+	expectAtimeUpdate(t, atimeTicker, requestCount)
 	read(ctx, proxy, []*repb.Digest{fooDigestProto, fooDigestProto}, map[string]string{fooDigest: "foo"}, t)
 	require.Equal(t, int32(0), requestCount.Load())
+	expectAtimeUpdate(t, atimeTicker, requestCount)
 
 	read(ctx, proxy, []*repb.Digest{barrDigestProto, barrrDigestProto, bazDigestProto}, map[string]string{}, t)
 	require.Equal(t, int32(1), requestCount.Load())
+	expectNoAtimeUpdate(t, atimeTicker, requestCount)
 	update(ctx, casClient, map[*repb.Digest]string{bazDigestProto: "baz"}, t)
-	require.Equal(t, int32(2), requestCount.Load())
+	require.Equal(t, int32(1), requestCount.Load())
+	expectNoAtimeUpdate(t, atimeTicker, requestCount)
 
 	read(ctx, proxy, []*repb.Digest{barrDigestProto, barrrDigestProto, bazDigestProto}, map[string]string{bazDigest: "baz"}, t)
-	require.Equal(t, int32(3), requestCount.Load())
+	require.Equal(t, int32(1), requestCount.Load())
+	expectNoAtimeUpdate(t, atimeTicker, requestCount)
 	read(ctx, proxy, []*repb.Digest{fooDigestProto, bazDigestProto}, map[string]string{fooDigest: "foo", bazDigest: "baz"}, t)
+	expectAtimeUpdate(t, atimeTicker, requestCount)
 
 	update(ctx, casClient, map[*repb.Digest]string{quxDigestProto: "qux"}, t)
 	read(ctx, proxy, []*repb.Digest{quxDigestProto, quxDigestProto}, map[string]string{quxDigest: "qux"}, t)
+	expectNoAtimeUpdate(t, atimeTicker, requestCount)
 }
 
 func makeTree(ctx context.Context, client bspb.ByteStreamClient, t *testing.T) (*repb.Digest, []string) {
@@ -279,7 +334,9 @@ func TestGetTree(t *testing.T) {
 	conn, unaryRequests, streamRequests := runRemoteCASS(ctx, testenv.GetTestEnv(t), t)
 	casClient := repb.NewContentAddressableStorageClient(conn)
 	bsClient := bspb.NewByteStreamClient(conn)
-	proxyConn := runCASProxy(ctx, conn, testenv.GetTestEnv(t), t)
+	proxyEnv := testenv.GetTestEnv(t)
+	proxyEnv.SetAtimeUpdater(&noOpAtimeUpdater{})
+	proxyConn := runCASProxy(ctx, conn, proxyEnv, t)
 	casProxy := repb.NewContentAddressableStorageClient(proxyConn)
 	bsProxy := bspb.NewByteStreamClient(proxyConn)
 

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -132,4 +132,5 @@ type Env interface {
 	GetRegistryService() interfaces.RegistryService
 	GetPubSub() interfaces.PubSub
 	GetClock() clockwork.Clock
+	GetAtimeUpdater() interfaces.AtimeUpdater
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1538,3 +1538,9 @@ type AuthService interface {
 type RegistryService interface {
 	RegisterHandlers(mux HttpServeMux)
 }
+
+type AtimeUpdater interface {
+	Enqueue(ctx context.Context, instanceName string, digests []*repb.Digest, digestFunction repb.DigestFunction_Value)
+	EnqueueByResourceName(ctx context.Context, downloadString string)
+	EnqueueByFindMissingRequest(ctx context.Context, req *repb.FindMissingBlobsRequest)
+}

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -130,6 +130,7 @@ type RealEnv struct {
 	registryService                  interfaces.RegistryService
 	pubsub                           interfaces.PubSub
 	clock                            clockwork.Clock
+	atimeUpdater                     interfaces.AtimeUpdater
 }
 
 // NewRealEnv returns an environment for use in servers.
@@ -788,4 +789,11 @@ func (r *RealEnv) GetClock() clockwork.Clock {
 }
 func (r *RealEnv) SetClock(clock clockwork.Clock) {
 	r.clock = clock
+}
+
+func (r *RealEnv) GetAtimeUpdater() interfaces.AtimeUpdater {
+	return r.atimeUpdater
+}
+func (r *RealEnv) SetAtimeUpdater(updater interfaces.AtimeUpdater) {
+	r.atimeUpdater = updater
 }


### PR DESCRIPTION
Whoops, this PR turned out a bit bigger than I expected. Most of it's tests, though, so hopefully it's still palatable but let me know if not.

This PR adds an `AtimeUpdater` interface and implementation that exposes functions for enqueueing atime updates to be written to the remote cache. This is intended to address the issue that artifacts served out of the Cache Proxy's local cache won't have their remote atimes updated and thus may expire prematurely. The `AtimeUpdater` is best effort and will drop requested updates if the number of pending updates exceeds flag-configured thresholds. Internally, it maintains a set of "updates" (effectively FindMissingBlobsRequests) per group, with one update per instance-name/digest-type per group. It flushes these to the remote cache in a round robin fashion on an interval that's controlled by a flag, sending one update per group per tick to try and achieve some degree of fairness between groups. Lastly, this PR hooks up the BS proxy and CAS proxy to the atime updater, enqueuing updates for locally accessed cache entries.

Interesting things that may warrant discussion:
- I chose not to send updates through a channel, instead passing them synchronously, copying them into the set of pending updates, and then returning. This may be slow or block in some cases, but I tried to prevent that.
- I bet the updater is passing arguments by value instead of by pointer a bit too much and that should probably be cleaned up for performance.
- I'm not sure it's necessary to enqueue updates for BS.Read() and CAS.BatchGetBlobs(), but I couldn't convince myself it's _not_ necessary...

**Related issues**: N/A
