### PR TITLE
Update protobuf from 26.0 -> 28.1 and absl to latest lts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,7 +47,7 @@ bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_a
 # abseil-cpp 20240722.0 in BCR does not have feature parity with its github analog
 archive_override(
     module_name = "abseil-cpp",
-    # integrity = "sha256-f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3=",
+    integrity = "sha256-9Q5awxGoE4Laf6dblzEOS5AGR0+VYKxG9UqZZ/B9SuM=",
     strip_prefix = "abseil-cpp-20240722.0",
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
 )
@@ -57,8 +57,7 @@ bazel_dep(name = "protobuf", version = "28.0", repo_name = "com_google_protobuf"
 # 28.1 is not released yet on BCR
 archive_override(
     module_name = "protobuf",
-    # integrity = "sha256-3b8bf6e96499a744bd014c60b58f797715a758093abf859f1d902194b8e1f8c9=",
-    # patch_args = ["-p1"],
+    integrity = "sha256-O4v26WSZp0S9AUxgtY95dxWnWAk6v4WfHZAhlLjh+Mk=",
     patches = [
         "//buildpatches:com_google_protobuf_18241.patch",
         "//buildpatches:com_google_protobuf_18242.patch",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,6 +42,9 @@ single_version_override(
     ],
 )
 
+bazel_dep(name = "protobuf", version = "28.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
+
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.23.0")
 go_sdk.nogo(nogo = "@//:vet")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,7 +42,7 @@ single_version_override(
     ],
 )
 
-bazel_dep(name = "protobuf", version = "28.1", repo_name = "com_google_protobuf")
+# bazel_dep(name = "protobuf", version = "28.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ switched_rules.use_languages(
 )
 
 # Needed for com_google_protobuf
-bazel_dep(name = "rules_python", version = "0.31.0")
+bazel_dep(name = "rules_python", version = "0.33.2")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,8 +42,29 @@ single_version_override(
     ],
 )
 
-# bazel_dep(name = "protobuf", version = "28.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
+# abseil-cpp 20240722.0 in BCR does not have feature parity with its github analog
+archive_override(
+    module_name = "abseil-cpp",
+    # integrity = "sha256-f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3=",
+    strip_prefix = "abseil-cpp-20240722.0",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
+)
+
+bazel_dep(name = "protobuf", version = "28.0", repo_name = "com_google_protobuf")
+# 28.1 is not released yet on BCR
+archive_override(
+    module_name = "protobuf",
+    # integrity = "sha256-3b8bf6e96499a744bd014c60b58f797715a758093abf859f1d902194b8e1f8c9=",
+    # patch_args = ["-p1"],
+    patches = [
+        "//buildpatches:com_google_protobuf_18241.patch",
+        "//buildpatches:com_google_protobuf_18242.patch",
+        "//buildpatches:com_google_protobuf_18243.patch",
+    ],
+    strip_prefix = "protobuf-28.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v28.1/protobuf-28.1.tar.gz"],
+)
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.23.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,6 +43,7 @@ single_version_override(
 )
 
 bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
