### PR TITLE
Revert "Revert #7788 and #7799"

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -324,6 +324,12 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, cmd *repb.Command, execu
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
+	txInfo.FileCount += 2 // for stdout and stderr
+	txInfo.BytesTransferred += int64(len(cmdResult.Stdout) + len(cmdResult.Stderr))
+	txInfo.FileCount += int64(len(cmdResult.AuxiliaryLogs))
+	for _, b := range cmdResult.AuxiliaryLogs {
+		txInfo.BytesTransferred += int64(len(b))
+	}
 	executeResponse.Result.StdoutDigest = stdoutDigest
 	executeResponse.Result.StderrDigest = stderrDigest
 	executeResponse.ServerLogs = serverLogs

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2186,7 +2186,7 @@ message IOStats {
   // the end time of the last link operation.
   google.protobuf.Duration local_cache_link_duration = 8;
 
-  // The number of files uploaded in this tree.
+  // The number of files (and dirs and trees) uploaded in this tree.
   int64 file_upload_count = 4;
 
   // The total size of uploaded data.

--- a/server/cache/dirtools/BUILD
+++ b/server/cache/dirtools/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/metrics",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/claims",

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -50,7 +50,7 @@ func TestUploadTree(t *testing.T) {
 			symlinkPaths:   map[string]string{},
 			expectedResult: &repb.ActionResult{},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
+				FileCount:        1,
 				BytesTransferred: 0,
 			},
 		},
@@ -76,8 +76,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        2,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -113,8 +113,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        4,
+				BytesTransferred: 244,
 			},
 		},
 		{
@@ -150,8 +150,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        2,
+				BytesTransferred: 108,
 			},
 		},
 		{
@@ -193,8 +193,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        2,
+				BytesTransferred: 108,
 			},
 		},
 		{
@@ -234,8 +234,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        2,
+				BytesTransferred: 108,
 			},
 		},
 		{
@@ -282,8 +282,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        4,
+				BytesTransferred: 256,
 			},
 		},
 		{
@@ -336,8 +336,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        4,
+				BytesTransferred: 256,
 			},
 		},
 		{
@@ -388,8 +388,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        4,
+				BytesTransferred: 256,
 			},
 		},
 		{
@@ -426,8 +426,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 104,
+				FileCount:        4,
+				BytesTransferred: 284,
 			},
 		},
 		{
@@ -447,8 +447,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
-				BytesTransferred: 0,
+				FileCount:        1,
+				BytesTransferred: 8,
 			},
 		},
 		{
@@ -468,8 +468,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
-				BytesTransferred: 0,
+				FileCount:        1,
+				BytesTransferred: 8,
 			},
 		},
 		{
@@ -494,8 +494,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        1,
-				BytesTransferred: 1,
+				FileCount:        3,
+				BytesTransferred: 84,
 			},
 		},
 		{
@@ -534,8 +534,8 @@ func TestUploadTree(t *testing.T) {
 				//   Dir:  a/b/e/g
 				//   File: a/b/c/fileA.txt
 				//
-				FileCount:        6,
-				BytesTransferred: 381,
+				FileCount:        7,
+				BytesTransferred: 849,
 			},
 		},
 		{
@@ -571,8 +571,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        5,
+				BytesTransferred: 244,
 			},
 		},
 		{
@@ -592,8 +592,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
-				BytesTransferred: 0,
+				FileCount:        1,
+				BytesTransferred: 8,
 			},
 		},
 	} {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1190,6 +1190,13 @@ var (
 		Help:      "Total number of bytes uploaded during remote execution.",
 	})
 
+	SkippedOutputBytes = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "skipped_output_bytes",
+		Help:      "Total number of output bytes that weren't uploaded after remote execution.",
+	})
+
 	FileUploadDurationUsec = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -571,6 +571,7 @@ type BatchCASUploader struct {
 	instanceName    string
 	digestFunction  repb.DigestFunction_Value
 	unsentBatchSize int64
+	stats           UploadStats
 }
 
 // NewBatchCASUploader returns an uploader to be used only for the given request
@@ -622,9 +623,12 @@ func (ul *BatchCASUploader) Upload(d *repb.Digest, rsc io.ReadSeekCloser) error 
 	// De-dupe uploads by digest.
 	dk := digest.NewKey(d)
 	if _, ok := ul.uploads[dk]; ok {
+		ul.stats.DuplicateBytes += d.GetSizeBytes()
 		return rsc.Close()
 	}
 	ul.uploads[dk] = struct{}{}
+	ul.stats.UploadedObjects++
+	ul.stats.UploadedBytes += d.GetSizeBytes()
 
 	rsc.Seek(0, 0)
 	r := io.ReadCloser(rsc)
@@ -754,6 +758,17 @@ func (ul *BatchCASUploader) Wait() error {
 		}
 	}
 	return ul.eg.Wait()
+}
+
+// UploadStats contains the statistics for a batch of uploads.
+type UploadStats struct {
+	UploadedObjects, UploadedBytes, DuplicateBytes int64
+}
+
+// Stats returns information about all the uploads in this BatchCASUploader.
+// It's only correct to call it after Wait.
+func (ul *BatchCASUploader) Stats() UploadStats {
+	return ul.stats
 }
 
 type bytesReadSeekCloser struct {


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#7851

This rolls forward
- Include stdout, stderr, and auxiliary logs in file upload metrics (https://github.com/buildbuddy-io/buildbuddy/pull/7799)
- After executing, don't upload outputs that already exist remotely (https://github.com/buildbuddy-io/buildbuddy/pull/7788)