### PR TITLE
Cache OCI image layers and manifests in the CAS

### DIFF
--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -26,7 +26,7 @@ go_library(
 
 go_test(
     name = "ociregistry_test",
-    timeout = "medium",
+    timeout = "moderate",
     srcs = ["ociregistry_test.go"],
     deps = [
         ":ociregistry",

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -33,6 +33,7 @@ go_test(
         "//enterprise/server/util/oci",
         "//proto:registry_go_proto",
         "//server/environment",
+        "//server/remote_cache/byte_stream_server",
         "//server/testutil/testenv",
         "//server/testutil/testport",
         "//server/testutil/testregistry",
@@ -40,6 +41,8 @@ go_test(
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//:grpc",
     ],
 )
 

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -33,7 +33,6 @@ go_test(
         "//enterprise/server/util/oci",
         "//proto:registry_go_proto",
         "//server/environment",
-        "//server/remote_cache/byte_stream_server",
         "//server/testutil/testcache",
         "//server/testutil/testenv",
         "//server/testutil/testport",
@@ -43,7 +42,6 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
-        "@org_golang_google_grpc//:grpc",
     ],
 )
 

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -34,6 +34,7 @@ go_test(
         "//proto:registry_go_proto",
         "//server/environment",
         "//server/remote_cache/byte_stream_server",
+        "//server/testutil/testcache",
         "//server/testutil/testenv",
         "//server/testutil/testport",
         "//server/testutil/testregistry",

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -26,7 +26,7 @@ go_library(
 
 go_test(
     name = "ociregistry_test",
-    timeout = "short",
+    timeout = "medium",
     srcs = ["ociregistry_test.go"],
     deps = [
         ":ociregistry",

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -6,9 +6,13 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/ociregistry",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/environment",
         "//server/metrics",
         "//server/real_environment",
+        "//server/remote_cache/cachetools",
+        "//server/remote_cache/digest",
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/status",

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -232,8 +232,8 @@ func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter,
 	var rc io.ReadCloser
 
 	casDigest := &repb.Digest{
-		Hash:      blobSHA256Digest, // your SHA256 string
-		SizeBytes: blobSize,         // the size of your blob
+		Hash:      blobSHA256Digest,
+		SizeBytes: blobSize,
 	}
 	bsClient := r.env.GetByteStreamClient()
 	resourceName := digest.NewResourceName(

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -191,6 +191,8 @@ func getImage(ctx context.Context, ref name.Reference) (gcr.Image, error) {
 	return img, nil
 }
 
+// imageName in this case is OPTIONAL_DOMAIN:OPTIONAL_PORT/IMAGE. No tag.
+// For example, `alpine` or `someregistry.com:8080/alpine`.
 func fetchLayerFromRemoteRegistry(imageName, layerSHA256Digest string) (gcr.Layer, error) {
 	d, err := name.NewDigest(imageName + "@sha256:" + layerSHA256Digest)
 	if err != nil {

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -267,12 +267,7 @@ func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter,
 		rspb.CacheType_CAS,
 		repb.DigestFunction_SHA256,
 	)
-	fetchingFullLayer := offset == 0 && (limit == 0 || limit >= length)
-	if fetchingFullLayer {
-		err = cachetools.GetBlob(ctx, bsClient, resourceName, w)
-	} else {
-		err = cachetools.GetPartialBlob(ctx, bsClient, resourceName, w, offset, limit)
-	}
+	err = cachetools.GetBlobRange(ctx, bsClient, resourceName, w, offset, limit)
 	if err == nil {
 		return
 	}
@@ -285,6 +280,7 @@ func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter,
 	}
 	defer rc.Close()
 
+	fetchingFullLayer := offset == 0 && (limit == 0 || limit >= length)
 	if fetchingFullLayer {
 		tr := io.TeeReader(rc, w)
 		_, _, err = cachetools.UploadFromReader(ctx, bsClient, resourceName, tr)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -287,7 +287,11 @@ func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter,
 		_, _, err = cachetools.UploadFromReader(ctx, bsClient, resourceName, tr)
 	} else {
 		if offset > 0 {
-			io.CopyN(io.Discard, rc, offset)
+			_, err := io.CopyN(io.Discard, rc, offset)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("could not discard offset bytes: %s", err), http.StatusInternalServerError)
+				return
+			}
 		}
 		if limit != 0 && limit < length {
 			length = limit

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -267,6 +267,7 @@ func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter,
 		rspb.CacheType_CAS,
 		repb.DigestFunction_SHA256,
 	)
+	resourceName.SetCompressor(repb.Compressor_ZSTD)
 	err = cachetools.GetBlobRange(ctx, bsClient, resourceName, w, offset, limit)
 	if err == nil {
 		return

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -103,11 +103,11 @@ func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Reques
 	// Request for a blob (full layer or layer chunk).
 	if m := blobReqRE.FindStringSubmatch(req.RequestURI); len(m) == 3 {
 		imageName := m[1]
-		refName := m[2]
+		blobDigest := m[2]
 		if forwardedRegistry != "" {
 			imageName = forwardedRegistry + "/" + imageName
 		}
-		r.handleBlobRequest(ctx, w, req, imageName, refName)
+		r.handleBlobRequest(ctx, w, req, imageName, blobDigest)
 		return
 	}
 	http.NotFound(w, req)
@@ -188,12 +188,12 @@ func getImage(ctx context.Context, ref name.Reference) (v1.Image, error) {
 
 // handleBlobRequest fetches all or part of a blob from a remote registry.
 // Used to pull OCI image layers.
-func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter, req *http.Request, imageName, refName string) {
+func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter, req *http.Request, imageName, blobDigest string) {
 	reqStartTime := time.Now()
 
-	d, err := name.NewDigest(imageName + "@" + refName)
+	d, err := name.NewDigest(imageName + "@" + blobDigest)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("invalid hash %q: %s", refName, err), http.StatusNotFound)
+		http.Error(w, fmt.Sprintf("invalid hash %q: %s", blobDigest, err), http.StatusNotFound)
 		return
 	}
 

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -204,51 +204,6 @@ func fetchLayerFromRemoteRegistry(imageName, layerSHA256Digest string) (gcr.Laye
 	return layer, nil
 }
 
-type startEndWriter struct {
-	w     io.Writer
-	start int64
-	end   int64
-	pos   int64
-}
-
-func newStartEndWriter(w io.Writer, start, end int64) (*startEndWriter, error) {
-	if end < start {
-		return nil, fmt.Errorf("newStartEndWriter end (%d) must be greater or equal to start (%d)", end, start)
-	}
-	sew := &startEndWriter{
-		w:     w,
-		start: start,
-		end:   end,
-		pos:   0,
-	}
-	return sew, nil
-}
-
-func (sew *startEndWriter) Write(p []byte) (n int, err error) {
-	bytesBeforeStart := min(max(0, sew.start-sew.pos), int64(len(p)))
-	bytesToWrite := min(int64(len(p))-bytesBeforeStart, max(sew.end-(sew.pos+bytesBeforeStart), 0))
-	log.Debugf("sew.Write pos %d, len %d, start %d, end %d", sew.pos, len(p), sew.start, sew.end)
-	if bytesToWrite > 0 {
-		n, err := sew.w.Write(p[bytesBeforeStart : bytesBeforeStart+bytesToWrite])
-		written := bytesBeforeStart + int64(n)
-		if err != nil {
-			sew.pos += written
-			log.Debugf("sew wrote %d: %s", written, err)
-			return int(written), err
-		}
-		if int64(n) < bytesToWrite {
-			sew.pos += written
-			log.Debugf("sew wrote %d", written)
-			return int(written), nil
-		}
-	}
-	bytesAfterEnd := max((int64(len(p))+sew.pos)-sew.end, 0)
-	written := bytesBeforeStart + bytesToWrite + bytesAfterEnd
-	sew.pos += written
-	log.Debugf("sew before %d, toWrite %d, after %d, written %d", bytesBeforeStart, bytesToWrite, bytesAfterEnd, written)
-	return int(written), nil
-}
-
 // handleBlobRequest fetches all or part of a blob from a remote registry.
 // Used to pull OCI image layers.
 func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter, req *http.Request, imageName, blobSHA256Digest string) {
@@ -301,17 +256,6 @@ func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter,
 		}()
 	}
 
-	var casWriter io.Writer
-	fetchingFullLayer := offset == 0 && (limit == 0 || limit >= length)
-	if fetchingFullLayer {
-		casWriter = w
-	} else {
-		casWriter, err = newStartEndWriter(w, offset, offset+limit)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("could not create CAS writer: %s", err), http.StatusInternalServerError)
-			return
-		}
-	}
 	casDigest := &repb.Digest{
 		Hash:      blobSHA256Digest,
 		SizeBytes: blobSize,
@@ -323,39 +267,43 @@ func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter,
 		rspb.CacheType_CAS,
 		repb.DigestFunction_SHA256,
 	)
-	err = cachetools.GetBlob(ctx, bsClient, resourceName, casWriter)
-	fetchingFromCAS := err == nil
-
-	if fetchingFromCAS {
-		return
+	fetchingFullLayer := offset == 0 && (limit == 0 || limit >= length)
+	if fetchingFullLayer {
+		err = cachetools.GetBlob(ctx, bsClient, resourceName, w)
 	} else {
-		rc, err := layer.Compressed()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("could not create blob reader: %s", err), http.StatusInternalServerError)
-			return
-		}
-		defer rc.Close()
+		err = cachetools.GetPartialBlob(ctx, bsClient, resourceName, w, offset, limit)
+	}
+	if err == nil {
+		return
+	}
 
-		if fetchingFullLayer {
-			tr := io.TeeReader(rc, w)
-			_, _, err = cachetools.UploadFromReader(ctx, bsClient, resourceName, tr)
-		} else {
-			if offset > 0 {
-				io.CopyN(io.Discard, rc, offset)
-			}
-			if limit != 0 && limit < length {
-				length = limit
-			}
-			limitedReader := io.LimitReader(rc, length)
-			_, err = io.Copy(w, limitedReader)
-		}
+	// could not fetch from CAS, fetching from remote registry
+	rc, err := layer.Compressed()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("could not create blob reader: %s", err), http.StatusInternalServerError)
+		return
+	}
+	defer rc.Close()
 
