### PR TITLE
Use the correct context for local CAS proxy writes.

### DIFF
--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -104,7 +104,7 @@ func (s *CASServerProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMis
 }
 
 func (s *CASServerProxy) BatchUpdateBlobs(ctx context.Context, req *repb.BatchUpdateBlobsRequest) (*repb.BatchUpdateBlobsResponse, error) {
-	_, err := s.local.BatchUpdateBlobs(context.Background(), req)
+	_, err := s.local.BatchUpdateBlobs(ctx, req)
 	if err != nil {
 		log.Warningf("Local BatchUpdateBlobs error: %s", err)
 	}
@@ -196,7 +196,7 @@ func (s *CASServerProxy) batchReadBlobsRemote(ctx context.Context, readReq *repb
 			Compressor: response.Compressor,
 		})
 	}
-	if _, err := s.local.BatchUpdateBlobs(context.Background(), &updateReq); err != nil {
+	if _, err := s.local.BatchUpdateBlobs(ctx, &updateReq); err != nil {
 		log.Warningf("Error locally updating blobs: %s", err)
 	}
 	return readResp, nil


### PR DESCRIPTION
context.Background() doesn't have creds so these writes were always failing in dev. Whoops!

**Related issues**: N/A
