### PR TITLE
Fix small bug in filecache.filecachePath

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -151,7 +151,7 @@ func filecachePath(rootDir, key string) string {
 	// Don't use filepath.Join since it's relatively slow and allocates more.
 	if *includeSubdirPrefix {
 		groupDir, file := filepath.Split(key)
-		return rootDir + "/" + groupDir + "/" + file[:4] + "/" + file
+		return rootDir + "/" + groupDir + file[:4] + "/" + file
 	}
 	return rootDir + "/" + key
 }
@@ -251,6 +251,9 @@ func groupSpecificKey(groupID string, node *repb.FileNode) string {
 
 func groupIDStringFromContext(ctx context.Context) string {
 	if c, err := claims.ClaimsFromContext(ctx); err == nil {
+		if len(c.GroupID) == 0 {
+			log.CtxWarning(ctx, "Empty group id")
+		}
 		return c.GroupID
 	}
 	return interfaces.AuthAnonymousUser


### PR DESCRIPTION
When `--executor.include_subdir_prefix` is enabled, this used to return paths with double slashes, because `filepath.Split("foo/bar")` returns `["foo/", "bar"]`. It didn't break anything since `//` is treated the same as `/` pretty much everywhere, but it did make error logs more confusing.

I also added a log for empty group IDs, since that can potentially result in very different paths.