### PR TITLE
refactor: get rid of unneeded prefixing logic for queries

### DIFF
--- a/enterprise/server/execution_search_service/execution_search_service.go
+++ b/enterprise/server/execution_search_service/execution_search_service.go
@@ -185,14 +185,14 @@ func (s *ExecutionSearchService) SearchExecutions(ctx context.Context, req *expb
 		if f.GetMetric().Execution == nil {
 			continue
 		}
-		str, args, err := filter.GenerateFilterStringAndArgs(f, "")
+		str, args, err := filter.GenerateFilterStringAndArgs(f)
 		if err != nil {
 			return nil, err
 		}
 		q.AddWhereClause(str, args...)
 	}
 	for _, f := range req.GetQuery().GetDimensionFilter() {
-		str, args, err := filter.GenerateDimensionFilterStringAndArgs(f, "")
+		str, args, err := filter.GenerateDimensionFilterStringAndArgs(f)
 		if err != nil {
 			return nil, err
 		}
@@ -200,7 +200,7 @@ func (s *ExecutionSearchService) SearchExecutions(ctx context.Context, req *expb
 	}
 
 	for _, f := range req.GetQuery().GetGenericFilters() {
-		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, "", stat_filter.ObjectTypes_EXECUTION_OBJECTS)
+		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, stat_filter.ObjectTypes_EXECUTION_OBJECTS)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -397,7 +397,7 @@ func (i *InvocationStatService) addWhereClauses(q *query_builder.Query, tq *stpb
 	}
 
 	for _, f := range tq.GetFilter() {
-		str, args, err := filter.GenerateFilterStringAndArgs(f, "")
+		str, args, err := filter.GenerateFilterStringAndArgs(f)
 		if err != nil {
 			return err
 		}
@@ -407,7 +407,7 @@ func (i *InvocationStatService) addWhereClauses(q *query_builder.Query, tq *stpb
 		if !includeExecutionDimensionFilters && f.GetDimension().Execution != nil {
 			continue
 		}
-		str, args, err := filter.GenerateDimensionFilterStringAndArgs(f, "")
+		str, args, err := filter.GenerateDimensionFilterStringAndArgs(f)
 		if err != nil {
 			return err
 		}
@@ -418,7 +418,7 @@ func (i *InvocationStatService) addWhereClauses(q *query_builder.Query, tq *stpb
 		queryObjects = sfpb.ObjectTypes_EXECUTION_OBJECTS
 	}
 	for _, f := range tq.GetGenericFilters() {
-		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, "", queryObjects)
+		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, queryObjects)
 		if err != nil {
 			return err
 		}
@@ -898,7 +898,7 @@ type QueryAndBuckets = struct {
 // empty response.
 func (i *InvocationStatService) getHeatmapQueryAndBuckets(ctx context.Context, req *stpb.GetStatHeatmapRequest) (*QueryAndBuckets, error) {
 	table := getTableForMetric(req.GetMetric())
-	metric, err := filter.MetricToDbField(req.GetMetric(), "")
+	metric, err := filter.MetricToDbField(req.GetMetric())
 	if err != nil {
 		return nil, err
 	}
@@ -1065,7 +1065,7 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 	}
 
 	for _, f := range req.GetQuery().GetFilter() {
-		str, args, err := filter.GenerateFilterStringAndArgs(f, "")
+		str, args, err := filter.GenerateFilterStringAndArgs(f)
 		if err != nil {
 			return nil, err
 		}
@@ -1075,7 +1075,7 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 		if f.GetDimension().Invocation == nil {
 			continue
 		}
-		str, args, err := filter.GenerateDimensionFilterStringAndArgs(f, "")
+		str, args, err := filter.GenerateDimensionFilterStringAndArgs(f)
 		if err != nil {
 			return nil, err
 		}
@@ -1083,7 +1083,7 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 	}
 
 	for _, f := range req.GetQuery().GetGenericFilters() {
-		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, "", sfpb.ObjectTypes_INVOCATION_OBJECTS)
+		s, a, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(f, sfpb.ObjectTypes_INVOCATION_OBJECTS)
 		if err != nil {
 			return nil, err
 		}
@@ -1168,7 +1168,7 @@ func getDrilldownQueryFilter(filters []*sfpb.StatFilter) (string, []interface{},
 	var result []string
 	var resultArgs []interface{}
 	for _, f := range filters[:] {
-		str, args, err := filter.GenerateFilterStringAndArgs(f, "")
+		str, args, err := filter.GenerateFilterStringAndArgs(f)
 		if err != nil {
 			return "", nil, err
 		}

--- a/server/util/filter/filter.go
+++ b/server/util/filter/filter.go
@@ -11,86 +11,86 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-func executionMetricToDbField(m stat_filter.ExecutionMetricType, tablePrefix string) (string, error) {
+func executionMetricToDbField(m stat_filter.ExecutionMetricType) (string, error) {
 	switch m {
 	case stat_filter.ExecutionMetricType_UPDATED_AT_USEC_EXECUTION_METRIC:
-		return tablePrefix + "updated_at_usec", nil
+		return "updated_at_usec", nil
 	case stat_filter.ExecutionMetricType_QUEUE_TIME_USEC_EXECUTION_METRIC:
-		return fmt.Sprintf("IF(%sworker_start_timestamp_usec < %squeued_timestamp_usec, 0, (%sworker_start_timestamp_usec - %squeued_timestamp_usec))", tablePrefix, tablePrefix, tablePrefix, tablePrefix), nil
+		return "IF(worker_start_timestamp_usec < queued_timestamp_usec, 0, (worker_start_timestamp_usec - queued_timestamp_usec))", nil
 	case stat_filter.ExecutionMetricType_INPUT_DOWNLOAD_TIME_EXECUTION_METRIC:
-		return fmt.Sprintf("(%sinput_fetch_completed_timestamp_usec - %sinput_fetch_start_timestamp_usec)", tablePrefix, tablePrefix), nil
+		return "(input_fetch_completed_timestamp_usec - input_fetch_start_timestamp_usec)", nil
 	case stat_filter.ExecutionMetricType_REAL_EXECUTION_TIME_EXECUTION_METRIC:
-		return fmt.Sprintf("(%sexecution_completed_timestamp_usec - %sexecution_start_timestamp_usec)", tablePrefix, tablePrefix), nil
+		return "(execution_completed_timestamp_usec - execution_start_timestamp_usec)", nil
 	case stat_filter.ExecutionMetricType_OUTPUT_UPLOAD_TIME_EXECUTION_METRIC:
-		return fmt.Sprintf("(%soutput_upload_completed_timestamp_usec - %soutput_upload_start_timestamp_usec)", tablePrefix, tablePrefix), nil
+		return "(output_upload_completed_timestamp_usec - output_upload_start_timestamp_usec)", nil
 	case stat_filter.ExecutionMetricType_PEAK_MEMORY_EXECUTION_METRIC:
-		return tablePrefix + "peak_memory_bytes", nil
+		return "peak_memory_bytes", nil
 	case stat_filter.ExecutionMetricType_INPUT_DOWNLOAD_SIZE_EXECUTION_METRIC:
-		return tablePrefix + "file_download_size_bytes", nil
+		return "file_download_size_bytes", nil
 	case stat_filter.ExecutionMetricType_OUTPUT_UPLOAD_SIZE_EXECUTION_METRIC:
-		return tablePrefix + "file_upload_size_bytes", nil
+		return "file_upload_size_bytes", nil
 	default:
 		return "", status.InvalidArgumentErrorf("Invalid field: %s", m.String())
 	}
 }
 
-func invocationMetricToDbField(m stat_filter.InvocationMetricType, tablePrefix string) (string, error) {
+func invocationMetricToDbField(m stat_filter.InvocationMetricType) (string, error) {
 	switch m {
 	case stat_filter.InvocationMetricType_DURATION_USEC_INVOCATION_METRIC:
-		return tablePrefix + "duration_usec", nil
+		return "duration_usec", nil
 	case stat_filter.InvocationMetricType_UPDATED_AT_USEC_INVOCATION_METRIC:
-		return tablePrefix + "updated_at_usec", nil
+		return "updated_at_usec", nil
 	case stat_filter.InvocationMetricType_CAS_CACHE_MISSES_INVOCATION_METRIC:
-		return tablePrefix + "cas_cache_misses", nil
+		return "cas_cache_misses", nil
 	case stat_filter.InvocationMetricType_CAS_CACHE_DOWNLOAD_SIZE_INVOCATION_METRIC:
-		return tablePrefix + "total_download_size_bytes", nil
+		return "total_download_size_bytes", nil
 	case stat_filter.InvocationMetricType_CAS_CACHE_UPLOAD_SIZE_INVOCATION_METRIC:
-		return tablePrefix + "total_upload_size_bytes", nil
+		return "total_upload_size_bytes", nil
 	case stat_filter.InvocationMetricType_CAS_CACHE_DOWNLOAD_SPEED_INVOCATION_METRIC:
-		return tablePrefix + "download_throughput_bytes_per_second", nil
+		return "download_throughput_bytes_per_second", nil
 	case stat_filter.InvocationMetricType_CAS_CACHE_UPLOAD_SPEED_INVOCATION_METRIC:
-		return tablePrefix + "upload_throughput_bytes_per_second", nil
+		return "upload_throughput_bytes_per_second", nil
 	case stat_filter.InvocationMetricType_ACTION_CACHE_MISSES_INVOCATION_METRIC:
-		return tablePrefix + "action_cache_misses", nil
+		return "action_cache_misses", nil
 	case stat_filter.InvocationMetricType_TIME_SAVED_USEC_INVOCATION_METRIC:
-		return tablePrefix + "total_cached_action_exec_usec", nil
+		return "total_cached_action_exec_usec", nil
 	default:
 		return "", status.InvalidArgumentErrorf("Invalid field: %s", m.String())
 	}
 }
 
-func executionDimensionToDbField(m stat_filter.ExecutionDimensionType, tablePrefix string) (string, error) {
+func executionDimensionToDbField(m stat_filter.ExecutionDimensionType) (string, error) {
 	switch m {
 	case stat_filter.ExecutionDimensionType_WORKER_EXECUTION_DIMENSION:
-		return tablePrefix + "worker", nil
+		return "worker", nil
 	default:
 		return "", status.InvalidArgumentErrorf("Invalid field: %s", m.String())
 	}
 }
 
-func invocationDimensionToDbField(m stat_filter.InvocationDimensionType, tablePrefix string) (string, error) {
+func invocationDimensionToDbField(m stat_filter.InvocationDimensionType) (string, error) {
 	switch m {
 	case stat_filter.InvocationDimensionType_BRANCH_INVOCATION_DIMENSION:
-		return tablePrefix + "branch", nil
+		return "branch", nil
 	default:
 		return "", status.InvalidArgumentErrorf("Invalid field: %s", m.String())
 	}
 }
 
-func MetricToDbField(m *stat_filter.Metric, tablePrefix string) (string, error) {
+func MetricToDbField(m *stat_filter.Metric) (string, error) {
 	if m == nil {
 		return "", status.InvalidArgumentErrorf("Filter metric must not be nil")
 	}
 	if m.Invocation != nil {
-		return invocationMetricToDbField(m.GetInvocation(), tablePrefix)
+		return invocationMetricToDbField(m.GetInvocation())
 	} else if m.Execution != nil {
-		return executionMetricToDbField(m.GetExecution(), tablePrefix)
+		return executionMetricToDbField(m.GetExecution())
 	}
 	return "", status.InvalidArgumentErrorf("Invalid filter: %v", m)
 }
 
-func GenerateFilterStringAndArgs(f *stat_filter.StatFilter, tablePrefix string) (string, []interface{}, error) {
-	metric, err := MetricToDbField(f.GetMetric(), tablePrefix)
+func GenerateFilterStringAndArgs(f *stat_filter.StatFilter) (string, []interface{}, error) {
+	metric, err := MetricToDbField(f.GetMetric())
 	if err != nil {
 		return "", nil, err
 	}
@@ -106,20 +106,20 @@ func GenerateFilterStringAndArgs(f *stat_filter.StatFilter, tablePrefix string) 
 	return fmt.Sprintf("(%s >= ?)", metric), []interface{}{f.GetMin()}, nil
 }
 
-func DimensionToDbField(m *stat_filter.Dimension, tablePrefix string) (string, error) {
+func DimensionToDbField(m *stat_filter.Dimension) (string, error) {
 	if m == nil {
 		return "", status.InvalidArgumentErrorf("Filter dimension must not be nil")
 	}
 	if m.Invocation != nil {
-		return invocationDimensionToDbField(m.GetInvocation(), tablePrefix)
+		return invocationDimensionToDbField(m.GetInvocation())
 	} else if m.Execution != nil {
-		return executionDimensionToDbField(m.GetExecution(), tablePrefix)
+		return executionDimensionToDbField(m.GetExecution())
 	}
 	return "", status.InvalidArgumentErrorf("Invalid filter: %v", m)
 }
 
-func GenerateDimensionFilterStringAndArgs(f *stat_filter.DimensionFilter, tablePrefix string) (string, []interface{}, error) {
-	metric, err := DimensionToDbField(f.GetDimension(), tablePrefix)
+func GenerateDimensionFilterStringAndArgs(f *stat_filter.DimensionFilter) (string, []interface{}, error) {
+	metric, err := DimensionToDbField(f.GetDimension())
 	if err != nil {
 		return "", nil, err
 	}
@@ -139,7 +139,7 @@ func getStringAndArgs(databaseQueryTemplate string, v interface{}, columnName st
 	return str, args
 }
 
-func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFilter, tablePrefix string, qType stat_filter.ObjectTypes) (string, []interface{}, error) {
+func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFilter, qType stat_filter.ObjectTypes) (string, []interface{}, error) {
 	if f == nil {
 		return "", nil, status.InvalidArgumentError("invalid nil entry in filter list")
 	}
@@ -196,6 +196,6 @@ func ValidateAndGenerateGenericFilterQueryStringAndArgs(f *stat_filter.GenericFi
 		return "", nil, status.InternalErrorf("Unknown filter category: %s", typeOptions.GetCategory())
 	}
 
-	qStr, qArgs := getStringAndArgs(operandOptions.GetDatabaseQueryString(), arg, tablePrefix+typeOptions.GetDatabaseColumnName(), f.GetNegate())
+	qStr, qArgs := getStringAndArgs(operandOptions.GetDatabaseQueryString(), arg, typeOptions.GetDatabaseColumnName(), f.GetNegate())
 	return qStr, qArgs, nil
 }

--- a/server/util/filter/filter_test.go
+++ b/server/util/filter/filter_test.go
@@ -14,7 +14,6 @@ import (
 func TestValidGenericFilters(t *testing.T) {
 	cases := []struct {
 		filter        *stat_filter.GenericFilter
-		prefix        string
 		filterType    stat_filter.ObjectTypes
 		expectedQStr  string
 		expectedQArgs []interface{}
@@ -27,9 +26,8 @@ func TestValidGenericFilters(t *testing.T) {
 					IntValue: []int64{10000},
 				},
 			},
-			prefix:        "i.",
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
-			expectedQStr:  "i.duration_usec > ?",
+			expectedQStr:  "duration_usec > ?",
 			expectedQArgs: []interface{}{int64(10000)},
 		},
 		{
@@ -40,9 +38,8 @@ func TestValidGenericFilters(t *testing.T) {
 					StringValue: []string{"http://github.com/buildbuddy-io/buildbuddy"},
 				},
 			},
-			prefix:        "i.",
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
-			expectedQStr:  "i.repo_url IN ?",
+			expectedQStr:  "repo_url IN ?",
 			expectedQArgs: []interface{}{[]string{"http://github.com/buildbuddy-io/buildbuddy"}},
 		},
 		{
@@ -53,7 +50,6 @@ func TestValidGenericFilters(t *testing.T) {
 					StringValue: []string{"siggisim", "tylerw"},
 				},
 			},
-			prefix:        "",
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "user IN ?",
 			expectedQArgs: []interface{}{[]string{"siggisim", "tylerw"}},
@@ -66,14 +62,13 @@ func TestValidGenericFilters(t *testing.T) {
 					IntValue: []int64{10001},
 				},
 			},
-			prefix:        "e.",
 			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
-			expectedQStr:  "e.created_at_usec < ?",
+			expectedQStr:  "created_at_usec < ?",
 			expectedQArgs: []interface{}{int64(10001)},
 		},
 	}
 	for _, tc := range cases {
-		qStr, qArgs, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(tc.filter, tc.prefix, tc.filterType)
+		qStr, qArgs, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(tc.filter, tc.filterType)
 		assert.Nil(t, err)
 		assert.Equal(t, tc.expectedQStr, qStr)
 		assert.ElementsMatch(t, tc.expectedQArgs, qArgs)
@@ -83,7 +78,6 @@ func TestValidGenericFilters(t *testing.T) {
 func TestInvalidGenericFilters(t *testing.T) {
 	cases := []struct {
 		filter           *stat_filter.GenericFilter
-		prefix           string
 		filterType       stat_filter.ObjectTypes
 		errorTypeFn      func(error) bool
 		errorExplanation string
@@ -96,7 +90,6 @@ func TestInvalidGenericFilters(t *testing.T) {
 					StringValue: []string{"duration_usec shouldn't accept a string"},
 				},
 			},
-			prefix:           "",
 			filterType:       stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			errorTypeFn:      status.IsInvalidArgumentError,
 			errorExplanation: "duration_usec shouldn't accept a string",
@@ -109,14 +102,13 @@ func TestInvalidGenericFilters(t *testing.T) {
 					IntValue: []int64{10001},
 				},
 			},
-			prefix:           "e.",
 			filterType:       stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			errorTypeFn:      status.IsInvalidArgumentError,
 			errorExplanation: "Shouldn't be able to filter execution creation time on invocations.",
 		},
 	}
 	for _, tc := range cases {
-		_, _, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(tc.filter, tc.prefix, tc.filterType)
+		_, _, err := filter.ValidateAndGenerateGenericFilterQueryStringAndArgs(tc.filter, tc.filterType)
 		assert.True(t, tc.errorTypeFn(err), tc.errorExplanation)
 	}
 }


### PR DESCRIPTION
this cleans up some freaky string concats in query code that i've never really liked much--these callsites were all being used correctly, but a messed up call could theoretically lead to injection.

doesn't seem to me that we actually need `i.` on the search service queries, and that was the only place this was being used.