### PR TITLE
Allow multiple firecracker test shards to run concurrently on a single machine

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -106,7 +106,12 @@ go_test(
         "test.Pool": "bare",
         "test.use-self-hosted-executors": "true",
         "test.container-image": "none",
+        # These tests can get pretty expensive when running on a cold executor
+        # because of OCI image conversion. Size the task manually to avoid OOM.
+        # TODO: include test ext4 images as deps to avoid conversion.
+        "test.EstimatedComputeUnits": "5",
     },
+    shard_count = 30,
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment

--- a/server/testutil/testnetworking/BUILD
+++ b/server/testutil/testnetworking/BUILD
@@ -6,8 +6,5 @@ go_library(
     srcs = ["testnetworking.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testnetworking",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/testutil/testfs",
-        "@com_github_stretchr_testify//require",
-    ],
+    deps = ["@com_github_stretchr_testify//require"],
 )


### PR DESCRIPTION
Follow-up from https://github.com/buildbuddy-io/buildbuddy/pull/7429

* Add optional `flock`-based IP range locking to prevent concurrent test shards from trying to use the same IP range concurrently.
  * This is useful for firecracker tests, as well as running multiple firecracker executors locally. 
* Don't try to clean up network namespaces in tests, because they might be in use.
   * I don't expect that too many of these will accumulate, but if it does happen, we can find a way to clean up "orphaned" namespaces, maybe by associating them with lockfiles.
* Don't try to clean up the shared executor root directory in tests either, to prevent converted ext4 image files from disappearing mid-test.
  * Added a TODO to provision these images as data deps of the test instead of converting during the test.
* Set `shard_count` on `firecracker_test`. (This won't actually buy us a ton of concurrency until we disable exclusive task scheduling on the bare pool.)

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3758
