### PR TITLE
Schema changes for serving Executions page using ClickHouse

### DIFF
--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2359,7 +2359,10 @@ message StoredExecution {
   int64 output_upload_completed_timestamp_usec = 27;
 
   int32 invocation_link_type = 28;
-  
+
   int32 status_code = 29;
   int32 exit_code = 30;
+
+  string command_snippet = 31;
+  string status_message = 32;
 }

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -192,6 +192,10 @@ type Execution struct {
 	CachedResult bool
 	DoNotCache   bool
 
+	// Long string fields
+	CommandSnippet string
+	StatusMessage  string
+
 	// Fields from Invocations
 	User             string
 	Host             string


### PR DESCRIPTION
This PR adds the missing pieces of data needed to render the Executions page via ClickHouse. Updates both the ClickHouse table schema as well as its proto representation (`StoredExecution`).

**Related issues**: N/A
