### PR TITLE
[ci_runner] Support build remotely and running locally via bash command

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1123,13 +1123,3 @@ func contains(m map[string]string, elem string) bool {
 	_, ok := m[elem]
 	return ok
 }
-
-// Returns the bazel command - i.e. `build` or `run`
-func getBazelCommand(bazelArgs []string) string {
-	for _, arg := range bazelArgs {
-		if !strings.HasPrefix(arg, "--") {
-			return arg
-		}
-	}
-	return ""
-}

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1123,3 +1123,13 @@ func contains(m map[string]string, elem string) bool {
 	_, ok := m[elem]
 	return ok
 }
+
+// Returns the bazel command - i.e. `build` or `run`
+func getBazelCommand(bazelArgs []string) string {
+	for _, arg := range bazelArgs {
+		if !strings.HasPrefix(arg, "--") {
+			return arg
+		}
+	}
+	return ""
+}

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -73,6 +73,8 @@ const (
 	// Name of the bazel output base dir. This is written under the workspace
 	// so that it can be cleaned up when the workspace is cleaned up.
 	outputBaseDirName = "output-base"
+	// Name of the dir where we write bazel run scripts.
+	runScriptDirName = "bazel-run-scripts"
 
 	// Fraction of disk space that must be in use before we attempt to reclaim
 	// disk space.
@@ -223,6 +225,9 @@ type workspace struct {
 	//             WORKSPACE
 	//             buildbuddy.yaml  (optional workflow config)
 	//             ...
+	//         bazel-run-scripts/   (generated run scripts for targets that were
+	//                              built remotely, but intended to run locally
+	//                              on the client's machine)
 	//
 	// The CI runner stays in the rootDir while setting up the repo, and then
 	// changes to the "repo-root" dir just before executing any actions.
@@ -1180,6 +1185,42 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			uploader.UploadDirectory(namedSetID, artifactsDir) // does not return an error
 		}
 
+		// If extracting run information from builds was requested,
+		// extract it and send it via the event stream.
+		runScriptDir := filepath.Join(ws.rootDir, runScriptDirName)
+		if _, err = os.Stat(runScriptDir); err == nil {
+			err = filepath.Walk(runScriptDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if !info.IsDir() {
+					runScriptInfo, err := processRunScript(ctx, path)
+					if err != nil {
+						return err
+					}
+					e := &bespb.BuildEvent{
+						Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_RunTargetAnalyzed{}},
+						Payload: &bespb.BuildEvent_RunTargetAnalyzed{RunTargetAnalyzed: &bespb.RunTargetAnalyzed{
+							Arguments:          runScriptInfo.args,
+							RunfilesRoot:       runScriptInfo.runfilesRoot,
+							Runfiles:           runScriptInfo.runfiles,
+							RunfileDirectories: runScriptInfo.runfileDirs,
+						}},
+					}
+					ar.reporter.Publish(e)
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			// Clear the directory so it's in a clean state for future steps
+			if err := os.RemoveAll(runScriptDir); err != nil {
+				return err
+			}
+		}
+
 		duration := time.Since(cmdStartTime)
 		completedEvent := &bespb.BuildEvent{
 			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_RemoteRunnerStepCompleted{
@@ -1245,7 +1286,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		// Instead of actually running the target, have Bazel write out a run script using the --script_path flag and
 		// extract run options (i.e. args, runfile information) from the generated run script.
 		runScript := ""
-		isRunCmd := args[0] == "run"
+		isRunCmd := getBazelCommand(args) == "run"
 		if isRunCmd && *recordRunMetadata {
 			tmpDir, err := os.MkdirTemp("", "bazel-run-script-*")
 			if err != nil {
@@ -1389,6 +1430,16 @@ func (ar *actionRunner) workspaceStatusEvent() *bespb.BuildEvent {
 			},
 		}},
 	}
+}
+
+// Returns the bazel command - i.e. `build` or `run`
+func getBazelCommand(bazelArgs []string) string {
+	for _, arg := range bazelArgs {
+		if !strings.HasPrefix(arg, "--") {
+			return arg
+		}
+	}
+	return ""
 }
 
 // This should only be used for WorkflowConfiguredEvents--it explicitly labels
@@ -2218,8 +2269,15 @@ func (ws *workspace) writeBazelWrapperScript() error {
 			}
 		}
 
+		cmd := fmt.Sprintf(
+			"BAZEL_WRAPPER_MODE=1 BAZEL_BIN=%q CI_RUNNER_ROOT=%q RECORD_RUN_METADATA=%v exec %s \"$@\"",
+			*bazelCommand,
+			ws.rootDir,
+			*recordRunMetadata,
+			os.Getenv("BUILDBUDDY_CI_RUNNER_ABSPATH"),
+		)
 		contents := `#!/usr/bin/env sh
-BAZEL_WRAPPER_MODE=1 BAZEL_BIN=` + fmt.Sprintf("%q", *bazelCommand) + ` CI_RUNNER_ROOT=` + fmt.Sprintf("%q", ws.rootDir) + ` exec ` + os.Getenv("BUILDBUDDY_CI_RUNNER_ABSPATH") + ` "$@"
+` + cmd + `
 `
 		if err := os.WriteFile(wrapperPath, []byte(contents), 0755); err != nil {
 			return status.InternalErrorf("Failed to write to %s: %s", wrapperPath, err)
@@ -2630,7 +2688,8 @@ func runCredentialHelper() error {
 
 func runBazelWrapper() error {
 	rootPath := os.Getenv("CI_RUNNER_ROOT")
-	bazelCmd := os.Getenv("BAZEL_BIN")
+	bazelBin := os.Getenv("BAZEL_BIN")
+	recordRunMetadata := os.Getenv("RECORD_RUN_METADATA") == "true"
 
 	// These arguments are passed as env vars so we don't have to parse out flags
 	// intended for the bazel wrapper from startup options intended to be passed through
@@ -2679,12 +2738,25 @@ func runBazelWrapper() error {
 		return err
 	}
 
-	args := append([]string{bazelCmd}, append(startupArgs, originalArgs...)...)
-	args = appendBazelSubcommandArgs(args, metadataFlag)
+	bazelCmd := append([]string{bazelBin}, append(startupArgs, originalArgs...)...)
+	bazelCmd = appendBazelSubcommandArgs(bazelCmd, metadataFlag)
+
+	// Users can request to build a target on the remote runner and run them locally.
+	// To support this, have Bazel write out a run script using the --script_path flag and
+	// extract run options (i.e. args, runfile information) from the generated run script.
+	if recordRunMetadata && getBazelCommand(filteredOriginalArgs) == "run" {
+		runScriptDir := filepath.Join(rootPath, runScriptDirName)
+		if err := os.MkdirAll(runScriptDir, 0755); err != nil {
+			return err
+		}
+
+		runScriptPath := filepath.Join(runScriptDir, "run.sh")
+		bazelCmd = appendBazelSubcommandArgs(bazelCmd, "--script_path="+runScriptPath)
+	}
 
 	// Replace the process running the bazel wrapper with the process running bazel,
 	// so there are no remaining traces of the wrapper script.
-	return syscall.Exec(bazelCmd, args, os.Environ())
+	return syscall.Exec(bazelBin, bazelCmd, os.Environ())
 }
 
 // Attempts to free up disk space.

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -360,76 +360,141 @@ func TestCancel(t *testing.T) {
 }
 
 func TestFetchRemoteBuildOutputs(t *testing.T) {
-	defer os.Unsetenv("STEPS_MODE")
-	for _, stepsModeEnabled := range []string{"0", "1"} {
-		os.Setenv("STEPS_MODE", stepsModeEnabled)
+	clonePrivateTestRepo(t)
 
-		clonePrivateTestRepo(t)
+	// Run a server and executor locally to run remote bazel against
+	personalAccessToken := os.Getenv("PRIVATE_TEST_REPO_GIT_ACCESS_TOKEN")
+	env, bbServer, _ := runLocalServerAndExecutor(t, personalAccessToken)
 
-		// Run a server and executor locally to run remote bazel against
-		personalAccessToken := os.Getenv("PRIVATE_TEST_REPO_GIT_ACCESS_TOKEN")
-		env, bbServer, _ := runLocalServerAndExecutor(t, personalAccessToken)
+	// Create a workflow for the same repo - will be used to fetch the git token
+	dbh := env.GetDBHandle()
+	require.NotNil(t, dbh)
+	err := dbh.NewQuery(context.Background(), "create_git_repo_for_test").Create(&tables.GitRepository{
+		RepoURL: "https://github.com/buildbuddy-io/private-test-repo",
+		GroupID: env.GroupID1,
+	})
+	require.NoError(t, err)
 
-		// Create a workflow for the same repo - will be used to fetch the git token
-		dbh := env.GetDBHandle()
-		require.NotNil(t, dbh)
-		err := dbh.NewQuery(context.Background(), "create_git_repo_for_test").Create(&tables.GitRepository{
-			RepoURL: "https://github.com/buildbuddy-io/private-test-repo",
-			GroupID: env.GroupID1,
+	// Run remote bazel
+	randomStr := fmt.Sprintf("%d", time.Now().UnixMilli())
+	exitCode, err := remotebazel.HandleRemoteBazel([]string{
+		fmt.Sprintf("--remote_runner=%s", bbServer.GRPCAddress()),
+		// Have the ci runner use the "none" isolation type because it's simpler
+		// to setup than a firecracker runner
+		"--runner_exec_properties=workload-isolation-type=none",
+		"--runner_exec_properties=container-image=",
+		// Ensure the build is happening on a clean runner, because if the build
+		// artifact is locally cached, we won't upload it to the remote cache
+		// and we won't be able to fetch it.
+		"--runner_exec_properties=instance_name=" + randomStr,
+		// Pass a startup flag to test parsing
+		"--digest_function=BLAKE3",
+		"build",
+		":hello_world_go",
+		fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1)})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	// Check that the remote build output was fetched locally.
+	// The outputs will be downloaded to a directory that may change with the platform,
+	// so recursively search for the build output named `hello_world_go`.
+	findFile := func(rootDir, targetFile string) (string, error) {
+		var outputPath string
+		err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !d.IsDir() && d.Name() == targetFile {
+				outputPath = path
+				return filepath.SkipAll // Stop searching further once the file is found
+			}
+
+			return nil
 		})
-		require.NoError(t, err)
-
-		// Run remote bazel
-		randomStr := time.Now().String()
-		exitCode, err := remotebazel.HandleRemoteBazel([]string{
-			fmt.Sprintf("--remote_runner=%s", bbServer.GRPCAddress()),
-			// Have the ci runner use the "none" isolation type because it's simpler
-			// to setup than a firecracker runner
-			"--runner_exec_properties=workload-isolation-type=none",
-			"--runner_exec_properties=container-image=",
-			// Ensure the build is happening on a clean runner, because if the build
-			// artifact is locally cached, we won't upload it to the remote cache
-			// and we won't be able to fetch it.
-			"--runner_exec_properties=instance_name=" + randomStr,
-			// Pass a startup flag to test parsing
-			"--digest_function=BLAKE3",
-			"build",
-			":hello_world_go",
-			fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1)})
-		require.NoError(t, err)
-		require.Equal(t, 0, exitCode)
-
-		// Check that the remote build output was fetched locally.
-		// The outputs will be downloaded to a directory that may change with the platform,
-		// so recursively search for the build output named `hello_world_go`.
-		findFile := func(rootDir, targetFile string) (string, error) {
-			var outputPath string
-			err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if !d.IsDir() && d.Name() == targetFile {
-					outputPath = path
-					return filepath.SkipAll // Stop searching further once the file is found
-				}
-
-				return nil
-			})
-			return outputPath, err
-		}
-		downloadedOutputPath, err := findFile(remotebazel.BuildBuddyArtifactDir, "hello_world_go")
-		require.NoError(t, err)
-
-		// Make sure we can successfully run the fetched binary.
-		err = os.Chmod(downloadedOutputPath, 0755)
-		require.NoError(t, err)
-
-		var buf bytes.Buffer
-		cmd := exec.Command(downloadedOutputPath)
-		cmd.Stdout = &buf
-		err = cmd.Run()
-		require.NoError(t, err)
-		require.Equal(t, "Hello! I'm a go program.\n", buf.String())
+		return outputPath, err
 	}
+	downloadedOutputPath, err := findFile(remotebazel.BuildBuddyArtifactDir, "hello_world_go")
+	require.NoError(t, err)
+
+	// Make sure we can successfully run the fetched binary.
+	err = os.Chmod(downloadedOutputPath, 0755)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	cmd := exec.Command(downloadedOutputPath)
+	cmd.Stdout = &buf
+	err = cmd.Run()
+	require.NoError(t, err)
+	require.Equal(t, "Hello! I'm a go program.\n", buf.String())
+}
+
+func TestBuildRemotelyRunLocally(t *testing.T) {
+	os.Setenv("STEPS_MODE", "1")
+	defer os.Unsetenv("STEPS_MODE")
+
+	clonePrivateTestRepo(t)
+
+	// Run a server and executor locally to run remote bazel against
+	personalAccessToken := os.Getenv("PRIVATE_TEST_REPO_GIT_ACCESS_TOKEN")
+	env, bbServer, _ := runLocalServerAndExecutor(t, personalAccessToken)
+
+	// Create a workflow for the same repo - will be used to fetch the git token
+	dbh := env.GetDBHandle()
+	require.NotNil(t, dbh)
+	err := dbh.NewQuery(context.Background(), "create_git_repo_for_test").Create(&tables.GitRepository{
+		RepoURL: "https://github.com/buildbuddy-io/private-test-repo",
+		GroupID: env.GroupID1,
+	})
+	require.NoError(t, err)
+
+	// Run remote bazel
+	randomStr := fmt.Sprintf("%d", time.Now().UnixMilli())
+	exitCode, err := remotebazel.HandleRemoteBazel([]string{
+		fmt.Sprintf("--remote_runner=%s", bbServer.GRPCAddress()),
+		// Have the ci runner use the "none" isolation type because it's simpler
+		// to setup than a firecracker runner
+		"--runner_exec_properties=workload-isolation-type=none",
+		"--runner_exec_properties=container-image=",
+		// Ensure the build is happening on a clean runner, because if the build
+		// artifact is locally cached, we won't upload it to the remote cache
+		// and we won't be able to fetch it.
+		"--runner_exec_properties=instance_name=" + randomStr,
+		// Pass a startup flag to test parsing
+		"--digest_function=BLAKE3",
+		"--run_remotely=0",
+		"run",
+		":hello_world_go",
+		fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1)})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	// Check that the remote runner didn't run the script
+	bbClient := env.GetBuildBuddyServiceClient()
+	ctx := env.WithUserID(context.Background(), env.UserID1)
+	reqCtx := &ctxpb.RequestContext{
+		UserId:  &uidpb.UserId{Id: env.UserID1},
+		GroupId: env.GroupID1,
+	}
+	searchRsp, err := bbClient.SearchInvocation(ctx, &inpb.SearchInvocationRequest{
+		RequestContext: reqCtx,
+		Query:          &inpb.InvocationQuery{GroupId: env.GroupID1},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, len(searchRsp.GetInvocation()))
+
+	var childInv *inpb.Invocation
+	for _, inv := range searchRsp.GetInvocation() {
+		if inv.Command == "run" {
+			childInv = inv
+		}
+	}
+	require.NotNil(t, childInv)
+
+	logResp, err := bbClient.GetEventLogChunk(ctx, &elpb.GetEventLogChunkRequest{
+		InvocationId: childInv.InvocationId,
+		MinLines:     math.MaxInt32,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(logResp.GetBuffer()), "Hello! I'm a go program.")
 }


### PR DESCRIPTION
We have a remote bazel feature that builds the target remotely and runs the executable locally. This happens automatically in the CLI, as opposed to building the target remotely, and then the user manually running the executable that was fetched locally (here's the [PR](https://github.com/buildbuddy-io/buildbuddy/commit/fa9409e55400bd34c19b7e7282d4468999c056fc) where the behavior was introduced). This PR adds support in the new Steps syntax - this is the last missing feature before feature parity with BazelCommands