### PR TITLE
[OCI mirror] Resolve manifest digests to be able to read manifests from cache

### DIFF
--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -144,19 +144,19 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 	if inreq.URL.Scheme != "" {
 		scheme = inreq.URL.Scheme
 	}
-	u := url.URL{
+	u := &url.URL{
 		Scheme: scheme,
 		Host:   gcrname.DefaultRegistry,
 		Path:   "/v2/",
 	}
 	upreq, err := http.NewRequest(inreq.Method, u.String(), nil)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("could not make %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)
+		http.Error(w, fmt.Sprintf("could not make %s request to upstream registry '%s': %s", inreq.Method, u, err), http.StatusNotFound)
 		return
 	}
 	upresp, err := http.DefaultClient.Do(upreq.WithContext(ctx))
 	if err != nil {
-		http.Error(w, fmt.Sprintf("transport error making %s request to upstream registry '%s': %s", inreq.Method, u.String(), err), http.StatusNotFound)
+		http.Error(w, fmt.Sprintf("transport error making %s request to upstream registry '%s': %s", inreq.Method, u, err), http.StatusNotFound)
 		return
 	}
 	defer upresp.Body.Close()
@@ -183,14 +183,14 @@ func makeUpstreamRequest(ctx context.Context, method, acceptHeader, authorizatio
 	case ocipb.OCIResourceType_UNKNOWN:
 		return nil, fmt.Errorf("unknown OCI resource type, expected blobs or manifests")
 	}
-	u := url.URL{
+	u := &url.URL{
 		Scheme: ref.Context().Scheme(),
 		Host:   ref.Context().RegistryStr(),
 		Path:   path,
 	}
 	upreq, err := http.NewRequest(method, u.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not make %s request to upstream registry '%s': %s", method, u.String(), err)
+		return nil, fmt.Errorf("could not make %s request to upstream registry '%s': %s", method, u, err)
 	}
 	if acceptHeader != "" {
 		upreq.Header.Set(headerAccept, acceptHeader)

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -167,7 +167,7 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 	_, err = io.Copy(w, upresp.Body)
 	if err != nil {
 		if err != context.Canceled {
-			log.CtxWarningf(ctx, "error writing response body for '%s', upstream '%s': %s", inreq.URL.String(), u.String(), err)
+			log.CtxWarningf(ctx, "error writing response body for '%s', upstream '%s': %s", inreq.URL, u, err)
 		}
 		return
 	}
@@ -201,27 +201,27 @@ func makeUpstreamRequest(ctx context.Context, method, acceptHeader, authorizatio
 	return http.DefaultClient.Do(upreq.WithContext(ctx))
 }
 
-func parseContentLengthHeader(header string) (int64, bool, error) {
-	if header == "" {
+func parseContentLengthHeader(value string) (int64, bool, error) {
+	if value == "" {
 		return 0, false, nil
 	}
-	contentLength, err := strconv.ParseInt(header, 10, 64)
+	contentLength, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		return 0, false, fmt.Errorf("could not parse %s header (value '%s'): %s", headerContentLength, header, err)
+		return 0, false, fmt.Errorf("could not parse %s header (value '%s'): %s", headerContentLength, value, err)
 	}
 	if contentLength < 0 {
-		return 0, false, fmt.Errorf("%s header must be 0 or greater, received value '%s'", headerContentLength, header)
+		return 0, false, fmt.Errorf("%s header must be 0 or greater, received value '%s'", headerContentLength, value)
 	}
 	return contentLength, true, nil
 }
 
-func parseDockerContentDigestHeader(header string) (*gcr.Hash, error) {
-	if header == "" {
+func parseDockerContentDigestHeader(value string) (*gcr.Hash, error) {
+	if value == "" {
 		return nil, nil
 	}
-	hash, err := gcr.NewHash(header)
+	hash, err := gcr.NewHash(value)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse %s header (value '%s'): %s", headerDockerContentDigest, header, err)
+		return nil, fmt.Errorf("could not parse %s header (value '%s'): %s", headerDockerContentDigest, value, err)
 	}
 	return &hash, nil
 }
@@ -343,12 +343,12 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 	if upresp.StatusCode == http.StatusOK && inreq.Method == http.MethodGet && hasLength && hash != nil && hasContentType {
 		err := writeBlobOrManifestToCacheAndResponse(ctx, upresp.Body, w, bsClient, acClient, resolvedRef, ociResourceType, *hash, contentType, contentLength)
 		if err != nil && err != context.Canceled {
-			log.CtxWarningf(ctx, "error writing response body to cache for '%s': %s", inreq.URL.String(), err)
+			log.CtxWarningf(ctx, "error writing response body to cache for '%s': %s", inreq.URL, err)
 		}
 	} else {
 		_, err = io.Copy(w, upresp.Body)
 		if err != nil && err != context.Canceled {
-			log.CtxWarningf(ctx, "error writing response body for '%s': %s", inreq.URL.String(), err)
+			log.CtxWarningf(ctx, "error writing response body for '%s': %s", inreq.URL, err)
 		}
 	}
 }

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -272,7 +272,7 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 	resolvedRefIsDigest := identifierIsDigest
 	if ociResourceType == ocipb.OCIResourceType_MANIFEST && !identifierIsDigest && inreq.Method == http.MethodGet {
 		// Fetching a manifest by tag.
-		// Singe the mapping from tag to digest can change, we only look up manifests and blobs in the CAS by digest.
+		// Since the mapping from tag to digest can change, we only look up manifests and blobs in the CAS by digest.
 		// Docker Hub does not count "version checks" (HEAD requests) against the rate limit.
 		// So make a HEAD request for the manifest, find its digest, and see if we can fetch from CAS.
 		hash, err := resolveManifestDigest(ctx, inreq.Header.Get(headerAccept), inreq.Header.Get(headerAuthorization), ociResourceType, ref)


### PR DESCRIPTION
OCI clients can fetch OCI image manifests by tag (for example, `latest`) or digest. The mapping from tag to manifest can change (and often does for `latest`), so the mirror only caches manifests by digest.

This means that every time an OCI client makes a GET request for a manifest tag, the mirror makes an upstream GET request  to Docker Hub. [This GET request counts as a "pull"](https://docs.docker.com/docker-hub/usage/pulls/). Starting March 31, 2025, Docker Hub will enforce a 10 pulls per hour rate limit for unauthenticated users.

"Version checks" do not count as pulls. I _think_ that a version check is a HEAD request.

This change has the mirror make a HEAD request to find the digest for a manifest tag. The mirror can then use the digest to look up the manifest in the cache. On the first GET for a particular manifest, that will cause the mirror to make 2 upstream requests. Subsequent GETs will still make upstream HEAD requests, but then be able to fetch the manifest payload from cache.