### PR TITLE
Delay dialing the vm exec server when we load a snapshot

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1112,6 +1112,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 		}
 		return status.UnavailableErrorf("error resuming VM: %s", err)
 	}
+	c.createFromSnapshot = true
 
 	return nil
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2072,7 +2072,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 		}
 	}
 	if c.createFromSnapshot {
-		err := c.initialize(ctx, result)
+		err := c.resetGuestState(ctx, result)
 		if err != nil {
 			result.Error = status.WrapError(err, "Failed to initialize firecracker VM exec client")
 			return result
@@ -2177,7 +2177,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	return result
 }
 
-func (c *FirecrackerContainer) initialize(ctx context.Context, result *interfaces.CommandResult) error {
+func (c *FirecrackerContainer) resetGuestState(ctx context.Context, result *interfaces.CommandResult) error {
 	conn, err := c.vmExecConn(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is similar to https://github.com/buildbuddy-io/buildbuddy/pull/8296, but also works when loading from a snapshot, and not just when creating a new machine. It seems that the Initialize() call can be delayed without breaking anything.