### PR TITLE
Fix flaky CASProxyTest

### DIFF
--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -74,7 +74,6 @@ type atimeUpdater struct {
 
 	maxDigestsPerUpdate int
 	maxUpdatesPerGroup  int
-	updateInterval      time.Duration
 	rpcTimeout          time.Duration
 
 	remote repb.ContentAddressableStorageClient
@@ -95,7 +94,6 @@ func Register(env *real_environment.RealEnv) error {
 		updates:             make(map[string]*atimeUpdates),
 		maxDigestsPerUpdate: *atimeUpdaterMaxDigestsPerUpdate,
 		maxUpdatesPerGroup:  *atimeUpdaterMaxUpdatesPerGroup,
-		updateInterval:      *atimeUpdaterBatchUpdateInterval,
 		rpcTimeout:          *atimeUpdaterRpcTimeout,
 		remote:              remote,
 	}


### PR DESCRIPTION
This test became flaky after https://github.com/buildbuddy-io/buildbuddy/pull/7783 because it assumes the atime-update interval is 30 seconds. Changed the test to explicitly set a value and use that in the test instead of relying on the default value.

Here's 1000/1000 green runs: https://buildbuddy.buildbuddy.io/invocation/0f73573a-a98a-4dc3-8570-181218774d4f