### PR TITLE
api/GetAction: add handling for failed build action

### DIFF
--- a/enterprise/server/api/BUILD
+++ b/enterprise/server/api/BUILD
@@ -49,6 +49,7 @@ go_test(
         "//proto:api_key_go_proto",
         "//proto:build_event_stream_go_proto",
         "//proto:build_events_go_proto",
+        "//proto:failure_details_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:resource_go_proto",
         "//proto/api/v1:api_v1_go_proto",


### PR DESCRIPTION
When an invocation failed because of a non-test(aka build) action, the
TargetCompleted event will not contains the relevant output files.
Relevant stderr/stdout of the failed action can be found in the
ActionCompleted event instead.

Enhance the GetAction rpc logic by only handling successful
TargetCompleted events. For the failed cases, add additional logic to
create Action entries from ActionCompleted events.

Refactor FillActionFromBuildEvent to switch on event id instead of event
payload.
