### PR TITLE
server-side changes for supporting generic filters in invocation search 

### DIFF
--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -350,6 +350,14 @@ func (s *InvocationSearchService) buildPrimaryQuery(ctx context.Context, fields 
 		}
 		q.AddWhereClause(str, args...)
 	}
+	for _, f := range req.GetQuery().GetGenericFilters() {
+		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, "i.", sfpb.SupportedObjects_INVOCATIONS_SUPPORTED)
+		if err != nil {
+			log.Printf("%+v", err)
+			continue
+		}
+		q.AddWhereClause(s, a...)
+	}
 
 	// Clickhouse doesn't hold permissions data, but we need to *always*
 	// check permissions when we query from the main DB.  This is handled

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -351,7 +351,7 @@ func (s *InvocationSearchService) buildPrimaryQuery(ctx context.Context, fields 
 		q.AddWhereClause(str, args...)
 	}
 	for _, f := range req.GetQuery().GetGenericFilters() {
-		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, "i.", sfpb.SupportedObjects_INVOCATIONS_SUPPORTED)
+		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, "i.", sfpb.ObjectTypes_INVOCATION_OBJECTS)
 		if err != nil {
 			log.Printf("%+v", err)
 			continue

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -353,8 +353,7 @@ func (s *InvocationSearchService) buildPrimaryQuery(ctx context.Context, fields 
 	for _, f := range req.GetQuery().GetGenericFilters() {
 		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, "i.", sfpb.ObjectTypes_INVOCATION_OBJECTS)
 		if err != nil {
-			log.Printf("%+v", err)
-			continue
+			return "", nil, err
 		}
 		q.AddWhereClause(s, a...)
 	}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -290,6 +290,9 @@ proto_library(
 proto_library(
     name = "stat_filter_proto",
     srcs = ["stat_filter.proto"],
+    deps = [
+        "@com_google_protobuf//:descriptor_proto",
+    ],
 )
 
 proto_library(
@@ -1950,6 +1953,9 @@ ts_proto_library(
 ts_proto_library(
     name = "stat_filter_ts_proto",
     proto = ":stat_filter_proto",
+    deps = [
+        ":descriptor_ts_proto",
+    ],
 )
 
 ts_proto_library(

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -315,6 +315,8 @@ message InvocationQuery {
 
   // Plaintext tags for the targets built (exact match). Ex: "my-cool-tag"
   repeated string tags = 16;
+
+  repeated stat_filter.GenericFilter generic_filters = 18;
 }
 
 message InvocationSort {

--- a/proto/stat_filter.proto
+++ b/proto/stat_filter.proto
@@ -146,15 +146,7 @@ enum FilterType {
     supported_objects:
       [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
-  TAG_FILTER_TYPE = 6 [(filter_type_options) = {
-    category:
-      STRING_FILTER_CATEGORY;
-    database_column_name:
-      "tag";
-    supported_objects:
-      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
-  }];
-  COMMAND_FILTER_TYPE = 7 [(filter_type_options) = {
+  COMMAND_FILTER_TYPE = 6 [(filter_type_options) = {
     category:
       STRING_FILTER_CATEGORY;
     database_column_name:
@@ -162,7 +154,7 @@ enum FilterType {
     supported_objects:
       [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
-  HOST_FILTER_TYPE = 8 [(filter_type_options) = {
+  HOST_FILTER_TYPE = 7 [(filter_type_options) = {
     category:
       STRING_FILTER_CATEGORY;
     database_column_name:
@@ -170,7 +162,7 @@ enum FilterType {
     supported_objects:
       [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
-  COMMIT_SHA_FILTER_TYPE = 9 [(filter_type_options) = {
+  COMMIT_SHA_FILTER_TYPE = 8 [(filter_type_options) = {
     category:
       STRING_FILTER_CATEGORY;
     database_column_name:
@@ -178,13 +170,21 @@ enum FilterType {
     supported_objects:
       [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
-  BRANCH_FILTER_TYPE = 10 [(filter_type_options) = {
+  BRANCH_FILTER_TYPE = 9 [(filter_type_options) = {
     category:
       STRING_FILTER_CATEGORY;
     database_column_name:
       "branch_name";
     supported_objects:
       [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
+  }];
+  WORKER_FILTER_TYPE = 10 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "worker";
+    supported_objects:
+      [EXECUTION_OBJECTS];
   }];
   INVOCATION_CREATED_AT_USEC_FILTER_TYPE = 11 [(filter_type_options) = {
     category:
@@ -223,14 +223,6 @@ enum FilterType {
       INT_FILTER_CATEGORY;
     database_column_name:
       "updated_at_usec";
-    supported_objects:
-      [EXECUTION_OBJECTS];
-  }];
-  WORKER_FILTER_TYPE = 16 [(filter_type_options) = {
-    category:
-      STRING_FILTER_CATEGORY;
-    database_column_name:
-      "worker";
     supported_objects:
       [EXECUTION_OBJECTS];
   }];

--- a/proto/stat_filter.proto
+++ b/proto/stat_filter.proto
@@ -73,7 +73,7 @@ enum FilterArgumentCount {
 }
 
 enum ObjectTypes {
-  NO_OBJECTS = 0;
+  UNKNOWN_OBJECTS = 0;
   INVOCATION_OBJECTS = 1;
   EXECUTION_OBJECTS = 2;
   TARGET_STATUS_OBJECTS = 3;
@@ -104,7 +104,7 @@ message FilterValue {
 enum FilterType {
   UNKNOWN_FILTER_TYPE = 0 [(filter_type_options) = {
     supported_objects:
-      [NO_OBJECTS];
+      [];
   }];
   TEXT_MATCH_FILTER_TYPE = 1 [(filter_type_options) = {
     category:

--- a/proto/stat_filter.proto
+++ b/proto/stat_filter.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package stat_filter;
 
+import "google/protobuf/descriptor.proto";
+
 enum InvocationMetricType {
   UNKNOWN_INVOCATION_METRIC = 0;
   DURATION_USEC_INVOCATION_METRIC = 1;
@@ -56,4 +58,138 @@ message Dimension {
 message DimensionFilter {
   Dimension dimension = 1;
   string value = 2;
+}
+
+enum FilterCategory {
+  UNKNOWN_FILTER_CATEGORY = 0;
+  STRING_FILTER_CATEGORY = 1;
+  INT_FILTER_CATEGORY = 2;
+}
+
+enum FilterArgumentCount {
+  UNKNOWN_FILTER_ARGUMENT_COUNT = 0;
+  ONE_FILTER_ARGUMENT_COUNT = 1;
+  MANY_FILTER_ARGUMENT_COUNT = 2;
+}
+
+enum SupportedObjects {
+  NO_SUPPORT = 0;
+  INVOCATIONS_SUPPORTED = 1;
+  EXECUTIONS_SUPPORTED = 2;
+  TARGET_STATUSES_SUPPORTED = 3;
+}
+
+message FilterTypeOptions {
+  FilterCategory category = 1;
+  string database_column_name = 2;
+  repeated SupportedObjects supported_objects = 3;
+}
+
+message FilterOperandOptions {
+  repeated FilterCategory supported_categories = 1;
+  string database_query_string = 2;
+  FilterArgumentCount argument_count = 3;
+}
+
+extend google.protobuf.EnumValueOptions {
+  FilterTypeOptions filter_type_options = 7000;
+  FilterOperandOptions filter_operand_options = 7001;
+}
+
+message FilterValue {
+  repeated string string_value = 1;
+  repeated int64 int_value = 2;
+}
+
+enum FilterType {
+  UNKNOWN_FILTER_TYPE = 0 [(filter_type_options) = {
+    supported_objects:
+      [NO_SUPPORT];
+  }];
+  TEXT_MATCH_FILTER_TYPE = 1 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  REPO_URL_FILTER_TYPE = 2 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "repo_url";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  USER_FILTER_TYPE = 3 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "user";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  INVOCATION_DURATION_USEC_FILTER_TYPE = 4 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "duration_usec";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED];
+  }];
+  PATTERN_FILTER_TYPE = 5 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "pattern";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+}
+
+enum FilterOperand {
+  UNKNOWN_FILTER_OPERAND = 0 [(filter_operand_options) = {
+    supported_categories:
+      [];
+  }];
+  GREATER_THAN_OPERAND = 1 [(filter_operand_options) = {
+    supported_categories:
+      [INT_FILTER_CATEGORY];
+    database_query_string:
+      "?field > ?value";
+    argument_count:
+      ONE_FILTER_ARGUMENT_COUNT;
+  }];
+  LESS_THAN_OPERAND = 2 [(filter_operand_options) = {
+    supported_categories:
+      [INT_FILTER_CATEGORY];
+    database_query_string:
+      "?field < ?value";
+    argument_count:
+      ONE_FILTER_ARGUMENT_COUNT;
+  }];
+  IN_OPERAND = 3 [(filter_operand_options) = {
+    supported_categories:
+      [INT_FILTER_CATEGORY, STRING_FILTER_CATEGORY];
+    database_query_string:
+      "?field IN ?value";
+    argument_count:
+      MANY_FILTER_ARGUMENT_COUNT;
+  }];
+  TEXT_MATCH_OPERAND = 4 [(filter_operand_options) = {
+    supported_categories:
+      [STRING_FILTER_CATEGORY];
+    database_query_string:
+      "INSTR(pattern, ?value) > 0 OR INSTR(user, ?value) > 0 OR INSTR(repo_url, ?value) > 0";
+    argument_count:
+      ONE_FILTER_ARGUMENT_COUNT;
+  }];
+}
+
+message GenericFilter {
+  FilterType type = 1;
+  FilterOperand operand = 2;
+  FilterValue value = 3;
+  bool negate = 4;
 }

--- a/proto/stat_filter.proto
+++ b/proto/stat_filter.proto
@@ -72,17 +72,17 @@ enum FilterArgumentCount {
   MANY_FILTER_ARGUMENT_COUNT = 2;
 }
 
-enum SupportedObjects {
-  NO_SUPPORT = 0;
-  INVOCATIONS_SUPPORTED = 1;
-  EXECUTIONS_SUPPORTED = 2;
-  TARGET_STATUSES_SUPPORTED = 3;
+enum ObjectTypes {
+  NO_OBJECTS = 0;
+  INVOCATION_OBJECTS = 1;
+  EXECUTION_OBJECTS = 2;
+  TARGET_STATUS_OBJECTS = 3;
 }
 
 message FilterTypeOptions {
   FilterCategory category = 1;
   string database_column_name = 2;
-  repeated SupportedObjects supported_objects = 3;
+  repeated ObjectTypes supported_objects = 3;
 }
 
 message FilterOperandOptions {
@@ -104,7 +104,7 @@ message FilterValue {
 enum FilterType {
   UNKNOWN_FILTER_TYPE = 0 [(filter_type_options) = {
     supported_objects:
-      [NO_SUPPORT];
+      [NO_OBJECTS];
   }];
   TEXT_MATCH_FILTER_TYPE = 1 [(filter_type_options) = {
     category:
@@ -112,7 +112,7 @@ enum FilterType {
     database_column_name:
       "";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   REPO_URL_FILTER_TYPE = 2 [(filter_type_options) = {
     category:
@@ -120,7 +120,7 @@ enum FilterType {
     database_column_name:
       "repo_url";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   USER_FILTER_TYPE = 3 [(filter_type_options) = {
     category:
@@ -128,7 +128,7 @@ enum FilterType {
     database_column_name:
       "user";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   INVOCATION_DURATION_USEC_FILTER_TYPE = 4 [(filter_type_options) = {
     category:
@@ -136,7 +136,7 @@ enum FilterType {
     database_column_name:
       "duration_usec";
     supported_objects:
-      [INVOCATIONS_SUPPORTED];
+      [INVOCATION_OBJECTS];
   }];
   PATTERN_FILTER_TYPE = 5 [(filter_type_options) = {
     category:
@@ -144,7 +144,7 @@ enum FilterType {
     database_column_name:
       "pattern";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   TAG_FILTER_TYPE = 6 [(filter_type_options) = {
     category:
@@ -152,7 +152,7 @@ enum FilterType {
     database_column_name:
       "tag";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   COMMAND_FILTER_TYPE = 7 [(filter_type_options) = {
     category:
@@ -160,7 +160,7 @@ enum FilterType {
     database_column_name:
       "command";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   HOST_FILTER_TYPE = 8 [(filter_type_options) = {
     category:
@@ -168,7 +168,7 @@ enum FilterType {
     database_column_name:
       "host";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   COMMIT_SHA_FILTER_TYPE = 9 [(filter_type_options) = {
     category:
@@ -176,7 +176,7 @@ enum FilterType {
     database_column_name:
       "commit_sha";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   BRANCH_FILTER_TYPE = 10 [(filter_type_options) = {
     category:
@@ -184,7 +184,7 @@ enum FilterType {
     database_column_name:
       "branch_name";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   INVOCATION_CREATED_AT_USEC_FILTER_TYPE = 11 [(filter_type_options) = {
     category:
@@ -192,7 +192,7 @@ enum FilterType {
     database_column_name:
       "created_at_usec";
     supported_objects:
-      [INVOCATIONS_SUPPORTED];
+      [INVOCATION_OBJECTS];
   }];
   EXECUTION_CREATED_AT_USEC_FILTER_TYPE = 12 [(filter_type_options) = {
     category:
@@ -200,7 +200,7 @@ enum FilterType {
     database_column_name:
       "created_at_usec";
     supported_objects:
-      [EXECUTIONS_SUPPORTED];
+      [EXECUTION_OBJECTS];
   }];
   ROLE_FILTER_TYPE = 13 [(filter_type_options) = {
     category:
@@ -208,7 +208,7 @@ enum FilterType {
     database_column_name:
       "role";
     supported_objects:
-      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+      [INVOCATION_OBJECTS, EXECUTION_OBJECTS];
   }];
   INVOCATION_UPDATED_AT_USEC_FILTER_TYPE = 14 [(filter_type_options) = {
     category:
@@ -216,7 +216,7 @@ enum FilterType {
     database_column_name:
       "updated_at_usec";
     supported_objects:
-      [INVOCATIONS_SUPPORTED];
+      [INVOCATION_OBJECTS];
   }];
   EXECUTION_UPDATED_AT_USEC_FILTER_TYPE = 15 [(filter_type_options) = {
     category:
@@ -224,7 +224,7 @@ enum FilterType {
     database_column_name:
       "updated_at_usec";
     supported_objects:
-      [EXECUTIONS_SUPPORTED];
+      [EXECUTION_OBJECTS];
   }];
   WORKER_FILTER_TYPE = 16 [(filter_type_options) = {
     category:
@@ -232,9 +232,9 @@ enum FilterType {
     database_column_name:
       "worker";
     supported_objects:
-      [EXECUTIONS_SUPPORTED];
+      [EXECUTION_OBJECTS];
   }];
-  // TODO(jdhollen): invocation status.
+  // TODO(jdhollen): invocation status (special enum), tags (string array)
 }
 
 enum FilterOperand {

--- a/proto/stat_filter.proto
+++ b/proto/stat_filter.proto
@@ -146,6 +146,95 @@ enum FilterType {
     supported_objects:
       [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
   }];
+  TAG_FILTER_TYPE = 6 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "tag";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  COMMAND_FILTER_TYPE = 7 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "command";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  HOST_FILTER_TYPE = 8 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "host";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  COMMIT_SHA_FILTER_TYPE = 9 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "commit_sha";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  BRANCH_FILTER_TYPE = 10 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "branch_name";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  INVOCATION_CREATED_AT_USEC_FILTER_TYPE = 11 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "created_at_usec";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED];
+  }];
+  EXECUTION_CREATED_AT_USEC_FILTER_TYPE = 12 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "created_at_usec";
+    supported_objects:
+      [EXECUTIONS_SUPPORTED];
+  }];
+  ROLE_FILTER_TYPE = 13 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "role";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED, EXECUTIONS_SUPPORTED];
+  }];
+  INVOCATION_UPDATED_AT_USEC_FILTER_TYPE = 14 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "updated_at_usec";
+    supported_objects:
+      [INVOCATIONS_SUPPORTED];
+  }];
+  EXECUTION_UPDATED_AT_USEC_FILTER_TYPE = 15 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "updated_at_usec";
+    supported_objects:
+      [EXECUTIONS_SUPPORTED];
+  }];
+  WORKER_FILTER_TYPE = 16 [(filter_type_options) = {
+    category:
+      STRING_FILTER_CATEGORY;
+    database_column_name:
+      "worker";
+    supported_objects:
+      [EXECUTIONS_SUPPORTED];
+  }];
+  // TODO(jdhollen): invocation status.
 }
 
 enum FilterOperand {

--- a/server/util/filter/BUILD
+++ b/server/util/filter/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "filter",
@@ -8,5 +8,20 @@ go_library(
     deps = [
         "//proto:stat_filter_go_proto",
         "//server/util/status",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+    ],
+)
+
+go_test(
+    name = "filter_test",
+    size = "small",
+    srcs = ["filter_test.go"],
+    deps = [
+        ":filter",
+        "//proto:stat_filter_go_proto",
+        "//server/util/status",
+        "@com_github_stretchr_testify//assert",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/server/util/filter/filter.go
+++ b/server/util/filter/filter.go
@@ -2,9 +2,13 @@ package filter
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/proto/stat_filter"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 func executionMetricToDbField(m stat_filter.ExecutionMetricType, tablePrefix string) (string, error) {
@@ -120,4 +124,81 @@ func GenerateDimensionFilterStringAndArgs(f *stat_filter.DimensionFilter, tableP
 		return "", nil, err
 	}
 	return fmt.Sprintf("(%s = ?)", metric), []interface{}{f.GetValue()}, nil
+}
+
+func getStringAndArgs(databaseQueryTemplate string, v interface{}, columnName string, negate bool) (string, []interface{}) {
+	str := strings.ReplaceAll(databaseQueryTemplate, "?field", columnName)
+	var args []interface{}
+	for strings.Contains(str, "?value") {
+		str = strings.Replace(str, "?value", "?", 1)
+		args = append(args, v)
+	}
+	if negate {
+		str = fmt.Sprintf("NOT(%s)", str)
+	}
+	return str, args
+}
+
+func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFilter, tablePrefix string, qType stat_filter.SupportedObjects) (string, []interface{}, error) {
+	if f == nil {
+		return "", nil, status.InvalidArgumentError("invalid nil entry in filter list")
+	}
+
+	// Enum value descriptors (i.e., for "GREATER_THAN") are nested inside of
+	// enum type descriptors ("Operand"), so we need to dig around for them.
+	operandDescriptorOptions := protoreflect.EnumValueDescriptor(f.GetOperand().Descriptor().Values().ByNumber(f.GetOperand().Number())).Options()
+	if operandDescriptorOptions == nil {
+		return "", nil, status.InvalidArgumentErrorf("Unknown operand value: %s", f.GetOperand())
+	}
+	operandOptions := proto.GetExtension(operandDescriptorOptions, stat_filter.E_FilterOperandOptions).(*stat_filter.FilterOperandOptions)
+	if operandOptions == nil {
+		return "", nil, status.InternalErrorf("Operand has no options specified: %s", f.GetOperand())
+	}
+
+	typeDescriptorOptions := protoreflect.EnumValueDescriptor(f.GetType().Descriptor().Values().ByNumber(f.GetType().Number())).Options()
+	if typeDescriptorOptions == nil {
+		return "", nil, status.InvalidArgumentErrorf("Unknown filter type: %s", f.GetType())
+	}
+	typeOptions := proto.GetExtension(typeDescriptorOptions, stat_filter.E_FilterTypeOptions).(*stat_filter.FilterTypeOptions)
+	if typeOptions == nil {
+		return "", nil, status.InvalidArgumentErrorf("Filter type has no options specified:: %s", f.GetType())
+	}
+
+	v := f.GetValue()
+	var arg interface{}
+	// We have information about the field we're filtering, the type of filter
+	// we are using, and the values passed to the filter.  Now we mush this all
+	// together to validate the request.
+	if !slices.Contains(operandOptions.GetSupportedCategories(), typeOptions.GetCategory()) {
+		return "", nil, status.InvalidArgumentErrorf("Filter %s does not support operand %s", f.GetType(), f.GetOperand().String())
+	}
+	if slices.Contains(typeOptions.GetSupportedObjects(), stat_filter.SupportedObjects_NO_SUPPORT) {
+		return "", nil, status.InvalidArgumentErrorf("Filtering by %s not supported for %s", qType, f.GetType())
+	}
+	if !slices.Contains(typeOptions.GetSupportedObjects(), qType) {
+		return "", nil, status.InvalidArgumentErrorf("Filtering by %s not supported for %s", qType, f.GetType())
+	}
+
+	if typeOptions.GetCategory() == stat_filter.FilterCategory_INT_FILTER_CATEGORY {
+		if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_ONE_FILTER_ARGUMENT_COUNT && len(v.GetIntValue()) == 1 {
+			arg = v.GetIntValue()[0]
+		} else if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_MANY_FILTER_ARGUMENT_COUNT && len(v.GetIntValue()) > 0 {
+			arg = v.GetIntValue()
+		} else {
+			return "", nil, status.InvalidArgumentErrorf("Invalid value for integer filter: %s %s Value: %+v", f.GetType(), f.GetOperand(), v)
+		}
+	} else if typeOptions.GetCategory() == stat_filter.FilterCategory_STRING_FILTER_CATEGORY {
+		if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_ONE_FILTER_ARGUMENT_COUNT && len(v.GetStringValue()) == 1 {
+			arg = v.GetStringValue()[0]
+		} else if operandOptions.GetArgumentCount() == stat_filter.FilterArgumentCount_MANY_FILTER_ARGUMENT_COUNT && len(v.GetStringValue()) > 0 {
+			arg = v.GetStringValue()
+		} else {
+			return "", nil, status.InvalidArgumentErrorf("Invalid value for string filter: %s %s Value: %+v", f.GetType(), f.GetOperand(), v)
+		}
+	} else {
+		return "", nil, status.InternalErrorf("Unknown filter category: %s", typeOptions.GetCategory())
+	}
+
+	qStr, qArgs := getStringAndArgs(operandOptions.GetDatabaseQueryString(), arg, tablePrefix+typeOptions.GetDatabaseColumnName(), f.GetNegate())
+	return qStr, qArgs, nil
 }

--- a/server/util/filter/filter.go
+++ b/server/util/filter/filter.go
@@ -172,9 +172,6 @@ func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFi
 	if !slices.Contains(operandOptions.GetSupportedCategories(), typeOptions.GetCategory()) {
 		return "", nil, status.InvalidArgumentErrorf("Filter %s does not support operand %s", f.GetType(), f.GetOperand().String())
 	}
-	if slices.Contains(typeOptions.GetSupportedObjects(), stat_filter.ObjectTypes_NO_OBJECTS) {
-		return "", nil, status.InvalidArgumentErrorf("Filtering by %s not supported for %s", qType, f.GetType())
-	}
 	if !slices.Contains(typeOptions.GetSupportedObjects(), qType) {
 		return "", nil, status.InvalidArgumentErrorf("Filtering by %s not supported for %s", qType, f.GetType())
 	}

--- a/server/util/filter/filter.go
+++ b/server/util/filter/filter.go
@@ -139,7 +139,7 @@ func getStringAndArgs(databaseQueryTemplate string, v interface{}, columnName st
 	return str, args
 }
 
-func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFilter, tablePrefix string, qType stat_filter.SupportedObjects) (string, []interface{}, error) {
+func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFilter, tablePrefix string, qType stat_filter.ObjectTypes) (string, []interface{}, error) {
 	if f == nil {
 		return "", nil, status.InvalidArgumentError("invalid nil entry in filter list")
 	}
@@ -172,7 +172,7 @@ func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFi
 	if !slices.Contains(operandOptions.GetSupportedCategories(), typeOptions.GetCategory()) {
 		return "", nil, status.InvalidArgumentErrorf("Filter %s does not support operand %s", f.GetType(), f.GetOperand().String())
 	}
-	if slices.Contains(typeOptions.GetSupportedObjects(), stat_filter.SupportedObjects_NO_SUPPORT) {
+	if slices.Contains(typeOptions.GetSupportedObjects(), stat_filter.ObjectTypes_NO_OBJECTS) {
 		return "", nil, status.InvalidArgumentErrorf("Filtering by %s not supported for %s", qType, f.GetType())
 	}
 	if !slices.Contains(typeOptions.GetSupportedObjects(), qType) {

--- a/server/util/filter/filter_test.go
+++ b/server/util/filter/filter_test.go
@@ -15,21 +15,21 @@ func TestValidGenericFilters(t *testing.T) {
 	cases := []struct {
 		filter        *stat_filter.GenericFilter
 		prefix        string
-		filterType    stat_filter.SupportedObjects       
+		filterType    stat_filter.SupportedObjects
 		expectedQStr  string
 		expectedQArgs []interface{}
 	}{
 		{
-			filter:       &stat_filter.GenericFilter{
-				Type: stat_filter.FilterType_INVOCATION_DURATION_USEC_FILTER_TYPE,
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_INVOCATION_DURATION_USEC_FILTER_TYPE,
 				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
 				Value: &stat_filter.FilterValue{
 					IntValue: []int64{10000},
 				},
 			},
-			prefix: "i.",
-			filterType: stat_filter.SupportedObjects_INVOCATIONS_SUPPORTED,
-			expectedQStr: "i.duration_usec > ?",
+			prefix:        "i.",
+			filterType:    stat_filter.SupportedObjects_INVOCATIONS_SUPPORTED,
+			expectedQStr:  "i.duration_usec > ?",
 			expectedQArgs: []interface{}{int64(10000)},
 		},
 	}
@@ -43,21 +43,21 @@ func TestValidGenericFilters(t *testing.T) {
 
 func TestInvalidGenericFilters(t *testing.T) {
 	cases := []struct {
-		filter        *stat_filter.GenericFilter
-		prefix        string
-		filterType    stat_filter.SupportedObjects
-		errorTypeFn   func (error) bool
+		filter      *stat_filter.GenericFilter
+		prefix      string
+		filterType  stat_filter.SupportedObjects
+		errorTypeFn func(error) bool
 	}{
 		{
-			filter:       &stat_filter.GenericFilter{
-				Type: stat_filter.FilterType_INVOCATION_DURATION_USEC_FILTER_TYPE,
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_INVOCATION_DURATION_USEC_FILTER_TYPE,
 				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
 				Value: &stat_filter.FilterValue{
 					StringValue: []string{"duration_usec shouldn't accept a string"},
 				},
 			},
-			prefix: "",
-			filterType: stat_filter.SupportedObjects_INVOCATIONS_SUPPORTED,
+			prefix:      "",
+			filterType:  stat_filter.SupportedObjects_INVOCATIONS_SUPPORTED,
 			errorTypeFn: status.IsInvalidArgumentError,
 		},
 	}
@@ -77,11 +77,11 @@ func TestAllFilterTypesHaveRequiredOptions(t *testing.T) {
 		// Fully de-supported / unknown options: all that matters is that we'll always throw an error.
 		if slices.Contains(fto.GetSupportedObjects(), stat_filter.SupportedObjects_NO_SUPPORT) {
 			assert.Equal(t, 1, len(fto.GetSupportedObjects()))
-			continue;
+			continue
 		}
 
 		if descriptors.Get(i).Number() != stat_filter.FilterType_UNKNOWN_FILTER_TYPE.Number() &&
-		   descriptors.Get(i).Number() != stat_filter.FilterType_TEXT_MATCH_FILTER_TYPE.Number() {
+			descriptors.Get(i).Number() != stat_filter.FilterType_TEXT_MATCH_FILTER_TYPE.Number() {
 			assert.NotEmpty(t, fto.GetDatabaseColumnName())
 		}
 		assert.NotEmpty(t, fto.GetSupportedObjects())
@@ -102,7 +102,7 @@ func TestAllFilterOperandsHaveRequiredOptions(t *testing.T) {
 
 		assert.NotEmpty(t, foo.GetDatabaseQueryString())
 		assert.True(t, foo.GetArgumentCount().Enum().Number() > 0)
-		for _, c := range(foo.GetSupportedCategories()) {
+		for _, c := range foo.GetSupportedCategories() {
 			assert.True(t, c.Enum().Number() > 0)
 		}
 	}

--- a/server/util/filter/filter_test.go
+++ b/server/util/filter/filter_test.go
@@ -128,17 +128,16 @@ func TestAllFilterTypesHaveRequiredOptions(t *testing.T) {
 	for i := range descriptors.Len() {
 		fto := proto.GetExtension(descriptors.Get(i).Options(), stat_filter.E_FilterTypeOptions).(*stat_filter.FilterTypeOptions)
 
-		// Fully de-supported / unknown options: all that matters is that we'll always throw an error.
-		if slices.Contains(fto.GetSupportedObjects(), stat_filter.ObjectTypes_NO_OBJECTS) {
-			assert.Equal(t, 1, len(fto.GetSupportedObjects()))
-			continue
+		if len(fto.GetSupportedObjects()) == 0 {
+			// Don't need to worry about filter types that don't support any objects.
+			continue;
 		}
 
 		if descriptors.Get(i).Number() != stat_filter.FilterType_UNKNOWN_FILTER_TYPE.Number() &&
 			descriptors.Get(i).Number() != stat_filter.FilterType_TEXT_MATCH_FILTER_TYPE.Number() {
 			assert.NotEmpty(t, fto.GetDatabaseColumnName())
 		}
-		assert.NotEmpty(t, fto.GetSupportedObjects())
+		assert.False(t, slices.Contains(fto.GetSupportedObjects(), stat_filter.ObjectTypes_UNKNOWN_OBJECTS))
 		assert.True(t, fto.GetCategory().Enum().Number() > 0)
 	}
 }

--- a/server/util/filter/filter_test.go
+++ b/server/util/filter/filter_test.go
@@ -130,7 +130,7 @@ func TestAllFilterTypesHaveRequiredOptions(t *testing.T) {
 
 		if len(fto.GetSupportedObjects()) == 0 {
 			// Don't need to worry about filter types that don't support any objects.
-			continue;
+			continue
 		}
 
 		if descriptors.Get(i).Number() != stat_filter.FilterType_UNKNOWN_FILTER_TYPE.Number() &&

--- a/server/util/filter/filter_test.go
+++ b/server/util/filter/filter_test.go
@@ -1,0 +1,109 @@
+package filter_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/proto/stat_filter"
+	"github.com/buildbuddy-io/buildbuddy/server/util/filter"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestValidGenericFilters(t *testing.T) {
+	cases := []struct {
+		filter        *stat_filter.GenericFilter
+		prefix        string
+		filterType    stat_filter.SupportedObjects       
+		expectedQStr  string
+		expectedQArgs []interface{}
+	}{
+		{
+			filter:       &stat_filter.GenericFilter{
+				Type: stat_filter.FilterType_INVOCATION_DURATION_USEC_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{10000},
+				},
+			},
+			prefix: "i.",
+			filterType: stat_filter.SupportedObjects_INVOCATIONS_SUPPORTED,
+			expectedQStr: "i.duration_usec > ?",
+			expectedQArgs: []interface{}{int64(10000)},
+		},
+	}
+	for _, tc := range cases {
+		qStr, qArgs, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(tc.filter, tc.prefix, tc.filterType)
+		assert.Nil(t, err)
+		assert.Equal(t, tc.expectedQStr, qStr)
+		assert.ElementsMatch(t, tc.expectedQArgs, qArgs)
+	}
+}
+
+func TestInvalidGenericFilters(t *testing.T) {
+	cases := []struct {
+		filter        *stat_filter.GenericFilter
+		prefix        string
+		filterType    stat_filter.SupportedObjects
+		errorTypeFn   func (error) bool
+	}{
+		{
+			filter:       &stat_filter.GenericFilter{
+				Type: stat_filter.FilterType_INVOCATION_DURATION_USEC_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					StringValue: []string{"duration_usec shouldn't accept a string"},
+				},
+			},
+			prefix: "",
+			filterType: stat_filter.SupportedObjects_INVOCATIONS_SUPPORTED,
+			errorTypeFn: status.IsInvalidArgumentError,
+		},
+	}
+	for _, tc := range cases {
+		_, _, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(tc.filter, tc.prefix, tc.filterType)
+		assert.True(t, tc.errorTypeFn(err))
+	}
+}
+
+func TestAllFilterTypesHaveRequiredOptions(t *testing.T) {
+	// API is a little weird here--need to specify a single filter type to get
+	// the enum descriptor, which has an iterator over all values.  Whatever.
+	descriptors := stat_filter.FilterType.Descriptor(stat_filter.FilterType_PATTERN_FILTER_TYPE).Values()
+	for i := range descriptors.Len() {
+		fto := proto.GetExtension(descriptors.Get(i).Options(), stat_filter.E_FilterTypeOptions).(*stat_filter.FilterTypeOptions)
+
+		// Fully de-supported / unknown options: all that matters is that we'll always throw an error.
+		if slices.Contains(fto.GetSupportedObjects(), stat_filter.SupportedObjects_NO_SUPPORT) {
+			assert.Equal(t, 1, len(fto.GetSupportedObjects()))
+			continue;
+		}
+
+		if descriptors.Get(i).Number() != stat_filter.FilterType_UNKNOWN_FILTER_TYPE.Number() &&
+		   descriptors.Get(i).Number() != stat_filter.FilterType_TEXT_MATCH_FILTER_TYPE.Number() {
+			assert.NotEmpty(t, fto.GetDatabaseColumnName())
+		}
+		assert.NotEmpty(t, fto.GetSupportedObjects())
+		assert.True(t, fto.GetCategory().Enum().Number() > 0)
+	}
+}
+
+func TestAllFilterOperandsHaveRequiredOptions(t *testing.T) {
+	// API is a little weird here--need to specify a single operand to get
+	// the enum descriptor, which has an iterator over all values.  Whatever.
+	descriptors := stat_filter.FilterOperand.Descriptor(stat_filter.FilterOperand_GREATER_THAN_OPERAND).Values()
+	for i := range descriptors.Len() {
+		foo := proto.GetExtension(descriptors.Get(i).Options(), stat_filter.E_FilterOperandOptions).(*stat_filter.FilterOperandOptions)
+		if len(foo.GetSupportedCategories()) == 0 {
+			// Won't be applied to anything anyway, skip.
+			continue
+		}
+
+		assert.NotEmpty(t, foo.GetDatabaseQueryString())
+		assert.True(t, foo.GetArgumentCount().Enum().Number() > 0)
+		for _, c := range(foo.GetSupportedCategories()) {
+			assert.True(t, c.Enum().Number() > 0)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
this is partially done, but there's not really a need to flag-guard it.

leaving some todos to add remaining filter types as they're a little different from the primary ones in this pr.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
