### PR TITLE
Add region and self-hosted columns to Executions table

### DIFF
--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2396,6 +2396,10 @@ message StoredExecution {
   string worker = 7;
   int64 stage = 8;
 
+  // Executor metadata
+  bool self_hosted = 58;
+  string region = 59;
+
   // IO Stats
   int64 file_download_count = 9;
   int64 file_download_size_bytes = 10;

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -204,6 +204,8 @@ func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *schem
 		CreatedAtUsec:                      in.GetCreatedAtUsec(),
 		UserID:                             in.GetUserId(),
 		Worker:                             in.GetWorker(),
+		SelfHosted:                         in.GetSelfHosted(),
+		Region:                             in.GetRegion(),
 		Stage:                              in.GetStage(),
 		FileDownloadCount:                  in.GetFileDownloadCount(),
 		FileDownloadSizeBytes:              in.GetFileDownloadSizeBytes(),

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -157,6 +157,10 @@ type Execution struct {
 	UserID             string
 	Worker             string
 
+	// Executor metadata
+	SelfHosted bool
+	Region     string `gorm:"type:LowCardinality(String)"`
+
 	Stage int64
 
 	// RequestMetadata
@@ -294,6 +298,8 @@ func (e *Execution) AdditionalFields() []string {
 		"EffectiveIsolationType",
 		"RequestedTimeoutUsec",
 		"EffectiveTimeoutUsec",
+		"Region",
+		"SelfHosted",
 	}
 }
 


### PR DESCRIPTION
Not populating them yet, just adding to the schema.