### PR TITLE
In goinit, start dockerd in parallel with vmexec server

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -429,9 +429,6 @@ func main() {
 		})
 	}
 
-	if *initDockerd {
-		die(startDockerd(ctx))
-	}
 	eg.Go(func() error {
 		// Run the vmexec server as a child process so that when we call wait()
 		// to reap direct zombie children, we aren't stealing the WaitStatus
@@ -453,6 +450,10 @@ func main() {
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
 	})
+
+	if *initDockerd {
+		die(startDockerd(ctx))
+	}
 
 	log.Printf("Finished init in %s", time.Since(start))
 	if err := eg.Wait(); err != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -145,7 +145,7 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "944231998bb02eb681051f770d1e6c4dcecc8ad66c0ab59eb0866bbad815d051"
+		expectedHash    = "5fd223e2319947a697d6907eedcea3083ea224a72f5967139dc4e5bb097ebc6e"
 		expectedVersion = "14"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)


### PR DESCRIPTION
VM exec server will wait for dockerd to be started either way, but this lets VM exec start a bit earlier, which could reduce the latency for dialing VM exec from the host.