### PR TITLE
[SS] Add file name to metric for compressed bytes uploaded for snapshots

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -639,7 +639,8 @@ func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotK
 		ar.OutputFiles = append(ar.OutputFiles, out)
 		eg.Go(func() error {
 			ctx := egCtx
-			fileName := filepath.Base(filePath)
+			// This should be the name of the file - i.e. "initrd.cpio", "vmstate.snap", "vmlinux"
+			fileType := filepath.Base(filePath)
 			var d *repb.Digest
 			if *snaputil.EnableLocalSnapshotSharing || *snaputil.EnableRemoteSnapshotSharing {
 				var err error
@@ -661,12 +662,12 @@ func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotK
 					return err
 				}
 				d = &repb.Digest{
-					Hash:      hashStrings(gid, key.InstanceName, key.PlatformHash, key.ConfigurationHash, key.RunnerId, fileName),
+					Hash:      hashStrings(gid, key.InstanceName, key.PlatformHash, key.ConfigurationHash, key.RunnerId, fileType),
 					SizeBytes: info.Size(),
 				}
 			}
 			out.Digest = d
-			return snaputil.Cache(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), opts.Remote, d, key.InstanceName, filePath, fileName)
+			return snaputil.Cache(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), opts.Remote, d, key.InstanceName, filePath, fileType)
 		})
 	}
 	for name, cow := range opts.ChunkedFiles {

--- a/enterprise/server/remote_execution/snaputil/BUILD
+++ b/enterprise/server/remote_execution/snaputil/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",
+        "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -127,7 +127,7 @@ func GetBytes(ctx context.Context, localCache interfaces.FileCache, bsClient byt
 
 // Cache saves a file written to `path` to the local cache, and the remote cache
 // if remote snapshot sharing is enabled.
-func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, path string, metricsName string) error {
+func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, path string, fileTypeLabel string) error {
 	localCacheErr := cacheLocally(ctx, localCache, d, path)
 	if !*EnableRemoteSnapshotSharing || *RemoteSnapshotReadonly || !remoteEnabled {
 		return localCacheErr
@@ -149,7 +149,7 @@ func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytest
 	_, bytesUploaded, err := cachetools.UploadFromReader(ctx, bsClient, rn, file)
 	if err == nil && bytesUploaded > 0 {
 		metrics.SnapshotRemoteCacheUploadSizeBytes.With(prometheus.Labels{
-			metrics.FileName: metricsName,
+			metrics.FileName: fileTypeLabel,
 		}).Add(float64(bytesUploaded))
 	}
 	return err
@@ -157,7 +157,7 @@ func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytest
 
 // CacheBytes saves bytes to the cache.
 // It does this by writing the bytes to a temporary file in tmpDir.
-func CacheBytes(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, b []byte, name string) error {
+func CacheBytes(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, b []byte, fileTypeLabel string) error {
 	// Write temp file containing bytes
 	randStr, err := random.RandomString(10)
 	if err != nil {
@@ -173,7 +173,7 @@ func CacheBytes(ctx context.Context, localCache interfaces.FileCache, bsClient b
 		}
 	}()
 
-	return Cache(ctx, localCache, bsClient, remoteEnabled, d, remoteInstanceName, tmpPath, name)
+	return Cache(ctx, localCache, bsClient, remoteEnabled, d, remoteInstanceName, tmpPath, fileTypeLabel)
 }
 
 var chrootPrefix = regexp.MustCompile("^.*/firecracker/[^/]+/root/")

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/genproto/googleapis/bytestream"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -125,8 +126,8 @@ func GetBytes(ctx context.Context, localCache interfaces.FileCache, bsClient byt
 }
 
 // Cache saves a file written to `path` to the local cache, and the remote cache
-// if remote snapshot sharing is enabled
-func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, path string) error {
+// if remote snapshot sharing is enabled.
+func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, path string, name string) error {
 	localCacheErr := cacheLocally(ctx, localCache, d, path)
 	if !*EnableRemoteSnapshotSharing || *RemoteSnapshotReadonly || !remoteEnabled {
 		return localCacheErr
@@ -147,14 +148,16 @@ func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytest
 	defer file.Close()
 	_, bytesUploaded, err := cachetools.UploadFromReader(ctx, bsClient, rn, file)
 	if err == nil && bytesUploaded > 0 {
-		metrics.SnapshotRemoteCacheUploadSizeBytes.Add(float64(bytesUploaded))
+		metrics.SnapshotRemoteCacheUploadSizeBytes.With(prometheus.Labels{
+			metrics.FileName: name,
+		}).Add(float64(bytesUploaded))
 	}
 	return err
 }
 
 // CacheBytes saves bytes to the cache.
 // It does this by writing the bytes to a temporary file in tmpDir.
-func CacheBytes(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, b []byte) error {
+func CacheBytes(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, b []byte, name string) error {
 	// Write temp file containing bytes
 	randStr, err := random.RandomString(10)
 	if err != nil {
@@ -170,7 +173,7 @@ func CacheBytes(ctx context.Context, localCache interfaces.FileCache, bsClient b
 		}
 	}()
 
-	return Cache(ctx, localCache, bsClient, remoteEnabled, d, remoteInstanceName, tmpPath)
+	return Cache(ctx, localCache, bsClient, remoteEnabled, d, remoteInstanceName, tmpPath, name)
 }
 
 var chrootPrefix = regexp.MustCompile("^.*/firecracker/[^/]+/root/")

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -127,7 +127,7 @@ func GetBytes(ctx context.Context, localCache interfaces.FileCache, bsClient byt
 
 // Cache saves a file written to `path` to the local cache, and the remote cache
 // if remote snapshot sharing is enabled.
-func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, path string, name string) error {
+func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, path string, metricsName string) error {
 	localCacheErr := cacheLocally(ctx, localCache, d, path)
 	if !*EnableRemoteSnapshotSharing || *RemoteSnapshotReadonly || !remoteEnabled {
 		return localCacheErr
@@ -149,7 +149,7 @@ func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytest
 	_, bytesUploaded, err := cachetools.UploadFromReader(ctx, bsClient, rn, file)
 	if err == nil && bytesUploaded > 0 {
 		metrics.SnapshotRemoteCacheUploadSizeBytes.With(prometheus.Labels{
-			metrics.FileName: name,
+			metrics.FileName: metricsName,
 		}).Add(float64(bytesUploaded))
 	}
 	return err

--- a/enterprise/server/remote_execution/snaputil/snaputil_test.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil_test.go
@@ -52,7 +52,7 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test caching and fetching
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b, "")
 	require.NoError(t, err)
 	outputPath := filepath.Join(tmpDir, "fetch")
 	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, "", outputPath)
@@ -64,7 +64,7 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	require.Equal(t, randomStr, fetchedStr)
 
 	// Test rewriting same digest
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b, "")
 	require.NoError(t, err)
 
 	// Delete from remote cache, make sure we can still read
@@ -79,7 +79,7 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	require.Equal(t, randomStr, fetchedStr)
 
 	// Rewrite artifact and delete from local cache, make sure we can still read
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b, "")
 	require.NoError(t, err)
 	deleted := fc.DeleteFile(ctx, &repb.FileNode{Digest: d})
 	require.True(t, deleted)
@@ -92,7 +92,7 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 
 	// Test writing bogus digest
 	bogusDigest, _ := testdigest.NewRandomResourceAndBuf(t, 1000, rspb.CacheType_CAS, "")
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, bogusDigest.Digest, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, bogusDigest.Digest, "", b, "")
 	require.Error(t, err)
 }
 
