### PR TITLE
Update app image to pick up fixes for vulnerabilities

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -437,7 +437,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
     name = "buildbuddy_go_image_base",
-    digest = "sha256:388145607c79313a1e49b783a7ee71e4ef3df31d87c45adb46bfb9b257b643d1",
+    digest = "sha256:de4789799c7c27e3f172f81313adc30f100d632e53fac755a3965f799b685860",
     registry = "gcr.io",
     repository = "distroless/cc-debian12",
 )

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -134,7 +134,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
     name = "buildbuddy_go_image_base",
-    digest = "sha256:3172df37ef8caa768ce74ebbc7f0e2b6a2641d3b35d18659d36f3815e30fe620",
+    digest = "sha256:de4789799c7c27e3f172f81313adc30f100d632e53fac755a3965f799b685860",
     registry = "gcr.io",
     repository = "distroless/cc-debian11",
 )

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -136,7 +136,7 @@ container_pull(
     name = "buildbuddy_go_image_base",
     digest = "sha256:de4789799c7c27e3f172f81313adc30f100d632e53fac755a3965f799b685860",
     registry = "gcr.io",
-    repository = "distroless/cc-debian11",
+    repository = "distroless/cc-debian12",
 )
 
 # Base image that can be used to build images that are capable of running the Bazel binary.


### PR DESCRIPTION
Just bumping to the latest `gcr.io/distroless/cc-debian12` image.
