### PR TITLE
Fix race condition in //enterprise/server/raft/store:store_test

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -647,10 +647,13 @@ func (s *Store) Start() error {
 		s.replicaJanitor.Start(s.egCtx)
 		return nil
 	})
-	s.eg.Go(func() error {
-		s.checkIfReplicasNeedSplitting(s.egCtx)
-		return nil
-	})
+
+	if maxRangeSizeBytes := raftConfig.MaxRangeSizeBytes(); maxRangeSizeBytes != 0 {
+		s.eg.Go(func() error {
+			s.checkIfReplicasNeedSplitting(s.egCtx, maxRangeSizeBytes)
+			return nil
+		})
+	}
 	s.eg.Go(func() error {
 		s.updateStoreUsageTag(s.egCtx)
 		return nil
@@ -1790,10 +1793,7 @@ func (j *replicaJanitor) removeZombie(ctx context.Context, task zombieCleanupTas
 	return zombieCleanupNoAction, nil
 }
 
-func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context) {
-	if raftConfig.MaxRangeSizeBytes() == 0 {
-		return
-	}
+func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context, maxRangeSizeBytes int64) {
 	eventsCh := s.AddEventListener()
 	for {
 		select {
@@ -1814,7 +1814,7 @@ func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context) {
 				if !s.leaseKeeper.HaveLease(ctx, rangeID) {
 					continue
 				}
-				if estimatedDiskBytes < raftConfig.MaxRangeSizeBytes() {
+				if estimatedDiskBytes < maxRangeSizeBytes {
 					continue
 				}
 				repl, err := s.GetReplica(rangeID)

--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -191,9 +191,9 @@ func (ts *TestingStore) Stop() {
 	ctx := context.Background()
 	ctx, cancelFn := context.WithTimeout(ctx, 3*time.Second)
 	defer cancelFn()
-	ts.Store.Stop(ctx)
-	ts.gm.Leave()
-	ts.gm.Shutdown()
+	require.NoError(ts.t, ts.Store.Stop(ctx))
+	require.NoError(ts.t, ts.gm.Leave())
+	require.NoError(ts.t, ts.gm.Shutdown())
 	ts.closed = true
 }
 


### PR DESCRIPTION
Example failure: https://buildbuddy.buildbuddy.io/invocation/1ea34ada-e298-4e8a-98f6-2aebc76fdb4a?target=%2F%2Fenterprise%2Fserver%2Fraft%2Fstore%3Astore_test&targetStatus=6#@31

I also added checks for errors in TestingStore.Close()