### PR TITLE
Show org join requests on member page

### DIFF
--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -677,7 +677,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
           )}
         </div>
         {this.props.tab === "#users" && this.props.user?.canCall("getGroupUsers") && (
-          <OrgJoinRequestsComponent user={this.props.user} />
+          <OrgJoinRequestsComponent user={this.props.user} includeMargin={true} />
         )}
         {Boolean(this.state.invocations?.length || this.state.aggregateStats?.length) && (
           <div className="container nopadding-dense">

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -212,8 +212,11 @@
 .org-join-requests {
   background: #e3f2fd;
   padding: 32px 0 38px 0;
-  margin: 16px;
   border-radius: 8px;
+}
+
+.org-join-requests.with-margin {
+  margin: 16px;
 }
 
 .org-join-requests .org-join-requests-grid {

--- a/enterprise/app/org/org_join_requests.tsx
+++ b/enterprise/app/org/org_join_requests.tsx
@@ -7,6 +7,7 @@ import { user_id } from "../../../proto/user_id_ts_proto";
 
 export interface OrgJoinRequestsComponentProps {
   user: User;
+  includeMargin?: boolean;
 }
 
 interface State {
@@ -71,7 +72,7 @@ export default class OrgJoinRequests extends React.Component<OrgJoinRequestsComp
     if (!this.state.users?.length) return <></>;
 
     return (
-      <div className="org-join-requests">
+      <div className={`org-join-requests ${this.props.includeMargin ? "with-margin" : ""}`}>
         <div className="container narrow">
           <h2 className="org-join-requests-header">New user requests</h2>
           <div className="org-join-requests-grid">

--- a/enterprise/app/settings/BUILD
+++ b/enterprise/app/settings/BUILD
@@ -20,6 +20,7 @@ ts_library(
         "//enterprise/app/encryption",
         "//enterprise/app/iprules",
         "//enterprise/app/org:edit_org",
+        "//enterprise/app/org:org_join_requests",
         "//enterprise/app/org:org_members",
         "//enterprise/app/quota",
         "//enterprise/app/secrets",

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -18,6 +18,7 @@ import Link from "../../../app/components/link/link";
 import CompleteGitHubAppInstallationDialog from "./github_complete_installation";
 import EncryptionComponent from "../encryption/encryption";
 import IpRulesComponent from "../iprules/iprules";
+import OrgJoinRequests from "../org/org_join_requests";
 
 export interface SettingsProps {
   user: User;
@@ -241,6 +242,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                   )}
                   {activeTabId === TabId.OrgMembers && (
                     <>
+                      <OrgJoinRequests user={this.props.user} />
                       <div className="settings-option-title">Members of {this.props.user.selectedGroupName()}</div>
                       <OrgMembersComponent user={this.props.user} />
                     </>


### PR DESCRIPTION
We currently only show org join requests on the Users page, which is a common source of confusion.

With this change, they will also appear on the Org members page on the settings tab.