### PR TITLE
[raft] clean up some logs

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -280,7 +280,6 @@ func (s *Session) SyncProposeLocal(ctx context.Context, nodehost NodeHost, range
 	}
 	var raftResponse dbsm.Result
 
-	// log.CtxDebugf(ctx, "sync propose local with session %+v", batch.GetSession())
 	err = RunNodehostFn(ctx, func(ctx context.Context) error {
 		ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
 		spn.SetName("nodehost.SyncPropose")

--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -339,7 +339,7 @@ func (rq *Queue) shouldQueue(ctx context.Context, repl IReplica) (bool, float64)
 
 	if !rq.store.HaveLease(ctx, rd.GetRangeId()) {
 		// The store doesn't have lease for this range. do not queue.
-		rq.log.Debugf("should not queue because we don't have lease")
+		rq.log.Debugf("should not queue range %d because we don't have lease", rd.GetRangeId())
 		return false, 0
 	}
 
@@ -350,7 +350,7 @@ func (rq *Queue) shouldQueue(ctx context.Context, repl IReplica) (bool, float64)
 
 	action, priority := rq.computeAction(rd, usage, repl.ReplicaID())
 	if action == DriverNoop {
-		rq.log.Debugf("should not queue because no-op")
+		rq.log.Debugf("should not queue range %d because no-op", rd.GetRangeId())
 		return false, 0
 	}
 	return true, priority

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1566,7 +1566,6 @@ func (sm *Replica) singleUpdate(db pebble.IPebbleDB, entry dbsm.Entry) (dbsm.Ent
 	}
 	entry.Result = getEntryResult(entry.Cmd, rspBuf)
 	if reqSession != nil {
-		// sm.log.Debugf("[%s] save session %+v", sm.name(), reqSession)
 		if err := sm.updateSession(wb, reqSession, rspBuf); err != nil {
 			entry.Result = errorEntry(err)
 			return entry, nil

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -189,7 +189,10 @@ func (lw *logWriter) Write(d []byte) (int, error) {
 	if strings.Contains(s, "[DEBUG]") {
 		log.Debug(s)
 	} else if strings.Contains(s, "[INFO]") {
-		log.Info(s)
+		// Excludes "EventMemberUpdate", because it's verbose and not that useful.
+		if !strings.Contains(s, "EventMemberUpdate") {
+			log.Info(s)
+		}
 	} else {
 		log.Warning(s)
 	}


### PR DESCRIPTION
- Fully remove the debugging logs for investigating session mismatch index
- Remove EventMemberUpdate serf log
- Add range id into "should not queue" messages
- In sender.TryReplicas, only log when TryReplicas failed.  Log all debugging
  messages at once so we can have a better idea of what's going on.
