### PR TITLE
pebble: add test to validate revert after ratchet

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -85,7 +85,7 @@ var (
 	evictionRateLimit         = flag.Int("cache.pebble.eviction_rate_limit", 300, "Maximum number of entries to evict per second (per partition).")
 	includeMetadataSize       = flag.Bool("cache.pebble.include_metadata_size", false, "If true, include metadata size")
 	enableTableBloomFilter    = flag.Bool("cache.pebble.enable_table_bloom_filter", true, "If true, write bloom filter data with pebble SSTables.")
-	enableAutoRachet          = flag.Bool("cache.pebble.enable_auto_rachet", false, "If true, automatically upgrade on-disk format to latest version.")
+	enableAutoRatchet         = flag.Bool("cache.pebble.enable_auto_ratchet", false, "If true, automatically upgrade on-disk format to latest version.")
 
 	activeKeyVersion  = flag.Int64("cache.pebble.active_key_version", int64(filestore.UnspecifiedKeyVersion), "The key version new data will be written with. If negative, will write to the highest existing version in the database, or the highest known version if a new database is created.")
 	migrationQPSLimit = flag.Int("cache.pebble.migration_qps_limit", 50, "QPS limit for data version migration")
@@ -493,7 +493,7 @@ func defaultPebbleOptions(mc *pebble.MetricsCollector) *pebble.Options {
 			},
 		}
 	}
-	if *enableAutoRachet {
+	if *enableAutoRatchet {
 		opts.FormatMajorVersion = pebble.FormatNewest
 	}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3018,8 +3018,8 @@ func TestSampling(t *testing.T) {
 	}
 }
 
-func TestRachetDB(t *testing.T) {
-	flags.Set(t, "cache.pebble.enable_auto_rachet", true)
+func TestRatchetDB(t *testing.T) {
+	flags.Set(t, "cache.pebble.enable_auto_ratchet", true)
 	rootDir := testfs.MakeTempDir(t)
 
 	// Init DB with default format
@@ -3042,7 +3042,7 @@ func TestRachetDB(t *testing.T) {
 	require.NoError(t, err)
 	desc, err := pebble.Peek(rootDir, vfs.Default)
 	require.NoError(t, err)
-	require.Equal(t, pebble.FormatNewest, desc.FormatMajorVersion, "db should be racheted to the newest format")
+	require.Equal(t, pebble.FormatNewest, desc.FormatMajorVersion, "db should be ratcheted to the newest format")
 }
 
 func TestGCSBlobStorage(t *testing.T) {


### PR DESCRIPTION
s/rachet/ratchet/g

Add a test to help us validate the ability for us to open a ratcheted DB
after a deployment rollback.
