### PR TITLE
github/workflows: Improve caching in CI workflow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -127,7 +127,7 @@ common:ci --config=remote-minimal
 common:ci --build_metadata=ROLE=CI
 common:ci --build_metadata=VISIBILITY=PUBLIC
 common:ci --remote_instance_name=buildbuddy-io/buildbuddy/ci
-common:ci --repository_cache=/home/runner/repo-cache/
+common:ci --repository_cache=~/repo-cache/
 common:ci --flaky_test_attempts=2
 common:ci --color=yes
 common:ci --disk_cache=
@@ -136,7 +136,7 @@ common:ci --disk_cache=
 # Configuration used for untrusted GitHub actions-based CI
 common:untrusted-ci --config=remote-minimal
 common:untrusted-ci --remote_instance_name=buildbuddy-io/buildbuddy/untrusted-ci
-common:untrusted-ci --repository_cache=/home/runner/repo-cache/untrusted/
+common:untrusted-ci --repository_cache=~/repo-cache/untrusted/
 common:untrusted-ci --disk_cache=
 common:untrusted-ci --flaky_test_attempts=2
 common:untrusted-ci --remote_executor=grpcs://remote.buildbuddy.io
@@ -211,11 +211,13 @@ common:release-shared --strip=always
 common:release --config=release-shared
 common:release --config=remote-prod-shared
 common:release --config=target-linux-x86
+common:release --repository_cache=~/repo-cache/
 common:release --remote_instance_name=buildbuddy-io/buildbuddy/release
 common:release --remote_download_toplevel
 
 # Configuration used for release-mac workflow
 common:release-mac --config=release-shared
+common:release-mac --repository_cache=~/repo-cache/
 
 # Configuration used for release-m1 workflow
 common:release-m1 --config=release-shared

--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -1,0 +1,61 @@
+name: "Restore download caches"
+description: "Restores external dependencies caches, and outputs cache-hit statuses."
+inputs:
+  repo-cache-dir:
+    description: "The directory where the Bazel Repo cache is stored."
+    required: true
+    default: "~/repo-cache/"
+  go-mod-cache-dir:
+    description: "The directory where the Go Mod cache is stored."
+    required: true
+    default: "/home/runner/go-mod-cache/"
+  yarn-cache-dir:
+    description: "The directory where the Yarn cache is stored."
+    required: true
+    default: ~/.cache/yarn/v6/
+outputs:
+  repo-cache-hit:
+    description: "Cache hit status for Bazel Repo Cache"
+    value: ${{ steps.repo-cache-restore.outputs.cache-hit }}
+  go-mod-cache-hit:
+    description: "Cache hit status for Go Mod Cache"
+    value: ${{ steps.go-mod-cache-restore.outputs.cache-hit }}
+  yarn-cache-hit:
+    description: "Cache hit status for Yarn Cache"
+    value: ${{ steps.yarn-cache-restore.outputs.cache-hit }}
+runs:
+  using: composite
+  # Github Actions does not allow overwriting an existing cache key.
+  # So we write a new cache key for each run attempt, while restoring the cache with a prefix match.
+  #
+  # Reference: https://github.com/actions/cache/pull/1452
+  steps:
+    - name: Restore Bazel Repo Cache
+      uses: actions/cache/restore@v4
+      id: repo-cache-restore
+      with:
+        path: ${{ inputs.repo-cache-dir }}
+        key: repo-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'deps.bzl') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          repo-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'deps.bzl') }}-
+          repo-cache-${{ runner.os }}-
+
+    - name: Restore Go Mod Cache
+      uses: actions/cache/restore@v4
+      id: go-mod-cache-restore
+      with:
+        path: ${{ inputs.go-mod-cache-dir }}
+        key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}-
+          go-mod-cache-${{ runner.os }}-
+
+    - name: Restore Yarn Cache
+      uses: actions/cache/restore@v4
+      id: yarn-cache-restore
+      with:
+        path: ${{ inputs.yarn-cache-dir }}
+        key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}-
+          yarn-cache-${{ runner.os }}-

--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -4,15 +4,15 @@ inputs:
   repo-cache-dir:
     description: "The directory where the Bazel Repo cache is stored."
     required: true
-    default: "~/repo-cache/"
+    default: "~/repo-cache"
   go-mod-cache-dir:
     description: "The directory where the Go Mod cache is stored."
     required: true
-    default: "/home/runner/go-mod-cache/"
+    default: "/home/runner/go-mod-cache"
   yarn-cache-dir:
     description: "The directory where the Yarn cache is stored."
     required: true
