### PR TITLE
Add missing `r` to would-be python raw string for regex

### DIFF
--- a/server/metrics/generate_docs.py
+++ b/server/metrics/generate_docs.py
@@ -125,7 +125,7 @@ class DocsGenerator(object):
             self.state = "MARKDOWN_BLOCK"
 
         if self.state == "MARKDOWN_BLOCK":
-            m = re.match("^//\s*(.*)", line)
+            m = re.match(r"^//\s*(.*)", line)
             if m:
                 self.output_lines.append(m.group(1))
             else:


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Fixes a warning about invalid escape sequence `\s`. This is supposed to be interpreted as the whitespace wildcard by the regex implementation, not as a special character by the python interpreter, so we just make it a raw string.


<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
