### PR TITLE
Ignore invalid UTF-8 when replaying logs

### DIFF
--- a/tools/replay_invocation/replay_invocation.go
+++ b/tools/replay_invocation/replay_invocation.go
@@ -202,7 +202,7 @@ func main() {
 
 		a := &anypb.Any{}
 		if err := a.MarshalFrom(buildEvent); err != nil {
-			log.Fatalf("Error marshaling bazel event to any: %s", err.Error())
+			log.Fatalf("Error marshaling bazel event to any: %s (event: %s)", err, buildEvent)
 		}
 		req := pepb.PublishBuildToolEventStreamRequest{
 			OrderedBuildEvent: &pepb.OrderedBuildEvent{
@@ -234,7 +234,6 @@ func main() {
 				os.Stderr.Write(b)
 			}
 
-			sequenceNum += 1
 			a := &anypb.Any{}
 			buildEvent := &espb.BuildEvent{
 				Id: &espb.BuildEventId{Id: &espb.BuildEventId_Progress{}},
@@ -243,8 +242,10 @@ func main() {
 				}},
 			}
 			if err := a.MarshalFrom(buildEvent); err != nil {
-				log.Fatalf("Error marshaling bazel event to any: %s", err.Error())
+				log.Warningf("Error marshaling bazel progress event to any; dropping event: %s", err)
+				continue
 			}
+			sequenceNum += 1
 			stream.Send(&pepb.PublishBuildToolEventStreamRequest{
 				OrderedBuildEvent: &pepb.OrderedBuildEvent{
 					StreamId:       streamID,


### PR DESCRIPTION
When replaying invocation logs as progress events, marshaling one of the events failed because the invocation logs contained invalid UTF-8 and could not be marshaled to string. This seems like it might be a bug, but make this a warning for now, so that other events can still be replayed even if the logs are problematic.