### PR TITLE
bzlmod: move things from WORKSPACE.bzlmod to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -455,6 +455,64 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "cloudprober",
+    build_file_content = "exports_files([\"cloudprober\"])",
+    sha256 = "0a824a6e224d9810514f4a2f4a13f09488672ad483bb0e978c16d8a6b3372625",
+    strip_prefix = "cloudprober-v0.11.2-ubuntu-x86_64",
+    urls = ["https://github.com/google/cloudprober/releases/download/v0.11.2/cloudprober-v0.11.2-ubuntu-x86_64.zip"],
+)
+
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+# AWS RDS instance certs are signed by an AWS CA.
+# The cert is necessary to validate connections to AWS RDS instances when TLS is enabled.
+http_file(
+    name = "aws_rds_certs",
+    downloaded_file_path = "rds-combined-ca-bundle.pem",
+    sha256 = "ed2b625ceeca0ebacf413972c33acbeb65a6c6b94d0c6434f1bb006cd4904ede",
+    url = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+)
+
+install_static_dependencies_ext = use_extension(":deps.bzl", "install_static_dependencies_ext")
+use_repo(
+    install_static_dependencies_ext,
+    "com_github_buildbuddy_io_podman_static_podman-linux-amd64",
+    "com_github_buildbuddy_io_podman_static_podman-linux-arm64",
+    "com_github_buildbuddy_io_protoc_gen_protobufjs",
+    "com_github_buildbuddy_io_soci_snapshotter-static-linux-amd64",
+    "com_github_containerd_stargz_snapshotter-v0.11.4-linux-amd64",
+    "com_github_containers_crun_crun-linux-amd64",
+    "com_github_containers_crun_crun-linux-arm64",
+    "com_github_firecracker_microvm_firecracker",
+    "com_github_googlecloudplatform_docker-credential-gcr-linux-amd64",
+    "com_github_googlecloudplatform_docker-credential-gcr-linux-arm64",
+    "com_github_krallin_tini_tini-linux-amd64",
+    "com_github_krallin_tini_tini-linux-arm64",
+    "com_github_opencontainers_runc_runc-linux-amd64",
+    "com_github_opencontainers_runc_runc-linux-arm64",
+    "com_github_redis_redis-redis-server-v6.2.1-linux-arm64",
+    "com_github_redis_redis-redis-server-v6.2.1-linux-x86_64",
+    "com_github_redis_redis-redis-server-v6.2.6-darwin-arm64",
+    "com_github_redis_redis-redis-server-v6.2.6-darwin-x86_64",
+    "com_github_rootless_containers_rootlesskit-linux-amd64",
+    "com_github_rootless_containers_rootlesskit-linux-arm64",
+    "io_bazel_bazel-5.3.2-darwin-x86_64",
+    "io_bazel_bazel-5.3.2-linux-arm64",
+    "io_bazel_bazel-5.3.2-linux-x86_64",
+    "io_bazel_bazel-6.5.0-darwin-x86_64",
+    "io_bazel_bazel-6.5.0-linux-x86_64",
+    "io_bazel_bazel-7.1.0-darwin-x86_64",
+    "io_bazel_bazel-7.1.0-linux-x86_64",
+    "io_bazel_bazelisk-1.17.0-darwin-amd64",
+    "io_bazel_bazelisk-1.17.0-darwin-arm64",
+    "io_bazel_bazelisk-1.17.0-linux-amd64",
+    "net_busybox_busybox-linux-amd64",
+    "net_busybox_busybox-linux-arm64",
+    "org_kernel_git_linux_kernel-vmlinux",
+    "org_llvm_llvm_clang-format_linux-x86_64",
+)
+
 bazel_dep(name = "rules_oci", version = "2.0.0")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
