### PR TITLE
actually wait for treecache writes to finish.

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -218,6 +218,9 @@ const (
 	// The TreeCache status: hit/miss/invalid_entry.
 	TreeCacheLookupStatus = "status"
 
+	// The TreeCache set status: success/deadline_exceeded/other_error
+	TreeCacheSetStatus = "status"
+
 	// The TreeCache split lookup status: hit/miss/failure
 	TreeCacheSplitLookupStatus = "status"
 
@@ -754,11 +757,13 @@ var (
 		Help:      "Total number of splits written to TreeCache.",
 	})
 
-	TreeCacheSetCount = promauto.NewCounter(prometheus.CounterOpts{
+	TreeCacheSetCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "tree_cache_set_count",
 		Help:      "Total number of TreeCache sets.",
+	}, []string{
+		TreeCacheSetStatus,
 	})
 
 	TreeCacheBytesTransferred = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -40,6 +40,7 @@ go_test(
     name = "content_addressable_storage_server_test",
     size = "small",
     srcs = ["content_addressable_storage_server_test.go"],
+    shard_count = 4,
     deps = [
         ":content_addressable_storage_server",
         "//proto:remote_execution_go_proto",

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/remote_cache/directory_size",
         "//server/remote_cache/hit_tracker",
+        "//server/util/background",
         "//server/util/capabilities",
         "//server/util/compression",
         "//server/util/grpc_client",

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/directory_size"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/hit_tracker"
+	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -742,9 +743,15 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		return nil
 	}
 
-	cacheCtx, cacheCancel := context.WithCancelCause(ctx)
-	defer cacheCancel(context.Canceled)
-	eg, gCtx := errgroup.WithContext(cacheCtx)
+	cacheCtx, cacheCancel := background.ExtendContextForFinalization(ctx, 1*time.Second)
+	cacheEG, cacheEGCtx := errgroup.WithContext(cacheCtx)
+	// Finalize tree cache sets; but don't wait forever.
+	defer func() {
+		go func() {
+			cacheEG.Wait()
+			cacheCancel()
+		}()
+	}()
 
 	var fetch func(ctx context.Context, dirWithDigest *capb.DirectoryWithDigest, level int) ([]*capb.DirectoryWithDigest, error)
 	fetch = func(ctx context.Context, dirWithDigest *capb.DirectoryWithDigest, level int) ([]*capb.DirectoryWithDigest, error) {
@@ -800,8 +807,8 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 					Children: make([]*capb.DirectoryWithDigest, len(allDescendents)),
 				}
 				copy(treeCache.Children, allDescendents)
-				eg.Go(func() error {
-					return s.cacheTreeNode(gCtx, dirWithDigest, treeCachePointer, treeCache)
+				cacheEG.Go(func() error {
+					return s.cacheTreeNode(cacheEGCtx, dirWithDigest, treeCachePointer, treeCache)
 				})
 			}
 		}
@@ -823,15 +830,6 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 	log.Debugf("GetTree fetched %d dirs from cache across %d calls in cumulative %s (total time: %s)", dirCount, fetchCount, fetchDuration, time.Since(rpcStart))
 	if rspSizeBytes > 0 {
 		return stream.Send(rsp)
-	}
-
-	// Finalize tree cache sets; but don't wait forever.
-	go func() {
-		<-time.After(*maxTreeCacheSetDuration)
-		cacheCancel(status.DeadlineExceededErrorf("reached %s time limit for caching tree information, moving on", *maxTreeCacheSetDuration))
-	}()
-	if err := eg.Wait(); err != nil {
-		log.Warningf("Error populating tree cache: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
by my read, we are basically always killing the trecache write content via a direct `defer cancelFunc()` call (we never actually make it to the block of code where we wait on the cache write error group)

this change should make it so that we return the rpc but hang onto the context for up to a second to finish cache writes.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
