### PR TITLE
Make prober script easier to run locally

### DIFF
--- a/tools/probers/bazelrbe/BUILD
+++ b/tools/probers/bazelrbe/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/tools/probers/bazelrbe",
     visibility = ["//visibility:private"],
     deps = [
-        "//server/util/bazel",
         "//server/util/log",
         "//server/util/status",
     ],


### PR DESCRIPTION
- Default the bazel binary to "bazel" so that we don't have to pass `--bazel_binary=bazel`
- Don't use `bazel.Invoke()` - it uses a new HOME directory for every invocation which means bazel is re-downloaded and re-installed on each run, which takes a while. Instead, use the system HOME directory so that bazel is installed to `~/.cache` but point `--output_base` into the temp dir so that nothing from the build is persisted.