### PR TITLE
Clean up ci_runner debug logs

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -610,11 +610,6 @@ func (r *buildEventReporter) emitBuildEventsForBazelCommands(output string) {
 }
 
 func main() {
-	if os.Getenv("CI_RUNNER_DEBUG") == "1" {
-		*backendLog.LogLevel = "debug"
-		backendLog.Configure()
-	}
-	backendLog.Debugf("Top of main")
 	if err := run(); err != nil {
 		if result, ok := err.(*actionResult); ok {
 			os.Exit(result.exitCode)
@@ -635,13 +630,10 @@ func run() error {
 			return err
 		}
 	}
-	backendLog.Debugf("Finished parsing flags")
 	if *credentialHelper {
-		backendLog.Debugf("Running credential helper")
 		return runCredentialHelper()
 	}
 	if isBazelWrapper {
-		backendLog.Debugf("Running bazel wrapper")
 		return runBazelWrapper()
 	}
 
@@ -673,7 +665,6 @@ func run() error {
 
 	// Use a context without a timeout for the build event reporter, so that even
 	// if the `timeout` is reached, any events will finish getting published
-	backendLog.Debugf("Initializing build event reporter")
 	buildEventReporter, err := newBuildEventReporter(contextWithoutTimeout, *besBackend, ws.buildbuddyAPIKey, *invocationID, *workflowID != "" /*=isWorkflow*/)
 	if err != nil {
 		return err
@@ -699,7 +690,6 @@ func run() error {
 	}
 	// Change the current working directory to respect WORKDIR_OVERRIDE, if set.
 	if wd := os.Getenv("WORKDIR_OVERRIDE"); wd != "" {
-		backendLog.Debugf("Initializing working directory %s", wd)
 		if err := os.MkdirAll(wd, 0755); err != nil {
 			return status.WrapError(err, "create WORKDIR_OVERRIDE directory")
 		}
@@ -733,13 +723,10 @@ func run() error {
 		return status.WrapError(err, "disable interactivity")
 	}
 
-	backendLog.Debugf("Completed checking configuration requirements")
-
 	// Write default bazelrc
 	if err := writeBazelrc(buildbuddyBazelrcPath, buildEventReporter.invocationID, runID, rootDir); err != nil {
 		return status.WrapError(err, "write "+buildbuddyBazelrcPath)
 	}
-	backendLog.Debugf("Completed writing bazelrc")
 	// Delete bazelrc before exiting. Use abs path since we might cd after this
 	// point.
 	absBazelrcPath, err := filepath.Abs(buildbuddyBazelrcPath)
@@ -760,22 +747,18 @@ func run() error {
 	// Make sure we have a bazel / bazelisk binary available.
 	if *bazelCommand == "" {
 		bazeliskPath := filepath.Join(rootDir, bazeliskBinaryName)
-		backendLog.Debugf("Preparing to extract bazelisk")
 		if err := extractBazelisk(bazeliskPath); err != nil {
 			return status.WrapError(err, "failed to extract bazelisk")
 		}
-		backendLog.Debugf("Finished extracting bazelisk")
 		*bazelCommand = bazeliskPath
 
 	}
 
 	// Use the bazel wrapper script, which adds some common flags to all
 	// Bazel builds.
-	backendLog.Debugf("Preparing to write bazel wrapper script")
 	if err := ws.writeBazelWrapperScript(); err != nil {
 		return status.WrapError(err, "write bazel wrapper script")
 	}
-	backendLog.Debugf("Finished write bazel wrapper script")
 
 	if *shutdownAndExit {
 		ws.log.Println("--shutdown_and_exit requested; will run bazel shutdown then exit.")
@@ -804,7 +787,6 @@ func run() error {
 		return nil
 	}
 
-	backendLog.Debugf("Starting build event reporter")
 	if err := buildEventReporter.Start(ws.startTime); err != nil {
 		return status.WrapError(err, "could not publish started event")
 	}

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -610,6 +610,10 @@ func (r *buildEventReporter) emitBuildEventsForBazelCommands(output string) {
 }
 
 func main() {
+	if os.Getenv("CI_RUNNER_DEBUG") == "1" {
+		*backendLog.LogLevel = "debug"
+		backendLog.Configure()
+	}
 	if err := run(); err != nil {
 		if result, ok := err.(*actionResult); ok {
 			os.Exit(result.exitCode)

--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -46,8 +46,6 @@ var (
 )
 
 func constructExecCommand(command *repb.Command, workDir string, stdio *interfaces.Stdio) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer, error) {
-	log.Debugf("Top of constructExecCommand")
-	defer log.Debugf("Finished constructExecCommand")
 	if stdio == nil {
 		stdio = &interfaces.Stdio{}
 	}
@@ -74,7 +72,6 @@ func constructExecCommand(command *repb.Command, workDir string, stdio *interfac
 	// the process doesn't consume its stdin. See
 	// https://go.dev/play/p/DpKaVrx8d8G
 	if stdio.Stdin != nil {
-		log.Debugf("Get stdin pipe")
 		inp, err := cmd.StdinPipe()
 		if err != nil {
 			return nil, nil, nil, status.InternalErrorf("failed to get stdin pipe: %s", err)
@@ -89,7 +86,6 @@ func constructExecCommand(command *repb.Command, workDir string, stdio *interfac
 		cmd.Stdout = io.MultiWriter(cmd.Stdout, logWriter)
 		cmd.Stderr = io.MultiWriter(cmd.Stderr, logWriter)
 	}
-	log.Debugf("Preparing to get default sys proc attr")
 	cmd.SysProcAttr = getDefaultSysProcAttr()
 	for _, envVar := range command.GetEnvironmentVariables() {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
@@ -193,11 +189,9 @@ func startNewProcess(ctx context.Context, cmd *exec.Cmd) (*process, error) {
 		cmd:        cmd,
 		terminated: make(chan struct{}),
 	}
-	log.Debugf("Preparing to run process prestart")
 	if err := p.preStart(); err != nil {
 		return nil, fmt.Errorf("fail to setup preStart: %w", err)
 	}
-	log.Debugf("Preparing to run command start")
 	if err := p.cmd.Start(); err != nil {
 		return nil, err
 	}
@@ -250,7 +244,6 @@ func RunWithProcessTreeCleanup(ctx context.Context, cmd *exec.Cmd, opts *RunOpts
 		opts = &RunOpts{}
 	}
 
-	log.CtxDebugf(ctx, "Preparing to start new process")
 	p, err := startNewProcess(ctx, cmd)
 	if err != nil {
 		return nil, err

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -437,15 +437,11 @@ type VM interface {
 // PullImageIfNecessary pulls the image configured for the container if it
 // is not cached locally.
 func PullImageIfNecessary(ctx context.Context, env environment.Env, ctr CommandContainer, creds oci.Credentials, imageRef string) error {
-	if *debugUseLocalImagesOnly || imageRef == "" {
-		return nil
-	}
-
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
-	log.CtxDebugf(ctx, "Preparing to pull image")
-	defer log.CtxDebugf(ctx, "Finished pulling image")
-
+	if *debugUseLocalImagesOnly {
+		return nil
+	}
 	cacheAuth := env.GetImageCacheAuthenticator()
 	if cacheAuth == nil || env.GetAuthenticator() == nil {
 		// If we don't have an authenticator available, fall back to

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -437,11 +437,12 @@ type VM interface {
 // PullImageIfNecessary pulls the image configured for the container if it
 // is not cached locally.
 func PullImageIfNecessary(ctx context.Context, env environment.Env, ctr CommandContainer, creds oci.Credentials, imageRef string) error {
-	ctx, span := tracing.StartSpan(ctx)
-	defer span.End()
-	if *debugUseLocalImagesOnly {
+	if *debugUseLocalImagesOnly || imageRef == "" {
 		return nil
 	}
+
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
 	cacheAuth := env.GetImageCacheAuthenticator()
 	if cacheAuth == nil || env.GetAuthenticator() == nil {
 		// If we don't have an authenticator available, fall back to

--- a/enterprise/server/remote_execution/containers/bare/BUILD
+++ b/enterprise/server/remote_execution/containers/bare/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//enterprise/server/util/procstats",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
-        "//server/util/log",
         "//server/util/status",
     ],
 )

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -13,7 +13,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/procstats"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -82,7 +81,6 @@ func (c *bareCommandContainer) Signal(ctx context.Context, sig syscall.Signal) e
 }
 
 func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, workDir string, stdio *interfaces.Stdio) (result *interfaces.CommandResult) {
-	log.CtxDebugf(ctx, "Beginning exec in container")
 	var statsListener procstats.Listener
 	if c.opts.EnableStats {
 		defer container.Metrics.Unregister(c)
@@ -92,7 +90,6 @@ func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, work
 	}
 
 	if *enableLogFiles {
-		log.CtxDebugf(ctx, "Creating log files")
 		stdoutPath := workDir + ".stdout"
 		stdoutFile, err := os.Create(stdoutPath)
 		if err != nil {
@@ -130,7 +127,6 @@ func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, work
 		stdio.Stderr = io.MultiWriter(stdio.Stderr, stderrFile)
 	}
 
-	log.CtxDebugf(ctx, "Preparing to run command")
 	return commandutil.RunWithOpts(ctx, cmd, &commandutil.RunOpts{
 		Dir:           workDir,
 		StatsListener: statsListener,

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -212,8 +212,7 @@ func (r *taskRunner) String() string {
 		truncate(r.key.InstanceName, 8, "..."), truncate(ph, 8, ""))
 }
 
-func (r *taskRunner) pullCredentials(ctx context.Context) (oci.Credentials, error) {
-	log.CtxDebugf(ctx, "Pulling credentials")
+func (r *taskRunner) pullCredentials() (oci.Credentials, error) {
 	return oci.CredentialsFromProperties(r.PlatformProperties)
 }
 
@@ -233,7 +232,7 @@ func (r *taskRunner) PrepareForTask(ctx context.Context) error {
 
 	// Pull the container image before Run() is called, so that we don't
 	// use up the whole exec ctx timeout with a slow container pull.
-	creds, err := r.pullCredentials(ctx)
+	creds, err := r.pullCredentials()
 	if err != nil {
 		return err
 	}
@@ -299,7 +298,6 @@ func (r *taskRunner) DownloadInputs(ctx context.Context, ioStats *repb.IOStats) 
 
 // Run runs the task that is currently bound to the command runner.
 func (r *taskRunner) Run(ctx context.Context) (res *interfaces.CommandResult) {
-	log.CtxDebugf(ctx, "Starting run")
 	start := time.Now()
 	defer func() {
 		// Discard nonsensical PSI full-stall durations which are greater
@@ -348,11 +346,10 @@ func (r *taskRunner) Run(ctx context.Context) (res *interfaces.CommandResult) {
 	command := r.task.GetCommand()
 
 	if !r.PlatformProperties.RecycleRunner {
-		log.CtxDebugf(ctx, "Runner is not recyclable - running full container lifecycle")
 		// If the container is not recyclable, then use `Run` to walk through
 		// the entire container lifecycle in a single step.
 		// TODO: Remove this `Run` method and call lifecycle methods directly.
-		creds, err := r.pullCredentials(ctx)
+		creds, err := r.pullCredentials()
 		if err != nil {
 			return commandutil.ErrorResult(err)
 		}
@@ -370,7 +367,7 @@ func (r *taskRunner) Run(ctx context.Context) (res *interfaces.CommandResult) {
 	r.p.mu.RUnlock()
 	switch s {
 	case initial:
-		creds, err := r.pullCredentials(ctx)
+		creds, err := r.pullCredentials()
 		if err != nil {
 			return commandutil.ErrorResult(err)
 		}
@@ -395,7 +392,6 @@ func (r *taskRunner) Run(ctx context.Context) (res *interfaces.CommandResult) {
 	}
 
 	if _, ok := persistentworker.Key(r.PlatformProperties, command.GetArguments()); ok {
-		log.CtxDebugf(ctx, "Sending persistent work request")
 		return r.sendPersistentWorkRequest(ctx, command)
 	}
 


### PR DESCRIPTION
This PR reverts 2 debug logging PRs, as we have narrowed in on the source of the problem.
The third commit includes some changes from those PRs I would like to maintain.

- Revert "[ci_runner] Add more debug logs (#7379)"
- Revert "Add debug logging to runner (#7324)"


<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
