### PR TITLE
[RB] Fix retry behavior in CLI

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -914,9 +914,9 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	for {
 		inRsp, executeResponse, latestErr = attemptRun(ctx, bbClient, execClient, req)
 
-		if len(inRsp.GetInvocation()) > 0 && inRsp.GetInvocation()[0].Success ||
-			!rexec.Retryable(err) ||
-			status.IsDeadlineExceededError(err) ||
+		if latestErr == nil ||
+			!rexec.Retryable(latestErr) ||
+			status.IsDeadlineExceededError(latestErr) ||
 			ctx.Err() != nil {
 			retry = false
 		}
@@ -925,7 +925,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 			break
 		}
 
-		log.Warnf("Remote run failed due to transient error. Retrying: %s", err)
+		log.Warnf("Remote run failed due to transient error. Retrying: %s", latestErr)
 		retryCount++
 	}
 

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -2067,9 +2067,8 @@ func (s *SchedulerServer) reEnqueueTask(ctx context.Context, taskID, leaseID, re
 		if _, err := s.deleteTask(ctx, taskID); err != nil {
 			return err
 		}
-		msg := fmt.Sprintf("Task %q does not have retries enabled. Not re-enqueuing. Last failure: %s", taskID, reason)
-		log.Infof(msg)
-		if err := s.env.GetRemoteExecutionService().MarkExecutionFailed(ctx, taskID, status.InternalError(msg)); err != nil {
+		log.Infof(fmt.Sprintf("Task %q does not have retries enabled. Not re-enqueuing.", taskID))
+		if err := s.env.GetRemoteExecutionService().MarkExecutionFailed(ctx, taskID, status.InternalError(reason)); err != nil {
 			log.CtxWarningf(ctx, "Could not mark execution failed for task %q: %s", taskID, err)
 		}
 		return nil


### PR DESCRIPTION
Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/4494#event-16433445516

Also remove `Not re-enqueuing.` message from the error returned by the scheduler, because it can be confusing when the CLI does retry the run