### PR TITLE
Refactor github logic to prepare for supporting 2 github apps

### DIFF
--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -233,6 +233,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
       .linkGitHubAppInstallation(
         github.LinkAppInstallationRequest.create({
           installationId: selectedInstallation?.id,
+          appId: selectedInstallation?.appId,
         })
       )
       .catch((e) => error_service.handleError(e));

--- a/enterprise/app/settings/github_complete_installation.tsx
+++ b/enterprise/app/settings/github_complete_installation.tsx
@@ -37,11 +37,15 @@ export default class CompleteGitHubAppInstallationDialog extends React.Component
   };
 
   private linkInstallation() {
+    if (!this.props.search.get("installation_id")  || !this.props.search.get("app_id")) {
+      throw new Error("installation_id and app_id query params are expected to be set");
+    }
     this.setState({ isLinkInstallationLoading: true });
     rpcService.service
       .linkGitHubAppInstallation(
         github.LinkAppInstallationRequest.create({
-          installationId: Long.fromString(this.props.search.get("installation_id") || ""),
+          installationId: Long.fromString(this.props.search.get("installation_id")!),
+          appId: Long.fromString(this.props.search.get("app_id")!),
         })
       )
       .then(() => {

--- a/enterprise/app/settings/github_complete_installation.tsx
+++ b/enterprise/app/settings/github_complete_installation.tsx
@@ -37,7 +37,7 @@ export default class CompleteGitHubAppInstallationDialog extends React.Component
   };
 
   private linkInstallation() {
-    if (!this.props.search.get("installation_id")  || !this.props.search.get("app_id")) {
+    if (!this.props.search.get("installation_id") || !this.props.search.get("app_id")) {
       throw new Error("installation_id and app_id query params are expected to be set");
     }
     this.setState({ isLinkInstallationLoading: true });

--- a/enterprise/app/settings/github_complete_installation.tsx
+++ b/enterprise/app/settings/github_complete_installation.tsx
@@ -37,15 +37,17 @@ export default class CompleteGitHubAppInstallationDialog extends React.Component
   };
 
   private linkInstallation() {
-    if (!this.props.search.get("installation_id") || !this.props.search.get("app_id")) {
+    const installationId = this.props.search.get("installation_id");
+    const appId = this.props.search.get("app_id");
+    if (!installationId || !appId) {
       throw new Error("installation_id and app_id query params are expected to be set");
     }
     this.setState({ isLinkInstallationLoading: true });
     rpcService.service
       .linkGitHubAppInstallation(
         github.LinkAppInstallationRequest.create({
-          installationId: Long.fromString(this.props.search.get("installation_id")!),
-          appId: Long.fromString(this.props.search.get("app_id")!),
+          installationId: Long.fromString(installationId),
+          appId: Long.fromString(appId),
         })
       )
       .then(() => {

--- a/enterprise/app/settings/github_link.tsx
+++ b/enterprise/app/settings/github_link.tsx
@@ -98,6 +98,7 @@ export default class GitHubLink extends React.Component<Props, State> {
       .unlinkGitHubAppInstallation(
         github.UnlinkAppInstallationRequest.create({
           installationId: installation.installationId,
+          appId: installation.appId,
         })
       )
       .then(() => {

--- a/enterprise/app/workflows/github_app_import.tsx
+++ b/enterprise/app/workflows/github_app_import.tsx
@@ -252,6 +252,7 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
           </div>
         </div>
         <div className="container content-container">
+          {/*TODO: Maggie - combine the link and install steps into one*/}
           {!this.props.user.githubLinked && (
             <Banner type="info" className="install-app-banner">
               <div>To get started, link a GitHub account to your BuildBuddy account.</div>

--- a/enterprise/server/githubapp/BUILD
+++ b/enterprise/server/githubapp/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/interfaces",
         "//server/real_environment",
         "//server/tables",
+        "//server/util/alert",
         "//server/util/authutil",
         "//server/util/db",
         "//server/util/flag",

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -1108,8 +1108,8 @@ func (a *GitHubApp) handleInstall(ctx context.Context, groupID, setupAction stri
 	// desired org.
 	if groupID == "" {
 		redirect := fmt.Sprintf(
-			"/settings/org/github/complete-installation?installation_id=%d&installation_owner=%s",
-			installationID, installation.GetAccount().GetLogin())
+			"/settings/org/github/complete-installation?installation_id=%d&installation_owner=%s&app_id=%d",
+			installationID, installation.GetAccount().GetLogin(), installation.GetAppID())
 		return redirect, nil
 	}
 	if err := a.linkInstallation(ctx, installation, groupID); err != nil {
@@ -1283,6 +1283,7 @@ func (a *GitHubApp) GetGithubUserInstallations(ctx context.Context, req *ghpb.Ge
 	for _, i := range installations {
 		installation := &ghpb.UserInstallation{
 			Id:         i.GetID(),
+			AppId:      i.GetAppID(),
 			Login:      i.Account.GetLogin(),
 			Url:        i.GetHTMLURL(),
 			TargetType: i.GetTargetType(),

--- a/enterprise/server/githubauth/githubauth.go
+++ b/enterprise/server/githubauth/githubauth.go
@@ -126,7 +126,23 @@ func (a *githubAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error
 }
 
 func (a *githubAuthenticator) handler() *github.OAuthHandler {
-	return a.env.GetGitHubApp().OAuthHandler().(*github.OAuthHandler)
+	// We always use the read-write github app for login for legacy reasons.
+	// Previously, we only offered a read-write app, and customers onboarded to it.
+	// Even though login only needs read access, there is no easy way to transfer
+	// customers to the read-only app once we added support for it.
+	//
+	// Using the read-write app does NOT mean that users have to grant write access
+	// for login. In GitHub, authorizing and installing a GitHub app are different.
+	// When *authorizing*, our read-write app only requests read access to emails.
+	// In GitHub terminology, you are authorizing an Oauth app.
+	// When *installing*, our read-write app requests write access to certain resources.
+	// In GitHub terminology, you are installing a GitHub app.
+	//
+	// TLDR: The login flow only prompts the user to authorize the app, so the user won't
+	// be asked to grant any write permissions, even though it's technically under
+	// our read-write app.
+	ghApp := a.env.GetGitHubAppService().GetReadWriteGitHubApp()
+	return ghApp.OAuthHandler().(*github.OAuthHandler)
 }
 
 func (a *githubAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *http.Request) context.Context {

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -330,11 +330,14 @@ func (r *runnerService) credentialEnvOverrides(ctx context.Context, req *rnpb.Ru
 }
 
 func (r *runnerService) getGitToken(ctx context.Context, repoURL string) (string, error) {
-	app := r.env.GetGitHubApp()
-	if app == nil {
-		return "", status.UnimplementedError("GitHub App is not configured")
+	gh := r.env.GetGitHubAppService()
+	if gh == nil {
+		return "", status.UnimplementedError("Not implemented")
 	}
-
+	app, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return "", err
+	}
 	u, err := r.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return "", err

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -334,7 +334,7 @@ func (r *runnerService) getGitToken(ctx context.Context, repoURL string) (string
 	if gh == nil {
 		return "", status.UnimplementedError("Not implemented")
 	}
-	app, err := gh.GetGitHubAppForGroup(ctx)
+	app, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/server/test/integration/remote_bazel/BUILD
+++ b/enterprise/server/test/integration/remote_bazel/BUILD
@@ -30,7 +30,6 @@ go_test(
         "//cli/remotebazel",
         "//enterprise/server/backends/kms",
         "//enterprise/server/execution_service",
-        "//enterprise/server/githubapp",
         "//enterprise/server/hostedrunner",
         "//enterprise/server/invocation_search_service",
         "//enterprise/server/secrets",

--- a/enterprise/server/test/integration/remote_bazel/BUILD
+++ b/enterprise/server/test/integration/remote_bazel/BUILD
@@ -30,6 +30,7 @@ go_test(
         "//cli/remotebazel",
         "//enterprise/server/backends/kms",
         "//enterprise/server/execution_service",
+        "//enterprise/server/githubapp",
         "//enterprise/server/hostedrunner",
         "//enterprise/server/invocation_search_service",
         "//enterprise/server/secrets",

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/remotebazel"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/kms"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_service"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/githubapp"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_search_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/secrets"
@@ -272,7 +273,9 @@ func runLocalServerAndExecutor(t *testing.T, githubToken string, repoURL string,
 			e.SetWorkflowService(service.NewWorkflowService(e))
 			iss := invocation_search_service.NewInvocationSearchService(e, e.GetDBHandle(), e.GetOLAPDBHandle())
 			e.SetInvocationSearchService(iss)
-			e.SetGitHubApp(&testgit.FakeGitHubApp{Token: githubToken})
+			gh, err := githubapp.NewAppService(e)
+			require.NoError(t, err)
+			gh.SetReadWriteApp(&testgit.FakeGitHubApp{Token: githubToken})
 			runner, err := hostedrunner.New(e)
 			require.NoError(t, err)
 			e.SetRunnerService(runner)

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -713,7 +713,7 @@ func (ws *workflowService) enableExtraKytheIndexingAction(ctx context.Context, g
 func (ws *workflowService) getRepositoryWorkflow(ctx context.Context, groupID string, repoURL *gitutil.RepoURL) (*repositoryWorkflow, error) {
 	gh := ws.env.GetGitHubAppService()
 	if gh == nil {
-		return nil, status.UnimplementedError("Not implemented")
+		return nil, status.UnimplementedError("No GitHub app configured")
 	}
 	app, err := gh.GetGitHubAppForGroup(ctx)
 	if err != nil {
@@ -831,7 +831,12 @@ func (ws *workflowService) GetWorkflowHistory(ctx context.Context) (*wfpb.GetWor
 	if ws.env.GetDBHandle() == nil || ws.env.GetOLAPDBHandle() == nil {
 		return nil, status.FailedPreconditionError("database not configured")
 	}
-	linkedRepos, err := ws.env.GetGitHubAppService().GetLinkedGitHubRepos(ctx)
+	gh := ws.env.GetGitHubAppService()
+	if gh == nil {
+		return nil, status.UnimplementedError("No GitHub app configured")
+	}
+
+	linkedRepos, err := gh.GetLinkedGitHubRepos(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -711,15 +711,19 @@ func (ws *workflowService) enableExtraKytheIndexingAction(ctx context.Context, g
 }
 
 func (ws *workflowService) getRepositoryWorkflow(ctx context.Context, groupID string, repoURL *gitutil.RepoURL) (*repositoryWorkflow, error) {
-	app := ws.env.GetGitHubApp()
-	if app == nil {
-		return nil, status.UnimplementedError("GitHub App is not configured")
+	gh := ws.env.GetGitHubAppService()
+	if gh == nil {
+		return nil, status.UnimplementedError("Not implemented")
+	}
+	app, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	if err := authutil.AuthorizeGroupAccess(ctx, ws.env, groupID); err != nil {
 		return nil, err
 	}
 	gitRepository := &tables.GitRepository{}
-	err := ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_get_for_repo").Raw(`
+	err = ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_get_for_repo").Raw(`
 		SELECT *
 		FROM "GitRepositories"
 		WHERE group_id = ?
@@ -827,8 +831,15 @@ func (ws *workflowService) GetWorkflowHistory(ctx context.Context) (*wfpb.GetWor
 	if ws.env.GetDBHandle() == nil || ws.env.GetOLAPDBHandle() == nil {
 		return nil, status.FailedPreconditionError("database not configured")
 	}
-
-	linkedRepos, err := ws.env.GetGitHubApp().GetLinkedGitHubRepos(ctx)
+	gh := ws.env.GetGitHubAppService()
+	if gh == nil {
+		return nil, status.UnimplementedError("GitHub app service not enabled")
+	}
+	app, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
+	}
+	linkedRepos, err := app.GetLinkedGitHubRepos(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -715,7 +715,7 @@ func (ws *workflowService) getRepositoryWorkflow(ctx context.Context, groupID st
 	if gh == nil {
 		return nil, status.UnimplementedError("No GitHub app configured")
 	}
-	app, err := gh.GetGitHubAppForGroup(ctx)
+	app, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -831,15 +831,7 @@ func (ws *workflowService) GetWorkflowHistory(ctx context.Context) (*wfpb.GetWor
 	if ws.env.GetDBHandle() == nil || ws.env.GetOLAPDBHandle() == nil {
 		return nil, status.FailedPreconditionError("database not configured")
 	}
-	gh := ws.env.GetGitHubAppService()
-	if gh == nil {
-		return nil, status.UnimplementedError("GitHub app service not enabled")
-	}
-	app, err := gh.GetGitHubAppForGroup(ctx)
-	if err != nil {
-		return nil, err
-	}
-	linkedRepos, err := app.GetLinkedGitHubRepos(ctx)
+	linkedRepos, err := ws.env.GetGitHubAppService().GetLinkedGitHubRepos(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/workspace/workspace_service.go
+++ b/enterprise/server/workspace/workspace_service.go
@@ -329,7 +329,7 @@ func pathExists(path string, nodes []*wspb.Node) bool {
 func (s *workspaceService) nodesFromGitHub(ctx context.Context, githubRepo, ref string) ([]*wspb.Node, string, error) {
 	gh := s.env.GetGitHubAppService()
 	if gh == nil {
-		return nil, "", status.UnimplementedError("Not implemented")
+		return nil, "", status.UnimplementedError("No GitHub app configured")
 	}
 	a, err := gh.GetGitHubAppForGroup(ctx)
 	if err != nil {

--- a/enterprise/server/workspace/workspace_service.go
+++ b/enterprise/server/workspace/workspace_service.go
@@ -331,7 +331,7 @@ func (s *workspaceService) nodesFromGitHub(ctx context.Context, githubRepo, ref 
 	if gh == nil {
 		return nil, "", status.UnimplementedError("No GitHub app configured")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, "", err
 	}
@@ -403,7 +403,7 @@ func (s *workspaceService) getGithubFileFromSha(ctx context.Context, githubRepo,
 	if gh == nil {
 		return nil, status.UnimplementedError("No GitHub app configured")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +440,7 @@ func (s *workspaceService) getGithubFileFromPath(ctx context.Context, githubRepo
 	if gh == nil {
 		return nil, status.UnimplementedError("No GitHub app configured")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/workspace/workspace_service.go
+++ b/enterprise/server/workspace/workspace_service.go
@@ -327,9 +327,13 @@ func pathExists(path string, nodes []*wspb.Node) bool {
 }
 
 func (s *workspaceService) nodesFromGitHub(ctx context.Context, githubRepo, ref string) ([]*wspb.Node, string, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
-		return nil, "", status.UnimplementedError("No GitHub app configured")
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
+		return nil, "", status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, "", err
 	}
 
 	repo, err := git.ParseGitHubRepoURL(githubRepo)
@@ -395,9 +399,13 @@ func resourceNameForNode(workspaceName string, node *wspb.Node) *rspb.ResourceNa
 // Github
 
 func (s *workspaceService) getGithubFileFromSha(ctx context.Context, githubRepo, path, sha string) (*wspb.GetWorkspaceFileResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("No GitHub app configured")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	repo, err := git.ParseGitHubRepoURL(githubRepo)
@@ -428,9 +436,13 @@ func (s *workspaceService) getGithubFileFromSha(ctx context.Context, githubRepo,
 }
 
 func (s *workspaceService) getGithubFileFromPath(ctx context.Context, githubRepo, ref, path string) (*wspb.GetWorkspaceFileResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("No GitHub app configured")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	repo, err := git.ParseGitHubRepoURL(githubRepo)

--- a/proto/github.proto
+++ b/proto/github.proto
@@ -49,8 +49,8 @@ message UnlinkGitHubAccountResponse {
 message LinkAppInstallationRequest {
   context.RequestContext request_context = 1;
 
-  // The installation ID to link. This is unique to every user that has
-  // installed the app. Required.
+  // The installation ID to link. This is unique to every GitHub account that
+  // has installed the app. Required.
   int64 installation_id = 2;
 
   // The ID of the GitHub app being linked.
@@ -63,8 +63,8 @@ message LinkAppInstallationResponse {
 }
 
 message AppInstallation {
-  // The installation ID. This is unique to every user that has installed the
-  // app.
+  // The installation ID. This is unique to every GitHub account that has
+  // installed the app.
   int64 installation_id = 1;
 
   // The GitHub username or organization where the app is installed.

--- a/proto/github.proto
+++ b/proto/github.proto
@@ -49,9 +49,13 @@ message UnlinkGitHubAccountResponse {
 message LinkAppInstallationRequest {
   context.RequestContext request_context = 1;
 
-  // The installation ID to link.
-  // Required.
+  // The installation ID to link. This is unique to every user that has
+  // installed the app. Required.
   int64 installation_id = 2;
+
+  // The ID of the GitHub app being linked.
+  // Required.
+  int64 app_id = 3;
 }
 
 message LinkAppInstallationResponse {
@@ -59,7 +63,8 @@ message LinkAppInstallationResponse {
 }
 
 message AppInstallation {
-  // The GitHub App installation ID.
+  // The installation ID. This is unique to every user that has installed the
+  // app.
   int64 installation_id = 1;
 
   // The GitHub username or organization where the app is installed.
@@ -68,6 +73,10 @@ message AppInstallation {
 
   // The group ID to which the installation is linked.
   string group_id = 3;
+
+  // The ID of the GitHub app being linked. There are only 2 possible values,
+  // corresponding to either the read-write or read-only app.
+  int64 app_id = 4;
 }
 
 // A request to list GitHub App installations accessible to user as well as
@@ -102,7 +111,11 @@ message UnlinkAppInstallationRequest {
   context.RequestContext request_context = 1;
 
   // The installation ID to unlink.
+  // This is unique to every user that has installed the app.
   int64 installation_id = 2;
+
+  // The ID of the GitHub app being unlinked.
+  int64 app_id = 3;
 }
 
 message UnlinkAppInstallationResponse {
@@ -189,6 +202,7 @@ message UserInstallation {
   string url = 3;
   string target_type = 4;
   UserInstallationPermissions permissions = 5;
+  int64 app_id = 6;
 }
 
 message UserInstallationPermissions {

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -512,7 +512,7 @@ func (c *GithubClient) getAppInstallationToken(ctx context.Context, ownerRepo st
 	if gh == nil {
 		return nil, status.UnimplementedError("No GitHub app configured")
 	}
-	app, err := gh.GetGitHubAppForGroup(ctx)
+	app, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -165,7 +165,7 @@ func getLegacyOAuthHandler(env environment.Env) *OAuthHandler {
 	a := NewOAuthHandler(env, *clientID, legacyClientSecret(), legacyOAuthAppPath)
 	a.GroupLinkEnabled = true
 	// Only enable user-level linking if the new GitHub App is not yet enabled.
-	a.UserLinkEnabled = env.GetGitHubApp() == nil
+	a.UserLinkEnabled = env.GetGitHubAppService() == nil
 	return a
 }
 
@@ -508,9 +508,13 @@ func (c *GithubClient) CreateStatus(ctx context.Context, ownerRepo string, commi
 }
 
 func (c *GithubClient) getAppInstallationToken(ctx context.Context, ownerRepo string) (*github.InstallationToken, error) {
-	app := c.env.GetGitHubApp()
-	if app == nil {
-		return nil, nil
+	gh := c.env.GetGitHubAppService()
+	if gh == nil {
+		return nil, status.UnimplementedError("No GitHub app configured")
+	}
+	app, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	parts := strings.Split(ownerRepo, "/")
 	if len(parts) != 2 {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1505,46 +1505,78 @@ func (s *BuildBuddyServer) UnlinkGitHubAccount(ctx context.Context, req *ghpb.Un
 }
 
 func (s *BuildBuddyServer) LinkGitHubAppInstallation(ctx context.Context, req *ghpb.LinkAppInstallationRequest) (*ghpb.LinkAppInstallationResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.LinkGitHubAppInstallation(ctx, req)
 }
 func (s *BuildBuddyServer) GetGitHubAppInstallations(ctx context.Context, req *ghpb.GetAppInstallationsRequest) (*ghpb.GetAppInstallationsResponse, error) {
-	a := s.env.GetGitHubApp()
+	a := s.env.GetGitHubAppService()
 	if a == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	return a.GetGitHubAppInstallations(ctx, req)
+	installations, err := a.GetGitHubAppInstallations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res := &ghpb.GetAppInstallationsResponse{}
+	for _, i := range installations {
+		res.Installations = append(res.Installations, &ghpb.AppInstallation{
+			GroupId:        i.GroupID,
+			InstallationId: i.InstallationID,
+			Owner:          i.Owner,
+		})
+	}
+	return res, nil
 }
 func (s *BuildBuddyServer) UnlinkGitHubAppInstallation(ctx context.Context, req *ghpb.UnlinkAppInstallationRequest) (*ghpb.UnlinkAppInstallationResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.UnlinkGitHubAppInstallation(ctx, req)
 }
 func (s *BuildBuddyServer) GetAccessibleGitHubRepos(ctx context.Context, req *ghpb.GetAccessibleReposRequest) (*ghpb.GetAccessibleReposResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetAccessibleGitHubRepos(ctx, req)
 }
 func (s *BuildBuddyServer) GetLinkedGitHubRepos(ctx context.Context, req *ghpb.GetLinkedReposRequest) (*ghpb.GetLinkedReposResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetLinkedGitHubRepos(ctx)
 }
 func (s *BuildBuddyServer) LinkGitHubRepo(ctx context.Context, req *ghpb.LinkRepoRequest) (*ghpb.LinkRepoResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	rsp, err := a.LinkGitHubRepo(ctx, req)
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rsp, err := a.LinkGitHubRepo(ctx, req.GetRepoUrl())
 	if err != nil {
 		return nil, err
 	}
@@ -1554,9 +1586,13 @@ func (s *BuildBuddyServer) LinkGitHubRepo(ctx context.Context, req *ghpb.LinkRep
 	return rsp, nil
 }
 func (s *BuildBuddyServer) UnlinkGitHubRepo(ctx context.Context, req *ghpb.UnlinkRepoRequest) (*ghpb.UnlinkRepoResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	rsp, err := a.UnlinkGitHubRepo(ctx, req)
 	if err != nil {
@@ -2033,193 +2069,289 @@ func (s *BuildBuddyServer) GetAuditLogs(ctx context.Context, request *alpb.GetAu
 }
 
 func (s *BuildBuddyServer) CreateRepo(ctx context.Context, request *repb.CreateRepoRequest) (*repb.CreateRepoResponse, error) {
-	gh := s.env.GetGitHubApp()
+	gh := s.env.GetGitHubAppService()
 	if gh == nil {
-		return nil, status.UnimplementedError("Github service not configured")
+		return nil, status.UnimplementedError("Not implemented")
 	}
-	return gh.CreateRepo(ctx, request)
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return a.CreateRepo(ctx, request)
 }
 
 func (s *BuildBuddyServer) GetGithubUserInstallations(ctx context.Context, req *ghpb.GetGithubUserInstallationsRequest) (*ghpb.GetGithubUserInstallationsResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubUserInstallations(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubUser(ctx context.Context, req *ghpb.GetGithubUserRequest) (*ghpb.GetGithubUserResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubUser(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubRepo(ctx context.Context, req *ghpb.GetGithubRepoRequest) (*ghpb.GetGithubRepoResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubRepo(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubContent(ctx context.Context, req *ghpb.GetGithubContentRequest) (*ghpb.GetGithubContentResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubContent(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubTree(ctx context.Context, req *ghpb.GetGithubTreeRequest) (*ghpb.GetGithubTreeResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubTree(ctx, req)
 }
 
 func (s *BuildBuddyServer) CreateGithubTree(ctx context.Context, req *ghpb.CreateGithubTreeRequest) (*ghpb.CreateGithubTreeResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.CreateGithubTree(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubBlob(ctx context.Context, req *ghpb.GetGithubBlobRequest) (*ghpb.GetGithubBlobResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubBlob(ctx, req)
 }
 
 func (s *BuildBuddyServer) CreateGithubBlob(ctx context.Context, req *ghpb.CreateGithubBlobRequest) (*ghpb.CreateGithubBlobResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.CreateGithubBlob(ctx, req)
 }
 
 func (s *BuildBuddyServer) CreateGithubPull(ctx context.Context, req *ghpb.CreateGithubPullRequest) (*ghpb.CreateGithubPullResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.CreateGithubPull(ctx, req)
 }
 
 func (s *BuildBuddyServer) MergeGithubPull(ctx context.Context, req *ghpb.MergeGithubPullRequest) (*ghpb.MergeGithubPullResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.MergeGithubPull(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubCompare(ctx context.Context, req *ghpb.GetGithubCompareRequest) (*ghpb.GetGithubCompareResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubCompare(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubForks(ctx context.Context, req *ghpb.GetGithubForksRequest) (*ghpb.GetGithubForksResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubForks(ctx, req)
 }
 
 func (s *BuildBuddyServer) CreateGithubFork(ctx context.Context, req *ghpb.CreateGithubForkRequest) (*ghpb.CreateGithubForkResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.CreateGithubFork(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubCommits(ctx context.Context, req *ghpb.GetGithubCommitsRequest) (*ghpb.GetGithubCommitsResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubCommits(ctx, req)
 }
 
 func (s *BuildBuddyServer) CreateGithubCommit(ctx context.Context, req *ghpb.CreateGithubCommitRequest) (*ghpb.CreateGithubCommitResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.CreateGithubCommit(ctx, req)
 }
 
 func (s *BuildBuddyServer) UpdateGithubRef(ctx context.Context, req *ghpb.UpdateGithubRefRequest) (*ghpb.UpdateGithubRefResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.UpdateGithubRef(ctx, req)
 }
 
 func (s *BuildBuddyServer) CreateGithubRef(ctx context.Context, req *ghpb.CreateGithubRefRequest) (*ghpb.CreateGithubRefResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.CreateGithubRef(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubPullRequest(ctx context.Context, req *ghpb.GetGithubPullRequestRequest) (*ghpb.GetGithubPullRequestResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubPullRequest(ctx, req)
 }
 
 func (s *BuildBuddyServer) CreateGithubPullRequestComment(ctx context.Context, req *ghpb.CreateGithubPullRequestCommentRequest) (*ghpb.CreateGithubPullRequestCommentResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.CreateGithubPullRequestComment(ctx, req)
 }
 
 func (s *BuildBuddyServer) UpdateGithubPullRequestComment(ctx context.Context, req *ghpb.UpdateGithubPullRequestCommentRequest) (*ghpb.UpdateGithubPullRequestCommentResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.UpdateGithubPullRequestComment(ctx, req)
 }
 
 func (s *BuildBuddyServer) DeleteGithubPullRequestComment(ctx context.Context, req *ghpb.DeleteGithubPullRequestCommentRequest) (*ghpb.DeleteGithubPullRequestCommentResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.DeleteGithubPullRequestComment(ctx, req)
 }
 
 func (s *BuildBuddyServer) GetGithubPullRequestDetails(ctx context.Context, req *ghpb.GetGithubPullRequestDetailsRequest) (*ghpb.GetGithubPullRequestDetailsResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.GetGithubPullRequestDetails(ctx, req)
 }
 
 func (s *BuildBuddyServer) SendGithubPullRequestReview(ctx context.Context, req *ghpb.SendGithubPullRequestReviewRequest) (*ghpb.SendGithubPullRequestReviewResponse, error) {
-	a := s.env.GetGitHubApp()
-	if a == nil {
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
+	}
+	a, err := gh.GetGitHubAppForGroup(ctx)
+	if err != nil {
+		return nil, err
 	}
 	return a.SendGithubPullRequestReview(ctx, req)
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1547,13 +1547,12 @@ func (s *BuildBuddyServer) UnlinkGitHubAppInstallation(ctx context.Context, req 
 	return a.UnlinkGitHubAppInstallation(ctx, req)
 }
 
-// TODO: This should be using the token
 func (s *BuildBuddyServer) GetAccessibleGitHubRepos(ctx context.Context, req *ghpb.GetAccessibleReposRequest) (*ghpb.GetAccessibleReposResponse, error) {
 	gh := s.env.GetGitHubAppService()
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1571,7 +1570,7 @@ func (s *BuildBuddyServer) LinkGitHubRepo(ctx context.Context, req *ghpb.LinkRep
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1589,7 +1588,7 @@ func (s *BuildBuddyServer) UnlinkGitHubRepo(ctx context.Context, req *ghpb.Unlin
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2072,21 +2071,19 @@ func (s *BuildBuddyServer) CreateRepo(ctx context.Context, request *repb.CreateR
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return a.CreateRepo(ctx, request)
 }
 
-// TODO: This should be used with token?
-// But in reality it should probably be through an app, but we don't gate this at any point
 func (s *BuildBuddyServer) GetGithubUserInstallations(ctx context.Context, req *ghpb.GetGithubUserInstallationsRequest) (*ghpb.GetGithubUserInstallationsResponse, error) {
 	gh := s.env.GetGitHubAppService()
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2098,7 +2095,7 @@ func (s *BuildBuddyServer) GetGithubUser(ctx context.Context, req *ghpb.GetGithu
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2110,7 +2107,7 @@ func (s *BuildBuddyServer) GetGithubRepo(ctx context.Context, req *ghpb.GetGithu
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2122,7 +2119,7 @@ func (s *BuildBuddyServer) GetGithubContent(ctx context.Context, req *ghpb.GetGi
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2134,7 +2131,7 @@ func (s *BuildBuddyServer) GetGithubTree(ctx context.Context, req *ghpb.GetGithu
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2146,7 +2143,7 @@ func (s *BuildBuddyServer) CreateGithubTree(ctx context.Context, req *ghpb.Creat
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2158,7 +2155,7 @@ func (s *BuildBuddyServer) GetGithubBlob(ctx context.Context, req *ghpb.GetGithu
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2170,7 +2167,7 @@ func (s *BuildBuddyServer) CreateGithubBlob(ctx context.Context, req *ghpb.Creat
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2182,7 +2179,7 @@ func (s *BuildBuddyServer) CreateGithubPull(ctx context.Context, req *ghpb.Creat
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2194,7 +2191,7 @@ func (s *BuildBuddyServer) MergeGithubPull(ctx context.Context, req *ghpb.MergeG
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2206,7 +2203,7 @@ func (s *BuildBuddyServer) GetGithubCompare(ctx context.Context, req *ghpb.GetGi
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2218,7 +2215,7 @@ func (s *BuildBuddyServer) GetGithubForks(ctx context.Context, req *ghpb.GetGith
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2230,7 +2227,7 @@ func (s *BuildBuddyServer) CreateGithubFork(ctx context.Context, req *ghpb.Creat
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2242,7 +2239,7 @@ func (s *BuildBuddyServer) GetGithubCommits(ctx context.Context, req *ghpb.GetGi
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2254,7 +2251,7 @@ func (s *BuildBuddyServer) CreateGithubCommit(ctx context.Context, req *ghpb.Cre
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2266,7 +2263,7 @@ func (s *BuildBuddyServer) UpdateGithubRef(ctx context.Context, req *ghpb.Update
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2278,7 +2275,7 @@ func (s *BuildBuddyServer) CreateGithubRef(ctx context.Context, req *ghpb.Create
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2290,7 +2287,7 @@ func (s *BuildBuddyServer) GetGithubPullRequest(ctx context.Context, req *ghpb.G
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2302,7 +2299,7 @@ func (s *BuildBuddyServer) CreateGithubPullRequestComment(ctx context.Context, r
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2314,7 +2311,7 @@ func (s *BuildBuddyServer) UpdateGithubPullRequestComment(ctx context.Context, r
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2326,7 +2323,7 @@ func (s *BuildBuddyServer) DeleteGithubPullRequestComment(ctx context.Context, r
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2338,7 +2335,7 @@ func (s *BuildBuddyServer) GetGithubPullRequestDetails(ctx context.Context, req 
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2350,7 +2347,7 @@ func (s *BuildBuddyServer) SendGithubPullRequestReview(ctx context.Context, req 
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubApp(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1557,15 +1557,7 @@ func (s *BuildBuddyServer) GetAccessibleGitHubRepos(ctx context.Context, req *gh
 	return a.GetAccessibleGitHubRepos(ctx, req)
 }
 func (s *BuildBuddyServer) GetLinkedGitHubRepos(ctx context.Context, req *ghpb.GetLinkedReposRequest) (*ghpb.GetLinkedReposResponse, error) {
-	gh := s.env.GetGitHubAppService()
-	if gh == nil {
-		return nil, status.UnimplementedError("Not implemented")
-	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return a.GetLinkedGitHubRepos(ctx)
+	return s.env.GetGitHubAppService().GetLinkedGitHubRepos(ctx)
 }
 func (s *BuildBuddyServer) LinkGitHubRepo(ctx context.Context, req *ghpb.LinkRepoRequest) (*ghpb.LinkRepoResponse, error) {
 	gh := s.env.GetGitHubAppService()

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1509,7 +1509,7 @@ func (s *BuildBuddyServer) LinkGitHubAppInstallation(ctx context.Context, req *g
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubAppWithID(req.GetAppId())
 	if err != nil {
 		return nil, err
 	}
@@ -1530,6 +1530,7 @@ func (s *BuildBuddyServer) GetGitHubAppInstallations(ctx context.Context, req *g
 			GroupId:        i.GroupID,
 			InstallationId: i.InstallationID,
 			Owner:          i.Owner,
+			AppId:          i.AppID,
 		})
 	}
 	return res, nil
@@ -1539,12 +1540,14 @@ func (s *BuildBuddyServer) UnlinkGitHubAppInstallation(ctx context.Context, req 
 	if gh == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	a, err := gh.GetGitHubAppForGroup(ctx)
+	a, err := gh.GetGitHubAppWithID(req.GetAppId())
 	if err != nil {
 		return nil, err
 	}
 	return a.UnlinkGitHubAppInstallation(ctx, req)
 }
+
+// TODO: This should be using the token
 func (s *BuildBuddyServer) GetAccessibleGitHubRepos(ctx context.Context, req *ghpb.GetAccessibleReposRequest) (*ghpb.GetAccessibleReposResponse, error) {
 	gh := s.env.GetGitHubAppService()
 	if gh == nil {
@@ -2076,6 +2079,8 @@ func (s *BuildBuddyServer) CreateRepo(ctx context.Context, request *repb.CreateR
 	return a.CreateRepo(ctx, request)
 }
 
+// TODO: This should be used with token?
+// But in reality it should probably be through an app, but we don't gate this at any point
 func (s *BuildBuddyServer) GetGithubUserInstallations(ctx context.Context, req *ghpb.GetGithubUserInstallationsRequest) (*ghpb.GetGithubUserInstallationsResponse, error) {
 	gh := s.env.GetGitHubAppService()
 	if gh == nil {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1557,7 +1557,11 @@ func (s *BuildBuddyServer) GetAccessibleGitHubRepos(ctx context.Context, req *gh
 	return a.GetAccessibleGitHubRepos(ctx, req)
 }
 func (s *BuildBuddyServer) GetLinkedGitHubRepos(ctx context.Context, req *ghpb.GetLinkedReposRequest) (*ghpb.GetLinkedReposResponse, error) {
-	return s.env.GetGitHubAppService().GetLinkedGitHubRepos(ctx)
+	gh := s.env.GetGitHubAppService()
+	if gh == nil {
+		return nil, status.UnimplementedError("Not implemented")
+	}
+	return gh.GetLinkedGitHubRepos(ctx)
 }
 func (s *BuildBuddyServer) LinkGitHubRepo(ctx context.Context, req *ghpb.LinkRepoRequest) (*ghpb.LinkRepoResponse, error) {
 	gh := s.env.GetGitHubAppService()

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -81,7 +81,7 @@ type Env interface {
 	GetRepoDownloader() interfaces.RepoDownloader
 	GetWorkflowService() interfaces.WorkflowService
 	GetWorkspaceService() interfaces.WorkspaceService
-	GetGitHubApp() interfaces.GitHubApp
+	GetGitHubAppService() interfaces.GitHubAppService
 	GetRunnerService() interfaces.RunnerService
 	GetGitProviders() interfaces.GitProviders
 	GetUsageService() interfaces.UsageService

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -651,7 +651,6 @@ type GitHubApp interface {
 	LinkGitHubAppInstallation(context.Context, *ghpb.LinkAppInstallationRequest) (*ghpb.LinkAppInstallationResponse, error)
 	UnlinkGitHubAppInstallation(context.Context, *ghpb.UnlinkAppInstallationRequest) (*ghpb.UnlinkAppInstallationResponse, error)
 
-	GetLinkedGitHubRepos(context.Context) (*ghpb.GetLinkedReposResponse, error)
 	LinkGitHubRepo(ctx context.Context, repoURL string) (*ghpb.LinkRepoResponse, error)
 	UnlinkGitHubRepo(context.Context, *ghpb.UnlinkRepoRequest) (*ghpb.UnlinkRepoResponse, error)
 
@@ -706,6 +705,8 @@ type GitHubApp interface {
 // operations.
 type GitHubAppService interface {
 	GetGitHubAppInstallations(context.Context) ([]*tables.GitHubAppInstallation, error)
+	GetLinkedGitHubRepos(context.Context) (*ghpb.GetLinkedReposResponse, error)
+
 	GetGitHubAppForGroup(ctx context.Context) (GitHubApp, error)
 	GetReadWriteGitHubApp() GitHubApp
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -641,7 +641,7 @@ type SnapshotService interface {
 	InvalidateSnapshot(ctx context.Context, key *fcpb.SnapshotKey) (string, error)
 }
 
-// GitHubApp represents with a specific instance of either the read-only or read-write
+// GitHubApp represents a specific instance of either the read-only or read-write
 // BuildBuddy GitHub app.
 type GitHubApp interface {
 	// TODO(bduffany): Add webhook handler and repo management API

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -674,6 +674,9 @@ type GitHubApp interface {
 	// OAuthHandler returns the OAuth flow HTTP handler.
 	OAuthHandler() http.Handler
 
+	// IsTokenValid returns whether the oauth token is valid for the current app.
+	IsTokenValid(ctx context.Context, oauthToken string) bool
+
 	// Passthroughs
 	GetGithubUserInstallations(ctx context.Context, req *ghpb.GetGithubUserInstallationsRequest) (*ghpb.GetGithubUserInstallationsResponse, error)
 	GetGithubUser(ctx context.Context, req *ghpb.GetGithubUserRequest) (*ghpb.GetGithubUserResponse, error)
@@ -706,8 +709,7 @@ type GitHubApp interface {
 type GitHubAppService interface {
 	GetReadWriteGitHubApp() GitHubApp
 	GetGitHubAppWithID(appID int64) (GitHubApp, error)
-	GetGitHubAppForGroup(ctx context.Context) (GitHubApp, error)
-	GetGitHubAppForToken(token string) (GitHubApp, error)
+	GetGitHubApp(ctx context.Context) (GitHubApp, error)
 
 	GetGitHubAppInstallations(context.Context) ([]*tables.GitHubAppInstallation, error)
 	GetLinkedGitHubRepos(context.Context) (*ghpb.GetLinkedReposResponse, error)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -704,11 +704,13 @@ type GitHubApp interface {
 // GitHubApp the user has installed (read-only vs read-write) and is used for app-agnostic
 // operations.
 type GitHubAppService interface {
+	GetReadWriteGitHubApp() GitHubApp
+	GetGitHubAppWithID(appID int64) (GitHubApp, error)
+	GetGitHubAppForGroup(ctx context.Context) (GitHubApp, error)
+	GetGitHubAppForToken(token string) (GitHubApp, error)
+
 	GetGitHubAppInstallations(context.Context) ([]*tables.GitHubAppInstallation, error)
 	GetLinkedGitHubRepos(context.Context) (*ghpb.GetLinkedReposResponse, error)
-
-	GetGitHubAppForGroup(ctx context.Context) (GitHubApp, error)
-	GetReadWriteGitHubApp() GitHubApp
 }
 
 type RunnerService interface {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -641,15 +641,18 @@ type SnapshotService interface {
 	InvalidateSnapshot(ctx context.Context, key *fcpb.SnapshotKey) (string, error)
 }
 
+// GitHubApp represents with a specific instance of either the read-only or read-write
+// BuildBuddy GitHub app.
 type GitHubApp interface {
 	// TODO(bduffany): Add webhook handler and repo management API
 
+	AppID() int64
+
 	LinkGitHubAppInstallation(context.Context, *ghpb.LinkAppInstallationRequest) (*ghpb.LinkAppInstallationResponse, error)
-	GetGitHubAppInstallations(context.Context, *ghpb.GetAppInstallationsRequest) (*ghpb.GetAppInstallationsResponse, error)
 	UnlinkGitHubAppInstallation(context.Context, *ghpb.UnlinkAppInstallationRequest) (*ghpb.UnlinkAppInstallationResponse, error)
 
 	GetLinkedGitHubRepos(context.Context) (*ghpb.GetLinkedReposResponse, error)
-	LinkGitHubRepo(context.Context, *ghpb.LinkRepoRequest) (*ghpb.LinkRepoResponse, error)
+	LinkGitHubRepo(ctx context.Context, repoURL string) (*ghpb.LinkRepoResponse, error)
 	UnlinkGitHubRepo(context.Context, *ghpb.UnlinkRepoRequest) (*ghpb.UnlinkRepoResponse, error)
 
 	GetAccessibleGitHubRepos(context.Context, *ghpb.GetAccessibleReposRequest) (*ghpb.GetAccessibleReposResponse, error)
@@ -696,6 +699,15 @@ type GitHubApp interface {
 	UpdateGithubPullRequestComment(ctx context.Context, req *ghpb.UpdateGithubPullRequestCommentRequest) (*ghpb.UpdateGithubPullRequestCommentResponse, error)
 	DeleteGithubPullRequestComment(ctx context.Context, req *ghpb.DeleteGithubPullRequestCommentRequest) (*ghpb.DeleteGithubPullRequestCommentResponse, error)
 	SendGithubPullRequestReview(ctx context.Context, req *ghpb.SendGithubPullRequestReviewRequest) (*ghpb.SendGithubPullRequestReviewResponse, error)
+}
+
+// GitHubAppService is a wrapper for GitHubApp. It's needed to determine the specific
+// GitHubApp the user has installed (read-only vs read-write) and is used for app-agnostic
+// operations.
+type GitHubAppService interface {
+	GetGitHubAppInstallations(context.Context) ([]*tables.GitHubAppInstallation, error)
+	GetGitHubAppForGroup(ctx context.Context) (GitHubApp, error)
+	GetReadWriteGitHubApp() GitHubApp
 }
 
 type RunnerService interface {

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -464,7 +464,7 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 	if wfs := env.GetWorkflowService(); wfs != nil {
 		mux.Handle("/webhooks/workflow/", interceptors.WrapExternalHandler(env, wfs))
 	}
-	if gha := env.GetGitHubApp(); gha != nil {
+	if gha := env.GetGitHubAppService(); gha != nil {
 		mux.Handle("/webhooks/github/app", interceptors.WrapExternalHandler(env, gha.WebhookHandler()))
 		mux.Handle("/auth/github/app/link/", interceptors.WrapAuthenticatedExternalHandler(env, gha.OAuthHandler()))
 	}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -465,8 +465,10 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 		mux.Handle("/webhooks/workflow/", interceptors.WrapExternalHandler(env, wfs))
 	}
 	if gha := env.GetGitHubAppService(); gha != nil {
-		mux.Handle("/webhooks/github/app", interceptors.WrapExternalHandler(env, gha.WebhookHandler()))
-		mux.Handle("/auth/github/app/link/", interceptors.WrapAuthenticatedExternalHandler(env, gha.OAuthHandler()))
+		mux.Handle("/webhooks/github/app", interceptors.WrapExternalHandler(env, gha.GetReadWriteGitHubApp().WebhookHandler()))
+		mux.Handle("/auth/github/app/link/", interceptors.WrapAuthenticatedExternalHandler(env, gha.GetReadWriteGitHubApp().OAuthHandler()))
+		// TODO(Maggie): Read only app should use the callbacks `webhooks/github/app/readonly`
+		// and `/auth/github/app/readonly/link/`
 	}
 
 	if gcp := env.GetGCPService(); gcp != nil {

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -45,7 +45,7 @@ type RealEnv struct {
 	workspaceService                 interfaces.WorkspaceService
 	runnerService                    interfaces.RunnerService
 	gitProviders                     interfaces.GitProviders
-	gitHubApp                        interfaces.GitHubApp
+	githubAppService                 interfaces.GitHubAppService
 	gitHubStatusService              interfaces.GitHubStatusService
 	staticFilesystem                 fs.FS
 	appFilesystem                    fs.FS
@@ -424,11 +424,11 @@ func (r *RealEnv) GetGitProviders() interfaces.GitProviders {
 func (r *RealEnv) SetGitProviders(gp interfaces.GitProviders) {
 	r.gitProviders = gp
 }
-func (r *RealEnv) SetGitHubApp(val interfaces.GitHubApp) {
-	r.gitHubApp = val
+func (r *RealEnv) GetGitHubAppService() interfaces.GitHubAppService {
+	return r.githubAppService
 }
-func (r *RealEnv) GetGitHubApp() interfaces.GitHubApp {
-	return r.gitHubApp
+func (r *RealEnv) SetGitHubAppService(v interfaces.GitHubAppService) {
+	r.githubAppService = v
 }
 func (r *RealEnv) SetGitHubStatusService(val interfaces.GitHubStatusService) {
 	r.gitHubStatusService = val

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -167,7 +167,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		ConfiguredIssuers:                      env.GetAuthenticator().PublicIssuers(),
 		DefaultToDenseMode:                     *defaultToDenseMode,
 		GithubEnabled:                          github.IsLegacyOAuthAppEnabled(),
-		GithubAppEnabled:                       env.GetGitHubApp() != nil,
+		GithubAppEnabled:                       env.GetGitHubAppService() != nil,
 		GithubAuthEnabled:                      github.AuthEnabled(env),
 		AnonymousUsageEnabled:                  env.GetAuthenticator().AnonymousUsageEnabled(ctx),
 		TestDashboardEnabled:                   target_tracker.TargetTrackingEnabled(),

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -556,6 +556,9 @@ func (ts *TargetStatus) TableName() string {
 // GitHubAppInstallation represents a BuildBuddy GitHub App installation linked
 // to an organization.
 //
+// For now, a BB group can only have one app installed at a time (either read-write
+// or read-only).
+//
 // We'll listen to app uninstallation webhook events to proactively remove these
 // from the DB, but this is not 100% reliable, so GitHub is ultimately the
 // source of truth for whether an installation is valid or not. Typically, the
@@ -572,7 +575,8 @@ type GitHubAppInstallation struct {
 	GroupID string `gorm:"primaryKey"`
 	Perms   int32  `gorm:"not null"`
 
-	// InstallationID is the GitHub app installation ID.
+	// InstallationID is the GitHub app installation ID. This a unique value
+	// for every user that has installed a GitHub app.
 	InstallationID int64 `gorm:"not null"`
 
 	// Owner is the GitHub login of the installation (either a user or
@@ -580,6 +584,11 @@ type GitHubAppInstallation struct {
 	// store it here so that we can run queries to associate repos with
 	// installations.
 	Owner string `gorm:"primaryKey"`
+
+	// AppID is the ID for the GitHub app that this installation corresponds to.
+	// There are only 2 possible app IDs - corresponding to either the read-write
+	// or read-only BB GitHub app.
+	AppID int64
 }
 
 func (gh *GitHubAppInstallation) TableName() string {
@@ -605,6 +614,10 @@ type GitRepository struct {
 	// within this repository should run as a non-root user by default.
 	// TODO(http://go/b/3286): Remove this field after completing migration.
 	DefaultNonRootRunner bool `gorm:"not null;default:0"`
+
+	// The ID of the BuildBuddy Github app this repository was authorized for.
+	// (i.e. either the read-only or the read-write app)
+	AppID int64
 }
 
 func (g *GitRepository) TableName() string {

--- a/server/testutil/testgit/testgit.go
+++ b/server/testutil/testgit/testgit.go
@@ -169,9 +169,14 @@ func configure(t testing.TB, repoPath string) {
 // FakeGitHubApp implements the github app interface for tests.
 type FakeGitHubApp struct {
 	interfaces.GitHubApp
-	Token string
+	Token     string
+	MockAppID int64
 }
 
 func (a *FakeGitHubApp) GetRepositoryInstallationToken(ctx context.Context, repo *tables.GitRepository) (string, error) {
 	return a.Token, nil
+}
+
+func (a *FakeGitHubApp) AppID() int64 {
+	return a.MockAppID
 }

--- a/server/testutil/testgit/testgit.go
+++ b/server/testutil/testgit/testgit.go
@@ -166,6 +166,17 @@ func configure(t testing.TB, repoPath string) {
 	`)
 }
 
+// FakeGitHubAppService implements the github app service interface for tests.
+type FakeGitHubAppService struct {
+	interfaces.GitHubAppService
+
+	App interfaces.GitHubApp
+}
+
+func (s *FakeGitHubAppService) GetGitHubApp(ctx context.Context) (interfaces.GitHubApp, error) {
+	return s.App, nil
+}
+
 // FakeGitHubApp implements the github app interface for tests.
 type FakeGitHubApp struct {
 	interfaces.GitHubApp


### PR DESCRIPTION
TODO: Backfill appID in database for `GitRepository` and `GitHubAppInstallation`

This PR adds a wrapper for every place we use GithubApp. Now that we'll support 2 different versions of the app, we need to reference the appropriate one