### PR TITLE
Fix race condition in `bazelisk.Run` when redirecting both stderr and stdout to the same buffer

### DIFF
--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//cli/cli_command",
         "//cli/parser",
         "//cli/version",
-        "//server/util/lockingbuffer",
     ],
 )
 

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -1,6 +1,7 @@
 package help
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/cli_command"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/version"
-	"github.com/buildbuddy-io/buildbuddy/server/util/lockingbuffer"
 )
 
 const (
@@ -68,7 +68,7 @@ func showHelp(subcommand string, modifiers []string) (exitCode int, err error) {
 		bazelArgs = append(bazelArgs, subcommand)
 	}
 	bazelArgs = append(bazelArgs, modifiers...)
-	buf := lockingbuffer.New()
+	buf := &bytes.Buffer{}
 	exitCode, err = bazelisk.Run(bazelArgs, &bazelisk.RunOpts{Stdout: buf, Stderr: buf})
 	if err != nil {
 		io.Copy(os.Stdout, buf)


### PR DESCRIPTION
This fixes a race condition `bazelisk.Run` where if both the out and err buffers were the same, two pipes pointing to the same buffer were created with accompanying goroutines, and the buffer could thus be accessed in two different goroutines. This solves the problem by checking to see if the buffer is the same between both out and err, and then creating only one pipe if it is. This was previously sidestepped in `cli/help/help.go` by passing a `lockingbuffer`, but that requirement is undocumented, and it seems that removing the possibility of the race condition is likely better than documenting such a requirement for future ease of use.