@@ -113,7 +113,7 @@ func TestCacheAndFetchArtifact_LocalOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read and write bytes from local cache
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", b, "")
 	require.NoError(t, err)
 	outputPath := filepath.Join(tmpDir, "fetch")
 	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", outputPath)
@@ -148,7 +148,7 @@ func TestCacheAndFetchBytes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test caching and fetching
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b, "")
 	require.NoError(t, err)
 	fetchedBytes, err := snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", tmpDir)
 	require.NoError(t, err)

--- a/enterprise/server/remote_execution/snaputil/snaputil_test.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil_test.go
@@ -50,12 +50,14 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	b := []byte(randomStr)
 	d, err := digest.Compute(bytes.NewReader(b), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
+	remoteInstanceName := ""
+	fileTypeLabel := "test"
 
 	// Test caching and fetching
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b, "")
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, b, fileTypeLabel)
 	require.NoError(t, err)
 	outputPath := filepath.Join(tmpDir, "fetch")
-	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, "", outputPath)
+	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, outputPath)
 	require.NoError(t, err)
 	require.Equal(t, snaputil.ChunkSourceLocalFilecache, chunkSrc)
 
@@ -64,35 +66,35 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	require.Equal(t, randomStr, fetchedStr)
 
 	// Test rewriting same digest
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b, "")
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, b, fileTypeLabel)
 	require.NoError(t, err)
 
 	// Delete from remote cache, make sure we can still read
-	rn := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_BLAKE3).ToProto()
+	rn := digest.NewResourceName(d, remoteInstanceName, rspb.CacheType_CAS, repb.DigestFunction_BLAKE3).ToProto()
 	err = env.GetCache().Delete(ctx, rn)
 	require.NoError(t, err)
 	outputPathLocalFetch := filepath.Join(tmpDir, "fetch_local")
