### PR TITLE
Add some diagnostic logs for missing group_id

### DIFF
--- a/server/util/claims/BUILD
+++ b/server/util/claims/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/util/authutil",
         "//server/util/capabilities",
         "//server/util/flag",
+        "//server/util/log",
         "//server/util/lru",
         "//server/util/request_context",
         "//server/util/role",


### PR DESCRIPTION
Could not repro this locally, so adding some diagnostic logs.

Related: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4191