### PR TITLE
redis: respect rediss://

### DIFF
--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -185,6 +185,10 @@ func (o *Opts) toRingOpts() (*redis.RingOptions, error) {
 		TLSConfig:          o.TLSConfig,
 	}
 	for i, addr := range o.Addrs {
+		if !strings.HasPrefix(addr, "redis://") || !strings.HasPrefix(addr, "rediss://") || !strings.HasPrefix(addr, "unix://") {
+			// Assume tcp if no scheme is provided.
+			addr = "redis://" + addr
+		}
 		opt, err := redis.ParseURL(addr)
 		if err != nil {
 			return nil, status.FailedPreconditionErrorf("invalid redis shard address %q: %s", addr, err)

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -97,7 +97,9 @@ func ShardsToOpts(shards []string, username, password string) *Opts {
 		}
 		if i > 0 {
 			if u.Scheme != prevShardScheme {
-				log.Fatalf("All redis shards must use the same url scheme, but found %q and %q", prevShardScheme, u.Scheme)
+				// TODO(sluongng): return an error instead of logging.
+				log.Warningf("All redis shards must use the same url scheme, but found %q and %q", prevShardScheme, u.Scheme)
+				break
 			}
 		}
 		prevShardScheme = u.Scheme

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -185,7 +185,7 @@ func (o *Opts) toRingOpts() (*redis.RingOptions, error) {
 		TLSConfig:          o.TLSConfig,
 	}
 	for i, addr := range o.Addrs {
-		if !strings.HasPrefix(addr, "redis://") || !strings.HasPrefix(addr, "rediss://") || !strings.HasPrefix(addr, "unix://") {
+		if !isRedisURI(addr) {
 			// Assume tcp if no scheme is provided.
 			addr = "redis://" + addr
 		}

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -68,43 +68,30 @@ func TargetToOptions(redisTarget string) *redis.Options {
 	}
 }
 
-func TargetToOpts(redisTarget string, useTLS bool) *Opts {
+func TargetToOpts(redisTarget string) *Opts {
 	if redisTarget == "" {
 		return nil
 	}
 	libOpts := TargetToOptions(redisTarget)
-	var tlsConfig *tls.Config
-	if useTLS {
-		tlsConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}
-	}
 	return &Opts{
 		Addrs:     []string{libOpts.Addr},
 		Network:   libOpts.Network,
 		Username:  libOpts.Username,
 		Password:  libOpts.Password,
 		DB:        libOpts.DB,
-		TLSConfig: tlsConfig,
+		TLSConfig: libOpts.TLSConfig,
 	}
 }
 
-func ShardsToOpts(shards []string, useTLS bool, username, password string) *Opts {
+func ShardsToOpts(shards []string, username, password string) *Opts {
 	if len(shards) == 0 {
 		return nil
 	}
-	var tlsConfig *tls.Config
-	if useTLS {
-		tlsConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}
-	}
-	return &Opts{
-		Addrs:     shards,
-		Username:  username,
-		Password:  password,
-		TLSConfig: tlsConfig,
-	}
+	opt := TargetToOpts(shards[0])
+	opt.Addrs = shards
+	opt.Username = username
+	opt.Password = password
+	return opt
 }
 
 type HealthChecker struct {


### PR DESCRIPTION
Effectively revert https://github.com/buildbuddy-io/buildbuddy/pull/7978
as user could already enable TLS by using "rediss://" url scheme.

This would not work in case of a Shared Redis setup using Ring Client,
so ensure that we use the first shard address to setup the Ring Client
options. If the first shard address uses "rediss://", TLS will be
enabled and if it uses "redis://", TLS will be disabled.
