### PR TITLE
Fix lxcfs cpuinfo

### DIFF
--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -79,6 +79,12 @@ func setupCgroups() (string, error) {
 	}
 	log.Infof("Set up task cgroup at %s", taskCgroupPath)
 
+	// Enable the same controllers for the child cgroups that were enabled
+	// for the starting cgroup.
+	if err := cgroup.DelegateControllers(filepath.Join(cgroup.RootPath, startingCgroup)); err != nil {
+		return "", fmt.Errorf("inherit subtree control: %w", err)
+	}
+
 	taskCgroupRelpath := filepath.Join(startingCgroup, taskCgroupName)
 	return taskCgroupRelpath, nil
 }


### PR DESCRIPTION
Fix lxcfs cpuinfo not respecting cpuset when `executor.child_cgroups_enabled` is set.

On initialization, lxcfs looks up the current cgroup for pid 1 (in the current pid namespace) and makes an assumption that this cgroup's controllers will be the same controllers that are enabled for all child cgroups: https://github.com/lxc/lxcfs/blob/42b57f265a31261a0b69dc1f040cbcfe58a9c6a1/src/cgroups/cgfsng.c#L1036-L1054

So to make lxcfs happy, we need to enable cgroup controllers in the executor cgroup before starting lxcfs.

The fact that we aren't explicitly enabling cgroup controllers in the child cgroups made me wonder whether cgroups were working at all. After some experimentation, it seems that these cgroup controllers are only getting enabled because crun automatically enables them for us (based on the contents of `buildbuddy.executor/cgroup.controllers` before and after running a container). We can't rely on this automatic setup for lxcfs though, because at the time when we start lxcfs, we haven't yet invoked crun for the first time, so it hasn't set up the controllers for us.