### PR TITLE
Add debug logic for fault error

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/resources",
         "//server/util/alert",
         "//server/util/boundedstack",
+        "//server/util/flag",
         "//server/util/lockmap",
         "//server/util/log",
         "//server/util/lru",

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -2,7 +2,6 @@ package copy_on_write
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -22,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/boundedstack"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lockmap"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
@@ -56,8 +56,12 @@ const (
 	lruEvictionConcurrency = 2
 )
 
-var maxEagerFetchesPerSec = flag.Int("executor.snaploader_max_eager_fetches_per_sec", 1000, "Max number of chunks snaploader can eagerly fetch in the background per second.")
-var eagerFetchConcurrency = flag.Int("executor.snaploader_eager_fetch_concurrency", 32, "Max number of goroutines allowed to run concurrently when eagerly fetching chunks.")
+var (
+	maxEagerFetchesPerSec = flag.Int("executor.snaploader_max_eager_fetches_per_sec", 1000, "Max number of chunks snaploader can eagerly fetch in the background per second.")
+	eagerFetchConcurrency = flag.Int("executor.snaploader_eager_fetch_concurrency", 32, "Max number of goroutines allowed to run concurrently when eagerly fetching chunks.")
+
+	debugValidateMmapFileSize = flag.Bool("debug_validate_mmap_file_size", false, "Validate memory-mapped file size when mapping.", flag.Internal)
+)
 
 // Total number of mmapped bytes by file name. The map value is an int64 pointer
 // which should be atomically updated. This backs the mapped bytes gauge vector
@@ -1046,6 +1050,17 @@ func mmapDataFromPath(path string, sizeBytes int64, fileNameLabel string) ([]byt
 		return nil, err
 	}
 	defer f.Close()
+
+	if *debugValidateMmapFileSize {
+		stat, err := f.Stat()
+		if err != nil {
+			return nil, status.WrapErrorf(err, "mmap %q: stat", path)
+		}
+		if stat.Size() != sizeBytes {
+			return nil, status.InternalErrorf("mmap %q: file size %d != provided size %d", path, stat.Size(), sizeBytes)
+		}
+	}
+
 	return mmapDataFromFd(int(f.Fd()), int(sizeBytes), fileNameLabel)
 }
 


### PR DESCRIPTION
The `mmap` call will happily succeed if we provide a `sizeBytes` that is larger than the actual file size, but a subsequent out-of-bounds read will fail with an "unexpected fault address" error and crash the executor.

Add some temporary debug logic to check whether this is causing the fault errors that we see occasionally.