### PR TITLE
Aspect_rules_swc: upgrade to v2.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -443,6 +443,9 @@ use_repo(node, "nodejs_toolchains")
 
 register_toolchains("@nodejs_toolchains//:all")
 
+# SWC (for transpiling TS -> JS)
+bazel_dep(name = "aspect_rules_swc", version = "2.0.0")
+
 toolchains_musl = use_extension("@toolchains_musl//:toolchains_musl.bzl", "toolchains_musl", dev_dependency = True)
 toolchains_musl.config(
     extra_target_compatible_with = ["//toolchains:musl_on"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -427,12 +427,12 @@ use_repo(
 # Keep in sync with build_bazel_rules_nodejs in WORKSPACE.bzlmod
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 single_version_override(
-    version = "5.8.2",
     module_name = "rules_nodejs",
     patch_strip = 1,
     patches = [
         "@@//buildpatches:build_bazel_rules_nodejs.patch",
     ],
+    version = "5.8.2",
 )
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -426,16 +426,12 @@ use_repo(
 # Note that this is 'rules_nodejs-core'
 # Keep in sync with build_bazel_rules_nodejs in WORKSPACE.bzlmod
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
-archive_override(
+single_version_override(
+    version = "5.8.2",
     module_name = "rules_nodejs",
-    integrity = "sha256-dko7N1e7jDxqArozRHMaPXHlWCIK3LDPfkPJu6LDe6g=",
     patch_strip = 1,
     patches = [
-        "@@//buildpatches:bzlmod_rules_nodejs.patch",
         "@@//buildpatches:build_bazel_rules_nodejs.patch",
-    ],
-    urls = [
-        "https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -426,11 +426,16 @@ use_repo(
 # Note that this is 'rules_nodejs-core'
 # Keep in sync with build_bazel_rules_nodejs in WORKSPACE.bzlmod
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
-single_version_override(
+archive_override(
     module_name = "rules_nodejs",
+    integrity = "sha256-dko7N1e7jDxqArozRHMaPXHlWCIK3LDPfkPJu6LDe6g=",
     patch_strip = 1,
     patches = [
+        "@@//buildpatches:bzlmod_rules_nodejs.patch",
         "@@//buildpatches:build_bazel_rules_nodejs.patch",
+    ],
+    urls = [
+        "https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -465,7 +465,7 @@ load("@aspect_rules_swc//swc:repositories.bzl", "swc_register_toolchains")
 
 swc_register_toolchains(
     name = "swc",
-    swc_version =  "v1.3.78", # LATEST_SWC_VERSION
+    swc_version = "v1.3.78",  # LATEST_SWC_VERSION
 )
 
 # Web testing

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -465,7 +465,7 @@ load("@aspect_rules_swc//swc:repositories.bzl", "swc_register_toolchains")
 
 swc_register_toolchains(
     name = "swc",
-    swc_version = "v1.3.78",  # LATEST_SWC_VERSION
+    swc_version = "v1.3.78",
 )
 
 # Web testing

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -461,11 +461,11 @@ load("@aspect_rules_swc//swc:dependencies.bzl", "rules_swc_dependencies")
 
 rules_swc_dependencies()
 
-load("@aspect_rules_swc//swc:repositories.bzl", "LATEST_SWC_VERSION", "swc_register_toolchains")
+load("@aspect_rules_swc//swc:repositories.bzl", "swc_register_toolchains")
 
 swc_register_toolchains(
     name = "swc",
-    swc_version = LATEST_SWC_VERSION,
+    swc_version =  "v1.3.78", # LATEST_SWC_VERSION
 )
 
 # Web testing

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -450,23 +450,22 @@ load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "
 esbuild_repositories(npm_repository = "npm")
 
 # SWC (for transpiling TS -> JS)
-
 http_archive(
     name = "aspect_rules_swc",
-    sha256 = "206a89aae3a04831123b43962a3864e8ab1652b703c4af58d84b04174360137d",
-    strip_prefix = "rules_swc-0.4.0",
-    url = "https://github.com/aspect-build/rules_swc/archive/refs/tags/v0.4.0.tar.gz",
+    sha256 = "d63d7b283249fa942f78d2716ecff3edbdc10104ee1b9a6b9464ece471ef95ea",
+    strip_prefix = "rules_swc-2.0.0",
+    url = "https://github.com/aspect-build/rules_swc/releases/download/v2.0.0/rules_swc-v2.0.0.tar.gz",
 )
 
 load("@aspect_rules_swc//swc:dependencies.bzl", "rules_swc_dependencies")
 
 rules_swc_dependencies()
 
-load("@aspect_rules_swc//swc:repositories.bzl", "swc_register_toolchains")
+load("@aspect_rules_swc//swc:repositories.bzl", "LATEST_SWC_VERSION", "swc_register_toolchains")
 
 swc_register_toolchains(
     name = "swc",
-    swc_version = "v1.2.141",
+    swc_version = LATEST_SWC_VERSION,
 )
 
 # Web testing

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -184,26 +184,6 @@ load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "
 
 esbuild_repositories(npm_repository = "npm")
 
-# SWC (for transpiling TS -> JS)
-
-http_archive(
-    name = "aspect_rules_swc",
-    sha256 = "206a89aae3a04831123b43962a3864e8ab1652b703c4af58d84b04174360137d",
-    strip_prefix = "rules_swc-0.4.0",
-    url = "https://github.com/aspect-build/rules_swc/archive/refs/tags/v0.4.0.tar.gz",
-)
-
-load("@aspect_rules_swc//swc:dependencies.bzl", "rules_swc_dependencies")
-
-rules_swc_dependencies()
-
-load("@aspect_rules_swc//swc:repositories.bzl", "swc_register_toolchains")
-
-swc_register_toolchains(
-    name = "swc",
-    swc_version = "v1.2.141",
-)
-
 # Web testing
 
 http_archive(

--- a/buildpatches/bzlmod_rules_nodejs.patch
+++ b/buildpatches/bzlmod_rules_nodejs.patch
@@ -1,0 +1,22 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -0,0 +1,19 @@
++"bzlmod declaration for bazelbuild/rules_nodejs"
++
++module(
++    name = "rules_nodejs",
++    compatibility_level = 1,
++    version = "5.8.2",
++)
++
++bazel_dep(name = "bazel_skylib", version = "1.1.1")
++bazel_dep(name = "platforms", version = "0.0.5")
++
++node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
++
++# Note, this gets the default version of Node.js from
++# https://github.com/bazelbuild/rules_nodejs/blob/5.8.0/nodejs/repositories.bzl#L11
++node.toolchain(name = "nodejs")
++
++use_repo(node, "nodejs_toolchains")
++register_toolchains("@nodejs_toolchains//:all")

--- a/rules/typescript/index.bzl
+++ b/rules/typescript/index.bzl
@@ -1,10 +1,10 @@
-load("@aspect_rules_swc//swc:swc.bzl", "swc_transpiler")
+load("@aspect_rules_swc//swc:defs.bzl", "swc_compile")
 load("@npm//@bazel/esbuild:index.bzl", "esbuild")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("@npm//@bazel/typescript:index.bzl", "ts_project")
 
 def _swc(**kwargs):
-    swc_transpiler(
+    swc_compile(
         swcrc = "//:.swcrc",
         **kwargs
     )


### PR DESCRIPTION
Upgrade swc to the latest version so that we are not stuck with the
older aspect transitive dependencies such as their aspect_bazel_lib.

This should unlock us from experimenting with other aspect rules such as
rules_oci.
