### PR TITLE
Add memory usage timelines

### DIFF
--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -70,7 +70,8 @@ const TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS: Map<string, string> = new Map([
   // Event names/arg keys from executor profiles.
   // These are controlled by us, and defined in
   // enterprise/server/execution_service/execution_service.go
-  ["CPU usage", "cpu"],
+  ["CPU usage (cores)", "cpu"],
+  ["Memory usage (KB)", "memory"],
 ]);
 
 export async function readProfile(

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -64,7 +64,7 @@ var (
 	// operation fails due to the container already being removed.
 	ErrRemoved = status.UnavailableError("container has been removed")
 
-	recordCPUTimelines            = flag.Bool("executor.record_cpu_timelines", false, "Capture CPU timeseries data in UsageStats for each task.")
+	recordUsageTimelines          = flag.Bool("executor.record_usage_timelines", false, "Capture resource usage timeseries data in UsageStats for each task.")
 	imagePullTimeout              = flag.Duration("executor.image_pull_timeout", 5*time.Minute, "How long to wait for the container image to be pulled before returning an Unavailable (retryable) error for an action execution attempt. Applies to all isolation types (docker, firecracker, etc.)")
 	debugUseLocalImagesOnly       = flag.Bool("debug_use_local_images_only", false, "Do not pull OCI images and only used locally cached images. This can be set to test local image builds during development without needing to push to a container registry. Not intended for production use.")
 	DebugEnableAnonymousRecycling = flag.Bool("debug_enable_anonymous_runner_recycling", false, "Whether to enable runner recycling for unauthenticated requests. For debugging purposes only - do not use in production.")
@@ -250,11 +250,14 @@ type UsageStats struct {
 // that TaskStats() can just return a view of the data rather than requiring a
 // full re-encoding.
 type timelineState struct {
-	lastTimestamp int64
-	lastCPUSample int64
+	lastTimestamp    int64
+	lastCPUSample    int64
+	lastMemorySample int64
 	// When adding new fields here, also update:
 	// - The size calculation in updateTimeline()
 	// - The test
+	// - The trace format adapter logic in execution_service.go
+	// - TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS in trace_events.ts
 }
 
 func (s *UsageStats) clock() clockwork.Clock {
@@ -280,7 +283,7 @@ func (s *UsageStats) Reset() {
 	s.peakMemoryUsageBytes = 0
 
 	now := s.clock().Now()
-	if *recordCPUTimelines {
+	if *recordUsageTimelines {
 		s.timeline = &repb.UsageTimeline{StartTime: tspb.New(now)}
 		s.timelineState = timelineState{}
 		s.updateTimeline(now)
@@ -335,9 +338,18 @@ func (s *UsageStats) TaskStats() *repb.UsageStats {
 }
 
 func (s *UsageStats) updateTimeline(now time.Time) {
-	if 8*(len(s.timeline.GetCpuSamples())+len(s.timeline.GetTimestamps())) > timeseriesSizeLimitBytes {
+	totalLength := 0
+	for _, s := range [][]int64{
+		s.timeline.GetTimestamps(),
+		s.timeline.GetCpuSamples(),
+		s.timeline.GetMemoryKbSamples(),
+	} {
+		totalLength += len(s)
+	}
+	if 8*totalLength > timeseriesSizeLimitBytes {
 		return
 	}
+
 	// Update timestamps
 	ts := now.UnixMilli()
 	tsDelta := ts - s.timelineState.lastTimestamp
@@ -349,6 +361,12 @@ func (s *UsageStats) updateTimeline(now time.Time) {
 	cpuDelta := cpu - s.timelineState.lastCPUSample
 	s.timeline.CpuSamples = append(s.timeline.CpuSamples, cpuDelta)
 	s.timelineState.lastCPUSample = cpu
+
+	// Update memory samples with current memory in KB (1000 bytes).
+	mem := s.last.GetMemoryBytes() / 1e3
+	memDelta := mem - s.timelineState.lastMemorySample
+	s.timeline.MemoryKbSamples = append(s.timeline.MemoryKbSamples, memDelta)
+	s.timelineState.lastMemorySample = mem
 }
 
 // Update updates the usage for the current task, given a reading from the
@@ -359,7 +377,7 @@ func (s *UsageStats) Update(lifetimeStats *repb.UsageStats) {
 	if lifetimeStats.GetMemoryBytes() > s.peakMemoryUsageBytes {
 		s.peakMemoryUsageBytes = lifetimeStats.GetMemoryBytes()
 	}
-	if *recordCPUTimelines {
+	if *recordUsageTimelines {
 		s.updateTimeline(s.clock().Now())
 	}
 }

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2290,8 +2290,8 @@ message UsageTimeline {
   // cumulative CPU-millis used since the start time.
   repeated int64 cpu_samples = 3;
 
-  // Delta-encoded memory usage.
-  repeated int64 memory_bytes_samples = 4;
+  // Delta-encoded memory usage in kilobytes (1000 bytes).
+  repeated int64 memory_kb_samples = 4;
 
   // Delta-encoded total bytes read, totaled across all block devices.
   repeated int64 rbytes_total_samples = 5;


### PR DESCRIPTION
Example:

![image](https://github.com/user-attachments/assets/7d814b76-6ee9-42a6-a626-857130460e92)

This screenshot is from running this python script as a test action. It repeatedly doubles the length of a string, starting from a string of length 1, sleeping for a bit before each doubling operation. It runs this whole procedure for 3 total iterations, sleeping a bit between each run.

```python
import gc
import time

for _ in range(3):
  s = "A"
  while len(s) < 100e6:
    s += s
    gc.collect()
    time.sleep(0.25)
  time.sleep(1)
  gc.collect()
```