### PR TITLE
properly detect when treecache finalization context exceeds deadline

### DIFF
--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -544,7 +544,7 @@ func (s *ContentAddressableStorageServer) cacheTreeNode(ctx context.Context, roo
 			metrics.TreeCacheOperation: "write",
 		}).Add(float64(len(buf) + childBytesWritten))
 	} else {
-		if context.Cause(ctx) != nil && status.IsDeadlineExceededError(context.Cause(ctx)) {
+		if context.Cause(ctx) != nil && context.Cause(ctx) == context.DeadlineExceeded {
 			metrics.TreeCacheSetCount.With(prometheus.Labels{
 				metrics.TreeCacheSetStatus: "deadline_exceeded",
 			}).Inc()

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -548,7 +548,7 @@ func (s *ContentAddressableStorageServer) cacheTreeNode(ctx context.Context, roo
 			metrics.TreeCacheSetCount.With(prometheus.Labels{
 				metrics.TreeCacheSetStatus: "deadline_exceeded",
 			}).Inc()
-			log.Debugf("Could not set treeCache blob: %s", context.Cause(ctx))
+			log.Debugf("Could not set treeCache blob: %s. TreeCache directory count: %d, split count: %d", context.Cause(ctx), len(treeCache.Children), len(childCaches))
 		} else {
 			metrics.TreeCacheSetCount.With(prometheus.Labels{
 				metrics.TreeCacheSetStatus: "other_error",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
improve debug logging a bit, too
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
