### PR TITLE
Timing profile: update thread sort and metrics

### DIFF
--- a/app/trace/constants.ts
+++ b/app/trace/constants.ts
@@ -6,7 +6,7 @@
 export const MODEL_X_PER_SECOND = 1_000_000;
 
 export const EVENTS_PANEL_HEIGHT = 540;
-export const LINE_PLOTS_PANEL_HEIGHT = 360;
+export const LINE_PLOTS_PANEL_HEIGHT = 400;
 
 export const TIMESTAMP_HEADER_SIZE = 16;
 export const TIMESTAMP_HEADER_COLOR = "rgba(236, 239, 241, 0.9)"; // "#ECEFF1" with alpha


### PR DESCRIPTION
Sort threads using thread id to show the events in a more consistent
order.

Increase the default height of line plots panel to 400 to accomodate for
Bazel 8 flipping --experimental_collect_system_network_usage to true and
added 2 lanes for network upload/download.
