### PR TITLE
chore: Update Go SDK to 1.23.6

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,7 +56,7 @@ archive_override(
 bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.23.4")
+go_sdk.download(version = "1.23.6")
 go_sdk.nogo(nogo = "@//:vet")
 use_repo(
     go_sdk,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -190,7 +190,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_nogo", "
 
 go_rules_dependencies()
 
-GO_SDK_VERSION = "1.23.4"
+GO_SDK_VERSION = "1.23.6"
 
 # Register multiple Go SDKs so that we can perform cross-compilation remotely.
 # i.e. We might want to trigger a Linux AMD64 Go build remotely from a MacOS ARM64 laptop.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbuddy-io/buildbuddy
 
-go 1.23.4
+go 1.23.6
 
 replace (
 	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.7.0-buildbuddy // keep in sync with buildpatches/com_github_awslabs_soci_snapshotter.patch


### PR DESCRIPTION
> go1.23.5 (released 2025-01-16) includes security fixes to the crypto/x509 and
> net/http packages, as well as bug fixes to the compiler, the runtime, and the
> net package. See the Go 1.23.5 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.23.5+label%3ACherryPickApproved

> go1.23.6 (released 2025-02-04) includes security fixes to the crypto/elliptic
> package, as well as bug fixes to the compiler and the go command. See the Go
> 1.23.6 milestone on our issue tracker for details.

https://github.com/golang/go/issues?q=milestone%3AGo1.23.6+label%3ACherryPickApproved
