### PR TITLE
Upgrade prettier since the old one is incompatible with newer libc versions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,5 @@
   "semi": true,
   "singleQuote": false,
   "printWidth": 120,
-  "jsxBracketSameLine": true
+  "bracketSameLine": true
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "moment": "^2.29.4",
     "monaco-editor": "0.47.0",
     "path-browserify": "^1.0.1",
-    "prettier": "^2.1.1",
+    "prettier": "3.3.3",
     "protobufjs": "^7.2.5",
     "react": "^16.8.6",
     "react-date-range": "^1.3.0",

--- a/tools/checkstyle/checkstyle.sh
+++ b/tools/checkstyle/checkstyle.sh
@@ -59,7 +59,7 @@ run ProtoFormat \
 
 run PrettierFormat \
   env PRETTIER_PATH="$PRETTIER_PATH" \
-  tools/prettier/prettier.sh --loglevel=warn --check
+  tools/prettier/prettier.sh --log-level=warn --check
 
 wait
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,10 +862,10 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-prettier@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 prop-types@15, prop-types@^15.5.10, prop-types@^15.7.2:
   version "15.7.2"


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Ran into this on ubuntu 2204 when trying get buildbuddy building on arm.

`jsxBracketSameLine` is deprecated, now just `bracketSameLine`: https://prettier.io/blog/2021/09/09/2.4.0.html#:~:text=This%20release%20renames%20the%20jsxBracketSameLine,such%20as%20class%20static%20blocks

`--loglevel` was renamed to `--log-level`

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
