### PR TITLE
Add executor flag to create child cgroups for executor and actions

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -242,13 +242,13 @@ func main() {
 	imageCacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	env.SetImageCacheAuthenticator(imageCacheAuth)
 
-	actionsCgroupParent, err := getActionsCgroupParent()
+	tasksCgroupParent, err := setupCgroups()
 	if err != nil {
-		log.Fatalf("Failed to get cgroup of executor process: %s", err)
+		log.Fatalf("cgroup setup failed: %s", err)
 	}
 
 	runnerPool, err := runner.NewPool(env, cacheRoot, &runner.PoolOptions{
-		CgroupParent: actionsCgroupParent,
+		CgroupParent: tasksCgroupParent,
 	})
 	if err != nil {
 		log.Fatalf("Failed to initialize runner pool: %s", err)

--- a/enterprise/server/cmd/executor/executor_notlinux.go
+++ b/enterprise/server/cmd/executor/executor_notlinux.go
@@ -4,7 +4,7 @@ package main
 
 import "context"
 
-func getActionsCgroupParent() (string, error) {
+func setupCgroups() (string, error) {
 	return "", nil
 }
 

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// Standard path where cgroupfs is expected to be mounted.
-	cgroupfsPath = "/sys/fs/cgroup"
+	RootPath = "/sys/fs/cgroup"
 
 	// Placeholder value representing the container ID in cgroup path templates.
 	cidPlaceholder = "{{.ContainerID}}"
@@ -355,7 +355,7 @@ func (p *Paths) find(ctx context.Context, cid string) error {
 	}
 	start := time.Now()
 	var v2DirTemplate, v1CPUTemplate, v1MemoryTemplate string
-	err := filepath.WalkDir(cgroupfsPath, func(path string, dir fs.DirEntry, err error) error {
+	err := filepath.WalkDir(RootPath, func(path string, dir fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -396,7 +396,7 @@ func (p *Paths) find(ctx context.Context, cid string) error {
 		return nil
 	}
 
-	return status.InternalErrorf("failed to locate cgroup under %s", cgroupfsPath)
+	return status.InternalErrorf("failed to locate cgroup under %s", RootPath)
 }
 
 // readInt64FromFile reads a file expected to contain a single int64.


### PR DESCRIPTION
Add a flag to allow the executor to create child cgroups for the executor and action processes.

This should fix several issues:
- The current cpu weight for action processes is being applied relative to cgroup siblings in the cgroup root on the host node. This is not desired - CPU resources should be distributed _within_ the executor container cgroup, so that we respect quota/limits etc. and ensure that we don't mess with the relative weights between other pods on the node.
- Placing the executor within a sibling cgroup of action cgroups allows us to assign CPU weight to the executor process itself, which gets weighted against all action cgroups.
- k8s pod metrics should now work properly (assuming those metrics are driven by scraping the cgroup metrics from the container cgroup)
- On k8s we're currently creating action cgroups in the host node cgroup namespace, which means we're leaving garbage behind that accumulates until the node is restarted. This should be fixed as well, since k8s will tear down the executor container cgroup for us, which now includes all of the per-action cgroups.

Tested locally by running the executor in a cgroup that would simulate a k8s container cgroup.

The idle state looks like this:

```
/sys/fs/cgroup/executor-container-test/buildbuddy.executor/cgroup.procs:
- 1873893: executor (./bazel-bin/enterprise/server/cmd/executor/executo...)
/sys/fs/cgroup/executor-container-test/buildbuddy.executor.tasks/cgroup.procs:
/sys/fs/cgroup/executor-container-test/cgroup.procs:
```

When running a `sleep 5` action, it looks like this:

```
/sys/fs/cgroup/executor-container-test/buildbuddy.executor/cgroup.procs:
- 1873893: executor (./bazel-bin/enterprise/server/cmd/executor/executo...)
- 1891167: 3 (crun --log-format=json --cgroup-manager=cgroupfs r...)
/sys/fs/cgroup/executor-container-test/buildbuddy.executor.tasks/cgroup.procs:
/sys/fs/cgroup/executor-container-test/buildbuddy.executor.tasks/d2947fe257999362e84f96eb4e9e67349116e3fbd1c3e0b983b95c4e4946defe/cgroup.procs:
- 1891169: sleep (sleep 5 ...)
/sys/fs/cgroup/executor-container-test/cgroup.procs:
```

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/4112
Partially addresses https://github.com/buildbuddy-io/buildbuddy-internal/issues/4110 since we are not configuring these cgroups yet.