### PR TITLE
Add a remote usage service for tracking cache download from Cache Proxies

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//enterprise/server/remote_execution/execution_server",
         "//enterprise/server/remote_execution/redis_client",
         "//enterprise/server/remote_execution/snaploader",
+        "//enterprise/server/remoteusage",
         "//enterprise/server/scheduling/scheduler_server",
         "//enterprise/server/scheduling/task_router",
         "//enterprise/server/scim",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/registry"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/execution_server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remoteusage"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scim"
@@ -139,6 +140,7 @@ func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
 	env.SetRunnerService(runnerService)
 
 	auth_service.Register(env)
+	remoteusage.Register(env)
 
 	env.SetSplashPrinter(&splash.Printer{})
 }

--- a/enterprise/server/remoteusage/BUILD
+++ b/enterprise/server/remoteusage/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "remoteusage",
+    srcs = ["remoteusage.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remoteusage",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:usage_go_proto",
+        "//server/real_environment",
+    ],
+)

--- a/enterprise/server/remoteusage/remoteusage.go
+++ b/enterprise/server/remoteusage/remoteusage.go
@@ -1,0 +1,22 @@
+package remoteusage
+
+import (
+	"context"
+
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+
+	usagepb "github.com/buildbuddy-io/buildbuddy/proto/usage"
+)
+
+func Register(env *real_environment.RealEnv) {
+	env.SetRemoteUsageService(&Service{})
+}
+
+type Service struct {
+}
+
+func (u *Service) Record(ctx context.Context, req *usagepb.RecordRequest) (*usagepb.RecordResponse, error) {
+	// TODO(iain): verify caller identity before recording usage. This should
+	// be done automatically by usage.go, but confirm.
+	return &usagepb.RecordResponse{}, nil
+}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1129,6 +1129,7 @@ go_proto_library(
     name = "usage_go_proto",
     compilers = [
         "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/usage",

--- a/proto/usage.proto
+++ b/proto/usage.proto
@@ -56,3 +56,20 @@ message Usage {
   // the sum of execution time of cached objects.
   int64 total_cached_action_exec_usec = 8;
 }
+
+message RecordRequest {
+  // TODO(iain):
+  //   - Convert usage.go's Increment() function to accept a proto version of
+  //     tables.UsageLabels and tables.UsageCounts.
+  //   - Add a remote-client version of the above that sends Record() RPCs.
+  //   - Make Cache Proxy use that remote-client version of usage.
+  //   - Hook up remoteusage.Service to the Redis-backed usage.
+  //   - Look into what, if any other data we'd like for Cache Proxy usage
+  //     (probably cloud and region)
+}
+
+message RecordResponse {}
+
+service RemoteUsageService {
+  rpc Record(RecordRequest) returns (RecordResponse);
+}

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -134,4 +134,5 @@ type Env interface {
 	GetClock() clockwork.Clock
 	GetAtimeUpdater() interfaces.AtimeUpdater
 	GetCPULeaser() interfaces.CPULeaser
+	GetRemoteUsageService() interfaces.RemoteUsageService
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1596,3 +1596,7 @@ type CPULeaser interface {
 type OCIRegistry interface {
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
 }
+
+type RemoteUsageService interface {
+	Record(ctx context.Context, req *usagepb.RecordRequest) (*usagepb.RecordResponse, error)
+}

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
         "//proto:soci_go_proto",
+        "//proto:usage_go_proto",
         "//proto/api/v1:api_v1_go_proto",
         "//server/backends/blobstore",
         "//server/backends/disk_cache",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -65,6 +65,7 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	socipb "github.com/buildbuddy-io/buildbuddy/proto/soci"
+	usagepb "github.com/buildbuddy-io/buildbuddy/proto/usage"
 	bburl "github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	static_bundle "github.com/buildbuddy-io/buildbuddy/static"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
@@ -317,6 +318,9 @@ func registerServices(env *real_environment.RealEnv, grpcServer *grpc.Server) {
 	}
 	if auth := env.GetAuthService(); auth != nil {
 		authpb.RegisterAuthServiceServer(grpcServer, auth)
+	}
+	if usageService := env.GetRemoteUsageService(); usageService != nil {
+		usagepb.RegisterRemoteUsageServiceServer(grpcServer, usageService)
 	}
 }
 

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -133,6 +133,7 @@ type RealEnv struct {
 	atimeUpdater                     interfaces.AtimeUpdater
 	cpuLeaser                        interfaces.CPULeaser
 	ociRegistry                      interfaces.OCIRegistry
+	remoteUsageService               interfaces.RemoteUsageService
 }
 
 // NewRealEnv returns an environment for use in servers.
@@ -812,4 +813,11 @@ func (r *RealEnv) GetOCIRegistry() interfaces.OCIRegistry {
 }
 func (r *RealEnv) SetOCIRegistry(ociRegistry interfaces.OCIRegistry) {
 	r.ociRegistry = ociRegistry
+}
+
+func (r *RealEnv) GetRemoteUsageService() interfaces.RemoteUsageService {
+	return r.remoteUsageService
+}
+func (r *RealEnv) SetRemoteUsageService(u interfaces.RemoteUsageService) {
+	r.remoteUsageService = u
 }


### PR DESCRIPTION
This PR just adds the skeleton of a remote usage service for tracking cache download from the Cache Proxy. Currently the request is empty, but I'll add stuff to it in a follow-up. My plan, as outlined by the TODOs in usage.proto is to:
- Change the [`UsageTracker` interface](https://github.com/buildbuddy-io/buildbuddy/blob/2bcd046665ece47cf1c2a08b1117b69a265a8049/server/interfaces/interfaces.go#L591) to accept protocol buffers instead of tables data.
- Add a remote-client version of the `UsageTracker` interface which will send usage data to the endpoint added in this PR, using some sort of batching/best-effort behavior if necessary.
- Make the Cache Proxy use the remote-client `UsageTracker`.
- Hook up the App's, Redis-backed `UsageTracker` to the service added in this PR.

Open to feedback, though.