### PR TITLE
Fix --remote_header propagation in CLI local cache proxy

### DIFF
--- a/server/cache_proxy/cache_proxy.go
+++ b/server/cache_proxy/cache_proxy.go
@@ -417,6 +417,10 @@ func (qw *queueWorker) EnqueueRemoteWrite(ctx context.Context, wreq *bspb.WriteR
 }
 
 func (qw *queueWorker) RemoteWriteBlocked(ctx context.Context, wreq *bspb.WriteRequest) error {
+	// Copy all incoming metadata to outgoing RPCs.
+	md, _ := metadata.FromIncomingContext(ctx)
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
 	return qw.handleWriteRequest(ctx, wreq.GetResourceName())
 }
 


### PR DESCRIPTION
Fixes a small regression from https://github.com/buildbuddy-io/buildbuddy/pull/7563

The PR restructured some things so that we can use `log.Ctx*` to get more helpful logs. But it introduced a bug - the previous code was correctly propagating _all_ gRPC metadata to the remote cache (i.e. all `--remote_header` values) but that PR made it so that we only propagate the metadata allowed by the RPC interceptors (API key, bazel requestmetadata, etc.)