### PR TITLE
[raft] try other replicas with range-not-present error

### DIFF
--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -109,7 +109,7 @@ var (
 
 // Error constants -- sender recognizes these errors.
 var (
-	RangeNotFoundMsg     = "Range not present"   // break
+	RangeNotFoundMsg     = "Range not present"   // continue
 	RangeNotLeasedMsg    = "Range not leased"    // continue
 	RangeNotCurrentMsg   = "Range not current"   // break
 	RangeLeaseInvalidMsg = "Range lease invalid" // continue

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -329,9 +329,9 @@ func (s *Sender) TryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 			m := status.Message(err)
 			switch {
 			// range not found, no replicas are likely to have it; bail.
-			case strings.HasPrefix(m, constants.RangeNotFoundMsg), strings.HasPrefix(m, constants.RangeNotCurrentMsg):
+			case strings.HasPrefix(m, constants.RangeNotCurrentMsg):
 				return 0, status.OutOfRangeErrorf("failed to TryReplicas on c%dn%d: no replicas are likely to have it: %s", replica.GetRangeId(), replica.GetReplicaId(), m)
-			case strings.HasPrefix(m, constants.RangeNotLeasedMsg), strings.HasPrefix(m, constants.RangeLeaseInvalidMsg):
+			case strings.HasPrefix(m, constants.RangeNotLeasedMsg), strings.HasPrefix(m, constants.RangeLeaseInvalidMsg), strings.HasPrefix(m, constants.RangeNotFoundMsg):
 				logs = append(logs, fmt.Sprintf("skipping c%dn%d: out of range: %s", replica.GetRangeId(), replica.GetReplicaId(), err))
 				continue
 			default:


### PR DESCRIPTION
We return range-not-present error when the range is not present in openRanges.

The intention of this error is if we hit the wrong machine, then we don't want
to try all replicas. However, openRanges is not appropriate for this check; it
didn't represent all replicas that should be on this machine; but what was
currently open; during rollout or shutting down, this is only a subset of all
the ranges that should be on the machine.
