### PR TITLE
[SS] Disable balloon for non-workflows

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2905,6 +2905,10 @@ func (c *FirecrackerContainer) VMConfig() *fcpb.VMConfiguration {
 }
 
 func (c *FirecrackerContainer) isBalloonEnabled() bool {
+	// The balloon is intended to reduce memory snapshot size. If recycling is not
+	// enabled and we don't plan to generate a snapshot, don't enable it.
+	// Also disable the balloon for firecracker actions with local-only-snapshot-sharing
+	// (i.e. not workflows), as there seems to be negative performance implications.
 	return *snaputil.EnableBalloon && c.recyclingEnabled && c.supportsRemoteSnapshots
 }
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2905,7 +2905,7 @@ func (c *FirecrackerContainer) VMConfig() *fcpb.VMConfiguration {
 }
 
 func (c *FirecrackerContainer) isBalloonEnabled() bool {
-	return *snaputil.EnableBalloon && c.recyclingEnabled
+	return *snaputil.EnableBalloon && c.recyclingEnabled && c.supportsRemoteSnapshots
 }
 
 // machineHasBalloon returns whether a balloon was initialized in a machine.


### PR DESCRIPTION
Prior to enabling the balloon, there were consistently `failed to sync workspace: failed to connect to VM: context deadline exceeded` errors in [executor-workflow](https://console.cloud.google.com/logs/query;query=%22failed%20to%20connect%20to%20VM:%20context%20deadline%20exceeded%22%0Alabels.%22k8s-pod%2Fapp%22%3D%22executor-workflows%22%0Aresource.labels.namespace_name%3D%22executor-prod%22;summaryFields=:false:32:beginning;lfeCustomFields=resource%252Flabels%252Fzone,jsonPayload%252Fkubernetes%252Flabels%252Fapp;cursorTimestamp=2025-03-06T21:26:22.498634932Z;duration=P7D?project=flame-build), but not in `executor` in both [cloud](https://console.cloud.google.com/logs/query;query=%22failed%20to%20connect%20to%20VM:%20context%20deadline%20exceeded%22%0Alabels.%22k8s-pod%2Fapp%22%3D%22executor%22%0Aresource.labels.namespace_name%3D%22executor-prod%22;summaryFields=:false:32:beginning;lfeCustomFields=resource%252Flabels%252Fzone,jsonPayload%252Fkubernetes%252Flabels%252Fapp;cursorTimestamp=2025-03-06T21:26:22.498634932Z;duration=P7D?project=flame-build) and [SJC](https://console.cloud.google.com/logs/query;query=%22failed%20to%20connect%20to%20VM:%20context%20deadline%20exceeded%22%0Aresource.labels.zone%3D%22us-sjc%22;summaryFields=:false:32:beginning;lfeCustomFields=resource%252Flabels%252Fzone,jsonPayload%252Fkubernetes%252Flabels%252Fapp;cursorTimestamp=2025-03-06T21:26:22.498634932Z;duration=P7D?project=flame-build). 

After enabling the balloon, there are fewer errors in `executor-workflows`, but errors occur in `executor` in both cloud and SJC. 

Disable the balloon for non-workflow firecracker actions