### PR TITLE
[RB] Log the run request

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -3,6 +3,7 @@ package remotebazel
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -782,6 +783,14 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 
 	if *timeout != 0 {
 		req.Timeout = timeout.String()
+	}
+
+	encodedReq, err := json.Marshal(req)
+	if err != nil {
+		log.Debugf("Failed to marshall req: %s", err)
+	}
+	if len(encodedReq) > 0 {
+		log.Debugf("Run request: %s", string(encodedReq))
 	}
 
 	log.Printf("\nWaiting for available remote runner...\n")


### PR DESCRIPTION
While debugging remote bazel, it can sometimes be easier to recommend customers use the Run RPC instead of the CLI. Log the JSON payload so that it's easier to use 

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
