### PR TITLE
[raft] size

### DIFF
--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//server/util/proto",
         "//server/util/status",
         "//server/util/statusz",
+        "@com_github_elastic_gosigar//:gosigar",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go-grpc-prometheus",
         "@com_github_hashicorp_serf//serf",
         "@com_github_jonboulle_clockwork//:clockwork",

--- a/enterprise/server/raft/usagetracker/BUILD
+++ b/enterprise/server/raft/usagetracker/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//server/util/status",
         "//server/util/timeutil",
         "@com_github_docker_go_units//:go-units",
-        "@com_github_elastic_gosigar//:gosigar",
         "@com_github_hashicorp_serf//serf",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
1. DiskCachePartitionUsage should report local usage instead of global usage.
   Right now per-pod partition usage is the same. It's less useful to monitor.
   We can sum them together if we want to know the global partition usage.
2. when we calculate store usage, use file system free and used instead of
   parition size. 