-    default: ~/.cache/yarn/v6/
+    default: "~/.cache/yarn/v6"
 outputs:
   repo-cache-hit:
     description: "Cache hit status for Bazel Repo Cache"

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -1,0 +1,51 @@
+name: "Save download caches conditionally"
+description: "Conditionally saves external dependencies caches based on cache-hit status."
+inputs:
+  repo-cache-hit:
+    description: 'Cache hit status for Bazel Repo Cache'
+    required: true
+  repo-cache-dir:
+    description: 'The Bazel Repo cache directory path'
+    required: true
+    default: '~/repo-cache'
+  go-mod-cache-hit:
+    description: 'Cache hit status for Go Mod Cache'
+    required: true
+  go-mod-cache-dir:
+    description: 'The Go Mod cache directory path'
+    required: true
+    default: '/home/runner/go-mod-cache'
+  yarn-cache-hit:
+    description: 'Cache hit status for Yarn Cache'
+    required: true
+  yarn-cache-dir:
+    description: 'The Yarn cache directory path'
+    required: true
+    default: ~/.cache/yarn/v6/
+runs:
+  using: "composite"
+  # Github Actions does not allow overwriting an existing cache key.
+  # So we write a new cache key for each run attempt, while restoring the cache with a prefix match.
+  #
+  # Reference: https://github.com/actions/cache/pull/1452
+  steps:
+    - name: Save Bazel Repo Cache
+      uses: actions/cache/save@v4
+      if: always() && ${{ inputs.repo-cache-hit != 'true' }}
+      with:
+        path: ${{ inputs.repo-cache-dir }}
+        key: repo-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'deps.bzl') }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+    - name: Save Go Mod Cache
+      uses: actions/cache/save@v4
+      if: always() && ${{ inputs.go-mod-cache-hit != 'true' }}
+      with:
+        path: ${{ inputs.go-mod-cache-dir }}
+        key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+    - name: Save Yarn Cache
+      uses: actions/cache/save@v4
+      if: always() && ${{ inputs.yarn-cache-hit != 'true' }}
+      with:
+        path: ${{ inputs.yarn-cache-dir }}
+        key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -7,21 +7,21 @@ inputs:
   repo-cache-dir:
     description: 'The Bazel Repo cache directory path'
     required: true
-    default: '~/repo-cache'
+    default: "~/repo-cache"
   go-mod-cache-hit:
     description: 'Cache hit status for Go Mod Cache'
     required: true
   go-mod-cache-dir:
     description: 'The Go Mod cache directory path'
     required: true
-    default: '/home/runner/go-mod-cache'
+    default: "/home/runner/go-mod-cache"
   yarn-cache-hit:
     description: 'Cache hit status for Yarn Cache'
     required: true
   yarn-cache-dir:
     description: 'The Yarn cache directory path'
     required: true
-    default: ~/.cache/yarn/v6/
+    default: "~/.cache/yarn/v6"
 runs:
   using: "composite"
   # Github Actions does not allow overwriting an existing cache key.

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -9,26 +9,17 @@ jobs:
   build:
     runs-on: windows-2022
     if: "!contains(github.event.head_commit.message, 'ci skip')"
-    env:
-      GO_REPOSITORY_USE_HOST_CACHE: 1
-      GOMODCACHE: "D:/go-mod-cache"
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Mount Bazel cache
-        uses: actions/cache@v4
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
         with:
-          path: "D:/bazel/repo-cache/"
-          key: repo-cache
-
-      - name: Mount Go cache
-        uses: actions/cache@v4
-        with:
-          path: "D:/go-mod-cache/"
-          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}
-          restore-keys: go-mod-cache-${{ runner.os }}-
+          repo-cache-dir: "D:/bazel/repo-cache/"
+          go-mod-cache-dir: "D:/go-mod-cache/"
+          yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"
 
       # This step would list out all files under $vs2022Path for debugging purposes.
       # - name: "Find CL"
@@ -48,6 +39,8 @@ jobs:
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: "D:/go-mod-cache"
         # Because "startup" options could not be assigned to different configs in .bazelrc, we are adding them directly here.
         # These options follow the best practices in https://bazel.build/configure/windows. Specifically:
         #   - Set output_user_root to the shortest path possible to avoid Windows path length limitations.
