### PR TITLE
Return execution metadata even when execution fails

### DIFF
--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -285,10 +285,6 @@ func assemble(name string, md *repb.ExecuteOperationMetadata, rsp *repb.ExecuteR
 	return op, nil
 }
 
-func AssembleFailed(stage repb.ExecutionStage_Value, name string, d *digest.ResourceName, status error) (*longrunning.Operation, error) {
-	return Assemble(stage, name, d, ErrorResponse(status))
-}
-
 func ErrorResponse(err error) *repb.ExecuteResponse {
 	return &repb.ExecuteResponse{
 		Status: gstatus.Convert(err).Proto(),
@@ -336,9 +332,8 @@ func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest *dige
 	}
 }
 
-func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest *digest.ResourceName, finalErr error) error {
-	stage := repb.ExecutionStage_COMPLETED
-	op, err := AssembleFailed(stage, taskID, adInstanceDigest, finalErr)
+func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest *digest.ResourceName, er *repb.ExecuteResponse) error {
+	op, err := Assemble(repb.ExecutionStage_COMPLETED, taskID, adInstanceDigest, er)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -1018,12 +1018,24 @@ func (c *Command) Wait() *CommandResult {
 	return result
 }
 
-// MustFailToStart asserts that the command did not begin execution due to an
-// error such as a bad request (no executors registered, missing inputs, invalid
+// MustFailToSchedule asserts that the command did not get sent to an executor
+// due to an error such as a bad request (no executors registered, invalid
 // platform props, etc). This returns the raw error that was encountered.
-func (c *Command) MustFailToStart() error {
+func (c *Command) MustFailToSchedule() error {
 	result := c.getResult()
 	require.Nil(c.env.t, result.ActionResult, "command unexpectedly return an action result")
+	require.Error(c.env.t, result.Err, "command should have failed to schedule")
+	return result.Err
+}
+
+// MustFailToStart asserts that the command did not begin execution due to an
+// error such as missing inputs, failing to pull container, of failing to
+// upload inputs. This returns the raw error that was encountered.
+func (c *Command) MustFailToStart() error {
+	result := c.getResult()
+	require.NotEmpty(
+		c.env.t, result.ActionResult.GetExecutionMetadata().GetWorker(),
+		"exepcted execution_metadata.worker to help debugging")
 	require.Error(c.env.t, result.Err, "command should have failed to start")
 	return result.Err
 }

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -608,7 +608,7 @@ func TestSimpleCommandWithPoolSelectionViaPlatformProp_Failure(t *testing.T) {
 		OutputDirectories: []string{"output_dir"},
 		OutputFiles:       []string{"output.txt"},
 	}, opts)
-	err := cmd.MustFailToStart()
+	err := cmd.MustFailToSchedule()
 
 	require.Contains(t, err.Error(), `No registered executors in pool "foo"`)
 	taskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
@@ -2112,7 +2112,7 @@ func TestCustomResources(t *testing.T) {
 				{Name: "resources:foo", Value: "2.0"},
 			}},
 		}, &rbetest.ExecuteOpts{})
-		err := cmd.MustFailToStart()
+		err := cmd.MustFailToSchedule()
 		require.Error(t, err, "command should fail to start")
 		require.Regexp(t, "no registered executors .* can fit a task with .* foo=2", err.Error())
 	}


### PR DESCRIPTION
This allows us to show information like the executor host ID when the executor fails due to some transient issue.

**Related issues**: http://go/b/937

Originally, I was going to use the Operation.metadata field for this, but I think it's clunky, and with a few small changes, it seems safe to return an Operation.result even when the execution failed.

The executions tab used to look like 
![image](https://github.com/user-attachments/assets/eda3774d-eefa-4574-9d12-fe8bb3034d99)

Now it looks like 
![image](https://github.com/user-attachments/assets/47645845-c858-4b28-b4b3-87a7dfd0c429)

Note that the executor host ID is filled in.
