### PR TITLE
Filter sampled tasks to ones that fit on the node

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -50,6 +50,7 @@ go_test(
     deps = [
         "//enterprise/server/remote_execution/execution_server",
         "//enterprise/server/remote_execution/platform",
+        "//enterprise/server/tasksize",
         "//enterprise/server/testutil/enterprise_testenv",
         "//enterprise/server/testutil/testredis",
         "//proto:remote_execution_go_proto",


### PR DESCRIPTION
Fixes an issue where `assignWorkToNode` results in indefinite queue buildup if a task can't fit on some executors in the pool.

Context: https://buildbuddy-corp.slack.com/archives/C06DBLTGC2V/p1739598075814869