### PR TITLE
Add run ID to invocations to link parent invocation attempts with children

### DIFF
--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -153,6 +153,14 @@ message Invocation {
   // remote bazel invocation runs bazel commands, each of those is a child
   // invocation).
   repeated Invocation child_invocations = 36;
+
+  // A unique ID for each run of an invocation. If the invocation is retried,
+  // this should change with each retry.
+  string run_id = 37;
+
+  // If set, the run ID of the parent invocation that invoked this invocation
+  // (i.e. a workflow or remote bazel invocation).
+  string parent_run_id = 38;
 }
 
 message InvocationEvent {

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -181,9 +181,9 @@ func (d *InvocationDB) LookupInvocation(ctx context.Context, invocationID string
 	return ti, nil
 }
 
-func (d *InvocationDB) LookupChildInvocations(ctx context.Context, parentInvocationID string) ([]*tables.Invocation, error) {
+func (d *InvocationDB) LookupChildInvocations(ctx context.Context, parentRunID string) ([]*tables.Invocation, error) {
 	rq := d.h.NewQuery(ctx, "invocationdb_get_child_invocations").Raw(
-		`SELECT * FROM "Invocations" WHERE parent_invocation_id = ? ORDER BY created_at_usec`, parentInvocationID)
+		`SELECT * FROM "Invocations" WHERE parent_run_id = ? ORDER BY created_at_usec`, parentRunID)
 	return db.ScanAll(rq, &tables.Invocation{})
 }
 
@@ -356,5 +356,7 @@ func TableInvocationToProto(i *tables.Invocation) *inpb.Invocation {
 	// claims the tags are.
 	out.Tags, _ = invocation_format.SplitAndTrimAndDedupeTags(i.Tags, false)
 	out.ParentInvocationId = i.ParentInvocationID
+	out.ParentRunId = i.ParentRunID
+	out.RunId = i.RunID
 	return out
 }

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1527,6 +1527,8 @@ func (e *EventChannel) tableInvocationFromProto(p *inpb.Invocation, blobID strin
 	}
 	i.Tags = tags
 	i.ParentInvocationID = p.ParentInvocationId
+	i.ParentRunID = p.ParentRunId
+	i.RunID = p.RunId
 
 	userGroupPerms, err := perms.ForAuthenticatedGroup(e.ctx, e.env)
 	if err != nil {

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -115,7 +115,9 @@ type fieldPriorities struct {
 	Command,
 	Pattern,
 	Tags,
-	ParentInvocationId int
+	ParentInvocationId,
+	ParentRunId,
+	RunId int
 }
 
 func NewStreamingEventParser(invocation *inpb.Invocation) *StreamingEventParser {
@@ -435,6 +437,12 @@ func (sep *StreamingEventParser) fillInvocationFromBuildMetadata(metadata map[st
 	if parentInvocationId, ok := metadata["PARENT_INVOCATION_ID"]; ok && parentInvocationId != "" {
 		sep.setParentInvocationId(parentInvocationId, priority)
 	}
+	if parentRunId, ok := metadata["PARENT_RUN_ID"]; ok && parentRunId != "" {
+		sep.setParentRunId(parentRunId, priority)
+	}
+	if runId, ok := metadata["RUN_ID"]; ok && runId != "" {
+		sep.setRunId(runId, priority)
+	}
 	return nil
 }
 
@@ -519,5 +527,19 @@ func (sep *StreamingEventParser) setParentInvocationId(value string, priority in
 	if sep.priority.ParentInvocationId <= priority {
 		sep.priority.ParentInvocationId = priority
 		sep.invocation.ParentInvocationId = value
+	}
+}
+
+func (sep *StreamingEventParser) setParentRunId(value string, priority int) {
+	if sep.priority.ParentRunId <= priority {
+		sep.priority.ParentRunId = priority
+		sep.invocation.ParentRunId = value
+	}
+}
+
+func (sep *StreamingEventParser) setRunId(value string, priority int) {
+	if sep.priority.RunId <= priority {
+		sep.priority.RunId = priority
+		sep.invocation.RunId = value
 	}
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -141,8 +141,9 @@ func (s *BuildBuddyServer) GetInvocation(ctx context.Context, req *inpb.GetInvoc
 		}
 	}
 
-	if req.GetLookup().GetFetchChildInvocations() {
-		children, err := s.env.GetInvocationDB().LookupChildInvocations(ctx, inv.GetInvocationId())
+	// Fetch children by run ID so that we don't fetch children from earlier retries
+	if req.GetLookup().GetFetchChildInvocations() && inv.GetRunId() != "" {
+		children, err := s.env.GetInvocationDB().LookupChildInvocations(ctx, inv.GetRunId())
 		if err != nil {
 			return nil, err
 		}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -415,7 +415,7 @@ type InvocationDB interface {
 	LookupGroupFromInvocation(ctx context.Context, invocationID string) (*tables.Group, error)
 	LookupGroupIDFromInvocation(ctx context.Context, invocationID string) (string, error)
 	LookupExpiredInvocations(ctx context.Context, cutoffTime time.Time, limit int) ([]*tables.Invocation, error)
-	LookupChildInvocations(ctx context.Context, parentInvocationID string) ([]*tables.Invocation, error)
+	LookupChildInvocations(ctx context.Context, parentRunID string) ([]*tables.Invocation, error)
 	DeleteInvocation(ctx context.Context, invocationID string) error
 	DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *UserInfo, invocationID string) error
 	FillCounts(ctx context.Context, log *telpb.TelemetryStat) error

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -157,6 +157,7 @@ type Invocation struct {
 	InvocationUUID                   []byte `gorm:"size:16;default:NULL;uniqueIndex:invocation_invocation_uuid;unique"`
 	Success                          bool
 	Attempt                          uint64 `gorm:"not null;default:0"`
+	RunID                            string
 	BazelExitCode                    string
 
 	// The user-specified setting of how to download outputs from remote cache.
@@ -173,6 +174,7 @@ type Invocation struct {
 	Tags string
 
 	ParentInvocationID string `gorm:"index:parent_invocation_id_index"`
+	ParentRunID        string `gorm:"index:parent_run_id_index"`
 }
 
 func (i *Invocation) TableName() string {

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -117,6 +117,8 @@ type Invocation struct {
 	RemoteExecutionEnabled            bool
 	Tags                              []string `gorm:"type:Array(String);"`
 	ParentInvocationUUID              string
+	RunID                             string
+	ParentRunID                       string
 }
 
 func (i *Invocation) ExcludedFields() []string {
@@ -479,5 +481,7 @@ func ToInvocationFromPrimaryDB(ti *tables.Invocation) (*Invocation, error) {
 		RemoteExecutionEnabled:            ti.RemoteExecutionEnabled,
 		Tags:                              invocation_format.ConvertDBTagsToOLAP(ti.Tags),
 		ParentInvocationUUID:              parentInvocationUUID,
+		RunID:                             ti.RunID,
+		ParentRunID:                       ti.ParentRunID,
 	}, nil
 }


### PR DESCRIPTION
This PR adds the concept of a "run ID" - a unique identifier for each invocation retry attempt - so that we can fetch children invocations for only the current retry attempt

We should not fetch children invocations using the parent's invocation ID, because if the parent has been retried, we will fetch children from all retry attempts

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
