### PR TITLE
Tweak website alignment

### DIFF
--- a/website/src/css/common.module.css
+++ b/website/src/css/common.module.css
@@ -43,7 +43,7 @@
 
 .container {
   display: flex;
-  max-width: 1296px;
+  max-width: 1344px;
   padding: 0 24px;
   gap: 36px;
   justify-content: center;


### PR DESCRIPTION
This aligns headers flush with nav bar logo for larger screen sizes (which looks nice).

Before
<img width="355" alt="Screenshot 2024-12-03 at 2 38 03 PM" src="https://github.com/user-attachments/assets/a5cd9028-a6ce-4bdc-aa88-4cc510c23989">

After
<img width="333" alt="Screenshot 2024-12-03 at 2 39 09 PM" src="https://github.com/user-attachments/assets/b7e3882e-6368-4927-847a-4037256dca19">
