### PR TITLE
go_sdk: register go toolchains manually

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,6 @@ common:local --bes_results_url=http://localhost:8080/invocation/
 common:local --bes_backend=grpc://localhost:1985
 common:local --remote_cache=grpc://localhost:1985
 common:local --remote_upload_local_results
-common:local --extra_execution_platforms=//platforms:local_config_platform
 
 # Build with --config=dev to send build logs to the dev server
 common:dev --bes_results_url=https://buildbuddy.buildbuddy.dev/invocation/

--- a/.bazelrc
+++ b/.bazelrc
@@ -42,10 +42,8 @@ common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
 
 common:target-linux-x86 --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
-common:target-linux-x86 --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_x86_64
 
 common:target-linux-arm64 --platforms=@buildbuddy_toolchain//:platform_linux_arm64
-common:target-linux-arm64 --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_arm64
 
 # Build with --config=remote to use BuildBuddy RBE.
 common:remote --config=remote-shared

--- a/.bazelrc
+++ b/.bazelrc
@@ -41,7 +41,6 @@ common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
 
 common:target-linux-x86 --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
-
 common:target-linux-arm64 --platforms=@buildbuddy_toolchain//:platform_linux_arm64
 
 # Build with --config=remote to use BuildBuddy RBE.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -490,9 +490,9 @@ oci_pull(
 # Keep up-to-date with docs/rbe-setup.md and docs/rbe-github-actions.md
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "7b9ce903bd0cbf21879c83e264ae9453e143377616935dc1825f7c8c1c2a9688",
-    strip_prefix = "buildbuddy-toolchain-285db08fc6785f0d051ecdcdf7f2910eb0459641",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/285db08fc6785f0d051ecdcdf7f2910eb0459641.tar.gz"],
+    integrity = "sha256-HupO9xeeYDAybxZiXmUFk6W5bAlNnM3c2e8cwkutEpc=",
+    strip_prefix = "buildbuddy-toolchain-eb143d1cf81dcc3ddbf0be5b9950cf8c14aa2de9",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/eb143d1cf81dcc3ddbf0be5b9950cf8c14aa2de9.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
@@ -577,6 +577,7 @@ register_toolchains(
 )
 
 register_execution_platforms(
+    "//platforms:local_config_platform",
     "@buildbuddy_toolchain//:platform_linux_arm64",
     "@buildbuddy_toolchain//:platform_linux_x86_64",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -214,6 +214,7 @@ http_archive(
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:build_bazel_rules_nodejs.patch",
+        "//buildpatches:rules_nodejs_exec_toolchain.patch",
     ],
     sha256 = "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
@@ -227,7 +228,16 @@ load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(
     name = "nodejs",
+    register = False,
     node_version = "18.13.0",
+)
+
+register_toolchains(
+    "@nodejs_toolchains//:darwin_amd64_toolchain_exec",
+    "@nodejs_toolchains//:darwin_arm64_toolchain_exec",
+    "@nodejs_toolchains//:linux_amd64_toolchain_exec",
+    "@nodejs_toolchains//:linux_arm64_toolchain_exec",
+    "@nodejs_toolchains//:windows_amd64_toolchain_exec",
 )
 
 load("@rules_nodejs//nodejs:yarn_repositories.bzl", "yarn_repositories")
@@ -503,6 +513,7 @@ load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "UBUNTU22_04_IMAGE", "bu
 
 buildbuddy(
     name = "buildbuddy_toolchain",
+    gcc_version = "11",
     container_image = UBUNTU22_04_IMAGE,
 )
 
@@ -577,9 +588,9 @@ register_toolchains(
 )
 
 register_execution_platforms(
-    "//platforms:local_config_platform",
     "@buildbuddy_toolchain//:platform_linux_arm64",
     "@buildbuddy_toolchain//:platform_linux_x86_64",
+    # "//platforms:local_config_platform",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,6 +97,7 @@ go_download_sdk(
     name = "go_sdk_linux",
     goarch = "amd64",
     goos = "linux",
+    register_toolchains = False,
     version = GO_SDK_VERSION,
 )
 
@@ -104,6 +105,7 @@ go_download_sdk(
     name = "go_sdk_linux_arm64",
     goarch = "arm64",
     goos = "linux",
+    register_toolchains = False,
     version = GO_SDK_VERSION,
 )
 
@@ -111,6 +113,7 @@ go_download_sdk(
     name = "go_sdk_darwin",
     goarch = "amd64",
     goos = "darwin",
+    register_toolchains = False,
     version = GO_SDK_VERSION,
 )
 
@@ -118,6 +121,7 @@ go_download_sdk(
     name = "go_sdk_darwin_arm64",
     goarch = "arm64",
     goos = "darwin",
+    register_toolchains = False,
     version = GO_SDK_VERSION,
 )
 
@@ -125,6 +129,7 @@ go_download_sdk(
     name = "go_sdk_windows",
     goarch = "amd64",
     goos = "windows",
+    register_toolchains = False,
     version = GO_SDK_VERSION,
 )
 
@@ -132,6 +137,7 @@ go_download_sdk(
     name = "go_sdk_windows_arm64",
     goarch = "arm64",
     goos = "windows",
+    register_toolchains = False,
     version = GO_SDK_VERSION,
 )
 
@@ -139,7 +145,14 @@ go_register_nogo(
     nogo = "@//:vet",
 )
 
-go_register_toolchains()
+register_toolchains(
+    "@go_sdk_linux_toolchains//:go_linux_amd64",
+    "@go_sdk_linux_arm64_toolchains//:go_linux_arm64",
+    "@go_sdk_darwin_toolchains//:go_darwin_amd64",
+    "@go_sdk_darwin_arm64_toolchains//:go_darwin_arm64",
+    "@go_sdk_windows_toolchains//:go_windows_amd64",
+    "@go_sdk_windows_arm64_toolchains//:go_windows_arm64",
+)
 
 gazelle_dependencies(
     go_env = {
@@ -486,11 +499,11 @@ load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
 
 buildbuddy_deps()
 
-load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "UBUNTU20_04_IMAGE", "buildbuddy")
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "UBUNTU22_04_IMAGE", "buildbuddy")
 
 buildbuddy(
     name = "buildbuddy_toolchain",
-    container_image = UBUNTU20_04_IMAGE,
+    container_image = UBUNTU22_04_IMAGE,
 )
 
 http_archive(
@@ -560,6 +573,12 @@ http_file(
 
 register_toolchains(
     "@buildbuddy_toolchain//:ubuntu_cc_toolchain",
+    "@buildbuddy_toolchain//:ubuntu_cc_toolchain_arm64",
+)
+
+register_execution_platforms(
+    "@buildbuddy_toolchain//:platform_linux_arm64",
+    "@buildbuddy_toolchain//:platform_linux_x86_64",
 )
 
 http_archive(

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -151,9 +151,9 @@ container_pull(
 # Keep up-to-date with docs/rbe-setup.md and docs/rbe-github-actions.md
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "7b9ce903bd0cbf21879c83e264ae9453e143377616935dc1825f7c8c1c2a9688",
-    strip_prefix = "buildbuddy-toolchain-285db08fc6785f0d051ecdcdf7f2910eb0459641",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/285db08fc6785f0d051ecdcdf7f2910eb0459641.tar.gz"],
+    integrity = "sha256-HupO9xeeYDAybxZiXmUFk6W5bAlNnM3c2e8cwkutEpc=",
+    strip_prefix = "buildbuddy-toolchain-eb143d1cf81dcc3ddbf0be5b9950cf8c14aa2de9",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/eb143d1cf81dcc3ddbf0be5b9950cf8c14aa2de9.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/buildpatches/rules_nodejs_exec_toolchain.patch
+++ b/buildpatches/rules_nodejs_exec_toolchain.patch
@@ -1,0 +1,30 @@
+diff --git a/nodejs/private/toolchains_repo.bzl b/nodejs/private/toolchains_repo.bzl
+index 5c874f4..9345c6e 100755
+--- a/nodejs/private/toolchains_repo.bzl
++++ b/nodejs/private/toolchains_repo.bzl
+@@ -114,6 +114,13 @@ toolchain(
+     toolchain = "@{user_node_repository_name}_{platform}//:node_toolchain",
+     toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+ )
++toolchain(
++    name = "{platform}_toolchain_exec",
++    exec_compatible_with = {compatible_with},
++    target_compatible_with = {compatible_with},
++    toolchain = "@{user_node_repository_name}_{platform}//:node_toolchain",
++    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
++)
+ """.format(
+             platform = platform,
+             name = repository_ctx.attr.name,
+diff --git a/nodejs/repositories.bzl b/nodejs/repositories.bzl
+index d00c294..053b092 100755
+--- a/nodejs/repositories.bzl
++++ b/nodejs/repositories.bzl
+@@ -404,6 +404,7 @@ def nodejs_register_toolchains(name, register = True, **kwargs):
+         )
+         if register:
+             native.register_toolchains(
++                "@%s_toolchains//:%s_toolchain_exec" % (name, platform),
+                 "@%s_toolchains//:%s_toolchain_target" % (name, platform),
+                 "@%s_toolchains//:%s_toolchain" % (name, platform),
+             )

--- a/deps.bzl
+++ b/deps.bzl
@@ -6506,6 +6506,11 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-linux-x86_64"],
     )
     http_file(
+        name = "io_bazel_bazel-6.5.0-linux-arm64",
+        executable = True,
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-linux-arm64"],
+    )
+    http_file(
         name = "io_bazel_bazel-7.1.0-darwin-x86_64",
         executable = True,
         sha256 = "52ad8d57c22e4f873c724473a09ecfd98966c3a2950e102a7bd7e8c612b8001c",
@@ -6516,6 +6521,11 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         executable = True,
         sha256 = "62d62c699c1eb9f9be6a88030912a54d19fe45ae29329c7e5c53aba787492522",
         urls = ["https://github.com/bazelbuild/bazel/releases/download/7.1.0/bazel-7.1.0-linux-x86_64"],
+    )
+    http_file(
+        name = "io_bazel_bazel-7.1.0-linux-arm64",
+        executable = True,
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/7.1.0/bazel-7.1.0-linux-arm64"],
     )
     http_file(
         name = "io_bazel_bazelisk-1.17.0-darwin-amd64",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "clean": "bazel clean && rm -rf node_modules"
   },
   "devDependencies": {
-    "@bazel/esbuild": "^5.4.0",
-    "@bazel/jasmine": "^5.4.0",
-    "@bazel/typescript": "^5.4.0",
+    "@bazel/esbuild": "^5.8.1",
+    "@bazel/jasmine": "^5.8.1",
+    "@bazel/typescript": "^5.8.1",
     "@types/d3-scale": "^3.0.0",
     "@types/d3-time": "^3.0.0",
     "@types/dagre-d3": "^0.4.39",

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -56,7 +56,9 @@ platform(
 
 platform(
     name = "local_config_platform",
-    constraint_values = HOST_CONSTRAINTS,
+    constraint_values = HOST_CONSTRAINTS + [
+        "@bazel_tools//tools/cpp:gcc",
+    ],
     parents = [get_parent_from_constraints(HOST_CONSTRAINTS)],
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,12 +16,12 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@bazel/esbuild@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@bazel/esbuild/-/esbuild-5.4.0.tgz#94b68f71726c96f60937e0c2bb71ab04c6a0b868"
-  integrity sha512-jX5aPvlXqi1pqNOogJRYUiUCCqC+378QZestcW3MG/vHyMavVTCC4xvas94nnhtzc7UvufOWhYz/S1m8Orca8g==
+"@bazel/esbuild@^5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@bazel/esbuild/-/esbuild-5.8.1.tgz#74668d33bfb29652cbe8e2852aa8dca5e0839e73"
+  integrity sha512-8k4LL8P3ivCnFeBOcjiFxL8U+M5VtEGuOyIqm2hfEiP8xDWsZLS7YQ7KhshKJy7Elh2dlK9oGgMtl0D/x9kxxg==
 
-"@bazel/jasmine@^5.4.0":
+"@bazel/jasmine@^5.8.1":
   version "5.8.1"
   resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-5.8.1.tgz#c549f10806474ff742f37544733fbfdccf78ba66"
   integrity sha512-052veW5EbJRH+5hL4l9Sf99bTmdKQ5WXXMF0QiBOZcA3ZHYMAaKfYNO+brutiWoX6FrBloiskLrMzF8OiHBqyw==
@@ -29,7 +29,7 @@
     c8 "~7.5.0"
     jasmine-reporters "~2.5.0"
 
-"@bazel/typescript@^5.4.0":
+"@bazel/typescript@^5.8.1":
   version "5.8.1"
   resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-5.8.1.tgz#74a76af434fad7930893cf3e98b4cc201e52dc65"
   integrity sha512-NAJ8WQHZL1WE1YmRoCrq/1hhG15Mvy/viWh6TkvFnBeEhNUiQUsA5GYyhU1ztnBIYW03nATO3vwhAEfO7Q0U5g==


### PR DESCRIPTION
For every go_download_sdk() repository call, we create a corresponding
"*_toolchains" repository that contain all the Bazel "toolchain()"
definitions, one for each possible "target_compatible_with" platform.
combination. For example, given "go_sdk_linux", we would get all 58
toolchain definitions like this.

```bash
> bazel 2>/dev/null query 'kind(toolchain, @go_sdk_linux_toolchains//...)'
@go_sdk_linux_toolchains//:go_aix_ppc64
@go_sdk_linux_toolchains//:go_android_386
...
@go_sdk_linux_toolchains//:go_windows_arm
@go_sdk_linux_toolchains//:go_windows_arm64
```

and they are mostly differ by the target_compatible_with attribute

```bash
> diff -u \
    <(bazel 2>/dev/null query '@go_sdk_linux_toolchains//:go_windows_arm' --output=build) \
    <(bazel 2>/dev/null query '@go_sdk_linux_toolchains//:go_windows_arm64' --output=build)

--- /dev/fd/11	2024-11-08 14:05:00.124008382 +0100
+++ /dev/fd/12	2024-11-08 14:05:00.125347497 +0100
@@ -1,16 +1,16 @@
 # /private/var/tmp/_bazel_sluongng/06e573a93bc2d6a9cad4ad41f00b4310/external/go_sdk_linux_toolchains/BUILD.bazel:9:25
 toolchain(
-  name = "go_windows_arm",
-  generator_name = "go_windows_arm",
+  name = "go_windows_arm64",
+  generator_name = "go_windows_arm64",
   generator_function = "declare_bazel_toolchains",
   generator_location = "/private/var/tmp/_bazel_sluongng/06e573a93bc2d6a9cad4ad41f00b4310/external/go_sdk_linux_toolchains/BUILD.bazel:9:25",
   toolchain_type = "@io_bazel_rules_go//go:toolchain",
   exec_compatible_with = ["@io_bazel_rules_go//go/toolchain:linux", "@io_bazel_rules_go//go/toolchain:amd64"],
-  target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:armv7"],
+  target_compatible_with = ["@platforms//os:windows", "@platforms//cpu:aarch64"],
   target_settings = ["@go_sdk_linux_toolchains//:sdk_version_setting"],
-  toolchain = "@go_sdk_linux//:go_windows_arm-impl",
+  toolchain = "@go_sdk_linux//:go_windows_arm64-impl",
 )
-# Rule go_windows_arm instantiated at (most recent call last):
+# Rule go_windows_arm64 instantiated at (most recent call last):
 #   /private/var/tmp/_bazel_sluongng/06e573a93bc2d6a9cad4ad41f00b4310/external/go_sdk_linux_toolchains/BUILD.bazel:9:25             in <toplevel>
 #   /private/var/tmp/_bazel_sluongng/06e573a93bc2d6a9cad4ad41f00b4310/external/io_bazel_rules_go/go/private/go_toolchain.bzl:216:25 in declare_bazel_toolchains

exit 1
```

What this effectively tell Bazel is that you can use the Go toolchain
that runs on linux x86 and produce a Windows ARM64 binary, or a binary
targeting any of the 58 platforms listed. While this cross build is
possible for pure Go, in practice, we found that this is not the case
for CGO related code paths.

When we tried to register multiple execution platforms in the same
build, we got an GoStdlib action like this

```
Arguments
  bazel-out/platform_linux_x86_64-opt-exec/bin/external/go_sdk_linux/builder_reset/builder stdlib
    -sdk external/go_sdk_linux
    -goroot external/go_sdk_linux
    -installsuffix linux_arm64
    -out bazel-out/platform_linux_arm64-fastbuild/bin/external/io_bazel_rules_go/stdlib_
    -package std
    -package runtime/cgo
    -gcflags

Environment variables
  CC=/usr/bin/gcc
  CGO_CFLAGS=-U_FORTIFY_SOURCE -fstack-protector -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -fno-canonical-system-headers -Wno-builtin-macro-redefined -D__DATE__="redacted" -D__TIMESTAMP__="redacted" -D__TIME__="redacted"
  CGO_ENABLED=1
  CGO_LDFLAGS=-fuse-ld=gold -Wl,-no-as-needed -Wl,-z,relro,-z,now -B/usr/bin -pass-exit-codes -lm
  GOARCH=arm64
  GODEBUG=winsymlink=0
  GOEXPERIMENT=nocoverageredesign
  GOOS=linux
  GOPATH=
  GOROOT=external/go_sdk_linux
  GOROOT_FINAL=GOROOT
  GOTOOLCHAIN=local
  PATH=/usr/bin:/bin

Platform properties
  Arch=amd64
  OSFamily=Linux
  container-image=docker://gcr.io/flame-public/rbe-ubuntu22-04:latest
  dockerNetwork=off
```

This action was executed on an x86 Executor, with an x86 toolchain but
tried to produce an arm64 artifact. This failed spectacularly with:

```
gcc_arm64.S: Assembler messages:
gcc_arm64.S:30: Error: no such instruction: `stp x29,x30,[sp,'
gcc_arm64.S:34: Error: too many memory references for `mov'
gcc_arm64.S:36: Error: no such instruction: `stp x19,x20,[sp,'
gcc_arm64.S:39: Error: no such instruction: `stp x21,x22,[sp,'
gcc_arm64.S:42: Error: no such instruction: `stp x23,x24,[sp,'
gcc_arm64.S:45: Error: no such instruction: `stp x25,x26,[sp,'
gcc_arm64.S:48: Error: no such instruction: `stp x27,x28,[sp,'
gcc_arm64.S:52: Error: too many memory references for `mov'
gcc_arm64.S:53: Error: too many memory references for `mov'
gcc_arm64.S:54: Error: too many memory references for `mov'
gcc_arm64.S:56: Error: no such instruction: `blr x20'
gcc_arm64.S:57: Error: no such instruction: `blr x19'
gcc_arm64.S:59: Error: no such instruction: `ldp x27,x28,[sp,'
gcc_arm64.S:62: Error: no such instruction: `ldp x25,x26,[sp,'
gcc_arm64.S:65: Error: no such instruction: `ldp x23,x24,[sp,'
gcc_arm64.S:68: Error: no such instruction: `ldp x21,x22,[sp,'
gcc_arm64.S:71: Error: no such instruction: `ldp x19,x20,[sp,'
gcc_arm64.S:74: Error: no such instruction: `ldp x29,x30,[sp],'
stdlib: error running subcommand external/go_sdk_linux/bin/go: exit status 1
```

Disable automatic toolchain registration in all Go SDKs.
Replace them with manual registration, effectively disabling all
cross build use cases.
