### PR TITLE
Add charts for executor node CPU usage by pod

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -80,7 +80,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 217
+            "y": 225
           },
           "hiddenSeries": false,
           "id": 21,
@@ -187,7 +187,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 224
+            "y": 232
           },
           "hiddenSeries": false,
           "id": 6270,
@@ -284,7 +284,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 231
+            "y": 239
           },
           "hiddenSeries": false,
           "id": 932,
@@ -420,7 +420,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 231
+            "y": 239
           },
           "id": 5492,
           "options": {
@@ -493,7 +493,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 146
+            "y": 154
           },
           "hiddenSeries": false,
           "id": 348,
@@ -581,7 +581,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 146
+            "y": 154
           },
           "hiddenSeries": false,
           "id": 804,
@@ -701,7 +701,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 19
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 6840,
@@ -794,7 +794,7 @@
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 19
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 25,
@@ -888,7 +888,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 27
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 1232,
@@ -1002,7 +1002,7 @@
             "h": 8,
             "w": 12,
             "x": 9,
-            "y": 27
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 65,
@@ -1096,7 +1096,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 35
+            "y": 43
           },
           "hiddenSeries": false,
           "id": 13,
@@ -1262,7 +1262,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 220
+            "y": 228
           },
           "id": 1182,
           "options": {
@@ -1358,7 +1358,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 220
+            "y": 228
           },
           "id": 1186,
           "options": {
@@ -1451,7 +1451,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 228
+            "y": 236
           },
           "id": 1183,
           "options": {
@@ -1545,7 +1545,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 228
+            "y": 236
           },
           "id": 1187,
           "options": {
@@ -1638,7 +1638,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 236
+            "y": 244
           },
           "id": 1184,
           "options": {
@@ -1732,7 +1732,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 236
+            "y": 244
           },
           "id": 1188,
           "options": {
@@ -1805,7 +1805,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 365
+            "y": 373
           },
           "hiddenSeries": false,
           "id": 230,
@@ -1894,7 +1894,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 365
+            "y": 373
           },
           "hiddenSeries": false,
           "id": 310,
@@ -1993,7 +1993,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 373
+            "y": 381
           },
           "hiddenSeries": false,
           "id": 312,
@@ -2110,7 +2110,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 375
+            "y": 383
           },
           "hiddenSeries": false,
           "id": 254,
@@ -2206,7 +2206,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 375
+            "y": 383
           },
           "hiddenSeries": false,
           "id": 251,
@@ -2331,7 +2331,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 383
+            "y": 391
           },
           "hiddenSeries": false,
           "id": 250,
@@ -2457,7 +2457,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 383
+            "y": 391
           },
           "hiddenSeries": false,
           "id": 252,
@@ -2583,7 +2583,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 391
+            "y": 399
           },
           "hiddenSeries": false,
           "id": 253,
@@ -2737,7 +2737,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 119
+            "y": 127
           },
           "hiddenSeries": false,
           "id": 17,
@@ -2828,7 +2828,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 119
+            "y": 127
           },
           "hiddenSeries": false,
           "id": 19,
@@ -2921,7 +2921,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 127
+            "y": 135
           },
           "hiddenSeries": false,
           "id": 4,
@@ -3031,7 +3031,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 127
+            "y": 135
           },
           "hiddenSeries": false,
           "id": 9,
@@ -3170,7 +3170,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 136
+            "y": 144
           },
           "id": 6656,
           "options": {
@@ -3263,7 +3263,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 136
+            "y": 144
           },
           "id": 6834,
           "options": {
@@ -3318,7 +3318,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 144
+            "y": 152
           },
           "hiddenSeries": false,
           "id": 646,
