### PR TITLE
Emit COW and UFFD metrics for stages other than init

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2235,14 +2235,14 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 
 	stage = "exec"
 	result, vmHealthy := c.sendExecRequestToGuest(ctx, conn, cmd, guestWorkspaceMountDir, stdio)
-	c.emitCOWAndUFFDMetrics(stage)
-	stage = "post_exec"
 
 	ctx, cancel = background.ExtendContextForFinalization(ctx, finalizationTimeout)
 	defer cancel()
 
 	// If FUSE is enabled then outputs are already in the workspace.
 	if c.fsLayout == nil && !*disableWorkspaceSync {
+		c.emitCOWAndUFFDMetrics(stage)
+		stage = "copy_workspace_outputs"
 		// Unmount the workspace and pause the VM before syncing to ensure that
 		// the guest's FS cache is flushed to the backing file on the host and
 		// that no concurrent operations can occur while we're reading the

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -742,6 +742,8 @@ func (c *COWStore) updateUsageSummary(operation string, startTime time.Time) {
 	c.chunkOperationToUsageSummary[operation] = summary
 }
 
+// EmitUsageMetrics will export cumulative metrics for the given stage, and then
+// reset them.
 func (c *COWStore) EmitUsageMetrics(stage string) {
 	c.usageLock.Lock()
 	defer c.usageLock.Unlock()
@@ -757,6 +759,7 @@ func (c *COWStore) EmitUsageMetrics(stage string) {
 			logStr += fmt.Sprintf("\n%s: {total duration (millisec): %v, count: %v}", op, summary.totalDuration.Milliseconds(), summary.totalCount)
 		}
 	}
+	c.chunkOperationToUsageSummary = make(map[string]usageSummary, 0)
 
 	log.CtxDebug(c.ctx, logStr)
 }

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -373,6 +373,8 @@ func (h *Handler) handle(ctx context.Context, memoryStore *copy_on_write.COWStor
 	}
 }
 
+// EmitSummaryMetrics will export cumulative metrics for the given stage, and
+// then reset them.
 func (h *Handler) EmitSummaryMetrics(stage string) {
 	// Read the total accumulated duration and reset the counter to 0.
 	pageFaultTotalDuration := time.Duration(h.pageFaultTotalDurationNanos.Swap(0))


### PR DESCRIPTION
Also emit the metrics for stages that fail.

Previously, we only got these metrics up to the point where the balloon is inflated.