### PR TITLE
Always close the writeState's decompressorCloser in ByteStreamServer.Write()

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -359,6 +359,9 @@ func (w *writeState) Commit() error {
 }
 
 func (w *writeState) Close() error {
+	if w.decompressorCloser != nil {
+		w.decompressorCloser.Close()
+	}
 	return w.cacheCloser.Close()
 }
 


### PR DESCRIPTION
The `decompressorCloser` that's opened on [lines 307/315 of byte_stream_server.go](https://github.com/buildbuddy-io/buildbuddy/blob/6733ce557e5c064e278e8dd3f018cc8068df11d7/server/remote_cache/byte_stream_server/byte_stream_server.go#L303-L322) is only closed if [writeState.Flush](https://github.com/buildbuddy-io/buildbuddy/blob/6733ce557e5c064e278e8dd3f018cc8068df11d7/server/remote_cache/byte_stream_server/byte_stream_server.go#L333) is called, which only happens on [receiving the final frame of the ByteStream.Write](https://github.com/buildbuddy-io/buildbuddy/blob/6733ce557e5c064e278e8dd3f018cc8068df11d7/server/remote_cache/byte_stream_server/byte_stream_server.go#L425-L430). If that Write() loop exits early, then the decompressorCloser leaks, including goroutines from the zstd library that accumulate memory. That can happen if any of these returns are hit:
* https://github.com/buildbuddy-io/buildbuddy/blob/6733ce557e5c064e278e8dd3f018cc8068df11d7/server/remote_cache/byte_stream_server/byte_stream_server.go#L378
* https://github.com/buildbuddy-io/buildbuddy/blob/6733ce557e5c064e278e8dd3f018cc8068df11d7/server/remote_cache/byte_stream_server/byte_stream_server.go#L381
* https://github.com/buildbuddy-io/buildbuddy/blob/6733ce557e5c064e278e8dd3f018cc8068df11d7/server/remote_cache/byte_stream_server/byte_stream_server.go#L417
* https://github.com/buildbuddy-io/buildbuddy/blob/6733ce557e5c064e278e8dd3f018cc8068df11d7/server/remote_cache/byte_stream_server/byte_stream_server.go#L421

This PR fixes the issue by `Close()`ing the decompressorCloser in `streamState.Close()` (which is `defer`ed after the `streamState` is created).

This causes a bad goroutine leak in CacheProxy because those error cases are hit often right now (I'm working on fixing that too!), as you can see in the graph of goroutines over the last week and a less-bad goroutine leak in the App:
![Screenshot 2024-10-28 at 4 44 36 PM](https://github.com/user-attachments/assets/5ec946f9-4230-400f-8beb-99de89d15af6)