### PR TITLE
.github/workflows: fix cache paths on windows

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -17,8 +17,8 @@ jobs:
         id: restore-caches
         uses: ./.github/actions/cache-restore
         with:
-          repo-cache-dir: "D:/bazel/repo-cache/"
-          go-mod-cache-dir: "D:/go-mod-cache/"
+          repo-cache-dir: "D:/bazel/repo-cache"
+          go-mod-cache-dir: "D:/go-mod-cache"
           yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"
 
       # This step would list out all files under $vs2022Path for debugging purposes.

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -39,8 +39,8 @@ jobs:
         id: restore-caches
         uses: ./.github/actions/cache-restore
         with:
-          repo-cache-dir: "D:/bazel/repo-cache/"
-          go-mod-cache-dir: "D:/go-mod-cache/"
+          repo-cache-dir: "D:/bazel/repo-cache"
+          go-mod-cache-dir: "D:/go-mod-cache"
           yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"
 
       - name: Build and Upload Artifacts
@@ -61,8 +61,8 @@ jobs:
         if: always()
         with:
           repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          repo-cache-dir: "D:/bazel/repo-cache/"
+          repo-cache-dir: "D:/bazel/repo-cache"
           go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          go-mod-cache-dir: "D:/go-mod-cache/"
+          go-mod-cache-dir: "D:/go-mod-cache"
           yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
           yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"


### PR DESCRIPTION
If we don't use a consistent cache path, there won't be any cache hits.
Fix all Windows cache paths to not use trailing path separator so that
deps download caching would actually work.
