### PR TITLE
Don't show an error banner after successfully logging out

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -107,7 +107,7 @@ func (a *authenticator) Logout(w http.ResponseWriter, r *http.Request) error {
 	for _, authenticator := range a.http {
 		authenticator.Logout(w, r)
 	}
-	return status.UnauthenticatedError("Logged out!")
+	return nil
 }
 func (a *authenticator) Auth(w http.ResponseWriter, r *http.Request) error {
 	errors := make([]error, 0)

--- a/enterprise/server/githubauth/githubauth.go
+++ b/enterprise/server/githubauth/githubauth.go
@@ -196,11 +196,11 @@ func (a *githubAuthenticator) Logout(w http.ResponseWriter, r *http.Request) err
 	// their access token.
 	jwt := cookie.GetCookie(r, cookie.JWTCookie)
 	if jwt == "" {
-		return status.UnauthenticatedError("Logged out!")
+		return nil
 	}
 	sessionID := cookie.GetCookie(r, cookie.SessionIDCookie)
 	if sessionID == "" {
-		return status.UnauthenticatedError("Logged out!")
+		return nil
 	}
 
 	if authDB := a.env.GetAuthDB(); authDB != nil {
@@ -208,7 +208,7 @@ func (a *githubAuthenticator) Logout(w http.ResponseWriter, r *http.Request) err
 			log.Errorf("Error clearing user session on logout: %s", err)
 		}
 	}
-	return status.UnauthenticatedError("Logged out!")
+	return nil
 }
 
 func (a *githubAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {

--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -783,11 +783,11 @@ func (a *OpenIDAuthenticator) Logout(w http.ResponseWriter, r *http.Request) err
 	// their access token.
 	jwt := cookie.GetCookie(r, cookie.JWTCookie)
 	if jwt == "" {
-		return status.UnauthenticatedError("Logged out!")
+		return nil
 	}
 	sessionID := cookie.GetCookie(r, cookie.SessionIDCookie)
 	if sessionID == "" {
-		return status.UnauthenticatedError("Logged out!")
+		return nil
 	}
 
 	if authDB := a.env.GetAuthDB(); authDB != nil {
@@ -795,7 +795,7 @@ func (a *OpenIDAuthenticator) Logout(w http.ResponseWriter, r *http.Request) err
 			log.Errorf("Error clearing user session on logout: %s", err)
 		}
 	}
-	return status.UnauthenticatedError("Logged out!")
+	return nil
 }
 
 func (a *OpenIDAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error {

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -319,7 +319,7 @@ func (a *SAMLAuthenticator) Logout(w http.ResponseWriter, r *http.Request) error
 	if sp, err := a.serviceProviderFromRequest(r); err == nil {
 		sp.Session.DeleteSession(w, r)
 	}
-	return status.UnauthenticatedError("Logged out!")
+	return nil
 }
 
 func (a *SAMLAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -443,7 +443,7 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 	auth := env.GetAuthenticator()
 	mux.Handle("/login/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Login)))
 	mux.Handle("/auth/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Auth)))
-	mux.Handle("/logout/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Logout)))
+	mux.Handle("/logout/", interceptors.SetSecurityHeaders(interceptors.DefaultRedirect(interceptors.RedirectOnError(auth.Logout), "/")))
 
 	if err := github.Register(env); err != nil {
 		log.Fatalf("%v", err)

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -398,14 +398,6 @@ func Logout(wt *WebTester) {
 // Fails the test if the error banner was shown at any point during the test.
 func assertErrorBannerNeverShown(wt *WebTester) {
 	logs := wt.LogString()
-	// TODO(bduffany): fix error banner displayed for these tests and remove
-	// this check.
-	if name := wt.t.Name(); name == "TestAuthenticatedInvocation_CacheEnabled" ||
-		name == "TestAuthenticatedInvocation_PersonalAPIKey_CacheEnabled" ||
-		name == "TestSAMLBasicLogin" ||
-		name == "TestSAMLViewInvocation" {
-		return
-	}
 	if strings.Contains(logs, "Displaying error banner") {
 		assert.Fail(wt.t, "Error banner was displayed during test", "%s", logs)
 	}


### PR DESCRIPTION
When clicking "Logout" we show an error banner to the user. This is a tad confusing because we logged out successfully. It also means that we have to opt out some of our webdriver tests (which test the logout behavior) from a [new assertion](https://github.com/buildbuddy-io/buildbuddy/pull/8128) that makes sure we don't display error banners during tests.

This PR fixes the logout handler to stop returning an error, so that we will no longer show the error banner. Instead, we'll just redirect to the login page. I considered showing a "success" banner in this case but I don't think it's really necessary since it's pretty clear the user is logged out, as they're now seeing the login page.