+
 # abseil-cpp 20240722.0 in BCR does not have feature parity with its github analog
 archive_override(
     module_name = "abseil-cpp",
@@ -52,6 +53,7 @@ archive_override(
 )
 
 bazel_dep(name = "protobuf", version = "28.0", repo_name = "com_google_protobuf")
+
 # 28.1 is not released yet on BCR
 archive_override(
     module_name = "protobuf",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -59,8 +59,11 @@ archive_override(
     module_name = "protobuf",
     integrity = "sha256-O4v26WSZp0S9AUxgtY95dxWnWAk6v4WfHZAhlLjh+Mk=",
     patches = [
+        # https://github.com/protocolbuffers/protobuf/pull/18241
         "//buildpatches:com_google_protobuf_18241.patch",
+        # https://github.com/protocolbuffers/protobuf/pull/18242
         "//buildpatches:com_google_protobuf_18242.patch",
+        # https://github.com/protocolbuffers/protobuf/pull/18243
         "//buildpatches:com_google_protobuf_18243.patch",
     ],
     strip_prefix = "protobuf-28.1",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,9 +62,9 @@ http_archive(
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed",
-    strip_prefix = "abseil-cpp-20230802.1",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
+    sha256 = "f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3",
+    strip_prefix = "abseil-cpp-20240722.0",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
 )
 
 load(":deps.bzl", "install_go_mod_dependencies", "install_static_dependencies")
@@ -246,9 +246,15 @@ googletest_deps()
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "e32100a8013870d24ffc37dad6781a61e5d0c99501bcb04d39c340a1c44a8e63",
-    strip_prefix = "protobuf-26.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protobuf-26.0.tar.gz"],
+    patch_args = ["-p1"],
+    patches = [
+        "//buildpatches:com_google_protobuf_18241.patch",
+        "//buildpatches:com_google_protobuf_18242.patch",
+        "//buildpatches:com_google_protobuf_18243.patch",
+    ],
+    sha256 = "3b8bf6e96499a744bd014c60b58f797715a758093abf859f1d902194b8e1f8c9",
+    strip_prefix = "protobuf-28.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v28.1/protobuf-28.1.tar.gz"],
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -247,8 +247,11 @@ googletest_deps()
 http_archive(
     name = "com_google_protobuf",
     patches = [
+        # https://github.com/protocolbuffers/protobuf/pull/18241
         "//buildpatches:com_google_protobuf_18241.patch",
+        # https://github.com/protocolbuffers/protobuf/pull/18242
         "//buildpatches:com_google_protobuf_18242.patch",
+        # https://github.com/protocolbuffers/protobuf/pull/18243
         "//buildpatches:com_google_protobuf_18243.patch",
     ],
     sha256 = "3b8bf6e96499a744bd014c60b58f797715a758093abf859f1d902194b8e1f8c9",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -246,7 +246,6 @@ googletest_deps()
 
 http_archive(
     name = "com_google_protobuf",
-    patch_args = ["-p1"],
     patches = [
         "//buildpatches:com_google_protobuf_18241.patch",
         "//buildpatches:com_google_protobuf_18242.patch",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,7 +62,7 @@ http_archive(
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3",
+    integrity = "sha256-9Q5awxGoE4Laf6dblzEOS5AGR0+VYKxG9UqZZ/B9SuM=",
     strip_prefix = "abseil-cpp-20240722.0",
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
 )
@@ -246,6 +246,7 @@ googletest_deps()
 
 http_archive(
     name = "com_google_protobuf",
+    integrity = "sha256-O4v26WSZp0S9AUxgtY95dxWnWAk6v4WfHZAhlLjh+Mk=",
     patches = [
         # https://github.com/protocolbuffers/protobuf/pull/18241
         "//buildpatches:com_google_protobuf_18241.patch",
@@ -254,7 +255,6 @@ http_archive(
         # https://github.com/protocolbuffers/protobuf/pull/18243
         "//buildpatches:com_google_protobuf_18243.patch",
     ],
-    sha256 = "3b8bf6e96499a744bd014c60b58f797715a758093abf859f1d902194b8e1f8c9",
     strip_prefix = "protobuf-28.1",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v28.1/protobuf-28.1.tar.gz"],
 )

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -13,13 +13,6 @@ http_archive(
 
 # Go
 
-http_archive(
-    name = "com_google_absl",
-    sha256 = "987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed",
-    strip_prefix = "abseil-cpp-20230802.1",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
-)
-
 load(":deps.bzl", "install_static_dependencies")
 
 install_static_dependencies()
@@ -87,13 +80,6 @@ http_archive(
 load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
 
 googletest_deps()
-
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "e32100a8013870d24ffc37dad6781a61e5d0c99501bcb04d39c340a1c44a8e63",
-    strip_prefix = "protobuf-26.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protobuf-26.0.tar.gz"],
-)
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -81,6 +81,19 @@ load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
 
 googletest_deps()
 
+http_archive(
+    name = "com_google_protobuf",
+    patch_args = ["-p1"],
+    patches = [
+        "//buildpatches:com_google_protobuf_18241.patch",
+        "//buildpatches:com_google_protobuf_18242.patch",
+        "//buildpatches:com_google_protobuf_18243.patch",
+    ],
+    sha256 = "3b8bf6e96499a744bd014c60b58f797715a758093abf859f1d902194b8e1f8c9",
+    strip_prefix = "protobuf-28.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v28.1/protobuf-28.1.tar.gz"],
+)
+
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -81,19 +81,6 @@ load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
 
 googletest_deps()
 
-http_archive(
-    name = "com_google_protobuf",
-    patch_args = ["-p1"],
-    patches = [
-        "//buildpatches:com_google_protobuf_18241.patch",
-        "//buildpatches:com_google_protobuf_18242.patch",
-        "//buildpatches:com_google_protobuf_18243.patch",
-    ],
-    sha256 = "3b8bf6e96499a744bd014c60b58f797715a758093abf859f1d902194b8e1f8c9",
-    strip_prefix = "protobuf-28.1",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v28.1/protobuf-28.1.tar.gz"],
-)
-
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()

--- a/buildpatches/com_google_protobuf_18241.patch
+++ b/buildpatches/com_google_protobuf_18241.patch
@@ -1,0 +1,28 @@
+diff --git a/src/google/protobuf/wire_format_lite.cc b/src/google/protobuf/wire_format_lite.cc
+index 6a9caa904..4dd5fb5ba 100644
+--- a/src/google/protobuf/wire_format_lite.cc
++++ b/src/google/protobuf/wire_format_lite.cc
+@@ -665,9 +665,11 @@ static size_t VarintSize(const T* data, const int n) {
+     if (x > 0x1FFFFF) sum++;
+     if (x > 0xFFFFFFF) sum++;
+   }
++#ifdef __clang__
+ // Clang is not smart enough to see that this loop doesn't run many times
+ // NOLINTNEXTLINE(google3-runtime-pragma-loop-hint): b/315043579
+ #pragma clang loop vectorize(disable) unroll(disable) interleave(disable)
++#endif
+   for (; i < n; i++) {
+     uint32_t x = data[i];
+     if (ZigZag) {
+@@ -707,9 +709,11 @@ static size_t VarintSize64(const T* data, const int n) {
+     if (x > 0x1FFFFF) sum++;
+     if (x > 0xFFFFFFF) sum++;
+   }
++#ifdef __clang__
+ // Clang is not smart enough to see that this loop doesn't run many times
+ // NOLINTNEXTLINE(google3-runtime-pragma-loop-hint): b/315043579
+ #pragma clang loop vectorize(disable) unroll(disable) interleave(disable)
++#endif
+   for (; i < n; i++) {
+     uint64_t x = data[i];
+     if (ZigZag) {

--- a/buildpatches/com_google_protobuf_18241.patch
+++ b/buildpatches/com_google_protobuf_18241.patch
@@ -1,7 +1,5 @@
-diff --git a/src/google/protobuf/wire_format_lite.cc b/src/google/protobuf/wire_format_lite.cc
-index 6a9caa904..4dd5fb5ba 100644
---- a/src/google/protobuf/wire_format_lite.cc
-+++ b/src/google/protobuf/wire_format_lite.cc
+--- src/google/protobuf/wire_format_lite.cc
++++ src/google/protobuf/wire_format_lite.cc
 @@ -665,9 +665,11 @@ static size_t VarintSize(const T* data, const int n) {
      if (x > 0x1FFFFF) sum++;
      if (x > 0xFFFFFFF) sum++;

--- a/buildpatches/com_google_protobuf_18242.patch
+++ b/buildpatches/com_google_protobuf_18242.patch
@@ -1,0 +1,251 @@
+diff --git a/src/google/protobuf/compiler/java/full/enum.cc b/src/google/protobuf/compiler/java/full/enum.cc
+index 30db3b413..bf158c45c 100644
+--- a/src/google/protobuf/compiler/java/full/enum.cc
++++ b/src/google/protobuf/compiler/java/full/enum.cc
+@@ -29,6 +29,8 @@
+ // Must be last.
+ #include "google/protobuf/port_def.inc"
+ 
++using std::size_t;
++
+ namespace google {
+ namespace protobuf {
+ namespace compiler {
+@@ -74,15 +76,15 @@ void EnumNonLiteGenerator::Generate(io::Printer* printer) {
+ 
+   bool ordinal_is_index = true;
+   std::string index_text = "ordinal()";
+-  for (int i = 0; i < canonical_values_.size(); i++) {
+-    if (canonical_values_[i]->index() != i) {
++  for (size_t i = 0; i < canonical_values_.size(); i++) {
++    if (static_cast<size_t>(canonical_values_[i]->index()) != i) {
+       ordinal_is_index = false;
+       index_text = "index";
+       break;
+     }
+   }
+ 
+-  for (int i = 0; i < canonical_values_.size(); i++) {
++  for (size_t i = 0; i < canonical_values_.size(); i++) {
+     absl::flat_hash_map<absl::string_view, std::string> vars;
+     vars["name"] = canonical_values_[i]->name();
+     vars["index"] = absl::StrCat(canonical_values_[i]->index());
+@@ -122,7 +124,7 @@ void EnumNonLiteGenerator::Generate(io::Printer* printer) {
+   printer->Outdent();
+   printer->Print("}\n");
+ 
+-  for (int i = 0; i < aliases_.size(); i++) {
++  for (size_t i = 0; i < aliases_.size(); i++) {
+     absl::flat_hash_map<absl::string_view, std::string> vars;
+     vars["classname"] = descriptor_->name();
+     vars["name"] = aliases_[i].value->name();
+@@ -206,7 +208,7 @@ void EnumNonLiteGenerator::Generate(io::Printer* printer) {
+   printer->Indent();
+   printer->Indent();
+ 
+-  for (int i = 0; i < canonical_values_.size(); i++) {
++  for (size_t i = 0; i < canonical_values_.size(); i++) {
+     printer->Print("case $number$: return $name$;\n", "name",
+                    canonical_values_[i]->name(), "number",
+                    absl::StrCat(canonical_values_[i]->number()));
+@@ -387,7 +389,7 @@ void EnumNonLiteGenerator::Generate(io::Printer* printer) {
+
+ 
+ bool EnumNonLiteGenerator::CanUseEnumValues() {
+-  if (canonical_values_.size() != descriptor_->value_count()) {
++  if (canonical_values_.size() != static_cast<size_t>(descriptor_->value_count())) {
+     return false;
+   }
+   for (int i = 0; i < descriptor_->value_count(); i++) {
+diff --git a/src/google/protobuf/compiler/java/full/message.cc b/src/google/protobuf/compiler/java/full/message.cc
+index 887dfe2b2..0787422a5 100644
+--- a/src/google/protobuf/compiler/java/full/message.cc
++++ b/src/google/protobuf/compiler/java/full/message.cc
+@@ -43,6 +43,8 @@
+ // Must be last.
+ #include "google/protobuf/port_def.inc"
+ 
++using std::size_t;
++
+ namespace google {
+ namespace protobuf {
+ namespace compiler {
+@@ -804,7 +806,7 @@ void ImmutableMessageGenerator::GenerateDescriptorMethods(
+         "  switch (number) {\n");
+     printer->Indent();
+     printer->Indent();
+-    for (int i = 0; i < map_fields.size(); ++i) {
++    for (size_t i = 0; i < map_fields.size(); ++i) {
+       const FieldDescriptor* field = map_fields[i];
+       const FieldGeneratorInfo* info = context_->GetFieldGeneratorInfo(field);
+       printer->Print(
+diff --git a/src/google/protobuf/compiler/java/full/message_builder.cc b/src/google/protobuf/compiler/java/full/message_builder.cc
+index 53de5d324..63f808f5d 100644
+--- a/src/google/protobuf/compiler/java/full/message_builder.cc
++++ b/src/google/protobuf/compiler/java/full/message_builder.cc
+@@ -39,6 +39,8 @@
+ // Must be last.
+ #include "google/protobuf/port_def.inc"
+ 
++using std::size_t;
++
+ namespace google {
+ namespace protobuf {
+ namespace compiler {
+@@ -211,7 +213,7 @@ void MessageBuilderGenerator::GenerateDescriptorMethods(io::Printer* printer) {
+         "  switch (number) {\n");
+     printer->Indent();
+     printer->Indent();
+-    for (int i = 0; i < map_fields.size(); ++i) {
++    for (size_t i = 0; i < map_fields.size(); ++i) {
+       const FieldDescriptor* field = map_fields[i];
+       const FieldGeneratorInfo* info = context_->GetFieldGeneratorInfo(field);
+       printer->Print(
+@@ -237,7 +239,7 @@ void MessageBuilderGenerator::GenerateDescriptorMethods(io::Printer* printer) {
+         "  switch (number) {\n");
+     printer->Indent();
+     printer->Indent();
+-    for (int i = 0; i < map_fields.size(); ++i) {
++    for (size_t i = 0; i < map_fields.size(); ++i) {
+       const FieldDescriptor* field = map_fields[i];
+       const FieldGeneratorInfo* info = context_->GetFieldGeneratorInfo(field);
+       printer->Print(
+diff --git a/src/google/protobuf/compiler/java/lite/enum.cc b/src/google/protobuf/compiler/java/lite/enum.cc
+index 8e3c57cf9..87c4e7294 100644
+--- a/src/google/protobuf/compiler/java/lite/enum.cc
++++ b/src/google/protobuf/compiler/java/lite/enum.cc
+@@ -25,6 +25,8 @@
+ #include "google/protobuf/descriptor.pb.h"
+ #include "google/protobuf/io/printer.h"
+ 
++using std::size_t;
++
+ namespace google {
+ namespace protobuf {
+ namespace compiler {
+@@ -67,7 +69,7 @@ void EnumLiteGenerator::Generate(io::Printer* printer) {
+   printer->Annotate("classname", descriptor_);
+   printer->Indent();
+ 
+-  for (int i = 0; i < canonical_values_.size(); i++) {
++  for (size_t i = 0; i < canonical_values_.size(); i++) {
+     absl::flat_hash_map<absl::string_view, std::string> vars;
+     vars["name"] = canonical_values_[i]->name();
+     vars["number"] = absl::StrCat(canonical_values_[i]->number());
+@@ -91,7 +93,7 @@ void EnumLiteGenerator::Generate(io::Printer* printer) {
+ 
+   // -----------------------------------------------------------------
+ 
+-  for (int i = 0; i < aliases_.size(); i++) {
++  for (size_t i = 0; i < aliases_.size(); i++) {
+     absl::flat_hash_map<absl::string_view, std::string> vars;
+     vars["classname"] = descriptor_->name();
+     vars["name"] = aliases_[i].value->name();
+@@ -162,7 +164,7 @@ void EnumLiteGenerator::Generate(io::Printer* printer) {
+   printer->Indent();
+   printer->Indent();
+ 
+-  for (int i = 0; i < canonical_values_.size(); i++) {
++  for (size_t i = 0; i < canonical_values_.size(); i++) {
+     printer->Print("case $number$: return $name$;\n", "name",
+                    canonical_values_[i]->name(), "number",
+                    absl::StrCat(canonical_values_[i]->number()));
+diff --git a/src/google/protobuf/compiler/rust/relative_path.cc b/src/google/protobuf/compiler/rust/relative_path.cc
+index e214dada4..6027f1ac7 100644
+--- a/src/google/protobuf/compiler/rust/relative_path.cc
++++ b/src/google/protobuf/compiler/rust/relative_path.cc
+@@ -16,6 +16,8 @@
+ #include "absl/strings/str_split.h"
+ #include "absl/strings/string_view.h"
+ 
++using std::size_t;
++
+ namespace google {
+ namespace protobuf {
+ namespace compiler {
+@@ -62,7 +64,7 @@ std::string RelativePath::Relative(const RelativePath& dest) const {
+     result.push_back(segment);
+   }
+   // Push `..` from the common ancestor to the current path.
+-  for (int i = 0; i < current_segments.size(); ++i) {
++  for (size_t i = 0; i < current_segments.size(); ++i) {
+     result.push_back("..");
+   }
+   absl::c_reverse(result);
+diff --git a/src/google/protobuf/descriptor.h b/src/google/protobuf/descriptor.h
+index f6ac34155..120d02df1 100644
+--- a/src/google/protobuf/descriptor.h
++++ b/src/google/protobuf/descriptor.h
+@@ -32,6 +32,7 @@
+ #define GOOGLE_PROTOBUF_DESCRIPTOR_H__
+ 
+ #include <atomic>
++#include <cstddef>
+ #include <cstdint>
+ #include <iterator>
+ #include <memory>
+@@ -65,6 +66,7 @@
+ #define PROTOBUF_IGNORE_DEPRECATION_STOP
+ #endif
+ 
++using std::size_t;
+ 
+ namespace google {
+ namespace protobuf {
+diff --git a/src/google/protobuf/io/printer.h b/src/google/protobuf/io/printer.h
+index 7677e9dbb..6d49b0e2e 100644
+--- a/src/google/protobuf/io/printer.h
++++ b/src/google/protobuf/io/printer.h
+@@ -39,6 +39,8 @@
+ // Must be included last.
+ #include "google/protobuf/port_def.inc"
+ 
++using std::size_t;
++
+ namespace google {
+ namespace protobuf {
+ namespace io {
+@@ -124,7 +126,7 @@ class AnnotationProtoCollector : public AnnotationCollector {
+                      const std::string& file_path, const std::vector<int>& path,
+                      absl::optional<Semantic> semantic) override {
+     auto* annotation = annotation_proto_->add_annotation();
+-    for (int i = 0; i < path.size(); ++i) {
++    for (size_t i = 0; i < path.size(); ++i) {
+       annotation->add_path(path[i]);
+     }
+     annotation->set_source_file(file_path);
+diff --git a/upb/io/string.h b/upb/io/string.h
+index ffaffb009..7cb3b6614 100644
+--- a/upb/io/string.h
++++ b/upb/io/string.h
+@@ -102,7 +102,7 @@ UPB_INLINE bool upb_String_AppendFmtV(upb_String* s, const char* fmt,
+   char* buf = (char*)malloc(capacity);
+   bool out = false;
+   for (;;) {
+-    const int n = _upb_vsnprintf(buf, capacity, fmt, args);
++    const size_t n = _upb_vsnprintf(buf, capacity, fmt, args);
+     if (n < 0) break;
+     if (n < capacity) {
+       out = upb_String_Append(s, buf, n);
+diff --git a/upb_generator/file_layout.cc b/upb_generator/file_layout.cc
+index ad3d8fde8..e51fc4c78 100644
+--- a/upb_generator/file_layout.cc
++++ b/upb_generator/file_layout.cc
+@@ -14,6 +14,8 @@
+ #include "upb/reflection/def.hpp"
+ #include "upb_generator/common.h"
+ 
++using std::size_t;
++
+ namespace upb {
+ namespace generator {
+ 
+@@ -58,7 +60,7 @@ std::vector<upb::EnumDefPtr> SortedEnums(upb::FileDefPtr file,
+ std::vector<uint32_t> SortedUniqueEnumNumbers(upb::EnumDefPtr e) {
+   std::vector<uint32_t> values;
+   values.reserve(e.value_count());
+-  for (int i = 0; i < e.value_count(); i++) {
++  for (size_t i = 0; i < e.value_count(); i++) {
+     values.push_back(static_cast<uint32_t>(e.value(i).number()));
+   }
+   std::sort(values.begin(), values.end());

--- a/buildpatches/com_google_protobuf_18242.patch
+++ b/buildpatches/com_google_protobuf_18242.patch
@@ -1,7 +1,6 @@
-diff --git a/src/google/protobuf/compiler/java/full/enum.cc b/src/google/protobuf/compiler/java/full/enum.cc
-index 30db3b413..bf158c45c 100644
---- a/src/google/protobuf/compiler/java/full/enum.cc
-+++ b/src/google/protobuf/compiler/java/full/enum.cc
+diff src/google/protobuf/compiler/java/full/enum.cc src/google/protobuf/compiler/java/full/enum.cc
+--- src/google/protobuf/compiler/java/full/enum.cc
++++ src/google/protobuf/compiler/java/full/enum.cc
 @@ -29,6 +29,8 @@
  // Must be last.
  #include "google/protobuf/port_def.inc"
@@ -57,10 +56,9 @@ index 30db3b413..bf158c45c 100644
      return false;
    }
    for (int i = 0; i < descriptor_->value_count(); i++) {
-diff --git a/src/google/protobuf/compiler/java/full/message.cc b/src/google/protobuf/compiler/java/full/message.cc
-index 887dfe2b2..0787422a5 100644
---- a/src/google/protobuf/compiler/java/full/message.cc
-+++ b/src/google/protobuf/compiler/java/full/message.cc
+diff src/google/protobuf/compiler/java/full/message.cc src/google/protobuf/compiler/java/full/message.cc
+--- src/google/protobuf/compiler/java/full/message.cc
++++ src/google/protobuf/compiler/java/full/message.cc
 @@ -43,6 +43,8 @@
  // Must be last.
  #include "google/protobuf/port_def.inc"
@@ -79,10 +77,9 @@ index 887dfe2b2..0787422a5 100644
        const FieldDescriptor* field = map_fields[i];
        const FieldGeneratorInfo* info = context_->GetFieldGeneratorInfo(field);
        printer->Print(
-diff --git a/src/google/protobuf/compiler/java/full/message_builder.cc b/src/google/protobuf/compiler/java/full/message_builder.cc
-index 53de5d324..63f808f5d 100644
---- a/src/google/protobuf/compiler/java/full/message_builder.cc
-+++ b/src/google/protobuf/compiler/java/full/message_builder.cc
+diff src/google/protobuf/compiler/java/full/message_builder.cc src/google/protobuf/compiler/java/full/message_builder.cc
+--- src/google/protobuf/compiler/java/full/message_builder.cc
++++ src/google/protobuf/compiler/java/full/message_builder.cc
 @@ -39,6 +39,8 @@
  // Must be last.
  #include "google/protobuf/port_def.inc"
@@ -110,10 +107,9 @@ index 53de5d324..63f808f5d 100644
        const FieldDescriptor* field = map_fields[i];
        const FieldGeneratorInfo* info = context_->GetFieldGeneratorInfo(field);
        printer->Print(
-diff --git a/src/google/protobuf/compiler/java/lite/enum.cc b/src/google/protobuf/compiler/java/lite/enum.cc
-index 8e3c57cf9..87c4e7294 100644
---- a/src/google/protobuf/compiler/java/lite/enum.cc
-+++ b/src/google/protobuf/compiler/java/lite/enum.cc
+diff src/google/protobuf/compiler/java/lite/enum.cc src/google/protobuf/compiler/java/lite/enum.cc
+--- src/google/protobuf/compiler/java/lite/enum.cc
++++ src/google/protobuf/compiler/java/lite/enum.cc
 @@ -25,6 +25,8 @@
  #include "google/protobuf/descriptor.pb.h"
  #include "google/protobuf/io/printer.h"
@@ -150,10 +146,9 @@ index 8e3c57cf9..87c4e7294 100644
      printer->Print("case $number$: return $name$;\n", "name",
                     canonical_values_[i]->name(), "number",
                     absl::StrCat(canonical_values_[i]->number()));
-diff --git a/src/google/protobuf/compiler/rust/relative_path.cc b/src/google/protobuf/compiler/rust/relative_path.cc
-index e214dada4..6027f1ac7 100644
---- a/src/google/protobuf/compiler/rust/relative_path.cc
-+++ b/src/google/protobuf/compiler/rust/relative_path.cc
+diff src/google/protobuf/compiler/rust/relative_path.cc src/google/protobuf/compiler/rust/relative_path.cc
+--- src/google/protobuf/compiler/rust/relative_path.cc
++++ src/google/protobuf/compiler/rust/relative_path.cc
 @@ -16,6 +16,8 @@
  #include "absl/strings/str_split.h"
  #include "absl/strings/string_view.h"
@@ -172,10 +167,9 @@ index e214dada4..6027f1ac7 100644
      result.push_back("..");
    }
    absl::c_reverse(result);
-diff --git a/src/google/protobuf/descriptor.h b/src/google/protobuf/descriptor.h
-index f6ac34155..120d02df1 100644
---- a/src/google/protobuf/descriptor.h
-+++ b/src/google/protobuf/descriptor.h
+diff src/google/protobuf/descriptor.h src/google/protobuf/descriptor.h
+--- src/google/protobuf/descriptor.h
++++ src/google/protobuf/descriptor.h
 @@ -32,6 +32,7 @@
  #define GOOGLE_PROTOBUF_DESCRIPTOR_H__
  
@@ -192,10 +186,9 @@ index f6ac34155..120d02df1 100644
  
  namespace google {
  namespace protobuf {
-diff --git a/src/google/protobuf/io/printer.h b/src/google/protobuf/io/printer.h
-index 7677e9dbb..6d49b0e2e 100644
---- a/src/google/protobuf/io/printer.h
-+++ b/src/google/protobuf/io/printer.h
+diff src/google/protobuf/io/printer.h src/google/protobuf/io/printer.h
+--- src/google/protobuf/io/printer.h
++++ src/google/protobuf/io/printer.h
 @@ -39,6 +39,8 @@
  // Must be included last.
  #include "google/protobuf/port_def.inc"
@@ -214,10 +207,9 @@ index 7677e9dbb..6d49b0e2e 100644
        annotation->add_path(path[i]);
      }
      annotation->set_source_file(file_path);
-diff --git a/upb/io/string.h b/upb/io/string.h
-index ffaffb009..7cb3b6614 100644
---- a/upb/io/string.h
-+++ b/upb/io/string.h
+diff upb/io/string.h upb/io/string.h
+--- upb/io/string.h
++++ upb/io/string.h
 @@ -102,7 +102,7 @@ UPB_INLINE bool upb_String_AppendFmtV(upb_String* s, const char* fmt,
    char* buf = (char*)malloc(capacity);
    bool out = false;
@@ -227,10 +219,9 @@ index ffaffb009..7cb3b6614 100644
      if (n < 0) break;
      if (n < capacity) {
        out = upb_String_Append(s, buf, n);
-diff --git a/upb_generator/file_layout.cc b/upb_generator/file_layout.cc
-index ad3d8fde8..e51fc4c78 100644
---- a/upb_generator/file_layout.cc
-+++ b/upb_generator/file_layout.cc
+diff upb_generator/file_layout.cc upb_generator/file_layout.cc
+--- upb_generator/file_layout.cc
++++ upb_generator/file_layout.cc
 @@ -14,6 +14,8 @@
  #include "upb/reflection/def.hpp"
  #include "upb_generator/common.h"

--- a/buildpatches/com_google_protobuf_18243.patch
+++ b/buildpatches/com_google_protobuf_18243.patch
@@ -1,7 +1,5 @@
-diff --git a/src/google/protobuf/generated_message_tctable_lite.cc b/src/google/protobuf/generated_message_tctable_lite.cc
-index f2dc1334d..546086b58 100644
---- a/src/google/protobuf/generated_message_tctable_lite.cc
-+++ b/src/google/protobuf/generated_message_tctable_lite.cc
+--- src/google/protobuf/generated_message_tctable_lite.cc
++++ src/google/protobuf/generated_message_tctable_lite.cc
 @@ -525,7 +525,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastGtR2(PROTOBUF_TC_PARAM_DECL) {
  //////////////////////////////////////////////////////////////////////////////
  

--- a/buildpatches/com_google_protobuf_18243.patch
+++ b/buildpatches/com_google_protobuf_18243.patch
@@ -1,0 +1,166 @@
+diff --git a/src/google/protobuf/generated_message_tctable_lite.cc b/src/google/protobuf/generated_message_tctable_lite.cc
+index f2dc1334d..546086b58 100644
+--- a/src/google/protobuf/generated_message_tctable_lite.cc
++++ b/src/google/protobuf/generated_message_tctable_lite.cc
+@@ -525,7 +525,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastGtR2(PROTOBUF_TC_PARAM_DECL) {
+ //////////////////////////////////////////////////////////////////////////////
+ 
+ template <typename LayoutType, typename TagType>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularFixed(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularFixed(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -555,7 +555,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastF64S2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename LayoutType, typename TagType>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedFixed(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedFixed(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -590,7 +590,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastF64R2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename LayoutType, typename TagType>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedFixed(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedFixed(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -721,7 +721,7 @@ inline int64_t ZigZagDecodeHelper<int64_t, true>(int64_t value) {
+ 
+ // Prefetch the enum data, if necessary.
+ // We can issue the prefetch before we start parsing the ints.
+-PROTOBUF_ALWAYS_INLINE void PrefetchEnumData(uint16_t xform_val,
++inline PROTOBUF_ALWAYS_INLINE void PrefetchEnumData(uint16_t xform_val,
+                                              TcParseTableBase::FieldAux aux) {
+ }
+ 
+@@ -733,7 +733,7 @@ PROTOBUF_ALWAYS_INLINE void PrefetchEnumData(uint16_t xform_val,
+ // way more common than the kTvEnum cases. It is also called from places that
+ // already have out-of-line functions (like MpVarint) so an extra out-of-line
+ // call to `ValidateEnum` does not affect much.
+-PROTOBUF_ALWAYS_INLINE bool EnumIsValidAux(int32_t val, uint16_t xform_val,
++inline PROTOBUF_ALWAYS_INLINE bool EnumIsValidAux(int32_t val, uint16_t xform_val,
+                                            TcParseTableBase::FieldAux aux) {
+   if (xform_val == field_layout::kTvRange) {
+     auto lo = aux.enum_range.start;
+@@ -749,7 +749,7 @@ PROTOBUF_ALWAYS_INLINE bool EnumIsValidAux(int32_t val, uint16_t xform_val,
+ }  // namespace
+ 
+ template <typename FieldType, typename TagType, bool zigzag>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularVarint(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularVarint(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -810,7 +810,7 @@ PROTOBUF_NOINLINE const char* TcParser::SingularVarBigint(
+ }
+ 
+ template <typename FieldType>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::FastVarintS1(
+     PROTOBUF_TC_PARAM_DECL) {
+   using TagType = uint8_t;
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+@@ -893,7 +893,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastZ64S2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename FieldType, typename TagType, bool zigzag>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedVarint(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedVarint(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -958,7 +958,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastZ64R2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename FieldType, typename TagType, bool zigzag>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedVarint(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedVarint(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -1060,7 +1060,7 @@ PROTOBUF_NOINLINE const char* TcParser::MpUnknownEnumFallback(
+ }
+ 
+ template <typename TagType, uint16_t xform_val>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularEnum(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularEnum(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -1102,7 +1102,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastEvS2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename TagType, uint16_t xform_val>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedEnum(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedEnum(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -1154,7 +1154,7 @@ PROTOBUF_NOINLINE void TcParser::AddUnknownEnum(MessageLite* msg,
+ }
+ 
+ template <typename TagType, uint16_t xform_val>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedEnum(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedEnum(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -1211,7 +1211,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastEvP2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename TagType, uint8_t min>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularEnumSmallRange(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularEnumSmallRange(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -1249,7 +1249,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastEr1S2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename TagType, uint8_t min>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedEnumSmallRange(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedEnumSmallRange(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -1291,7 +1291,7 @@ PROTOBUF_NOINLINE const char* TcParser::FastEr1R2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename TagType, uint8_t min>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedEnumSmallRange(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::PackedEnumSmallRange(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -1406,7 +1406,7 @@ PROTOBUF_ALWAYS_INLINE inline bool IsValidUTF8(ArenaStringPtr& field) {
+ }  // namespace
+ 
+ template <typename TagType, typename FieldType, TcParser::Utf8Type utf8>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularString(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::SingularString(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -1514,7 +1514,7 @@ const char* TcParser::FastUcS2(PROTOBUF_TC_PARAM_DECL) {
+ }
+ 
+ template <typename TagType, typename FieldType, TcParser::Utf8Type utf8>
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedString(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::RepeatedString(
+     PROTOBUF_TC_PARAM_DECL) {
+   if (PROTOBUF_PREDICT_FALSE(data.coded_tag<TagType>() != 0)) {
+     PROTOBUF_MUSTTAIL return MiniParse(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+@@ -2208,7 +2208,7 @@ PROTOBUF_NOINLINE const char* TcParser::MpString(PROTOBUF_TC_PARAM_DECL) {
+   PROTOBUF_MUSTTAIL return ToTagDispatch(PROTOBUF_TC_PARAM_NO_DATA_PASS);
+ }
+ 
+-PROTOBUF_ALWAYS_INLINE const char* TcParser::ParseRepeatedStringOnce(
++inline PROTOBUF_ALWAYS_INLINE const char* TcParser::ParseRepeatedStringOnce(
+     const char* ptr, SerialArena* serial_arena, ParseContext* ctx,
+     RepeatedPtrField<std::string>& field) {
+   int size = ReadSize(&ptr);


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

~Need to confirm this builds on all of our production platforms; 27.3 did not and blocked release last week.~

All warnings are removed; builds both with and without bazelmod.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
