### PR TITLE
[Cache Proxy] preserve client-identity header in async atime updates

### DIFF
--- a/enterprise/server/atime_updater/BUILD
+++ b/enterprise/server/atime_updater/BUILD
@@ -13,8 +13,10 @@ go_library(
         "//server/metrics",
         "//server/real_environment",
         "//server/remote_cache/digest",
+        "//server/util/authutil",
         "//server/util/log",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
     ],
 )
@@ -31,10 +33,12 @@ go_test(
         "//server/remote_cache/digest",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
+        "//server/util/authutil",
         "//server/util/log",
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//metadata",
     ],
 )

--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -11,8 +11,11 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"google.golang.org/grpc/metadata"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	gstatus "google.golang.org/grpc/status"
@@ -31,6 +34,12 @@ var (
 	atimeUpdaterBatchUpdateInterval = flag.Duration("cache_proxy.remote_atime_update_interval", 5*time.Second, "The time interval to wait between sending access time updates to the remote cache.")
 	atimeUpdaterRpcTimeout          = flag.Duration("cache_proxy.remote_atime_rpc_timeout", 1*time.Second, "RPC timeout to use when updating blob access times in the remote cache.")
 )
+
+// A single authorization (JWT, client-identity, etc.) header.
+type authHeader struct {
+	key   string
+	value string
+}
 
 // A pending batch of atime updates (basically a FindMissingBlobsRequest).
 // Stored as a struct so digest keys can be stored in a set for de-duping.
