### PR TITLE
Ensure overlay tmp dirs get cleaned up

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -230,12 +230,6 @@ func (c *ociContainer) rootfsPath() string {
 	return filepath.Join(c.bundlePath(), "rootfs")
 }
 
-// Returns the root path where overlay workdir and upperdir for this container
-// are stored.
-func (c *ociContainer) overlayTmpPath() string {
-	return c.workDir + ".overlay"
-}
-
 // Returns the standard config.json path expected by crun.
 func (c *ociContainer) configPath() string {
 	return filepath.Join(c.bundlePath(), "config.json")
@@ -575,11 +569,11 @@ func (c *ociContainer) createRootfs(ctx context.Context) error {
 		lowerDirs = append(lowerDirs, path)
 	}
 	// Create workdir and upperdir.
-	workdir := filepath.Join(c.overlayTmpPath(), "work")
+	workdir := filepath.Join(c.bundlePath(), "tmp", "rootfs.work")
 	if err := os.MkdirAll(workdir, 0755); err != nil {
 		return fmt.Errorf("create overlay workdir: %w", err)
 	}
-	upperdir := filepath.Join(c.overlayTmpPath(), "upper")
+	upperdir := filepath.Join(c.bundlePath(), "tmp", "rootfs.upper")
 	if err := os.MkdirAll(upperdir, 0755); err != nil {
 		return fmt.Errorf("create overlay upperdir: %w", err)
 	}

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -403,7 +403,6 @@ TEST_ENV_VAR=foo
 		return nil
 	})
 	require.NoError(t, err)
-	assert.True(t, testfs.Exists(t, "", filepath.Join(wd+".overlay", "upper", "bin", "foo.txt")))
 }
 
 func TestCreateExecPauseUnpause(t *testing.T) {


### PR DESCRIPTION
Move the overlayfs temp directories (workdir, upperdir) into the OCI bundle directory so that they get cleaned up during `Remove()`.

**Related issues**: N/A
