### PR TITLE
Fix up some 'invocation in progress' logic in the UI

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -323,12 +323,12 @@ ts_library(
     deps = [
         "//app/components/button",
         "//app/components/select",
+        "//app/errors:error_service",
         "//app/format",
         "//app/invocation:invocation_exec_log_card",
         "//app/invocation:invocation_execution_table",
         "//app/invocation:invocation_execution_util",
         "//app/invocation:invocation_model",
-        "//app/router",
         "//app/service:rpc_service",
         "//proto:execution_stats_ts_proto",
         "//proto:remote_execution_ts_proto",

--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -15,7 +15,6 @@ import Link from "../components/link/link";
 import { digestToString } from "../util/cache";
 
 interface Props {
-  inProgress: boolean;
   model: InvocationModel;
   search: URLSearchParams;
   filter: string;
@@ -183,7 +182,7 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
     if (!this.state.log?.length) {
       return (
         <div className="invocation-execution-empty-state">
-          No execution log actions for this invocation{this.props.inProgress && <span> yet</span>}.
+          No execution log actions for this invocation{this.props.model.isInProgress() && <span> yet</span>}.
         </div>
       );
     }

--- a/app/invocation/invocation_fetch_card.tsx
+++ b/app/invocation/invocation_fetch_card.tsx
@@ -4,7 +4,6 @@ import InvocationModel from "./invocation_model";
 
 interface Props {
   model: InvocationModel;
-  inProgress: boolean;
 }
 
 interface State {

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -669,6 +669,17 @@ export default class InvocationModel {
     return this.invocation.invocationStatus === InvocationStatus.PARTIAL_INVOCATION_STATUS;
   }
 
+  /**
+   * Returns whether basic invocation metadata has been received yet, such as
+   * user, bazel command, target pattern etc.
+   */
+  isMetadataLoaded() {
+    // Just return whether we have any events. This logic works because the
+    // server doesn't persist any events until all invocation metadata is
+    // loaded.
+    return this.invocation.event.length > 0;
+  }
+
   getFaviconType() {
     let invocationStatus = this.invocation.invocationStatus;
     if (invocationStatus == invocation_status.InvocationStatus.DISCONNECTED_INVOCATION_STATUS) {


### PR DESCRIPTION
- Remove `inProgress` state from the InvocationComponent - it doesn't actually indicate whether the invocation is in progress. In reality, it indicates "invocation was started but we haven't received metadata yet", which is only true for a brief period at the start of the invocation, and false for the majority of the time that the invocation is actually in progress.
- Fix downstream components to stop depending on this state and instead reference `model.isInProgress()`
- Fix up logic in `InvocationExecutionCard` which refetches executions while the invocation is in progress. Currently it triggers a new refetch each time the invocation model changes, which happens very frequently. Instead we should only refetch if the invocation ID changes. Also fix up error handling and loading state.

**Related issues**: N/A
