### PR TITLE
Set firecracker CPU overprovisioning back to 3 for now

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -81,7 +81,7 @@ var dieOnFirecrackerFailure = flag.Bool("executor.die_on_firecracker_failure", f
 var workspaceDiskSlackSpaceMB = flag.Int64("executor.firecracker_workspace_disk_slack_space_mb", 2_000, "Extra space to allocate to firecracker workspace disks, in megabytes. ** Experimental **")
 var healthCheckInterval = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
 var healthCheckTimeout = flag.Duration("executor.firecracker_health_check_timeout", 30*time.Second, "Timeout for VM health check requests.")
-var overprovisionCPUs = flag.Int("executor.firecracker_overprovision_cpus", -1, "Number of CPUs to overprovision for VMs. This allows VMs to more effectively utilize CPU resources on the host machine. Set to -1 to allow all VMs to use max CPU.")
+var overprovisionCPUs = flag.Int("executor.firecracker_overprovision_cpus", 3, "Number of CPUs to overprovision for VMs. This allows VMs to more effectively utilize CPU resources on the host machine. Set to -1 to allow all VMs to use max CPU.")
 var initOnAllocAndFree = flag.Bool("executor.firecracker_init_on_alloc_and_free", false, "Set init_on_alloc=1 and init_on_free=1 in firecracker vms")
 
 var forceRemoteSnapshotting = flag.Bool("debug_force_remote_snapshots", false, "When remote snapshotting is enabled, force remote snapshotting even for tasks which otherwise wouldn't support it.")


### PR DESCRIPTION
This results in flakiness when running a lot of docker-in-firecracker actions concurrently.

Here's a run of `usage_test_mysql` with overprovisioning set to max (the current default): https://buildbuddy.buildbuddy.dev/invocation/59d2f757-f994-4c53-af0d-d9bde3a49614?target=%2F%2Fenterprise%2Fserver%2Fusage%3Ausage_test_mysql&targetStatus=7#470

And here's a run with overprovisioning set to 3 like we had before: https://buildbuddy.buildbuddy.dev/invocation/b11e9a45-f7b0-4b41-9cda-39de0659a93b?target=%2F%2Fenterprise%2Fserver%2Fusage%3Ausage_test_mysql&targetStatus=5

Opened https://github.com/buildbuddy-io/buildbuddy-internal/issues/3965 to remove this overprovisioning altogether, but I didn't want to make too drastic of a change just yet, so for now this PR is just setting the overprovisioning back to 3 like we had before.