### PR TITLE
[raft] remove some logs

### DIFF
--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//proto:raft_service_go_proto",
         "//server/environment",
         "//server/metrics",
-        "//server/util/canary",
         "//server/util/grpc_client",
         "//server/util/lockmap",
         "//server/util/log",

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
-	"github.com/buildbuddy-io/buildbuddy/server/util/canary"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lockmap"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -284,7 +283,6 @@ func (s *Session) SyncProposeLocal(ctx context.Context, nodehost NodeHost, range
 		ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
 		spn.SetName("nodehost.SyncPropose")
 		fnStart := s.clock.Now()
-		defer canary.Start("nodehost.SyncPropose", time.Second)()
 		defer func() {
 			spn.End()
 			metrics.RaftNodeHostMethodDurationUsec.With(prometheus.Labels{

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1630,7 +1630,6 @@ func (sm *Replica) singleUpdate(db pebble.IPebbleDB, entry dbsm.Entry) (dbsm.Ent
 // Update returns an error when there is unrecoverable error when updating the
 // on disk state machine.
 func (sm *Replica) Update(entries []dbsm.Entry) ([]dbsm.Entry, error) {
-	defer canary.Start("replica.Update", time.Second)()
 	startTime := time.Now()
 	db, err := sm.leaser.DB()
 	if err != nil {

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -29,6 +29,16 @@ var (
 	secretKey  = flag.String("gossip.secret_key", "", "The value should be either 16, 24, or 32 bytes.")
 )
 
+var (
+	// Logs that are not that useful.
+	excludedWarningLog = []string{
+		"serf: received old query registry_query_event from time",
+		"serf: reply for non-running query",
+		"serf: received old event",
+		"serf: received old query",
+	}
+)
+
 // A GossipManager will listen (on `advertiseAddress`), connect to `seeds`,
 // and gossip any information provided via the broker interface. To leave
 // gracefully, clients should call GossipManager.Leave() followed by
@@ -190,10 +200,17 @@ func (lw *logWriter) Write(d []byte) (int, error) {
 		log.Debug(s)
 	} else if strings.Contains(s, "[INFO]") {
 		// Excludes "EventMemberUpdate", because it's verbose and not that useful.
-		if !strings.Contains(s, "EventMemberUpdate") {
-			log.Info(s)
+		if strings.Contains(s, "EventMemberUpdate") {
+			return 0, nil
 		}
+		log.Info(s)
 	} else {
+		for _, excluded := range excludedWarningLog {
+			if strings.Contains(s, excluded) {
+				return 0, nil
+			}
+
+		}
 		log.Warning(s)
 	}
 


### PR DESCRIPTION
1. remove some serf logs that I never looked at during debugging
2. remove canary call on node.SyncPropose and replica.Update now that we report
metrics on the latency.
