### PR TITLE
close reader in fetch server

### DIFF
--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -200,6 +200,7 @@ func (p *FetchServer) rewriteToCache(ctx context.Context, blobDigest *repb.Diges
 		log.CtxErrorf(ctx, "Failed to get cache reader for %s: %s", digest.String(blobDigest), err)
 		return nil
 	}
+	defer reader.Close()
 
 	tmpFilePath, err := tempCopy(reader)
 	if err != nil {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
There is a pebble_db_handle_leak alert this morning indicating Reader() is not
properly closed.
