### PR TITLE
Prevent delete_build_root_on_startup from wiping image cache

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -304,9 +304,12 @@ func cleanBuildRoot() {
 		return
 	}
 
+	log.Infof("Cleaning build root directory")
+
+	n := 0
 	for _, entry := range entries {
-		// TODO: move cached firecracker/ociruntime images to a different
-		// directory.
+		// TODO(http://go/b/3994): move cached firecracker/ociruntime images to
+		// a different directory.
 		if entry.Name() == "executor" && !*deleteImageCacheOnStartup {
 			continue
 		}
@@ -315,6 +318,10 @@ func cleanBuildRoot() {
 		}
 		if err := os.RemoveAll(filepath.Join(rootDir, entry.Name())); err != nil {
 			log.Warningf("Failed to remove build root dir: %s", err)
+			continue
 		}
+		n++
 	}
+
+	log.Infof("Removed %d entries in build root directory", n)
 }


### PR DESCRIPTION
Running the executor with `--executor.delete_build_root_on_startup` deletes the contents of `--executor.build_root_directory`. This is where temporary files are stored (action workspaces, firecracker chroot dirs, etc.).

Unfortunately, this is also where cached firecracker / OCI images are stored (under an `executor` subdir).

This PR adds a temporary fix for this issue which is to only delete the `executor` directory if a separate flag `executor.delete_image_cache_on_startup` is set.

Eventually, we should move persistent files and temporary files to separate directories. Ideally, cached artifacts would be somehow stored in filecache - this is a little tricky though because OCI image layers in particular are represented as extracted directories, not single files.