### PR TITLE
Preserve window hash when navigating in editor

### DIFF
--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -854,7 +854,11 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
   }
 
   navigateToPath(path: string) {
-    window.history.pushState(undefined, "", `/code/${this.currentOwner()}/${this.currentRepo()}/${path}`);
+    window.history.pushState(
+      undefined,
+      "",
+      `/code/${this.currentOwner()}/${this.currentRepo()}/${path}${window.location.hash}`
+    );
   }
 
   async handleBuildClicked(args: string) {


### PR DESCRIPTION
This prevents the line number from getting lost during navigation.