@@ -62,3 +55,11 @@ jobs:
             $authArgs = @("--remote_header=x-buildbuddy-api-key=$apiKey")
           }
           bazelisk --output_user_root=D:/0 --windows_enable_symlinks build --config=untrusted-ci-windows @authArgs //enterprise/server/cmd/executor:executor
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-dir: "D:/bazel/repo-cache"
+          go-mod-cache-dir: "D:/go-mod-cache"
+          yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"

--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -35,12 +35,31 @@ jobs:
           # the version of the running binary.
           fetch-depth: 0
 
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
-          bazelisk build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
+          bazelisk build \
+            --config=release \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //server/cmd/buildbuddy:buildbuddy \
+            //enterprise/server/cmd/server:buildbuddy \
+            //enterprise/server/cmd/executor:executor
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64
           gh release upload ${{ inputs.version_tag }} buildbuddy-linux-amd64 buildbuddy-enterprise-linux-amd64 executor-enterprise-linux-amd64 --clobber
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}

--- a/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
@@ -51,10 +51,24 @@ jobs:
           && sudo apt update \
           && sudo apt install gh -y
 
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
           bazelisk build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-arm64
           gh release upload ${{ inputs.version_tag }} executor-enterprise-linux-arm64 --clobber
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}

--- a/.github/workflows/build-mac-intel-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-intel-github-release-artifacts.yaml
@@ -26,6 +26,8 @@ on:
 jobs:
   build:
     runs-on: macos-13
+    env:
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -35,13 +37,32 @@ jobs:
           # the version of the running binary.
           fetch-depth: 0
 
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVELOPER_DIR: /Library/Developer/CommandLineTools
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
-          bazelisk build --config=release-mac --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
+          bazelisk build \
+            --config=release-mac \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //server/cmd/buildbuddy:buildbuddy \
+            //enterprise/server/cmd/server:buildbuddy \
+            //enterprise/server/cmd/executor:executor
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-darwin-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-darwin-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-amd64
           gh release upload ${{ inputs.version_tag }} buildbuddy-darwin-amd64 buildbuddy-enterprise-darwin-amd64 executor-enterprise-darwin-amd64 --clobber
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}

--- a/.github/workflows/build-mac-m1-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-m1-github-release-artifacts.yaml
@@ -46,11 +46,25 @@ jobs:
           # the version of the running binary.
           fetch-depth: 0
 
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVELOPER_DIR: /Library/Developer/CommandLineTools
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
           bazelisk build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-arm64
           gh release upload ${{ inputs.version_tag }} executor-enterprise-darwin-arm64 --clobber
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -26,10 +26,6 @@ on:
 jobs:
   build:
     runs-on: windows-2022
-    env:
-      GO_REPOSITORY_USE_HOST_CACHE: 1
-      GOMODCACHE: "D:/go-mod-cache"
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,22 +35,19 @@ jobs:
           # the version of the running binary.
           fetch-depth: 0
 
-      - name: Mount Bazel Repository Cache
-        uses: actions/cache@v4
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
         with:
-          path: "D:/bazel/repo-cache/"
-          key: repo-cache
-
-      - name: Mount Go Cache
-        uses: actions/cache@v4
-        with:
-          path: "D:/go-mod-cache/"
-          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}
-          restore-keys: go-mod-cache-${{ runner.os }}-
+          repo-cache-dir: "D:/bazel/repo-cache/"
+          go-mod-cache-dir: "D:/go-mod-cache/"
+          yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"
 
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: "D:/go-mod-cache"
         run: |
           bazelisk --output_user_root=D:/0 build --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
           $execution_root = bazelisk --output_user_root=D:/0 info execution_root
@@ -62,3 +55,14 @@ jobs:
           $artifact_abs_path = "${execution_root}\${artifact_rel_path}"
           Copy-Item -Path $artifact_abs_path -Destination executor-enterprise-windows-amd64-beta.exe
           gh release upload ${{ inputs.version_tag }} executor-enterprise-windows-amd64-beta.exe --clobber
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          repo-cache-dir: "D:/bazel/repo-cache/"
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          go-mod-cache-dir: "D:/go-mod-cache/"
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,40 +12,32 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
-    env:
-      GO_REPOSITORY_USE_HOST_CACHE: 1
-      GOMODCACHE: /home/runner/go-mod-cache
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Mount Bazel cache
-        uses: actions/cache@v4
-        with:
-          path: "/home/runner/repo-cache/"
-          key: repo-cache
-
-      - name: Mount Go cache
-        uses: actions/cache@v4
-        with:
-          path: "/home/runner/go-mod-cache/"
-          key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}
-          restore-keys: go-mod-cache-${{ runner.os }}-
-
-      - name: Build
-        run: |
-          bazelisk build \
-              --config=ci \
-              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              //...
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
 
       - name: Test
