### PR TITLE
Set task_allowed_private_ips=default in executor.workflow.yaml

### DIFF
--- a/enterprise/config/executor.workflow.yaml
+++ b/enterprise/config/executor.workflow.yaml
@@ -11,6 +11,7 @@ executor:
   enable_firecracker: true
   enable_local_snapshot_sharing: true
   enable_remote_snapshot_sharing: true
-  task_allowed_private_ips: "default"
+  task_allowed_private_ips:
+    - "default"
 debug_stream_command_outputs: true
 debug_enable_anonymous_runner_recycling: true

--- a/enterprise/config/executor.workflow.yaml
+++ b/enterprise/config/executor.workflow.yaml
@@ -11,5 +11,6 @@ executor:
   enable_firecracker: true
   enable_local_snapshot_sharing: true
   enable_remote_snapshot_sharing: true
+  task_allowed_private_ips: "default"
 debug_stream_command_outputs: true
 debug_enable_anonymous_runner_recycling: true


### PR DESCRIPTION
When running RBE locally, this allows remote bazel to hit the locally running app.