### PR TITLE
Fix custom resources not being respected

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -528,6 +528,12 @@ func (h *executorHandle) getMostAccurateTaskSize(req *scpb.EnqueueTaskReservatio
 		}
 	}
 
+	// Preserve any parameters which aren't modeled by dynamic task sizing (disk
+	// space requirements and custom resources).
+	requestedSize := req.GetSchedulingMetadata().GetRequestedTaskSize()
+	size.CustomResources = requestedSize.GetCustomResources()
+	size.EstimatedFreeDiskBytes = requestedSize.GetEstimatedFreeDiskBytes()
+
 	return size
 }
 

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -10,10 +10,12 @@ go_test(
     timeout = "long",
     srcs = ["remote_execution_test.go"],
     exec_properties = {
-        "EstimatedComputeUnits": "5",
+        # TODO: figure out why this test needs such a high resource request in
+        # order to not be flaky.
+        "EstimatedComputeUnits": "16",
     },
     shard_count = 11,
-    tags = ["cpu:5"],
+    tags = ["cpu:8"],
     deps = [
         "//enterprise/server/build_event_publisher",
         "//enterprise/server/remote_execution/commandutil",
@@ -26,6 +28,7 @@ go_test(
         "//enterprise/server/util/execution",
         "//proto:build_event_stream_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:scheduler_go_proto",
         "//server/build_event_protocol/build_event_handler",
         "//server/interfaces",
         "//server/metrics",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -1304,6 +1304,27 @@ func (r *testRunner) Run(ctx context.Context) *interfaces.CommandResult {
 	return r.interceptor(ctx, r.Runner.Run)
 }
 
+type FakeTaskSizer struct {
+	GetImpl func(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize
+}
+
+var _ interfaces.TaskSizer = (*FakeTaskSizer)(nil)
+
+func (f *FakeTaskSizer) Get(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize {
+	if f.GetImpl == nil {
+		return nil
+	}
+	return f.GetImpl(ctx, task)
+}
+
+func (f *FakeTaskSizer) Update(ctx context.Context, action *repb.Action, cmd *repb.Command, md *repb.ExecutedActionMetadata) error {
+	return nil
+}
+
+func (f *FakeTaskSizer) Predict(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize {
+	return nil
+}
+
 // WaitForAnyPooledRunner waits for the runner pool count across all executors
 // to be at least 1. This can be called after a command is complete,
 // to ensure that the runner has been made available for recycling.


### PR DESCRIPTION
Custom resource requests were being dropped if a measured or predicted size is available.