### PR TITLE
Fix `buildfix.sh` with Bzlmod

### DIFF
--- a/tools/goimports/BUILD
+++ b/tools/goimports/BUILD
@@ -5,4 +5,7 @@ sh_binary(
         "@org_golang_x_tools//cmd/goimports",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )

--- a/tools/goimports/goimports.sh
+++ b/tools/goimports/goimports.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 # Runs goimports from the project root directory.
 
-set -euo pipefail
-
-if [[ -z "${RUNFILES_DIR+x}" ]]; then
-  export RUNFILES_DIR="$PWD"/..
-fi
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
 
 if [[ -n "${BUILD_WORKSPACE_DIRECTORY}" ]]; then
   cd "$BUILD_WORKSPACE_DIRECTORY"
@@ -16,7 +21,7 @@ fi
 if [[ "$GOIMPORTS_PATH" ]]; then
   GOIMPORTS_COMMAND=("$GOIMPORTS_PATH")
 else
-  GOIMPORTS_COMMAND=("${RUNFILES_DIR}/org_golang_x_tools/cmd/goimports/goimports_/goimports")
+  GOIMPORTS_COMMAND=("$(rlocation org_golang_x_tools/cmd/goimports/goimports_/goimports)")
 fi
 
 "${GOIMPORTS_COMMAND[@]}" "$@"

--- a/tools/prettier/BUILD
+++ b/tools/prettier/BUILD
@@ -5,4 +5,7 @@ sh_binary(
         "@npm//prettier/bin:prettier",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 # Runs prettier on all files that differ from the main branch.
 
-set -euo pipefail
-
-if [[ -z "${RUNFILES_DIR+x}" ]]; then
-  export RUNFILES_DIR="$PWD"/..
-fi
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
 
 if [[ -n "${BUILD_WORKSPACE_DIRECTORY}" ]]; then
   cd "$BUILD_WORKSPACE_DIRECTORY"
@@ -72,7 +77,7 @@ fi
 if [[ "$PRETTIER_PATH" ]]; then
   PRETTIER_COMMAND=("$PRETTIER_PATH")
 else
-  PRETTIER_COMMAND=("${RUNFILES_DIR}/npm/prettier/bin/prettier.sh" --bazel_node_working_dir="$PWD")
+  PRETTIER_COMMAND=("$(rlocation npm/prettier/bin/prettier.sh)" --bazel_node_working_dir="$PWD")
 fi
 
 "${PRETTIER_COMMAND[@]}" "${paths[@]}" "$@"


### PR DESCRIPTION
Use a runfiles library to automatically map the "friendly" (apparent) repo names to the resolved (canonical) runfiles directories.

Tested by adding `common --enable_bzlmod` to `user.bazelrc` and running `./buildfix.sh -a`.