### PR TITLE
[Cache Proxy]: attempt to drain the AtimeUpdater queue on server shutdown.

### DIFF
--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -334,5 +334,12 @@ func (u *atimeUpdater) update(ctx context.Context, groupID string, jwt string, r
 
 func (u *atimeUpdater) shutdown(ctx context.Context) error {
 	close(u.quit)
+
+	// Make a best-effort attempt to flush pending updates.
+	// TODO(iain): we could do something fancier here if necessary, like
+	// fire-and-forget these RPCs with a rate-limiter. Let's try this for now.
+	for found := true; found; found = u.sendUpdates(ctx) > 0 {
+	}
+
 	return nil
 }


### PR DESCRIPTION
This is just a simple first attempt which synchronously round-robins through groups, sending one atime-updating RPC per group, as long as there's anything to send. We could do something fancier in the future, like fire-and-forgetting these RPCs, or adding a cancellation timeout, but I figured we should just check and see how this does before worrying about that.