### PR TITLE
Ignore unknown device numbers in io.stat

### DIFF
--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -347,6 +347,10 @@ func readIOStat(r io.Reader) ([]*repb.CgroupIOStats, error) {
 			return nil, fmt.Errorf("fields unexpectedly empty")
 		}
 		dev := fields[0]
+		if dev == "(unknown)" {
+			// TODO(bduffany): figure out what these "(unknown)" devices are
+			continue
+		}
 		majStr, minStr, ok := strings.Cut(dev, ":")
 		if !ok {
 			return nil, fmt.Errorf("malformed device field")


### PR DESCRIPTION
In some cases, the `io.stat` file has some `(unknown)` devices instead of the expected `MAJOR:MINOR` device number format. Ignore these for now while we dig deeper into what these mean.