@@ -3432,7 +3432,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 152
+            "y": 160
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -3583,7 +3583,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 160
+            "y": 168
           },
           "id": 1338,
           "options": {
@@ -3684,7 +3684,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 168
+            "y": 176
           },
           "id": 2135,
           "options": {
@@ -3816,7 +3816,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 168
+            "y": 176
           },
           "id": 6732,
           "options": {
@@ -3937,7 +3937,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 176
+            "y": 184
           },
           "id": 6422,
           "options": {
@@ -4033,7 +4033,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 184
+            "y": 192
           },
           "id": 6428,
           "options": {
@@ -4131,7 +4131,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 192
+            "y": 200
           },
           "id": 2182,
           "options": {
@@ -4203,7 +4203,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 200
+            "y": 208
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -4373,7 +4373,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 193
+            "y": 201
           },
           "id": 6580,
           "options": {
@@ -4493,7 +4493,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 201
+            "y": 209
           },
           "id": 3763,
           "options": {
@@ -4622,7 +4622,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 209
+            "y": 217
           },
           "id": 5574,
           "options": {
@@ -4776,7 +4776,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 217
+            "y": 225
           },
           "id": 3846,
           "options": {
@@ -4872,7 +4872,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 225
+            "y": 233
           },
           "id": 5160,
           "options": {
@@ -4968,7 +4968,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 233
+            "y": 241
           },
           "id": 5242,
           "options": {
@@ -5063,7 +5063,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 241
+            "y": 249
           },
           "id": 5324,
           "options": {
@@ -5158,7 +5158,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 249
+            "y": 257
           },
           "id": 5406,
           "options": {
@@ -5265,7 +5265,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 229
+            "y": 237
           },
           "id": 3929,
           "options": {
@@ -5357,7 +5357,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 229
+            "y": 237
           },
           "id": 4011,
           "options": {
@@ -5449,7 +5449,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 237
+            "y": 245
           },
           "id": 4093,
           "options": {
@@ -5541,7 +5541,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 237
+            "y": 245
           },
           "id": 4175,
           "options": {
@@ -5633,7 +5633,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 245
+            "y": 253
           },
           "id": 4257,
           "options": {
@@ -5725,7 +5725,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 245
+            "y": 253
           },
           "id": 4339,
           "options": {
@@ -5817,7 +5817,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 253
+            "y": 261
           },
           "id": 4421,
           "options": {
@@ -5909,7 +5909,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 253
+            "y": 261
           },
           "id": 4503,
           "options": {
@@ -6001,7 +6001,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 261
+            "y": 269
           },
           "id": 4585,
           "options": {
@@ -6093,7 +6093,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 261
+            "y": 269
           },
           "id": 4667,
           "options": {
@@ -6185,7 +6185,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 269
+            "y": 277
           },
           "id": 4749,
           "options": {
@@ -6277,7 +6277,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 269
+            "y": 277
           },
           "id": 4831,
           "options": {
@@ -6369,7 +6369,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 277
+            "y": 285
           },
           "id": 4913,
           "options": {
@@ -6416,7 +6416,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 9
       },
       "id": 264,
       "panels": [
@@ -6444,7 +6444,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 370
+            "y": 378
           },
           "hiddenSeries": false,
           "id": 274,
@@ -6563,7 +6563,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 370
+            "y": 378
           },
           "hiddenSeries": false,
           "id": 276,
@@ -6660,7 +6660,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 378
+            "y": 386
           },
           "hiddenSeries": false,
           "id": 290,
@@ -6757,7 +6757,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 378
+            "y": 386
           },
           "hiddenSeries": false,
           "id": 292,
@@ -6854,7 +6854,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 386
+            "y": 394
           },
           "hiddenSeries": false,
           "id": 278,
@@ -6951,7 +6951,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 386
+            "y": 394
           },
           "hiddenSeries": false,
           "id": 280,
@@ -7049,7 +7049,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 12
       },
       "id": 38,
       "panels": [
@@ -7117,7 +7117,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 206
+            "y": 214
           },
           "id": 40,
           "options": {
@@ -7259,7 +7259,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 219
+            "y": 227
           },
           "id": 76,
           "options": {
@@ -7315,7 +7315,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 233
+            "y": 241
           },
           "hiddenSeries": false,
           "id": 42,
