### PR TITLE
Make the LRU OnEvict callback accept the key as well.

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -227,7 +227,7 @@ func NewDistributedCache(env environment.Env, c interfaces.Cache, config CacheCo
 	if config.LookasideCacheSizeBytes > 0 {
 		l, err := lru.NewLRU[lookasideCacheEntry](&lru.Config[lookasideCacheEntry]{
 			MaxSize: config.LookasideCacheSizeBytes,
-			OnEvict: func(v lookasideCacheEntry, reason lru.EvictionReason) {
+			OnEvict: func(key string, v lookasideCacheEntry, reason lru.EvictionReason) {
 				age := time.Since(time.UnixMilli(v.createdAtMillis))
 				metrics.LookasideCacheEvictionAgeMsec.With(prometheus.Labels{
 					metrics.LookasideCacheEvictionReason: convertEvictionReason(reason),

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -1290,7 +1290,7 @@ func NewMmapLRU() (*MmapLRU, error) {
 	ml := &MmapLRU{evictions: make(chan *Mmap, 1024)}
 	l, err := lru.NewLRU(&lru.Config[*Mmap]{
 		SizeFn: func(m *Mmap) int64 { return m.sizeBytes },
-		OnEvict: func(m *Mmap, reason lru.EvictionReason) {
+		OnEvict: func(key string, m *Mmap, reason lru.EvictionReason) {
 			// Manual evictions are triggered by calling Unmap(), so there's
 			// no need to unmap again.
 			if reason == lru.ManualEviction {

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -97,7 +97,7 @@ func sizeFn(v *entry) int64 {
 	return v.sizeBytes
 }
 
-func evictFn(v *entry, reason lru.EvictionReason) {
+func evictFn(key string, v *entry, reason lru.EvictionReason) {
 	if err := syscall.Unlink(v.value); err != nil {
 		log.Errorf("Failed to unlink filecache entry %q: %s", v.value, err)
 	}

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -602,7 +602,7 @@ func makeRecordFromInfo(key *fileKey, info fs.FileInfo) *fileRecord {
 	}
 }
 
-func (p *partition) evictFn(v *fileRecord, reason lru.EvictionReason) {
+func (p *partition) evictFn(key string, v *fileRecord, reason lru.EvictionReason) {
 	i, err := os.Stat(v.FullPath())
 	if err == nil {
 		lastUse := time.Unix(0, getLastUseNanos(i))

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1226,9 +1226,6 @@ type LRU[V any] interface {
 	// removed.
 	Remove(key string) bool
 
-	// Purge Remove()s all items in the LRU.
-	Purge()
-
 	// Returns the total "size" of the LRU.
 	Size() int64
 

--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -28,7 +28,7 @@ const (
 //
 // It is passed the value which was removed or evicted, as well the reason for
 // eviction.
-type EvictedCallback[V any] func(value V, reason EvictionReason)
+type EvictedCallback[V any] func(key string, value V, reason EvictionReason)
 type SizeFn[V any] func(value V) int64
 
 // Config specifies how the LRU cache is to be constructed.
@@ -82,17 +82,6 @@ func NewLRU[V any](config *Config[V]) (*LRU[V], error) {
 		updateInPlace: config.UpdateInPlace,
 	}
 	return c, nil
-}
-
-// Purge is used to completely clear the cache.
-func (c *LRU[V]) Purge() {
-	for k, v := range c.items {
-		if c.onEvict != nil {
-			c.onEvict(v.Value.(*Entry[V]).value, SizeEviction)
-		}
-		delete(c.items, k)
-	}
-	c.evictList.Init()
 }
 
 // Add adds a value to the cache. Returns true if the key was added.
@@ -235,6 +224,6 @@ func (c *LRU[V]) removeElement(e *list.Element, reason EvictionReason) {
 	delete(c.items, kv.key)
 	c.currentSize -= c.sizeFn(kv.value)
 	if c.onEvict != nil {
-		c.onEvict(kv.value, reason)
+		c.onEvict(kv.key, kv.value, reason)
 	}
 }


### PR DESCRIPTION
This will allow the filecache LRU to have smaller values.

I also removed the LRU.Purge method, since it's never used.