### PR TITLE
Disable "allow making builds public" by default and improve explanation

### DIFF
--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -193,7 +193,7 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
               name="sharingEnabled"
               checked={request.sharingEnabled}
             />
-            <span>Allow members of this org to make builds public (viewable by anyone with a link)</span>
+            <span>Allow members of this org to make builds public (viewable by anyone with a link, including all build artifacts)</span>
           </label>
         )}
         {capabilities.userOwnedExecutors && (

--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -193,7 +193,10 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
               name="sharingEnabled"
               checked={request.sharingEnabled}
             />
-            <span>Allow members of this org to make builds public (viewable by anyone with a link, including all build artifacts)</span>
+            <span>
+              Allow members of this org to make builds public (viewable by anyone with a link, including all build
+              artifacts)
+            </span>
           </label>
         )}
         {capabilities.userOwnedExecutors && (

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -225,7 +225,7 @@ type Group struct {
 	GithubToken *string
 	Model
 
-	SharingEnabled                    bool `gorm:"default:1"`
+	SharingEnabled                    bool `gorm:"default:0"`
 	UserOwnedKeysEnabled              bool `gorm:"not null;default:0"`
 	BotSuggestionsEnabled             bool `gorm:"not null;default:1"`
 	CodeSearchEnabled                 bool `gorm:"not null;default:0"`


### PR DESCRIPTION
Invocations shared publicly also provide access to the artifacts they reference, which organizations may rightly be cautious about. Allowing developers access to this features should require a conscious decision.