### PR TITLE
bzlmod: remove duplicated platforms archive

### DIFF
--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,16 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
-# Bazel platforms
-
-http_archive(
-    name = "platforms",
-    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
-    ],
-)
-
 # Go
 
 load(":deps.bzl", "install_static_dependencies")


### PR DESCRIPTION
this is already a bazel module declared in MODULE.bazel file
