### PR TITLE
[raft] move remove data out of removeReplica

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -132,7 +132,6 @@ func (e *aggErr) err() error {
 	}
 
 	if e.lastErr == dragonboat.ErrShardNotFound || e.lastErr == dragonboat.ErrRejected {
-		log.Errorf("last error: %s, last non-timeout error: %s, errors encountered: %+v", e.lastErr, e.lastNonTimeoutErr, e.errCount)
 		return e.lastErr
 	} else if status.IsOutOfRangeError(e.lastErr) {
 		return e.lastErr

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -132,6 +132,7 @@ func (e *aggErr) err() error {
 	}
 
 	if e.lastErr == dragonboat.ErrShardNotFound || e.lastErr == dragonboat.ErrRejected {
+		log.Errorf("last error: %s, last non-timeout error: %s, errors encountered: %+v", e.lastErr, e.lastNonTimeoutErr, e.errCount)
 		return e.lastErr
 	} else if status.IsOutOfRangeError(e.lastErr) {
 		return e.lastErr

--- a/enterprise/server/raft/driver/BUILD
+++ b/enterprise/server/raft/driver/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/driver",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/raft/client",
         "//enterprise/server/raft/config",
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/header",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -267,7 +267,7 @@ func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeH
 	usages, err := usagetracker.New(s.sender, s.leaser, gossipManager, s.NodeDescriptor(), partitions, clock)
 
 	if *enableDriver {
-		s.driverQueue = driver.NewQueue(s, gossipManager, nhLog, clock)
+		s.driverQueue = driver.NewQueue(s, gossipManager, nhLog, apiClient, clock)
 	}
 	s.deleteSessionWorker = newDeleteSessionsWorker(clock, s)
 
@@ -1042,7 +1042,10 @@ func (s *Store) syncRequestDeleteReplica(ctx context.Context, rangeID, replicaID
 	err = client.RunNodehostFn(ctx, func(ctx context.Context) error {
 		return s.nodeHost.SyncRequestDeleteReplica(ctx, rangeID, replicaID, configChangeID)
 	})
-	return err
+	if err != nil {
+		return status.InternalErrorf("nodehost.SyncRequestDeleteReplica failed for c%dn%d: %s", rangeID, replicaID, err)
+	}
+	return nil
 }
 
 // syncRequestStopAndDeleteReplica attempts to delete a replica but stops it if
@@ -2283,12 +2286,15 @@ func (s *Store) RemoveReplica(ctx context.Context, req *rfpb.RemoveReplicaReques
 	var replicaDesc *rfpb.ReplicaDescriptor
 	for _, replica := range req.GetRange().GetReplicas() {
 		if replica.GetReplicaId() == req.GetReplicaId() {
+			if replica.GetNhid() == s.NHID() {
+				return nil, status.InvalidArgumentErrorf("c%dn%d is on the node %s: cannot remove", req.GetRange().GetRangeId(), req.GetReplicaId(), s.NHID())
+			}
 			replicaDesc = replica
 			break
 		}
 	}
 	if replicaDesc == nil {
-		return nil, status.FailedPreconditionErrorf("No node with id %d found in range: %+v", req.GetReplicaId(), req.GetRange())
+		return nil, status.FailedPreconditionErrorf("No replica with replica_id %d found in range: %+v", req.GetReplicaId(), req.GetRange())
 	}
 
 	// First, update the range descriptor information to reflect the
@@ -2306,27 +2312,8 @@ func (s *Store) RemoveReplica(ctx context.Context, req *rfpb.RemoveReplicaReques
 		Range: rd,
 	}
 
-	// Remove the data from the now stopped node. This is best-effort only,
-	// because we can remove the replica when the node is dead; and in this case,
-	// we won't be able to connect to the node.
-	c, err := s.apiClient.GetForReplica(ctx, replicaDesc)
-	if err != nil {
-		s.log.Warningf("RemoveReplica unable to remove data on c%dn%d, err getting api client: %s", replicaDesc.GetRangeId(), replicaDesc.GetReplicaId(), err)
-		return rsp, nil
-	}
-	_, err = c.RemoveData(ctx, &rfpb.RemoveDataRequest{
-		RangeId:   replicaDesc.GetRangeId(),
-		ReplicaId: replicaDesc.GetReplicaId(),
-		Start:     rd.GetStart(),
-		End:       rd.GetEnd(),
-	})
-	if err != nil {
-		s.log.Warningf("RemoveReplica unable to remove data err: %s", err)
-		return rsp, nil
-	}
-
-	s.log.Infof("Removed shard: c%dn%d", replicaDesc.GetRangeId(), replicaDesc.GetReplicaId())
 	return rsp, nil
+
 }
 
 func (s *Store) reserveReplicaIDs(ctx context.Context, n int) ([]uint64, error) {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1042,10 +1042,7 @@ func (s *Store) syncRequestDeleteReplica(ctx context.Context, rangeID, replicaID
 	err = client.RunNodehostFn(ctx, func(ctx context.Context) error {
 		return s.nodeHost.SyncRequestDeleteReplica(ctx, rangeID, replicaID, configChangeID)
 	})
-	if err != nil {
-		return status.InternalErrorf("nodehost.SyncRequestDeleteReplica failed for c%dn%d: %s", rangeID, replicaID, err)
-	}
-	return nil
+	return err
 }
 
 // syncRequestStopAndDeleteReplica attempts to delete a replica but stops it if
@@ -2304,8 +2301,8 @@ func (s *Store) RemoveReplica(ctx context.Context, req *rfpb.RemoveReplicaReques
 		return nil, err
 	}
 
-	if err = s.syncRequestDeleteReplica(ctx, replicaDesc.GetRangeId(), replicaDesc.GetReplicaId()); err != nil {
-		return nil, err
+	if err = s.syncRequestDeleteReplica(ctx, req.GetRange().GetRangeId(), req.GetReplicaId()); err != nil {
+		return nil, status.InternalErrorf("nodehost.SyncRequestDeleteReplica failed for c%dn%d: %s", req.GetRange().GetRangeId(), req.GetReplicaId(), err)
 	}
 
 	rsp := &rfpb.RemoveReplicaResponse{


### PR DESCRIPTION
Also fix RemoveNodeFromCluster test. Sometimes test fail with shardNotFound when
we call removeReplica on the store where c2n4 resides.

Seperate RemoveData from RemoveReplica so that we can call try removeReplica on
different replicas (in following PRs)

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4220
