### PR TITLE
Count requests to OCI registry mirror (plus latency for fetching blobs and manifests)

### DIFF
--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -397,6 +397,7 @@ func routeLabel(r *http.Request) string {
 	if path == "/api/v1/metrics" {
 		return "/api/v1/metrics"
 	}
+	// OCI registry
 	if strings.HasPrefix(path, "/v2/") {
 		if strings.Contains(path, "/blobs/") {
 			return "/v2/[...]/blobs/[...]"

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -397,6 +397,17 @@ func routeLabel(r *http.Request) string {
 	if path == "/api/v1/metrics" {
 		return "/api/v1/metrics"
 	}
+	if strings.HasPrefix(path, "/v2/") {
+		if strings.Contains(path, "/blobs/") {
+			return "/v2/[...]/blobs/[...]"
+		} else if strings.Contains(path, "/manifests/") {
+			return "/v2/[...]/manifests/[...]"
+		} else if path == "/v2/" {
+			return "/v2/"
+		} else {
+			return "/v2/[...]"
+		}
+	}
 	return "[OTHER]"
 }
 

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -474,7 +474,7 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 	}
 	if ocireg := env.GetOCIRegistry(); ocireg != nil {
 		//According to the OCI Distribution Spec, registries must support requests to `/v2/` paths.
-		mux.Handle("/v2/", ocireg)
+		mux.Handle("/v2/", interceptors.WrapExternalHandler(env, ocireg))
 	}
 
 	if sp := env.GetSplashPrinter(); sp != nil {


### PR DESCRIPTION
Count requests to the OCI mirror registry by HTTP status code, HTTP method, whether it's a cache hit, and whether you're fetching a blob or manifest.
Measure request latency for successful GET requests of blobs or manifests.