@@ -60,10 +69,10 @@ func (u *atimeUpdate) toProto() *repb.FindMissingBlobsRequest {
 // the update will only keep one such atimeUpdate{} and if it gets too big will
 // discard additional digests until it's flushed.
 type atimeUpdates struct {
-	mu         sync.Mutex // protects jwt, updates, and atimeUpdate.digests.
-	jwt        string
-	updates    []*atimeUpdate
-	numDigests int
+	mu          sync.Mutex // protects jwt, updates, and atimeUpdate.digests.
+	authHeaders []authHeader
+	updates     []*atimeUpdate
+	numDigests  int
 }
 
 type atimeUpdater struct {
@@ -118,13 +127,45 @@ func (u *atimeUpdater) groupID(ctx context.Context) string {
 	return user.GetGroupID()
 }
 
+// Extracts the client-provided auth headers from the incoming context and
+// returns them in a slice so they can be reused for the async atime update.
+func getAuthHeaders(ctx context.Context, authenticator interfaces.Authenticator) []authHeader {
+	headers := []authHeader{}
+
+	if keys := metadata.ValueFromIncomingContext(ctx, authutil.ClientIdentityHeaderName); len(keys) > 0 {
+		// Return the last, non-empty client-identity header.
+		for i := len(keys) - 1; i >= 0; i-- {
+			if keys[i] != "" {
+				headers = append(headers, authHeader{
+					key:   authutil.ClientIdentityHeaderName,
+					value: keys[i],
+				})
+				break
+			}
+		}
+	}
+
+	if jwt := authenticator.TrustedJWTFromAuthContext(ctx); jwt != "" {
+		headers = append(headers, authHeader{
+			key:   authutil.ContextTokenStringKey,
+			value: jwt,
+		})
+	}
+	return headers
+}
+
 func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests []*repb.Digest, digestFunction repb.DigestFunction_Value) {
 	if len(digests) == 0 {
 		return
 	}
 
 	groupID := u.groupID(ctx)
-	jwt := u.authenticator.TrustedJWTFromAuthContext(ctx)
+	authHeaders := getAuthHeaders(ctx, u.authenticator)
+	if len(authHeaders) == 0 {
+		log.Infof("Dropping remote atime update due to missing auth headers in context")
+		return
+	}
+
 	u.mu.Lock()
 	updates, ok := u.updates[groupID]
 	if !ok {
@@ -144,8 +185,8 @@ func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests
 	updates.mu.Lock()
 	defer updates.mu.Unlock()
 
-	// Always use the most recent JWT for a group for remote atime updates.
-	updates.jwt = jwt
+	// Always use the most recent auth headers for a group for remote atime updates.
+	updates.authHeaders = authHeaders
 
 	// First, find the update that the new digests can be merged into, or create
 	// a new one if one doesn't exist.
@@ -253,7 +294,7 @@ func (u *atimeUpdater) sendUpdates(ctx context.Context) int {
 	// Remove updates to send and release the mutex before sending RPCs.
 	updatesToSend := map[string]*repb.FindMissingBlobsRequest{}
 	updatesSent := 0
-	jwts := map[string]string{}
+	authHeaders := map[string][]authHeader{}
 	u.mu.Lock()
 	for groupID, updates := range u.updates {
 		updates.mu.Lock()
@@ -263,7 +304,7 @@ func (u *atimeUpdater) sendUpdates(ctx context.Context) int {
 			continue
 		}
 		updatesToSend[groupID] = update
-		jwts[groupID] = updates.jwt
+		authHeaders[groupID] = updates.authHeaders
 		updates.numDigests -= len(update.BlobDigests)
 		updates.mu.Unlock()
 	}
@@ -272,7 +313,7 @@ func (u *atimeUpdater) sendUpdates(ctx context.Context) int {
 	for groupID, update := range updatesToSend {
 		updatesSent++
 		ctx, cancel := context.WithTimeout(ctx, u.rpcTimeout)
-		u.update(ctx, groupID, jwts[groupID], update)
+		u.update(ctx, groupID, authHeaders[groupID], update)
 		cancel()
 	}
 	return updatesSent
@@ -318,9 +359,21 @@ func (u *atimeUpdater) getUpdate(updates *atimeUpdates) *repb.FindMissingBlobsRe
 	return &req
 }
 
-func (u *atimeUpdater) update(ctx context.Context, groupID string, jwt string, req *repb.FindMissingBlobsRequest) {
+func (u *atimeUpdater) update(ctx context.Context, groupID string, authHeaders []authHeader, req *repb.FindMissingBlobsRequest) {
 	log.CtxDebugf(ctx, "Asynchronously processing %d atime updates for group %s", len(req.BlobDigests), groupID)
-	ctx = u.authenticator.AuthContextFromTrustedJWT(ctx, jwt)
+
+	// Repopulate the auth headers in the outgoing context.
+	for _, header := range authHeaders {
+		if header.key == authutil.ClientIdentityHeaderName {
+			ctx = metadata.AppendToOutgoingContext(ctx, authutil.ClientIdentityHeaderName, header.value)
+		} else if header.key == authutil.ContextTokenStringKey {
+			ctx = u.authenticator.AuthContextFromTrustedJWT(ctx, header.value)
+		} else {
+			log.Warningf("Ignoring unrecognized auth header: %s", header.key)
+			return
+		}
+	}
+
 	_, err := u.remote.FindMissingBlobs(ctx, req)
 	metrics.RemoteAtimeUpdatesSent.With(
 		prometheus.Labels{

--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -132,17 +132,14 @@ func (u *atimeUpdater) groupID(ctx context.Context) string {
 func getAuthHeaders(ctx context.Context, authenticator interfaces.Authenticator) []authHeader {
 	headers := []authHeader{}
 
-	if keys := metadata.ValueFromIncomingContext(ctx, authutil.ClientIdentityHeaderName); len(keys) > 0 {
-		// Return the last, non-empty client-identity header.
-		for i := len(keys) - 1; i >= 0; i-- {
-			if keys[i] != "" {
-				headers = append(headers, authHeader{
-					key:   authutil.ClientIdentityHeaderName,
-					value: keys[i],
-				})
-				break
-			}
-		}
+	keys := metadata.ValueFromIncomingContext(ctx, authutil.ClientIdentityHeaderName)
+	if len(keys) > 1 {
+		log.Warningf("Expected at most 1 client-identity header (found %d)", len(keys))
+	} else if len(keys) == 1 {
+		headers = append(headers, authHeader{
+			key:   authutil.ClientIdentityHeaderName,
+			value: keys[0],
+		})
 	}
 
 	if jwt := authenticator.TrustedJWTFromAuthContext(ctx); jwt != "" {

--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//server/testutil/testcompression",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
+        "//server/util/authutil",
         "//server/util/compression",
         "//server/util/prefix",
         "//server/util/status",
@@ -47,6 +48,7 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -152,8 +152,12 @@ func waitContains(ctx context.Context, env *testenv.TestEnv, rn *rspb.ResourceNa
 	return status.NotFoundErrorf("Timed out waiting for cache to contain %s", s)
 }
 
+func testContext() context.Context {
+	return metadata.NewOutgoingContext(context.Background(), metadata.Pairs(authutil.ClientIdentityHeaderName, "fakeheader"))
+}
+
 func TestRead(t *testing.T) {
-	ctx := context.Background()
+	ctx := testContext()
 	remoteEnv := testenv.GetTestEnv(t)
 	proxyEnv := testenv.GetTestEnv(t)
 	bs, _, _, requestCounter := runRemoteServices(ctx, remoteEnv, t)
@@ -249,7 +253,7 @@ func TestRead_RemoteAtimeUpdated(t *testing.T) {
 	rn, blob := testdigest.RandomCompressibleCASResourceBuf(t, 5e4, "" /*instanceName*/)
 	d := rn.Digest
 
-	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(authutil.ClientIdentityHeaderName, "fakeheader"))
+	ctx := testContext()
 	remoteEnv := testenv.GetTestEnv(t)
 	bs, cas, unaryRequestCounter, streamRequestCounter := runRemoteServices(ctx, remoteEnv, t)
 
@@ -351,7 +355,7 @@ func TestWrite(t *testing.T) {
 		run := func(t *testing.T) {
 			remoteEnv := testenv.GetTestEnv(t)
 			proxyEnv := testenv.GetTestEnv(t)
-			ctx := byte_stream.WithBazelVersion(t, context.Background(), tc.bazelVersion)
+			ctx := byte_stream.WithBazelVersion(t, testContext(), tc.bazelVersion)
 
 			// Enable compression
 			flags.Set(t, "cache.zstd_transcoding_enabled", true)

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcompression"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -24,6 +25,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
@@ -247,7 +249,7 @@ func TestRead_RemoteAtimeUpdated(t *testing.T) {
 	rn, blob := testdigest.RandomCompressibleCASResourceBuf(t, 5e4, "" /*instanceName*/)
 	d := rn.Digest
 
-	ctx := context.Background()
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(authutil.ClientIdentityHeaderName, "fakeheader"))
 	remoteEnv := testenv.GetTestEnv(t)
 	bs, cas, unaryRequestCounter, streamRequestCounter := runRemoteServices(ctx, remoteEnv, t)
 

--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -39,6 +39,7 @@ go_test(
         "//server/remote_cache/content_addressable_storage_server",
         "//server/testutil/cas",
         "//server/testutil/testenv",
+        "//server/util/authutil",
         "//server/util/testing/flags",
         "//server/util/uuid",
         "@com_github_jonboulle_clockwork//:clockwork",
@@ -46,5 +47,6 @@ go_test(
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
     ],
 )


### PR DESCRIPTION
Without this, async atime updates are rejected for organizations with IP rules enabled.