### PR TITLE
Don't run podman network setup container if podman isn't enabled

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -59,7 +59,6 @@ go_library(
         "@org_golang_google_grpc//encoding/gzip",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
-            "//enterprise/server/remote_execution/containers/podman",
             "//enterprise/server/remote_execution/vbd",
             "//server/util/networking",
         ],

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vbd"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
@@ -22,11 +21,6 @@ func setupNetworking(rootContext context.Context) {
 	}
 	if err := networking.ConfigureRoutingForIsolation(rootContext); err != nil {
 		fmt.Printf("Error configuring secondary network: %s", err)
-		os.Exit(1)
-	}
-
-	if err := podman.ConfigureIsolation(rootContext); err != nil {
-		fmt.Printf("Error configuring secondary network for podman: %s", err)
 		os.Exit(1)
 	}
 }

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -584,7 +584,7 @@ func NewPool(env environment.Env, cacheRoot string, opts *PoolOptions) (*pool, e
 		p.overrideProvider = opts.ContainerProvider
 	} else {
 		providers := map[platform.ContainerType]container.Provider{}
-		if err := p.registerContainerProviders(providers, platform.GetExecutorProperties()); err != nil {
+		if err := p.registerContainerProviders(env.GetServerContext(), providers, platform.GetExecutorProperties()); err != nil {
 			return nil, err
 		}
 		if len(providers) == 0 {

--- a/enterprise/server/remote_execution/runner/runner_darwin.go
+++ b/enterprise/server/remote_execution/runner/runner_darwin.go
@@ -13,7 +13,7 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
-func (p *pool) registerContainerProviders(providers map[platform.ContainerType]container.Provider, executor *platform.ExecutorProperties) error {
+func (p *pool) registerContainerProviders(ctx context.Context, providers map[platform.ContainerType]container.Provider, executor *platform.ExecutorProperties) error {
 	if executor.SupportsIsolation(platform.SandboxContainerType) {
 		providers[platform.SandboxContainerType] = &sandbox.Provider{}
 	}

--- a/enterprise/server/remote_execution/runner/runner_windows.go
+++ b/enterprise/server/remote_execution/runner/runner_windows.go
@@ -12,7 +12,7 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
-func (p *pool) registerContainerProviders(providers map[platform.ContainerType]container.Provider, executor *platform.ExecutorProperties) error {
+func (p *pool) registerContainerProviders(ctx context.Context, providers map[platform.ContainerType]container.Provider, executor *platform.ExecutorProperties) error {
 	if executor.SupportsIsolation(platform.BareContainerType) {
 		providers[platform.BareContainerType] = &bare.Provider{}
 	}


### PR DESCRIPTION
If podman is not enabled then don't run the warmup container (which ensures the correct rule ordering) but do continue to run the other networking setup.