### PR TITLE
Return a retryable error and short-circuit execution when any subprocess is OOM-killed

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/util/disk",
+        "//server/util/flag",
         "//server/util/hash",
         "//server/util/log",
         "//server/util/networking",
@@ -73,6 +74,7 @@ go_test(
     },
     deps = [
         ":ociruntime",
+        "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/persistentworker",
         "//enterprise/server/remote_execution/platform",

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -388,6 +388,7 @@ func TestCgroupSettings(t *testing.T) {
 			CpuQuotaLimitUsec:  proto.Int64(30 * 100 * 1e3),
 			CpuQuotaPeriodUsec: proto.Int64(1 * 100 * 1e3),
 			PidsMax:            proto.Int64(2048),
+			MemoryOomGroup:     proto.Bool(true),
 		}
 		assert.Empty(t, cmp.Diff(expected, actual, protocmp.Transform()))
 	}


### PR DESCRIPTION
Partially addresses https://github.com/buildbuddy-io/buildbuddy-internal/issues/4435

Before, if a subprocess within a test is OOM-killed, the test may continue execution and possibly fail with a non-zero exit code + OK gRPC status.

This behavior is not ideal for a few different reasons:
- It results in confusing errors - the user has to dig through test logs and look for possible hints that there may have been an OOM such as a "signal: killed" error, and even then it's not obvious whether the SIGKILL came from the OOM killer or something else on the system.
- It wastes time - the test may chug along running other test cases, only to then fail because of the OOM kill in an earlier test case.
- It causes unnecessary failures - if the OOM error was really our fault (because of over-scheduling), we should be able to transparently retry it, rather than reporting a non-zero exit status, which makes the user think they have a flaky test that they are responsible for.

The solution in this PR is enabling the cgroup setting `memory.oom.group` so that the whole container gets killed as soon as any child process gets an OOM, and we make sure to return an `Unavailable` error which is retryable. This only applies to OCI containers for now but in the future I think we could also apply this setting to the root cgroup within each Firecracker VM.

In the future, I think we could return a non-retryable `ResourceExhausted` error if the user has actually gone over some maximum memory limit. However, that is somewhat of an orthogonal issue. Today, we don't have a great idea of whether tasks are getting killed because they're using "too much" memory in some sense, or if it's more because the machine as a whole is under a lot of memory pressure. I think we can improve this in subsequent PRs by setting other memory-related cgroup settings such as `low`, `high`, and `max`.