### PR TITLE
Priority queue: implement PeekAt and RemoveAt

### DIFF
--- a/enterprise/server/scheduling/priority_queue/BUILD
+++ b/enterprise/server/scheduling/priority_queue/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -7,4 +7,14 @@ go_library(
     srcs = ["priority_queue.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_queue",
     deps = ["//proto:scheduler_go_proto"],
+)
+
+go_test(
+    name = "priority_queue_test",
+    srcs = ["priority_queue_test.go"],
+    deps = [
+        ":priority_queue",
+        "//proto:scheduler_go_proto",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/enterprise/server/scheduling/priority_queue/priority_queue.go
+++ b/enterprise/server/scheduling/priority_queue/priority_queue.go
@@ -1,59 +1,46 @@
+// Priority queue implementation that is tailored for the executor's local task
+// queue. In particular, it expects tasks to mostly be inserted at the end of
+// the priority queue, and tasks to mostly be removed from the front of the
+// queue. This allows us to avoid worrying about Push() and RemoveAt() being
+// slow for the most part.
+//
+// A more general-purpose implementation can be found in
+// server/util/priority_queue.go
+
 package priority_queue
 
 import (
-	"container/heap"
 	"sync"
 	"time"
 
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 )
 
-// A pqItem is the element managed by a priority queue.
 type pqItem struct {
 	value      *scpb.EnqueueTaskReservationRequest
 	priority   int
 	insertTime time.Time
 }
 
-// A priorityQueue implements heap.Interface and holds pqItems.
-type innerPQ []*pqItem
-
-func (pq innerPQ) Len() int { return len(pq) }
-func (pq innerPQ) Less(i, j int) bool {
+func less(pq []pqItem, i, j int) bool {
 	return pq[i].priority > pq[j].priority ||
 		(pq[i].priority == pq[j].priority && pq[i].insertTime.Before(pq[j].insertTime))
 }
-func (pq innerPQ) Swap(i, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-}
-func (pq *innerPQ) Push(x interface{}) {
-	item := x.(*pqItem)
-	*pq = append(*pq, item)
-}
-func (pq *innerPQ) Pop() interface{} {
-	old := *pq
-	n := len(old)
-	item := old[n-1]
-	old[n-1] = nil // avoid memory leak
-	*pq = old[0 : n-1]
-	return item
-}
 
 type PriorityQueue struct {
-	inner *innerPQ
+	items []pqItem
 	mu    sync.Mutex
 }
 
 func NewPriorityQueue() *PriorityQueue {
-	inner := make(innerPQ, 0)
-	return &PriorityQueue{
-		inner: &inner,
-	}
+	return &PriorityQueue{}
 }
 
 func (pq *PriorityQueue) Push(req *scpb.EnqueueTaskReservationRequest) {
 	pq.mu.Lock()
-	heap.Push(pq.inner, &pqItem{
+	defer pq.mu.Unlock()
+
+	pq.items = append(pq.items, pqItem{
 		value:      req,
 		insertTime: time.Now(),
 		// Note: the remote API specifies that higher `priority` values are
@@ -61,35 +48,68 @@ func (pq *PriorityQueue) Push(req *scpb.EnqueueTaskReservationRequest) {
 		// priority here.
 		priority: -int(req.GetSchedulingMetadata().GetPriority()),
 	})
-
-	pq.mu.Unlock()
+	// Perform one round of bubble-sort to get the item to the correct position
+	// in the list. Note that for executor scheduling, we expect most tasks to
+	// wind up at the end of the list, in which case this loop doesn't run at
+	// all.
+	for i := len(pq.items) - 1; i > 0 && less(pq.items, i, i-1); i-- {
+		pq.items[i], pq.items[i-1] = pq.items[i-1], pq.items[i]
+	}
 }
 
 func (pq *PriorityQueue) Pop() *scpb.EnqueueTaskReservationRequest {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	if len(*pq.inner) == 0 {
+	if len(pq.items) == 0 {
 		return nil
 	}
-	item := heap.Pop(pq.inner).(*pqItem)
+	item := pq.items[0]
+	// Release references to avoid leaking memory.
+	pq.items[0] = pqItem{}
+	pq.items = pq.items[1:]
+	return item.value
+}
+
+func (pq *PriorityQueue) RemoveAt(i int) *scpb.EnqueueTaskReservationRequest {
+	// Avoid expensive shift operation in the common case of removing the first
+	// element.
+	if i == 0 {
+		return pq.Pop()
+	}
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	if i >= len(pq.items) {
+		return nil
+	}
+	item := pq.items[i]
+	lastElement := &pq.items[len(pq.items)-1]
+	pq.items = append(pq.items[:i], pq.items[i+1:]...)
+	// After shifting forward, the backing array will have a duplicate element
+	// at the end. Release references held by this duplicate element to avoid
+	// leaking memory.
+	*lastElement = pqItem{}
 	return item.value
 }
 
 func (pq *PriorityQueue) Peek() *scpb.EnqueueTaskReservationRequest {
+	return pq.PeekAt(0)
+}
+
+func (pq *PriorityQueue) PeekAt(i int) *scpb.EnqueueTaskReservationRequest {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	if len(*pq.inner) == 0 {
+	if i >= len(pq.items) {
 		return nil
 	}
-	return (*pq.inner)[0].value
+	return pq.items[i].value
 }
 
 func (pq *PriorityQueue) GetAll() []*scpb.EnqueueTaskReservationRequest {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	var reservations []*scpb.EnqueueTaskReservationRequest
-	for _, i := range *pq.inner {
-		reservations = append(reservations, i.value)
+	reservations := make([]*scpb.EnqueueTaskReservationRequest, 0, len(pq.items))
+	for _, item := range pq.items {
+		reservations = append(reservations, item.value)
 	}
 	return reservations
 }
@@ -97,5 +117,5 @@ func (pq *PriorityQueue) GetAll() []*scpb.EnqueueTaskReservationRequest {
 func (pq *PriorityQueue) Len() int {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	return len(*pq.inner)
+	return len(pq.items)
 }

--- a/enterprise/server/scheduling/priority_queue/priority_queue_test.go
+++ b/enterprise/server/scheduling/priority_queue/priority_queue_test.go
@@ -1,0 +1,75 @@
+package priority_queue_test
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"slices"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_queue"
+	"github.com/stretchr/testify/require"
+
+	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
+)
+
+func TestIndexedOperations(t *testing.T) {
+	// Run the test several times to get high confidence that we're covering
+	// edge cases, since each run is randomized.
+	for range 1000 {
+		// Choose initial queue size randomly from [0, 16).
+		n := rand.N(16)
+		// Create n expectedTasks with numbered task IDs.
+		// All expectedTasks have the same priority for this test, so the queue
+		// should behave like a FIFO queue.
+		expectedTasks := make([]*scpb.EnqueueTaskReservationRequest, n)
+		for j := range n {
+			expectedTasks[j] = &scpb.EnqueueTaskReservationRequest{
+				TaskId: fmt.Sprintf("%d", j),
+			}
+		}
+		// Shuffle the tasks.
+		rand.Shuffle(n, func(i, j int) {
+			expectedTasks[i], expectedTasks[j] = expectedTasks[j], expectedTasks[i]
+		})
+		// Create a priority queue and enqueue all of the tasks.
+		pq := priority_queue.NewPriorityQueue()
+		for _, task := range expectedTasks {
+			pq.Push(task)
+		}
+		// Perform a random number of Push and RemoveAt operations. For each
+		// iteration, verify that PeekAt() returns the expected tasks.
+		for range rand.N(n + 1) {
+			r := rand.Float64()
+			if r < 0.5 {
+				// Remove a random task.
+				removedTask := pq.RemoveAt(rand.N(pq.Len()))
+				expectedTasks = slices.DeleteFunc(expectedTasks, func(el *scpb.EnqueueTaskReservationRequest) bool {
+					return el == removedTask
+				})
+			} else {
+				// Add a new task.
+				task := &scpb.EnqueueTaskReservationRequest{
+					TaskId: fmt.Sprintf("%d", n),
+				}
+				n++
+				pq.Push(task)
+				expectedTasks = append(expectedTasks, task)
+			}
+			// Check that PeekAt() returns the expected results.
+			for i := range expectedTasks {
+				peekedTask := pq.PeekAt(i)
+				require.Equal(t, expectedTasks[i], peekedTask)
+			}
+			require.Equal(t, len(expectedTasks), pq.Len())
+			require.Nil(t, pq.PeekAt(len(expectedTasks)))
+		}
+		// Pop all remaining tasks and verify the order.
+		for _, task := range expectedTasks {
+			dequeuedTask := pq.Pop()
+			require.Equal(t, task.GetTaskId(), dequeuedTask.GetTaskId())
+		}
+		// Verify that the queue is empty.
+		require.Nil(t, pq.Pop())
+		require.Equal(t, 0, pq.Len())
+	}
+}

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -70,7 +70,7 @@ func newTaskQueue() *taskQueue {
 }
 
 func (t *taskQueue) GetAll() []*scpb.EnqueueTaskReservationRequest {
-	var reservations []*scpb.EnqueueTaskReservationRequest
+	reservations := make([]*scpb.EnqueueTaskReservationRequest, 0, len(t.taskIDs))
 
 	for e := t.pqs.Front(); e != nil; e = e.Next() {
 		pq, ok := e.Value.(*groupPriorityQueue)

--- a/server/util/priority_queue/priority_queue.go
+++ b/server/util/priority_queue/priority_queue.go
@@ -89,7 +89,7 @@ func (pq *PriorityQueue[V]) Peek() (V, bool) {
 func (pq *PriorityQueue[V]) GetAll() []V {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	var allValues []V
+	allValues := make([]V, 0, len(*pq.inner))
 	for _, i := range *pq.inner {
 		allValues = append(allValues, i.value)
 	}


### PR DESCRIPTION
In order to allow tasks to "skip ahead" in the queue, we need to support indexed Peek and Remove operations.

These are difficult to implement using `container/heap`, so this PR changes the backing data structure to be a slice. Because this reduces the efficiency of some operations, it's questionable whether this same approach is also a good idea for the general-purpose priority queue in `server/util/priority_queue` so I opted to make this change only in the executor-specific implementation for now.

If we do wind up needing PeekAt / RemoveAt for the general case, then we could maybe use an LLRB tree (or optimized variants like btree) but I didn't want to go down that rabbit hole for now.

This also makes a few other misc tweaks such as pre-allocating the size for the slices returned by `GetAll()`.