### PR TITLE
Don't try to finalize invocation we never get an options event for

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -809,7 +809,7 @@ func (e *EventChannel) Close() {
 }
 
 func (e *EventChannel) FinalizeInvocation(iid string) error {
-	if e.isVoid {
+	if e.isVoid || !e.hasReceivedEventWithOptions {
 		return nil
 	}
 


### PR DESCRIPTION
Without an options event, we don't know anything useful about the build - so there's no point in trying to finalize (it will fail because we never wrote the invocation row in the first place).

In the future we could write some special tombstone row in the invocation here which we could render as an unknown build in the UI - but I'm not convinced that behavior is much better than this behavior "Not found".

This fixes an issue where if you do a build with an invalid flag with bes enabled:
```
bazel build //... --not_a_real_flag_name
```

Bazel will retry 4 times and fail each time with the error `Attempt %d of invocation %s pre-empted by more recent attempt, invocation not finalized.` because we never get an options event. 

This causes the command to appear to hang for a few seconds (while the bes retries happen).

After this change, the build completes ~instantly (but no BES entry is created, so the invocation behavior is unchanged).