### PR TITLE
Fix bug in `CanonicalizeStartupArgs`

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -585,7 +585,7 @@ func canonicalizeArgs(args []string, onlyStartupOptions bool) ([]string, error) 
 		optionDefinitions = append(optionDefinitions, optionDefinition)
 		if token == schema.Command {
 			if onlyStartupOptions {
-				return append(out, args[i:]...), nil
+				return arg.JoinExecutableArgs(append(out, args[i:]...), execArgs), nil
 			}
 			// When we see the bazel command token, switch to parsing command
 			// options instead of startup options.

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -498,6 +498,7 @@ func TestCanonicalizeStartupArgs(t *testing.T) {
 		"--bes_backend=",
 		"--remote_header", "x-buildbuddy-foo=1",
 		"--remote_header", "x-buildbuddy-bar=2",
+		"--", "hello",
 	}
 
 	canonicalArgs, err := canonicalizeArgs(args, true)
@@ -522,6 +523,7 @@ func TestCanonicalizeStartupArgs(t *testing.T) {
 		"--bes_backend=",
 		"--remote_header", "x-buildbuddy-foo=1",
 		"--remote_header", "x-buildbuddy-bar=2",
+		"--", "hello",
 	}
 	assert.Equal(t, expectedCanonicalArgs, canonicalArgs)
 }


### PR DESCRIPTION
Fixed a bug where the execArgs were not being re-attached after canonicalizing the startup args.

Also modified a test to confirm the new behavior.
