### PR TITLE
Add stages to the firecracker_stage_duration_usec metric

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/uuid",
+        "//third_party/singleflight",
         "@com_github_armon_circbuf//:circbuf",
         "@com_github_firecracker_microvm_firecracker_go_sdk//:firecracker-go-sdk",
         "@com_github_firecracker_microvm_firecracker_go_sdk//client/models",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1124,7 +1124,6 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	execClient := vmxpb.NewExecClient(conn)
 	_, err = execClient.Initialize(ctx, &vmxpb.InitializeRequest{
@@ -1287,7 +1286,6 @@ func (c *FirecrackerContainer) createAndAttachWorkspace(ctx context.Context) err
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	execClient := vmxpb.NewExecClient(conn)
 
 	workspaceExt4Path := filepath.Join(c.getChroot(), workspaceFSName)
@@ -2133,7 +2131,6 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	if err != nil {
 		return commandutil.ErrorResult(status.InternalErrorf("Firecracker exec failed: failed to dial VM exec port: %s", err))
 	}
-	defer conn.Close()
 
 	result, vmHealthy := c.SendExecRequestToGuest(ctx, conn, cmd, guestWorkspaceMountDir, stdio)
 
@@ -2422,6 +2419,7 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 	if c.releaseCPUs != nil {
 		c.releaseCPUs()
 	}
+	c.vmExec.conn.Close()
 	c.vmExec.once = &sync.Once{}
 
 	pauseTime := time.Since(start)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2422,6 +2422,7 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 	if c.releaseCPUs != nil {
 		c.releaseCPUs()
 	}
+	c.vmExec.once = &sync.Once{}
 
 	pauseTime := time.Since(start)
 	log.CtxDebugf(ctx, "Pause took %s", pauseTime)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1965,17 +1965,6 @@ func (c *FirecrackerContainer) vmExecConn(ctx context.Context) (*grpc.ClientConn
 	return conn, err
 }
 
-func (c *FirecrackerContainer) vmExecConn(ctx context.Context) (*grpc.ClientConn, error) {
-	conn, _, err := c.vmExec.singleflight.Do(ctx, "",
-		func(ctx context.Context) (*grpc.ClientConn, error) {
-			if c.vmExec.conn == nil && c.vmExec.err == nil {
-				c.vmExec.conn, c.vmExec.err = c.dialVMExecServer(ctx)
-			}
-			return c.vmExec.conn, c.vmExec.err
-		})
-	return conn, err
-}
-
 func (c *FirecrackerContainer) dialVMExecServer(ctx context.Context) (*grpc.ClientConn, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -536,7 +536,7 @@ type FirecrackerContainer struct {
 	//
 	// This can be used to understand the total time it takes to execute a task,
 	// including VM startup time
-	currentTaskInitTimeUsec time.Time
+	currentTaskInitTime time.Time
 
 	executorConfig *ExecutorConfig
 
@@ -1785,7 +1785,7 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 }
 
 func (c *FirecrackerContainer) create(ctx context.Context) error {
-	c.currentTaskInitTimeUsec = time.Now()
+	c.currentTaskInitTime = time.Now()
 	c.rmOnce = &sync.Once{}
 	c.rmErr = nil
 
@@ -2071,7 +2071,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 		execDuration := time.Since(start)
 		log.CtxDebugf(ctx, "Exec took %s", execDuration)
 
-		timeSinceContainerInit := time.Since(c.currentTaskInitTimeUsec)
+		timeSinceContainerInit := time.Since(c.currentTaskInitTime)
 		c.observeStageDuration("task_lifecycle", timeSinceContainerInit)
 		c.observeStageDuration("exec", execDuration)
 	}()
@@ -2597,7 +2597,7 @@ func (c *FirecrackerContainer) Unpause(ctx context.Context) error {
 
 func (c *FirecrackerContainer) unpause(ctx context.Context) error {
 	c.recycled = true
-	c.currentTaskInitTimeUsec = time.Now()
+	c.currentTaskInitTime = time.Now()
 
 	log.CtxInfof(ctx, "Unpausing VM")
 


### PR DESCRIPTION
I added the `pull_image` and `remove` stages, and I split `init` into `create` and `unpause`.