@@ -476,4 +534,8 @@ use_repo(
     "bazel_oci_image_base_linux_amd64",
     "buildbuddy_go_oci_image_base",
     "buildbuddy_go_oci_image_base_linux_amd64",
+)
+
+register_toolchains(
+    "//toolchains:ubuntu_cc_toolchain",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -335,8 +335,6 @@ load(
 
 _go_image_repos()
 
-all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
-
 # Kubernetes
 
 http_archive(
@@ -547,7 +545,6 @@ http_file(
 )
 
 register_toolchains(
-    "//toolchains:sh_toolchain",
     "//toolchains:ubuntu_cc_toolchain",
 )
 

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,11 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
-# Go
-
-load(":deps.bzl", "install_static_dependencies")
-
-install_static_dependencies()
-
 # In Bazel Central Registry, rules_nodejs before 6.0 is actually rules_nodejs-core,
 # which is a trimmed version of build_bazel_rules_nodejs.
 #
@@ -64,8 +58,6 @@ load(
 )
 
 container_repositories()
-
-all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
 
 # Kubernetes
 
@@ -170,14 +162,6 @@ buildbuddy(
     container_image = UBUNTU20_04_IMAGE,
 )
 
-http_archive(
-    name = "cloudprober",
-    build_file_content = "exports_files([\"cloudprober\"])",
-    sha256 = "0a824a6e224d9810514f4a2f4a13f09488672ad483bb0e978c16d8a6b3372625",
-    strip_prefix = "cloudprober-v0.11.2-ubuntu-x86_64",
-    urls = ["https://github.com/google/cloudprober/releases/download/v0.11.2/cloudprober-v0.11.2-ubuntu-x86_64.zip"],
-)
-
 # esbuild (for bundling JS)
 
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
@@ -206,17 +190,3 @@ browser_repositories(chromium = True)
 load("@io_bazel_rules_webtesting//web:go_repositories.bzl", web_test_go_repositories = "go_repositories")
 
 web_test_go_repositories()
-
-# AWS RDS instance certs are signed by an AWS CA.
-# The cert is necessary to validate connections to AWS RDS instances when TLS is enabled.
-http_file(
-    name = "aws_rds_certs",
-    downloaded_file_path = "rds-combined-ca-bundle.pem",
-    sha256 = "ed2b625ceeca0ebacf413972c33acbeb65a6c6b94d0c6434f1bb006cd4904ede",
-    url = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
-)
-
-register_toolchains(
-    "//toolchains:sh_toolchain",
-    "//toolchains:ubuntu_cc_toolchain",
-)

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,4 +1,5 @@
 load("@bazel_gazelle//:deps.bzl", "go_repository")
+load("@bazel_skylib//lib:modules.bzl", "modules")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 # The podman version used in tests and distributed with the buildbuddy executor image.
@@ -6682,3 +6683,5 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         downloaded_file_path = "runc",
         executable = True,
     )
+
+install_static_dependencies_ext = modules.as_extension(install_static_dependencies)

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -1,20 +1,3 @@
-# TODO(bduffany): The sh_toolchain config here is a workaround for
-# https://github.com/aspect-build/rules_swc/issues/20
-# We should probably either move these to the buildbuddy-toolchain repo
-# or add a symlink from /usr/bin/bash -> /bin/bash to remove the need for these.
-load("@bazel_tools//tools/sh:sh_toolchain.bzl", "sh_toolchain")
-
-sh_toolchain(
-    name = "bash_rbe",
-    path = "/bin/bash",
-)
-
-toolchain(
-    name = "sh_toolchain",
-    toolchain = ":bash_rbe",
-    toolchain_type = "@bazel_tools//tools/sh:toolchain_type",
-)
-
 # A duplicate of @buildbuddy_toolchain//:ubuntu_cc_toolchain
 # with correct cc_compiler constraint value.
 # TODO(sluongng): upstream this to buildbuddy-toolchain


### PR DESCRIPTION
Introduce an extension which wrap around our install_static_dependencies
macro so that we can load all those deps from MODULE.bazel file.

Moved the remaining standalone http_archive and http_file to
MODULE.bazel.

Moved register_toolchains call to MODULE.bazel.

Remove unused all_content variable in both WORKSPACE file.

Remove sh_toolchain. We needed a custom sh_toolchain for rbe due to the issue reported in https://github.com/aspect-build/rules_swc/issues/20.
Now that we have upgraded rules_swc, we should be able to build without an explicit sh_toolchain registered.

Note: merge https://github.com/buildbuddy-io/buildbuddy-internal/pull/3922 first.
