### PR TITLE
Include stdout, stderr, and auxiliary logs in file upload metrics

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -324,7 +324,7 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, cmd *repb.Command, execu
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
-	txInfo.FileCount += 2 //for stdout and stderr
+	txInfo.FileCount += 2 // for stdout and stderr
 	txInfo.BytesTransferred += int64(len(cmdResult.Stdout) + len(cmdResult.Stderr))
 	txInfo.FileCount += int64(len(cmdResult.AuxiliaryLogs))
 	for _, b := range cmdResult.AuxiliaryLogs {

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -324,6 +324,12 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, cmd *repb.Command, execu
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
+	txInfo.FileCount += 2 //for stdout and stderr
+	txInfo.BytesTransferred += int64(len(cmdResult.Stdout) + len(cmdResult.Stderr))
+	txInfo.FileCount += int64(len(cmdResult.AuxiliaryLogs))
+	for _, b := range cmdResult.AuxiliaryLogs {
+		txInfo.BytesTransferred += int64(len(b))
+	}
 	executeResponse.Result.StdoutDigest = stdoutDigest
 	executeResponse.Result.StderrDigest = stderrDigest
 	executeResponse.ServerLogs = serverLogs

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2186,7 +2186,7 @@ message IOStats {
   // the end time of the last link operation.
   google.protobuf.Duration local_cache_link_duration = 8;
 
-  // The number of files uploaded in this tree.
+  // The number of files (and dirs and trees) uploaded in this tree.
   int64 file_upload_count = 4;
 
   // The total size of uploaded data.

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -276,6 +276,7 @@ func (f *fileToUpload) FileNode() *repb.FileNode {
 func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, txInfo *TransferInfo, env environment.Env, filesToUpload []*fileToUpload, instanceName string, digestFunction repb.DigestFunction_Value) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
 	type batchResult struct {
 		files                      []*fileToUpload
 		skippedFiles, skippedBytes int64

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -504,7 +504,6 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 				if err != nil {
 					return nil, err
 				}
-
 				txInfo.FileCount += 1
 				txInfo.BytesTransferred += fileNode.GetDigest().GetSizeBytes()
 				directory.Files = append(directory.Files, fileNode)
@@ -530,7 +529,6 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 
 	// Upload output files to the remote cache and also add them to the local
 	// cache since they are likely to be used as inputs to subsequent actions.
-
 	if err := uploadMissingFiles(ctx, uploader, txInfo, env, filesToUpload, instanceName, digestFunction); err != nil {
 		return nil, err
 	}

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -273,74 +273,6 @@ func (f *fileToUpload) FileNode() *repb.FileNode {
 	}
 }
 
-func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, env environment.Env, filesToUpload []*fileToUpload, instanceName string, digestFunction repb.DigestFunction_Value) (skippedFiles, skippedBytes int64, _ error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	type batchResult struct {
-		files                      []*fileToUpload
-		skippedFiles, skippedBytes int64
-	}
-	batches := make(chan batchResult, 1)
-	var wg sync.WaitGroup
-	cas := env.GetContentAddressableStorageClient()
-
-	for batch := range slices.Chunk(filesToUpload, 1000) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			req := &repb.FindMissingBlobsRequest{
-				DigestFunction: digestFunction,
-				InstanceName:   instanceName,
-			}
-			for _, f := range batch {
-				req.BlobDigests = append(req.BlobDigests, f.digest)
-			}
-			var skippedFiles, skippedBytes int64
-			resp, err := cas.FindMissingBlobs(ctx, req)
-			if err != nil {
-				log.CtxWarningf(ctx, "Failed to find missing output blobs: %s", err)
-			} else {
-				missing := make(map[string]struct{}, len(resp.GetMissingBlobDigests()))
-				for _, d := range resp.GetMissingBlobDigests() {
-					missing[d.GetHash()] = struct{}{}
-				}
-				missingLen := 0
-				for _, uploadableFile := range batch {
-					if _, ok := missing[uploadableFile.digest.GetHash()]; ok {
-						batch[missingLen] = uploadableFile
-						missingLen++
-					} else {
-						skippedFiles++
-						skippedBytes += uploadableFile.digest.GetSizeBytes()
-					}
-				}
-				batch = batch[:missingLen]
-			}
-			select {
-			case <-ctx.Done():
-				// If the reader errored and returned, don't block forever
-			case batches <- batchResult{files: batch, skippedFiles: skippedFiles, skippedBytes: skippedBytes}:
-			}
-		}()
-	}
-
-	go func() {
-		wg.Wait()
-		close(batches)
-	}()
-
-	fc := env.GetFileCache()
-	for batch := range batches {
-		skippedFiles += batch.skippedFiles
-		skippedBytes += batch.skippedBytes
-		if err := uploadFiles(ctx, uploader, fc, batch.files); err != nil {
-			return 0, 0, err
-		}
-	}
-	return skippedFiles, skippedBytes, nil
-}
-
 func uploadFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, fc interfaces.FileCache, filesToUpload []*fileToUpload) error {
 	for _, uploadableFile := range filesToUpload {
 		// Add output files to the filecache.
@@ -529,8 +461,7 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 
 	// Upload output files to the remote cache and also add them to the local
 	// cache since they are likely to be used as inputs to subsequent actions.
-	skippedFiles, skippedBytes, err := uploadMissingFiles(ctx, uploader, env, filesToUpload, instanceName, digestFunction)
-	if err != nil {
+	if err := uploadFiles(ctx, uploader, env.GetFileCache(), filesToUpload); err != nil {
 		return nil, err
 	}
 	metrics.SkippedOutputBytes.Add(float64(skippedBytes))

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -273,13 +273,13 @@ func (f *fileToUpload) FileNode() *repb.FileNode {
 	}
 }
 
-func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, txInfo *TransferInfo, env environment.Env, filesToUpload []*fileToUpload, instanceName string, digestFunction repb.DigestFunction_Value) error {
+func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, env environment.Env, filesToUpload []*fileToUpload, instanceName string, digestFunction repb.DigestFunction_Value) (alreadyPresentBytes int64, _ error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	type batchResult struct {
-		files                      []*fileToUpload
-		skippedFiles, skippedBytes int64
+		files        []*fileToUpload
+		presentBytes int64
 	}
 	batches := make(chan batchResult, 1)
 	var wg sync.WaitGroup
@@ -296,7 +296,7 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 			for _, f := range batch {
 				req.BlobDigests = append(req.BlobDigests, f.digest)
 			}
-			var skippedFiles, skippedBytes int64
+			var presentBytes int64
 			resp, err := cas.FindMissingBlobs(ctx, req)
 			if err != nil {
 				log.CtxWarningf(ctx, "Failed to find missing output blobs: %s", err)
@@ -311,8 +311,7 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 						batch[missingLen] = uploadableFile
 						missingLen++
 					} else {
-						skippedFiles++
-						skippedBytes += uploadableFile.digest.GetSizeBytes()
+						presentBytes += uploadableFile.digest.GetSizeBytes()
 					}
 				}
 				batch = batch[:missingLen]
@@ -320,7 +319,7 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 			select {
 			case <-ctx.Done():
 				// If the reader errored and returned, don't block forever
-			case batches <- batchResult{files: batch, skippedFiles: skippedFiles, skippedBytes: skippedBytes}:
+			case batches <- batchResult{files: batch, presentBytes: presentBytes}:
 			}
 		}()
 	}
