### PR TITLE
script for setting up a GCE VM to build and run app, executor

### DIFF
--- a/tools/gce-startup-script.sh
+++ b/tools/gce-startup-script.sh
@@ -1,0 +1,39 @@
+# This script installs packages necessary to build and run the BuildBuddy app and executors
+# on a Linux VM. As of 2025-03-17 it works when spinning up a Google Compute Engine VM.
+# Here's the command I used to create the VM, from the buildbuddy/ directory:
+#
+# gcloud compute instances create $YOUR_VM_NAME \
+#  --zone=us-central1-a \
+#  --machine-type=n2-standard-16 \
+#  --enable-nested-virtualization \
+#  --boot-disk-size=200GB \
+#  --metadata-from-file startup-script=tools/gce-startup-script.sh
+#
+# The `google-startup-scripts` service executes the script.
+# Logs from the script will appear under `google_metadata_script_runner` in /var/log/syslog.
+# It is possible to ssh into the VM before the script finishes executing, so check logs if
+# binaries are missing.
+
+set -e
+
+apt-get update && \
+apt-get install -y --no-install-recommends \
+	acl \
+	build-essential \
+	git \
+	podman \
+	redis \
+	skopeo
+
+# Install bazelisk
+wget -q https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64
+mv bazelisk-linux-amd64 /usr/local/bin/bazelisk
+pushd /usr/local/bin
+chmod ugo+x bazelisk
+ln -s bazelisk bazel
+popd
+
+# Install Go
+wget -q https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
+rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.1.linux-amd64.tar.gz
+echo 'export PATH="$PATH:/usr/local/go/bin"' >> /etc/profile

--- a/tools/gce-startup-script.sh
+++ b/tools/gce-startup-script.sh
@@ -13,6 +13,11 @@
 # Logs from the script will appear under `google_metadata_script_runner` in /var/log/syslog.
 # It is possible to ssh into the VM before the script finishes executing, so check logs if
 # binaries are missing.
+#
+# If you would like to run Firecracker VMs with the executor, you must run these commands once:
+# 	sudo setfacl -m u:${USER}:rw /dev/kvm
+#	[ -r /dev/kvm ] && [ -w /dev/kvm ] && echo "OK" || echo "FAIL" # indicates your user can read/write /dev/kvm
+# 	tools/enable_local_firecracker.sh
 
 set -e
 
@@ -32,8 +37,3 @@ pushd /usr/local/bin
 chmod ugo+x bazelisk
 ln -s bazelisk bazel
 popd
-
-# Install Go
-wget -q https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
-rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.1.linux-amd64.tar.gz
-echo 'export PATH="$PATH:/usr/local/go/bin"' >> /etc/profile


### PR DESCRIPTION
Running the BuildBuddy app or an executor on a Linux VM requires certain packages to be installed.
This script installs those packages.
After the script completes, you need to run `sudo ./tools/enable_local_firecracker.sh` to install Firecracker.

As of today (2025-03-17), I can verify that running this script at machine creation time lets you run the app and an executor with the OCI runtime and Firecracker enabled.
```
gcloud compute instances create $YOUR_VM_NAME \
  --zone=$A_HANDY_GCE_ZONE_SUCH_AS_us-central1-a \
  --machine-type=n2-standard-16 \
  --enable-nested-virtualization \
  --boot-disk-size=200GB \
  --metadata-from-file startup-script=tools/gce-startup-script.sh
```