### PR TITLE
Reduce the number of buckets for firecracker_exec_dial_duration_usec

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1328,7 +1328,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",
 		Name:      "exec_dial_duration_usec",
-		Buckets:   durationUsecBuckets(1*time.Millisecond, 5*time.Minute, 1.25),
+		Buckets:   durationUsecBuckets(50*time.Millisecond, 2*time.Minute, 2),
 		Help:      "Time taken to dial the VM guest execution server after it has been started or resumed, in **microseconds**.",
 	}, []string{
 		CreatedFromSnapshot,


### PR DESCRIPTION
Previously, this metric had 57 buckets, which made it very slow to query. This change makes it have 12 buckets.