### PR TITLE
workspace: register nogo separately

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,7 +83,7 @@ install_static_dependencies()
 install_go_mod_dependencies()
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_nogo", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -135,9 +135,11 @@ go_download_sdk(
     version = GO_SDK_VERSION,
 )
 
-go_register_toolchains(
+go_register_nogo(
     nogo = "@//:vet",
 )
+
+go_register_toolchains()
 
 gazelle_dependencies(
     go_env = {


### PR DESCRIPTION
In recent version of rules_go, `go_register_nogo` was changed to a macro
wrapper which apply a sane default for `includes` and `excludes`
packages to run nogo over. However, the `go_register_nogo` inside
`go_register_toolchains` that we are currently using was not the new
macro wrapper, but the original repository rule. As a result, we are
running nogo validation actions over external packages and made our
build slower, especially when using local execution.

Register nogo separately using the macro wrapper so we don't need to
validate nogo for external `go_repository` targets.

Upstream discussion: https://github.com/bazelbuild/rules_go/issues/4137
