### PR TITLE
Test pulling from OCI registry mirror using `docker` in Firecracker VM

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -128,6 +128,7 @@ go_test(
     ],
     deps = [
         ":firecracker",
+        "//enterprise/server/ociregistry",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/filecache",
@@ -156,6 +157,7 @@ go_test(
         "//server/testutil/testfs",
         "//server/testutil/testmetrics",
         "//server/testutil/testnetworking",
+        "//server/testutil/testport",
         "//server/util/disk",
         "//server/util/log",
         "//server/util/networking",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1742,11 +1742,10 @@ func TestFirecrackerRunWithDockerMirror(t *testing.T) {
 			c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{}, opts)
 			require.NoError(t, err)
 
-			configTemplate := `{
-    "insecure-registries": ["%s"],
-    "registry-mirrors": ["%s"]
+			dockerConfig := `{
+    "insecure-registries": ["`+registryHost+`"],
+    "registry-mirrors": ["`+registryURL`"]
 }`
-			dockerConfig := fmt.Sprintf(configTemplate, registryHost, registryURL)
 			bashScript := fmt.Sprintf(`set -e
 cat > /etc/docker/daemon.json <<EOF
 %s

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1743,9 +1743,10 @@ func TestFirecrackerRunWithDockerMirror(t *testing.T) {
 			require.NoError(t, err)
 
 			dockerConfig := `{
-    "insecure-registries": ["`+registryHost+`"],
-    "registry-mirrors": ["`+registryURL`"]
+    "insecure-registries": ["` + registryHost + `"],
+    "registry-mirrors": ["` + registryURL + `"]
 }`
+			//TODO(dan): pass docker config into VM as metadata, do not reload `dockerd`
 			bashScript := fmt.Sprintf(`set -e
 cat > /etc/docker/daemon.json <<EOF
 %s


### PR DESCRIPTION
I'm targeting the `dockerd`-running-in-Firecracker path as the best starting place for the caching OCI registry mirror. Before rolling out the OCI registry mirror to dev and prod, I want to make sure that path works!

This change tests 3 cases:
1. Pulling an image name that includes the registry mirror address.
2. Pulling the vanilla image name.
3. Having the registry mirror respond 404 to requests for the manifest, forcing `docker` to fall back to Docker Hub.

To build confidence that the tests actually pull from the mirror, I count the requests that go to the mirror. It would be fantastic if the OCI image itself could tell you where the bytes come from, but I have not found a way of doing that. Suggestions welcome!