### PR TITLE
Cache Proxy: add grafana graph tracking atime_updater performance

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -80,7 +80,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 201
+            "y": 217
           },
           "hiddenSeries": false,
           "id": 21,
@@ -187,7 +187,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 208
+            "y": 224
           },
           "hiddenSeries": false,
           "id": 6270,
@@ -284,7 +284,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 215
+            "y": 231
           },
           "hiddenSeries": false,
           "id": 932,
@@ -420,7 +420,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 215
+            "y": 231
           },
           "id": 5492,
           "options": {
@@ -493,7 +493,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 130
+            "y": 146
           },
           "hiddenSeries": false,
           "id": 348,
@@ -581,7 +581,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 130
+            "y": 146
           },
           "hiddenSeries": false,
           "id": 804,
@@ -701,7 +701,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 3
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 6840,
@@ -794,7 +794,7 @@
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 3
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 25,
@@ -888,7 +888,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 11
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 1232,
@@ -1002,7 +1002,7 @@
             "h": 8,
             "w": 12,
             "x": 9,
-            "y": 11
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 65,
@@ -1096,7 +1096,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 19
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 13,
@@ -1262,7 +1262,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 204
+            "y": 220
           },
           "id": 1182,
           "options": {
@@ -1358,7 +1358,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 204
+            "y": 220
           },
           "id": 1186,
           "options": {
@@ -1451,7 +1451,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 212
+            "y": 228
           },
           "id": 1183,
           "options": {
@@ -1545,7 +1545,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 212
+            "y": 228
           },
           "id": 1187,
           "options": {
@@ -1638,7 +1638,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 220
+            "y": 236
           },
           "id": 1184,
           "options": {
@@ -1732,7 +1732,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 220
+            "y": 236
           },
           "id": 1188,
           "options": {
@@ -1805,7 +1805,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 349
+            "y": 365
           },
           "hiddenSeries": false,
           "id": 230,
@@ -1894,7 +1894,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 349
+            "y": 365
           },
           "hiddenSeries": false,
           "id": 310,
@@ -1993,7 +1993,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 357
+            "y": 373
           },
           "hiddenSeries": false,
           "id": 312,
@@ -2110,7 +2110,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 359
+            "y": 375
           },
           "hiddenSeries": false,
           "id": 254,
@@ -2206,7 +2206,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 359
+            "y": 375
           },
           "hiddenSeries": false,
           "id": 251,
@@ -2331,7 +2331,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 367
+            "y": 383
           },
           "hiddenSeries": false,
           "id": 250,
@@ -2457,7 +2457,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 367
+            "y": 383
           },
           "hiddenSeries": false,
           "id": 252,
@@ -2583,7 +2583,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 375
+            "y": 391
           },
           "hiddenSeries": false,
           "id": 253,
@@ -2737,7 +2737,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 103
+            "y": 119
           },
           "hiddenSeries": false,
           "id": 17,
@@ -2828,7 +2828,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 103
+            "y": 119
           },
           "hiddenSeries": false,
           "id": 19,
@@ -2921,7 +2921,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 111
+            "y": 127
           },
           "hiddenSeries": false,
           "id": 4,
@@ -3031,7 +3031,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 111
+            "y": 127
           },
           "hiddenSeries": false,
           "id": 9,
@@ -3170,7 +3170,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 120
+            "y": 136
           },
           "id": 6656,
           "options": {
@@ -3263,7 +3263,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 120
+            "y": 136
           },
           "id": 6834,
           "options": {
@@ -3318,7 +3318,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 128
+            "y": 144
           },
           "hiddenSeries": false,
           "id": 646,
