### PR TITLE
Build Event Handler: don't log error when context is canceled

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1121,7 +1121,9 @@ func (e *EventChannel) processSingleEvent(event *inpb.InvocationEvent, iid strin
 	case *build_event_stream.BuildEvent_Progress:
 		if e.logWriter != nil {
 			if _, err := e.logWriter.Write(e.ctx, append([]byte(p.Progress.Stderr), []byte(p.Progress.Stdout)...)); err != nil {
-				log.Errorf("Error writing build logs for event: %s\nEvent: %s", err, event)
+				if err != context.Canceled {
+					log.Errorf("Error writing build logs for event: %s\nEvent: %s", err, event)
+				}
 			}
 			// Don't store the log in the protostream if we're
 			// writing it separately to blobstore


### PR DESCRIPTION
When Bazel drop the grpc connection, ignore the log write error.
