### PR TITLE
Fix bytestream_uri_prefix parsing

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -367,13 +367,25 @@ export default class InvocationModel {
     return "Cache on";
   }
 
-  private parseBytestreamURIPrefix(): URL | null {
+  private parseBytestreamURIPrefix() {
     let prefix = this.optionsMap.get("remote_bytestream_uri_prefix");
     if (!prefix) return null;
-    try {
-      return new URL(prefix);
-    } catch {
-      return null; // invalid URL
+
+    // Strip protocol
+    prefix = prefix.replace(/^[a-z]+:\/\//, "");
+
+    // Split host/path
+    let idx = prefix.indexOf("/");
+    if (idx >= 0) {
+      return {
+        host: prefix.substring(0, idx),
+        pathname: prefix.substring(idx),
+      };
+    } else {
+      return {
+        host: prefix,
+        pathname: "",
+      };
     }
   }
 


### PR DESCRIPTION
In the last PR I switched to `new URL()` for parsing the bytestream URI prefix, thinking it'd be cleaner than manually parsing... but when testing that approach, I think I was somehow using stale JS :skull: `new URL()` totally fails to parse `"localhost:1985"` or even `"grpc://localhost:1985"`