### PR TITLE
[RB] Show full child command in UI

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -104,6 +104,7 @@ ts_library(
     deps = [
         "//app/components/link",
         "//app/format",
+        "//app/invocation:invocation_model",
         "//proto:invocation_status_ts_proto",
         "//proto:invocation_ts_proto",
         "@npm//@types/react",

--- a/app/invocation/child_invocation_card.tsx
+++ b/app/invocation/child_invocation_card.tsx
@@ -53,23 +53,6 @@ export default class ChildInvocationCard extends React.Component<ChildInvocation
     }
   }
 
-  private simplifyCommandLine(commandLine: string): string {
-    // Remove the bazel command string
-    if (commandLine.startsWith("bazel ")) {
-      commandLine = commandLine.slice("bazel ".length);
-    }
-
-    // Strip all --remote_header flags
-    commandLine = commandLine.replace(/\s*--remote_header=[^\s]+/g, "");
-    // Strip the options we manually added
-    commandLine = commandLine.replace(" --config=buildbuddy_bes_backend", "");
-    commandLine = commandLine.replace(" --config=buildbuddy_bes_results_url", "");
-    commandLine = commandLine.replace(" --config=buildbuddy_remote_cache", "");
-    commandLine = commandLine.replace(/\s*--invocation_id=[^\s]+/g, "");
-
-    return commandLine;
-  }
-
   render() {
     const inv = this.props.invocation;
     const invModel = new InvocationModel(inv);
@@ -79,7 +62,6 @@ export default class ChildInvocationCard extends React.Component<ChildInvocation
     if (command == "") {
       command = `${inv.command} ${inv.pattern.join(" ")}`;
     }
-    command = this.simplifyCommandLine(command);
 
     return (
       <Link

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -853,6 +853,7 @@ export default class InvocationModel {
   }
 
   explicitCommandLine() {
+    // TODO(Maggie): Clean up - will always be redacted
     // We allow overriding EXPLICIT_COMMAND_LINE to enable tools that wrap bazel
     // to append bazel args but still preserve the appearance of the original
     // command line. The effective command line can still be used to see the

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -853,7 +853,6 @@ export default class InvocationModel {
   }
 
   explicitCommandLine() {
-    // TODO(Maggie): Clean up - will always be redacted
     // We allow overriding EXPLICIT_COMMAND_LINE to enable tools that wrap bazel
     // to append bazel args but still preserve the appearance of the original
     // command line. The effective command line can still be used to see the

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1042,8 +1042,9 @@ func parseArgs(commandLineArgs []string) (bazelArgs []string, execArgs []string,
 	// app backend as the remote runner.
 	bazelArgs = arg.Remove(bazelArgs, "bes_backend")
 	bazelArgs = arg.Remove(bazelArgs, "remote_cache")
-	bazelArgs = append(bazelArgs, "--bes_backend="+*remoteRunner)
-	bazelArgs = append(bazelArgs, "--remote_cache="+*remoteRunner)
+	bazelArgs = append(bazelArgs, "--config=buildbuddy_bes_backend")
+	bazelArgs = append(bazelArgs, "--config=buildbuddy_bes_results_url")
+	bazelArgs = append(bazelArgs, "--config=buildbuddy_remote_cache")
 
 	return bazelArgs, execArgs, nil
 }

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -2,7 +2,6 @@ package invocationdb
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"strings"
 	"time"
@@ -186,12 +185,8 @@ func (d *InvocationDB) LookupChildInvocations(ctx context.Context, parentRunID s
 	rq := d.h.NewQuery(ctx, "invocationdb_get_child_invocations").Raw(
 		`SELECT invocation_id FROM "Invocations" WHERE parent_run_id = ? ORDER BY created_at_usec`, parentRunID)
 	iids := make([]string, 0)
-	err := rq.IterateRaw(func(ctx context.Context, row *sql.Rows) error {
-		var iid *string
-		if err := row.Scan(&iid); err != nil {
-			return err
-		}
-		iids = append(iids, *iid)
+	err := db.ScanEach(rq, func(ctx context.Context, inv *tables.Invocation) error {
+		iids = append(iids, inv.InvocationID)
 		return nil
 	})
 	if err != nil {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1428,7 +1428,6 @@ func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid 
 	}
 
 	invocation := invocationdb.TableInvocationToProto(ti)
-	streamID := GetStreamIdFromInvocationIdAndAttempt(iid, ti.Attempt)
 
 	var scoreCard *capb.ScoreCard
 	eg, ctx := errgroup.WithContext(ctx)
@@ -1453,79 +1452,7 @@ func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid 
 	})
 
 	eg.Go(func() error {
-		var screenWriter *terminal.ScreenWriter
-		if !invocation.HasChunkedEventLogs {
-			screenWriter = terminal.NewScreenWriter()
-		}
-		var redactor *redact.StreamingRedactor
-		if ti.RedactionFlags&redact.RedactionFlagStandardRedactions != redact.RedactionFlagStandardRedactions {
-			// only redact if we hadn't redacted enough, only parse again if we redact
-			redactor = redact.NewStreamingRedactor(env)
-		}
-		beValues := accumulator.NewBEValues(invocation)
-		events := []*inpb.InvocationEvent{}
-		structuredCommandLines := []*command_line.CommandLine{}
-		err := streamRawInvocationEvents(env, ctx, streamID, func(event *inpb.InvocationEvent) error {
-			if redactor != nil {
-				if err := redactor.RedactAPIKeysWithSlowRegexp(ctx, event.BuildEvent); err != nil {
-					return err
-				}
-				if err := redactor.RedactMetadata(event.BuildEvent); err != nil {
-					return err
-				}
-				if err := beValues.AddEvent(event.BuildEvent); err != nil {
-					return err
-				}
-			}
-
-			switch p := event.BuildEvent.Payload.(type) {
-			case *build_event_stream.BuildEvent_Started:
-				// Drop child pattern expanded events since this list can be
-				// very long and we don't render these currently.
-				event.BuildEvent.Children = nil
-			case *build_event_stream.BuildEvent_Expanded:
-				if len(event.BuildEvent.GetId().GetPattern().GetPattern()) > 0 {
-					pattern, truncated := TruncateStringSlice(event.BuildEvent.GetId().GetPattern().GetPattern(), maxPatternLengthBytes)
-					invocation.PatternsTruncated = truncated
-					event.BuildEvent.GetId().GetPattern().Pattern = pattern
-				}
-				// Don't return child TargetConfigured events to the UI; the UI
-				// only cares about the actual TargetConfigured event payloads.
-				event.BuildEvent.Children = nil
-				// UI doesn't render TestSuiteExpansions yet (though we probably
-				// should at some point?) So don't return these either.
-				p.Expanded.TestSuiteExpansions = nil
-			case *build_event_stream.BuildEvent_Progress:
-				if screenWriter != nil {
-					screenWriter.Write([]byte(p.Progress.Stderr))
-					screenWriter.Write([]byte(p.Progress.Stdout))
-				}
-				// Don't serve progress event contents to the UI since they are too
-				// large. Instead, logs are available either via the
-				// console_buffer field or the separate logs RPC.
-				p.Progress.Stderr = ""
-				p.Progress.Stdout = ""
-			case *build_event_stream.BuildEvent_StructuredCommandLine:
-				structuredCommandLines = append(structuredCommandLines, p.StructuredCommandLine)
-			}
-
-			if err := cb(event); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-
-		invocation.Event = events
-		// TODO: Can we remove this StructuredCommandLine field? These are
-		// already available in the events list.
-		invocation.StructuredCommandLine = structuredCommandLines
-		if screenWriter != nil {
-			invocation.ConsoleBuffer = string(screenWriter.Render())
-		}
-		return nil
+		return LookupInvocationEventsWithCallback(ctx, env, invocation, ti.RedactionFlags, cb)
 	})
 
 	if err := eg.Wait(); err != nil {
@@ -1534,6 +1461,81 @@ func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid 
 
 	invocation.ScoreCard = scoreCard
 	return invocation, nil
+}
+
+func LookupInvocationEventsWithCallback(ctx context.Context, env environment.Env, inv *inpb.Invocation, invRedactionFlags int32, cb invocationEventCB) error {
+	var screenWriter *terminal.ScreenWriter
+	if !inv.HasChunkedEventLogs {
+		screenWriter = terminal.NewScreenWriter()
+	}
+	var redactor *redact.StreamingRedactor
+	if invRedactionFlags&redact.RedactionFlagStandardRedactions != redact.RedactionFlagStandardRedactions {
+		// only redact if we hadn't redacted enough, only parse again if we redact
+		redactor = redact.NewStreamingRedactor(env)
+	}
+	beValues := accumulator.NewBEValues(inv)
+	structuredCommandLines := []*command_line.CommandLine{}
+	streamID := GetStreamIdFromInvocationIdAndAttempt(inv.GetInvocationId(), inv.GetAttempt())
+	err := streamRawInvocationEvents(env, ctx, streamID, func(event *inpb.InvocationEvent) error {
+		if redactor != nil {
+			if err := redactor.RedactAPIKeysWithSlowRegexp(ctx, event.BuildEvent); err != nil {
+				return err
+			}
+			if err := redactor.RedactMetadata(event.BuildEvent); err != nil {
+				return err
+			}
+			if err := beValues.AddEvent(event.BuildEvent); err != nil {
+				return err
+			}
+		}
+
+		switch p := event.BuildEvent.Payload.(type) {
+		case *build_event_stream.BuildEvent_Started:
+			// Drop child pattern expanded events since this list can be
+			// very long and we don't render these currently.
+			event.BuildEvent.Children = nil
+		case *build_event_stream.BuildEvent_Expanded:
+			if len(event.BuildEvent.GetId().GetPattern().GetPattern()) > 0 {
+				pattern, truncated := TruncateStringSlice(event.BuildEvent.GetId().GetPattern().GetPattern(), maxPatternLengthBytes)
+				inv.PatternsTruncated = truncated
+				event.BuildEvent.GetId().GetPattern().Pattern = pattern
+			}
+			// Don't return child TargetConfigured events to the UI; the UI
+			// only cares about the actual TargetConfigured event payloads.
+			event.BuildEvent.Children = nil
+			// UI doesn't render TestSuiteExpansions yet (though we probably
+			// should at some point?) So don't return these either.
+			p.Expanded.TestSuiteExpansions = nil
+		case *build_event_stream.BuildEvent_Progress:
+			if screenWriter != nil {
+				screenWriter.Write([]byte(p.Progress.Stderr))
+				screenWriter.Write([]byte(p.Progress.Stdout))
+			}
+			// Don't serve progress event contents to the UI since they are too
+			// large. Instead, logs are available either via the
+			// console_buffer field or the separate logs RPC.
+			p.Progress.Stderr = ""
+			p.Progress.Stdout = ""
+		case *build_event_stream.BuildEvent_StructuredCommandLine:
+			structuredCommandLines = append(structuredCommandLines, p.StructuredCommandLine)
+		}
+
+		if err := cb(event); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// TODO: Can we remove this StructuredCommandLine field? These are
+	// already available in the events list.
+	inv.StructuredCommandLine = structuredCommandLines
+	if screenWriter != nil {
+		inv.ConsoleBuffer = string(screenWriter.Render())
+	}
+	return nil
 }
 
 func (e *EventChannel) tableInvocationFromProto(p *inpb.Invocation, blobID string) (*tables.Invocation, error) {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1452,7 +1452,7 @@ func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid 
 	})
 
 	eg.Go(func() error {
-		return LookupInvocationEventsWithCallback(ctx, env, invocation, ti.RedactionFlags, cb)
+		return FetchAllInvocationEventsWithCallback(ctx, env, invocation, ti.RedactionFlags, cb)
 	})
 
 	if err := eg.Wait(); err != nil {
@@ -1463,7 +1463,7 @@ func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid 
 	return invocation, nil
 }
 
-func LookupInvocationEventsWithCallback(ctx context.Context, env environment.Env, inv *inpb.Invocation, invRedactionFlags int32, cb invocationEventCB) error {
+func FetchAllInvocationEventsWithCallback(ctx context.Context, env environment.Env, inv *inpb.Invocation, invRedactionFlags int32, cb invocationEventCB) error {
 	var screenWriter *terminal.ScreenWriter
 	if !inv.HasChunkedEventLogs {
 		screenWriter = terminal.NewScreenWriter()

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -35,7 +35,6 @@ go_library(
         "//proto:workspace_go_proto",
         "//proto:zip_go_proto",
         "//server/backends/chunkstore",
-        "//server/backends/invocationdb",
         "//server/build_event_protocol/build_event_handler",
         "//server/build_event_protocol/event_index",
         "//server/capabilities_filter",
@@ -65,6 +64,7 @@ go_library(
         "//server/util/subdomain",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_x_sync//errgroup",
         "@org_golang_x_time//rate",
     ],
 )

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -414,7 +414,7 @@ type InvocationDB interface {
 	LookupGroupFromInvocation(ctx context.Context, invocationID string) (*tables.Group, error)
 	LookupGroupIDFromInvocation(ctx context.Context, invocationID string) (string, error)
 	LookupExpiredInvocations(ctx context.Context, cutoffTime time.Time, limit int) ([]*tables.Invocation, error)
-	LookupChildInvocations(ctx context.Context, parentRunID string) ([]*tables.Invocation, error)
+	LookupChildInvocations(ctx context.Context, parentRunID string) ([]string, error)
 	DeleteInvocation(ctx context.Context, invocationID string) error
 	DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *UserInfo, invocationID string) error
 	FillCounts(ctx context.Context, log *telpb.TelemetryStat) error


### PR DESCRIPTION
Currently, the UI will only show the command and the pattern - i.e. `build //...`. Show the full explicit command line to include all flags specified by the user. This will bring the UI closer to how it looked before the bash steps refactor

Note that this won't apply automatically for workflows - some more refactoring is required to consolidate the deprecated `BazelCommand` syntax with the new `Steps` syntax

Before this PR:
<img width="376" alt="Screenshot 2024-10-17 at 11 42 49 AM" src="https://github.com/user-attachments/assets/8f20ad65-0b7e-4c22-865f-cb3f6e238b72">

After:
<img width="763" alt="Screenshot 2024-10-17 at 11 42 33 AM" src="https://github.com/user-attachments/assets/0082f6f2-8f77-4566-a174-e7064ce337fe">



**Related issues**: N/A
