### PR TITLE
proto: update Bazel protos

### DIFF
--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -660,6 +660,10 @@ message OutputGroup {
   // Indicates that one or more of the output group's files were not built
   // successfully (the generating action failed).
   bool incomplete = 4;
+
+  // Inlined files that belong to this output group, requested via
+  // --build_event_inline_output_groups.
+  repeated File inline_files = 5;
 }
 
 // Payload of the event indicating the completion of a target. The target is
@@ -982,6 +986,9 @@ message BuildMetrics {
       // This is only set if all the actions reported a time
       google.protobuf.Duration system_time = 5;
       google.protobuf.Duration user_time = 6;
+
+      // The total number of actions of this type registered during the build.
+      int64 actions_created = 7;
     }
     // Contains the top N actions by number of actions executed.
     repeated ActionData action_data = 4;
@@ -1193,6 +1200,11 @@ message BuildMetrics {
     // Number of SkyValues that were evaluated and found clean, i.e. equal to
     // their previous version.
     repeated EvaluationStat cleaned_values = 13;
+    // Number of evaluations to build SkyValues. This includes restarted
+    // evaluations, which means there can be multiple evaluations per built
+    // SkyValue. Subtract built_values from this number to get the number of
+    // restarted evaluations.
+    repeated EvaluationStat evaluated_values = 17;
 
     // For SkyKeys in 'done values' where the SkyValue is of type
     // RuleConfiguredTargetValue, we pull those out separately and report the

--- a/proto/failure_details.proto
+++ b/proto/failure_details.proto
@@ -150,6 +150,7 @@ message FailureDetail {
     ModCommand mod_command = 183;
     BuildReport build_report = 184;
     Skyfocus skyfocus = 185;
+    RemoteAnalysisCaching remote_analysis_caching = 186;
   }
 
   reserved 102;         // For internal use
@@ -227,6 +228,11 @@ message Spawn {
     //   refactored to prohibit undetailed failures
     UNSPECIFIED_EXECUTION_FAILURE = 12 [(metadata) = { exit_code: 1 }];
     FORBIDDEN_INPUT = 13 [(metadata) = { exit_code: 1 }];
+    // This also includes other remote cache errors, not just evictions,
+    // if --incompatible_remote_use_new_exit_code_for_lost_inputs is set.
+    // TODO: Rename it to a more general name when
+    // --experimental_remote_cache_eviction_retries is moved to
+    // non-experimental.
     REMOTE_CACHE_EVICTED = 14 [(metadata) = { exit_code: 39 }];
     SPAWN_LOG_IO_EXCEPTION = 15 [(metadata) = { exit_code: 36 }];
   }
@@ -377,6 +383,17 @@ message Skyfocus {
     NON_WORKING_SET_CHANGE = 1 [(metadata) = { exit_code: 2 }];
     CONFIGURATION_CHANGE = 2 [(metadata) = { exit_code: 2 }];
     DISALLOWED_OPERATION_ON_FOCUSED_GRAPH = 3 [(metadata) = { exit_code: 2 }];
+  }
+
+  Code code = 1;
+}
+
+// Failure details for errors produced during remote analysis caching.
+message RemoteAnalysisCaching {
+  enum Code {
+    REMOTE_ANALYSIS_CACHING_UNKNOWN = 0 [(metadata) = { exit_code: 1 }];
+    SERIALIZED_FRONTIER_PROFILE_FAILED = 1 [(metadata) = { exit_code: 1 }];
+    PROJECT_FILE_NOT_FOUND = 2 [(metadata) = { exit_code: 2 }];
   }
 
   Code code = 1;
@@ -733,6 +750,7 @@ message LocalExecution {
   enum Code {
     LOCAL_EXECUTION_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
     LOCKFREE_OUTPUT_PREREQ_UNMET = 1 [(metadata) = { exit_code: 2 }];
+    UNTRACKED_RESOURCE = 2 [(metadata) = { exit_code: 1 }];
   }
 
   Code code = 1;
@@ -785,6 +803,8 @@ message Sandbox {
     MOUNT_TARGET_DOES_NOT_EXIST = 9 [(metadata) = { exit_code: 1 }];
     SUBPROCESS_START_FAILED = 10 [(metadata) = { exit_code: 36 }];
     FORBIDDEN_INPUT = 11 [(metadata) = { exit_code: 1 }];
+    COPY_INPUTS_IO_EXCEPTION = 12 [(metadata) = { exit_code: 36 }];
+    COPY_OUTPUTS_IO_EXCEPTION = 13 [(metadata) = { exit_code: 36 }];
   }
 
   Code code = 1;
@@ -943,6 +963,8 @@ message DumpCommand {
     STARLARK_HEAP_DUMP_FAILED = 5 [(metadata) = { exit_code: 8 }];
     reserved 6;  // For internal use
     SKYFRAME_MEMORY_DUMP_FAILED = 7 [(metadata) = { exit_code: 7 }];
+    // deprecated, moved to the RemoteAnalysisCaching message.
+    reserved 8;
   }
 
   Code code = 1;
@@ -1147,6 +1169,7 @@ message SymlinkAction {
     EXECUTABLE_INPUT_CHECK_IO_EXCEPTION = 3 [(metadata) = { exit_code: 1 }];
     LINK_CREATION_IO_EXCEPTION = 4 [(metadata) = { exit_code: 1 }];
     LINK_TOUCH_IO_EXCEPTION = 5 [(metadata) = { exit_code: 1 }];
+    LINK_LOG_IO_EXCEPTION = 6 [(metadata) = { exit_code: 36 }];
   }
 
   Code code = 1;

--- a/proto/spawn.proto
+++ b/proto/spawn.proto
@@ -379,7 +379,7 @@ message ExecLogEntry {
     // Entry ID of the set of inputs. Unset means empty.
     uint32 input_set_id = 4;
 
-    // Entry ID of the set of tool inputs. Unset means empty.
+    // Entry ID of the subset of inputs that are tools. Unset means empty.
     uint32 tool_set_id = 5;
 
     // The set of outputs.


### PR DESCRIPTION
Update all relevant Bazel protos.

Skip on the deprecations removal in spawn.proto as it would break our
existing code, which supports the older compact exec log format.
