### PR TITLE
workflows/windows: Enable Bazel and Go download cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -146,7 +146,7 @@ common:untrusted-ci --remote_cache=grpcs://remote.buildbuddy.io
 
 # Disabled RBE for Windows
 common:untrusted-ci-windows --remote_instance_name=buildbuddy-io/buildbuddy/untrusted-ci-windows
-common:untrusted-ci-windows --repository_cache=D:/repo-cache/untrusted
+common:untrusted-ci-windows --repository_cache=D:/bazel/repo-cache/
 common:untrusted-ci-windows --disk_cache=
 common:untrusted-ci-windows --flaky_test_attempts=2
 common:untrusted-ci-windows --bes_results_url=https://app.buildbuddy.io/invocation/
@@ -221,6 +221,7 @@ common:release-mac --config=release-shared
 common:release-m1 --config=release-shared
 
 # Configuration used for release-windows workflow
+common:release-windows --repository_cache=D:/bazel/repo-cache/
 common:release-windows --config=release-shared
 common:release-windows --config=cache
 common:release-windows --remote_instance_name=buildbuddy-io/buildbuddy/release-windows

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -9,10 +9,26 @@ jobs:
   build:
     runs-on: windows-2022
     if: "!contains(github.event.head_commit.message, 'ci skip')"
+    env:
+      GO_REPOSITORY_USE_HOST_CACHE: 1
+      GOMODCACHE: "D:/go-mod-cache"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Mount Bazel cache
+        uses: actions/cache@v4
+        with:
+          path: "D:/bazel/repo-cache/"
+          key: repo-cache
+
+      - name: Mount Go cache
+        uses: actions/cache@v4
+        with:
+          path: "D:/go-mod-cache/"
+          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}
+          restore-keys: go-mod-cache-${{ runner.os }}-
 
       # This step would list out all files under $vs2022Path for debugging purposes.
       # - name: "Find CL"

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -26,6 +26,10 @@ on:
 jobs:
   build:
     runs-on: windows-2022
+    env:
+      GO_REPOSITORY_USE_HOST_CACHE: 1
+      GOMODCACHE: "D:/go-mod-cache"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,6 +38,19 @@ jobs:
           # We need to fetch git tags to obtain the latest version tag to report
           # the version of the running binary.
           fetch-depth: 0
+
+      - name: Mount Bazel Repository Cache
+        uses: actions/cache@v4
+        with:
+          path: "D:/bazel/repo-cache/"
+          key: repo-cache
+
+      - name: Mount Go Cache
+        uses: actions/cache@v4
+        with:
+          path: "D:/go-mod-cache/"
+          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}
+          restore-keys: go-mod-cache-${{ runner.os }}-
 
       - name: Build and Upload Artifacts
         env:


### PR DESCRIPTION
Cache external dependencies downloads to speed up these workflows.
