### PR TITLE
rules_webtesting: upgrade to latest commit

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -281,7 +281,6 @@ use_repo(
     "com_github_azure_azure_storage_blob_go",
     "com_github_bazelbuild_bazelisk",
     "com_github_bazelbuild_buildtools",
-    "com_github_bazelbuild_rules_webtesting",
     "com_github_bduffany_godemon",
     "com_github_bits_and_blooms_bloom_v3",
     "com_github_bojand_ghz",
@@ -537,4 +536,39 @@ use_repo(
     "buildbuddy_go_oci_image_base_linux_amd64",
     "busybox",
     "busybox_linux_amd64",
+)
+
+bazel_dep(name = "rules_webtesting")
+archive_override(
+    module_name = "rules_webtesting",
+    integrity = "sha256-wJV/ZIAEYtzoEynx+f6NYA1ilAIrK6ppbUuaeI0+j3Y=",
+    strip_prefix = "rules_webtesting-7a1c88f61e35ee5ce0892ae24e2aa2a3106cbfed",
+    urls = [
+        "https://github.com/bazelbuild/rules_webtesting/archive/7a1c88f61e35ee5ce0892ae24e2aa2a3106cbfed.tar.gz",
+    ],
+)
+
+# dependencies of rules_webtesting module
+# TODO(sluongng): remove this once rules_scala is released on Central Registry
+archive_override(
+    module_name = "rules_scala",
+    integrity = "sha256-+Sc7oo2LlLxL12lg0TdBgGsr83CUTKZnMrrZL6tGMm0=",
+    strip_prefix = "rules_scala-219e63983e8e483e66ebf70372969ba227382001",
+    urls = [
+        "https://github.com/mbland/rules_scala/archive/219e63983e8e483e66ebf70372969ba227382001.tar.gz",
+    ],
+)
+
+browser_repositories = use_extension("@rules_webtesting//web:extension.bzl", "browser_repositories_extension")
+browser_repositories.install(version = "0.3.4")
+use_repo(
+    browser_repositories,
+    "org_chromium_chromedriver_linux_x64",
+    "org_chromium_chromedriver_macos_arm64",
+    "org_chromium_chromedriver_macos_x64",
+    "org_chromium_chromedriver_windows_x64",
+    "org_chromium_chromium_linux_x64",
+    "org_chromium_chromium_macos_arm64",
+    "org_chromium_chromium_macos_x64",
+    "org_chromium_chromium_windows_x64",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -602,25 +602,17 @@ swc_register_toolchains(
 # Web testing
 
 http_archive(
-    name = "io_bazel_rules_webtesting",
-    integrity = "sha256-VlUJ/CRGCcaT+JlNBVN+mA9bZEeVDhd03gHPnRstqnE=",
-    strip_prefix = "rules_webtesting-ce5e6d63b23b01c2a71178ef764384f64a81ad23",
+    name = "rules_webtesting",
+    integrity = "sha256-wJV/ZIAEYtzoEynx+f6NYA1ilAIrK6ppbUuaeI0+j3Y=",
+    strip_prefix = "rules_webtesting-7a1c88f61e35ee5ce0892ae24e2aa2a3106cbfed",
     urls = [
-        "https://github.com/bazelbuild/rules_webtesting/archive/ce5e6d63b23b01c2a71178ef764384f64a81ad23.tar.gz",
+        "https://github.com/bazelbuild/rules_webtesting/archive/7a1c88f61e35ee5ce0892ae24e2aa2a3106cbfed.tar.gz",
     ],
 )
 
-load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
+load("@rules_webtesting//web/versioned:browsers-0.3.4.bzl", "browser_repositories")
 
-web_test_repositories()
-
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
-
-browser_repositories(chromium = True)
-
-load("@io_bazel_rules_webtesting//web:go_repositories.bzl", web_test_go_repositories = "go_repositories")
-
-web_test_go_repositories()
+browser_repositories()
 
 register_toolchains(
     "@buildbuddy_toolchain//:all",

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -160,26 +160,3 @@ container_pull(
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
 
 esbuild_repositories(npm_repository = "npm")
-
-# Web testing
-
-http_archive(
-    name = "io_bazel_rules_webtesting",
-    integrity = "sha256-VlUJ/CRGCcaT+JlNBVN+mA9bZEeVDhd03gHPnRstqnE=",
-    strip_prefix = "rules_webtesting-ce5e6d63b23b01c2a71178ef764384f64a81ad23",
-    urls = [
-        "https://github.com/bazelbuild/rules_webtesting/archive/ce5e6d63b23b01c2a71178ef764384f64a81ad23.tar.gz",
-    ],
-)
-
-load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
-
-web_test_repositories()
-
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
-
-browser_repositories(chromium = True)
-
-load("@io_bazel_rules_webtesting//web:go_repositories.bzl", web_test_go_repositories = "go_repositories")
-
-web_test_go_repositories()

--- a/deps.bzl
+++ b/deps.bzl
@@ -456,8 +456,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_bazelbuild_rules_webtesting",
         importpath = "github.com/bazelbuild/rules_webtesting",
-        sum = "h1:zmBkl2nxjRojoW9PtGVEtW/91kHieotlD7cL9vFq06c=",
-        version = "v0.0.0-20210910170740-6b2ef24cfe95",
+        sum = "h1:8iFEccri5HBi43hKpNGesGtekRZNZIMB0vVaHXB2QXs=",
+        version = "v0.2.1-0.20250212231324-7a1c88f61e35",
     )
     go_repository(
         name = "com_github_bduffany_godemon",
@@ -2336,8 +2336,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_gorilla_mux",
         importpath = "github.com/gorilla/mux",
-        sum = "h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=",
-        version = "v1.7.3",
+        sum = "h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=",
+        version = "v1.8.1",
     )
     go_repository(
         name = "com_github_gorilla_websocket",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/bazelbuild/bazelisk v0.0.0-20250107101242-0a4dc6b170da
 	github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44
 	github.com/bazelbuild/rules_go v0.52.0
-	github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95
+	github.com/bazelbuild/rules_webtesting v0.2.1-0.20250212231324-7a1c88f61e35
 	github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/bojand/ghz v0.120.0
@@ -75,7 +75,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/tink/go v1.7.0
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/mux v1.7.3
+	github.com/gorilla/mux v1.8.1
 	github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hanwen/go-fuse/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44 h1:FGzENZi+S
 github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
 github.com/bazelbuild/rules_go v0.52.0 h1:+ozpngVAW67pCAwfhepaXSSrG3yHcj8K9hNAxSYBno4=
 github.com/bazelbuild/rules_go v0.52.0/go.mod h1:M+YrupNArA7OiTlv++rFUgQ6Sm+ZXbQ5HPUj0cGa0us=
-github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95 h1:zmBkl2nxjRojoW9PtGVEtW/91kHieotlD7cL9vFq06c=
-github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95/go.mod h1:M+vCvqp/1BViNuVL630BoiGqld9Q1vQzvf9bN/dWTeg=
+github.com/bazelbuild/rules_webtesting v0.2.1-0.20250212231324-7a1c88f61e35 h1:8iFEccri5HBi43hKpNGesGtekRZNZIMB0vVaHXB2QXs=
+github.com/bazelbuild/rules_webtesting v0.2.1-0.20250212231324-7a1c88f61e35/go.mod h1:v9uZWLrWZWyJdpqVPhOtq67qoSB3MhhiAQXMwNlnYf4=
 github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e h1:Th4pNly+xoH2szOq4aA+uAFmg5h37BCyq3pFqnZGJ70=
 github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e/go.mod h1:led5f4NrGeXrUKOlQA36mgNtNs7gVo86eZUOX42q5+8=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
@@ -941,8 +941,9 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/rules/webdriver/index.bzl
+++ b/rules/webdriver/index.bzl
@@ -12,7 +12,7 @@
 # propagate exec_properties to the underlying web_test target.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
-load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
+load("@rules_webtesting//web:web.bzl", "web_test_suite")
 
 DEFAULT_WRAPPED_TEST_TAGS = ("manual", "noci")
 
@@ -41,7 +41,7 @@ def go_web_test_suite(
         fail("shard_count should be set to match the number of tests to ensure that tests are run in parallel.")
 
     browsers = browsers or [
-        "@io_bazel_rules_webtesting//browsers:chromium-local",
+        "@rules_webtesting//browsers:chromium-local",
     ]
     tags = tags or []
     if "webdriver" not in tags:

--- a/server/testutil/webtester/BUILD
+++ b/server/testutil/webtester/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-# gazelle:resolve go github.com/bazelbuild/rules_webtesting/go/webtest @io_bazel_rules_webtesting//go/webtest:go_default_library
+# gazelle:resolve go github.com/bazelbuild/rules_webtesting/go/webtest @rules_webtesting//go/webtest:go_default_library
 
 go_library(
     name = "webtester",
@@ -14,6 +14,6 @@ go_library(
         "@com_github_tebeka_selenium//:selenium",
         "@com_github_tebeka_selenium//chrome",
         "@com_github_tebeka_selenium//log",
-        "@io_bazel_rules_webtesting//go/webtest:go_default_library",
+        "@rules_webtesting//go/webtest:go_default_library",
     ],
 )


### PR DESCRIPTION
Upgrade rules_webtesting to latest commit.

The repo has been updated to be bzlmod compatible so we have to rename
it to remove the io_bazel_ prefix. Moved the setup from WORKSPACE.bzlmod
into MODULE.bazel.

Upgrade our browser repository from 0.3.3 to 0.3.4.
