### PR TITLE
Log the error from umount when it fails in the background

### DIFF
--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -145,7 +145,6 @@ func (f *FS) Unmount(ctx context.Context) error {
 				log.CtxInfof(ctx, "Unmounted %s in the background, even after the context was canceled", f.mountPath)
 			}
 		}
-		resultCh <- f.unmount(ctx)
 		close(resultCh)
 	}()
 	select {

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -130,6 +130,7 @@ func (f *FS) Unmount(ctx context.Context) error {
 	// Log an error if this happens, since this is a goroutine leak.
 	resultCh := make(chan error)
 	go func() {
+		defer close(resultCh)
 		err := f.unmount(ctx)
 		select {
 		case resultCh <- err:
@@ -142,7 +143,6 @@ func (f *FS) Unmount(ctx context.Context) error {
 				log.CtxInfof(ctx, "Unmounted %s in the background, even after the context was canceled", f.mountPath)
 			}
 		}
-		close(resultCh)
 	}()
 	select {
 	case err := <-resultCh:

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -128,9 +128,25 @@ func (f *FS) Unmount(ctx context.Context) error {
 	// Unmount in the background to prevent tasks from being blocked if it
 	// hangs forever.
 	// Log an error if this happens, since this is a goroutine leak.
-	resultCh := make(chan error, 1)
+	resultCh := make(chan error, 0)
 	go func() {
+		err := f.unmount(ctx)
+		select {
+		case resultCh <- err:
+			if err != nil {
+				log.CtxErrorf(ctx, "Failed to unmount %s: %s", f.mountPath, err)
+			} else {
+				log.CtxDebugf(ctx, "Unmounted %s", f.mountPath)
+			}
+		default:
+			if err != nil {
+				log.CtxErrorf(ctx, "Failed to unmount %s in the background after context was cancelled: %s", f.mountPath, err)
+			} else {
+				log.CtxInfof(ctx, "Unmounted %s in the background, even after the context was canceled", f.mountPath)
+			}
+		}
 		resultCh <- f.unmount(ctx)
+		close(resultCh)
 	}()
 	select {
 	case err := <-resultCh:
@@ -159,7 +175,7 @@ func (f *FS) unmount(ctx context.Context) error {
 		// If we successfully unmounted, then the mount path should point to
 		// an empty dir. Remove it.
 		if err := os.Remove(f.mountPath); err != nil {
-			log.CtxErrorf(ctx, "Failed to unmount vbd: %s", err)
+			log.CtxErrorf(ctx, "Failed to remove vbd mount path %s: %s", f.mountPath, err)
 		}
 	}
 	if err := os.Remove(f.lockFile.Name()); err != nil {
@@ -167,11 +183,6 @@ func (f *FS) unmount(ctx context.Context) error {
 	}
 	if err := f.lockFile.Close(); err != nil {
 		log.CtxErrorf(ctx, "Failed to unlock vbd lock file: %s", err)
-	}
-	if ctx.Err() != nil {
-		log.CtxInfof(ctx, "Unmounted %s in the background, even after the context was canceled", f.mountPath)
-	} else {
-		log.CtxDebugf(ctx, "Unmounted %s", f.mountPath)
 	}
 	return err
 }

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -133,12 +133,16 @@ func (f *FS) Unmount(ctx context.Context) error {
 		err := f.unmount(ctx)
 		select {
 		case resultCh <- err:
+			// Since resultCh is unbuffered, this only happens when the outer
+			// function received from the channel and will return this err.
 			if err != nil {
 				log.CtxErrorf(ctx, "Failed to unmount %s: %s", f.mountPath, err)
 			} else {
 				log.CtxDebugf(ctx, "Unmounted %s", f.mountPath)
 			}
 		default:
+			// Nobodoy is listening on resultCh, which means the context
+			// expired.
 			if err != nil {
 				log.CtxErrorf(ctx, "Failed to unmount %s in the background after context was cancelled: %s", f.mountPath, err)
 			} else {

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -135,14 +135,7 @@ func (f *FS) Unmount(ctx context.Context) error {
 		case resultCh <- err:
 			// Since resultCh is unbuffered, this only happens when the outer
 			// function received from the channel and will return this err.
-			if err != nil {
-				log.CtxErrorf(ctx, "Failed to unmount %s: %s", f.mountPath, err)
-			} else {
-				log.CtxDebugf(ctx, "Unmounted %s", f.mountPath)
-			}
-		default:
-			// Nobodoy is listening on resultCh, which means the context
-			// expired.
+		case <-ctx.Done():
 			if err != nil {
 				log.CtxErrorf(ctx, "Failed to unmount %s in the background after context was cancelled: %s", f.mountPath, err)
 			} else {

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -128,7 +128,7 @@ func (f *FS) Unmount(ctx context.Context) error {
 	// Unmount in the background to prevent tasks from being blocked if it
 	// hangs forever.
 	// Log an error if this happens, since this is a goroutine leak.
-	resultCh := make(chan error, 0)
+	resultCh := make(chan error)
 	go func() {
 		err := f.unmount(ctx)
 		select {


### PR DESCRIPTION
Previously, we logged `Unmounted %s in the background, even after the context was canceled`, even if the `f.server.Unmount()` call failed.

Also, there was a logging only race, where the context wouldn't be expired in the child goroutine, so it wouldn't log anything, and then it would be expired in the parent goroutine, which would indicate that we might unmount in the background.