### PR TITLE
Move private range blackholing to veth pair setup and enable it by default.

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -851,7 +851,7 @@ func configureSecondaryNetwork(ctx context.Context) error {
 // network interface or private IP range blackholing, depending on config
 // options.
 func ConfigureIsolation(ctx context.Context) error {
-	if !networking.IsSecondaryNetworkEnabled() && !networking.IsPrivateRangeBlackholingEnabled() {
+	if !networking.IsSecondaryNetworkEnabled() {
 		return nil
 	}
 
@@ -874,12 +874,6 @@ func ConfigureIsolation(ctx context.Context) error {
 		return configureSecondaryNetwork(ctx)
 	}
 
-	if networking.IsPrivateRangeBlackholingEnabled() {
-		if err := networking.ConfigurePrivateRangeBlackholing(ctx, podmanDefaultNetworkIPRange); err != nil {
-			return err
-		}
-		return nil
-	}
 	return nil
 }
 


### PR DESCRIPTION
Since we no longer enable the podman isolation, we can configure this entirely in the veth pair setup.

I'm making the task IP range configurable to support running multiple executors and only applying the policy for the range of the current executor doesn't make much sense.