### PR TITLE
Fix invalid UTF-8 when replaying invocation logs

### DIFF
--- a/tools/replay_invocation/BUILD
+++ b/tools/replay_invocation/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/util/log",
         "//server/util/proto",
         "//server/util/protofile",
+        "//server/util/status",
         "@com_github_google_uuid//:uuid",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//metadata",

--- a/tools/replay_invocation/replay_invocation.go
+++ b/tools/replay_invocation/replay_invocation.go
@@ -202,7 +202,7 @@ func main() {
 
 		a := &anypb.Any{}
 		if err := a.MarshalFrom(buildEvent); err != nil {
-			log.Fatalf("Error marshaling bazel event to any: %s", err.Error())
+			log.Fatalf("Error marshaling bazel event to any: %s (event: %s)", err, buildEvent)
 		}
 		req := pepb.PublishBuildToolEventStreamRequest{
 			OrderedBuildEvent: &pepb.OrderedBuildEvent{
@@ -234,7 +234,6 @@ func main() {
 				os.Stderr.Write(b)
 			}
 
-			sequenceNum += 1
 			a := &anypb.Any{}
 			buildEvent := &espb.BuildEvent{
 				Id: &espb.BuildEventId{Id: &espb.BuildEventId_Progress{}},
@@ -243,8 +242,10 @@ func main() {
 				}},
 			}
 			if err := a.MarshalFrom(buildEvent); err != nil {
-				log.Fatalf("Error marshaling bazel event to any: %s", err.Error())
+				log.Warningf("Error marshaling bazel progress event to any; dropping event: %s", err)
+				continue
 			}
+			sequenceNum += 1
 			stream.Send(&pepb.PublishBuildToolEventStreamRequest{
 				OrderedBuildEvent: &pepb.OrderedBuildEvent{
 					StreamId:       streamID,

--- a/tools/replay_invocation/replay_invocation.go
+++ b/tools/replay_invocation/replay_invocation.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/protofile"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -202,7 +203,7 @@ func main() {
 
 		a := &anypb.Any{}
 		if err := a.MarshalFrom(buildEvent); err != nil {
-			log.Fatalf("Error marshaling bazel event to any: %s (event: %s)", err, buildEvent)
+			log.Fatalf("Error marshaling bazel event to any: %s", err.Error())
 		}
 		req := pepb.PublishBuildToolEventStreamRequest{
 			OrderedBuildEvent: &pepb.OrderedBuildEvent{
@@ -223,13 +224,10 @@ func main() {
 	// events.
 	logsBlobstorePrefix := eventlog.GetEventLogPathFromInvocationIdAndAttempt(*invocationID, uint64(*attemptNumber))
 	log.Infof("Fetching log chunks from %s_*", logsBlobstorePrefix)
-	reader := chunkstore.New(bs, &chunkstore.ChunkstoreOptions{}).Reader(ctx, logsBlobstorePrefix)
-	buf := make([]byte, 4096)
+	chunks := chunkstore.New(bs, &chunkstore.ChunkstoreOptions{})
 	for i := 0; ; i++ {
-		n, err := reader.Read(buf)
-
-		if n > 0 {
-			b := buf[:n]
+		b, err := chunks.ReadChunk(ctx, logsBlobstorePrefix, uint16(i))
+		if len(b) > 0 {
 			if *printLogs {
 				os.Stderr.Write(b)
 			}
@@ -257,13 +255,14 @@ func main() {
 			})
 		}
 
-		if err == io.EOF {
+		if status.IsNotFoundError(err) {
 			break
 		}
 		if err != nil {
 			log.Errorf("Failed to read log chunks: %s", err)
 			break
 		}
+		log.Infof("Replayed log chunk %d", i)
 	}
 
 	if err := stream.CloseSend(); err != nil {


### PR DESCRIPTION
Read the logs chunk-by-chunk instead of 4096 bytes at a time. This fixes an issue where a read into the buffer stops before a UTF-8 sequence has terminated, resulting in an invalid UTF-8 string which proto fails to marshal.