@@ -3432,7 +3432,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 136
+            "y": 152
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -3583,7 +3583,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 144
+            "y": 160
           },
           "id": 1338,
           "options": {
@@ -3684,7 +3684,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 152
+            "y": 168
           },
           "id": 2135,
           "options": {
@@ -3816,7 +3816,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152
+            "y": 168
           },
           "id": 6732,
           "options": {
@@ -3937,7 +3937,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 160
+            "y": 176
           },
           "id": 6422,
           "options": {
@@ -4033,7 +4033,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 168
+            "y": 184
           },
           "id": 6428,
           "options": {
@@ -4131,7 +4131,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 176
+            "y": 192
           },
           "id": 2182,
           "options": {
@@ -4203,7 +4203,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 184
+            "y": 200
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -4373,7 +4373,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 177
+            "y": 193
           },
           "id": 6580,
           "options": {
@@ -4493,7 +4493,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 185
+            "y": 201
           },
           "id": 3763,
           "options": {
@@ -4622,7 +4622,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 193
+            "y": 209
           },
           "id": 5574,
           "options": {
@@ -4776,7 +4776,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 201
+            "y": 217
           },
           "id": 3846,
           "options": {
@@ -4872,7 +4872,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 209
+            "y": 225
           },
           "id": 5160,
           "options": {
@@ -4968,7 +4968,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 217
+            "y": 233
           },
           "id": 5242,
           "options": {
@@ -5063,7 +5063,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 225
+            "y": 241
           },
           "id": 5324,
           "options": {
@@ -5158,7 +5158,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 233
+            "y": 249
           },
           "id": 5406,
           "options": {
@@ -5265,7 +5265,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 213
+            "y": 229
           },
           "id": 3929,
           "options": {
@@ -5357,7 +5357,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 213
+            "y": 229
           },
           "id": 4011,
           "options": {
@@ -5449,7 +5449,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 221
+            "y": 237
           },
           "id": 4093,
           "options": {
@@ -5541,7 +5541,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 221
+            "y": 237
           },
           "id": 4175,
           "options": {
@@ -5633,7 +5633,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 229
+            "y": 245
           },
           "id": 4257,
           "options": {
@@ -5725,7 +5725,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 229
+            "y": 245
           },
           "id": 4339,
           "options": {
@@ -5817,7 +5817,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 237
+            "y": 253
           },
           "id": 4421,
           "options": {
@@ -5909,7 +5909,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 237
+            "y": 253
           },
           "id": 4503,
           "options": {
@@ -6001,7 +6001,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 245
+            "y": 261
           },
           "id": 4585,
           "options": {
@@ -6093,7 +6093,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 245
+            "y": 261
           },
           "id": 4667,
           "options": {
@@ -6185,7 +6185,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 253
+            "y": 269
           },
           "id": 4749,
           "options": {
@@ -6277,7 +6277,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 253
+            "y": 269
           },
           "id": 4831,
           "options": {
@@ -6369,7 +6369,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 261
+            "y": 277
           },
           "id": 4913,
           "options": {
@@ -6444,7 +6444,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 354
+            "y": 370
           },
           "hiddenSeries": false,
           "id": 274,
@@ -6563,7 +6563,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 354
+            "y": 370
           },
           "hiddenSeries": false,
           "id": 276,
@@ -6660,7 +6660,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 362
+            "y": 378
           },
           "hiddenSeries": false,
           "id": 290,
@@ -6757,7 +6757,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 362
+            "y": 378
           },
           "hiddenSeries": false,
           "id": 292,
@@ -6854,7 +6854,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 370
+            "y": 386
           },
           "hiddenSeries": false,
           "id": 278,
@@ -6951,7 +6951,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 370
+            "y": 386
           },
           "hiddenSeries": false,
           "id": 280,
@@ -7117,7 +7117,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 190
+            "y": 206
           },
           "id": 40,
           "options": {
@@ -7259,7 +7259,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 203
+            "y": 219
           },
           "id": 76,
           "options": {
@@ -7315,7 +7315,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 217
+            "y": 233
           },
           "hiddenSeries": false,
           "id": 42,
@@ -7407,7 +7407,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 217
+            "y": 233
           },
           "hiddenSeries": false,
           "id": 46,
@@ -7499,7 +7499,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 225
+            "y": 241
           },
           "hiddenSeries": false,
           "id": 44,
@@ -7628,7 +7628,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 209
+            "y": 225
           },
           "hiddenSeries": false,
           "id": 498,
