### PR TITLE
Codesearch: use less memory when indexing

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -300,6 +300,7 @@ use_repo(
     "com_github_bazelbuild_buildtools",
     "com_github_bazelbuild_rules_webtesting",
     "com_github_bduffany_godemon",
+    "com_github_bits_and_blooms_bloom_v3",
     "com_github_bojand_ghz",
     "com_github_bradfitz_gomemcache",
     "com_github_buildbuddy_io_tensorflow_proto",

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -33,7 +33,7 @@ var (
 
 const batchFlushSizeBytes = 1_000_000_000 // flush batch every 1G
 
-type postingLists map[string][]uint64
+type postingLists map[string]posting.List
 
 type Writer struct {
 	db  *pebble.DB
@@ -44,7 +44,7 @@ type Writer struct {
 	namespace         string
 	tokenizers        map[types.FieldType]types.Tokenizer
 	fieldPostingLists map[string]postingLists
-	deletes           []uint64
+	deletes           posting.List
 	batch             *pebble.Batch
 }
 
@@ -63,7 +63,7 @@ func NewWriter(db *pebble.DB, namespace string) (*Writer, error) {
 		namespace:         namespace,
 		tokenizers:        make(map[types.FieldType]types.Tokenizer),
 		fieldPostingLists: make(map[string]postingLists),
-		deletes:           make([]uint64, 0),
+		deletes:           posting.NewList(),
 		batch:             db.NewBatch(),
 	}, nil
 }
@@ -267,7 +267,7 @@ func (w *Writer) UpdateDocument(matchField types.Field, newDoc types.Document) e
 	fieldsStart := w.storedFieldKey(oldDocID, "")
 	fieldsEnd := w.storedFieldKey(oldDocID, "\xff")
 	w.batch.DeleteRange(fieldsStart, fieldsEnd, nil)
-	w.deletes = append(w.deletes, oldDocID)
+	w.deletes.Add(oldDocID)
 
 	// Delete key so that AddDocument can rewrite it.
 	w.batch.Delete(key, nil)
@@ -312,7 +312,10 @@ func (w *Writer) AddDocument(doc types.Document) error {
 
 		for tokenizer.Next() == nil {
 			ngram := string(tokenizer.Ngram())
-			postingLists[ngram] = append(postingLists[ngram], docID)
+			if _, ok := postingLists[ngram]; !ok {
+				postingLists[ngram] = posting.NewList()
+			}
+			postingLists[ngram].Add(docID)
 		}
 
 		if field.Stored() {
@@ -345,9 +348,7 @@ func (w *Writer) Flush() error {
 	mu := sync.Mutex{}
 	eg := new(errgroup.Group)
 	eg.SetLimit(runtime.GOMAXPROCS(0))
-	writePLs := func(key []byte, ids []uint64) error {
-		pl := posting.NewList(ids...)
-
+	writePLs := func(key []byte, pl posting.List) error {
 		buf, err := posting.Marshal(pl)
 		if err != nil {
 			return err
@@ -379,7 +380,7 @@ func (w *Writer) Flush() error {
 			})
 		}
 	}
-	if len(w.deletes) > 0 {
+	if w.deletes.GetCardinality() > 0 {
 		eg.Go(func() error {
 			plKey := w.postingListKey(types.DeletesField, types.DeletesField)
 			return writePLs(plKey, w.deletes)

--- a/codesearch/posting/posting.go
+++ b/codesearch/posting/posting.go
@@ -43,6 +43,24 @@ func NewList(ids ...uint64) List {
 	return &roaringWrapper{bm}
 }
 
+func GetSerializedSizeInBytes(pl List) int {
+	bm, ok := pl.(*roaringWrapper)
+	if !ok {
+		panic("not roaringWrapper")
+	}
+	return int(bm.GetSerializedSizeInBytes())
+}
+
+func MarshalInto(pl List, buf []byte) error {
+	bm, ok := pl.(*roaringWrapper)
+	if !ok {
+		panic("not roaringWrapper")
+	}
+	stream := bytes.NewBuffer(buf)
+	_, err := bm.Bitmap.WriteTo(stream)
+	return err
+}
+
 func Marshal(pl List) ([]byte, error) {
 	bm, ok := pl.(*roaringWrapper)
 	if !ok {

--- a/codesearch/posting/posting.go
+++ b/codesearch/posting/posting.go
@@ -37,7 +37,9 @@ func (w *roaringWrapper) And(l List) {
 
 func NewList(ids ...uint64) List {
 	bm := roaring64.New()
-	bm.AddMany(ids)
+	if len(ids) > 0 {
+		bm.AddMany(ids)
+	}
 	return &roaringWrapper{bm}
 }
 

--- a/codesearch/token/BUILD
+++ b/codesearch/token/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//codesearch/sparse",
         "//codesearch/types",
         "//server/util/status",
+        "@com_github_bits_and_blooms_bloom_v3//:bloom",
     ],
 )
 

--- a/codesearch/token/token.go
+++ b/codesearch/token/token.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/codesearch/sparse"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/bits-and-blooms/bloom/v3"
 )
 
 // validUTF8 reports whether the byte pair can appear in a
@@ -311,7 +312,8 @@ type SparseNgramTokenizer struct {
 	opts        *Options
 	scanner     *bufio.Scanner
 	hasher      hash.Hash32
-	alreadySeen *sparse.Set
+	trigramsSeen *sparse.Set
+	longramsSeen *bloom.BloomFilter
 	ngrams      []string
 	s           []rune
 	st          []hashAndPosition
@@ -327,7 +329,8 @@ func NewSparseNgramTokenizer(mods ...Option) *SparseNgramTokenizer {
 	return &SparseNgramTokenizer{
 		opts:        opts,
 		hasher:      fnv.New32(),
-		alreadySeen: sparse.NewSet(1<<32 - 1),
+		trigramsSeen: sparse.NewSet(1 << 24),
+		longramsSeen: bloom.NewWithEstimates(100000, 0.0001),
 		ngrams:      make([]string, 0),
 		s:           make([]rune, bufio.MaxScanTokenSize),
 		st:          make([]hashAndPosition, 0),
@@ -337,7 +340,8 @@ func NewSparseNgramTokenizer(mods ...Option) *SparseNgramTokenizer {
 
 func (tt *SparseNgramTokenizer) Reset(r io.Reader) {
 	tt.scanner = bufio.NewScanner(r)
-	tt.alreadySeen.Reset()
+	tt.trigramsSeen.Reset()
+	tt.longramsSeen.ClearAll()
 	tt.ngrams = tt.ngrams[:0]
 	tt.s = tt.s[:0]
 	tt.st = tt.st[:0]
@@ -350,6 +354,21 @@ func (tt *SparseNgramTokenizer) Type() types.FieldType {
 func (tt *SparseNgramTokenizer) Ngram() []byte {
 	gram := tt.ngrams[len(tt.ngrams)-1]
 	return unsafe.Slice(unsafe.StringData(gram), len(gram))
+}
+
+func (tt *SparseNgramTokenizer) TestOrAdd(buf []byte) bool {
+	if len(buf) < 3 {
+		panic("too short of a trigram")
+	} else if len(buf) == 3 {
+		tri := uint32(buf[0])<<16 | uint32(buf[1])<<8 | uint32(buf[2])
+		found := tt.trigramsSeen.Has(tri)
+		if !found {
+			tt.trigramsSeen.Add(tri)
+		}
+		return found
+	} else {
+		return tt.longramsSeen.TestOrAdd(buf)
+	}
 }
 
 func (tt *SparseNgramTokenizer) refillLine() error {
@@ -428,10 +447,8 @@ func (tt *SparseNgramTokenizer) buildAllNgrams() {
 			count := i + 2 - start
 			if count <= tt.opts.MaxNgramLength {
 				buf := tt.toBytes(s[start : start+count])
-				ngramID := tt.hashNgram(buf)
-				if !tt.alreadySeen.Has(ngramID) {
+				if !tt.TestOrAdd(buf) {
 					tt.ngrams = append(tt.ngrams, string(buf))
-					tt.alreadySeen.Add(ngramID)
 				}
 			}
 			for len(tt.st) > 1 && tt.st[len(tt.st)-1].hash == tt.st[len(tt.st)-2].hash {
@@ -444,10 +461,8 @@ func (tt *SparseNgramTokenizer) buildAllNgrams() {
 			count := i + 2 - start
 			if count <= tt.opts.MaxNgramLength {
 				buf := tt.toBytes(s[start : start+count])
-				ngramID := tt.hashNgram(buf)
-				if !tt.alreadySeen.Has(ngramID) {
+				if !tt.TestOrAdd(buf) {
 					tt.ngrams = append(tt.ngrams, string(buf))
-					tt.alreadySeen.Add(ngramID)
 				}
 			}
 		}

--- a/codesearch/token/token.go
+++ b/codesearch/token/token.go
@@ -10,10 +10,10 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
+	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/sparse"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/bits-and-blooms/bloom/v3"
 )
 
 // validUTF8 reports whether the byte pair can appear in a
@@ -309,15 +309,15 @@ func BuildCoveringNgrams(in string, mods ...Option) []string {
 }
 
 type SparseNgramTokenizer struct {
-	opts        *Options
-	scanner     *bufio.Scanner
-	hasher      hash.Hash32
+	opts         *Options
+	scanner      *bufio.Scanner
+	hasher       hash.Hash32
 	trigramsSeen *sparse.Set
 	longramsSeen *bloom.BloomFilter
-	ngrams      []string
-	s           []rune
-	st          []hashAndPosition
-	stringTemp  []byte
+	ngrams       []string
+	s            []rune
+	st           []hashAndPosition
+	stringTemp   []byte
 }
 
 func NewSparseNgramTokenizer(mods ...Option) *SparseNgramTokenizer {
@@ -327,14 +327,14 @@ func NewSparseNgramTokenizer(mods ...Option) *SparseNgramTokenizer {
 	}
 
 	return &SparseNgramTokenizer{
-		opts:        opts,
-		hasher:      fnv.New32(),
+		opts:         opts,
+		hasher:       fnv.New32(),
 		trigramsSeen: sparse.NewSet(1 << 24),
 		longramsSeen: bloom.NewWithEstimates(100000, 0.0001),
-		ngrams:      make([]string, 0),
-		s:           make([]rune, bufio.MaxScanTokenSize),
-		st:          make([]hashAndPosition, 0),
-		stringTemp:  make([]byte, utf8.UTFMax*opts.MaxNgramLength),
+		ngrams:       make([]string, 0),
+		s:            make([]rune, bufio.MaxScanTokenSize),
+		st:           make([]hashAndPosition, 0),
+		stringTemp:   make([]byte, utf8.UTFMax*opts.MaxNgramLength),
 	}
 }
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -503,8 +503,14 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_bits_and_blooms_bitset",
         importpath = "github.com/bits-and-blooms/bitset",
-        sum = "h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=",
-        version = "v1.12.0",
+        sum = "h1:Gd2c8lSNf9pKXom5JtD7AaKO8o7fGQ2LtFj1436qilA=",
+        version = "v1.14.3",
+    )
+    go_repository(
+        name = "com_github_bits_and_blooms_bloom_v3",
+        importpath = "github.com/bits-and-blooms/bloom/v3",
+        sum = "h1:VfknkqV4xI+PsaDIsoHueyxVDZrfvMn56jeWUzvzdls=",
+        version = "v3.7.0",
     )
     go_repository(
         name = "com_github_bkaradzic_go_lz4",
@@ -4580,6 +4586,12 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         importpath = "github.com/tv42/httpunix",
         sum = "h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=",
         version = "v0.0.0-20191220191345-2ba4b9c3382c",
+    )
+    go_repository(
+        name = "com_github_twmb_murmur3",
+        importpath = "github.com/twmb/murmur3",
+        sum = "h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=",
+        version = "v1.1.6",
     )
     go_repository(
         name = "com_github_ugorji_go",

--- a/go.mod
+++ b/go.mod
@@ -202,7 +202,8 @@ require (
 	github.com/beevik/etree v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/bits-and-blooms/bitset v1.12.0 // indirect
+	github.com/bits-and-blooms/bitset v1.14.3 // indirect
+	github.com/bits-and-blooms/bloom/v3 v3.7.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/bufbuild/protocompile v0.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/bazelbuild/rules_go v0.50.1
 	github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95
 	github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e
+	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/bojand/ghz v0.120.0
 	github.com/bradfitz/gomemcache v0.0.0-20230611145640-acc696258285
 	github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6
@@ -203,7 +204,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bits-and-blooms/bitset v1.14.3 // indirect
-	github.com/bits-and-blooms/bloom/v3 v3.7.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/bufbuild/protocompile v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,13 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
+github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bitset v1.14.3 h1:Gd2c8lSNf9pKXom5JtD7AaKO8o7fGQ2LtFj1436qilA=
+github.com/bits-and-blooms/bitset v1.14.3/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bloom/v3 v3.7.0 h1:VfknkqV4xI+PsaDIsoHueyxVDZrfvMn56jeWUzvzdls=
+github.com/bits-and-blooms/bloom/v3 v3.7.0/go.mod h1:VKlUSvp0lFIYqxJjzdnSsZEw4iHb1kOL2tfHTgyJBHg=
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
@@ -1631,6 +1636,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
+github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.sum
+++ b/go.sum
@@ -278,7 +278,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.14.3 h1:Gd2c8lSNf9pKXom5JtD7AaKO8o7fGQ2LtFj1436qilA=
 github.com/bits-and-blooms/bitset v1.14.3/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
@@ -1636,6 +1635,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
+github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=


### PR DESCRIPTION
- Don't allocate giant sparse sets in the tokenizer
- Don't copy between []uint64 and posting lists
- Use less memory by encoding directly into the pebble batch without additional allocs