-	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, "", outputPathLocalFetch)
+	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, outputPathLocalFetch)
 	require.NoError(t, err)
 	require.Equal(t, snaputil.ChunkSourceLocalFilecache, chunkSrc)
 	fetchedStr = testfs.ReadFileAsString(t, tmpDir, "fetch_local")
 	require.Equal(t, randomStr, fetchedStr)
 
 	// Rewrite artifact and delete from local cache, make sure we can still read
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b, "")
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, b, fileTypeLabel)
 	require.NoError(t, err)
 	deleted := fc.DeleteFile(ctx, &repb.FileNode{Digest: d})
 	require.True(t, deleted)
 	outputPathRemoteFetch := filepath.Join(tmpDir, "fetch_remote")
-	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, "", outputPathRemoteFetch)
+	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, outputPathRemoteFetch)
 	require.NoError(t, err)
 	require.Equal(t, snaputil.ChunkSourceRemoteCache, chunkSrc)
 	fetchedStr = testfs.ReadFileAsString(t, tmpDir, "fetch_remote")
 	require.Equal(t, randomStr, fetchedStr)
 
 	// Test writing bogus digest
-	bogusDigest, _ := testdigest.NewRandomResourceAndBuf(t, 1000, rspb.CacheType_CAS, "")
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, bogusDigest.Digest, "", b, "")
+	bogusDigest, _ := testdigest.NewRandomResourceAndBuf(t, 1000, rspb.CacheType_CAS, remoteInstanceName)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, bogusDigest.Digest, remoteInstanceName, b, fileTypeLabel)
 	require.Error(t, err)
 }
 
@@ -111,12 +113,14 @@ func TestCacheAndFetchArtifact_LocalOnly(t *testing.T) {
 	b := []byte(randomStr)
 	d, err := digest.Compute(bytes.NewReader(b), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
+	remoteInstanceName := ""
+	fileTypeLabel := "test"
 
 	// Read and write bytes from local cache
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", b, "")
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, remoteInstanceName, b, fileTypeLabel)
 	require.NoError(t, err)
 	outputPath := filepath.Join(tmpDir, "fetch")
-	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", outputPath)
+	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, remoteInstanceName, outputPath)
 	require.NoError(t, err)
 	require.Equal(t, snaputil.ChunkSourceLocalFilecache, chunkSrc)
 	// Read bytes from outputPath and validate with original bytes
@@ -127,7 +131,7 @@ func TestCacheAndFetchArtifact_LocalOnly(t *testing.T) {
 	deleted := fc.DeleteFile(ctx, &repb.FileNode{Digest: d})
 	require.True(t, deleted)
 	outputPathRemoteFetch := filepath.Join(tmpDir, "fetch_err")
-	_, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", outputPathRemoteFetch)
+	_, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, remoteInstanceName, outputPathRemoteFetch)
 	require.True(t, status.IsUnavailableError(err))
 }
 
@@ -146,18 +150,20 @@ func TestCacheAndFetchBytes(t *testing.T) {
 	b := []byte(randomStr)
 	d, err := digest.Compute(bytes.NewReader(b), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
+	remoteInstanceName := ""
+	fileTypeLabel := "test"
 
 	// Test caching and fetching
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b, "")
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, b, fileTypeLabel)
 	require.NoError(t, err)
-	fetchedBytes, err := snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", tmpDir)
+	fetchedBytes, err := snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, tmpDir)
 	require.NoError(t, err)
 	require.Equal(t, randomStr, string(fetchedBytes))
 
 	// Delete from local cache, make sure we can still read
 	deleted := fc.DeleteFile(ctx, &repb.FileNode{Digest: d})
 	require.True(t, deleted)
-	fetchedBytes, err = snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", tmpDir)
+	fetchedBytes, err = snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), true, d, remoteInstanceName, tmpDir)
 	require.NoError(t, err)
 	require.Equal(t, randomStr, string(fetchedBytes))
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1270,11 +1270,13 @@ var (
 		CreatedFromSnapshot,
 	})
 
-	SnapshotRemoteCacheUploadSizeBytes = promauto.NewCounter(prometheus.CounterOpts{
+	SnapshotRemoteCacheUploadSizeBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",
 		Name:      "snapshot_remote_cache_upload_size_bytes",
-		Help:      "After a copy-on-write snapshot has been used, the total count of bytes dirtied.",
+		Help:      "After a copy-on-write snapshot has been used, the total count of compressed bytes written to the cache (i.e. will be 0 if the artifact is already cached).",
+	}, []string{
+		FileName,
 	})
 
 	COWSnapshotDirtyChunkRatio = promauto.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
This [graph](https://metrics.buildbuddy.io/d/KI6NxDWSk/workflow-snapshotting?orgId=1&refresh=1m&viewPanel=14) provides a misleading view of how much snapshot data we're writing to the remote cache, because it tracks non-compressed data and doesn't account for data that already exists in the cache.

Add file name to the metric that tracks compressed data that is actually written to the cache