### PR TITLE
Cache Proxy: add a flag that makes Cache Proxy always serve GetTree requests from the remote, authoritative cache.

### DIFF
--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//server/remote_cache/content_addressable_storage_server",
         "//server/testutil/cas",
         "//server/testutil/testenv",
+        "//server/util/testing/flags",
         "//server/util/uuid",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -24,7 +24,7 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
-var enableGetTreeCaching = flag.Bool("cache_proxy.enable_get_tree_caching", false, "")
+var enableGetTreeCaching = flag.Bool("cache_proxy.enable_get_tree_caching", false, "If true, the Cache Proxy attempts to serve GetTree requests out of the local cache. If false, GetTree requests are always proxied to the remote, authoritative cache.")
 
 type CASServerProxy struct {
 	atimeUpdater interfaces.AtimeUpdater

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -2,7 +2,9 @@ package content_addressable_storage_server_proxy
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -21,6 +23,8 @@ import (
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
+
+var enableGetTreeCaching = flag.Bool("cache_proxy.enable_get_tree_caching", false, "")
 
 type CASServerProxy struct {
 	atimeUpdater interfaces.AtimeUpdater
@@ -219,6 +223,33 @@ func (s *CASServerProxy) batchReadBlobsRemote(ctx context.Context, readReq *repb
 }
 
 func (s *CASServerProxy) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
+	if *enableGetTreeCaching {
+		return s.getTree(req, stream)
+	}
+	return s.getTreeWithoutCaching(req, stream)
+}
+
+func (s *CASServerProxy) getTreeWithoutCaching(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
+	remoteStream, err := s.remote.GetTree(stream.Context(), req)
+	if err != nil {
+		return err
+	}
+	for {
+		rsp, err := remoteStream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if err = stream.Send(rsp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *CASServerProxy) getTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
 	ctx, spn := tracing.StartSpan(stream.Context())
 	defer spn.End()
 


### PR DESCRIPTION
This is just conditionally reverting https://github.com/buildbuddy-io/buildbuddy/pull/7319/files behind a flag. The idea here is that `GetTree` is especially susceptible to cross-zone latency because every level of the tree that isn't cached incurs an addition roundtrip latency.

**Related issues**: N/A
