### PR TITLE
Record IO stats only for build_root device

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -888,6 +888,14 @@ export default class InvocationActionCardComponent extends React.Component<Props
               Peak disk usage: {fs.target} ({fs.fstype}): {format.bytes(fs.usedBytes)} of {format.bytes(fs.totalBytes)}
             </div>
           ))}
+          {usageStats.cgroupIoStats && (
+            <>
+              <div>Disk bytes read: {format.bytes(usageStats.cgroupIoStats.rbytes)}</div>
+              <div>Disk bytes written: {format.bytes(usageStats.cgroupIoStats.wbytes)}</div>
+              <div>Disk write operations: {format.count(usageStats.cgroupIoStats.wios)}</div>
+              <div>Disk read operations: {format.count(usageStats.cgroupIoStats.rios)}</div>
+            </>
+          )}
         </div>
         {usageStats.cpuPressure && this.renderPSI("CPU", usageStats.cpuPressure)}
         {usageStats.memoryPressure && this.renderPSI("Memory", usageStats.memoryPressure)}

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -891,9 +891,9 @@ export default class InvocationActionCardComponent extends React.Component<Props
           {usageStats.cgroupIoStats && (
             <>
               <div>Disk bytes read: {format.bytes(usageStats.cgroupIoStats.rbytes)}</div>
+              <div>Disk read operations: {format.count(usageStats.cgroupIoStats.rios)}</div>
               <div>Disk bytes written: {format.bytes(usageStats.cgroupIoStats.wbytes)}</div>
               <div>Disk write operations: {format.count(usageStats.cgroupIoStats.wios)}</div>
-              <div>Disk read operations: {format.count(usageStats.cgroupIoStats.rios)}</div>
             </>
           )}
         </div>

