### PR TITLE
Use unique index instead of table lock for usage inserts

### DIFF
--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -23,6 +23,7 @@ go_library(
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
+        "@io_gorm_gorm//clause",
     ],
 )
 


### PR DESCRIPTION
The table locking approach doesn't play nicely with usage queries running concurrently; switch to a unique index for now.

It's harder to add new label columns when using a unique index, but we can think of alternate approaches as part of migrating this table to ClickHouse. For example, we could hash the usage labels and only include that hash in the unique index, rather than each individual label column.