### PR TITLE
Add logging for delete_build_root_on_startup

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//server/real_environment",
         "//server/resources",
         "//server/ssl",
+        "//server/util/canary",
         "//server/util/disk",
         "//server/util/flag",
         "//server/util/grpc_client",


### PR DESCRIPTION
Also use `disk.ForceRemove()` instead of `os.RemoveAll()` - this func is sometimes needed to work around permissions issues, which historically have been more problematic on macOS.