### PR TITLE
Fix typo in trimQueue

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -503,7 +503,7 @@ func (q *PriorityTaskScheduler) getNextTask() *scpb.EnqueueTaskReservationReques
 // This function returns true if a task was successfully dequeued.
 func (q *PriorityTaskScheduler) trimQueue() bool {
 	nextTask := q.getNextTask()
-	if q == nil {
+	if nextTask == nil {
 		return false
 	}
 


### PR DESCRIPTION
This doesn't actually change the correctness afaict, just lets us avoid an extra TaskExistsRequest