### PR TITLE
Remove linux go build constraint for uffd

### DIFF
--- a/enterprise/server/remote_execution/uffd/BUILD
+++ b/enterprise/server/remote_execution/uffd/BUILD
@@ -9,17 +9,14 @@ go_library(
         "@platforms//os:linux",
     ],
     visibility = ["//visibility:public"],
-    deps = select({
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//enterprise/server/remote_execution/copy_on_write",
-            "//server/metrics",
-            "//server/util/log",
-            "//server/util/status",
-            "@com_github_prometheus_client_golang//prometheus",
-            "@org_golang_x_sys//unix",
-        ],
-        "//conditions:default": [],
-    }),
+    deps = [
+        "//enterprise/server/remote_execution/copy_on_write",
+        "//server/metrics",
+        "//server/util/log",
+        "//server/util/status",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_x_sys//unix",
+    ],
 )
 
 package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -1,5 +1,3 @@
-//go:build linux && !android
-
 package uffd
 
 import (


### PR DESCRIPTION
We don't need the go build constraint because the BUILD file contains a `target_compatible_with` platform. This makes it easier to edit the file with an IDE, even on non-linux platforms

This was originally added here https://github.com/buildbuddy-io/buildbuddy/pull/7965, then reverted due to the separate changes in that PR