### PR TITLE
track inlined bytes for all getactionresultrequest files.

### DIFF
--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -291,8 +291,6 @@ func (s *ActionCacheServer) maybeInlineOutputFiles(ctx context.Context, req *rep
 			continue
 		}
 
-		inlinedBytes += contentsSize
-
 		// An additional "contents" field requires 1 byte for the tag field
 		// (5:LEN), the bytes for the varint encoding of the length of the
 		// contents and the contents themselves.
@@ -300,6 +298,7 @@ func (s *ActionCacheServer) maybeInlineOutputFiles(ctx context.Context, req *rep
 		if budget < totalSize {
 			continue
 		}
+		inlinedBytes += contentsSize
 		budget -= totalSize
 		filesToInline = append(filesToInline, f)
 	}

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -104,7 +104,8 @@ func TestInlineSingleFileTooLarge(t *testing.T) {
 	assert.Equal(t, digestA, actionResult.OutputFiles[0].Digest)
 	assert.Empty(t, actionResult.OutputFiles[0].Contents)
 
-	testmetrics.AssertHistogramSamples(t, metrics.CacheRequestedInlineSizeBytes, float64(size))
+	// Shouldn't count any data at all: file isn't included in output.
+	testmetrics.AssertHistogramSamples(t, metrics.CacheRequestedInlineSizeBytes, 0)
 	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.CacheEvents.With(
 		prometheus.Labels{
 			metrics.CacheTypeLabel:      "action_cache",


### PR DESCRIPTION
i've changed the meaning of this metric; i'd be happy to rename it if you want.  instead of tracking the size of the first requested file, the function now tracks the actual size of all files that are sent on the response.