### PR TITLE
explain: Do not limit input proto size

### DIFF
--- a/cli/explain/compactgraph/compactgraph.go
+++ b/cli/explain/compactgraph/compactgraph.go
@@ -44,8 +44,9 @@ func ReadCompactLog(in io.Reader) (*CompactGraph, string, error) {
 	cg.spawns = make(map[string]*Spawn)
 	previousInputs := make(map[uint32]Input)
 	previousInputs[0] = emptyInputSet
+	unmarshalOpts := protodelim.UnmarshalOptions{MaxSize: -1}
 	for {
-		err = protodelim.UnmarshalFrom(r, &entry)
+		err = unmarshalOpts.UnmarshalFrom(r, &entry)
 		if err == io.EOF {
 			break
 		}


### PR DESCRIPTION
Individual exec log entries can grow past 4 MiB and there is no reason to cap their size (`MaxSize` is not used for buffer presizing).

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
