### PR TITLE
Fix spacing in exec log card header

### DIFF
--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -220,7 +220,7 @@ export default class SpawnCardComponent extends React.Component<Props, State> {
             <div className="invocation-content-header">
               <div className="title">
                 Remotely executed actions (
-                {!!incompleteCount && <span>{format.formatWithCommas(incompleteCount)} in progress, </span>}
+                {!!incompleteCount && `${format.formatWithCommas(incompleteCount)} in progress, `}
                 {format.formatWithCommas(completedCount)} completed)
               </div>
 


### PR DESCRIPTION
The span made this render as (note the extra space):
```
Remotely executed actions ( 16 in progress, 2,411 completed)
```