### PR TITLE
Add bytes-proxied metrics to BSProxy and CASProxy servers

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -397,9 +397,9 @@ func (c *Cache) getLookasideEntry(r *rspb.ResourceName) ([]byte, error) {
 	}
 	c.lookasideMu.Unlock()
 
-	lookupStatus := "miss"
+	lookupStatus := metrics.MissStatusLabel
 	if found {
-		lookupStatus = "hit"
+		lookupStatus = metrics.HitStatusLabel
 	}
 	metrics.LookasideCacheLookupCount.With(prometheus.Labels{
 		metrics.LookasideCacheLookupStatus: lookupStatus,
@@ -965,7 +965,7 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 						// Record which lookup round we found this resource in.
 						metrics.DistributedCachePeerLookups.With(prometheus.Labels{
 							metrics.DistributedCacheOperation: "FindMissing",
-							metrics.CacheHitMissStatus:        "hit",
+							metrics.CacheHitMissStatus:        metrics.HitStatusLabel,
 						}).Observe(float64(lookups))
 					}
 				}
@@ -994,7 +994,7 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 		}
 		metrics.DistributedCachePeerLookups.With(prometheus.Labels{
 			metrics.DistributedCacheOperation: "FindMissing",
-			metrics.CacheHitMissStatus:        "miss",
+			metrics.CacheHitMissStatus:        metrics.MissStatusLabel,
 		}).Observe(float64(lookups))
 	}
 
@@ -1054,7 +1054,7 @@ func (c *Cache) distributedReader(ctx context.Context, rn *rspb.ResourceName, of
 			backfill()
 			metrics.DistributedCachePeerLookups.With(prometheus.Labels{
 				metrics.DistributedCacheOperation: metricsLabel,
-				metrics.CacheHitMissStatus:        "hit",
+				metrics.CacheHitMissStatus:        metrics.HitStatusLabel,
 			}).Observe(float64(lookups))
 			return r, err
 		}
@@ -1070,7 +1070,7 @@ func (c *Cache) distributedReader(ctx context.Context, rn *rspb.ResourceName, of
 	}
 	metrics.DistributedCachePeerLookups.With(prometheus.Labels{
 		metrics.DistributedCacheOperation: metricsLabel,
-		metrics.CacheHitMissStatus:        "miss",
+		metrics.CacheHitMissStatus:        metrics.MissStatusLabel,
 	}).Observe(float64(lookups))
 	c.log.CtxDebugf(ctx, "Exhausted all peers attempting to read %q. Peerset: %+v", rn.GetDigest().GetHash(), ps)
 	return nil, status.NotFoundErrorf("Exhausted all peers attempting to read %q.", rn.GetDigest().GetHash())

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -163,8 +163,8 @@ func TestBasicReadWrite(t *testing.T) {
 	assert.Equal(t, []testmetrics.HistogramValues{
 		{
 			Labels: map[string]string{
-				"op":     "Reader",
-				"status": "hit",
+				"op":                       "Reader",
+				metrics.CacheHitMissStatus: metrics.HitStatusLabel,
 			},
 			// For each of the 100 objects, we did a Read on all 3 distributed
 			// caches, which should have done only 1 lookup each (from the local
@@ -893,8 +893,8 @@ func TestFindMissing(t *testing.T) {
 	assert.Equal(t, []testmetrics.HistogramValues{
 		{
 			Labels: map[string]string{
-				"op":     "FindMissing",
-				"status": "hit",
+				"op":                       "FindMissing",
+				metrics.CacheHitMissStatus: metrics.HitStatusLabel,
 			},
 			// Each hit only requires 1 peer lookup, and we did 3 FindMissing
 			// calls (loop count above) * 100 hits for each call (number of
@@ -903,8 +903,8 @@ func TestFindMissing(t *testing.T) {
 		},
 		{
 			Labels: map[string]string{
-				"op":     "FindMissing",
-				"status": "miss",
+				"op":                       "FindMissing",
+				metrics.CacheHitMissStatus: metrics.MissStatusLabel,
 			},
 			// Each miss should result in 3 peer lookups (replication factor),
 			// and we did 3 FindMissing calls (loop count above) * 70 misses

--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//status",
     ],
 )
 


### PR DESCRIPTION
I thought that I would be able to measure this using the prometheus gRPC metrics, but I couldn't find one tracking bytes. This will require updating the dashboards because I changed some of the metric names, will follow-up with that. I tried this out in dev for a couple of hours and it looks like we're proxying a lot of bytes there!

![Screenshot 2025-02-03 at 12 06 37 PM](https://github.com/user-attachments/assets/9b962d0f-a217-4f4d-ad89-d5ab7388452e)