### PR TITLE
[raft] store last replica id per range

### DIFF
--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -72,10 +72,10 @@ var (
 
 	// System Keys:
 	// The last replicaID that was generated.
-	LastReplicaIDKey = keys.MakeKey(SystemPrefix, []byte("last_replica_id"))
+	LastReplicaIDKeyPrefix = keys.MakeKey(SystemPrefix, []byte("last_replica_id"))
 
 	// The last rangeID that was generated.
-	LastRangeIDKey = keys.MakeKey(SystemPrefix, []byte("last_range_id"))
+	LastRangeIDKey = keys.MakeKey(SystemPrefix, []byte("last_range_id-"))
 
 	// A prefix to prepend to transaction records. Transaction Records were written
 	// by the transaction coordinator when the transaction state changes. They

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -238,10 +238,10 @@ func TestAutomaticSplitting(t *testing.T) {
 	mrd := s1.GetRange(1)
 	for {
 		ranges := fetchRangeDescriptorsFromMetaRange(ctx, t, s1, mrd)
-		if len(ranges) == 2 && s1.HaveLease(ctx, 4) {
+		if len(ranges) == 2 && s1.HaveLease(ctx, 3) {
 			rd2 := s1.GetRange(2)
-			rd4 := s1.GetRange(4)
-			if !bytes.Equal(rd2.GetEnd(), keys.MaxByte) && bytes.Equal(rd4.GetEnd(), keys.MaxByte) {
+			rd3 := s1.GetRange(3)
+			if !bytes.Equal(rd2.GetEnd(), keys.MaxByte) && bytes.Equal(rd3.GetEnd(), keys.MaxByte) {
 				break
 			}
 		}
@@ -559,8 +559,8 @@ func TestSplitNonMetaRange(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	s = testutil.GetStoreWithRangeLease(t, ctx, stores, 4)
-	rd = s.GetRange(4)
+	s = testutil.GetStoreWithRangeLease(t, ctx, stores, 3)
+	rd = s.GetRange(3)
 	// Veirfy that nhid in the rangea descriptor matches the registry.
 	for _, repl := range rd.GetReplicas() {
 		nhid, _, err := sf.Registry().ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
@@ -570,9 +570,9 @@ func TestSplitNonMetaRange(t *testing.T) {
 	header = headerFromRangeDescriptor(rd)
 	require.Equal(t, 3, len(rd.GetReplicas()))
 
-	// Expect that a new cluster was added with rangeID = 4
+	// Expect that a new cluster was added with rangeID = 3
 	// having 3 replicas.
-	replicas := getMembership(t, s1, ctx, 4)
+	replicas := getMembership(t, s1, ctx, 3)
 	require.Equal(t, 3, len(replicas))
 
 	// Check that all files are still found.
@@ -588,11 +588,11 @@ func TestSplitNonMetaRange(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	testutil.WaitForRangeLease(t, ctx, stores, 5)
+	testutil.WaitForRangeLease(t, ctx, stores, 4)
 
-	// Expect that a new cluster was added with rangeID = 5
+	// Expect that a new cluster was added with rangeID = 4
 	// having 3 replicas.
-	replicas = getMembership(t, s1, ctx, 5)
+	replicas = getMembership(t, s1, ctx, 4)
 	require.Equal(t, 3, len(replicas))
 
 	// Check that all files are found.
@@ -643,7 +643,7 @@ func TestPostFactoSplit(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expect that a new cluster was added with a replica.
-	replicas := getMembership(t, s1, ctx, 4)
+	replicas := getMembership(t, s1, ctx, 3)
 	require.Equal(t, 1, len(replicas))
 
 	// Check that all files are found.
@@ -879,6 +879,12 @@ func TestSplitAcrossClusters(t *testing.T) {
 			Key:   keys.RangeMetaKey(initialRD.GetEnd()),
 			Value: protoBytes,
 		},
+	}).Add(&rfpb.IncrementRequest{
+		Key:   constants.LastRangeIDKey,
+		Delta: uint64(1),
+	}).Add(&rfpb.IncrementRequest{
+		Key:   keys.MakeKey(constants.LastReplicaIDKeyPrefix, []byte("2")),
+		Delta: uint64(1),
 	}).ToProto()
 	require.NoError(t, err)
 


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4546

Also, make it so that we don't skip range 3. 