### PR TITLE
Delay dialing the VM exec server

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1293,6 +1293,7 @@ func (c *FirecrackerContainer) createAndAttachWorkspace(ctx context.Context) err
 		return err
 	}
 	execClient := vmxpb.NewExecClient(conn)
+
 	// UpdateGuestDrive can only be called after the VM boots (https://github.com/firecracker-microvm/firecracker/blob/c862760999f15d27034098a53a4d5bee3fba829d/src/firecracker/swagger/firecracker.yaml#L256-L260)
 	// The only way to tell if the VM booted seems to be monitoring its stdout.
 	// Instead we'll just wait for the vm exec server to start above, which
@@ -1301,6 +1302,7 @@ func (c *FirecrackerContainer) createAndAttachWorkspace(ctx context.Context) err
 	if err := c.machine.UpdateGuestDrive(ctx, workspaceDriveID, chrootRelativeImagePath); err != nil {
 		return status.UnavailableErrorf("error updating workspace drive attached to snapshot: %s", err)
 	}
+
 	if err := c.mountWorkspace(ctx, execClient); err != nil {
 		return status.WrapError(err, "failed to remount workspace after update")
 	}


### PR DESCRIPTION
The dial doesn't succeed until the VM exec server is healthy, so we might as well give it so more time to start and do other work in the meantime. I think this will reduce the dial latency by at least 100ms. For actions that take more than 1s to createWorkspaceImage, I think this will nearly eliminate the dial latency.