### PR TITLE
Improve cpuset configuration

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -186,7 +186,7 @@ func GetConfiguredEnvironmentOrDie(cacheRoot string, healthChecker *healthcheck.
 	xl := xcode.NewXcodeLocator()
 	realEnv.SetXcodeLocator(xl)
 
-	leaser, err := cpuset.NewLeaser()
+	leaser, err := cpuset.NewLeaser(cpuset.LeaserOpts{})
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -263,7 +263,7 @@ func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEn
 	fc.WaitForDirectoryScanToComplete()
 	env.SetFileCache(fc)
 
-	leaser, err := cpuset.NewLeaser()
+	leaser, err := cpuset.NewLeaser(cpuset.LeaserOpts{})
 	require.NoError(t, err)
 	env.SetCPULeaser(leaser)
 	flags.Set(t, "executor.cpu_leaser.enable", true)

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -118,7 +118,7 @@ func imageConfigTestImage(t *testing.T) string {
 }
 
 func installLeaserInEnv(t testing.TB, env *real_environment.RealEnv) {
-	leaser, err := cpuset.NewLeaser()
+	leaser, err := cpuset.NewLeaser(cpuset.LeaserOpts{})
 	require.NoError(t, err)
 	env.SetCPULeaser(leaser)
 	flags.Set(t, "executor.cpu_leaser.enable", true)

--- a/enterprise/server/util/cpuset/cpuset.go
+++ b/enterprise/server/util/cpuset/cpuset.go
@@ -36,15 +36,15 @@ var _ interfaces.CPULeaser = (*CPULeaser)(nil)
 
 type CPULeaser struct {
 	mu                 sync.Mutex
-	cpus               []cpuInfo
+	cpus               []CPUInfo
 	leases             []lease
 	load               map[int]int
 	physicalProcessors int
 }
 
-type cpuInfo struct {
-	processor  int // cpuset id
-	physicalID int // numa node
+type CPUInfo struct {
+	Processor  int // cpuset id
+	PhysicalID int // numa node
 }
 
 type lease struct {
@@ -53,12 +53,12 @@ type lease struct {
 	location string // only set if *warnAboutLeaks is enabled
 }
 
-func toCPUInfos(processors []int, physicalID int) []cpuInfo {
-	infos := make([]cpuInfo, len(processors))
+func toCPUInfos(processors []int, physicalID int) []CPUInfo {
+	infos := make([]CPUInfo, len(processors))
 	for i, p := range processors {
-		infos[i] = cpuInfo{
-			processor:  p,
-			physicalID: physicalID,
+		infos[i] = CPUInfo{
+			Processor:  p,
+			PhysicalID: physicalID,
 		}
 	}
 	return infos
@@ -75,91 +75,114 @@ func Format[I constraints.Integer](cpus ...I) string {
 	return strings.Join(cpuStrings, ",")
 }
 
-// parseCPUs parses a string like "0,1-2" or "0:0-127,1:128-255" to cpuInfos.
+// parseCPUs parses a list of CPUs from a comma-separated list of
+// "NODE:CPU_RANGE" pairs where the "NODE:" prefix is optional, and CPU_RANGE
+// can either be a single CPU index or a range of CPUs like "0-127".
 //
-// This string is a comma-separated list of "NODE:CPU_RANGE" pairs where the
-// "NODE:" prefix is optional.
+// Examples:
+// - Single CPU: "0"
+// - Multiple CPUs: "0,1,2"
+// - CPU range: "0-127"
+// - CPU range with node: "0:0-127"
+// - Multiple CPUs or CPU ranges, with optional nodes: "0:0-127,128-255,256"
 //
-// If the NODE isn't set, physicalIDs is used to map processor ids to physical
-// ids. Otherwise, the returned CPUs will have physicalID set to -1.
-func parseCPUs(s string, physicalIDs map[int]int) ([]cpuInfo, error) {
-	var cpus []cpuInfo
+// If the NODE prefix is omitted, -1 is returned, and the caller is responsible
+// for mapping these processor IDs to physical IDs.
+func parseCPUs(s string) ([]CPUInfo, error) {
+	var cpus []CPUInfo
 	nodeRanges := strings.Split(s, ",")
 	for _, r := range nodeRanges {
 		physicalID := -1
 		if numaStr, rangeStr, ok := strings.Cut(r, ":"); ok {
 			numaID, err := strconv.Atoi(numaStr)
 			if err != nil {
-				return cpus, fmt.Errorf("malformed NUMA node %q", numaStr)
+				return nil, fmt.Errorf("invalid NUMA node %q", numaStr)
 			}
 			physicalID = numaID
 			r = rangeStr
 		}
-		startStr, endStr, _ := strings.Cut(r, "-")
+		startStr, endStr, isRange := strings.Cut(r, "-")
 		start, err := strconv.Atoi(startStr)
 		if err != nil {
-			return cpus, fmt.Errorf("malformed CPU start index %q", startStr)
+			if isRange {
+				return nil, fmt.Errorf("invalid CPU range start index %q", startStr)
+			}
+			return nil, fmt.Errorf("invalid CPU index %q", startStr)
 		}
 		end := start
-		if endStr != "" {
+		if isRange {
 			n, err := strconv.Atoi(endStr)
 			if err != nil {
-				return cpus, fmt.Errorf("malformed CPU end index %q", endStr)
+				return nil, fmt.Errorf("invalid CPU range end index %q", endStr)
 			}
 			if n < start {
-				return cpus, fmt.Errorf("invalid CPU range end index %d: must exceed start index %d", n, start)
+				return nil, fmt.Errorf("invalid CPU range end index %d: must exceed start index %d", n, start)
 			}
 			end = n
 		}
 		for processor := start; processor <= end; processor++ {
-			info := cpuInfo{
-				processor:  processor,
-				physicalID: physicalID,
-			}
-			if info.physicalID == -1 {
-				id, ok := physicalIDs[processor]
-				if !ok {
-					return nil, fmt.Errorf("unknown physical ID for CPU %d (invalid CPU index?)", processor)
-				}
-				info.physicalID = id
-			}
-			cpus = append(cpus, info)
+			cpus = append(cpus, CPUInfo{
+				Processor:  processor,
+				PhysicalID: physicalID,
+			})
 		}
 	}
 	return cpus, nil
 }
 
-func NewLeaser() (*CPULeaser, error) {
+type LeaserOpts struct {
+	// SystemCPUs is the set of available CPUs on the current system. If empty,
+	// CPU information will be fetched from the OS.
+	SystemCPUs []CPUInfo
+}
+
+func NewLeaser(opts LeaserOpts) (*CPULeaser, error) {
+	systemCPUs := opts.SystemCPUs
+	if len(systemCPUs) == 0 {
+		c, err := GetCPUs()
+		if err != nil {
+			return nil, fmt.Errorf("get CPUs: %w", err)
+		}
+		systemCPUs = c
+	}
+
 	cl := &CPULeaser{
 		leases: make([]lease, 0, MaxNumLeases),
 		load:   make(map[int]int, 0),
 	}
 
-	// CPU ranges can be overridden via flag, but we unconditionally get the
-	// CPUs from the OS so that we can map CPU numbers to NUMA nodes.
-	cpus, err := GetCPUs()
-	if err != nil {
-		return nil, fmt.Errorf("get CPUs: %w", err)
-	}
+	leaseableCPUs := systemCPUs
 	if *cpuLeaserCPUSet != "" {
-		physicalIDs := make(map[int]int, len(cpus))
-		for _, cpu := range cpus {
-			physicalIDs[cpu.processor] = cpu.physicalID
-		}
-		c, err := parseCPUs(*cpuLeaserCPUSet, physicalIDs)
+		c, err := parseCPUs(*cpuLeaserCPUSet)
 		if err != nil {
 			return nil, err
 		}
-		cpus = c
+		// Validate "NODE:" prefixes against system CPU information, or populate
+		// them if they were omitted.
+		physicalIDs := make(map[int]int, len(systemCPUs))
+		for _, cpu := range systemCPUs {
+			physicalIDs[cpu.Processor] = cpu.PhysicalID
+		}
+		for i := range c {
+			cpu := &c[i]
+			if cpu.PhysicalID == -1 {
+				cpu.PhysicalID = physicalIDs[cpu.Processor]
+			} else {
+				if physicalIDs[cpu.Processor] != cpu.PhysicalID {
+					return nil, fmt.Errorf("invalid node ID %d for CPU %d: does not match OS-reported ID %d", cpu.PhysicalID, cpu.Processor, physicalIDs[cpu.Processor])
+				}
+			}
+		}
+		leaseableCPUs = c
 	}
 
-	cl.cpus = make([]cpuInfo, len(cpus))
+	cl.cpus = make([]CPUInfo, len(leaseableCPUs))
 
 	processors := make(map[int]struct{}, 0)
-	for i, cpu := range cpus {
+	for i, cpu := range leaseableCPUs {
 		cl.cpus[i] = cpu
-		cl.load[cpu.processor] = 0
-		processors[cpu.physicalID] = struct{}{}
+		cl.load[cpu.Processor] = 0
+		processors[cpu.PhysicalID] = struct{}{}
 	}
 	cl.physicalProcessors = len(processors)
 	log.Debugf("NewLeaser with %d processors and %d cores", cl.physicalProcessors, len(cl.cpus))
@@ -211,9 +234,9 @@ func (l *CPULeaser) Acquire(milliCPU int64, taskID string, opts ...any) (int, []
 	}
 
 	// Put all CPUs in a priority queue.
-	pq := priority_queue.New[cpuInfo]()
+	pq := priority_queue.New[CPUInfo]()
 	for _, cpuInfo := range l.cpus {
-		numTasks := l.load[cpuInfo.processor]
+		numTasks := l.load[cpuInfo.Processor]
 		// we want the least loaded cpus first, so give the
 		// cpus with more tasks a more negative score.
 		pq.Push(cpuInfo, -1*numTasks)
@@ -227,7 +250,7 @@ func (l *CPULeaser) Acquire(milliCPU int64, taskID string, opts ...any) (int, []
 	numaCount := make(map[int]int, l.physicalProcessors)
 	for i := 0; i < numCPUs; i++ {
 		c := leastLoaded[i]
-		numaCount[c.physicalID]++
+		numaCount[c.PhysicalID]++
 	}
 	selectedNode := -1
 	numCores := 0
@@ -241,11 +264,11 @@ func (l *CPULeaser) Acquire(milliCPU int64, taskID string, opts ...any) (int, []
 	// Now filter the set of CPUs to just the selected numaNode.
 	leaseSet := make([]int, 0, numCPUs)
 	for _, c := range leastLoaded {
-		if c.physicalID != selectedNode {
+		if c.PhysicalID != selectedNode {
 			continue
 		}
-		leaseSet = append(leaseSet, c.processor)
-		l.load[c.processor] += 1
+		leaseSet = append(leaseSet, c.Processor)
+		l.load[c.Processor] += 1
 		if len(leaseSet) == numCPUs {
 			break
 		}

--- a/enterprise/server/util/cpuset/cpuset_test.go
+++ b/enterprise/server/util/cpuset/cpuset_test.go
@@ -59,7 +59,7 @@ func TestCPUSetOverhead(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", true)
 	flags.Set(t, "executor.cpu_leaser.overhead", .20)
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 2)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0-47")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-47")
 
 	cs, err := cpuset.NewLeaser()
 	require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestCPUSetOverhead(t *testing.T) {
 
 func TestCPUSetDisabled(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", false)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0-47")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-47")
 
 	cs, err := cpuset.NewLeaser()
 	require.NoError(t, err)
@@ -199,11 +199,13 @@ func TestMaxNumberOfLeases(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.overhead", 0)
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
 	flags.Set(t, "executor.cpu_leaser.cpuset", "0")
+	// Don't log warnings to avoid spamming test logs.
+	flags.Set(t, "executor.cpu_leaser.warn_about_leaks", false)
 
 	cs, err := cpuset.NewLeaser()
 	require.NoError(t, err)
 
-	numLeases := cpuset.MaxNumLeases * 3
+	numLeases := cpuset.MaxNumLeases
 	taskIDs := make([]string, numLeases)
 	cancels := make([]func(), numLeases)
 	for i := 0; i < numLeases; i++ {

--- a/enterprise/server/util/cpuset/cpuset_test.go
+++ b/enterprise/server/util/cpuset/cpuset_test.go
@@ -10,13 +10,107 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseCPUs(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		input         string      // cpuset spec for CPUs returned by getTestCPUs
+		expectedCPUs  map[int]int // expected CPU => node mapping
+		expectedError string
+	}{
+		{
+			name:         "single CPU",
+			input:        "0",
+			expectedCPUs: map[int]int{0: 0},
+		},
+		{
+			name:         "multiple CPUs",
+			input:        "0,1",
+			expectedCPUs: map[int]int{0: 0, 1: 0},
+		},
+		{
+			name:         "CPU range",
+			input:        "0-2",
+			expectedCPUs: map[int]int{0: 0, 1: 0, 2: 0},
+		},
+		{
+			name:         "multiple CPUs and ranges",
+			input:        "0,1-2,3",
+			expectedCPUs: map[int]int{0: 0, 1: 0, 2: 0, 3: 0},
+		},
+		{
+			name:         "multiple nodes and ranges with nodes",
+			input:        "0:0,1:128-129,1",
+			expectedCPUs: map[int]int{0: 0, 128: 1, 129: 1, 1: 0},
+		},
+		{
+			name:          "invalid CPU",
+			input:         "invalid",
+			expectedError: `invalid CPU index "invalid"`,
+		},
+		{
+			name:          "valid node with invalid CPU",
+			input:         "0:invalid",
+			expectedError: `invalid CPU index "invalid"`,
+		},
+		{
+			name:          "invalid CPU range start",
+			input:         "0:invalid-1",
+			expectedError: `invalid CPU range start index "invalid"`,
+		},
+		{
+			name:          "invalid CPU range end",
+			input:         "0:0-invalid",
+			expectedError: `invalid CPU range end index "invalid"`,
+		},
+		{
+			name:          "CPU range end less than start",
+			input:         "0:1-0",
+			expectedError: `invalid CPU range end index 0: must exceed start index 1`,
+		},
+		{
+			name:          "missing CPU range end",
+			input:         "0:0-",
+			expectedError: `invalid CPU range end index ""`,
+		},
+		{
+			name:          "invalid node",
+			input:         "1:0",
+			expectedError: `invalid node ID 1 for CPU 0: does not match OS-reported ID 0`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			flags.Set(t, "executor.cpu_leaser.enable", true)
+			flags.Set(t, "executor.cpu_leaser.cpuset", test.input)
+			cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
+			if test.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedError)
+				return
+			}
+
+			// Lease 1 more than the number of CPUs we're expecting,
+			// and make sure all the returned CPUs are in the expected set.
+			actualCPUs := map[int]int{}
+			for i := 0; i < len(test.expectedCPUs)+1; i++ {
+				task := uuid.New()
+				node, cpus, cancel := cs.Acquire(1000, task, cpuset.WithNoOverhead())
+				defer cancel()
+				for _, cpu := range cpus {
+					actualCPUs[cpu] = node
+				}
+			}
+			assert.Equal(t, test.expectedCPUs, actualCPUs)
+		})
+	}
+}
+
 func TestCPUSetAcquireRelease(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", true)
 	flags.Set(t, "executor.cpu_leaser.overhead", 0)
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0-3")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3")
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 	task1 := uuid.New()
 	_, cpus1, cancel1 := cs.Acquire(3000, task1)
@@ -35,9 +129,9 @@ func TestEvenDistributionUnderLoad(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", true)
 	flags.Set(t, "executor.cpu_leaser.overhead", 0)
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0-3")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3")
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 
 	counts := make(map[int]int, 4)
@@ -61,7 +155,7 @@ func TestCPUSetOverhead(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 2)
 	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-47")
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 	task1 := uuid.New()
 	_, cpus1, cancel1 := cs.Acquire(1100, task1)
@@ -92,7 +186,7 @@ func TestCPUSetDisabled(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", false)
 	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-47")
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 	task1 := uuid.New()
 	numa1, cpus1, cancel1 := cs.Acquire(1100, task1)
@@ -104,30 +198,34 @@ func TestCPUSetDisabled(t *testing.T) {
 
 func TestCPUSetDisabledNumaBalancing(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", false)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:4-7")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:130-133")
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
-	numaNodesSeen := make(map[int]struct{}, 0)
+	nodeFrequency := make(map[int]int, 0)
 	for i := 0; i < 1000; i++ {
 		task := uuid.New()
 		numa, _, cancel := cs.Acquire(1100, task)
-		numaNodesSeen[numa] = struct{}{}
+		nodeFrequency[numa]++
 		cancel()
 	}
-	assert.Equal(t, 2, len(numaNodesSeen))
+	assert.Equal(t, 2, len(nodeFrequency))
+	// TODO: figure out why the node frequencies are sometimes slightly
+	// different, e.g. 498/502 instead of an even 500/500 split.
+	assert.InDelta(t, nodeFrequency[0], nodeFrequency[1], 4)
 }
 
 func TestCPUSetDisabledManualCPUSet(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", false)
 	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-1,3")
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 	task1 := uuid.New()
 	numa1, cpus1, cancel1 := cs.Acquire(1100, task1)
 	defer cancel1()
 	assert.Equal(t, 0, numa1)
+	// Should return all configured CPUs.
 	assert.Equal(t, []int{0, 1, 3}, cpus1)
 }
 
@@ -135,11 +233,11 @@ func TestNumaNodeFairness(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", true)
 	flags.Set(t, "executor.cpu_leaser.overhead", 0)
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-1,1:4-7,0:2-3")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-1,1:128-131,0:2-3")
 
 	var allCPUs []int
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 	task1 := uuid.New()
 	_, cpus1, cancel1 := cs.Acquire(4000, task1)
@@ -151,7 +249,7 @@ func TestNumaNodeFairness(t *testing.T) {
 	defer cancel2()
 	allCPUs = append(allCPUs, cpus2...)
 
-	assert.ElementsMatch(t, []int{0, 1, 2, 3, 4, 5, 6, 7}, allCPUs)
+	assert.ElementsMatch(t, []int{0, 1, 2, 3, 128, 129, 130, 131}, allCPUs)
 
 	task3 := uuid.New()
 	_, cpus3, cancel3 := cs.Acquire(8000, task3)
@@ -163,9 +261,9 @@ func TestNumaNodesAreNotSplit(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", true)
 	flags.Set(t, "executor.cpu_leaser.overhead", 0)
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:4-7")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:128-131")
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 	task1 := uuid.New()
 	_, cpus1, cancel1 := cs.Acquire(4000, task1)
@@ -177,9 +275,9 @@ func TestNonContiguousNumaNodes(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", true)
 	flags.Set(t, "executor.cpu_leaser.overhead", 0)
 	flags.Set(t, "executor.cpu_leaser.min_overhead", 0)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "3:0-3,9:4-7")
+	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:128-131")
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 
 	task1 := uuid.New()
@@ -202,10 +300,10 @@ func TestMaxNumberOfLeases(t *testing.T) {
 	// Don't log warnings to avoid spamming test logs.
 	flags.Set(t, "executor.cpu_leaser.warn_about_leaks", false)
 
-	cs, err := cpuset.NewLeaser()
+	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
 	require.NoError(t, err)
 
-	numLeases := cpuset.MaxNumLeases
+	numLeases := cpuset.MaxNumLeases * 3
 	taskIDs := make([]string, numLeases)
 	cancels := make([]func(), numLeases)
 	for i := 0; i < numLeases; i++ {
@@ -226,4 +324,21 @@ func TestMaxNumberOfLeases(t *testing.T) {
 	for _, load := range cs.TestOnlyGetLoads() {
 		require.Equal(t, 0, load)
 	}
+}
+
+// Returns test CPU info:
+//
+// 0-127: physical node 0
+// 128-255: physical node 1
+// 256-383: physical node 0
+// 384-511: physical node 1
+func getTestCPUs() []cpuset.CPUInfo {
+	var out []cpuset.CPUInfo
+	for i := 0; i < 512; i++ {
+		out = append(out, cpuset.CPUInfo{
+			Processor:  i,
+			PhysicalID: (i / 128) % 2,
+		})
+	}
+	return out
 }

--- a/enterprise/server/util/cpuset/numcpu_darwin.go
+++ b/enterprise/server/util/cpuset/numcpu_darwin.go
@@ -6,13 +6,15 @@ import (
 	"github.com/elastic/gosigar"
 )
 
-func GetCPUs() []cpuInfo {
+func GetCPUs() ([]cpuInfo, error) {
 	cpuList := gosigar.CpuList{}
-	cpuList.Get()
+	if err := cpuList.Get(); err != nil {
+		return nil, err
+	}
 
 	nodes := make([]int, len(cpuList.List))
 	for i := 0; i < len(cpuList.List); i++ {
 		nodes[i] = i
 	}
-	return toCPUInfos(nodes, 0)
+	return toCPUInfos(nodes, 0), nil
 }

--- a/enterprise/server/util/cpuset/numcpu_darwin.go
+++ b/enterprise/server/util/cpuset/numcpu_darwin.go
@@ -6,7 +6,7 @@ import (
 	"github.com/elastic/gosigar"
 )
 
-func GetCPUs() ([]cpuInfo, error) {
+func GetCPUs() ([]CPUInfo, error) {
 	cpuList := gosigar.CpuList{}
 	if err := cpuList.Get(); err != nil {
 		return nil, err

--- a/enterprise/server/util/cpuset/numcpu_linux.go
+++ b/enterprise/server/util/cpuset/numcpu_linux.go
@@ -8,14 +8,14 @@ import (
 	"github.com/prometheus/procfs"
 )
 
-func GetCPUs() []cpuInfo {
+func GetCPUs() ([]cpuInfo, error) {
 	fs, err := procfs.NewDefaultFS()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	cpuInfos, err := fs.CPUInfo()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	nodes := make([]cpuInfo, len(cpuInfos))
@@ -28,5 +28,5 @@ func GetCPUs() []cpuInfo {
 		}
 		nodes[i] = c
 	}
-	return nodes
+	return nodes, nil
 }

--- a/enterprise/server/util/cpuset/numcpu_linux.go
+++ b/enterprise/server/util/cpuset/numcpu_linux.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/procfs"
 )
 
-func GetCPUs() ([]cpuInfo, error) {
+func GetCPUs() ([]CPUInfo, error) {
 	fs, err := procfs.NewDefaultFS()
 	if err != nil {
 		return nil, err
@@ -18,13 +18,13 @@ func GetCPUs() ([]cpuInfo, error) {
 		return nil, err
 	}
 
-	nodes := make([]cpuInfo, len(cpuInfos))
+	nodes := make([]CPUInfo, len(cpuInfos))
 	for i, info := range cpuInfos {
-		c := cpuInfo{
-			processor: int(info.Processor),
+		c := CPUInfo{
+			Processor: int(info.Processor),
 		}
 		if i, err := strconv.Atoi(info.PhysicalID); err == nil {
-			c.physicalID = int(i)
+			c.PhysicalID = int(i)
 		}
 		nodes[i] = c
 	}

--- a/enterprise/server/util/cpuset/numcpu_windows.go
+++ b/enterprise/server/util/cpuset/numcpu_windows.go
@@ -6,13 +6,15 @@ import (
 	"github.com/elastic/gosigar"
 )
 
-func GetCPUs() []cpuInfo {
+func GetCPUs() ([]cpuInfo, error) {
 	cpuList := gosigar.CpuList{}
-	cpuList.Get()
+	if err := cpuList.Get(); err != nil {
+		return nil, err
+	}
 
 	nodes := make([]int, len(cpuList.List))
 	for i := 0; i < len(cpuList.List); i++ {
 		nodes[i] = i
 	}
-	return toCPUInfos(nodes, 0)
+	return toCPUInfos(nodes, 0), nil
 }

--- a/enterprise/server/util/cpuset/numcpu_windows.go
+++ b/enterprise/server/util/cpuset/numcpu_windows.go
@@ -6,7 +6,7 @@ import (
 	"github.com/elastic/gosigar"
 )
 
-func GetCPUs() ([]cpuInfo, error) {
+func GetCPUs() ([]CPUInfo, error) {
 	cpuList := gosigar.CpuList{}
 	if err := cpuList.Get(); err != nil {
 		return nil, err

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -90,7 +90,7 @@ func getToolEnv() *real_environment.RealEnv {
 	fc.WaitForDirectoryScanToComplete()
 	re.SetFileCache(fc)
 
-	leaser, err := cpuset.NewLeaser()
+	leaser, err := cpuset.NewLeaser(cpuset.LeaserOpts{})
 	if err != nil {
 		log.Fatalf("Failed to set up cpuset leaser: %s", err)
 	}


### PR DESCRIPTION
- Don't require NUMA node to be specified when setting the CPU ranges flag; instead allow passing only CPU ranges and infer the NUMA node automatically. See https://github.com/buildbuddy-io/buildbuddy-internal/pull/4558#discussion_r1989994829
- If the NUMA node is specified (e.g. if we want to make the config more explicit / make it clearer which nodes we're using) then validate that the nodes actually correspond to the provided CPUs.
- Don't ignore errors in GetCPUs.
- Make parsing slightly more intuitive: split the `NODE:CPUS` strings on `:` first then `-`, instead of the other way around.
- Improve error messaging when we fail to parse the cpuset flag.
