### PR TITLE
[raft] clean up zombies where the initial members were not set up properly

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -260,6 +260,10 @@ type ClusterBootstrapInfo struct {
 	Replicas       []*rfpb.ReplicaDescriptor
 }
 
+func (cbi ClusterBootstrapInfo) InitialMembersForTesting() map[uint64]string {
+	return cbi.initialMembers
+}
+
 func MakeBootstrapInfo(rangeID, firstReplicaID uint64, nodeGrpcAddrs map[string]string) *ClusterBootstrapInfo {
 	bi := &ClusterBootstrapInfo{
 		rangeID:        rangeID,

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -155,7 +155,7 @@ func (e *aggErr) err() error {
 		return nil
 	}
 
-	if e.lastErr == dragonboat.ErrShardNotFound || e.lastErr == dragonboat.ErrRejected {
+	if e.lastErr == dragonboat.ErrShardNotFound || e.lastErr == dragonboat.ErrRejected || e.lastErr == dragonboat.ErrShardNotReady {
 		return e.lastErr
 	} else if status.IsOutOfRangeError(e.lastErr) {
 		return e.lastErr


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4571

1. added a new zombie clean up action: stopReplica.
2. In the case where getMembership returns shard is not ready; we stopReplica
   and call RemoveData
3. Added a test case 
