### PR TITLE
Use `os.Getuid()` instead of `user.Current()` if we only want the uid

### DIFF
--- a/enterprise/server/util/ociconv/ociconv.go
+++ b/enterprise/server/util/ociconv/ociconv.go
@@ -31,15 +31,11 @@ const (
 )
 
 var (
-	isRoot bool
+	isRoot = os.Getuid() == 0
 
 	// Single-flight group used to dedupe firecracker image conversions.
 	conversionGroup singleflight.Group[string, string]
 )
-
-func init() {
-	isRoot = os.Getuid() == 0
-}
 
 func hashFile(filename string) (string, error) {
 	f, err := os.Open(filename)

--- a/enterprise/server/util/ociconv/ociconv.go
+++ b/enterprise/server/util/ociconv/ociconv.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"sort"
 	"syscall"
@@ -39,12 +38,7 @@ var (
 )
 
 func init() {
-	u, err := user.Current()
-	if err != nil {
-		log.Warningf("could not determine current user: %s", err)
-	} else {
-		isRoot = u.Uid == "0"
-	}
+	isRoot = os.Getuid() == 0
 }
 
 func hashFile(filename string) (string, error) {


### PR DESCRIPTION
`os.Getuid` has no failure mode, whereas `user.Current` can fail even though the uid was successfully retrieved. Since we don't care about any part of the user except for the uid, retrieving the other user info is extraneous work and complicates error handling unnecessarily, reporting a warning and short-cicuiting the `isRoot` logic even though we have the uid.

