### PR TITLE
Fix test data race from closing vm exec server

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -57,7 +57,6 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/uuid",
-        "//third_party/singleflight",
         "@com_github_armon_circbuf//:circbuf",
         "@com_github_firecracker_microvm_firecracker_go_sdk//:firecracker-go-sdk",
         "@com_github_firecracker_microvm_firecracker_go_sdk//client/models",


### PR DESCRIPTION
After understanding this code a bit more, I don't think we need to worry about concurrent callers to vmExecConn().

With the existing code, the race detector complains because `singleflight.Do` creates a goroutine which will write to `c.vmExec.conn`, while `c.Remove` might read from that field. The race detector has no way of proving that `Remove()` won't be called until `vmExecConn()` returns. Getting rid of singleflight actually removes this "race".

This was only [failing in tests](https://buildbuddy.buildbuddy.dev/invocation/3d08e9e7-de8b-4983-bdf3-6f507ac77ce1?target=%2F%2Fenterprise%2Fserver%2Fremote_execution%2Fcontainers%2Ffirecracker%3Afirecracker_test&targetStatus=6#@95).

I couldn't reproduce it, even with `bazel test //enterprise/server/remote_execution/containers/firecracker:firecracker_test --config=remote --test_filter=TestFirecrackerRun_Timeout_DebugOutputIsAvailable --test_sharding_strategy=disabled --runs_per_test=100 --config=race --test_tag_filters=+bare --build_tag_filters=+bare --config=race`, so I'm sort of guessing that this will fix the issue.