### PR TITLE
[raft] use clock from the env

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -174,16 +174,16 @@ func New(env environment.Env, rootDir, raftAddress, grpcAddr string, partitions 
 		return nil, err
 	}
 	leaser := pebble.NewDBLeaser(db)
-	clock := clockwork.NewRealClock()
-	return NewWithArgs(env, rootDir, nodeHost, gossipManager, sender, registry, raftListener, apiClient, grpcAddr, partitions, db, leaser, clock)
+	return NewWithArgs(env, rootDir, nodeHost, gossipManager, sender, registry, raftListener, apiClient, grpcAddr, partitions, db, leaser)
 }
 
-func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeHost, gossipManager interfaces.GossipService, sender *sender.Sender, registry registry.NodeRegistry, listener *listener.RaftListener, apiClient *client.APIClient, grpcAddress string, partitions []disk.Partition, db pebble.IPebbleDB, leaser pebble.Leaser, clock clockwork.Clock) (*Store, error) {
+func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeHost, gossipManager interfaces.GossipService, sender *sender.Sender, registry registry.NodeRegistry, listener *listener.RaftListener, apiClient *client.APIClient, grpcAddress string, partitions []disk.Partition, db pebble.IPebbleDB, leaser pebble.Leaser) (*Store, error) {
 	nodeLiveness := nodeliveness.New(env.GetServerContext(), nodeHost.ID(), sender)
 
 	nhLog := log.NamedSubLogger(nodeHost.ID())
 	eventsChan := make(chan events.Event, 100)
 
+	clock := env.GetClock()
 	session := client.NewSessionWithClock(clock)
 	lkSession := client.NewSessionWithClock(clock)
 

--- a/enterprise/server/raft/testutil/BUILD
+++ b/enterprise/server/raft/testutil/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//enterprise/server/raft/store",
         "//enterprise/server/util/pebble",
         "//proto:raft_go_proto",
-        "//server/environment",
         "//server/gossip",
         "//server/testutil/testenv",
         "//server/testutil/testfs",

--- a/enterprise/server/raft/testutil/BUILD
+++ b/enterprise/server/raft/testutil/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//enterprise/server/raft/store",
         "//enterprise/server/util/pebble",
         "//proto:raft_go_proto",
+        "//server/environment",
         "//server/gossip",
         "//server/testutil/testenv",
         "//server/testutil/testfs",

--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -111,6 +111,7 @@ func (sf *StoreFactory) NewStore(t *testing.T) *TestingStore {
 	require.NoError(t, err, "unexpected error creating NodeHost")
 
 	te := testenv.GetTestEnv(t)
+	te.SetClock(sf.clock)
 	apiClient := client.NewAPIClient(te, nodeHost.ID(), reg)
 
 	rc := rangecache.New()
@@ -126,7 +127,7 @@ func (sf *StoreFactory) NewStore(t *testing.T) *TestingStore {
 	require.NoError(t, err)
 	leaser := pebble.NewDBLeaser(db)
 	ts.leaser = leaser
-	store, err := store.NewWithArgs(te, ts.RootDir, nodeHost, gm, s, reg, raftListener, apiClient, ts.GRPCAddress, partitions, db, leaser, sf.clock)
+	store, err := store.NewWithArgs(te, ts.RootDir, nodeHost, gm, s, reg, raftListener, apiClient, ts.GRPCAddress, partitions, db, leaser)
 	require.NoError(t, err)
 	require.NotNil(t, store)
 	store.Start()


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
In raft/store, use the clock from the environment. This will allow me to share
a fake clock between raft_cache and raft_store without adding a new argument to
store.New.
