### PR TITLE
Reapply "website: add support to run from within the directory (#7399)" (#7421)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ buildbuddy-key.pem
 enterprise/config/user-configs
 
 # Bazel compact execution log
-/bazel_compact_exec_log.binpb.zst
+bazel_compact_exec_log.binpb.zst

--- a/rules/yarn/index.bzl
+++ b/rules/yarn/index.bzl
@@ -1,23 +1,31 @@
 DEFAULT_CMD_TPL = """
+set -e
+
 # NOTE: BazelBinResolverPlugin in docusaurus.config.js depends on ROOTDIR being set
 # to the original execution working directory.
-export ROOTDIR=$$(pwd) &&
-export PACKAGEDIR=$$(dirname $(location {package})) &&
-export PATH=$$ROOTDIR/$$(dirname $(location {yarn})):$$ROOTDIR/$$(dirname $(location {node})):$$PATH &&
-cd $$PACKAGEDIR &&
-yarn install &&
-yarn {command} &&
-cd build &&
-tar -cvf ../build.tar * &&
-cd $$ROOTDIR &&
+export ROOTDIR=$$(pwd)
+export PACKAGEDIR=$$(dirname $(location {package}))
+export PATH=$$ROOTDIR/$$(dirname $(location {yarn})):$$ROOTDIR/$$(dirname $(location {node})):$$PATH
+cd "$$PACKAGEDIR"
+yarn install
+yarn {command}
+cd build
+tar -cvf ../build.tar *
+cd $$ROOTDIR
 mv $$PACKAGEDIR/build.tar $@
 """
 
 EXECUTABLE_CMD_TPL = """
 cat << EOF > $@
-export PATH=$$(pwd)/$$(dirname $(location {yarn})):$$(pwd)/$$(dirname $(location {node})):$$PATH &&
-cd $$(dirname $(location {package})) &&
-yarn install &&
+set -e
+export PATH=$$(pwd)/$$(dirname $(location {yarn})):$$(pwd)/$$(dirname $(location {node})):$$PATH
+if [ -n "\\$$BUILD_WORKSPACE_DIRECTORY" ]; then
+    WS_DIR="\\$$BUILD_WORKSPACE_DIRECTORY/"
+else
+    WS_DIR=""
+fi
+cd "\\$$WS_DIR"$$(dirname $(location {package}))
+yarn install
 yarn {command}
 EOF
 """


### PR DESCRIPTION
Instead of using the variable directly, use a proxy `WS_DIR` variable so
that if BUILD_WORKSPACE_DIRECTORY is unset, we just gona pass and empty
string to `cd`.

Also replaced all the `&&` with `set -e` to simplify the script.
