### PR TITLE
Remove os.Stat from disk.EnsureDirectoryExists

### DIFF
--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -42,10 +42,8 @@ type PartitionMapping struct {
 }
 
 func EnsureDirectoryExists(dir string) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return os.MkdirAll(dir, 0755)
-	}
-	return nil
+	// This could be inlined, but there many callers in many files.
+	return os.MkdirAll(dir, 0755)
 }
 
 // RemoveIfExists attempts to remove the given named file or (empty) directory,

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -41,6 +41,8 @@ type PartitionMapping struct {
 	PartitionID string `yaml:"partition_id" json:"partition_id" usage:"The partition to use if the Group ID and prefix match."`
 }
 
+// EnsureDirectoryExists is a synonym for os.MkdirAll(dir, 0755). It returns an
+// error if dir exists but isn't a directory.
 func EnsureDirectoryExists(dir string) error {
 	// This could be inlined, but there many callers in many files.
 	return os.MkdirAll(dir, 0755)


### PR DESCRIPTION
This stat call isn't necessary, since os.MkDirAll first does a stat by itself.

This change does affect behavior a bit. Previously, if the path was a file, the function would return nil. Now it returns an error. As far as I can tell, this shouldn't matter in practice.

I don't think this will improve performance in dev or prod, since creating directories seems to be rare. But when running a local server without any directories, this doubles up the number of stat calls, and each one occupies a thread, making it more likely that the process dies because it tries to create more than 10k threads.