### PR TITLE
    gosdk: upgrade to 1.24.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,7 +77,7 @@ bazel_dep(name = "aspect_rules_js", version = "2.1.3")
 bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.23.6")
+go_sdk.download(version = "1.24.1")
 go_sdk.nogo(nogo = "@//:vet")
 use_repo(
     go_sdk,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -190,7 +190,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_nogo", "
 
 go_rules_dependencies()
 
-GO_SDK_VERSION = "1.23.6"
+GO_SDK_VERSION = "1.24.1"
 
 # Register multiple Go SDKs so that we can perform cross-compilation remotely.
 # i.e. We might want to trigger a Linux AMD64 Go build remotely from a MacOS ARM64 laptop.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbuddy-io/buildbuddy
 
-go 1.23.6
+go 1.24.1
 
 replace (
 	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.7.0-buildbuddy // keep in sync with buildpatches/com_github_awslabs_soci_snapshotter.patch


### PR DESCRIPTION
This contains a fix that broke our build previously on 1.24.0

References:
- https://tip.golang.org/doc/go1.24
- https://github.com/golang/go/issues?q=milestone%3AGo1.24.1+label%3ACherryPickApproved

