### PR TITLE
Upgrade `rules_nodejs` to pick up newer node versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -421,14 +421,14 @@ use_repo(
 
 # Note that this is 'rules_nodejs-core'
 # Keep in sync with build_bazel_rules_nodejs in WORKSPACE.bzlmod
-bazel_dep(name = "rules_nodejs", version = "5.8.2")
+bazel_dep(name = "rules_nodejs", version = "5.8.5")
 single_version_override(
     module_name = "rules_nodejs",
     patch_strip = 1,
     patches = [
         "@@//buildpatches:build_bazel_rules_nodejs.patch",
     ],
-    version = "5.8.2",
+    version = "5.8.5",
 )
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -192,8 +192,8 @@ http_archive(
     patches = [
         "//buildpatches:build_bazel_rules_nodejs.patch",
     ],
-    sha256 = "94070eff79305be05b7699207fbac5d2608054dd53e6109f7d00d923919ff45a",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-5.8.2.tar.gz"],
+    sha256 = "a1295b168f183218bc88117cf00674bcd102498f294086ff58318f830dd9d9d1",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.5/rules_nodejs-5.8.5.tar.gz"],
 )
 
 http_archive(
@@ -202,8 +202,8 @@ http_archive(
     patches = [
         "//buildpatches:build_bazel_rules_nodejs.patch",
     ],
-    sha256 = "764a3b3757bb8c3c6a02ba3344731a3d71e558220adcb0cf7e43c9bba2c37ba8",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
+    sha256 = "0c2277164b1752bb71ecfba3107f01c6a8fb02e4835a790914c71dfadcf646ba",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.5/rules_nodejs-core-5.8.5.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")


### PR DESCRIPTION
The current version of `rules_nodejs` does not list in its `node_versions.bzl` any versions newer than `18.13.0`, but we need `18.17.0` or newer for a newer version of `cheerio`.
