### PR TITLE
execution_service: populate target/mnemonic in GetExecution response

### DIFF
--- a/enterprise/server/execution_search_service/BUILD
+++ b/enterprise/server/execution_search_service/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//enterprise/server/util/execution",
         "//proto:execution_stats_go_proto",
         "//proto:invocation_status_go_proto",
+        "//proto:remote_execution_go_proto",
         "//proto:stat_filter_go_proto",
         "//server/build_event_protocol/invocation_format",
         "//server/environment",
@@ -22,5 +23,6 @@ go_library(
         "//server/util/perms",
         "//server/util/query_builder",
         "//server/util/status",
+        "//server/util/tracing",
     ],
 )

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -75,7 +75,6 @@ message ExecutionSummary {
       executed_action_metadata = 8;
 }
 
-// Next Tag: 12
 message Execution {
   reserved 4, 10;
   // The digest of the [Action][build.bazel.remote.execution.v2.Action] to
@@ -128,6 +127,13 @@ message Execution {
   // retried internally, this Execution will reflect the latest execution
   // attempt.
   string execution_id = 14;
+
+  // Information about Bazel build target which created this Action's Execution.
+  // Note that these fields could be empty if the client does not send a
+  // RequestMetadata with these fields populated.
+  // TODO(sluongng): add configuration field.
+  string target_label = 15;
+  string action_mnemonic = 16;
 }
 
 // Auxiliary metadata with BuildBuddy-specific information.

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -908,6 +908,7 @@ type ExecutionNode interface {
 
 type ExecutionSearchService interface {
 	SearchExecutions(ctx context.Context, req *espb.SearchExecutionRequest) (*espb.SearchExecutionResponse, error)
+	FetchExecutionRequestMetadata(ctx context.Context, invocationID string, execIDs []string) (map[string]*repb.RequestMetadata, error)
 }
 
 // TaskRouter decides which execution nodes should execute a task.

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -908,7 +908,7 @@ type ExecutionNode interface {
 
 type ExecutionSearchService interface {
 	SearchExecutions(ctx context.Context, req *espb.SearchExecutionRequest) (*espb.SearchExecutionResponse, error)
-	FetchExecutionRequestMetadata(ctx context.Context, invocationID string, execIDs []string) (map[string]*repb.RequestMetadata, error)
+	FetchExecutionRequestMetadata(ctx context.Context, invocationID string, startTime int64, endTime int64, execIDs []string) (map[string]*repb.RequestMetadata, error)
 }
 
 // TaskRouter decides which execution nodes should execute a task.


### PR DESCRIPTION
Populate target_label and action_mnemonic from OLAP DB to enrich
GetExecution responses.

This change was first introduced in 688b7da0e947fb2b1ec804366a7e14c13b96e1b4
which was an early version of PR #6577.  It was abandoned at the time
to simplify the change.  Now that we have written the data into
ClickHouse for quite some time, let's try to make use of them.
