### PR TITLE
explain: Let `--old` default to the build before the last one

### DIFF
--- a/cli/storage/BUILD
+++ b/cli/storage/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "storage",
@@ -14,3 +14,10 @@ go_library(
 )
 
 package(default_visibility = ["//cli:__subpackages__"])
+
+go_test(
+    name = "storage_test",
+    srcs = ["storage_test.go"],
+    embed = [":storage"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/cli/storage/storage_test.go
+++ b/cli/storage/storage_test.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	// Change to a directory that looks like a Bazel workspace so that
+	// workspace.Path() can find it.
+	workspaceDir, err := os.MkdirTemp("", "storage_test")
+	if err != nil {
+		panic(err)
+	}
+	if err = os.Chdir(workspaceDir); err != nil {
+		panic(err)
+	}
+	if err = os.WriteFile("MODULE.bazel", []byte{}, 0644); err != nil {
+		panic(err)
+	}
+
+	exitCode := m.Run()
+	_ = os.RemoveAll(workspaceDir)
+	os.Exit(exitCode)
+}
+
+func TestPreviousFlagStorage(t *testing.T) {
+	for maxValues := 1; maxValues <= 3; maxValues++ {
+		t.Run("maxValues="+strconv.Itoa(maxValues), func(t *testing.T) {
+			previousCacheDir := os.Getenv("BUILDBUDDY_CACHE_DIR")
+			err := os.Setenv("BUILDBUDDY_CACHE_DIR", t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				err := os.Setenv("BUILDBUDDY_CACHE_DIR", previousCacheDir)
+				require.NoError(t, err)
+			})
+
+			flag := "flag" + strconv.Itoa(maxValues)
+			rng := rand.New(rand.NewSource(int64(maxValues)))
+
+			for numStores := 0; numStores <= 3*maxValues; numStores++ {
+				var expectedValues []string
+				for i := numStores; i > 0 && i > numStores-maxValues; i-- {
+					expectedValues = append(expectedValues, fmt.Sprintf("value_%d", i))
+				}
+				for len(expectedValues) < maxValues {
+					expectedValues = append(expectedValues, "")
+				}
+
+				var actualValues []string
+				for i := 1; i <= maxValues; i++ {
+					v, err := GetNthPreviousFlag(flag, i)
+					require.NoError(t, err)
+					actualValues = append(actualValues, v)
+				}
+
+				require.Equalf(t, expectedValues, actualValues, "numStores=%d", numStores)
+
+				value := fmt.Sprintf("value_%d", numStores+1)
+				flagAndValue := fmt.Sprintf("--%s=%s", flag, value)
+				var argsIn []string
+				var backup string
+				// Deterministically vary whether the flag is specified explicitly.
+				if rng.Int()%2 == 0 {
+					argsIn = []string{flagAndValue}
+					backup = ""
+				} else {
+					argsIn = []string{}
+					backup = value
+				}
+				argsOut := saveFlag(argsIn, flag, backup, maxValues)
+				require.Equal(t, flagAndValue, argsOut[len(argsOut)-1])
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This is based on extending `storage` to persist an arbitrary number of values per flag.

Example:

```shell
$ bb build //cli --config=remote
$ # modify cli/storage/storage.go
$ bb build //cli --config=remote
$ bb explain
RunNogo //cli/storage:storage (bazel-out/platform_linux_x86_64-fastbuild/bin/cli/storage/storage.facts)
  inputs changed:
    cli/storage/storage.go: content changed

GoCompilePkg //cli/storage:storage (bazel-out/platform_linux_x86_64-fastbuild/bin/cli/storage/storage.a)
  inputs changed:
    cli/storage/storage.go: content changed
  transitively invalidated:
        10 GoCompilePkg
        10 RunNogo
         1 GoLink
```