### PR TITLE
Populate self-hosted and region fields in ClickHouse

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -393,10 +393,16 @@ func (s *ExecutionServer) recordExecution(
 		executionProto.PredictedMemoryBytes = schedulingMeta.GetPredictedTaskSize().GetEstimatedMemoryBytes()
 		executionProto.PredictedMilliCpu = schedulingMeta.GetPredictedTaskSize().GetEstimatedMilliCpu()
 		executionProto.PredictedFreeDiskBytes = schedulingMeta.GetPredictedTaskSize().GetEstimatedFreeDiskBytes()
+		executionProto.SelfHosted = schedulingMeta.GetExecutorGroupId() != s.env.GetSchedulerService().GetSharedExecutorPoolGroupID()
 
 		request := auxMeta.GetExecuteRequest()
 		executionProto.SkipCacheLookup = request.GetSkipCacheLookup()
 		executionProto.ExecutionPriority = request.GetExecutionPolicy().GetPriority()
+
+		regionHeaderValues := metadata.ValueFromIncomingContext(ctx, "x-buildbuddy-executor-region")
+		if len(regionHeaderValues) > 0 {
+			executionProto.Region = regionHeaderValues[len(regionHeaderValues)-1]
+		}
 
 		inv, err := s.env.GetExecutionCollector().GetInvocation(ctx, link.GetInvocationId())
 		if err != nil {

--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//server/util/tracing",
         "//server/util/usageutil",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_x_text//language",
         "@org_golang_x_text//message",
     ],

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1058,6 +1058,10 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 	return s, nil
 }
 
+func (s *SchedulerServer) GetSharedExecutorPoolGroupID() string {
+	return *sharedExecutorPoolGroupID
+}
+
 func (s *SchedulerServer) GetPoolInfo(ctx context.Context, os, requestedPool, workflowID string, poolType interfaces.PoolType) (*interfaces.PoolInfo, error) {
 	// Note: The defaultPoolName flag only applies to the shared executor pool.
 	// The pool name for self-hosted pools is always determined directly from

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -854,6 +854,7 @@ type SchedulerService interface {
 	ReEnqueueTask(ctx context.Context, req *scpb.ReEnqueueTaskRequest) (*scpb.ReEnqueueTaskResponse, error)
 	GetExecutionNodes(ctx context.Context, req *scpb.GetExecutionNodesRequest) (*scpb.GetExecutionNodesResponse, error)
 	GetPoolInfo(ctx context.Context, os, requestedPool, workflowID string, poolType PoolType) (*PoolInfo, error)
+	GetSharedExecutorPoolGroupID() string
 }
 
 // PoolInfo holds high level metadata for an executor pool.


### PR DESCRIPTION
Tested locally with self-hosted executors and shared executors, and also checked the region column.