### PR TITLE
Don't wait for enqueue response when enqueing extra work on idle executors.

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -416,7 +416,7 @@ func (h *executorHandle) handleTaskReservationResponse(response *scpb.EnqueueTas
 	delete(h.replies, response.GetTaskId())
 }
 
-func (h *executorHandle) EnqueueTaskReservation(ctx context.Context, req *scpb.EnqueueTaskReservationRequest) (*scpb.EnqueueTaskReservationResponse, error) {
+func (h *executorHandle) EnqueueTaskReservation(ctx context.Context, req *scpb.EnqueueTaskReservationRequest, waitForResponse bool) error {
 	// EnqueueTaskReservation may be called multiple times and OpenTelemetry doesn't have clear documentation as to
 	// whether it's safe to call Inject using a carrier that already has metadata so we clone the proto to be defensive.
 	// We also clone to avoid mutating the proto in adjustTaskSize below.
@@ -424,7 +424,7 @@ func (h *executorHandle) EnqueueTaskReservation(ctx context.Context, req *scpb.E
 	tracing.InjectProtoTraceMetadata(ctx, req.GetTraceMetadata(), func(m *tpb.Metadata) { req.TraceMetadata = m })
 
 	if req.GetSchedulingMetadata() == nil {
-		return nil, status.InvalidArgumentError("request is missing scheduling metadata")
+		return status.InvalidArgumentError("request is missing scheduling metadata")
 	}
 
 	// At this point, we haven't yet used the measured size or predicted size at
@@ -455,24 +455,27 @@ func (h *executorHandle) EnqueueTaskReservation(ctx context.Context, req *scpb.E
 	select {
 	case h.requests <- enqueueTaskReservationRequest{proto: reqProto, response: rspCh}:
 	case <-ctx.Done():
-		return nil, status.CanceledErrorf("could not enqueue task reservation %q", req.GetTaskId())
+		return status.CanceledErrorf("could not enqueue task reservation %q", req.GetTaskId())
 	case <-timeout.C:
 		log.CtxWarningf(ctx, "Could not enqueue task reservation %q on to work stream within timeout", req.GetTaskId())
-		return nil, status.DeadlineExceededErrorf("could not enqueue task reservation %q on to stream", req.GetTaskId())
+		return status.DeadlineExceededErrorf("could not enqueue task reservation %q on to stream", req.GetTaskId())
 	}
 	if !timeout.Stop() {
 		<-timeout.C
 	}
 
+	if !waitForResponse {
+		return nil
+	}
+
 	select {
 	case <-ctx.Done():
-		return nil, status.CanceledErrorf("could not enqueue task reservation %q", req.GetTaskId())
-	case rsp := <-rspCh:
-
+		return status.CanceledErrorf("could not enqueue task reservation %q", req.GetTaskId())
+	case <-rspCh:
 		metrics.RemoteExecutionEnqueuedTaskMilliCPU.Observe(float64(req.GetTaskSize().GetEstimatedMilliCpu()))
 		metrics.RemoteExecutionEnqueuedTaskMemoryBytes.Observe(float64(req.GetTaskSize().GetEstimatedMemoryBytes()))
 
-		return rsp, nil
+		return nil
 	}
 }
 
@@ -1254,7 +1257,7 @@ func (s *SchedulerServer) assignWorkToNode(ctx context.Context, handle *executor
 
 	numEnqueued := 0
 	for _, req := range reqs {
-		if _, err = handle.EnqueueTaskReservation(ctx, req); err != nil {
+		if err := handle.EnqueueTaskReservation(ctx, req, false /*=waitForResponse*/); err != nil {
 			return numEnqueued, err
 		}
 		numEnqueued += 1
@@ -1913,7 +1916,7 @@ func enqueueOnConnectedExecutor(ctx context.Context, node *executionNode, reques
 		log.CtxErrorf(ctx, "nil handle for a local executor %q", node.GetExecutorId())
 		return false, nil
 	}
-	_, err := node.handle.EnqueueTaskReservation(ctx, request)
+	err := node.handle.EnqueueTaskReservation(ctx, request, true /*=waitForResponse*/)
 	if err != nil {
 		log.CtxInfof(ctx, "Failed to enqueue task on connected executor: %s", err)
 	}


### PR DESCRIPTION
We can treat these enqueues as best-effort. 
This also applies to newly connected executors being assigned the initial batch of work. 

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4404