### PR TITLE
Store request and default sizes in SchedulingMetadata

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -605,7 +605,9 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		return "", nil, status.InternalErrorf("Error marshalling execution task %q: %s", executionID, err)
 	}
 
-	taskSize := tasksize.Estimate(executionTask)
+	defaultTaskSize := tasksize.Default(executionTask)
+	requestedTaskSize := tasksize.Requested(executionTask)
+	taskSize := tasksize.Combine(executionTask, defaultTaskSize, requestedTaskSize)
 	measuredSize := sizer.Get(ctx, executionTask)
 	var predictedSize *scpb.TaskSize
 	if measuredSize == nil {
@@ -630,8 +632,10 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		Arch:              props.Arch,
 		Pool:              pool.Name,
 		TaskSize:          taskSize,
+		DefaultTaskSize:   defaultTaskSize,
 		MeasuredTaskSize:  measuredSize,
 		PredictedTaskSize: predictedSize,
+		RequestedTaskSize: requestedTaskSize,
 		ExecutorGroupId:   pool.GroupID,
 		TaskGroupId:       taskGroupID,
 		Priority:          req.GetExecutionPolicy().GetPriority(),

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -607,7 +607,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 
 	defaultTaskSize := tasksize.Default(executionTask)
 	requestedTaskSize := tasksize.Requested(executionTask)
-	taskSize := tasksize.Combine(executionTask, defaultTaskSize, requestedTaskSize)
+	taskSize := tasksize.ApplyLimits(executionTask, tasksize.Override(defaultTaskSize, requestedTaskSize))
 	measuredSize := sizer.Get(ctx, executionTask)
 	var predictedSize *scpb.TaskSize
 	if measuredSize == nil {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -802,7 +802,7 @@ func (p *pool) warmupImage(ctx context.Context, cfg *WarmupConfig) error {
 		SchedulingMetadata: &scpb.SchedulingMetadata{
 			// Note: this will use the default task size estimates and not
 			// measurement-based task sizing, which requires the app.
-			TaskSize: tasksize.Default(task),
+			TaskSize: tasksize.ApplyLimits(task, tasksize.Default(task)),
 		},
 		ExecutionTask: task,
 	}

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -802,7 +802,7 @@ func (p *pool) warmupImage(ctx context.Context, cfg *WarmupConfig) error {
 		SchedulingMetadata: &scpb.SchedulingMetadata{
 			// Note: this will use the default task size estimates and not
 			// measurement-based task sizing, which requires the app.
-			TaskSize: tasksize.Estimate(task),
+			TaskSize: tasksize.Default(task),
 		},
 		ExecutionTask: task,
 	}

--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/testutil/testredis",
         "//proto:remote_execution_go_proto",
+        "//proto:scheduler_go_proto",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/testing/flags",

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -42,8 +42,8 @@ const (
 
 	// Default resource estimates
 
-	DefaultMemEstimate      = int64(400 * 1e6)
-	WorkflowMemEstimate     = int64(8 * 1e9)
+	DefaultMemEstimate      = int64(400 * 1e6) // 400 MB
+	WorkflowMemEstimate     = int64(8 * 1e9)   // 8 GB
 	DefaultCPUEstimate      = int64(600)
 	DefaultFreeDiskEstimate = int64(100 * 1e6) // 100 MB
 
@@ -52,7 +52,7 @@ const (
 	// for task overhead that is not measured explicitly (e.g. task setup).
 
 	MinimumMilliCPU    = int64(250)
-	MinimumMemoryBytes = int64(6_000_000)
+	MinimumMemoryBytes = int64(6_000_000) // 6 MB
 
 	// Additional resources needed depending on task characteristics
 
@@ -167,7 +167,7 @@ func (s *taskSizer) Get(ctx context.Context, task *repb.ExecutionTask) *scpb.Tas
 		// executor run this task once to estimate the size.
 		return nil
 	}
-	return applyMinimums(task, &scpb.TaskSize{
+	return applyLimits(task, &scpb.TaskSize{
 		EstimatedMemoryBytes: recordedSize.EstimatedMemoryBytes,
 		EstimatedMilliCpu:    recordedSize.EstimatedMilliCpu,
 	})
@@ -177,7 +177,7 @@ func (s *taskSizer) Predict(ctx context.Context, task *repb.ExecutionTask) *scpb
 	if s.model == nil {
 		return nil
 	}
-	return applyMinimums(task, s.model.Predict(ctx, task))
+	return applyLimits(task, s.model.Predict(ctx, task))
 }
 
 func (s *taskSizer) Update(ctx context.Context, cmd *repb.Command, md *repb.ExecutedActionMetadata) error {
@@ -376,15 +376,42 @@ func testSize(task *repb.ExecutionTask) (s string, ok bool) {
 	return "", false
 }
 
-// Estimate returns the default task size estimate for a task. It respects hints
-// from the task such as test size and estimated compute units, but does not use
-// information about historical task executions.
-func Estimate(task *repb.ExecutionTask) *scpb.TaskSize {
+// Request returns the explictily requested task size as described in
+// https://www.buildbuddy.io/docs/rbe-platforms#runner-resource-allocation.
+// There is no validation or clamping of the values so we can save exactly what
+// the user requested. EstimatedMemory and EstimatedCPU override
+// EstimatedComputeUnits.
+func Requested(task *repb.ExecutionTask) *scpb.TaskSize {
+	props, err := platform.ParseProperties(task)
+	if err != nil {
+		log.Infof("Failed to parse task properties, using empty requested size: %s", err)
+		return new(scpb.TaskSize)
+	}
+	cpu := int64(props.EstimatedComputeUnits * ComputeUnitsToMilliCPU)
+	mem := int64(props.EstimatedComputeUnits * ComputeUnitsToRAMBytes)
+	if props.EstimatedMemoryBytes > 0 {
+		cpu = props.EstimatedMilliCPU
+	}
+	if props.EstimatedMemoryBytes > 0 {
+		mem = props.EstimatedMemoryBytes
+	}
+	return &scpb.TaskSize{
+		EstimatedMemoryBytes:   mem,
+		EstimatedMilliCpu:      cpu,
+		EstimatedFreeDiskBytes: props.EstimatedFreeDiskBytes,
+		CustomResources:        props.CustomResources,
+	}
+}
+
+// Default returns the default task size estimate for a task. This depends on
+// properties like test size and isolation type, but it doesn't reflect the
+// explicitly requested size. Values are clamped within specific ranges.
+func Default(task *repb.ExecutionTask) *scpb.TaskSize {
 	props, err := platform.ParseProperties(task)
 	if err != nil {
 		log.Infof("Failed to parse task properties, using default estimation: %s", err)
 
-		return applyMinimums(task, &scpb.TaskSize{
+		return applyLimits(task, &scpb.TaskSize{
 			EstimatedMemoryBytes:   DefaultMemEstimate,
 			EstimatedMilliCpu:      DefaultCPUEstimate,
 			EstimatedFreeDiskBytes: DefaultFreeDiskEstimate,
@@ -412,33 +439,25 @@ func Estimate(task *repb.ExecutionTask) *scpb.TaskSize {
 		}
 	}
 
-	if props.EstimatedComputeUnits > 0 {
-		cpuEstimate = int64(props.EstimatedComputeUnits * ComputeUnitsToMilliCPU)
-		memEstimate = int64(props.EstimatedComputeUnits * ComputeUnitsToRAMBytes)
-	}
-	if props.EstimatedMilliCPU > 0 {
-		cpuEstimate = props.EstimatedMilliCPU
-	}
-	if props.EstimatedMemoryBytes > 0 {
-		memEstimate = props.EstimatedMemoryBytes
-	}
-	if props.EstimatedFreeDiskBytes > 0 {
-		freeDiskEstimate = props.EstimatedFreeDiskBytes
-	}
-	if freeDiskEstimate > MaxEstimatedFreeDisk {
-		log.Infof("Task %q requested %d free disk which is more than the max %d", task.GetExecutionId(), freeDiskEstimate, MaxEstimatedFreeDisk)
-		freeDiskEstimate = MaxEstimatedFreeDisk
-	}
-
-	return applyMinimums(task, &scpb.TaskSize{
+	return applyLimits(task, &scpb.TaskSize{
 		EstimatedMemoryBytes:   memEstimate,
 		EstimatedMilliCpu:      cpuEstimate,
 		EstimatedFreeDiskBytes: freeDiskEstimate,
-		CustomResources:        props.CustomResources,
 	})
 }
 
-func applyMinimums(task *repb.ExecutionTask, size *scpb.TaskSize) *scpb.TaskSize {
+// Combine joins two task sizes, generally by taking the max of each field. It
+// clamps values to allowed ranges.
+func Combine(task *repb.ExecutionTask, a, b *scpb.TaskSize) *scpb.TaskSize {
+	return applyLimits(task, &scpb.TaskSize{
+		EstimatedMemoryBytes:   max(a.GetEstimatedMemoryBytes(), b.GetEstimatedMemoryBytes()),
+		EstimatedMilliCpu:      max(a.GetEstimatedMilliCpu(), b.GetEstimatedMilliCpu()),
+		EstimatedFreeDiskBytes: max(a.GetEstimatedFreeDiskBytes(), b.GetEstimatedFreeDiskBytes()),
+		CustomResources:        append(a.GetCustomResources(), b.GetCustomResources()...),
+	})
+}
+
+func applyLimits(task *repb.ExecutionTask, size *scpb.TaskSize) *scpb.TaskSize {
 	if size == nil {
 		return nil
 	}
@@ -457,6 +476,10 @@ func applyMinimums(task *repb.ExecutionTask, size *scpb.TaskSize) *scpb.TaskSize
 	}
 	if clone.EstimatedMemoryBytes < minMemoryBytes {
 		clone.EstimatedMemoryBytes = minMemoryBytes
+	}
+	if clone.EstimatedFreeDiskBytes > MaxEstimatedFreeDisk {
+		log.Infof("Task %q requested %d free disk which is more than the max %d", task.GetExecutionId(), clone.EstimatedFreeDiskBytes, MaxEstimatedFreeDisk)
+		clone.EstimatedFreeDiskBytes = MaxEstimatedFreeDisk
 	}
 	return clone
 }

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -167,7 +167,7 @@ func (s *taskSizer) Get(ctx context.Context, task *repb.ExecutionTask) *scpb.Tas
 		// executor run this task once to estimate the size.
 		return nil
 	}
-	return applyLimits(task, &scpb.TaskSize{
+	return ApplyLimits(task, &scpb.TaskSize{
 		EstimatedMemoryBytes: recordedSize.EstimatedMemoryBytes,
 		EstimatedMilliCpu:    recordedSize.EstimatedMilliCpu,
 	})
@@ -177,7 +177,7 @@ func (s *taskSizer) Predict(ctx context.Context, task *repb.ExecutionTask) *scpb
 	if s.model == nil {
 		return nil
 	}
-	return applyLimits(task, s.model.Predict(ctx, task))
+	return ApplyLimits(task, s.model.Predict(ctx, task))
 }
 
 func (s *taskSizer) Update(ctx context.Context, cmd *repb.Command, md *repb.ExecutedActionMetadata) error {
@@ -342,7 +342,7 @@ func commandKey(cmd *repb.Command) (string, error) {
 	return fmt.Sprintf("%s/%x", arg0, sha256.Sum256(b)), nil
 }
 
-func estimateFromTestSize(testSize string) (int64, int64) {
+func estimateFromTestSize(testSize string) (bytes int64, milliCPU int64) {
 	mb := 0
 	cpu := 0
 
@@ -376,7 +376,7 @@ func testSize(task *repb.ExecutionTask) (s string, ok bool) {
 	return "", false
 }
 
-// Request returns the explictily requested task size as described in
+// Requested returns the explictily requested task size as described in
 // https://www.buildbuddy.io/docs/rbe-platforms#runner-resource-allocation.
 // There is no validation or clamping of the values so we can save exactly what
 // the user requested. EstimatedMemory and EstimatedCPU override
@@ -405,59 +405,62 @@ func Requested(task *repb.ExecutionTask) *scpb.TaskSize {
 
 // Default returns the default task size estimate for a task. This depends on
 // properties like test size and isolation type, but it doesn't reflect the
-// explicitly requested size. Values are clamped within specific ranges.
+// explicitly requested size. Values are NOT clamped within allowed ranges,
+// so ApplyLimits should be called before using this size.
 func Default(task *repb.ExecutionTask) *scpb.TaskSize {
+	size := &scpb.TaskSize{
+		EstimatedMemoryBytes:   DefaultMemEstimate,
+		EstimatedMilliCpu:      DefaultCPUEstimate,
+		EstimatedFreeDiskBytes: DefaultFreeDiskEstimate,
+	}
 	props, err := platform.ParseProperties(task)
 	if err != nil {
 		log.Infof("Failed to parse task properties, using default estimation: %s", err)
-
-		return applyLimits(task, &scpb.TaskSize{
-			EstimatedMemoryBytes:   DefaultMemEstimate,
-			EstimatedMilliCpu:      DefaultCPUEstimate,
-			EstimatedFreeDiskBytes: DefaultFreeDiskEstimate,
-		})
+		return size
 	}
 
-	memEstimate := DefaultMemEstimate
 	// Set default mem estimate based on whether this is a workflow.
 	if props.WorkflowID != "" {
-		memEstimate = WorkflowMemEstimate
+		size.EstimatedMemoryBytes = WorkflowMemEstimate
 	}
-	cpuEstimate := DefaultCPUEstimate
-	freeDiskEstimate := DefaultFreeDiskEstimate
 
 	if s, ok := testSize(task); ok {
-		memEstimate, cpuEstimate = estimateFromTestSize(s)
+		size.EstimatedMemoryBytes, size.EstimatedMilliCpu = estimateFromTestSize(s)
 	}
 
 	if props.WorkloadIsolationType == string(platform.FirecrackerContainerType) {
-		memEstimate += FirecrackerAdditionalMemEstimateBytes
+		size.EstimatedMemoryBytes += FirecrackerAdditionalMemEstimateBytes
 		// Note: props.InitDockerd is only supported for docker-in-firecracker.
 		if props.InitDockerd {
-			freeDiskEstimate += DockerInFirecrackerAdditionalDiskEstimateBytes
-			memEstimate += DockerInFirecrackerAdditionalMemEstimateBytes
+			size.EstimatedFreeDiskBytes += DockerInFirecrackerAdditionalDiskEstimateBytes
+			size.EstimatedMemoryBytes += DockerInFirecrackerAdditionalMemEstimateBytes
 		}
 	}
-
-	return applyLimits(task, &scpb.TaskSize{
-		EstimatedMemoryBytes:   memEstimate,
-		EstimatedMilliCpu:      cpuEstimate,
-		EstimatedFreeDiskBytes: freeDiskEstimate,
-	})
+	return size
 }
 
-// Combine joins two task sizes, generally by taking the max of each field. It
-// clamps values to allowed ranges.
-func Combine(task *repb.ExecutionTask, a, b *scpb.TaskSize) *scpb.TaskSize {
-	return applyLimits(task, &scpb.TaskSize{
-		EstimatedMemoryBytes:   max(a.GetEstimatedMemoryBytes(), b.GetEstimatedMemoryBytes()),
-		EstimatedMilliCpu:      max(a.GetEstimatedMilliCpu(), b.GetEstimatedMilliCpu()),
-		EstimatedFreeDiskBytes: max(a.GetEstimatedFreeDiskBytes(), b.GetEstimatedFreeDiskBytes()),
-		CustomResources:        append(a.GetCustomResources(), b.GetCustomResources()...),
-	})
+// Override uses all non-empty values from over to override values in base.
+// Both arguments are unmodified. Values are NOT clamped within allowed ranges,
+// so ApplyLimits should be called before using this size.
+func Override(base, over *scpb.TaskSize) *scpb.TaskSize {
+	res := base.CloneVT()
+	if over.GetEstimatedMemoryBytes() > 0 {
+		res.EstimatedMemoryBytes = over.GetEstimatedMemoryBytes()
+	}
+	if over.GetEstimatedMilliCpu() > 0 {
+		res.EstimatedMilliCpu = over.GetEstimatedMilliCpu()
+	}
+	if over.GetEstimatedFreeDiskBytes() > 0 {
+		res.EstimatedFreeDiskBytes = over.GetEstimatedFreeDiskBytes()
+	}
+	if len(over.GetCustomResources()) > 0 {
+		res.CustomResources = over.GetCustomResources()
+	}
+	return res
 }
 
-func applyLimits(task *repb.ExecutionTask, size *scpb.TaskSize) *scpb.TaskSize {
+// ApplyLimits clamps each value in size to within an allowed range.
+func ApplyLimits(task *repb.ExecutionTask, size *scpb.TaskSize) *scpb.TaskSize {
 	if size == nil {
 		return nil
 	}

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -18,17 +18,18 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 )
 
-func TestEstimate_EmptyTask_DefaultEstimate(t *testing.T) {
-	ts := tasksize.Estimate(&repb.ExecutionTask{})
+func TestDefault_EmptyTask_DefaultEstimate(t *testing.T) {
+	ts := tasksize.Default(&repb.ExecutionTask{})
 
 	assert.Equal(t, tasksize.DefaultMemEstimate, ts.EstimatedMemoryBytes)
 	assert.Equal(t, tasksize.DefaultCPUEstimate, ts.EstimatedMilliCpu)
 	assert.Equal(t, tasksize.DefaultFreeDiskEstimate, ts.EstimatedFreeDiskBytes)
 }
 
-func TestEstimate_TestTask_RespectsTestSize(t *testing.T) {
+func TestDefault_TestTask_RespectsTestSize(t *testing.T) {
 	for _, testCase := range []struct {
 		size                                  string
 		expectedMemoryBytes, expectedMilliCPU int64
@@ -36,7 +37,7 @@ func TestEstimate_TestTask_RespectsTestSize(t *testing.T) {
 		{"small", 20 * 1e6, 1000},
 		{"enormous", 800 * 1e6, 1000},
 	} {
-		ts := tasksize.Estimate(&repb.ExecutionTask{
+		ts := tasksize.Default(&repb.ExecutionTask{
 			Command: &repb.Command{
 				EnvironmentVariables: []*repb.Command_EnvironmentVariable{
 					{Name: "TEST_SIZE", Value: testCase.size},
@@ -50,7 +51,7 @@ func TestEstimate_TestTask_RespectsTestSize(t *testing.T) {
 	}
 }
 
-func TestEstimate_TestTask_Firecracker_AddsAdditionalResources(t *testing.T) {
+func TestDefault_TestTask_Firecracker_AddsAdditionalResources(t *testing.T) {
 	for _, testCase := range []struct {
 		size                string
 		isolationType       platform.ContainerType
@@ -64,7 +65,7 @@ func TestEstimate_TestTask_Firecracker_AddsAdditionalResources(t *testing.T) {
 		{"small", platform.FirecrackerContainerType, false /*=initDockerd*/, 20*1e6 + tasksize.FirecrackerAdditionalMemEstimateBytes, 1000, tasksize.DefaultFreeDiskEstimate},
 		{"enormous", platform.FirecrackerContainerType, true /*=initDockerd*/, 800*1e6 + tasksize.FirecrackerAdditionalMemEstimateBytes + tasksize.DockerInFirecrackerAdditionalMemEstimateBytes, 1000, tasksize.DefaultFreeDiskEstimate + tasksize.DockerInFirecrackerAdditionalDiskEstimateBytes},
 	} {
-		ts := tasksize.Estimate(&repb.ExecutionTask{
+		ts := tasksize.Default(&repb.ExecutionTask{
 			Command: &repb.Command{
 				Platform: &repb.Platform{
 					Properties: []*repb.Platform_Property{
@@ -85,8 +86,27 @@ func TestEstimate_TestTask_Firecracker_AddsAdditionalResources(t *testing.T) {
 
 }
 
-func TestEstimate_BCUPlatformProps_ConvertsBCUToTaskSize(t *testing.T) {
-	ts := tasksize.Estimate(&repb.ExecutionTask{
+func TestRequested_ViolatingLimits(t *testing.T) {
+	const disk = tasksize.MaxEstimatedFreeDisk * 10
+	ts := tasksize.Requested(&repb.ExecutionTask{
+		Command: &repb.Command{
+			Platform: &repb.Platform{
+				Properties: []*repb.Platform_Property{
+					{Name: "EstimatedCPU", Value: " 100m "},
+					{Name: "EstimatedMemory", Value: " 100 "},
+					{Name: "EstimatedFreeDiskBytes", Value: fmt.Sprintf("%d", disk)},
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, int64(100), ts.EstimatedMemoryBytes)
+	assert.Equal(t, int64(100), ts.EstimatedMilliCpu)
+	assert.Equal(t, disk, ts.EstimatedFreeDiskBytes)
+}
+
+func TestRequested_BCUPlatformProps_ConvertsBCUToTaskSize(t *testing.T) {
+	ts := tasksize.Requested(&repb.ExecutionTask{
 		Command: &repb.Command{
 			Platform: &repb.Platform{
 				Properties: []*repb.Platform_Property{
@@ -98,24 +118,63 @@ func TestEstimate_BCUPlatformProps_ConvertsBCUToTaskSize(t *testing.T) {
 
 	assert.Equal(t, int64(2*2.5*1e9), ts.EstimatedMemoryBytes)
 	assert.Equal(t, int64(2*1000), ts.EstimatedMilliCpu)
-	assert.Equal(t, tasksize.DefaultFreeDiskEstimate, ts.EstimatedFreeDiskBytes)
+	assert.Equal(t, int64(0), ts.EstimatedFreeDiskBytes)
 }
 
-func TestEstimate_DiskSizePlatformProp_UsesPropValueForDiskSize(t *testing.T) {
-	const disk = tasksize.DefaultFreeDiskEstimate * 10
-	ts := tasksize.Estimate(&repb.ExecutionTask{
+func TestRequested_BCUPlatformProps_Overriden(t *testing.T) {
+	ts := tasksize.Requested(&repb.ExecutionTask{
 		Command: &repb.Command{
 			Platform: &repb.Platform{
 				Properties: []*repb.Platform_Property{
-					{Name: "EstimatedFreeDiskBytes", Value: fmt.Sprintf("%d", disk)},
+					{Name: "EstimatedCPU", Value: "1"},
+					{Name: "EstimatedMemory", Value: "60000000"},
+					{Name: "estimatedcomputeunits", Value: "2"},
 				},
 			},
 		},
 	})
 
-	assert.Equal(t, tasksize.DefaultMemEstimate, ts.EstimatedMemoryBytes)
-	assert.Equal(t, tasksize.DefaultCPUEstimate, ts.EstimatedMilliCpu)
-	assert.Equal(t, disk, ts.EstimatedFreeDiskBytes)
+	assert.Equal(t, int64(60000000), ts.EstimatedMemoryBytes)
+	assert.Equal(t, int64(1000), ts.EstimatedMilliCpu)
+	assert.Equal(t, int64(0), ts.EstimatedFreeDiskBytes)
+}
+
+func TestCombine(t *testing.T) {
+	sz := tasksize.Combine(
+		&repb.ExecutionTask{},
+		&scpb.TaskSize{
+			EstimatedMemoryBytes:   10_000_000_000,
+			EstimatedMilliCpu:      300,
+			EstimatedFreeDiskBytes: 30_000_000_000,
+			CustomResources:        []*scpb.CustomResource{{Name: "foo", Value: 0.5}},
+		},
+		&scpb.TaskSize{
+			EstimatedMemoryBytes:   20_000_000_000,
+			EstimatedMilliCpu:      500,
+			EstimatedFreeDiskBytes: 15_000_000_000,
+			CustomResources:        []*scpb.CustomResource{{Name: "bar", Value: 1}},
+		})
+	require.Equal(t, int64(500), sz.EstimatedMilliCpu)
+	require.Equal(t, int64(20_000_000_000), sz.EstimatedMemoryBytes)
+	require.Equal(t, int64(30_000_000_000), sz.EstimatedFreeDiskBytes)
+	require.Equal(t, []*scpb.CustomResource{
+		{Name: "foo", Value: 0.5},
+		{Name: "bar", Value: 1},
+	}, sz.GetCustomResources())
+}
+
+func TestCombine_RespectsLimits(t *testing.T) {
+	sz := tasksize.Combine(
+		&repb.ExecutionTask{},
+		&scpb.TaskSize{
+			EstimatedMemoryBytes:   0,
+			EstimatedMilliCpu:      0,
+			EstimatedFreeDiskBytes: tasksize.MaxEstimatedFreeDisk * 10,
+		},
+		nil)
+	require.Equal(t, tasksize.MinimumMilliCPU, sz.EstimatedMilliCpu)
+	require.Equal(t, tasksize.MinimumMemoryBytes, sz.EstimatedMemoryBytes)
+	require.Equal(t, tasksize.MaxEstimatedFreeDisk, sz.EstimatedFreeDiskBytes)
 }
 
 func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
@@ -177,7 +236,7 @@ func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
 		"subsequent milliCPU estimate should equal recorded milliCPU")
 }
 
-func TestEstimate_RespectsMilliCPULimit(t *testing.T) {
+func TestSizer_RespectsMilliCPULimit(t *testing.T) {
 	flags.Set(t, "remote_execution.use_measured_task_sizes", true)
 
 	env := testenv.GetTestEnv(t)
@@ -198,7 +257,7 @@ func TestEstimate_RespectsMilliCPULimit(t *testing.T) {
 	execStart := time.Now()
 	md := &repb.ExecutedActionMetadata{
 		UsageStats: &repb.UsageStats{
-			CpuNanos:        8000 * 1e9,
+			CpuNanos:        8000 * 1e9, // 8000 seconds
 			PeakMemoryBytes: 1e9,
 		},
 		// Set a 1s execution duration
@@ -215,28 +274,6 @@ func TestEstimate_RespectsMilliCPULimit(t *testing.T) {
 	assert.Equal(
 		t, int64(7500), ts.GetEstimatedMilliCpu(),
 		"subsequent milliCPU estimate should equal recorded milliCPU")
-}
-
-func TestEstimate_RespectsMinimumCpuSize(t *testing.T) {
-	sz := tasksize.Estimate(&repb.ExecutionTask{
-		Command: &repb.Command{Platform: &repb.Platform{
-			Properties: []*repb.Platform_Property{{
-				Name: "EstimatedCPU", Value: "1m",
-			}},
-		}},
-	})
-	require.Equal(t, tasksize.MinimumMilliCPU, sz.EstimatedMilliCpu)
-}
-
-func TestEstimate_RespectsMinimumMemorySize(t *testing.T) {
-	sz := tasksize.Estimate(&repb.ExecutionTask{
-		Command: &repb.Command{Platform: &repb.Platform{
-			Properties: []*repb.Platform_Property{{
-				Name: "EstimatedMemory", Value: "1e3",
-			}},
-		}},
-	})
-	require.Equal(t, tasksize.MinimumMemoryBytes, sz.EstimatedMemoryBytes)
 }
 
 func TestSizer_RespectsMinimumSize(t *testing.T) {


### PR DESCRIPTION
This is working towards fixing buildbuddy-io/buildbuddy-internal#4108