### PR TITLE
docs/rbe-setup: fix wrong usage of action_env

### DIFF
--- a/docs/rbe-setup.md
+++ b/docs/rbe-setup.md
@@ -221,15 +221,37 @@ Some rules (like protobuf) are particularly sensitive to changes in environment 
 
 [Bazel docs](https://docs.bazel.build/versions/master/command-line-reference.html#flag--incompatible_strict_action_env)
 
-### --action_env
+### --action_env, --test_env
 
-You can set environment variables that are available to actions with the `--action_env` flag. This is commonly used to set `BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN` which tells bazel not to auto-detect the C++ toolchain.
+You can set environment variables that are available to actions with the `--action_env` flag.
+If you want to set environment variables that are only available to test actions, you can use the `--test_env` flag.
+
+This is commonly used to set ennvironment variables such as `GO_TEST_WRAP_TESTV=1`, which modify how `go_test` rule handles the XML reports.
 
 ```bash
---action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+--test_env=GO_TEST_WRAP_TESTV=1
 ```
 
-[Bazel docs](https://docs.bazel.build/versions/master/command-line-reference.html#flag--define)
+[`--action_env` Bazel docs](https://docs.bazel.build/versions/master/command-line-reference.html#flag--action_env)
+[`--test_env` Bazel docs](https://docs.bazel.build/versions/master/command-line-reference.html#flag--test_env)
+
+### --repo_env
+
+This flag set additional environment variables that are available to repository rules executions.
+It's commonly used to set environment variables that are used to augment how toolchains and external repositories are prepared before the build phase.
+
+```bash
+# Tell Bazel to not detect the CC toolchain automatically from the host machine to improve hermeticity.
+# This requires you to declare and register a CC toolchain explicitly.
+--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+# Tell Gazelle's go_repository rule to use the path set in GOMODCACHE (or GOPATH) as a local cache directory.
+# This can be useful to speed up Go modules downloads.
+--repo_env=GO_REPOSITORY_USE_HOST_CACHE=1
+--repo_env=GOMODCACHE=/some-path/my-go-mod-cache
+```
+
+[Bazel docs](https://docs.bazel.build/versions/master/command-line-reference.html#flag--repo_env)
 
 ### --define
 
@@ -356,7 +378,7 @@ build:remote --tool_java_language_version=11
 build:remote --java_runtime_version=remotejdk_11
 build:remote --tool_java_runtime_version=remotejdk_11
 build:remote --crosstool_top=@rbe_default//cc:toolchain
-build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:remote --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 # Platform flags:
 # The toolchain container used for execution is defined in the target indicated
 # by "extra_execution_platforms", "host_platform" and "platforms".

--- a/docs/rbe-setup.md
+++ b/docs/rbe-setup.md
@@ -226,7 +226,7 @@ Some rules (like protobuf) are particularly sensitive to changes in environment 
 You can set environment variables that are available to actions with the `--action_env` flag.
 If you want to set environment variables that are only available to test actions, you can use the `--test_env` flag.
 
-This is commonly used to set ennvironment variables such as `GO_TEST_WRAP_TESTV=1`, which modify how `go_test` rule handles the XML reports.
+This is commonly used to set environment variables such as `GO_TEST_WRAP_TESTV=1`, which modifies how the `go_test` rule handles the XML reports.
 
 ```bash
 --test_env=GO_TEST_WRAP_TESTV=1
@@ -237,8 +237,8 @@ This is commonly used to set ennvironment variables such as `GO_TEST_WRAP_TESTV=
 
 ### --repo_env
 
-This flag set additional environment variables that are available to repository rules executions.
-It's commonly used to set environment variables that are used to augment how toolchains and external repositories are prepared before the build phase.
+This flag sets additional environment variables that are available to repository rules executions.
+It's commonly used to set environment variables that are used to augment how toolchains and external repositories are prepared.
 
 ```bash
 # Tell Bazel to not detect the CC toolchain automatically from the host machine to improve hermeticity.


### PR DESCRIPTION
BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN is used in a repository rule so
setting it in --action_env will have no effect.

Use --repo_env instead and add documentation for it

Properly document --action_env and --test_env as well while we are at
it.
