### PR TITLE
[RB] Fix fetching remote build outputs

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//proto:invocation_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:runner_go_proto",
+        "//proto/api/v1:common_go_proto",
         "//server/environment",
         "//server/real_environment",
         "//server/remote_cache/cachetools",


### PR DESCRIPTION
Remote bazel can be used to build a target on a remote runner, and then the CLI will fetch the build outputs to be used locally.

A couple things were broken:
* The CLI uses certain build events to identify and fetch build outputs, but [this PR](https://github.com/buildbuddy-io/buildbuddy/pull/4490) moved target-level events from the `Event` field to `TargetGroups`. This PR updates the CLI to use the new field
* Verifies that the build uses `--remote_upload_local_results` so that remote build outputs can be fetched from the cache