### PR TITLE
Remove NUMA setting in jailer config

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -992,7 +992,6 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 			ID:             c.id,
 			UID:            fcclient.Int(unix.Geteuid()),
 			GID:            fcclient.Int(unix.Getegid()),
-			NumaNode:       fcclient.Int(0), // TODO(tylerw): randomize this?
 			ExecFile:       c.executorConfig.FirecrackerBinaryPath,
 			ChrootStrategy: fcclient.NewNaiveChrootStrategy(""),
 			Stdout:         c.vmLogWriter(),


### PR DESCRIPTION
This prevents using all available CPUs on machines that have multiple nodes, since it gets translated to `cpuset.cpus` and `cpuset.mems`: https://github.com/firecracker-microvm/firecracker-go-sdk/blob/f74f43bb036d832e6599a5716b669b4f04242c80/jailer.go#L141-L144