### PR TITLE
[FC] Add a platform property to specify a snapshot key to start from

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -677,7 +677,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 			}).Inc()
 		}
 	} else {
-		c.snapshotKeySet = &fcpb.SnapshotKeySet{BranchKey: opts.OverrideSnapshotKey}
+		c.snapshotKeySet = &fcpb.SnapshotKeySet{BranchKey: opts.OverrideSnapshotKey, WriteKey: opts.OverrideSnapshotKey}
 		c.createFromSnapshot = true
 
 		// TODO(bduffany): add version info to snapshots. For example, if a
@@ -861,6 +861,10 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	defer func() {
 		log.CtxDebugf(ctx, "SaveSnapshot took %s", time.Since(start))
 	}()
+
+	if c.snapshotKeySet.GetWriteKey() == nil {
+		return status.InvalidArgumentErrorf("write key required to save snapshot")
+	}
 
 	baseMemSnapshotPath := filepath.Join(c.getChroot(), fullMemSnapshotName)
 	memSnapshotPath := filepath.Join(c.getChroot(), snapshotDetails.memSnapshotName)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -487,6 +487,7 @@ func (p *Provider) New(ctx context.Context, args *container.Init) (container.Com
 		BlockDevice:            args.BlockDevice,
 		ExecutorConfig:         p.executorConfig,
 		CPUWeightMillis:        sizeEstimate.GetEstimatedMilliCpu(),
+		OverrideSnapshotKey:    args.Props.OverrideSnapshotKey,
 	}
 	c, err := NewContainer(ctx, p.env, args.Task.GetExecutionTask(), opts)
 	if err != nil {
@@ -677,6 +678,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		}
 	} else {
 		c.snapshotKeySet = &fcpb.SnapshotKeySet{BranchKey: opts.OverrideSnapshotKey}
+		c.createFromSnapshot = true
 
 		// TODO(bduffany): add version info to snapshots. For example, if a
 		// breaking change is made to the vmexec API, the executor should not

--- a/enterprise/server/remote_execution/platform/BUILD
+++ b/enterprise/server/remote_execution/platform/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["platform.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform",
     deps = [
+        "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
         "//server/environment",
@@ -17,6 +18,7 @@ go_library(
         "//server/util/usageutil",
         "@com_github_docker_go_units//:go-units",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )
 
@@ -26,6 +28,7 @@ go_test(
     srcs = ["platform_test.go"],
     embed = [":platform"],
     deps = [
+        "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
         "//server/testutil/testenv",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -605,6 +605,11 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotKey, opts *CacheSnapshotOptions) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
+
+	if key == nil {
+		return status.InvalidArgumentErrorf("key required to cache snapshot")
+	}
+
 	vmConfig, err := anypb.New(opts.VMConfiguration)
 	if err != nil {
 		return err


### PR DESCRIPTION
BE support so that we can use remote bazel to start from a specific snapshot key