### PR TITLE
static: provide a flag to turn off community link

### DIFF
--- a/app/docs/setup.tsx
+++ b/app/docs/setup.tsx
@@ -81,8 +81,18 @@ export default class SetupComponent extends React.Component<Props> {
           Visit our <a href="https://www.buildbuddy.io/docs/introduction">documentation</a> for more information on
           setting up, configuring, and using BuildBuddy.
           <h2>Get in touch!</h2>
-          Join our <a href="https://community.buildbuddy.io">Slack channel</a> or email us at{" "}
-          <a href="mailto:hello@buildbuddy.io">hello@buildbuddy.io</a> if you have any questions or feature requests!
+          {capabilities.config.commmunityLinkEnabled ? (
+            <>
+              Join our <a href="https://community.buildbuddy.io">Slack channel</a> or email us at{" "}
+              <a href="mailto:hello@buildbuddy.io">hello@buildbuddy.io</a> if you have any questions or feature
+              requests!
+            </>
+          ) : (
+            <>
+              Email us at <a href="mailto:hello@buildbuddy.io">hello@buildbuddy.io</a> if you have any questions or
+              feature requests!
+            </>
+          )}
         </div>
       </div>
     );

--- a/app/docs/setup.tsx
+++ b/app/docs/setup.tsx
@@ -81,7 +81,7 @@ export default class SetupComponent extends React.Component<Props> {
           Visit our <a href="https://www.buildbuddy.io/docs/introduction">documentation</a> for more information on
           setting up, configuring, and using BuildBuddy.
           <h2>Get in touch!</h2>
-          {capabilities.config.commmunityLinkEnabled ? (
+          {capabilities.config.communityLinksEnabled ? (
             <>
               Join our <a href="https://community.buildbuddy.io">Slack channel</a> or email us at{" "}
               <a href="mailto:hello@buildbuddy.io">hello@buildbuddy.io</a> if you have any questions or feature

--- a/app/footer/footer.tsx
+++ b/app/footer/footer.tsx
@@ -24,7 +24,7 @@ export default class FooterComponent extends React.Component {
         <a href="mailto:hello@buildbuddy.io" target="_blank">
           Contact us
         </a>
-        {capabilities.config.commmunityLinkEnabled && (
+        {capabilities.config.communityLinksEnabled && (
           <a href="https://community.buildbuddy.io" target="_blank">
             Slack
           </a>

--- a/app/footer/footer.tsx
+++ b/app/footer/footer.tsx
@@ -24,9 +24,11 @@ export default class FooterComponent extends React.Component {
         <a href="mailto:hello@buildbuddy.io" target="_blank">
           Contact us
         </a>
-        <a href="https://community.buildbuddy.io" target="_blank">
-          Slack
-        </a>
+        {capabilities.config.commmunityLinkEnabled && (
+          <a href="https://community.buildbuddy.io" target="_blank">
+            Slack
+          </a>
+        )}
         <a href="https://twitter.com/buildbuddy_io" target="_blank">
           Twitter
         </a>

--- a/app/menu/menu.tsx
+++ b/app/menu/menu.tsx
@@ -115,11 +115,13 @@ export default class MenuComponent extends React.Component<Props, State> {
                   <li onClick={this.dismissMenu.bind(this)}>
                     <a href="mailto:hello@buildbuddy.io">Contact us</a>
                   </li>
-                  <li onClick={this.dismissMenu.bind(this)}>
-                    <a target="_blank" href="https://community.buildbuddy.io">
-                      BuildBuddy Slack
-                    </a>
-                  </li>
+                  {capabilities.config.commmunityLinkEnabled && (
+                    <li onClick={this.dismissMenu.bind(this)}>
+                      <a target="_blank" href="https://community.buildbuddy.io">
+                        BuildBuddy Slack
+                      </a>
+                    </li>
+                  )}
                   {capabilities.auth &&
                     capabilities.github &&
                     this.props.user &&

--- a/app/menu/menu.tsx
+++ b/app/menu/menu.tsx
@@ -115,7 +115,7 @@ export default class MenuComponent extends React.Component<Props, State> {
                   <li onClick={this.dismissMenu.bind(this)}>
                     <a href="mailto:hello@buildbuddy.io">Contact us</a>
                   </li>
-                  {capabilities.config.commmunityLinkEnabled && (
+                  {capabilities.config.communityLinksEnabled && (
                     <li onClick={this.dismissMenu.bind(this)}>
                       <a target="_blank" href="https://community.buildbuddy.io">
                         BuildBuddy Slack

--- a/config/buildbuddy.local.yaml
+++ b/config/buildbuddy.local.yaml
@@ -2,7 +2,6 @@ app:
   log_error_stack_traces: true
   streaming_http_enabled: true
   invocation_log_streaming_enabled: true
-  community_link_enabed: false
 storage:
   ttl_seconds: 86400 # One day in seconds.
   disk:

--- a/config/buildbuddy.local.yaml
+++ b/config/buildbuddy.local.yaml
@@ -2,6 +2,7 @@ app:
   log_error_stack_traces: true
   streaming_http_enabled: true
   invocation_log_streaming_enabled: true
+  community_link_enabed: false
 storage:
   ttl_seconds: 86400 # One day in seconds.
   disk:

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -174,6 +174,9 @@ message FrontendConfig {
 
   // The Content Security Policy nonce to use for inline <style> elements.
   string csp_nonce = 57;
+
+  // Whether the community link is enabled in the UI.
+  bool commmunity_link_enabled = 58;
 }
 
 message Region {

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -175,8 +175,8 @@ message FrontendConfig {
   // The Content Security Policy nonce to use for inline <style> elements.
   string csp_nonce = 57;
 
-  // Whether the community link is enabled in the UI.
-  bool commmunity_link_enabled = 58;
+  // Whether the community links is enabled in the UI.
+  bool community_links_enabled = 58;
 }
 
 message Region {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -65,7 +65,7 @@ var (
 	targetFlakesUIEnabled                  = flag.Bool("app.target_flakes_ui_enabled", false, "If set, show some fancy new features for analyzing flakes.")
 	codeEditorV2Enabled                    = flag.Bool("app.code_editor_v2_enabled", false, "If set, show v2 of code editor that stores state on server instead of local storage.")
 	bazelButtonsEnabled                    = flag.Bool("app.bazel_buttons_enabled", false, "If set, show remote bazel buttons in the UI.")
-	communityLinkEnabled                   = flag.Bool("app.community_link_enabed", true, "If set, show a link to BuildBuddy community in the UI.")
+	communityLinksEnabled                  = flag.Bool("app.community_links_enabed", true, "If set, show links to BuildBuddy community in the UI.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -212,7 +212,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		CodeEditorV2Enabled:                    *codeEditorV2Enabled,
 		BazelButtonsEnabled:                    *bazelButtonsEnabled,
 		CspNonce:                               nonce,
-		CommmunityLinkEnabled:                  *communityLinkEnabled,
+		CommunityLinksEnabled:                  *communityLinksEnabled,
 	}
 
 	configJSON, err := protojson.Marshal(&config)

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -65,6 +65,7 @@ var (
 	targetFlakesUIEnabled                  = flag.Bool("app.target_flakes_ui_enabled", false, "If set, show some fancy new features for analyzing flakes.")
 	codeEditorV2Enabled                    = flag.Bool("app.code_editor_v2_enabled", false, "If set, show v2 of code editor that stores state on server instead of local storage.")
 	bazelButtonsEnabled                    = flag.Bool("app.bazel_buttons_enabled", false, "If set, show remote bazel buttons in the UI.")
+	communityLinkEnabled                   = flag.Bool("app.community_link_enabed", true, "If set, show a link to BuildBuddy community in the UI.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -211,6 +212,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		CodeEditorV2Enabled:                    *codeEditorV2Enabled,
 		BazelButtonsEnabled:                    *bazelButtonsEnabled,
 		CspNonce:                               nonce,
+		CommmunityLinkEnabled:                  *communityLinkEnabled,
 	}
 
 	configJSON, err := protojson.Marshal(&config)


### PR DESCRIPTION
Provide a flag for some deployments to not display our community Slack
on the UI.
