### PR TITLE
Run vmexec_test in a VM

### DIFF
--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -29,7 +29,11 @@ go_library(
 go_test(
     name = "vmexec_test",
     srcs = ["vmexec_test.go"],
-    flaky = True,
+    exec_properties = {
+        # Run in a firecracker VM since this test runs sync() and we don't want
+        # to cause unnecessary IO on the host machine.
+        "test.workload-isolation-type": "firecracker",
+    },
     deps = [
         ":vmexec",
         "//enterprise/server/remote_execution/commandutil",


### PR DESCRIPTION
`vmexec_test` runs `sync` which is very slow if the host FS is under a lot of contention, since it causes all pending writes to be flushed to disk and then waits for those writes to complete.