### PR TITLE
Allow admin API keys for a 'parent' group to affect child groups.

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -236,6 +236,10 @@ func (g *apiKeyGroup) GetCapabilities() int32 {
 	return g.Capabilities
 }
 
+func (g *apiKeyGroup) HasCapability(cap akpb.ApiKey_Capability) bool {
+	return g.Capabilities&int32(cap) != 0
+}
+
 func (g *apiKeyGroup) GetUseGroupOwnedExecutors() bool {
 	return g.UseGroupOwnedExecutors
 }
@@ -357,7 +361,7 @@ func (d *AuthDB) fillChildGroupIDs(ctx context.Context, akg *apiKeyGroup) error 
 	if !akg.IsParent {
 		return nil
 	}
-	if akg.GetCapabilities()&int32(akpb.ApiKey_ORG_ADMIN_CAPABILITY) == 0 {
+	if !akg.HasCapability(akpb.ApiKey_ORG_ADMIN_CAPABILITY) {
 		return nil
 	}
 	rq := d.h.NewQuery(ctx, "authdb_get_child_group_ids").Raw(`

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -199,9 +199,17 @@ func (d *AuthDB) backfillUnencryptedKeys() error {
 }
 
 type apiKeyGroup struct {
-	APIKeyID               string
-	UserID                 string
-	GroupID                string
+	APIKeyID string
+	UserID   string
+	GroupID  string
+	// The ChildGroupIDs below is only populated if a group is marked as a
+	// 'parent' group.
+	IsParent bool
+	// If an API key from a parent group is allowed to manage child groups,
+	// those child groups will appear in this list. This is currently only used
+	// for external user management via SCIM/API where an admin API key from the
+	// parent group is used to manage all the related groups and their users.
+	ChildGroupIDs          []string `gorm:"-"`
 	Capabilities           int32
 	UseGroupOwnedExecutors bool
 	CacheEncryptionEnabled bool
@@ -218,6 +226,10 @@ func (g *apiKeyGroup) GetUserID() string {
 
 func (g *apiKeyGroup) GetGroupID() string {
 	return g.GroupID
+}
+
+func (g *apiKeyGroup) GetChildGroupIDs() []string {
+	return g.ChildGroupIDs
 }
 
 func (g *apiKeyGroup) GetCapabilities() int32 {
@@ -339,6 +351,32 @@ func (d *AuthDB) fillDecryptedAPIKey(ak *tables.APIKey) error {
 	return nil
 }
 
+func (d *AuthDB) fillChildGroupIDs(ctx context.Context, akg *apiKeyGroup) error {
+	// If the group is not designated as a parent then don't bother doing a
+	// query.
+	if !akg.IsParent {
+		return nil
+	}
+	if akg.GetCapabilities()&int32(akpb.ApiKey_ORG_ADMIN_CAPABILITY) == 0 {
+		return nil
+	}
+	rq := d.h.NewQuery(ctx, "authdb_get_child_group_ids").Raw(`
+		SELECT child.group_id 
+		FROM "Groups" parent
+		JOIN "Groups" child on parent.saml_idp_metadata_url = child.saml_idp_metadata_url
+		WHERE parent.group_id = ?
+		  AND child.group_id != ?
+	`, akg.GetGroupID(), akg.GetGroupID())
+	groupIDs, err := db.ScanAll(rq, &struct{ GroupID string }{})
+	if err != nil {
+		return err
+	}
+	for _, groupID := range groupIDs {
+		akg.ChildGroupIDs = append(akg.ChildGroupIDs, groupID.GroupID)
+	}
+	return nil
+}
+
 func (d *AuthDB) GetAPIKeyGroupFromAPIKey(ctx context.Context, apiKey string) (interfaces.APIKeyGroup, error) {
 	apiKey = strings.TrimSpace(apiKey)
 	if strings.Contains(apiKey, " ") || len(apiKey) != apiKeyLength {
@@ -394,6 +432,9 @@ func (d *AuthDB) GetAPIKeyGroupFromAPIKey(ctx context.Context, apiKey string) (i
 			}
 			return nil, err
 		}
+		if err := d.fillChildGroupIDs(ctx, akg); err != nil {
+			return nil, err
+		}
 		if d.apiKeyGroupCache != nil {
 			metrics.APIKeyLookupCount.With(prometheus.Labels{metrics.APIKeyLookupStatus: "cache_miss"}).Inc()
 			d.apiKeyGroupCache.Add(cacheKey, akg)
@@ -433,6 +474,9 @@ func (d *AuthDB) GetAPIKeyGroupFromAPIKeyID(ctx context.Context, apiKeyID string
 		if db.IsRecordNotFound(err) {
 			return nil, status.UnauthenticatedErrorf("Invalid API key ID %q", redactInvalidAPIKey(apiKeyID))
 		}
+		return nil, err
+	}
+	if err := d.fillChildGroupIDs(ctx, akg); err != nil {
 		return nil, err
 	}
 	if d.apiKeyGroupCache != nil {
@@ -494,7 +538,8 @@ func (d *AuthDB) newAPIKeyGroupQuery(subDomain string, allowUserOwnedKeys bool) 
 			g.group_id,
 			g.use_group_owned_executors,
 			g.cache_encryption_enabled,
-			g.enforce_ip_rules
+			g.enforce_ip_rules,
+			g.is_parent
 		FROM "Groups" AS g,
 		"APIKeys" AS ak
 	`)

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -363,7 +363,8 @@ func (d *UserDB) UpdateGroup(ctx context.Context, g *tables.Group) (string, erro
 			cache_encryption_enabled = ?,
 			suggestion_preference = ?,
 			restrict_clean_workflow_runs_to_admins = ?,
-			enforce_ip_rules = ?
+			enforce_ip_rules = ?,
+			is_parent = ?
 		WHERE group_id = ?`,
 		g.Name,
 		g.URLIdentifier,
@@ -378,6 +379,7 @@ func (d *UserDB) UpdateGroup(ctx context.Context, g *tables.Group) (string, erro
 		g.SuggestionPreference,
 		g.RestrictCleanWorkflowRunsToAdmins,
 		g.EnforceIPRules,
+		g.IsParent,
 		g.GroupID,
 	).Exec().Error
 	if err != nil {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -427,6 +427,7 @@ type APIKeyGroup interface {
 	GetAPIKeyID() string
 	GetUserID() string
 	GetGroupID() string
+	GetChildGroupIDs() []string
 	GetUseGroupOwnedExecutors() bool
 	GetCacheEncryptionEnabled() bool
 	GetEnforceIPRules() bool

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -239,7 +239,7 @@ type Group struct {
 	EnforceIPRules         bool `gorm:"not null;default:0"`
 
 	// The SAML IDP Metadata URL for this group.
-	SamlIdpMetadataUrl string
+	SamlIdpMetadataUrl string `gorm:"index:group_saml_idp_metadata_url_idx"`
 
 	InvocationWebhookURL string `gorm:"not null;default:''"`
 
@@ -248,6 +248,10 @@ type Group struct {
 	// The public key and encrypted private key. Used to upload secrets.
 	PublicKey           string
 	EncryptedPrivateKey string
+
+	// When a Group is designated as a "parent" then any Admin keys from that
+	// org also work for managing groups with the same SAML IDP Metadata URL.
+	IsParent bool `gorm:"not null;default:0"`
 }
 
 func (g *Group) TableName() string {

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -141,18 +141,26 @@ func APIKeyGroupClaims(akg interfaces.APIKeyGroup) *Claims {
 	if akg.GetCapabilities()&int32(akpb.ApiKey_ORG_ADMIN_CAPABILITY) > 0 {
 		keyRole = role.Admin
 	}
+	allowedGroups := []string{akg.GetGroupID()}
+	groupMemberships := []*interfaces.GroupMembership{{
+		GroupID:      akg.GetGroupID(),
+		Capabilities: capabilities.FromInt(akg.GetCapabilities()),
+		Role:         keyRole,
+	}}
+	for _, cg := range akg.GetChildGroupIDs() {
+		allowedGroups = append(allowedGroups, cg)
+		groupMemberships = append(groupMemberships, &interfaces.GroupMembership{
+			GroupID:      cg,
+			Capabilities: capabilities.FromInt(akg.GetCapabilities()),
+			Role:         keyRole,
+		})
+	}
 	return &Claims{
-		APIKeyID:      akg.GetAPIKeyID(),
-		UserID:        akg.GetUserID(),
-		GroupID:       akg.GetGroupID(),
-		AllowedGroups: []string{akg.GetGroupID()},
-		GroupMemberships: []*interfaces.GroupMembership{
-			{
-				GroupID:      akg.GetGroupID(),
-				Capabilities: capabilities.FromInt(akg.GetCapabilities()),
-				Role:         keyRole,
-			},
-		},
+		APIKeyID:               akg.GetAPIKeyID(),
+		UserID:                 akg.GetUserID(),
+		GroupID:                akg.GetGroupID(),
+		AllowedGroups:          allowedGroups,
+		GroupMemberships:       groupMemberships,
 		Capabilities:           capabilities.FromInt(akg.GetCapabilities()),
 		UseGroupOwnedExecutors: akg.GetUseGroupOwnedExecutors(),
 		CacheEncryptionEnabled: akg.GetCacheEncryptionEnabled(),


### PR DESCRIPTION
Groups are considered related if they have the same SAML Metadata URL.

Only keys for groups marked as 'parent' are allowed access to related groups.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
