### PR TITLE
Fix `buildfix.sh`

### DIFF
--- a/buildfix.sh
+++ b/buildfix.sh
@@ -41,7 +41,7 @@ done < <(git ls-files '*.go')
 bazel run "${BAZEL_QUIET_FLAGS[@]}" //:gofmt -- -w "${GO_SRCS[@]}"
 
 echo "Building and running goimports..."
-bazel run "${BAZEL_QUIET_FLAGS[@]}" //:goimports.sh -- -w "${GO_SRCS[@]}"
+bazel run "${BAZEL_QUIET_FLAGS[@]}" //tools/goimports -- -w "${GO_SRCS[@]}"
 
 echo "Formatting .proto files..."
 protos=()


### PR DESCRIPTION
After #8198, `buildfix.sh` pointed to a non-existent `//:goimports.sh` target. Point it to the right one!