### PR TITLE
workflows: add Action Names and Env to Run Workflow button

### DIFF
--- a/enterprise/app/workflows/BUILD
+++ b/enterprise/app/workflows/BUILD
@@ -13,7 +13,6 @@ ts_library(
         "//app/capabilities",
         "//app/components/button",
         "//app/components/button:link_button",
-        "//app/components/checkbox",
         "//app/components/dialog:simple_modal_dialog",
         "//app/components/input",
         "//app/components/link",

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -418,14 +418,15 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
       .executeWorkflow(
         new workflow.ExecuteWorkflowRequest({
           pushedRepoUrl: this.props.repoUrl,
+          // Parse "var=val" pairs from the input field to Record<string, string>
           env: this.state.runWorkflowActionNames
             .split(",")
             .filter((n) => n.includes("="))
-            .reduce((acc: Record<string, string>, n) => {
-              const [k, v] = n.split("=");
-              if (k && v) {
-                acc[k] = v;
-              }
+            .map((n) => n.trim().split("="))
+            .filter(([k, v]) => k && v)
+            .map(([k, v]) => [k.trim(), v.trim()])
+            .reduce((acc: Record<string, string>, [k, v]) => {
+              acc[k] = v;
               return acc;
             }, {}),
           actionNames: this.state.runWorkflowEnvs

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -419,16 +419,14 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
         new workflow.ExecuteWorkflowRequest({
           pushedRepoUrl: this.props.repoUrl,
           // Parse "var1=val1,var2=val2" string from the input field to Record<string, string>
-          env: this.state.runWorkflowEnv
-            .split(",")
-            .filter((n) => n.includes("="))
-            .map((n) => n.trim().split("="))
-            .filter((parts) => parts.length)
-            .map(([name, ...valueParts]) => [name, valueParts.join("=")])
-            .reduce((acc: Record<string, string>, [k, v]) => {
-              acc[k] = v;
-              return acc;
-            }, {}),
+          env: Object.fromEntries<string>(
+            this.state.runWorkflowEnv
+              .split(",")
+              .filter((n) => n.includes("="))
+              .map((n) => n.trim().split("="))
+              .filter((parts) => parts.length)
+              .map(([name, ...valueParts]) => [name, valueParts.join("=")])
+          ),
           actionNames: this.state.runWorkflowActionNames
             .split(",")
             .map((n) => n.trim())

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -416,7 +416,10 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
       .executeWorkflow(
         new workflow.ExecuteWorkflowRequest({
           pushedRepoUrl: this.props.repoUrl,
-          actionNames: this.state.runWorkflowActionNames.split(",").map(n => n.trim()),
+          actionNames: this.state.runWorkflowActionNames
+            .split(",")
+            .map((n) => n.trim())
+            .filter((n) => n.length > 0),
           pushedBranch: this.state.runWorkflowBranch,
           targetRepoUrl: this.props.repoUrl,
           targetBranch: this.state.runWorkflowBranch,

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -423,8 +423,8 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
             .split(",")
             .filter((n) => n.includes("="))
             .map((n) => n.trim().split("="))
-            .filter(([k, v]) => k && v)
-            .map(([k, v]) => [k.trim(), v.trim()])
+            .filter((parts) => parts.length)
+            .map(([name, ...valueParts]) => [name, valueParts.join("=")])
             .reduce((acc: Record<string, string>, [k, v]) => {
               acc[k] = v;
               return acc;

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -23,7 +23,6 @@ import TextInput from "../../../app/components/input/input";
 import alert_service from "../../../app/alert/alert_service";
 import errorService from "../../../app/errors/error_service";
 import Spinner from "../../../app/components/spinner/spinner";
-import Checkbox from "../../../app/components/checkbox/checkbox";
 import ActionListComponent from "./action_list";
 
 type Workflow = workflow.GetWorkflowsResponse.Workflow;
@@ -359,6 +358,7 @@ type RepoItemState = {
   isMenuOpen: boolean;
 
   showRunWorkflowInput: boolean;
+  runWorkflowActionNames: string;
   runWorkflowBranch: string;
   runWorkflowVisibility: string;
   isWorkflowRunning: boolean;
@@ -370,6 +370,7 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
   state: RepoItemState = {
     isMenuOpen: false,
     showRunWorkflowInput: false,
+    runWorkflowActionNames: "",
     runWorkflowBranch: "",
     runWorkflowVisibility: "",
     isWorkflowRunning: false,
@@ -415,6 +416,7 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
       .executeWorkflow(
         new workflow.ExecuteWorkflowRequest({
           pushedRepoUrl: this.props.repoUrl,
+          actionNames: this.state.runWorkflowActionNames.split(",").map(n => n.trim()),
           pushedBranch: this.state.runWorkflowBranch,
           targetRepoUrl: this.props.repoUrl,
           targetBranch: this.state.runWorkflowBranch,
@@ -528,6 +530,11 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
                     <TextInput
                       placeholder={"e.g. PUBLIC (optional)"}
                       onChange={(e) => this.setState({ runWorkflowVisibility: e.target.value })}
+                    />
+                    <div className="title">Action Names:</div>
+                    <TextInput
+                      placeholder={"e.g. Test,Build"}
+                      onChange={(e) => this.setState({ runWorkflowActionNames: e.target.value })}
                     />
                     <FilledButton onClick={this.runWorkflow.bind(this)} disabled={this.state.runWorkflowBranch === ""}>
                       Run

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -359,6 +359,7 @@ type RepoItemState = {
 
   showRunWorkflowInput: boolean;
   runWorkflowActionNames: string;
+  runWorkflowEnvs: string;
   runWorkflowBranch: string;
   runWorkflowVisibility: string;
   isWorkflowRunning: boolean;
@@ -371,6 +372,7 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
     isMenuOpen: false,
     showRunWorkflowInput: false,
     runWorkflowActionNames: "",
+    runWorkflowEnvs: "",
     runWorkflowBranch: "",
     runWorkflowVisibility: "",
     isWorkflowRunning: false,
@@ -416,7 +418,17 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
       .executeWorkflow(
         new workflow.ExecuteWorkflowRequest({
           pushedRepoUrl: this.props.repoUrl,
-          actionNames: this.state.runWorkflowActionNames
+          env: this.state.runWorkflowActionNames
+            .split(",")
+            .filter((n) => n.includes("="))
+            .reduce((acc: Record<string, string>, n) => {
+              const [k, v] = n.split("=");
+              if (k && v) {
+                acc[k] = v;
+              }
+              return acc;
+            }, {}),
+          actionNames: this.state.runWorkflowEnvs
             .split(",")
             .map((n) => n.trim())
             .filter((n) => n.length > 0),
@@ -538,6 +550,11 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
                     <TextInput
                       placeholder={"e.g. Test,Build"}
                       onChange={(e) => this.setState({ runWorkflowActionNames: e.target.value })}
+                    />
+                    <div className="title">Environment Variables:</div>
+                    <TextInput
+                      placeholder={"e.g. VAR1=value1,VAR2=value2"}
+                      onChange={(e) => this.setState({ runWorkflowEnvs: e.target.value })}
                     />
                     <FilledButton onClick={this.runWorkflow.bind(this)} disabled={this.state.runWorkflowBranch === ""}>
                       Run

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -359,7 +359,7 @@ type RepoItemState = {
 
   showRunWorkflowInput: boolean;
   runWorkflowActionNames: string;
-  runWorkflowEnvs: string;
+  runWorkflowEnv: string;
   runWorkflowBranch: string;
   runWorkflowVisibility: string;
   isWorkflowRunning: boolean;
@@ -372,7 +372,7 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
     isMenuOpen: false,
     showRunWorkflowInput: false,
     runWorkflowActionNames: "",
-    runWorkflowEnvs: "",
+    runWorkflowEnv: "",
     runWorkflowBranch: "",
     runWorkflowVisibility: "",
     isWorkflowRunning: false,
@@ -418,8 +418,8 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
       .executeWorkflow(
         new workflow.ExecuteWorkflowRequest({
           pushedRepoUrl: this.props.repoUrl,
-          // Parse "var=val" pairs from the input field to Record<string, string>
-          env: this.state.runWorkflowActionNames
+          // Parse "var1=val1,var2=val2" string from the input field to Record<string, string>
+          env: this.state.runWorkflowEnv
             .split(",")
             .filter((n) => n.includes("="))
             .map((n) => n.trim().split("="))
@@ -429,7 +429,7 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
               acc[k] = v;
               return acc;
             }, {}),
-          actionNames: this.state.runWorkflowEnvs
+          actionNames: this.state.runWorkflowActionNames
             .split(",")
             .map((n) => n.trim())
             .filter((n) => n.length > 0),
@@ -555,7 +555,7 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
                     <div className="title">Environment Variables:</div>
                     <TextInput
                       placeholder={"e.g. VAR1=value1,VAR2=value2"}
-                      onChange={(e) => this.setState({ runWorkflowEnvs: e.target.value })}
+                      onChange={(e) => this.setState({ runWorkflowEnv: e.target.value })}
                     />
                     <FilledButton onClick={this.runWorkflow.bind(this)} disabled={this.state.runWorkflowBranch === ""}>
                       Run


### PR DESCRIPTION
Let user decide which action to run from our web UI.
The field accepts multiple action names separated by comma (`,`).

Custom input could be provided via environment variables.
The environment variables should be specified in comma-separated key-value pairs.
For example: `VAR1=value1,VAR2=value2`.
