### PR TITLE
Rename `OptionDefinitionSet` to `Parser`

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -237,8 +237,8 @@ func (p *Parser) AddOptionDefinition(o *OptionDefinition) error {
 // index is returned as len(list), which the caller should handle.
 //
 // If args[start] corresponds to an option definition that is not known by the
-// option definition set, the returned values will be (nil, "", start+1). It is
-// up to the caller to decide how args[start] should be interpreted.
+// parser, the returned values will be (nil, "", start+1). It is up to the
+// caller to decide how args[start] should be interpreted.
 func (p *Parser) Next(command string, args []string, start int) (optionDefinition *OptionDefinition, value string, next int, err error) {
 	if start > len(args) {
 		return nil, "", -1, fmt.Errorf("arg index %d out of bounds", start)

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -59,7 +59,7 @@ var (
 	// make this a var so the test can replace it.
 	bazelHelp = runBazelHelpWithCache
 
-	parserOnce = sync.OnceValue(
+	generateParsersOnce = sync.OnceValue(
 		func() *struct {
 			parserOnce map[string]*Parser
 			error
@@ -90,7 +90,7 @@ var (
 				commands map[string]struct{}
 				error
 			}
-			p, err := GetParser()
+			p, err := GetParsers()
 			if err != nil {
 				return &Return{nil, err}
 			}
@@ -561,8 +561,8 @@ func GetParserFromProto(flagCollection *bfpb.FlagCollection) (map[string]*Parser
 	return sets, nil
 }
 
-func GetParser() (map[string]*Parser, error) {
-	once := parserOnce()
+func GetParsers() (map[string]*Parser, error) {
+	once := generateParsersOnce()
 	return once.parserOnce, once.error
 }
 


### PR DESCRIPTION
We rename `OptionDefinitionSet` to `Parser` in preparation for instanitiating it as a singleton containing the only set of `OptionDefinition`s as well as the set of supported bazel commands, and also because it has the parsing methods as its member methods.

In addition to it being a more descriptive name, it is also much shorter, which is generally preferable.
