### PR TITLE
oci runtime: set CPU weight according to task size

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -77,6 +77,7 @@ go_test(
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
+        "//proto:scheduler_go_proto",
         "//proto:worker_go_proto",
         "//server/interfaces",
         "//server/testutil/testenv",


### PR DESCRIPTION
Behind a flag, sets cgroup2 `cpu.weight` so that when the executor doesn't have spare CPU capacity, it throttles the CPU usage of each OCI container proportionally to estimated task size. This (roughly) guarantees that each action gets _at least_ the amount of CPU specified in the task size.

The behavior today is that `cpu.weight` is effectively set to `100` (the default value) for every task. So if the executor is fully loaded and all containers are CPU-constrained, each container will get equal CPU time, regardless of task size. This is not ideal because it means that tasks which are properly sized are unfairly throttled.

The OCI specification uses the "shares" naming (and unit scaling) instead of "weight" because that's what it was called in cgroup v1, and presumably the name "shares" was kept for backwards compatibility. So the naming convention in this PR is to use "shares" to match the OCI spec.

I tested with this setup:
- My machine has 16 cores/32 threads
- I ran a "properly sized" action with an estimated CPU of 30, which spins up 30 `python` processes each running a large, fixed number of NOPs (`for _ in range(int(500e6)): pass`), and waits for them to complete.
- When run on its own, this action takes ~16s
- Then I tried the following: in parallel with the python action, run another "poorly sized" action with an estimated CPU of 2 (i.e. the 2 remaining CPUs on my machine), which spins up 64 instances of `head -c 50000000000 </dev/zero >/dev/null` in parallel, then waits for them to complete. So this action wants to use 32X the CPU that it is sized for.
- With CPU shares disabled, the python action gets slower because it's now competing with the poorly sized action: it slows down to 26-27s (~10s slower).
- With CPU shares enabled, the python action consistently takes ~16s like it does when run on its own.