@@ -7407,7 +7407,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 233
+            "y": 241
           },
           "hiddenSeries": false,
           "id": 46,
@@ -7499,7 +7499,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 241
+            "y": 249
           },
           "hiddenSeries": false,
           "id": 44,
@@ -7596,7 +7596,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 13
       },
       "id": 458,
       "panels": [
@@ -7628,7 +7628,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 225
+            "y": 233
           },
           "hiddenSeries": false,
           "id": 498,
@@ -7727,7 +7727,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 225
+            "y": 233
           },
           "hiddenSeries": false,
           "id": 542,
@@ -7865,7 +7865,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 234
+            "y": 242
           },
           "hideTimeOverride": true,
           "id": 506,
@@ -7930,7 +7930,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 243
+            "y": 251
           },
           "hiddenSeries": false,
           "id": 496,
@@ -8034,7 +8034,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 253
+            "y": 261
           },
           "hiddenSeries": false,
           "id": 500,
@@ -8138,7 +8138,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 253
+            "y": 261
           },
           "hiddenSeries": false,
           "id": 504,
@@ -8241,7 +8241,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 14
       },
       "id": 48,
       "panels": [
@@ -8260,7 +8260,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 48
           },
           "hiddenSeries": false,
           "id": 50,
@@ -8351,7 +8351,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 40
+            "y": 48
           },
           "hiddenSeries": false,
           "id": 53,
@@ -8441,7 +8441,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 51,
@@ -8532,7 +8532,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 55,
@@ -8629,7 +8629,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 15
       },
       "id": 384,
       "panels": [
@@ -8696,7 +8696,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 137
+            "y": 145
           },
           "id": 742,
           "options": {
@@ -8799,7 +8799,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 137
+            "y": 145
           },
           "id": 422,
           "options": {
@@ -8899,7 +8899,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 145
+            "y": 153
           },
           "id": 420,
           "options": {
@@ -8999,7 +8999,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 145
+            "y": 153
           },
           "id": 6504,
           "options": {
@@ -9148,7 +9148,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 153
+            "y": 161
           },
           "id": 1223,
           "options": {
@@ -9319,7 +9319,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 153
+            "y": 161
           },
           "id": 1224,
           "options": {
@@ -9375,7 +9375,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 161
+            "y": 169
           },
           "id": 6943,
           "options": {
@@ -9467,7 +9467,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 161
+            "y": 169
           },
           "id": 6944,
           "options": {
@@ -9587,7 +9587,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 169
+            "y": 177
           },
           "id": 7133,
           "options": {
@@ -9776,7 +9776,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 169
+            "y": 177
           },
           "id": 7039,
           "options": {
@@ -9903,7 +9903,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 16
       },
       "id": 107,
       "panels": [
@@ -9924,7 +9924,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 122,
@@ -10013,7 +10013,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 116,
@@ -10106,7 +10106,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 112,
@@ -10202,7 +10202,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 120,
@@ -10296,7 +10296,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 118,
@@ -10385,7 +10385,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 124,
@@ -10478,7 +10478,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 17
       },
       "id": 7916,
       "panels": [
@@ -10502,7 +10502,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 8022,
@@ -10599,7 +10599,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 8128,
@@ -10736,7 +10736,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 8406,
@@ -10848,7 +10848,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 18
       },
       "id": 28,
       "panels": [
@@ -10871,7 +10871,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 128
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 190,
@@ -11119,7 +11119,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 128
+            "y": 19
           },
           "id": 159,
           "options": {
@@ -11218,7 +11218,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 136
+            "y": 27
           },
           "hiddenSeries": false,
           "id": 210,
