### PR TITLE
Add the COW name and size to the tracing span in snaploader.cacheCOW

### DIFF
--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
+        "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_x_sync//errgroup",


### PR DESCRIPTION
When looking at traces, this will make it easy to tell if the memory or disk COWStore took longer to save.

I suspect that the disk one always takes longer. If that's the case, we could start it before we create or merge the memory one.