### PR TITLE
Add a few convenience features to get_executions

### DIFF
--- a/enterprise/tools/get_executions/BUILD
+++ b/enterprise/tools/get_executions/BUILD
@@ -7,7 +7,9 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//proto:buildbuddy_service_go_proto",
+        "//proto:context_go_proto",
         "//proto:execution_stats_go_proto",
+        "//proto:scheduler_go_proto",
         "//server/util/flag",
         "//server/util/grpc_client",
         "//server/util/log",


### PR DESCRIPTION
* Allow replacing the `worker` field with the executor hostnames instead of host IDs. This is done by looking up the shared executor listing using the GetExecutionNodes API.
* Allow inlining the execute response (just adds a flag that sets `inline_execute_response=true` in the request).