### PR TITLE
server: Add more sources to the CSP

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -228,6 +228,15 @@ yarn_install(
     name = "npm",
     exports_directories_only = False,
     package_json = "//:package.json",
+    patch_args = [
+        "-p1",
+        "--binary",
+    ],
+    post_install_patches = [
+        # Patch out use of eval to satisfy a strict CSP.
+        # https://github.com/protobufjs/protobuf.js/issues/593
+        "//buildpatches:protobuf.js_inquire.patch",
+    ],
     symlink_node_modules = False,
     yarn_lock = "//:yarn.lock",
 )

--- a/buildpatches/protobuf.js_inquire.patch
+++ b/buildpatches/protobuf.js_inquire.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@protobufjs/inquire/index.js b/node_modules/@protobufjs/inquire/index.js
+index 33778b5..2132aac 100644
+--- a/node_modules/@protobufjs/inquire/index.js
++++ b/node_modules/@protobufjs/inquire/index.js
+@@ -9,7 +9,7 @@ module.exports = inquire;
+  */
+ function inquire(moduleName) {
+     try {
+-        var mod = eval("quire".replace(/^/,"re"))(moduleName); // eslint-disable-line no-eval
++        var mod = require(moduleName); // eslint-disable-line no-eval
+         if (mod && (mod.length || Object.keys(mod).length))
+             return mod;
+     } catch (e) {} // eslint-disable-line no-empty

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -47,10 +47,13 @@ const contentSecurityPolicyReportingEndpointName = "csp-endpoint"
 var contentSecurityPolicyTemplate = strings.Join([]string{
 	"default-src 'self'",
 	"style-src 'self' https://fonts.googleapis.com/css",
-	"script-src 'self' https://www.googletagmanager.com 'nonce-%s'",
+	// libsodium.js requires 'wasm-unsafe-eval' to avoid a fallback to asm.js.
+	"script-src 'self' 'strict-dynamic' 'nonce-%s' 'wasm-unsafe-eval'",
 	"font-src 'self' https://fonts.gstatic.com",
-	"img-src 'self' https://www.googletagmanager.com",
-	"connect-src 'self' https://www.googletagmanager.com",
+	// We directly embed profile images from Google accounts and don't control their URLs.
+	"img-src 'self' https:",
+	// libsodium.js requires data: for wasm.
+	"connect-src 'self' https://www.googletagmanager.com data:",
 	"form-action 'self'",
 	"frame-src 'none'",
 	"worker-src 'none'",

--- a/static/index.html
+++ b/static/index.html
@@ -25,7 +25,7 @@
     </script>
 
     {{if .GaEnabled}}
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156160991-2"></script>
+    <script {{.Nonce}} async src="https://www.googletagmanager.com/gtag/js?id=UA-156160991-2"></script>
     <script {{.Nonce}}>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -41,5 +41,5 @@
       <div class="loading"></div>
     </div>
   </body>
-  <script type="module" src="{{.JsEntryPointPath}}"></script>
+  <script {{.Nonce}} type="module" src="{{.JsEntryPointPath}}"></script>
 </html>


### PR DESCRIPTION
* Allow dynamic loading of scripts such as Monaco via strict-dynamic
* Allow more image sources
* Add directives required by libsodium.js
* Patch out an unnecessary use of `eval`

**Related issues**: buildbuddy-io/buildbuddy-internal#3911
