### PR TITLE
[raft] move handle events before replica initiation

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -287,6 +287,9 @@ func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeH
 		s.queryForMetarange(gctx)
 		return nil
 	})
+	s.eg.Go(func() error {
+		return s.handleEvents(s.egCtx)
+	})
 
 	nodeHostInfo := nodeHost.GetNodeHostInfo(dragonboat.NodeHostInfoOption{})
 	previouslyStartedReplicas := make([]*rfpb.ReplicaDescriptor, 0, len(nodeHostInfo.LogInfo))
@@ -482,9 +485,6 @@ func (s *Store) AddEventListener() <-chan events.Event {
 // ranges on this node.
 func (s *Store) Start() error {
 	s.usages.Start()
-	s.eg.Go(func() error {
-		return s.handleEvents(s.egCtx)
-	})
 	s.eg.Go(func() error {
 		s.acquireNodeLiveness(s.egCtx)
 		return nil


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When replica.setRange, it will send usage event to the store events channel. But
we started handling events after the replicas are initiated. This might cause
the events channel to be blocked. 
