### PR TITLE
Clean up some debug logging in podman

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -233,16 +233,6 @@ func (s *UsageStats) Reset() {
 	s.peakMemoryUsageBytes = 0
 }
 
-// TODO: remove after debugging stats issue
-func (s *UsageStats) Clone() *UsageStats {
-	clone := *s
-	if s.last != nil {
-		clone.last = s.last.CloneVT()
-	}
-	// Baseline PSI protos are readonly; no need to clone.
-	return &clone
-}
-
 // TaskStats returns the usage stats for an executed task.
 func (s *UsageStats) TaskStats() *repb.UsageStats {
 	if s.last == nil {


### PR DESCRIPTION
This is no longer useful because we aren't actively running podman in prod.