### PR TITLE
Remove empty 'env' from workflow

### DIFF
--- a/.github/workflows/build-mac-intel-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-intel-github-release-artifacts.yaml
@@ -26,8 +26,6 @@ on:
 jobs:
   build:
     runs-on: macos-13
-    env:
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy/actions/runs/13928825454