### PR TITLE
Reland checkstyle/buildfix runfiles changes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 common --noenable_bzlmod
 common --lockfile_mode=update
+common --nolegacy_external_runfiles
 
 common --enable_platform_specific_config=true
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -488,6 +488,7 @@ use_repo(
     "org_kernel_git_linux_kernel-vmlinux",
     "org_kernel_git_linux_kernel-vmlinux-arm64",
     "org_llvm_llvm_clang-format_linux-x86_64",
+    "org_llvm_llvm_clang-format_macos-x86_64",
 )
 
 bazel_dep(name = "rules_oci", version = "2.0.0")

--- a/deps.bzl
+++ b/deps.bzl
@@ -6557,7 +6557,7 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         name = "org_llvm_llvm_clang-format_macos-x86_64",
         executable = True,
         integrity = "sha256-lxFvZNl/socLSqKXWLuo+w/n87HtikvBL6qSfs/ewZY=",
-        urls = [""https://storage.googleapis.com/buildbuddy-tools/binaries/clang-format/clang-format-15_darwin-x86_64""],
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/clang-format/clang-format-15_darwin-x86_64"],
     )
 
     http_file(

--- a/deps.bzl
+++ b/deps.bzl
@@ -6546,12 +6546,18 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         executable = True,
     )
 
