### PR TITLE
Pool bufio.Writers of different sizes

### DIFF
--- a/server/util/bytebufferpool/bytebufferpool.go
+++ b/server/util/bytebufferpool/bytebufferpool.go
@@ -1,6 +1,8 @@
 package bytebufferpool
 
 import (
+	"bufio"
+	"io"
 	"math/bits"
 	"sync"
 )
@@ -83,4 +85,75 @@ func (bp *VariableSizePool) Put(buf []byte) {
 		idx = len(bp.pools) - 1
 	}
 	bp.pools[idx].Put(buf)
+}
+
+// BufioWriter exists because bufio.Writer does not expose the size of the
+// internal buffer, is needed when returning a bufio.Writer to the pool. As a
+// workaround, use bufio.Writer as an anonymous embedded struct and keep the
+// size it was initialized with.
+type BufioWriter struct {
+	*bufio.Writer
+	size int
+}
+
+func newWriterSize(w io.Writer, size int) *BufioWriter {
+	return &BufioWriter{
+		Writer: bufio.NewWriterSize(io.Discard, size),
+		size:   size,
+	}
+}
+
+type VariableWriteBufPool struct {
+	// pools contain slices of capacities that are powers of 2. the slice itself
+	// is indexed by the exponent.
+	// index 0 containing a pool of 2^0 capacity slices, index 1 containing 2^1
+	// capacity slices and so forth.
+	pools         []sync.Pool
+	maxBufferSize int
+}
+
+// NewVariableWriteBufPool returns a byte buffer pool that can be used when the
+// buffer size is not fixed. It internally maintains pools of different
+// bufio.WriteBuffers in different sizes to accomadate the requested size.
+func NewVariableWriteBufPool(maxBufferSize int) *VariableWriteBufPool {
+	bp := &VariableWriteBufPool{}
+	for size := 1; ; size *= 2 {
+		size := size
+		bp.pools = append(bp.pools, sync.Pool{
+			New: func() any {
+				return newWriterSize(io.Discard, size)
+			},
+		})
+		if size >= maxBufferSize {
+			break
+		}
+	}
+	return bp
+}
+
+// Get returns a BufioWriter with an internal buffer >= length.
+func (bp *VariableWriteBufPool) Get(length int64) *BufioWriter {
+	// Calculate the smallest power of 2 exponent x where 2^x >= length
+	idx := bits.Len64(uint64(length - 1))
+	if length == 0 {
+		idx = 0
+	}
+	if idx >= len(bp.pools) {
+		idx = len(bp.pools) - 1
+	}
+	t := bp.pools[idx].Get()
+	return t.(*BufioWriter)
+}
+
+// Put returns a BufioWriter back into the pool.
+func (bp *VariableWriteBufPool) Put(w *BufioWriter) {
+	// Calculate the largest power of 2 exponent x where 2^x <= cap
+	idx := bits.Len64(uint64(w.size)) - 1
+	if idx < 0 {
+		return
+	}
+	if idx >= len(bp.pools) {
+		idx = len(bp.pools) - 1
+	}
+	bp.pools[idx].Put(w)
 }

--- a/server/util/bytebufferpool/bytebufferpool.go
+++ b/server/util/bytebufferpool/bytebufferpool.go
@@ -96,7 +96,7 @@ type BufioWriter struct {
 	size int
 }
 
-func newWriterSize(w io.Writer, size int) *BufioWriter {
+func newWriterSize(size int) *BufioWriter {
 	return &BufioWriter{
 		Writer: bufio.NewWriterSize(io.Discard, size),
 		size:   size,
@@ -121,7 +121,7 @@ func NewVariableWriteBufPool(maxBufferSize int) *VariableWriteBufPool {
 		size := size
 		bp.pools = append(bp.pools, sync.Pool{
 			New: func() any {
-				return newWriterSize(io.Discard, size)
+				return newWriterSize(size)
 			},
 		})
 		if size >= maxBufferSize {


### PR DESCRIPTION
To prevent heap from possibly growing out of control -- use variable sized write buffers in cacheproxy.