### PR TITLE
Fall back to original registry if mirror cannot serve request

### DIFF
--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -22,8 +22,8 @@ go_library(
 
 go_test(
     name = "ociregistry_test",
-    srcs = ["ociregistry_test.go"],
     timeout = "short",
+    srcs = ["ociregistry_test.go"],
     deps = [
         ":ociregistry",
         "//enterprise/server/util/oci",

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -23,6 +23,7 @@ go_library(
 go_test(
     name = "ociregistry_test",
     srcs = ["ociregistry_test.go"],
+    timeout = "short",
     deps = [
         ":ociregistry",
         "//enterprise/server/util/oci",

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -35,7 +35,6 @@ go_test(
         "//server/testutil/testenviron",
         "//server/testutil/testfs",
         "//server/testutil/testregistry",
-        "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -35,6 +35,7 @@ go_test(
         "//server/testutil/testenviron",
         "//server/testutil/testfs",
         "//server/testutil/testregistry",
+        "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -295,6 +295,7 @@ func (t *mirrorTransport) RoundTrip(in *http.Request) (out *http.Response, err e
 				}
 				return t.inner.RoundTrip(fallbackRequest)
 			}
+			return out, nil // Return successful mirror response
 		}
 	}
 	return t.inner.RoundTrip(in)

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -224,7 +224,6 @@ func Resolve(ctx context.Context, imageName string, platform *rgpb.Platform, cre
 	if len(*mirrors) > 0 {
 		remoteOpts = append(remoteOpts, remote.WithTransport(newMirrorTransport(remote.DefaultTransport, *mirrors)))
 	}
-	log.CtxInfof(ctx, "imageRef %v, remoteOpts %v", imageRef, remoteOpts)
 	remoteDesc, err := remote.Get(imageRef, remoteOpts...)
 	if err != nil {
 		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -276,7 +276,6 @@ func newMirrorTransport(inner http.RoundTripper, mirrors []MirrorConfig) http.Ro
 }
 
 func (t *mirrorTransport) RoundTrip(in *http.Request) (out *http.Response, err error) {
-	log.Infof("original request %s %s", in.Method, in.URL)
 	for _, mirror := range t.mirrors {
 		if match, err := mirror.matches(in.URL); err == nil && match {
 			mirroredRequest, err := mirror.rewriteRequest(in)
@@ -290,7 +289,6 @@ func (t *mirrorTransport) RoundTrip(in *http.Request) (out *http.Response, err e
 				continue
 			}
 			if out.StatusCode < http.StatusOK || out.StatusCode >= 300 {
-				log.Infof("mirror non-2XX response: %d, falling back", out.StatusCode)
 				fallbackRequest, err := mirror.fallbackRequest(in)
 				if err != nil {
 					log.Errorf("error rewriting fallback request: %s", err)
@@ -300,6 +298,5 @@ func (t *mirrorTransport) RoundTrip(in *http.Request) (out *http.Response, err e
 			}
 		}
 	}
-	log.Infof("falling back to original: %s %s", in.Method, in.URL)
 	return t.inner.RoundTrip(in)
 }

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -59,7 +59,7 @@ func (mc MirrorConfig) rewriteRequest(originalRequest *http.Request) (*http.Requ
 	return req, nil
 }
 
-func (mc MirrorConfig) fallbackRequest(originalRequest *http.Request) (*http.Request, error) {
+func (mc MirrorConfig) rewriteFallbackRequest(originalRequest *http.Request) (*http.Request, error) {
 	originalURL, err := url.Parse(mc.OriginalURL)
 	if err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func (t *mirrorTransport) RoundTrip(in *http.Request) (out *http.Response, err e
 				continue
 			}
 			if out.StatusCode < http.StatusOK || out.StatusCode >= 300 {
-				fallbackRequest, err := mirror.fallbackRequest(in)
+				fallbackRequest, err := mirror.rewriteFallbackRequest(in)
 				if err != nil {
 					log.Errorf("error rewriting fallback request: %s", err)
 					continue


### PR DESCRIPTION
The OCI registry mirror under `enterprise/server/ociregistry` can only serve manifests and pulls for public registries. Mirroring private registries is not supported.

Configuring a mirror works at the domain level. So, for example, mirroring `gcr.io` will cause all requests that would to go `gcr.io` to go to the mirror. While rolling out the OCI registry mirror, I do not want to break image pulls from an entire domain!

So, this change causes `oci.Resolve()` to fall back to the original registry domain if the mirror returns a non-2XX HTTP status code. I've added a test to make sure `oci.Resolve()` does indeed fall back.