### PR TITLE
Install en_US.UTF-8 locale in rbe-ubuntu22-04

### DIFF
--- a/dockerfiles/rbe-ubuntu22-04/Dockerfile
+++ b/dockerfiles/rbe-ubuntu22-04/Dockerfile
@@ -86,6 +86,15 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# en_US.UTF-8 locale
+#
+# Bazel forces the locale to be en_US.UTF-8 (not C.UTF-8) for Java actions.
+RUN apt-get update && \
+apt-get install -y --no-install-recommends \
+  locales \
+  && \
+locale-gen en_US.UTF-8 && \
+apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Provision a non-root user named "buildbuddy" and set up passwordless sudo.
 # Non-root users are needed for some bazel toolchains, such as hermetic python.


### PR DESCRIPTION
This is a port of https://github.com/buildbuddy-io/buildbuddy/pull/7704/files which was merged while this 22.04 image was WIP.