### PR TITLE
Use finer-grained buckets for execution durations

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -864,7 +864,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
 		Name:      "executed_action_metadata_durations_usec",
-		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*day, 2),
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*day, 1.2),
 		Help:      "Time spent in each stage of action execution, in **microseconds**. Queries should filter or group by the `stage` label, taking care not to aggregate different stages.",
 	}, []string{
 		ExecutedActionStageLabel,


### PR DESCRIPTION
The prober latency chart isn't super useful because these buckets are too coarse-grained.

We made these coarse-grained a while back due to issues with high cardinality, but I think we can probably handle higher cardinality now that we're on victoriametrics and we've also restricted the group_id label to a hard-coded list.