### PR TITLE
[RB] Fix test

### DIFF
--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -493,7 +493,7 @@ func TestBuildRemotelyRunLocally(t *testing.T) {
 
 	var parentInv *inpb.Invocation
 	for _, inv := range searchRsp.GetInvocation() {
-		if inv.Command != "run" {
+		if inv.GetParentRunId() == "" {
 			parentInv = inv
 		}
 	}

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -491,16 +491,16 @@ func TestBuildRemotelyRunLocally(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(searchRsp.GetInvocation()))
 
-	var childInv *inpb.Invocation
+	var parentInv *inpb.Invocation
 	for _, inv := range searchRsp.GetInvocation() {
-		if inv.Command == "run" {
-			childInv = inv
+		if inv.Command != "run" {
+			parentInv = inv
 		}
 	}
-	require.NotNil(t, childInv)
+	require.NotNil(t, parentInv)
 
 	logResp, err := bbClient.GetEventLogChunk(ctx, &elpb.GetEventLogChunkRequest{
-		InvocationId: childInv.InvocationId,
+		InvocationId: parentInv.InvocationId,
 		MinLines:     math.MaxInt32,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
I realized there is a small mistake in this test. During a `bazel run` on the remote runner, the execution output is always in the outer parent invocation, not the child invocation. So this test would always succeed, even if something is broken