### PR TITLE
[SS] Give balloon more time to inflate

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2689,7 +2689,7 @@ func (c *FirecrackerContainer) updateBalloon(ctx context.Context, targetSizeMib 
 
 		if math.Abs(float64(currentBalloonSize-lastBalloonSize)) < 100 {
 			slowCount++
-			if slowCount == 2 {
+			if slowCount == 5 {
 				// If the rate of inflation is consistently slow or stops, just stop early.
 				// Give the balloon a second chance in case there is resource contention
 				// that temporarily slows the balloon inflation.


### PR DESCRIPTION
Based on these [logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22flame-build%22%0Aresource.labels.location%3D%22us-west1%22%0Aresource.labels.cluster_name%3D%22dev-nv8eh%22%0Aresource.labels.namespace_name%3D%22executor-dev%22%0A--%20labels.k8s-pod%2Fapp%3D%22executor%22%0A--%20severity%3D%2528WARNING%20OR%20ERROR%20OR%20CRITICAL%20OR%20ALERT%20OR%20EMERGENCY%2529%0A%22balloon%22;summaryFields=:true:32:end;cursorTimestamp=2025-02-27T22:20:32.032991606Z;startTime=2025-02-27T22:07:19.191Z;endTime=2025-02-27T22:22:19.191Z?project=flame-build&pageState=(%22savedViews%22:(%22i%22:%220c6fd25fd59f4d32b822b9bbf52ac66b%22,%22c%22:%5B%22gke%2Fus-west1%2Fprod-hs6in%22%5D,%22n%22:%5B%5D))&pli=1), we're not giving the balloon enough time to inflate and are cutting it off too early

Part of the reason is that the first time we enter the for loop, it's a couple usec after we started inflating the balloon and the balloon has barely started inflating. That sets `slowCount=1`. Then based on the logs it appears that the balloon always starts to inflate slowly, so by the second iteration, it sets `slowCount=2` and we stop the inflation. With a max slowCount of 5, we'll give a 1.5s buffer to the balloon before cutting it off