### PR TITLE
Fix '0' rendered in action page

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -796,7 +796,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
         ...actionResult.outputSymlinks,
       ].map((output) => output.path);
       const missingOutputs = command.outputPaths.filter((expected) => !actualOutputs.includes(expected));
-      return missingOutputs.length && renderOutline(renderMissingOutputPaths(missingOutputs));
+      return !!missingOutputs.length && renderOutline(renderMissingOutputPaths(missingOutputs));
     }
 
     const actualFiles = [


### PR DESCRIPTION
Removes this "0" rendered between output symlinks and stderr:

![image](https://github.com/user-attachments/assets/b2206029-5e8f-43ec-ae30-70dad371d0a7)
