### PR TITLE
timing profile: add unit to some time series lanes

### DIFF
--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -77,7 +77,10 @@ const TIME_SERIES_EVENT_NAMES = new Map<string, seriesMetadata>([
   ["CPU usage (total)", { argKey: "system cpu", displayName: "CPU usage (System)" }],
   ["Memory usage (total)", { argKey: "system memory", displayName: "Memory usage (System, in MB)" }],
   ["System load average", { argKey: "load" }],
-  ["Network Up usage (total)", { argKey: "system network up (Mbps)", displayName: "Network Up usage (System, in Mbps)" }],
+  [
+    "Network Up usage (total)",
+    { argKey: "system network up (Mbps)", displayName: "Network Up usage (System, in Mbps)" },
+  ],
   [
     "Network Down usage (total)",
     { argKey: "system network down (Mbps)", displayName: "Network Down usage (System, in Mbps)" },

--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -73,14 +73,14 @@ const TIME_SERIES_EVENT_NAMES = new Map<string, seriesMetadata>([
   // These are defined by bazel / not controlled by us.
   ["action count", { argKey: "action" }],
   ["CPU usage (Bazel)", { argKey: "cpu" }],
-  ["Memory usage (Bazel)", { argKey: "memory", displayName: "Memory usage (Bazel) (MBytes)" }],
-  ["CPU usage (total)", { argKey: "system cpu" }],
-  ["Memory usage (total)", { argKey: "system memory", displayName: "Memory usage (total) (MBytes)" }],
+  ["Memory usage (Bazel)", { argKey: "memory", displayName: "Memory usage (Bazel, in MB)" }],
+  ["CPU usage (total)", { argKey: "system cpu", displayName: "CPU usage (System)" }],
+  ["Memory usage (total)", { argKey: "system memory", displayName: "Memory usage (System, in MB)" }],
   ["System load average", { argKey: "load" }],
-  ["Network Up usage (total)", { argKey: "system network up (Mbps)", displayName: "Network Up usage (total) (Mbps)" }],
+  ["Network Up usage (total)", { argKey: "system network up (Mbps)", displayName: "Network Up usage (System, in Mbps)" }],
   [
     "Network Down usage (total)",
-    { argKey: "system network down (Mbps)", displayName: "Network Down usage (total) (Mbps)" },
+    { argKey: "system network down (Mbps)", displayName: "Network Down usage (System, in Mbps)" },
   ],
 
   // Event names/arg keys from executor profiles.

--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -48,42 +48,53 @@ export type TimeSeries = {
   events: TimeSeriesEvent[];
 };
 
+type seriesMetadata = {
+  argKey: string;
+  displayName?: string;
+};
+
 // A list of names of events that contain a timestamp and a value in args.
+//
+// The names from Bazel profiles will be displayed as-is, unless a displayName
+// is provided in the seriesMetadata object.
 //
 // We only render timeseries which are defined in this list. The order of the
 // entries in this list determines the order in which the timeseries are
 // displayed in the trace viewer panel.
 //
-// An example event for Bazel CPU usage looks like this: {"name": "CPU usage
-// (bazel)", ..., "args": {"cpu": 0.84}}
-const TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS_ENTRIES: [string, string][] = [
+// An example event for Bazel CPU usage looks like this:
+// {
+//   "name": "CPU usage (bazel)",
+//   ...,
+//   "args": {"cpu": 0.84}
+// }
+const TIME_SERIES_EVENT_NAMES = new Map<string, seriesMetadata>([
   // Event names/arg keys from Bazel profiles.
   // These are defined by bazel / not controlled by us.
-  ["action count", "action"],
-  ["CPU usage (Bazel)", "cpu"],
-  ["Memory usage (Bazel)", "memory"],
-  ["CPU usage (total)", "system cpu"],
-  ["Memory usage (total)", "system memory"],
-  ["System load average", "load"],
-  ["Network Up usage (total)", "system network up (Mbps)"],
-  ["Network Down usage (total)", "system network down (Mbps)"],
+  ["action count", { argKey: "action" }],
+  ["CPU usage (Bazel)", { argKey: "cpu" }],
+  ["Memory usage (Bazel)", { argKey: "memory", displayName: "Memory usage (Bazel) (MBytes)" }],
+  ["CPU usage (total)", { argKey: "system cpu" }],
+  ["Memory usage (total)", { argKey: "system memory", displayName: "Memory usage (total) (MBytes)" }],
+  ["System load average", { argKey: "load" }],
+  ["Network Up usage (total)", { argKey: "system network up (Mbps)", displayName: "Network Up usage (total) (Mbps)" }],
+  [
+    "Network Down usage (total)",
+    { argKey: "system network down (Mbps)", displayName: "Network Down usage (total) (Mbps)" },
+  ],
 
   // Event names/arg keys from executor profiles.
-  // These are controlled by us, and defined in
+  // These are controlled by us, {argKey: and defined in
   // enterprise/server/execution_service/execution_service.go
-  ["CPU usage (cores)", "cpu"],
-  ["Memory usage (KB)", "memory"],
-  ["Disk read bandwidth (MB/s)", "disk-read-bw"],
-  ["Disk read IOPS", "disk-read-iops"],
-  ["Disk write bandwidth (MB/s)", "disk-write-bw"],
-  ["Disk write IOPS", "disk-write-iops"],
-];
+  ["CPU usage (cores)", { argKey: "cpu" }],
+  ["Memory usage (KB)", { argKey: "memory" }],
+  ["Disk read bandwidth (MB/s)", { argKey: "disk-read-bw" }],
+  ["Disk read IOPS", { argKey: "disk-read-iops" }],
+  ["Disk write bandwidth (MB/s)", { argKey: "disk-write-bw" }],
+  ["Disk write IOPS", { argKey: "disk-write-iops" }],
+]);
 
-const TIME_SERIES_EVENT_ORDER = new Map<string, number>(
-  TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS_ENTRIES.map(([eventName, _argKey], index) => [eventName, index])
-);
-
-const TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS = new Map(TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS_ENTRIES);
+const TIME_SERIES_EVENT_ORDER = new Map(Array.from(TIME_SERIES_EVENT_NAMES).map(([name], index) => [name, index]));
 
 export async function readProfile(
   body: ReadableStream<Uint8Array>,
@@ -221,7 +232,7 @@ function normalizeThreadNames(events: TraceEvent[]) {
 }
 
 export function buildTimeSeries(events: TraceEvent[]): TimeSeries[] {
-  events = events.filter((event) => TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS.has(event.name));
+  events = events.filter((event) => TIME_SERIES_EVENT_NAMES.has(event.name));
   events.sort(timeSeriesEventComparator);
 
   const timelines: TimeSeries[] = [];
@@ -232,13 +243,13 @@ export function buildTimeSeries(events: TraceEvent[]): TimeSeries[] {
       // Encountered new type of time series data
       name = event.name;
       timeSeries = {
-        name,
+        name: TIME_SERIES_EVENT_NAMES.get(name)?.displayName || name,
         events: [],
       };
       timelines.push(timeSeries);
     }
     for (const key in event.args) {
-      if (key == TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS.get(event.name)) {
+      if (key == TIME_SERIES_EVENT_NAMES.get(event.name)?.argKey) {
         event.value = event.args[key];
       }
     }

--- a/app/trace/trace_viewer_model.ts
+++ b/app/trace/trace_viewer_model.ts
@@ -39,6 +39,7 @@ export type LinePlotModel = {
   yMax: number;
   darkColor: string;
   lightColor: string;
+  unit?: string;
 };
 
 export function buildTraceViewerModel(trace: Profile, fitToContent?: boolean): TraceViewerModel {
@@ -115,7 +116,7 @@ function buildLinePlotsPanel(events: TraceEvent[], fitToContent?: boolean): Pane
     constants.TIME_SERIES_HEIGHT +
     constants.SECTION_PADDING_BOTTOM;
   const sections: SectionModel[] = [];
-  for (const { name, events } of timeSeries) {
+  for (const { name, events, unit } of timeSeries) {
     const xs: number[] = [];
     const ys: number[] = [];
     let yMax = 0;
@@ -137,6 +138,7 @@ function buildLinePlotsPanel(events: TraceEvent[], fitToContent?: boolean): Pane
         yMax,
         darkColor: getMaterialChartColor(index),
         lightColor: getLightMaterialChartColor(index),
+        unit,
       },
     });
     sectionY += sectionHeight;

--- a/app/trace/trace_viewer_panel.ts
+++ b/app/trace/trace_viewer_panel.ts
@@ -241,7 +241,8 @@ export default class Panel {
         constants.TIME_SERIES_HEIGHT;
       const pointClientY = plotClientBottom - (mouseModelY / section.linePlot.yMax) * constants.TIME_SERIES_HEIGHT;
       fillCircle(ctx, x, pointClientY, 2, section.linePlot.darkColor);
-      fillTextBox(ctx, String(truncateDecimals(mouseModelY, 2)), textBoxX, pointClientY - 6, {
+      const unit = section.linePlot.unit ? " " + section.linePlot.unit : "";
+      fillTextBox(ctx, String(truncateDecimals(mouseModelY, 2)) + unit, textBoxX, pointClientY - 6, {
         boxPadding: 1,
         boxRadius: 8,
         xAnchor,


### PR DESCRIPTION
Some time series lanes, such as "Memory usage" and "Network usage"
lanes can display a wide range of metric values that made it hard for
users to "guess" the unit being recorded.

Override the event name in Bazel profile with our own display name with
a unit attached to make it easier to read these metrics.
