### PR TITLE
Remove PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-<!-- Optional: Provide additional context (beyond the PR title). -->
-
-<!-- Optional: link a GitHub issue.
-     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->
-
-**Related issues**: N/A


### PR DESCRIPTION
This PR template results in `git log` being cluttered, since we enabled the GitHub setting to use the PR description as the commit message for PR squash+merge commits.