### PR TITLE
Remove unused import in `remote_runner.proto`

### DIFF
--- a/proto/api/v1/remote_runner.proto
+++ b/proto/api/v1/remote_runner.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package api.v1;
 
-import "google/rpc/status.proto";
-
 message RunRequest {
   // URL of the repo the remote workspace should be initialized for
   // Ex. "https://github.com/some-user/acme"


### PR DESCRIPTION
`google/rpc/status.proto` is unused in `proto/api/v1/remote_runner.proto`, which causes a logged warning during build.
