### PR TITLE
firecracker: set jailer cgroup CPU weight according to task size

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -138,7 +138,10 @@ go_deps.module_override(
 )
 go_deps.module_override(
     patch_strip = 1,
-    patches = ["@@//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_jailer.patch"],
+    patches = [
+        "@@//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_jailer.patch",
+        "@@//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_cgroup.patch",
+    ],
     path = "github.com/firecracker-microvm/firecracker-go-sdk",
 )
 go_deps.module_override(

--- a/buildpatches/com_github_firecracker_microvm_firecracker_go_sdk_cgroup.patch
+++ b/buildpatches/com_github_firecracker_microvm_firecracker_go_sdk_cgroup.patch
@@ -1,0 +1,114 @@
+From 82d24f54a9a8cad65d8949816e3f6e85a134017d Mon Sep 17 00:00:00 2001
+From: Brandon Duffany <brandon@buildbuddy.io>
+Date: Wed, 6 Nov 2024 17:01:44 -0500
+Subject: [PATCH] Support jailer cgroup args
+
+Signed-off-by: Brandon Duffany <brandon@buildbuddy.io>
+---
+ jailer.go      | 29 ++++++++++++++++++++++++++++-
+ jailer_test.go |  4 ++++
+ 2 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/jailer.go b/jailer.go
+index 208de670..3246738d 100644
+--- a/jailer.go
++++ b/jailer.go
+@@ -85,6 +85,10 @@ type JailerConfig struct {
+ 	// CgroupVersion is the version of the cgroup filesystem to use.
+ 	CgroupVersion string
+ 
++	// CgroupArgs are cgroup settings applied by the jailer. Each arg must be
++	// formatted like <cgroup_file>=<value>, like "cpu.shares=10"
++	CgroupArgs []string
++
+ 	// Stdout specifies the IO writer for STDOUT to use when spawning the jailer.
+ 	Stdout io.Writer
+ 	// Stderr specifies the IO writer for STDERR to use when spawning the jailer.
+@@ -109,6 +113,7 @@ type JailerCommandBuilder struct {
+ 	daemonize       bool
+ 	firecrackerArgs []string
+ 	cgroupVersion   string
++	cgroupArgs      []string
+ 
+ 	stdin  io.Reader
+ 	stdout io.Writer
+@@ -143,6 +148,10 @@ func (b JailerCommandBuilder) Args() []string {
+ 		args = append(args, "--cgroup", fmt.Sprintf("cpuset.cpus=%s", cpulist))
+ 	}
+ 
++	for _, cgroupArg := range b.cgroupArgs {
++		args = append(args, "--cgroup", cgroupArg)
++	}
++
+ 	if len(b.cgroupVersion) > 0 {
+ 		args = append(args, "--cgroup-version", b.cgroupVersion)
+ 	}
+@@ -204,13 +213,30 @@ func (b JailerCommandBuilder) WithExecFile(path string) JailerCommandBuilder {
+ 	return b
+ }
+ 
+-// WithNumaNode uses the specfied node for the jailer. This represents the numa
++// WithNumaNode uses the specified node for the jailer. This represents the numa
+ // node that the process will get assigned to.
++// Note: this is a convenience function that just sets the values of the cgroup
++// files "cpuset.mems" and "cpuset.cpus".
++// If those files are also configured using WithCgroupArgs, the values passed to
++// WithCgroupArgs will take precedence.
+ func (b JailerCommandBuilder) WithNumaNode(node int) JailerCommandBuilder {
+ 	b.node = node
+ 	return b
+ }
+ 
++// WithCgroupArgs sets cgroup file values to be set by the jailer.
++// Each arg must be of the form <cgroup_file>=<value>.
++// Each call to this function resets the cgroup arguments, rather than
++// appending.
++//
++// Example:
++//
++//	b = b.WithCgroupArgs("cpu.shares=10")
++func (b JailerCommandBuilder) WithCgroupArgs(cgroupArgs ...string) JailerCommandBuilder {
++	b.cgroupArgs = cgroupArgs
++	return b
++}
++
+ // WithChrootBaseDir will set the given path as the chroot base directory. This
+ // specifies where chroot jails are built and defaults to /srv/jailer.
+ func (b JailerCommandBuilder) WithChrootBaseDir(path string) JailerCommandBuilder {
+@@ -348,6 +374,7 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
+ 		WithChrootBaseDir(cfg.JailerCfg.ChrootBaseDir).
+ 		WithDaemonize(cfg.JailerCfg.Daemonize).
+ 		WithCgroupVersion(cfg.JailerCfg.CgroupVersion).
++		WithCgroupArgs(cfg.JailerCfg.CgroupArgs...).
+ 		WithFirecrackerArgs(fcArgs...).
+ 		WithStdout(stdout).
+ 		WithStderr(stderr)
+diff --git a/jailer_test.go b/jailer_test.go
+index 7c7017bc..6037cd27 100644
+--- a/jailer_test.go
++++ b/jailer_test.go
+@@ -103,6 +103,7 @@ func TestJailerBuilder(t *testing.T) {
+ 				UID:            Int(123),
+ 				GID:            Int(100),
+ 				NumaNode:       Int(0),
++				CgroupArgs:     []string{"cpu.shares=10"},
+ 				ChrootStrategy: NewNaiveChrootStrategy("kernel-image-path"),
+ 				ExecFile:       "/path/to/firecracker",
+ 				ChrootBaseDir:  "/tmp",
+@@ -123,6 +124,8 @@ func TestJailerBuilder(t *testing.T) {
+ 				"cpuset.mems=0",
+ 				"--cgroup",
+ 				fmt.Sprintf("cpuset.cpus=%s", getNumaCpuset(0)),
++				"--cgroup",
++				"cpu.shares=10",
+ 				"--cgroup-version",
+ 				"2",
+ 				"--chroot-base-dir",
+@@ -146,6 +149,7 @@ func TestJailerBuilder(t *testing.T) {
+ 				WithUID(IntValue(c.jailerCfg.UID)).
+ 				WithGID(IntValue(c.jailerCfg.GID)).
+ 				WithNumaNode(IntValue(c.jailerCfg.NumaNode)).
++				WithCgroupArgs(c.jailerCfg.CgroupArgs...).
+ 				WithCgroupVersion(c.jailerCfg.CgroupVersion).
+ 				WithExecFile(c.jailerCfg.ExecFile)
+ 

--- a/deps.bzl
+++ b/deps.bzl
@@ -1509,11 +1509,13 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         name = "com_github_firecracker_microvm_firecracker_go_sdk",
         importpath = "github.com/firecracker-microvm/firecracker-go-sdk",
         patch_args = ["-p1"],
-        # TODO(bduffany): when
-        # https://github.com/firecracker-microvm/firecracker-go-sdk/pull/510 is
-        # merged, cherry-pick the final revision into our fork, and remove this
-        # patch.
-        patches = ["@{}//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_jailer.patch".format(workspace_name)],
+        # TODO(bduffany): remove these patches when the corresponding PRs are merged
+        patches = [
+            # https://github.com/firecracker-microvm/firecracker-go-sdk/pull/510
+            "@{}//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_jailer.patch".format(workspace_name),
+            # https://github.com/firecracker-microvm/firecracker-go-sdk/pull/600
+            "@{}//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_cgroup.patch".format(workspace_name),
+        ],
         sum = "h1:n9Q3BKnUAW0x1D1x2I2QIj0T/5K6UYL6JKkPvwwARw0=",
         version = "v0.0.0-20241028184712-f74f43bb036d",
     )

--- a/enterprise/server/remote_execution/containers/firecracker/containeropts.go
+++ b/enterprise/server/remote_execution/containers/firecracker/containeropts.go
@@ -41,6 +41,10 @@ type ContainerOpts struct {
 	// The action directory with inputs / outputs.
 	ActionWorkingDirectory string
 
+	// CPUWeightMillis is the CPU weight to assign to this VM, expressed as
+	// CPU-millis. This is set to the task size.
+	CPUWeightMillis int64
+
 	// Optional flags -- these will default to sane values.
 	// They are here primarily for debugging and running
 	// VMs outside of the normal action-execution framework.


### PR DESCRIPTION
Because of CPU overprovisioning, VMs can unfairly eat into each other's CPU allocation. Setting `cpu.weight` as a cgroup option (via the jailer) fixes this by providing a better CPU guarantee for VMs when the machine is under load.

Test:
* VM A (accurately sized): EstimatedCPU=31, run 31x CPU-bound processes for a fixed number of cycles.
* VM B (poorly sized): EstimatedCPU=1, run 32x CPU-bound processes for a fixed number of cycles.

In this test, VM B should get throttled to 1000m CPU usage, from its overprovisioned maximum of 4000m. When enabling `cpu.weight` I could see using `top` that it was indeed getting throttled as expected, whereas without CPU weight it was allowed to use 400% CPU, unfairly eating into VM A's CPU allocation. Enabling `cpu.weight` also reduces the exec duration of VM A from ~18.9s to ~16.9s.

One thing that still needs to be tested is whether this plays nicely with the CPU weights set by the OCI runtime. I suspect it might not because crun places containers in a subtree (`libpod_parent`). I plan to test this separately (before turning on this firecracker flag) and will send a follow-up PR if any changes need to be made.