### PR TITLE
[RB] Handle retries in the CLI rather than server-side

### DIFF
--- a/docs/remote-bazel-introduction.md
+++ b/docs/remote-bazel-introduction.md
@@ -273,7 +273,7 @@ curl -d '{
 https://app.buildbuddy.io/api/v1/Run
 ```
 
-### Non-idempotency
+### Retry behavior
 
 By default, Remote Bazel runs are assumed to be idempotent and are automatically
 retried on transient errors. If this is not the case and it is important that your

--- a/docs/remote-bazel-introduction.md
+++ b/docs/remote-bazel-introduction.md
@@ -217,6 +217,9 @@ The following configuration options are supported:
   will mirror the local state (including any non-committed local diffs).
 - `--script`: If set, the bash code to run on the remote runner instead of a Bazel command.
   - See `Running bash scripts below` for more details.
+- `--disable_retry`: By default, remote runs are automatically retried on transient
+  errors. If your remote command is not idempotent (such as if you're running
+  a deploy command), you should set this to true to disable retries.
 
 In order to run the CLI with debug logs enabled, you can add `--verbose=1` between
 `bb` and `remote`. Note that this is a different syntax from the rest of the
@@ -269,6 +272,12 @@ curl -d '{
 -H 'Content-Type: application/json' \
 https://app.buildbuddy.io/api/v1/Run
 ```
+
+### Non-idempotency
+
+By default, Remote Bazel runs are assumed to be idempotent and are automatically
+retried on transient errors. If this is not the case and it is important that your
+commands run at most once, you should disable automatic retries with `--disable_retry`.
 
 ### Private GitHub repos
 


### PR DESCRIPTION
Extracted CLI code from https://github.com/buildbuddy-io/buildbuddy/pull/8172

This PR disables automatic retries when using the remote bazel CLI. The CLI then implements retry behavior itself so it can detect when a retry is happening

This fixes a bug where if the remote run fails due to a transient error, the CLI will report a failure. However the scheduler may retry the run in the background and it may eventually succeed. When users go to the invocation link, they'll see that it succeeded despite expecting a failure

Slack thread (Issue 2): https://buildbuddy-corp.slack.com/archives/C07GMM2VBLY/p1734595804049229?thread_ts=1734595606.837269&cid=C07GMM2VBLY

Should be merged after https://github.com/buildbuddy-io/buildbuddy/pull/8172 is rolled out