### PR TITLE
Store the executor hostname in clickhouse

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -164,6 +164,14 @@ func getExecutorHostID() string {
 	return hostID
 }
 
+func getExecutorHostName() string {
+	name, err := os.Hostname()
+	if err != nil {
+		log.Warningf("Failed to get hostname: %s", err)
+	}
+	return name
+}
+
 func GetConfiguredEnvironmentOrDie(cacheRoot string, healthChecker *healthcheck.HealthChecker) *real_environment.RealEnv {
 	realEnv := real_environment.NewRealEnv(healthChecker)
 
@@ -303,7 +311,7 @@ func main() {
 		log.Fatalf("Failed to initialize runner pool: %s", err)
 	}
 
-	executor, err := remote_executor.NewExecutor(env, executorID, getExecutorHostID(), runnerPool)
+	executor, err := remote_executor.NewExecutor(env, executorID, getExecutorHostID(), getExecutorHostName(), runnerPool)
 	if err != nil {
 		log.Fatalf("Error initializing ExecutionServer: %s", err)
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -375,6 +375,8 @@ func (s *ExecutionServer) recordExecution(
 		executionProto.DiskWriteOperations = md.GetUsageStats().GetCgroupIoStats().GetWios()
 		executionProto.DiskReadOperations = md.GetUsageStats().GetCgroupIoStats().GetRios()
 
+		executionProto.ExecutorHostname = auxMeta.GetExecutorHostname()
+
 		executionProto.EffectiveIsolationType = auxMeta.GetIsolationType()
 		executionProto.RequestedIsolationType = platform.CoerceContainerType(properties.WorkloadIsolationType)
 

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -70,9 +70,10 @@ type Executor struct {
 	runnerPool interfaces.RunnerPool
 	id         string
 	hostID     string
+	hostname   string
 }
 
-func NewExecutor(env environment.Env, id, hostID string, runnerPool interfaces.RunnerPool) (*Executor, error) {
+func NewExecutor(env environment.Env, id, hostID, hostname string, runnerPool interfaces.RunnerPool) (*Executor, error) {
 	if err := disk.EnsureDirectoryExists(runnerPool.GetBuildRoot()); err != nil {
 		return nil, err
 	}
@@ -80,6 +81,7 @@ func NewExecutor(env environment.Env, id, hostID string, runnerPool interfaces.R
 		env:        env,
 		id:         id,
 		hostID:     hostID,
+		hostname:   hostname,
 		runnerPool: runnerPool,
 	}, nil
 }
@@ -209,6 +211,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		PlatformOverrides:  task.GetPlatformOverrides(),
 		ExecuteRequest:     task.GetExecuteRequest(),
 		SchedulingMetadata: st.GetSchedulingMetadata(),
+		ExecutorHostname:   s.hostname,
 	}
 	opStateChangeFn := operation.GetStateChangeFunc(stream, taskID, adInstanceDigest)
 	stateChangeFn := operation.StateChangeFunc(func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -829,7 +829,7 @@ func (r *Env) addExecutor(t testing.TB, options *ExecutorOptions) *Executor {
 
 	runnerPool := NewTestRunnerPool(r.t, env, localCacheDirectory, options.RunInterceptor)
 
-	exec, err := executor.NewExecutor(env, executorID, executorHostID, runnerPool)
+	exec, err := executor.NewExecutor(env, executorID, executorHostID, "fake-host-name", runnerPool)
 	if err != nil {
 		assert.FailNowf(r.t, fmt.Sprintf("could not create executor %q", options.Name), err.Error())
 	}

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -146,6 +146,8 @@ message ExecutionAuxiliaryMetadata {
 
   // The effective action timeout. Either user requested or the default.
   google.protobuf.Duration timeout = 6;
+
+  string executor_hostname = 7;
 }
 
 message ExecutionLookup {

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2435,6 +2435,7 @@ message StoredExecution {
   int64 created_at_usec = 5;
   string user_id = 6;
   string worker = 7;
+  string executor_hostname = 60;
   int64 stage = 8;
 
   // Executor metadata

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -204,6 +204,7 @@ func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *schem
 		CreatedAtUsec:                      in.GetCreatedAtUsec(),
 		UserID:                             in.GetUserId(),
 		Worker:                             in.GetWorker(),
+		ExecutorHostname:                   in.GetExecutorHostname(),
 		SelfHosted:                         in.GetSelfHosted(),
 		Region:                             in.GetRegion(),
 		Stage:                              in.GetStage(),

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -156,6 +156,7 @@ type Execution struct {
 	CreatedAtUsec      int64
 	UserID             string
 	Worker             string
+	ExecutorHostname   string
 
 	// Executor metadata
 	SelfHosted bool
@@ -300,6 +301,7 @@ func (e *Execution) AdditionalFields() []string {
 		"EffectiveTimeoutUsec",
 		"Region",
 		"SelfHosted",
+		"ExecutorHostname",
 	}
 }
 


### PR DESCRIPTION
This will allow evaluating experiments where we want a feature to be on/off on a whole machine.

Initially, I want to evaluate https://github.com/buildbuddy-io/buildbuddy/pull/8655.