### PR TITLE
Don't panic in kythe

### DIFF
--- a/codesearch/kythestorage/BUILD
+++ b/codesearch/kythestorage/BUILD
@@ -7,7 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
+        "//server/util/claims",
         "//server/util/log",
+        "//server/util/status",
         "@com_github_cockroachdb_pebble//:pebble",
         "@io_kythe//kythe/go/storage/keyvalue",
     ],


### PR DESCRIPTION
I was stupidly returning the value from pebble.Get directly, forgetting that it's lifetime is only valid until closer.Close() is called. This meant that in the rare case we got two simultaneous requests, the bytes would get invalidated before being read and we'd hit a NPE.

The fix is to copy the bytes before returning them.

One small other fix -- I used ClaimsFromContext to get the groupID to avoid reparsing a jwt.