### PR TITLE
Move 'unsupported tar header' logs to debug-level

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -1451,7 +1451,7 @@ func downloadLayer(ctx context.Context, layer ctr.Layer, destDir string) error {
 				return status.UnavailableErrorf("create directory: %s", err)
 			}
 		} else {
-			log.CtxInfof(ctx, "Ignoring unsupported tar header %q type %q in oci layer", header.Name, header.Typeflag)
+			log.CtxDebugf(ctx, "Ignoring unsupported tar header %q type %q in oci layer", header.Name, header.Typeflag)
 			continue
 		}
 


### PR DESCRIPTION
These logs are pretty noisy and in practice only `/dev/` paths are logged, which is expected.