### PR TITLE
[RB] Fix error handling

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -940,7 +940,11 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		}
 		rsp, err := rexec.Wait(rexec.NewRetryingStream(ctx, execClient, waitExecutionStream, executionID))
 		if err != nil {
-			return fmt.Errorf("wait execution: %w", err)
+			return fmt.Errorf("wait execution: %v", err)
+		} else if rsp.Err != nil {
+			return fmt.Errorf("wait execution: %v", rsp.Err)
+		} else if rsp.ExecuteResponse.GetResult() == nil {
+			return fmt.Errorf("empty execute response from WaitExecution: %v", rsp.ExecuteResponse.GetStatus())
 		}
 		executeResponse = rsp.ExecuteResponse
 		return nil


### PR DESCRIPTION
WaitExecution will sometimes set the error on the rsp object, which we were previously failing to check for

Because the default value of an int is 0, if the execute response result was unset, we would sometimes incorrectly return the default value which looks like a success code

Fixes #1 from this thread: https://buildbuddy-corp.slack.com/archives/C07GMM2VBLY/p1734595606837269