### PR TITLE
Deflake TestFilecache

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -58,6 +58,7 @@ func TestFilecache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	fc.WaitForDirectoryScanToComplete()
 
 	baseDir := testfs.MakeTempDir(t)
 	// Write a non-executable file


### PR DESCRIPTION
Passes with `--runs_per_test=1000` now.

**Related issues**: N/A
