### PR TITLE
[raft] add logs in driver when we are not considering rebalancing leases

### DIFF
--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -245,6 +245,8 @@ func (rq *Queue) computeAction(rd *rfpb.RangeDescriptor, usage *rfpb.ReplicaUsag
 			action := DriverRebalanceLease
 			return action, action.Priority()
 		}
+	} else {
+		rq.log.Debugf("do not consider rebalance because range %d is not healthy. num of suspect replicas: %d, num deadReplicas: %d", rd.GetRangeId(), len(replicasByStatus.SuspectReplicas), numDeadReplicas)
 	}
 
 	action := DriverNoop


### PR DESCRIPTION

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4527
