### PR TITLE
Differentiate between cached and uncached tests in test grid

### DIFF
--- a/enterprise/app/tap/grid_common.ts
+++ b/enterprise/app/tap/grid_common.ts
@@ -4,6 +4,6 @@ export const COLOR_MODE_PARAM = "color";
 
 export type ColorMode = "status" | "timing";
 
-export type SortMode = "target" | "count" | "pass" | "avgDuration" | "maxDuration" | "flake";
+export type SortMode = "target" | "count" | "pass" | "avgDuration" | "maxDuration" | "flake" | "cached";
 
 export type SortDirection = "asc" | "desc";

--- a/enterprise/app/tap/grid_sort_controls.tsx
+++ b/enterprise/app/tap/grid_sort_controls.tsx
@@ -51,6 +51,7 @@ export default class GridSortControlsComponent extends React.Component<Props> {
             <Option value="avgDuration">Average duration</Option>
             <Option value="maxDuration">Max duration</Option>
             <Option value="flake">Flake percentage</Option>
+            <Option value="cached">Cached percentage</Option>
           </Select>
         </div>
         <div className="tap-sort-control">

--- a/enterprise/app/tap/tap.css
+++ b/enterprise/app/tap/tap.css
@@ -365,6 +365,9 @@ SKIPPED = 13;
   color: #444;
 }
 
+.tap .tap-block.cached {
+  opacity: 0.5;
+}
 .tap .tap-block.status-0 {
   background-color: #888;
 }

--- a/enterprise/app/workflows/action_list.tsx
+++ b/enterprise/app/workflows/action_list.tsx
@@ -179,7 +179,7 @@ export default class ActionListComponent extends React.Component<ActionListCompo
                   {latestCompletedRun && (
                     <div className="subtitle">
                       {getRunStatusText(latestRunStatus)} at <GitCommit className="icon inline-icon" />{" "}
-                      {format.formatCommitHash(latestCompletedRun.commitSha)}
+                      {format.formatCommitHash(latestCompletedRun.commitSha)} in {latestCompletedRun.duration}
                     </div>
                   )}
                   {!latestCompletedRun && <div className="subtitle">No runs in last 7 days.</div>}

--- a/enterprise/app/workflows/action_list.tsx
+++ b/enterprise/app/workflows/action_list.tsx
@@ -179,7 +179,7 @@ export default class ActionListComponent extends React.Component<ActionListCompo
                   {latestCompletedRun && (
                     <div className="subtitle">
                       {getRunStatusText(latestRunStatus)} at <GitCommit className="icon inline-icon" />{" "}
-                      {format.formatCommitHash(latestCompletedRun.commitSha)} in {latestCompletedRun.duration}
+                      {format.formatCommitHash(latestCompletedRun.commitSha)}
                     </div>
                   )}
                   {!latestCompletedRun && <div className="subtitle">No runs in last 7 days.</div>}


### PR DESCRIPTION
Cached test runs are rendered with 50% opacity.

Also shows percentage cached in test summary stats, and allows sorting by cache percentage ascending / descending.

Uses an (imperfect) heuristic to tell whether or not a test was cached (if the tests's start time was before the invocation's start time). This can lead to some false negatives, but should be alright for this use-case.