### PR TITLE
bazel: Drop `experimental` prefix from `--execution_log_compact_file`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -296,7 +296,7 @@ common --experimental_profile_include_primary_output
 common --noslim_profile
 # Include compact execution log
 # TODO(sluongng): make Bazel writes this to output_base automatically
-common --experimental_execution_log_compact_file=bazel_compact_exec_log.binpb.zst
+common --execution_log_compact_file=bazel_compact_exec_log.binpb.zst
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:


### PR DESCRIPTION
The experimental form is deprecated since Bazel 7.4.0.