### PR TITLE
Fix artifact downloads in UI when remote_bytestream_uri_prefix is set

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -367,11 +367,26 @@ export default class InvocationModel {
     return "Cache on";
   }
 
+  private parseBytestreamURIPrefix(): URL | null {
+    let prefix = this.optionsMap.get("remote_bytestream_uri_prefix");
+    if (!prefix) return null;
+    try {
+      return new URL(prefix);
+    } catch {
+      return null; // invalid URL
+    }
+  }
+
   /**
    * Returns the hostname or hostname:port of the cache address used as the
    * remote cache target for this invocation.
    */
   private getCacheAddress(): string | undefined {
+    const prefix = this.parseBytestreamURIPrefix();
+    if (prefix) {
+      return prefix.host;
+    }
+
     const orderedOptions = ["remote_cache", "remote_executor", "cache_backend", "rbe_backend"];
 
     for (const optionName of orderedOptions) {


### PR DESCRIPTION
Context: https://buildbuddy-corp.slack.com/archives/C03JL0YT6G5/p1727292745614949
