### PR TITLE
cacheload: use ticker instead of after

### DIFF
--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -240,11 +240,12 @@ func main() {
 
 	// Periodically print read and write QPS.
 	eg.Go(func() error {
+		ticker := time.NewTicker(time.Second)
 		for {
 			select {
 			case <-gctx.Done():
 				return nil
-			case <-time.After(time.Second):
+			case <-ticker.C:
 				log.Printf("Write: %.1f, Read: %.1f QPS (%s avg)", writeQPSCounter.Get(), readQPSCounter.Get(), *qpsAvgWindow)
 			}
 		}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
cacheload in raft-dev got fatal error "too many concurrent timer firings"
