### PR TITLE
Remove context ToBackground util

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -957,7 +957,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 	c.rmOnce = &sync.Once{}
 	c.rmErr = nil
 
-	vmCtx, cancelVmCtx := context.WithCancelCause(background.ToBackground(ctx))
+	vmCtx, cancelVmCtx := context.WithCancelCause(context.WithoutCancel(ctx))
 	c.vmCtx = vmCtx
 	c.cancelVmCtx = cancelVmCtx
 
@@ -1914,7 +1914,7 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	c.rmOnce = &sync.Once{}
 	c.rmErr = nil
 
-	vmCtx, cancel := context.WithCancelCause(background.ToBackground(ctx))
+	vmCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
 	c.vmCtx = vmCtx
 	c.cancelVmCtx = cancel
 

--- a/server/util/background/background.go
+++ b/server/util/background/background.go
@@ -55,13 +55,6 @@ func (ctx *disconnectedContext) Value(key interface{}) interface{} {
 	return ctx.parent.Value(key)
 }
 
-// ToBackground returns a background context from the given context, removing
-// any cancellation and deadlines associated with the context, but preserving
-// all context values such as auth info and outgoing gRPC metadata.
-func ToBackground(ctx context.Context) context.Context {
-	return newDisconnectedContext(ctx)
-}
-
 // Long story short: sometimes you need just a little more time to do a write
 // or clean things up, even after a client has cancelled the request (and
 // therefore the context) but you still need all the auth credentials and


### PR DESCRIPTION
Can be replaced with `context.WithoutCancel` added in go 1.21