### PR TITLE
[RB] Fix a couple bazel button bugs

### DIFF
--- a/app/target/target_v2.tsx
+++ b/app/target/target_v2.tsx
@@ -22,7 +22,7 @@ import CacheRequestsCardComponent from "../invocation/cache_requests_card";
 import InvocationModel from "../invocation/invocation_model";
 import FlakyTargetChipComponent from "./flaky_target_chip";
 import { OutlinedButton } from "../components/button/button";
-import { supportsRemoteRun, triggerRemoteRun } from "../util/remote_runner";
+import { commandWithRemoteRunnerFlags, supportsRemoteRun, triggerRemoteRun } from "../util/remote_runner";
 import LinkGithubRepoModal from "../invocation/link_github_repo_modal";
 
 const Status = api_common.v1.Status;
@@ -244,8 +244,10 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
       this.setState({ isLinkRepoModalOpen: true });
       return;
     }
-    const command = `bazel query "allpaths(${this.props.model.invocation.pattern}, ${target})" --output=graph`;
-    triggerRemoteRun(this.props.model, command, true /*autoOpenChild*/);
+    const command = commandWithRemoteRunnerFlags(
+      `bazel query "allpaths(${this.props.model.invocation.pattern}, ${target})" --output=graph`
+    );
+    triggerRemoteRun(this.props.model, command, true /*autoOpenChild*/, null);
   }
 
   render() {

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -178,6 +178,7 @@ ts_library(
         "//app/service:rpc_service",
         "//proto:git_ts_proto",
         "//proto:github_ts_proto",
+        "//proto:remote_execution_ts_proto",
         "//proto:runner_ts_proto",
         "@npm//tslib",
     ],

--- a/app/util/remote_runner.tsx
+++ b/app/util/remote_runner.tsx
@@ -71,8 +71,9 @@ export function triggerRemoteRun(
 
 // commandWithRemoteRunnerFlags adds useful flags to bazel commands run on a remote runner
 export function commandWithRemoteRunnerFlags(command: string): string {
-  // The buildbuddy_ configs point to the corresponding env that created the workflow
-  // action (Ex. If it was created in dev, points to the dev app)
+  // The buildbuddy_ configs point to the corresponding env that created the remote runner
+  // action (Ex. If it was created in dev, points to the dev app).
+  // These configs are defined in a .bazelrc the ci_runner creates in ci_runner/main.go
   const addlFlags =
     "--remote_cache_compression --config=buildbuddy_bes_backend --config=buildbuddy_bes_results_url --config=buildbuddy_remote_cache";
   command = appendBazelSubCommandArgs(command, addlFlags);

--- a/app/util/remote_runner.tsx
+++ b/app/util/remote_runner.tsx
@@ -4,17 +4,32 @@ import { runner } from "../../proto/runner_ts_proto";
 import rpcService from "../service/rpc_service";
 import { github } from "../../proto/github_ts_proto";
 import error_service from "../errors/error_service";
+import { build } from "../../proto/remote_execution_ts_proto";
 
 export async function supportsRemoteRun(repoUrl: string): Promise<boolean> {
   const rsp = await rpcService.service.getLinkedGitHubRepos(new github.GetLinkedReposRequest());
   return rsp.repoUrls.filter((url) => url === repoUrl).length > 0;
 }
 
-export function triggerRemoteRun(invocationModel: InvocationModel, command: string, autoOpenChild: boolean) {
-  const addlFlags =
-    "--remote_cache_compression --config=buildbuddy_bes_backend --config=buildbuddy_bes_results_url --config=buildbuddy_remote_cache";
-  command = appendBazelSubCommandArgs(command, addlFlags);
+export function triggerRemoteRun(
+  invocationModel: InvocationModel,
+  command: string,
+  autoOpenChild: boolean,
+  platformProps: Map<string, string> | null
+) {
   command = command.replaceAll(/--[a-zA-Z_]+='\<REDACTED\>'/g, "");
+  let execProps: build.bazel.remote.execution.v2.Platform.Property[] = [];
+  if (platformProps) {
+    for (let [key, value] of platformProps) {
+      execProps.push(
+        new build.bazel.remote.execution.v2.Platform.Property({
+          name: key,
+          value: value,
+        })
+      );
+    }
+  }
+
   const request = new runner.RunRequest({
     gitRepo: new git.GitRepo({
       repoUrl: invocationModel.getRepo(),
@@ -37,6 +52,7 @@ export function triggerRemoteRun(invocationModel: InvocationModel, command: stri
       GIT_REPO_DEFAULT_BRANCH: "master",
       GIT_BASE_BRANCH: "main",
     },
+    execProperties: execProps,
   });
 
   rpcService.service
@@ -51,6 +67,16 @@ export function triggerRemoteRun(invocationModel: InvocationModel, command: stri
     .catch((error) => {
       error_service.handleError(error);
     });
+}
+
+// commandWithRemoteRunnerFlags adds useful flags to bazel commands run on a remote runner
+export function commandWithRemoteRunnerFlags(command: string): string {
+  // The buildbuddy_ configs point to the corresponding env that created the workflow
+  // action (Ex. If it was created in dev, points to the dev app)
+  const addlFlags =
+    "--remote_cache_compression --config=buildbuddy_bes_backend --config=buildbuddy_bes_results_url --config=buildbuddy_remote_cache";
+  command = appendBazelSubCommandArgs(command, addlFlags);
+  return command;
 }
 
 // appendBazelSubcommandArgs appends bazel arguments to a bazel command

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -147,10 +147,15 @@ var (
 	// of separate scripts.
 	credentialHelper = flag.Bool("credential_helper", false, "Run in git credential helper mode. For internal usage only.")
 
-	besBackend         = flag.String("bes_backend", "", "gRPC endpoint for BuildBuddy's BES backend.")
-	cacheBackend       = flag.String("cache_backend", "", "gRPC endpoint for BuildBuddy Cache.")
-	rbeBackend         = flag.String("rbe_backend", "", "gRPC endpoint for BuildBuddy RBE.")
-	besResultsURL      = flag.String("bes_results_url", "", "URL prefix for BuildBuddy invocation URLs.")
+	// In order to ensure bazel commands point to the correct env (Ex. if the remote
+	// run was triggered in dev, it should point to the dev app), set --config=buildbuddy_bes_backend,
+	// --config=buildbuddy_bes_results_url --config=buildbuddy_remote_cache, and/or --config=buildbuddy_remote_executor.
+	// These configs are defined in a .bazelrc the ci_runner creates.
+	besBackend    = flag.String("bes_backend", "", "gRPC endpoint for BuildBuddy's BES backend.")
+	cacheBackend  = flag.String("cache_backend", "", "gRPC endpoint for BuildBuddy Cache.")
+	rbeBackend    = flag.String("rbe_backend", "", "gRPC endpoint for BuildBuddy RBE.")
+	besResultsURL = flag.String("bes_results_url", "", "URL prefix for BuildBuddy invocation URLs.")
+
 	remoteInstanceName = flag.String("remote_instance_name", "", "Remote instance name used to retrieve patches (for hosted bazel) or the remote instance name running the workflow action.")
 	workflowID         = flag.String("workflow_id", "", "ID of the workflow associated with this CI run.")
 	actionName         = flag.String("action_name", "", "If set, run the specified action and *only* that action, ignoring trigger conditions.")
@@ -2347,9 +2352,9 @@ func writeBazelrc(path, invocationID, runID, rootDir string) error {
 		lines = append(lines, "common --bes_header=x-buildbuddy-client-identity="+identity)
 	}
 
-	// Primitive configs pointing to BB endpoints. These are purposely very
-	// fine-grained and do not include any options other than the backend
-	// URLs for now. They are all prefixed with "buildbuddy_" to avoid conflicting
+	// These configs point to the same env that triggered the remote run
+	// (i.e. if the remote run was triggered in dev, they point to the dev app).
+	// They are all prefixed with "buildbuddy_" to avoid conflicting
 	// with existing .bazelrc configs in the wild.
 	lines = append(lines, []string{
 		"common:buildbuddy_bes_backend --bes_backend=" + *besBackend,


### PR DESCRIPTION
* Add a missing space in a command
* Only add bazel flags to bazel commands
* Support platform properties
* For the bb explain button, use commit shas rather than branches when comparing 2 invocations
**Related issues**: N/A
