### PR TITLE
Improve shell token handling in remotebazel

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//server/util/flag",
         "//server/util/grpc_client",
         "//server/util/rexec",
+        "//server/util/shlex",
         "//server/util/status",
         "@com_github_alecaivazis_survey_v2//:survey",
         "@com_github_go_git_go_git_v5//:go-git",

--- a/server/util/shlex/BUILD
+++ b/server/util/shlex/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "shlex",
+    srcs = ["shlex.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/shlex",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_google_shlex//:shlex",
+    ],
+)
+
+go_test(
+    name = "shlex_test",
+    srcs = ["shlex_test.go"],
+    deps = [
+        ":shlex",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/shlex/shlex.go
+++ b/server/util/shlex/shlex.go
@@ -1,0 +1,64 @@
+// shlex contains facilities for shell code parsing and generation.
+
+package shlex
+
+import (
+	"regexp"
+	"strings"
+
+	gshlex "github.com/google/shlex"
+)
+
+var (
+	allSafeCharsRegexp   = regexp.MustCompile(`^[A-Za-z0-9/_\-]+$`)
+	flagAssignmentRegexp = regexp.MustCompile(`^--[A-Za-z_-]+=`)
+)
+
+// Split parses the given shell command and returns the canonical tokenized
+// arguments.
+//
+// Example:
+//
+//	shlex.Split("  foo --bar='/Quoted/Path/With Spaces'  ")
+//	// Returns: []string{"foo", "--bar=/Quoted/Path/With Spaces"}
+func Split(command string) ([]string, error) {
+	return gshlex.Split(command)
+}
+
+// Quote escapes the given shell tokens so that each argument would be treated
+// as verbatim elements of an arguments list.
+//
+// Example:
+//
+//	shlex.Quote("foo", "--path=has spaces", "quote's", "~")
+//	// Returns: `foo --path='has spaces' 'quote'\''s' '~'`
+//
+// In this example, the first argument does not need to be escaped and can be
+// rendered safely. The second argument has to be escaped because it has a
+// space. Because it looks like a flag, we treat it specially by placing the
+// quotes around the flag value (after the =). The third argument has a single
+// quote and must be escaped to prevent the shell from warning about an unclosed
+// delimiter. The fourth argument has a tilde which would be expanded to $HOME,
+// so must also be escaped.
+func Quote(tokens ...string) string {
+	out := ""
+	for i, arg := range tokens {
+		out += quoteSingle(arg)
+		if i < len(tokens)-1 {
+			out += " "
+		}
+	}
+	return out
+}
+
+func quoteSingle(arg string) string {
+	if allSafeCharsRegexp.MatchString(arg) {
+		return arg
+	}
+	// If we have a flag assignment like "--foo=bar baz" then keep the "--foo"
+	// part unquoted so it renders more closely to how a human would enter it at
+	// the command line.
+	prefix := flagAssignmentRegexp.FindString(arg)
+	suffix := strings.TrimPrefix(arg, prefix)
+	return prefix + `'` + strings.ReplaceAll(suffix, `'`, `'\''`) + `'`
+}

--- a/server/util/shlex/shlex_test.go
+++ b/server/util/shlex/shlex_test.go
@@ -1,0 +1,21 @@
+package shlex_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/shlex"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuote(t *testing.T) {
+	tokens := []string{
+		"foo",
+		"--path=has spaces",
+		"quote's",
+		"~",
+	}
+	require.Equal(
+		t,
+		`foo --path='has spaces' 'quote'\''s' '~'`,
+		shlex.Quote(tokens...))
+}


### PR DESCRIPTION
* `strings.Join(bazelArgs, " ")` is incorrect if any of the bazel args contains a space or a shell special character - fix by adding a `shlex.Quote()` function (added a new `shlex` package since there are a few other places where I think we could use this)
* One user is depending on the current incorrect behavior to be able to pass arbitrary commands. To support this use case, add a new `--script` arg for passing arbitrary shell scripts