### PR TITLE
server: Set `X-Content-Type-Options: nosniff`

### DIFF
--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -46,6 +46,7 @@ func SetSecurityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("Content-Security-Policy", "frame-ancestors 'none'")
 		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
 		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -213,6 +213,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "text/html")
 	err = tpl.ExecuteTemplate(w, indexTemplateFilename, &FrontendTemplateData{
 		StylePath:        stylePath,
 		JsEntryPointPath: jsPath,


### PR DESCRIPTION
Go's `http` package automatically sets `Content-Type` based on file extensions (and possibly content, but only as a fallback), so we only need to set the header manually when not going through `http` methods.

**Related issues**: buildbuddy-io/buildbuddy-internal#3911

