### PR TITLE
ui: Use existing exec logs for "compare" Bazel button

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -86,6 +86,7 @@ ts_library(
         "//app/util:errors",
         "//app/util:proto",
         "//app/util:remote_runner",
+        "//proto:build_event_stream_ts_proto",
         "//proto:cache_ts_proto",
         "//proto:field_mask_ts_proto",
         "//proto:invocation_status_ts_proto",


### PR DESCRIPTION
This avoids unnecessary Bazel invocations if the builds had the execution log uploaded.