### PR TITLE
Add support for downloading both files when diffing

### DIFF
--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -1388,22 +1388,28 @@ export default class CodeComponent extends React.Component<Props, State> {
                 onClick={() => {
                   const bsUrl = this.props.search.get("bytestream_url");
                   const invocationId = this.props.search.get("invocation_id");
+                  const filename = this.props.search.get("filename") || "";
                   if (!bsUrl || !invocationId) {
                     return;
                   }
                   const zip = this.props.search.get("z");
                   if (zip) {
-                    rpcService.downloadBytestreamZipFile(
-                      this.props.search.get("filename") || "",
-                      bsUrl,
-                      zip,
-                      invocationId
-                    );
+                    rpcService.downloadBytestreamZipFile(filename, bsUrl, zip, invocationId);
                   } else {
                     rpcService.downloadBytestreamFile(this.props.search.get("filename") || "", bsUrl, invocationId);
+                    let compareUrl = this.props.search.get("compare_bytestream_url");
+                    let compareInvocationID = this.props.search.get("compare_invocation_id");
+                    let compareFilename = this.props.search.get("compare_filename") || "";
+                    if (compareUrl) {
+                      rpcService.downloadBytestreamFile(
+                        filename == compareFilename ? filename + ".modified" : compareFilename,
+                        compareUrl,
+                        compareInvocationID || invocationId
+                      );
+                    }
                   }
                 }}>
-                <Download /> Download File
+                <Download /> Download File{this.props.search.get("compare_filename") ? "s" : ""}
               </OutlinedButton>
             </div>
           )}


### PR DESCRIPTION
Right now when diffing in the code UI, you can only download the original file.

This change makes it so both files get downloaded