### PR TITLE
Add webdriver test for action page

### DIFF
--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1637,11 +1637,7 @@ func TestRedisRestart(t *testing.T) {
 	}
 	app := buildbuddy_enterprise.RunWithConfig(t, buildbuddy_enterprise.DefaultAppConfig(t), buildbuddy_enterprise.NoAuthConfig, args...)
 
-	_ = testexecutor.Run(
-		t,
-		testexecutor.ExecutorRunfilePath,
-		[]string{"--executor.app_target=" + app.GRPCAddress()},
-	)
+	_ = testexecutor.Run(t, "--executor.app_target="+app.GRPCAddress())
 
 	ctx := context.Background()
 	ws := testbazel.MakeTempWorkspace(t, workspaceContents)

--- a/enterprise/server/test/webdriver/invocation/BUILD
+++ b/enterprise/server/test/webdriver/invocation/BUILD
@@ -11,9 +11,11 @@ go_web_test_suite(
     shard_count = 3,
     deps = [
         "//enterprise/server/testutil/buildbuddy_enterprise",
+        "//enterprise/server/testutil/testexecutor",
         "//server/testutil/testbazel",
         "//server/testutil/webtester",
         "//server/util/uuid",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/testutil/testexecutor/BUILD
+++ b/enterprise/server/testutil/testexecutor/BUILD
@@ -10,7 +10,7 @@ go_library(
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testexecutor",
     x_defs = {
-        "ExecutorRunfilePath": "$(rlocationpath //enterprise/server/cmd/executor)",
+        "executorRlocationpath": "$(rlocationpath //enterprise/server/cmd/executor)",
     },
     deps = [
         "//server/testutil/testport",

--- a/enterprise/server/testutil/testexecutor/testexecutor.go
+++ b/enterprise/server/testutil/testexecutor/testexecutor.go
@@ -15,27 +15,22 @@ type Executor struct {
 }
 
 // set by x_defs in BUILD file
-var ExecutorRunfilePath string
+var executorRlocationpath string
 
-// Run a local BuildBuddy executor for the scope of the given test case.
-//
-// The given command path and config file path refer to the workspace-relative runfile
-// paths of the executor server binary.
-func Run(t *testing.T, commandPath string, commandArgs []string) *Executor {
+// Run a local BuildBuddy executor binary for the scope of the given test case.
+func Run(t *testing.T, args ...string) *Executor {
 	e := &Executor{
 		httpPort:       testport.FindFree(t),
 		monitoringPort: testport.FindFree(t),
 	}
-	args := []string{
-		"--app.log_level=debug",
-		fmt.Sprintf("--port=%d", e.httpPort),
-		fmt.Sprintf("--monitoring_port=%d", e.monitoringPort),
-	}
-	args = append(args, commandArgs...)
-
 	testserver.Run(t, &testserver.Opts{
-		BinaryRunfilePath:     commandPath,
-		Args:                  args,
+		BinaryRunfilePath: executorRlocationpath,
+		Args: append(
+			args,
+			"--app.log_level=debug",
+			fmt.Sprintf("--port=%d", e.httpPort),
+			fmt.Sprintf("--monitoring_port=%d", e.monitoringPort),
+		),
 		HTTPPort:              e.httpPort,
 		HealthCheckServerType: "prod-buildbuddy-executor",
 	})

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -107,7 +107,8 @@ func New(t *testing.T) *WebTester {
 		// the webdriver if the screenshot fails.
 		assert.NoError(t, err, "failed to take end-of-test screenshot")
 
-		if t.Failed() {
+		if *endOfTestDelay > 0 {
+			t.Logf("Sleeping for %s (-webdriver_end_of_test_delay)", *endOfTestDelay)
 			time.Sleep(*endOfTestDelay)
 		}
 		err = driver.Quit()
@@ -127,6 +128,11 @@ func (wt *WebTester) CurrentURL() string {
 	url, err := wt.driver.CurrentURL()
 	require.NoError(wt.t, err)
 	return url
+}
+
+// Refresh reloads the page.
+func (wt *WebTester) Refresh() {
+	wt.Get(wt.CurrentURL())
 }
 
 // Returns the <body> element of the current page. Exactly one body element


### PR DESCRIPTION
The action page breaks often because the `/file/download` logic is pretty complex as well as the logic in `invocation_action_card.tsx`. So, it seems worth expanding the existing webdriver test to not just check the executions listing for the test build, but also click through to the action page.

To make this change, we need to update the current test to actually execute the build on an executor. Currently when the test build runs, it fails because there are no registered executors. The current test just asserts that the failed execution is displayed in the UI. By running an executor in the test, we can successfully run the execution and click through to the action page to see the action result.

This PR only tests a single auth scenario: the invocation is authenticated, and the user is logged in while trying to view the action page. I would like to expand this test in future PRs with more auth scenarios:
- Authenticated invocation, view while impersonating
- Anonymous invocation, view while logged in + not logged in
- Authenticated invocation made public, view while logged in + not logged in + impersonating
