### PR TITLE
Add duration and CPU usage metrics for networking commands

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -287,6 +287,10 @@ const (
 	// CreatedFromSnapshot indicates if a firecracker execution used a
 	// snapshot.
 	CreatedFromSnapshot = "created_from_snapshot"
+
+	// Command being run. Specific arguments to the command are omitted to
+	// reduce metric cardinality.
+	CommandName = "command"
 )
 
 // Label value constants
@@ -1194,6 +1198,26 @@ var (
 		Name:      "file_upload_duration_usec",
 		Buckets:   coarseMicrosecondToHour,
 		Help:      "Per-file upload duration during remote execution, in **microseconds**.",
+	})
+
+	NetworkingCommandDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "networking_command_duration_usec",
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 10*time.Minute, 1.5),
+		Help:      "Duration of networking commands, in **microseconds**.",
+	}, []string{
+		CommandName,
+	})
+
+	NetworkingCommandCPUUsageUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "networking_command_cpu_usage_usec",
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 10*time.Minute, 1.5),
+		Help:      "CPU usage of networking commands, in **CPU-microseconds**.",
+	}, []string{
+		CommandName,
 	})
 
 	FirecrackerStageDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{

--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",
+        "//server/util/tracing",
         "//server/util/uuid",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_vishvananda_netlink//:netlink",

--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/networking",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/metrics",
         "//server/util/alert",
         "//server/util/background",
         "//server/util/flag",
@@ -13,6 +14,7 @@ go_library(
         "//server/util/random",
         "//server/util/status",
         "//server/util/uuid",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_vishvananda_netlink//:netlink",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sys//unix",


### PR DESCRIPTION
CPU usage example:

![image](https://github.com/user-attachments/assets/ce01574e-c1cb-47aa-ab8c-6d9d2782344d)
