### PR TITLE
With consecutive doc IDs, bring back roaring bitsets

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -300,7 +300,6 @@ use_repo(
     "com_github_bazelbuild_buildtools",
     "com_github_bazelbuild_rules_webtesting",
     "com_github_bduffany_godemon",
-    "com_github_bmkessler_streamvbyte",
     "com_github_bojand_ghz",
     "com_github_bradfitz_gomemcache",
     "com_github_buildbuddy_io_tensorflow_proto",

--- a/codesearch/posting/BUILD
+++ b/codesearch/posting/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["posting.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/posting",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_bmkessler_streamvbyte//:streamvbyte"],
+    deps = ["@com_github_roaringbitmap_roaring//roaring64"],
 )
 
 go_test(
@@ -13,6 +13,8 @@ go_test(
     srcs = ["posting_test.go"],
     deps = [
         ":posting",
+        "@com_github_roaringbitmap_roaring//roaring64",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/codesearch/posting/BUILD
+++ b/codesearch/posting/BUILD
@@ -13,7 +13,6 @@ go_test(
     srcs = ["posting_test.go"],
     deps = [
         ":posting",
-        "@com_github_roaringbitmap_roaring//roaring64",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/codesearch/posting/posting.go
+++ b/codesearch/posting/posting.go
@@ -53,7 +53,7 @@ func Marshal(pl List) ([]byte, error) {
 
 func Unmarshal(buf []byte) (List, error) {
 	readStream := bytes.NewReader(buf)
-	pl3 := roaring64.New()
+	pl := roaring64.New()
 	for len(buf) > 0 {
 		plTemp := roaring64.New()
 		n, err := plTemp.ReadFrom(readStream)
@@ -61,9 +61,9 @@ func Unmarshal(buf []byte) (List, error) {
 			return nil, err
 		}
 		buf = buf[n:]
-		pl3.Or(plTemp)
+		pl.Or(plTemp)
 	}
-	return &roaringWrapper{pl3}, nil
+	return &roaringWrapper{pl}, nil
 }
 
 // A fieldMap is a collection of postingLists that are keyed by the field that

--- a/codesearch/posting/posting.go
+++ b/codesearch/posting/posting.go
@@ -1,10 +1,9 @@
 package posting
 
 import (
-	"encoding/binary"
-	"github.com/bmkessler/streamvbyte"
-	"slices"
-	"sort"
+	"bytes"
+
+	"github.com/RoaringBitmap/roaring/roaring64"
 )
 
 type List interface {
@@ -17,178 +16,54 @@ type List interface {
 	Clear()
 }
 
+type roaringWrapper struct {
+	*roaring64.Bitmap
+}
+
+func (w *roaringWrapper) Or(l List) {
+	bm, ok := l.(*roaringWrapper)
+	if !ok {
+		panic("not roaringWrapper")
+	}
+	w.Bitmap.Or(bm.Bitmap)
+}
+func (w *roaringWrapper) And(l List) {
+	bm, ok := l.(*roaringWrapper)
+	if !ok {
+		panic("not roaringWrapper")
+	}
+	w.Bitmap.And(bm.Bitmap)
+}
+
 func NewList(ids ...uint64) List {
-	if len(ids) > 0 {
-		slices.Sort(ids)
-		ids = slices.Compact(ids)
-		pl := uint64PostingList(ids)
-		return &pl
-	}
-	n := uint64PostingList(make([]uint64, 0))
-	return &n
-}
-
-type uint64PostingList []uint64
-
-func (pl *uint64PostingList) Or(pl2 List) {
-	var l []uint64
-	l1 := *pl
-	l2 := pl2.ToArray()
-	i := 0
-	j := 0
-	for i < len(l1) || j < len(l2) {
-		switch {
-		case j == len(l2) || (i < len(l1) && l1[i] < l2[j]):
-			l = append(l, l1[i])
-			i++
-		case i == len(l1) || (j < len(l2) && l1[i] > l2[j]):
-			l = append(l, l2[j])
-			j++
-		case l1[i] == l2[j]:
-			l = append(l, l1[i])
-			i++
-			j++
-		}
-	}
-	*pl = l
-}
-func (pl *uint64PostingList) And(pl2 List) {
-	var l []uint64
-	l1 := *pl
-	l2 := pl2.ToArray()
-	i := 0
-	j := 0
-	for i < len(l1) && j < len(l2) {
-		switch {
-		case l1[i] < l2[j]:
-			i++
-		case l2[j] < l1[i]:
-			j++
-		case l1[i] == l2[j]:
-			l = append(l, l2[j])
-			i++
-		}
-	}
-	*pl = l
-}
-
-func (pl *uint64PostingList) Add(u uint64) {
-	idx, alreadyPresent := slices.BinarySearch(*pl, u)
-	if !alreadyPresent {
-		*pl = slices.Insert(*pl, idx, u)
-	}
-}
-
-func (pl *uint64PostingList) Remove(u uint64) {
-	idx, alreadyPresent := slices.BinarySearch(*pl, u)
-	if alreadyPresent {
-		*pl = slices.Delete(*pl, idx, idx+1)
-	}
-}
-func (pl *uint64PostingList) GetCardinality() uint64 {
-	return uint64(len(*pl))
-}
-func (pl *uint64PostingList) ToArray() []uint64 {
-	return *pl
-}
-func (pl *uint64PostingList) Clear() {
-	*pl = (*pl)[:0]
+	bm := roaring64.New()
+	bm.AddMany(ids)
+	return &roaringWrapper{bm}
 }
 
 func Marshal(pl List) ([]byte, error) {
-	upl, ok := pl.(*uint64PostingList)
+	bm, ok := pl.(*roaringWrapper)
 	if !ok {
-		panic("not uint64PostingList")
+		panic("not roaringWrapper")
 	}
-
-	var encoded []byte
-	remainingIDs := *upl
-	for len(remainingIDs) > 0 {
-		generation := uint32(remainingIDs[0] >> 32)
-
-		// walk forward until we encounter an ID with a different top 32
-		// bits.
-		end := 0
-		for end = 0; end < len(remainingIDs); end++ {
-			if uint32(remainingIDs[end]>>32) != generation {
-				break
-			}
-		}
-
-		// chop off the top 32 bits of all the IDs and encode that as
-		// the "generation".
-		ids := make([]uint32, end)
-		for i, d := range remainingIDs[:end] {
-			ids[i] = uint32(d)
-		}
-		remainingIDs = remainingIDs[end:]
-
-		// prepare a buffer big enough to hold our IDs.
-		buf := make([]byte, streamvbyte.MaxSize32(len(ids))+4+4+4)
-
-		// Encode the length of the list.
-		listLength := uint32(len(ids))
-		if _, err := binary.Encode(buf[4:8], binary.LittleEndian, listLength); err != nil {
-			return nil, err
-		}
-
-		// Encode the generation.
-		if _, err := binary.Encode(buf[8:12], binary.LittleEndian, generation); err != nil {
-			return nil, err
-		}
-
-		// Encode the rest of the data.
-		d := streamvbyte.EncodeDeltaUint32(buf[12:], ids, 0)
-
-		// Encode the length of the actual buf buffer into the first
-		// 4 bytes.
-		if _, err := binary.Encode(buf[0:4], binary.LittleEndian, uint32(d)); err != nil {
-			return nil, err
-		}
-		encoded = append(encoded, buf[:d+12]...)
-	}
-	return encoded, nil
+	stream := bytes.NewBuffer(make([]byte, 0, int(bm.GetSerializedSizeInBytes())))
+	_, err := bm.Bitmap.WriteTo(stream)
+	return stream.Bytes(), err
 }
 
 func Unmarshal(buf []byte) (List, error) {
-	var sections [][]uint64
+	readStream := bytes.NewReader(buf)
+	pl3 := roaring64.New()
 	for len(buf) > 0 {
-		bufLength := uint32(0)
-		if _, err := binary.Decode(buf[0:4], binary.LittleEndian, &bufLength); err != nil {
+		plTemp := roaring64.New()
+		n, err := plTemp.ReadFrom(readStream)
+		if err != nil {
 			return nil, err
 		}
-
-		listLength := uint32(0)
-		if _, err := binary.Decode(buf[4:8], binary.LittleEndian, &listLength); err != nil {
-			return nil, err
-		}
-
-		generation := uint32(0)
-		if _, err := binary.Decode(buf[8:12], binary.LittleEndian, &generation); err != nil {
-			return nil, err
-		}
-
-		lowerIDs := make([]uint32, listLength)
-		streamvbyte.DecodeDeltaUint32(lowerIDs, buf[12:12+bufLength], 0)
-
-		l := make([]uint64, listLength)
-		for i, lower := range lowerIDs {
-			l[i] = uint64(generation)<<32 | uint64(lower)
-		}
-
-		sections = append(sections, l)
-		buf = buf[bufLength+12:]
+		buf = buf[n:]
+		pl3.Or(plTemp)
 	}
-	sort.Slice(sections, func(i, j int) bool {
-		return sections[i][0] < sections[j][0]
-	})
-
-	l := sections[0]
-	for _, s := range sections[1:] {
-		l = append(l, s...)
-	}
-	pl := uint64PostingList(l)
-	return &pl, nil
+	return &roaringWrapper{pl3}, nil
 }
 
 // A fieldMap is a collection of postingLists that are keyed by the field that

--- a/codesearch/posting/posting_test.go
+++ b/codesearch/posting/posting_test.go
@@ -1,7 +1,6 @@
 package posting_test
 
 import (
-	"bytes"
 	"math/rand"
 	"testing"
 

--- a/codesearch/posting/posting_test.go
+++ b/codesearch/posting/posting_test.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/RoaringBitmap/roaring/roaring64"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/posting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -167,34 +166,6 @@ func TestMerge(t *testing.T) {
 
 	pl3, err := posting.Unmarshal(combined)
 	assert.NoError(t, err)
-
-	assert.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7, 8}, pl3.ToArray())
-}
-
-func TestMerge2(t *testing.T) {
-	stream := new(bytes.Buffer)
-
-	pl1 := roaring64.New()
-	pl1.AddMany([]uint64{1, 2, 3, 4, 5})
-	_, err := pl1.WriteTo(stream)
-	assert.NoError(t, err)
-
-	pl2 := roaring64.New()
-	pl2.AddMany([]uint64{6, 7, 8})
-	_, err = pl2.WriteTo(stream)
-	assert.NoError(t, err)
-
-	buf := stream.Bytes()
-	readStream := bytes.NewBuffer(stream.Bytes())
-
-	pl3 := roaring64.New()
-	for len(buf) > 0 {
-		plTemp := roaring64.New()
-		n, err := plTemp.ReadFrom(readStream)
-		assert.NoError(t, err)
-		buf = buf[n:]
-		pl3.Or(plTemp)
-	}
 
 	assert.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7, 8}, pl3.ToArray())
 }

--- a/codesearch/posting/posting_test.go
+++ b/codesearch/posting/posting_test.go
@@ -1,10 +1,14 @@
 package posting_test
 
 import (
+	"bytes"
+	"math/rand"
 	"testing"
 
+	"github.com/RoaringBitmap/roaring/roaring64"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/posting"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAdd(t *testing.T) {
@@ -146,4 +150,97 @@ func TestFieldMapAnd(t *testing.T) {
 
 	assert.Equal(t, []uint64{2}, fm["test"].ToArray())
 	assert.Equal(t, []uint64{2}, fm["test2"].ToArray())
+}
+
+func TestMerge(t *testing.T) {
+	pl1 := posting.NewList(1, 2, 3, 4, 5)
+	buf1, err := posting.Marshal(pl1)
+	assert.NoError(t, err)
+
+	pl2 := posting.NewList(6, 7, 8)
+	buf2, err := posting.Marshal(pl2)
+	assert.NoError(t, err)
+
+	combined := make([]byte, len(buf1)+len(buf2))
+	copy(combined, buf1)
+	copy(combined[len(buf1):], buf2)
+
+	pl3, err := posting.Unmarshal(combined)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7, 8}, pl3.ToArray())
+}
+
+func TestMerge2(t *testing.T) {
+	stream := new(bytes.Buffer)
+
+	pl1 := roaring64.New()
+	pl1.AddMany([]uint64{1, 2, 3, 4, 5})
+	_, err := pl1.WriteTo(stream)
+	assert.NoError(t, err)
+
+	pl2 := roaring64.New()
+	pl2.AddMany([]uint64{6, 7, 8})
+	_, err = pl2.WriteTo(stream)
+	assert.NoError(t, err)
+
+	buf := stream.Bytes()
+	readStream := bytes.NewBuffer(stream.Bytes())
+
+	pl3 := roaring64.New()
+	for len(buf) > 0 {
+		plTemp := roaring64.New()
+		n, err := plTemp.ReadFrom(readStream)
+		assert.NoError(t, err)
+		buf = buf[n:]
+		pl3.Or(plTemp)
+	}
+
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7, 8}, pl3.ToArray())
+}
+
+func BenchmarkListSerializationPosting(b *testing.B) {
+	ids := make([]uint64, 1_000_000)
+	for i := 0; i < len(ids); i++ {
+		if i == 0 {
+			ids[i] = 1
+		} else {
+			ids[i] = ids[i-1] + uint64(rand.Intn(5))
+		}
+	}
+
+	b.ReportAllocs()
+	b.StopTimer()
+	for n := 0; n < b.N; n++ {
+		b.StartTimer()
+		pl := posting.NewList(ids...)
+		_, err := posting.Marshal(pl)
+		b.StopTimer()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkListDeserializationPosting(b *testing.B) {
+	ids := make([]uint64, 1_000_000)
+	for i := 0; i < len(ids); i++ {
+		if i == 0 {
+			ids[i] = 1
+		} else {
+			ids[i] = ids[i-1] + uint64(rand.Intn(5))
+		}
+	}
+
+	pl := posting.NewList(ids...)
+	buf, err := posting.Marshal(pl)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.StopTimer()
+	for n := 0; n < b.N; n++ {
+		b.StartTimer()
+		pl, err := posting.Unmarshal(buf)
+		_ = pl.ToArray()
+		b.StopTimer()
+		require.NoError(b, err)
+	}
 }

--- a/deps.bzl
+++ b/deps.bzl
@@ -555,12 +555,6 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         version = "v0.0.0-20160611221934-b7ed37b82869",
     )
     go_repository(
-        name = "com_github_bmkessler_streamvbyte",
-        importpath = "github.com/bmkessler/streamvbyte",
-        sum = "h1:QvzfNFkZD66P1f8s8FwMMVLxPd6Wa2/uqQh8gDhq3Ss=",
-        version = "v0.1.0",
-    )
-    go_repository(
         name = "com_github_bojand_ghz",
         build_directives = [
             "gazelle:resolve go github.com/prometheus/client_model/go @{}//proto:prometheus_client_go_proto".format(workspace_name),

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/bazelbuild/rules_go v0.50.1
 	github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95
 	github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e
-	github.com/bmkessler/streamvbyte v0.1.0
 	github.com/bojand/ghz v0.120.0
 	github.com/bradfitz/gomemcache v0.0.0-20230611145640-acc696258285
 	github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,6 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/bmkessler/streamvbyte v0.1.0 h1:QvzfNFkZD66P1f8s8FwMMVLxPd6Wa2/uqQh8gDhq3Ss=
-github.com/bmkessler/streamvbyte v0.1.0/go.mod h1:0SZTdGk1trQB2LOWZC7lNfF6SDN05cfv371DkrcUWeA=
 github.com/bojand/ghz v0.120.0 h1:6F4wsmZVwFg5UnD+/R+IABWk6sKE/0OKIBdUQUZnOdo=
 github.com/bojand/ghz v0.120.0/go.mod h1:HfECuBZj1v02XObGnRuoZgyB1PR24/25dIYiJIMjJnE=
 github.com/bradfitz/gomemcache v0.0.0-20230611145640-acc696258285 h1:Dr+ezPI5ivhMn/3WOoB86XzMhie146DNaBbhaQWZHMY=


### PR DESCRIPTION
StreamVByte custom:

BenchmarkListSerializationPosting
BenchmarkListSerializationPosting-24      	     100	  13748341 ns/op	 7682248 B/op	       4 allocs/op
BenchmarkListDeserializationPosting
BenchmarkListDeserializationPosting-24    	     442	   2313002 ns/op	 9644653 B/op	       5 allocs/op


Roaring (w/ ToArray())

BenchmarkListSerializationPosting
BenchmarkListSerializationPosting-24      	     160	   7717982 ns/op	 5730012 B/op	     525 allocs/op
BenchmarkListDeserializationPosting
BenchmarkListDeserializationPosting-24    	     446	   2603957 ns/op	 6942231 B/op	     149 allocs/op

Roaring (no ToArray()):

BenchmarkListSerializationPosting
BenchmarkListSerializationPosting-24      	     158	   7183902 ns/op	 5730642 B/op	     525 allocs/op
BenchmarkListDeserializationPosting
BenchmarkListDeserializationPosting-24    	    8188	    137140 ns/op	  514024 B/op	     145 allocs/op
