### PR TITLE
Add optional CPU limit to OCI runtime.

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -48,7 +48,7 @@ var (
 	runtimeRoot    = flag.String("executor.oci.runtime_root", "", "Root directory for storage of container state (see <runtime> --help for default)")
 	imageCacheRoot = flag.String("executor.oci.image_cache_root", "", "Root directory for cached OCI images. Defaults to './executor/oci/images' relative to the configured executor.root_directory")
 	pidsLimit      = flag.Int64("executor.oci.pids_limit", 2048, "PID limit for OCI runtime. Set to -1 for unlimited PIDs.")
-	cpuLimit       = flag.Int("executor.oci.cpu_limit", 0, "Hard limit for CPU resources, expressed as CPU count. Default is no limit.")
+	cpuLimit       = flag.Int("executor.oci.cpu_limit", 0, "Hard limit for CPU resources, expressed as CPU count. Default (0) is no limit.")
 	dns            = flag.String("executor.oci.dns", "8.8.8.8", "Specifies a custom DNS server for use inside OCI containers. If set to the empty string, mount /etc/resolv.conf from the host.")
 	netPoolSize    = flag.Int("executor.oci.network_pool_size", 0, "Limit on the number of networks to be reused between containers. Setting to 0 disables pooling. Setting to -1 uses the recommended default.")
 )

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -48,6 +48,7 @@ var (
 	runtimeRoot    = flag.String("executor.oci.runtime_root", "", "Root directory for storage of container state (see <runtime> --help for default)")
 	imageCacheRoot = flag.String("executor.oci.image_cache_root", "", "Root directory for cached OCI images. Defaults to './executor/oci/images' relative to the configured executor.root_directory")
 	pidsLimit      = flag.Int64("executor.oci.pids_limit", 2048, "PID limit for OCI runtime. Set to -1 for unlimited PIDs.")
+	cpuLimit       = flag.Int("executor.oci.cpu_limit", 0, "Hard limit for CPU resources, expressed as CPU count. Default is no limit.")
 	dns            = flag.String("executor.oci.dns", "8.8.8.8", "Specifies a custom DNS server for use inside OCI containers. If set to the empty string, mount /etc/resolv.conf from the host.")
 	netPoolSize    = flag.Int("executor.oci.network_pool_size", 0, "Limit on the number of networks to be reused between containers. Setting to 0 disables pooling. Setting to -1 uses the recommended default.")
 )
@@ -639,6 +640,15 @@ func (c *ociContainer) createSpec(ctx context.Context, cmd *repb.Command) (*spec
 	if err != nil {
 		return nil, fmt.Errorf("get container user: %w", err)
 	}
+
+	cpuSpecs := &specs.LinuxCPU{}
+	if *cpuLimit != 0 {
+		cpuSpecs = &specs.LinuxCPU{
+			Quota:  pointer(int64(*cpuLimit * 100_000)),
+			Period: pointer(uint64(100_000)),
+		}
+	}
+
 	spec := specs.Spec{
 		Version: ociVersion,
 		Process: &specs.Process{
@@ -763,6 +773,7 @@ func (c *ociContainer) createSpec(ctx context.Context, cmd *repb.Command) (*spec
 			},
 			Resources: &specs.LinuxResources{
 				Pids: pids,
+				CPU:  cpuSpecs,
 			},
 			// TODO: grok MaskedPaths and ReadonlyPaths - just copied from podman.
 			MaskedPaths: []string{

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -643,9 +643,10 @@ func (c *ociContainer) createSpec(ctx context.Context, cmd *repb.Command) (*spec
 
 	cpuSpecs := &specs.LinuxCPU{}
 	if *cpuLimit != 0 {
+		period := 100 * time.Millisecond
 		cpuSpecs = &specs.LinuxCPU{
-			Quota:  pointer(int64(*cpuLimit * 100_000)),
-			Period: pointer(uint64(100_000)),
+			Quota:  pointer(int64(*cpuLimit) * period.Microseconds()),
+			Period: pointer(uint64(period.Microseconds())),
 		}
 	}
 


### PR DESCRIPTION
We can use this to set an upper bound on CPUs so that the CPU count looks uniform regardless of the underlying hardware.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/3853

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
