### PR TITLE
fix a bug in tasksize.Requested

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -410,7 +410,7 @@ func Requested(task *repb.ExecutionTask) *scpb.TaskSize {
 	}
 	cpu := int64(props.EstimatedComputeUnits * ComputeUnitsToMilliCPU)
 	mem := int64(props.EstimatedComputeUnits * ComputeUnitsToRAMBytes)
-	if props.EstimatedMemoryBytes > 0 {
+	if props.EstimatedMilliCPU > 0 {
 		cpu = props.EstimatedMilliCPU
 	}
 	if props.EstimatedMemoryBytes > 0 {

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -125,11 +125,11 @@ func TestRequested_BCUPlatformProps_ConvertsBCUToTaskSize(t *testing.T) {
 }
 
 func TestRequested_BCUPlatformProps_Overriden(t *testing.T) {
+	// only override ram
 	ts := tasksize.Requested(&repb.ExecutionTask{
 		Command: &repb.Command{
 			Platform: &repb.Platform{
 				Properties: []*repb.Platform_Property{
-					{Name: "EstimatedCPU", Value: "1"},
 					{Name: "EstimatedMemory", Value: "60000000"},
 					{Name: "estimatedcomputeunits", Value: "2"},
 				},
@@ -138,6 +138,22 @@ func TestRequested_BCUPlatformProps_Overriden(t *testing.T) {
 	})
 
 	assert.Equal(t, int64(60000000), ts.EstimatedMemoryBytes)
+	assert.Equal(t, int64(2*1000), ts.EstimatedMilliCpu)
+	assert.Equal(t, int64(0), ts.EstimatedFreeDiskBytes)
+
+	// only override cpu
+	ts = tasksize.Requested(&repb.ExecutionTask{
+		Command: &repb.Command{
+			Platform: &repb.Platform{
+				Properties: []*repb.Platform_Property{
+					{Name: "EstimatedCPU", Value: "1"},
+					{Name: "estimatedcomputeunits", Value: "2"},
+				},
+			},
+		},
+	})
+
+	assert.Equal(t, int64(2*2.5*1e9), ts.EstimatedMemoryBytes)
 	assert.Equal(t, int64(1000), ts.EstimatedMilliCpu)
 	assert.Equal(t, int64(0), ts.EstimatedFreeDiskBytes)
 }


### PR DESCRIPTION
I introduced this in https://github.com/buildbuddy-io/buildbuddy/pull/7920 and found it using the new clickhouse fields.

If the user only  sets CPU, it takes no affect. If the user only sets RAM, it sets CPU to 0, which later gets overridden  to 600 from the default.

I fixed this and added tests.