### PR TITLE
Workflows: re-enable remote downloader

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -100,8 +100,7 @@ common:workflows --flaky_test_attempts=2
 common:workflows --config=buildbuddy_bes_backend
 common:workflows --config=buildbuddy_bes_results_url
 common:workflows --config=buildbuddy_remote_cache
-# Temporarily disabled while testing blake3.
-#common:workflows --config=buildbuddy_experimental_remote_downloader
+common:workflows --config=buildbuddy_experimental_remote_downloader
 
 common:race --@io_bazel_rules_go//go/config:race
 

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,7 +10,6 @@ actions:
         branches:
           - "*"
     bazel_commands:
-      - clean --expunge
       - test //... --config=linux-workflows --config=race --test_tag_filters=-performance,-docker,-bare
   - name: Test with BzlMod
     container_image: ubuntu-20.04

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,6 +10,7 @@ actions:
         branches:
           - "*"
     bazel_commands:
+      - clean --expunge
       - test //... --config=linux-workflows --config=race --test_tag_filters=-performance,-docker,-bare
   - name: Test with BzlMod
     container_image: ubuntu-20.04


### PR DESCRIPTION
This has been fixed to be compatible with blake3.
