### PR TITLE
Improve histogram buckets for 2 firecracker metrics

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -313,6 +313,18 @@ const (
 
 // Bucket constants
 var (
+	// These buckets have very little precision:
+	// 0 = 1µs
+	// 1 = 10µs
+	// 2 = 100µs
+	// 3 = 1ms
+	// 4 = 10ms
+	// 5 = 100ms
+	// 6 = 1s
+	// 7 = 10s
+	// 8 = 1m40s
+	// 9 = inf
+	// It's probably better to use something specific to the given metric.
 	coarseMicrosecondToHour = durationUsecBuckets(1*time.Microsecond, 1*time.Hour, 10)
 )
 
@@ -1406,7 +1418,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",
 		Name:      "cow_snapshot_page_fault_total_duration_usec",
-		Buckets:   durationUsecBuckets(1*time.Microsecond, 10*time.Minute, 10),
+		Buckets:   durationUsecBuckets(100*time.Millisecond, 10*time.Minute, 2.3),
 		Help:      "For a snapshotted VM, total time spent fulfilling page faults.",
 	}, []string{
 		Stage,
@@ -1416,7 +1428,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",
 		Name:      "cow_snapshot_chunk_operation_duration_usec",
-		Buckets:   durationUsecBuckets(1*time.Microsecond, 10*time.Minute, 10),
+		Buckets:   durationUsecBuckets(100*time.Millisecond, 10*time.Minute, 2.3),
 		Help:      "For a COW snapshot, cumulative time spent on an operation type.",
 	}, []string{
 		FileName,
@@ -3133,7 +3145,8 @@ var (
 
 // exponentialBucketRange returns prometheus.ExponentialBuckets specified in
 // terms of a min and max value, rather than needing to explicitly calculate the
-// number of buckets.
+// number of buckets. You can use go/buckets (go.dev/play/p/-9T203IuxF1)
+// to help you come up with sensible buckets for your metric.
 func exponentialBucketRange(min, max, factor float64) []float64 {
 	if min < 0 || min >= max {
 		panic(fmt.Sprintf("exponentialBucketRange: expected 0 < min < max, got min=%f, max=%f", min, max))


### PR DESCRIPTION
This increases bucket count from 9 to 11, but it adds a lot more precision between 1s and 10min.

The previous buckets were
```
0 = 1µs
1 = 10µs
2 = 100µs
3 = 1ms
4 = 10ms
5 = 100ms
6 = 1s
7 = 10s
8 = 1m40s
9 = inf
```
Now they are
```
0 = 100ms
1 = 229.999ms
2 = 528.999ms
3 = 1.216699s
4 = 2.798409s
5 = 6.436342s
6 = 14.803588s
7 = 34.048254s
8 = 1m18.310985s
9 = 3m0.115266s
10 = 6m54.265112s
11 = inf
```