### PR TITLE
Don't try to set flag after expansion if value hasn't changed.

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -62,11 +62,11 @@ func expandStringValue(value string) (string, error) {
 	return expandedValue, nil
 }
 
-func expandSecrets() error {
+func expandFlagValues() error {
 	var lastErr error
 	common.DefaultFlagSet.VisitAll(func(f *flag.Flag) {
 		if err := flagutil.Expand(f.Value, expandStringValue); err != nil {
-			lastErr = err
+			lastErr = fmt.Errorf("could not expand flag %q: %s", f.Name, err)
 		}
 	})
 	return lastErr
@@ -77,7 +77,7 @@ func LoadFromData(data string) error {
 	if err := flagyaml.PopulateFlagsFromData(data); err != nil {
 		return err
 	}
-	return expandSecrets()
+	return expandFlagValues()
 }
 
 // LoadFromFile parses the flags and loads the config file specified by
@@ -102,7 +102,7 @@ func Load() error {
 	if os.IsNotExist(err) {
 		log.Warningf("No config file found at %s.", configFile)
 		// Expand secrets in flags even if config wasn't loaded from file.
-		return expandSecrets()
+		return expandFlagValues()
 	}
 
 	return LoadFromFile(configFile)

--- a/server/util/flagutil/common/common.go
+++ b/server/util/flagutil/common/common.go
@@ -360,9 +360,15 @@ func Expand(v flag.Value, mapper func(string) (string, error)) error {
 		return nil
 	}
 	// Otherwise, expand directly using String/Set.
-	exp, err := mapper(v.String())
+	val := v.String()
+	exp, err := mapper(val)
 	if err != nil {
 		return err
+	}
+	// If the value is the same after expansion then don't update the flag.
+	// Some third-party flags fail on v.Set(v.String())
+	if val == exp {
+		return nil
 	}
 	return v.Set(exp)
 }


### PR DESCRIPTION
Some third-party flags don't support being set back to their string representation.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
