### PR TITLE
Fix prettier.sh again

### DIFF
--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -73,11 +73,13 @@ function paths_to_format() {
 }
 
 paths=()
+format=0
 while read -r path; do
   paths+=("$path")
+  format=1
 done < <(paths_to_format)
 
-if [[ ${#paths} -eq -0 ]]; then
+if [[ "$format" -eq 0 ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
Now getting `/root/workspace/output-base/execroot/buildbuddy/bazel-out/platform_linux_x86_64-fastbuild/bin/tools/checkstyle/checkstyle.runfiles/buildbuddy/tools/prettier/prettier.sh: line 80: paths: unbound variable`

Desperately need to rewrite this in Go