### PR TITLE
[raft] track range size

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1262,7 +1262,11 @@ func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context) {
 				if !s.leaseKeeper.HaveLease(ctx, rangeID) {
 					continue
 				}
-				if rangeUsageEvent.ReplicaUsage.GetEstimatedDiskBytesUsed() < raftConfig.MaxRangeSizeBytes() {
+				estimatedDiskBytes := rangeUsageEvent.ReplicaUsage.GetEstimatedDiskBytesUsed()
+				metrics.RaftBytes.With(prometheus.Labels{
+					metrics.RaftRangeIDLabel: strconv.Itoa(int(rangeID)),
+				}).Set(float64(estimatedDiskBytes))
+				if estimatedDiskBytes < raftConfig.MaxRangeSizeBytes() {
 					continue
 				}
 				repl, err := s.GetReplica(rangeID)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Range Size tracking was accidentally deleted as part of https://github.com/buildbuddy-io/buildbuddy/pull/7473/
because usage tracker is no longer listening to rangeUsageUpdated events.

This PR added the tracking in the store where we listen to the rangeUsageUpdated
events.
