### PR TITLE
Rename a span attribute in snaploader.cacheCOW

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -859,7 +859,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 		defer func() {
 			span.SetAttributes(
 				attribute.String("cow_name", name),
-				attribute.Int64("cow_size_bytes", size),
+				attribute.Int64("cow_size_bytes", size), // This includes non-dirty and all-zero chunks
 				attribute.Int64("dirty_bytes", dirtyBytes),
 				attribute.Int64("dirty_chunks", dirtyChunkCount),
 				attribute.Int64("empty_bytes", emptyBytes),

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -859,7 +859,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 		defer func() {
 			span.SetAttributes(
 				attribute.String("cow_name", name),
-				attribute.Int64("uncompressed_bytes", size),
+				attribute.Int64("cow_size_bytes", size),
 				attribute.Int64("dirty_bytes", dirtyBytes),
 				attribute.Int64("dirty_chunks", dirtyChunkCount),
 				attribute.Int64("empty_bytes", emptyBytes),


### PR DESCRIPTION
uncompressed_bytes isn't really clear. Is it byte sent remotely, locally, or what? cow_size_bytes makes it clear that it's the size of the COWStore, including non-dirty and all zero chunks.