### PR TITLE
Add priority field to workflow action config

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -42,6 +42,7 @@ type Action struct {
 	SelfHosted        bool              `yaml:"self_hosted"`
 	ContainerImage    string            `yaml:"container_image"`
 	ResourceRequests  ResourceRequests  `yaml:"resource_requests"`
+	Priority          int               `yaml:"priority"`
 	User              string            `yaml:"user"`
 	GitCleanExclude   []string          `yaml:"git_clean_exclude"`
 	GitFetchFilters   []string          `yaml:"git_fetch_filters"`

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1548,6 +1548,9 @@ func (ws *workflowService) attemptExecuteWorkflowAction(ctx context.Context, key
 		SkipCacheLookup: true,
 		ActionDigest:    ad,
 		DigestFunction:  repb.DigestFunction_BLAKE3,
+		ExecutionPolicy: &repb.ExecutionPolicy{
+			Priority: int32(workflowAction.Priority),
+		},
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Allow setting workflow action priorities, using the same semantics as the `--remote_execution_priority` flag in bazel (priority only applies within an org, not across orgs)