### PR TITLE
Apply env overrides when retrying manually dispatched workflows

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,10 +1,4 @@
 actions:
-  - name: Maggie
-    container_image: ubuntu-20.04
-    steps:
-      - run: echo $K
-    env:
-      K: V
   - name: Test
     container_image: ubuntu-20.04
     triggers:

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,4 +1,10 @@
 actions:
+  - name: Maggie
+    container_image: ubuntu-20.04
+    steps:
+      - run: echo $K
+    env:
+      K: V
   - name: Test
     container_image: ubuntu-20.04
     triggers:


### PR DESCRIPTION
If you execute a workflow from the API, you can override any env vars that were set in your workflow config. We weren't correctly applying these in the workflow retry button

Fixes https://github.com/buildbuddy-io/buildbuddy/issues/8557