### PR TITLE
reapi: favor platform set in Action over Command

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -614,7 +614,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		c.vmIdx = opts.ForceVMIdx
 	}
 
-	c.supportsRemoteSnapshots = *snaputil.EnableRemoteSnapshotSharing && (platform.IsCICommand(task.GetCommand()) || *forceRemoteSnapshotting)
+	c.supportsRemoteSnapshots = *snaputil.EnableRemoteSnapshotSharing && (platform.IsCICommand(task.GetCommand(), platform.GetProto(task.GetAction(), task.GetCommand())) || *forceRemoteSnapshotting)
 
 	if opts.OverrideSnapshotKey == nil {
 		c.vmConfig.DebugMode = *debugTerminal
@@ -640,7 +640,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		// If recycling is enabled and a snapshot exists, then when calling
 		// Create(), load the snapshot instead of creating a new VM.
 
-		recyclingEnabled := platform.IsTrue(platform.FindValue(task.GetCommand().GetPlatform(), platform.RecycleRunnerPropertyName))
+		recyclingEnabled := platform.IsTrue(platform.FindValue(platform.GetProto(task.GetAction(), task.GetCommand()), platform.RecycleRunnerPropertyName))
 		if recyclingEnabled && *snaputil.EnableLocalSnapshotSharing {
 			snap, err := loader.GetSnapshot(ctx, c.snapshotKeySet, c.supportsRemoteSnapshots)
 			c.createFromSnapshot = (err == nil)

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -147,7 +147,7 @@ func isTaskMisconfigured(err error) bool {
 
 func isClientBazel(task *repb.ExecutionTask) bool {
 	// TODO(bduffany): Find a more reliable way to determine this.
-	return !platform.IsCICommand(task.GetCommand())
+	return !platform.IsCICommand(task.GetCommand(), platform.GetProto(task.GetAction(), task.GetCommand()))
 }
 
 func shouldRetry(task *repb.ExecutionTask, taskError error) bool {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -280,7 +280,8 @@ func (r *taskRunner) DownloadInputs(ctx context.Context, ioStats *repb.IOStats) 
 	if err != nil {
 		return err
 	}
-	if platform.IsCICommand(r.task.GetCommand()) && !ci_runner_util.CanInitFromCache(r.PlatformProperties.OS, r.PlatformProperties.Arch) {
+	if platform.IsCICommand(r.task.GetCommand(), platform.GetProto(r.task.GetAction(), r.task.GetCommand())) &&
+		!ci_runner_util.CanInitFromCache(r.PlatformProperties.OS, r.PlatformProperties.Arch) {
 		if err := r.Workspace.AddCIRunner(ctx); err != nil {
 			return err
 		}
@@ -943,7 +944,7 @@ func (p *pool) Get(ctx context.Context, st *repb.ScheduledTask) (interfaces.Runn
 	key := &rnpb.RunnerKey{
 		GroupId:             groupID,
 		InstanceName:        task.GetExecuteRequest().GetInstanceName(),
-		Platform:            task.GetCommand().GetPlatform(),
+		Platform:            platform.GetProto(task.GetAction(), task.GetCommand()),
 		PersistentWorkerKey: persistentWorkerKey,
 	}
 

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/copy_on_write",
+        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/snaputil",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
@@ -48,7 +49,7 @@ const (
 // SnapshotKeySet returns the cache keys for potential snapshot matches,
 // as well as the key that should be written to.
 func (l *FileCacheLoader) SnapshotKeySet(ctx context.Context, task *repb.ExecutionTask, configurationHash, runnerID string) (*fcpb.SnapshotKeySet, error) {
-	pd, err := digest.ComputeForMessage(task.GetCommand().GetPlatform(), repb.DigestFunction_SHA256)
+	pd, err := digest.ComputeForMessage(platform.GetProto(task.GetAction(), task.GetCommand()), repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, status.WrapErrorf(err, "failed to compute platform hash")
 	}

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -292,7 +292,7 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, cmd *repb.Command, execu
 			// runner should be removed and cannot affect any files in the
 			// workspace anymore, so it is safe to rename the outputs files in
 			// upperdir here rather than copying.
-			recyclingEnabled := platform.IsTrue(platform.FindValue(ws.task.GetCommand().GetPlatform(), platform.RecycleRunnerPropertyName))
+			recyclingEnabled := platform.IsTrue(platform.FindValue(platform.GetProto(ws.task.GetAction(), ws.task.GetCommand()), platform.RecycleRunnerPropertyName))
 			opts := overlayfs.ApplyOpts{AllowRename: !recyclingEnabled}
 			if err := ws.overlay.Apply(egCtx, opts); err != nil {
 				return status.WrapError(err, "apply overlay upperdir changes")

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1730,7 +1730,7 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 
 	attempts := 0
 	var rankedNodes []interfaces.RankedExecutionNode
-	nonPreferredDelay := getNonPreferredSchedulingDelay(cmd)
+	nonPreferredDelay := getNonPreferredSchedulingDelay(platform.GetProto(task.GetAction(), cmd))
 	delayable := enqueueRequest.GetDelay() == nil
 	for len(successfulReservations) < probeCount {
 		// If the queue of ranked, candidate nodes is empty, refresh them.
@@ -1749,7 +1749,7 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 			if len(candidateNodes) == 0 {
 				return status.UnavailableErrorf("requested executor ID not found")
 			}
-			rankedNodes = s.taskRouter.RankNodes(ctx, cmd, remoteInstanceName, toNodeInterfaces(candidateNodes))
+			rankedNodes = s.taskRouter.RankNodes(ctx, task.GetAction(), cmd, remoteInstanceName, toNodeInterfaces(candidateNodes))
 		}
 
 		select {
@@ -1794,8 +1794,8 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 
 // Returns the delay that should be applied to executions scheduled on
 // non-preferred execution nodes.
-func getNonPreferredSchedulingDelay(cmd *repb.Command) time.Duration {
-	delayProperty := platform.FindValue(cmd.GetPlatform(), platform.RunnerRecyclingMaxWaitPropertyName)
+func getNonPreferredSchedulingDelay(plat *repb.Platform) time.Duration {
+	delayProperty := platform.FindValue(plat, platform.RunnerRecyclingMaxWaitPropertyName)
 	if delayProperty == "" {
 		return defaultSchedulingDelay
 	}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -51,7 +51,7 @@ func (n fakeRankedNode) IsPreferred() bool {
 	return n.preferred
 }
 
-func (f *fakeTaskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) []interfaces.RankedExecutionNode {
+func (f *fakeTaskRouter) RankNodes(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) []interfaces.RankedExecutionNode {
 	rankedNodes := make([]interfaces.RankedExecutionNode, len(nodes))
 	for i, node := range nodes {
 		preferred := false
@@ -77,7 +77,7 @@ func (f *fakeTaskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remot
 	return rankedNodes
 }
 
-func (f *fakeTaskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorInstanceID string) {
+func (f *fakeTaskRouter) MarkComplete(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorInstanceID string) {
 }
 
 type schedulerOpts struct {

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -102,14 +102,14 @@ func nonePreferred(nodes []interfaces.ExecutionNode) []interfaces.RankedExecutio
 
 // RankNodes returns the input nodes ordered by their affinity to the given
 // routing properties.
-func (tr *taskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) []interfaces.RankedExecutionNode {
+func (tr *taskRouter) RankNodes(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) []interfaces.RankedExecutionNode {
 	nodes = copyNodes(nodes)
 
 	rand.Shuffle(len(nodes), func(i, j int) {
 		nodes[i], nodes[j] = nodes[j], nodes[i]
 	})
 
-	params := getRoutingParams(ctx, tr.env, cmd, remoteInstanceName)
+	params := getRoutingParams(ctx, tr.env, action, cmd, remoteInstanceName)
 	strategy := tr.selectRouter(params)
 	if strategy == nil {
 		return nonePreferred(nodes)
@@ -179,8 +179,8 @@ func (tr *taskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteIn
 // MarkComplete updates the routing table after a task is completed, so that
 // future tasks with those properties are more likely to be fulfilled by the
 // given node.
-func (tr *taskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorHostID string) {
-	params := getRoutingParams(ctx, tr.env, cmd, remoteInstanceName)
+func (tr *taskRouter) MarkComplete(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorHostID string) {
+	params := getRoutingParams(ctx, tr.env, action, cmd, remoteInstanceName)
 	strategy := tr.selectRouter(params)
 	if strategy == nil {
 		return
@@ -221,16 +221,21 @@ func (tr *taskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remot
 // Contains the parameters required to make a routing decision.
 type routingParams struct {
 	cmd                *repb.Command
+	platform           *repb.Platform
 	remoteInstanceName string
 	groupID            string
 }
 
-func getRoutingParams(ctx context.Context, env environment.Env, cmd *repb.Command, remoteInstanceName string) routingParams {
+func getRoutingParams(ctx context.Context, env environment.Env, action *repb.Action, cmd *repb.Command, remoteInstanceName string) routingParams {
 	groupID := interfaces.AuthAnonymousUser
 	if u, err := env.GetAuthenticator().AuthenticatedUser(ctx); err == nil {
 		groupID = u.GetGroupID()
 	}
-	return routingParams{cmd: cmd, remoteInstanceName: remoteInstanceName, groupID: groupID}
+	return routingParams{
+		cmd:                cmd,
+		platform:           platform.GetProto(action, cmd),
+		remoteInstanceName: remoteInstanceName,
+		groupID:            groupID}
 }
 
 // Selects and returns a Router to use, or nil if none applies.
@@ -273,10 +278,10 @@ type Router interface {
 type ciRunnerRouter struct{}
 
 func (ciRunnerRouter) Applies(params routingParams) bool {
-	return platform.IsCICommand(params.cmd) && platform.IsTrue(platform.FindValue(params.cmd.GetPlatform(), platform.RecycleRunnerPropertyName))
+	return platform.IsCICommand(params.cmd, params.platform) && platform.IsTrue(platform.FindValue(params.platform, platform.RecycleRunnerPropertyName))
 }
 
-func (ciRunnerRouter) preferredNodeLimit(params routingParams) int {
+func (ciRunnerRouter) preferredNodeLimit(_ routingParams) int {
 	return ciRunnerPreferredNodeLimit
 }
 
@@ -288,11 +293,7 @@ func (ciRunnerRouter) routingKeys(params routingParams) ([]string, error) {
 		parts = append(parts, params.remoteInstanceName)
 	}
 
-	p := params.cmd.GetPlatform()
-	if p == nil {
-		p = &repb.Platform{}
-	}
-	b, err := proto.Marshal(p)
+	b, err := proto.Marshal(params.platform)
 	if err != nil {
 		return nil, status.InternalErrorf("failed to marshal Command: %s", err)
 	}
@@ -301,7 +302,7 @@ func (ciRunnerRouter) routingKeys(params routingParams) ([]string, error) {
 	// For workflow tasks, route using git branch name so that when re-running the
 	// workflow multiple times using the same branch, the runs are more likely
 	// to hit an executor with a warmer snapshot cache.
-	if platform.IsCICommand(params.cmd) {
+	if platform.IsCICommand(params.cmd, params.platform) {
 		envVarNames := []string{"GIT_BRANCH"}
 		if *defaultBranchRoutingEnabled {
 			envVarNames = append(envVarNames, "GIT_BASE_BRANCH", "GIT_REPO_DEFAULT_BRANCH")
@@ -347,7 +348,7 @@ func (affinityRouter) Applies(params routingParams) bool {
 	return *affinityRoutingEnabled && getFirstOutput(params.cmd) != ""
 }
 
-func (affinityRouter) preferredNodeLimit(params routingParams) int {
+func (affinityRouter) preferredNodeLimit(_ routingParams) int {
 	return defaultPreferredNodeLimit
 }
 
@@ -358,11 +359,7 @@ func (affinityRouter) routingKey(params routingParams) (string, error) {
 		parts = append(parts, params.remoteInstanceName)
 	}
 
-	platform := params.cmd.GetPlatform()
-	if platform == nil {
-		platform = &repb.Platform{}
-	}
-	b, err := proto.Marshal(platform)
+	b, err := proto.Marshal(params.platform)
 	if err != nil {
 		return "", status.InternalErrorf("failed to marshal Command: %s", err)
 	}

--- a/enterprise/server/scheduling/task_router/task_router_test.go
+++ b/enterprise/server/scheduling/task_router/task_router_test.go
@@ -42,13 +42,13 @@ func TestTaskRouter_RankNodes_Workflows_ReturnsLatestRunnerThatExecutedWorkflow(
 	}
 	instanceName := "test-instance"
 
-	router.MarkComplete(ctx, cmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, cmd, instanceName, executorHostID1)
 
 	nodes := sequentiallyNumberedNodes(100)
 
 	// Task should now be routed to executor 1.
 
-	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
+	ranked := router.RankNodes(ctx, nil, cmd, instanceName, nodes)
 
 	requireSameExecutionNodes(t, nodes, ranked)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
@@ -58,12 +58,12 @@ func TestTaskRouter_RankNodes_Workflows_ReturnsLatestRunnerThatExecutedWorkflow(
 
 	// Mark the same task complete by executor 2 as well.
 
-	router.MarkComplete(ctx, cmd, instanceName, executorHostID2)
+	router.MarkComplete(ctx, nil, cmd, instanceName, executorHostID2)
 
 	// Task should now be routed to executor 2, since executor 2 ran the task
 	// more recently.
 
-	ranked = router.RankNodes(ctx, cmd, instanceName, nodes)
+	ranked = router.RankNodes(ctx, nil, cmd, instanceName, nodes)
 
 	requireSameExecutionNodes(t, nodes, ranked)
 	require.Equal(t, executorHostID2, ranked[0].GetExecutionNode().GetExecutorHostId())
@@ -86,13 +86,13 @@ func TestTaskRouter_RankNodes_RoutesByHostID(t *testing.T) {
 	}
 	instanceName := "test-instance"
 
-	router.MarkComplete(ctx, cmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, cmd, instanceName, executorHostID1)
 
 	nodes := sequentiallyNumberedNodes(100)
 
 	// Task should now be routed to executor 1.
 
-	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
+	ranked := router.RankNodes(ctx, nil, cmd, instanceName, nodes)
 
 	requireSameExecutionNodes(t, nodes, ranked)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
@@ -109,7 +109,7 @@ func TestTaskRouter_RankNodes_RoutesByHostID(t *testing.T) {
 
 	// Task should now be routed to the new node on this restarted host.
 
-	ranked = router.RankNodes(ctx, cmd, instanceName, nodes)
+	ranked = router.RankNodes(ctx, nil, cmd, instanceName, nodes)
 
 	requireSameExecutionNodes(t, nodes, ranked)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
@@ -136,13 +136,13 @@ func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
 
 	// No executor should be preferred.
 	nodes := sequentiallyNumberedNodes(100)
-	ranked := router.RankNodes(ctx, firstCmd, instanceName, nodes)
+	ranked := router.RankNodes(ctx, nil, firstCmd, instanceName, nodes)
 	requireNotAlwaysRanked(0, executorHostID1, t, router, ctx, firstCmd, instanceName)
 	requireNonSequential(t, ranked)
 	requireNonePreferred(t, ranked)
 
 	// Mark the task as complete by executor 1.
-	router.MarkComplete(ctx, firstCmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, firstCmd, instanceName, executorHostID1)
 
 	secondCmd := &repb.Command{
 		Platform: &repb.Platform{
@@ -158,7 +158,7 @@ func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
 	}
 
 	// Task should now be routed to executor 1.
-	ranked = router.RankNodes(ctx, secondCmd, instanceName, nodes)
+	ranked = router.RankNodes(ctx, nil, secondCmd, instanceName, nodes)
 
 	requireSameExecutionNodes(t, nodes, ranked)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
@@ -167,7 +167,7 @@ func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
 	requireNonePreferred(t, ranked[1:])
 
 	// Mark the task complete by executor 2 as well.
-	router.MarkComplete(ctx, secondCmd, instanceName, executorHostID2)
+	router.MarkComplete(ctx, nil, secondCmd, instanceName, executorHostID2)
 
 	// If the first output is specified as an OutputFile rather than an
 	// OutputPath, the routing should still consider this.
@@ -184,7 +184,7 @@ func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
 		OutputFiles: []string{"/bazel-out/foo.a"},
 	}
 
-	ranked = router.RankNodes(ctx, thirdCmd, instanceName, nodes)
+	ranked = router.RankNodes(ctx, nil, thirdCmd, instanceName, nodes)
 
 	// Task should now be routed to executor 2, with executor 1 ranked randomly
 	requireSameExecutionNodes(t, nodes, ranked)
@@ -224,12 +224,12 @@ func TestTaskRouter_RankNodes_AffinityRoutingNoOutputs(t *testing.T) {
 	}
 	instanceName := "test-instance"
 
-	router.MarkComplete(ctx, cmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, cmd, instanceName, executorHostID1)
 
 	nodes := sequentiallyNumberedNodes(100)
 
 	// No nodes should be preferred as there are no outputs to route using.
-	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
+	ranked := router.RankNodes(ctx, nil, cmd, instanceName, nodes)
 	requireSameExecutionNodes(t, nodes, ranked)
 	requireNonSequential(t, ranked)
 	requireNotAlwaysRanked(0, executorHostID1, t, router, ctx, cmd, instanceName)
@@ -251,12 +251,12 @@ func TestTaskRouter_RankNodes_AffinityRoutingDisabled(t *testing.T) {
 	}
 	instanceName := "test-instance"
 
-	router.MarkComplete(ctx, cmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, cmd, instanceName, executorHostID1)
 
 	nodes := sequentiallyNumberedNodes(100)
 
 	// No nodes should be preferred as affinity routing is disabled.
-	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
+	ranked := router.RankNodes(ctx, nil, cmd, instanceName, nodes)
 	requireSameExecutionNodes(t, nodes, ranked)
 	requireNonSequential(t, ranked)
 	requireNotAlwaysRanked(0, executorHostID1, t, router, ctx, cmd, instanceName)
@@ -269,7 +269,7 @@ func TestTaskRouter_RankNodes_JustShufflesIfCommandIsNotAvailable(t *testing.T) 
 	ctx := withAuthUser(t, context.Background(), env, "US1")
 	instanceName := ""
 
-	ranked := router.RankNodes(ctx, nil /*=cmd*/, instanceName, nodes)
+	ranked := router.RankNodes(ctx, nil /*=action*/, nil /*=cmd*/, instanceName, nodes)
 
 	requireReordered(t, nodes, ranked)
 }
@@ -281,7 +281,7 @@ func TestTaskRouter_MarkComplete_DoesNotAffectNonRecyclableTasks(t *testing.T) {
 	cmd := &repb.Command{}
 	instanceName := "test-instance"
 
-	router.MarkComplete(ctx, cmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, cmd, instanceName, executorHostID1)
 
 	requireNotAlwaysRanked(0, executorHostID1, t, router, ctx, cmd, instanceName)
 }
@@ -299,7 +299,7 @@ func TestTaskRouter_MarkComplete_DoesNotAffectOtherGroups(t *testing.T) {
 	}
 	instanceName := "test-instance"
 
-	router.MarkComplete(ctx1, cmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx1, nil, cmd, instanceName, executorHostID1)
 
 	ctx2 := withAuthUser(t, context.Background(), env, "US2")
 
@@ -319,7 +319,7 @@ func TestTaskRouter_MarkComplete_DoesNotAffectOtherRemoteInstances(t *testing.T)
 	}
 	instanceName1 := "test-instance"
 
-	router.MarkComplete(ctx, cmd, instanceName1, executorHostID1)
+	router.MarkComplete(ctx, nil, cmd, instanceName1, executorHostID1)
 
 	instanceName2 := "another-test-instance"
 
@@ -344,11 +344,11 @@ func TestTaskRouter_WorkflowGitRefRouting(t *testing.T) {
 		},
 		Arguments: []string{"./buildbuddy_ci_runner"},
 	}
-	router.MarkComplete(ctx, mainBranchCmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, mainBranchCmd, instanceName, executorHostID1)
 
 	// executor1 should now be the preferred executor when running this workflow
 	// on the main branch.
-	ranked := router.RankNodes(ctx, mainBranchCmd, instanceName, nodes)
+	ranked := router.RankNodes(ctx, nil, mainBranchCmd, instanceName, nodes)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
 
 	// executor1 should not necessarily be preferred when running this workflow
@@ -385,7 +385,7 @@ func TestTaskRouter_WorkflowGitRefRouting_DefaultRef(t *testing.T) {
 		},
 		Arguments: []string{"./buildbuddy_ci_runner"},
 	}
-	router.MarkComplete(ctx, mainBranchCmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, mainBranchCmd, instanceName, executorHostID1)
 
 	// Even though this workflow is running on a different branch, executor1
 	// should be preferred because it ran the workflow on a matching
@@ -401,17 +401,17 @@ func TestTaskRouter_WorkflowGitRefRouting_DefaultRef(t *testing.T) {
 		},
 		Arguments: []string{"./buildbuddy_ci_runner"},
 	}
-	ranked := router.RankNodes(ctx, prBranchCmd, instanceName, nodes)
+	ranked := router.RankNodes(ctx, nil, prBranchCmd, instanceName, nodes)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
 	// Mark executor1 as having completed a workflow run on the pr branch.
-	router.MarkComplete(ctx, prBranchCmd, instanceName, executorHostID1)
+	router.MarkComplete(ctx, nil, prBranchCmd, instanceName, executorHostID1)
 
 	// Simulate executor2 running a workflow on the "main" branch.
-	router.MarkComplete(ctx, mainBranchCmd, instanceName, executorHostID2)
+	router.MarkComplete(ctx, nil, mainBranchCmd, instanceName, executorHostID2)
 
 	// The router should prioritize routing a workflow for the pr branch to the
 	// executor that last ran the pr branch, not the one that last ran the default branch.
-	ranked = router.RankNodes(ctx, prBranchCmd, instanceName, nodes)
+	ranked = router.RankNodes(ctx, nil, prBranchCmd, instanceName, nodes)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
 }
 
@@ -435,7 +435,7 @@ func requireNotAlwaysRanked(rank int, executorID string, t *testing.T, router in
 	nodes := sequentiallyNumberedNodes(100)
 	nTrials := 10
 	for i := 0; i < nTrials; i++ {
-		ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
+		ranked := router.RankNodes(ctx, nil, cmd, instanceName, nodes)
 
 		require.Equal(t, len(nodes), len(ranked))
 		if ranked[rank].GetExecutionNode().GetExecutorHostId() != executorID {

--- a/enterprise/server/tasksize_model/tasksize_model.go
+++ b/enterprise/server/tasksize_model/tasksize_model.go
@@ -295,8 +295,9 @@ func (m *Model) featureVector(task *repb.ExecutionTask) []float32 {
 		envFloat32(cmd, "TEST_TIMEOUT", 300),
 		envFloat32(cmd, "TEST_TOTAL_SHARDS", 1),
 	)
-	features = appendOneHot(features, m.config.OSValues, platform.FindValue(cmd.GetPlatform(), "OSFamily"))
-	features = appendOneHot(features, m.config.ArchValues, platform.FindValue(cmd.GetPlatform(), "Arch"))
+	platformProto := platform.GetProto(task.GetAction(), task.GetCommand())
+	features = appendOneHot(features, m.config.OSValues, platform.FindValue(platformProto, "OSFamily"))
+	features = appendOneHot(features, m.config.ArchValues, platform.FindValue(platformProto, "Arch"))
 	features = appendOneHot(features, m.config.Tools, tool)
 	features = appendOneHot(features, m.config.TestSizes, envValue(cmd, "TEST_SIZE"))
 	features = m.appendExtensionCounts(features, cmd)

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -290,7 +290,8 @@ func (c *Command) processUpdatesAsync(ctx context.Context, stream repb.Execution
 
 func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name string, inputRootDigest *repb.Digest, commandProto *repb.Command, timeout time.Duration) (*Command, error) {
 	commandProto = commandProto.CloneVT()
-	// Remove the platform from the command and set it in the action since that is new since RE API v2.2. This lets us test the new path.
+	// Remove the platform from the command and set it in the action since that
+	// is new since RE API v2.2. This lets us test the new path.
 	plat := commandProto.GetPlatform()
 	commandProto.Platform = nil
 	commandDigest, err := cachetools.UploadProto(ctx, c.gRPClientSource.GetByteStreamClient(), instanceName, repb.DigestFunction_SHA256, commandProto)

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -289,6 +289,10 @@ func (c *Command) processUpdatesAsync(ctx context.Context, stream repb.Execution
 }
 
 func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name string, inputRootDigest *repb.Digest, commandProto *repb.Command, timeout time.Duration) (*Command, error) {
+	commandProto = commandProto.CloneVT()
+	// Remove the platform from the command and set it in the action since that is new since RE API v2.2. This lets us test the new path.
+	plat := commandProto.GetPlatform()
+	commandProto.Platform = nil
 	commandDigest, err := cachetools.UploadProto(ctx, c.gRPClientSource.GetByteStreamClient(), instanceName, repb.DigestFunction_SHA256, commandProto)
 	if err != nil {
 		return nil, status.UnknownErrorf("unable to upload command %q to CAS: %s", name, err)
@@ -297,6 +301,7 @@ func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name s
 	action := &repb.Action{
 		CommandDigest:   commandDigest,
 		InputRootDigest: inputRootDigest,
+		Platform:        plat,
 	}
 	if timeout != 0 {
 		action.Timeout = durationpb.New(timeout)

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1457,7 +1457,7 @@ func newFixedNodeTaskRouter(executorIDs []string) *fixedNodeTaskRouter {
 	return &fixedNodeTaskRouter{executorIDs: idSet}
 }
 
-func (f *fixedNodeTaskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) []interfaces.RankedExecutionNode {
+func (f *fixedNodeTaskRouter) RankNodes(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) []interfaces.RankedExecutionNode {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	var out []interfaces.RankedExecutionNode
@@ -1469,7 +1469,7 @@ func (f *fixedNodeTaskRouter) RankNodes(ctx context.Context, cmd *repb.Command, 
 	return out
 }
 
-func (f *fixedNodeTaskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorHostID string) {
+func (f *fixedNodeTaskRouter) MarkComplete(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorHostID string) {
 }
 
 func (f *fixedNodeTaskRouter) UpdateSubset(executorIDs []string) {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -895,12 +895,12 @@ type TaskRouter interface {
 	// suitability are returned in random order (for load balancing purposes).
 	//
 	// If an error occurs, the input nodes should be returned in random order.
-	RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []ExecutionNode) []RankedExecutionNode
+	RankNodes(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName string, nodes []ExecutionNode) []RankedExecutionNode
 
 	// MarkComplete notifies the router that the command has been completed by the
 	// given executor instance. Subsequent calls to RankNodes may assign a higher
 	// rank to nodes with the given instance ID, given similar commands.
-	MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorInstanceID string)
+	MarkComplete(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorInstanceID string)
 }
 
 // TaskSizer allows storing, retrieving, and predicting task size measurements for a task.


### PR DESCRIPTION
In REAPI v2.2, the usage of platform in Command was deprecated over in Action. Although most of the older REAPI clients, such as Bazel, are setting it in both, newer clients such as Buck2 would only set it in Action message.

This change replace most of existing command.GetPlatform() calls with action.GetPlatform() while using the command value as fallback.

This was heavily inspired by https://github.com/buildbuddy-io/buildbuddy/pull/7550, but with a few more changes.

I tried a simpler approach where we overwrite command.platform with action.platform, but because we read the original protos by digest in ExecutionServer.markTaskComplete, this doesn't work.

Closes buildbuddy-io/buildbuddy-internal#3863