### PR TITLE
Revert #7788 and #7799

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -324,12 +324,6 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, cmd *repb.Command, execu
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
-	txInfo.FileCount += 2 // for stdout and stderr
-	txInfo.BytesTransferred += int64(len(cmdResult.Stdout) + len(cmdResult.Stderr))
-	txInfo.FileCount += int64(len(cmdResult.AuxiliaryLogs))
-	for _, b := range cmdResult.AuxiliaryLogs {
-		txInfo.BytesTransferred += int64(len(b))
-	}
 	executeResponse.Result.StdoutDigest = stdoutDigest
 	executeResponse.Result.StderrDigest = stderrDigest
 	executeResponse.ServerLogs = serverLogs

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2186,7 +2186,7 @@ message IOStats {
   // the end time of the last link operation.
   google.protobuf.Duration local_cache_link_duration = 8;
 
-  // The number of files (and dirs and trees) uploaded in this tree.
+  // The number of files uploaded in this tree.
   int64 file_upload_count = 4;
 
   // The total size of uploaded data.

--- a/server/cache/dirtools/BUILD
+++ b/server/cache/dirtools/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
-        "//server/metrics",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/claims",

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -8,14 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
-	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
@@ -273,74 +271,6 @@ func (f *fileToUpload) FileNode() *repb.FileNode {
 	}
 }
 
-func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, env environment.Env, filesToUpload []*fileToUpload, instanceName string, digestFunction repb.DigestFunction_Value) (skippedFiles, skippedBytes int64, _ error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	type batchResult struct {
-		files                      []*fileToUpload
-		skippedFiles, skippedBytes int64
-	}
-	batches := make(chan batchResult, 1)
-	var wg sync.WaitGroup
-	cas := env.GetContentAddressableStorageClient()
-
-	for batch := range slices.Chunk(filesToUpload, 1000) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			req := &repb.FindMissingBlobsRequest{
-				DigestFunction: digestFunction,
-				InstanceName:   instanceName,
-			}
-			for _, f := range batch {
-				req.BlobDigests = append(req.BlobDigests, f.digest)
-			}
-			var skippedFiles, skippedBytes int64
-			resp, err := cas.FindMissingBlobs(ctx, req)
-			if err != nil {
-				log.CtxWarningf(ctx, "Failed to find missing output blobs: %s", err)
-			} else {
-				missing := make(map[string]struct{}, len(resp.GetMissingBlobDigests()))
-				for _, d := range resp.GetMissingBlobDigests() {
-					missing[d.GetHash()] = struct{}{}
-				}
-				missingLen := 0
-				for _, uploadableFile := range batch {
-					if _, ok := missing[uploadableFile.digest.GetHash()]; ok {
-						batch[missingLen] = uploadableFile
-						missingLen++
-					} else {
-						skippedFiles++
-						skippedBytes += uploadableFile.digest.GetSizeBytes()
-					}
-				}
-				batch = batch[:missingLen]
-			}
-			select {
-			case <-ctx.Done():
-				// If the reader errored and returned, don't block forever
-			case batches <- batchResult{files: batch, skippedFiles: skippedFiles, skippedBytes: skippedBytes}:
-			}
-		}()
-	}
-
-	go func() {
-		wg.Wait()
-		close(batches)
-	}()
-
-	fc := env.GetFileCache()
-	for batch := range batches {
-		skippedFiles += batch.skippedFiles
-		skippedBytes += batch.skippedBytes
-		if err := uploadFiles(ctx, uploader, fc, batch.files); err != nil {
-			return 0, 0, err
-		}
-	}
-	return skippedFiles, skippedBytes, nil
-}
-
 func uploadFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, fc interfaces.FileCache, filesToUpload []*fileToUpload) error {
 	for _, uploadableFile := range filesToUpload {
 		// Add output files to the filecache.
@@ -529,13 +459,9 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 
 	// Upload output files to the remote cache and also add them to the local
 	// cache since they are likely to be used as inputs to subsequent actions.
-	skippedFiles, skippedBytes, err := uploadMissingFiles(ctx, uploader, env, filesToUpload, instanceName, digestFunction)
-	if err != nil {
+	if err := uploadFiles(ctx, uploader, env.GetFileCache(), filesToUpload); err != nil {
 		return nil, err
 	}
-	metrics.SkippedOutputBytes.Add(float64(skippedBytes))
-	txInfo.FileCount -= skippedFiles
-	txInfo.BytesTransferred -= skippedBytes
 
 	// Upload Directory protos.
 	// TODO: skip uploading Directory protos which are not part of any tree?

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -273,13 +273,13 @@ func (f *fileToUpload) FileNode() *repb.FileNode {
 	}
 }
 
-func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, env environment.Env, filesToUpload []*fileToUpload, instanceName string, digestFunction repb.DigestFunction_Value) (alreadyPresentBytes int64, _ error) {
+func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, env environment.Env, filesToUpload []*fileToUpload, instanceName string, digestFunction repb.DigestFunction_Value) (skippedFiles, skippedBytes int64, _ error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	type batchResult struct {
-		files        []*fileToUpload
-		presentBytes int64
+		files                      []*fileToUpload
+		skippedFiles, skippedBytes int64
 	}
 	batches := make(chan batchResult, 1)
 	var wg sync.WaitGroup
@@ -296,7 +296,7 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 			for _, f := range batch {
 				req.BlobDigests = append(req.BlobDigests, f.digest)
 			}
-			var presentBytes int64
+			var skippedFiles, skippedBytes int64
 			resp, err := cas.FindMissingBlobs(ctx, req)
 			if err != nil {
 				log.CtxWarningf(ctx, "Failed to find missing output blobs: %s", err)
@@ -311,7 +311,8 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 						batch[missingLen] = uploadableFile
 						missingLen++
 					} else {
-						presentBytes += uploadableFile.digest.GetSizeBytes()
+						skippedFiles++
+						skippedBytes += uploadableFile.digest.GetSizeBytes()
 					}
 				}
 				batch = batch[:missingLen]
@@ -319,7 +320,7 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 			select {
 			case <-ctx.Done():
 				// If the reader errored and returned, don't block forever
-			case batches <- batchResult{files: batch, presentBytes: presentBytes}:
+			case batches <- batchResult{files: batch, skippedFiles: skippedFiles, skippedBytes: skippedBytes}:
 			}
 		}()
 	}
