### PR TITLE
Dedupe task reservations

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -54,11 +54,11 @@ type taskQueue struct {
 	pqs *list.List
 	// Map to allow quick lookup of a specific *groupPriorityQueue element in the pqs list.
 	pqByGroupID map[string]*list.Element
+	// Map tracking all task IDs across all groups.
+	taskIDs map[string]struct{}
 	// The *groupPriorityQueue element from which the next task will be obtained.
 	// Will be nil when there are no tasks remaining.
 	currentPQ *list.Element
-	// Number of tasks across all queues.
-	numTasks int
 }
 
 func newTaskQueue() *taskQueue {
@@ -66,6 +66,7 @@ func newTaskQueue() *taskQueue {
 		pqs:         list.New(),
 		pqByGroupID: make(map[string]*list.Element),
 		currentPQ:   nil,
+		taskIDs:     make(map[string]struct{}),
 	}
 }
 
@@ -85,7 +86,17 @@ func (t *taskQueue) GetAll() []*scpb.EnqueueTaskReservationRequest {
 	return reservations
 }
 
-func (t *taskQueue) Enqueue(req *scpb.EnqueueTaskReservationRequest) {
+// Enqueue enqueues a task reservation request into the task queue.
+// If the task is already enqueued, it will not be enqueued again.
+// Returns true if the task was enqueued, false if it was already enqueued.
+func (t *taskQueue) Enqueue(req *scpb.EnqueueTaskReservationRequest) (ok bool) {
+	// Don't enqueue the same task twice to avoid inflating queue length
+	// metrics. Duplicate enqueues can happen when the executor asks for more
+	// work during mostly-idle periods, since the scheduler doesn't know which
+	// tasks that are already in our queue.
+	if t.HasTask(req.GetTaskId()) {
+		return false
+	}
 	taskGroupID := req.GetSchedulingMetadata().GetTaskGroupId()
 	var pq *groupPriorityQueue
 	if el, ok := t.pqByGroupID[taskGroupID]; ok {
@@ -93,7 +104,7 @@ func (t *taskQueue) Enqueue(req *scpb.EnqueueTaskReservationRequest) {
 		if !ok {
 			// Why would this ever happen?
 			log.Error("not a *groupPriorityQueue!??!")
-			return
+			return false
 		}
 	} else {
 		pq = &groupPriorityQueue{
@@ -107,7 +118,7 @@ func (t *taskQueue) Enqueue(req *scpb.EnqueueTaskReservationRequest) {
 		}
 	}
 	pq.Push(req)
-	t.numTasks++
+	t.taskIDs[req.GetTaskId()] = struct{}{}
 	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: taskGroupID}).Set(float64(pq.Len()))
 	if req.GetSchedulingMetadata().GetTrackQueuedTaskSize() {
 		metrics.RemoteExecutionAssignedOrQueuedEstimatedMilliCPU.
@@ -115,6 +126,7 @@ func (t *taskQueue) Enqueue(req *scpb.EnqueueTaskReservationRequest) {
 		metrics.RemoteExecutionAssignedOrQueuedEstimatedRAMBytes.
 			Add(float64(req.TaskSize.EstimatedMemoryBytes))
 	}
+	return true
 }
 
 func (t *taskQueue) Dequeue() *scpb.EnqueueTaskReservationRequest {
@@ -129,7 +141,7 @@ func (t *taskQueue) Dequeue() *scpb.EnqueueTaskReservationRequest {
 		return nil
 	}
 	req := pq.Pop()
-
+	delete(t.taskIDs, req.GetTaskId())
 	t.currentPQ = t.currentPQ.Next()
 	if pq.Len() == 0 {
 		t.pqs.Remove(pqEl)
@@ -138,7 +150,6 @@ func (t *taskQueue) Dequeue() *scpb.EnqueueTaskReservationRequest {
 	if t.currentPQ == nil {
 		t.currentPQ = t.pqs.Front()
 	}
-	t.numTasks--
 	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: req.GetSchedulingMetadata().GetTaskGroupId()}).Set(float64(pq.Len()))
 	if req.GetSchedulingMetadata().GetTrackQueuedTaskSize() {
 		metrics.RemoteExecutionAssignedOrQueuedEstimatedMilliCPU.
@@ -163,7 +174,12 @@ func (t *taskQueue) Peek() *scpb.EnqueueTaskReservationRequest {
 }
 
 func (t *taskQueue) Len() int {
-	return t.numTasks
+	return len(t.taskIDs)
+}
+
+func (t *taskQueue) HasTask(taskID string) bool {
+	_, ok := t.taskIDs[taskID]
+	return ok
 }
 
 type Options struct {
@@ -299,6 +315,14 @@ func (q *PriorityTaskScheduler) Shutdown(ctx context.Context) error {
 func (q *PriorityTaskScheduler) EnqueueTaskReservation(ctx context.Context, req *scpb.EnqueueTaskReservationRequest) (*scpb.EnqueueTaskReservationResponse, error) {
 	ctx = log.EnrichContext(ctx, log.ExecutionIDKey, req.GetTaskId())
 
+	q.mu.Lock()
+	alreadyEnqueued := q.q.HasTask(req.GetTaskId())
+	q.mu.Unlock()
+	if alreadyEnqueued {
+		log.CtxDebugf(ctx, "Task %q is already enqueued, skipping", req.GetTaskId())
+		return &scpb.EnqueueTaskReservationResponse{}, nil
+	}
+
 	if req.GetTaskSize().GetEstimatedMemoryBytes() > q.ramBytesCapacity ||
 		req.GetTaskSize().GetEstimatedMilliCpu() > q.cpuMillisCapacity {
 		// TODO(bduffany): Return an error here instead. Currently we cannot
@@ -314,8 +338,15 @@ func (q *PriorityTaskScheduler) EnqueueTaskReservation(ctx context.Context, req 
 
 	enqueueFn := func() {
 		q.mu.Lock()
-		q.q.Enqueue(req)
+		ok := q.q.Enqueue(req)
 		q.mu.Unlock()
+		if !ok {
+			// Already enqueued. This normally shouldn't happen since we checked
+			// HasTask above, but that check can return false if a task is
+			// delayed and waiting to be enqueued, but not actually enqueued
+			// yet.
+			return
+		}
 		log.CtxInfof(ctx, "Added task %+v to pq.", req)
 		// Wake up the scheduling loop so that it can run the task if there are
 		// enough resources available.

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
@@ -81,3 +81,15 @@ func TestTaskQueue_MultipleGroups(t *testing.T) {
 	require.Equal(t, "group1Task3", q.Dequeue().GetTaskId())
 	require.Nil(t, q.Dequeue())
 }
+
+func TestTaskQueue_DedupesTasks(t *testing.T) {
+	q := newTaskQueue()
+
+	require.True(t, q.Enqueue(newTaskReservationRequest("1", testGroupID1, 0)))
+	require.False(t, q.Enqueue(newTaskReservationRequest("1", testGroupID1, 0)))
+
+	require.Equal(t, 1, q.Len())
+	require.Equal(t, "1", q.Dequeue().GetTaskId())
+	require.Equal(t, 0, q.Len())
+	require.Nil(t, q.Dequeue())
+}


### PR DESCRIPTION
While working on a different issue, I noticed locally that while an executor was eagerly requesting work during idle periods, the queue length kept going up. This was surprising because I had enqueued a fixed set of 100 tasks, but the queue length climbed to over 200.

The issue was that although the executor was under the `excess_capacity_threshold` on CPU and RAM, it was fully utilized on custom resources (`gpu`), because all of the tasks in the queue were requesting 100% of `gpu` resources. So the executor kept requesting more work, and because we don't dedupe tasks, this drove up the queue length. To address this specific case, we could incorporate custom resources into the excess capacity threshold.

But I think the queue can still build up with duplicate tasks in other cases, too. For example, if the executor is stuck at <40% utilization because the current task is taking a long time, but the next task in the queue is very large and cannot schedule, then the executor will keep requesting more work, likely getting a lot of duplicate tasks. The new queue pruning logic might help with this, but it's not guaranteed, especially if multiple executors in a pool are in this state.

Because it's a pretty small change, it seems worth just dropping tasks if they are already in the queue, just so that we never have to wonder whether duplicate tasks are inflating the queue length.

This change should not cause legitimate executions to be dropped, because the only time the same task ID should be legitimately executed twice is during a retry attempt. In the retry case, we explicitly send more probes, so retries should still continue to work properly.