### PR TITLE
tell people to install CLI over HTTPS

### DIFF
--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -752,7 +752,7 @@ ${commandWithRemoteRunnerFlags(compareModel.explicitCommandLine() + " --experime
     }
 
     const command = `
-curl -fsSL install.buildbuddy.io | bash
+curl -fsSL https://install.buildbuddy.io | bash
 ${generateExecLogCmd1}
 ${generateExecLogCmd2}
 output=$(bb explain --old ${execLogOrInvocationId1} --new ${execLogOrInvocationId2})

--- a/cli/README.md
+++ b/cli/README.md
@@ -3,7 +3,7 @@
 Install BuildBuddy CLI
 
 ```
-curl -fsSL install.buildbuddy.io | bash
+curl -fsSL https://install.buildbuddy.io | bash
 ```
 
 Kick off a Bazel build using BuildBuddy UI

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@ It's written in [go](https://go.dev/), [fully open source](https://github.com/bu
 The easiest way to install the BuildBuddy CLI is by running this simple bash script, which works on both MacOS and Linux:
 
 ```bash
-curl -fsSL install.buildbuddy.io | bash
+curl -fsSL https://install.buildbuddy.io | bash
 ```
 
 If you're not comfortable executing random bash scripts from the internet (we totally get it!), you can take a look at what this script is doing under the hood, by visiting [install.buildbuddy.io](https://install.buildbuddy.io) in your browser.
@@ -29,7 +29,7 @@ You can perform those steps manually yourself if you'd like!
 You can update the cli by re-running the installation script:
 
 ```bash
-curl -fsSL install.buildbuddy.io | bash
+curl -fsSL https://install.buildbuddy.io | bash
 ```
 
 If you installed BuildBuddy manually instead, you can repeat those installation steps to update your CLI.

--- a/website/src/pages/cli.tsx
+++ b/website/src/pages/cli.tsx
@@ -85,7 +85,7 @@ function Component() {
           }
           bigImage={true}
           lessPadding={true}
-          snippet={"curl -fsSL install.buildbuddy.io | bash"}
+          snippet={"curl -fsSL https://install.buildbuddy.io | bash"}
           primaryButtonText=""
           secondaryButtonText="View docs"
           secondaryButtonHref="/docs/cli"


### PR DESCRIPTION
Thanks to @skeggse for pointing out `curl` implicitly goes to port 80 unless you specify `https://`!

context: https://buildbuddy-corp.slack.com/archives/C057TAUAQ7P/p1741901313234809