### PR TITLE
Set "backing path" for all parent directories.

### DIFF
--- a/enterprise/server/util/vfs_server/vfs_server.go
+++ b/enterprise/server/util/vfs_server/vfs_server.go
@@ -661,10 +661,14 @@ func (p *Server) createFile(ctx context.Context, request *vfspb.CreateRequest, p
 		if err := os.MkdirAll(wsPath, 0755); err != nil {
 			return nil, nil, syscallErrStatus(err)
 		}
-		parentNode.mu.Lock()
-		parentNode.backingPath = wsPath
+
 		parentBackingPath = wsPath
-		parentNode.mu.Unlock()
+		for n := parentNode; n != nil; n = n.parent {
+			n.mu.Lock()
+			n.backingPath = wsPath
+			n.mu.Unlock()
+			wsPath = filepath.Dir(wsPath)
+		}
 	}
 
 	localFilePath := filepath.Join(parentBackingPath, name)


### PR DESCRIPTION
The backing path is used to indicate whether the vfs node is backed by a real directory/file in the scratch directory.

When creating parent directories, we were only setting the backing path for the immediate parent even if we created multiple levels of directories.