@@ -11357,7 +11357,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 136
+            "y": 27
           },
           "id": 1209,
           "options": {
@@ -11452,7 +11452,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 144
+            "y": 35
           },
           "id": 31,
           "options": {
@@ -11502,7 +11502,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 144
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 178,
@@ -11620,6 +11620,263 @@
                 "scaleDistribution": {
                   "type": "linear"
                 },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "cpu"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 8505,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "sum by (nodename, pod) (rate(node_cpu_seconds_total{region=\"${region}\", mode=~\"(user|system)\"}[${window}]) * on (instance) group_left(nodename) (node_uname_info) * on (nodename) group_left(pod) (label_replace(kube_pod_info{pod=~\"${pool}-[^-]+-[^-]+\"}, \"nodename\", \"$1\", \"node\", \"(.*)\")))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{pod}} (node: {{nodename}})",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Node CPU usage",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "cpu"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "mean"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineWidth",
+                    "value": 2
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 8606,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "avg(sum by (nodename, pod) (rate(node_cpu_seconds_total{region=\"${region}\", mode=~\"(user|system)\"}[${window}]) * on (instance) group_left(nodename) (node_uname_info) * on (nodename) group_left(pod) (label_replace(kube_pod_info{pod=~\"${pool}-[^-]+-[^-]+\"}, \"nodename\", \"$1\", \"node\", \"(.*)\"))))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "mean",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.1, sum by (nodename, pod) (rate(node_cpu_seconds_total{region=\"${region}\", mode=~\"(user|system)\"}[${window}]) * on (instance) group_left(nodename) (node_uname_info) * on (nodename) group_left(pod) (label_replace(kube_pod_info{pod=~\"${pool}-[^-]+-[^-]+\"}, \"nodename\", \"$1\", \"node\", \"(.*)\"))))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "p10",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.5, sum by (nodename, pod) (rate(node_cpu_seconds_total{region=\"${region}\", mode=~\"(user|system)\"}[${window}]) * on (instance) group_left(nodename) (node_uname_info) * on (nodename) group_left(pod) (label_replace(kube_pod_info{pod=~\"${pool}-[^-]+-[^-]+\"}, \"nodename\", \"$1\", \"node\", \"(.*)\"))))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "p50",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "quantile(0.9, sum by (nodename, pod) (rate(node_cpu_seconds_total{region=\"${region}\", mode=~\"(user|system)\"}[${window}]) * on (instance) group_left(nodename) (node_uname_info) * on (nodename) group_left(pod) (label_replace(kube_pod_info{pod=~\"${pool}-[^-]+-[^-]+\"}, \"nodename\", \"$1\", \"node\", \"(.*)\"))))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "p90",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Node CPU usage summary",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "auto",
                 "spanNulls": false,
                 "stacking": {
@@ -11651,7 +11908,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152
+            "y": 51
           },
           "id": 1216,
           "options": {
@@ -11781,7 +12038,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152
+            "y": 51
           },
           "id": 1231,
           "options": {
@@ -11865,7 +12122,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 160
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 33,
@@ -11957,7 +12214,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 160
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 35,
@@ -12047,7 +12304,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 168
+            "y": 67
           },
           "hiddenSeries": false,
           "id": 129,
@@ -12140,7 +12397,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 168
+            "y": 67
           },
           "hiddenSeries": false,
           "id": 102,
@@ -12281,7 +12538,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 176
+            "y": 75
           },
           "id": 1195,
           "options": {
@@ -12328,7 +12585,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 176
+            "y": 75
           },
           "hiddenSeries": false,
           "id": 180,
@@ -12470,7 +12727,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 184
+            "y": 83
           },
           "id": 1202,
           "options": {
@@ -12629,7 +12886,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 184
+            "y": 83
           },
           "id": 1196,
           "options": {
@@ -12687,7 +12944,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 192
+            "y": 91
           },
           "id": 7139,
           "options": {
@@ -12768,7 +13025,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 192
+            "y": 91
           },
           "id": 7145,
           "options": {
@@ -12849,7 +13106,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 200
+            "y": 99
           },
           "id": 7151,
           "options": {
@@ -12930,7 +13187,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 200
+            "y": 99
           },
           "id": 7157,
           "options": {
@@ -13011,7 +13268,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 208
+            "y": 107
           },
           "id": 7163,
           "options": {
@@ -13092,7 +13349,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 208
+            "y": 107
           },
           "id": 7169,
           "options": {
@@ -13172,7 +13429,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 21
       },
       "id": 83,
       "panels": [
@@ -13192,7 +13449,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 135
+            "y": 143
           },
           "hiddenSeries": false,
           "id": 85,
@@ -13295,7 +13552,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 135
+            "y": 143
           },
           "hiddenSeries": false,
           "id": 87,
@@ -13389,7 +13646,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 144
+            "y": 152
           },
           "hiddenSeries": false,
           "id": 91,
