### PR TITLE
Allow specifying a default login slug

### DIFF
--- a/enterprise/app/login/login.tsx
+++ b/enterprise/app/login/login.tsx
@@ -45,17 +45,17 @@ export default class LoginComponent extends React.Component<Props, State> {
   }
 
   isOrgSpecific() {
-    return this.isJoiningOrg() || capabilities.config.customerSubdomain;
+    return this.isJoiningOrg() || capabilities.config.defaultLoginSlug || capabilities.config.customerSubdomain;
   }
 
   getUrlSlug() {
     if (this.isJoiningOrg()) {
       return window.location.pathname.split("/").pop();
     }
-    if (this.isOrgSpecific()) {
+    if (this.isOrgSpecific() && capabilities.config.customerSubdomain) {
       return window.location.host.split(".")[0];
     }
-    return "";
+    return capabilities.config.defaultLoginSlug;
   }
 
   async fetchOrgName() {

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -177,6 +177,9 @@ message FrontendConfig {
 
   // Whether the community links is enabled in the UI.
   bool community_links_enabled = 58;
+
+  // If set, the login page will default to using this slug.
+  string default_login_slug = 59;
 }
 
 message Region {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -67,6 +67,7 @@ var (
 	targetFlakesUIEnabled                  = flag.Bool("app.target_flakes_ui_enabled", false, "If set, show some fancy new features for analyzing flakes.")
 	bazelButtonsEnabled                    = flag.Bool("app.bazel_buttons_enabled", false, "If set, show remote bazel buttons in the UI.")
 	communityLinksEnabled                  = flag.Bool("app.community_links_enabled", true, "If set, show links to BuildBuddy community in the UI.")
+	defaultLoginSlug                       = flag.String("app.default_login_slug", "", "If set, the login page will default to using this slug.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -214,6 +215,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		BazelButtonsEnabled:                    *bazelButtonsEnabled,
 		CspNonce:                               nonce,
 		CommunityLinksEnabled:                  *communityLinksEnabled,
+		DefaultLoginSlug:                       *defaultLoginSlug,
 	}
 
 	configJSON, err := protojson.Marshal(&config)


### PR DESCRIPTION
This enables configuring the login page buttons to use a specific organization slug with the `app.default_login_slug` flag / config option.

Particularly useful for installations that don't use customer-specific subdomains.