### PR TITLE
Use guest VM stats for peak memory reporting

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2742,6 +2742,10 @@ func combineHostAndGuestStats(host, guest *repb.UsageStats) *repb.UsageStats {
 	// the host without introspection into the ext4 metadata blocks - just
 	// continue to get these from the guest for now.
 	stats.PeakFileSystemUsage = guest.GetPeakFileSystemUsage()
+	// Host memory usage stats might be confusing to the user, because the
+	// firecracker process might hold some extra memory that isn't visible to
+	// the guest. Use guest stats for memory usage too, for now.
+	stats.PeakMemoryBytes = guest.GetPeakMemoryBytes()
 	return stats
 }
 


### PR DESCRIPTION
Since switching to the host cgroup for memory usage reporting, we've gotten a few user reports where the UI shows the VM's memory usage exceeding the available memory. Switch back to guest stats for now.