### PR TITLE
Enable anonymous recycling when API key is unset

### DIFF
--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container",
     deps = [
         "//enterprise/server/remote_execution/block_io",
+        "//enterprise/server/remote_execution/executor_auth",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/util/oci",

--- a/enterprise/server/remote_execution/executor_auth/BUILD
+++ b/enterprise/server/remote_execution/executor_auth/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "executor_auth",
+    srcs = ["executor_auth.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor_auth",
+    visibility = ["//visibility:public"],
+    deps = ["//server/util/flag"],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/remote_execution/executor_auth/executor_auth.go
+++ b/enterprise/server/remote_execution/executor_auth/executor_auth.go
@@ -1,0 +1,15 @@
+package executor_auth
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+)
+
+var (
+	apiKey = flag.String("executor.api_key", "", "API Key used to authorize the executor with the BuildBuddy app server.", flag.Secret)
+)
+
+// APIKey returns the configured API key used to authenticate the executor with
+// the BuildBuddy app server.
+func APIKey() string {
+	return *apiKey
+}

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -942,7 +942,7 @@ func (p *pool) Get(ctx context.Context, st *repb.ScheduledTask) (interfaces.Runn
 	if user != nil {
 		groupID = user.GetGroupID()
 	}
-	if !*container.DebugEnableAnonymousRecycling && (props.RecycleRunner && err != nil) {
+	if !container.AnonymousRecyclingEnabled() && (props.RecycleRunner && err != nil) {
 		return nil, status.InvalidArgumentError(
 			"runner recycling is not supported for anonymous builds " +
 				`(recycling was requested via platform property "recycle-runner=true")`)

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -1075,7 +1075,7 @@ func groupID(ctx context.Context, env environment.Env) (string, error) {
 	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err == nil {
 		gid = u.GetGroupID()
-	} else if !authutil.IsAnonymousUserError(err) && !*container.DebugEnableAnonymousRecycling {
+	} else if !authutil.IsAnonymousUserError(err) && !container.AnonymousRecyclingEnabled() {
 		return "", err
 	}
 	return gid, nil

--- a/enterprise/server/scheduling/scheduler_client/BUILD
+++ b/enterprise/server/scheduling/scheduler_client/BUILD
@@ -7,8 +7,8 @@ go_library(
     srcs = ["scheduler_client.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_client",
     deps = [
+        "//enterprise/server/remote_execution/executor_auth",
         "//enterprise/server/scheduling/priority_task_scheduler",
-        "//enterprise/server/scheduling/task_leaser",
         "//proto:scheduler_go_proto",
         "//server/environment",
         "//server/resources",

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor_auth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_task_scheduler"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_leaser"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
@@ -290,7 +290,7 @@ func NewRegistration(env environment.Env, taskScheduler *priority_task_scheduler
 	if err != nil {
 		return nil, status.InternalErrorf("Error determining node properties: %s", err)
 	}
-	apiKey := task_leaser.APIKey()
+	apiKey := executor_auth.APIKey()
 	if options.APIKeyOverride != "" {
 		apiKey = options.APIKeyOverride
 	}

--- a/enterprise/server/scheduling/task_leaser/BUILD
+++ b/enterprise/server/scheduling/task_leaser/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["task_leaser.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_leaser",
     deps = [
+        "//enterprise/server/remote_execution/executor_auth",
         "//proto:scheduler_go_proto",
         "//server/environment",
         "//server/util/authutil",

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/BUILD
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/BUILD
@@ -13,6 +13,7 @@ go_test(
         "//server/testutil/testmetrics",
         "//server/util/bazel",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testmetrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -366,6 +367,9 @@ func TestActionWithRunnerRecycling_InvalidArgument(t *testing.T) {
 func setup(t *testing.T) *rbetest.Env {
 	env := rbetest.NewRBETestEnv(t)
 	env.AddBuildBuddyServer()
+	// Run the executor with an API key to more closely match a production
+	// setup.
+	flags.Set(t, "executor.api_key", env.APIKey1)
 	env.AddExecutor(t)
 	// observe initial count so that we can get the diff at the end of the test
 	_ = tasksStarted(t)


### PR DESCRIPTION
The `--debug_enable_anonymous_runner_recycling` flag is needed to enable runner recycling for anonymous executions. This adds a bit of unnecessary configuration complexity for local development, and possibly also some on-prem scenarios where executors are run without auth. If `--executor.api_key` is unset, then we're already running as part of an anonymous auth setup, so anonymous runner recycling should be allowed.