### PR TITLE
[RB] Fix race condition with fetching completed execution data

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -777,6 +777,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		return 1, status.UnavailableErrorf("could not connect to BuildBuddy remote bazel service %q: %s", opts.Server, err)
 	}
 	bbClient := bbspb.NewBuildBuddyServiceClient(conn)
+	execClient := repb.NewExecutionClient(conn)
 
 	reqOS := runtime.GOOS
 	if *execOs != "" {
@@ -908,7 +909,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 
 	eg := errgroup.Group{}
 	var inRsp *inpb.GetInvocationResponse
-	var exRsp *espb.GetExecutionResponse
+	var executeResponse *repb.ExecuteResponse
 	eg.Go(func() error {
 		var err error
 		inRsp, err = bbClient.GetInvocation(ctx, &inpb.GetInvocationRequest{Lookup: &inpb.InvocationLookup{InvocationId: iid}})
@@ -921,27 +922,30 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		return nil
 	})
 	eg.Go(func() error {
-		var err error
-		for i := 0; i < 5; i++ {
-			exRsp, err = bbClient.GetExecution(ctx, &espb.GetExecutionRequest{ExecutionLookup: &espb.ExecutionLookup{
-				InvocationId: iid,
-			}})
-			if err != nil {
-				return fmt.Errorf("could not retrieve ci_runner execution: %s", err)
-			}
-			if len(exRsp.GetExecution()) == 0 {
-				return fmt.Errorf("ci_runner execution not found")
-			}
-			if exRsp.GetExecution()[0].GetStage() == repb.ExecutionStage_COMPLETED {
-				break
-			}
-			time.Sleep(200 * time.Millisecond)
+		execution, err := bbClient.GetExecution(ctx, &espb.GetExecutionRequest{ExecutionLookup: &espb.ExecutionLookup{
+			InvocationId: iid,
+		}})
+		if err != nil {
+			return fmt.Errorf("could not retrieve ci_runner execution: %s", err)
 		}
-		if exRsp.GetExecution()[0].GetStage() != repb.ExecutionStage_COMPLETED {
-			return fmt.Errorf("ci_runner execution is unexpectedly not completed: %v", exRsp.GetExecution()[0])
+		if len(execution.GetExecution()) == 0 {
+			return fmt.Errorf("ci_runner execution not found")
 		}
+		executionID := execution.GetExecution()[0].GetExecutionId()
+		waitExecutionStream, err := execClient.WaitExecution(ctx, &repb.WaitExecutionRequest{
+			Name: executionID,
+		})
+		if err != nil {
+			return fmt.Errorf("wait execution: %w", err)
+		}
+		rsp, err := rexec.Wait(rexec.NewRetryingStream(ctx, execClient, waitExecutionStream, executionID))
+		if err != nil {
+			return fmt.Errorf("wait execution: %w", err)
+		}
+		executeResponse = rsp.ExecuteResponse
 		return nil
 	})
+
 	err = eg.Wait()
 	if err != nil {
 		return 1, err
@@ -966,7 +970,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		}
 	}
 
-	exitCode := int(exRsp.GetExecution()[0].ExitCode)
+	exitCode := int(executeResponse.GetResult().GetExitCode())
 	if opts.FetchOutputs && exitCode == 0 {
 		if childIID != "" {
 			conn, err := grpc_client.DialSimple(opts.Server)

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -922,14 +922,23 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	})
 	eg.Go(func() error {
 		var err error
-		exRsp, err = bbClient.GetExecution(ctx, &espb.GetExecutionRequest{ExecutionLookup: &espb.ExecutionLookup{
-			InvocationId: iid,
-		}})
-		if err != nil {
-			return fmt.Errorf("could not retrieve ci_runner execution: %s", err)
+		for i := 0; i < 5; i++ {
+			exRsp, err = bbClient.GetExecution(ctx, &espb.GetExecutionRequest{ExecutionLookup: &espb.ExecutionLookup{
+				InvocationId: iid,
+			}})
+			if err != nil {
+				return fmt.Errorf("could not retrieve ci_runner execution: %s", err)
+			}
+			if len(exRsp.GetExecution()) == 0 {
+				return fmt.Errorf("ci_runner execution not found")
+			}
+			if exRsp.GetExecution()[0].GetStage() == repb.ExecutionStage_COMPLETED {
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
 		}
-		if len(exRsp.GetExecution()) == 0 {
-			return fmt.Errorf("ci_runner execution not found")
+		if exRsp.GetExecution()[0].GetStage() != repb.ExecutionStage_COMPLETED {
+			return fmt.Errorf("ci_runner execution is unexpectedly not completed: %v", exRsp.GetExecution()[0])
 		}
 		return nil
 	})


### PR DESCRIPTION
Fixes https://buildbuddy-corp.slack.com/archives/C07GMM2VBLY/p1733333761499139?thread_ts=1731949897.755029&cid=C07GMM2VBLY

The CLI sometimes reports the wrong exit code (0, even when the remote run failed). This is because there can be a slight delay between when the remote runner execution finishes, and when the execution is successfully updated in the DB with the final exit code. Make sure to check that the execution is complete before using the exit code.