### PR TITLE
Turn on app-controlled cgroup settings by default

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -51,7 +51,7 @@ var (
 	leaseGracePeriod             = flag.Duration("remote_execution.lease_grace_period", 10*time.Second, "How long to wait for the executor to renew the lease after the TTL duration has elapsed.")
 	leaseReconnectGracePeriod    = flag.Duration("remote_execution.lease_reconnect_grace_period", 1*time.Second, "How long to delay re-enqueued tasks in order to allow the previous lease holder to renew its lease (following a server shutdown).")
 	maxSchedulingDelay           = flag.Duration("remote_execution.max_scheduling_delay", 5*time.Second, "Max duration that actions can sit in a non-preferred executor's queue before they are executed.")
-	cgroupSettingsEnabled        = flag.Bool("remote_execution.cgroup_settings_enabled", false, "Apply cgroup2 settings to Linux executions.")
+	cgroupSettingsEnabled        = flag.Bool("remote_execution.cgroup_settings_enabled", true, "Apply cgroup2 settings to Linux executions.")
 )
 
 const (


### PR DESCRIPTION
It's enabled everywhere now, except locally and for on-prem apps. This shouldn't affect on-prem apps much, since only firecracker and oci isolation types support it, and those aren't commonly used on-prem as far as we know.