### PR TITLE
metrics: record task queue length with executor pool name

### DIFF
--- a/enterprise/server/backends/prom/prom.go
+++ b/enterprise/server/backends/prom/prom.go
@@ -40,13 +40,13 @@ var (
 	MetricConfigs = []*MetricConfig{
 		{
 			sourceMetricName: "buildbuddy_remote_execution_queue_length",
-			LabelNames:       []string{podNameLabel},
+			LabelNames:       []string{podNameLabel, metrics.ExecutorPool},
 			ExportedFamily: &dto.MetricFamily{
 				Name: proto.String("exported_buildbuddy_remote_execution_queue_length"),
 				Help: proto.String("Number of actions currently waiting in the executor queue."),
 				Type: dto.MetricType_GAUGE.Enum(),
 			},
-			Examples: "sum by(pod_name) (exported_buildbuddy_remote_execution_queue_length)",
+			Examples: "sum by(pod_name, executor_pool) (exported_buildbuddy_remote_execution_queue_length)",
 		},
 		{
 			sourceMetricName: "buildbuddy_invocation_duration_usec_exported",

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -104,7 +104,12 @@ func (t *taskQueue) Enqueue(req *scpb.EnqueueTaskReservationRequest) {
 	}
 	pq.Push(req)
 	t.numTasks++
-	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: taskGroupID}).Set(float64(pq.Len()))
+	metrics.RemoteExecutionQueueLength.
+		With(prometheus.Labels{
+			metrics.ExecutorPool: req.GetSchedulingMetadata().GetPool(),
+			metrics.GroupID:      taskGroupID,
+		}).
+		Set(float64(pq.Len()))
 	if req.GetSchedulingMetadata().GetTrackQueuedTaskSize() {
 		metrics.RemoteExecutionAssignedOrQueuedEstimatedMilliCPU.
 			Add(float64(req.TaskSize.EstimatedMilliCpu))
@@ -135,7 +140,12 @@ func (t *taskQueue) Dequeue() *scpb.EnqueueTaskReservationRequest {
 		t.currentPQ = t.pqs.Front()
 	}
 	t.numTasks--
-	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: req.GetSchedulingMetadata().GetTaskGroupId()}).Set(float64(pq.Len()))
+	metrics.RemoteExecutionQueueLength.
+		With(prometheus.Labels{
+			metrics.ExecutorPool: req.GetSchedulingMetadata().GetPool(),
+			metrics.GroupID:      req.GetSchedulingMetadata().GetTaskGroupId(),
+		}).
+		Set(float64(pq.Len()))
 	if req.GetSchedulingMetadata().GetTrackQueuedTaskSize() {
 		metrics.RemoteExecutionAssignedOrQueuedEstimatedMilliCPU.
 			Sub(float64(req.TaskSize.EstimatedMilliCpu))

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -128,6 +128,9 @@ const (
 	// Group (organization) ID associated with the request.
 	GroupID = "group_id"
 
+	// Executor pool name associated with the task.
+	ExecutorPool = "executor_pool"
+
 	// OS associated with the request.
 	OS = "os"
 
@@ -1042,6 +1045,7 @@ var (
 		Help:      "Number of actions currently waiting in the executor queue.",
 	}, []string{
 		GroupID,
+		ExecutorPool,
 	})
 
 	// #### Examples


### PR DESCRIPTION
For some executor deployments, users might want to implement autoscaling differently for different executor pools.

Decorate our queue length metric with pool name and export it through prom API.