### PR TITLE
Log stack trace to debug nil digest error

### DIFF
--- a/server/remote_cache/digest/BUILD
+++ b/server/remote_cache/digest/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/util/alert",
+        "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
         "@com_github_google_uuid//:uuid",

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -14,11 +14,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/zeebo/blake3"
@@ -528,6 +530,10 @@ func IsCacheDebuggingEnabled(ctx context.Context) bool {
 }
 
 func MissingDigestError(d *repb.Digest) error {
+	if d == nil {
+		log.Infof("MissingDigestError called with nil digest. Stack trace:\n%s", string(debug.Stack()))
+	}
+
 	pf := &errdetails.PreconditionFailure{}
 	pf.Violations = append(pf.Violations, &errdetails.PreconditionFailure_Violation{
 		Type:    "MISSING",


### PR DESCRIPTION
We saw `Digest <nil> not found` internally and I also saw this while looking at some customer executions.

Specifically the error I saw was `"rpc error: code = FailedPrecondition desc = Digest <nil> not found"`

Based on this error message I think this happens when a nil digest is passed to `MissingDigestError()`. Log a stack trace when this happens so we can find the misbehaving caller.

**Related issues**: N/A
