### PR TITLE
Cache Proxy: Introduce a peekable wrapper around ByteStream_WriteServer stream and use it in ByteStreamServerProxy.Write()

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//metadata",
     ],
 )
 


### PR DESCRIPTION
This is necessary for proxying ByteStream.Write() requests to peers because the resource name, which is required to determine which peer to proxy to, comes in the first frame of the write stream.

**Related issues**: N/A
