### PR TITLE
build_event_handler: validate bazel_event type

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -766,7 +766,9 @@ func isChildInvocationsConfiguredEvent(bazelBuildEvent *build_event_stream.Build
 func readBazelEvent(obe *pepb.OrderedBuildEvent, out *build_event_stream.BuildEvent) error {
 	switch buildEvent := obe.Event.Event.(type) {
 	case *bepb.BuildEvent_BazelEvent:
-		return buildEvent.BazelEvent.UnmarshalTo(out)
+		if buildEvent.BazelEvent.MessageIs(out) {
+			return buildEvent.BazelEvent.UnmarshalTo(out)
+		}
 	}
 	return fmt.Errorf("Not a bazel event %s", obe)
 }


### PR DESCRIPTION
Based on the conversation in
https://github.com/googleapis/googleapis/pull/988, the `bazel_event`
Any field could be used for generic events instead of just Bazel's
`build_event_stream.BuildEvent`.

Add validation to the current logic to make sure that we are receiving
build_event_stream.BuildEvent.

This could be extended in the future to support BuckEvent.
