### PR TITLE
Switch from kythe-v0.0.67d to kythe-v0.0.67f

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -168,7 +168,7 @@ func NewConfig(r io.Reader) (*BuildBuddyConfig, error) {
 	return cfg, nil
 }
 
-const kytheDownloadURL = "https://storage.googleapis.com/buildbuddy-tools/archives/kythe-v0.0.67d.tar.gz"
+const kytheDownloadURL = "https://storage.googleapis.com/buildbuddy-tools/archives/kythe-v0.0.67f.tar.gz"
 
 func checkoutKythe(dirName, downloadURL string) string {
 	buf := fmt.Sprintf(`


### PR DESCRIPTION
Build: https://app.buildbuddy.io/invocation/99450de4-855d-4cff-8c29-4668e9f08823

Command: `blaze build --config=static --config=release --config=remote --@io_bazel_rules_go//go/config:static kythe/release:release`