### PR TITLE
Cache Proxy: Introduce a class for managing proxy peers.

### DIFF
--- a/enterprise/server/cache_proxy_peers/BUILD
+++ b/enterprise/server/cache_proxy_peers/BUILD
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "cache_proxy_peers",
+    srcs = ["cache_proxy_peers.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cache_proxy_peers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
+        "//server/remote_cache/digest",
+        "//server/util/flag",
+        "//server/util/grpc_client",
+        "//server/util/log",
+        "//server/util/rangemap",
+        "//server/util/status",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+    ],
+)
+
+go_test(
+    name = "cache_proxy_peers_test",
+    size = "small",
+    srcs = ["cache_proxy_peers_test.go"],
+    deps = [
+        ":cache_proxy_peers",
+        "//server/remote_cache/digest",
+        "//server/testutil/testenv",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/cache_proxy_peers/cache_proxy_peers.go
+++ b/enterprise/server/cache_proxy_peers/cache_proxy_peers.go
@@ -1,0 +1,105 @@
+package cache_proxy_peers
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rangemap"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+var (
+	peersFlag = flag.Slice("cache_proxy.peers.addresses", []string{}, "The gRPC addresses of the set of cache-proxy peers.")
+	localFlag = flag.String("cache_proxy.peers.local_address", "", "The gRPC address of this cache-proxy server. Should be one of the peers in --cache_proxy.peers.addresses.")
+)
+
+const (
+	minHash        = "0000000000000000000000000000000000000000000000000000000000000000"
+	maxHash        = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	maxHashPlusOne = "g"
+)
+
+type Peer struct {
+	Local     bool
+	BSClient  bspb.ByteStreamClient
+	CASClient repb.ContentAddressableStorageClient
+}
+
+type Peers struct {
+	rangeMap *rangemap.RangeMap // values are Peer{}s (above)
+}
+
+func New(env environment.Env) (Peers, error) {
+	peers := Peers{rangeMap: rangemap.New()}
+
+	// If no peers are specified, handle all traffic locally.
+	if len(*peersFlag) == 0 {
+		log.Infof("No peers specified, assigning hash key range ['%s', '%s') to local server.", minHash, maxHashPlusOne)
+		peers.rangeMap.Add([]byte(minHash), []byte(maxHashPlusOne), Peer{Local: true})
+		return peers, nil
+	}
+
+	// Divide the hash key space into ranges and assign one range to each peer.
+	// TODO(iain): this assume keys are 64-byte hex strings.
+	min, ok := new(big.Int).SetString(minHash, 16)
+	if !ok {
+		return Peers{}, status.InternalErrorf("Error initializing CacheProxy peers: invalid min hash (%s)", minHash)
+	}
+	max, ok := new(big.Int).SetString(maxHash, 16)
+	if !ok {
+		return Peers{}, status.InternalErrorf("Error initializing CacheProxy peers: invalid max hash (%s)", maxHash)
+	}
+	numPeers := big.NewInt(int64(len(*peersFlag)))
+	one := big.NewInt(int64(1))
+
+	cur := min
+	inc := new(big.Int).Add(new(big.Int).Div(max, numPeers), one)
+	next := inc
+	for _, peerAddr := range *peersFlag {
+		start := fmt.Sprintf("%x", cur)
+		end := fmt.Sprintf("%x", next)
+
+		// If 'next' maxes or overflows the 64-byte hash key space, set end to
+		// "g" so it covers the entire tail end of the hash key space. Note
+		// rangemap tail bounds are exclusive, so use 'g' to include 'ffff...'.
+		if next.Cmp(max) >= 0 {
+			end = maxHashPlusOne
+		}
+
+		log.Infof("Assigning hash key range ['%s', '%s') to peer %s (I am %s)", start, end, peerAddr, *localFlag)
+		peer := Peer{Local: true}
+		if peerAddr != *localFlag {
+			conn, err := grpc_client.DialInternal(env, peerAddr)
+			if err != nil {
+				return Peers{}, status.InternalErrorf("Error dialing peer %s: %s", peerAddr, err.Error())
+			}
+			peer = Peer{
+				Local:     false,
+				BSClient:  bspb.NewByteStreamClient(conn),
+				CASClient: repb.NewContentAddressableStorageClient(conn),
+			}
+		}
+
+		peers.rangeMap.Add([]byte(start), []byte(end), peer)
+		cur = next
+		next = new(big.Int).Add(cur, inc)
+	}
+
+	return peers, nil
+}
+
+func (p Peers) Get(key digest.Key) (Peer, error) {
+	raw := p.rangeMap.Lookup([]byte(key.Hash))
+	if raw == nil {
+		return Peer{}, status.NotFoundErrorf("Peer responsible for hash %s not found", key.Hash)
+	}
+	return raw.(Peer), nil
+}

--- a/enterprise/server/cache_proxy_peers/cache_proxy_peers_test.go
+++ b/enterprise/server/cache_proxy_peers/cache_proxy_peers_test.go
@@ -1,0 +1,115 @@
+package cache_proxy_peers_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/cache_proxy_peers"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	firstQuarterStart  = "0000000000000000000000000000000000000000000000000000000000000000"
+	firstQuarterEnd    = "3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	secondQuarterStart = "40000000000000000000000000000000000000000000000000000000000000000"
+	secondQuarterEnd   = "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	thirdQuarterStart  = "8000000000000000000000000000000000000000000000000000000000000000"
+	thirdQuarterEnd    = "bfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	fourthQuarterStart = "c000000000000000000000000000000000000000000000000000000000000000"
+	fourthQuarterEnd   = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+	firstHalfStart  = firstQuarterStart
+	firstHalfEnd    = secondQuarterEnd
+	secondHalfStart = thirdQuarterStart
+	secondHalfEnd   = fourthQuarterEnd
+
+	minHash = firstQuarterStart
+	maxHash = fourthQuarterEnd
+)
+
+func TestNew(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	// No peers
+	peers, err := cache_proxy_peers.New(env)
+	require.NoError(t, err)
+	require.True(t, getPeer(t, peers, minHash).Local)
+	require.True(t, getPeer(t, peers, maxHash).Local)
+
+	// One local peer
+	flags.Set(t, "cache_proxy.peers.local_address", "localhost:1")
+	flags.Set(t, "cache_proxy.peers.addresses", []string{"localhost:1"})
+	peers, err = cache_proxy_peers.New(env)
+	require.NoError(t, err)
+	require.True(t, getPeer(t, peers, minHash).Local)
+	require.True(t, getPeer(t, peers, maxHash).Local)
+
+	// One remote peer
+	flags.Set(t, "cache_proxy.peers.local_address", "localhost:1")
+	flags.Set(t, "cache_proxy.peers.addresses", []string{"localhost:2"})
+	peers, err = cache_proxy_peers.New(env)
+	require.NoError(t, err)
+	require.False(t, getPeer(t, peers, minHash).Local)
+	require.False(t, getPeer(t, peers, maxHash).Local)
+
+	// Two peers
+	flags.Set(t, "cache_proxy.peers.local_address", "localhost:1")
+	flags.Set(t, "cache_proxy.peers.addresses", generatePeers(2))
+	peers, err = cache_proxy_peers.New(env)
+	require.NoError(t, err)
+	require.True(t, getPeer(t, peers, firstHalfStart).Local)
+	require.True(t, getPeer(t, peers, firstHalfEnd).Local)
+	requireSamePeer(t, peers, firstHalfStart, firstHalfEnd)
+	requireDifferentPeer(t, peers, firstHalfEnd, secondHalfStart)
+	require.False(t, getPeer(t, peers, secondHalfStart).Local)
+	require.False(t, getPeer(t, peers, secondHalfEnd).Local)
+	requireSamePeer(t, peers, secondHalfStart, secondHalfEnd)
+
+	// Four peers
+	flags.Set(t, "cache_proxy.peers.local_address", "localhost:1")
+	flags.Set(t, "cache_proxy.peers.addresses", generatePeers(4))
+	peers, err = cache_proxy_peers.New(env)
+	require.NoError(t, err)
+	require.True(t, getPeer(t, peers, firstQuarterStart).Local)
+	require.True(t, getPeer(t, peers, firstQuarterEnd).Local)
+	require.False(t, getPeer(t, peers, secondQuarterStart).Local)
+	require.False(t, getPeer(t, peers, fourthQuarterEnd).Local)
+	requireSamePeer(t, peers, firstQuarterStart, firstQuarterEnd)
+	requireDifferentPeer(t, peers, firstQuarterEnd, secondQuarterStart)
+	requireSamePeer(t, peers, secondQuarterStart, secondQuarterEnd)
+	requireDifferentPeer(t, peers, secondQuarterEnd, thirdQuarterStart)
+	requireSamePeer(t, peers, thirdQuarterStart, thirdQuarterEnd)
+	requireDifferentPeer(t, peers, thirdQuarterEnd, fourthQuarterStart)
+	requireSamePeer(t, peers, fourthQuarterStart, fourthQuarterEnd)
+
+	// Try prime-number peer counts to ensure the full hash range is covered.
+	for _, i := range []int{7, 13, 43, 97, 1009} {
+		flags.Set(t, "cache_proxy.peers.addresses", generatePeers(i))
+		requireDifferentPeer(t, peers, minHash, maxHash)
+	}
+}
+
+func generatePeers(count int) []string {
+	peers := []string{}
+	for i := range count {
+		peers = append(peers, fmt.Sprintf("localhost:%d", i+1))
+	}
+	return peers
+}
+
+func requireSamePeer(t *testing.T, peers cache_proxy_peers.Peers, first, second string) {
+	require.Equal(t, getPeer(t, peers, first), getPeer(t, peers, second))
+}
+
+func requireDifferentPeer(t *testing.T, peers cache_proxy_peers.Peers, first, second string) {
+	require.NotEqual(t, getPeer(t, peers, first), getPeer(t, peers, second))
+}
+
+func getPeer(t *testing.T, peers cache_proxy_peers.Peers, key string) cache_proxy_peers.Peer {
+	peer, err := peers.Get(digest.Key{Hash: key})
+	require.NoError(t, err)
+	return peer
+}

