### PR TITLE
Use remote authenticator in codesearch service

### DIFF
--- a/codesearch/cmd/server/BUILD
+++ b/codesearch/cmd/server/BUILD
@@ -11,10 +11,10 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//codesearch/server",
+        "//enterprise/server/remoteauth",
         "//proto:codesearch_service_go_proto",
         "//proto:kythe_service_go_proto",
         "//server/config",
-        "//server/nullauth",
         "//server/real_environment",
         "//server/util/flag",
         "//server/util/grpc_client",

--- a/codesearch/cmd/server/server.go
+++ b/codesearch/cmd/server/server.go
@@ -4,8 +4,8 @@ import (
 	"net"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/server"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remoteauth"
 	"github.com/buildbuddy-io/buildbuddy/server/config"
-	"github.com/buildbuddy-io/buildbuddy/server/nullauth"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -49,7 +49,12 @@ func main() {
 
 	healthChecker := healthcheck.NewHealthChecker(*serverType)
 	env := real_environment.NewRealEnv(healthChecker)
-	env.SetAuthenticator(nullauth.NewNullAuthenticator(true /*anonymousEnabled*/, ""))
+
+	authenticator, err := remoteauth.NewRemoteAuthenticator()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	env.SetAuthenticator(authenticator)
 
 	monitoring.StartMonitoringHandler(env, *monitoringAddr)
 

--- a/codesearch/cmd/server/server.go
+++ b/codesearch/cmd/server/server.go
@@ -52,7 +52,7 @@ func main() {
 
 	authenticator, err := remoteauth.NewRemoteAuthenticator()
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err.Error())
 	}
 	env.SetAuthenticator(authenticator)
 


### PR DESCRIPTION
This will allow for authed requests to the app (we need to read files from the cache) and let me remove that namespace hack from the buildbuddy app (can do it in codesearch directly instead).