### PR TITLE
Don't fallback to grpc if bytestream dialing is restricted

### DIFF
--- a/server/remote_cache/byte_stream_client/byte_stream_client.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client.go
@@ -179,7 +179,7 @@ func (p *pooledByteStreamClient) StreamBytestreamFileChunk(ctx context.Context, 
 	}
 
 	// If that didn't work, try plain old grpc.
-	if err != nil {
+	if !*restrictBytestreamDialing && err != nil {
 		err = p.streamFromUrl(ctx, url, false, offset, limit, writer)
 	}
 


### PR DESCRIPTION
When bytestream dialing is restricted, we'll only dial our own endpoints which are always grpcs.