### PR TITLE
Upgrade `node` to `18.20.3` to support newer npm deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -434,7 +434,7 @@ single_version_override(
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 node.toolchain(
     name = "nodejs",
-    node_version = "18.13.0",
+    node_version = "18.20.3",
 )
 use_repo(node, "nodejs_toolchains")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -214,7 +214,7 @@ load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(
     name = "nodejs",
-    node_version = "18.13.0",
+    node_version = "18.20.3",
 )
 
 load("@rules_nodejs//nodejs:yarn_repositories.bzl", "yarn_repositories")


### PR DESCRIPTION
`cheerio` version `1.0.0` requires `node` version `18.7.0` or newer.
