### PR TITLE
[raft] use ctx log

### DIFF
--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -395,14 +395,14 @@ func (lk *LeaseKeeper) HaveLease(ctx context.Context, rid uint64) bool {
 
 		shouldHaveLease := leader && open
 		if shouldHaveLease && !valid {
-			lk.log.Warningf("HaveLease range: %d valid: %t, should have lease: %t", rangeID, valid, shouldHaveLease)
+			lk.log.CtxWarningf(ctx, "HaveLease range: %d valid: %t, should have lease: %t", rangeID, valid, shouldHaveLease)
 			la.queueInstruction(&leaseInstruction{
 				rangeID: rangeID,
 				reason:  "should have range",
 				action:  Acquire,
 			})
 		} else if !shouldHaveLease && valid {
-			lk.log.Warningf("HaveLease range: %d valid: %t, should have lease: %t", rangeID, valid, shouldHaveLease)
+			lk.log.CtxWarningf(ctx, "HaveLease range: %d valid: %t, should have lease: %t", rangeID, valid, shouldHaveLease)
 			la.queueInstruction(&leaseInstruction{
 				rangeID: rangeID,
 				reason:  "should not have range",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -867,7 +867,7 @@ func (s *Store) IsLeader(rangeID uint64) bool {
 }
 
 func (s *Store) TransferLeadership(ctx context.Context, req *rfpb.TransferLeadershipRequest) (*rfpb.TransferLeadershipResponse, error) {
-	log.Debugf("request to transfer leadership of range %d to replica %d", req.GetRangeId(), req.GetTargetReplicaId())
+	log.CtxDebugf(ctx, "request to transfer leadership of range %d to replica %d", req.GetRangeId(), req.GetTargetReplicaId())
 	if err := s.nodeHost.RequestLeaderTransfer(req.GetRangeId(), req.GetTargetReplicaId()); err != nil {
 		return nil, err
 	}
@@ -1834,7 +1834,7 @@ func (s *Store) SplitRange(ctx context.Context, req *rfpb.SplitRangeRequest) (*r
 		servers[r.GetNhid()] = grpcAddr
 	}
 	bootstrapInfo := bringup.MakeBootstrapInfo(newRangeID, 1, servers)
-	log.Debugf("StartShard called with bootstrapInfo: %+v", bootstrapInfo)
+	log.CtxDebugf(ctx, "StartShard called with bootstrapInfo: %+v", bootstrapInfo)
 	if err := bringup.StartShard(ctx, s.apiClient, bootstrapInfo, stubBatch); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ctx log can associate the log with the request_id, this can help us to
understand some of the sender debug logs better.
