### PR TITLE
Fix action merging handling of `do_not_cache` and `skip_cache_lookup`

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -733,12 +733,10 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 		}
 	}
 
-	action := &repb.Action{}
-	if err := cachetools.ReadProtoFromCAS(ctx, s.cache, adInstanceDigest, action); err != nil {
-		log.CtxWarningf(ctx, "Error fetching action: %s", err.Error())
+	action, err := s.fetchAction(ctx, adInstanceDigest)
+	if err != nil {
 		return err
 	}
-
 	if !action.DoNotCache {
 		// Check if there's already an identical action pending execution. If
 		// so, wait on the result of that execution instead of starting a new

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1132,6 +1132,10 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			if err != nil {
 				return status.InternalErrorf("Failed to parse platform properties: %s", err)
 			}
+			// Keep this close to, but before the cacheActionResult call: Since any action that can merge into this one
+			// may specify skip_cache_lookup, we need to ensure that the result is not visible in the cache before the
+			// action is merged. At the same time, we don't want the window between the calls to be too large to avoid
+			// reducing the effectiveness of merging.
 			if err := action_merger.DeletePendingExecution(ctx, s.rdb, taskID); err != nil {
 				log.CtxWarningf(ctx, "could not delete pending execution %q: %s", taskID, err)
 			}

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -148,14 +148,15 @@ func TestDispatch(t *testing.T) {
 	ctx, err := env.GetAuthenticator().(*testauth.TestAuthenticator).WithAuthenticatedUser(ctx, "US1")
 	require.NoError(t, err)
 
-	arn := uploadAction(ctx, t, env, "" /*=instanceName*/, repb.DigestFunction_SHA256, &repb.Action{})
+	action := &repb.Action{}
+	arn := uploadAction(ctx, t, env, "" /*=instanceName*/, repb.DigestFunction_SHA256, action)
 	ad := arn.GetDigest()
 
 	// note: AttachUserPrefix is normally done by Execute(), which wraps
 	// Dispatch().
 	ctx, err = prefix.AttachUserPrefixToContext(ctx, env)
 	require.NoError(t, err)
-	taskID, err := s.Dispatch(ctx, &repb.ExecuteRequest{ActionDigest: ad})
+	taskID, err := s.Dispatch(ctx, &repb.ExecuteRequest{ActionDigest: ad}, action)
 	require.NoError(t, err)
 
 	rn, err := digest.ParseUploadResourceName(taskID)

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -287,7 +287,7 @@ func (c *Command) processUpdatesAsync(ctx context.Context, stream repb.Execution
 	}
 }
 
-func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name string, inputRootDigest *repb.Digest, commandProto *repb.Command, timeout time.Duration) (*Command, error) {
+func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name string, inputRootDigest *repb.Digest, commandProto *repb.Command, timeout time.Duration, doNotCache bool) (*Command, error) {
 	commandProto = commandProto.CloneVT()
 	// Remove the platform from the command and set it in the action since that
 	// is new since RE API v2.2. This lets us test the new path.
@@ -302,6 +302,7 @@ func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name s
 		CommandDigest:   commandDigest,
 		InputRootDigest: inputRootDigest,
 		Platform:        plat,
+		DoNotCache:      doNotCache,
 	}
 	if timeout != 0 {
 		action.Timeout = durationpb.New(timeout)

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -1146,7 +1146,7 @@ func (r *Env) ExecuteControlledCommand(name string, opts *ExecuteControlledOpts)
 
 	inputRootDigest := r.setupRootDirectoryWithTestCommandBinary(ctx)
 
-	cmd, err := r.rbeClient.PrepareCommand(ctx, defaultInstanceName, name, inputRootDigest, command, 0 /*=timeout*/)
+	cmd, err := r.rbeClient.PrepareCommand(ctx, defaultInstanceName, name, inputRootDigest, command, 0, false)
 	if err != nil {
 		assert.FailNow(r.t, fmt.Sprintf("Could not prepare command %q", name), err.Error())
 	}
@@ -1195,6 +1195,8 @@ type ExecuteOpts struct {
 	// Whether action cache should be checked for existing results. By default,
 	// we skip the action cache check for tests.
 	CheckCache bool
+	// Whether to set the Action.DoNotCache field.
+	DoNotCacheAction bool
 }
 
 func (r *Env) Execute(command *repb.Command, opts *ExecuteOpts) *Command {
@@ -1224,7 +1226,7 @@ func (r *Env) Execute(command *repb.Command, opts *ExecuteOpts) *Command {
 	}
 
 	name := strings.Join(command.GetArguments(), " ")
-	cmd, err := r.rbeClient.PrepareCommand(ctx, defaultInstanceName, name, inputRootDigest, command, opts.ActionTimeout)
+	cmd, err := r.rbeClient.PrepareCommand(ctx, defaultInstanceName, name, inputRootDigest, command, opts.ActionTimeout, opts.DoNotCacheAction)
 	if err != nil {
 		assert.FailNowf(r.t, fmt.Sprintf("unable to request action execution for command %q", name), err.Error())
 	}

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1357,7 +1357,7 @@ func TestSaturateTaskQueue(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			cmd := rbe.Execute(cmdProto, &rbetest.ExecuteOpts{})
+			cmd := rbe.Execute(cmdProto, &rbetest.ExecuteOpts{DoNotCacheAction: true})
 			res := cmd.Wait()
 
 			require.NoError(t, res.Err)
@@ -1779,9 +1779,9 @@ func TestActionMerging_Success(t *testing.T) {
 	WaitForPendingExecution(rbe.GetRedisClient(), op3)
 	require.NotEqual(t, op2, op3, "actions under different organizations should not be merged")
 
-	cmd4 := rbe.Execute(cmd, &rbetest.ExecuteOpts{CheckCache: true, APIKey: rbe.APIKey1, InvocationID: "invocation4"})
+	cmd4 := rbe.Execute(cmd, &rbetest.ExecuteOpts{CheckCache: false, APIKey: rbe.APIKey1, InvocationID: "invocation4"})
 	op4 := cmd4.WaitAccepted()
-	require.Equal(t, op3, op4, "expected actions to be merged")
+	require.Equal(t, op3, op4, "expected actions to be merged, even with skip_cache_lookup")
 }
 
 func TestActionMerging_LongTask(t *testing.T) {
@@ -1931,6 +1931,49 @@ touch %s`, counter, fname)
 	op4 := cmd4.WaitAccepted()
 	require.NotEqual(t, op1, op4, "expected action to be hedged")
 	require.Equal(t, "FAST", strings.Trim(cmd4.Wait().Stdout, "\n"))
+}
+
+func TestActionMerging_DisabledWithDoNotCache(t *testing.T) {
+	rbe := rbetest.NewRBETestEnv(t)
+
+	rbe.AddBuildBuddyServer()
+	rbe.AddExecutor(t)
+
+	platform := &repb.Platform{
+		Properties: []*repb.Platform_Property{
+			{Name: "OSFamily", Value: runtime.GOOS},
+			{Name: "Arch", Value: runtime.GOARCH},
+		},
+	}
+
+	cmd := &repb.Command{
+		Arguments: []string{"sh", "-c", "sleep 10"},
+		Platform:  platform,
+	}
+
+	numOps := 5
+	wg := sync.WaitGroup{}
+	ops := make(chan string, numOps)
+	for i := range numOps {
+		wg.Add(1)
+		go func() {
+			exec := rbe.Execute(cmd, &rbetest.ExecuteOpts{
+				CheckCache:       true,
+				DoNotCacheAction: true,
+				InvocationID:     fmt.Sprintf("invocation%d", i),
+			})
+			ops <- exec.WaitAccepted()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	close(ops)
+
+	opsSet := make(map[string]struct{})
+	for op := range ops {
+		opsSet[op] = struct{}{}
+	}
+	require.Len(t, opsSet, numOps, "expected all ops to be unique")
 }
 
 func TestAppShutdownDuringExecution_PublishOperationRetried(t *testing.T) {

--- a/enterprise/tools/rbeperf/rbeperf.go
+++ b/enterprise/tools/rbeperf/rbeperf.go
@@ -297,7 +297,7 @@ func prepareCommand(ctx context.Context, rbeClient *rbeclient.Client, byteStream
 		Arguments: commandArgs,
 		Platform:  &repb.Platform{Properties: platformProps},
 	}
-	cmd, err := rbeClient.PrepareCommand(ctx, *remoteInstanceName, name, inputRootDigest, command, 0 /*=timeout*/)
+	cmd, err := rbeClient.PrepareCommand(ctx, *remoteInstanceName, name, inputRootDigest, command, 0 /*=timeout*/, false /*=doNotCache*/)
 	if err != nil {
 		return nil, status.UnknownErrorf("could not prepare command %q: %v", name, err)
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -840,7 +840,7 @@ type SplashPrinter interface {
 }
 
 type RemoteExecutionService interface {
-	Dispatch(ctx context.Context, req *repb.ExecuteRequest) (string, error)
+	Dispatch(ctx context.Context, req *repb.ExecuteRequest, action *repb.Action) (string, error)
 	Execute(req *repb.ExecuteRequest, stream repb.Execution_ExecuteServer) error
 	WaitExecution(req *repb.WaitExecutionRequest, stream repb.Execution_WaitExecutionServer) error
 	PublishOperation(stream repb.Execution_PublishOperationServer) error


### PR DESCRIPTION
`skip_cache_lookup` should not prevent action merging (it currently does), but `do_not_cache` should (it currently doesn't). The former is used by Bazel when an action result is discovered to be invalid, but that can't have happened while the merged execution is still executing. The latter powers `--runs_per_test` and thus won't be useful to detect flakes if action merging is used.

Since `--runs_per_test` sets both fields to `true`, we did correctly disable action merging for it, but for the wrong reason. Other code paths may not do this though.

See https://github.com/bazelbuild/remote-apis/commit/cfe8e540cbb424e3ebc649ddcbc91190f70e23a6 for the intended semantics.