### PR TITLE
Set cached_result=true when there is a cache hit in the execution ser…

### DIFF
--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -353,7 +353,9 @@ func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest *di
 // ExecuteResponseWithCachedResult returns an ExecuteResponse for an action
 // result served from cache.
 func ExecuteResponseWithCachedResult(ar *repb.ActionResult) *repb.ExecuteResponse {
-	return ExecuteResponseWithResult(ar, nil /*=err*/)
+	r := ExecuteResponseWithResult(ar, nil /*=err*/)
+	r.CachedResult = true
+	return r
 }
 
 // ExecuteResponseWithResult returns an ExecuteResponse for an action result


### PR DESCRIPTION
…vice

Without this, these cache hits look like executions to bazel. I don't think it matters to functionality, but it does underreport the cache hit ratio.