### PR TITLE
Fix HTTP file download auth

### DIFF
--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1960,9 +1960,6 @@ func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseW
 		return http.StatusBadRequest, err
 	}
 
-	// TODO(siggisim): Figure out why this JWT is overriding authority auth and remove.
-	ctx = context.WithValue(ctx, "x-buildbuddy-jwt", nil)
-
 	var zipReference = params.Get("z")
 	if len(zipReference) > 0 {
 		b, err := base64.StdEncoding.DecodeString(zipReference)


### PR DESCRIPTION
Since we're no longer authenticating using API key auth, we need the JWT.