### PR TITLE
[raft] don't do extra work on removed zombies

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1500,6 +1500,7 @@ func newReplicaJanitor(clock clockwork.Clock, store *Store) *replicaJanitor {
 		tasks:           make(chan zombieCleanupTask, 500),
 		rangeIDsInQueue: make(map[uint64]bool),
 		lastDetectedAt:  make(map[uint64]time.Time),
+		removedZombies:  make(map[string]bool),
 		store:           store,
 	}
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2352,11 +2352,13 @@ var (
 		Help:      "The total number of pending zombie cleanup tasks",
 	})
 
-	RaftZombieCleanupErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+	RaftZombieCleanup = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "raft",
-		Name:      "zombie_cleanup_errors",
-		Help:      "The total number of zombie cleanup errors",
+		Name:      "zombie_cleanup",
+		Help:      "The total number of zombie cleanups",
+	}, []string{
+		StatusHumanReadableLabel,
 	})
 
 	APIKeyLookupCount = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
When we detect raft zombies, we queries node host with log info which contains
all replicas that have been started in the history. This means that zombies that
have been successfully deleted in the past will always be in the list. 

This PR creates a map to track removed zombies; so that we don't look up for
range descriptors of removed zombies.

Also track the number of zombies deleted successfully. 
