### PR TITLE
[raft] remove zero paddings from replica name

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -2097,7 +2097,7 @@ func New(leaser pebble.Leaser, rangeID, replicaID uint64, store IStore, broadcas
 }
 
 func getName(rangeID, replicaID uint64) string {
-	return fmt.Sprintf("c%04dn%04d", rangeID, replicaID)
+	return fmt.Sprintf("c%dn%d", rangeID, replicaID)
 }
 
 func LocalKeyPrefix(rangeID, replicaID uint64) []byte {

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -900,7 +900,7 @@ func TestClearStateBeforeApplySnapshot(t *testing.T) {
 
 	// Verify that local range key exists, and the value is the same as the local
 	// range in the snapshot.
-	localRangeKey := keys.MakeKey(constants.LocalPrefix, []byte("c0001n0002-"), constants.LocalRangeKey)
+	localRangeKey := keys.MakeKey(constants.LocalPrefix, []byte("c1n2-"), constants.LocalRangeKey)
 	buf, closer, err := repl2.DB().Get(localRangeKey)
 	require.NotEmpty(t, buf)
 	require.NoError(t, err)
@@ -911,7 +911,7 @@ func TestClearStateBeforeApplySnapshot(t *testing.T) {
 	closer.Close()
 
 	// Verify that local last applied index key exists, and the value is not zero.
-	localIndexKey := keys.MakeKey(constants.LocalPrefix, []byte("c0001n0002-"), constants.LastAppliedIndexKey)
+	localIndexKey := keys.MakeKey(constants.LocalPrefix, []byte("c1n2-"), constants.LastAppliedIndexKey)
 	buf, closer, err = repl2.DB().Get(localIndexKey)
 	require.NotEmpty(t, buf)
 	require.NoError(t, err)


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4540

We don't need to worry about overflowing after removing the zero paddings.
