### PR TITLE
fix incorrect date date range rendering in filters ui.

### DIFF
--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -274,7 +274,7 @@ function usingSubDayTimeRange(startDate: Date, endDate?: Date): boolean {
   return +endCopy !== +endDate;
 }
 
-export function formatDateRangeStringForDisplay(startDate: Date, endDate?: Date, { now = new Date() } = {}) {
+export function formatDateRange(startDate: Date, endDate?: Date, { now = new Date() } = {}) {
   let startFormat, endFormat;
 
   // Time range isn't just midnight-midnight--maybe 8:30-12:30 or something like that.
@@ -414,7 +414,7 @@ export default {
   formatCommitHash,
   formatRole,
   formatWithCommas,
-  formatDateRangeStringForDisplay,
+  formatDateRange,
   colorHash,
   enumLabel,
   formatDateFromUsec,

--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -274,7 +274,7 @@ function usingSubDayTimeRange(startDate: Date, endDate?: Date): boolean {
   return +endCopy !== +endDate;
 }
 
-export function formatDateRange(startDate: Date, endDate?: Date, { now = new Date() } = {}) {
+export function formatDateRangeStringForDisplay(startDate: Date, endDate?: Date, { now = new Date() } = {}) {
   let startFormat, endFormat;
 
   // Time range isn't just midnight-midnight--maybe 8:30-12:30 or something like that.
@@ -414,7 +414,7 @@ export default {
   formatCommitHash,
   formatRole,
   formatWithCommas,
-  formatDateRange,
+  formatDateRangeStringForDisplay,
   colorHash,
   enumLabel,
   formatDateFromUsec,

--- a/enterprise/app/auditlogs/auditlogs.tsx
+++ b/enterprise/app/auditlogs/auditlogs.tsx
@@ -3,7 +3,7 @@ import moment from "moment";
 import rpcService from "../../../app/service/rpc_service";
 import { auditlog } from "../../../proto/auditlog_ts_proto";
 import * as proto from "../../../app/util/proto";
-import { formatDate, formatDateRangeStringForDisplay } from "../../../app/format/format";
+import { formatDate, formatDateRange } from "../../../app/format/format";
 import Button, { OutlinedButton } from "../../../app/components/button/button";
 import { Calendar } from "lucide-react";
 import Popup from "../../../app/components/popup/popup";
@@ -244,10 +244,7 @@ export default class AuditLogsComponent extends React.Component<AuditLogsCompone
                 onClick={this.onOpenDatePicker.bind(this)}>
                 <Calendar className="icon" />
                 <span>
-                  {formatDateRangeStringForDisplay(
-                    this.state.dateRange.startDate!,
-                    this.getRealEndTime(this.state.dateRange.endDate)
-                  )}
+                  {formatDateRange(this.state.dateRange.startDate!, this.getRealEndTime(this.state.dateRange.endDate))}
                 </span>
               </OutlinedButton>
               <Popup

--- a/enterprise/app/auditlogs/auditlogs.tsx
+++ b/enterprise/app/auditlogs/auditlogs.tsx
@@ -3,8 +3,7 @@ import moment from "moment";
 import rpcService from "../../../app/service/rpc_service";
 import { auditlog } from "../../../proto/auditlog_ts_proto";
 import * as proto from "../../../app/util/proto";
-import * as format from "../../../app/format/format";
-import { formatDateRange } from "../../../app/format/format";
+import { formatDateRangeStringForDisplay } from "../../../app/format/format";
 import Button, { OutlinedButton } from "../../../app/components/button/button";
 import { Calendar } from "lucide-react";
 import Popup from "../../../app/components/popup/popup";
@@ -51,10 +50,7 @@ export default class AuditLogsComponent extends React.Component<AuditLogsCompone
     // Default start time to the midnight today, local time.
     const start = dateRange.startDate ?? moment().startOf("day").toDate();
     // Default end time to the end of today, local time (regardless of start date).
-    const end = moment(dateRange.endDate ?? new Date())
-      .add(1, "day")
-      .startOf("day")
-      .toDate();
+    const end = this.getRealEndTime(dateRange.endDate);
     let req = auditlog.GetAuditLogsRequest.create({
       pageToken: this.state.nextPageToken,
       timestampAfter: proto.dateToTimestamp(start),
@@ -219,6 +215,13 @@ export default class AuditLogsComponent extends React.Component<AuditLogsCompone
     this.fetchAuditLogs(dateRange);
   }
 
+  private getRealEndTime(endDate?: Date): Date {
+    return moment(endDate ?? new Date())
+      .add(1, "day")
+      .startOf("day")
+      .toDate();
+  }
+
   render() {
     return (
       <div className="audit-logs-page">
@@ -237,7 +240,12 @@ export default class AuditLogsComponent extends React.Component<AuditLogsCompone
                 className="date-picker-button icon-text-button"
                 onClick={this.onOpenDatePicker.bind(this)}>
                 <Calendar className="icon" />
-                <span>{formatDateRange(this.state.dateRange.startDate!, this.state.dateRange.endDate!)}</span>
+                <span>
+                  {formatDateRangeStringForDisplay(
+                    this.state.dateRange.startDate!,
+                    this.getRealEndTime(this.state.dateRange.endDate)
+                  )}
+                </span>
               </OutlinedButton>
               <Popup
                 anchor="left"

--- a/enterprise/app/auditlogs/auditlogs.tsx
+++ b/enterprise/app/auditlogs/auditlogs.tsx
@@ -3,7 +3,7 @@ import moment from "moment";
 import rpcService from "../../../app/service/rpc_service";
 import { auditlog } from "../../../proto/auditlog_ts_proto";
 import * as proto from "../../../app/util/proto";
-import { formatDateRangeStringForDisplay } from "../../../app/format/format";
+import { formatDate, formatDateRangeStringForDisplay } from "../../../app/format/format";
 import Button, { OutlinedButton } from "../../../app/components/button/button";
 import { Calendar } from "lucide-react";
 import Popup from "../../../app/components/popup/popup";
@@ -215,6 +215,9 @@ export default class AuditLogsComponent extends React.Component<AuditLogsCompone
     this.fetchAuditLogs(dateRange);
   }
 
+  // We let the date picker say that the end of a date range is "2024-10-02"
+  // when what we really mean is "midnight 2024-10-03, exclusive".  This
+  // function does that conversion.
   private getRealEndTime(endDate?: Date): Date {
     return moment(endDate ?? new Date())
       .add(1, "day")
@@ -280,7 +283,7 @@ export default class AuditLogsComponent extends React.Component<AuditLogsCompone
                 {this.state.entries.map((entry) => {
                   return (
                     <div className="audit-log-entry">
-                      <div className="timestamp">{format.formatDate(proto.timestampToDate(entry.eventTime || {}))}</div>
+                      <div className="timestamp">{formatDate(proto.timestampToDate(entry.eventTime || {}))}</div>
                       <div className="user">{this.renderUser(entry.authenticationInfo!)}</div>
                       <div className="resource">{this.renderResource(entry.resource!)}</div>
                       <div className="method">{this.renderAction(entry.action)}</div>

--- a/enterprise/app/filter/filter.tsx
+++ b/enterprise/app/filter/filter.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react";
 import Checkbox from "../../../app/components/checkbox/checkbox";
 import Radio from "../../../app/components/radio/radio";
-import { compactDurationSec, formatDateRangeStringForDisplay } from "../../../app/format/format";
+import { compactDurationSec, formatDateRange } from "../../../app/format/format";
 import router from "../../../app/router/router";
 import {
   DIMENSION_PARAM_NAME,
@@ -379,7 +379,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
         .startOf("day")
         .toDate();
       return {
-        label: formatDateRangeStringForDisplay(start, undefined, { now }),
+        label: formatDateRange(start, undefined, { now }),
         isSelected: () =>
           this.props.search.get(LAST_N_DAYS_PARAM_NAME) === String(n) ||
           (!isDateRangeSelected && n === DEFAULT_LAST_N_DAYS),

--- a/enterprise/app/filter/filter.tsx
+++ b/enterprise/app/filter/filter.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react";
 import Checkbox from "../../../app/components/checkbox/checkbox";
 import Radio from "../../../app/components/radio/radio";
-import { compactDurationSec, formatDateRange } from "../../../app/format/format";
+import { compactDurationSec, formatDateRangeStringForDisplay } from "../../../app/format/format";
 import router from "../../../app/router/router";
 import {
   DIMENSION_PARAM_NAME,
@@ -56,7 +56,7 @@ import {
   parseStatusParam,
   toStatusParam,
   statusToString,
-  getDisplayDateRange,
+  getDateRangeForPicker,
   isAnyNonDateFilterSet,
   DATE_PARAM_FORMAT,
   DEFAULT_LAST_N_DAYS,
@@ -69,6 +69,7 @@ import {
   DURATION_SLIDER_MAX_VALUE,
   getFiltersFromDimensionParam,
   getDimensionName,
+  getDateRangeStringForDisplay,
 } from "./filter_util";
 import TextInput from "../../../app/components/input/input";
 
@@ -344,7 +345,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
   }
 
   render() {
-    const { startDate, endDate } = getDisplayDateRange(this.props.search);
+    const { startDate, endDate } = getDateRangeForPicker(this.props.search);
 
     const roleValue = this.props.search.get(ROLE_PARAM_NAME) || "";
     const statusValue = this.props.search.get(STATUS_PARAM_NAME) || "";
@@ -378,7 +379,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
         .startOf("day")
         .toDate();
       return {
-        label: formatDateRange(start, undefined, { now }),
+        label: formatDateRangeStringForDisplay(start, undefined, { now }),
         isSelected: () =>
           this.props.search.get(LAST_N_DAYS_PARAM_NAME) === String(n) ||
           (!isDateRangeSelected && n === DEFAULT_LAST_N_DAYS),
@@ -670,7 +671,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
         <div className="popup-wrapper">
           <OutlinedButton className="date-picker-button icon-text-button" onClick={this.onOpenDatePicker.bind(this)}>
             <Calendar className="icon" />
-            <span>{formatDateRange(startDate, endDate)}</span>
+            <span>{getDateRangeStringForDisplay(this.props.search)}</span>
           </OutlinedButton>
           <Popup
             isOpen={this.state.isDatePickerOpen}

--- a/enterprise/app/filter/filter.tsx
+++ b/enterprise/app/filter/filter.tsx
@@ -69,7 +69,7 @@ import {
   DURATION_SLIDER_MAX_VALUE,
   getFiltersFromDimensionParam,
   getDimensionName,
-  getDateRangeStringForDisplay,
+  formatDateRangeFromUrlParams,
 } from "./filter_util";
 import TextInput from "../../../app/components/input/input";
 
@@ -671,7 +671,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
         <div className="popup-wrapper">
           <OutlinedButton className="date-picker-button icon-text-button" onClick={this.onOpenDatePicker.bind(this)}>
             <Calendar className="icon" />
-            <span>{getDateRangeStringForDisplay(this.props.search)}</span>
+            <span>{formatDateRangeFromUrlParams(this.props.search)}</span>
           </OutlinedButton>
           <Popup
             isOpen={this.state.isDatePickerOpen}

--- a/enterprise/app/filter/filter_util.tsx
+++ b/enterprise/app/filter/filter_util.tsx
@@ -317,7 +317,7 @@ export function formatDateRangeDurationFromSearchParams(search: URLSearchParams)
   return diff == 1 ? "day" : `${diff} days`;
 }
 
-export function getDateRangeStringForDisplay(search: URLSearchParams): string {
+export function formatDateRangeFromUrlParams(search: URLSearchParams): string {
   // XXX: This needs to care whether the selected range is a whole day or a specific time.
   const { startDate, endDate } = getDateRangeForStringFromUrlParams(search);
   return formatDateRange(startDate, endDate);

--- a/enterprise/app/filter/filter_util.tsx
+++ b/enterprise/app/filter/filter_util.tsx
@@ -1,5 +1,5 @@
 import capabilities from "../../../app/capabilities/capabilities";
-import { differenceInCalendarDays, durationMillis, formatDateRangeStringForDisplay } from "../../../app/format/format";
+import { differenceInCalendarDays, durationMillis, formatDateRange } from "../../../app/format/format";
 import * as proto from "../../../app/util/proto";
 import { google as google_duration } from "../../../proto/duration_ts_proto";
 import { google as google_timestamp } from "../../../proto/timestamp_ts_proto";
@@ -320,7 +320,7 @@ export function formatDateRangeDurationFromSearchParams(search: URLSearchParams)
 export function getDateRangeStringForDisplay(search: URLSearchParams): string {
   // XXX: This needs to care whether the selected range is a whole day or a specific time.
   const { startDate, endDate } = getDateRangeForStringFromUrlParams(search);
-  return formatDateRangeStringForDisplay(startDate, endDate);
+  return formatDateRange(startDate, endDate);
 }
 
 export function isAnyDimensionFilterSet(param: string): boolean {

--- a/enterprise/app/trends/summary_card.tsx
+++ b/enterprise/app/trends/summary_card.tsx
@@ -5,7 +5,7 @@ import * as format from "../../../app/format/format";
 import { stats } from "../../../proto/stats_ts_proto";
 import {
   isAnyNonDateFilterSet,
-  getDateRangeStringForDisplay,
+  formatDateRangeFromUrlParams,
   formatDateRangeDurationFromSearchParams,
 } from "../filter/filter_util";
 
@@ -67,7 +67,7 @@ export default class TrendsSummaryCard extends React.Component<Props> {
     return (
       <div className="trend-chart">
         <div className="trend-chart-title">
-          Summary ({getDateRangeStringForDisplay(this.props.search)}
+          Summary ({formatDateRangeFromUrlParams(this.props.search)}
           {isAnyNonDateFilterSet(this.props.search) ? ", including filters" : ""})
         </div>
         <div className="trend-summary-block">

--- a/enterprise/app/trends/summary_card.tsx
+++ b/enterprise/app/trends/summary_card.tsx
@@ -5,7 +5,7 @@ import * as format from "../../../app/format/format";
 import { stats } from "../../../proto/stats_ts_proto";
 import {
   isAnyNonDateFilterSet,
-  formatDateRangeFromSearchParams,
+  getDateRangeStringForDisplay,
   formatDateRangeDurationFromSearchParams,
 } from "../filter/filter_util";
 
@@ -67,7 +67,7 @@ export default class TrendsSummaryCard extends React.Component<Props> {
     return (
       <div className="trend-chart">
         <div className="trend-chart-title">
-          Summary ({formatDateRangeFromSearchParams(this.props.search)}
+          Summary ({getDateRangeStringForDisplay(this.props.search)}
           {isAnyNonDateFilterSet(this.props.search) ? ", including filters" : ""})
         </div>
         <div className="trend-summary-block">


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
right now, if you pick, say, sep 10-15 in the date picker, the filter text winds up saying "sep 10-14".  it's been like this for a while.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
