### PR TITLE
Extend deadline for networking cleanup

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1690,9 +1690,11 @@ func (c *FirecrackerContainer) cleanupNetworking(ctx context.Context) error {
 	network := c.network
 	c.network = nil
 
-	// Even if the context was canceled, extend the life of the context for
-	// cleanup
-	ctx, cancel := background.ExtendContextForFinalization(ctx, time.Second*1)
+	// Even if the context was canceled, allow a little bit of extra time to
+	// clean up networking. If we fail to clean up networking, then the IP
+	// address will remain locked and won't be usable by other VMs in the
+	// future.
+	ctx, cancel := background.ExtendContextForFinalization(ctx, 5*time.Second)
 	defer cancel()
 
 	ctx, span := tracing.StartSpan(ctx)


### PR DESCRIPTION
Initial attempt at fixing the `network_cleanup_failed` errors. A lot of these are failing with "deadline exceeded," so try extending the deadline by a few seconds.

We are also seeing some of the `iptables` commands fail with `signal: killed` but I'm not sure if this is the same error (because `CommandContext` is implemented by sending SIGKILL when the context deadline expires) or if this is an OOM-kill. Will look into this separately.