### PR TITLE
[raft] client-side health check

### DIFF
--- a/enterprise/server/raft/cache/BUILD
+++ b/enterprise/server/raft/cache/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/filestore",
         "//enterprise/server/raft/bringup",
+        "//enterprise/server/raft/constants",
         "//enterprise/server/raft/logger",
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/registry",

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/bringup"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/registry"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
@@ -194,7 +195,7 @@ func Register(env *real_environment.RealEnv) error {
 			return nil
 		},
 	)
-	env.GetHealthChecker().AddHealthCheck("raft_cache", rc)
+	env.GetHealthChecker().AddHealthCheck(constants.HealthCheckName, rc)
 	return nil
 }
 

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -93,7 +93,7 @@ func (c *APIClient) getClient(ctx context.Context, peer string) (returnedClient 
 		return rfspb.NewApiClient(conn), nil
 	}
 	log.Debugf("Creating new client for peer: %q", peer)
-	conn, err := grpc_client.DialSimple("grpc://" + peer)
+	conn, err := grpc_client.DialSimple("grpc://"+peer, grpc_client.HealthCheckGRPCOption(constants.HealthCheckName))
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -19,7 +19,8 @@ const (
 	NodePartitionUsageEvent   = "node_partition_usage_event"
 	PlacementDriverQueryEvent = "placement_driver_query_event"
 
-	CacheName = "raft"
+	CacheName       = "raft"
+	HealthCheckName = "raft_cache"
 )
 
 // Key range contants

--- a/enterprise/server/raft/sender/BUILD
+++ b/enterprise/server/raft/sender/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//enterprise/server/raft/rbuilder",
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
+        "//server/metrics",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/rangemap",

--- a/enterprise/server/raft/sender/BUILD
+++ b/enterprise/server/raft/sender/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//server/util/retry",
         "//server/util/status",
         "//server/util/tracing",
+        "@com_github_prometheus_client_golang//prometheus",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",
         "@org_golang_google_grpc//status",

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rangemap"
@@ -330,6 +331,7 @@ func (s *Sender) TryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 			switch {
 			// range not found, no replicas are likely to have it; bail.
 			case strings.HasPrefix(m, constants.RangeNotFoundMsg), strings.HasPrefix(m, constants.RangeNotCurrentMsg):
+				metrics.RaftRangeNotPresentErrorCount.Inc()
 				return 0, status.OutOfRangeErrorf("failed to TryReplicas on c%dn%d: no replicas are likely to have it: %s", replica.GetRangeId(), replica.GetReplicaId(), m)
 			case strings.HasPrefix(m, constants.RangeNotLeasedMsg), strings.HasPrefix(m, constants.RangeLeaseInvalidMsg):
 				logs = append(logs, fmt.Sprintf("skipping c%dn%d: out of range: %s", replica.GetRangeId(), replica.GetReplicaId(), err))

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2384,6 +2384,13 @@ var (
 		Help:      "The total number of eviction errors",
 	})
 
+	RaftRangeNotPresentErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "range_not_present_errors",
+		Help:      "The total number of range not present error",
+	})
+
 	RaftListenerEventsDropped = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "raft",

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2384,11 +2384,13 @@ var (
 		Help:      "The total number of eviction errors",
 	})
 
-	RaftRangeNotPresentErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+	RaftRangeNotPresentErrorCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "raft",
 		Name:      "range_not_present_errors",
 		Help:      "The total number of range not present error",
+	}, []string{
+		RaftNodeHostIDLabel,
 	})
 
 	RaftListenerEventsDropped = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -2,6 +2,7 @@ package grpc_client
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/rand/v2"
 	"net/url"
@@ -36,6 +37,12 @@ const (
 
 var (
 	poolSize = flag.Int("grpc_client.pool_size", 15, "Number of connections to create to each target.")
+
+	serviceConfig = `{
+	"healthCheckConfig": {
+		"serviceName": "%s"
+	}
+}`
 )
 
 type clientConn struct {
@@ -336,4 +343,8 @@ func CommonGRPCClientOptions() []grpc.DialOption {
 			PermitWithoutStream: true,
 		}),
 	}
+}
+
+func HealthCheckGRPCOption(serviceName string) grpc.DialOption {
+	return grpc.WithDefaultServiceConfig(fmt.Sprintf(serviceConfig, serviceName))
 }


### PR DESCRIPTION
During rollout, server A can call server B that is still being initialized; as 
a result, server B can return `Range Not Present` error. Instead of trying
the next replica, we will try to look up range descriptor again and this can
slow things down.

This change allows us to do client-side health check: https://grpc.io/docs/guides/health-checking/#enabling-client-health-checking

https://github.com/buildbuddy-io/buildbuddy-internal/issues/3745
