### PR TITLE
Configure grpc keepalive enforcement policy for the cli sidecar

### DIFF
--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -131,6 +131,7 @@ func initializeGRPCServer(env *real_environment.RealEnv) (*grpc.Server, net.List
 		grpc.ChainUnaryInterceptor(inactivityUnaryInterceptor(), interceptors.PropagateAPIKeyUnaryInterceptor()),
 		grpc.ChainStreamInterceptor(inactivityStreamInterceptor(), interceptors.PropagateAPIKeyStreamInterceptor()),
 		grpc.MaxRecvMsgSize(grpc_server.MaxRecvMsgSizeBytes()),
+		grpc_server.KeepaliveEnforcementPolicy(),
 	}
 	grpcServer := grpc.NewServer(grpcOptions...)
 	reflection.Register(grpcServer)

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -239,11 +239,11 @@ func CommonGRPCServerOptionsWithConfig(env environment.Env, config GRPCServerCon
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 		experimental.BufferPool(mem.DefaultBufferPool()),
 		grpc.MaxRecvMsgSize(MaxRecvMsgSizeBytes()),
-		keepaliveEnforcementPolicy(),
+		KeepaliveEnforcementPolicy(),
 	}
 }
 
-func keepaliveEnforcementPolicy() grpc.ServerOption {
+func KeepaliveEnforcementPolicy() grpc.ServerOption {
 	// Set to avoid errors: Bandwidth exhausted HTTP/2 error code: ENHANCE_YOUR_CALM Received Goaway too_many_pings
 	return grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 		MinTime:             10 * time.Second, // If a client pings more than once every 10 seconds, terminate the connection


### PR DESCRIPTION
The go default value is [5 min](https://github.com/grpc/grpc-go/blob/v1.70.0/keepalive/keepalive.go#L94) - but we often recommend users configure Bazel's --[grpc_keepalive_time](https://bazel.build/reference/command-line-reference#flag--grpc_keepalive_time)=30s flag.

Our servers already set this to 10s, but this change updates the cli's sidecar to also use 10s.