### PR TITLE
execution_service: rename trace span for step before input download

### DIFF
--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -267,7 +267,7 @@ func (es *ExecutionService) WriteExecutionProfile(ctx context.Context, w io.Writ
 			end:   metadata.GetWorkerCompletedTimestamp(),
 		},
 		{
-			name:  "pull image",
+			name:  "prepare runner",
 			tid:   executorTID,
 			start: metadata.GetWorkerStartTimestamp(),
 			end:   metadata.GetInputFetchStartTimestamp(),


### PR DESCRIPTION
This step may not include image download on Executor using "bare"
sandbox.

Instead, it's a combination of:
- Action Cache check
- Runner recycling
  + Runner cleanup
  + Prepare output directories
- Download container image

Rename this to "prepare runner" to better describe the span.
