### PR TITLE
Only touch version number when updating bazel module version via sidekick

### DIFF
--- a/enterprise/app/sidekick/module/module.tsx
+++ b/enterprise/app/sidekick/module/module.tsx
@@ -105,7 +105,7 @@ export default class ModuleSidekick extends React.Component<Props, State> {
     ]);
   }
 
-  update(match: RegExpMatchArray, module: Module) {
+  update(match: RegExpMatchArray, latestVersion: string) {
     let start = this.props.editor.getModel()?.getPositionAt(match.index || 0)!;
     let end = this.props.editor.getModel()?.getPositionAt((match.index || 0) + match[0].length)!;
     let range = new monaco.Selection(start.lineNumber, start?.column, end?.lineNumber, end.column);
@@ -113,7 +113,7 @@ export default class ModuleSidekick extends React.Component<Props, State> {
     this.props.editor.executeEdits(null, [
       {
         range: range,
-        text: module.module_snippet?.trim() + "\n" || "unknown",
+        text: match[0].replaceAll(match?.groups?.version || "unknown", latestVersion),
       },
     ]);
   }
@@ -172,7 +172,7 @@ export default class ModuleSidekick extends React.Component<Props, State> {
                   onUpdate={
                     (latestMatch?.groups?.version &&
                       m.groups?.version != latestMatch?.groups?.version &&
-                      (() => this.update(m, matchingModule!))) ||
+                      (() => this.update(m, latestMatch?.groups?.version))) ||
                     undefined
                   }
                   selected={true}

--- a/enterprise/app/sidekick/module/module.tsx
+++ b/enterprise/app/sidekick/module/module.tsx
@@ -172,7 +172,7 @@ export default class ModuleSidekick extends React.Component<Props, State> {
                   onUpdate={
                     (latestMatch?.groups?.version &&
                       m.groups?.version != latestMatch?.groups?.version &&
-                      (() => this.update(m, latestMatch?.groups?.version))) ||
+                      (() => this.update(m, latestMatch?.groups?.version || ""))) ||
                     undefined
                   }
                   selected={true}


### PR DESCRIPTION
Previously we'd just replace the full module snippet with the example snippet from the docs.

This could be destructive if either the example snippet includes weird stuff (like comments), or if usage is non-standard (i.e. has some extra args).

With this change, we just touch the version argument and bump it to the latest version when update is clicked.