### PR TITLE
Clean up firecracker cgroups manually

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2465,22 +2465,20 @@ func (c *FirecrackerContainer) stopMachine(ctx context.Context) error {
 	if err := c.machine.StopVMM(); err != nil {
 		return status.WrapError(err, "kill firecracker")
 	}
-
-	defer func() {
-		// Once the VM exits, delete the cgroup.
-		// Jailer docs say that this cleanup must be handled by us:
-		// https://github.com/firecracker-microvm/firecracker/blob/main/docs/jailer.md#observations
-		if err := os.Remove(filepath.Join("/sys/fs/cgroup", c.id)); err != nil && !os.IsNotExist(err) {
-			log.CtxWarningf(ctx, "Failed to remove jailer cgroup: %s", err)
-		}
-	}()
-
 	// StopVMM just sends SIGTERM to firecracker; wait for the firecracker
 	// process to exit. SIGTERM error is expected, so ignore it.
 	if err := c.machine.Wait(ctx); err != nil && !isExitErrorSIGTERM(err) {
 		return status.WrapError(err, "wait for firecracker to exit")
 	}
 	c.machine = nil
+
+	// Once the VM exits, delete the cgroup.
+	// Jailer docs say that this cleanup must be handled by us:
+	// https://github.com/firecracker-microvm/firecracker/blob/main/docs/jailer.md#observations
+	if err := os.Remove(filepath.Join("/sys/fs/cgroup", c.id)); err != nil && !os.IsNotExist(err) {
+		log.CtxWarningf(ctx, "Failed to remove jailer cgroup: %s", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The cgroups created by jailer aren't deleted automatically. From the [jailer docs](https://github.com/firecracker-microvm/firecracker/blob/main/docs/jailer.md#observations):

> It’s up to the user to handle cleanup after running the jailer. One way to do this involves registering handlers with the cgroup notify_on_release mechanism, while being wary about potential race conditions (the instance crashing before the subscription process is complete, for example).

Rather than using `notify_on_release`, this PR just deletes the cgroup after the firecracker process exits, since the cgroup should no longer have any pids present at that point.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/4101