### PR TITLE
github/workflows: cache go module downloads

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: "/home/runner/go-mod-cache/"
-          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', 'deps.bzl') }}
+          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}
           restore-keys: go-mod-cache-${{ runner.os }}-
 
       - name: Build

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
+    env:
+      GO_REPOSITORY_USE_HOST_CACHE: 1
+      GOMODCACHE: /home/runner/go-mod-cache
 
     steps:
       - name: Checkout
@@ -22,6 +25,13 @@ jobs:
         with:
           path: "/home/runner/repo-cache/"
           key: repo-cache
+
+      - name: Mount Go cache
+        uses: actions/cache@v4
+        with:
+          path: "/home/runner/go-mod-cache/"
+          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', 'deps.bzl') }}
+          restore-keys: go-mod-cache-${{ runner.os }}-
 
       - name: Build
         run: |


### PR DESCRIPTION
Our go_repository repos are download by @bazel_gazelle//cmd/fetch_repo
which does not use Bazel's repo cache but a local temporary directory.
Setting the variable GO_REPOSITORY_USE_HOST_CACHE=1 tells go_repository
downloads to respect either GOPATH or GOMODCACHE (usually a sub dir of
GOPATH) environment variables to cache the download contents.

Set the cache key to files which may invalidate the cache to make sure
we always use a fresh download cache when updating external
dependencies.
