### PR TITLE
Add a mechanism for executors to detect registration issues.

### DIFF
--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -23,7 +23,10 @@ import (
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 )
 
-var pool = flag.String("executor.pool", "", "Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified.")
+var (
+	pool                         = flag.String("executor.pool", "", "Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified.")
+	registrationStreamAckTimeout = flag.Duration("executor.registration_stream_ack_timeout", 0, "If non-zero, the executor will continuously validate that it's registered with a scheduler to receive work and will re-register if an ack is not received within this amount of time.")
+)
 
 const (
 	schedulerCheckInInterval         = 5 * time.Second
@@ -85,6 +88,8 @@ type Registration struct {
 	apiKey          string
 	shutdownSignal  chan struct{}
 
+	lastRegistrationAck time.Time
+
 	mu          sync.Mutex
 	connected   bool
 	idleSeconds atomic.Int64
@@ -113,6 +118,9 @@ func (r *Registration) processWorkStream(ctx context.Context, stream scpb.Schedu
 	registrationMsg := &scpb.RegisterAndStreamWorkRequest{
 		RegisterExecutorRequest: &scpb.RegisterExecutorRequest{Node: r.node},
 	}
+	if *registrationStreamAckTimeout != 0 {
+		registrationMsg.RegisterExecutorRequest.AcknowledgeRegistration = true
+	}
 
 	select {
 	case <-ctx.Done():
@@ -139,6 +147,10 @@ func (r *Registration) processWorkStream(ctx context.Context, stream scpb.Schedu
 			requestMoreWorkTicker.Reset(moreWorkResponse.GetDelay().AsDuration())
 			return false, nil
 		}
+		if msg.RegisterExecutorResponse != nil {
+			r.lastRegistrationAck = time.Now()
+			return false, nil
+		}
 		if msg.EnqueueTaskReservationRequest == nil {
 			out, _ := prototext.Marshal(msg)
 			return false, status.FailedPreconditionErrorf("message from scheduler did not contain a task reservation request:\n%s", string(out))
@@ -157,6 +169,9 @@ func (r *Registration) processWorkStream(ctx context.Context, stream scpb.Schedu
 	case err := <-schedulerErr:
 		return false, status.WrapError(err, "failed to receive message from scheduler")
 	case <-registrationTicker.C:
+		if *registrationStreamAckTimeout != 0 && time.Since(r.lastRegistrationAck) > *registrationStreamAckTimeout {
+			return false, status.DeadlineExceededErrorf("have not received registration ack from scheduler in %s", time.Since(r.lastRegistrationAck))
+		}
 		if err := stream.Send(registrationMsg); err != nil {
 			return false, status.UnavailableErrorf("could not send registration message: %s", err)
 		}
@@ -200,6 +215,10 @@ func (r *Registration) monitorExcessCapacity(ctx context.Context) {
 func (r *Registration) maintainRegistrationAndStreamWork(ctx context.Context) {
 	registrationMsg := &scpb.RegisterAndStreamWorkRequest{
 		RegisterExecutorRequest: &scpb.RegisterExecutorRequest{Node: r.node},
+	}
+	if *registrationStreamAckTimeout != 0 {
+		registrationMsg.RegisterExecutorRequest.AcknowledgeRegistration = true
+		r.lastRegistrationAck = time.Now()
 	}
 
 	defer r.setConnected(false)
@@ -278,6 +297,10 @@ func (r *Registration) Start(ctx context.Context) {
 // NewRegistration creates a handle to maintain registration with a scheduler server.
 // The registration is not initiated until Start is called on the returned handle.
 func NewRegistration(env environment.Env, taskScheduler *priority_task_scheduler.PriorityTaskScheduler, executorID, executorHostID string, options *Options) (*Registration, error) {
+	if *registrationStreamAckTimeout != 0 && *registrationStreamAckTimeout < schedulerCheckInInterval*2 {
+		return nil, status.InvalidArgumentErrorf("executor.registration_stream_ack_timeout should be at least %s", schedulerCheckInInterval*2)
+	}
+
 	poolName := *pool
 	if poolName == "" {
 		poolName = resources.GetPoolName()

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -347,6 +347,9 @@ func (h *executorHandle) Serve(ctx context.Context) error {
 				}
 				h.setRegistration(registration)
 				executorID = registration.GetExecutorId()
+				if req.GetRegisterExecutorRequest().AcknowledgeRegistration {
+					h.requests <- enqueueTaskReservationRequest{proto: &scpb.RegisterAndStreamWorkResponse{RegisterExecutorResponse: &scpb.RegisterExecutorResponse{}}}
+				}
 			} else if req.GetEnqueueTaskReservationResponse() != nil {
 				h.handleTaskReservationResponse(req.GetEnqueueTaskReservationResponse())
 				lastWorkTime = time.Time{}
@@ -540,9 +543,9 @@ func (h *executorHandle) startTaskReservationStreamer() {
 						log.CtxWarningf(h.stream.Context(), "Error sending task reservation response: %s", err)
 						return
 					}
-				case msg.GetAskForMoreWorkResponse() != nil:
+				default:
 					if err := h.stream.Send(msg); err != nil {
-						log.CtxWarningf(h.stream.Context(), "Error sending task reservation response: %s", err)
+						log.CtxWarningf(h.stream.Context(), "Error sending response: %s", err)
 						return
 					}
 				}

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -411,6 +411,15 @@ message EnqueueTaskReservationResponse {
 
 message RegisterExecutorRequest {
   ExecutionNode node = 1;
+
+  // If set to true, the scheduler is expected to send a
+  // RegisterExecuteResponse message to indicate that the executor is still
+  // registered to receive work.
+  bool acknowledge_registration = 2;
+}
+
+message RegisterExecutorResponse {
+
 }
 
 // AskForMoreWorkRequest may be sent from the executor to the scheduler when
@@ -457,6 +466,9 @@ message RegisterAndStreamWorkResponse {
 
   // How long to backoff if a AskForMoreWorkRequest was sent.
   AskForMoreWorkResponse ask_for_more_work_response = 4;
+
+  // Response acknowledging the registration request.
+  RegisterExecutorResponse register_executor_response = 5;
 }
 
 service Scheduler {

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -418,9 +418,7 @@ message RegisterExecutorRequest {
   bool acknowledge_registration = 2;
 }
 
-message RegisterExecutorResponse {
-
-}
+message RegisterExecutorResponse {}
 
 // AskForMoreWorkRequest may be sent from the executor to the scheduler when
 // the executor detects it is idle. If more unclaimed work is available, the


### PR DESCRIPTION
When enabled, the executor will ask the scheduler to send a message back whenever it receives a registration request. If the executor does not hear back within the specified deadline then the executor will establish a new registration stream.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4404