### PR TITLE
Increase size of firecracker_test

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -119,7 +119,7 @@ go_test(
         # These tests can get pretty expensive when running on a cold executor
         # because of OCI image conversion. Size the task manually to avoid OOM.
         # TODO: include test ext4 images as deps to avoid conversion.
-        "test.EstimatedComputeUnits": "5",
+        "test.EstimatedComputeUnits": "10",
     },
     shard_count = 30,
     tags = [


### PR DESCRIPTION
Should help reduce the chance of timeouts which can result in networking garbage being left over on the machine: https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1732555141310049?thread_ts=1732553501.715329&cid=C01D5GHRJ59