### PR TITLE
Return PublishLifecycleEvent errors instead of logging in sync mode

### DIFF
--- a/server/build_event_protocol/build_event_proxy/BUILD
+++ b/server/build_event_protocol/build_event_proxy/BUILD
@@ -15,6 +15,5 @@ go_library(
         "//server/util/status",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_protobuf//types/known/emptypb",
-        "@org_golang_x_sync//errgroup",
     ],
 )


### PR DESCRIPTION
In `synchronous` mode, Bazel will retry the request if it fails, so don't log a warning internally (Bazel will log the warning if all retry attempts fail).