### PR TITLE
Add a test for qps.go

### DIFF
--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//server/util/rangemap",
         "//server/util/status",
         "@com_github_docker_go_units//:go-units",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_lni_dragonboat_v4//statemachine",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_rpc//status",

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -26,6 +26,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	"github.com/docker/go-units"
+	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
@@ -2085,8 +2086,8 @@ func New(leaser pebble.Leaser, rangeID, replicaID uint64, store IStore, broadcas
 		partitionMetadata:   make(map[string]*sgpb.PartitionMetadata),
 		lastUsageCheckIndex: 0,
 		fileStorer:          filestore.New(),
-		readQPS:             qps.NewCounter(5 * time.Second),
-		raftProposeQPS:      qps.NewCounter(5 * time.Second),
+		readQPS:             qps.NewCounter(5*time.Second, clockwork.NewRealClock()),
+		raftProposeQPS:      qps.NewCounter(5*time.Second, clockwork.NewRealClock()),
 		broadcast:           broadcast,
 		lockedKeys:          make(map[string][]byte),
 		prepared:            make(map[string]pebble.Batch),

--- a/server/util/qps/BUILD
+++ b/server/util/qps/BUILD
@@ -1,8 +1,18 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "qps",
     srcs = ["qps.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/qps",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "qps_test",
+    size = "small",
+    srcs = ["qps_test.go"],
+    deps = [
+        ":qps",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/server/util/qps/BUILD
+++ b/server/util/qps/BUILD
@@ -5,14 +5,18 @@ go_library(
     srcs = ["qps.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/qps",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_jonboulle_clockwork//:clockwork",
+    ],
 )
 
 go_test(
     name = "qps_test",
     size = "small",
     srcs = ["qps_test.go"],
+    embed = [":qps"],
     deps = [
-        ":qps",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/qps/qps.go
+++ b/server/util/qps/qps.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
 type bin struct {
@@ -30,27 +32,19 @@ type Counter struct {
 	// first full averaging period elapses, this will always equal len(counts).
 	nValidBins uint64
 	window     time.Duration
+	clock      clockwork.Clock
 	startOnce  sync.Once
-	ticker     <-chan time.Time
 	stop       chan struct{}
 }
 
 // NewCounter returns a QPS counter using the given duration as the averaging
 // window. The caller must call Stop() on the returned counter when it is no
 // longer needed.
-func NewCounter(window time.Duration) *Counter {
-	return new(window, nil)
-}
-
-func NewCounterForTesting(window time.Duration, ticker <-chan time.Time) *Counter {
-	return new(window, ticker)
-}
-
-func new(window time.Duration, ticker <-chan time.Time) *Counter {
+func NewCounter(window time.Duration, clock clockwork.Clock) *Counter {
 	return &Counter{
 		nValidBins: 1,
 		window:     window,
-		ticker:     ticker,
+		clock:      clock,
 		stop:       make(chan struct{}),
 	}
 }
@@ -77,29 +71,30 @@ func (c *Counter) Get() float64 {
 	return qps
 }
 
+// Advances to the next bin, resets its current count, and marks it valid if
+// it is still marked invalid.
+func (c *Counter) update() {
+	idx := atomic.LoadUint64(&c.idx)
+	idx = (idx + 1) % uint64(len(c.counts))
+	atomic.StoreUint64(&c.idx, idx)
+
+	c.bin(int(idx)).Reset()
+
+	nv := atomic.LoadUint64(&c.nValidBins)
+	nv = min(nv+1, uint64(len(c.counts)))
+	atomic.StoreUint64(&c.nValidBins, nv)
+}
+
 func (c *Counter) start() {
-	if c.ticker == nil {
-		ticker := time.NewTicker(time.Duration(float64(c.window) / float64(len(c.counts))))
-		c.ticker = ticker.C
-		defer ticker.Stop()
-	}
+	t := c.clock.NewTicker(time.Duration(float64(c.window) / float64(len(c.counts))))
+	defer t.Stop()
 	for {
 		select {
 		case <-c.stop:
 			return
-		case <-c.ticker:
+		case <-t.Chan():
 		}
-		// Advance to the next bin, reset its current count, and mark it valid
-		// if we haven't done so already.
-		idx := atomic.LoadUint64(&c.idx)
-		idx = (idx + 1) % uint64(len(c.counts))
-		atomic.StoreUint64(&c.idx, idx)
-
-		c.bin(int(idx)).Reset()
-
-		nv := atomic.LoadUint64(&c.nValidBins)
-		nv = min(nv+1, uint64(len(c.counts)))
-		atomic.StoreUint64(&c.nValidBins, nv)
+		c.update()
 	}
 }
 

--- a/server/util/qps/qps_test.go
+++ b/server/util/qps/qps_test.go
@@ -23,8 +23,6 @@ func TestQPS(t *testing.T) {
 	for i := 0; i < 29; i++ {
 		counter.update()
 	}
-	// The current bin is incremented asynchronously upon receiving a tick via
-	// the ticker channel. Give it some time to run.
 	require.Equal(t, float64(24), counter.Get())
 
 	// Test cases where the ring buffer is  full.

--- a/server/util/qps/qps_test.go
+++ b/server/util/qps/qps_test.go
@@ -1,0 +1,71 @@
+package qps_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/qps"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQPS(t *testing.T) {
+	ticker := make(chan time.Time, 1)
+	counter := qps.NewCounterForTesting(5*time.Second, ticker)
+
+	// Test cases where the ring buffer is not full.
+	require.Equal(t, float64(0), counter.Get())
+	counter.Inc()
+	require.Equal(t, float64(12), counter.Get())
+	for i := 0; i < 59; i++ {
+		counter.Inc()
+	}
+	require.Equal(t, float64(720), counter.Get())
+	for i := 0; i < 29; i++ {
+		ticker <- time.Now()
+	}
+	// The current bin is incremented asynchronously upon receiving a tick via
+	// the ticker channel. Give it some time to run.
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, float64(24), counter.Get())
+
+	// Test cases where the ring buffer is  full.
+	for i := 0; i < 100; i++ {
+		ticker <- time.Now()
+	}
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, float64(0), counter.Get())
+	for i := 0; i < 61; i++ {
+		ticker <- time.Now()
+		time.Sleep(10 * time.Millisecond)
+		counter.Inc()
+	}
+	require.Equal(t, float64(12), counter.Get())
+	for i := 0; i < 60; i++ {
+		ticker <- time.Now()
+		time.Sleep(10 * time.Millisecond)
+		for j := 0; j < i; j++ {
+			counter.Inc()
+		}
+	}
+	// Sum(0, n) = n * (n-1) / 2
+	// So, sum(0, 60) = 60 * 59 / 2 = 1,770
+	// 1,770 Queries / 5s = 354 QPS.
+	require.Equal(t, float64(354), counter.Get())
+}
+
+func TestRaciness(t *testing.T) {
+	ticker := make(chan time.Time, 1)
+	counter := qps.NewCounterForTesting(5*time.Second, ticker)
+
+	for i := 1; i < 1000; i++ {
+		go func() {
+			for j := i; j < 1000; j++ {
+				counter.Inc()
+				if i%2 == 0 {
+					counter.Get()
+				}
+			}
+			ticker <- time.Now()
+		}()
+	}
+}

--- a/tools/cacheload/BUILD
+++ b/tools/cacheload/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//server/util/qps",
         "//server/util/retry",
         "//server/util/status",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",

--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/qps"
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/sync/errgroup"
@@ -231,9 +232,9 @@ func main() {
 	eg, gctx := errgroup.WithContext(ctx)
 
 	writtenDigests := make(chan *repb.Digest, 1_000_000)
-	writeQPSCounter := qps.NewCounter(*qpsAvgWindow)
+	writeQPSCounter := qps.NewCounter(*qpsAvgWindow, clockwork.NewRealClock())
 	defer writeQPSCounter.Stop()
-	readQPSCounter := qps.NewCounter(*qpsAvgWindow)
+	readQPSCounter := qps.NewCounter(*qpsAvgWindow, clockwork.NewRealClock())
 	defer readQPSCounter.Stop()
 
 	readsPerWrite := int(math.Ceil(float64(*readQPS) / float64(*writeQPS)))


### PR DESCRIPTION
I would like to use a similar time-binning ring buffer to track error rates for performing failover in a new gRPC client. This is the first step towards extracting the time-binning logic into a different place where it can be reused.