### PR TITLE
WORKSPACE: cleanup and use http_archive in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -447,3 +447,14 @@ toolchains_musl = use_extension("@toolchains_musl//:toolchains_musl.bzl", "toolc
 toolchains_musl.config(
     extra_target_compatible_with = ["//toolchains:musl_on"],
 )
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_github_sluongng_nogo_analyzer",
+    sha256 = "a74a5e44751d292d17bd879e5aa8b40baa94b5dc2f043df1e3acbb3e23ead073",
+    strip_prefix = "nogo-analyzer-0.0.2",
+    urls = [
+        "https://github.com/sluongng/nogo-analyzer/archive/refs/tags/v0.0.2.tar.gz",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -322,16 +322,6 @@ _go_image_repos()
 
 all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
 
-# CPIO
-
-http_archive(
-    name = "org_gnu_cpio",
-    build_file_content = all_content,
-    sha256 = "e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88",
-    strip_prefix = "cpio-2.13",
-    url = "https://ftp.gnu.org/gnu/cpio/cpio-2.13.tar.gz",
-)
-
 # Kubernetes
 
 http_archive(

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -6,17 +6,6 @@ load(":deps.bzl", "install_static_dependencies")
 
 install_static_dependencies()
 
-# Golang staticcheck
-
-http_archive(
-    name = "com_github_sluongng_nogo_analyzer",
-    sha256 = "a74a5e44751d292d17bd879e5aa8b40baa94b5dc2f043df1e3acbb3e23ead073",
-    strip_prefix = "nogo-analyzer-0.0.2",
-    urls = [
-        "https://github.com/sluongng/nogo-analyzer/archive/refs/tags/v0.0.2.tar.gz",
-    ],
-)
-
 # In Bazel Central Registry, rules_nodejs before 6.0 is actually rules_nodejs-core,
 # which is a trimmed version of build_bazel_rules_nodejs.
 #
@@ -52,28 +41,6 @@ yarn_install(
     yarn_lock = "//:yarn.lock",
 )
 
-# Proto -- must be before container_repositories so we don't inherit their rules_pkg.
-
-# NB: The name must be "com_google_protobuf".
-
-# Required by com_google_protobuf
-http_archive(
-    name = "com_google_googletest",
-    sha256 = "730215d76eace9dd49bf74ce044e8daa065d175f1ac891cc1d6bb184ef94e565",
-    strip_prefix = "googletest-f53219cdcb7b084ef57414efea92ee5b71989558",
-    urls = [
-        "https://github.com/google/googletest/archive/f53219cdcb7b084ef57414efea92ee5b71989558.tar.gz",
-    ],
-)
-
-load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
-
-googletest_deps()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
 # Docker
 
 http_archive(
@@ -99,16 +66,6 @@ load(
 container_repositories()
 
 all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
-
-# CPIO
-
-http_archive(
-    name = "org_gnu_cpio",
-    build_file_content = all_content,
-    sha256 = "e87470d9c984317f658567c03bfefb6b0c829ff17dbf6b0de48d71a4c8f3db88",
-    strip_prefix = "cpio-2.13",
-    url = "https://ftp.gnu.org/gnu/cpio/cpio-2.13.tar.gz",
-)
 
 # Kubernetes
 


### PR DESCRIPTION
Cleanup usage of gnu_cpio, we rewrote it in Go a while ago.

Remove the protobuf deps in WORKSPACE.bzlmod, they should be
automatically pulled by bzlmod from bcr.

Move nogo-analyzer from WORKSPACE.bzlmod to MODULE.bazel as a POC for
using repo rules inside the MODULE.bazel file.
