### PR TITLE
Get last observed memory value from guest too

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2745,6 +2745,7 @@ func combineHostAndGuestStats(host, guest *repb.UsageStats) *repb.UsageStats {
 	// Host memory usage stats might be confusing to the user, because the
 	// firecracker process might hold some extra memory that isn't visible to
 	// the guest. Use guest stats for memory usage too, for now.
+	stats.MemoryBytes = guest.GetMemoryBytes()
 	stats.PeakMemoryBytes = guest.GetPeakMemoryBytes()
 	return stats
 }


### PR DESCRIPTION
Missed this in https://github.com/buildbuddy-io/buildbuddy/pull/8175