@@ -13482,7 +13739,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 144
+            "y": 152
           },
           "hiddenSeries": false,
           "id": 93,
@@ -13585,7 +13842,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 25
       },
       "id": 71,
       "panels": [
@@ -13621,7 +13878,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 73,
@@ -13714,7 +13971,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 79,
@@ -13853,7 +14110,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 75
           },
           "id": 2087,
           "options": {
@@ -13955,7 +14212,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 67
+            "y": 75
           },
           "id": 2039,
           "options": {
@@ -14026,7 +14283,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 29
       },
       "id": 1088,
       "panels": [
@@ -14092,7 +14349,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 243
+            "y": 251
           },
           "id": 1127,
           "options": {
@@ -14188,7 +14445,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 243
+            "y": 251
           },
           "id": 1166,
           "options": {
@@ -14297,7 +14554,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 251
+            "y": 259
           },
           "id": 1168,
           "options": {
@@ -14368,7 +14625,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 32
       },
       "id": 8,
       "panels": [
@@ -14390,7 +14647,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 324
+            "y": 332
           },
           "hiddenSeries": false,
           "id": 2,
@@ -14503,7 +14760,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 324
+            "y": 332
           },
           "hiddenSeries": false,
           "id": 578,
@@ -14600,7 +14857,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 33
       },
       "id": 1346,
       "panels": [
@@ -14620,7 +14877,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 369
+            "y": 377
           },
           "hiddenSeries": false,
           "id": 2556,
@@ -14727,7 +14984,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 382
+            "y": 390
           },
           "hiddenSeries": false,
           "id": 2840,
@@ -14826,7 +15083,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 396
+            "y": 404
           },
           "hiddenSeries": false,
           "id": 2890,
@@ -14920,7 +15177,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 396
+            "y": 404
           },
           "hiddenSeries": false,
           "id": 2940,
@@ -15058,7 +15315,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 404
+            "y": 412
           },
           "id": 1353,
           "links": [
@@ -15114,7 +15371,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 34
       },
       "id": 5641,
       "panels": [
@@ -15180,7 +15437,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 153
+            "y": 161
           },
           "id": 5595,
           "options": {
@@ -15273,7 +15530,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 153
+            "y": 161
           },
           "id": 5608,
           "options": {
@@ -15367,7 +15624,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 161
+            "y": 169
           },
           "id": 5622,
           "options": {
@@ -15461,7 +15718,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 161
+            "y": 169
           },
           "id": 5629,
           "options": {
@@ -15554,7 +15811,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 169
+            "y": 177
           },
           "id": 5615,
           "options": {
@@ -15595,7 +15852,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 35
       },
       "id": 7275,
       "panels": [
@@ -15663,7 +15920,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 107
+            "y": 115
           },
           "id": 7381,
           "options": {
@@ -15784,7 +16041,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 107
+            "y": 115
           },
           "id": 7382,
           "options": {
@@ -15883,7 +16140,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 115
+            "y": 123
           },
           "id": 7489,
           "options": {
@@ -15982,7 +16239,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 115
+            "y": 123
           },
           "id": 7488,
           "options": {
@@ -16078,7 +16335,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123
+            "y": 131
           },
           "id": 7595,
           "options": {


### PR DESCRIPTION
In the executor pool panels, add charts showing the CPU usage of all of the pods' host nodes for all executor pods in each pool. This is useful for seeing the node CPU usage corresponding to a particular pod.

![image](https://github.com/user-attachments/assets/6c83d394-ea02-443a-a762-5389235720d3)
