### PR TITLE
reviews: add shortcut to go straight to GitHub PR page

### DIFF
--- a/enterprise/app/review/review_list.tsx
+++ b/enterprise/app/review/review_list.tsx
@@ -163,6 +163,17 @@ interface PRProps {
 }
 
 class PR extends React.Component<PRProps> {
+  private onClick(e: React.MouseEvent<HTMLAnchorElement>) {
+    if (e.ctrlKey && e.shiftKey) {
+      // When clicking with Ctrl+Shift+Click, go directly to the GitHub PR page.
+      e.preventDefault();
+      window.open(
+        `https://github.com/${this.props.pr.owner}/${this.props.pr.repo}/pull/${Number(this.props.pr.number)}`,
+        "_blank"
+      );
+    }
+  }
+
   render() {
     let reviewers: React.ReactNode[] = [];
     let unresolved = false;
@@ -192,7 +203,10 @@ class PR extends React.Component<PRProps> {
     }
 
     return (
-      <Link className="pr" href={router.getReviewUrl(this.props.pr.owner, this.props.pr.repo, +this.props.pr.number)}>
+      <Link
+        className="pr"
+        href={router.getReviewUrl(this.props.pr.owner, this.props.pr.repo, +this.props.pr.number)}
+        onClick={(e) => this.onClick(e)}>
         <div>{this.props.pr.number}</div>
         <div>{this.props.pr.author}</div>
         <div>


### PR DESCRIPTION
For browsing PRs, I prefer our review listing over GitHub's, so I use the reviews page heavily. But after clicking a review, I always click the little GitHub icon to go to the pull requests page, because I find the GitHub review page easier to use.

This change makes it so that clicking a review with Ctrl+Shift+Click goes straight to the GitHub PR page (in a new tab), to save a little bit of time.

**Related issues**: N/A