@@ -7727,7 +7727,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 209
+            "y": 225
           },
           "hiddenSeries": false,
           "id": 542,
@@ -7865,7 +7865,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 218
+            "y": 234
           },
           "hideTimeOverride": true,
           "id": 506,
@@ -7930,7 +7930,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 227
+            "y": 243
           },
           "hiddenSeries": false,
           "id": 496,
@@ -8034,7 +8034,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 237
+            "y": 253
           },
           "hiddenSeries": false,
           "id": 500,
@@ -8138,7 +8138,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 237
+            "y": 253
           },
           "hiddenSeries": false,
           "id": 504,
@@ -8260,7 +8260,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 50,
@@ -8351,7 +8351,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 53,
@@ -8441,7 +8441,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 48
           },
           "hiddenSeries": false,
           "id": 51,
@@ -8532,7 +8532,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 48
           },
           "hiddenSeries": false,
           "id": 55,
@@ -8696,7 +8696,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 121
+            "y": 137
           },
           "id": 742,
           "options": {
@@ -8799,7 +8799,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 121
+            "y": 137
           },
           "id": 422,
           "options": {
@@ -8899,7 +8899,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 129
+            "y": 145
           },
           "id": 420,
           "options": {
@@ -8999,7 +8999,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 129
+            "y": 145
           },
           "id": 6504,
           "options": {
@@ -9148,7 +9148,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 137
+            "y": 153
           },
           "id": 1223,
           "options": {
@@ -9319,7 +9319,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 137
+            "y": 153
           },
           "id": 1224,
           "options": {
@@ -9375,7 +9375,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 145
+            "y": 161
           },
           "id": 6943,
           "options": {
@@ -9467,7 +9467,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 145
+            "y": 161
           },
           "id": 6944,
           "options": {
@@ -9587,7 +9587,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 153
+            "y": 169
           },
           "id": 7133,
           "options": {
@@ -9776,7 +9776,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 153
+            "y": 169
           },
           "id": 7039,
           "options": {
@@ -9924,7 +9924,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 122,
@@ -10013,7 +10013,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 116,
@@ -10106,7 +10106,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 112,
@@ -10202,7 +10202,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 120,
@@ -10296,7 +10296,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 118,
@@ -10385,7 +10385,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 124,
@@ -10481,227 +10481,361 @@
         "y": 18
       },
       "id": 7916,
-      "panels": [
-        {
-          "aliasColors": {
-            "Failure": "dark-red",
-            "failure": "red",
-            "success": "green"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 19
-          },
-          "hiddenSeries": false,
-          "id": 8022,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "editorMode": "code",
-              "expr": "sum by (status) (rate(buildbuddy_proxy_byte_stream_reads{region=\"${region}\"}[${window}]))",
-              "interval": "",
-              "legendFormat": "{{invocation_status}}",
-              "queryType": "randomWalk",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Bytestream Proxy Performance",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:608",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:609",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {
-            "Failure": "dark-red",
-            "failure": "red",
-            "success": "green"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 19
-          },
-          "hiddenSeries": false,
-          "id": 8128,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:590",
-              "alias": "/digest.*/",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "editorMode": "code",
-              "expr": "sum by (status) (rate(buildbuddy_proxy_content_addressable_storage_reads{region=\"${region}\"}[${window}]))",
-              "format": "time_series",
-              "interval": "",
-              "legendFormat": "request {{status}}",
-              "queryType": "randomWalk",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "editorMode": "code",
-              "expr": "sum by (status) (rate(buildbuddy_proxy_content_addressable_storage_digest_reads{region=\"${region}\"}[${window}]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "digest {{status}}",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "CAS Proxy Performance",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:608",
-              "format": "string",
-              "label": "",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:609",
-              "format": "ops",
-              "label": "",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": true
-          }
-        }
-      ],
+      "panels": [],
       "title": "Cache proxy",
       "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Failure": "dark-red",
