### PR TITLE
[raft] mark replicas as removed in range descriptor before we remove from raft

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2540,6 +2540,7 @@ func (s *Store) removeReplicaFromRangeDescriptor(ctx context.Context, rangeID, r
 	newDescriptor := proto.Clone(oldDescriptor).(*rfpb.RangeDescriptor)
 	for i, replica := range newDescriptor.Replicas {
 		if replica.GetReplicaId() == replicaID {
+			newDescriptor.Removed = append(newDescriptor.Removed, newDescriptor.Replicas[i])
 			newDescriptor.Replicas = append(newDescriptor.Replicas[:i], newDescriptor.Replicas[i+1:]...)
 			break
 		}

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -524,6 +524,11 @@ message RangeDescriptor {
 
   optional uint64 last_added_replica_id = 6;
   optional int64 last_replica_added_at_usec = 7;
+
+  // Replicas marked to be removed from the raft and pebble systems. Once a
+  // a replica is removed from the system successfully, it will be removed from
+  // this list.
+  repeated ReplicaDescriptor removed = 8;
 }
 
 // SyncPropose, in proto form.


### PR DESCRIPTION
Background: https://docs.google.com/document/d/1Vk5TqjFYykkmgtXTOmygtN9HI0fP0zYd6WHd8wOa6bo/edit?tab=t.0