@@ -330,19 +329,14 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 		close(batches)
 	}()
 
-	var skippedFiles, skippedBytes int64
 	fc := env.GetFileCache()
 	for batch := range batches {
-		skippedFiles += batch.skippedFiles
-		skippedBytes += batch.skippedBytes
+		alreadyPresentBytes += batch.presentBytes
 		if err := uploadFiles(ctx, uploader, fc, batch.files); err != nil {
-			return err
+			return 0, err
 		}
 	}
-	metrics.SkippedOutputBytes.Add(float64(skippedBytes))
-	txInfo.FileCount -= skippedFiles
-	txInfo.BytesTransferred -= skippedBytes
-	return nil
+	return alreadyPresentBytes, nil
 }
 
 func uploadFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, fc interfaces.FileCache, filesToUpload []*fileToUpload) error {
@@ -532,7 +526,8 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 
 	// Upload output files to the remote cache and also add them to the local
 	// cache since they are likely to be used as inputs to subsequent actions.
-	if err := uploadMissingFiles(ctx, uploader, txInfo, env, filesToUpload, instanceName, digestFunction); err != nil {
+	alreadyPresentBytes, err := uploadMissingFiles(ctx, uploader, env, filesToUpload, instanceName, digestFunction)
+	if err != nil {
 		return nil, err
 	}
 
@@ -578,9 +573,13 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 	if err := uploader.Wait(); err != nil {
 		return nil, err
 	}
-	endTime := time.Now()
-	txInfo.TransferDuration = endTime.Sub(startTime)
-	return txInfo, nil
+	uploadStats := uploader.Stats()
+	metrics.SkippedOutputBytes.Add(float64(alreadyPresentBytes + uploadStats.DuplicateBytes))
+	return &TransferInfo{
+		TransferDuration: time.Since(startTime),
+		FileCount:        uploadStats.UploadedObjects,
+		BytesTransferred: uploadStats.UploadedBytes,
+	}, nil
 }
 
 type FilePointer struct {

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -281,8 +281,9 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 		skippedFiles, skippedBytes int64
 	}
 	batches := make(chan batchResult, 1)
-	wg := sync.WaitGroup{}
+	var wg sync.WaitGroup
 	cas := env.GetContentAddressableStorageClient()
+
 	for batch := range slices.Chunk(filesToUpload, 1000) {
 		wg.Add(1)
 		go func() {

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -276,12 +276,13 @@ func (f *fileToUpload) FileNode() *repb.FileNode {
 func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, txInfo *TransferInfo, env environment.Env, filesToUpload []*fileToUpload, instanceName string, digestFunction repb.DigestFunction_Value) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	wg := sync.WaitGroup{}
 	type batchResult struct {
 		files                      []*fileToUpload
 		skippedFiles, skippedBytes int64
 	}
 	batches := make(chan batchResult, 1)
+	wg := sync.WaitGroup{}
+	cas := env.GetContentAddressableStorageClient()
 	for batch := range slices.Chunk(filesToUpload, 1000) {
 		wg.Add(1)
 		go func() {

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -50,7 +50,7 @@ func TestUploadTree(t *testing.T) {
 			symlinkPaths:   map[string]string{},
 			expectedResult: &repb.ActionResult{},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
+				FileCount:        1,
 				BytesTransferred: 0,
 			},
 		},
@@ -76,8 +76,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        2,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -113,8 +113,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        4,
+				BytesTransferred: 244,
 			},
 		},
 		{
@@ -150,8 +150,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        2,
+				BytesTransferred: 108,
 			},
 		},
 		{
@@ -193,8 +193,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        2,
+				BytesTransferred: 108,
 			},
 		},
 		{
@@ -234,8 +234,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        2,
+				BytesTransferred: 108,
 			},
 		},
 		{
@@ -282,8 +282,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        4,
+				BytesTransferred: 256,
 			},
 		},
 		{
@@ -336,8 +336,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        4,
+				BytesTransferred: 256,
 			},
 		},
 		{
@@ -388,8 +388,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        4,
+				BytesTransferred: 256,
 			},
 		},
 		{
@@ -426,8 +426,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 104,
+				FileCount:        4,
+				BytesTransferred: 284,
 			},
 		},
 		{
@@ -447,8 +447,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
-				BytesTransferred: 0,
+				FileCount:        1,
+				BytesTransferred: 8,
 			},
 		},
 		{
@@ -468,8 +468,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
-				BytesTransferred: 0,
+				FileCount:        1,
+				BytesTransferred: 8,
 			},
 		},
 		{
@@ -494,8 +494,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        3,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -534,8 +534,8 @@ func TestUploadTree(t *testing.T) {
 				//   Dir:  a/b/e/g
 				//   File: a/b/c/fileA.txt
 				//
-				FileCount:        6,
-				BytesTransferred: 381,
+				FileCount:        7,
+				BytesTransferred: 849,
 			},
 		},
 		{
@@ -571,8 +571,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        5,
+				BytesTransferred: 244,
 			},
 		},
 		{
@@ -592,8 +592,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
-				BytesTransferred: 0,
+				FileCount:        1,
+				BytesTransferred: 8,
 			},
 		},
 	} {


### PR DESCRIPTION
Now the `file_upload_count` and `file_upload_size_bytes` metrics will include these files and bytes.

Also addresses the last comment from buildbuddy-io/buildbuddy/pull/7788