### PR TITLE
fix: error log typo

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -521,7 +521,7 @@ func incompleteExecutionError(ctx context.Context, exitCode int, err error) erro
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		log.Infof("Ignoring command error likely caused by %s: %s", ctxErr, err)
 		if ctxErr == context.DeadlineExceeded {
-			return status.DeadlineExceededError("deadline exceeeded")
+			return status.DeadlineExceededError("deadline exceeded")
 		}
 		if ctxErr == context.Canceled {
 			return status.AbortedError("context canceled")


### PR DESCRIPTION
I copied the error message `DEADLINE_EXCEEDED: deadline exceeeded` from the UI and couldn't find any results, later realized it was because of the three `e` in `exceeeded`.