### PR TITLE
Make --config=local builds work on Arm Macs when also using local executors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,6 +41,10 @@ common:remote --config=remote-shared
 common:remote --config=cache
 common:remote --remote_executor=grpcs://buildbuddy.buildbuddy.io
 
+
+common:linux --platforms=//platforms:linux_x86_64
+common:linux --extra_execution_platforms=//platforms:linux_x86_64
+
 #common:remote-linux --config=remote
 #common:remote-linux --platforms=//platforms:linux_x86_64
 #common:remote-linux --extra_execution_platforms=//platforms:linux_x86_64

--- a/.bazelrc
+++ b/.bazelrc
@@ -250,6 +250,10 @@ common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 common:macos --macos_minimum_os=12.0
 common:macos --host_macos_minimum_os=12.0
 
+# Make --config=local builds work on Arm Macs when also using local executors.
+common:macos --platforms=//platforms:macos_arm64
+common:macos --extra_execution_platforms=//platforms:macos_arm64
+
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.
 common:webdriver-debug --test_arg=-webdriver_headless=false

--- a/.bazelrc
+++ b/.bazelrc
@@ -35,13 +35,15 @@ common:remote-shared --remote_timeout=600
 common:remote-shared --remote_download_minimal
 common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
-common:remote-shared --platforms=//platforms:linux_x86_64
-common:remote-shared --extra_execution_platforms=//platforms:linux_x86_64
 
 # Build with --config=remote to use BuildBuddy RBE.
 common:remote --config=remote-shared
 common:remote --config=cache
 common:remote --remote_executor=grpcs://buildbuddy.buildbuddy.io
+
+#common:remote-linux --config=remote
+#common:remote-linux --platforms=//platforms:linux_x86_64
+#common:remote-linux --extra_execution_platforms=//platforms:linux_x86_64
 
 # Build with --config=remote-dev to use BuildBuddy RBE.
 common:remote-dev --config=remote-shared
@@ -251,8 +253,8 @@ common:macos --macos_minimum_os=12.0
 common:macos --host_macos_minimum_os=12.0
 
 # Make --config=local builds work on Arm Macs when also using local executors.
-common:macos --platforms=//platforms:macos_arm64
-common:macos --extra_execution_platforms=//platforms:macos_arm64
+#common:macos --platforms=//platforms:macos_arm64
+#common:macos --extra_execution_platforms=//platforms:macos_arm64
 
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.


### PR DESCRIPTION
Without these flags, remote execution fails because bazel tries to build for the linux_arm64 platform, and the locally running RBE doesn't support that.
