### PR TITLE
Clean up ParentInvocationID column

### DIFF
--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -355,7 +355,6 @@ func TableInvocationToProto(i *tables.Invocation) *inpb.Invocation {
 	// Don't bother with validation here; just give the user whatever the DB
 	// claims the tags are.
 	out.Tags, _ = invocation_format.SplitAndTrimAndDedupeTags(i.Tags, false)
-	out.ParentInvocationId = i.ParentInvocationID
 	out.ParentRunId = i.ParentRunID
 	out.RunId = i.RunID
 	return out

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1526,7 +1526,6 @@ func (e *EventChannel) tableInvocationFromProto(p *inpb.Invocation, blobID strin
 		return nil, err
 	}
 	i.Tags = tags
-	i.ParentInvocationID = p.ParentInvocationId
 	i.ParentRunID = p.ParentRunId
 	i.RunID = p.RunId
 

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -173,8 +173,7 @@ type Invocation struct {
 
 	Tags string
 
-	ParentInvocationID string `gorm:"index:parent_invocation_id_index"`
-	ParentRunID        string `gorm:"index:parent_run_id_index"`
+	ParentRunID string `gorm:"index:parent_run_id_index"`
 }
 
 func (i *Invocation) TableName() string {

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -184,10 +184,7 @@ func (h *DBHandle) insertWithRetrier(ctx context.Context, tableName string, numE
 }
 
 func (h *DBHandle) FlushInvocationStats(ctx context.Context, ti *tables.Invocation) error {
-	inv, err := schema.ToInvocationFromPrimaryDB(ti)
-	if err != nil {
-		return err
-	}
+	inv := schema.ToInvocationFromPrimaryDB(ti)
 	if err := h.insertWithRetrier(ctx, inv.TableName(), 1, inv); err != nil {
 		return status.UnavailableErrorf("failed to insert invocation (invocation_id = %q), err: %s", ti.InvocationID, err)
 	}

--- a/server/util/clickhouse/schema/BUILD
+++ b/server/util/clickhouse/schema/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//server/tables",
         "//server/util/log",
         "//server/util/status",
-        "//server/util/uuid",
         "@io_gorm_gorm//:gorm",
     ],
 )

--- a/server/util/clickhouse/schema/schema_test.go
+++ b/server/util/clickhouse/schema/schema_test.go
@@ -112,11 +112,7 @@ func TestToInvocationFromPrimaryDB(t *testing.T) {
 	src := &tables.Invocation{}
 	err := faker.FakeData(src)
 	require.NoError(t, err)
-	// ParentInvocationID is expected in a specific format to be convertible
-	// to a UUID
-	src.ParentInvocationID = "1d6968b3-d2be-4ad0-b194-f08359ce36ba"
-	dest, err := ToInvocationFromPrimaryDB(src)
-	require.NoError(t, err)
+	dest := ToInvocationFromPrimaryDB(src)
 
 	primaryInvType := reflect.TypeOf(*src)
 	primaryInvFields := reflect.VisibleFields(primaryInvType)


### PR DESCRIPTION
This was originally added so that we could fetch child invocations for a parent invocation. However it didn't work well if the parent invocation was retried. Went with this approach instead: https://github.com/buildbuddy-io/buildbuddy/pull/7333

**Related issues**: N/A
