### PR TITLE
github/workflows: fix path syntax in release-cli

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Restore caches
         id: restore-caches
-        uses: buildbuddy/.github/actions/cache-restore
+        uses: ./buildbuddy/.github/actions/cache-restore
 
       - name: Build Artifacts
         id: build
@@ -207,7 +207,7 @@ jobs:
             "${{ steps.build.outputs.BINARY }}.sha256"
 
       - name: Save caches
-        uses: buildbuddy/.github/actions/cache-save
+        uses: ./buildbuddy/.github/actions/cache-save
         if: always()
         with:
           repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}


### PR DESCRIPTION
Follow up from #8679

```
Error
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```

