### PR TITLE
feat: Use CodecV2 for proto encoding/decoding

### DIFF
--- a/server/util/paging/BUILD
+++ b/server/util/paging/BUILD
@@ -19,6 +19,7 @@ go_test(
     deps = [
         ":paging",
         "//proto:pagination_go_proto",
+        "//server/util/vtprotocodec",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/paging/paging_test.go
+++ b/server/util/paging/paging_test.go
@@ -4,11 +4,16 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/paging"
+	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pgpb "github.com/buildbuddy-io/buildbuddy/proto/pagination"
 )
+
+func init() {
+	vtprotocodec.Register()
+}
 
 func TestDecodeAndEncodeOffsetLimit(t *testing.T) {
 	in := &pgpb.OffsetLimit{Offset: 1000, Limit: 100}

--- a/server/util/proto/BUILD
+++ b/server/util/proto/BUILD
@@ -21,3 +21,32 @@ go_test(
         "@org_golang_google_protobuf//proto",
     ],
 )
+
+go_test(
+    name = "proto_bench_test",
+    srcs = ["proto_test.go"],
+    args = [
+        # can be narrow down to specific benchmark with this Bazel flag:
+        #   --test_arg='-test.bench=BenchmarkMarshal/name=New/'
+        "-test.bench=.",
+    ],
+    exec_properties = {
+        "test.Pool": "bare",
+        "test.use-self-hosted-executors": "true",
+        "test.container-image": "none",
+        "test.EstimatedComputeUnits": "16",
+    },
+    tags = [
+        "manual",
+        "no-cache",
+    ],
+    deps = [
+        ":proto",
+        "//proto:cache_go_proto",
+        "//proto:distributed_cache_go_proto",
+        "//proto:storage_go_proto",
+        "@com_github_go_faker_faker_v4//:faker",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//proto",
+    ],
+)

--- a/server/util/proto/BUILD
+++ b/server/util/proto/BUILD
@@ -5,7 +5,12 @@ go_library(
     srcs = ["proto.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/proto",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_google_protobuf//proto"],
+    deps = [
+        "//server/util/vtprotocodec",
+        "@org_golang_google_grpc//encoding",
+        "@org_golang_google_grpc//mem",
+        "@org_golang_google_protobuf//proto",
+    ],
 )
 
 go_test(

--- a/server/util/proto/proto_test.go
+++ b/server/util/proto/proto_test.go
@@ -136,7 +136,6 @@ func benchmarkMarshal(b *testing.B, marshalFn marshalFunc, data []protoMessage) 
 			b.Fatal(err)
 		}
 	}
-
 }
 
 func benchmarkUnmarshal(b *testing.B, unmarshalFn unmarshalFunc, providerFn providerFunc, data [][]byte) {
@@ -152,7 +151,6 @@ func benchmarkUnmarshal(b *testing.B, unmarshalFn unmarshalFunc, providerFn prov
 			b.Fatal(err)
 		}
 	}
-
 }
 
 func BenchmarkMarshal(b *testing.B) {
@@ -160,7 +158,10 @@ func BenchmarkMarshal(b *testing.B) {
 		"Old": func(v protoMessage) ([]byte, error) {
 			return proto.MarshalOld(v)
 		},
-		"New": func(v protoMessage) ([]byte, error) {
+		"VT": func(v protoMessage) ([]byte, error) {
+			return proto.MarshalVT(v)
+		},
+		"VTWithBuffer": func(v protoMessage) ([]byte, error) {
 			return proto.Marshal(v)
 		},
 	}
@@ -177,11 +178,14 @@ func BenchmarkMarshal(b *testing.B) {
 
 func BenchmarkUnmarshal(b *testing.B) {
 	unmarshalFns := map[string]unmarshalFunc{
-		"New": func(buf []byte, v protoMessage) error {
-			return proto.Unmarshal(buf, v)
-		},
 		"Old": func(buf []byte, v protoMessage) error {
 			return gproto.Unmarshal(buf, v)
+		},
+		"VT": func(buf []byte, v protoMessage) error {
+			return proto.UnmarshalVT(buf, v)
+		},
+		"VTWithBuffer": func(buf []byte, v protoMessage) error {
+			return proto.Unmarshal(buf, v)
 		},
 	}
 

--- a/server/util/vtprotocodec/BUILD
+++ b/server/util/vtprotocodec/BUILD
@@ -6,9 +6,9 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec",
     visibility = ["//visibility:public"],
     deps = [
-        "//server/util/proto",
         "@org_golang_google_grpc//encoding",
         "@org_golang_google_grpc//encoding/proto",
         "@org_golang_google_grpc//mem",
+        "@org_golang_google_protobuf//proto",
     ],
 )


### PR DESCRIPTION
Route all proto encode/decode through encoding.CodecV2, which is
implemented in vtprotocodec package. This means that proto encode/decode
will attempt to reuse the pre-allocated mem.DefaultBuffer as much as
possible.

Move the `VTProtoMessage` struct def to `vtprotocodec` package so that
we can reverse the dependency to this

```
//server/util/proto -- depends on --> //server/util/vtprotocodec
```

This enables us to access the codecv2 through the official `encoding.GetCodecV2(vtprotocodec.Name)` API and thus, unexport the `vtprotocodec.codecV2` struct.
