### PR TITLE
make podman_test timeout a little bit shorter

### DIFF
--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -6,6 +6,7 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 go_test(
     name = "podman_test",
     size = "large",
+    timeout = "moderate",
     srcs = ["podman_test.go"],
     data = [
         "//enterprise/server/remote_execution/containers/ociruntime:crun",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
unfortunately this one sometimes butts up on a minute, so just doing `moderate` for now--300s instead of 900s
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
