### PR TITLE
github/workflows: fix release-cli cache loads

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Restore caches
         id: restore-caches
-        uses: ./.github/actions/cache-restore
+        uses: buildbuddy/.github/actions/cache-restore
 
       - name: Build Artifacts
         id: build
@@ -207,7 +207,7 @@ jobs:
             "${{ steps.build.outputs.BINARY }}.sha256"
 
       - name: Save caches
-        uses: ./.github/actions/cache-save
+        uses: buildbuddy/.github/actions/cache-save
         if: always()
         with:
           repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}


### PR DESCRIPTION
release-cli workflow is a bit special where it operates on multiple
repos instead of just one

```
.github/workflows/release-cli.yaml
19:        uses: actions/checkout@v3
20-        with:
21-          # We need to fetch git tags to obtain the latest cli version tag.
22-          fetch-depth: 0
--
44:        uses: actions/checkout@v3
45-        with:
46-          repository: buildbuddy-io/bazel
47-          path: bazel-fork
--
81:        uses: actions/checkout@v3
82-        with:
83-          path: buildbuddy
84-
--
86:        uses: actions/checkout@v3
87-        with:
88-          repository: buildbuddy-io/plugins
89-          path: plugins
--
156:        uses: actions/checkout@v3
157-        with:
158-          path: buildbuddy
159-
```

Adjust the paths which we load our composite action to match the checkout
path of buildbuddy repo.
