### PR TITLE
Set action mnemonic for workflows and remote bazel

### DIFF
--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -377,7 +377,10 @@ func (r *runnerService) Run(ctx context.Context, req *rnpb.RunRequest) (*rnpb.Ru
 	}
 	log.Debugf("Uploaded runner action to cache. Digest: %s/%d", actionDigest.GetHash(), actionDigest.GetSizeBytes())
 
-	execCtx, err := bazel_request.WithRequestMetadata(ctx, &repb.RequestMetadata{ToolInvocationId: invocationID})
+	execCtx, err := bazel_request.WithRequestMetadata(ctx, &repb.RequestMetadata{
+		ToolInvocationId: invocationID,
+		ActionMnemonic:   "RemoteBazelRun",
+	})
 	if err != nil {
 		return nil, status.WrapError(err, "add request metadata to ctx")
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1519,7 +1519,10 @@ func (ws *workflowService) attemptExecuteWorkflowAction(ctx context.Context, key
 		return "", err
 	}
 
-	execCtx, err := bazel_request.WithRequestMetadata(ctx, &repb.RequestMetadata{ToolInvocationId: invocationID})
+	execCtx, err := bazel_request.WithRequestMetadata(ctx, &repb.RequestMetadata{
+		ToolInvocationId: invocationID,
+		ActionMnemonic:   "BuildBuddyWorkflowRun",
+	})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This will allow us to more easily distinguish between workflows, remote bazel, and "normal" bazel actions when looking at executions in clickhouse.