### PR TITLE
Fix queue pruning loop condition

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -630,7 +630,7 @@ func (q *PriorityTaskScheduler) Start() error {
 				case <-q.rootContext.Done():
 					return
 				case <-ticker.Chan():
-					for exists := q.trimQueue(); !exists; {
+					for trimmed := q.trimQueue(); trimmed; {
 					}
 				}
 			}


### PR DESCRIPTION
Fixes a busy loop issue when `executor.queue_trim_interval` is enabled (>0), since `trimQueue` returns false when nothing was trimmed, which is the case most of the time.

Reproduced the busy loop issue locally and confirmed that this fixes it.