-    # TODO: mac build
     http_file(
         name = "org_llvm_llvm_clang-format_linux-x86_64",
         executable = True,
-        sha256 = "85b1c2591274422234955e906aee39e6f793a88a74f3efc49a1852a0646ce08f",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/clang-format/clang-format-14_linux-x86_64"],
+        integrity = "sha256-BQxgAlbiJeq+lgjSj0kv6Gc8bn9d6sWcbalzIjx2TWw=",
+        urls = ["https://github.com/angular/clang-format/raw/140dcf58048423922f88592176b48d8f2a2fa3f0/bin/linux_x64/clang-format"],
+    )
+
+    http_file(
+        name = "org_llvm_llvm_clang-format_macos-x86_64",
+        executable = True,
+        integrity = "sha256-lxFvZNl/socLSqKXWLuo+w/n87HtikvBL6qSfs/ewZY=",
+        urls = ["https://github.com/angular/clang-format/raw/140dcf58048423922f88592176b48d8f2a2fa3f0/bin/darwin_x64/clang-format"],
     )
 
     http_file(

--- a/deps.bzl
+++ b/deps.bzl
@@ -6550,14 +6550,14 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         name = "org_llvm_llvm_clang-format_linux-x86_64",
         executable = True,
         integrity = "sha256-BQxgAlbiJeq+lgjSj0kv6Gc8bn9d6sWcbalzIjx2TWw=",
-        urls = ["https://github.com/angular/clang-format/raw/140dcf58048423922f88592176b48d8f2a2fa3f0/bin/linux_x64/clang-format"],
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/clang-format/clang-format-15_linux-x86_64"],
     )
 
     http_file(
         name = "org_llvm_llvm_clang-format_macos-x86_64",
         executable = True,
         integrity = "sha256-lxFvZNl/socLSqKXWLuo+w/n87HtikvBL6qSfs/ewZY=",
-        urls = ["https://github.com/angular/clang-format/raw/140dcf58048423922f88592176b48d8f2a2fa3f0/bin/darwin_x64/clang-format"],
+        urls = [""https://storage.googleapis.com/buildbuddy-tools/binaries/clang-format/clang-format-15_darwin-x86_64""],
     )
 
     http_file(

--- a/tools/checkstyle/BUILD
+++ b/tools/checkstyle/BUILD
@@ -6,6 +6,6 @@ sh_binary(
         "//:gofmt",
         "//cli/cmd/bb",
         "//tools/clang-format",
-        "@npm//prettier/bin:prettier",
+        "//tools/prettier",
     ],
 )

--- a/tools/checkstyle/checkstyle.sh
+++ b/tools/checkstyle/checkstyle.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
-GO_PATH="$(readlink ./go)"
-GOFMT_PATH="$(readlink ./gofmt)"
-BB_PATH="$(readlink ./cli/cmd/bb/bb_/bb)"
-PRETTIER_PATH="$(readlink ./external/npm/prettier/bin/prettier.sh)"
-CLANG_FORMAT_PATH="$(readlink ./tools/clang-format/clang-format)"
+export RUNFILES_DIR=$(cd ../ && pwd)
+
+# Use absolute paths as we cd to the WORKSPACE directory below.
+GO_PATH="$(pwd)/go"
+GOFMT_PATH="$(pwd)/gofmt"
+BB_PATH="$(pwd)/cli/cmd/bb/bb_/bb"
+PRETTIER_PATH="$(pwd)/tools/prettier/prettier.sh"
+CLANG_FORMAT_PATH="$(pwd)/tools/clang-format/clang-format"
 
 # Make sure 'go' is in $PATH (gazelle depends on this).
 # TODO: set up the env properly to point to the bazel-provisioned SDK root
 export PATH="$PATH:$PWD"
-
-export RUNFILES_DIR=$(cd ../ && pwd)
-export RUNFILES="${RUNFILES_DIR}_manifest"
 
 cd "$BUILD_WORKSPACE_DIRECTORY"
 
@@ -58,8 +58,7 @@ run ProtoFormat \
   tools/clang-format/clang-format.sh --dry-run
 
 run PrettierFormat \
-  env PRETTIER_PATH="$PRETTIER_PATH" \
-  tools/prettier/prettier.sh --log-level=warn --check
+  "$PRETTIER_PATH" --log-level=warn --check
 
 wait
 

--- a/tools/clang-format/BUILD
+++ b/tools/clang-format/BUILD
@@ -1,9 +1,8 @@
 genrule(
     name = "clang-format_crossplatform",
     srcs = select({
-        # TODO: mac build
-        # "@bazel_tools//src/conditions:darwin": ["@org_llvm_llvm_clang-format_darwin-arm64//file:downloaded"],
-        "//conditions:default": ["@org_llvm_llvm_clang-format_linux-x86_64//file:downloaded"],
+        "@platforms//os:macos": ["@org_llvm_llvm_clang-format_macos-x86_64//file:downloaded"],
+        "@platforms//os:linux": ["@org_llvm_llvm_clang-format_linux-x86_64//file:downloaded"],
     }),
     outs = ["clang-format"],
     cmd_bash = "cp $(SRCS) $@",

--- a/tools/prettier/BUILD
+++ b/tools/prettier/BUILD
@@ -1,0 +1,8 @@
+sh_binary(
+    name = "prettier",
+    srcs = ["prettier.sh"],
+    data = [
+        "@npm//prettier/bin:prettier",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # Runs prettier on all files that differ from the main branch.
 
-set -e
+set -euo pipefail
+
+if [[ -z "${RUNFILES_DIR+x}" ]]; then
+  export RUNFILES_DIR="$PWD"/..
+fi
+
+if [[ -n "${BUILD_WORKSPACE_DIRECTORY}" ]]; then
+  cd "$BUILD_WORKSPACE_DIRECTORY"
+fi
 
 : "${PRETTIER_PATH:=}"
 : "${DIFF_BASE:=}"
@@ -57,15 +65,14 @@ while read -r path; do
   paths+=("$path")
 done < <(paths_to_format)
 
-if [[ -z "${paths[*]}" ]]; then
+if [[ -z "${paths[*]+}" ]]; then
   exit 0
 fi
 
-# Run bazel quietly; see: https://github.com/bazelbuild/bazel/issues/4867#issuecomment-796208829
 if [[ "$PRETTIER_PATH" ]]; then
   PRETTIER_COMMAND=("$PRETTIER_PATH")
 else
-  PRETTIER_COMMAND=("../npm/prettier/bin/prettier.sh" --bazel_node_working_dir="$PWD")
+  PRETTIER_COMMAND=("${RUNFILES_DIR}/npm/prettier/bin/prettier.sh" --bazel_node_working_dir="$PWD")
 fi
 
 "${PRETTIER_COMMAND[@]}" "${paths[@]}" "$@"

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -65,14 +65,7 @@ fi
 if [[ "$PRETTIER_PATH" ]]; then
   PRETTIER_COMMAND=("$PRETTIER_PATH")
 else
-  tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
-  bazel run @npm//prettier/bin:prettier --script_path="$tmp/run.sh" &>"$tmp/build.log" || {
-    cat "$tmp/build.log" >&2
-    exit 1
-  }
-  chmod +x "$tmp/run.sh"
-  PRETTIER_COMMAND=("$tmp/run.sh" --bazel_node_working_dir="$PWD")
+  PRETTIER_COMMAND=("../npm/prettier/bin/prettier.sh" --bazel_node_working_dir="$PWD")
 fi
 
 "${PRETTIER_COMMAND[@]}" "${paths[@]}" "$@"


### PR DESCRIPTION
Reverts the revert https://github.com/buildbuddy-io/buildbuddy/commit/d9d19f0c4bdc195611bf02638b4723abdf159246 with the following additional fixes:
* Use `bazel run` for everything in `buildfix.sh`.
* Always use a hermetic `clang-format` 15 binary (reusing the binaries from the Angular project).
* Fix runfiles handling in prettier wrapper, which is called from `//tools/checkstyle` after `cd`ing into a different directory.