### PR TITLE
[raft] set error in Entry instead of returning it directly

### DIFF
--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -53,5 +53,6 @@ go_test(
         "//server/util/uuid",
         "@com_github_lni_dragonboat_v4//statemachine",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )


### PR DESCRIPTION
This should preventing raft panicking when there is an update error.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4141
