### PR TITLE
bazelrc: fix config=local exec platform

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,7 @@ common:local --bes_results_url=http://localhost:8080/invocation/
 common:local --bes_backend=grpc://localhost:1985
 common:local --remote_cache=grpc://localhost:1985
 common:local --remote_upload_local_results
-common:local --extra_execution_platforms=//platforms:local_config_platform
+common:local --extra_execution_platforms=@local_config_platform//:host
 
 # Build with --config=dev to send build logs to the dev server
 common:dev --bes_results_url=https://buildbuddy.buildbuddy.dev/invocation/

--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,7 @@ common:local --bes_results_url=http://localhost:8080/invocation/
 common:local --bes_backend=grpc://localhost:1985
 common:local --remote_cache=grpc://localhost:1985
 common:local --remote_upload_local_results
-common:local --extra_execution_platforms=@local_config_platform//:host
+common:local --extra_execution_platforms=@buildbuddy_toolchain//:platform
 
 # Build with --config=dev to send build logs to the dev server
 common:dev --bes_results_url=https://buildbuddy.buildbuddy.dev/invocation/


### PR DESCRIPTION
The platform definition in //platforms was removed in an earlier PR.
Replace it with Bazel's default platform