-		if err != nil {
-			if err != context.Canceled {
-				log.CtxWarningf(ctx, "error serving %q: %s", req.RequestURI, err)
-			}
-			return
+	if fetchingFullLayer {
+		tr := io.TeeReader(rc, w)
+		_, _, err = cachetools.UploadFromReader(ctx, bsClient, resourceName, tr)
+	} else {
+		if offset > 0 {
+			io.CopyN(io.Discard, rc, offset)
 		}
+		if limit != 0 && limit < length {
+			length = limit
+		}
+		limitedReader := io.LimitReader(rc, length)
+		_, err = io.Copy(w, limitedReader)
+	}
+
+	if err != nil {
+		if err != context.Canceled {
+			log.CtxWarningf(ctx, "error serving %q: %s", req.RequestURI, err)
+		}
+		return
 	}
 }
 

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -53,21 +53,15 @@ func runMirrorRegistry(t *testing.T, env environment.Env, counter *atomic.Int32)
 
 func runByteStreamServer(ctx context.Context, t *testing.T, env *testenv.TestEnv) *grpc.ClientConn {
 	byteStreamServer, err := byte_stream_server.NewByteStreamServer(env)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	grpcServer, runFunc, lis := testenv.RegisterLocalGRPCServer(t, env)
 	bspb.RegisterByteStreamServer(grpcServer, byteStreamServer)
 
 	go runFunc()
 
-	// TODO(vadim): can we remove the MsgSize override from the default options?
-	clientConn, err := testenv.LocalGRPCConn(ctx, lis, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(4*1024*1024)))
-	if err != nil {
-		t.Error(err)
-	}
-
+	clientConn, err := testenv.LocalGRPCConn(ctx, lis)
+	require.NoError(t, err)
 	return clientConn
 }
 

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -149,7 +149,7 @@ func GetBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.Reso
 	})
 }
 
-func GetPartialBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, out io.Writer, offset, limit int64) error {
+func GetBlobRange(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, out io.Writer, offset, limit int64) error {
 	return getWithRetry(ctx, "ByteStream.Read", out, func(ctx context.Context, w io.Writer) error {
 		return getBlob(ctx, bsClient, r, w, offset, limit)
 	})


### PR DESCRIPTION
We want to use our OCI image registry as a read-through cache. On docker pull, store image layers and manifests in the CAS.

If there's a failure writing to the CAS, the blob request will fail. The docker client falls back to pulling from Docker Hub if requests to the mirror do not succeed, so I think we can tolerate failed reads due to caching errors.