### PR TITLE
[raft] extend deadline when updating atime

### DIFF
--- a/enterprise/server/raft/cache/BUILD
+++ b/enterprise/server/raft/cache/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/interfaces",
         "//server/real_environment",
         "//server/remote_cache/digest",
+        "//server/util/background",
         "//server/util/disk",
         "//server/util/flag",
         "//server/util/flagutil/types",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Before the server stopped, we wanted to flush the atime. We need a little extra
time otherwise the last flush will fail with context canceled.
