### PR TITLE
Don't start executor if expected Xcode versions are not present

### DIFF
--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 	"unsafe"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -66,6 +66,7 @@ func (x *xcodeLocator) verify() {
 	requiredXcodes := strings.Split(*requiredXcodeVersions, ",")
 	for _, requiredXcode := range requiredXcodes {
 		if _, ok := x.versions[requiredXcode]; !ok {
+			time.Sleep(10 * time.Second)
 			log.Fatalf("Failed to locate required Xcode version %s", requiredXcode)
 		}
 	}

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 	"unsafe"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -67,7 +66,6 @@ func (x *xcodeLocator) verify() {
 	requiredXcodes := strings.Split(*requiredXcodeVersions, ",")
 	for _, requiredXcode := range requiredXcodes {
 		if _, ok := x.versions[requiredXcode]; !ok {
-			time.Sleep(10 * time.Second)
 			log.Fatalf("Failed to locate required Xcode version %s", requiredXcode)
 		}
 	}


### PR DESCRIPTION
Today when we provision and start up mac executors we do a bunch of stuff to install the OS and Xcode and simulators, and then start up the executor on the machine. However, if any of the prerequisite steps, like installing the OS or Xcodes, fail then we just skip 'em and then the running executor won't be able to serve some RBE requests because it doesn't have all of the correct dependencies. This PR is the first of two that'll make starting the executor fail if any of the desired Xcodes aren't present on the host machine, which is better than quietly starting up and failing to serve RBE requests. It adds a new flag, `--executor.required_xcode_versions` that specifies a comma-delimited list of Xcode versions that must be present on the host system for the executor to come up healthy. There's another one coming that'll set that flag for our mac deployments.

**Related issues**: N/A
