### PR TITLE
Fetch ExecuteResult when WaitExecution is done

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -166,7 +166,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
           this.setState({ actionResult: operation.response.result });
         }
         if (operation.done) {
-          this.fetchExecuteResponseOrActionResult()
+          this.fetchExecuteResponseOrActionResult();
         }
       },
       error: (error) => {

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -165,6 +165,9 @@ export default class InvocationActionCardComponent extends React.Component<Props
         if (operation.response?.result) {
           this.setState({ actionResult: operation.response.result });
         }
+        if (operation.done) {
+          this.fetchExecuteResponseOrActionResult()
+        }
       },
       error: (error) => {
         // TODO: better error handling

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -165,6 +165,8 @@ export default class InvocationActionCardComponent extends React.Component<Props
         if (operation.response?.result) {
           this.setState({ actionResult: operation.response.result });
         }
+        // Fetch the full response from cache, since it contains
+        // some additional metadata not sent on the stream.
         if (operation.done) {
           this.fetchExecuteResponseOrActionResult();
         }


### PR DESCRIPTION
This lets us get all the metadata that is stored in the ExecutedResult, but isn't sent on wait operation.