### PR TITLE
[raft] add spn for getForClient

### DIFF
--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -26,6 +26,7 @@ go_library(
         "@com_github_lni_dragonboat_v4//statemachine",
         "@com_github_prometheus_client_golang//prometheus",
         "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//codes",
         "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//status",
     ],


### PR DESCRIPTION
One trace during rollout shows that "TryReplica: fn" started 3.2 seconds after "TryReplica" started indicating `client.GetForReplica` is slow. 