### PR TITLE
Clean up runfiles access in checkstyle

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 common --noenable_bzlmod
 common --lockfile_mode=update
+common --nolegacy_external_runfiles
 
 common --enable_platform_specific_config=true
 

--- a/tools/checkstyle/BUILD
+++ b/tools/checkstyle/BUILD
@@ -6,6 +6,6 @@ sh_binary(
         "//:gofmt",
         "//cli/cmd/bb",
         "//tools/clang-format",
-        "@npm//prettier/bin:prettier",
+        "//tools/prettier",
     ],
 )

--- a/tools/checkstyle/checkstyle.sh
+++ b/tools/checkstyle/checkstyle.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
-GO_PATH="$(readlink ./go)"
-GOFMT_PATH="$(readlink ./gofmt)"
-BB_PATH="$(readlink ./cli/cmd/bb/bb_/bb)"
-PRETTIER_PATH="$(readlink ./external/npm/prettier/bin/prettier.sh)"
-CLANG_FORMAT_PATH="$(readlink ./tools/clang-format/clang-format)"
+export RUNFILES_DIR=$(cd ../ && pwd)
+
+# Use absolute paths as we cd to the WORKSPACE directory below.
+GO_PATH="$(pwd)/go"
+GOFMT_PATH="$(pwd)/gofmt"
+BB_PATH="$(pwd)/cli/cmd/bb/bb_/bb"
+PRETTIER_PATH="$(pwd)/tools/prettier/prettier.sh"
+CLANG_FORMAT_PATH="$(pwd)/tools/clang-format/clang-format"
 
 # Make sure 'go' is in $PATH (gazelle depends on this).
 # TODO: set up the env properly to point to the bazel-provisioned SDK root
 export PATH="$PATH:$PWD"
-
-export RUNFILES_DIR=$(cd ../ && pwd)
-export RUNFILES="${RUNFILES_DIR}_manifest"
 
 cd "$BUILD_WORKSPACE_DIRECTORY"
 
@@ -58,8 +58,7 @@ run ProtoFormat \
   tools/clang-format/clang-format.sh --dry-run
 
 run PrettierFormat \
-  env PRETTIER_PATH="$PRETTIER_PATH" \
-  tools/prettier/prettier.sh --log-level=warn --check
+  "$PRETTIER_PATH" --log-level=warn --check
 
 wait
 

--- a/tools/prettier/BUILD
+++ b/tools/prettier/BUILD
@@ -1,0 +1,8 @@
+sh_binary(
+    name = "prettier",
+    srcs = ["prettier.sh"],
+    data = [
+        "@npm//prettier/bin:prettier",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -65,14 +65,7 @@ fi
 if [[ "$PRETTIER_PATH" ]]; then
   PRETTIER_COMMAND=("$PRETTIER_PATH")
 else
-  tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
-  bazel run @npm//prettier/bin:prettier --script_path="$tmp/run.sh" &>"$tmp/build.log" || {
-    cat "$tmp/build.log" >&2
-    exit 1
-  }
-  chmod +x "$tmp/run.sh"
-  PRETTIER_COMMAND=("$tmp/run.sh" --bazel_node_working_dir="$PWD")
+  PRETTIER_COMMAND=("../npm/prettier/bin/prettier.sh" --bazel_node_working_dir="$PWD")
 fi
 
 "${PRETTIER_COMMAND[@]}" "${paths[@]}" "$@"


### PR DESCRIPTION
It's not necessary (and in many cases less hermetic due to binaries looking for data in the output base, not their runfiles directory) to `readlink` runfiles paths, they just need to be made absolute before cd'ing.

Also have the `prettier` wrapper look up `prettier` from runfiles without a nested Bazel invocation and fix its runfiles path to work with `--nolegacy_external_runfiles`.