### PR TITLE
Enable task sizer for Firecracker CPU

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -139,11 +139,6 @@ func (s *taskSizer) Get(ctx context.Context, task *repb.ExecutionTask) *scpb.Tas
 	if props.DisableMeasuredTaskSize {
 		return nil
 	}
-	// Don't use measured task sizes for Firecracker tasks for now, since task
-	// sizes are used as hard limits on allowed resources.
-	if props.WorkloadIsolationType == string(platform.FirecrackerContainerType) {
-		return nil
-	}
 	statusLabel := "hit"
 	defer func() {
 		groupID, _ := s.groupKey(ctx)
@@ -167,10 +162,19 @@ func (s *taskSizer) Get(ctx context.Context, task *repb.ExecutionTask) *scpb.Tas
 		// executor run this task once to estimate the size.
 		return nil
 	}
-	return applyMinimums(task, &scpb.TaskSize{
+	size := applyMinimums(task, &scpb.TaskSize{
 		EstimatedMemoryBytes: recordedSize.EstimatedMemoryBytes,
 		EstimatedMilliCpu:    recordedSize.EstimatedMilliCpu,
 	})
+	// Don't size memory automatically for Firecracker VMs, since if we size it
+	// incorrectly, it can cause OOM errors.
+	// TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/3824):
+	// use these sizes for determining how many VMs to schedule concurrently,
+	// but not for the upper limit on VM size.
+	if props.WorkloadIsolationType == string(platform.FirecrackerContainerType) {
+		size.EstimatedMemoryBytes = 0
+	}
+	return size
 }
 
 func (s *taskSizer) Predict(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize {


### PR DESCRIPTION
- For firecracker tasks, the task sizer now returns CPU estimates based on the last recorded size, but sets the memory estimate to 0.
- The scheduler server handles this properly [here](https://github.com/buildbuddy-io/buildbuddy/blob/6d565dbb90a895d525ea79e1018108f0d870ce54/enterprise/server/scheduling/scheduler_server/scheduler_server.go#L425-L462) - it checks EstimatedCPU and EstimatedMemory separately on both the recorded size + modeled size, and ignores them if they are 0, using the statically estimated size instead.
- The tensorflow model is still completely disabled for Firecracker tasks ([here](https://github.com/buildbuddy-io/buildbuddy/blob/6d565dbb90a895d525ea79e1018108f0d870ce54/enterprise/server/tasksize_model/tasksize_model.go#L209-L213))
- We're already storing task sizes for Firecracker, just not using them. So no changes are needed to the task sizer's `Update()` method.

**Related issues**: N/A
