### PR TITLE
Provide config options to add additional OAuth scopes for OIDC

### DIFF
--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -54,6 +54,7 @@ const (
 
 	// The key that the basicAuth object is stored under in the
 	// context.
+	// test
 	contextBasicAuthKey = "basicauth.user"
 
 	// The key any error is stored under if the user could not be

--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -38,6 +38,7 @@ var (
 	oauthProviders       = flag.Slice("auth.oauth_providers", []OauthProvider{}, "The list of oauth providers to use to authenticate.")
 	disableRefreshToken  = flag.Bool("auth.disable_refresh_token", false, "If true, the offline_access scope which requests refresh tokens will not be requested.")
 	forceApproval        = flag.Bool("auth.force_approval", false, "If true, when a user doesn't have a session (first time logging in, or manually logged out) force the auth provider to show the consent screen allowing the user to select an account if they have multiple. This isn't supported by all auth providers.")
+	additionalScopes     = flag.Bool("auth.oauth_scopes", []string{}, "The list of any additional OAuth scopes needed by the application.")
 )
 
 type OauthProvider struct {
@@ -54,7 +55,6 @@ const (
 
 	// The key that the basicAuth object is stored under in the
 	// context.
-	// test
 	contextBasicAuthKey = "basicauth.user"
 
 	// The key any error is stored under if the user could not be
@@ -260,6 +260,10 @@ func createAuthenticatorsFromConfig(ctx context.Context, env environment.Env, au
 					if authConfig.IssuerURL != "https://accounts.google.com" && !*disableRefreshToken {
 						scopes = append(scopes, oidc.ScopeOfflineAccess)
 					}
+                    // Add in additional user-provided scopes.
+                    if len(*additionalScopes) > 0 {
+                        scopes = append(scopes, *additionalScopes...)
+                    }
 					// Configure an OpenID Connect aware OAuth2 client.
 					authenticator.cachedOauth2Config = &oauth2.Config{
 						ClientID:     authConfig.ClientID,

--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -260,10 +260,10 @@ func createAuthenticatorsFromConfig(ctx context.Context, env environment.Env, au
 					if authConfig.IssuerURL != "https://accounts.google.com" && !*disableRefreshToken {
 						scopes = append(scopes, oidc.ScopeOfflineAccess)
 					}
-                    // Add in additional user-provided scopes.
-                    if len(*additionalScopes) > 0 {
-                        scopes = append(scopes, *additionalScopes...)
-                    }
+					// Add in additional user-provided scopes.
+					if len(*additionalScopes) > 0 {
+						scopes = append(scopes, *additionalScopes...)
+					}
 					// Configure an OpenID Connect aware OAuth2 client.
 					authenticator.cachedOauth2Config = &oauth2.Config{
 						ClientID:     authConfig.ClientID,

--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -38,7 +38,7 @@ var (
 	oauthProviders       = flag.Slice("auth.oauth_providers", []OauthProvider{}, "The list of oauth providers to use to authenticate.")
 	disableRefreshToken  = flag.Bool("auth.disable_refresh_token", false, "If true, the offline_access scope which requests refresh tokens will not be requested.")
 	forceApproval        = flag.Bool("auth.force_approval", false, "If true, when a user doesn't have a session (first time logging in, or manually logged out) force the auth provider to show the consent screen allowing the user to select an account if they have multiple. This isn't supported by all auth providers.")
-	additionalScopes     = flag.Bool("auth.oauth_scopes", []string{}, "The list of any additional OAuth scopes needed by the application.")
+	additionalScopes     = flag.Slice("auth.oauth_scopes", []string{}, "The list of any additional OAuth scopes needed by the application.")
 )
 
 type OauthProvider struct {


### PR DESCRIPTION
We have a use case where we need to be able to filter out users on login by LDAP groups. Our OIDC provider is currently unable to do a group search on LDAP because the OAuth scopes baked into Buildbuddy do not include `groups`. This PR would allow users to add custom OAuth scopes if additional permissions are needed.