### PR TITLE
server: Use a strict CSP for all pages

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -3,4 +3,8 @@ import ReactDOM from "react-dom";
 
 import RootComponent from "./root/root";
 
+/* Monaco loads some libraries using require(), ignore these for now. */
+// @ts-ignore
+window.require = () => {};
+
 ReactDOM.render(<RootComponent />, document.getElementById("app") as HTMLElement);

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -19,6 +19,7 @@ body {
   display: flex;
   flex-direction: column;
   word-break: break-word;
+  background-color: #fff;
 
   --code-font: "Source Code Pro", monospace;
 }

--- a/server/http/csp/BUILD.bazel
+++ b/server/http/csp/BUILD.bazel
@@ -5,5 +5,5 @@ go_library(
     srcs = ["csp.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/http/csp",
     visibility = ["//visibility:public"],
-    deps = ["//server/util/alert"],
+    deps = ["//server/util/log"],
 )

--- a/server/http/csp/BUILD.bazel
+++ b/server/http/csp/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "csp",
+    srcs = ["csp.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/http/csp",
+    visibility = ["//visibility:public"],
+)

--- a/server/http/csp/BUILD.bazel
+++ b/server/http/csp/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["csp.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/http/csp",
     visibility = ["//visibility:public"],
+    deps = ["//server/util/alert"],
 )

--- a/server/http/csp/csp.go
+++ b/server/http/csp/csp.go
@@ -1,0 +1,5 @@
+package csp
+
+// Nonce is the context key type for the per-request CSP nonce.
+// The associated value is always of type template.HTMLAttr.
+type Nonce struct{}

--- a/server/http/csp/csp.go
+++ b/server/http/csp/csp.go
@@ -1,10 +1,11 @@
 package csp
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
 // Nonce is the context key type for the per-request CSP nonce.
@@ -16,8 +17,8 @@ const ReportingEndpoint = "/csp-report"
 var ReportingHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	report, err := io.ReadAll(r.Body)
 	if err != nil {
-		alert.UnexpectedEvent("csp_violation_report_failure", err.Error())
+		log.CtxWarning(r.Context(), fmt.Sprintf("CSP report failure: %s", err))
 		return
 	}
-	alert.UnexpectedEvent("csp_violation", string(report))
+	log.CtxWarning(r.Context(), fmt.Sprintf("CSP violation: %s", string(report)))
 })

--- a/server/http/csp/csp.go
+++ b/server/http/csp/csp.go
@@ -1,7 +1,6 @@
 package csp
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 
@@ -17,8 +16,8 @@ const ReportingEndpoint = "/csp-report"
 var ReportingHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	report, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.CtxWarning(r.Context(), fmt.Sprintf("CSP report failure: %s", err))
+		log.CtxInfof(r.Context(), "CSP report failure: %s", err)
 		return
 	}
-	log.CtxWarning(r.Context(), fmt.Sprintf("CSP violation: %s", string(report)))
+	log.CtxInfof(r.Context(), "CSP violation: %s", report)
 })

--- a/server/http/csp/csp.go
+++ b/server/http/csp/csp.go
@@ -1,5 +1,23 @@
 package csp
 
+import (
+	"io"
+	"net/http"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+)
+
 // Nonce is the context key type for the per-request CSP nonce.
 // The associated value is always of type template.HTMLAttr.
 type Nonce struct{}
+
+const ReportingEndpoint = "/csp-report"
+
+var ReportingHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	report, err := io.ReadAll(r.Body)
+	if err != nil {
+		alert.UnexpectedEvent("csp_violation_report_failure", err.Error())
+		return
+	}
+	alert.UnexpectedEvent("csp_violation", string(report))
+})

--- a/server/http/interceptors/BUILD
+++ b/server/http/interceptors/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//proto:context_go_proto",
         "//server/capabilities_filter",
         "//server/environment",
