### PR TITLE
windows: upgrade msvc version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,12 +26,12 @@ buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbudd
 buildbuddy.platform(buildbuddy_container_image = "UBUNTU20_04_IMAGE")
 buildbuddy.msvc_toolchain(
     # This is the MSVC available on Github Action win22 image
-    # https://github.com/actions/runner-images/blob/win22/20250127.1/images/windows/Windows2022-Readme.md
+    # https://github.com/actions/runner-images/blob/win22/20250303.1/images/windows/Windows2022-Readme.md
     msvc_edition = "Enterprise",
     msvc_release = "2022",
     # From 'Microsoft Visual C++ 2022 Minimum Runtime' for x64 architecture
-    # https://github.com/actions/runner-images/blob/win22/20250127.1/images/windows/Windows2022-Readme.md#microsoft-visual-c
-    msvc_version = "14.42.34433",
+    # https://github.com/actions/runner-images/blob/win22/20250303.1/images/windows/Windows2022-Readme.md#microsoft-visual-c
+    msvc_version = "14.43.34808",
 )
 
 switched_rules = use_extension("@googleapis//:extensions.bzl", "switched_rules")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -558,12 +558,12 @@ buildbuddy(
     name = "buildbuddy_toolchain",
     container_image = UBUNTU20_04_IMAGE,
     # This is the MSVC available on Github Action win22 image
-    # https://github.com/actions/runner-images/blob/win22/20250127.1/images/windows/Windows2022-Readme.md
+    # https://github.com/actions/runner-images/blob/win22/20250303.1/images/windows/Windows2022-Readme.md
     msvc_edition = "Enterprise",
     msvc_release = "2022",
     # From 'Microsoft Visual C++ 2022 Minimum Runtime' for x64 architecture
-    # https://github.com/actions/runner-images/blob/win22/20250127.1/images/windows/Windows2022-Readme.md#microsoft-visual-c
-    msvc_version = "14.42.34433",
+    # https://github.com/actions/runner-images/blob/win22/20250303.1/images/windows/Windows2022-Readme.md#microsoft-visual-c
+    msvc_version = "14.43.34808",
 )
 
 http_archive(


### PR DESCRIPTION
Note: the msvc version in Github's documentation is incorrect.
Reported via https://github.com/actions/runner-images/issues/11730
