### PR TITLE
Store OCI image layers and manifests in the CAS

### DIFF
--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/proto",
+        "//server/util/status",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -6,8 +6,12 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/ociregistry",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/environment",
         "//server/real_environment",
+        "//server/remote_cache/cachetools",
+        "//server/remote_cache/digest",
         "//server/util/log",
         "//server/util/prefix",
         "@com_github_google_go_containerregistry//pkg/name",
@@ -22,10 +26,12 @@ go_test(
     deps = [
         ":ociregistry",
         "//server/environment",
+        "//server/testutil/testcache",
         "//server/testutil/testenv",
         "//server/testutil/testport",
         "//server/testutil/testregistry",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )
 

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -28,13 +28,11 @@ go_test(
     srcs = ["ociregistry_test.go"],
     deps = [
         ":ociregistry",
-        "//server/environment",
         "//server/testutil/testcache",
         "//server/testutil/testenv",
         "//server/testutil/testport",
         "//server/testutil/testregistry",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )
 

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/ociregistry",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:ociregistry_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/environment",
@@ -14,8 +15,10 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/log",
         "//server/util/prefix",
+        "//server/util/proto",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )
 

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -213,6 +213,11 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 		path = "/v2/" + ref.Context().RepositoryStr() + "/blobs/" + ref.Identifier()
 	case ocipb.OCIResourceType_MANIFEST:
 		path = "/v2/" + ref.Context().RepositoryStr() + "/manifests/" + ref.Identifier()
+	case ocipb.OCIResourceType_UNKNOWN:
+		message := fmt.Sprintf("unknown OCI resource type, expected blobs or manifests: %s", inreq.URL.Path)
+		log.CtxError(ctx, message)
+		http.Error(w, message, http.StatusNotFound)
+		return
 	}
 	u := url.URL{
 		Scheme: ref.Context().Scheme(),

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -117,12 +117,8 @@ func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Reques
 }
 
 func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, inreq *http.Request) {
-	scheme := "https"
-	if inreq.URL.Scheme != "" {
-		scheme = inreq.URL.Scheme
-	}
 	u := url.URL{
-		Scheme: scheme,
+		Scheme: inreq.URL.Scheme,
 		Host:   gcrname.DefaultRegistry,
 		Path:   "/v2/",
 	}

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -71,6 +71,7 @@ func (r *registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // This registry does not support resumable pulls via the Range header.
 func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	log.CtxDebugf(ctx, "%s %s", req.Method, req.URL)
 	ctx, err := prefix.AttachUserPrefixToContext(ctx, r.env)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("could not attach user prefix: %s", err), http.StatusInternalServerError)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -284,10 +284,8 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 		}
 	} else {
 		_, err = io.Copy(w, upresp.Body)
-		if err != nil {
-			if err != context.Canceled {
-				log.CtxWarningf(ctx, "error writing response body for '%s', upstream '%s': %s", inreq.URL.String(), u.String(), err)
-			}
+		if err != nil && err != context.Canceled {
+			log.CtxWarningf(ctx, "error writing response body for '%s', upstream '%s': %s", inreq.URL.String(), u.String(), err)
 		}
 	}
 }

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -131,9 +131,6 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 		http.Error(w, fmt.Sprintf("could not make %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)
 		return
 	}
-	if inreq.Header.Get(headerAuthorization) != "" {
-		upreq.Header.Set(headerAuthorization, inreq.Header.Get(headerAuthorization))
-	}
 	upresp, err := http.DefaultClient.Do(upreq.WithContext(ctx))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("transport error making %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -121,7 +121,6 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 	if inreq.URL.Scheme != "" {
 		scheme = inreq.URL.Scheme
 	}
-
 	u := url.URL{
 		Scheme: scheme,
 		Host:   gcrname.DefaultRegistry,
@@ -132,8 +131,8 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 		http.Error(w, fmt.Sprintf("could not make %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)
 		return
 	}
-	if inreq.Header.Get("Accept") != "" {
-		upreq.Header.Set("Accept", inreq.Header.Get("Accept"))
+	if inreq.Header.Get(headerAuthorization) != "" {
+		upreq.Header.Set(headerAuthorization, inreq.Header.Get(headerAuthorization))
 	}
 	upresp, err := http.DefaultClient.Do(upreq.WithContext(ctx))
 	if err != nil {

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -71,7 +71,6 @@ func (r *registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // This registry does not support resumable pulls via the Range header.
 func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	log.CtxDebugf(ctx, "%s %s", req.Method, req.URL)
 	ctx, err := prefix.AttachUserPrefixToContext(ctx, r.env)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("could not attach user prefix: %s", err), http.StatusInternalServerError)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -117,8 +117,12 @@ func (r *registry) handleRegistryRequest(w http.ResponseWriter, req *http.Reques
 }
 
 func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, inreq *http.Request) {
+	scheme := "https"
+	if inreq.URL.Scheme != "" {
+		scheme = inreq.URL.Scheme
+	}
 	u := url.URL{
-		Scheme: inreq.URL.Scheme,
+		Scheme: scheme,
 		Host:   gcrname.DefaultRegistry,
 		Path:   "/v2/",
 	}

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -122,6 +122,7 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 	if inreq.URL.Scheme != "" {
 		scheme = inreq.URL.Scheme
 	}
+
 	u := url.URL{
 		Scheme: scheme,
 		Host:   gcrname.DefaultRegistry,
@@ -131,6 +132,9 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 	if err != nil {
 		http.Error(w, fmt.Sprintf("could not make %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)
 		return
+	}
+	if inreq.Header.Get("Accept") != "" {
+		upreq.Header.Set("Accept", inreq.Header.Get("Accept"))
 	}
 	upresp, err := http.DefaultClient.Do(upreq.WithContext(ctx))
 	if err != nil {

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -23,9 +23,6 @@ func runMirrorRegistry(t *testing.T, env environment.Env) string {
 	require.Nil(t, err)
 	port := testport.FindFree(t)
 
-	mux := http.NewServeMux()
-	mux.Handle("/", ocireg)
-
 	listenHostPort := fmt.Sprintf("localhost:%d", port)
 	server := &http.Server{Handler: ocireg}
 	lis, err := net.Listen("tcp", listenHostPort)

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -36,6 +36,7 @@ type pullTestCase struct {
 type simplePullTestCase struct {
 	name                     string
 	method                   string
+	headers                  map[string]string
 	blobsOrManifests         string
 	identifierOverride       string
 	expectedStatus           int
@@ -216,17 +217,17 @@ func TestPull(t *testing.T) {
 			expectedUpstreamRequests: 0,
 		},
 		{
-			name:   "GET request with Range header for existing blob fails",
-			method: http.MethodGet,
-			path:   "/v2/" + testImageName + "/blobs/" + testLayerDigest.String(),
+			name:             "GET request with Range header for existing blob fails",
+			method:           http.MethodGet,
+			blobsOrManifests: "blobs",
 			headers: map[string]string{
 				"Range": "bytes=0-7",
 			},
 			expectedStatus: http.StatusNotImplemented,
 		},
 		{
-			name:                     "repeated HEAD requests for existing blob use CAS",
-			method:                   http.MethodHead,
+			name:                     "repeated GET requests for existing blob use CAS",
+			method:                   http.MethodGet,
 			blobsOrManifests:         "blobs",
 			expectedStatus:           http.StatusOK,
 			expectedMirrorRequests:   2,

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testregistry"
 	"github.com/stretchr/testify/require"
-
-	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
 type pullTestCase struct {
@@ -40,10 +38,6 @@ func TestPull(t *testing.T) {
 	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
 	testcache.Setup(t, te, localGRPClis)
 	go runServer()
-
-	conn, err := testenv.LocalGRPCConn(context.TODO(), localGRPClis)
-	require.NoError(t, err)
-	te.SetByteStreamClient(bspb.NewByteStreamClient(conn))
 
 	upstreamCounter := atomic.Int32{}
 	testreg := testregistry.Run(t, testregistry.Opts{

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -158,13 +158,13 @@ func TestPull(t *testing.T) {
 		{
 			name:           "PUT request for existing manifest digest fails",
 			method:         http.MethodPut,
-			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/" + testManifestDigest,
 			expectedStatus: http.StatusNotFound,
 		},
 		{
 			name:           "DELETE request for existing manifest tag fails",
 			method:         http.MethodDelete,
-			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/" + testManifestDigest,
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
 			expectedStatus: http.StatusNotFound,
 		},
 		{

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -40,6 +40,10 @@ func TestPull(t *testing.T) {
 			return true
 		},
 	})
+	t.Cleanup(func() {
+		err := testreg.Shutdown(context.TODO())
+		require.NoError(t, err)
+	})
 	testImageName, testImage := testreg.PushRandomImage(t)
 	require.NotEmpty(t, testImageName)
 

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -164,7 +164,7 @@ func TestPull(t *testing.T) {
 		{
 			name:           "DELETE request for existing manifest tag fails",
 			method:         http.MethodDelete,
-			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/latest",
+			path:           mirrorAddr + "/v2/" + testImageName + "/manifests/" + testManifestDigest,
 			expectedStatus: http.StatusNotFound,
 		},
 		{

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -19,20 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type pullTestCase struct {
-	name                     string
-	method                   string
-	path                     string
-	headers                  map[string]string
-	expectedStatus           int
-	expectedDigest           string
-	expectedContentLength    int64
-	expectedBody             []byte
-	expectedMirrorRequests   int32
-	expectedUpstreamRequests int32
-	repeatRequestToHitCache  bool
-}
-
 type simplePullTestCase struct {
 	name                     string
 	method                   string

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -234,6 +234,15 @@ func TestPull(t *testing.T) {
 			expectedUpstreamRequests: 1,
 			repeatRequestToHitCache:  true,
 		},
+		{
+			name:                     "repeated GET requests for existing manifest digest use CAS",
+			method:                   http.MethodGet,
+			blobsOrManifests:         "manifests",
+			expectedStatus:           http.StatusOK,
+			expectedMirrorRequests:   2,
+			expectedUpstreamRequests: 1,
+			repeatRequestToHitCache:  true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -223,7 +223,9 @@ func TestPull(t *testing.T) {
 			headers: map[string]string{
 				"Range": "bytes=0-7",
 			},
-			expectedStatus: http.StatusNotImplemented,
+			expectedStatus:           http.StatusNotImplemented,
+			expectedMirrorRequests:   1,
+			expectedUpstreamRequests: 0,
 		},
 		{
 			name:                     "repeated GET requests for existing blob use CAS",

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -23,6 +23,9 @@ func runMirrorRegistry(t *testing.T, env environment.Env) string {
 	require.Nil(t, err)
 	port := testport.FindFree(t)
 
+	mux := http.NewServeMux()
+	mux.Handle("/", ocireg)
+
 	listenHostPort := fmt.Sprintf("localhost:%d", port)
 	server := &http.Server{Handler: ocireg}
 	lis, err := net.Listen("tcp", listenHostPort)

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -853,7 +853,6 @@ proto_library(
     srcs = ["ociregistry.proto"],
 )
 
-
 # Go proto rules below here
 go_proto_library(
     name = "prometheus_client_go_proto",
@@ -1994,7 +1993,7 @@ go_proto_library(
         "@io_bazel_rules_go//proto:go_proto",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/ociregistry",
-    proto = ":ociregistry_proto"
+    proto = ":ociregistry_proto",
 )
 
 # TypeScript proto rules below here

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -848,6 +848,12 @@ proto_library(
     ],
 )
 
+proto_library(
+    name = "ociregistry_proto",
+    srcs = ["ociregistry.proto"],
+)
+
+
 # Go proto rules below here
 go_proto_library(
     name = "prometheus_client_go_proto",
@@ -1980,6 +1986,15 @@ go_proto_library(
         "@io_kythe//kythe/proto:storage_go_proto",
         "@io_kythe//kythe/proto:xref_go_proto",
     ],
+)
+
+go_proto_library(
+    name = "ociregistry_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/ociregistry",
+    proto = ":ociregistry_proto"
 )
 
 # TypeScript proto rules below here

--- a/proto/ociregistry.proto
+++ b/proto/ociregistry.proto
@@ -2,16 +2,48 @@ syntax = "proto3";
 
 package ociregistry;
 
-message OCIActionResultKey {
-  string key_version = 1;
-  string registry = 2;
-  string repository = 3;
-  string blobs_or_manifests = 4;
-  string hash_algorithm = 5;
-  string hash_hex = 6;
-}
+// The `ociregistry` package contains an OCI mirror registry
+// that can pull OCI container images from upstream registries
+// and store them in the CAS. It is a read-through cache for OCI image
+// layers and manifests.
 
+// `docker pull busybox` will make requests for the `busybox` image at
+// the `latest` tag:
+// GET /v2/busybox/manifests/latest
+// GET /v2/busybox/blobs/sha256:<a_sha256_digest>
+//
+// In order to serve these requests from the CAS, the OCI mirror registry needs to
+// map image name, resource type (blob or manifest), and digest to the size of the payload (content length).
+// The OCI mirror registry also needs to be able to respond with the content type for the blob or manifest.
+// We store this metadata (content length and content type) in the AC.
+
+// Metadata needed for serving a manifest or layer from the CAS.
 message OCIBlobMetadata {
   int64 content_length = 1;
   string content_type = 2;
+}
+
+// OCI image registries serve either blobs (layers) or manifests.
+enum OCIResourceType {
+    BLOB = 0;
+    MANIFEST = 1;
+}
+
+// The key for looking up the metadata in the AC.
+message OCIActionResultKey {
+  // Optional hostname or IP address (and optional port).
+  // Leaving this empty implies Docker Hub (index.docker.io).
+  string registry = 1;
+
+  // Commonly referred to as the "image name." For example, `busybox` contains an empty registry string
+  // and a repository name of `busybox`.
+  string repository = 2;
+
+  OCIResourceType resource_type = 3;
+
+  // All OCI registries must support 'sha256'. It is possible to see 'sha512' as well.
+  string hash_algorithm = 4;
+
+  // Digest as a hex string.
+  string hash_hex = 5;
 }

--- a/proto/ociregistry.proto
+++ b/proto/ociregistry.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package ociregistry;
+
+message OCIActionResultKey {
+    string key_version = 1;
+    string registry = 2;
+    string repository = 3;
+    string blobs_or_manifests = 4;
+    string hash_algorithm = 5;
+    string hash_hex = 6;
+}
+
+message OCIBlobMetadata {
+    int64 content_length = 1;
+    string content_type = 2;
+}

--- a/proto/ociregistry.proto
+++ b/proto/ociregistry.proto
@@ -26,8 +26,9 @@ message OCIBlobMetadata {
 
 // OCI image registries serve either blobs (layers) or manifests.
 enum OCIResourceType {
-  BLOB = 0;
-  MANIFEST = 1;
+  UNKNOWN = 0;
+  BLOB = 1;
+  MANIFEST = 2;
 }
 
 // The key for looking up the metadata in the AC.

--- a/proto/ociregistry.proto
+++ b/proto/ociregistry.proto
@@ -3,15 +3,15 @@ syntax = "proto3";
 package ociregistry;
 
 message OCIActionResultKey {
-    string key_version = 1;
-    string registry = 2;
-    string repository = 3;
-    string blobs_or_manifests = 4;
-    string hash_algorithm = 5;
-    string hash_hex = 6;
+  string key_version = 1;
+  string registry = 2;
+  string repository = 3;
+  string blobs_or_manifests = 4;
+  string hash_algorithm = 5;
+  string hash_hex = 6;
 }
 
 message OCIBlobMetadata {
-    int64 content_length = 1;
-    string content_type = 2;
+  int64 content_length = 1;
+  string content_type = 2;
 }

--- a/proto/ociregistry.proto
+++ b/proto/ociregistry.proto
@@ -12,10 +12,11 @@ package ociregistry;
 // GET /v2/busybox/manifests/latest
 // GET /v2/busybox/blobs/sha256:<a_sha256_digest>
 //
-// In order to serve these requests from the CAS, the OCI mirror registry needs to
-// map image name, resource type (blob or manifest), and digest to the size of the payload (content length).
-// The OCI mirror registry also needs to be able to respond with the content type for the blob or manifest.
-// We store this metadata (content length and content type) in the AC.
+// In order to serve these requests from the CAS, the OCI mirror registry needs
+// to map image name, resource type (blob or manifest), and digest to the size
+// of the payload (content length). The OCI mirror registry also needs to be
+// able to respond with the content type for the blob or manifest. We store this
+// metadata (content length and content type) in the AC.
 
 // Metadata needed for serving a manifest or layer from the CAS.
 message OCIBlobMetadata {
@@ -25,8 +26,8 @@ message OCIBlobMetadata {
 
 // OCI image registries serve either blobs (layers) or manifests.
 enum OCIResourceType {
-    BLOB = 0;
-    MANIFEST = 1;
+  BLOB = 0;
+  MANIFEST = 1;
 }
 
 // The key for looking up the metadata in the AC.
@@ -35,13 +36,14 @@ message OCIActionResultKey {
   // Leaving this empty implies Docker Hub (index.docker.io).
   string registry = 1;
 
-  // Commonly referred to as the "image name." For example, `busybox` contains an empty registry string
-  // and a repository name of `busybox`.
+  // Commonly referred to as the "image name." For example, `busybox` contains
+  // an empty registry string and a repository name of `busybox`.
   string repository = 2;
 
   OCIResourceType resource_type = 3;
 
-  // All OCI registries must support 'sha256'. It is possible to see 'sha512' as well.
+  // All OCI registries must support 'sha256'. It is possible to see 'sha512' as
+  // well.
   string hash_algorithm = 4;
 
   // Digest as a hex string.

--- a/server/testutil/testregistry/testregistry.go
+++ b/server/testutil/testregistry/testregistry.go
@@ -107,6 +107,15 @@ func (r *Registry) PushRandomImage(t *testing.T) (string, gcr.Image) {
 	return r.Push(t, image, "test"), image
 }
 
+func (r *Registry) PushNamedImage(t *testing.T, imageName string) (string, gcr.Image) {
+	files := map[string][]byte{
+		"/tmp/" + imageName: []byte(imageName),
+	}
+	image, err := crane.Image(files)
+	require.NoError(t, err)
+	return r.Push(t, image, imageName), image
+}
+
 func (r *Registry) Shutdown(ctx context.Context) error {
 	if r.server != nil {
 		return r.server.Shutdown(ctx)

--- a/server/testutil/testregistry/testregistry.go
+++ b/server/testutil/testregistry/testregistry.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/require"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	gcr "github.com/google/go-containerregistry/pkg/v1"
 )
 
 type Opts struct {
@@ -73,7 +73,7 @@ func (r *Registry) ImageAddress(imageName string) string {
 	return fmt.Sprintf("%s:%d/%s", r.host, r.port, imageName)
 }
 
-func (r *Registry) Push(t *testing.T, image v1.Image, imageName string) string {
+func (r *Registry) Push(t *testing.T, image gcr.Image, imageName string) string {
 	fullImageName := r.ImageAddress(imageName)
 	ref, err := name.ParseReference(fullImageName)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func (r *Registry) Push(t *testing.T, image v1.Image, imageName string) string {
 	return fullImageName
 }
 
-func (r *Registry) PushIndex(t *testing.T, idx v1.ImageIndex, imageName string) string {
+func (r *Registry) PushIndex(t *testing.T, idx gcr.ImageIndex, imageName string) string {
 	fullImageName := r.ImageAddress(imageName)
 	ref, err := name.ParseReference(fullImageName)
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func (r *Registry) PushIndex(t *testing.T, idx v1.ImageIndex, imageName string) 
 	return fullImageName
 }
 
-func (r *Registry) PushRandomImage(t *testing.T) (string, v1.Image) {
+func (r *Registry) PushRandomImage(t *testing.T) (string, gcr.Image) {
 	files := map[string][]byte{}
 	buffer := bytes.Buffer{}
 	buffer.Grow(1024)
@@ -117,7 +117,7 @@ func (r *Registry) Shutdown(ctx context.Context) error {
 // ImageFromRlocationpath returns an Image from an rlocationpath.
 // The rlocationpath should be set via x_defs in the BUILD file, and the
 // rlocationpath target should be an OCI image target (e.g. oci.pull)
-func ImageFromRlocationpath(t *testing.T, rlocationpath string) v1.Image {
+func ImageFromRlocationpath(t *testing.T, rlocationpath string) gcr.Image {
 	indexPath, err := runfiles.Rlocation(rlocationpath)
 	require.NoError(t, err)
 	idx, err := layout.ImageIndexFromPath(indexPath)
@@ -134,17 +134,17 @@ func ImageFromRlocationpath(t *testing.T, rlocationpath string) v1.Image {
 // bytesLayer implements partial.UncompressedLayer from raw bytes.
 type bytesLayer struct {
 	content   []byte
-	diffID    v1.Hash
+	diffID    gcr.Hash
 	mediaType types.MediaType
 }
 
 // NewBytesLayer returns an image layer representing the given bytes.
 //
 // testtar.EntryBytes may be useful for constructing tarball contents.
-func NewBytesLayer(t *testing.T, b []byte) v1.Layer {
+func NewBytesLayer(t *testing.T, b []byte) gcr.Layer {
 	layer, err := partial.UncompressedToLayer(&bytesLayer{
 		mediaType: types.OCILayer,
-		diffID: v1.Hash{
+		diffID: gcr.Hash{
 			Algorithm: "sha256",
 			Hex:       fmt.Sprintf("%x", sha256.Sum256(b)),
 		},
@@ -155,7 +155,7 @@ func NewBytesLayer(t *testing.T, b []byte) v1.Layer {
 }
 
 // DiffID implements partial.UncompressedLayer
-func (ul *bytesLayer) DiffID() (v1.Hash, error) {
+func (ul *bytesLayer) DiffID() (gcr.Hash, error) {
 	return ul.diffID, nil
 }
 


### PR DESCRIPTION
This change adds caching to the OCI registry mirror. It depends on #8468. Please review #8468 first!

When a client makes a GET request _by digest_ for a blob (layer) or manifest, the registry mirror will
1. see if the payload exists in the CAS and return it if it does;
2. otherwise, fetch the payload from an upstream registry and
3. store payload in the CAS if successfully found in the upstream registry.

If there is an error reading from or writing to the CAS, the request will fail.

People typically fetch manifests by tag (i.e., `latest`). The mapping from tag to OCI image can change. For example, `latest` changes every time people upload a new version of an image. Therefore I do not cache OCI image manifests by tag nor do I cache the mapping from tag to digest.

This means that `docker pull imagename` or `docker pull imagename:latest` will make at least one GET request to the upstream registry, which I think counts against the Docker Hub pull rate limit. It is possible to perform a HEAD request to the upstream registry for the manifest tag, read the digest from the response, then look up the manifest by digest in the CAS. That behavior can come in a follow-on change.