### PR TITLE
explain: Parallelize parsing and graph construction

### DIFF
--- a/cli/explain/compactgraph/BUILD.bazel
+++ b/cli/explain/compactgraph/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "@com_github_klauspost_compress//zstd",
         "@org_golang_google_protobuf//encoding/protodelim",
         "@org_golang_x_exp//maps",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 


### PR DESCRIPTION
Small execlog (Bazel@HEAD vs Bazel@HEAD~30):

```
  Time (mean ± σ):     139.3 ms ±   3.3 ms    [User: 445.7 ms, System: 69.8 ms]
  Range (min … max):   133.4 ms … 146.2 ms    21 runs

  Time (mean ± σ):     103.2 ms ±   1.8 ms    [User: 482.2 ms, System: 59.3 ms]
  Range (min … max):    99.4 ms … 106.3 ms    28 runs
```

Large execlog (~250MB compressed):

```
  Time (mean ± σ):      5.260 s ±  0.060 s    [User: 12.502 s, System: 0.619 s]
  Range (min … max):    5.173 s …  5.351 s    10 runs

  Time (mean ± σ):      3.331 s ±  0.062 s    [User: 12.379 s, System: 0.760 s]
  Range (min … max):    3.256 s …  3.436 s    10 runs
```