### PR TITLE
Suppress git init branch name warning

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2008,7 +2008,7 @@ func (ws *workspace) config(ctx context.Context) error {
 }
 
 func (ws *workspace) init(ctx context.Context) error {
-	if _, err := git(ctx, ws.log, "init"); err != nil {
+	if _, err := git(ctx, ws.log, "init", "--quiet"); err != nil {
 		return status.UnknownError("git init failed")
 	}
 	return nil


### PR DESCRIPTION
The initial branch name doesn't really matter since we always fetch git refs from upstream, but git prints a verbose warning if we don't set one explicitly, which is a little annoying.