### PR TITLE
Shard remote_bazel_test

### DIFF
--- a/enterprise/server/test/integration/remote_bazel/BUILD
+++ b/enterprise/server/test/integration/remote_bazel/BUILD
@@ -17,6 +17,7 @@ go_test(
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "remote-bazel-integration",
     },
+    shard_count = 7,
     tags = [
         # Use the "docker" tag to only run this on authenticated BB workflows
         # to support runner recycling


### PR DESCRIPTION
remote_bazel_test is slow - it took 4m30s to run in this invocation: https://buildbuddy.buildbuddy.io/invocation/63457942-a7e5-4b4c-8de2-3bbe977b551f?target=%2F%2Fenterprise%2Fserver%2Ftest%2Fintegration%2Fremote_bazel%3Aremote_bazel_test&targetStatus=5

Setting up shard_count brings this to a little over 1m.

Ideally we would also remove some of the network dependencies in this test since it's still very heavy (it downloads and installs bazel multiple times per test case, clones from github.com, and fetches external bazel deps like rules_go)