### PR TITLE
[SS] Drop the page cache before inflating the balloon

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2600,11 +2600,12 @@ func (c *FirecrackerContainer) reclaimMemoryWithBalloon(ctx context.Context) err
 	if err != nil {
 		return status.InternalErrorf("failed to dial VM exec port: %s", err)
 	}
+	// TODO(Maggie): Don't depend on sh existing within the container image
 	client := vmxpb.NewExecClient(conn)
 	cmd := &repb.Command{
-		Arguments: []string{"sudo", "sh", "-c", "echo 3 > /proc/sys/vm/drop_caches"},
+		Arguments: []string{"sh", "-c", "echo 3 > /proc/sys/vm/drop_caches"},
 	}
-	res := vmexec_client.Execute(ctx, client, cmd, "/workspace/", c.user, nil /* statsListener*/, &interfaces.Stdio{})
+	res := vmexec_client.Execute(ctx, client, cmd, "/workspace/", "0:0", nil /* statsListener*/, &interfaces.Stdio{})
 	if res.Error != nil {
 		return res.Error
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2594,24 +2594,27 @@ func (c *FirecrackerContainer) reclaimMemoryWithBalloon(ctx context.Context) err
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
+	// Drop the page cache to free up more memory for the balloon.
+	// The balloon will only allocate free memory.
 	conn, err := c.vmExecConn(ctx)
 	if err != nil {
 		return status.InternalErrorf("failed to dial VM exec port: %s", err)
 	}
 	client := vmxpb.NewExecClient(conn)
 	cmd := &repb.Command{
-		Arguments: []string{"sh", "-c", "free | awk '/^Mem:/ {print $7}'"},
+		Arguments: []string{"sudo", "sh", "-c", "echo 3 > /proc/sys/vm/drop_caches"},
 	}
 	res := vmexec_client.Execute(ctx, client, cmd, "/workspace/", c.user, nil /* statsListener*/, &interfaces.Stdio{})
 	if res.Error != nil {
 		return res.Error
 	}
-	availableMemKB, err := strconv.Atoi(strings.TrimSpace(string(res.Stdout)))
-	if err != nil {
-		return status.WrapErrorf(err, "parse available mem: %s", string(res.Stdout))
-	}
 
-	balloonSizeMB := int64(float64(availableMemKB/1024) * .9)
+	stats, err := c.machine.GetBalloonStats(ctx)
+	if err != nil {
+		return err
+	}
+	availableMemMB := stats.AvailableMemory / 1e6
+	balloonSizeMB := int64(float64(availableMemMB) * .9)
 	if err := c.updateBalloon(ctx, balloonSizeMB); err != nil {
 		return status.WrapError(err, "inflate balloon")
 	}
@@ -2639,6 +2642,7 @@ func (c *FirecrackerContainer) updateBalloon(ctx context.Context, targetSizeMib 
 
 	// Wait for the balloon to reach its target size.
 	pollInterval := 300 * time.Millisecond
+	slowCount := 0
 	for {
 		stats, err := c.machine.GetBalloonStats(ctx)
 		if err != nil {
@@ -2648,11 +2652,20 @@ func (c *FirecrackerContainer) updateBalloon(ctx context.Context, targetSizeMib 
 		currentBalloonSize = *stats.ActualMib
 		if currentBalloonSize == targetSizeMib {
 			return nil
-		} else if math.Abs(float64(currentBalloonSize-lastBalloonSize)) < 100 {
-			// If the rate of inflation slows or stops, just stop early.
-			return nil
 		} else if time.Since(start) >= maxUpdateBalloonDuration {
 			return nil
+		}
+
+		if math.Abs(float64(currentBalloonSize-lastBalloonSize)) < 100 {
+			slowCount++
+			if slowCount == 2 {
+				// If the rate of inflation is consistently slow or stops, just stop early.
+				// Give the balloon a second chance in case there is resource contention
+				// that temporarily slows the balloon inflation.
+				return nil
+			}
+		} else {
+			slowCount = 0
 		}
 
 		select {


### PR DESCRIPTION
The balloon won't allocate memory from the page cache, so explicitly drop the cache before trying to reclaim memory with the balloon ([verified that behavior in this thread](https://lore.kernel.org/all/CAJuQAmpDUyve2S+oxp9tLUhuRcnddXnNztC5PmYOOCpY6c68xg@mail.gmail.com/))

Also: 
* pull available memory from the balloon stats, instead of trying to parse it from bash output
* loosen early exit logic for balloon inflation. In my testing there were some cases where there might be a slight delay in balloon inflation, but then it speeds up

From my testing, dropping the page cache didn't seem to have a significant impact on workflow execution performance. In my tests, I: 
A) Ran a build on a clean VM. This filled up the page cache
B) Started from the snapshot (with the page cache) and ran a fully cached build. It took [41s](https://app.buildbuddy.io/invocation/5560a781-cdf0-463b-b3fc-7eeb1fcb8341)
C) Started from snapshot A and dropped the page cache. Then I saved that snapshot, resumed it, and ran a fully cached build. It took [42.1s](https://app.buildbuddy.io/invocation/8f4f91fd-4601-4d09-9e9d-8020b9892dc1) (The reason I did an intermediary snapshot save is I was curious how lack of page cache would affect git performance as well) 

This makes sense to me because for snapshotted VMs, data in the page cache still needs to be fetched as a chunk from our cache. The assumption that the page cache is very quickly accessible doesn't necessarily hold