### PR TITLE
Add gauge metric for open invocation streams

### DIFF
--- a/server/build_event_protocol/build_event_server/BUILD
+++ b/server/build_event_protocol/build_event_server/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:publish_build_event_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/metrics",
         "//server/real_environment",
         "//server/util/log",
         "//server/util/status",

--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -79,6 +80,9 @@ func closeForwardingStreams(clients []pepb.PublishBuildEvent_PublishBuildToolEve
 // decide to re-send every build event for which an ACK has not been received. If so, it
 // adds an OPEN_STREAM event.
 func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.PublishBuildEvent_PublishBuildToolEventStreamServer) error {
+	metrics.InvocationOpenStreams.Inc()
+	defer metrics.InvocationOpenStreams.Dec()
+
 	ctx := stream.Context()
 	// Semantically, the protocol requires we ack events in order.
 	acks := make([]int, 0)

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -374,6 +374,13 @@ var (
 		GroupID,
 	})
 
+	InvocationOpenStreams = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "invocation",
+		Name:      "open_streams",
+		Help:      "Number of build event streams currently being handled by the server.",
+	})
+
 	BuildEventCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "invocation",


### PR DESCRIPTION
Unfortunately it doesn't look like the grpc metrics already have a metric like "RPCs currently being handled" - add a new metric for tracking the number of build event stream RPCs in-flight.