### PR TITLE
Remove unused dockerclient optional functionality from firecracker image pull path

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -24,7 +24,6 @@ go_library(
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
-        "//enterprise/server/remote_execution/containers/docker",
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/snaploader",

--- a/enterprise/server/util/ociconv/BUILD
+++ b/enterprise/server/util/ociconv/BUILD
@@ -7,7 +7,6 @@ go_library(
     srcs = ["ociconv.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ociconv",
     deps = [
-        "//enterprise/server/remote_execution/containers/docker",
         "//enterprise/server/util/ext4",
         "//enterprise/server/util/oci",
         "//server/util/disk",
@@ -15,7 +14,6 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "//third_party/singleflight",
-        "@com_github_docker_docker//client",
     ],
 )
 

--- a/enterprise/server/util/ociconv/ociconv_test.go
+++ b/enterprise/server/util/ociconv/ociconv_test.go
@@ -21,7 +21,7 @@ func TestOciconv(t *testing.T) {
 		"mirror.gcr.io/ubuntu:22.04",
 	} {
 		t.Run("image="+img, func(t *testing.T) {
-			_, err := ociconv.CreateDiskImage(ctx, nil /*=docker*/, root, img, oci.Credentials{})
+			_, err := ociconv.CreateDiskImage(ctx, root, img, oci.Credentials{})
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
This complicates migrating away from skopeo / umoci and is unused, so remove it.