### PR TITLE
kythe: use rbe instead of local exec

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -187,7 +187,9 @@ fi`, dirName, downloadURL)
 func buildWithKythe(dirName string) string {
 	buildFlags := []string{
 		"--remote_download_minimal",
-		"--experimental_remote_cache_ttl=10000d", // Workaround until Bazel 8.2.0 is released
+		// Workaround until Bazel 8.2.0 is released with this fix:
+		//   https://github.com/bazelbuild/bazel/pull/25398
+		"--experimental_remote_cache_ttl=10000d",
 		`--remote_download_regex='.*\.kzip$'`,
 		"--config=buildbuddy_bes_backend",
 		"--config=buildbuddy_bes_results_url",

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -185,10 +185,24 @@ fi`, dirName, downloadURL)
 }
 
 func buildWithKythe(dirName string) string {
-	bazelConfigFlags := `--config=buildbuddy_bes_backend --config=buildbuddy_bes_results_url`
+	// The ordering of these `--config=` flags is important here because `remote-minimal`
+	// could have included it's own BES/Cache/Executor backend so we want to override
+	// those with the ones provided in `buildbuddy.bazelrc` by keeping the `buildbuddy_`
+	// configs last.
 	return fmt.Sprintf(`
 export KYTHE_DIR="$BUILDBUDDY_CI_RUNNER_ROOT_DIR"/%s
-bazel --bazelrc="$KYTHE_DIR"/extractors.bazelrc build --override_repository kythe_release="$KYTHE_DIR" %s //...`, dirName, bazelConfigFlags)
+bazel \
+	--bazelrc="$KYTHE_DIR"/extractors.bazelrc \
+	build \
+	--override_repository=kythe_release="$KYTHE_DIR" \
+	--config=remote-minimal \
+	--remote_download_regex='.*\.kzip$' \
+	--config=buildbuddy_bes_backend \
+	--config=buildbuddy_bes_results_url \
+	--config=buildbuddy_remote_cache \
+	--config=buildbuddy_experimental_remote_downloader \
+	--config=buildbuddy_remote_executor \
+	//...`, dirName)
 }
 
 func prepareKytheOutputs(dirName string) string {
@@ -225,9 +239,7 @@ func KytheIndexingAction(targetRepoDefaultBranch string) *Action {
 		},
 		ContainerImage: `ubuntu-20.04`,
 		ResourceRequests: ResourceRequests{
-			CPU:    "24",   // 24 BCU
-			Memory: "60GB", // 24 BCU
-			Disk:   "100GB",
+			Disk: "100GB",
 		},
 		Steps: []*rnpb.Step{
 			{

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -185,6 +185,15 @@ fi`, dirName, downloadURL)
 }
 
 func buildWithKythe(dirName string) string {
+	buildFlags := []string{
+		"--remote_download_minimal",
+		"--experimental_remote_cache_ttl=10000d", // Workaround until Bazel 8.2.0 is released
+		`--remote_download_regex='.*\.kzip$'`,
+		"--config=buildbuddy_bes_backend",
+		"--config=buildbuddy_bes_results_url",
+		"--config=buildbuddy_experimental_remote_downloader",
+		"--config=buildbuddy_remote_executor",
+	}
 	// The ordering of these `--config=` flags is important here because `remote-minimal`
 	// could have included it's own BES/Cache/Executor backend so we want to override
 	// those with the ones provided in `buildbuddy.bazelrc` by keeping the `buildbuddy_`
@@ -195,14 +204,8 @@ bazel \
 	--bazelrc="$KYTHE_DIR"/extractors.bazelrc \
 	build \
 	--override_repository=kythe_release="$KYTHE_DIR" \
-	--config=remote-minimal \
-	--remote_download_regex='.*\.kzip$' \
-	--config=buildbuddy_bes_backend \
-	--config=buildbuddy_bes_results_url \
-	--config=buildbuddy_remote_cache \
-	--config=buildbuddy_experimental_remote_downloader \
-	--config=buildbuddy_remote_executor \
-	//...`, dirName)
+	%s \
+	//...`, dirName, strings.Join(buildFlags, " "))
 }
 
 func prepareKytheOutputs(dirName string) string {


### PR DESCRIPTION
Switch to use `--config=remote-minimal` with a regex to download all
kzip files to help save local resources.
