### PR TITLE
[Cache Proxy]: record human-readable gRPC response codes in atime-updater gRPC metric

### DIFF
--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -272,7 +272,7 @@ func (u *atimeUpdater) update(ctx context.Context, groupID string, jwt string, u
 	metrics.RemoteAtimeUpdatesSent.With(
 		prometheus.Labels{
 			metrics.GroupID:     groupID,
-			metrics.StatusLabel: fmt.Sprintf("%d", gstatus.Code(err).String()),
+			metrics.StatusLabel: gstatus.Code(err).String(),
 		}).Inc()
 	if err != nil {
 		log.CtxWarningf(ctx, "Error sending FindMissingBlobs request to update remote atimes for group %s: %s", groupID, err)

--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -272,7 +272,7 @@ func (u *atimeUpdater) update(ctx context.Context, groupID string, jwt string, u
 	metrics.RemoteAtimeUpdatesSent.With(
 		prometheus.Labels{
 			metrics.GroupID:     groupID,
-			metrics.StatusLabel: fmt.Sprintf("%d", gstatus.Code(err)),
+			metrics.StatusLabel: fmt.Sprintf("%d", gstatus.Code(err).String()),
 		}).Inc()
 	if err != nil {
 		log.CtxWarningf(ctx, "Error sending FindMissingBlobs request to update remote atimes for group %s: %s", groupID, err)


### PR DESCRIPTION
This metrics currently has values like "0" and "5." This PR switches to using the human-readable gRPC code as the value, e.g. "OK" or "NOT_FOUND," similar to the other gRPC graphs.