### PR TITLE
Fix typo for community link flag

### DIFF
--- a/server/static/static.go
+++ b/server/static/static.go
@@ -66,7 +66,7 @@ var (
 	invocationLogStreamingEnabled          = flag.Bool("app.invocation_log_streaming_enabled", false, "If set, the UI will stream invocation logs instead of polling.")
 	targetFlakesUIEnabled                  = flag.Bool("app.target_flakes_ui_enabled", false, "If set, show some fancy new features for analyzing flakes.")
 	bazelButtonsEnabled                    = flag.Bool("app.bazel_buttons_enabled", false, "If set, show remote bazel buttons in the UI.")
-	communityLinksEnabled                  = flag.Bool("app.community_links_enabed", true, "If set, show links to BuildBuddy community in the UI.")
+	communityLinksEnabled                  = flag.Bool("app.community_links_enabled", true, "If set, show links to BuildBuddy community in the UI.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")


### PR DESCRIPTION
This PR is to change a typo in name of a recently added flag for community flag.

Not sure if we need backward compatibility of both old and new flag name. 
However considering that this is a newly added name, IMO it should be fine to directly fix the typo.