### PR TITLE
[raft] add range descriptor from meta range in debug info

### DIFF
--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -634,6 +634,7 @@ message GetRangeDebugInfoRequest {
 message GetRangeDebugInfoResponse {
   string nhid = 1;
   RangeDescriptor range_descriptor = 2;
+  RangeDescriptor range_descriptor_in_meta_range = 6;
   RaftLeaderInfo leader = 3;
   bool has_lease = 4;
   RaftMembership membership = 5;


### PR DESCRIPTION
Currently, the range descriptor returned by GetRangeDebugInfo is from
openRanges. If a range descriptor is missing from openRanges, it doesn't
necessarily mean it doesn't exist in meta range. To answer this question, I want
to have a seperate field that read directly from meta range.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4526
