### PR TITLE
[raft] add metrics for nodehost.SyncPropose errors

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -182,6 +182,9 @@ const (
 	// The type of nodehost method: "SyncPropose", "SyncRead"
 	RaftNodeHostMethodLabel = "nodehost_method"
 
+	// The error returned by dragonboat library
+	RaftDragonboatError = "dragonboat_error"
+
 	// The ID of a raft client session
 	RaftSessionIDLabel = "session_id"
 
@@ -2440,6 +2443,16 @@ var (
 	}, []string{
 		RaftSessionIDLabel,
 		RaftRangeIDLabel,
+	})
+
+	RaftNodeHostMethodErrorCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "nodehost_method_errors",
+		Help:      "The total number of nodehost method",
+	}, []string{
+		RaftNodeHostMethodLabel,
+		RaftDragonboatError,
 	})
 
 	RaftNodeHostMethodDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
This metric can help us understand the health at the dragonboat library. For
example, if we get a lot of timeout errors, we know that dragonboat is
overloaded. This can be helpful in understanding latency/performance issues.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/3745
