### PR TITLE
math/rand: replace rand.Read with crypto/rand

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3,6 +3,7 @@ package pebble_cache_test
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -2348,7 +2349,7 @@ func TestMigrateVersions(t *testing.T) {
 
 func generateKMSKey(t *testing.T, kmsDir string, id string) string {
 	key := make([]byte, 32)
-	_, err := rand.Read(key)
+	_, err := crand.Read(key)
 	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(kmsDir, id), key, 0644)
 	require.NoError(t, err)
@@ -2359,10 +2360,10 @@ func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI st
 	kmsClient := env.GetKMS()
 
 	masterKeyPart := make([]byte, 32)
-	_, err := rand.Read(masterKeyPart)
+	_, err := crand.Read(masterKeyPart)
 	require.NoError(t, err)
 	groupKeyPart := make([]byte, 32)
-	_, err = rand.Read(groupKeyPart)
+	_, err = crand.Read(groupKeyPart)
 	require.NoError(t, err)
 
 	masterAEAD, err := kmsClient.FetchMasterKey()

--- a/enterprise/server/selfauth/selfauth.go
+++ b/enterprise/server/selfauth/selfauth.go
@@ -1,12 +1,12 @@
 package selfauth
 
 import (
+	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"math/big"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"

--- a/enterprise/tools/rbeperf/rbeperf.go
+++ b/enterprise/tools/rbeperf/rbeperf.go
@@ -11,10 +11,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/csv"
 	"flag"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -4,9 +4,9 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"flag"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"


### PR DESCRIPTION
For more info: https://pkg.go.dev/math/rand#Read

```
Deprecated: For almost all use cases, crypto/rand.Read is more appropriate.
If a deterministic source is required, use math/rand/v2.ChaCha8.Read.
```

Replace it with crypto/rand.
