### PR TITLE
app/target: remove redundant boolean clause

### DIFF
--- a/app/target/target_artifacts_card.tsx
+++ b/app/target/target_artifacts_card.tsx
@@ -41,7 +41,7 @@ export default class TargetArtifactsCardComponent extends React.Component<Props,
       return;
     }
     let testOutputsUri = this.props.files.find(
-      (file: build_event_stream.File) => true && file.name === TargetArtifactsCardComponent.ZIPPED_OUTPUTS_FILE
+      (file: build_event_stream.File) => file.name === TargetArtifactsCardComponent.ZIPPED_OUTPUTS_FILE
     )?.uri;
 
     if (!testOutputsUri || !testOutputsUri.startsWith("bytestream://")) {


### PR DESCRIPTION
Fix for this warning

```
INFO: From Splitting Javascript ../../../app/app.tsx [esbuild]:
▲ [WARNING] The "&&" operator here will always return the right operand [suspicious-logical-operator]

    app/target/target_artifacts_card.js:37:90:
      37 │ ....props.files.find((file)=>true && file.name === TargetArtifacts...
         ╵                                   ~~

  The "=>" symbol creates an arrow function expression in JavaScript. Did you mean to use the greater-than-or-equal-to operator ">=" here instead?

    app/target/target_artifacts_card.js:37:83:
      37 │ ... = this.props.files.find((file)=>true && file.name === TargetAr...
         │                                   ~~
         ╵                                   >=

INFO: From Splitting Javascript ../../../enterprise/app/app.tsx [esbuild]:
▲ [WARNING] The "&&" operator here will always return the right operand [suspicious-logical-operator]

    app/target/target_artifacts_card.js:37:90:
      37 │ ....props.files.find((file)=>true && file.name === TargetArtifacts...
         ╵                                   ~~

  The "=>" symbol creates an arrow function expression in JavaScript. Did you mean to use the greater-than-or-equal-to operator ">=" here instead?

    app/target/target_artifacts_card.js:37:83:
      37 │ ... = this.props.files.find((file)=>true && file.name === TargetAr...
         │                                   ~~
         ╵                                   >=

```