### PR TITLE
Reuse vmexec connections in firecracker.go

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/uuid",
+        "//third_party/singleflight",
         "@com_github_armon_circbuf//:circbuf",
         "@com_github_firecracker_microvm_firecracker_go_sdk//:firecracker-go-sdk",
         "@com_github_firecracker_microvm_firecracker_go_sdk//client/models",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1124,7 +1124,6 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	execClient := vmxpb.NewExecClient(conn)
 	_, err = execClient.Initialize(ctx, &vmxpb.InitializeRequest{
@@ -1287,7 +1286,6 @@ func (c *FirecrackerContainer) createAndAttachWorkspace(ctx context.Context) err
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	execClient := vmxpb.NewExecClient(conn)
 
 	workspaceExt4Path := filepath.Join(c.getChroot(), workspaceFSName)
@@ -2133,7 +2131,6 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	if err != nil {
 		return commandutil.ErrorResult(status.InternalErrorf("Firecracker exec failed: failed to dial VM exec port: %s", err))
 	}
-	defer conn.Close()
 
 	result, vmHealthy := c.SendExecRequestToGuest(ctx, conn, cmd, guestWorkspaceMountDir, stdio)
 
@@ -2422,6 +2419,7 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 	if c.releaseCPUs != nil {
 		c.releaseCPUs()
 	}
+	c.vmExec.conn.Close()
 	c.vmExec.once = &sync.Once{}
 
 	pauseTime := time.Since(start)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2422,6 +2422,7 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 	if c.releaseCPUs != nil {
 		c.releaseCPUs()
 	}
+	c.vmExec.once = &sync.Once{}
 
 	pauseTime := time.Since(start)
 	log.CtxDebugf(ctx, "Pause took %s", pauseTime)


### PR DESCRIPTION
This will save a tiny bit of time, but that's not the main reason I'm making the change.

Currently, the FirecrackerExecDialDurationUsec metric records the time for 3 dials per action. The first dial is much slower, but the 2nd and 3rd one drive down the average for the metric, so it seems that the par action dial is faster than it really is.