### PR TITLE
[raft] rename LocalSessionPrefix to SessionPrefix

### DIFF
--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -70,6 +70,7 @@ var (
 	// descriptors.
 	SystemPrefix = keys.Key{systemPrefixByte}
 
+	// System Keys:
 	// The last replicaID that was generated.
 	LastReplicaIDKey = keys.MakeKey(SystemPrefix, []byte("last_replica_id"))
 
@@ -82,6 +83,10 @@ var (
 	// transaction entries written by replicas when preparing the transactions.
 	TxnRecordPrefix = keys.MakeKey(SystemPrefix, []byte("txn-record-"))
 
+	// A prefix to prepend to session keys
+	SessionPrefix = keys.MakeKey(SystemPrefix, []byte("session-"))
+
+	// Local Keys:
 	// When the cluster was created.
 	ClusterSetupTimeKey = keys.MakeKey(LocalPrefix, []byte("cluster_setup_time"))
 
@@ -100,9 +105,6 @@ var (
 
 	// A prefix to prepend to transactions.
 	LocalTransactionPrefix = keys.MakeKey(LocalPrefix, []byte("txn-"))
-
-	// A prefix to prepend to session keys
-	LocalSessionPrefix = keys.MakeKey(SystemPrefix, []byte("session-"))
 )
 
 // Error constants -- sender recognizes these errors.

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1217,7 +1217,7 @@ func (sm *Replica) updateAtime(wb pebble.Batch, req *rfpb.UpdateAtimeRequest) (*
 }
 
 func (sm *Replica) deleteSessions(wb pebble.Batch, req *rfpb.DeleteSessionsRequest) (*rfpb.DeleteSessionsResponse, error) {
-	start, end := keys.Range(sm.replicaLocalKey(constants.LocalSessionPrefix))
+	start, end := keys.Range(sm.replicaLocalKey(constants.SessionPrefix))
 	iterOpts := &pebble.IterOptions{
 		UpperBound: end,
 	}
@@ -1413,7 +1413,7 @@ func (sm *Replica) getLastRespFromSession(db ReplicaReader, reqSession *rfpb.Ses
 	if reqSession == nil {
 		return nil, nil
 	}
-	sessionKey := keys.MakeKey(constants.LocalSessionPrefix, reqSession.GetId())
+	sessionKey := keys.MakeKey(constants.SessionPrefix, reqSession.GetId())
 	buf, err := sm.lookup(db, sessionKey)
 	if err != nil {
 		if status.IsNotFoundError(err) {
@@ -1466,7 +1466,7 @@ func (sm *Replica) updateSession(wb pebble.Batch, reqSession *rfpb.Session, rspB
 	if err != nil {
 		return status.InternalErrorf("[%s] failed to marshal session: %s", sm.name(), err)
 	}
-	sessionKey := keys.MakeKey(constants.LocalSessionPrefix, reqSession.GetId())
+	sessionKey := keys.MakeKey(constants.SessionPrefix, reqSession.GetId())
 	wb.Set(sm.replicaLocalKey(sessionKey), sessionBuf, nil)
 	return nil
 }

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -728,7 +728,7 @@ func TestApplySnapshotEntriesDeleted(t *testing.T) {
 	fr1 := rt.writeRandom(header, defaultPartition, 1000)
 	fr2 := rt.writeRandom(header, defaultPartition, 1000)
 
-	localSessionKey := keys.MakeKey(constants.LocalSessionPrefix, []byte("abcd"))
+	localSessionKey := keys.MakeKey(constants.SessionPrefix, []byte("abcd"))
 
 	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
@@ -1490,7 +1490,7 @@ func TestDeleteSessions(t *testing.T) {
 		require.NoError(t, err)
 	}
 	// Verify that session 1 is deleted and session 2 is not
-	start, end := keys.Range(constants.LocalSessionPrefix)
+	start, end := keys.Range(constants.SessionPrefix)
 	buf, err := rbuilder.NewBatchBuilder().Add(&rfpb.ScanRequest{
 		Start:    start,
 		End:      end,

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -747,7 +747,7 @@ func TestManySplits(t *testing.T) {
 
 func readSessionIDs(t *testing.T, ctx context.Context, rangeID uint64, store *testutil.TestingStore) []string {
 	rd := store.GetRange(rangeID)
-	start, end := keys.Range(constants.LocalSessionPrefix)
+	start, end := keys.Range(constants.SessionPrefix)
 	req, err := rbuilder.NewBatchBuilder().Add(&rfpb.ScanRequest{
 		Start:    start,
 		End:      end,


### PR DESCRIPTION
because the session key uses system prefix instead of local prefix
