### PR TITLE
Add support for {{region}} template string in container image names

### DIFF
--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -28,6 +28,7 @@ var (
 )
 
 func TestParse_ContainerImage_Success(t *testing.T) {
+	flags.Set(t, "executor.container_registry_region", "us-test1")
 	for _, testCase := range []struct {
 		execProps         *ExecutorProperties
 		imageProp         string
@@ -49,6 +50,8 @@ func TestParse_ContainerImage_Success(t *testing.T) {
 		{docker, "docker://alpine", "container-image", "alpine"},
 		{docker, "docker://alpine", "Container-Image", "alpine"},
 		{docker, "docker://caseSensitiveUrl", "container-image", "caseSensitiveUrl"},
+		{docker, "docker://{{region}}.gcr.io/{{region}}-ubuntu:latest", "container-image", "us-test1.gcr.io/us-test1-ubuntu:latest"},
+		{docker, "docker://{{region}}.gcr.io/{{region}}-ubuntu:latest", "Container-image", "us-test1.gcr.io/us-test1-ubuntu:latest"},
 	} {
 		plat := &repb.Platform{Properties: []*repb.Platform_Property{
 			{Name: testCase.containerImageKey, Value: testCase.imageProp},


### PR DESCRIPTION
All occurrences of  `{{region}}` in the provided container image name will be replaced with the value of `--executor.container_registry_region` in the executor that runs the task.

**Related issues**: N/A
