### PR TITLE
Use action.platform instead of command.platform in one more place

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1175,7 +1175,7 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceNa
 	if sizer := s.env.GetTaskSizer(); sizer != nil && execErr == nil && executeResponse.GetResult().GetExitCode() == 0 {
 		// TODO(vanja) should this be done when the executor got a cache hit?
 		md := executeResponse.GetResult().GetExecutionMetadata()
-		if err := sizer.Update(ctx, cmd, md); err != nil {
+		if err := sizer.Update(ctx, action, cmd, md); err != nil {
 			log.CtxWarningf(ctx, "Failed to update task size: %s", err)
 		}
 	}

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -201,13 +201,13 @@ func (s *taskSizer) Predict(ctx context.Context, task *repb.ExecutionTask) *scpb
 	return ApplyLimits(task, s.model.Predict(ctx, task))
 }
 
-func (s *taskSizer) Update(ctx context.Context, cmd *repb.Command, md *repb.ExecutedActionMetadata) error {
+func (s *taskSizer) Update(ctx context.Context, action *repb.Action, cmd *repb.Command, md *repb.ExecutedActionMetadata) error {
 	if !*useMeasuredSizes {
 		return nil
 	}
 	statusLabel := "ok"
 	defer func() {
-		props, err := platform.ParseProperties(&repb.ExecutionTask{Command: cmd})
+		props, err := platform.ParseProperties(&repb.ExecutionTask{Action: action, Command: cmd})
 		if err != nil {
 			log.CtxInfof(ctx, "Failed to parse task properties: %s", err)
 		}

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -252,7 +252,7 @@ func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
 		// Set the completed timestamp so that the exec duration is 2 seconds.
 		ExecutionCompletedTimestamp: timestamppb.New(execStart.Add(2 * time.Second)),
 	}
-	err = sizer.Update(ctx, task.GetCommand(), md)
+	err = sizer.Update(ctx, task.GetAction(), task.GetCommand(), md)
 
 	require.NoError(t, err)
 
@@ -294,7 +294,7 @@ func TestSizer_RespectsMilliCPULimit(t *testing.T) {
 		ExecutionStartTimestamp:     timestamppb.New(execStart),
 		ExecutionCompletedTimestamp: timestamppb.New(execStart.Add(1 * time.Second)),
 	}
-	err = sizer.Update(ctx, task.GetCommand(), md)
+	err = sizer.Update(ctx, task.GetAction(), task.GetCommand(), md)
 	require.NoError(t, err)
 
 	ts := sizer.Get(ctx, task)
@@ -335,7 +335,7 @@ func TestSizer_RespectsMinimumSize(t *testing.T) {
 		ExecutionCompletedTimestamp: timestamppb.New(execStart.Add(1 * time.Second)),
 	}
 
-	err = sizer.Update(ctx, task.GetCommand(), md)
+	err = sizer.Update(ctx, task.GetAction(), task.GetCommand(), md)
 	require.NoError(t, err)
 
 	ts := sizer.Get(ctx, task)
@@ -351,7 +351,7 @@ func TestSizer_RespectsMinimumSize(t *testing.T) {
 			},
 		},
 	}
-	err = sizer.Update(ctx, task.GetCommand(), md)
+	err = sizer.Update(ctx, task.GetAction(), task.GetCommand(), md)
 	require.NoError(t, err)
 
 	ts = sizer.Get(ctx, task)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -932,7 +932,7 @@ type TaskSizer interface {
 	Predict(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize
 
 	// Update records a measured task size.
-	Update(ctx context.Context, cmd *repb.Command, md *repb.ExecutedActionMetadata) error
+	Update(ctx context.Context, action *repb.Action, cmd *repb.Command, md *repb.ExecutedActionMetadata) error
 }
 
 // ScheduledTask represents an execution task along with its scheduling metadata


### PR DESCRIPTION
I guess I missed this one as well.