### PR TITLE
pass docker registry mirror info from executor to guest vm via MMDS

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -534,7 +534,7 @@ func resizeExt4FS(devicePath, mountPath string) error {
 	return nil
 }
 
-func fetchMMDSKeyOrError(key string) ([]byte, error) {
+func fetchMMDSKey(key string) ([]byte, error) {
 	resp, err := http.Get(mmdsURL + key)
 	if err != nil {
 		return []byte{}, err

--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -186,7 +186,7 @@ func startDockerd(ctx context.Context) error {
 		return err
 	}
 
-	dockerdDaemonJSON, err := fetchMMDSKeyOrError("dockerd_daemon_json")
+	dockerdDaemonJSON, err := fetchMMDSKey("dockerd_daemon_json")
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -44,6 +44,7 @@ const (
 
 	dockerdInitTimeout       = 30 * time.Second
 	dockerdDefaultSocketPath = "/var/run/docker.sock"
+	mmdsURL                  = "http://169.254.169.254/"
 
 	// EXT4_IOC_RESIZE_FS is the ioctl constant for resizing an ext4 FS.
 	// Computed from C: https://gist.github.com/bduffany/ce9b594c2166ea1a4564cba1b5ed652d
@@ -534,7 +535,7 @@ func resizeExt4FS(devicePath, mountPath string) error {
 }
 
 func fetchMMDSKeyOrError(key string) ([]byte, error) {
-	resp, err := http.Get("http://169.254.169.254/" + key)
+	resp, err := http.Get(mmdsURL + key)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -537,17 +537,17 @@ func resizeExt4FS(devicePath, mountPath string) error {
 func fetchMMDSKey(key string) ([]byte, error) {
 	resp, err := http.Get(mmdsURL + key)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return []byte{}, fmt.Errorf("MMDS request failed with status %d", resp.StatusCode)
+		return nil, fmt.Errorf("MMDS request failed with status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	return body, nil

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -100,7 +100,7 @@ genrule(
 # //enterprise/server/remote_execution/containers/firecracker:firecracker_test
 go_test(
     name = "firecracker_test",
-#    timeout = "long",
+    timeout = "long",
     srcs = [
         "firecracker_performance_test.go",
         "firecracker_test.go",
@@ -118,7 +118,7 @@ go_test(
         # TODO: include test ext4 images as deps to avoid conversion.
         "test.EstimatedComputeUnits": "10",
     },
-    shard_count = 4,
+    shard_count = 30,
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -51,6 +51,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/background",
         "//server/util/disk",
+        "//server/util/flag",
         "//server/util/log",
         "//server/util/networking",
         "//server/util/status",
@@ -100,7 +101,7 @@ genrule(
 # //enterprise/server/remote_execution/containers/firecracker:firecracker_test
 go_test(
     name = "firecracker_test",
-    timeout = "long",
+#    timeout = "long",
     srcs = [
         "firecracker_performance_test.go",
         "firecracker_test.go",
@@ -118,7 +119,7 @@ go_test(
         # TODO: include test ext4 images as deps to avoid conversion.
         "test.EstimatedComputeUnits": "10",
     },
-    shard_count = 30,
+    shard_count = 1,
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -101,7 +101,7 @@ genrule(
 # //enterprise/server/remote_execution/containers/firecracker:firecracker_test
 go_test(
     name = "firecracker_test",
-    timeout = "long",
+#    timeout = "long",
     srcs = [
         "firecracker_performance_test.go",
         "firecracker_test.go",
@@ -119,7 +119,7 @@ go_test(
         # TODO: include test ext4 images as deps to avoid conversion.
         "test.EstimatedComputeUnits": "10",
     },
-    shard_count = 30,
+    shard_count = 4,
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -101,7 +101,7 @@ genrule(
 # //enterprise/server/remote_execution/containers/firecracker:firecracker_test
 go_test(
     name = "firecracker_test",
-#    timeout = "long",
+    timeout = "long",
     srcs = [
         "firecracker_performance_test.go",
         "firecracker_test.go",
@@ -119,7 +119,7 @@ go_test(
         # TODO: include test ext4 images as deps to avoid conversion.
         "test.EstimatedComputeUnits": "10",
     },
-    shard_count = 1,
+    shard_count = 30,
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -101,7 +101,7 @@ genrule(
 # //enterprise/server/remote_execution/containers/firecracker:firecracker_test
 go_test(
     name = "firecracker_test",
-#    timeout = "long",
+    timeout = "long",
     srcs = [
         "firecracker_performance_test.go",
         "firecracker_test.go",
@@ -119,7 +119,7 @@ go_test(
         # TODO: include test ext4 images as deps to avoid conversion.
         "test.EstimatedComputeUnits": "10",
     },
-    shard_count = 4,
+    shard_count = 30,
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -100,7 +100,7 @@ genrule(
 # //enterprise/server/remote_execution/containers/firecracker:firecracker_test
 go_test(
     name = "firecracker_test",
-    timeout = "long",
+#    timeout = "long",
     srcs = [
         "firecracker_performance_test.go",
         "firecracker_test.go",
@@ -118,7 +118,7 @@ go_test(
         # TODO: include test ext4 images as deps to avoid conversion.
         "test.EstimatedComputeUnits": "10",
     },
-    shard_count = 30,
+    shard_count = 4,
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1458,6 +1458,8 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 					HostDevName: tapDeviceName,
 					MacAddress:  tapDeviceMac,
 				},
+				// We only use MMDS for the dockerd config,
+				// which is only needed if dockerd is enabled.
 				AllowMMDS: c.vmConfig.InitDockerd,
 			},
 		}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1776,6 +1776,8 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 
 func withMetadata(metadata interface{}) fcclient.Opt {
 	return func(m *fcclient.Machine) {
+		// Set metadata during init, before the VM instance is created,
+		// since goinit expects metadata to be available on startup.
 		m.Handlers.FcInit = m.Handlers.FcInit.AppendAfter(fcclient.ConfigMmdsHandlerName, fcclient.NewSetMetadataHandler(metadata))
 	}
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -112,7 +112,7 @@ const (
 	//
 	// NOTE: this is part of the snapshot cache key, so bumping this version
 	// will make existing cached snapshots unusable.
-	GuestAPIVersion = "14"
+	GuestAPIVersion = "15"
 
 	// How long to wait when dialing the vmexec server inside the VM.
 	vSocketDialTimeout = 60 * time.Second

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1854,7 +1854,7 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 		fcclient.WithLogger(getLogrusLogger()),
 	}
 	if c.vmConfig.InitDockerd {
-		dockerDaemonConfig, err := writeDockerDaemonConfig()
+		dockerDaemonConfig, err := getDockerDaemonConfig()
 		if err != nil {
 			return status.InternalErrorf("Could not write Docker daemon config: %s", err)
 		}
@@ -1883,7 +1883,7 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	return nil
 }
 
-func writeDockerDaemonConfig() ([]byte, error) {
+func getDockerDaemonConfig() ([]byte, error) {
 	config := map[string][]string{}
 	if len(*firecrackerVMDockerMirrors) > 0 {
 		config["registry-mirrors"] = *firecrackerVMDockerMirrors

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1855,10 +1855,17 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	if err != nil {
 		return status.InternalErrorf("Failed starting machine: %s", err)
 	}
+	metadata := map[string]string{}
 	if *firecrackerVMDockerMirror != "" {
-		err = m.SetMetadata(ctx, map[string]string{"firecracker_vm_docker_mirror": *firecrackerVMDockerMirror})
+		metadata["firecracker_vm_docker_mirror"] = *firecrackerVMDockerMirror
+	}
+	if *firecrackerVMDockerInsecureRegistry != "" {
+		metadata["firecracker_vm_docker_insecure_registry"] = *firecrackerVMDockerInsecureRegistry
+	}
+	if len(metadata) > 0 {
+		err = m.SetMetadata(ctx, metadata)
 		if err != nil {
-			return status.InternalErrorf("Firecracker VM Docker mirror set, but could not set metadata on machine: %s", err)
+			return status.InternalErrorf("Could not pass metadata to machine over MMDS: %s", err)
 		}
 	}
 	c.machine = m

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -3,8 +3,8 @@ package firecracker
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"io/fs"
@@ -50,6 +50,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -76,17 +77,17 @@ import (
 )
 
 var (
-	firecrackerCgroupVersion            = flag.String("executor.firecracker_cgroup_version", "", "Specifies the cgroup version for firecracker to use.")
-	debugStreamVMLogs                   = flag.Bool("executor.firecracker_debug_stream_vm_logs", false, "Stream firecracker VM logs to the terminal.")
-	debugTerminal                       = flag.Bool("executor.firecracker_debug_terminal", false, "Run an interactive terminal in the Firecracker VM connected to the executor's controlling terminal. For debugging only.")
-	dieOnFirecrackerFailure             = flag.Bool("executor.die_on_firecracker_failure", false, "Makes the host executor process die if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
-	workspaceDiskSlackSpaceMB           = flag.Int64("executor.firecracker_workspace_disk_slack_space_mb", 2_000, "Extra space to allocate to firecracker workspace disks, in megabytes. ** Experimental **")
-	healthCheckInterval                 = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
-	healthCheckTimeout                  = flag.Duration("executor.firecracker_health_check_timeout", 30*time.Second, "Timeout for VM health check requests.")
-	overprovisionCPUs                   = flag.Int("executor.firecracker_overprovision_cpus", 3, "Number of CPUs to overprovision for VMs. This allows VMs to more effectively utilize CPU resources on the host machine. Set to -1 to allow all VMs to use max CPU.")
-	initOnAllocAndFree                  = flag.Bool("executor.firecracker_init_on_alloc_and_free", false, "Set init_on_alloc=1 and init_on_free=1 in firecracker vms")
-	firecrackerVMDockerMirror           = flag.String("executor.firecracker_vm_docker_mirror", "", "The host and port to use as a registry mirror for public Docker images. Only used if InitDockerd is set to true.")
-	firecrackerVMDockerInsecureRegistry = flag.String("executor.firecracker_vm_docker_insecure_registry", "", "Tell Docker to communicate over HTTP with this URL. Only used if InitDockerd is set to true.")
+	firecrackerCgroupVersion              = flag.String("executor.firecracker_cgroup_version", "", "Specifies the cgroup version for firecracker to use.")
+	debugStreamVMLogs                     = flag.Bool("executor.firecracker_debug_stream_vm_logs", false, "Stream firecracker VM logs to the terminal.")
+	debugTerminal                         = flag.Bool("executor.firecracker_debug_terminal", false, "Run an interactive terminal in the Firecracker VM connected to the executor's controlling terminal. For debugging only.")
+	dieOnFirecrackerFailure               = flag.Bool("executor.die_on_firecracker_failure", false, "Makes the host executor process die if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
+	workspaceDiskSlackSpaceMB             = flag.Int64("executor.firecracker_workspace_disk_slack_space_mb", 2_000, "Extra space to allocate to firecracker workspace disks, in megabytes. ** Experimental **")
+	healthCheckInterval                   = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
+	healthCheckTimeout                    = flag.Duration("executor.firecracker_health_check_timeout", 30*time.Second, "Timeout for VM health check requests.")
+	overprovisionCPUs                     = flag.Int("executor.firecracker_overprovision_cpus", 3, "Number of CPUs to overprovision for VMs. This allows VMs to more effectively utilize CPU resources on the host machine. Set to -1 to allow all VMs to use max CPU.")
+	initOnAllocAndFree                    = flag.Bool("executor.firecracker_init_on_alloc_and_free", false, "Set init_on_alloc=1 and init_on_free=1 in firecracker vms")
+	firecrackerVMDockerMirrors            = flag.Slice("executor.firecracker_vm_docker_mirrors", []string{}, "Registry mirror hosts (and ports) for public Docker images. Only used if InitDockerd is set to true.")
+	firecrackerVMDockerInsecureRegistries = flag.Slice("executor.firecracker_vm_docker_insecure_registries", []string{}, "Tell Docker to communicate over HTTP with these URLs. Only used if InitDockerd is set to true.")
 
 	forceRemoteSnapshotting = flag.Bool("debug_force_remote_snapshots", false, "When remote snapshotting is enabled, force remote snapshotting even for tasks which otherwise wouldn't support it.")
 	disableWorkspaceSync    = flag.Bool("debug_disable_firecracker_workspace_sync", false, "Do not sync the action workspace to the guest, instead using the existing workspace from the VM snapshot.")
@@ -583,6 +584,9 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 
 	if opts.VMConfiguration == nil {
 		return nil, status.InvalidArgumentError("missing VMConfiguration")
+	}
+	if opts.VMConfiguration.InitDockerd && !opts.VMConfiguration.EnableNetworking {
+		return nil, status.FailedPreconditionError("InitDockerd set to true but EnableNetworking set to false. EnableNetworking must also be set to true to pass dockerd configuration over MMDS.")
 	}
 
 	vmLog, err := NewVMLog(vmLogTailBufSize)
@@ -1855,21 +1859,34 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	if err != nil {
 		return status.InternalErrorf("Failed starting machine: %s", err)
 	}
-	metadata := map[string]string{}
-	if *firecrackerVMDockerMirror != "" {
-		metadata["firecracker_vm_docker_mirror"] = *firecrackerVMDockerMirror
+	dockerDaemonConfig, err := writeDockerDaemonConfig()
+	if err != nil {
+		return status.InternalErrorf("Could not write Docker daemon config: %s", err)
 	}
-	if *firecrackerVMDockerInsecureRegistry != "" {
-		metadata["firecracker_vm_docker_insecure_registry"] = *firecrackerVMDockerInsecureRegistry
+	metadata := map[string]string{
+		"dockerd_daemon_json": string(dockerDaemonConfig),
 	}
-	if len(metadata) > 0 {
-		err = m.SetMetadata(ctx, metadata)
-		if err != nil {
-			return status.InternalErrorf("Could not pass metadata to machine over MMDS: %s", err)
-		}
+	err = m.SetMetadata(ctx, metadata)
+	if err != nil {
+		return status.InternalErrorf("Could not pass metadata to Firecracker VM over MMDS: %s", err)
 	}
 	c.machine = m
 	return nil
+}
+
+func writeDockerDaemonConfig() ([]byte, error) {
+	config := map[string][]string{}
+	if len(*firecrackerVMDockerMirrors) > 0 {
+		config["registry-mirrors"] = *firecrackerVMDockerMirrors
+	}
+	if len(*firecrackerVMDockerInsecureRegistries) > 0 {
+		config["insecure-registries"] = *firecrackerVMDockerInsecureRegistries
+	}
+	configJSON, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return []byte{}, err
+	}
+	return configJSON, nil
 }
 
 func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn *grpc.ClientConn, cmd *repb.Command, workDir string, stdio *interfaces.Stdio) (_ *interfaces.CommandResult, healthy bool) {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -112,7 +112,7 @@ const (
 	//
 	// NOTE: this is part of the snapshot cache key, so bumping this version
 	// will make existing cached snapshots unusable.
-	GuestAPIVersion = "15"
+	GuestAPIVersion = "14"
 
 	// How long to wait when dialing the vmexec server inside the VM.
 	vSocketDialTimeout = 60 * time.Second

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1889,7 +1889,7 @@ func writeDockerDaemonConfig() ([]byte, error) {
 	}
 	configJSON, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 	return configJSON, nil
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1458,7 +1458,7 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 					HostDevName: tapDeviceName,
 					MacAddress:  tapDeviceMac,
 				},
-				AllowMMDS: true,
+				AllowMMDS: c.vmConfig.InitDockerd,
 			},
 		}
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1859,16 +1859,18 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	if err != nil {
 		return status.InternalErrorf("Failed starting machine: %s", err)
 	}
-	dockerDaemonConfig, err := writeDockerDaemonConfig()
-	if err != nil {
-		return status.InternalErrorf("Could not write Docker daemon config: %s", err)
-	}
-	metadata := map[string]string{
-		"dockerd_daemon_json": string(dockerDaemonConfig),
-	}
-	err = m.SetMetadata(ctx, metadata)
-	if err != nil {
-		return status.InternalErrorf("Could not pass metadata to Firecracker VM over MMDS: %s", err)
+	if c.vmConfig.InitDockerd {
+		dockerDaemonConfig, err := writeDockerDaemonConfig()
+		if err != nil {
+			return status.InternalErrorf("Could not write Docker daemon config: %s", err)
+		}
+		metadata := map[string]string{
+			"dockerd_daemon_json": string(dockerDaemonConfig),
+		}
+		err = m.SetMetadata(ctx, metadata)
+		if err != nil {
+			return status.InternalErrorf("Could not pass metadata to Firecracker VM over MMDS: %s", err)
+		}
 	}
 	c.machine = m
 	return nil

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1671,11 +1671,6 @@ func TestFirecrackerRunWithDockerMirror(t *testing.T) {
 		return404            bool
 		expectedRequestCount int32
 	}{
-		// {
-		// 	name:                 "explicitly_pull_from_mirror",
-		// 	return404:            false,
-		// 	expectedRequestCount: 6,
-		// },
 		{
 			name:                 "pull_busybox_through_mirror",
 			return404:            false,

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -146,7 +146,7 @@ func TestGuestAPIVersion(t *testing.T) {
 	// which will negatively affect customer experience. Be careful!
 	const (
 		expectedHash    = "ee5246ca59e7ac7ac4c2248e36e786d2e68f1085df92b510c0e5565bb7d0863e"
-		expectedVersion = "15"
+		expectedVersion = "14"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -145,7 +145,7 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "ee5246ca59e7ac7ac4c2248e36e786d2e68f1085df92b510c0e5565bb7d0863e"
+		expectedHash    = "cbbd55617b7c4f954ce3ca2df806711b44b9bfd0370bc4210f0242c07488147a"
 		expectedVersion = "14"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -145,8 +145,8 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "f10a9504012ed162ede6f2fe661ee0d32af426430262b173a6e018283ea053e1"
-		expectedVersion = "14"
+		expectedHash    = "ee5246ca59e7ac7ac4c2248e36e786d2e68f1085df92b510c0e5565bb7d0863e"
+		expectedVersion = "15"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -145,7 +145,7 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "cbbd55617b7c4f954ce3ca2df806711b44b9bfd0370bc4210f0242c07488147a"
+		expectedHash    = "944231998bb02eb681051f770d1e6c4dcecc8ad66c0ab59eb0866bbad815d051"
 		expectedVersion = "14"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)


### PR DESCRIPTION
We'd like to be able to have `dockerd` running inside a Firecracker VM be able to pull images from registry mirrors (and, for tests, be able to pull from insecure registries).

This change introduces `executor.firecracker_vm_docker_mirrors` and `executor.firecracker_vm_docker_insecure_registries` flags. When either is set, the host machine writes their values as JSON and passes that JSON to the VM over the [microVM Metadata Service](https://github.com/firecracker-microvm/firecracker/blob/main/docs/mmds/mmds-user-guide.md), also known as the Firecracker Metadata API or MMDS.

This change bumps the Firecracker guest API version. I'm not sure if that bump is strictly necessary or warranted.