### PR TITLE
move pebble_cache.pebbleEventListener to pebble.MetricsCollector

### DIFF
--- a/enterprise/server/util/pebble/BUILD
+++ b/enterprise/server/util/pebble/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/util/alert",
+        "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
         "@com_github_cockroachdb_pebble//:pebble",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
This allows us to reuse this struct in raft.

Also pebble.EventListener is already claimed so I renamed to
pebble.MetricsCollector