+        env:
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
           bazelisk test \
-              --config=ci \
-              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              //...
+            --config=ci \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //...
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
 
       - name: Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,16 +14,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Build
-        run: |
-          bazelisk build \
-              --config=untrusted-ci \
-              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              //...
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+        with:
+          repo-cache-dir: ~/repo-cache/untrusted/
 
       - name: Test
+        env:
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
           bazelisk test \
-              --config=untrusted-ci \
-              --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              //...
+            --config=untrusted-ci \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //...
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -157,10 +157,16 @@ jobs:
         with:
           path: buildbuddy
 
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+
       - name: Build Artifacts
         id: build
         env:
           XCODE_VERSION: 12.4
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
           set -x  # print executed commands
           if [[ "$OSTYPE" == darwin* ]]; then
@@ -176,9 +182,11 @@ jobs:
           VERSION=${{ needs.push-tag.outputs.version }}
 
           cd "${GITHUB_WORKSPACE}/buildbuddy"
-          bazelisk build //cli/cmd/bb \
+          bazelisk build \
+              --repository_cache='~/repo-cache/' \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              --//cli/version:cli_version="$VERSION"
+              --//cli/version:cli_version="$VERSION" \
+              //cli/cmd/bb
 
           BINARY="bazel-${VERSION}-${OS}-${ARCH}"
           cp bazel-bin/cli/cmd/bb/bb_/bb "$BINARY"
@@ -197,6 +205,14 @@ jobs:
             "${{ needs.push-tag.outputs.version }}" \
             "${{ steps.build.outputs.BINARY }}" \
             "${{ steps.build.outputs.BINARY }}.sha256"
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
 
   publish-release:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -32,10 +32,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc g++
 
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+
       - name: Run tests
+        env:
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
           BUILD_FLAGS=(
             --config=cache
+            --repository_cache=~/repo-cache
             --bes_backend=remote.buildbuddy.io
             --bes_results_url=https://app.buildbuddy.io/invocation/
             --remote_cache=remote.buildbuddy.io
@@ -57,3 +65,11 @@ jobs:
           # host has podman available.
           bazel test "${BUILD_FLAGS[@]}" --test_tag_filters=+docker \
             //enterprise/server/test/integration/podman:podman_test
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}

--- a/.github/workflows/website-pr.yaml
+++ b/.github/workflows/website-pr.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths:
+      - ".github/workflows/website-pr.yaml"
       - "docs/**"
       - "website/**"
       - "server/metrics/**"
@@ -18,11 +19,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+
       - name: Build Website
+        env:
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
           API_KEY="${{ secrets.BUILDBUDDY_ORG_API_KEY }}"
           API_KEY_ARGS=()
           if [[ "$API_KEY" ]]; then
             API_KEY_ARGS=("--remote_header=x-buildbuddy-api-key=$API_KEY")
           fi
-          bazelisk build //website:website --config=ci "${API_KEY_ARGS[@]}"
+          bazelisk build --repository_cache='~/repo-cache/' //website:website --config=ci "${API_KEY_ARGS[@]}"
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -19,9 +19,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Restore caches
+        id: restore-caches
+        uses: ./.github/actions/cache-restore
+
       - name: Build Website
+        env:
+          GO_REPOSITORY_USE_HOST_CACHE: 1
+          GOMODCACHE: /home/runner/go-mod-cache
         run: |
-          bazelisk build //website:website --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+          bazelisk build --repository_cache='~/repo-cache/' //website:website --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           rm -rf website/build
           mkdir -p website/build
           cd website/build
@@ -33,3 +40,11 @@ jobs:
         with:
           branch: gh-pages
           folder: website/build
+
+      - name: Save caches
+        uses: ./.github/actions/cache-save
+        if: always()
+        with:
+          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
+          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
+          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}


### PR DESCRIPTION
Follow up of reviews from https://github.com/buildbuddy-io/buildbuddy/pull/8608

Introduce 2 new composite actions
- .github/actions/cache-restore
- .github/actions/cache-save

which handle restoring and saving external dependencies download for
subsequent builds to re-use. This is currently limitted to Bazel's
downloads, go_repository downloads and our yarn_install downloads.

Add these composite actions to all existing workflows that invoke
`bazelisk`.

