### PR TITLE
Request more work when executor is idle

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -568,6 +568,10 @@ func (q *PriorityTaskScheduler) HasExcessCapacity() bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	if q.shuttingDown {
+		return false
+	}
+
 	// If more than n% of RAM is used; don't request extra work.
 	if float64(q.ramBytesUsed) > float64(q.ramBytesCapacity)*(*excessCapacityThreshold) {
 		return false

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -35,7 +35,7 @@ import (
 var (
 	exclusiveTaskScheduling = flag.Bool("executor.exclusive_task_scheduling", false, "If true, only one task will be scheduled at a time. Default is false")
 	shutdownCleanupDuration = flag.Duration("executor.shutdown_cleanup_duration", 15*time.Second, "The minimum duration during the shutdown window to allocate for cleaning up containers. This is capped to the value of `max_shutdown_duration`.")
-	excessCapacityThreshold = flag.Float64("executor.excess_capacity_threshold", .20, "A percentage (of RAM and CPU) utilazation below which this executor may request additional work")
+	excessCapacityThreshold = flag.Float64("executor.excess_capacity_threshold", .20, "A percentage (of RAM and CPU) utilization below which this executor may request additional work")
 )
 
 var shuttingDownLogOnce sync.Once

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -33,7 +33,7 @@ const (
 	// idle, before requesting more work from the scheduler. The scheduler
 	// itself controls how long the executor will backoff after requesting
 	// more work, so this timeout is only used on the initial call.
-	idleExecutorMoreWorkTimeout = 1 * time.Second
+	idleExecutorMoreWorkTimeout = 5 * time.Second
 )
 
 // Options provide overrides for executor registration properties.

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -348,7 +348,7 @@ func (h *executorHandle) Serve(ctx context.Context) error {
 				executorID = registration.GetExecutorId()
 			} else if req.GetEnqueueTaskReservationResponse() != nil {
 				h.handleTaskReservationResponse(req.GetEnqueueTaskReservationResponse())
-				lastWorkTime = time.Now()
+				lastWorkTime = time.Time{}
 			} else if req.GetShuttingDownRequest() != nil {
 				log.CtxInfof(ctx, "Executor %q is going away, re-enqueueing %d task reservations", executorID, len(req.GetShuttingDownRequest().GetTaskId()))
 				// Remove the executor first so that we don't try to send any work its way.

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -280,7 +280,7 @@ func (h *executorHandle) setRegistration(r *scpb.ExecutionNode) {
 	h.registration = r
 }
 
-func truncateDuration(d, min, max time.Duration) time.Duration {
+func clampDuration(d, min, max time.Duration) time.Duration {
 	if d < min {
 		d = min
 	}
@@ -378,7 +378,7 @@ func (h *executorHandle) Serve(ctx context.Context) error {
 					continue
 				}
 				if numEnqueued == 0 {
-					newDelay := truncateDuration(timeSinceLastWork*2, 5*time.Second, time.Minute)
+					newDelay := clampDuration(timeSinceLastWork*2, 5*time.Second, time.Minute)
 					h.setMoreWorkDelay(newDelay) // exponential backoff.
 				}
 			} else {

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -990,7 +990,9 @@ func (c *Command) getResult() *CommandResult {
 			var stdout, stderr string
 			if result.ActionResult != nil {
 				ctx := context.Background()
-				ctx = c.env.WithAPIKey(ctx, c.apiKey)
+				if c.apiKey != "" {
+					ctx = c.env.WithAPIKey(ctx, c.apiKey)
+				}
 				var err error
 				stdout, stderr, err = c.env.GetStdoutAndStderr(ctx, result.ActionResult, result.InstanceName)
 				if err != nil {

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -252,6 +252,18 @@ message RegisterExecutorRequest {
   ExecutionNode node = 1;
 }
 
+// AskForMoreWorkRequest may be sent from the executor to the scheduler when
+// the executor detects it is idle. If more unclaimed work is available, the
+// scheduler may enqueue some of it on this executor.
+message AskForMoreWorkRequest {}
+
+// AskForMoreWorkResponse is sent from the scheduler to executor in reply to
+// AskForMoreWorkRequest. It indicates the minimum amount of time the executor
+// must wait before sending another AskForMoreWorkRequest.
+message AskForMoreWorkResponse {
+  google.protobuf.Duration delay = 1;
+}
+
 message ShuttingDownRequest {
   // Task IDs that are in the executor queue.
   repeated string task_id = 1;
@@ -272,12 +284,18 @@ message RegisterAndStreamWorkRequest {
 
   // Notifications to the scheduler that this executor is going away.
   ShuttingDownRequest shutting_down_request = 3;
+
+  // Request more work, if idle.
+  AskForMoreWorkRequest ask_for_more_work_request = 4;
 }
 
 message RegisterAndStreamWorkResponse {
   // Request to enqueue a task reservation. A EnqueueTaskReservationResponse
   // message will be sent to ack the task reservation.
   EnqueueTaskReservationRequest enqueue_task_reservation_request = 3;
+
+  // How long to backoff if a AskForMoreWorkRequest was sent.
+  AskForMoreWorkResponse ask_for_more_work_response = 4;
 }
 
 service Scheduler {


### PR DESCRIPTION
Work today is enqueued on executors in two ways:
 1) When an Execute() request comes in, work is pushed to already running executors
 2) When new executors come online, if there is unclaimed work, some of it may be enqueued on them

This CL introduces a third mechanism, which is that when an executor has excess capacity, it can request more work from the scheduler. The scheduler may enqueue unclaimed work on the executor if any exists, or if not, it will tell the executor to back off before asking again.

The exponential backoff period starts at 5 seconds of inactivity and maxes out at 60 seconds, so the min / max additional QPS we'd expect to see with say 10K executors is between (10K/5 - 10K/60) == 2000QPS max, 166QPS Min. All of these requests are messages on the existing stream, not new RPCs.

The reason to introduce this is to improve utilization across the fleet, because we can get "unlucky" with scheduling large tasks and end up with some executors having long queues and others no queue. This should even out the workload.