### PR TITLE
Don't affinity/CI-route to executors if the previous execution on that node failed

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1180,10 +1180,13 @@ func (s *ExecutionServer) cacheActionResult(ctx context.Context, actionResourceN
 func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceName *digest.ResourceName, executeResponse *repb.ExecuteResponse, action *repb.Action, cmd *repb.Command, properties *platform.Properties) error {
 	execErr := gstatus.ErrorProto(executeResponse.GetStatus())
 	router := s.env.GetTaskRouter()
-	// Only update the router if a task was actually executed
-	if execErr == nil && router != nil && !executeResponse.GetCachedResult() {
+	if router != nil && !executeResponse.GetCachedResult() {{
 		executorHostID := executeResponse.GetResult().GetExecutionMetadata().GetWorker()
-		router.MarkComplete(ctx, action, cmd, actionResourceName.GetInstanceName(), executorHostID)
+		if execErr == nil && executeResponse.GetResult().GetExitCode() == 0 {
+			router.MarkSucceeded(ctx, action, cmd, actionResourceName.GetInstanceName(), executorHostID)
+		} else {
+			router.MarkFailed(ctx, action, cmd, actionResourceName.GetInstanceName(), executorHostID)
+		}
 	}
 
 	// Skip sizer and usage updates for teed work.

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -75,7 +75,6 @@ const (
 	unsetContainerImageVal = "none"
 
 	RecycleRunnerPropertyName            = "recycle-runner"
-	AffinityRoutingPropertyName          = "affinity-routing"
 	RunnerRecyclingMaxWaitPropertyName   = "runner-recycling-max-wait"
 	PreserveWorkspacePropertyName        = "preserve-workspace"
 	overlayfsWorkspacePropertyName       = "overlayfs-workspace"
@@ -186,7 +185,6 @@ type Properties struct {
 	DockerUser                string
 	DockerNetwork             string
 	RecycleRunner             bool
-	AffinityRouting           bool
 	RunnerRecyclingMaxWait    time.Duration
 	EnableVFS                 bool
 	IncludeSecrets            bool
@@ -385,7 +383,6 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		DockerUser:                stringProp(m, DockerUserPropertyName, ""),
 		DockerNetwork:             stringProp(m, dockerNetworkPropertyName, ""),
 		RecycleRunner:             recycleRunner,
-		AffinityRouting:           boolProp(m, AffinityRoutingPropertyName, false),
 		DefaultTimeout:            timeout,
 		TerminationGracePeriod:    terminationGracePeriod,
 		RunnerRecyclingMaxWait:    runnerRecyclingMaxWait,

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -242,10 +242,10 @@ func (tr *taskRouter) RankNodes(ctx context.Context, action *repb.Action, cmd *r
 	return ranked
 }
 
-// MarkComplete updates the routing table after a task is completed, so that
+// MarkSucceeded updates the routing table after a task is completed, so that
 // future tasks with those properties are more likely to be fulfilled by the
 // given node.
-func (tr *taskRouter) MarkComplete(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorHostID string) {
+func (tr *taskRouter) MarkSucceeded(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorHostID string) {
 	params := getRoutingParams(ctx, tr.env, action, cmd, remoteInstanceName)
 	strategy := tr.selectRouter(params)
 	if strategy == nil {
@@ -282,6 +282,29 @@ func (tr *taskRouter) MarkComplete(ctx context.Context, action *repb.Action, cmd
 	}
 
 	log.Debugf("Preferred executor host ID %q added to %q", executorHostID, routingKey)
+}
+
+// MarkFailed clears the routing table after a task fails. This makes it so
+// that subsequent executions will run on random execution nodes.
+func (tr *taskRouter) MarkFailed(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorHostID string) {
+	params := getRoutingParams(ctx, tr.env, action, cmd, remoteInstanceName)
+	strategy := tr.selectRouter(params)
+	if strategy == nil {
+		return
+	}
+	_, routingKeys, err := strategy.RoutingInfo(params)
+	if err != nil {
+		log.Errorf("Failed to compute routing info: %s", err)
+		return
+	}
+	for _, routingKey := range routingKeys {
+		// Note: -1 means remove all occurrences.
+		if res := tr.rdb.LRem(ctx, routingKey, -1, executorHostID); res.Err() != nil {
+			log.Errorf("Error removing task routing state from redis: %s", res.Err())
+		} else {
+			log.Debugf("Removed %s from routing key %s", executorHostID, routingKey)
+		}
+	}
 }
 
 // Contains the parameters required to make a routing decision.

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -925,10 +925,16 @@ type TaskRouter interface {
 	// If an error occurs, the input nodes should be returned in random order.
 	RankNodes(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName string, nodes []ExecutionNode) []RankedExecutionNode
 
-	// MarkComplete notifies the router that the command has been completed by the
-	// given executor instance. Subsequent calls to RankNodes may assign a higher
-	// rank to nodes with the given instance ID, given similar commands.
-	MarkComplete(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorInstanceID string)
+	// MarkSucceeded notifies the task router that the provided command
+	// completed successfully on the given executor instance. Subsequent calls
+	// to RankNodes may rank this executor higher for similar commands.
+	MarkSucceeded(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorInstanceID string)
+
+	// MarkFailed notifies the task router that the provided command was
+	// unsuccessful on the given executor instance. Note that there is no
+	// indication if this is because of an executor issue, or because the
+	// action was invalid.
+	MarkFailed(ctx context.Context, action *repb.Action, cmd *repb.Command, remoteInstanceName, executorInstanceID string)
 }
 
 // TaskSizer allows storing, retrieving, and predicting task size measurements for a task.


### PR DESCRIPTION
Also remove the affinity routing platform property, it's not used anymore.