### PR TITLE
dockerfiles: Use mirror.gcr.io for base images

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -2,7 +2,7 @@
 # See README for details.
 
 # debian 12
-FROM debian@sha256:35286826a88dc879b4f438b645ba574a55a14187b483d09213a024dc0c0a64ed
+FROM mirror.gcr.io/debian@sha256:35286826a88dc879b4f438b645ba574a55a14187b483d09213a024dc0c0a64ed
 
 RUN apt-get update && \
     apt-get install -y \

--- a/dockerfiles/run_script/Dockerfile
+++ b/dockerfiles/run_script/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 RUN apk add --no-cache bash
 ADD run_script.sh /
 CMD /run_script.sh

--- a/dockerfiles/test_images/net_tools/Dockerfile
+++ b/dockerfiles/test_images/net_tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM mirror.gcr.io/ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y \

--- a/dockerfiles/test_images/nonroot_user_image/Dockerfile
+++ b/dockerfiles/test_images/nonroot_user_image/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM mirror.gcr.io/busybox
 
 USER 1000

--- a/dockerfiles/test_images/ociruntime_test/image_config_test_image/Dockerfile
+++ b/dockerfiles/test_images/ociruntime_test/image_config_test_image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mirror.gcr.io/alpine
 
 # Test layer ordering: later edit to the file should be reflected
 RUN mkdir -p /test/ && echo 1 > /test/foo

--- a/dockerfiles/test_images/xfsprogs_image/Dockerfile
+++ b/dockerfiles/test_images/xfsprogs_image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
+FROM mirror.gcr.io/alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 
 RUN apk add bash xfsprogs
 


### PR DESCRIPTION
This should help us when the Docker Hub rate limit comes online.
