### PR TITLE
[raft] RemoveReplica

### DIFF
--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -587,10 +587,23 @@ message AddReplicaResponse {
   RangeDescriptor range = 1;
 }
 
+// RemoveReplicaRequest specifies a request to remove the replica from raft 
+// memberhsip, and remove the replica from the range descriptor. It does *not*
+// remove the data from the machine.
 message RemoveReplicaRequest {
+  // Either specify range or range_id:
+  //  -- When a range is provided, it is expected that the range is up-to-date. The
+  // call removes the replica from the range descriptor and also from the raft
+  // membership.
+  //  -- When a range_id is provided, it is expected that the replica_id is 
+  // already removed from the range descriptor. For example, when we detected a
+  // zombie.
   RangeDescriptor range = 1;
+  uint64 range_id = 3;
+
   uint64 replica_id = 2;
 }
+
 message RemoveReplicaResponse {
   // The range with the specified node removed.
   RangeDescriptor range = 1;

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -587,15 +587,16 @@ message AddReplicaResponse {
   RangeDescriptor range = 1;
 }
 
-// RemoveReplicaRequest specifies a request to remove the replica from raft 
+// RemoveReplicaRequest specifies a request to remove the replica from raft
 // memberhsip, and remove the replica from the range descriptor. It does *not*
 // remove the data from the machine.
 message RemoveReplicaRequest {
   // Either specify range or range_id:
-  //  -- When a range is provided, it is expected that the range is up-to-date. The
+  //  -- When a range is provided, it is expected that the range is up-to-date.
+  //  The
   // call removes the replica from the range descriptor and also from the raft
   // membership.
-  //  -- When a range_id is provided, it is expected that the replica_id is 
+  //  -- When a range_id is provided, it is expected that the replica_id is
   // already removed from the range descriptor. For example, when we detected a
   // zombie.
   RangeDescriptor range = 1;


### PR DESCRIPTION
Allow RemoveRequest to take a request without range. If we are removing zombies,
that means the replica is not in the descriptor, so we don't need the range
descriptor in that case. But we still want to check that the server is the lease
holder of that range. 

Known issue: the Cleanup Zombie test can become flaky if we are removing
a leader. I will address it in a follow up PR when I refactor the zombie code.
