### PR TITLE
Write execution stdout/stderr to files instead of buffering

### DIFF
--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -194,7 +194,7 @@ func execute(cmdArgs []string) error {
 	log.Debugf("Execution completed in %s", time.Since(stageStart))
 	stageStart = time.Now()
 	log.Debugf("Downloading result")
-	res, err := rexec.GetResult(ctx, env, *instanceName, df, rsp.ExecuteResponse.GetResult())
+	res, err := rexec.GetResult(ctx, env, os.Stdout, os.Stderr, *instanceName, df, rsp.ExecuteResponse.GetResult())
 	if err != nil {
 		return status.WrapError(err, "execution failed")
 	}
@@ -206,8 +206,7 @@ func execute(cmdArgs []string) error {
 		log.Debugf("Execution metadata: %s", string(b))
 	}
 
-	os.Stdout.Write(res.Stdout)
-	os.Stderr.Write(res.Stderr)
+	os.Exit(res.ExitCode)
 
 	return nil
 }

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -362,7 +362,7 @@ type CommandContainer interface {
 	//
 	// It is approximately the same as calling PullImageIfNecessary, Create,
 	// Exec, then Remove.
-	Run(ctx context.Context, command *repb.Command, workingDir string, creds oci.Credentials) *interfaces.CommandResult
+	Run(ctx context.Context, command *repb.Command, stdio *interfaces.Stdio, workingDir string, creds oci.Credentials) *interfaces.CommandResult
 
 	// IsImageCached returns whether the configured image is cached locally.
 	IsImageCached(ctx context.Context) (bool, error)
@@ -607,7 +607,7 @@ func (t *TracedCommandContainer) IsolationType() string {
 	return t.Delegate.IsolationType()
 }
 
-func (t *TracedCommandContainer) Run(ctx context.Context, command *repb.Command, workingDir string, creds oci.Credentials) *interfaces.CommandResult {
+func (t *TracedCommandContainer) Run(ctx context.Context, command *repb.Command, stdio *interfaces.Stdio, workingDir string, creds oci.Credentials) *interfaces.CommandResult {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
 
@@ -617,7 +617,7 @@ func (t *TracedCommandContainer) Run(ctx context.Context, command *repb.Command,
 		return &interfaces.CommandResult{ExitCode: noExitCode, Error: ErrRemoved}
 	}
 
-	return t.Delegate.Run(ctx, command, workingDir, creds)
+	return t.Delegate.Run(ctx, command, stdio, workingDir, creds)
 }
 
 func (t *TracedCommandContainer) IsImageCached(ctx context.Context) (bool, error) {

--- a/enterprise/server/remote_execution/containers/bare/BUILD
+++ b/enterprise/server/remote_execution/containers/bare/BUILD
@@ -23,6 +23,7 @@ go_test(
     srcs = ["bare_test.go"],
     deps = [
         ":bare",
+        "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
         "//server/testutil/testfs",

--- a/enterprise/server/remote_execution/containers/bare/bare_test.go
+++ b/enterprise/server/remote_execution/containers/bare/bare_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/bare"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
-	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -36,12 +36,12 @@ func TestHelloWorldOnBareMetal(t *testing.T) {
 	tempDir := makeTempDirWithWorldTxt(t)
 	cmd := &repb.Command{
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
-			&repb.Command_EnvironmentVariable{Name: "GREETING", Value: "Hello"},
+			{Name: "GREETING", Value: "Hello"},
 		},
 		Arguments: []string{"sh", "-c", fmt.Sprintf("printf \"$GREETING $(cat %s/world.txt)!\"", tempDir)},
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
-				&repb.Platform_Property{
+				{
 					Name:  "container-image",
 					Value: "none",
 				},
@@ -52,46 +52,17 @@ func TestHelloWorldOnBareMetal(t *testing.T) {
 	defer cancel()
 
 	bareContainer := bare.NewBareCommandContainer(&bare.Opts{})
-	result := bareContainer.Run(ctx, cmd, tempDir, oci.Credentials{})
+	buf := &commandutil.OutputBuffers{}
+	result := bareContainer.Run(ctx, cmd, buf.Stdio(), tempDir, oci.Credentials{})
 
 	if result.Error != nil {
 		t.Fatal(result.Error)
 	}
 	assert.Regexp(t, "^(/usr)?/bin/sh\\s", result.CommandDebugString, "sanity check: command should be run bare")
-	assert.Equal(t, "Hello world!", string(result.Stdout),
+	assert.Equal(t, "Hello world!", buf.Stdout.String(),
 		"stdout should equal 'Hello world!' ('$GREETING' env var should be replaced with 'Hello', and "+
 			"tempfile containing 'world' should be readable.)",
 	)
-	assert.Empty(t, string(result.Stderr), "stderr should be empty")
+	assert.Empty(t, buf.Stderr.String(), "stderr should be empty")
 	assert.Equal(t, 0, result.ExitCode, "should exit with success")
-}
-
-func TestLogFiles(t *testing.T) {
-	flags.Set(t, "executor.bare.enable_log_files", true)
-	ctx := context.Background()
-	ctr := bare.NewBareCommandContainer(&bare.Opts{})
-	workDir := testfs.MakeTempDir(t)
-
-	result := ctr.Run(ctx, &repb.Command{Arguments: []string{"bash", "-ec", `
-		echo test-stdout >&1
-		echo test-stderr >&2
-		while true; do
-			logged_stderr=$(cat "$(pwd).stderr")
-			logged_stdout=$(cat "$(pwd).stdout")
-			if [[ $logged_stderr == test-stderr ]] && [[ $logged_stdout == test-stdout ]]; then
-				exit 0
-			fi
-			if [[ -n $logged_stderr ]] && [[ -n $logged_stdout ]]; then
-				echo >&2 "Unexpected contents: stderr='$logged_stderr' stdout='$logged_stdout'"
-				exit 1
-			fi
-			# Wait a little bit and try again in case the log files have not
-			# been flushed yet.
-			sleep 0.01
-		done
-	`}}, workDir, oci.Credentials{})
-
-	assert.Equal(t, "test-stderr\n", string(result.Stderr))
-	assert.Equal(t, "test-stdout\n", string(result.Stdout))
-	assert.Equal(t, 0, result.ExitCode)
 }

--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -42,6 +42,7 @@ go_test(
     tags = ["docker"],
     deps = [
         ":docker",
+        "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -69,6 +69,7 @@ go_test(
     },
     deps = [
         ":ociruntime",
+        "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/persistentworker",
         "//enterprise/server/remote_execution/platform",

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//server/util/retry",
         "//server/util/status",
         "//server/util/tracing",
+        "@com_github_armon_circbuf//:circbuf",
         "@com_github_masterminds_semver_v3//:semver",
         "@com_github_prometheus_client_golang//prometheus",
     ],

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -317,8 +317,8 @@ func (c *sandbox) IsolationType() string {
 	return "sandbox"
 }
 
-func (c *sandbox) Run(ctx context.Context, command *repb.Command, workDir string, _ oci.Credentials) *interfaces.CommandResult {
-	return c.runCmdInSandbox(ctx, command, workDir, &interfaces.Stdio{})
+func (c *sandbox) Run(ctx context.Context, command *repb.Command, stdio *interfaces.Stdio, workDir string, _ oci.Credentials) *interfaces.CommandResult {
+	return c.runCmdInSandbox(ctx, command, workDir, stdio)
 }
 
 func (c *sandbox) Create(ctx context.Context, workDir string) error {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -329,7 +329,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	}
 
 	if cmdResult.ExitCode != 0 {
-		log.CtxDebugf(ctx, "%q finished with non-zero exit code (%d). Err: %s, Stdout: %s, Stderr: %s", taskID, cmdResult.ExitCode, cmdResult.Error, cmdResult.Stdout, cmdResult.Stderr)
+		log.CtxDebugf(ctx, "Task failed with exit code %d, error %q", cmdResult.ExitCode, cmdResult.Error)
 	}
 	// Exit codes < 0 mean that the command either never started or was killed.
 	// Make sure we return an error in this case.

--- a/enterprise/server/remote_execution/persistentworker/persistentworker.go
+++ b/enterprise/server/remote_execution/persistentworker/persistentworker.go
@@ -125,7 +125,7 @@ func Start(ctx context.Context, workspace *workspace.Workspace, container contai
 	return w
 }
 
-func (w *Worker) Exec(ctx context.Context, command *repb.Command) *interfaces.CommandResult {
+func (w *Worker) Exec(ctx context.Context, command *repb.Command, stdio *interfaces.Stdio) *interfaces.CommandResult {
 	// Clear any stderr that might be associated with a previous request.
 	w.stderr.Reset()
 
@@ -166,8 +166,10 @@ func (w *Worker) Exec(ctx context.Context, command *repb.Command) *interfaces.Co
 			"failed to read persistent work response: %s\npersistent worker stderr:\n%s",
 			err, w.stderrDebugString()))
 	}
+	if _, err := stdio.Stderr.Write([]byte(rsp.Output)); err != nil {
+		log.CtxWarningf(ctx, "Failed to write persistent work response output to stderr writer: %s", err)
+	}
 	return &interfaces.CommandResult{
-		Stderr:   []byte(rsp.Output),
 		ExitCode: int(rsp.ExitCode),
 	}
 }

--- a/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
+++ b/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
@@ -1,7 +1,6 @@
 package vmexec_client
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"os"
@@ -41,15 +40,14 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	var stderr, stdout bytes.Buffer
 	if stdio == nil {
 		stdio = &interfaces.Stdio{}
 	}
-	stdoutw := io.Writer(&stdout)
+	stdoutw := io.Discard
 	if stdio.Stdout != nil {
 		stdoutw = stdio.Stdout
 	}
-	stderrw := io.Writer(&stderr)
+	stderrw := io.Discard
 	if stdio.Stderr != nil {
 		stderrw = stdio.Stderr
 	}
@@ -146,8 +144,6 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 	}
 	result := &interfaces.CommandResult{
 		ExitCode:   exitCode,
-		Stderr:     stderr.Bytes(),
-		Stdout:     stdout.Bytes(),
 		Error:      err,
 		UsageStats: stats,
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1044,10 +1044,6 @@ type CommandResult struct {
 	Error error
 	// CommandDebugString indicates the command that was run, for debugging purposes only.
 	CommandDebugString string
-	// Stdout from the command. This may contain data even if there was an Error.
-	Stdout []byte
-	// Stderr from the command. This may contain data even if there was an Error.
-	Stderr []byte
 	// AuxiliaryLogs contain extra logs associated with the task that may be
 	// useful to present to the user.
 	AuxiliaryLogs map[string][]byte


### PR DESCRIPTION
This PR turned out to be much larger than expected so I'll probably try to find a way to split this into smaller PRs. Just putting this here for reference and to let all of the CI tests run to uncover more potential issues.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3752
