### PR TITLE
Assume the executor is self hosted when it doesn't send aux meta

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -393,7 +393,7 @@ func (s *ExecutionServer) recordExecution(
 		executionProto.PredictedMemoryBytes = schedulingMeta.GetPredictedTaskSize().GetEstimatedMemoryBytes()
 		executionProto.PredictedMilliCpu = schedulingMeta.GetPredictedTaskSize().GetEstimatedMilliCpu()
 		executionProto.PredictedFreeDiskBytes = schedulingMeta.GetPredictedTaskSize().GetEstimatedFreeDiskBytes()
-		executionProto.SelfHosted = schedulingMeta.GetExecutorGroupId() != s.env.GetSchedulerService().GetSharedExecutorPoolGroupID()
+		executionProto.SelfHosted = schedulingMeta == nil || (schedulingMeta.GetExecutorGroupId() != s.env.GetSchedulerService().GetSharedExecutorPoolGroupID())
 
 		request := auxMeta.GetExecuteRequest()
 		executionProto.SkipCacheLookup = request.GetSkipCacheLookup()
@@ -1077,7 +1077,7 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			if err != nil {
 				log.CtxWarningf(ctx, "Failed to parse ExecutionAuxiliaryMetadata: %s", err)
 			} else if !ok {
-				log.CtxWarningf(ctx, "Failed to find ExecutionAuxiliaryMetadata: %s", err)
+				log.CtxInfof(ctx, "Failed to find ExecutionAuxiliaryMetadata. Executor is probably self-hosted and not updated since 2024-12-13.")
 			}
 			actionRN, err := digest.ParseUploadResourceName(taskID)
 			if err != nil {


### PR DESCRIPTION
This will correctly set the `self_hosted` field in clickhouse without forcing clients to update their executors.

I also slightly improved the log statement when the aux meta is missing.