### PR TITLE
[RB] Always cancel remote bazel run at end of CLI to prevent missing retries

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -940,7 +940,11 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		}
 		rsp, err := rexec.Wait(rexec.NewRetryingStream(ctx, execClient, waitExecutionStream, executionID))
 		if err != nil {
-			return fmt.Errorf("wait execution: %w", err)
+			return fmt.Errorf("wait execution: %v", err)
+		} else if rsp.Err != nil {
+			return fmt.Errorf("wait execution: %v", rsp.Err)
+		} else if rsp.ExecuteResponse.GetResult() == nil {
+			return fmt.Errorf("empty execute response from WaitExecution: %v", rsp.ExecuteResponse.GetStatus())
 		}
 		executeResponse = rsp.ExecuteResponse
 		return nil

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -877,13 +877,8 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	log.Debugf("Invocation ID: %s", iid)
 
 	// If the remote bazel process is canceled or killed, cancel the remote run
-	isInvocationRunning := true
 	go func() {
 		<-ctx.Done()
-
-		if !isInvocationRunning {
-			return
-		}
 
 		// Use a non-cancelled context to ensure the remote executions are
 		// canceled
@@ -905,7 +900,6 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 			return 1, status.WrapError(err, "streaming logs")
 		}
 	}
-	isInvocationRunning = false
 
 	eg := errgroup.Group{}
 	var inRsp *inpb.GetInvocationResponse


### PR DESCRIPTION
A customer reported a bug where the remote bazel invocation was canceled due to a "stream terminated by RST_STREAM" error (which often occurs when an executor loses connection to an app server due to a rollout). That error was immediately returned to the CLI, which reported that the remote run failed. However that execution was retried, and eventually succeeded.

We should just cancel the invocation in this case, so the CLI reports the correct status of the final results of the remote run. We don't want a case where the CLI reports that the run failed, which may lead the client to rerun the remote bazel command, which in this case would've caused duplicate runs

If the invocation did already complete running, the CancelExecutions will be a no-op

Fixes #2 here: https://buildbuddy-corp.slack.com/archives/C07GMM2VBLY/p1734595804049229?thread_ts=1734595606.837269&cid=C07GMM2VBLY