### PR TITLE
periodically trim already-finished tasks from front of the executor queue.

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/usageutil",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//metadata",
         "@org_golang_x_text//language",

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -624,7 +624,8 @@ func (q *PriorityTaskScheduler) Start() error {
 				case <-q.rootContext.Done():
 					return
 				case <-ticker.Chan():
-					for exists := q.trimQueue(); !exists; {}
+					for exists := q.trimQueue(); !exists; {
+					}
 				}
 			}
 		}()

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -125,9 +125,6 @@ var (
 		Help:    "WorkQueue wait time [milliseconds]",
 		Buckets: prometheus.ExponentialBuckets(1, 2, 20),
 	})
-	redisCheckClaimExists = redis.NewScript(`
-		return redis.call("exists", KEYS[1]) == 0 then
-	`)
 	// Claim field is set only if task exists & claim field is not present.
 	// Return values:
 	//  - 0 claim failed for unknown reason (shouldn't happen)

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -407,6 +407,21 @@ func (tl *taskLease) Renew() error {
 	return nil
 }
 
+func (tl *taskLease) Finalize() error {
+	err := tl.stream.Send(&scpb.LeaseTaskRequest{
+		TaskId: tl.taskID,
+		Finalize: true,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = tl.stream.Recv()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (e *fakeExecutor) Claim(taskID string) *taskLease {
 	stream, err := e.schedulerClient.LeaseTask(e.ctx)
 	require.NoError(e.t, err)
@@ -692,7 +707,7 @@ func TestSchedulingDelay_PreferredExecutorUnhealthy(t *testing.T) {
 	fe2.EnsureTaskNotReceived(taskID)
 	fe1.WaitForTaskWithDelay(taskID, 0*time.Second)
 }
-
+ 
 func TestEnqueueTaskReservation_DoesntOverwriteDelay(t *testing.T) {
 	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
 
@@ -702,4 +717,27 @@ func TestEnqueueTaskReservation_DoesntOverwriteDelay(t *testing.T) {
 	taskID := enqueueTaskReservation(ctx, t, env, 3*time.Second)
 
 	fe1.WaitForTaskWithDelay(taskID, 3*time.Second)
+}
+
+func TestEnqueueTaskReservation_Exists(t *testing.T) {
+	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
+
+	fe := newFakeExecutor(ctx, t, env.GetSchedulerClient())
+	fe.Register()
+
+	taskID := scheduleTask(ctx, t, env, map[string]string{platform.RetryPropertyName: "false"})
+	fe.WaitForTask(taskID)
+	lease := fe.Claim(taskID)
+
+	resp, err := env.GetSchedulerClient().TaskExists(ctx, &scpb.TaskExistsRequest{TaskId: taskID})
+
+	require.Nil(t, err)
+	require.True(t, resp.GetExists())
+
+	lease.Finalize()
+
+	resp, err = env.GetSchedulerClient().TaskExists(ctx, &scpb.TaskExistsRequest{TaskId: taskID})
+
+	require.Nil(t, err)
+	require.False(t, resp.GetExists())
 }

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -409,7 +409,7 @@ func (tl *taskLease) Renew() error {
 
 func (tl *taskLease) Finalize() error {
 	err := tl.stream.Send(&scpb.LeaseTaskRequest{
-		TaskId: tl.taskID,
+		TaskId:   tl.taskID,
 		Finalize: true,
 	})
 	if err != nil {
@@ -707,7 +707,7 @@ func TestSchedulingDelay_PreferredExecutorUnhealthy(t *testing.T) {
 	fe2.EnsureTaskNotReceived(taskID)
 	fe1.WaitForTaskWithDelay(taskID, 0*time.Second)
 }
- 
+
 func TestEnqueueTaskReservation_DoesntOverwriteDelay(t *testing.T) {
 	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
 

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -17,6 +17,15 @@ message NodeAddress {
   int32 port = 2;
 }
 
+message TaskExistsRequest {
+  // The task ID being checked.
+  string task_id = 1;
+}
+
+message TaskExistsResponse {
+  bool exists = 1;
+}
+
 message LeaseTaskRequest {
   // The task for which to request a lease. If successful, a LeaseTaskResponse
   // will be returned containing the serialized task and duration of the lease.
@@ -455,6 +464,8 @@ service Scheduler {
       returns (stream RegisterAndStreamWorkResponse) {}
 
   rpc LeaseTask(stream LeaseTaskRequest) returns (stream LeaseTaskResponse) {}
+
+  rpc TaskExists(TaskExistsRequest) returns (TaskExistsResponse) {}
 
   rpc ScheduleTask(ScheduleTaskRequest) returns (ScheduleTaskResponse) {}
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -857,6 +857,7 @@ type SchedulerService interface {
 	ExistsTask(ctx context.Context, taskID string) (bool, error)
 	EnqueueTaskReservation(ctx context.Context, req *scpb.EnqueueTaskReservationRequest) (*scpb.EnqueueTaskReservationResponse, error)
 	ReEnqueueTask(ctx context.Context, req *scpb.ReEnqueueTaskRequest) (*scpb.ReEnqueueTaskResponse, error)
+	TaskExists(ctx context.Context, req *scpb.TaskExistsRequest) (*scpb.TaskExistsResponse, error)
 	GetExecutionNodes(ctx context.Context, req *scpb.GetExecutionNodesRequest) (*scpb.GetExecutionNodesResponse, error)
 	GetPoolInfo(ctx context.Context, os, requestedPool, workflowID string, poolType PoolType) (*PoolInfo, error)
 	GetSharedExecutorPoolGroupID() string


### PR DESCRIPTION
currently, we don't prune tasks from executor queues until we're actually taking on new work.  when we're under load, this means some executors can have artificially long "queues" of tasks that have already been finished by other executors.

this change works around this case by periodically checking if the frontmost entry in the task queue has already been finished by another worker (indicated by the record not existing in redis anymore).  when such an entry is found, the worker will continue picking entries off the front of the queue until it's either empty or finds a task that hasn't been completed yet.  this should help us scale up more efficiently.

as a toy example: if we have an average queue length of 20, scale up when the average queue length is >5, and all of our tasks take 20 minutes, then doubling the number of running executors will cut queue length to 10--so we keep scaling up and quadruple (!) the number of executors we have running, even if we only needed a few extra executors in order to take on all tasks.