### PR TITLE
pebble_cache: add a flag to enable auto rachet

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -85,6 +85,7 @@ var (
 	evictionRateLimit         = flag.Int("cache.pebble.eviction_rate_limit", 300, "Maximum number of entries to evict per second (per partition).")
 	includeMetadataSize       = flag.Bool("cache.pebble.include_metadata_size", false, "If true, include metadata size")
 	enableTableBloomFilter    = flag.Bool("cache.pebble.enable_table_bloom_filter", false, "If true, write bloom filter data with pebble SSTables.")
+	enableAutoRachet          = flag.Bool("cache.pebble.enable_auto_rachet", false, "If true, automatically upgrade on-disk format to latest version.")
 
 	activeKeyVersion  = flag.Int64("cache.pebble.active_key_version", int64(filestore.UnspecifiedKeyVersion), "The key version new data will be written with. If negative, will write to the highest existing version in the database, or the highest known version if a new database is created.")
 	migrationQPSLimit = flag.Int("cache.pebble.migration_qps_limit", 50, "QPS limit for data version migration")
@@ -487,6 +488,9 @@ func defaultPebbleOptions(mc *pebble.MetricsCollector) *pebble.Options {
 				FilterPolicy: pebble.BloomFilterPolicy(10),
 			},
 		}
+	}
+	if *enableAutoRachet {
+		opts.FormatMajorVersion = pebble.FormatNewest
 	}
 
 	// The threshold of L0 read-amplification at which compaction concurrency

--- a/enterprise/server/util/pebble/BUILD
+++ b/enterprise/server/util/pebble/BUILD
@@ -25,6 +25,7 @@ go_test(
     deps = [
         ":pebble",
         "//server/testutil/testfs",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",
     ],

--- a/enterprise/server/util/pebble/pebble.go
+++ b/enterprise/server/util/pebble/pebble.go
@@ -41,6 +41,7 @@ var NoSync = pebble.NoSync
 var Sync = pebble.Sync
 var ErrNotFound = pebble.ErrNotFound
 
+var FormatNewest = pebble.FormatNewest
 var NewCache = pebble.NewCache
 var WithFlushedWAL = pebble.WithFlushedWAL
 var Peek = pebble.Peek
@@ -193,6 +194,9 @@ type IPebbleDB interface {
 	// even if hard links are used, the space overhead for the checkpoint will
 	// increase over time as the DB performs compactions.
 	Checkpoint(destDir string, opts ...pebble.CheckpointOption) error
+
+	// Returns the major version of the underlying pebble DB.
+	FormatMajorVersion() pebble.FormatMajorVersion
 }
 
 type instrumentedIter struct {
@@ -422,6 +426,11 @@ func (idb *instrumentedDB) NewBatch() Batch {
 func (idb *instrumentedDB) NewIndexedBatch() Batch {
 	batch := idb.db.NewIndexedBatch()
 	return &instrumentedBatch{batch, batch, idb}
+}
+
+// FormatMajorVersion returns the major version of the underlying pebble DB.
+func (idb *instrumentedDB) FormatMajorVersion() pebble.FormatMajorVersion {
+	return idb.db.FormatMajorVersion()
 }
 
 func Open(dbDir string, id string, options *pebble.Options) (IPebbleDB, error) {

--- a/enterprise/server/util/pebble/pebble_test.go
+++ b/enterprise/server/util/pebble/pebble_test.go
@@ -64,7 +64,7 @@ func TestRachetDB(t *testing.T) {
 	err = dbV1.Close()
 	require.NoError(t, err)
 
-	// Re-open DB with rachetting
+	// Re-open DB with racheting
 	db, err := pebble.Open(rootDir, "testing", &pebblev1.Options{FormatMajorVersion: pebblev1.FormatNewest})
 	require.NoError(t, err)
 	require.Equal(t, pebblev1.FormatNewest, db.FormatMajorVersion(), "expected rachetted DB to be at newest format")

--- a/enterprise/server/util/pebble/pebble_test.go
+++ b/enterprise/server/util/pebble/pebble_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+
+	pebblev1 "github.com/cockroachdb/pebble"
 )
 
 func TestCloseLeasedDB(t *testing.T) {
@@ -48,4 +50,29 @@ func TestCloseLeasedDB(t *testing.T) {
 	// (even though we did these in opposite order). This is to check
 	// that the serialization is working properly.
 	require.Less(t, dbReturnTime, leaserCloseTime)
+}
+
+func TestRachetDB(t *testing.T) {
+	rootDir := testfs.MakeTempDir(t)
+
+	// Open a new DB and write a value
+	dbV1, err := pebblev1.Open(rootDir, &pebblev1.Options{})
+	require.NoError(t, err)
+	require.Equal(t, pebblev1.FormatMostCompatible, dbV1.FormatMajorVersion(), "expected new dbV1 to be at most compatible format")
+	err = dbV1.Set([]byte("key"), []byte("value"), &pebblev1.WriteOptions{Sync: true})
+	require.NoError(t, err)
+	err = dbV1.Close()
+	require.NoError(t, err)
+
+	// Re-open DB with rachetting
+	db, err := pebble.Open(rootDir, "testing", &pebblev1.Options{FormatMajorVersion: pebblev1.FormatNewest})
+	require.NoError(t, err)
+	require.Equal(t, pebblev1.FormatNewest, db.FormatMajorVersion(), "expected rachetted DB to be at newest format")
+	val, closer, err := db.Get([]byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, "value", string(val), "expected value to be preserved after rachet")
+	err = closer.Close()
+	require.NoError(t, err)
+	err = db.Close()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
PebbleDB comes with multiple on-disk format versions(0). If we don't
specify a FormatMajorVersion inside pebble.Options when we initialize
the DB, the default format is FormatMostCompatible, the second-oldest
version available.

To prepare for a future upgrade to PebbleV2(1), we want to upgrade all
DBs to the latest on-disk format available.  By setting
`FormatMostCompatible: FormatNewest`, the `pebble.Open()` func will
automatically migrate the on-disk format to the latest version.

The migrations are done in a backward-compatible manner (2).  If there
are any errors during the migration, the existing DB should not be
affected.  Despite that, safeguard the migration with a feature flag,
disabled by default, so that we can test this in dev first.

Add a test to verify the expected behavior before/after ratcheting.
This test should be extended in the future to accommodate the V2
upgrade (1).

(0):
https://github.com/cockroachdb/pebble/blob/53918335bb8c71a6420644e86d66f4f4a3ccf38f/format_major_version.go#L50
(1): https://github.com/buildbuddy-io/buildbuddy/pull/8488
(2): https://github.com/cockroachdb/pebble/blob/53918335bb8c71a6420644e86d66f4f4a3ccf38f/format_major_version.go#L244
