### PR TITLE
Cache Proxy: make the local cache a distributed cache wrapping a pebble cache.

### DIFF
--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//enterprise/server/action_cache_server_proxy",
         "//enterprise/server/atime_updater",
         "//enterprise/server/backends/configsecrets",
+        "//enterprise/server/backends/distributed",
         "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/byte_stream_server_proxy",
         "//enterprise/server/capabilities_server_proxy",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/action_cache_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/atime_updater"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/distributed"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/capabilities_server_proxy"
@@ -84,6 +85,9 @@ func main() {
 	}
 	if c := env.GetCache(); c == nil {
 		log.Fatalf("No local cache configured")
+	}
+	if err := distributed.Register(env); err != nil {
+		log.Fatal(err.Error())
 	}
 
 	env.SetListenAddr(*listen)


### PR DESCRIPTION
This is the simplest way to support peering between Cache Proxy servers.

**Related issues**: N/A
