### PR TITLE
[raft] fixing some bugs in zombie cleanup

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -100,7 +100,7 @@ func TestAddGetRemoveRange(t *testing.T) {
 	require.Nil(t, gotRd)
 }
 
-func TestCleanupZombieReplicas(t *testing.T) {
+func TestCleanupZombieReplicaNotInRangeDescriptor(t *testing.T) {
 	// Prevent driver kicks in to add the replica back to the store.
 	flags.Set(t, "cache.raft.min_replicas_per_range", 1)
 	flags.Set(t, "cache.raft.min_meta_range_replicas", 3)


### PR DESCRIPTION
1. should not ignore ShardNotFound when requesting delete replica. When
   this happens, the replica membership was not changed
2. always stop replica before removing data. There are some cases where
   after requesting delete replica, the node is not deleted or unloaded.
3. fix a bug where we will always return an error when we are supposed
   to ignore ErrRejected.

also, rename a zombie test to make it more descriptive since we have
three zombie tests now.
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4577