### PR TITLE
test case successful only if it has no error/failure/skipped child nodes

### DIFF
--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -53,10 +53,15 @@ export default class TargetTestCasesCardComponent extends React.Component<Props>
   }
 
   render() {
-    let testCases = Array.from(this.props.testSuite.getElementsByTagName("testcase")).filter(
-      (testCase) =>
-        !this.props.tagName || (this.props.tagName && testCase.getElementsByTagName(this.props.tagName).length > 0)
-    );
+    let testCases = Array.from(this.props.testSuite.getElementsByTagName("testcase")).filter((testCase) => {
+      let isSuccessCard = this.props.tagName === undefined;
+      let hasMatchingChildren = testCase.getElementsByTagName(this.props.tagName).length > 0;
+      let hasFailureErrorSkippedChildren =
+        testCase.getElementsByTagName("failure").length > 0 ||
+        testCase.getElementsByTagName("error").length > 0 ||
+        testCase.getElementsByTagName("skipped").length > 0;
+      return (isSuccessCard && !hasFailureErrorSkippedChildren) || (!isSuccessCard && hasMatchingChildren);
+    });
     return (
       testCases.length > 0 && (
         <div className={`card artifacts ${this.getCardClass()}`}>

--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -55,7 +55,8 @@ export default class TargetTestCasesCardComponent extends React.Component<Props>
   render() {
     let testCases = Array.from(this.props.testSuite.getElementsByTagName("testcase")).filter((testCase) => {
       let isSuccessCard = this.props.tagName === undefined;
-      let hasMatchingChildren = testCase.getElementsByTagName(this.props.tagName).length > 0;
+      let hasMatchingChildren =
+        this.props.tagName !== undefined && testCase.getElementsByTagName(this.props.tagName).length > 0;
       let hasFailureErrorSkippedChildren =
         testCase.getElementsByTagName("failure").length > 0 ||
         testCase.getElementsByTagName("error").length > 0 ||


### PR DESCRIPTION
@fzakaria noticed that failing test cases would show on both the failure card and the success card. Turns out our filtering logic was not looking for `<failure>`, `<skipped>`, or `<error>` child nodes in all cases! This change fixes that filtering logic.