### PR TITLE
[raft] When stop the store, usage tracker should also be stopped

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -513,6 +513,7 @@ func (s *Store) Stop(ctx context.Context) error {
 		s.log.Infof("Store: shutdown finished in %s", time.Since(now))
 	}()
 
+	s.usages.Stop()
 	if s.egCancel != nil {
 		s.egCancel()
 		s.leaseKeeper.Stop()


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
