### PR TITLE
setpgid in networking commands

### DIFF
--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -82,6 +82,7 @@ func sudoCommand(ctx context.Context, args ...string) ([]byte, error) {
 		args = append([]string{"sudo", "-A"}, args...)
 	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, status.InternalErrorf("run %q: %s: %s", cmd, err, string(out))


### PR DESCRIPTION
When shutting down an executor locally with Ctrl+C, some networking commands were immediately killed. We generally don't want commands to be killed until the graceful shutdown period has elapsed. Have networking commands enable `setpgid` to fix this.