### PR TITLE
Add join and switch accounts buttons to the access denied page

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -1126,6 +1126,14 @@
   color: black;
 }
 
+.state-page button.request-button {
+  margin-top: 16px;
+}
+
+.state-page button.switch-button {
+  margin-top: 8px;
+}
+
 .state-page .error-text {
   color: #d32f2f;
 }

--- a/enterprise/app/org/join_org.tsx
+++ b/enterprise/app/org/join_org.tsx
@@ -118,7 +118,7 @@ export default class JoinOrgComponent extends React.Component<JoinOrgComponentPr
             <div className="submit-result request-submitted">
               <div>
                 Your request to join <span className="org-name">{org.name}</span> has been submitted.
-                <br />A member of this organization can approve your request.
+                <br />An organization admin can approve your request by visiting the organization members page.
               </div>
             </div>
           </div>

--- a/enterprise/app/org/join_org.tsx
+++ b/enterprise/app/org/join_org.tsx
@@ -118,7 +118,8 @@ export default class JoinOrgComponent extends React.Component<JoinOrgComponentPr
             <div className="submit-result request-submitted">
               <div>
                 Your request to join <span className="org-name">{org.name}</span> has been submitted.
-                <br />An organization admin can approve your request by visiting the organization members page.
+                <br />
+                An organization admin can approve your request by visiting the organization members page.
               </div>
             </div>
           </div>

--- a/enterprise/app/org/org_access_denied.tsx
+++ b/enterprise/app/org/org_access_denied.tsx
@@ -1,6 +1,6 @@
 import { User } from "../../../app/auth/user";
 import React from "react";
-import FilledButton from "../../../app/components/button/button";
+import FilledButton, { OutlinedButton } from "../../../app/components/button/button";
 import authService from "../../../app/auth/auth_service";
 import router from "../../../app/router/router";
 import { user } from "../../../proto/user_ts_proto";
@@ -27,9 +27,23 @@ export default class OrgAccessDeniedComponent extends React.Component<Props> {
             <div className="titles">
               <div className="title">Access denied</div>
             </div>
-            {!deniedByIpRules && <div className="details">You are not authorized to access this site.</div>}
+            {!deniedByIpRules && <div className="details">You are not authorized to access this organization.</div>}
             {deniedByIpRules && <div className="details">Access blocked by Organization IP Rules.</div>}
-            {this.props.user?.subdomainGroupID && (
+            {!deniedByIpRules && (
+              <div>
+              <FilledButton onClick={() => {window.location.href="/join/"}} className="request-button">
+                  Request to join organization
+                </FilledButton>
+              </div>
+              )}
+            {!deniedByIpRules && (
+              <div>
+              <OutlinedButton onClick={() => {window.location.href="/logout/"}} className="switch-button">
+                  Switch accounts
+                </OutlinedButton>
+              </div>
+              )}
+            { (
               <div>
                 <FilledButton onClick={this.handleImpersonateClicked.bind(this)} className="impersonate-button">
                   Impersonate owner

--- a/enterprise/app/org/org_access_denied.tsx
+++ b/enterprise/app/org/org_access_denied.tsx
@@ -31,25 +31,33 @@ export default class OrgAccessDeniedComponent extends React.Component<Props> {
             {deniedByIpRules && <div className="details">Access blocked by Organization IP Rules.</div>}
             {!deniedByIpRules && (
               <div>
-              <FilledButton onClick={() => {window.location.href="/join/"}} className="request-button">
+                <FilledButton
+                  onClick={() => {
+                    window.location.href = "/join/";
+                  }}
+                  className="request-button">
                   Request to join organization
                 </FilledButton>
               </div>
-              )}
+            )}
             {!deniedByIpRules && (
               <div>
-              <OutlinedButton onClick={() => {window.location.href="/logout/"}} className="switch-button">
+                <OutlinedButton
+                  onClick={() => {
+                    window.location.href = "/logout/";
+                  }}
+                  className="switch-button">
                   Switch accounts
                 </OutlinedButton>
               </div>
-              )}
-            { (
+            )}
+            {
               <div>
                 <FilledButton onClick={this.handleImpersonateClicked.bind(this)} className="impersonate-button">
                   Impersonate owner
                 </FilledButton>
               </div>
-            )}
+            }
           </div>
         </div>
       </div>

--- a/enterprise/app/org/org_access_denied.tsx
+++ b/enterprise/app/org/org_access_denied.tsx
@@ -51,7 +51,7 @@ export default class OrgAccessDeniedComponent extends React.Component<Props> {
                 </OutlinedButton>
               </div>
             )}
-            {
+            {this.props.user?.subdomainGroupID && 
               <div>
                 <FilledButton onClick={this.handleImpersonateClicked.bind(this)} className="impersonate-button">
                   Impersonate owner

--- a/enterprise/app/org/org_access_denied.tsx
+++ b/enterprise/app/org/org_access_denied.tsx
@@ -51,13 +51,13 @@ export default class OrgAccessDeniedComponent extends React.Component<Props> {
                 </OutlinedButton>
               </div>
             )}
-            {this.props.user?.subdomainGroupID && 
+            {this.props.user?.subdomainGroupID && (
               <div>
                 <FilledButton onClick={this.handleImpersonateClicked.bind(this)} className="impersonate-button">
                   Impersonate owner
                 </FilledButton>
               </div>
-            }
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Currently if you get served the "Access denied page" because you visited an invocation you don't have access to, it's very unclear what options you have / what next step you should take.

This change makes your options clearer / more actionable by adding two buttons:
- Request to join organization
- Switch accounts

Which allows users to either request access to the organization (pending admin approval) or switch accounts where they can login to a different account that may have access to this invocation.