### PR TITLE
integration/remote_execution_test: increase compute unit

### DIFF
--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -13,6 +13,7 @@ go_test(
         "EstimatedComputeUnits": "5",
     },
     shard_count = 11,
+    tags = ["cpu:5"],
     deps = [
         "//enterprise/server/build_event_publisher",
         "//enterprise/server/remote_execution/commandutil",

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -9,7 +9,9 @@ go_test(
     # make these tests run faster
     timeout = "long",
     srcs = ["remote_execution_test.go"],
-    args = ["--test.v"],
+    exec_properties = {
+        "EstimatedComputeUnits": "5",
+    },
     shard_count = 11,
     deps = [
         "//enterprise/server/build_event_publisher",


### PR DESCRIPTION
We have a few tests that follow this pattern:
```
for i := 0; i < 10; i++ {
    ...
    cmds = append(cmds, cmd)
}
...
for _, cmd := range cmds {
    cmd := cmd
    eg.Go(func() error {
        ...
    }
}
eg.Wait()
```

so let's make sure that we have at least 5 CPU to run these commands in
parallel.

Disabled verbose logging as we start to get warnings like this from Bazel
```
stdout (/.../bazel-out/_tmp/actions/stdout-8) 9609824 exceeds maximum size of --experimental_ui_max_stdouterr_bytes=1048576 bytes; skipping
```
