### PR TITLE
Fix block device detection logic

### DIFF
--- a/enterprise/server/remote_execution/block_io/block_io_unix.go
+++ b/enterprise/server/remote_execution/block_io/block_io_unix.go
@@ -3,12 +3,9 @@
 package block_io
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -19,26 +16,16 @@ type Device struct {
 	Maj, Min int64
 }
 
-// LookupBlockDevice returns the block device for the filesystem mounted at
-// the given path.
+// LookupDevice returns the block device for the filesystem mounted at
+// the given path. The path must exist.
 func LookupDevice(path string) (*Device, error) {
-	// Get the device like /dev/sda1 etc.
-	dev, err := getDeviceFromPath(path)
-	if err != nil {
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
 		return nil, err
 	}
 
-	// Stat the device to get Rdev, then extract major/minor device nums.
-	fileInfo, err := os.Stat(dev)
-	if err != nil {
-		return nil, fmt.Errorf("stat %q: %w", dev, err)
-	}
-	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		return nil, err
-	}
-	major := unix.Major(uint64(stat.Rdev))
-	minor := unix.Minor(uint64(stat.Rdev))
+	major := unix.Major(uint64(stat.Dev))
+	minor := unix.Minor(uint64(stat.Dev))
 	blkDev := &Device{
 		Maj: int64(major),
 		Min: int64(minor),
@@ -67,38 +54,4 @@ func ParseMajMin(str string) (major, minor int, _ error) {
 
 func (dev *Device) String() string {
 	return fmt.Sprintf("%d:%d", dev.Maj, dev.Min)
-}
-
-// getDeviceFromPath finds the mountpoint associated with the given path
-// and returns the block device mounted there.
-func getDeviceFromPath(path string) (string, error) {
-	file, err := os.Open("/proc/mounts")
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	var mountPoint string
-	var device string
-	for scanner.Scan() {
-		line := scanner.Text()
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
-		mountDir := fields[1]
-		if strings.HasPrefix(path, mountDir) && len(mountDir) > len(mountPoint) && fields[0] != "(unknown)" {
-			mountPoint = mountDir
-			device = fields[0]
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", err
-	}
-	if device == "" {
-		return "", fmt.Errorf("could not find mount point for directory")
-	}
-	return device, nil
 }

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -605,6 +605,7 @@ func NewPool(env environment.Env, cacheRoot string, opts *PoolOptions) (*pool, e
 	if err != nil {
 		log.Warningf("Failed to locate block device for build root directory %q - IO stats may not work properly: %s", *rootDirectory, err)
 	} else {
+		log.Infof("Detected block device %s from build root directory %q", dev, *rootDirectory)
 		p.blockDevice = dev
 	}
 


### PR DESCRIPTION
Use the `dev` field from `stat_t` to get the device numbers from the path, instead of trying to look up the associated block device special file under `/dev/` and using the `rdev` field from that.

Fixes 2 issues:
- The `/dev/*` device may not be mounted inside the executor container, so `stat` will fail.
- On macOS, `/proc/mounts` isn't a thing, so we can't look up the `/dev/*` device path from it.