### PR TITLE
Fix error banner opt-out check

### DIFF
--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -410,7 +410,8 @@ func assertErrorBannerNeverShown(wt *WebTester) {
 	// this check.
 	if name := wt.t.Name(); name == "TestAuthenticatedInvocation_CacheEnabled" ||
 		name == "TestAuthenticatedInvocation_PersonalAPIKey_CacheEnabled" ||
-		name == "TestSAMLLogin" {
+		name == "TestSAMLBasicLogin" ||
+		name == "TestSAMLViewInvocation" {
 		return
 	}
 	if strings.Contains(logs, "Displaying error banner") {


### PR DESCRIPTION
This opt-out check is going away in https://github.com/buildbuddy-io/buildbuddy/pull/8140 but there are a few lingering issues with that PR. Update the test names for a short-term fix.