### PR TITLE
Allow a few more operations with user key management

### DIFF
--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -78,6 +78,10 @@ message CreateApiKeyResponse {
 message GetApiKeysRequest {
   context.RequestContext request_context = 1;
 
+  // The ID of the user to get API keys for.
+  // ex: "US123456789"
+  string user_id = 3;
+
   // The ID of the group to get API keys for.
   // ex: "GR123456789"
   string group_id = 2;

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -476,7 +476,7 @@ type AuthDB interface {
 	GetUserOwnedKeysEnabled() bool
 
 	// GetUserAPIKeys returns all user-owned API keys within a group.
-	GetUserAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error)
+	GetUserAPIKeys(ctx context.Context, userID, groupID string) ([]*tables.APIKey, error)
 
 	// CreateUserAPIKey creates a user-owned API key within the group. The given
 	// user must be a member of the group. If the request is not authenticated


### PR DESCRIPTION
- Allow assigning API key capabilities when creating a key for a user other than the authenticated user (ORG_ADMIN keys only)
- Allow listing keys for users other than the authenticated user (ORG_ADMIN keys only)

**Related issues**: N/A
