### PR TITLE
Log a message when pebble_cache creates a new default partition

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -453,6 +453,7 @@ func ensureDefaultPartitionExists(opts *Options) {
 	if foundDefaultPartition {
 		return
 	}
+	log.Info("No pebble default partition found, creating one.")
 	opts.Partitions = append(opts.Partitions, disk.Partition{
 		ID:           DefaultPartitionID,
 		MaxSizeBytes: opts.MaxSizeBytes,


### PR DESCRIPTION
We don't currently log anything if pebble_cache starts up with an empty directory. This shouldn't happen that much in prod, and it'd be nice to search the logs for when it does.