### PR TITLE
Remove need to call umoci, use crane tools

### DIFF
--- a/enterprise/server/util/ociconv/BUILD
+++ b/enterprise/server/util/ociconv/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "//third_party/singleflight",
+        "@com_github_google_go_containerregistry//pkg/v1/mutate",
     ],
 )
 


### PR DESCRIPTION
OLD     --- PASS: TestOciconv/image=mirror.gcr.io/ubuntu:22.04 (4.10s)
NEW    --- PASS: TestOciconv/image=mirror.gcr.io/ubuntu:22.04 (2.57s)

Images are the same size (125MB) and contain the same number of files and dirs.