### PR TITLE
Fix vmstart

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -88,6 +88,7 @@ var (
 
 	forceRemoteSnapshotting = flag.Bool("debug_force_remote_snapshots", false, "When remote snapshotting is enabled, force remote snapshotting even for tasks which otherwise wouldn't support it.")
 	disableWorkspaceSync    = flag.Bool("debug_disable_firecracker_workspace_sync", false, "Do not sync the action workspace to the guest, instead using the existing workspace from the VM snapshot.")
+	debugDisableCgroup      = flag.Bool("debug_disable_cgroup", false, "Disable firecracker cgroup setup.")
 )
 
 //go:embed guest_api_hash.sha256
@@ -2578,6 +2579,9 @@ func (c *FirecrackerContainer) setupCgroup(ctx context.Context) error {
 	c.cgroupSettings.CpusetCpus = toInt32s(leasedCPUs)
 	c.cgroupSettings.NumaNode = pointer(int32(numaNode))
 
+	if *debugDisableCgroup {
+		return nil
+	}
 	if err := os.MkdirAll(c.cgroupPath(), 0755); err != nil {
 		return status.UnavailableErrorf("create cgroup: %s", err)
 	}

--- a/enterprise/tools/vmstart/BUILD
+++ b/enterprise/tools/vmstart/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//enterprise/server/remote_execution/containers/firecracker",
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/vbd",
+        "//enterprise/server/util/cpuset",
         "//enterprise/server/util/oci",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vbd"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/cpuset"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -89,6 +90,12 @@ func getToolEnv() *real_environment.RealEnv {
 	fc.WaitForDirectoryScanToComplete()
 	re.SetFileCache(fc)
 
+	leaser, err := cpuset.NewLeaser()
+	if err != nil {
+		log.Fatalf("Failed to set up cpuset leaser: %s", err)
+	}
+	re.SetCPULeaser(leaser)
+
 	conn, err := grpc_client.DialSimple(*cacheTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to cache '%s': %s", *cacheTarget, err)
@@ -151,6 +158,7 @@ func main() {
 		log.Fatalf("Must be run as root: 'bazel run --run_under=sudo'")
 	}
 	flagutil.SetValueForFlagName("debug_enable_anonymous_runner_recycling", true, nil, false)
+	flagutil.SetValueForFlagName("debug_disable_cgroup", false, nil, false)
 	flagutil.SetValueForFlagName("executor.enable_local_snapshot_sharing", true, nil, false)
 	flagutil.SetValueForFlagName("executor.enable_remote_snapshot_sharing", true, nil, false)
 	flagutil.SetValueForFlagName("executor.remote_snapshot_readonly", true, nil, false)
@@ -184,6 +192,9 @@ func run(ctx context.Context, env environment.Env) error {
 	}
 	if err := vbd.CleanStaleMounts(); err != nil {
 		log.Warningf("Failed to clean stale VBD mounts: %s", err)
+	}
+	if err := networking.Configure(ctx); err != nil {
+		return status.WrapError(err, "configure networking")
 	}
 
 	if *apiKey != "" {

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -158,7 +158,7 @@ func main() {
 		log.Fatalf("Must be run as root: 'bazel run --run_under=sudo'")
 	}
 	flagutil.SetValueForFlagName("debug_enable_anonymous_runner_recycling", true, nil, false)
-	flagutil.SetValueForFlagName("debug_disable_cgroup", false, nil, false)
+	flagutil.SetValueForFlagName("debug_disable_cgroup", true, nil, false)
 	flagutil.SetValueForFlagName("executor.enable_local_snapshot_sharing", true, nil, false)
 	flagutil.SetValueForFlagName("executor.enable_remote_snapshot_sharing", true, nil, false)
 	flagutil.SetValueForFlagName("executor.remote_snapshot_readonly", true, nil, false)


### PR DESCRIPTION
Also add a `--debug_disable_cgroup` flag since we don't support cgroup v1 and the GCP VMs we're using for testing have a weird hybrid cgroup setup