### PR TITLE
cli/fix: Ignore hidden directories

### DIFF
--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -95,7 +95,13 @@ func walk(moduleOrWorkspaceFile string) error {
 				return err
 			}
 			if d.IsDir() {
-				return nil
+				// Don't recurse into hidden directories such as .git or .ijwb
+				// (IntelliJ).
+				if strings.HasPrefix(d.Name(), ".") {
+					return filepath.SkipDir
+				} else {
+					return nil
+				}
 			}
 			// .bzl files are formatted directly by buildifier.
 			if strings.HasSuffix(path, ".bzl") {


### PR DESCRIPTION
`bazel run //tools/checkstyle` failed for me because it found the `.bzl` file templates for IntelliJ's aspect templates in `.ijwb`. Skipping folders such as `.git` probably also improves runtime.