### PR TITLE
Allow configuration of openai endpoint via flag

### DIFF
--- a/enterprise/server/backends/openai/openai.go
+++ b/enterprise/server/backends/openai/openai.go
@@ -15,7 +15,6 @@ var endpoint = flag.String("openai.endpoint", "https://api.openai.com/v1/chat/co
 var apiKey = flag.String("openai.api_key", "", "OpenAI API key", flag.Secret)
 var Model = flag.String("openai.model", "gpt-4o", "OpenAI model name to use. Find them here: https://platform.openai.com/docs/models")
 
-
 func IsConfigured() bool {
 	return *apiKey != ""
 }

--- a/enterprise/server/backends/openai/openai.go
+++ b/enterprise/server/backends/openai/openai.go
@@ -11,12 +11,10 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
+var endpoint = flag.String("openai.endpoint", "https://api.openai.com/v1/chat/completions", "OpenAI endpoint")
 var apiKey = flag.String("openai.api_key", "", "OpenAI API key", flag.Secret)
-var Model = flag.String("openai.model", "gpt-3.5-turbo", "OpenAI model name to use. Find them here: https://platform.openai.com/docs/models")
+var Model = flag.String("openai.model", "gpt-4o", "OpenAI model name to use. Find them here: https://platform.openai.com/docs/models")
 
-const (
-	chatCompletionsEndpoint = "https://api.openai.com/v1/chat/completions"
-)
 
 func IsConfigured() bool {
 	return *apiKey != ""
@@ -28,7 +26,7 @@ func GetCompletions(data *CompletionRequest) (*CompletionResponse, error) {
 		return nil, err
 	}
 
-	postRequest, err := http.NewRequest("POST", chatCompletionsEndpoint, bytes.NewBuffer(jsonData))
+	postRequest, err := http.NewRequest("POST", *endpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +47,7 @@ func GetCompletions(data *CompletionRequest) (*CompletionResponse, error) {
 	}
 
 	if postResp.StatusCode != http.StatusOK {
-		log.Debugf("error getting completions from openai: %+v body: %+v", postResp.StatusCode, string(body))
+		log.Warningf("error getting completions from openai: %+v body: %+v", postResp.StatusCode, string(body))
 		return nil, status.UnavailableError("Unable to contact suggestion provider.") // todo
 	}
 


### PR DESCRIPTION
This allows you to easily use any openai-compatible endpoint.

Also bumps the default model from `gpt-3.5-turbo` to `gpt-4o`.

Finally, bumps debug log to warning (since it's only logged in an actual error case).