### PR TITLE
[SS] Cleanup flags and debug data

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -121,7 +121,7 @@ func getExecutorHostID() string {
 func GetConfiguredEnvironmentOrDie(cacheRoot string, healthChecker *healthcheck.HealthChecker) *real_environment.RealEnv {
 	realEnv := real_environment.NewRealEnv(healthChecker)
 
-	mmapLRUEnabled := *platform.EnableFirecracker && (*snaputil.EnableLocalSnapshotSharing || *snaputil.EnableRemoteSnapshotSharing)
+	mmapLRUEnabled := *platform.EnableFirecracker && snaputil.IsChunkedSnapshotSharingEnabled()
 	if err := resources.Configure(mmapLRUEnabled); err != nil {
 		log.Fatal(status.Message(err))
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -106,9 +106,6 @@ go_test(
         "firecracker_test.go",
     ],
     args = [
-        "--executor.firecracker_enable_vbd=true",
-        "--executor.firecracker_enable_merged_rootfs=true",
-        "--executor.firecracker_enable_uffd=true",
         "--executor.enable_local_snapshot_sharing=true",
         "--executor.enable_remote_snapshot_sharing=true",
     ],

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -79,9 +79,6 @@ var (
 	firecrackerCgroupVersion  = flag.String("executor.firecracker_cgroup_version", "", "Specifies the cgroup version for firecracker to use.")
 	debugStreamVMLogs         = flag.Bool("executor.firecracker_debug_stream_vm_logs", false, "Stream firecracker VM logs to the terminal.")
 	debugTerminal             = flag.Bool("executor.firecracker_debug_terminal", false, "Run an interactive terminal in the Firecracker VM connected to the executor's controlling terminal. For debugging only.")
-	enableVBD                 = flag.Bool("executor.firecracker_enable_vbd", false, "Enables the FUSE-based virtual block device interface for block devices.")
-	EnableRootfs              = flag.Bool("executor.firecracker_enable_merged_rootfs", false, "Merges the containerfs and scratchfs into a single rootfs, removing the need to use overlayfs for the guest's root filesystem. Requires NBD to also be enabled.")
-	enableUFFD                = flag.Bool("executor.firecracker_enable_uffd", false, "Enables userfaultfd for firecracker VMs.")
 	dieOnFirecrackerFailure   = flag.Bool("executor.die_on_firecracker_failure", false, "Makes the host executor process die if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
 	workspaceDiskSlackSpaceMB = flag.Int64("executor.firecracker_workspace_disk_slack_space_mb", 2_000, "Extra space to allocate to firecracker workspace disks, in megabytes. ** Experimental **")
 	healthCheckInterval       = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
@@ -581,12 +578,6 @@ var _ container.VM = (*FirecrackerContainer)(nil)
 func NewContainer(ctx context.Context, env environment.Env, task *repb.ExecutionTask, opts ContainerOpts) (*FirecrackerContainer, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
-	if *snaputil.EnableLocalSnapshotSharing && !(*enableVBD && *enableUFFD) {
-		return nil, status.FailedPreconditionError("executor configuration error: local snapshot sharing requires VBD and UFFD to be enabled")
-	}
-	if *EnableRootfs && !*enableVBD {
-		return nil, status.FailedPreconditionError("executor configuration error: merged rootfs requires VBD to be enabled")
-	}
 
 	if opts.VMConfiguration == nil {
 		return nil, status.InvalidArgumentError("missing VMConfiguration")
@@ -655,10 +646,8 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 			return nil, err
 		}
 
-		// TODO(Maggie): Once local snapshot sharing is stable, remove runner ID
-		// from the snapshot key
 		runnerID := c.id
-		if *snaputil.EnableLocalSnapshotSharing {
+		if snaputil.IsChunkedSnapshotSharingEnabled() {
 			runnerID = ""
 		}
 		c.snapshotKeySet, err = loader.SnapshotKeySet(ctx, task, cd.GetHash(), runnerID)
@@ -669,7 +658,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		// Create(), load the snapshot instead of creating a new VM.
 
 		recyclingEnabled := platform.IsTrue(platform.FindValue(platform.GetProto(task.GetAction(), task.GetCommand()), platform.RecycleRunnerPropertyName))
-		if recyclingEnabled && *snaputil.EnableLocalSnapshotSharing {
+		if recyclingEnabled && snaputil.IsChunkedSnapshotSharingEnabled() {
 			snap, err := loader.GetSnapshot(ctx, c.snapshotKeySet, c.supportsRemoteSnapshots)
 			c.createFromSnapshot = (err == nil)
 			label := ""
@@ -685,6 +674,9 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 			}).Inc()
 		}
 	} else {
+		if !snaputil.IsChunkedSnapshotSharingEnabled() {
+			return nil, status.InvalidArgumentError("chunked snapshot sharing must be enabled to provide an override snapshot key")
+		}
 		c.snapshotKeySet = &fcpb.SnapshotKeySet{BranchKey: opts.OverrideSnapshotKey, WriteKey: opts.OverrideSnapshotKey}
 		c.createFromSnapshot = true
 
@@ -874,6 +866,8 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		return status.InvalidArgumentErrorf("write key required to save snapshot")
 	}
 
+	snapshotSharingEnabled := snaputil.IsChunkedSnapshotSharingEnabled()
+
 	baseMemSnapshotPath := filepath.Join(c.getChroot(), fullMemSnapshotName)
 	memSnapshotPath := filepath.Join(c.getChroot(), snapshotDetails.memSnapshotName)
 
@@ -890,7 +884,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	// If we're creating a snapshot for the first time, create a COWStore from
 	// the initial full snapshot. (If we have a diff snapshot, then we already
 	// updated the memoryStore in mergeDiffSnapshot above).
-	if *enableUFFD && c.memoryStore == nil {
+	if snapshotSharingEnabled && c.memoryStore == nil {
 		memChunkDir := filepath.Join(c.getChroot(), memoryChunkDirName)
 		memoryStore, err := c.convertToCOW(ctx, memSnapshotPath, memChunkDir)
 		if err != nil {
@@ -911,20 +905,17 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		Recycled:            c.recycled,
 		Remote:              c.supportsRemoteSnapshots,
 	}
-	if *enableVBD {
+	if snapshotSharingEnabled {
 		if c.rootStore != nil {
 			opts.ChunkedFiles[rootDriveID] = c.rootStore
 		} else {
 			opts.ContainerFSPath = filepath.Join(c.getChroot(), containerFSName)
 			opts.ChunkedFiles[scratchDriveID] = c.scratchStore
 		}
+		opts.ChunkedFiles[memoryChunkDirName] = c.memoryStore
 	} else {
 		opts.ContainerFSPath = filepath.Join(c.getChroot(), containerFSName)
 		opts.ScratchFSPath = filepath.Join(c.getChroot(), scratchFSName)
-	}
-	if *enableUFFD {
-		opts.ChunkedFiles[memoryChunkDirName] = c.memoryStore
-	} else {
 		opts.MemSnapshotPath = memSnapshotPath
 	}
 
@@ -1017,8 +1008,9 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 		return err
 	}
 
+	snapshotSharingEnabled := snaputil.IsChunkedSnapshotSharingEnabled()
 	var snapOpt fcclient.Opt
-	if *enableUFFD {
+	if snapshotSharingEnabled {
 		uffdType := fcclient.WithMemoryBackend(fcmodels.MemoryBackendBackendTypeUffd, uffdSockName)
 		snapOpt = fcclient.WithSnapshot("" /*=memFilePath*/, vmStateSnapshotName, uffdType)
 	} else {
@@ -1071,7 +1063,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 	if err != nil {
 		return status.WrapError(err, "failed to unpack snapshot")
 	}
-	if len(unpacked.ChunkedFiles) > 0 && !(*enableVBD || *enableUFFD) {
+	if len(unpacked.ChunkedFiles) > 0 && !snapshotSharingEnabled {
 		return status.InternalError("copy_on_write support is disabled but snapshot contains chunked files")
 	}
 	for name, cow := range unpacked.ChunkedFiles {
@@ -1145,7 +1137,7 @@ func (c *FirecrackerContainer) initScratchImage(ctx context.Context, path string
 	if err := ext4.MakeEmptyImage(ctx, path, scratchDiskSizeBytes); err != nil {
 		return err
 	}
-	if !*enableVBD {
+	if !snaputil.IsChunkedSnapshotSharingEnabled() {
 		return nil
 	}
 	chunkDir := filepath.Join(filepath.Dir(path), scratchDriveID)
@@ -1389,7 +1381,7 @@ func getBootArgs(vmConfig *fcpb.VMConfiguration) string {
 	if vmConfig.EnableDockerdTcp {
 		initArgs = append(initArgs, "-enable_dockerd_tcp")
 	}
-	if *EnableRootfs {
+	if snaputil.IsChunkedSnapshotSharingEnabled() {
 		initArgs = append(initArgs, "-enable_rootfs")
 	}
 	if platform.VFSEnabled() {
@@ -1435,7 +1427,7 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 			TrackDirtyPages: fcclient.Bool(true),
 		},
 	}
-	if *EnableRootfs {
+	if snaputil.IsChunkedSnapshotSharingEnabled() {
 		cfg.Drives = append(cfg.Drives, fcmodels.Drive{
 			DriveID:      fcclient.String(rootDriveID),
 			PathOnHost:   &rootFS,
@@ -1629,7 +1621,7 @@ func (c *FirecrackerContainer) setupUFFDHandler(ctx context.Context) error {
 }
 
 func (c *FirecrackerContainer) setupVBDMounts(ctx context.Context) error {
-	if !*enableVBD {
+	if !snaputil.IsChunkedSnapshotSharingEnabled() {
 		return nil
 	}
 
@@ -1816,7 +1808,9 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 		return err
 	}
 
-	if *EnableRootfs {
+	if snaputil.IsChunkedSnapshotSharingEnabled() {
+		rootFSPath = filepath.Join(c.getChroot(), rootDriveID+vbdMountDirSuffix, vbd.FileName)
+		scratchFSPath = filepath.Join(c.getChroot(), scratchDriveID+vbdMountDirSuffix, vbd.FileName)
 		if err := c.initRootfsStore(ctx); err != nil {
 			return status.WrapError(err, "create root image")
 		}
@@ -1829,11 +1823,6 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	// Create the workspace drive placeholder contents.
 	if err := os.WriteFile(workspacePlaceholderPath, nil, 0644); err != nil {
 		return status.UnavailableErrorf("write workspace placeholder file: %s", err)
-	}
-
-	if *enableVBD {
-		rootFSPath = filepath.Join(c.getChroot(), rootDriveID+vbdMountDirSuffix, vbd.FileName)
-		scratchFSPath = filepath.Join(c.getChroot(), scratchDriveID+vbdMountDirSuffix, vbd.FileName)
 	}
 
 	if err := c.setupCgroup(ctx); err != nil {
@@ -2222,7 +2211,7 @@ func (c *FirecrackerContainer) PullImage(ctx context.Context, creds oci.Credenti
 
 	// If we're creating from a snapshot, we don't need to pull the base image
 	// since the rootfs image contains our full desired disk contents.
-	if c.createFromSnapshot && *EnableRootfs {
+	if c.createFromSnapshot {
 		return nil
 	}
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -525,10 +525,6 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 }
 
 func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
-	if !*snaputil.EnableLocalSnapshotSharing {
-		t.Skip("Snapshot sharing is not enabled")
-	}
-
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
@@ -679,10 +675,6 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 }
 
 func TestFirecracker_RemoteSnapshotSharing(t *testing.T) {
-	if !*snaputil.EnableRemoteSnapshotSharing {
-		t.Skip("Snapshot sharing is not enabled")
-	}
-
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	rootDir := testfs.MakeTempDir(t)
@@ -850,10 +842,6 @@ func TestFirecracker_RemoteSnapshotSharing(t *testing.T) {
 }
 
 func TestFirecracker_RemoteSnapshotSharing_RemoteInstanceName(t *testing.T) {
-	if !*snaputil.EnableRemoteSnapshotSharing {
-		t.Skip("Snapshot sharing is not enabled")
-	}
-
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	cfg := getExecutorConfig(t)
@@ -922,10 +910,6 @@ printf '%s' $ATTEMPT_NUMBER | tee ./attempts
 }
 
 func TestFirecracker_SnapshotSharing_MergeQueueBranches(t *testing.T) {
-	if !*snaputil.EnableRemoteSnapshotSharing {
-		t.Skip("Snapshot sharing is not enabled")
-	}
-
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	cfg := getExecutorConfig(t)
@@ -1031,10 +1015,6 @@ cat ./attempts
 }
 
 func TestFirecracker_LocalSnapshotSharing_ContainerImageChunksExpiredFromCache(t *testing.T) {
-	if !*snaputil.EnableRemoteSnapshotSharing {
-		t.Skip("Snapshot sharing is not enabled")
-	}
-
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	cfg := getExecutorConfig(t)
@@ -1102,10 +1082,6 @@ printf '%s' $ATTEMPT_NUMBER | tee ./attempts
 }
 
 func TestFirecrackerSnapshotVersioning(t *testing.T) {
-	if !*snaputil.EnableLocalSnapshotSharing {
-		t.SkipNow()
-	}
-
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	rootDir := testfs.MakeTempDir(t)
@@ -1216,7 +1192,7 @@ func TestFirecrackerComplexFileMapping(t *testing.T) {
 		assert.Fail(t, "/workspace disk usage was not reported")
 	} else {
 		expectedWorkspaceDev := "/dev/vdc"
-		if *firecracker.EnableRootfs {
+		if snaputil.IsChunkedSnapshotSharingEnabled() {
 			expectedWorkspaceDev = "/dev/vdb"
 		}
 
@@ -1240,7 +1216,7 @@ func TestFirecrackerComplexFileMapping(t *testing.T) {
 	}
 	if rootFSU == nil {
 		assert.Fail(t, "root (/) disk usage was not reported")
-	} else if *firecracker.EnableRootfs {
+	} else if snaputil.IsChunkedSnapshotSharingEnabled() {
 		assert.Equal(t, "ext4", rootFSU.GetFstype())
 		assert.Equal(t, "/dev/vda", rootFSU.GetSource())
 	} else {
@@ -1584,7 +1560,7 @@ func TestFirecrackerRunWithDockerOverUDS(t *testing.T) {
 
 	assert.Equal(t, 0, res.ExitCode)
 	expectedStorageDriver := "vfs"
-	if *firecracker.EnableRootfs {
+	if snaputil.IsChunkedSnapshotSharingEnabled() {
 		expectedStorageDriver = "overlay2"
 	}
 	assert.Equal(t, "Hello\nworld\n Storage Driver: "+expectedStorageDriver+"\n", string(res.Stdout), "stdout should contain pwd output")

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -987,7 +987,7 @@ func (p *pool) Get(ctx context.Context, st *repb.ScheduledTask) (interfaces.Runn
 	// workload is for branch `feature_two`, we should create a new runner intended
 	// for `feature_two`, rather than reuse the runner for branch `feature_one`, which would be more stale
 	snapshotEnabledRunner := platform.ContainerType(props.WorkloadIsolationType) == platform.FirecrackerContainerType &&
-		(*snaputil.EnableRemoteSnapshotSharing || *snaputil.EnableLocalSnapshotSharing)
+		snaputil.IsChunkedSnapshotSharingEnabled()
 	if props.RecycleRunner && !snapshotEnabledRunner {
 		r := p.takeWithRetry(ctx, key)
 		if r != nil {
@@ -1362,7 +1362,7 @@ func (p *pool) TryRecycle(ctx context.Context, r interfaces.Runner, finishedClea
 	// the pool logic for them. Just save the snapshot with `Container.Pause`,
 	// which also removes the container.
 	snapshotEnabledRunner := platform.ContainerType(cr.PlatformProperties.WorkloadIsolationType) == platform.FirecrackerContainerType &&
-		(*snaputil.EnableRemoteSnapshotSharing || *snaputil.EnableLocalSnapshotSharing)
+		snaputil.IsChunkedSnapshotSharingEnabled()
 	if snapshotEnabledRunner {
 		if err := cr.Container.Pause(ctx); err != nil {
 			// TODO(vanja) maybe recycled should be set to true here?

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -141,7 +141,7 @@ func (l *FileCacheLoader) currentSnapshotVersion(ctx context.Context, key *fcpb.
 }
 
 func gitRefs(task *repb.ExecutionTask) (branchRef string, fallbackRefs []string) {
-	if !*snaputil.EnableRemoteSnapshotSharing && !*snaputil.EnableLocalSnapshotSharing {
+	if !snaputil.IsChunkedSnapshotSharingEnabled() {
 		return "", nil
 	}
 
@@ -640,7 +640,7 @@ func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotK
 		eg.Go(func() error {
 			ctx := egCtx
 			var d *repb.Digest
-			if *snaputil.EnableLocalSnapshotSharing || *snaputil.EnableRemoteSnapshotSharing {
+			if snaputil.IsChunkedSnapshotSharingEnabled() {
 				var err error
 				d, err = fileDigest(filePath)
 				if err != nil {

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -210,3 +210,19 @@ func ChunkSourceLabel(c ChunkSource) string {
 		return "invalid_chunk_source"
 	}
 }
+
+// Chunked snapshot sharing allows snapshot files to be split into smaller chunks,
+// which can be cached locally or remotely. These chunks are then provided to
+// the guest using userfaultfd for memory and VBD for disk.
+//
+// When enabled, we can use VBD to support a single rootfs. This removes the need
+// to use overlayfs with the read-only container image (containerfs) and the
+// writeable scratch disk image (scratchfs).
+//
+// If disabled, Firecracker can still resume from full snapshot files stored on disk.
+// However, these files are too large to transfer between machines and will be lost
+// if the executor shuts down. Instead of a single root filesystem,
+// there will be separate containerfs and scratchfs.
+func IsChunkedSnapshotSharingEnabled() bool {
+	return *EnableRemoteSnapshotSharing || *EnableLocalSnapshotSharing
+}


### PR DESCRIPTION
Many of these features only work in tandem, so eliminate some of the snapshot related flags. Only keep `enable_remote_snapshot_sharing` and `enable_local_snapshot_sharing`.

Also cleanup some debug logging in uffd.go