### PR TITLE
integration/podman: pin busybox image to stable

### DIFF
--- a/enterprise/server/test/integration/podman/podman_test.go
+++ b/enterprise/server/test/integration/podman/podman_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 const (
-	busyboxImage = "mirror.gcr.io/library/busybox"
+	busyboxImage = "mirror.gcr.io/library/busybox:1.36.1@sha256:c230832bd3b0be59a6c47ed64294f9ce71e91b327957920b6929a0caa8353140"
 )
 
 func writeFile(t *testing.T, parentDir, fileName, content string) {

--- a/enterprise/server/test/integration/podman/podman_test.go
+++ b/enterprise/server/test/integration/podman/podman_test.go
@@ -643,6 +643,7 @@ func TestPodmanRun_RecordsStats(t *testing.T) {
 	assert.Greater(t, res.UsageStats.PeakMemoryBytes, int64(0), "peak mem usage should be > 0")
 }
 
+// TODO(http://go/b/3924): Figure out why this test fails on newer versions of busybox.
 func TestSignal(t *testing.T) {
 	ctx := context.Background()
 	buildRoot := testfs.MakeTempDir(t)


### PR DESCRIPTION
The unstable version has some weird behavior that affect how signal is
handled and failed our TestSignal test consistently.

Let's downgrade our image from latest to stable and pin it with a
SHA256.
