### PR TITLE
ociruntime: fix blocking on unknown tar header

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -102,6 +102,72 @@ go_test(
     ],
 )
 
+# keep
+go_test(
+    name = "ociruntime_pull_test",
+    srcs = ["ociruntime_test.go"],
+    args = ["-test.run=TestPullImage"],
+    data = [
+        ":busybox",
+        ":crun",
+        "//enterprise/server/remote_execution/runner/testworker",
+        "@busybox",
+    ],
+    env = {
+        "BB_INTEGRATION": "true",
+    },
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:ac701954d2c522d0d2b5296323127cacaaf77627e69db848a8d6ecb53149d344",
+        "test.EstimatedComputeUnits": "2",
+        "test.EstimatedFreeDiskBytes": "10GB",
+    },
+    tags = [
+        "manual",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        # TODO: GitHub Actions arm runners are running into cgroup-related issues;
+        # fix and re-enable on arm64.
+        "@platforms//cpu:x86_64",
+    ],
+    x_defs = {
+        "crunRlocationpath": "$(rlocationpath :crun)",
+        "busyboxRlocationpath": "$(rlocationpath :busybox)",
+        "ociBusyboxRlocationpath": "$(rlocationpath @busybox)",
+        "testworkerRlocationpath": "$(rlocationpath //enterprise/server/remote_execution/runner/testworker)",
+    },
+    deps = [
+        ":ociruntime",
+        "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/persistentworker",
+        "//enterprise/server/remote_execution/platform",
+        "//enterprise/server/remote_execution/workspace",
+        "//enterprise/server/util/oci",
+        "//proto:remote_execution_go_proto",
+        "//proto:scheduler_go_proto",
+        "//proto:worker_go_proto",
+        "//server/interfaces",
+        "//server/testutil/testenv",
+        "//server/testutil/testfs",
+        "//server/testutil/testnetworking",
+        "//server/testutil/testregistry",
+        "//server/testutil/testshell",
+        "//server/testutil/testtar",
+        "//server/util/disk",
+        "//server/util/proto",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "//server/util/uuid",
+        "@com_github_google_go_containerregistry//pkg/crane",
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@com_github_google_go_containerregistry//pkg/v1/mutate",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
+    ],
+)
+
 alias(
     name = "crun",
     actual = select({

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -1337,6 +1337,9 @@ func downloadLayer(ctx context.Context, layer ctr.Layer, destDir string) error {
 				return status.UnavailableErrorf("create directory: %s", err)
 			}
 		case tar.TypeReg:
+			if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+				return status.UnavailableErrorf("create directory: %s", err)
+			}
 			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, os.FileMode(header.Mode))
 			if err != nil {
 				return status.UnavailableErrorf("create file: %s", err)
@@ -1369,7 +1372,7 @@ func downloadLayer(ctx context.Context, layer ctr.Layer, destDir string) error {
 				return status.UnavailableErrorf("chown file: %s", err)
 			}
 		default:
-			return status.UnavailableErrorf("unsupported tar entry type %q", header.Typeflag)
+			log.CtxInfof(ctx, "Ignoring unsupported tar header %q type %q in oci layer", header.Name, header.Typeflag)
 		}
 	}
 


### PR DESCRIPTION
It seems like our "executor-docker-default" image contains quite a few
`/dev/*` entries in a layer on the image.

These are either block or character devices that don't do much on the
container itself and should be safe to ignore.
