### PR TITLE
[raft] close the db and stop replicaInitStatusWaiter when we close the store

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -520,6 +520,7 @@ func (s *Store) Stop(ctx context.Context) error {
 		s.eg.Wait()
 	}
 	s.updateTagsWorker.Stop()
+	s.replicaInitStatusWaiter.Stop()
 
 	s.log.Info("Store: waitgroups finished")
 	s.nodeHost.Close()
@@ -533,6 +534,10 @@ func (s *Store) Stop(ctx context.Context) error {
 	// Wait for all active requests to be finished.
 	s.leaser.Close()
 	s.log.Info("Store: leaser closed")
+
+	if err := s.db.Close(); err != nil {
+		return err
+	}
 	return grpc_server.GRPCShutdown(ctx, s.grpcServer)
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
