### PR TITLE
OCI registry mirror that passes through HTTP requests to upstream registry

### DIFF
--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -7,16 +7,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
-        "//server/metrics",
         "//server/real_environment",
         "//server/util/log",
         "//server/util/prefix",
-        "//server/util/status",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
-        "@com_github_google_go_containerregistry//pkg/v1/remote",
-        "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
-        "@com_github_google_go_containerregistry//pkg/v1/types",
     ],
 )
 
@@ -26,15 +21,10 @@ go_test(
     srcs = ["ociregistry_test.go"],
     deps = [
         ":ociregistry",
-        "//enterprise/server/util/oci",
-        "//proto:registry_go_proto",
         "//server/environment",
         "//server/testutil/testenv",
         "//server/testutil/testport",
         "//server/testutil/testregistry",
-        "//server/util/testing/flags",
-        "@com_github_google_go_containerregistry//pkg/v1:pkg",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -64,6 +64,7 @@ func (r *registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // (to cut down on the number of API calls to Docker Hub and on bandwidth).
 // handleRegistryRequest implements just enough of the [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
 // to allow clients to pull OCI images from remote registries that do not require authentication.
+// This registry does not support resumable pulls via the Range header.
 func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	log.CtxDebugf(ctx, "%s %s", req.Method, req.URL)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -9,17 +9,11 @@ import (
 	"net/url"
 
 	"regexp"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
-	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	gcrname "github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
@@ -99,21 +93,26 @@ func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Reques
 		// However, go-containerregistry has a separate Reference type and refers to this string as `identifier`.
 		identifier := m[2] // referrred to as <reference> in the OCI distribution spec, can be a tag or digest
 
-		r.handleManifestRequest(ctx, w, req, repository, identifier)
+		r.handleBlobsOrManifestsRequest(ctx, w, req, "manifests", repository, identifier)
 		return
 	}
 
 	// Request for a blob (full layer or layer chunk).
 	if m := blobReqRE.FindStringSubmatch(req.RequestURI); len(m) == 3 {
-		imageName := m[1]
-		refName := m[2]
-		r.handleBlobRequest(ctx, w, req, imageName, refName)
+		// The image repository name. See the comment above on repository names for manifest requests.
+		repository := m[1]
+
+		// For blobs, the identifier is a digest
+		// (such as "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef").
+		// According to the OCI image distribution spec, registries must support sha256, and may support sha512.
+		identifier := m[2]
+		r.handleBlobsOrManifestsRequest(ctx, w, req, "blobs", repository, identifier)
 		return
 	}
 	http.NotFound(w, req)
 }
 
-func (r *registry) handleManifestRequest(ctx context.Context, w http.ResponseWriter, inreq *http.Request, repository, identifier string) {
+func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.ResponseWriter, inreq *http.Request, blobsOrManifests, repository, identifier string) {
 	ref, err := parseReference(repository, identifier)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error parsing image repository '%s' and identifier '%s': %s", repository, identifier, err), http.StatusNotFound)
@@ -122,7 +121,7 @@ func (r *registry) handleManifestRequest(ctx context.Context, w http.ResponseWri
 	u := url.URL{
 		Scheme: ref.Context().Scheme(),
 		Host:   ref.Context().RegistryStr(),
-		Path:   fmt.Sprintf("/v2/%s/manifests/%s", ref.Context().RepositoryStr(), ref.Identifier()),
+		Path:   fmt.Sprintf("/v2/%s/%s/%s", ref.Context().RepositoryStr(), blobsOrManifests, ref.Identifier()),
 	}
 	upreq, err := http.NewRequest(inreq.Method, u.String(), nil)
 	if err != nil {
@@ -157,124 +156,4 @@ func parseReference(repository, identifier string) (gcrname.Reference, error) {
 		return nil, err
 	}
 	return ref, nil
-}
-
-// handleBlobRequest fetches all or part of a blob from a remote registry.
-// Used to pull OCI image layers.
-func (r *registry) handleBlobRequest(ctx context.Context, w http.ResponseWriter, req *http.Request, imageName, refName string) {
-	reqStartTime := time.Now()
-
-	d, err := gcrname.NewDigest(imageName + "@" + refName)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("invalid hash %q: %s", refName, err), http.StatusNotFound)
-		return
-	}
-
-	layer, err := r.getBlob(ctx, d)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("error fetching layer %q: %s", d, err), http.StatusNotFound)
-		return
-	}
-	blobSize, err := layer.Size()
-	if err != nil {
-		http.Error(w, fmt.Sprintf("error getting layer size %q: %s", d, err), http.StatusNotFound)
-		return
-	}
-
-	w.Header().Set("Content-Length", strconv.FormatInt(blobSize, 10))
-
-	// If this is a HEAD request, and we have already figured out the blob
-	// length then we are done.
-	if req.Method == http.MethodHead {
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-
-	offset := int64(0)
-	limit := int64(0)
-
-	if r := req.Header.Get("Range"); r != "" {
-		parsedRanges, err := parseRangeHeader(r)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if len(parsedRanges) != 1 {
-			http.Error(w, "multipart range requests not supported", http.StatusBadRequest)
-			return
-		}
-		parsedRange := parsedRanges[0]
-		start := parsedRange.start
-		end := parsedRange.end
-		size := parsedRange.end - parsedRange.start + 1
-
-		offset = start
-		limit = size
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, blobSize))
-		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
-		w.WriteHeader(http.StatusPartialContent)
-		defer func() {
-			metrics.RegistryBlobRangeLatencyUsec.Observe(float64(time.Since(reqStartTime).Microseconds()))
-		}()
-	}
-
-	rc, err := layer.Compressed()
-	if err != nil {
-		http.Error(w, fmt.Sprintf("could not create blob reader: %s", err), http.StatusInternalServerError)
-		return
-	}
-	defer rc.Close()
-
-	if offset > 0 {
-		io.CopyN(io.Discard, rc, offset)
-	}
-	length := blobSize
-	if limit != 0 && limit < length {
-		length = limit
-	}
-	limitedReader := io.LimitReader(rc, length)
-	_, err = io.Copy(w, limitedReader)
-	if err != nil {
-		if err != context.Canceled {
-			log.CtxWarningf(ctx, "error serving %q: %s", req.RequestURI, err)
-		}
-		return
-	}
-}
-
-func (r *registry) getBlob(ctx context.Context, d gcrname.Digest) (gcr.Layer, error) {
-	return remote.Layer(d)
-}
-
-type byteRange struct {
-	start, end int64
-}
-
-func parseRangeHeader(val string) ([]byteRange, error) {
-	// Format of the header value is bytes=1-10[, 10-20]
-	if !strings.HasPrefix(val, rangeHeaderBytesPrefix) {
-		return nil, status.FailedPreconditionErrorf("range header %q does not have valid prefix", val)
-	}
-	val = strings.TrimPrefix(val, rangeHeaderBytesPrefix)
-	ranges := strings.Split(val, ",")
-	var parsedRanges []byteRange
-	for _, r := range ranges {
-		rParts := strings.Split(strings.TrimSpace(r), "-")
-		if len(rParts) != 2 {
-			return nil, status.FailedPreconditionErrorf("range header %q not valid, invalid range %q", val, r)
-		}
-		start, err := strconv.ParseInt(rParts[0], 10, 64)
-		if err != nil {
-			return nil, status.FailedPreconditionErrorf("range header %q not valid, range %q has invalid start: %s", val, r, err)
-		}
-		end, err := strconv.ParseInt(rParts[1], 10, 64)
-		if err != nil {
-			return nil, status.FailedPreconditionErrorf("range header %q not valid, range %q has invalid end: %s", val, r, err)
-		}
-		if end < start {
-			return nil, status.FailedPreconditionErrorf("range header %q not valid, range %q has invalid bounds", val, r)
-		}
-		parsedRanges = append(parsedRanges, byteRange{start: start, end: end})
-	}
-	return parsedRanges, nil
 }

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -20,9 +20,10 @@ import (
 )
 
 const (
-	rangeHeaderBytesPrefix = "bytes="
-
-	dockerContentDigestHeader = "Docker-Content-Digest"
+	headerAccept              = "Accept"
+	headerContentType         = "Content-Type"
+	headerDockerContentDigest = "Docker-Content-Digest"
+	headerContentLength       = "Content-Length"
 )
 
 var (
@@ -131,8 +132,8 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 		http.Error(w, fmt.Sprintf("could not make %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)
 		return
 	}
-	if inreq.Header.Get("Accept") != "" {
-		upreq.Header.Set("Accept", inreq.Header.Get("Accept"))
+	if inreq.Header.Get(headerAccept) != "" {
+		upreq.Header.Set(headerAccept, inreq.Header.Get(headerAccept))
 	}
 	upresp, err := http.DefaultClient.Do(upreq.WithContext(ctx))
 	if err != nil {
@@ -141,9 +142,9 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 	}
 	defer upresp.Body.Close()
 
-	w.Header().Add("Content-Type", upresp.Header.Get("Content-Type"))
-	w.Header().Add("Docker-Content-Digest", upresp.Header.Get("Docker-Content-Digest"))
-	w.Header().Add("Content-Length", upresp.Header.Get("Content-Length"))
+	w.Header().Add(headerContentType, upresp.Header.Get(headerContentType))
+	w.Header().Add(headerDockerContentDigest, upresp.Header.Get(headerDockerContentDigest))
+	w.Header().Add(headerContentLength, upresp.Header.Get(headerContentLength))
 	w.WriteHeader(upresp.StatusCode)
 	_, err = io.Copy(w, upresp.Body)
 	if err != nil {

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -124,6 +124,7 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 	defer upresp.Body.Close()
 	w.Header().Add("Content-Type", upresp.Header.Get("Content-Type"))
 	w.Header().Add("Docker-Content-Digest", upresp.Header.Get("Docker-Content-Digest"))
+	w.Header().Add("Content-Length", upresp.Header.Get("Content-Length"))
 	w.WriteHeader(upresp.StatusCode)
 	_, err = io.Copy(w, upresp.Body)
 	if err != nil {

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -68,7 +68,6 @@ func (r *registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // This registry does not support resumable pulls via the Range header.
 func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	log.CtxDebugf(ctx, "%s %s", req.Method, req.URL)
 	ctx, err := prefix.AttachUserPrefixToContext(ctx, r.env)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("could not attach user prefix: %s", err), http.StatusInternalServerError)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -73,6 +73,10 @@ func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Reques
 		http.Error(w, fmt.Sprintf("could not attach user prefix: %s", err), http.StatusInternalServerError)
 		return
 	}
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		http.Error(w, fmt.Sprintf("unsupported HTTP method %s", req.Method), http.StatusNotFound)
+		return
+	}
 	// Clients issue a GET or HEAD /v2/ request to verify that this  is a registry endpoint.
 	if req.RequestURI == "/v2/" {
 		w.WriteHeader(http.StatusOK)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -26,6 +26,7 @@ const (
 	headerContentLength       = "Content-Length"
 	headerAuthorization       = "Authorization"
 	headerWWWAuthenticate     = "WWW-Authenticate"
+	headerRange               = "Range"
 )
 
 var (
@@ -144,6 +145,11 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 }
 
 func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.ResponseWriter, inreq *http.Request, blobsOrManifests, repository, identifier string) {
+	if inreq.Header.Get(headerRange) != "" {
+		http.Error(w, "Range headers not supported", http.StatusNotImplemented)
+		return
+	}
+
 	if "blobs" == blobsOrManifests && !isDigest(identifier) {
 		http.Error(w, fmt.Sprintf("can only retrieve blobs by digest, received '%s'", identifier), http.StatusNotFound)
 		return

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -111,12 +111,8 @@ func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Reques
 }
 
 func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, inreq *http.Request) {
-	scheme := "https"
-	if inreq.URL.Scheme != "" {
-		scheme = inreq.URL.Scheme
-	}
 	u := url.URL{
-		Scheme: scheme,
+		Scheme: inreq.URL.Scheme,
 		Host:   gcrname.DefaultRegistry,
 		Path:   "/v2/",
 	}

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -112,8 +112,12 @@ func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Reques
 }
 
 func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, inreq *http.Request) {
+	scheme := "https"
+	if inreq.URL.Scheme != "" {
+		scheme = inreq.URL.Scheme
+	}
 	u := url.URL{
-		Scheme: inreq.URL.Scheme,
+		Scheme: scheme,
 		Host:   gcrname.DefaultRegistry,
 		Path:   "/v2/",
 	}

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -126,9 +126,6 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 		http.Error(w, fmt.Sprintf("could not make %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)
 		return
 	}
-	if inreq.Header.Get(headerAuthorization) != "" {
-		upreq.Header.Set(headerAuthorization, inreq.Header.Get(headerAuthorization))
-	}
 	upresp, err := http.DefaultClient.Do(upreq.WithContext(ctx))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("transport error making %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -84,7 +84,12 @@ func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Reques
 	}
 
 	// Clients issue a GET or HEAD /v2/ request to verify that this  is a registry endpoint.
-	// Some clients may pass credentials with this request to check whether they are authorized.
+	//
+	// When pulling an image from either a public or private repository, the `docker` client
+	// will first issue a GET request to /v2/.
+	// If authentication to Docker Hub (index.docker.io) is necessary, the client expects to
+	// receive HTTP 401 and a `WWW-Authenticate` header. The client will then authenticate
+	// and pass Authorization headers with subsequent requests.
 	if req.RequestURI == "/v2/" {
 		r.handleV2Request(ctx, w, req)
 		return

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -136,6 +136,49 @@ func TestPull(t *testing.T) {
 			expectedDigest:        testManifestDigest,
 			expectedContentLength: testManifestSize,
 		},
+		{
+			name:           "POST request to /blobs/uploads/ fails",
+			method:         http.MethodPost,
+			path:           mirrorAddr + "/v2/" + testImageName + "/blobs/uploads/",
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "PUT request for new manifest tag fails",
+			method:         http.MethodPut,
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/newtag",
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "PUT request for existing manifest fails",
+			method:         http.MethodPut,
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "DELETE request for existing manifest tag fails",
+			method:         http.MethodDelete,
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "DELETE request for existing manifest digest fails",
+			method:         http.MethodDelete,
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/" + testManifestDigest,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "DELETE request for nonexistent blob fails",
+			method:         http.MethodDelete,
+			path:           mirrorAddr + "/v2/" + testImageName + "/blobs/" + nonExistentDigest,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "DELETE request for existing blob fails",
+			method:         http.MethodDelete,
+			path:           mirrorAddr + "/v2/" + testImageName + "/blobs/" + testLayerDigest.String(),
+			expectedStatus: http.StatusNotFound,
+		},
+
 		// {
 		// 	name:           "HEAD request to manifest[1] path (digest)",
 		// 	method:         http.MethodHead,

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -23,9 +23,6 @@ func runMirrorRegistry(t *testing.T, env environment.Env) string {
 	require.Nil(t, err)
 	port := testport.FindFree(t)
 
-	mux := http.NewServeMux()
-	mux.Handle("/", ocireg)
-
 	listenHostPort := fmt.Sprintf("localhost:%d", port)
 	server := &http.Server{Handler: ocireg}
 	lis, err := net.Listen("tcp", listenHostPort)

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -190,7 +190,6 @@ func TestPull(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req, err := http.NewRequest(tc.method, tc.path, nil)
 			require.NoError(t, err)
-
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedStatus, resp.StatusCode)
@@ -210,34 +209,6 @@ func TestPull(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedContentLength, contentLength)
 			}
-			// Execute test case
-			// Add your test implementation here
-			// Example:
-			// resp, err := client.Do(req)
-			// if err != nil {
-			//     t.Fatal(err)
-			// }
-			// if resp.StatusCode != tc.expectedStatus {
-			//     t.Errorf("expected status %d, got %d", tc.expectedStatus, resp.StatusCode)
-			// }
-			//
-			// if tc.checkOCIJSON {
-			//     // Verify OCI-conforming JSON response
-			// }
 		})
 	}
-
-	// 			g.Specify("HEAD request to nonexistent blob should result in 404 response", func() {
-	// 			g.Specify("HEAD request to existing blob should yield 200", func() {
-	// 			g.Specify("GET nonexistent blob should result in 404 response", func() {
-	// 			g.Specify("GET request to existing blob URL should yield 200", func() {
-	// 			g.Specify("HEAD request to nonexistent manifest should return 404", func() {
-	// 			g.Specify("HEAD request to manifest[0] path (digest) should yield 200 response", func() {
-	// 			g.Specify("HEAD request to manifest[1] path (digest) should yield 200 response", func() {
-	// 			g.Specify("HEAD request to manifest path (tag) should yield 200 response", func() {
-	// 			g.Specify("GET nonexistent manifest should return 404", func() {
-	// 			g.Specify("GET request to manifest[0] path (digest) should yield 200 response", func() {
-	// 			g.Specify("GET request to manifest[1] path (digest) should yield 200 response", func() {
-	// 			g.Specify("GET request to manifest path (tag) should yield 200 response", func() {
-	// 			g.Specify("400 response body should contain OCI-conforming JSON message", func() {
 }

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -86,13 +86,13 @@ func TestPull(t *testing.T) {
 
 	tests := []pullTestCase{
 		{
-			name:           "HEAD request to nonexistent blob",
+			name:           "HEAD request for nonexistent blob fails",
 			method:         http.MethodHead,
 			path:           mirrorAddr + "/v2/" + testImageName + "/blobs/" + nonExistentDigest,
 			expectedStatus: http.StatusNotFound,
 		},
 		{
-			name:                  "HEAD request to existing blob",
+			name:                  "HEAD request for existing blob succeeds",
 			method:                http.MethodHead,
 			path:                  mirrorAddr + "/v2/" + testImageName + "/blobs/" + testLayerDigest.String(),
 			expectedStatus:        http.StatusOK,
@@ -100,13 +100,13 @@ func TestPull(t *testing.T) {
 			expectedContentLength: testLayerSize,
 		},
 		{
-			name:           "GET nonexistent blob",
+			name:           "GET request for nonexistent blob fails",
 			method:         http.MethodGet,
 			path:           mirrorAddr + "/v2/" + testImageName + "/blobs/" + nonExistentDigest,
 			expectedStatus: http.StatusNotFound,
 		},
 		{
-			name:                  "GET request to existing blob",
+			name:                  "GET request for existing blob succeeds",
 			method:                http.MethodGet,
 			path:                  mirrorAddr + "/v2/" + testImageName + "/blobs/" + testLayerDigest.String(),
 			expectedStatus:        http.StatusOK,
@@ -115,13 +115,13 @@ func TestPull(t *testing.T) {
 			expectedContentLength: testLayerSize,
 		},
 		{
-			name:           "HEAD request to nonexistent manifest",
+			name:           "HEAD request for nonexistent manifest fails",
 			method:         http.MethodHead,
 			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/" + nonExistentManifestRef,
 			expectedStatus: http.StatusNotFound,
 		},
 		{
-			name:                  "HEAD request to latest manifest",
+			name:                  "HEAD request for existing manifest tag succeeds",
 			method:                http.MethodHead,
 			path:                  mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
 			expectedStatus:        http.StatusOK,
@@ -129,7 +129,7 @@ func TestPull(t *testing.T) {
 			expectedContentLength: testManifestSize,
 		},
 		{
-			name:                  "HEAD request to manifest by digest",
+			name:                  "HEAD request for existing manifest digest succeeds",
 			method:                http.MethodHead,
 			path:                  mirrorAddr + "/v2/" + testImageName + "/manifests/" + testManifestDigest,
 			expectedStatus:        http.StatusOK,
@@ -149,7 +149,13 @@ func TestPull(t *testing.T) {
 			expectedStatus: http.StatusNotFound,
 		},
 		{
-			name:           "PUT request for existing manifest fails",
+			name:           "PUT request for existing manifest tag fails",
+			method:         http.MethodPut,
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "PUT request for existing manifest digest fails",
 			method:         http.MethodPut,
 			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
 			expectedStatus: http.StatusNotFound,
@@ -157,7 +163,7 @@ func TestPull(t *testing.T) {
 		{
 			name:           "DELETE request for existing manifest tag fails",
 			method:         http.MethodDelete,
-			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/" + testManifestDigest,
 			expectedStatus: http.StatusNotFound,
 		},
 		{
@@ -178,63 +184,6 @@ func TestPull(t *testing.T) {
 			path:           mirrorAddr + "/v2/" + testImageName + "/blobs/" + testLayerDigest.String(),
 			expectedStatus: http.StatusNotFound,
 		},
-
-		// {
-		// 	name:           "HEAD request to manifest[1] path (digest)",
-		// 	method:         http.MethodHead,
-		// 	path:           "/v2/repo/manifests/sha256:manifest1",
-		// 	expectedStatus: http.StatusOK,
-		// 	isManifest:     true,
-		// 	exists:         true,
-		// },
-		// {
-		// 	name:           "HEAD request to manifest path (tag)",
-		// 	method:         http.MethodHead,
-		// 	path:           "/v2/repo/manifests/latest",
-		// 	expectedStatus: http.StatusOK,
-		// 	isManifest:     true,
-		// 	exists:         true,
-		// },
-		// {
-		// 	name:           "GET nonexistent manifest",
-		// 	method:         http.MethodGet,
-		// 	path:           "/v2/repo/manifests/nonexistent",
-		// 	expectedStatus: http.StatusNotFound,
-		// 	isManifest:     true,
-		// 	exists:         false,
-		// },
-		// {
-		// 	name:           "GET request to manifest[0] path (digest)",
-		// 	method:         http.MethodGet,
-		// 	path:           "/v2/repo/manifests/sha256:manifest0",
-		// 	expectedStatus: http.StatusOK,
-		// 	isManifest:     true,
-		// 	exists:         true,
-		// },
-		// {
-		// 	name:           "GET request to manifest[1] path (digest)",
-		// 	method:         http.MethodGet,
-		// 	path:           "/v2/repo/manifests/sha256:manifest1",
-		// 	expectedStatus: http.StatusOK,
-		// 	isManifest:     true,
-		// 	exists:         true,
-		// },
-		// {
-		// 	name:           "GET request to manifest path (tag)",
-		// 	method:         http.MethodGet,
-		// 	path:           "/v2/repo/manifests/latest",
-		// 	expectedStatus: http.StatusOK,
-		// 	isManifest:     true,
-		// 	exists:         true,
-		// },
-		// {
-		// 	name:           "400 response body contains OCI-conforming JSON",
-		// 	method:         http.MethodGet,
-		// 	path:           "/v2/repo/manifests/invalid",
-		// 	expectedStatus: http.StatusBadRequest,
-		// 	isManifest:     true,
-		// 	checkOCIJSON:   true,
-		// },
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
The `ociregistry` is now an OCI registry mirror that supports HEAD and GET requests to retrieve manifests and blobs. It makes requests to an upstream registry (`index.docker.io` by default). It does nothing else.

The tests come from [01_pull_test.go](https://github.com/opencontainers/distribution-spec/blob/main/conformance/01_pull_test.go) in the OCI distribution spec.

`ociregistry_test` previously relied on `oci.Resolve`. That was a mistake. Testing the HTTP interface directly gives me more confidence that this registry will work for different clients out in the wild.

TODO:
1. Cache manifests and blobs in the CAS. See #8510.
2. Remove `X-Forwarded-Host` header from `oci.Resolve`. Unnecessary and not in any spec.