### PR TITLE
gosdk: upgrade to 1.23.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -67,7 +67,7 @@ single_version_override(
 )
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.23.1")
+go_sdk.download(version = "1.23.2")
 go_sdk.nogo(nogo = "@//:vet")
 use_repo(
     go_sdk,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,7 +87,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchai
 
 go_rules_dependencies()
 
-GO_SDK_VERSION = "1.23.1"
+GO_SDK_VERSION = "1.23.2"
 
 # Register multiple Go SDKs so that we can perform cross-compilation remotely.
 # i.e. We might want to trigger a Linux AMD64 Go build remotely from a MacOS ARM64 laptop.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbuddy-io/buildbuddy
 
-go 1.23.1
+go 1.23.2
 
 replace (
 	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.7.0-buildbuddy // keep in sync with buildpatches/com_github_awslabs_soci_snapshotter.patch


### PR DESCRIPTION
Reference: https://github.com/golang/go/issues?q=milestone%3AGo1.23.2+label%3ACherryPickApproved
