### PR TITLE
[ci_runner] Clean up bazel_sub_command flag

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -166,7 +166,6 @@ var (
 	serializedAction   = flag.String("serialized_action", "", "If set, run this b64+yaml encoded action, ignoring trigger conditions.")
 	invocationID       = flag.String("invocation_id", "", "If set, use the specified invocation ID for the workflow action. Ignored if action_name is not set.")
 	visibility         = flag.String("visibility", "", "If set, use the specified value for VISIBILITY build metadata for the workflow invocation.")
-	bazelSubCommand    = flag.String("bazel_sub_command", "", "If set, run the bazel command specified by these args and ignore all triggering and configured actions.")
 	timeout            = flag.Duration("timeout", 0, "Timeout before all commands will be canceled automatically.")
 
 	// Flags to configure setting up git repo
@@ -1284,9 +1283,6 @@ func getActionNameForWorkflowConfiguredEvent() (string, error) {
 		}
 		return a.Name, nil
 	}
-	if *bazelSubCommand != "" {
-		return "run", nil
-	}
 	if *actionName != "" {
 		return *actionName, nil
 	}
@@ -1297,14 +1293,6 @@ func getActionToRun() (*config.Action, error) {
 	if *serializedAction != "" {
 		return deserializeAction(*serializedAction)
 	}
-	if *bazelSubCommand != "" {
-		return &config.Action{
-			Name: "run",
-			DeprecatedBazelCommands: []string{
-				*bazelSubCommand,
-			},
-		}, nil
-	}
 	if *actionName != "" {
 		cfg, err := readConfig()
 		if err != nil {
@@ -1314,7 +1302,7 @@ func getActionToRun() (*config.Action, error) {
 		// actions with a matching action name.
 		return findAction(cfg.Actions, *actionName)
 	}
-	return nil, status.InvalidArgumentError("One of --action or --bazel_sub_command must be specified.")
+	return nil, status.InvalidArgumentError("an action to run must be specified")
 }
 
 func deserializeAction(actionString string) (*config.Action, error) {

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -27,6 +27,7 @@ go_test(
         "ciRunnerRunfilePath": "$(rlocationpath //enterprise/server/cmd/ci_runner)",
     },
     deps = [
+        "//enterprise/server/workflow/config",
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
         "//proto:eventlog_go_proto",
@@ -34,6 +35,7 @@ go_test(
         "//proto:invocation_status_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:remote_execution_log_go_proto",
+        "//proto:runner_go_proto",
         "//server/remote_cache/cachetools",
         "//server/testutil/app",
         "//server/testutil/buildbuddy",
@@ -44,6 +46,7 @@ go_test(
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_bazel_rules_go//go/runfiles:go_default_library",
         "@org_golang_google_protobuf//encoding/protodelim",
     ],


### PR DESCRIPTION
This flag was originally added so that remote bazel could specify the command to run. Now that we're always sending the commands in --serialized_action, we can remove it

Should be merged after https://github.com/buildbuddy-io/buildbuddy/pull/7835 has been deployed