### PR TITLE
Speculative fix for top-level artifact downloads despite BwoB

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -68,6 +68,10 @@ common:remote --remote_download_toplevel
 common:remote-minimal --config=remote-prod-shared
 common:remote-minimal --config=target-linux-x86
 common:remote-minimal --remote_download_minimal
+# Work around a Bazel issue that results in all top-level outputs being downloaded
+# after this period has passed for a warm Bazel server even with
+# --remote_download_minimal.
+common:remote-minimal --experimental_remote_cache_ttl=10000d
 
 # Specify arch to do cross-platform builds on remote until the go toolchain can
 # accomodate multiple execution platforms


### PR DESCRIPTION
When a top-level artifact was produced by a BwoB build, Bazel will download it even with `--remote_download_minimal` after the period specified by `--experimental_remote_cache_ttl` has passed (assuming that the Bazel server is still running). This is unexpected as only the metadata should be refreshed (i.e., a find missing blobs request should be sent).

While we wait for the Bazel fix (https://github.com/bazelbuild/bazel/pull/25398), set this to a high value to work around the issue. This could negatively impact the handling of remote cache evictions.