### PR TITLE
[raft] Implement a raft command to fetch multiple range descriptors at once

### DIFF
--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -95,6 +95,10 @@ func (bb *BatchBuilder) Add(m proto.Message) *BatchBuilder {
 		req.Value = &rfpb.RequestUnion_DeleteSessions{
 			DeleteSessions: value,
 		}
+	case *rfpb.FetchRangesRequest:
+		req.Value = &rfpb.RequestUnion_FetchRanges{
+			FetchRanges: value,
+		}
 	default:
 		bb.setErr(status.FailedPreconditionErrorf("BatchBuilder.Add handling for %+v not implemented.", m))
 		return bb
@@ -328,6 +332,15 @@ func (br *BatchResponse) DeleteSessionsResponse(n int) (*rfpb.DeleteSessionsResp
 	}
 	u := br.cmd.GetUnion()[n]
 	return u.GetDeleteSessions(), br.unionError(u)
+}
+
+func (br *BatchResponse) FetchRangesResponse(n int) (*rfpb.FetchRangesResponse, error) {
+	br.checkIndex(n)
+	if br.err != nil {
+		return nil, br.err
+	}
+	u := br.cmd.GetUnion()[n]
+	return u.GetFetchRanges(), br.unionError(u)
 }
 
 type txnStatement struct {

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -207,6 +207,14 @@ message DeleteSessionsRequest {
 
 message DeleteSessionsResponse {}
 
+message FetchRangesRequest {
+	repeated uint64 range_ids = 1;
+}
+
+message FetchRangesResponse {
+	repeated RangeDescriptor ranges = 1;
+}
+
 // Raft CMD API, used to encode raft commands that are replicated via raft and
 // written to a log. Everything written via SyncPropose must be a RequestUnion
 // wrapped in a BatchCmdRequest..
@@ -220,6 +228,7 @@ message RequestUnion {
     CASRequest cas = 5;
     FindSplitPointRequest find_split_point = 14;
     DeleteSessionsRequest delete_sessions = 16;
+	FetchRangesRequest fetch_ranges = 17;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetRequest get = 7;
@@ -249,6 +258,7 @@ message ResponseUnion {
     CASResponse cas = 6;
     FindSplitPointResponse find_split_point = 15;
     DeleteSessionsResponse delete_sessions = 17;
+	FetchRangesResponse fetch_ranges = 18;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetResponse get = 8;

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -208,11 +208,11 @@ message DeleteSessionsRequest {
 message DeleteSessionsResponse {}
 
 message FetchRangesRequest {
-	repeated uint64 range_ids = 1;
+  repeated uint64 range_ids = 1;
 }
 
 message FetchRangesResponse {
-	repeated RangeDescriptor ranges = 1;
+  repeated RangeDescriptor ranges = 1;
 }
 
 // Raft CMD API, used to encode raft commands that are replicated via raft and
@@ -228,7 +228,7 @@ message RequestUnion {
     CASRequest cas = 5;
     FindSplitPointRequest find_split_point = 14;
     DeleteSessionsRequest delete_sessions = 16;
-	FetchRangesRequest fetch_ranges = 17;
+    FetchRangesRequest fetch_ranges = 17;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetRequest get = 7;
@@ -258,7 +258,7 @@ message ResponseUnion {
     CASResponse cas = 6;
     FindSplitPointResponse find_split_point = 15;
     DeleteSessionsResponse delete_sessions = 17;
-	FetchRangesResponse fetch_ranges = 18;
+    FetchRangesResponse fetch_ranges = 18;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetResponse get = 8;


### PR DESCRIPTION
In sender, use fetchRanges when we fetch active replicas and also fetch
multiple range descriptors at once. The latter is needed in zombie
cleanup in following PRs.

Currently, we use scan to fetch multiple ranges. However, scan returns all range
replicas and the client filter them out. Assuming we have M machines and
N ranges, the client only needs 3N/M ranges on average. So filtering out at the
replica level can save the data transferred on the network.
