### PR TITLE
[raft] monitor dropped listener events and eviction error

### DIFF
--- a/enterprise/server/raft/listener/BUILD
+++ b/enterprise/server/raft/listener/BUILD
@@ -7,7 +7,9 @@ go_library(
     srcs = ["listener.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/listener",
     deps = [
+        "//server/metrics",
         "//server/util/log",
         "@com_github_lni_dragonboat_v4//raftio",
+        "@com_github_prometheus_client_golang//prometheus",
     ],
 )

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -231,6 +231,7 @@ func (pu *partitionUsage) processEviction(ctx context.Context) {
 			return res, nil
 		})
 		if err != nil {
+			metrics.RaftEvictionErrorCount.Inc()
 			log.Warningf("failed to evict %d keys: %s", len(keys), err)
 		}
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -175,6 +175,7 @@ const (
 
 	// The ID of a raft nodehost.
 	RaftNodeHostIDLabel = "node_host_id"
+
 	// The range ID of a raft region.
 	RaftRangeIDLabel = "range_id"
 
@@ -186,7 +187,9 @@ const (
 
 	// Raft Listener Event Type
 	RaftListenerEventType = "listener_event"
-	RaftListenerID        = "listener_id"
+
+	// The ID of a raft listener
+	RaftListenerID = "listener_id"
 
 	// Binary version. Example: `v2.0.0`.
 	VersionLabel = "version"

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -184,6 +184,10 @@ const (
 	// Raft RangeCache event type: `hit`, `miss`, or `update`.
 	RaftRangeCacheEventTypeLabel = "rangecache_event_type"
 
+	// Raft Listener Event Type
+	RaftListenerEventType = "listener_event"
+	RaftListenerID        = "listener_id"
+
 	// Binary version. Example: `v2.0.0`.
 	VersionLabel = "version"
 
@@ -2301,6 +2305,23 @@ var (
 		Help:      "The time spent on replica.Update in **microseconds**.",
 	}, []string{
 		RaftRangeIDLabel,
+	})
+
+	RaftEvictionErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "eviction_errors",
+		Help:      "The total number of eviction errors",
+	})
+
+	RaftListenerEventsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "listener_events_dropped",
+		Help:      "The total number of eviction errors",
+	}, []string{
+		RaftListenerID,
+		RaftListenerEventType,
 	})
 
 	APIKeyLookupCount = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**:
https://github.com/buildbuddy-io/buildbuddy-internal/issues/3963,
https://github.com/buildbuddy-io/buildbuddy-internal/issues/3962, https://github.com/buildbuddy-io/buildbuddy-internal/issues/3964
Also increase the default chan size for leader update and node ready.


