### PR TITLE
bazelrc: run validation action as aspect

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -217,6 +217,17 @@ common --experimental_inprocess_symlink_creation
 # separately and let us know which tests is slow.
 common --test_env=GO_TEST_WRAP_TESTV=1
 
+# In rules_go v0.50.0, nogo static analysis was moved from GoCompilePkg to a couple of
+# actions: RunNogo and ValidateNogo. Among these, ValidateNogo is a validation action*.
+# When the validation runs on top of the go_test binary, it will prevent the test 
+# execution (TestRunner) until the validation is success.
+#
+# This flag will run the validation action as an aspect, which will not block the test
+# execution.
+#
+# *: https://bazel.build/extending/rules#validation_actions
+common --experimental_use_validation_aspect=true
+
 # Workaround for Bazel 7:
 # rules_docker (archived) defines a transition that helps ensure building containers with binary would use the same platform for both.
 # Reference: https://github.com/bazelbuild/rules_docker/pull/1963


### PR DESCRIPTION
This should make our Go tests executions a bit more parallelized.
