### PR TITLE
remove usage of rand.Seed()

### DIFF
--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -41,7 +41,6 @@ import (
 )
 
 func TestSessionInsertUpdateDeleteRead(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	ctx := context.Background()
 	env := setupEnv(t)
 	adb := env.GetAuthDB()
@@ -245,7 +244,6 @@ func TestBackfillUnencryptedKeys(t *testing.T) {
 }
 
 func TestGetAPIKeyGroupFromAPIKeyID(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	ctx := context.Background()
 	env := setupEnv(t)
 	adb := env.GetAuthDB()
@@ -320,7 +318,6 @@ func TestGetAPIKeys(t *testing.T) {
 }
 
 func TestGetAPIKeyGroup_UserOwnedKeys(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	ctx := context.Background()
 	env := setupEnv(t)
 	adb := env.GetAuthDB()
@@ -387,7 +384,6 @@ func TestGetAPIKeyGroup_UserOwnedKeys(t *testing.T) {
 }
 
 func TestLookupUserFromSubID(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	ctx := context.Background()
 	env := setupEnv(t)
 	adb := env.GetAuthDB()

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2390,8 +2390,6 @@ func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI st
 }
 
 func getCrypterEnv(t *testing.T) (*testenv.TestEnv, string) {
-	rand.Seed(time.Now().UnixMicro())
-
 	kmsDir := testfs.MakeTempDir(t)
 	masterKeyURI := generateKMSKey(t, kmsDir, "masterKey")
 

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -216,8 +216,6 @@ func createKey(t *testing.T, env environment.Env, clock clockwork.Clock, keyID, 
 }
 
 func getEnv(t *testing.T) (*testenv.TestEnv, *fakeKMS) {
-	mrand.Seed(time.Now().UnixMicro())
-
 	kms := newFakeKMS(t)
 
 	generateKMSKey(t, kms, "master")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_performance_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_performance_test.go
@@ -59,8 +59,6 @@ func TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking(t *testing.T) {
 	flags.Set(t, "app.log_level", "fatal")
 	log.Configure()
 
-	rand.Seed(time.Now().UnixNano())
-
 	var containersToCleanup []*firecracker.FirecrackerContainer
 	t.Cleanup(func() {
 		for _, vm := range containersToCleanup {

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil"
@@ -40,7 +39,6 @@ const (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
 	// Ensure some memory is allocated for the shared LRU.
 	if err := resources.Configure(true /*=snapshotSharingEnabled*/); err != nil {
 		log.Fatalf("Failed to configure resources: %s", err)

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -382,10 +382,6 @@ func TestRunnerPool_Shutdown_RemovesPausedRunners(t *testing.T) {
 }
 
 func TestRunnerPool_Shutdown_RunnersReturnRetriableOrNilError(t *testing.T) {
-	seed := time.Now().UnixNano()
-	rand.Seed(seed)
-	t.Logf("Random seed: %d", seed)
-
 	env := newTestEnv(t)
 	ctx := withAuthenticatedUser(t, context.Background(), env, "US1")
 

--- a/enterprise/server/scheduling/task_router/task_router_test.go
+++ b/enterprise/server/scheduling/task_router/task_router_test.go
@@ -3,9 +3,7 @@ package task_router_test
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
@@ -573,8 +571,6 @@ func newTaskRouter(t *testing.T, env environment.Env) interfaces.TaskRouter {
 }
 
 func newTestEnv(t *testing.T) environment.Env {
-	rand.Seed(time.Now().UnixNano())
-
 	redisTarget := testredis.Start(t).Target
 	env := enterprise_testenv.GetCustomTestEnv(t, &enterprise_testenv.Options{
 		RedisTarget: redisTarget,

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -229,10 +229,6 @@ func (r *Env) setupRootDirectoryWithTestCommandBinary(ctx context.Context) *repb
 // The returned environment does not have any executors by default. Use the
 // Add*Executor functions to add executors.
 func NewRBETestEnv(t *testing.T) *Env {
-	seed := time.Now().UnixNano()
-	rand.Seed(seed)
-	log.Infof("Test seed: %d", seed)
-
 	redisTarget := testredis.Start(t).Target
 	envOpts := &enterprise_testenv.Options{RedisTarget: redisTarget}
 

--- a/enterprise/server/test/webdriver/invocation/invocation_test.go
+++ b/enterprise/server/test/webdriver/invocation/invocation_test.go
@@ -131,8 +131,6 @@ func TestAuthenticatedInvocation_CacheEnabled(t *testing.T) {
 }
 
 func TestAuthenticatedInvocation_PersonalAPIKey_CacheEnabled(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-
 	wt := webtester.New(t)
 	target := buildbuddy_enterprise.SetupWebTarget(t)
 

--- a/enterprise/server/util/dsingleflight/dsingleflight_test.go
+++ b/enterprise/server/util/dsingleflight/dsingleflight_test.go
@@ -24,7 +24,6 @@ func TestDo(t *testing.T) {
 	c := New(rdb)
 	ctx := context.Background()
 
-	rand.Seed(time.Now().UnixNano())
 	key := fmt.Sprintf("key-%d", rand.Int())
 
 	wg, ctx := errgroup.WithContext(ctx)
@@ -70,7 +69,6 @@ func TestDoError(t *testing.T) {
 	c := New(rdb)
 	ctx := context.Background()
 
-	rand.Seed(time.Now().UnixNano())
 	key := fmt.Sprintf("key-%d", rand.Int())
 
 	wg, ctx := errgroup.WithContext(ctx)

--- a/enterprise/tools/rbeperf/rbeperf.go
+++ b/enterprise/tools/rbeperf/rbeperf.go
@@ -808,8 +808,6 @@ func (c *ClientSource) GetByteStreamClient() bspb.ByteStreamClient {
 
 func main() {
 	flag.Parse()
-	rand.Seed(time.Now().UnixNano())
-
 	if *verbose {
 		*log.LogLevel = "debug"
 	}

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker"
@@ -163,8 +162,6 @@ func main() {
 		// snapshot instead of hot-swapping it with a local one.
 		flagutil.SetValueForFlagName("debug_disable_firecracker_workspace_sync", true, nil, false)
 	}
-
-	rand.Seed(time.Now().Unix())
 
 	env := getToolEnv()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/server/remote_cache/scorecard/scorecard_test.go
+++ b/server/remote_cache/scorecard/scorecard_test.go
@@ -216,7 +216,6 @@ func TestGetCacheScoreCard_GroupByActionOrderByDurationDesc(t *testing.T) {
 }
 
 func TestGetCacheScoreCard_GroupByTargetOrderByDuration(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	expectedResults := []*capb.ScoreCard_Result{}
 	// Set up results so that expected action IDs alternate within each target
 	// group, and so that durations across groups have some overlap.

--- a/server/util/consistent_hash/consistent_hash_test.go
+++ b/server/util/consistent_hash/consistent_hash_test.go
@@ -21,7 +21,6 @@ import (
 const numVnodes = 100
 
 func TestNodesetOrderIndependence(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	assert := assert.New(t)
 	ch := consistent_hash.NewConsistentHash(consistent_hash.CRC32, numVnodes)
 
@@ -57,7 +56,6 @@ func TestNodesetOrderIndependence(t *testing.T) {
 }
 
 func TestGetAllReplicas(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	assert := assert.New(t)
 	ch := consistent_hash.NewConsistentHash(consistent_hash.CRC32, numVnodes)
 
@@ -81,8 +79,6 @@ func TestGetAllReplicas(t *testing.T) {
 }
 
 func TestEvenLoadDistribution(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-
 	rng := bufio.NewReader(rand.New(rand.NewSource(time.Now().UnixNano())))
 
 	// Record the frequency of each host returned by Get() across 1M random
@@ -123,7 +119,6 @@ func BenchmarkGetAllReplicas(b *testing.B) {
 		{Name: "SHA256/10000_vnodes", HashFunction: consistent_hash.SHA256, NumVnodes: 10000},
 	} {
 		b.Run(test.Name, func(b *testing.B) {
-			rand.Seed(time.Now().UnixNano())
 			assert := assert.New(b)
 			ch := consistent_hash.NewConsistentHash(test.HashFunction, test.NumVnodes)
 

--- a/server/util/lockingbuffer/lockingbuffer_test.go
+++ b/server/util/lockingbuffer/lockingbuffer_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestLockingBuffer_ReadWrite(t *testing.T) {
-	rand.Seed(int64(time.Now().UnixNano()))
-
 	buf := lockingbuffer.New()
 
 	writer := func(val string, writeCount int, done *bool, doneLock *sync.RWMutex) {
@@ -97,8 +95,6 @@ func charCount(s string, c byte) int {
 }
 
 func TestLockingBuffer_ReadAll(t *testing.T) {
-	rand.Seed(int64(time.Now().UnixNano()))
-
 	buf := lockingbuffer.New()
 
 	writer := func(val string, writeCount int, done *bool, doneLock *sync.RWMutex) {

--- a/server/util/random/random.go
+++ b/server/util/random/random.go
@@ -3,7 +3,6 @@ package random
 import (
 	"io"
 	"sync"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 
@@ -22,10 +21,6 @@ func init() {
 }
 
 func RandUint64() uint64 {
-	once.Do(func() {
-		mrand.Seed(time.Now().UnixNano())
-		log.Debugf("Seeded random with current time!")
-	})
 	return mrand.Uint64()
 }
 

--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -140,8 +139,6 @@ func main() {
 	if *bazelBinary == "" {
 		log.Fatalf("--bazel_binary is required")
 	}
-
-	rand.Seed(time.Now().UnixNano())
 
 	err := runProbe()
 	if err != nil {


### PR DESCRIPTION
See https://pkg.go.dev/math/rand#Seed for more info

```
If Seed is not called, the generator is seeded randomly at program startup.

Prior to Go 1.20, the generator was seeded like Seed(1) at program startup. To
force the old behavior, call Seed(1) at program startup. Alternately, set
GODEBUG=randautoseed=0 in the environment before making any calls to functions in
this package.

Deprecated: As of Go 1.20 there is no reason to call Seed with a random value.
Programs that call Seed with a known value to get a specific sequence of results
should use New(NewSource(seed)) to obtain a local random generator.
```

Since we don't use `rand.Seed()` to generate deterministic randomized value, there
is no need too replace it with `Rand.Seed()`.

Remove all `rand.Seed()` calls.
