### PR TITLE
Revert "only send timeline data with ActionResults when it is explicitly requested."

### DIFF
--- a/enterprise/server/util/execution/execution.go
+++ b/enterprise/server/util/execution/execution.go
@@ -116,10 +116,9 @@ func GetCachedExecuteResponse(ctx context.Context, ac repb.ActionCacheClient, ta
 		return nil, err
 	}
 	req := &repb.GetActionResultRequest{
-		ActionDigest:        d,
-		InstanceName:        rn.GetInstanceName(),
-		DigestFunction:      rn.GetDigestFunction(),
-		IncludeTimelineData: true,
+		ActionDigest:   d,
+		InstanceName:   rn.GetInstanceName(),
+		DigestFunction: rn.GetDigestFunction(),
 	}
 	rsp, err := ac.GetActionResult(ctx, req)
 	if err != nil {

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -1599,14 +1599,6 @@ message GetActionResultRequest {
   // length of the action digest hash and the digest functions announced
   // in the server's capabilities.
   DigestFunction.Value digest_function = 6;
-
-  // BUILDBUDDY-SPECIFIC FIELDS BELOW.
-  // Started at field #1000 to avoid conflicts with Bazel.
-
-  // If true, the server will include execution timeline data in the
-  // buildbuddy-specific UsageStats field.  This data is large and
-  // shouldn't be sent to Bazel for normal action cache fetches.
-  bool include_timeline_data = 1000;
 }
 
 // A request message for

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -190,10 +190,6 @@ func (s *ActionCacheServer) GetActionResult(ctx context.Context, req *repb.GetAc
 		return nil, err
 	}
 
-	if !req.GetIncludeTimelineData() && rsp.GetExecutionMetadata().GetUsageStats() != nil {
-		rsp.GetExecutionMetadata().GetUsageStats().Timeline = nil
-	}
-
 	isCacheHit = true
 	uncompressedResultSizeBytes = int64(proto.Size(rsp))
 


### PR DESCRIPTION
this doesn't actually do anything; timeline data is only stored in the weird ExecuteResponse-based AC entries that we save.