### PR TITLE
Fix filecache scan deleting entries added by concurrent actions

### DIFF
--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -32,7 +32,6 @@ go_test(
     deps = [
         ":filecache",
         "//proto:remote_execution_go_proto",
-        "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
         "//server/testutil/testfs",
@@ -40,7 +39,6 @@ go_test(
         "//server/util/claims",
         "//server/util/hash",
         "//server/util/log",
-        "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
During the initial filecache scan, we repeatedly call `AddFile()` on each scanned file.

The current implementation of `AddFile()` is:
1. Evict any existing entry. If an entry does exist, unlink it from the destination path, via the OnEvict callback.
2. Hardlink the file from the source path to its dest path.

For the filecache scan specifically, this logic is not ideal for two reasons:
* At best, it's unnecessary. Passing the same argument to `os.Link()` twice is always an error: either `EEXIST` (file already exists) or `ENOENT` (no such file or directory). So we're performing a bunch of syscalls which are guaranteed to return errors, which we then ignore. This is a bunch of unnecessary work.
* At worst, an action can race with the filecache background scan to update a cache key (e.g. during input download or output upload). If the scan calls `AddFile()` on a file it discovered, but an action was running concurrently and already called `AddFile()` for the same key, then step (1) above will invoke the OnEvict callback, which deletes the cache entry and unlinks the existing file. Because we're linking the path from itself, we then fail to add the file.