### PR TITLE
oci runtime: support setting CPU hard-limits based on task size

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -77,6 +77,7 @@ go_test(
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
+        "//proto:scheduler_go_proto",
         "//proto:worker_go_proto",
         "//server/interfaces",
         "//server/testutil/testenv",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -44,12 +44,13 @@ import (
 )
 
 var (
-	Runtime     = flag.String("executor.oci.runtime", "", "OCI runtime")
-	runtimeRoot = flag.String("executor.oci.runtime_root", "", "Root directory for storage of container state (see <runtime> --help for default)")
-	pidsLimit   = flag.Int64("executor.oci.pids_limit", 2048, "PID limit for OCI runtime. Set to -1 for unlimited PIDs.")
-	cpuLimit    = flag.Int("executor.oci.cpu_limit", 0, "Hard limit for CPU resources, expressed as CPU count. Default (0) is no limit.")
-	dns         = flag.String("executor.oci.dns", "8.8.8.8", "Specifies a custom DNS server for use inside OCI containers. If set to the empty string, mount /etc/resolv.conf from the host.")
-	netPoolSize = flag.Int("executor.oci.network_pool_size", 0, "Limit on the number of networks to be reused between containers. Setting to 0 disables pooling. Setting to -1 uses the recommended default.")
+	Runtime          = flag.String("executor.oci.runtime", "", "OCI runtime")
+	runtimeRoot      = flag.String("executor.oci.runtime_root", "", "Root directory for storage of container state (see <runtime> --help for default)")
+	pidsLimit        = flag.Int64("executor.oci.pids_limit", 2048, "PID limit for OCI runtime. Set to -1 for unlimited PIDs.")
+	cpuLimit         = flag.Int("executor.oci.cpu_limit", 0, "Hard limit for CPU resources, expressed as CPU count. Default (0) is no limit.")
+	cpuRelativeLimit = flag.Int("executor.oci.cpu_relative_limit", -1, "CPU hard limit added to the task size, expressed as CPU count. If set to -1, only use cpu_limit as a hard limit.")
+	dns              = flag.String("executor.oci.dns", "8.8.8.8", "Specifies a custom DNS server for use inside OCI containers. If set to the empty string, mount /etc/resolv.conf from the host.")
+	netPoolSize      = flag.Int("executor.oci.network_pool_size", 0, "Limit on the number of networks to be reused between containers. Setting to 0 disables pooling. Setting to -1 uses the recommended default.")
 )
 
 const (
@@ -194,6 +195,8 @@ func (p *provider) New(ctx context.Context, args *container.Init) (container.Com
 		networkEnabled: args.Props.DockerNetwork != "off",
 		user:           args.Props.DockerUser,
 		forceRoot:      args.Props.DockerForceRoot,
+
+		milliCPU: args.Task.GetSchedulingMetadata().GetTaskSize().GetEstimatedMilliCpu(),
 	}, nil
 }
 
@@ -218,6 +221,8 @@ type ociContainer struct {
 	networkEnabled bool
 	user           string
 	forceRoot      bool
+
+	milliCPU int64 // milliCPU allocation from task size
 }
 
 // Returns the OCI bundle directory for the container.
@@ -692,13 +697,18 @@ func (c *ociContainer) createSpec(ctx context.Context, cmd *repb.Command) (*spec
 		return nil, fmt.Errorf("get container user: %w", err)
 	}
 
-	cpuSpecs := &specs.LinuxCPU{}
+	var milliCPUHardLimit int64
+	if *cpuRelativeLimit >= 0 {
+		milliCPUHardLimit = c.milliCPU + int64(*cpuRelativeLimit)*1000
+	}
 	if *cpuLimit != 0 {
+		milliCPUHardLimit = min(milliCPUHardLimit, int64(*cpuLimit)*1000)
+	}
+	cpuSpecs := &specs.LinuxCPU{}
+	if milliCPUHardLimit > 0 {
 		period := 100 * time.Millisecond
-		cpuSpecs = &specs.LinuxCPU{
-			Quota:  pointer(int64(*cpuLimit) * period.Microseconds()),
-			Period: pointer(uint64(period.Microseconds())),
-		}
+		cpuSpecs.Quota = pointer(int64(milliCPUHardLimit) * period.Microseconds() / 1000)
+		cpuSpecs.Period = pointer(uint64(period.Microseconds()))
 	}
 
 	spec := specs.Spec{

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -1106,7 +1106,7 @@ func TestHardLimits(t *testing.T) {
 	runtimeRoot := testfs.MakeTempDir(t)
 	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
 	// Enable exact hard-limits based on task size
-	flags.Set(t, "executor.oci.overprovision_cpus", 0)
+	flags.Set(t, "executor.oci.task_headroom_millicpu", 0)
 	buildRoot := testfs.MakeTempDir(t)
 	cacheRoot := testfs.MakeTempDir(t)
 	provider, err := ociruntime.NewProvider(env, buildRoot, cacheRoot)


### PR DESCRIPTION
Add a flag to set a CPU hard limit relative to the task size.

The eventual goal would be to set this new flag to `0` so that we are setting exact hard limits based on the task size, and the app would be responsible for building any "headroom" needed into the task size, since the app has more task sizing information and knows how "confident" it is about the task size.

Note that we currently also have `executor.oci.cpu_limit` which sets an absolute hard-limit. This absolute limit is now applied after the relative limit is applied.