### PR TITLE
Replace experimental maps package with maps in standard library

### DIFF
--- a/cli/explain/BUILD
+++ b/cli/explain/BUILD
@@ -22,7 +22,6 @@ go_library(
         "@com_github_google_go_cmp//cmp",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//metadata",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/cli/explain/compactgraph/BUILD.bazel
+++ b/cli/explain/compactgraph/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//proto:spawn_go_proto",
         "@com_github_klauspost_compress//zstd",
         "@org_golang_google_protobuf//encoding/protodelim",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/cli/explain/compactgraph/compactgraph.go
+++ b/cli/explain/compactgraph/compactgraph.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"path"
 	"slices"
 	"sort"
@@ -15,7 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/proto/spawn_diff"
 	"github.com/klauspost/compress/zstd"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/protodelim"
 

--- a/cli/explain/compactgraph/compactgraph.go
+++ b/cli/explain/compactgraph/compactgraph.go
@@ -473,8 +473,7 @@ func (cg *CompactGraph) visitSuccessors(node any, visitor func(input any)) {
 			visitor(transitiveSet)
 		}
 	case *SymlinkEntrySet:
-		targets := maps.Values(n.directEntries)
-		slices.SortFunc(targets, func(a, b Input) int {
+		targets := slices.SortedFunc(maps.Values(n.directEntries), func(a, b Input) int {
 			return cmp.Compare(a.Path(), b.Path())
 		})
 		for _, target := range targets {

--- a/cli/explain/compactgraph/input.go
+++ b/cli/explain/compactgraph/input.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
@@ -345,8 +344,7 @@ func protoToSymlinkEntrySet(s *spawn.ExecLogEntry_SymlinkEntrySet, previousInput
 	contentHash := sha256.New()
 	contentHash.Write([]byte{symlinkEntrySetContent})
 
-	paths := maps.Keys(s.DirectEntries)
-	slices.Sort(paths)
+	paths := slices.Sorted(maps.Keys(s.DirectEntries))
 	directEntries := make(map[string]Input, len(paths))
 	for _, p := range paths {
 		directEntries[p] = previousInputs[s.DirectEntries[p]]
@@ -451,8 +449,7 @@ func (r *RunfilesTree) ComputeMapping(workspaceRunfilesDirectory, hashFunction s
 	// Populate the exact content hash so that consumers don't need to recompute the mapping to determine whether the
 	// tree changed.
 	contentHash := sha256.New()
-	sortedRunfilesPaths := maps.Keys(m)
-	sort.Strings(sortedRunfilesPaths)
+	sortedRunfilesPaths := slices.Sorted(maps.Keys(m))
 	for _, p := range sortedRunfilesPaths {
 		_ = binary.Write(contentHash, binary.LittleEndian, uint64(len(p)))
 		contentHash.Write([]byte(p))

--- a/cli/explain/compactgraph/input.go
+++ b/cli/explain/compactgraph/input.go
@@ -1,10 +1,12 @@
 package compactgraph
 
 import (
+	"cmp"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"iter"
+	"maps"
 	"path"
 	"regexp"
 	"slices"
@@ -13,7 +15,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/proto/spawn"
-	"golang.org/x/exp/maps"
 )
 
 type Hash = []byte
@@ -251,9 +252,8 @@ func (s *InputSet) Flatten() []Input {
 		}
 	}
 
-	inputs := maps.Keys(inputsSet)
-	sort.Slice(inputs, func(i, j int) bool {
-		return inputs[i].Path() < inputs[j].Path()
+	inputs := slices.SortedFunc(maps.Keys(inputsSet), func(i, j Input) int {
+		return cmp.Compare(i.Path(), j.Path())
 	})
 	return inputs
 }

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -468,7 +468,9 @@ func writeListDiff(w io.Writer, d *spawn_diff.ListDiff) {
 }
 
 func writeDictDiff(w io.Writer, d *spawn_diff.DictDiff) {
-	allKeys := append(maps.Keys(d.OldChanged), maps.Keys(d.NewChanged)...)
+	allKeys := make([]string, 0, len(d.OldChanged)+len(d.NewChanged))
+	allKeys = slices.AppendSeq(allKeys, maps.Keys(d.OldChanged))
+	allKeys = slices.AppendSeq(allKeys, maps.Keys(d.NewChanged))
 	slices.Sort(allKeys)
 	allKeys = slices.Compact(allKeys)
 

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"regexp"
@@ -27,7 +28,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	gocmp "github.com/google/go-cmp/cmp"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/grpc/metadata"
@@ -52,8 +52,7 @@ execution log and upload it to the BuildBuddy BES backend.
 type MapFlag map[string]string
 
 func (m MapFlag) String() string {
-	keys := maps.Keys(m)
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(m))
 	var parts []string
 	for _, k := range keys {
 		parts = append(parts, fmt.Sprintf("%s=%s", k, m[k]))

--- a/codesearch/index/BUILD
+++ b/codesearch/index/BUILD
@@ -15,7 +15,6 @@ go_library(
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_xiam_s_expr//ast",
         "@com_github_xiam_s_expr//parser",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -687,7 +687,7 @@ type docMatch struct {
 }
 
 func (dm *docMatch) FieldNames() []string {
-	return maps.Keys(dm.matchedPostings)
+	return slices.Collect(maps.Keys(dm.matchedPostings))
 }
 func (dm *docMatch) Docid() uint64 {
 	return dm.docid
@@ -719,7 +719,7 @@ func (d lazyDoc) Field(name string) types.Field {
 }
 
 func (d lazyDoc) Fields() []string {
-	return maps.Keys(d.fields)
+	return slices.Collect(maps.Keys(d.fields))
 }
 
 func (r *Reader) newLazyDoc(docid uint64) *lazyDoc {

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"regexp"
 	"runtime"
 	"slices"
-	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/pebble"
 	"github.com/xiam/s-expr/ast"
 	"github.com/xiam/s-expr/parser"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -369,8 +368,7 @@ func (w *Writer) Flush() error {
 		}
 		return nil
 	}
-	fieldNames := maps.Keys(w.fieldPostingLists)
-	sort.Strings(fieldNames)
+	fieldNames := slices.Sorted(maps.Keys(w.fieldPostingLists))
 	for _, fieldName := range fieldNames {
 		postingLists := w.fieldPostingLists[fieldName]
 		log.Printf("field: %q had %d ngrams", fieldName, len(postingLists))

--- a/codesearch/performance/BUILD
+++ b/codesearch/performance/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["performance.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/performance",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/log",
-        "@org_golang_x_exp//maps",
-    ],
+    deps = ["//server/util/log"],
 )

--- a/codesearch/performance/performance.go
+++ b/codesearch/performance/performance.go
@@ -2,12 +2,12 @@ package performance
 
 import (
 	"context"
+	"maps"
 	"slices"
 	"sync"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"golang.org/x/exp/maps"
 )
 
 type label int
@@ -107,11 +107,10 @@ func (t *Tracker) Add(key label, value int64) {
 
 func (t *Tracker) Keys() []label {
 	t.mu.Lock()
-	keys := maps.Keys(t.data)
+	keysIter := maps.Keys(t.data)
 	t.mu.Unlock()
 
-	slices.Sort(keys)
-	return keys
+	return slices.Sorted(keysIter)
 }
 
 func (t *Tracker) Get(key label) int64 {

--- a/codesearch/performance/performance.go
+++ b/codesearch/performance/performance.go
@@ -107,10 +107,11 @@ func (t *Tracker) Add(key label, value int64) {
 
 func (t *Tracker) Keys() []label {
 	t.mu.Lock()
-	keysIter := maps.Keys(t.data)
+	keys := slices.Collect(maps.Keys(t.data))
 	t.mu.Unlock()
 
-	return slices.Sorted(keysIter)
+	slices.Sort(keys)
+	return keys
 }
 
 func (t *Tracker) Get(key label) int64 {

--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sys//unix",
         "@org_golang_x_time//rate",

--- a/server/remote_cache/cachetools/BUILD
+++ b/server/remote_cache/cachetools/BUILD
@@ -21,7 +21,6 @@ go_library(
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -219,7 +219,7 @@ func batchReadBlobs(ctx context.Context, casClient repb.ContentAddressableStorag
 		})
 	}
 	if len(expected) > 0 {
-		return nil, status.UnknownErrorf("missing digests in response: %s", maps.Keys(expected))
+		return nil, status.UnknownErrorf("missing digests in response: %v", maps.Keys(expected))
 	}
 	return results, nil
 }

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -21,7 +22,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -219,7 +220,7 @@ func batchReadBlobs(ctx context.Context, casClient repb.ContentAddressableStorag
 		})
 	}
 	if len(expected) > 0 {
-		return nil, status.UnknownErrorf("missing digests in response: %v", maps.Keys(expected))
+		return nil, status.UnknownErrorf("missing digests in response: %s", slices.Collect(maps.Keys(expected)))
 	}
 	return results, nil
 }

--- a/server/util/consistent_hash/BUILD
+++ b/server/util/consistent_hash/BUILD
@@ -21,6 +21,5 @@ go_test(
         "//server/util/random",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//maps",
     ],
 )

--- a/server/util/consistent_hash/consistent_hash_test.go
+++ b/server/util/consistent_hash/consistent_hash_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand"
 	"slices"
 	"testing"
@@ -14,7 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 // Number of vnodes serving as a reasonable default for testing purposes.
@@ -103,8 +103,8 @@ func TestEvenLoadDistribution(t *testing.T) {
 		host := ch.Get(string(buf))
 		freq[host]++
 	}
-	minFreq := slices.Min(maps.Values(freq))
-	maxFreq := slices.Max(maps.Values(freq))
+	minFreq := slices.Min(slices.Collect(maps.Values(freq)))
+	maxFreq := slices.Max(slices.Collect(maps.Values(freq)))
 	skew := float64(maxFreq-minFreq) / float64(minFreq)
 	assert.Less(t, skew, 0.1)
 }

--- a/server/util/rexec/BUILD
+++ b/server/util/rexec/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//server/util/status",
         "@org_golang_google_genproto//googleapis/longrunning",
         "@org_golang_google_grpc//status",
-        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/util/rexec/rexec.go
+++ b/server/util/rexec/rexec.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -52,8 +51,7 @@ func MakePlatform(pairs ...string) (*repb.Platform, error) {
 	if err != nil {
 		return nil, err
 	}
-	names := maps.Keys(m)
-	sort.Strings(names)
+	names := slices.Sorted(maps.Keys(m))
 	p := &repb.Platform{Properties: make([]*repb.Platform_Property, 0, len(names))}
 	for _, name := range names {
 		p.Properties = append(p.Properties, &repb.Platform_Property{

--- a/server/util/rexec/rexec.go
+++ b/server/util/rexec/rexec.go
@@ -4,6 +4,8 @@ package rexec
 import (
 	"bytes"
 	"context"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 
@@ -14,7 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/genproto/googleapis/longrunning"
 
@@ -32,8 +33,7 @@ func MakeEnv(pairs ...string) ([]*repb.Command_EnvironmentVariable, error) {
 	if err != nil {
 		return nil, err
 	}
-	names := maps.Keys(m)
-	sort.Strings(names)
+	names := slices.Sorted(maps.Keys(m))
 	out := make([]*repb.Command_EnvironmentVariable, 0, len(m))
 	for _, name := range names {
 		out = append(out, &repb.Command_EnvironmentVariable{

--- a/tools/jaegerquery/BUILD
+++ b/tools/jaegerquery/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/log",
         "@org_golang_google_protobuf//types/known/timestamppb",
-        "@org_golang_x_exp//maps",
     ],
 )
 

--- a/tools/jaegerquery/jaegerquery.go
+++ b/tools/jaegerquery/jaegerquery.go
@@ -8,12 +8,14 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/signal"
-	"sort"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -21,7 +23,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"golang.org/x/exp/maps"
 
 	jaegerpb "github.com/buildbuddy-io/buildbuddy/proto/jaeger"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
@@ -101,9 +102,8 @@ func run() error {
 	}
 
 	// Sort by total duration, greatest to least
-	operations := maps.Keys(totalDurations)
-	sort.Slice(operations, func(i, j int) bool {
-		return totalDurations[operations[i]] > totalDurations[operations[j]]
+	operations := slices.SortedFunc(maps.Keys(totalDurations), func(a, b string) int {
+		return -cmp.Compare(totalDurations[a], totalDurations[b])
 	})
 	fmt.Printf("AVG_MS\tOP\n")
 	for _, op := range operations {


### PR DESCRIPTION
In exp/maps the Keys() and Values() return a slice, but in maps package, they
return iter.Seq instead.

