### PR TITLE
add a counter metric for filecache writes

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -378,7 +378,7 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 	}
 	metrics.FileCacheAddedFileSizeBytes.Observe(float64(e.sizeBytes))
 	metrics.FileCacheAddedFileBytesCount.With(prometheus.Labels{
-		metrics.GroupID:        groupID,
+		metrics.GroupID: groupID,
 	}).Add(float64(e.sizeBytes))
 	success := c.l.Add(k, e)
 	if !success {

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -377,6 +377,9 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 		sizeBytes:   sizeOnDisk,
 	}
 	metrics.FileCacheAddedFileSizeBytes.Observe(float64(e.sizeBytes))
+	metrics.FileCacheAddedFileBytesCount.With(prometheus.Labels{
+		metrics.GroupID:        groupID,
+	}).Add(float64(e.sizeBytes))
 	success := c.l.Add(k, e)
 	if !success {
 		return status.InternalErrorf("could not add key %s to filecache lru", k)

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1513,6 +1513,15 @@ var (
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 40),
 	})
 
+	FileCacheAddedFileBytesCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "blobstore",
+		Name:      "read_count",
+		Help:      "Total number of bytes written to the filecache by groupid.",
+	}, []string{
+		GroupID,
+	})
+
 	// ## Blobstore metrics
 	//
 	// "Blobstore" refers to the backing storage that BuildBuddy uses to

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1515,8 +1515,8 @@ var (
 
 	FileCacheAddedFileBytesCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
-		Subsystem: "blobstore",
-		Name:      "read_count",
+		Subsystem: "remote_execution",
+		Name:      "file_cache_added_file_bytes_count",
 		Help:      "Total number of bytes written to the filecache by groupid.",
 	}, []string{
 		GroupID,


### PR DESCRIPTION
so that we can tell how much _more_ disk we're using when we enable storing treecache data in the filecache.

the current metric is just a bucketed histogram and is kind of a pain to read.  if you'd rather that we just have the one metric, i can make do.