### PR TITLE
[raft] add traces around nodeliveness

### DIFF
--- a/enterprise/server/raft/nodeliveness/BUILD
+++ b/enterprise/server/raft/nodeliveness/BUILD
@@ -15,7 +15,9 @@ go_library(
         "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
+        "//server/util/tracing",
         "@com_github_hashicorp_serf//serf",
+        "@io_opentelemetry_go_otel//codes",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -124,7 +124,15 @@ func (l *Lease) GetRangeDescriptor() *rfpb.RangeDescriptor {
 	return l.rangeDescriptor
 }
 
-func (l *Lease) verifyLease(ctx context.Context, rl *rfpb.RangeLeaseRecord) error {
+func (l *Lease) verifyLease(ctx context.Context, rl *rfpb.RangeLeaseRecord) (returnedErr error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer func() {
+		if returnedErr != nil {
+			span.RecordError(returnedErr)
+			span.SetStatus(codes.Error, returnedErr.Error())
+		}
+		span.End()
+	}()
 	if rl == nil {
 		return status.FailedPreconditionError("Invalid rangeLease: nil")
 	}


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4528

Add more traces in the Lease flow, in particular capture errors returned by
verifyLease.
