### PR TITLE
Reduce memory usage of the filecache 

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -89,21 +89,22 @@ type entry struct {
 	// sizeBytes is the file size as reported by the original FileNode metadata
 	// when the file was added to the file cache.
 	sizeBytes int64
-	// value is the absolute path to the file.
-	value string
 }
 
 func sizeFn(v *entry) int64 {
 	return v.sizeBytes
 }
 
-func evictFn(key string, v *entry, reason lru.EvictionReason) {
-	if err := syscall.Unlink(v.value); err != nil {
-		log.Errorf("Failed to unlink filecache entry %q: %s", v.value, err)
-	}
-	if reason == lru.SizeEviction {
-		age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
-		metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))
+func evictFn(rootDir string) func(string, *entry, lru.EvictionReason) {
+	return func(key string, v *entry, reason lru.EvictionReason) {
+		fp := filecachePath(rootDir, key)
+		if err := syscall.Unlink(fp); err != nil {
+			log.Errorf("Failed to unlink filecache entry %q: %s", fp, err)
+		}
+		if reason == lru.SizeEviction {
+			age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
+			metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))
+		}
 	}
 }
 
@@ -123,7 +124,7 @@ func NewFileCache(rootDir string, maxSizeBytes int64, deleteContent bool) (*file
 	if err := disk.EnsureDirectoryExists(rootDir); err != nil {
 		return nil, err
 	}
-	l, err := lru.NewLRU[*entry](&lru.Config[*entry]{MaxSize: maxSizeBytes, OnEvict: evictFn, SizeFn: sizeFn})
+	l, err := lru.NewLRU[*entry](&lru.Config[*entry]{MaxSize: maxSizeBytes, OnEvict: evictFn(rootDir), SizeFn: sizeFn})
 	if err != nil {
 		return nil, err
 	}
@@ -146,12 +147,13 @@ func (c *fileCache) TempDir() string {
 	return filepath.Join(c.rootDir, tmpDir)
 }
 
-func (c *fileCache) filecachePath(key string) string {
+func filecachePath(rootDir, key string) string {
 	groupDir, file := filepath.Split(key)
+	// Don't use filepath.Join since it's relatively slow and allocates more.
 	if *includeSubdirPrefix {
-		return filepath.Join(c.rootDir, groupDir, file[:4], file)
+		return rootDir + "/" + groupDir + "/" + file[:4] + "/" + file
 	}
-	return filepath.Join(c.rootDir, groupDir, file)
+	return rootDir + "/" + groupDir + "/" + file
 }
 
 const sep = string(filepath.Separator)
@@ -276,13 +278,13 @@ func (c *fileCache) FastLinkFile(ctx context.Context, node *repb.FileNode, outpu
 	key := groupSpecificKey(groupID, node)
 
 	c.lock.Lock()
-	v, ok := c.l.Get(key)
+	ok := c.l.Contains(key)
 	c.lock.Unlock()
 	if !ok {
 		return false
 	}
 	start := time.Now()
-	if err := cloneOrLink(groupID, v.value, outputPath); err != nil {
+	if err := cloneOrLink(groupID, filecachePath(c.rootDir, key), outputPath); err != nil {
 		log.Warningf("Failed to link file from cache: %s", err)
 		return false
 	}
@@ -305,12 +307,12 @@ func (c *fileCache) Open(ctx context.Context, node *repb.FileNode) (f *os.File, 
 	key := groupSpecificKey(groupID, node)
 
 	c.lock.Lock()
-	v, ok := c.l.Get(key)
+	ok := c.l.Contains(key)
 	c.lock.Unlock()
 	if !ok {
 		return nil, status.NotFoundError("not found")
 	}
-	return os.Open(v.value)
+	return os.Open(filecachePath(c.rootDir, key))
 }
 
 func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existingFilePath string) error {
@@ -332,7 +334,7 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	fp := c.filecachePath(k)
+	fp := filecachePath(c.rootDir, k)
 
 	// If we're adding the file from the path where it should already exist
 	// (i.e. during the initial directory scan), and if it's already tracked in
@@ -366,7 +368,6 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 	e := &entry{
 		addedAtUsec: time.Now().UnixMicro(),
 		sizeBytes:   sizeOnDisk,
-		value:       fp,
 	}
 	metrics.FileCacheAddedFileSizeBytes.Observe(float64(e.sizeBytes))
 	success := c.l.Add(k, e)

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -319,7 +319,6 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 	// overwrite an existing link with different contents, all pointers
 	// to the old link would suddenly change to point to the new content,
 	// which is not good.
-	k := groupSpecificKey(groupID, node)
 
 	info, err := os.Stat(existingFilePath)
 	if err != nil {
@@ -330,27 +329,32 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 		return wrapOSError(err, "estimate disk usage")
 	}
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
+	k := groupSpecificKey(groupID, node)
 	fp := filecachePath(c.rootDir, k)
 
 	// If we're adding the file from the path where it should already exist
 	// (i.e. during the initial directory scan), and if it's already tracked in
 	// the LRU (i.e. another action added it concurrently with the scan), then
 	// short-circuit to avoid evicting the file.
-	if fp == existingFilePath && c.l.Contains(k) {
-		return nil
-	}
+	if fp == existingFilePath {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+		if c.l.Contains(k) {
+			return nil
+		}
+	} else {
+		// If the file being added is not already at the path where we expect it
+		// (i.e. it's being added from some action workspace), then remove and
+		// unlink any existing entry, then hardlink to the destination path.
 
-	// If the file being added is not already at the path where we expect it
-	// (i.e. it's being added from some action workspace), then remove and
-	// unlink any existing entry, then hardlink to the destination path.
-	if fp != existingFilePath {
-		c.l.Remove(k)
+		// TODO(vanja) Consider creating directories ahead of time. This would
+		// require learning about new groups.
 		if err := disk.EnsureDirectoryExists(filepath.Dir(fp)); err != nil {
 			return err
 		}
+		c.lock.Lock()
+		defer c.lock.Unlock()
+		c.l.Remove(k)
 		if err := cloneOrLink(groupID, existingFilePath, fp); err != nil {
 			return err
 		}

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -148,12 +148,12 @@ func (c *fileCache) TempDir() string {
 }
 
 func filecachePath(rootDir, key string) string {
-	groupDir, file := filepath.Split(key)
 	// Don't use filepath.Join since it's relatively slow and allocates more.
 	if *includeSubdirPrefix {
+		groupDir, file := filepath.Split(key)
 		return rootDir + "/" + groupDir + "/" + file[:4] + "/" + file
 	}
-	return rootDir + "/" + groupDir + "/" + file
+	return rootDir + "/" + key
 }
 
 const sep = string(filepath.Separator)
@@ -243,11 +243,10 @@ func (c *fileCache) scanDir() {
 }
 
 func groupSpecificKey(groupID string, node *repb.FileNode) string {
-	suffix := ""
 	if node.GetIsExecutable() {
-		suffix = "." + executableSuffix
+		return groupID + "/" + node.GetDigest().GetHash() + "." + executableSuffix
 	}
-	return groupID + "/" + node.GetDigest().GetHash() + suffix
+	return groupID + "/" + node.GetDigest().GetHash()
 }
 
 func groupIDStringFromContext(ctx context.Context) string {

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -361,6 +361,7 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 
 		// If the file being added is inside the filecache dir, and it
 		// is stored in an "old-style" location, then remove it.
+		// TODO(vanja) is there a bug in the second part of this if?
 		if strings.HasPrefix(existingFilePath, c.rootDir) && filepath.Base(fp) == filepath.Base(existingFilePath) {
 			if err := syscall.Unlink(existingFilePath); err != nil {
 				log.Errorf("Failed to unlink existing filecache path: %q: %s", existingFilePath, err)

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
@@ -565,18 +566,23 @@ func BenchmarkContainsAdd(b *testing.B) {
 	log.Configure()
 
 	for _, test := range []struct {
-		Name          string
-		Ops           int
-		AddedFraction float64
+		Name    string
+		Ops     int
+		MaxSize int64
 	}{
-		{Name: "100%Added/1K", Ops: 1000, AddedFraction: 1},
-		{Name: "95%Added/1K", Ops: 1000, AddedFraction: 0.95},
-		{Name: "50%Added/1K", Ops: 1000, AddedFraction: 0.5},
-		{Name: "0%Added/1K", Ops: 1000, AddedFraction: 0.0},
+		// Mostly calls just Contains()
+		{Name: "1K/10G", Ops: 1000, MaxSize: 10_000_000_000},
+		// Small capacity, so every add causes an evict.
+		{Name: "1K/1M", Ops: 1000, MaxSize: 1_000_000},
 	} {
 		b.Run(test.Name, func(b *testing.B) {
+			runtime.GC()
+			var m runtime.MemStats
+			runtime.ReadMemStats(&m)
+			startingHeap := m.HeapAlloc
+
 			root := testfs.MakeTempDir(b)
-			fc, err := filecache.NewFileCache(testfs.MakeDirAll(b, root, "cache"), 1_000_000, false /*=delete*/)
+			fc, err := filecache.NewFileCache(testfs.MakeDirAll(b, root, "cache"), test.MaxSize, false /*=delete*/)
 			require.NoError(b, err)
 			fc.WaitForDirectoryScanToComplete()
 			tmp := fc.TempDir()
@@ -598,9 +604,6 @@ func BenchmarkContainsAdd(b *testing.B) {
 					Name:   name,
 					Digest: d,
 				}
-				if float64(i)/float64(test.Ops) < test.AddedFraction {
-					fc.AddFile(ctx, node, path)
-				}
 				nodes[path] = node
 			}
 
@@ -609,7 +612,7 @@ func BenchmarkContainsAdd(b *testing.B) {
 				eg := &errgroup.Group{}
 				eg.SetLimit(100)
 				for path, node := range nodes {
-					node := node
+					path, node := path, node
 					eg.Go(func() error {
 						if !fc.ContainsFile(ctx, node) {
 							require.NoError(b, fc.AddFile(ctx, node, path))
@@ -622,6 +625,17 @@ func BenchmarkContainsAdd(b *testing.B) {
 				}
 				eg.Wait()
 			}
+			nodes = nil
+			runtime.GC()
+			runtime.ReadMemStats(&m)
+
+			b.ReportMetric(float64(m.HeapAlloc-startingHeap), "retained-heap")
+
+			// Keep a reference to these objects so they're not GCed before we
+			// read mem stats.
+			fc.WaitForDirectoryScanToComplete()
+			g.RandomDigestBuf(1)
+			_ = len(tmp)
 		})
 	}
 }

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -559,6 +559,7 @@ func BenchmarkFilecacheLink(b *testing.B) {
 }
 
 func BenchmarkContainsAdd(b *testing.B) {
+	// Use a simple Claims to speed up filecache.groupIDStringFromContext()
 	ctx := claims.AuthContextFromClaims(context.Background(), &claims.Claims{}, nil)
 	flags.Set(b, "app.log_level", "warn")
 	log.Configure()

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -559,7 +559,6 @@ func BenchmarkFilecacheLink(b *testing.B) {
 }
 
 func BenchmarkContainsAdd(b *testing.B) {
-	// Use a simple Claims to speed up filecache.groupIDStringFromContext()
 	ctx := claims.AuthContextFromClaims(context.Background(), &claims.Claims{}, nil)
 	flags.Set(b, "app.log_level", "warn")
 	log.Configure()

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -633,9 +633,9 @@ func BenchmarkContainsAdd(b *testing.B) {
 
 			// Keep a reference to these objects so they're not GCed before we
 			// read mem stats.
-			fc.WaitForDirectoryScanToComplete()
-			g.RandomDigestBuf(1)
-			_ = len(tmp)
+			runtime.KeepAlive(fc)
+			runtime.KeepAlive(g)
+			runtime.KeepAlive(tmp)
 		})
 	}
 }


### PR DESCRIPTION
Since the LRU now has string keys, we can use those to get the filecache paths, instead of storing the path in the LRU value.

I also simplified the benchmark and made it monitor retained memory usage.

This reduces memory usage by 25% compared to the previous version of the LRU (with hashed keys), and by 33% compared to the current LRU (with string keys). It also speeds it up a bit and reduces allocations.

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                      │ /tmp/baseline │          /tmp/simplekeys           │         /tmp/nopathinvalue         │
                      │    sec/op     │   sec/op     vs base               │   sec/op     vs base               │
ContainsAdd/1K/10G-24     642.8µ ± 2%   616.4µ ± 3%  -4.11% (p=0.000 n=50)   605.5µ ± 2%  -5.80% (p=0.000 n=50)
ContainsAdd/1K/1M-24      14.79m ± 1%   14.96m ± 1%       ~ (p=0.227 n=50)   14.64m ± 2%       ~ (p=0.207 n=50)
geomean                   3.083m        3.037m       -1.50%                  2.977m       -3.43%

                      │ /tmp/baseline │            /tmp/simplekeys            │          /tmp/nopathinvalue           │
                      │ retained-heap │ retained-heap  vs base                │ retained-heap  vs base                │
ContainsAdd/1K/10G-24     314.7k ± 2%     361.6k ± 2%  +14.91% (p=0.000 n=50)     232.9k ± 4%  -25.98% (n=50)
ContainsAdd/1K/1M-24      90.55k ± 6%    101.40k ± 5%  +11.98% (p=0.001 n=50)     69.58k ± 6%  -23.16% (p=0.000 n=50)
geomean                   168.8k          191.5k       +13.44%                    127.3k       -24.58%

                      │ /tmp/baseline │           /tmp/simplekeys           │         /tmp/nopathinvalue          │
                      │     B/op      │     B/op      vs base               │     B/op      vs base               │
ContainsAdd/1K/10G-24    165.3Ki ± 0%   165.2Ki ± 0%  -0.05% (p=0.000 n=50)   165.1Ki ± 0%  -0.12% (n=50)
ContainsAdd/1K/1M-24     1.380Mi ± 0%   1.374Mi ± 0%  -0.45% (p=0.001 n=50)   1.261Mi ± 0%  -8.61% (p=0.000 n=50)
geomean                  483.4Ki        482.2Ki       -0.25%                  461.8Ki       -4.46%

                      │ /tmp/baseline │          /tmp/simplekeys           │     /tmp/nopathinvalue      │
                      │   allocs/op   │  allocs/op   vs base               │  allocs/op   vs base        │
ContainsAdd/1K/10G-24     3.013k ± 0%   3.012k ± 0%  -0.03% (p=0.000 n=50)   3.011k ± 0%   -0.07% (n=50)
ContainsAdd/1K/1M-24      17.27k ± 0%   16.33k ± 0%  -5.42% (n=50)           15.42k ± 0%  -10.70% (n=50)
geomean                   7.213k        7.014k       -2.76%                  6.814k        -5.53%
```
