### PR TITLE
Fail webdriver tests if error banner is displayed

### DIFF
--- a/app/errors/error_service.ts
+++ b/app/errors/error_service.ts
@@ -3,6 +3,7 @@ import { BuildBuddyError, ErrorCode } from "../util/errors";
 import alertService from "../alert/alert_service";
 
 const ERROR_SEARCH_PARAM = "error";
+
 export class ErrorService {
   register() {
     let searchParams = new URLSearchParams(window.location.search);
@@ -14,6 +15,10 @@ export class ErrorService {
   }
 
   handleError(e: any, options?: { ignoreErrorCodes: ErrorCode[] }) {
+    // NOTE: keep this string in sync with webtester.go -
+    // web tests check for this message and fail the test if it's logged.
+    console.error(new Error("Displaying error banner"));
+
     console.error(e);
     const error = e instanceof BuildBuddyError ? e : BuildBuddyError.parse(e);
     if (options?.ignoreErrorCodes?.includes(error.code)) {

--- a/server/testutil/webtester/BUILD
+++ b/server/testutil/webtester/BUILD
@@ -13,6 +13,7 @@ go_library(
         "@com_github_stretchr_testify//require",
         "@com_github_tebeka_selenium//:selenium",
         "@com_github_tebeka_selenium//chrome",
+        "@com_github_tebeka_selenium//log",
         "@io_bazel_rules_webtesting//go/webtest:go_default_library",
     ],
 )

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tebeka/selenium"
 	"github.com/tebeka/selenium/chrome"
+
+	selenium_log "github.com/tebeka/selenium/log"
 )
 
 var (
@@ -88,6 +90,10 @@ func New(t *testing.T) *WebTester {
 		chrome.CapabilitiesKey: chrome.Capabilities{Args: chromeArgs},
 		"google:wslConfig":     map[string]any{"args": chromedriverArgs},
 	}
+	// Set the log level so that we can retrieve everything that was printed
+	// to the console.
+	capabilities.SetLogLevel(selenium_log.Browser, selenium_log.All)
+
 	driver, err := webtest.NewWebDriverSession(capabilities)
 	require.NoError(t, err, "failed to create webdriver session")
 	// Allow webdriver to wait a short period before giving up on finding an
@@ -102,6 +108,8 @@ func New(t *testing.T) *WebTester {
 	driver.SetImplicitWaitTimeout(*implicitWaitTimeout)
 	wt := &WebTester{t, driver}
 	t.Cleanup(func() {
+		assertErrorBannerNeverShown(wt)
+
 		err := wt.screenshot("END_OF_TEST")
 		// NOTE: `assert` here instead of `require` so that we still close down
 		// the webdriver if the screenshot fails.
@@ -115,6 +123,19 @@ func New(t *testing.T) *WebTester {
 		require.NoError(t, err)
 	})
 	return wt
+}
+
+// LogString returns the browser's console logs as a flat string.
+// This can be useful for checking that certain events did not occur, which
+// may otherwise be difficult to test using only the UI.
+func (wt *WebTester) LogString() string {
+	var builder strings.Builder
+	logs, err := wt.driver.Log(selenium_log.Browser)
+	require.NoError(wt.t, err)
+	for _, log := range logs {
+		builder.WriteString(fmt.Sprintf("[%s] %s\n", log.Level, log.Message))
+	}
+	return builder.String()
 }
 
 // Get navigates to the given URL.
@@ -375,6 +396,21 @@ func Login(wt *WebTester, target Target) {
 func Logout(wt *WebTester) {
 	ExpandSidebarOptions(wt)
 	wt.FindByDebugID("logout-button").Click()
+}
+
+// Fails the test if the error banner was shown at any point during the test.
+func assertErrorBannerNeverShown(wt *WebTester) {
+	logs := wt.LogString()
+	// TODO(bduffany): fix error banner displayed for these tests and remove
+	// this check.
+	if name := wt.t.Name(); name == "TestAuthenticatedInvocation_CacheEnabled" ||
+		name == "TestAuthenticatedInvocation_PersonalAPIKey_CacheEnabled" ||
+		name == "TestSAMLLogin" {
+		return
+	}
+	if strings.Contains(logs, "Displaying error banner") {
+		assert.Fail(wt.t, "Error banner was displayed during test", "%s", logs)
+	}
 }
 
 // ExpandSidebarOptions expands the sidebar options, exposing the section


### PR DESCRIPTION
We generally want to avoid showing error banners to the user. So, we should fail webdriver tests if the error banner is displayed at any point during the test.

This is a follow-up from https://github.com/buildbuddy-io/buildbuddy/pull/8117 - I verified that the new test logic fails with that commit reverted.

We show a "Logged out!" banner when logging out, so a few tests are opted out of this assertion currently. Removing that banner requires some minor auth changes so I split it into a separate PR.