### PR TITLE
router: apply additional encoding for period character

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -529,10 +529,12 @@ export function getRepoUrlPathParam(repo: string): string {
 }
 
 function getQueryString(params: Record<string, string>) {
-  return new URLSearchParams(Object.fromEntries(Object.entries(params).filter(([_, value]) => Boolean(value))))
-    .toString()
-    // %-encode periods since Slack doesn't treat trailing periods as part of the URL.
-    .replaceAll(".", "%2E");
+  return (
+    new URLSearchParams(Object.fromEntries(Object.entries(params).filter(([_, value]) => Boolean(value))))
+      .toString()
+      // %-encode periods since Slack doesn't treat trailing periods as part of the URL.
+      .replaceAll(".", "%2E")
+  );
 }
 
 function getModifiedUrl({ query, path }: { query?: Record<string, string>; path?: string }) {

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -531,6 +531,7 @@ export function getRepoUrlPathParam(repo: string): string {
 function getQueryString(params: Record<string, string>) {
   return new URLSearchParams(Object.fromEntries(Object.entries(params).filter(([_, value]) => Boolean(value))))
     .toString()
+    // %-encode periods since Slack doesn't treat trailing periods as part of the URL.
     .replaceAll(".", "%2E");
 }
 

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -529,9 +529,9 @@ export function getRepoUrlPathParam(repo: string): string {
 }
 
 function getQueryString(params: Record<string, string>) {
-  return new URLSearchParams(
-    Object.fromEntries(Object.entries(params).filter(([_, value]) => Boolean(value)))
-  ).toString();
+  return new URLSearchParams(Object.fromEntries(Object.entries(params).filter(([_, value]) => Boolean(value))))
+    .toString()
+    .replaceAll(".", "%2E");
 }
 
 function getModifiedUrl({ query, path }: { query?: Record<string, string>; path?: string }) {


### PR DESCRIPTION
Workaround for Slack's URL parsing does not accomodate for trailing
periods.
