### PR TITLE
[raft] refactor: add context to registry

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -54,7 +54,7 @@ type NodeHost interface {
 
 type IRegistry interface {
 	// Lookup the grpc address given a replica's rangeID and replicaID
-	ResolveGRPC(rangeID uint64, replicaID uint64) (string, string, error)
+	ResolveGRPC(ctx context.Context, rangeID uint64, replicaID uint64) (string, string, error)
 }
 
 type APIClient struct {
@@ -114,7 +114,7 @@ func (c *APIClient) GetForReplica(ctx context.Context, rd *rfpb.ReplicaDescripto
 		}
 		spn.End()
 	}()
-	addr, _, err := c.registry.ResolveGRPC(rd.GetRangeId(), rd.GetReplicaId())
+	addr, _, err := c.registry.ResolveGRPC(ctx, rd.GetRangeId(), rd.GetReplicaId())
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/registry/registry_test.go
+++ b/enterprise/server/raft/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -36,7 +37,9 @@ func requireResolves(t testing.TB, dnr registry.NodeRegistry, rangeID, replicaID
 	require.Equal(t, raftAddr, addr, dnr.String())
 	require.NotNil(t, key)
 
-	addr, key, err = dnr.ResolveGRPC(rangeID, replicaID)
+	ctx := context.Background()
+
+	addr, key, err = dnr.ResolveGRPC(ctx, rangeID, replicaID)
 	require.NoError(t, err)
 	require.Equal(t, grpcAddr, addr, dnr.String())
 	require.NotNil(t, key)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2182,7 +2182,7 @@ func (s *Store) SplitRange(ctx context.Context, req *rfpb.SplitRangeRequest) (*r
 		if r.GetNhid() == "" {
 			return nil, status.InternalErrorf("empty nhid in ReplicaDescriptor %+v", r)
 		}
-		grpcAddr, _, err := s.registry.ResolveGRPC(r.GetRangeId(), r.GetReplicaId())
+		grpcAddr, _, err := s.registry.ResolveGRPC(ctx, r.GetRangeId(), r.GetReplicaId())
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -498,7 +498,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 	rd := s.GetRange(2)
 	// Veirfy that nhid in the rangea descriptor matches the registry.
 	for _, repl := range rd.GetReplicas() {
-		nhid, _, err := sf.Registry().ResolveNHID(repl.GetRangeId(), repl.GetReplicaId())
+		nhid, _, err := sf.Registry().ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
 		require.NoError(t, err)
 		require.Equal(t, repl.GetNhid(), nhid)
 	}
@@ -517,7 +517,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 	rd = s.GetRange(4)
 	// Veirfy that nhid in the rangea descriptor matches the registry.
 	for _, repl := range rd.GetReplicas() {
-		nhid, _, err := sf.Registry().ResolveNHID(repl.GetRangeId(), repl.GetReplicaId())
+		nhid, _, err := sf.Registry().ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
 		require.NoError(t, err)
 		require.Equal(t, repl.GetNhid(), nhid)
 	}


### PR DESCRIPTION
prepare for the following PR to add trace into registry

We see traces where GetForReplica is slow, indicating queryPeers are slow.
