### PR TITLE
[RB] When starting from a snapshot, write to a different snapshot ID

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -862,16 +862,6 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 			Name:  "snapshot-key-override",
 			Value: *runFromSnapshot,
 		})
-		// By default, when specifying a snapshot key to start from, don't save
-		// changes back to that snapshot.
-		//
-		// We add this platform property to the front of the list so that if users
-		// want to save to the snapshot, they can override this behavior by setting
-		// `--runner_exec_properties=recycle-runner=true`.
-		platform.Properties = append([]*repb.Platform_Property{{
-			Name:  "recycle-runner",
-			Value: "false",
-		}}, platform.Properties...)
 	}
 
 	req := &rnpb.RunRequest{

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -684,7 +684,10 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		if !snaputil.IsChunkedSnapshotSharingEnabled() {
 			return nil, status.InvalidArgumentError("chunked snapshot sharing must be enabled to provide an override snapshot key")
 		}
-		c.snapshotKeySet = &fcpb.SnapshotKeySet{BranchKey: opts.OverrideSnapshotKey, WriteKey: opts.OverrideSnapshotKey}
+		writeSnapshotID := uuid.New()
+		writeKey := opts.OverrideSnapshotKey.CloneVT()
+		writeKey.SnapshotId = writeSnapshotID
+		c.snapshotKeySet = &fcpb.SnapshotKeySet{BranchKey: opts.OverrideSnapshotKey, WriteKey: writeKey}
 		c.createFromSnapshot = true
 
 		// TODO(bduffany): add version info to snapshots. For example, if a


### PR DESCRIPTION
There have been cases where I want to start from a snapshot and make some changes, but not change the original snapshot if I ever need to go back and reference it. It would still be nice to save the changed snapshot though