### PR TITLE
CLI: prevent option schema parsing from killing existing server

### DIFF
--- a/cli/test/integration/cli/BUILD
+++ b/cli/test/integration/cli/BUILD
@@ -19,6 +19,7 @@ go_test(
         "//server/testutil/testgit",
         "//server/util/retry",
         "@com_github_google_uuid//:uuid",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
Run `bazel help` in its own `output_base` so that we don't kill any running bazel server instance in the current workspace.