### PR TITLE
Don't copy the workspace VBD contents during workspace sync

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1653,16 +1653,12 @@ func (c *FirecrackerContainer) copyOutputsToWorkspace(ctx context.Context) error
 
 	workspaceExt4Path := filepath.Join(c.getChroot(), workspaceFSName)
 
-	if *enableVBD {
-		// Reassemble the workspace chunks into a single file.
-		// TODO(bduffany): figure out how to avoid doing this work, e.g. by
-		// mounting the workspace disk as a local NBD on the host.
-		// For now, this approach is acceptable because firecracker workspaces
-		// are typically small or empty (e.g. workflows run in $HOME rather than
-		// the workspace dir).
-		if err := c.workspaceStore.WriteFile(workspaceExt4Path); err != nil {
-			return err
+	if c.workspaceVBD != nil {
+		vbdFilePath, err := c.workspaceVBD.FilePath()
+		if err != nil {
+			return status.WrapError(err, "get VBD file path")
 		}
+		workspaceExt4Path = vbdFilePath
 	}
 
 	start := time.Now()

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -139,6 +140,15 @@ func (f *FS) Unmount(ctx context.Context) error {
 			"it may still be unmounted in the background, or there may be a goroutine leak: %s", f.mountPath, ctx.Err())
 		return ctx.Err()
 	}
+}
+
+// FilePath returns the path to the mounted VBD file.
+// It returns an error if the VBD is not mounted.
+func (f *FS) FilePath() (string, error) {
+	if f.mountPath == "" {
+		return "", status.UnavailableError("VBD is not mounted")
+	}
+	return filepath.Join(f.mountPath, FileName), nil
 }
 
 func (f *FS) unmount(ctx context.Context) error {


### PR DESCRIPTION
Since the workspace VBD now exposes the workspace block device contents as a plain old file (via FUSE), we can directly pass that file path to `ImageToDirectory()`, rather than first creating a full copy of the workspace contents. (This resolves the TODO here - this wasn't easily doable with NBD before, but is now possible with VBD)