### PR TITLE
Pin docker version to 24 in RBE ubuntu 22.04

### DIFF
--- a/dockerfiles/rbe-ubuntu22-04/Dockerfile
+++ b/dockerfiles/rbe-ubuntu22-04/Dockerfile
@@ -78,9 +78,9 @@ RUN apt-get update && \
     echo >/etc/apt/sources.list.d/docker.list "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-get update && \
     apt-get install -y \
-      docker-ce \
-      docker-ce-cli \
-      containerd.io \
+      docker-ce=5:24.0.9-1~ubuntu.22.04~jammy \
+      docker-ce-cli=5:24.0.9-1~ubuntu.22.04~jammy \
+      containerd.io=1.7.22-1 \
       && \
     apt-get remove -y gnupg && \
     apt-get autoremove -y && \


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Docker version > 24 currently can create images with mixed media types in the layers, which containerd does not handle gracefully and thus which do not work in GCP.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