--- a/enterprise/server/remote_execution/block_io/BUILD
+++ b/enterprise/server/remote_execution/block_io/BUILD
@@ -1,0 +1,52 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "block_io",
+    srcs = [
+        "block_io_unix.go",
+        "block_io_windows.go",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/block_io",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:aix": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:illumos": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//server/util/status",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/remote_execution/block_io/BUILD
+++ b/enterprise/server/remote_execution/block_io/BUILD
@@ -9,37 +9,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/block_io",
     visibility = ["//visibility:public"],
     deps = select({
-        "@io_bazel_rules_go//go/platform:aix": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@io_bazel_rules_go//go/platform:android": [
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:dragonfly": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@io_bazel_rules_go//go/platform:freebsd": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@io_bazel_rules_go//go/platform:illumos": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@io_bazel_rules_go//go/platform:ios": [
-            "@org_golang_x_sys//unix",
-        ],
         "@io_bazel_rules_go//go/platform:linux": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@io_bazel_rules_go//go/platform:netbsd": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@io_bazel_rules_go//go/platform:openbsd": [
-            "@org_golang_x_sys//unix",
-        ],
-        "@io_bazel_rules_go//go/platform:solaris": [
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:windows": [

--- a/enterprise/server/remote_execution/block_io/block_io_unix.go
+++ b/enterprise/server/remote_execution/block_io/block_io_unix.go
@@ -37,8 +37,8 @@ func LookupDevice(path string) (*Device, error) {
 	if !ok {
 		return nil, err
 	}
-	major := unix.Major(stat.Rdev)
-	minor := unix.Minor(stat.Rdev)
+	major := unix.Major(uint64(stat.Rdev))
+	minor := unix.Minor(uint64(stat.Rdev))
 	blkDev := &Device{
 		Maj: int64(major),
 		Min: int64(minor),

--- a/enterprise/server/remote_execution/block_io/block_io_unix.go
+++ b/enterprise/server/remote_execution/block_io/block_io_unix.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build (linux || darwin) && !android && !ios
 
 package block_io
 
@@ -49,23 +49,20 @@ func LookupDevice(path string) (*Device, error) {
 
 // ParseMajMin parses major/minor block device numbers formatted like
 // "MAJ:MIN"
-func ParseMajMin(str string) (*Device, error) {
+func ParseMajMin(str string) (major, minor int, _ error) {
 	majStr, minStr, ok := strings.Cut(str, ":")
 	if !ok {
-		return nil, fmt.Errorf("expected MAJ:MIN device numbers, got %q", str)
+		return 0, 0, fmt.Errorf("expected MAJ:MIN device numbers, got %q", str)
 	}
-	maj, err := strconv.Atoi(majStr)
+	major, err := strconv.Atoi(majStr)
 	if err != nil {
-		return nil, fmt.Errorf("malformed major device number")
+		return 0, 0, fmt.Errorf("malformed major device number")
 	}
-	min, err := strconv.Atoi(minStr)
+	minor, err = strconv.Atoi(minStr)
 	if err != nil {
-		return nil, fmt.Errorf("malformed minor device number")
+		return 0, 0, fmt.Errorf("malformed minor device number")
 	}
-	return &Device{
-		Maj: int64(maj),
-		Min: int64(min),
-	}, nil
+	return major, minor, nil
 }
 
 func (dev *Device) String() string {

--- a/enterprise/server/remote_execution/block_io/block_io_unix.go
+++ b/enterprise/server/remote_execution/block_io/block_io_unix.go
@@ -1,0 +1,107 @@
+//go:build unix
+
+package block_io
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Device represents a block device.
+type Device struct {
+	// Major and Minor device numbers.
+	Maj, Min int64
+}
+
+// LookupBlockDevice returns the block device for the filesystem mounted at
+// the given path.
+func LookupDevice(path string) (*Device, error) {
+	// Get the device like /dev/sda1 etc.
+	dev, err := getDeviceFromPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stat the device to get Rdev, then extract major/minor device nums.
+	fileInfo, err := os.Stat(dev)
+	if err != nil {
+		return nil, fmt.Errorf("stat %q: %w", dev, err)
+	}
+	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil, err
+	}
+	major := unix.Major(stat.Rdev)
+	minor := unix.Minor(stat.Rdev)
+	blkDev := &Device{
+		Maj: int64(major),
+		Min: int64(minor),
+	}
+
+	return blkDev, nil
+}
+
+// ParseMajMin parses major/minor block device numbers formatted like
+// "MAJ:MIN"
+func ParseMajMin(str string) (*Device, error) {
+	majStr, minStr, ok := strings.Cut(str, ":")
+	if !ok {
+		return nil, fmt.Errorf("expected MAJ:MIN device numbers, got %q", str)
+	}
+	maj, err := strconv.Atoi(majStr)
+	if err != nil {
+		return nil, fmt.Errorf("malformed major device number")
+	}
+	min, err := strconv.Atoi(minStr)
+	if err != nil {
+		return nil, fmt.Errorf("malformed minor device number")
+	}
+	return &Device{
+		Maj: int64(maj),
+		Min: int64(min),
+	}, nil
+}
+
+func (dev *Device) String() string {
+	return fmt.Sprintf("%d:%d", dev.Maj, dev.Min)
+}
+
+// getDeviceFromPath finds the mountpoint associated with the given path
+// and returns the block device mounted there.
+func getDeviceFromPath(path string) (string, error) {
+	file, err := os.Open("/proc/mounts")
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var mountPoint string
+	var device string
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		mountDir := fields[1]
+		if strings.HasPrefix(path, mountDir) && len(mountDir) > len(mountPoint) && fields[0] != "(unknown)" {
+			mountPoint = mountDir
+			device = fields[0]
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if device == "" {
+		return "", fmt.Errorf("could not find mount point for directory")
+	}
+	return device, nil
+}

--- a/enterprise/server/remote_execution/block_io/block_io_windows.go
+++ b/enterprise/server/remote_execution/block_io/block_io_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package block_io
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+type Device struct{}
+
+func LookupDevice(path string) (*Device, error) {
+	return nil, status.UnimplementedError("not yet implemented on windows")
+}

--- a/enterprise/server/remote_execution/cgroup/BUILD
+++ b/enterprise/server/remote_execution/cgroup/BUILD
@@ -5,11 +5,15 @@ go_library(
     srcs = ["cgroup.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup",
     visibility = ["//visibility:public"],
-    deps = [
-        "//proto:remote_execution_go_proto",
-        "//server/util/log",
-        "//server/util/status",
-    ],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//enterprise/server/remote_execution/block_io",
+            "//proto:remote_execution_go_proto",
+            "//server/util/log",
+            "//server/util/status",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/remote_execution/cgroup/BUILD
+++ b/enterprise/server/remote_execution/cgroup/BUILD
@@ -1,9 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "cgroup",
     srcs = ["cgroup.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup",
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = select({
         "@io_bazel_rules_go//go/platform:linux": [
@@ -16,12 +19,11 @@ go_library(
     }),
 )
 
-package(default_visibility = ["//enterprise:__subpackages__"])
-
 go_test(
     name = "cgroup_test",
     srcs = ["cgroup_test.go"],
     embed = [":cgroup"],
+    target_compatible_with = ["@platforms//os:linux"],
     deps = [
         "//proto:remote_execution_go_proto",
         "@com_github_google_go_cmp//cmp",

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -368,13 +368,13 @@ func readIOStat(r io.Reader) ([]*repb.CgroupIOStats, error) {
 			// TODO(bduffany): figure out what these "(unknown)" devices are
 			continue
 		}
-		dev, err := block_io.ParseMajMin(devStr)
+		major, minor, err := block_io.ParseMajMin(devStr)
 		if err != nil {
 			return nil, fmt.Errorf("parse block device: %w", err)
 		}
 		stat := &repb.CgroupIOStats{
-			Maj: dev.Maj,
-			Min: dev.Min,
+			Maj: int64(major),
+			Min: int64(minor),
 		}
 		for _, entry := range fields[1:] {
 			name, valStr, ok := strings.Cut(entry, "=")

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -1,3 +1,5 @@
+//go:build linux && !android
+
 package cgroup
 
 import (
@@ -14,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/block_io"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
@@ -57,17 +60,20 @@ func (p *Paths) CgroupVersion() int {
 	return 0 // unknown
 }
 
-func (p *Paths) Stats(ctx context.Context, cid string) (*repb.UsageStats, error) {
-	if err := p.find(ctx, cid); err != nil {
+// Stats returns cgroup stats for the cgroup matching the given name. If
+// blockDevice is non-nil, IO stats are included for the device, otherwise IO
+// stats are not reported.
+func (p *Paths) Stats(ctx context.Context, name string, blockDevice *block_io.Device) (*repb.UsageStats, error) {
+	if err := p.find(ctx, name); err != nil {
 		return nil, err
 	}
 
 	if p.CgroupVersion() == 1 {
-		return p.v1Stats(ctx, cid)
+		return p.v1Stats(ctx, name)
 	}
 
 	// cgroup v2 has all cgroup files under a single dir.
-	dir := strings.ReplaceAll(p.V2DirTemplate, cidPlaceholder, cid)
+	dir := strings.ReplaceAll(p.V2DirTemplate, cidPlaceholder, name)
 
 	// Read CPU usage.
 	// cpu.stat file contains a line like "usage_usec <N>"
@@ -86,11 +92,22 @@ func (p *Paths) Stats(ctx context.Context, cid string) (*repb.UsageStats, error)
 		return nil, err
 	}
 
-	// Read IO stats
-	ioStatPath := filepath.Join(dir, "io.stat")
-	ioStats, err := readIOStatFile(ioStatPath)
-	if err != nil {
-		return nil, err
+	// Read IO stats for the given block device
+	var ioStats *repb.CgroupIOStats
+	if blockDevice != nil {
+		ioStatPath := filepath.Join(dir, "io.stat")
+		stats, err := readIOStatFile(ioStatPath)
+		if err != nil {
+			return nil, err
+		}
+		// Find the stats for the block device we care about
+		// NOTE: we may not actually find stats if no IO has happened yet!
+		for _, stat := range stats {
+			if stat.Maj == blockDevice.Maj && stat.Min == blockDevice.Min {
+				ioStats = stat
+				break
+			}
+		}
 	}
 
 	// Read PSI metrics.
@@ -346,26 +363,18 @@ func readIOStat(r io.Reader) ([]*repb.CgroupIOStats, error) {
 		if len(fields) == 0 {
 			return nil, fmt.Errorf("fields unexpectedly empty")
 		}
-		dev := fields[0]
-		if dev == "(unknown)" {
+		devStr := fields[0]
+		if devStr == "(unknown)" {
 			// TODO(bduffany): figure out what these "(unknown)" devices are
 			continue
 		}
-		majStr, minStr, ok := strings.Cut(dev, ":")
-		if !ok {
-			return nil, fmt.Errorf("malformed device field")
-		}
-		maj, err := strconv.Atoi(majStr)
+		dev, err := block_io.ParseMajMin(devStr)
 		if err != nil {
-			return nil, fmt.Errorf("malformed major device number")
-		}
-		min, err := strconv.Atoi(minStr)
-		if err != nil {
-			return nil, fmt.Errorf("malformed minor device number")
+			return nil, fmt.Errorf("parse block device: %w", err)
 		}
 		stat := &repb.CgroupIOStats{
-			Maj: int64(maj),
-			Min: int64(min),
+			Maj: dev.Maj,
+			Min: dev.Min,
 		}
 		for _, entry := range fields[1:] {
 			name, valStr, ok := strings.Cut(entry, "=")

--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["container.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container",
     deps = [
+        "//enterprise/server/remote_execution/block_io",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/util/oci",

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -278,11 +278,9 @@ func TestUsageStats(t *testing.T) {
 
 	// Observe some cgroup usage.
 	s.Update(&repb.UsageStats{
-		CpuNanos:    1e9,
-		MemoryBytes: 50 * 1024 * 1024,
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0, Rbytes: 4096, Rios: 1},
-		},
+		CpuNanos:       1e9,
+		MemoryBytes:    50 * 1024 * 1024,
+		CgroupIoStats:  &repb.CgroupIOStats{Maj: 8, Min: 0, Rbytes: 4096, Rios: 1},
 		CpuPressure:    makePSI(100, 10),
 		MemoryPressure: makePSI(2_000, 200),
 		IoPressure:     makePSI(30_000, 3_000),
@@ -290,11 +288,9 @@ func TestUsageStats(t *testing.T) {
 
 	// Observe the same usage again but with higher memory.
 	s.Update(&repb.UsageStats{
-		CpuNanos:    1e9,
-		MemoryBytes: 55 * 1024 * 1024,
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0, Rbytes: 4096, Rios: 1},
-		},
+		CpuNanos:       1e9,
+		MemoryBytes:    55 * 1024 * 1024,
+		CgroupIoStats:  &repb.CgroupIOStats{Maj: 8, Min: 0, Rbytes: 4096, Rios: 1},
 		CpuPressure:    makePSI(100, 10),
 		MemoryPressure: makePSI(2_000, 200),
 		IoPressure:     makePSI(30_000, 3_000),
@@ -304,11 +300,9 @@ func TestUsageStats(t *testing.T) {
 	// observation. Also, accumulate some CPU, read ops, and pressure stall
 	// time.
 	s.Update(&repb.UsageStats{
-		CpuNanos:    2e9,
-		MemoryBytes: 45 * 1024 * 1024,
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0, Rbytes: 8192, Rios: 2},
-		},
+		CpuNanos:       2e9,
+		MemoryBytes:    45 * 1024 * 1024,
+		CgroupIoStats:  &repb.CgroupIOStats{Maj: 8, Min: 0, Rbytes: 8192, Rios: 2},
 		CpuPressure:    makePSI(150, 10),
 		MemoryPressure: makePSI(2_000, 200),
 		IoPressure:     makePSI(30_000, 3_000),
@@ -317,12 +311,10 @@ func TestUsageStats(t *testing.T) {
 		CpuNanos:        2e9,
 		MemoryBytes:     45 * 1024 * 1024,
 		PeakMemoryBytes: 55 * 1024 * 1024,
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0, Rbytes: 8192, Rios: 2},
-		},
-		CpuPressure:    makePSI(150, 10),
-		MemoryPressure: makePSI(2_000, 200),
-		IoPressure:     makePSI(30_000, 3_000),
+		CgroupIoStats:   &repb.CgroupIOStats{Maj: 8, Min: 0, Rbytes: 8192, Rios: 2},
+		CpuPressure:     makePSI(150, 10),
+		MemoryPressure:  makePSI(2_000, 200),
+		IoPressure:      makePSI(30_000, 3_000),
 	}, s.TaskStats(), protocmp.Transform()))
 
 	// Start a new task, using the same UsageStats instance. The cgroup
@@ -330,9 +322,7 @@ func TestUsageStats(t *testing.T) {
 	// should appear as though they were.
 	s.Reset()
 	require.Empty(t, cmp.Diff(&repb.UsageStats{
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0},
-		},
+		CgroupIoStats:  &repb.CgroupIOStats{Maj: 8, Min: 0},
 		CpuPressure:    makePSI(0, 0),
 		MemoryPressure: makePSI(0, 0),
 		IoPressure:     makePSI(0, 0),
@@ -342,11 +332,9 @@ func TestUsageStats(t *testing.T) {
 	// reported is memory, since all other usage should be relative to the last
 	// observation from the previous task.
 	s.Update(&repb.UsageStats{
-		CpuNanos:    2e9,
-		MemoryBytes: 45 * 1024 * 1024,
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0, Rbytes: 8192, Rios: 2},
-		},
+		CpuNanos:       2e9,
+		MemoryBytes:    45 * 1024 * 1024,
+		CgroupIoStats:  &repb.CgroupIOStats{Maj: 8, Min: 0, Rbytes: 8192, Rios: 2},
 		CpuPressure:    makePSI(150, 10),
 		MemoryPressure: makePSI(2_000, 200),
 		IoPressure:     makePSI(30_000, 3_000),
@@ -354,35 +342,26 @@ func TestUsageStats(t *testing.T) {
 	require.Empty(t, cmp.Diff(&repb.UsageStats{
 		MemoryBytes:     45 * 1024 * 1024,
 		PeakMemoryBytes: 45 * 1024 * 1024,
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0},
-		},
-		CpuPressure:    makePSI(0, 0),
-		MemoryPressure: makePSI(0, 0),
-		IoPressure:     makePSI(0, 0),
+		CgroupIoStats:   &repb.CgroupIOStats{Maj: 8, Min: 0},
+		CpuPressure:     makePSI(0, 0),
+		MemoryPressure:  makePSI(0, 0),
+		IoPressure:      makePSI(0, 0),
 	}, s.TaskStats(), protocmp.Transform()))
 
 	// Accumulate some CPU usage, pressure stall time, and write IO. Task stats
 	// should only reflect the accumulated amount.
 	s.Update(&repb.UsageStats{
-		CpuNanos:    2e9 + 7e9,
-		MemoryBytes: 45 * 1024 * 1024,
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0, Rbytes: 8192, Rios: 2, Wbytes: 4096, Wios: 1},
-			// Introduce a new block device too:
-			{Maj: 9, Min: 0, Wbytes: 28672, Wios: 7},
-		},
+		CpuNanos:       2e9 + 7e9,
+		MemoryBytes:    45 * 1024 * 1024,
+		CgroupIoStats:  &repb.CgroupIOStats{Maj: 8, Min: 0, Rbytes: 8192, Rios: 2, Wbytes: 4096, Wios: 1},
 		CpuPressure:    makePSI(150+117, 10+17),
 		MemoryPressure: makePSI(2_000+1_118, 200+118),
 		IoPressure:     makePSI(30_000+11_119, 3_000+1_119),
 	})
 	require.Empty(t, cmp.Diff(&repb.UsageStats{
-		CpuNanos:    7e9,
-		MemoryBytes: 45 * 1024 * 1024,
-		CgroupIoStats: []*repb.CgroupIOStats{
-			{Maj: 8, Min: 0, Wbytes: 4096, Wios: 1},
-			{Maj: 9, Min: 0, Wbytes: 28672, Wios: 7},
-		},
+		CpuNanos:        7e9,
+		MemoryBytes:     45 * 1024 * 1024,
+		CgroupIoStats:   &repb.CgroupIOStats{Maj: 8, Min: 0, Wbytes: 4096, Wios: 1},
 		PeakMemoryBytes: 45 * 1024 * 1024,
 		CpuPressure:     makePSI(117, 17),
 		MemoryPressure:  makePSI(1_118, 118),

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -15,6 +15,7 @@ go_library(
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/remote_execution/block_io",
         "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["podman.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman",
     deps = [
+        "//enterprise/server/remote_execution/block_io",
         "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -715,7 +715,7 @@ func (c *podmanCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, e
 		return nil, err
 	}
 
-	lifetimeStats, err := c.cgroupPaths.Stats(ctx, cid)
+	lifetimeStats, err := c.cgroupPaths.Stats(ctx, cid, nil /*TODO: blockDevice*/)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/block_io"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
@@ -215,6 +216,7 @@ func (p *Provider) New(ctx context.Context, args *container.Init) (container.Com
 		sociStore:         p.sociStore,
 		imageExistsCache:  p.imageExistsCache,
 		buildRoot:         p.buildRoot,
+		blockDevice:       args.BlockDevice,
 		options: &PodmanOptions{
 			ForceRoot:          args.Props.DockerForceRoot,
 			Init:               args.Props.DockerInit,
@@ -250,9 +252,10 @@ type podmanCommandContainer struct {
 	imageExistsCache *imageExistsCache
 	cgroupPaths      *cgroup.Paths
 
-	image     string
-	buildRoot string
-	workDir   string
+	image       string
+	buildRoot   string
+	workDir     string
+	blockDevice *block_io.Device
 
 	imageIsStreamable bool
 	sociStore         soci_store.Store
@@ -715,7 +718,7 @@ func (c *podmanCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, e
 		return nil, err
 	}
 
-	lifetimeStats, err := c.cgroupPaths.Stats(ctx, cid, nil /*TODO: blockDevice*/)
+	lifetimeStats, err := c.cgroupPaths.Stats(ctx, cid, c.blockDevice)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner",
     deps = [
         "//enterprise/server/auth",
+        "//enterprise/server/remote_execution/block_io",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/persistentworker",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -597,7 +597,7 @@ func NewPool(env environment.Env, cacheRoot string, opts *PoolOptions) (*pool, e
 
 	dev, err := block_io.LookupDevice(*rootDirectory)
 	if err != nil {
-		log.Warningf("Failed to locate block device for %s; io stats may not work properly: %s", *rootDirectory, err)
+		log.Warningf("Failed to locate block device for build root directory %q - IO stats may not work properly: %s", *rootDirectory, err)
 	} else {
 		p.blockDevice = dev
 	}

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2248,8 +2248,9 @@ message UsageStats {
   // Timeseries data.
   UsageTimeline timeline = 8;
 
-  // IO stats for each block device.
-  repeated CgroupIOStats cgroup_io_stats = 9;
+  // IO stats for the block device where all action IO happened (action inputs
+  // and outputs, overlayfs temporary files, etc.)
+  CgroupIOStats cgroup_io_stats = 9;
 }
 
 // Structured representation of the cgroup2 "io.stat" file.


### PR DESCRIPTION
Also show the IO stats in the UI - this was useful for E2E testing locally; figured it's a small enough change to include with this PR.

Here's the results from an sh_test that ran `head -c 10000000000 > /tmp/file.txt ; sync`

![image](https://github.com/user-attachments/assets/91b7e9e4-9d22-4931-9a96-4416248679d2)
