### PR TITLE
[raft] reduce snapshot entries

### DIFF
--- a/enterprise/server/raft/config/config.go
+++ b/enterprise/server/raft/config/config.go
@@ -23,7 +23,7 @@ func GetRaftConfig(rangeID, replicaID uint64) dbConfig.Config {
 		ElectionRTT:             20,
 		HeartbeatRTT:            2,
 		CheckQuorum:             true,
-		SnapshotEntries:         1000000,
+		SnapshotEntries:         100000,
 		CompactionOverhead:      500,
 		OrderedConfigChange:     true,
 		SnapshotCompressionType: dbConfig.Snappy,


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Right now we are not snopshotting frequently, so raft storage cannot be
reclaimed.
