### PR TITLE
[raft] set last access time in find response

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1160,9 +1160,12 @@ func (sm *Replica) find(db ReplicaReader, req *rfpb.FindRequest) (*rfpb.FindResp
 	}
 	defer iter.Close()
 
-	present := iter.SeekGE(req.GetKey()) && bytes.Equal(iter.Key(), req.GetKey())
+	fileMetadata, err := lookupFileMetadata(iter, req.GetKey())
+	present := (err == nil)
+
 	return &rfpb.FindResponse{
-		Present: present,
+		Present:        present,
+		LastAccessUsec: fileMetadata.GetLastAccessUsec(),
 	}, nil
 }
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -644,6 +644,8 @@ message FindRequest {
 }
 message FindResponse {
   bool present = 1;
+  // The last time this file record was accessed.
+  int64 last_access_usec = 2;
 }
 
 message GetRequest {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
In order to move atime update to raftCache from replica, we need to know know
last access time in findMissing because when we send atime update we want to
check if last access time is older than a threshold.
