### PR TITLE
Make drilldowns and flakes top level sidebar items

### DIFF
--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -19,6 +19,8 @@ import {
   PanelLeftOpen,
   Fingerprint,
   MessageCircle,
+  Snowflake,
+  ZoomIn,
 } from "lucide-react";
 import React from "react";
 import { User } from "../../../app/auth/auth_service";
@@ -142,14 +144,38 @@ export default class SidebarComponent extends React.Component<Props, State> {
             <List className="icon" />
             <span className="sidebar-item-text">All builds</span>
           </SidebarLink>
-          <SidebarLink selected={this.isTrendsSelected()} href={Path.trendsPath} title="Trends">
+          <SidebarLink
+            selected={this.isTrendsSelected() && this.props.tab != "#drilldown"}
+            href={Path.trendsPath}
+            title="Trends">
             <BarChart2 className="icon" />
             <span className="sidebar-item-text">Trends</span>
           </SidebarLink>
+          {capabilities.config.trendsHeatmapEnabled && (
+            <SidebarLink
+              selected={this.isTrendsSelected() && this.props.tab == "#drilldown"}
+              href={Path.trendsPath + "#drilldown"}
+              title="Drilldown">
+              <ZoomIn className="icon" />
+              <span className="sidebar-item-text">Drilldown</span>
+            </SidebarLink>
+          )}
           {capabilities.test && (
-            <SidebarLink selected={this.isTapSelected()} href={Path.tapPath} title="Tests">
+            <SidebarLink
+              selected={this.isTapSelected() && this.props.tab != "#flakes"}
+              href={Path.tapPath}
+              title="Tests">
               <LayoutGrid className="icon" />
               <span className="sidebar-item-text">Tests</span>
+            </SidebarLink>
+          )}
+          {capabilities.config.targetFlakesUiEnabled && (
+            <SidebarLink
+              selected={this.isTapSelected() && this.props.tab == "#flakes"}
+              href={Path.tapPath + "#flakes"}
+              title="Flakes">
+              <Snowflake className="icon" />
+              <span className="sidebar-item-text">Flakes</span>
             </SidebarLink>
           )}
           <SidebarLink selected={this.isUsersSelected()} href="/#users" title="Users">


### PR DESCRIPTION
These are our most hidden, but also some of our most valuable pages.

This change puts them in the sidebar (if enabled) to make them more easily accessible.

<img width="262" alt="Screenshot 2025-03-20 at 2 40 46 PM" src="https://github.com/user-attachments/assets/a49c9542-c0a6-40d1-a7c0-8b60a13aa6b8" />
