### PR TITLE
Remove workspacefs loopback mount code

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -49,7 +49,6 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
-        "//server/util/alert",
         "//server/util/background",
         "//server/util/disk",
         "//server/util/log",


### PR DESCRIPTION
We aren't actively using this code. The `debugfs` codepath is probably "fast enough" since we updated it to only copy output paths in https://github.com/buildbuddy-io/buildbuddy/pull/7959, and also this code is likely to be supplanted by FUSE anyway. If we do want to try this code again in the future, we can always bring it back, but should test thoroughly in dev first because we hit some issues with the loopback device approach last time.