### PR TITLE
Revert "website: add support to run from within the directory (#7399)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ buildbuddy-key.pem
 enterprise/config/user-configs
 
 # Bazel compact execution log
-bazel_compact_exec_log.binpb.zst
+/bazel_compact_exec_log.binpb.zst

--- a/rules/yarn/index.bzl
+++ b/rules/yarn/index.bzl
@@ -2,7 +2,7 @@ DEFAULT_CMD_TPL = """
 # NOTE: BazelBinResolverPlugin in docusaurus.config.js depends on ROOTDIR being set
 # to the original execution working directory.
 export ROOTDIR=$$(pwd) &&
-export PACKAGEDIR=\\$$BUILD_WORKSPACE_DIRECTORY/$$(dirname $(location {package})) &&
+export PACKAGEDIR=$$(dirname $(location {package})) &&
 export PATH=$$ROOTDIR/$$(dirname $(location {yarn})):$$ROOTDIR/$$(dirname $(location {node})):$$PATH &&
 cd $$PACKAGEDIR &&
 yarn install &&
@@ -16,7 +16,7 @@ mv $$PACKAGEDIR/build.tar $@
 EXECUTABLE_CMD_TPL = """
 cat << EOF > $@
 export PATH=$$(pwd)/$$(dirname $(location {yarn})):$$(pwd)/$$(dirname $(location {node})):$$PATH &&
-cd \\$$BUILD_WORKSPACE_DIRECTORY/$$(dirname $(location {package})) &&
+cd $$(dirname $(location {package})) &&
 yarn install &&
 yarn {command}
 EOF


### PR DESCRIPTION
This appears to be breaking dev autopush: https://github.com/buildbuddy-io/buildbuddy-internal/actions/runs/10798433205/job/29951922712

```
/bin/bash: line 6: cd: $BUILD_WORKSPACE_DIRECTORY/website: No such file or directory
```

**Related issues**: N/A
