### PR TITLE
Ensure that worker_completed_timestamp is set

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -199,19 +199,21 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 
 	stateChangeFn := operation.GetStateChangeFunc(stream, taskID, adInstanceDigest)
 	md := &repb.ExecutedActionMetadata{
-		Worker:               s.hostID,
-		QueuedTimestamp:      task.QueuedTimestamp,
-		WorkerStartTimestamp: timestamppb.Now(),
-		ExecutorId:           s.id,
-		IoStats:              &repb.IOStats{},
-		EstimatedTaskSize:    st.GetSchedulingMetadata().GetTaskSize(),
-		DoNotCache:           task.GetAction().GetDoNotCache(),
+		Worker:                   s.hostID,
+		QueuedTimestamp:          task.QueuedTimestamp,
+		WorkerStartTimestamp:     timestamppb.Now(),
+		WorkerCompletedTimestamp: timestamppb.Now(),
+		ExecutorId:               s.id,
+		IoStats:                  &repb.IOStats{},
+		EstimatedTaskSize:        st.GetSchedulingMetadata().GetTaskSize(),
+		DoNotCache:               task.GetAction().GetDoNotCache(),
 	}
 	finishWithErrFn := func(finalErr error) (retry bool, err error) {
 		if shouldRetry(task, finalErr) {
 			return true, finalErr
 		}
 		resp := operation.ErrorResponse(finalErr)
+		md.WorkerCompletedTimestamp = timestamppb.Now()
 		resp.Result = &repb.ActionResult{
 			ExecutionMetadata: md,
 		}


### PR DESCRIPTION
As of github.com/buildbuddy-io/buildbuddy/pull/7596, when executions fail due to an error (and not the action failing), worker_start_timestamp is set, but worker_finish_timestamp is 0, which results in large negative durations.

Always set the completed time to at least the start time, and possibly some larger value. This will start counting usage for errored executions.