### PR TITLE
[raft] change the start key of meta range from \x00 to \x02

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -329,7 +329,7 @@ func StartShard(ctx context.Context, apiClient *client.APIClient, bootstrapInfo 
 func SendStartShardRequests(ctx context.Context, session *client.Session, nodeHost *dragonboat.NodeHost, apiClient *client.APIClient, nodeGrpcAddrs map[string]string) error {
 	startingRanges := []*rfpb.RangeDescriptor{
 		&rfpb.RangeDescriptor{
-			Start:      keys.MinByte,
+			Start:      constants.MetaRangePrefix,
 			End:        keys.Key{constants.UnsplittableMaxByte},
 			Generation: 1,
 		},

--- a/enterprise/server/raft/rangelease/BUILD
+++ b/enterprise/server/raft/rangelease/BUILD
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
-        "//enterprise/server/raft/keys",
         "//enterprise/server/raft/nodeliveness",
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/replica",
@@ -28,6 +27,7 @@ go_test(
     deps = [
         ":rangelease",
         "//enterprise/server/raft/client",
+        "//enterprise/server/raft/constants",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/nodeliveness",
         "//enterprise/server/raft/replica",

--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/nodeliveness"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica"
@@ -33,7 +32,7 @@ const (
 
 func ContainsMetaRange(rd *rfpb.RangeDescriptor) bool {
 	r := rangemap.Range{Start: rd.Start, End: rd.End}
-	return r.Contains(keys.MinByte) && r.Contains([]byte{constants.UnsplittableMaxByte - 1})
+	return r.Contains(constants.MetaRangePrefix) && r.Contains([]byte{constants.UnsplittableMaxByte - 1})
 }
 
 type Lease struct {

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -1201,7 +1201,7 @@ func TestScanSharedDB(t *testing.T) {
 		em := newEntryMaker(t)
 
 		metarangeDescriptor := &rfpb.RangeDescriptor{
-			Start:      keys.MinByte,
+			Start:      constants.MetaRangePrefix,
 			End:        keys.Key{constants.UnsplittableMaxByte},
 			RangeId:    1,
 			Generation: 1,

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -785,7 +785,7 @@ func TestSplitAcrossClusters(t *testing.T) {
 
 	startingRanges := []*rfpb.RangeDescriptor{
 		&rfpb.RangeDescriptor{
-			Start:      keys.MinByte,
+			Start:      constants.MetaRangePrefix,
 			End:        keys.Key{constants.UnsplittableMaxByte},
 			Generation: 1,
 		},
@@ -1165,7 +1165,7 @@ func TestRebalance(t *testing.T) {
 
 	startingRanges := []*rfpb.RangeDescriptor{
 		&rfpb.RangeDescriptor{
-			Start:      keys.MinByte,
+			Start:      constants.MetaRangePrefix,
 			End:        keys.Key{constants.UnsplittableMaxByte},
 			Generation: 1,
 		},


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4100

Also add a test for ContainsMetaRange
