### PR TITLE
[raft] fix shutdown order

### DIFF
--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -166,9 +166,7 @@ func (la *leaseAgent) stop() {
 	la.cancel()
 	la.eg.Wait()
 
-	if la.l != nil {
-		la.l.Stop()
-	}
+	la.l.Stop()
 }
 
 func (la *leaseAgent) runloop() {

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -165,6 +165,10 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 func (la *leaseAgent) stop() {
 	la.cancel()
 	la.eg.Wait()
+
+	if la.l != nil {
+		la.l.Stop()
+	}
 }
 
 func (la *leaseAgent) runloop() {

--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -99,7 +99,6 @@ func (l *Lease) Stop() {
 }
 
 func (l *Lease) dropLease(ctx context.Context) error {
-
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -234,6 +234,12 @@ func (s *Sender) TryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
 	defer spn.End()
 	for i, replica := range rd.GetReplicas() {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+			// continue for loop
+		}
 		client, err := s.apiClient.GetForReplica(ctx, replica)
 		if err != nil {
 			if status.IsUnavailableError(err) {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -576,8 +576,8 @@ func (s *Store) Stop(ctx context.Context) error {
 	s.usages.Stop()
 	if s.egCancel != nil {
 		s.egCancel()
-		s.leaseKeeper.Stop()
 		s.liveness.Stop()
+		s.leaseKeeper.Stop()
 		s.eg.Wait()
 		s.log.Info("Store: waitgroups finished")
 	}

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -576,6 +576,10 @@ func (s *Store) Stop(ctx context.Context) error {
 	s.usages.Stop()
 	if s.egCancel != nil {
 		s.egCancel()
+		// Liveness should be shutdown before leasekeeper; Otherwise,
+		// liveness.ensureValidLease can keep sending requests to the store; and
+		// the leasekeeper can keep queuing the lease instructions; and thus
+		// leaseAgent.runloop unable to finish in time.
 		s.liveness.Stop()
 		s.leaseKeeper.Stop()
 		s.eg.Wait()

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -206,6 +206,10 @@ func TestAutomaticSplitting(t *testing.T) {
 }
 
 func TestAddNodeToCluster(t *testing.T) {
+	// disable txn cleanup and zombie scan, because advance the fake clock can
+	// prematurely trigger txn cleanup and zombie cleanup.
+	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
+	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
 	sf := testutil.NewStoreFactory(t)
 	s1 := sf.NewStore(t)
 	s2 := sf.NewStore(t)


### PR DESCRIPTION
1. stop liveness before leasekeeper. Previously, after we shutdown leasekeeper, liveness keepLeaseAlive which will send cas requests to the store. The leasekeeper will then continue queuing instructions causing leaseAgent.runloop unable to finish in time.
2. When we stop leaseagent, we will also stop the keepLeaseAlive. 
3. In lease.ensureValidLease, check if the context deadline is reached.
