### PR TITLE
Remove Sync call in vmexec_client

### DIFF
--- a/enterprise/server/remote_execution/vmexec_client/BUILD
+++ b/enterprise/server/remote_execution/vmexec_client/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//proto:vmexec_go_proto",
         "//server/interfaces",
-        "//server/util/background",
         "//server/util/log",
         "//server/util/rpcutil",
         "//server/util/status",


### PR DESCRIPTION
This code is unnecessary since the filesystem should effectively be synced when we unmount the workspace, just before copying output files back to the host.