+        "//server/http/csp",
         "//server/http/protolet",
         "//server/metrics",
         "//server/util/alert",

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -56,7 +56,6 @@ var contentSecurityPolicyTemplate = strings.Join([]string{
 	"worker-src 'none'",
 	"frame-ancestors 'none'",
 	"base-uri 'none'",
-	"upgrade-insecure-requests",
 	"block-all-mixed-content",
 	"report-to " + contentSecurityPolicyReportingEndpointName,
 	"report-uri " + csp.ReportingEndpoint,

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//server/buildbuddy_server",
         "//server/endpoint_urls/build_buddy_url",
         "//server/gossip",
+        "//server/http/csp",
         "//server/http/interceptors",
         "//server/http/protolet",
         "//server/interfaces",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/webhooks"
 	"github.com/buildbuddy-io/buildbuddy/server/buildbuddy_server"
 	"github.com/buildbuddy-io/buildbuddy/server/gossip"
+	"github.com/buildbuddy-io/buildbuddy/server/http/csp"
 	"github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/http/protolet"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -471,6 +472,8 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 	if sp := env.GetSplashPrinter(); sp != nil {
 		sp.PrintSplashScreen(bburl.WithPath("").Hostname(), *port, grpc_server.GRPCPort())
 	}
+
+	mux.Handle(csp.ReportingEndpoint, csp.ReportingHandler)
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", *listen, *port),

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/build_event_protocol/target_tracker",
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",
+        "//server/http/interceptors",
         "//server/invocation_stat_service/config",
         "//server/remote_cache/hit_tracker",
         "//server/remote_execution/config",

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -11,7 +11,7 @@ go_library(
         "//server/build_event_protocol/target_tracker",
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",
-        "//server/http/interceptors",
+        "//server/http/csp",
         "//server/invocation_stat_service/config",
         "//server/remote_cache/hit_tracker",
         "//server/remote_execution/config",

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -14,7 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/target_tracker"
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
+	"github.com/buildbuddy-io/buildbuddy/server/http/csp"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/hit_tracker"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/region"
@@ -216,14 +216,13 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	nonce := interceptors.SetContentSecurityPolicy(w.Header())
 	w.Header().Set("Content-Type", "text/html")
 	err = tpl.ExecuteTemplate(w, indexTemplateFilename, &FrontendTemplateData{
 		StylePath:        stylePath,
 		JsEntryPointPath: jsPath,
 		GaEnabled:        !*disableGA,
 		Config:           template.JS(configJSON),
-		Nonce:            nonce,
+		Nonce:            ctx.Value(csp.Nonce{}).(template.HTMLAttr),
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/static/index.html
+++ b/static/index.html
@@ -20,10 +20,13 @@
     <meta name="theme-color" content="#212121" />
     <meta charset="UTF-8" />
 
-    {{.ConfigScript}} {{if .GaEnabled}}
+    <script {{.Nonce}}>
+      window.buildbuddyConfig = {{.Config}};
+    </script>
+
+    {{if .GaEnabled}}
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156160991-2"></script>
-    {{/* Update the hash in interceptors.go#contentSecurityPolicy when changing this script. */}}
-    <script>
+    <script {{.Nonce}}>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
         dataLayer.push(arguments);

--- a/static/index.html
+++ b/static/index.html
@@ -20,20 +20,9 @@
     <meta name="theme-color" content="#212121" />
     <meta charset="UTF-8" />
 
-    <style>
-      body {
-        background-color: #fff;
-      }
-    </style>
-
-    <script>
-      window.buildbuddyConfig = {{.Config}};
-      {{/* Monaco loads some libraries using require(), ignore these for now. */}}
-      window.require = () => { };
-    </script>
-
-    {{if .GaEnabled}}
+    {{.ConfigScript}} {{if .GaEnabled}}
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156160991-2"></script>
+    {{/* Update the hash in interceptors.go#contentSecurityPolicy when changing this script. */}}
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {


### PR DESCRIPTION
The CSP allows at most the current origin (and subdomains) as well as a few inline scripts pinned by hashes.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: buildbuddy-io/buildbuddy-internal#3911
