### PR TITLE
Update debug logging flags in firecracker/README

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -111,6 +111,8 @@ go_test(
         "--executor.firecracker_enable_uffd=true",
         "--executor.enable_local_snapshot_sharing=true",
         "--executor.enable_remote_snapshot_sharing=true",
+        "--debug_stream_command_outputs",
+        "--executor.firecracker_debug_stream_vm_logs",
     ],
     exec_properties = {
         "test.Pool": "bare",

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -111,8 +111,6 @@ go_test(
         "--executor.firecracker_enable_uffd=true",
         "--executor.enable_local_snapshot_sharing=true",
         "--executor.enable_remote_snapshot_sharing=true",
-        "--debug_stream_command_outputs",
-        "--executor.firecracker_debug_stream_vm_logs",
     ],
     exec_properties = {
         "test.Pool": "bare",

--- a/enterprise/server/remote_execution/containers/firecracker/README.md
+++ b/enterprise/server/remote_execution/containers/firecracker/README.md
@@ -40,12 +40,15 @@ If you want to test workflows locally with firecracker, make sure to set
 You can run Firecracker in debug mode to see more detailed
 VM logs, including logs from the init binary and vmexec server.
 
-To run in debug mode, set `--executor.firecracker_debug_mode=true`
-on the executor, or pass `--test_arg=--executor.firecracker_debug_mode=true`
+To run in debug mode, set `--executor.firecracker_debug_stream_vm_logs=true`
+on the executor, or pass `--test_arg=--executor.firecracker_debug_stream_vm_logs=true`
 to `bazel test`.
 
 It's useful to use debug mode whenever the executor can't connect
 to the VM (indicating the VM might have crashed).
+
+You can also stream test outputs to stdout with `--debug_stream_command_outputs`
+passed either to the executor or as part of `--test_arg=...`.
 
 ### SSH into a VM
 


### PR DESCRIPTION
The old flag doesn't exist any more, and these are useful for understanding what broke in a failing test.