### PR TITLE
Allow groups to set action priorities within their own queues

### DIFF
--- a/enterprise/server/scheduling/priority_queue/priority_queue.go
+++ b/enterprise/server/scheduling/priority_queue/priority_queue.go
@@ -55,8 +55,11 @@ func (pq *PriorityQueue) Push(req *scpb.EnqueueTaskReservationRequest) {
 	pq.mu.Lock()
 	heap.Push(pq.inner, &pqItem{
 		value:      req,
-		priority:   0,
 		insertTime: time.Now(),
+		// Note: the remote API specifies that higher `priority` values are
+		// assigned to actions that should execute *later*, so we invert the
+		// priority here.
+		priority: -int(req.GetSchedulingMetadata().GetPriority()),
 	})
 
 	pq.mu.Unlock()

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
@@ -13,8 +13,14 @@ const (
 	testGroupID3 = "group3"
 )
 
-func newTaskReservationRequest(taskID, taskGroupID string) *scpb.EnqueueTaskReservationRequest {
-	return &scpb.EnqueueTaskReservationRequest{TaskId: taskID, SchedulingMetadata: &scpb.SchedulingMetadata{TaskGroupId: taskGroupID}}
+func newTaskReservationRequest(taskID, taskGroupID string, priority int32) *scpb.EnqueueTaskReservationRequest {
+	return &scpb.EnqueueTaskReservationRequest{
+		TaskId: taskID,
+		SchedulingMetadata: &scpb.SchedulingMetadata{
+			TaskGroupId: taskGroupID,
+			Priority:    priority,
+		},
+	}
 }
 
 func TestTaskQueue_SingleGroup(t *testing.T) {
@@ -22,7 +28,7 @@ func TestTaskQueue_SingleGroup(t *testing.T) {
 	require.Equal(t, 0, q.Len())
 	require.Nil(t, q.Peek())
 
-	q.Enqueue(newTaskReservationRequest("1", testGroupID1))
+	q.Enqueue(newTaskReservationRequest("1", testGroupID1, 0))
 	require.Equal(t, 1, q.Len())
 
 	// Peeking should return the reservation but not remove it.
@@ -39,27 +45,33 @@ func TestTaskQueue_SingleGroup(t *testing.T) {
 	require.Equal(t, 0, q.Len())
 	require.Nil(t, q.Peek())
 
-	q.Enqueue(newTaskReservationRequest("1", testGroupID1))
-	q.Enqueue(newTaskReservationRequest("2", testGroupID1))
-	q.Enqueue(newTaskReservationRequest("3", testGroupID1))
+	q.Enqueue(newTaskReservationRequest("2", testGroupID1, 0))
+	q.Enqueue(newTaskReservationRequest("3", testGroupID1, 0))
+	q.Enqueue(newTaskReservationRequest("4", testGroupID1, 0))
+	// Enqueue task "1" last but give it the highest priority so it gets
+	// dequeued first.
+	q.Enqueue(newTaskReservationRequest("1", testGroupID1, -1000))
 
 	require.Equal(t, "1", q.Dequeue().GetTaskId())
 	require.Equal(t, "2", q.Dequeue().GetTaskId())
 	require.Equal(t, "3", q.Dequeue().GetTaskId())
+	require.Equal(t, "4", q.Dequeue().GetTaskId())
 }
 
 func TestTaskQueue_MultipleGroups(t *testing.T) {
 	q := newTaskQueue()
 
 	// First group has 3 task reservations.
-	q.Enqueue(newTaskReservationRequest("group1Task1", testGroupID1))
-	q.Enqueue(newTaskReservationRequest("group1Task2", testGroupID1))
-	q.Enqueue(newTaskReservationRequest("group1Task3", testGroupID1))
+	q.Enqueue(newTaskReservationRequest("group1Task1", testGroupID1, 0))
+	q.Enqueue(newTaskReservationRequest("group1Task2", testGroupID1, 0))
+	q.Enqueue(newTaskReservationRequest("group1Task3", testGroupID1, 0))
 	// Second group has 1 task reservation.
-	q.Enqueue(newTaskReservationRequest("group2Task1", testGroupID2))
+	q.Enqueue(newTaskReservationRequest("group2Task1", testGroupID2, 0))
 	// Third group has 2 task reservations.
-	q.Enqueue(newTaskReservationRequest("group3Task1", testGroupID3))
-	q.Enqueue(newTaskReservationRequest("group3Task2", testGroupID3))
+	// group3Task1 is enqueued last, but has higher priority so it should be
+	// dequeued first.
+	q.Enqueue(newTaskReservationRequest("group3Task2", testGroupID3, 0))
+	q.Enqueue(newTaskReservationRequest("group3Task1", testGroupID3, -1000))
 
 	require.Equal(t, "group1Task1", q.Dequeue().GetTaskId())
 	require.Equal(t, "group2Task1", q.Dequeue().GetTaskId())

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -167,6 +167,18 @@ message SchedulingMetadata {
   // This is for metrics purposes only and shouldn't affect the behavior of the
   // scheduler or the executor.
   bool track_queued_task_size = 9;
+
+  // Optional task priority hint. Tasks with *lower* priority values will be
+  // prioritized over tasks with higher priority values, on a best-effort basis.
+  // Assigning priorities to tasks does not provide any strong guarantees about
+  // execution ordering.
+  //
+  // The default priority is 0, and priorities can be negative.
+  //
+  // In a multi-tenant scenario, this value does not affect the relative
+  // priority of tasks belonging to different groups; it only affects the
+  // relative priority of tasks within a group.
+  int32 priority = 11;
 }
 
 message ScheduleTaskRequest {


### PR DESCRIPTION
Allow users to pass `--remote_execution_priority` to set relative action priorities within their group. Per the remote API spec, a higher priority value means that the action should be executed later. For now, we limit values to be between -1000 and 1000.

**Related issues**: N/A