+        "failure": "red",
+        "success": "green"
+      },
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 8022,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(buildbuddy_proxy_byte_stream_reads{region=\"${region}\"}[${window}]))",
+          "interval": "",
+          "legendFormat": "{{invocation_status}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Bytestream Proxy Performance",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:608",
+          "format": "ops",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:609",
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {
+        "Failure": "dark-red",
+        "failure": "red",
+        "success": "green"
+      },
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 8128,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:590",
+          "alias": "/digest.*/",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(buildbuddy_proxy_content_addressable_storage_reads{region=\"${region}\"}[${window}]))",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "request {{status}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(buildbuddy_proxy_content_addressable_storage_digest_reads{region=\"${region}\"}[${window}]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "digest {{status}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "CAS Proxy Performance",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:608",
+          "format": "string",
+          "label": "",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:609",
+          "format": "ops",
+          "label": "",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": true
+      }
+    },
+    {
+      "aliasColors": {
+        "Failure": "dark-red",
+        "failure": "red",
+        "success": "green"
+      },
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          }
+        ]
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 8406,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:435",
+          "alias": "/request.*/",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(buildbuddy_proxy_remote_atime_updates{region=\"${region}\"}[${window}]))",
+          "interval": "",
+          "legendFormat": "digest {{status}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(buildbuddy_proxy_remote_atime_update_requests{region=\"${region}\"}[${window}]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "request {{status}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Remote Atime Updates (per-digest)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:608",
+          "format": "reqps",
+          "label": "",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:609",
+          "format": "reqps",
+          "label": "",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
     },
     {
       "collapsed": true,
@@ -10713,7 +10847,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 35
       },
       "id": 28,
       "panels": [
@@ -10736,7 +10870,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 112
+            "y": 128
           },
           "hiddenSeries": false,
           "id": 190,
@@ -10984,7 +11118,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 112
+            "y": 128
           },
           "id": 159,
           "options": {
@@ -11083,7 +11217,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 120
+            "y": 136
           },
           "hiddenSeries": false,
           "id": 210,
@@ -11222,7 +11356,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 120
+            "y": 136
           },
           "id": 1209,
           "options": {
@@ -11317,7 +11451,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 128
+            "y": 144
           },
           "id": 31,
           "options": {
@@ -11367,7 +11501,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 128
+            "y": 144
           },
           "hiddenSeries": false,
           "id": 178,
@@ -11516,7 +11650,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 136
+            "y": 152
           },
           "id": 1216,
           "options": {
@@ -11646,7 +11780,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 136
+            "y": 152
           },
           "id": 1231,
           "options": {
@@ -11730,7 +11864,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 144
+            "y": 160
           },
           "hiddenSeries": false,
           "id": 33,
@@ -11822,7 +11956,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 144
+            "y": 160
           },
           "hiddenSeries": false,
           "id": 35,
@@ -11912,7 +12046,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152
+            "y": 168
           },
           "hiddenSeries": false,
           "id": 129,
@@ -12005,7 +12139,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152
+            "y": 168
           },
           "hiddenSeries": false,
           "id": 102,
@@ -12146,7 +12280,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 160
+            "y": 176
           },
           "id": 1195,
           "options": {
@@ -12193,7 +12327,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 160
+            "y": 176
           },
           "hiddenSeries": false,
           "id": 180,
@@ -12335,7 +12469,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 168
+            "y": 184
           },
           "id": 1202,
           "options": {
@@ -12494,7 +12628,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 168
+            "y": 184
           },
           "id": 1196,
           "options": {
@@ -12552,7 +12686,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 176
+            "y": 192
           },
           "id": 7139,
           "options": {
@@ -12633,7 +12767,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 176
+            "y": 192
           },
           "id": 7145,
           "options": {
@@ -12714,7 +12848,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 184
+            "y": 200
           },
           "id": 7151,
           "options": {
@@ -12795,7 +12929,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 184
+            "y": 200
           },
           "id": 7157,
           "options": {
@@ -12876,7 +13010,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 192
+            "y": 208
           },
           "id": 7163,
           "options": {
@@ -12957,7 +13091,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 192
+            "y": 208
           },
           "id": 7169,
           "options": {
@@ -13037,7 +13171,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 38
       },
       "id": 83,
       "panels": [
@@ -13057,7 +13191,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 119
+            "y": 135
           },
           "hiddenSeries": false,
           "id": 85,
