### PR TITLE
Compress uploads more consistently

### DIFF
--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -417,6 +417,7 @@ func mirrorToCache(
 	if checksumFunc == storageFunc && expectedChecksum != "" && rsp.ContentLength >= 0 {
 		d := &repb.Digest{Hash: expectedChecksum, SizeBytes: rsp.ContentLength}
 		rn := digest.NewCASResourceName(d, remoteInstanceName, storageFunc)
+		rn.SetCompressor(repb.Compressor_ZSTD)
 		if _, _, err := cachetools.UploadFromReader(ctx, bsClient, rn, rsp.Body); err != nil {
 			return nil, status.UnavailableErrorf("failed to upload %s to cache: %s", digest.String(d), err)
 		}


### PR DESCRIPTION
We used to (configurably) apply upload compression only to `UploadFile`, not e.g. `UploadBlob`. Make this more principled by enabling compression on more code paths, but only if the file size is large enough to be worth it (see the linked Bazel discussion).

Always enable compression for the remote asset API as files fetched from the internet are overwhelmingly likely to be larger than 100 bytes anyway.