### PR TITLE
Don't use container runtimes bundled with podman-static release

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6985,6 +6985,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         sha256 = PODMAN_STATIC_SHA256_ARM64,
     )
 
+    # NOTE: crun 1.16.1 has a double-free bug. Before upgrading, be sure the
+    # release includes a fix for https://github.com/containers/crun/issues/1537
     http_file(
         name = "com_github_containers_crun_crun-linux-amd64",
         urls = ["https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-amd64-disable-systemd"],

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -82,6 +82,11 @@ genrule(
         # Remove README.md (not needed)
         rm "$$TMPDIR/README.md"
 
+        # Remove container runtimes that are included in podman-static
+        # release, since we provision the container runtime separately.
+        rm "$$TMPDIR/usr/local/bin/crun"
+        rm "$$TMPDIR/usr/local/bin/runc"
+
         # Replace /etc/containers/registries.conf with our custom config.
         rm "$$TMPDIR/etc/containers/registries.conf"
         cp "$$REGISTRIES_CONF" "$$TMPDIR/etc/containers/registries.conf"

--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -7,7 +7,10 @@ go_test(
     name = "podman_test",
     size = "large",
     srcs = ["podman_test.go"],
-    data = ["//enterprise/server/remote_execution/containers/podman:podman-static.tar.gz"],
+    data = [
+        "//enterprise/server/remote_execution/containers/ociruntime:crun",
+        "//enterprise/server/remote_execution/containers/podman:podman-static.tar.gz",
+    ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
         "test.EstimatedComputeUnits": "4",
@@ -28,6 +31,7 @@ go_test(
     ],
     target_compatible_with = ["@platforms//os:linux"],
     x_defs = {
+        "crunRlocationpath": "$(rlocationpath //enterprise/server/remote_execution/containers/ociruntime:crun)",
         "podmanArchiveRlocationpath": "$(rlocationpath //enterprise/server/remote_execution/containers/podman:podman-static.tar.gz)",
     },
     deps = [
@@ -44,6 +48,7 @@ go_test(
         "//server/testutil/testfs",
         "//server/util/disk",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_bazel_rules_go//go/runfiles:go_default_library",

--- a/enterprise/server/test/integration/podman/podman_test.go
+++ b/enterprise/server/test/integration/podman/podman_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -34,10 +35,12 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
+// Populated by x_defs in BUILD file.
 var (
 	// rlocationpath for podman-static.tar.gz.
-	// Populated by x_defs in BUILD file.
 	podmanArchiveRlocationpath string
+	// rlocationpath for crun.
+	crunRlocationpath string
 )
 
 const (
@@ -52,6 +55,10 @@ func writeFile(t *testing.T, parentDir, fileName, content string) {
 }
 
 func getTestEnv(t *testing.T) *testenv.TestEnv {
+	runtimePath, err := runfiles.Rlocation(crunRlocationpath)
+	require.NoError(t, err)
+	flags.Set(t, "executor.podman.runtime", runtimePath)
+
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
 	env.SetCommandRunner(&commandutil.CommandRunner{})


### PR DESCRIPTION
This PR should fix the memory corruption bug ("corrupted size vs. prev_size") mentioned in https://github.com/buildbuddy-io/buildbuddy-internal/issues/3631

It turns out that `podman-static` includes its own versions of `crun` and `runc` under `/usr/local/bin`, which has higher precedence in PATH than the ones we provision under /usr/bin. So when upgrading to the latest `podman-static` release, we inadvertently upgraded `crun` to version 1.16.1, which has a [double-free bug](https://github.com/containers/crun/issues/1537). This was causing the "corrupted size vs. prev_size" errors we were seeing in some teed actions.

The double-free bug won't be fixed until 1.16.2, so this PR effectively just downgrades us to 1.15 until 1.16.2 is available.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3631
