### PR TITLE
enterprise/app: Changed default filter to 7 days

### DIFF
--- a/enterprise/app/filter/filter_util.tsx
+++ b/enterprise/app/filter/filter_util.tsx
@@ -34,7 +34,7 @@ const DEFAULT_ROLE_PARAM_VALUE = "DEFAULT";
 
 export const DATE_PARAM_FORMAT = "YYYY-MM-DD";
 
-export const DEFAULT_LAST_N_DAYS = 30;
+export const DEFAULT_LAST_N_DAYS = 7;
 
 export type SortBy =
   | "start-time"


### PR DESCRIPTION
This commit reduces the default value for the filter from 30 to 7,
which is a more sensible default for our users.
