### PR TITLE
[raft] log rsm info logs for dragonboat library

### DIFF
--- a/enterprise/server/raft/logger/BUILD
+++ b/enterprise/server/raft/logger/BUILD
@@ -9,5 +9,6 @@ go_library(
     deps = [
         "//server/util/log",
         "@com_github_lni_dragonboat_v4//logger",
+        "@com_github_rs_zerolog//:zerolog",
     ],
 )


### PR DESCRIPTION
rsm info logs constains membership operations and there are less noisy than other packages. There are useful in debugging driver/split/zombie issues in general.

also removed nullLogger and used zerolog.Level(Disabled) instead. This allows us to control the log levels of dragonboat library easily.
