### PR TITLE
[raft] add metrics for lease action latency

### DIFF
--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -162,28 +162,35 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 	switch instruction.action {
 	case Acquire:
 		err := la.l.Lease(ctx)
+		dur := time.Since(start)
+		leaseAction := "Acquire"
 		metrics.RaftLeaseActionCount.With(prometheus.Labels{
 			metrics.RaftRangeIDLabel:         strconv.Itoa(int(rangeID)),
-			metrics.RaftLeaseActionLabel:     "Acquire",
+			metrics.RaftLeaseActionLabel:     leaseAction,
 			metrics.StatusHumanReadableLabel: status.MetricsLabel(err),
 		}).Inc()
 		if err != nil {
-			la.log.Errorf("Error acquiring rangelease (%s): %s %s", la.l.Desc(ctx), err, instruction)
+			la.log.Errorf("Error acquiring rangelease (%s): %s %s after %s", la.l.Desc(ctx), err, instruction, dur)
 			return
 		}
 		if !valid {
-			la.log.Debugf("Acquired lease [%s] %s after callback (%s)", la.l.Desc(ctx), time.Since(start), instruction)
+			la.log.Debugf("Acquired lease [%s] %s after callback (%s)", la.l.Desc(ctx), dur, instruction)
 			la.sendRangeEvent(events.EventRangeLeaseAcquired)
 			metrics.RaftLeases.With(prometheus.Labels{
 				metrics.RaftRangeIDLabel: strconv.Itoa(int(la.l.GetRangeDescriptor().GetRangeId())),
 			}).Inc()
+			metrics.RaftLeaseActionDurationMsec.With(prometheus.Labels{
+				metrics.RaftLeaseActionLabel: leaseAction,
+			}).Observe(float64(dur.Milliseconds()))
 		}
 	case Drop:
+		leaseAction := "Drop"
 		// This is a no-op if we don't have the lease.
 		err := la.l.Release(ctx)
+		dur := time.Since(start)
 		metrics.RaftLeaseActionCount.With(prometheus.Labels{
 			metrics.RaftRangeIDLabel:         strconv.Itoa(int(rangeID)),
-			metrics.RaftLeaseActionLabel:     "Drop",
+			metrics.RaftLeaseActionLabel:     leaseAction,
 			metrics.StatusHumanReadableLabel: status.MetricsLabel(err),
 		}).Inc()
 		if err != nil {
@@ -191,11 +198,14 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 			return
 		}
 		if valid {
-			la.log.Debugf("Dropped lease [%s] %s after callback (%s)", la.l.Desc(ctx), time.Since(start), instruction)
+			la.log.Debugf("Dropped lease [%s] %s after callback (%s)", la.l.Desc(ctx), dur, instruction)
 			la.sendRangeEvent(events.EventRangeLeaseDropped)
 			metrics.RaftLeases.With(prometheus.Labels{
 				metrics.RaftRangeIDLabel: strconv.Itoa(int(rangeID)),
 			}).Dec()
+			metrics.RaftLeaseActionDurationMsec.With(prometheus.Labels{
+				metrics.RaftLeaseActionLabel: leaseAction,
+			}).Observe(float64(dur.Milliseconds()))
 		}
 	}
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2381,6 +2381,16 @@ var (
 		StatusHumanReadableLabel,
 	})
 
+	RaftLeaseActionDurationMsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "lease_action_duration_msec",
+		Buckets:   durationMsecBuckets(1*time.Millisecond, 15*time.Second, 2),
+		Help:      "The duration of a lease action",
+	}, []string{
+		RaftLeaseActionLabel,
+	})
+
 	RaftZombieCleanupTasks = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "raft",


### PR DESCRIPTION
To make it easy to spot abnomalies when acquire leases. For example, there is an
instance where it took 16s to acquire lease while I was examining logs.
