### PR TITLE
Limit workspace Remove() parallelism

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -365,7 +365,6 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	// Note: we continue to upload outputs, stderr, etc. below even if
 	// cmdResult.Error is present, because these outputs are helpful
 	// for debugging.
-
 	ctx, cancel = background.ExtendContextForFinalization(ctx, uploadDeadlineExtension)
 	defer cancel()
 

--- a/enterprise/server/remote_execution/workspace/BUILD
+++ b/enterprise/server/remote_execution/workspace/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/interfaces",
         "//server/remote_cache/cachetools",
         "//server/util/disk",
+        "//server/util/flag",
         "//server/util/log",
         "//server/util/status",
         "//server/util/tracing",


### PR DESCRIPTION
Attempt to limit os.RemoveAll parallelism a little bit because it can swamp filesystems on very large machines (lol)