### PR TITLE
Have a seperate log level for serf log

### DIFF
--- a/server/gossip/BUILD
+++ b/server/gossip/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/util/statusz",
         "@com_github_hashicorp_memberlist//:memberlist",
         "@com_github_hashicorp_serf//serf",
+        "@com_github_rs_zerolog//:zerolog",
     ],
 )
 

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -28,7 +28,7 @@ var (
 	join       = flag.Slice("gossip.join", []string{}, "The nodes to join/gossip with. Ex. '1.2.3.4:1991,2.3.4.5:1991...'")
 	nodeName   = flag.String("gossip.node_name", "", "The gossip node's name. If empty will default to host_id.'")
 	secretKey  = flag.String("gossip.secret_key", "", "The value should be either 16, 24, or 32 bytes.")
-	logLevel   = flag.String("gossip.log_level", "warn", "The desired log level. Logs with a level >= this level will be emitted. One of {'fatal', 'error', 'warn', 'info', 'debug'}")
+	logLevel   = flag.String("gossip.log_level", "", "The desired log level for the gossip package. If empty, this flag will be ignored and app.log_level will be applied. Logs with a level >= this level will be emitted. One of {'fatal', 'error', 'warn', 'info', 'debug', ''}")
 )
 
 var (
@@ -243,10 +243,12 @@ func Register(env *real_environment.RealEnv) error {
 
 func New(nodeName, listenAddress string, join []string) (*GossipManager, error) {
 	subLog := log.NamedSubLogger(fmt.Sprintf("GossipManager(%s)", nodeName))
-	if l, err := zerolog.ParseLevel(*logLevel); err != nil {
-		return nil, err
-	} else {
-		subLog = subLog.Level(l)
+	if *logLevel != "" {
+		if l, err := zerolog.ParseLevel(*logLevel); err != nil {
+			return nil, err
+		} else {
+			subLog = subLog.Level(l)
+		}
 	}
 	log.Infof("Starting GossipManager on %q", listenAddress)
 

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
+	"github.com/rs/zerolog"
 
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/serf"
@@ -27,6 +28,7 @@ var (
 	join       = flag.Slice("gossip.join", []string{}, "The nodes to join/gossip with. Ex. '1.2.3.4:1991,2.3.4.5:1991...'")
 	nodeName   = flag.String("gossip.node_name", "", "The gossip node's name. If empty will default to host_id.'")
 	secretKey  = flag.String("gossip.secret_key", "", "The value should be either 16, 24, or 32 bytes.")
+	logLevel   = flag.String("gossip.log_level", "warn", "The desired log level. Logs with a level >= this level will be emitted. One of {'fatal', 'error', 'warn', 'info', 'debug'}")
 )
 
 var (
@@ -240,9 +242,13 @@ func Register(env *real_environment.RealEnv) error {
 }
 
 func New(nodeName, listenAddress string, join []string) (*GossipManager, error) {
-	log.Infof("Starting GossipManager on %q", listenAddress)
-
 	subLog := log.NamedSubLogger(fmt.Sprintf("GossipManager(%s)", nodeName))
+	if l, err := zerolog.ParseLevel(*logLevel); err != nil {
+		return nil, err
+	} else {
+		subLog = subLog.Level(l)
+	}
+	log.Infof("Starting GossipManager on %q", listenAddress)
 
 	bindAddr, bindPort, err := network.ParseAddress(listenAddress)
 	if err != nil {

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -288,6 +288,7 @@ func (l *Logger) CtxErrorf(ctx context.Context, format string, args ...interface
 	}).Inc()
 }
 
+// Level creates a child logger with the minimum accepted level set to level.
 func (l *Logger) Level(lvl zerolog.Level) Logger {
 	return Logger{
 		zl: l.zl.Level(lvl),

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -288,6 +288,12 @@ func (l *Logger) CtxErrorf(ctx context.Context, format string, args ...interface
 	}).Inc()
 }
 
+func (l *Logger) Level(lvl zerolog.Level) Logger {
+	return Logger{
+		zl: l.zl.Level(lvl),
+	}
+}
+
 // Fatal logs to the FATAL log. Arguments are handled in the manner of fmt.Print.
 // It calls os.Exit() with exit code 1.
 func (l *Logger) Fatal(message string) {


### PR DESCRIPTION
Serf Logs are noisy. When I am testing raft, I have main log level set to debug,
but I want to have serf logs at warning levels.

Created a new flag gossip.log_level to control serf log level.

Added a Level() call to log.Logger
