### PR TITLE
[RB] Target correct BES backend and add fallback keys to remote bazel buttons

### DIFF
--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -176,6 +176,7 @@ ts_library(
         "//app/errors:error_service",
         "//app/invocation:invocation_model",
         "//app/service:rpc_service",
+        "//proto:bazel_config_ts_proto",
         "//proto:git_ts_proto",
         "//proto:github_ts_proto",
         "//proto:runner_ts_proto",

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -176,7 +176,6 @@ ts_library(
         "//app/errors:error_service",
         "//app/invocation:invocation_model",
         "//app/service:rpc_service",
-        "//proto:bazel_config_ts_proto",
         "//proto:git_ts_proto",
         "//proto:github_ts_proto",
         "//proto:runner_ts_proto",

--- a/app/util/remote_runner.tsx
+++ b/app/util/remote_runner.tsx
@@ -4,13 +4,17 @@ import { runner } from "../../proto/runner_ts_proto";
 import rpcService from "../service/rpc_service";
 import { github } from "../../proto/github_ts_proto";
 import error_service from "../errors/error_service";
+import { bazel_config } from "../../proto/bazel_config_ts_proto";
 
 export async function supportsRemoteRun(repoUrl: string): Promise<boolean> {
   const rsp = await rpcService.service.getLinkedGitHubRepos(new github.GetLinkedReposRequest());
   return rsp.repoUrls.filter((url) => url === repoUrl).length > 0;
 }
 
-export function triggerRemoteRun(invocationModel: InvocationModel, command: string, autoOpenChild: boolean) {
+export async function triggerRemoteRun(invocationModel: InvocationModel, command: string, autoOpenChild: boolean) {
+  const addlFlags = await besFlags();
+  command = appendBazelSubCommandArgs(command, addlFlags);
+
   const request = new runner.RunRequest({
     gitRepo: new git.GitRepo({
       repoUrl: invocationModel.getRepo(),
@@ -26,6 +30,13 @@ export function triggerRemoteRun(invocationModel: InvocationModel, command: stri
     ],
     async: true,
     runRemotely: true,
+    // In order to increase the odds of hitting a warm snapshot, set the two
+    // most common default branch names as fallback keys (as a simplification
+    // over fetching the actual default branch name).
+    env: {
+      GIT_REPO_DEFAULT_BRANCH: "master",
+      GIT_BASE_BRANCH: "main",
+    },
   });
 
   rpcService.service
@@ -40,4 +51,29 @@ export function triggerRemoteRun(invocationModel: InvocationModel, command: stri
     .catch((error) => {
       error_service.handleError(error);
     });
+}
+
+// besFlags returns BES flags pointing to the current BuildBuddy server.
+export async function besFlags(): Promise<string> {
+  let request = new bazel_config.GetBazelConfigRequest({
+    host: window.location.host,
+    protocol: window.location.protocol,
+  });
+  const response = await rpcService.service.getBazelConfig(request);
+  const besResultsUrl = response.configOption.find((opt) => opt.flagName == "bes_results_url")?.flagValue;
+  const besBackend = response.configOption.find((opt) => opt.flagName == "bes_backend")?.flagValue;
+  return `--bes_results_url=${besResultsUrl} --bes_backend=${besBackend}`;
+}
+
+// appendBazelSubcommandArgs appends bazel arguments to a bazel command
+// *before* the arg separator ("--") if it exists, so that the arguments apply
+// to the bazel subcommand ("build", "run", etc.) and not the binary being run
+// (in the "bazel run" case).
+function appendBazelSubCommandArgs(cmd: string, args: string): string {
+  if (cmd == "") {
+    return "";
+  }
+  const splitCmd = cmd.split(" -- ", 2);
+  splitCmd[0] += " " + args + " ";
+  return splitCmd.join(" -- ");
 }

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2352,15 +2352,15 @@ func writeBazelrc(path, invocationID, runID, rootDir string) error {
 	// URLs for now. They are all prefixed with "buildbuddy_" to avoid conflicting
 	// with existing .bazelrc configs in the wild.
 	lines = append(lines, []string{
-		"build:buildbuddy_bes_backend --bes_backend=" + *besBackend,
-		"build:buildbuddy_bes_results_url --bes_results_url=" + *besResultsURL,
+		"common:buildbuddy_bes_backend --bes_backend=" + *besBackend,
+		"common:buildbuddy_bes_results_url --bes_results_url=" + *besResultsURL,
 	}...)
 	if *cacheBackend != "" {
-		lines = append(lines, "build:buildbuddy_remote_cache --remote_cache="+*cacheBackend)
-		lines = append(lines, "build:buildbuddy_experimental_remote_downloader --experimental_remote_downloader="+*cacheBackend)
+		lines = append(lines, "common:buildbuddy_remote_cache --remote_cache="+*cacheBackend)
+		lines = append(lines, "common:buildbuddy_experimental_remote_downloader --experimental_remote_downloader="+*cacheBackend)
 	}
 	if *rbeBackend != "" {
-		lines = append(lines, "build:buildbuddy_remote_executor --remote_executor="+*rbeBackend)
+		lines = append(lines, "common:buildbuddy_remote_executor --remote_executor="+*rbeBackend)
 	}
 
 	outputBase := filepath.Join(rootDir, outputBaseDirName)


### PR DESCRIPTION
In the ci_runner, we generate a bazelrc that points to the correct BES backend. However our .bazelrc (in the buildbuddy repo) contains
```
# By default, build logs get sent to the production server
common --bes_results_url=https://app.buildbuddy.io/invocation/
common --bes_backend=grpcs://remote.buildbuddy.io
```
which overrides that and always points to prod. We prioritize the workspace bazelrc over the ci_runner generated one. Explicitly add the bes flags to point to the correct server in dev and other envs

Also set fallback branch keys on the remote requests 

**Related issues**: N/A
