### PR TITLE
Draft PR for rbe-ubuntu-2204 so we can test building on arm

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,8 +40,8 @@ common:remote-shared --remote_timeout=600
 common:remote-shared --remote_download_minimal
 common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
-common:remote-shared --platforms=//platforms:linux_x86_64
-common:remote-shared --extra_execution_platforms=//platforms:linux_x86_64
+common:remote-shared --platforms=@buildbuddy_toolchain//:platform_linux
+common:remote-shared --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux
 
 # Build with --config=remote to use BuildBuddy RBE.
 common:remote --config=remote-shared

--- a/.bazelrc
+++ b/.bazelrc
@@ -40,8 +40,6 @@ common:remote-shared --remote_timeout=600
 common:remote-shared --remote_download_minimal
 common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
-common:remote-shared --platforms=@buildbuddy_toolchain//:platform_linux
-common:remote-shared --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux
 
 # Build with --config=remote to use BuildBuddy RBE.
 common:remote --config=remote-shared

--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04-16cpu
+    runs-on: ubuntu-22.04-16cpu
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   push-tag:
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && !contains(github.event.pull_request.body, 'release skip'))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -548,7 +548,3 @@ use_repo(
     "busybox",
     "busybox_linux_amd64",
 )
-
-register_toolchains(
-    "//toolchains:ubuntu_cc_toolchain",
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -477,9 +477,9 @@ oci_pull(
 # Keep up-to-date with docs/rbe-setup.md and docs/rbe-github-actions.md
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "baa9af1b9fcc96d18ac90a4dd68ebd2046c8beb76ed89aea9aabca30959ad30c",
-    strip_prefix = "buildbuddy-toolchain-287d6042ad151be92de03c83ef48747ba832c4e2",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/287d6042ad151be92de03c83ef48747ba832c4e2.tar.gz"],
+    sha256 = "747dbf28cb8b8d27b2d909aa05e00691fe6d9d8a28026e359cc4943261687592",
+    strip_prefix = "buildbuddy-toolchain-702567fd8a561ec94a0e8e7fd8aa00bb15d87b4f",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/702567fd8a561ec94a0e8e7fd8aa00bb15d87b4f.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
@@ -559,7 +559,7 @@ http_file(
 )
 
 register_toolchains(
-    "//toolchains:ubuntu_cc_toolchain",
+    "@buildbuddy_toolchain//:ubuntu_cc_toolchain",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -486,11 +486,11 @@ load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
 
 buildbuddy_deps()
 
-load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "UBUNTU20_04_IMAGE", "buildbuddy")
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "UBUNTU22_04_IMAGE", "buildbuddy")
 
 buildbuddy(
     name = "buildbuddy_toolchain",
-    container_image = UBUNTU20_04_IMAGE,
+    container_image = UBUNTU22_04_IMAGE,
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -493,6 +493,10 @@ buildbuddy(
     container_image = UBUNTU22_04_IMAGE,
 )
 
+register_execution_platforms(
+    "@buildbuddy_toolchain//:platform_linux",
+)
+
 http_archive(
     name = "cloudprober",
     build_file_content = "exports_files([\"cloudprober\"])",

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -151,9 +151,9 @@ container_pull(
 # Keep up-to-date with docs/rbe-setup.md and docs/rbe-github-actions.md
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "baa9af1b9fcc96d18ac90a4dd68ebd2046c8beb76ed89aea9aabca30959ad30c",
-    strip_prefix = "buildbuddy-toolchain-287d6042ad151be92de03c83ef48747ba832c4e2",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/287d6042ad151be92de03c83ef48747ba832c4e2.tar.gz"],
+    sha256 = "747dbf28cb8b8d27b2d909aa05e00691fe6d9d8a28026e359cc4943261687592",
+    strip_prefix = "buildbuddy-toolchain-702567fd8a561ec94a0e8e7fd8aa00bb15d87b4f",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/702567fd8a561ec94a0e8e7fd8aa00bb15d87b4f.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
@@ -195,3 +195,7 @@ browser_repositories(chromium = True)
 load("@io_bazel_rules_webtesting//web:go_repositories.bzl", web_test_go_repositories = "go_repositories")
 
 web_test_go_repositories()
+
+register_toolchains(
+    "@buildbuddy_toolchain//:ubuntu_cc_toolchain",
+)

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -160,11 +160,11 @@ load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
 
 buildbuddy_deps()
 
-load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "UBUNTU20_04_IMAGE", "buildbuddy")
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "UBUNTU22_04_IMAGE", "buildbuddy")
 
 buildbuddy(
     name = "buildbuddy_toolchain",
-    container_image = UBUNTU20_04_IMAGE,
+    container_image = UBUNTU22_04_IMAGE,
 )
 
 # esbuild (for bundling JS)

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,6 +1,6 @@
 actions:
   - name: Test
-    container_image: ubuntu-20.04
+    container_image: ubuntu-22.04
     triggers:
       push:
         branches:
@@ -12,7 +12,7 @@ actions:
     bazel_commands:
       - test //... --config=linux-workflows --config=race --test_tag_filters=-performance,-docker,-bare
   - name: Test with BzlMod
-    container_image: ubuntu-20.04
+    container_image: ubuntu-22.04
     resource_requests:
       disk: 27GB
     triggers:
@@ -25,7 +25,7 @@ actions:
     bazel_commands:
       - test //... --enable_bzlmod --config=linux-workflows --config=race --test_tag_filters=-performance,-docker,-bare
   - name: Check style
-    container_image: ubuntu-20.04
+    container_image: ubuntu-22.04
     triggers:
       push:
         branches:
@@ -84,7 +84,7 @@ actions:
         -//enterprise/server/remote_execution/runner:all
         -//enterprise/server/test/integration/...
   - name: Benchmark
-    container_image: ubuntu-20.04
+    container_image: ubuntu-22.04
     triggers:
       push:
         branches:
@@ -93,7 +93,7 @@ actions:
       - test //... --config=linux-workflows --config=performance --test_tag_filters=+performance
   # TODO(bduffany): Move docker tests to the Test workflow when they are fast enough.
   - name: Docker tests
-    container_image: ubuntu-20.04
+    container_image: ubuntu-22.04
     triggers:
       push:
         branches:
@@ -106,7 +106,7 @@ actions:
       # executing with high concurrency, and remove `--jobs=3`
       - test //... --config=linux-workflows --config=race --test_tag_filters=+docker --build_tag_filters=+docker --jobs=3
   - name: Baremetal tests
-    container_image: ubuntu-20.04
+    container_image: ubuntu-22.04
     triggers:
       push:
         branches:

--- a/docs/rbe-github-actions.md
+++ b/docs/rbe-github-actions.md
@@ -107,9 +107,9 @@ And the following lines to your `WORKSPACE` file:
 ```python title="WORKSPACE"
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "baa9af1b9fcc96d18ac90a4dd68ebd2046c8beb76ed89aea9aabca30959ad30c",
-    strip_prefix = "buildbuddy-toolchain-287d6042ad151be92de03c83ef48747ba832c4e2",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/287d6042ad151be92de03c83ef48747ba832c4e2.tar.gz"],
+    sha256 = "747dbf28cb8b8d27b2d909aa05e00691fe6d9d8a28026e359cc4943261687592",
+    strip_prefix = "buildbuddy-toolchain-702567fd8a561ec94a0e8e7fd8aa00bb15d87b4f",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/702567fd8a561ec94a0e8e7fd8aa00bb15d87b4f.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/docs/rbe-setup.md
+++ b/docs/rbe-setup.md
@@ -29,9 +29,9 @@ To get started with the BuildBuddy Toolchain, add the following lines to your `W
 ```python
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "baa9af1b9fcc96d18ac90a4dd68ebd2046c8beb76ed89aea9aabca30959ad30c",
-    strip_prefix = "buildbuddy-toolchain-287d6042ad151be92de03c83ef48747ba832c4e2",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/287d6042ad151be92de03c83ef48747ba832c4e2.tar.gz"],
+    sha256 = "747dbf28cb8b8d27b2d909aa05e00691fe6d9d8a28026e359cc4943261687592",
+    strip_prefix = "buildbuddy-toolchain-702567fd8a561ec94a0e8e7fd8aa00bb15d87b4f",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/702567fd8a561ec94a0e8e7fd8aa00bb15d87b4f.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/docs/workflows-config.md
+++ b/docs/workflows-config.md
@@ -230,19 +230,19 @@ Example `buildbuddy.yaml` file:
 ## Linux image configuration
 
 By default, workflows run on an Ubuntu 18.04-based image. You can use
-a newer, Ubuntu 20.04-based image using the `container_image` action
+a newer, Ubuntu 22.04-based image using the `container_image` action
 setting:
 
 ```yaml title="buildbuddy.yaml"
 actions:
   - name: "Test all targets"
-    container_image: "ubuntu-20.04" # <-- add this line
+    container_image: "ubuntu-22.04" # <-- add this line
     bazel_commands:
       - "bazel test //..."
 ```
 
-The supported values for `container_image` are `"ubuntu-18.04"` (default)
-or `"ubuntu-20.04"`.
+The supported values for `container_image` are `"ubuntu-18.04"` (default),
+`"ubuntu-20.04"`, or `"ubuntu-22.04"`.
 
 By default, workflow VMs have the following resources available:
 
@@ -378,8 +378,8 @@ A named group of Bazel commands that run when triggered.
   This option is ignored for macOS workflows, since macOS workflows are
   always required to be self-hosted.
 - **`container_image`** (`string`): The Linux container image to use
-  (has no effect for Mac workflows). Supported values are `"ubuntu-18.04"`
-  and `"ubuntu-20.04"`. Defaults to `"ubuntu-18.04"`.
+  (has no effect for Mac workflows). Supported values are `"ubuntu-18.04"`,
+  `"ubuntu-20.04"`, and `"ubuntu-22.04"`. Defaults to `"ubuntu-18.04"`.
 - **`resource_requests`** ([`ResourceRequests`](#resourcerequests)):
   the requested resources for this action.
 - **`user`** (`string`): User to run the workflow as. This can be set to

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -41,10 +41,11 @@ var (
 const (
 	Ubuntu16_04Image = "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0"
 	Ubuntu20_04Image = "gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622"
+	Ubuntu22_04Image     = "gcr.io/flame-public/rbe-ubuntu22-04@sha256:c7567f84d702b596c592d844adb0570526e262e60e2e1fe50c27177ee6d652ad"
 
 	Ubuntu18_04WorkflowsImage     = "gcr.io/flame-public/buildbuddy-ci-runner@sha256:8cf614fc4695789bea8321446402e7d6f84f6be09b8d39ec93caa508fa3e3cfc"
 	Ubuntu20_04WorkflowsImage     = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:c5092c8cb94471bb7c7fbd046cd80cb596dcc508f0833a748c035a1ba41f1681"
-	Ubuntu22_04WorkflowsImage     = "gcr.io/flame-public/rbe-ubuntu22-04@sha256:c7567f84d702b596c592d844adb0570526e262e60e2e1fe50c27177ee6d652ad"
+	Ubuntu22_04WorkflowsImage     = Ubuntu20_04Image
 	Ubuntu20_04GitHubActionsImage = "gcr.io/flame-public/rbe-ubuntu20-04-github-actions@sha256:2a3b50fa1aafcb8446c94ab5707270f92fa91abd64a0e049312d4a086d0abb1c"
 
 	// overrideHeaderPrefix is a prefix used to override platform props via

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -220,7 +220,7 @@ func KytheIndexingAction(targetRepoDefaultBranch string) *Action {
 		Triggers: &Triggers{
 			Push: &PushTrigger{Branches: pushTriggerBranches},
 		},
-		ContainerImage: `ubuntu-20.04`,
+		ContainerImage: `ubuntu-22.04`,
 		ResourceRequests: ResourceRequests{
 			CPU:    "24",   // 24 BCU
 			Memory: "60GB", // 24 BCU

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -1,25 +1,3 @@
-# A duplicate of @buildbuddy_toolchain//:ubuntu_cc_toolchain
-# with correct cc_compiler constraint value.
-# TODO(sluongng): upstream this to buildbuddy-toolchain
-toolchain(
-    name = "ubuntu_cc_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-        # This is not needed for the toolchain itself,
-        # but it helps us differentiate between the local platform and the remote RBE platform.
-        #
-        # For local builds, we do NOT want to use this toolchain as the gcc and glibc versions might differ.
-        "@bazel_tools//tools/cpp:gcc",
-    ],
-    target_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-    toolchain = "@buildbuddy_toolchain//:ubuntu_local_cc_toolchain",
-    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
-)
-
 constraint_setting(
     name = "use_musl",
     default_constraint_value = ":musl_off",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,13 @@
       "bazel-out/macos_arm64-fastbuild/bin",
       "bazel-out/macos_arm64-opt/bin",
       "bazel-out/macos_x86_64-fastbuild/bin",
-      "bazel-out/macos_x86_64-opt/bin"
+      "bazel-out/macos_x86_64-opt/bin",
+      "bazel-out/platform_linux_arm64-fastbuild/bin",
+      "bazel-out/platform_linux_arm64-opt/bin",
+      "bazel-out/platform_linux-fastbuild/bin",
+      "bazel-out/platform_linux-opt/bin",
+      "bazel-out/platform_linux_x86_64-fastbuild/bin",
+      "bazel-out/platform_linux_x86_64-opt/bin"
     ]
     // Note: we intentionally don't set "baseUrl": "." in order to force import
     // module specifiers to be relative.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,8 @@
       "bazel-out/platform_linux-opt/bin",
       "bazel-out/platform_linux_x86_64-fastbuild/bin",
       "bazel-out/platform_linux_x86_64-opt/bin"
+      "bazel-out/platform_windows-fastbuild/bin",
+      "bazel-out/platform_windows-opt/bin",
     ]
     // Note: we intentionally don't set "baseUrl": "." in order to force import
     // module specifiers to be relative.


### PR DESCRIPTION
- Use new buildbuddy-toolchain that supports arm by default
- Remove hard-coded x86_64 bits
- Add rootDirs to tsconfig for new platforms

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
