### PR TITLE
Don't report symlinks in output directory separately with `output_paths`

### DIFF
--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -398,36 +398,33 @@ func handleSymlink(dirHelper *DirHelper, rootDir string, cmd *repb.Command, acti
 	// Check whether the current client is using REAPI version before or after v2.1.
 	if len(cmd.OutputPaths) > 0 && len(cmd.OutputFiles) == 0 && len(cmd.OutputDirectories) == 0 {
 		// REAPI >= v2.1
-		for _, expectedPath := range cmd.OutputPaths {
-			if symlink.Path != expectedPath {
-				continue
-			}
-			actionResult.OutputSymlinks = append(actionResult.OutputSymlinks, symlink)
-			// REAPI specification:
-			//   Servers that wish to be compatible with v2.0 API should still
-			//   populate `output_file_symlinks` and `output_directory_symlinks`
-			//   in addition to `output_symlinks`.
-			//
-			// TODO(sluongng): Since v6.0.0, all the output directories are included in
-			// Action.input_root_digest. So we should be able to save a `stat()` call by
-			// checking wherether the symlink target was included as a directory inside
-			// input root or not.
-			//
-			// Reference:
-			//   https://github.com/bazelbuild/bazel/commit/4310aeb36c134e5fc61ed5cdfdf683f3e95f19b7
-			symlinkInfo, err := os.Stat(fqfn)
-			if err != nil {
-				// When encounter a dangling symlink, skip setting it to legacy fields.
-				// TODO(sluongng): do we care to log this?
-				log.Warningf("Could not find symlink %q's target: %s, skip legacy fields", fqfn, err)
-				return nil
-			}
-			if symlinkInfo.IsDir() {
-				actionResult.OutputDirectorySymlinks = append(actionResult.OutputDirectorySymlinks, symlink)
-			} else {
-				actionResult.OutputFileSymlinks = append(actionResult.OutputFileSymlinks, symlink)
-			}
-			break
+		if !dirHelper.IsOutputPath(fqfn) {
+			return nil
+		}
+		actionResult.OutputSymlinks = append(actionResult.OutputSymlinks, symlink)
+		// REAPI specification:
+		//   Servers that wish to be compatible with v2.0 API should still
+		//   populate `output_file_symlinks` and `output_directory_symlinks`
+		//   in addition to `output_symlinks`.
+		//
+		// TODO(sluongng): Since v6.0.0, all the output directories are included in
+		// Action.input_root_digest. So we should be able to save a `stat()` call by
+		// checking wherether the symlink target was included as a directory inside
+		// input root or not.
+		//
+		// Reference:
+		//   https://github.com/bazelbuild/bazel/commit/4310aeb36c134e5fc61ed5cdfdf683f3e95f19b7
+		symlinkInfo, err := os.Stat(fqfn)
+		if err != nil {
+			// When encounter a dangling symlink, skip setting it to legacy fields.
+			// TODO(sluongng): do we care to log this?
+			log.Warningf("Could not find symlink %q's target: %s, skip legacy fields", fqfn, err)
+			return nil
+		}
+		if symlinkInfo.IsDir() {
+			actionResult.OutputDirectorySymlinks = append(actionResult.OutputDirectorySymlinks, symlink)
+		} else {
+			actionResult.OutputFileSymlinks = append(actionResult.OutputFileSymlinks, symlink)
 		}
 		return nil
 	}

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -398,32 +398,36 @@ func handleSymlink(dirHelper *DirHelper, rootDir string, cmd *repb.Command, acti
 	// Check whether the current client is using REAPI version before or after v2.1.
 	if len(cmd.OutputPaths) > 0 && len(cmd.OutputFiles) == 0 && len(cmd.OutputDirectories) == 0 {
 		// REAPI >= v2.1
-		actionResult.OutputSymlinks = append(actionResult.OutputSymlinks, symlink)
-		// REAPI specification:
-		//   Servers that wish to be compatible with v2.0 API should still
-		//   populate `output_file_symlinks` and `output_directory_symlinks`
-		//   in addition to `output_symlinks`.
-		//
-		// TODO(sluongng): Since v6.0.0, all the output directories are included in
-		// Action.input_root_digest. So we should be able to save a `stat()` call by
-		// checking wherether the symlink target was included as a directory inside
-		// input root or not.
-		//
-		// Reference:
-		//   https://github.com/bazelbuild/bazel/commit/4310aeb36c134e5fc61ed5cdfdf683f3e95f19b7
-		symlinkInfo, err := os.Stat(fqfn)
-		if err != nil {
-			// When encounter a dangling symlink, skip setting it to legacy fields.
-			// TODO(sluongng): do we care to log this?
-			log.Warningf("Could not find symlink %q's target: %s, skip legacy fields", fqfn, err)
-			return nil
+		for _, expectedPath := range cmd.OutputPaths {
+			if symlink.Path == expectedPath {
+				actionResult.OutputSymlinks = append(actionResult.OutputSymlinks, symlink)
+				// REAPI specification:
+				//   Servers that wish to be compatible with v2.0 API should still
+				//   populate `output_file_symlinks` and `output_directory_symlinks`
+				//   in addition to `output_symlinks`.
+				//
+				// TODO(sluongng): Since v6.0.0, all the output directories are included in
+				// Action.input_root_digest. So we should be able to save a `stat()` call by
+				// checking wherether the symlink target was included as a directory inside
+				// input root or not.
+				//
+				// Reference:
+				//   https://github.com/bazelbuild/bazel/commit/4310aeb36c134e5fc61ed5cdfdf683f3e95f19b7
+				symlinkInfo, err := os.Stat(fqfn)
+				if err != nil {
+					// When encounter a dangling symlink, skip setting it to legacy fields.
+					// TODO(sluongng): do we care to log this?
+					log.Warningf("Could not find symlink %q's target: %s, skip legacy fields", fqfn, err)
+					return nil
+				}
+				if symlinkInfo.IsDir() {
+					actionResult.OutputDirectorySymlinks = append(actionResult.OutputDirectorySymlinks, symlink)
+				} else {
+					actionResult.OutputFileSymlinks = append(actionResult.OutputFileSymlinks, symlink)
+				}
+				return nil
+			}
 		}
-		if symlinkInfo.IsDir() {
-			actionResult.OutputDirectorySymlinks = append(actionResult.OutputDirectorySymlinks, symlink)
-			return nil
-		}
-
-		actionResult.OutputFileSymlinks = append(actionResult.OutputFileSymlinks, symlink)
 		return nil
 	}
 

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -431,6 +431,44 @@ func TestUploadTree(t *testing.T) {
 			},
 		},
 		{
+			name: "SymlinkInOutputDirWithOutputPaths",
+			cmd: &repb.Command{
+				OutputPaths: []string{
+					"a",
+				},
+			},
+			directoryPaths: []string{
+				"a",
+			},
+			fileContents: map[string]string{
+				"a/fileA.txt": "a",
+			},
+			symlinkPaths: map[string]string{
+				"a/linkA": "fileA.txt",
+			},
+			expectedResult: &repb.ActionResult{
+				OutputDirectories: []*repb.OutputDirectory{
+					{
+						Path: "a",
+						TreeDigest: getDigestForMsg(t, &repb.Tree{
+							Root: &repb.Directory{
+								Files: []*repb.FileNode{
+									{Name: "fileA.txt", Digest: &repb.Digest{Hash: hash.String("a"), SizeBytes: 1}},
+								},
+								Symlinks: []*repb.SymlinkNode{
+									{Name: "linkA", Target: "fileA.txt"},
+								},
+							},
+						}),
+					},
+				},
+			},
+			expectedInfo: &dirtools.TransferInfo{
+				FileCount:        4,
+				BytesTransferred: 284,
+			},
+		},
+		{
 			name: "DanglingFileSymlink",
 			cmd: &repb.Command{
 				OutputFiles: []string{"a"},


### PR DESCRIPTION
A symlink in an output directory should not be reported as an `output_{,directory,file}_symlink` unless it has been explicitly requested via `output_paths`. This matches the logic for REAPI < v2.1 using `output_directories` and `output_files`.

This fixes a failure in Bazel with `(Exit 34): /build/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/foo/... (File exists)`.