### PR TITLE
Version log improvements

### DIFF
--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -49,7 +49,7 @@ var (
 )
 
 func main() {
-	version.Print()
+	version.Print("BuildBuddy cache proxy")
 
 	// Flags must be parsed before config secrets integration is enabled since
 	// that feature itself depends on flag values.

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -52,6 +52,7 @@ go_library(
         "//server/util/tracing",
         "//server/util/usageutil",
         "//server/util/vtprotocodec",
+        "//server/version",
         "//server/xcode",
         "@com_github_google_uuid//:uuid",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -42,6 +42,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/buildbuddy-io/buildbuddy/server/util/usageutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
+	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"github.com/buildbuddy-io/buildbuddy/server/xcode"
 	"github.com/google/uuid"
 
@@ -187,6 +188,8 @@ func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker) *re
 }
 
 func main() {
+	version.Print("BuildBuddy executor")
+
 	setUmask()
 
 	rootContext := context.Background()

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -144,7 +144,7 @@ func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
 
 func main() {
 	rootContext := context.Background()
-	version.Print()
+	version.Print("BuildBuddy enterprise server")
 
 	// Flags must be parsed before config secrets integration is enabled since
 	// that feature itself depends on flag values.

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -56,7 +56,7 @@ func makeExecutionNode(pool, executorID, executorHostID string, options *Options
 		Os:                        resources.GetOS(),
 		Arch:                      resources.GetArch(),
 		Pool:                      strings.ToLower(pool),
-		Version:                   version.AppVersion(),
+		Version:                   version.Tag(),
 		ExecutorId:                executorID,
 		ExecutorHostId:            executorHostID,
 	}, nil

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -24,7 +24,7 @@ var (
 // which import from libmain.go.
 
 func main() {
-	version.Print()
+	version.Print("BuildBuddy")
 
 	flag.Parse()
 	if err := config.Load(); err != nil {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -105,7 +105,7 @@ func NewStaticFileServer(env environment.Env, fs fs.FS, rootPaths []string, appB
 			env.GetHealthChecker().AddHealthCheck("app_static_file_server", &healthChecker{jsPath: jsPath})
 		}
 
-		handler = handleRootPaths(env, rootPaths, template, version.AppVersion(), jsPath, stylePath, appBundleHash, handler)
+		handler = handleRootPaths(env, rootPaths, template, version.Tag(), jsPath, stylePath, appBundleHash, handler)
 	}
 	return &StaticFileServer{
 		handler: setCacheHeaders(handler),

--- a/server/telemetry/telemetry_client.go
+++ b/server/telemetry/telemetry_client.go
@@ -46,7 +46,7 @@ type TelemetryClient struct {
 func NewTelemetryClient(env environment.Env) *TelemetryClient {
 	return &TelemetryClient{
 		env:              env,
-		version:          version.AppVersion(),
+		version:          version.Tag(),
 		instanceUUID:     getInstanceUUID(),
 		installationUUID: getInstallationUUID(env),
 		failedLogs:       []*telpb.TelemetryLog{},

--- a/server/util/statusz/statusz.go
+++ b/server/util/statusz/statusz.go
@@ -166,7 +166,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Hostname:    hostname,
 		StartTime:   startTime,
 		CurrentTime: time.Now(),
-		AppVersion:  version.AppVersion(),
+		AppVersion:  version.Tag(),
 		GoVersion:   version.GoVersion(),
 		Sections:    orderedSections,
 	}

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -24,20 +24,20 @@ var versionTag string
 
 func init() {
 	metrics.Version.With(prometheus.Labels{
-		metrics.VersionLabel: AppVersion(),
+		metrics.VersionLabel: Tag(),
 		metrics.CommitLabel:  Commit(),
 	}).Set(1)
 }
 
-func Print() {
-	appVersion := fmt.Sprintf("BuildBuddy %s", AppVersion())
+func Print(name string) {
+	appVersion := fmt.Sprintf("%s %s", name, Tag())
 	if commitHash := Commit(); commitHash != unknownValue {
 		appVersion = fmt.Sprintf("%s (%s)", appVersion, commitHash)
 	}
 	log.Infof("%s compiled with %s", appVersion, GoVersion())
 }
 
-func AppVersion() string {
+func Tag() string {
 	if versionTag != "" && versionTag != "{STABLE_VERSION_TAG}" {
 		return versionTag
 	}


### PR DESCRIPTION
* Print version info in the executor, not just the apps
* Print the actual binary name rather than just "BuildBuddy" so we can distinguish between binaries more easily in logs
* Rename `AppVersion` to `Tag`
