### PR TITLE
server: Enforce CSP with `--app.strict_csp_enabled`

### DIFF
--- a/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
+++ b/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
@@ -99,6 +99,7 @@ func SetupWebTarget(t *testing.T, localArgs ...string) WebTarget {
 		args := append([]string{
 			"--cache.detailed_stats_enabled=true",
 			"--app.user_owned_keys_enabled=true",
+			"--app.strict_csp_enabled=true",
 		}, localArgs...)
 		return Run(t, args...)
 	case "remote":

--- a/server/http/csp/csp.go
+++ b/server/http/csp/csp.go
@@ -17,7 +17,7 @@ const ReportingEndpoint = "/csp-report"
 
 var ReportingHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	for _, report := range extractReports(r.Body) {
-		log.CtxDebug(r.Context(), report)
+		log.CtxWarning(r.Context(), report)
 	}
 })
 

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	upgradeInsecure  = flag.Bool("ssl.upgrade_insecure", false, "True if http requests should be redirected to https. Assumes http traffic is served on port 80 and https traffic is served on port 443 (typically via an ingress / load balancer).")
-	strictCspEnabled = flag.Bool("app.strict_csp_enabled", false, "If set, enable a strict CSP header in report only mode.")
+	strictCspEnabled = flag.Bool("app.strict_csp_enabled", false, "If set, set a strict CSP header. Violations are logged at warning level.")
 )
 
 const contentSecurityPolicyReportingEndpointName = "csp-endpoint"
@@ -94,8 +94,7 @@ func setContentSecurityPolicy(h http.Header) string {
 		panic(fmt.Sprintf("Failed to generate nonce: %s", err))
 	}
 	nonce := base64.StdEncoding.EncodeToString(nonceBytes)
-	// TODO: Enable this by dropping the "-Report-Only" suffix.
-	h.Set("Content-Security-Policy-Report-Only", getContentSecurityPolicyHeaderValue(nonce))
+	h.Set("Content-Security-Policy", getContentSecurityPolicyHeaderValue(nonce))
 	return nonce
 }
 


### PR DESCRIPTION
There haven't been any CSP reports in dev since the latest fix. The flag is only enabled in dev, but any violations reported after this point should be reported in a release-blocking fashion.

Also enables the flag in webdriver tests.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: buildbuddy-io/buildbuddy-internal#3911
