### PR TITLE
When firecracker times out waiting for the machine to start, include …

### DIFF
--- a/buildpatches/com_github_firecracker_microvm_firecracker_go_sdk_waitforsocketdebug.patch
+++ b/buildpatches/com_github_firecracker_microvm_firecracker_go_sdk_waitforsocketdebug.patch
@@ -1,0 +1,37 @@
+diff --git a/machine.go b/machine.go
+index a812b98..22ee018 100644
+--- a/machine.go
++++ b/machine.go
+@@ -1061,7 +1061,7 @@ func (m *Machine) refreshMachineConfiguration() error {
+ 
+ // waitForSocket waits for the given file to exist
+ func (m *Machine) waitForSocket(timeout time.Duration, exitchan chan error) error {
+-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
++	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Millisecond)
+ 
+ 	ticker := time.NewTicker(10 * time.Millisecond)
+ 
+@@ -1070,19 +1070,22 @@ func (m *Machine) waitForSocket(timeout time.Duration, exitchan chan error) erro
+ 		ticker.Stop()
+ 	}()
+ 
++	var lastErr error
+ 	for {
+ 		select {
+ 		case <-ctx.Done():
+-			return ctx.Err()
++			return errors.Join(ctx.Err(), lastErr)
+ 		case err := <-exitchan:
+ 			return err
+ 		case <-ticker.C:
+ 			if _, err := os.Stat(m.Cfg.SocketPath); err != nil {
++				lastErr = err
+ 				continue
+ 			}
+ 
+ 			// Send test HTTP request to make sure socket is available
+ 			if _, err := m.client.GetMachineConfiguration(); err != nil {
++				lastErr = err
+ 				continue
+ 			}
+ 

--- a/deps.bzl
+++ b/deps.bzl
@@ -1509,6 +1509,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
             # TODO: this PR only includes the CgroupArgs part of the patch.
             # Need another PR for the ParentCgroup part.
             "@{}//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_cgroup.patch".format(workspace_name),
+            # TODO(vanja) remove this if it doesn't help with debugging waitForSocket timeouts.
+            "@{}//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_waitforsocketdebug.patch".format(workspace_name),
         ],
         sum = "h1:n9Q3BKnUAW0x1D1x2I2QIj0T/5K6UYL6JKkPvwwARw0=",
         version = "v0.0.0-20241028184712-f74f43bb036d",


### PR DESCRIPTION
…the last error in the failure

This is a patch to the firecracker Go SDK. I'm not really sure if this will help with debugging these failures, but I think it's worth a shot.