### PR TITLE
Make cpuleaser numa-aware

### DIFF
--- a/enterprise/server/util/cpuset/BUILD
+++ b/enterprise/server/util/cpuset/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//server/util/log",
         "//server/util/priority_queue",
         "@org_golang_x_exp//constraints",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_exp//slices",
     ] + select({
         "@io_bazel_rules_go//go/platform:darwin": [

--- a/enterprise/server/util/cpuset/cpuset_test.go
+++ b/enterprise/server/util/cpuset/cpuset_test.go
@@ -43,7 +43,7 @@ func TestEvenDistributionUnderLoad(t *testing.T) {
 	counts := make(map[int]int, 4)
 	for i := 0; i < 100; i++ {
 		task := uuid.New()
-		cpus, cancel := cs.Acquire(3000, task)
+		cpus, cancel := cs.Acquire(1000, task)
 		for _, cpu := range cpus {
 			counts[cpu] += 1
 		}
@@ -51,7 +51,7 @@ func TestEvenDistributionUnderLoad(t *testing.T) {
 		defer cancel()
 	}
 	for _, count := range counts {
-		assert.Equal(t, 75, count)
+		assert.Equal(t, 25, count)
 	}
 }
 
@@ -103,4 +103,61 @@ func TestCPUSetDisabledManualCPUSet(t *testing.T) {
 	cpus1, cancel1 := cs.Acquire(1100, task1)
 	defer cancel1()
 	assert.Equal(t, []int{0, 1, 3}, cpus1)
+}
+
+func TestNumaNodeFairness(t *testing.T) {
+	flags.Set(t, "executor.cpu_leaser.enable", true)
+	flags.Set(t, "executor.cpu_leaser.overhead", 0)
+	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:4-7")
+
+	var allCPUs []int
+
+	cs, err := cpuset.NewLeaser()
+	require.NoError(t, err)
+	task1 := uuid.New()
+	cpus1, cancel1 := cs.Acquire(4000, task1)
+	defer cancel1()
+	allCPUs = append(allCPUs, cpus1...)
+
+	task2 := uuid.New()
+	cpus2, cancel2 := cs.Acquire(4000, task2)
+	defer cancel2()
+	allCPUs = append(allCPUs, cpus2...)
+
+	assert.ElementsMatch(t, []int{0, 1, 2, 3, 4, 5, 6, 7}, allCPUs)
+}
+
+func TestNumaNodesAreNotSplit(t *testing.T) {
+	flags.Set(t, "executor.cpu_leaser.enable", true)
+	flags.Set(t, "executor.cpu_leaser.overhead", 0)
+	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:4-7")
+
+	cs, err := cpuset.NewLeaser()
+	require.NoError(t, err)
+	task1 := uuid.New()
+	cpus1, cancel1 := cs.Acquire(4000, task1)
+	defer cancel1()
+	assert.Equal(t, 4, len(cpus1))
+}
+
+func TestNonContiguousNumaNodes(t *testing.T) {
+	flags.Set(t, "executor.cpu_leaser.enable", true)
+	flags.Set(t, "executor.cpu_leaser.overhead", 0)
+	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
+	flags.Set(t, "executor.cpu_leaser.cpuset", "3:0-3,9:4-7")
+
+	cs, err := cpuset.NewLeaser()
+	require.NoError(t, err)
+
+	task1 := uuid.New()
+	cpus1, cancel1 := cs.Acquire(4000, task1)
+	defer cancel1()
+
+	task2 := uuid.New()
+	cpus2, cancel2 := cs.Acquire(4000, task2)
+	defer cancel2()
+
+	assert.NotElementsMatch(t, cpus1, cpus2)
 }

--- a/enterprise/server/util/cpuset/cpuset_test.go
+++ b/enterprise/server/util/cpuset/cpuset_test.go
@@ -109,7 +109,7 @@ func TestNumaNodeFairness(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", true)
 	flags.Set(t, "executor.cpu_leaser.overhead", 0)
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:4-7")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-1,1:4-7,0:2-3")
 
 	var allCPUs []int
 
@@ -126,6 +126,11 @@ func TestNumaNodeFairness(t *testing.T) {
 	allCPUs = append(allCPUs, cpus2...)
 
 	assert.ElementsMatch(t, []int{0, 1, 2, 3, 4, 5, 6, 7}, allCPUs)
+
+	task3 := uuid.New()
+	cpus3, cancel3 := cs.Acquire(8000, task3)
+	defer cancel3()
+	assert.Equal(t, len(cpus3), 4)
 }
 
 func TestNumaNodesAreNotSplit(t *testing.T) {

--- a/enterprise/server/util/cpuset/numcpu_darwin.go
+++ b/enterprise/server/util/cpuset/numcpu_darwin.go
@@ -6,7 +6,7 @@ import (
 	"github.com/elastic/gosigar"
 )
 
-func GetCPUs() []int {
+func GetCPUs() []cpuInfo {
 	cpuList := gosigar.CpuList{}
 	cpuList.Get()
 
@@ -14,5 +14,5 @@ func GetCPUs() []int {
 	for i := 0; i < len(cpuList.List); i++ {
 		nodes[i] = i
 	}
-	return nodes
+	return toCPUInfos(nodes, 0)
 }

--- a/enterprise/server/util/cpuset/numcpu_linux.go
+++ b/enterprise/server/util/cpuset/numcpu_linux.go
@@ -4,9 +4,10 @@ package cpuset
 
 import (
 	"github.com/prometheus/procfs"
+	"strconv"
 )
 
-func GetCPUs() []int {
+func GetCPUs() []cpuInfo {
 	fs, err := procfs.NewDefaultFS()
 	if err != nil {
 		return nil
@@ -15,9 +16,16 @@ func GetCPUs() []int {
 	if err != nil {
 		return nil
 	}
-	nodes := make([]int, len(cpuInfos))
-	for i, cpuInfo := range cpuInfos {
-		nodes[i] = int(cpuInfo.Processor)
+
+	nodes := make([]cpuInfo, len(cpuInfos))
+	for i, info := range cpuInfos {
+		c := cpuInfo{
+			processor: int(info.Processor),
+		}
+		if i, err := strconv.Atoi(info.PhysicalID); err == nil {
+			c.physicalID = int(i)
+		}
+		nodes[i] = c
 	}
 	return nodes
 }

--- a/enterprise/server/util/cpuset/numcpu_windows.go
+++ b/enterprise/server/util/cpuset/numcpu_windows.go
@@ -6,7 +6,7 @@ import (
 	"github.com/elastic/gosigar"
 )
 
-func GetCPUs() []int {
+func GetCPUs() []cpuInfo {
 	cpuList := gosigar.CpuList{}
 	cpuList.Get()
 
@@ -14,5 +14,5 @@ func GetCPUs() []int {
 	for i := 0; i < len(cpuList.List); i++ {
 		nodes[i] = i
 	}
-	return nodes
+	return toCPUInfos(nodes, 0)
 }


### PR DESCRIPTION
Make the CPU Leaser numa aware (on linux).

The leaser will prefer to assign a set of processors from the least loaded numa node. It will never return processors from multiple numa nodes in the same lease -- if more processors are requested than are available on a single node, it will return all the processors from the least loaded node.

Obligatory https://www.youtube.com/watch?v=Cqd1Gvq-RBY