### PR TITLE
[CLI] Don't consult local CAS for findMissing

### DIFF
--- a/server/cache_proxy/cache_proxy.go
+++ b/server/cache_proxy/cache_proxy.go
@@ -174,19 +174,7 @@ func (p *CacheProxy) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddres
 }
 
 func (p *CacheProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMissingBlobsRequest) (*repb.FindMissingBlobsResponse, error) {
-	localMissing, err := p.localCAS.FindMissingBlobs(ctx, req)
-	if err == nil && len(localMissing.GetMissingBlobDigests()) == 0 {
-		return localMissing, nil
-	}
-	remainingReq := &repb.FindMissingBlobsRequest{
-		InstanceName: req.GetInstanceName(),
-	}
-	if err == nil {
-		remainingReq.BlobDigests = localMissing.GetMissingBlobDigests()
-	} else {
-		remainingReq.BlobDigests = req.GetBlobDigests()
-	}
-	return p.casClient.FindMissingBlobs(ctx, remainingReq)
+	return p.casClient.FindMissingBlobs(ctx, req)
 }
 
 func (p *CacheProxy) hasBlobLocally(ctx context.Context, instanceName string, d *repb.Digest) bool {


### PR DESCRIPTION
This is the CLI sidecar version of https://github.com/buildbuddy-io/buildbuddy/pull/8073

Consulting the local CAS leads to two issues:
1. We don't bump the TTL on remote cache objects that exist locally
2. If for whatever reason an action output is missing, bazel will never recover by re-uploading the missing artifact (if the artifact exists in the local CAS)

We already handle `GetActionResult`, `UpdateActionResult`, `BatchUpdateBlobs`, and `BatchReadBlobs` similarly.