@@ -331,12 +332,13 @@ func uploadMissingFiles(ctx context.Context, uploader *cachetools.BatchCASUpload
 
 	fc := env.GetFileCache()
 	for batch := range batches {
-		alreadyPresentBytes += batch.presentBytes
+		skippedFiles += batch.skippedFiles
+		skippedBytes += batch.skippedBytes
 		if err := uploadFiles(ctx, uploader, fc, batch.files); err != nil {
-			return 0, err
+			return 0, 0, err
 		}
 	}
-	return alreadyPresentBytes, nil
+	return skippedFiles, skippedBytes, nil
 }
 
 func uploadFiles(ctx context.Context, uploader *cachetools.BatchCASUploader, fc interfaces.FileCache, filesToUpload []*fileToUpload) error {
@@ -501,6 +503,7 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 				if err != nil {
 					return nil, err
 				}
+
 				txInfo.FileCount += 1
 				txInfo.BytesTransferred += fileNode.GetDigest().GetSizeBytes()
 				directory.Files = append(directory.Files, fileNode)
@@ -526,10 +529,13 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 
 	// Upload output files to the remote cache and also add them to the local
 	// cache since they are likely to be used as inputs to subsequent actions.
-	alreadyPresentBytes, err := uploadMissingFiles(ctx, uploader, env, filesToUpload, instanceName, digestFunction)
+	skippedFiles, skippedBytes, err := uploadMissingFiles(ctx, uploader, env, filesToUpload, instanceName, digestFunction)
 	if err != nil {
 		return nil, err
 	}
+	metrics.SkippedOutputBytes.Add(float64(skippedBytes))
+	txInfo.FileCount -= skippedFiles
+	txInfo.BytesTransferred -= skippedBytes
 
 	// Upload Directory protos.
 	// TODO: skip uploading Directory protos which are not part of any tree?
@@ -573,13 +579,9 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 	if err := uploader.Wait(); err != nil {
 		return nil, err
 	}
-	uploadStats := uploader.Stats()
-	metrics.SkippedOutputBytes.Add(float64(alreadyPresentBytes + uploadStats.DuplicateBytes))
-	return &TransferInfo{
-		TransferDuration: time.Since(startTime),
-		FileCount:        uploadStats.UploadedObjects,
-		BytesTransferred: uploadStats.UploadedBytes,
-	}, nil
+	endTime := time.Now()
+	txInfo.TransferDuration = endTime.Sub(startTime)
+	return txInfo, nil
 }
 
 type FilePointer struct {

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -50,7 +50,7 @@ func TestUploadTree(t *testing.T) {
 			symlinkPaths:   map[string]string{},
 			expectedResult: &repb.ActionResult{},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
+				FileCount:        0,
 				BytesTransferred: 0,
 			},
 		},
