### PR TITLE
Optimize copy_on_write.ConvertFileToCOW

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -846,7 +846,6 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 			// memory between kernel and user space.
 			limitedInput.N = writeLen
 			if _, err := io.Copy(chunkFile, limitedInput); err != nil {
-				// if _, err := io.CopyN(chunkFile, f, writeLen); err != nil {
 				return nil, err
 			}
 			// Seek to the next data block, starting from the end of the data

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -789,17 +789,9 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 		}
 	}()
 
-	totalSizeBytes, ioBlockSize, err := getFileDetails(filePath)
+	totalSizeBytes, err := getFileSize(filePath)
 	if err != nil {
 		return nil, err
-	}
-
-	// Copy buffer (large enough to copy one data block at a time).
-	copyBufPool := sync.Pool{
-		New: func() any {
-			copyBuf := make([]byte, ioBlockSize)
-			return &copyBuf
-		},
 	}
 
 	createChunk := func(f *os.File, chunkStartOffset int64) (*Mmap, error) {
@@ -814,10 +806,7 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 			return nil, status.InternalErrorf("initial data seek failed: %s", err)
 		}
 
-		chunkFileSize := chunkSizeBytes
-		if remainder := totalSizeBytes - chunkStartOffset; chunkFileSize > remainder {
-			chunkFileSize = remainder
-		}
+		chunkFileSize := min(chunkSizeBytes, totalSizeBytes-chunkStartOffset)
 		if dataOffset >= chunkStartOffset+chunkFileSize {
 			// Chunk contains no data; avoid writing a file.
 			return nil, nil
@@ -830,78 +819,71 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 		if err := chunkFile.Truncate(chunkFileSize); err != nil {
 			return nil, err
 		}
-		endOffset := chunkStartOffset + chunkSizeBytes
-		if endOffset > totalSizeBytes {
-			endOffset = totalSizeBytes
-		}
+		endOffset := min(chunkStartOffset+chunkSizeBytes, totalSizeBytes)
 
-		copyBuf := copyBufPool.Get().(*[]byte)
-		defer copyBufPool.Put(copyBuf)
-
+		limitedInput := &io.LimitedReader{R: f}
 		for dataOffset < endOffset {
-			chunkFileDataOffset := dataOffset - chunkStartOffset
-			dataBuf := *copyBuf
-			if remainder := chunkFileSize - chunkFileDataOffset; remainder < int64(len(dataBuf)) {
-				dataBuf = (*copyBuf)[:remainder]
-			}
-
-			// Copy the current data block to the output chunk file.
-			if _, err := io.ReadFull(f, dataBuf); err != nil {
+			// We have the start of a data range. Find the end as well so we
+			// know how many bytes to copy. Then seek back to start of the input
+			// and to the destination in the chunk file.
+			holeOffset, err := syscall.Seek(fd, dataOffset, unix.SEEK_HOLE)
+			if err != nil {
 				return nil, err
 			}
-			if _, err := chunkFile.WriteAt(dataBuf, chunkFileDataOffset); err != nil {
+			chunkFileDataOffset := dataOffset - chunkStartOffset
+			if _, err = chunkFile.Seek(chunkFileDataOffset, 0); err != nil {
+				return nil, err
+			}
+			if _, err := syscall.Seek(fd, dataOffset, unix.SEEK_SET); err != nil {
+				return nil, err
+			}
+			// Cap the write to just be in this chunk.
+			writeLen := min(holeOffset-dataOffset, chunkFileSize-chunkFileDataOffset)
+
+			// Copy the current data block to the output chunk file. This is
+			// faster than reading into a buffer and writing that, because it
+			// uses the copy_file_range syscall, so it doesn't have to copy
+			// memory between kernel and user space.
+			limitedInput.N = writeLen
+			if _, err := io.Copy(chunkFile, limitedInput); err != nil {
+				// if _, err := io.CopyN(chunkFile, f, writeLen); err != nil {
 				return nil, err
 			}
 			// Seek to the next data block, starting from the end of the data
 			// block we just copied.
-			dataOffset += int64(len(dataBuf))
+			dataOffset += writeLen
+			if dataOffset >= endOffset {
+				// We're past the end of this chunk
+				break
+			}
 
 			// Seek to the first non-empty offset >= `dataOffset`
 			dataOffset, err = syscall.Seek(fd, dataOffset, unix.SEEK_DATA)
-			if err != nil && err != syscall.ENXIO {
+			if err != nil {
+				if err == syscall.ENXIO {
+					break
+				}
 				return nil, err
-			}
-			if dataOffset >= endOffset || err == syscall.ENXIO {
-				// No more data in the file
-				break
 			}
 		}
 		return NewMmapLocalFile(ctx, env, dataDir, false /*=dirty*/, int(chunkFileSize), chunkStartOffset, remoteInstanceName, remoteEnabled)
 	}
 
 	eg, egCtx := errgroup.WithContext(ctx)
-	eg.SetLimit(fileConversionConcurrency)
-
-	openFilePool := make(chan *os.File, fileConversionConcurrency)
-	defer func() {
-		for len(openFilePool) > 0 {
-			f := <-openFilePool
-			f.Close()
-		}
-		close(openFilePool)
-	}()
-	for i := 0; i < fileConversionConcurrency; i++ {
-		f, err := os.Open(filePath)
-		if err != nil {
-			return nil, err
-		}
-		openFilePool <- f
-	}
-
 	var chunksMu sync.Mutex
-	for chunkStartOffset := int64(0); chunkStartOffset < totalSizeBytes; chunkStartOffset += chunkSizeBytes {
-		select {
-		case <-egCtx.Done():
-			// One goroutine failed - exit the for loop
-			return nil, eg.Wait()
-		default:
-			chunkStartOffset := chunkStartOffset
-			eg.Go(func() error {
-				f := <-openFilePool
-				defer func() {
-					openFilePool <- f
-				}()
-
+	chunkStarts := make(chan int64, fileConversionConcurrency)
+	for range fileConversionConcurrency {
+		eg.Go(func() error {
+			f, err := os.Open(filePath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			for chunkStartOffset := range chunkStarts {
+				if err := egCtx.Err(); err != nil {
+					// One goroutine failed - exit the for loop
+					return err
+				}
 				c, err := createChunk(f, chunkStartOffset)
 				if err != nil {
 					return status.WrapError(err, "failed to create chunk")
@@ -911,10 +893,20 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 					chunks = append(chunks, c)
 					chunksMu.Unlock()
 				}
-				return nil
-			})
+			}
+			return nil
+		})
+	}
+chunkLoop:
+	for chunkStartOffset := int64(0); chunkStartOffset < totalSizeBytes; chunkStartOffset += chunkSizeBytes {
+		select {
+		case <-egCtx.Done():
+			// One goroutine failed - exit the for loop
+			break chunkLoop
+		case chunkStarts <- chunkStartOffset:
 		}
 	}
+	close(chunkStarts)
 
 	if err := eg.Wait(); err != nil {
 		return nil, err
@@ -924,19 +916,17 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 	return NewCOWStore(ctx, env, name, chunks, chunkSizeBytes, totalSizeBytes, dataDir, remoteInstanceName, remoteEnabled)
 }
 
-func getFileDetails(filePath string) (totalSizeBytes int64, ioBlockSize int64, err error) {
+func getFileSize(filePath string) (totalSizeBytes int64, err error) {
 	f, err := os.Open(filePath)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
 	defer f.Close()
 	stat, err := f.Stat()
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
-	totalSizeBytes = stat.Size()
-	ioBlockSize = int64(stat.Sys().(*syscall.Stat_t).Blksize)
-	return totalSizeBytes, ioBlockSize, nil
+	return stat.Size(), nil
 }
 
 // getMmapLRU returns the shared LRU instance to be used for the mmap,

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -190,9 +190,7 @@ func TestCOW_SparseData(t *testing.T) {
 	// for each IO operation). This is the minimum seek size when using seek()
 	// with SEEK_DATA.
 	tmp := testfs.MakeTempDir(t)
-	stat, err := os.Stat(tmp)
-	require.NoError(t, err)
-	ioBlockSize := int64(stat.Sys().(*syscall.Stat_t).Blksize)
+	ioBlockSize := ioBlockSize(t, tmp)
 	// Use a chunk size that is a few times larger than the IO block size.
 	const blocksPerChunk = 4
 	chunkSize := ioBlockSize * blocksPerChunk
@@ -513,6 +511,52 @@ func BenchmarkCOW_ReadWritePerformance(b *testing.B) {
 	}
 }
 
+func BenchmarkConvertFileToCOW(b *testing.B) {
+	flags.Set(b, "app.log_level", "error")
+	log.Configure()
+
+	parentDir := testfs.MakeTempDir(b)
+	defer os.RemoveAll(parentDir)
+	testfs.MakeDirAll(b, parentDir, b.Name())
+	chunkSizeBytes := int64(os.Getpagesize() * 1000) // same as firecracker.cowChunkSizeBytes
+	blockSize := ioBlockSize(b, parentDir)
+	data := bytes.Repeat([]byte{1, 2, 3}, int(blockSize+117)) // Don't align writes to blocks
+
+	for _, sparnessRatio := range []float64{0, 0.1, 0.5, 0.9, 0.99, 1} {
+		b.Run(fmt.Sprintf("%vSparse", sparnessRatio), func(b *testing.B) {
+			inputPath := filepath.Join(parentDir, b.Name())
+			r := rand.New(rand.NewSource(1))
+			buf := make([]byte, 100_000_000) // 100MB
+			var total, written int
+			for i := 0; i < len(buf); i += len(data) {
+				total++
+				if r.Float64() >= sparnessRatio {
+					written++
+					copy(buf[i:], data)
+				}
+			}
+			writeSparseFile(b, inputPath, buf, blockSize)
+
+			b.ResetTimer()
+			for range b.N {
+				b.StopTimer()
+				outputDir, err := os.MkdirTemp(parentDir, "output")
+				require.NoError(b, err)
+				b.StartTimer()
+
+				_, err = copy_on_write.ConvertFileToCOW(context.Background(), nil, inputPath, chunkSizeBytes, outputDir, "", false)
+				require.NoError(b, err)
+
+				b.StopTimer()
+				os.RemoveAll(outputDir)
+				b.StartTimer()
+			}
+			b.StopTimer()
+			require.NoError(b, os.Remove(inputPath))
+		})
+	}
+}
+
 func testStore(t *testing.T, s interfaces.Store, path string) {
 	size, err := s.SizeBytes()
 	require.NoError(t, err, "SizeBytes failed")
@@ -774,7 +818,7 @@ func makeEmptyTempFile(t *testing.T, sizeBytes int64) string {
 // writeSparseFile writes only the data blocks from b to the given path, so
 // that the physical size of the file is minimal while still representing the
 // same underlying bytes.
-func writeSparseFile(t *testing.T, path string, b []byte, ioBlockSize int64) {
+func writeSparseFile(t testing.TB, path string, b []byte, ioBlockSize int64) {
 	f, err := os.Create(path)
 	require.NoError(t, err)
 	defer f.Close()

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -522,16 +522,13 @@ func BenchmarkConvertFileToCOW(b *testing.B) {
 	blockSize := ioBlockSize(b, parentDir)
 	data := bytes.Repeat([]byte{1, 2, 3}, int(blockSize+117)) // Don't align writes to blocks
 
-	for _, sparnessRatio := range []float64{0, 0.1, 0.5, 0.9, 0.99, 1} {
-		b.Run(fmt.Sprintf("%vSparse", sparnessRatio), func(b *testing.B) {
+	for _, sparsenessRatio := range []float64{0, 0.1, 0.5, 0.9, 0.99, 1} {
+		b.Run(fmt.Sprintf("%vSparse", sparsenessRatio), func(b *testing.B) {
 			inputPath := filepath.Join(parentDir, b.Name())
 			r := rand.New(rand.NewSource(1))
 			buf := make([]byte, 100_000_000) // 100MB
-			var total, written int
 			for i := 0; i < len(buf); i += len(data) {
-				total++
-				if r.Float64() >= sparnessRatio {
-					written++
+				if r.Float64() >= sparsenessRatio {
 					copy(buf[i:], data)
 				}
 			}


### PR DESCRIPTION
This method is used when unpacking container images and when saving the initial memory snapshot. The latter is on the critical path of the firecracker `pause` stage.

By using io.Copy with 2 files, we allow it to use the `copy_file_range` system call. This avoids copying memory between kernel and user space. Then we don't need a buffer in Go, which also allows copying bigger ranges instead of just one block at a time. This is where most of the improvement comes from.

Passing chunk starts through a channel instead of starting a new goroutine for every chunk gives another 1-2% improvement.

All together, this is about 36% faster on 100MB files without holes. Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                               │     base      │              optimized               │
                               │    sec/op     │    sec/op     vs base                │
ConvertFileToCOW/0Sparse-24      12.532m ±  1%   7.959m ±  3%  -36.49% (p=0.000 n=15)
ConvertFileToCOW/0.1Sparse-24    12.100m ±  0%   7.903m ±  1%  -34.68% (p=0.000 n=15)
ConvertFileToCOW/0.5Sparse-24     7.905m ±  0%   5.630m ±  1%  -28.78% (p=0.000 n=15)
ConvertFileToCOW/0.9Sparse-24     1.994m ±  1%   1.512m ±  1%  -24.17% (p=0.000 n=15)
ConvertFileToCOW/0.99Sparse-24    417.0µ ±  2%   382.9µ ±  6%   -8.16% (p=0.000 n=15)
ConvertFileToCOW/1Sparse-24       108.8µ ± 14%   123.7µ ± 26%        ~ (p=0.512 n=15)
geomean                           2.184m         1.714m        -21.51%

                               │     base     │              optimized              │
                               │     B/op     │     B/op      vs base               │
ConvertFileToCOW/0Sparse-24      3.962Mi ± 0%   3.925Mi ± 0%  -0.93% (p=0.000 n=15)
ConvertFileToCOW/0.1Sparse-24    3.963Mi ± 0%   3.925Mi ± 0%  -0.94% (p=0.000 n=15)
ConvertFileToCOW/0.5Sparse-24    3.964Mi ± 0%   3.925Mi ± 0%  -0.97% (p=0.000 n=15)
ConvertFileToCOW/0.9Sparse-24    3.966Mi ± 0%   3.925Mi ± 0%  -1.02% (p=0.000 n=15)
ConvertFileToCOW/0.99Sparse-24   3.967Mi ± 0%   3.924Mi ± 0%  -1.10% (p=0.000 n=15)
ConvertFileToCOW/1Sparse-24      3.915Mi ± 0%   3.914Mi ± 0%  -0.03% (p=0.000 n=15)
geomean                          3.956Mi        3.923Mi       -0.83%

                               │    base     │             optimized              │
                               │  allocs/op  │ allocs/op   vs base                │
ConvertFileToCOW/0Sparse-24       322.0 ± 0%   290.0 ± 0%   -9.94% (p=0.000 n=15)
ConvertFileToCOW/0.1Sparse-24     324.0 ± 0%   293.0 ± 0%   -9.57% (p=0.000 n=15)
ConvertFileToCOW/0.5Sparse-24     325.0 ± 0%   293.0 ± 0%   -9.85% (p=0.000 n=15)
ConvertFileToCOW/0.9Sparse-24     326.0 ± 0%   293.0 ± 0%  -10.12% (p=0.000 n=15)
ConvertFileToCOW/0.99Sparse-24    305.0 ± 0%   265.0 ± 0%  -13.11% (p=0.000 n=15)
ConvertFileToCOW/1Sparse-24      128.00 ± 0%   90.00 ± 1%  -29.69% (p=0.000 n=15)
geomean                           274.9        236.3       -14.05%
```