### PR TITLE
[raft] rollback all statements when there is preparation error

### DIFF
--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -169,9 +169,6 @@ func TestCommitPreparedTxn(t *testing.T) {
 		TxnState:      rfpb.TxnRecord_PREPARED,
 		Op:            rfpb.FinalizeOperation_COMMIT,
 		CreatedAtUsec: clock.Now().UnixMicro(),
-		Prepared: []*rfpb.RangeDescriptor{
-			txnProto.GetStatements()[0].GetRange(),
-		},
 	}
 	tc := txn.NewCoordinator(store, store.APIClient(), clock)
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -297,7 +297,7 @@ message TxnRecord {
   // When is this record first created
   int64 created_at_usec = 3;
   reserved 4;
-  repeated RangeDescriptor prepared = 6;
+  reserved 6;
   FinalizeOperation op = 5;
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
https://github.com/buildbuddy-io/buildbuddy-internal/issues/3932
