### PR TITLE
oci_image: verify container structure

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -550,3 +550,5 @@ use_repo(
 register_toolchains(
     "//toolchains:ubuntu_cc_toolchain",
 )
+
+bazel_dep(name = "container_structure_test", version = "1.19.1")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -374,6 +374,17 @@ load("@rules_oci//oci:repositories.bzl", "oci_register_toolchains")
 
 oci_register_toolchains(name = "oci")
 
+http_archive(
+    name = "container_structure_test",
+    integrity = "sha256-tWpT+3c0+TIWtg+M3TuY+712fp9BLAYdT6R5jlecSXE=",
+    strip_prefix = "container-structure-test-1.19.1",
+    urls = ["https://github.com/GoogleContainerTools/container-structure-test/archive/v1.19.1.tar.gz"],
+)
+
+load("@container_structure_test//:repositories.bzl", "container_structure_test_register_toolchain")
+
+container_structure_test_register_toolchain(name = "cst")
+
 load("@io_bazel_rules_docker//contrib:dockerfile_build.bzl", "dockerfile_image")
 
 dockerfile_image(

--- a/codesearch/cmd/server/BUILD
+++ b/codesearch/cmd/server/BUILD
@@ -57,6 +57,7 @@ container_push(
 pkg_tar(
     name = "tar",
     srcs = [":server"],
+    include_runfiles = True,
 )
 
 oci_image(

--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -56,6 +56,7 @@ container_image(
 pkg_tar(
     name = "tar",
     srcs = [":cache_proxy"],
+    include_runfiles = True,
 )
 
 oci_image(

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -1,7 +1,10 @@
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 # gazelle:default_visibility //enterprise:__subpackages__,@buildbuddy_internal//:__subpackages__
@@ -133,26 +136,64 @@ container_image(
     visibility = ["//visibility:public"],
 )
 
-# TODO(sluongng): Verify the layering of the image.
+container_test(
+    name = "docker_test",
+    configs = [":docker_test.yaml"],
+    driver = "tar",
+    image = ":buildbuddy_image",
+    tags = ["manual"],
+)
+
+pkg_files(
+    name = "binary_tar",
+    srcs = [":buildbuddy"],
+    attributes = pkg_attributes(mode = "0755"),
+    include_runfiles = True,
+    renames = {
+        # Since the binary is located in /buildbuddy, it will collide with our
+        # tmp_dir_symlink. Rename it to /server.
+        # TODO(sluongng): Remove usage of rules_docker and change the go_binary name to "server"
+        "buildbuddy": "server",
+    },
+)
+
+pkg_mklink(
+    name = "config_mklink",
+    link_name = "config.yaml",
+    target = "buildbuddy.runfiles/buildbuddy/enterprise/config/buildbuddy.release.yaml",
+)
+
+pkg_mklink(
+    name = "tmp_dir_mklink",
+    link_name = "buildbuddy",
+    target = "tmp",
+)
+
 pkg_tar(
     name = "tar",
     srcs = [
-        ":buildbuddy",
+        ":binary_tar",
+        ":config_mklink",
+        ":tmp_dir_mklink",
     ],
-    remap_paths = {
-        "/buildbuddy": "/app/server/cmd/buildbuddy/buildbuddy",
-    },
-    symlinks = {
-        "config.yaml": "app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/enterprise/config/buildbuddy.release.yaml",
-        "buildbuddy": "tmp",
-    },
 )
 
 oci_image(
     name = "oci_image",
     base = "@buildbuddy_go_oci_image_base",
-    entrypoint = ["/app/server/cmd/buildbuddy/buildbuddy"],
+    entrypoint = ["/server"],
     target_compatible_with = ["@platforms//os:linux"],
     tars = [":tar"],
     visibility = ["//visibility:public"],
+)
+
+container_structure_test(
+    name = "oci_test",
+    configs = [":oci_test.yaml"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+    },
+    image = ":oci_image",
+    tags = ["docker"],
 )

--- a/enterprise/server/cmd/server/docker_test.yaml
+++ b/enterprise/server/cmd/server/docker_test.yaml
@@ -1,0 +1,17 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  entrypoint: ["/app/enterprise/server/cmd/server/buildbuddy"]
+
+fileExistenceTests:
+  - name: "executable"
+    path: "/app/enterprise/server/cmd/server/buildbuddy"
+    shouldExist: true
+    isExecutableBy: any
+  - name: "default_config"
+    path: "/config.yaml"
+    shouldExist: true
+    isExecutableBy: any
+  - name: "tmp_dir"
+    path: "/buildbuddy"
+    shouldExist: true

--- a/enterprise/server/cmd/server/oci_test.yaml
+++ b/enterprise/server/cmd/server/oci_test.yaml
@@ -1,0 +1,16 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  entrypoint: ["/server"]
+
+fileExistenceTests:
+  - name: "executable"
+    path: "/server"
+    shouldExist: true
+    isExecutableBy: any
+  - name: "default_config"
+    path: "/config.yaml"
+    shouldExist: true
+  - name: "tmp_dir"
+    path: "/buildbuddy"
+    shouldExist: true

--- a/enterprise/tools/rbeperf/BUILD
+++ b/enterprise/tools/rbeperf/BUILD
@@ -63,6 +63,7 @@ container_push(
 pkg_tar(
     name = "tar",
     srcs = [":rbeperf"],
+    include_runfiles = True,
 )
 
 oci_image(

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -1,6 +1,10 @@
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 # Use the go_binary rule to create an executable from our main file. Depend on
 # the static_content we created above so they are included.
@@ -73,4 +77,58 @@ go_library(
         "//server/util/log",
         "//server/version",
     ],
+)
+
+pkg_files(
+    name = "binary_tar",
+    srcs = [":buildbuddy"],
+    attributes = pkg_attributes(mode = "0755"),
+    include_runfiles = True,
+    renames = {
+        # Since the binary is located in /buildbuddy, it will collide with our
+        # tmp_dir_symlink. Rename it to /server.
+        # TODO(sluongng): Remove usage of rules_docker and change the go_binary name to "server"
+        "buildbuddy": "server",
+    },
+)
+
+pkg_mklink(
+    name = "config_mklink",
+    link_name = "config.yaml",
+    target = "buildbuddy.runfiles/buildbuddy/config/buildbuddy.release.yaml",
+)
+
+pkg_mklink(
+    name = "tmp_dir_mklink",
+    link_name = "buildbuddy",
+    target = "tmp",
+)
+
+pkg_tar(
+    name = "tar",
+    srcs = [
+        ":binary_tar",
+        ":config_mklink",
+        ":tmp_dir_mklink",
+    ],
+)
+
+oci_image(
+    name = "oci_image",
+    base = "@buildbuddy_go_oci_image_base",
+    entrypoint = ["/server"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tars = [":tar"],
+    visibility = ["//visibility:public"],
+)
+
+container_structure_test(
+    name = "oci_test",
+    configs = [":oci_test.yaml"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+    },
+    image = ":oci_image",
+    tags = ["docker"],
 )

--- a/server/cmd/buildbuddy/oci_test.yaml
+++ b/server/cmd/buildbuddy/oci_test.yaml
@@ -1,0 +1,16 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  entrypoint: ["/server"]
+
+fileExistenceTests:
+  - name: "executable"
+    path: "/server"
+    shouldExist: true
+    isExecutableBy: any
+  - name: "default_config"
+    path: "/config.yaml"
+    shouldExist: true
+  - name: "tmp_dir"
+    path: "/buildbuddy"
+    shouldExist: true

--- a/server/util/bazel/defs.bzl
+++ b/server/util/bazel/defs.bzl
@@ -1,4 +1,5 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 def _extract_bazel_installation_impl(ctx):
     out_dir = ctx.actions.declare_directory(ctx.attr.out_dir)
@@ -57,9 +58,14 @@ def bazel_pkg_tar(name, versions = [], **kwargs):
             out_dir = "bazel-{}_install".format(version),
             **kwargs
         )
+    pkg_files(
+        name = "{}_files".format(name),
+        srcs = [":bazel-{}_crossplatform".format(version) for version in versions],
+        prefix = "bazel",
+        **kwargs
+    )
     pkg_tar(
         name = name,
-        srcs = [":bazel-{}_crossplatform".format(version) for version in versions],
-        package_dir = "/bazel",
+        srcs = ["{}_files".format(name)],
         **kwargs
     )

--- a/tools/cacheload/BUILD
+++ b/tools/cacheload/BUILD
@@ -61,6 +61,7 @@ container_push(
 pkg_tar(
     name = "tar",
     srcs = [":cacheload"],
+    include_runfiles = True,
 )
 
 oci_image(

--- a/tools/probers/BUILD
+++ b/tools/probers/BUILD
@@ -35,6 +35,7 @@ container_push(
 pkg_tar(
     name = "files_tar",
     srcs = [
+        "//server/util/bazel:bazel_binaries_tar_files",
         "//tools/probers/bazelrbe",
         "//tools/probers/remote_runner",
         "@cloudprober",

--- a/tools/smarter_device_manager/BUILD
+++ b/tools/smarter_device_manager/BUILD
@@ -33,6 +33,7 @@ container_push(
 pkg_tar(
     name = "tar",
     srcs = [":smarter-device-manager"],
+    include_runfiles = True,
 )
 
 oci_image(

--- a/tools/tcpproxy/BUILD
+++ b/tools/tcpproxy/BUILD
@@ -41,6 +41,7 @@ container_push(
 pkg_tar(
     name = "tar",
     srcs = [":tcpproxy"],
+    include_runfiles = True,
 )
 
 oci_image(


### PR DESCRIPTION
Pull in `container_structure_test` module to help us verify the existing
and up-coming container structure.

Setup 2 test targest:
- docker_test: using rules_docker's container_test to help us validate
  the old image structure. Using `tar` driver for the test so we don't
  need a docker daemon to run it. This test is tagged with "manual" so
  we can avoid building the docker image on unwanted platforms,
  consistent with all existing rules_docker targets.

- oci_test: use the newer container_structure_test rule to verify
  oci_image structure.

Using this test setup, we can verify that the old tar layout is very
different from the new tar layout:

- Old Layout

```
> tar -tvf ~/Downloads/buildbuddy_go_image-layer.tar
drwxr-xr-x  0 0      0           0 Jan  1  1970 ./
drwxr-xr-x  0 0      0           0 Jan  1  1970 ./app/
...
-r-xr-xr-x  0 0      0        2262 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/enterprise/LICENSE
...
-r-xr-xr-x  0 0      0    19664710 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/enterprise/app/app_bundle/app.js
-r-xr-xr-x  0 0      0          41 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/enterprise/app/sha.sum
...
-r-xr-xr-x  0 0      0        1047 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/enterprise/config/buildbuddy.local.yaml
...
-r-xr-xr-x  0 0      0        1150 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/static/favicon.ico
...
-r-xr-xr-x  0 0      0        2143 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/static/favicon/android-icon-144x144.png
...
-r-xr-xr-x  0 0      0         710 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/static/image/b_dark.svg
...
-r-xr-xr-x  0 0      0        2213 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/static/index.html
...
-r-xr-xr-x  0 0      0      150336 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/_solib_k8/libST-e821f40a66f6_external_Szlib_Slibz.so
...
-r-xr-xr-x  0 0      0   159524637 Jan  1  1970 ./app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/enterprise/server/cmd/server/buildbuddy_/buildbuddy
...
lrwxr-xr-x  0 0      0           0 Jan  1  1970 /app/enterprise/server/cmd/server/buildbuddy -> /app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/enterprise/server/cmd/server/buildbuddy_/buildbuddy
...
lrwxr-xr-x  0 0      0           0 Jan  1  1970 /app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/external -> /app/enterprise/server/cmd/server/buildbuddy.runfiles
```

- New layout

```
> tar -tvf bazel-out/darwin_arm64-opt/bin/enterprise/server/cmd/server/tar.tar

lrwxrwxrwx  0 0      0           0 Jan  1  2000 buildbuddy -> tmp
lrwxrwxrwx  0 0      0           0 Jan  1  2000 config.yaml -> buildbuddy.runfiles/buildbuddy/enterprise/config/buildbuddy.release.yaml
-rwxr-xr-x  0 0      0   197174754 Jan  1  2000 server
...
-rwxr-xr-x  0 0      0        2262 Jan  1  2000 server.runfiles/buildbuddy/enterprise/LICENSE
...
-rwxr-xr-x  0 0      0     8950024 Jan  1  2000 server.runfiles/buildbuddy/enterprise/app/app_bundle/app.js
-rwxr-xr-x  0 0      0          41 Jan  1  2000 server.runfiles/buildbuddy/enterprise/app/sha.sum
...
-rwxr-xr-x  0 0      0        1047 Jan  1  2000 server.runfiles/buildbuddy/enterprise/config/buildbuddy.local.yaml
...
-rwxr-xr-x  0 0      0        1150 Jan  1  2000 server.runfiles/buildbuddy/static/favicon.ico
...
-rwxr-xr-x  0 0      0        2143 Jan  1  2000 server.runfiles/buildbuddy/static/favicon/android-icon-144x144.png
...
-rwxr-xr-x  0 0      0         710 Jan  1  2000 server.runfiles/buildbuddy/static/image/b_dark.svg
...
-rwxr-xr-x  0 0      0        2213 Jan  1  2000 server.runfiles/buildbuddy/static/index.html
```

This is caused by the old rules_docker's `go_image` rule handles
runfiles differently than the latest mapping rules in `rules_pkg`.

Overall, it seems like `rules_pkg` mapping rules is much more flexible
while being a bit more verbose.
