### PR TITLE
Fix workflow error message

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -558,11 +558,6 @@ func (s *APIServer) ExecuteWorkflow(ctx context.Context, req *apipb.ExecuteWorkf
 	}
 	rsp, err := wfs.ExecuteWorkflow(ctx, r)
 	if err != nil {
-		if status.IsNotFoundError(err) {
-			return nil, status.NotFoundErrorf("Workflow for repo %s not found. Note that the legacy Workflow product"+
-				" is not supported for this API. See https://www.buildbuddy.io/docs/workflows-setup/ for more information"+
-				" on how to correctly setup Workflows.", req.GetRepoUrl())
-		}
 		return nil, err
 	}
 


### PR DESCRIPTION
There is more than one case where we return `NotFound`, so the current logic is causing us to return a misleading error in some cases.