### PR TITLE
[COW] Do not lock the lru when unmapping

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -1379,10 +1379,12 @@ func (ml *MmapLRU) processEviction(m *Mmap) {
 	// the LRU lock, in order to avoid deadlocks.
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	ml.mu.Lock()
-	defer ml.mu.Unlock()
 
-	if ml.lru.Contains(ml.key(m)) {
+	ml.mu.Lock()
+	lruContains := ml.lru.Contains(ml.key(m))
+	ml.mu.Unlock()
+
+	if lruContains {
 		// m was re-mapped by another goroutine before we could process this
 		// eviction - don't unmap.
 		return


### PR DESCRIPTION
The background lru eviction channel is not keeping up, because we are locking the LRU when unmapping chunks. This means that the unmaps are happening serially. Unmapping is slow, and we do not need the LRU to be locked while different chunks are being unmapped

This situation will now be possible: 
```
evict m1
> m1.mu.Lock()
> lru.Lock()
> lru.Unlock()
> blocks before we unmap and unlock m1

// Another goroutine
evict m2
> m2.mu.Lock()
> lru.Lock() <- This is a safe operation, because we are only taking the lock to see if the lru contains the m2 key. There is no reason we need to wait for m1 to finish unmapping beforehand

... 
```

Fixes https://buildbuddy-corp.slack.com/archives/C0154UFBCJ2/p1731014993153979