### PR TITLE
add clock to approxlru

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2488,6 +2488,7 @@ func newPartitionEvictor(ctx context.Context, part disk.Partition, fileStorer fi
 		EvictionEvictLatencyUsec:    metrics.PebbleCacheEvictionEvictLatencyUsec.With(metricLbls),
 		RateLimit:                   float64(*evictionRateLimit),
 		MaxSizeBytes:                int64(JanitorCutoffThreshold * float64(part.MaxSizeBytes)),
+		Clock:                       clock,
 		OnEvict: func(ctx context.Context, sample *approxlru.Sample[*evictionKey]) error {
 			return pe.evict(ctx, sample)
 		},

--- a/server/util/approxlru/BUILD
+++ b/server/util/approxlru/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/util/log",
         "//server/util/status",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_x_time//rate",
     ],


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When we test LRU, we usually create a fake clock; but it was not passed into
approxLRU, so the reported age in the logs are confusing since it was calculated
based on the real clock.
