### PR TITLE
Increase size+timeout of BEP test

### DIFF
--- a/server/test/integration/build_event_protocol/BUILD
+++ b/server/test/integration/build_event_protocol/BUILD
@@ -2,7 +2,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "build_event_protocol_test",
-    size = "small",
+    size = "enormous",
+    timeout = "long",
     srcs = ["build_event_protocol_test.go"],
     shard_count = 6,
     deps = [


### PR DESCRIPTION
build_event_protocol_test has been flaky on macOS - increase the test size + timeout to try and deflake.

**Related issues**: N/A
