### PR TITLE
After executing, don't upload outputs that already exist remotely

### DIFF
--- a/enterprise/server/remote_execution/dirtools/BUILD
+++ b/enterprise/server/remote_execution/dirtools/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/metrics",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/claims",

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1187,6 +1187,13 @@ var (
 		Help:      "Total number of bytes uploaded during remote execution.",
 	})
 
+	SkippedOutputBytes = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "skipped_output_bytes",
+		Help:      "Total number of output bytes that weren't uploaded after remote execution.",
+	})
+
 	FileUploadDurationUsec = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",


### PR DESCRIPTION
In local and dev experiments, this prevents the upload of about 30% of bytes, and makes the output_upload stage about 40% faster. The speed increase isn't really meaningful, since the output_upload stage only takes 13ms on average.

Some things I'm not sure about:

1. Instead of creating a new metric, should I add a dimension to an existing metric, like `buildbuddy_remote_execution_file_upload_size_bytes`? I'm leaning towards creating this new metric because we don't need a histogram for skipped bytes.
2. Instead of adding a new metric, should I just report the reduced amount to `buildbuddy_remote_execution_file_upload_size_bytes`? If I did that, it would be harder to know how many bytes were skipped, and I think it's still useful to know how many bytes would be uploaded without the optimization.
3. Should I update the attributes in the trace, or add another attribute here: https://github.com/buildbuddy-io/buildbuddy/blob/36907cc2adc9c49c4d80e2ee07140770935b33de/enterprise/server/remote_execution/workspace/workspace.go#L330-L331

Closes buildbuddy-io/buildbuddy-internal#3849