### PR TITLE
don't pointlessly recompute digests when splitting treecache trees

### DIFF
--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -903,7 +903,7 @@ func splitTree(rootDir *capb.DirectoryWithDigest, cache *capb.TreeCache) (*capb.
 			continue
 		}
 		allDigests[rn.GetDigest().GetHash()] = child
-		counter.Add(child.GetDirectory())
+		counter.AddDirWithDigest(child.GetResourceName().GetDigest(), child.GetDirectory())
 	}
 
 	rootTree := &capb.TreeCache{Children: []*capb.DirectoryWithDigest{rootDir}}

--- a/server/remote_cache/directory_size/directory_size.go
+++ b/server/remote_cache/directory_size/directory_size.go
@@ -69,14 +69,20 @@ func (dsc *directorySizeCounter) Add(dir *repb.Directory) error {
 	if err != nil {
 		return err
 	}
+
+	dsc.AddDirWithDigest(dirDigest, dir)
+	return nil
+}
+
+func (dsc *directorySizeCounter) AddDirWithDigest(dirDigest *repb.Digest, dir *repb.Directory) {
 	digestString := dirDigest.GetHash()
 	if _, ok := dsc.totalSize[digestString]; ok {
 		// We already finished computing this directory's size.
-		return nil
+		return
 	}
 	if _, ok := dsc.pendingSize[digestString]; ok {
 		// We're already in the process of computing this directory's size.
-		return nil
+		return
 	}
 
 	// We haven't seen this digest before, so start tracking it.
@@ -90,7 +96,7 @@ func (dsc *directorySizeCounter) Add(dir *repb.Directory) error {
 	// If this directory has no subdirectories, we're already done.
 	if len(dir.GetDirectories()) == 0 {
 		dsc.finish(digestString)
-		return nil
+		return
 	}
 
 	dsc.pendingChildren[digestString] = make(map[string]struct{})
@@ -120,7 +126,6 @@ func (dsc *directorySizeCounter) Add(dir *repb.Directory) error {
 	if len(dsc.pendingChildren[digestString]) == 0 {
 		dsc.finish(digestString)
 	}
-	return nil
 }
 
 func (dsc *directorySizeCounter) GetChildCount(digest string) int64 {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
this waste currently accounts for more than half of the cpu used by treesplitting.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
