### PR TITLE
Add bazel command to explicit command line for workflows

### DIFF
--- a/app/invocation/child_invocation_card.tsx
+++ b/app/invocation/child_invocation_card.tsx
@@ -53,6 +53,10 @@ export default class ChildInvocationCard extends React.Component<ChildInvocation
     }
   }
 
+  private stripFirstWordIfBazelBinary(command: string): string {
+    return command.replace(/^\s*\S*(?:\/|^)bazel(?:isk)?\s+/, "");
+  }
+
   render() {
     const inv = this.props.invocation;
     const invModel = new InvocationModel(inv);
@@ -62,6 +66,7 @@ export default class ChildInvocationCard extends React.Component<ChildInvocation
     if (command == "") {
       command = `${inv.command} ${inv.pattern.join(" ")}`;
     }
+    command = this.stripFirstWordIfBazelBinary(command);
 
     return (
       <Link

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2544,10 +2544,7 @@ func runBazelWrapper() error {
 	// Pass the original command as metadata, stripping the custom flags we've set,
 	// so that it can be displayed in the UI
 	filteredOriginalArgs := make([]string, 0, len(originalArgs))
-	for i, arg := range originalArgs {
-		if i == 0 && (arg == bazelBinaryName || arg == bazeliskBinaryName) {
-			continue
-		}
+	for _, arg := range originalArgs {
 		if strings.Contains(arg, "--invocation_id") ||
 			strings.Contains(arg, "--remote_header=") ||
 			strings.Contains(arg, "--config=buildbuddy_remote_cache") ||
@@ -2556,6 +2553,9 @@ func runBazelWrapper() error {
 			continue
 		}
 		filteredOriginalArgs = append(filteredOriginalArgs, arg)
+	}
+	if len(filteredOriginalArgs) > 0 && filteredOriginalArgs[0] != bazelBin {
+		filteredOriginalArgs = append([]string{bazelBin}, filteredOriginalArgs...)
 	}
 	originalArgsJSON, err := json.Marshal(filteredOriginalArgs)
 	if err != nil {


### PR DESCRIPTION
Now the explicit command line will look like this (before it didn't include the bazelisk command):
![Screenshot 2025-02-11 at 3 59 06 PM](https://github.com/user-attachments/assets/076e1dee-b094-46bc-81fb-f08372469b4b)

The primary intention for this change is that the [bb explain button](https://github.com/buildbuddy-io/buildbuddy/blob/master/app/invocation/cache_requests_card.tsx#L744) assumes that the explicit command line includes the bazel binary. Currently we get errors like [this](https://buildbuddy.buildbuddy.dev/invocation/6a1e30f3-6270-4621-8b0c-f5747714174e?queued=true)

This will also make it more obvious which bazel binary is running for workflows
