### PR TITLE
explain: Print invocation URLs if available

### DIFF
--- a/cli/explain/BUILD
+++ b/cli/explain/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//cli/arg",
         "//cli/explain/compactgraph",
         "//cli/log",
+        "//cli/storage",
         "//proto:spawn_diff_go_proto",
         "//proto:spawn_go_proto",
         "@com_github_google_go_cmp//cmp",

--- a/cli/explain/compactgraph/compactgraph_test.go
+++ b/cli/explain/compactgraph/compactgraph_test.go
@@ -658,7 +658,11 @@ func diffLogsAllowingError(t *testing.T, name, bazelVersion string) ([]*spawn_di
 	require.NoError(t, err)
 	newLog, err := compactgraph.ReadCompactLog(newLogFile)
 	require.NoError(t, err)
-	return compactgraph.Diff(oldLog, newLog)
+	result, err := compactgraph.Diff(oldLog, newLog)
+	if err != nil {
+		return nil, err
+	}
+	return result.SpawnDiffs, nil
 }
 
 func diffLogs(t *testing.T, name, bazelVersion string) []*spawn_diff.SpawnDiff {

--- a/cli/storage/storage.go
+++ b/cli/storage/storage.go
@@ -109,7 +109,8 @@ func WriteRepoConfig(key, value string) error {
 }
 
 const (
-	InvocationIDFlagName = "invocation_id"
+	InvocationIDFlagName  = "invocation_id"
+	BesResultsUrlFlagName = "bes_results_url"
 
 	// Use GetLastBackend instead of directly reading this flag.
 	besBackendFlagName = "bes_backend"
@@ -119,6 +120,7 @@ func SaveFlags(args []string) []string {
 	command := arg.GetCommand(args)
 	if command == "build" || command == "test" || command == "run" || command == "query" || command == "cquery" {
 		saveFlag(args, besBackendFlagName, "")
+		saveFlag(args, BesResultsUrlFlagName, "")
 		args = saveFlag(args, InvocationIDFlagName, uuid.New())
 	}
 	return args

--- a/proto/spawn.proto
+++ b/proto/spawn.proto
@@ -232,6 +232,9 @@ message ExecLogEntry {
 
     // Whether --experimental_sibling_repository_layout is enabled.
     bool sibling_repository_layout = 3;
+
+    // The ID of the invocation.
+    string id = 4;
   }
 
   // An input or output file.

--- a/proto/spawn_diff.proto
+++ b/proto/spawn_diff.proto
@@ -4,6 +4,12 @@ package spawn_diff;
 
 import "proto/spawn.proto";
 
+message DiffResult {
+  repeated SpawnDiff spawn_diffs = 1;
+  string old_invocation_id = 2;
+  string new_invocation_id = 3;
+}
+
 message SpawnDiff {
   string primary_output = 1;
   string target_label = 2;


### PR DESCRIPTION
The invocation ID is stored in the exec logs as of Bazel 7.5.0 and 8.1.0. The `--bes_results_url` is obtained from the flags parsed from the last build-like command, if available.