### PR TITLE
UpdateDocument

### DIFF
--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -165,7 +165,6 @@ func handleIndex(args []string) {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	defer iw.Flush()
 
 	for _, dir := range args {
 		repoURL := extractRepoURL(dir)
@@ -196,12 +195,16 @@ func handleIndex(args []string) {
 					return nil
 				}
 
-				if err := iw.AddDocument(doc); err != nil {
+				if err := iw.UpdateDocument(doc.Field(schema.IDField), doc); err != nil {
 					log.Fatal(err.Error())
 				}
 			}
 			return nil
 		})
+	}
+
+	if err := iw.Flush(); err != nil {
+		log.Fatal(err.Error())
 	}
 }
 

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -239,6 +239,36 @@ func (w *Writer) DeleteDocument(docID uint64) error {
 	return nil
 }
 
+func (w *Writer) UpdateDocument(matchField types.Field, newDoc types.Document) error {
+	key := w.postingListKey(string(matchField.Contents()), matchField.Name())
+	value, closer, err := w.db.Get(key)
+	if err != nil && err != pebble.ErrNotFound {
+		return err
+	} else if err == pebble.ErrNotFound {
+		// No old doc to delete -- add it and we're done.
+		return w.AddDocument(newDoc)
+	}
+	defer closer.Close()
+
+	postingList, err := posting.Unmarshal(value)
+	if err != nil {
+		return err
+	}
+	if postingList.GetCardinality() != 1 {
+		return status.FailedPreconditionErrorf("Update would impact > 1 docs")
+	}
+	oldDocID := postingList.ToArray()[0]
+
+	// Delete the previous document.
+	fieldsStart := w.storedFieldKey(oldDocID, "")
+	fieldsEnd := w.storedFieldKey(oldDocID, "\xff")
+	w.batch.DeleteRange(fieldsStart, fieldsEnd, nil)
+	w.deletes = append(w.deletes, oldDocID)
+	w.batch.Delete(key, nil)
+
+	return w.AddDocument(newDoc)
+}
+
 func (w *Writer) AddDocument(doc types.Document) error {
 	w.docIndex++
 
@@ -265,7 +295,7 @@ func (w *Writer) AddDocument(doc types.Document) error {
 				w.tokenizers[field.Type()] = token.NewSparseNgramTokenizer(token.WithMaxNgramLength(6))
 			case types.TrigramField:
 				w.tokenizers[field.Type()] = token.NewTrigramTokenizer()
-			case types.StringTokenField:
+			case types.KeywordField:
 				w.tokenizers[field.Type()] = token.NewWhitespaceTokenizer()
 			default:
 				return status.InternalErrorf("No tokenizer known for field type: %q", field.Type())

--- a/codesearch/schema/BUILD
+++ b/codesearch/schema/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//codesearch/types",
         "//server/util/git",
+        "@com_github_cespare_xxhash_v2//:xxhash",
         "@com_github_gabriel_vasile_mimetype//:mimetype",
         "@com_github_go_enry_go_enry_v2//:go-enry",
     ],

--- a/codesearch/schema/BUILD
+++ b/codesearch/schema/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//codesearch/types",
         "//server/util/git",
+        "//server/util/log",
         "@com_github_cespare_xxhash_v2//:xxhash",
         "@com_github_gabriel_vasile_mimetype//:mimetype",
         "@com_github_go_enry_go_enry_v2//:go-enry",

--- a/codesearch/schema/BUILD
+++ b/codesearch/schema/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//codesearch/types",
         "//server/util/git",
-        "//server/util/log",
         "@com_github_cespare_xxhash_v2//:xxhash",
         "@com_github_gabriel_vasile_mimetype//:mimetype",
         "@com_github_go_enry_go_enry_v2//:go-enry",

--- a/codesearch/schema/schema.go
+++ b/codesearch/schema/schema.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -63,9 +62,7 @@ func MakeDocument(name, commitSha string, repoURL *git.RepoURL, buf []byte) (typ
 	}
 
 	uniqueID := xxhash.Sum64String(repoURL.Owner + repoURL.Repo + name)
-	idBytes := binary.AppendUvarint(nil, uniqueID)
-	_ = idBytes
-	idBytes = []byte(fmt.Sprintf("%d", uniqueID))
+	idBytes := []byte(fmt.Sprintf("%d", uniqueID))
 	// Compute filetype
 	lang := strings.ToLower(enry.GetLanguage(filepath.Base(name), shortBuf))
 	doc := types.NewMapDocument(

--- a/codesearch/schema/schema.go
+++ b/codesearch/schema/schema.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/go-enry/go-enry/v2"
+
+	xxhash "github.com/cespare/xxhash/v2"
 )
 
 const (
@@ -23,6 +26,7 @@ const (
 	detectionBufferSize = 1000
 
 	// The following field names are used in the indexed docs.
+	IDField       = "id"
 	FilenameField = "filename"
 	ContentField  = "content"
 	LanguageField = "language"
@@ -58,16 +62,21 @@ func MakeDocument(name, commitSha string, repoURL *git.RepoURL, buf []byte) (typ
 		return nil, fmt.Errorf("skipping %s (non-utf8 content)", name)
 	}
 
+	uniqueID := xxhash.Sum64String(repoURL.Owner + repoURL.Repo + name)
+	idBytes := binary.AppendUvarint(nil, uniqueID)
+	_ = idBytes
+	idBytes = []byte(fmt.Sprintf("%d", uniqueID))
 	// Compute filetype
 	lang := strings.ToLower(enry.GetLanguage(filepath.Base(name), shortBuf))
 	doc := types.NewMapDocument(
 		map[string]types.NamedField{
+			IDField:       types.NewNamedField(types.KeywordField, IDField, idBytes, false /*=stored*/),
 			FilenameField: types.NewNamedField(types.TrigramField, FilenameField, []byte(name), true /*=stored*/),
 			ContentField:  types.NewNamedField(types.SparseNgramField, ContentField, buf, true /*=stored*/),
-			LanguageField: types.NewNamedField(types.StringTokenField, LanguageField, []byte(lang), true /*=stored*/),
-			OwnerField:    types.NewNamedField(types.StringTokenField, OwnerField, []byte(repoURL.Owner), true /*=stored*/),
-			RepoField:     types.NewNamedField(types.StringTokenField, RepoField, []byte(repoURL.Repo), true /*=stored*/),
-			SHAField:      types.NewNamedField(types.StringTokenField, SHAField, []byte(commitSha), true /*=stored*/),
+			LanguageField: types.NewNamedField(types.KeywordField, LanguageField, []byte(lang), true /*=stored*/),
+			OwnerField:    types.NewNamedField(types.KeywordField, OwnerField, []byte(repoURL.Owner), true /*=stored*/),
+			RepoField:     types.NewNamedField(types.KeywordField, RepoField, []byte(repoURL.Repo), true /*=stored*/),
+			SHAField:      types.NewNamedField(types.KeywordField, SHAField, []byte(commitSha), true /*=stored*/),
 		},
 	)
 	return doc, nil

--- a/codesearch/searcher/searcher_test.go
+++ b/codesearch/searcher/searcher_test.go
@@ -16,7 +16,7 @@ import (
 func makeTestDoc(ident, content string) types.Document {
 	doc := types.NewMapDocument(
 		map[string]types.NamedField{
-			"ident":   types.NewNamedField(types.StringTokenField, "ident", []byte(ident), true /*=stored*/),
+			"ident":   types.NewNamedField(types.KeywordField, "ident", []byte(ident), true /*=stored*/),
 			"content": types.NewNamedField(types.SparseNgramField, "content", []byte(content), true /*=stored*/),
 		},
 	)

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -154,7 +154,7 @@ func (css *codesearchServer) syncIndex(ctx context.Context, req *inpb.IndexReque
 			log.Debug(err.Error())
 			continue
 		}
-		if err := iw.AddDocument(doc); err != nil {
+		if err := iw.UpdateDocument(doc.Field(schema.IDField), doc); err != nil {
 			return nil, err
 		}
 	}

--- a/codesearch/token/token.go
+++ b/codesearch/token/token.go
@@ -125,7 +125,7 @@ func (wt *WhitespaceTokenizer) Reset(r io.Reader) {
 }
 
 func (wt *WhitespaceTokenizer) Type() types.FieldType {
-	return types.StringTokenField
+	return types.KeywordField
 }
 func (wt *WhitespaceTokenizer) Ngram() []byte {
 	return []byte(wt.tok)

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -9,7 +9,7 @@ type FieldType int32
 
 const (
 	TrigramField FieldType = iota
-	StringTokenField
+	KeywordField
 	SparseNgramField
 
 	DocIDField   = "_id"
@@ -20,8 +20,10 @@ func (ft FieldType) String() string {
 	switch ft {
 	case TrigramField:
 		return "TrigramToken"
-	case StringTokenField:
-		return "StringToken"
+	case KeywordField:
+		return "KeywordToken"
+	case SparseNgramField:
+		return "SparseNgramToken"
 	default:
 		return "UNKNOWN FIELD TYPE"
 	}
@@ -62,6 +64,7 @@ type Tokenizer interface {
 
 type IndexWriter interface {
 	AddDocument(doc Document) error
+	UpdateDocument(matchField Field, newDoc Document) error
 	DeleteDocument(docID uint64) error
 	Flush() error
 }

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -52,11 +52,7 @@ var (
 // more easily testable in a standalone fashion, IStore mocks out just the
 // necessary methods that a Replica requires a Store to have.
 type IStore interface {
-	AddRange(rd *rfpb.RangeDescriptor, r *Replica)
-	RemoveRange(rd *rfpb.RangeDescriptor, r *Replica)
-	Sender() *sender.Sender
 	SnapshotCluster(ctx context.Context, rangeID uint64) error
-	NHID() string
 }
 
 // Replica implements the interface IOnDiskStateMachine. More details of

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -54,6 +54,7 @@ type IStore interface {
 	AddRange(rd *rfpb.RangeDescriptor, r *Replica)
 	RemoveRange(rd *rfpb.RangeDescriptor, r *Replica)
 	SnapshotCluster(ctx context.Context, rangeID uint64) error
+	NHID() string
 }
 
 // Replica implements the interface IOnDiskStateMachine. More details of


### PR DESCRIPTION
Add UpdateDocument method to index writer to allow for updating an index in place. This method allows passing a matchField with the new doc -- if that field matches an existing document stored in the index, the old document will be deleted before the new document is added.

The matchField should be some unique value that should be unique within the index + namespace. For our schema: set it to a hash of (owner + repo + filename).

Other stuff:
- check the Flush error in CLI indexer
- Rename StringTokenField to KeywordField
- More tests