--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//enterprise/server/backends/configsecrets",
         "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/byte_stream_server_proxy",
+        "//enterprise/server/cache_proxy_peers",
         "//enterprise/server/capabilities_server_proxy",
         "//enterprise/server/content_addressable_storage_server_proxy",
         "//enterprise/server/remoteauth",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/cache_proxy_peers"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/capabilities_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/content_addressable_storage_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remoteauth"
@@ -208,6 +209,12 @@ func registerGRPCServices(grpcServer *grpc.Server, env *real_environment.RealEnv
 	// The atime updater must be registered after the remote CAS client (which
 	// it depends on), but before the local CAS server (which depends on it).
 	if err := atime_updater.Register(env); err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	// TODO(iain): pass peers into BS and CAS Proxies and forward requests.
+	_, err = cache_proxy_peers.New(env)
+	if err != nil {
 		log.Fatalf("%v", err)
 	}
 


### PR DESCRIPTION
This PR introduces a `cache_proxy_peers` package which initializes a set of Cache Proxy peers based on two flags:
- A slice of gRPC address containing the set of peers and
- A gRPC address identifying the local Cache Proxy server.

The set of peers can be initialized by calling a `New()` function which divides the hash key range into one range per host and initializes RPC clients for each host and stores the range & RPC clients in a rangemap. Right now this only supports 64-byte hex string hashes, but it should be simple enough to generalize to other key-spaces by adding parallel rangemaps for other key spaces.

**Related issues**: N/A
