### PR TITLE
Minor cleanup/refactor of namespaces + veth pair names

### DIFF
--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -33,7 +33,6 @@ go_test(
     deps = [
         ":networking",
         "//server/testutil/testnetworking",
-        "//server/util/uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",


### PR DESCRIPTION
This PR is a precursor to creating a `VMNetwork` struct to consolidate the setup/cleanup logic for firecracker VM networks so that it matches the new `ContainerNetwork` struct more closely. Having a `VMNetwork` struct will make it a little bit cleaner to introduce pooling logic for both types of networks, since they'll expose similar interfaces. It should also just make the code more consistent, since the firecracker networking logic has lots of details that are unnecessarily exposed to `firecracker.go`, while the OCI `ContainerNetwork` API is much more minimal. Having a `VMNetwork` struct with a minimal interface should help remove some of the complexity from `firecracker.go`.

---

* Refactor net namespaces so that they are represented as a struct:
  * When passing around the net namespaces as strings, it was a little confusing because we have prefixed namespaces (`bb-executor-<uuid>` and non-prefixed namespace IDs (just the `<uuid>` part). Passing around the namespace as a struct makes this a little less error-prone and more ergonomic.
  * Modeling the namespace as a struct also makes its a little more clear that it's a resource that needs to be cleaned up - it now has a `Delete()` method that needs to be called, similar to the cleanup methods in VethPair and ContainerNetwork.
* Rename veth1/veth0 to hostVeth/namespaceVeth respectively, since I keep forgetting which one is which

**Related issues**: N/A