@@ -13160,7 +13294,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 119
+            "y": 135
           },
           "hiddenSeries": false,
           "id": 87,
@@ -13254,7 +13388,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 128
+            "y": 144
           },
           "hiddenSeries": false,
           "id": 91,
@@ -13347,7 +13481,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 128
+            "y": 144
           },
           "hiddenSeries": false,
           "id": 93,
@@ -13450,7 +13584,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 43
       },
       "id": 71,
       "panels": [
@@ -13486,7 +13620,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 73,
@@ -13579,7 +13713,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 79,
@@ -13718,7 +13852,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 67
           },
           "id": 2087,
           "options": {
@@ -13820,7 +13954,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 67
           },
           "id": 2039,
           "options": {
@@ -13891,7 +14025,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 48
       },
       "id": 1088,
       "panels": [
@@ -13957,7 +14091,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 227
+            "y": 243
           },
           "id": 1127,
           "options": {
@@ -14053,7 +14187,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 227
+            "y": 243
           },
           "id": 1166,
           "options": {
@@ -14162,7 +14296,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 235
+            "y": 251
           },
           "id": 1168,
           "options": {
@@ -14233,7 +14367,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 55
       },
       "id": 8,
       "panels": [
@@ -14255,7 +14389,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 308
+            "y": 324
           },
           "hiddenSeries": false,
           "id": 2,
@@ -14368,7 +14502,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 308
+            "y": 324
           },
           "hiddenSeries": false,
           "id": 578,
@@ -14465,7 +14599,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 56
       },
       "id": 1346,
       "panels": [
@@ -14485,7 +14619,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 353
+            "y": 369
           },
           "hiddenSeries": false,
           "id": 2556,
@@ -14592,7 +14726,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 366
+            "y": 382
           },
           "hiddenSeries": false,
           "id": 2840,
@@ -14691,7 +14825,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 380
+            "y": 396
           },
           "hiddenSeries": false,
           "id": 2890,
@@ -14785,7 +14919,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 380
+            "y": 396
           },
           "hiddenSeries": false,
           "id": 2940,
@@ -14923,7 +15057,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 388
+            "y": 404
           },
           "id": 1353,
           "links": [
@@ -14979,7 +15113,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 57
       },
       "id": 5641,
       "panels": [
@@ -15045,7 +15179,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 137
+            "y": 153
           },
           "id": 5595,
           "options": {
@@ -15138,7 +15272,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 137
+            "y": 153
           },
           "id": 5608,
           "options": {
@@ -15232,7 +15366,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 145
+            "y": 161
           },
           "id": 5622,
           "options": {
@@ -15326,7 +15460,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 145
+            "y": 161
           },
           "id": 5629,
           "options": {
@@ -15419,7 +15553,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 153
+            "y": 169
           },
           "id": 5615,
           "options": {
@@ -15460,7 +15594,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 58
       },
       "id": 7275,
       "panels": [
@@ -15528,7 +15662,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 91
+            "y": 107
           },
           "id": 7381,
           "options": {
@@ -15649,7 +15783,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 91
+            "y": 107
           },
           "id": 7382,
           "options": {
@@ -15748,7 +15882,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 99
+            "y": 115
           },
           "id": 7489,
           "options": {
@@ -15847,7 +15981,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 99
+            "y": 115
           },
           "id": 7488,
           "options": {
@@ -15943,7 +16077,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 107
+            "y": 123
           },
           "id": 7595,
           "options": {


### PR DESCRIPTION
This PR adds a graph displaying these two metrics, which track performance of the async remote atime updater: https://github.com/buildbuddy-io/buildbuddy/blob/456426d2e0193f062162a681ec2ae414b0f20bf6/server/metrics/metrics.go#L2789-L2809

![Screenshot 2024-09-25 at 12 13 47 PM](https://github.com/user-attachments/assets/1e820dc1-2ad2-47ae-afbb-39356ec5687e)

**Related issues**: N/A
