### PR TITLE
Remove 'advanced' label from runner output heading

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -518,8 +518,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
         {!isBazelInvocation && (
           <div className="container">
             <div className="workflow-details-header">
-              <h2>Runner results (advanced)</h2>
-              <div>Raw output from the runner instance that executed the Bazel commands.</div>
+              <h2>Run results</h2>
             </div>
           </div>
         )}


### PR DESCRIPTION
Also remove the subtitle - this subtitle also makes it sound more "technical" than it is

**Related issues**: N/A
