### PR TITLE
Fix race condition in `bazelisk.Run`

### DIFF
--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -50,7 +50,8 @@ func Run(args []string, opts *RunOpts) (exitCode int, err error) {
 		defer close()
 	}
 	if opts.Stderr != nil {
-		close, err := redirectStdio(opts.Stderr, &os.Stderr)
+		errRedirect := &os.Stderr
+		close, err := redirectStdio(opts.Stderr, errRedirect)
 		if err != nil {
 			return -1, err
 		}
@@ -58,7 +59,7 @@ func Run(args []string, opts *RunOpts) (exitCode int, err error) {
 
 		// Prevent Bazelisk `log.Printf` call to write directly to stderr
 		oldWriter := goLog.Writer()
-		goLog.SetOutput(opts.Stderr)
+		goLog.SetOutput(*errRedirect)
 		defer goLog.SetOutput(oldWriter)
 	}
 	return core.RunBazelisk(args, repos)


### PR DESCRIPTION
Fixes a race condition that occurred when passing a buffer to replace stderr in `bazelisk.Run`. Previously, both the goroutine that redirected stderr and the `goLog` had access to the (non-threadsafe) underlying writer and could attempt to write to it in two separate threads. This PR replaces the bare pointer to the writer being passed to `goLog` with the `PipeWriter` we put in front of it, preventing the race condition.
