### PR TITLE
Widen perms in ForceRemove

### DIFF
--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -123,7 +123,7 @@ func ForceRemove(ctx context.Context, path string) error {
 		if entry.IsDir() {
 			// In order to remove dir entries and make sure we can further
 			// recurse into the dir, we need all bits set (RWX).
-			return os.Chmod(path, 0770)
+			return os.Chmod(path, 0777)
 		}
 		return nil
 	})


### PR DESCRIPTION
Use 777 instead of 770 perms. The permissions should be as wide as possible to maximize the chances of removing stubborn entries.