### PR TITLE
Write do_not_cache and cached_result to clickhouse

### DIFF
--- a/enterprise/server/util/execution/execution.go
+++ b/enterprise/server/util/execution/execution.go
@@ -49,6 +49,8 @@ func TableExecToProto(in *tables.Execution, invLink *sipb.StoredInvocationLink) 
 		OutputUploadCompletedTimestampUsec: in.OutputUploadCompletedTimestampUsec,
 		StatusCode:                         in.StatusCode,
 		ExitCode:                           in.ExitCode,
+		CachedResult:                       in.CachedResult,
+		DoNotCache:                         in.DoNotCache,
 	}
 }
 
@@ -96,6 +98,7 @@ func TableExecToClientProto(in *tables.Execution) (*espb.Execution, error) {
 				CpuNanos:        in.CPUNanos,
 				PeakMemoryBytes: in.PeakMemoryBytes,
 			},
+			DoNotCache: in.DoNotCache,
 		},
 		CommandSnippet: in.CommandSnippet,
 	}

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -1530,7 +1530,7 @@ message ExecutionStage {
 // Metadata about an ongoing
 // [execution][build.bazel.remote.execution.v2.Execution.Execute], which
 // will be contained in the [metadata
-// field][google.longrunning.Operation.response] of the
+// field][google.longrunning.Operation.metadata] of the
 // [Operation][google.longrunning.Operation].
 message ExecuteOperationMetadata {
   // The current stage of execution.
@@ -2431,6 +2431,9 @@ message StoredExecution {
 
   int32 status_code = 29;
   int32 exit_code = 30;
+
+  bool cached_result = 38;
+  bool do_not_cache = 39;
 
   string output_path = 31;
   string status_message = 32;

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -230,6 +230,8 @@ func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *schem
 		OutputUploadCompletedTimestampUsec: in.GetOutputUploadCompletedTimestampUsec(),
 		StatusCode:                         in.GetStatusCode(),
 		ExitCode:                           in.GetExitCode(),
+		DoNotCache:                         in.GetDoNotCache(),
+		CachedResult:                       in.GetCachedResult(),
 		InvocationLinkType:                 int8(in.GetInvocationLinkType()),
 		User:                               inv.GetUser(),
 		Host:                               inv.GetHost(),


### PR DESCRIPTION
Each boolean field is about 0.1% of our clickhouse write throughput. This is based on the success field.