### PR TITLE
Fix ByteStreamProxyServer resource name rewriting

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/real_environment",
+        "//server/remote_cache/digest",
         "//server/util/log",
         "//server/util/status",
         "@com_github_prometheus_client_golang//prometheus",

--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -22,7 +22,7 @@ go_library(
 
 go_test(
     name = "byte_stream_server_proxy_test",
-    size = "small",
+    size = "medium",
     srcs = ["byte_stream_server_proxy_test.go"],
     embed = [":byte_stream_server_proxy"],
     deps = [


### PR DESCRIPTION
The current strategy of just smashing "/uploads/00000000-0000-0000-0000-000000000000" on the front breaks instance names, as illustrated in the expanded byte_stream_server_proxy_test.

**Related issues**: N/A