@@ -76,8 +76,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        1,
+				BytesTransferred: 1,
 			},
 		},
 		{
@@ -113,8 +113,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        4,
-				BytesTransferred: 244,
+				FileCount:        2,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -150,8 +150,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 108,
+				FileCount:        1,
+				BytesTransferred: 1,
 			},
 		},
 		{
@@ -193,8 +193,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 108,
+				FileCount:        1,
+				BytesTransferred: 1,
 			},
 		},
 		{
@@ -234,8 +234,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 108,
+				FileCount:        1,
+				BytesTransferred: 1,
 			},
 		},
 		{
@@ -282,8 +282,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        4,
-				BytesTransferred: 256,
+				FileCount:        2,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -336,8 +336,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        4,
-				BytesTransferred: 256,
+				FileCount:        2,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -388,8 +388,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        4,
-				BytesTransferred: 256,
+				FileCount:        2,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -426,8 +426,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        4,
-				BytesTransferred: 284,
+				FileCount:        2,
+				BytesTransferred: 104,
 			},
 		},
 		{
@@ -447,8 +447,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 8,
+				FileCount:        0,
+				BytesTransferred: 0,
 			},
 		},
 		{
@@ -468,8 +468,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 8,
+				FileCount:        0,
+				BytesTransferred: 0,
 			},
 		},
 		{
@@ -494,8 +494,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        3,
-				BytesTransferred: 84,
+				FileCount:        1,
+				BytesTransferred: 1,
 			},
 		},
 		{
@@ -534,8 +534,8 @@ func TestUploadTree(t *testing.T) {
 				//   Dir:  a/b/e/g
 				//   File: a/b/c/fileA.txt
 				//
-				FileCount:        7,
-				BytesTransferred: 849,
+				FileCount:        6,
+				BytesTransferred: 381,
 			},
 		},
 		{
@@ -571,8 +571,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        5,
-				BytesTransferred: 244,
+				FileCount:        2,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -592,8 +592,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 8,
+				FileCount:        0,
+				BytesTransferred: 0,
 			},
 		},
 	} {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1187,13 +1187,6 @@ var (
 		Help:      "Total number of bytes uploaded during remote execution.",
 	})
 
-	SkippedOutputBytes = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: bbNamespace,
-		Subsystem: "remote_execution",
-		Name:      "skipped_output_bytes",
-		Help:      "Total number of output bytes that weren't uploaded after remote execution.",
-	})
-
 	FileUploadDurationUsec = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -565,7 +565,6 @@ type BatchCASUploader struct {
 	instanceName    string
 	digestFunction  repb.DigestFunction_Value
 	unsentBatchSize int64
-	stats           UploadStats
 }
 
 // NewBatchCASUploader returns an uploader to be used only for the given request
@@ -617,12 +616,9 @@ func (ul *BatchCASUploader) Upload(d *repb.Digest, rsc io.ReadSeekCloser) error 
 	// De-dupe uploads by digest.
 	dk := digest.NewKey(d)
 	if _, ok := ul.uploads[dk]; ok {
-		ul.stats.DuplicateBytes += d.GetSizeBytes()
 		return rsc.Close()
 	}
 	ul.uploads[dk] = struct{}{}
-	ul.stats.UploadedObjects++
-	ul.stats.UploadedBytes += d.GetSizeBytes()
 
 	rsc.Seek(0, 0)
 	r := io.ReadCloser(rsc)
@@ -752,17 +748,6 @@ func (ul *BatchCASUploader) Wait() error {
 		}
 	}
 	return ul.eg.Wait()
-}
-
-// UploadStats contains the statistics for a batch of uploads.
-type UploadStats struct {
-	UploadedObjects, UploadedBytes, DuplicateBytes int64
-}
-
-// Stats returns information about all the uploads in this BatchCASUploader.
-// It's only correct to call it after Wait.
-func (ul *BatchCASUploader) Stats() UploadStats {
-	return ul.stats
 }
 
 type bytesReadSeekCloser struct {


### PR DESCRIPTION
- **Revert "Include stdout, stderr, and auxiliary logs in file upload metrics (#7799)"**
- **Revert "After executing, don't upload outputs that already exist remotely (#7788)"**
