### PR TITLE
Add more diagnostics for CLI BES timeouts

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -224,7 +224,7 @@ func handleBazelCommand(start time.Time, args []string, originalArgs []string) (
 
 	// If bazel failed, show sidecar warnings/errors to help diagnose.
 	if exitCode != 0 && exitCode != bazelExitCodeTestFailure && sidecar != nil {
-		sidecar.PrintWarningsSince(start)
+		sidecar.PrintLogsSince(start)
 	}
 
 	return exitCode, nil

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -162,7 +162,7 @@ type Instance struct {
 	LogPath string
 }
 
-func (i *Instance) PrintWarningsSince(t time.Time) {
+func (i *Instance) PrintLogsSince(t time.Time) {
 	// TODO: only look at tail of logs, to limit IO
 	f, err := os.Open(i.LogPath)
 	if err != nil {
@@ -177,14 +177,11 @@ func (i *Instance) PrintWarningsSince(t time.Time) {
 		if !ok || !lt.After(t) {
 			continue
 		}
-		if !strings.Contains(line, "WRN") && !strings.Contains(line, "ERR") {
-			continue
-		}
 		lines = append(lines, line)
 	}
 	if len(lines) > 0 {
 		os.Stderr.WriteString("---\n")
-		log.Warnf("BuildBuddy CLI sidecar errors during this build:")
+		log.Printf("BuildBuddy CLI sidecar logs for this build:")
 		for _, line := range lines {
 			fmt.Print(line)
 			if !strings.HasSuffix(line, "\n") {

--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -116,6 +116,10 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 		forwardingStreams = append(forwardingStreams, fwdStream)
 	}
 
+	if len(forwardingStreams) > 0 {
+		log.CtxInfof(ctx, "Started build event forwarding streams")
+	}
+
 	disconnectWithErr := func(e error) error {
 		if channel != nil && streamID != nil {
 			log.CtxWarningf(ctx, "Disconnecting invocation %q: %s", streamID.InvocationId, e)
@@ -150,6 +154,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 			if err == io.EOF {
 				if s.synchronous {
 					// Close the streams early so that we can Wait() for any forwarding errors.
+					log.CtxInfof(ctx, "Closing build event forwarding stream")
 					closeStreamsOnce.Do(func() { closeForwardingStreams(forwardingStreams) })
 					if err := eg.Wait(); err != nil {
 						return disconnectWithErr(err)


### PR DESCRIPTION
- Log slow write warnings periodically instead of just once
- Add some info-level logs for BES proxying lifecycle
- Dump all logs on failure, not just warning/info

**Related issues**: N/A
