### PR TITLE
[RB] Fix an incorrect reference to remote branch vs local branch

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -356,7 +356,7 @@ func getBaseBranchAndCommit(remoteData string) (branch string, commit string, er
 	if currentBranchExistsRemotely {
 		branch = currentBranch
 
-		currentCommitHash, err := runGit("rev-parse", "HEAD")
+		currentCommitHash, err := getHeadCommitForLocalBranch("HEAD")
 		if err != nil {
 			return "", "", status.WrapError(err, "get current commit hash")
 		}

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -385,9 +385,9 @@ func getBaseBranchAndCommit(remoteData string) (branch string, commit string, er
 		}
 		branch = defaultBranch
 
-		defaultBranchCommitHash, err := getHeadCommitForRemoteBranch(remoteData, defaultBranch)
+		defaultBranchCommitHash, err := getHeadCommitForLocalBranch(defaultBranch)
 		if err != nil {
-			return "", "", status.WrapError(err, "get default branch commit hash")
+			return "", "", err
 		}
 		commit = defaultBranchCommitHash
 	}
@@ -443,7 +443,17 @@ func getHeadCommitForRemoteBranch(remoteData string, branch string) (string, err
 	if len(match) > 1 {
 		return match[1], nil
 	}
-	return "", status.NotFoundErrorf("Failed to get HEAD commit for branch %s from:\n%s", branch, remoteData)
+	return "", status.NotFoundErrorf("failed to get HEAD commit for remote branch %s from:\n%s", branch, remoteData)
+}
+
+// getHeadCommitForLocalBranch returns the commit at HEAD for the local branch.
+func getHeadCommitForLocalBranch(branch string) (string, error) {
+	headCommit, err := runGit("rev-parse", branch)
+	if err != nil {
+		return "", status.WrapErrorf(err, "get head commit for local branch %s", branch)
+	}
+	headCommit = strings.Trim(headCommit, "\n")
+	return headCommit, nil
 }
 
 // generates diffs between the current state of the repo and `baseCommit`

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -257,7 +257,7 @@ func TestGitConfig_BranchAndSha(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		// Setup a "local" repo
 		localRepoPath := testgit.MakeTempRepoClone(t, remoteRepoPath)
 		err := os.Chdir(localRepoPath)
@@ -267,6 +267,11 @@ func TestGitConfig_BranchAndSha(t *testing.T) {
 			testshell.Run(t, localRepoPath, "git checkout remote_b")
 		} else {
 			testshell.Run(t, localRepoPath, "git checkout -B local_only")
+
+			// Simulate that the remote master is ahead of the local master
+			testshell.Run(t, remoteRepoPath, "git checkout master")
+			newFileName := fmt.Sprintf("new_file%d.txt", i)
+			_ = testgit.CommitFiles(t, remoteRepoPath, map[string]string{newFileName: "exit 0"})
 		}
 		if !tc.localCommitExistsRemotely {
 			testgit.CommitFiles(t, localRepoPath, map[string]string{"local_file.txt": "exit 0"})


### PR DESCRIPTION
I introduced a bug in this commit: https://github.com/buildbuddy-io/buildbuddy/pull/7989

If your local branch does not exist remotely, we want to fallback to using the master branch. In the previous incorrect version, we'd use the remote master head commit. If this commit didn't exist locally, there'd be errors when we tried to diff against it to generate the diff patchsets