### PR TITLE
Log to clickhouse in execution_server.MarkExecutionFailed

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -998,31 +998,33 @@ func (s *ExecutionServer) MarkExecutionFailed(ctx context.Context, taskID string
 		log.CtxWarningf(ctx, "MarkExecutionFailed: error updating execution: %q: %s", taskID, err)
 		return err
 	}
-	err = func() error {
-		actionRN, err := digest.ParseUploadResourceName(taskID)
-		if err != nil {
-			return fmt.Errorf("Failed to parse taskID: %s", err)
-		}
-		action, cmd, err := s.fetchActionAndCommand(ctx, actionRN)
-		if err != nil {
-			return fmt.Errorf("Failed to fetch action and command: %s", err)
-		}
-		properties, err := platform.ParseProperties(&repb.ExecutionTask{Action: action, Command: cmd})
-		if err != nil {
-			return fmt.Errorf("Failed to parse platform properties: %s", err)
-		}
-		// We don't have a response, so we don't have response metadata. It's
-		// not required.
-		if err := s.recordExecution(ctx, taskID, action, nil, nil, properties); err != nil {
-			return fmt.Errorf("Failed to record execution: %s", err)
-		}
-		return nil
-	}()
+	err = s.recordFailedExecution(ctx, taskID)
 	if err != nil {
 		log.CtxWarningf(ctx, "MarkExecutionFailed: %s", err)
 	}
 	if err := s.cacheExecuteResponse(ctx, taskID, rsp); err != nil {
 		log.CtxWarningf(ctx, "MarkExecutionFailed: failed to cache execute response for execution %q: %s", taskID, err)
+	}
+	return nil
+}
+
+func (s *ExecutionServer) recordFailedExecution(ctx context.Context, taskID string) error {
+	actionRN, err := digest.ParseUploadResourceName(taskID)
+	if err != nil {
+		return fmt.Errorf("Failed to parse taskID: %s", err)
+	}
+	action, cmd, err := s.fetchActionAndCommand(ctx, actionRN)
+	if err != nil {
+		return fmt.Errorf("Failed to fetch action and command: %s", err)
+	}
+	properties, err := platform.ParseProperties(&repb.ExecutionTask{Action: action, Command: cmd})
+	if err != nil {
+		return fmt.Errorf("Failed to parse platform properties: %s", err)
+	}
+	// We don't have a response, so we don't have response metadata. It's
+	// not required.
+	if err := s.recordExecution(ctx, taskID, action, nil, nil, properties); err != nil {
+		return fmt.Errorf("Failed to record execution: %s", err)
 	}
 	return nil
 }

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -998,6 +998,29 @@ func (s *ExecutionServer) MarkExecutionFailed(ctx context.Context, taskID string
 		log.CtxWarningf(ctx, "MarkExecutionFailed: error updating execution: %q: %s", taskID, err)
 		return err
 	}
+	err = func() error {
+		actionRN, err := digest.ParseUploadResourceName(taskID)
+		if err != nil {
+			return fmt.Errorf("Failed to parse taskID: %s", err)
+		}
+		action, cmd, err := s.fetchActionAndCommand(ctx, actionRN)
+		if err != nil {
+			return fmt.Errorf("Failed to fetch action and command: %s", err)
+		}
+		properties, err := platform.ParseProperties(&repb.ExecutionTask{Action: action, Command: cmd})
+		if err != nil {
+			return fmt.Errorf("Failed to parse platform properties: %s", err)
+		}
+		// We don't have a response, so we don't have response metadata. It's
+		// not required.
+		if err := s.recordExecution(ctx, taskID, action, nil, nil, properties); err != nil {
+			return fmt.Errorf("Failed to record execution: %s", err)
+		}
+		return nil
+	}()
+	if err != nil {
+		log.CtxWarningf(ctx, "MarkExecutionFailed: %s", err)
+	}
 	if err := s.cacheExecuteResponse(ctx, taskID, rsp); err != nil {
 		log.CtxWarningf(ctx, "MarkExecutionFailed: failed to cache execute response for execution %q: %s", taskID, err)
 	}
@@ -1092,7 +1115,7 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			}
 			properties, err = platform.ParseProperties(&repb.ExecutionTask{Action: action, Command: cmd, PlatformOverrides: auxMeta.GetPlatformOverrides()})
 			if err != nil {
-				log.CtxWarningf(ctx, "Failed to parse platform properties: %s", err)
+				return status.InternalErrorf("Failed to parse platform properties: %s", err)
 			}
 			if err := s.cacheActionResult(ctx, actionRN, trimmedResponse, action); err != nil {
 				return status.UnavailableErrorf("Error uploading action result: %s", err.Error())


### PR DESCRIPTION
This used to be the behavior before I broke it in https://github.com/buildbuddy-io/buildbuddy/pull/8036, because I moved the `recordExecution` call out of `updateExecution`.

Also, fix a possible panic when platform.ParseProperties fails. All subsequent code assumes that the return platform is non-nil.