### PR TITLE
[raft] add grpc address tag to gossip

### DIFF
--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/uuid",
+        "@com_github_hashicorp_serf//serf",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_lni_dragonboat_v4//:dragonboat",
         "@com_github_lni_dragonboat_v4//client",

--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/uuid",
-        "@com_github_hashicorp_serf//serf",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_lni_dragonboat_v4//:dragonboat",
         "@com_github_lni_dragonboat_v4//client",

--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -6,8 +6,6 @@ import (
 
 // Gossip (broadcast) constants
 const (
-	NodeHostIDTag  = "node_host_id"
-	RaftAddressTag = "raft_address"
 	GRPCAddressTag = "grpc_address"
 	MetaRangeTag   = "meta_range"
 	ZoneTag        = "zone"


### PR DESCRIPTION
When we preload registry, we compute the address from serf address which
was a IP address instead of a hostname. As a result, we are storing two
clients under different names in APIClient.
