### PR TITLE
Add a no-op hit-tracking RPC service in the app

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//enterprise/server/experiments",
         "//enterprise/server/gcplink",
         "//enterprise/server/githubapp",
+        "//enterprise/server/hit_tracker_service",
         "//enterprise/server/hostedrunner",
         "//enterprise/server/invocation_search_service",
         "//enterprise/server/invocation_stat_service",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/gcplink"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/githubapp"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hit_tracker_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_search_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_stat_service"
@@ -140,6 +141,7 @@ func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
 	env.SetRunnerService(runnerService)
 
 	auth_service.Register(env)
+	hit_tracker_service.Register(env)
 
 	env.SetSplashPrinter(&splash.Printer{})
 }

--- a/enterprise/server/hit_tracker_service/BUILD
+++ b/enterprise/server/hit_tracker_service/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "hit_tracker_service",
+    srcs = ["hit_tracker_service.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/hit_tracker_service",
+    deps = [
+        "//proto:hit_tracker_go_proto",
+        "//server/real_environment",
+    ],
+)
+
+go_test(
+    name = "hit_tracker_service_test",
+    size = "small",
+    srcs = ["hit_tracker_service_test.go"],
+    deps = [
+        ":hit_tracker_service",
+        "//server/testutil/testenv",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/hit_tracker_service/hit_tracker_service.go
+++ b/enterprise/server/hit_tracker_service/hit_tracker_service.go
@@ -1,0 +1,20 @@
+package hit_tracker_service
+
+import (
+	"context"
+
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+
+	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
+)
+
+type HitTrackerService struct {
+}
+
+func Register(env *real_environment.RealEnv) {
+	env.SetHitTrackerServiceServer(&HitTrackerService{})
+}
+
+func (h HitTrackerService) Track(ctx context.Context, req *hitpb.TrackRequest) (*hitpb.TrackResponse, error) {
+	return &hitpb.TrackResponse{}, nil
+}

--- a/enterprise/server/hit_tracker_service/hit_tracker_service_test.go
+++ b/enterprise/server/hit_tracker_service/hit_tracker_service_test.go
@@ -1,0 +1,15 @@
+package hit_tracker_service_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hit_tracker_service"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHitTrackerService_DetailedStats(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+	hit_tracker_service.Register(env)
+	require.NotNil(t, env.GetHitTrackerServiceServer())
+}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -853,6 +853,15 @@ proto_library(
     srcs = ["ociregistry.proto"],
 )
 
+proto_library(
+    name = "hit_tracker_proto",
+    srcs = ["hit_tracker.proto"],
+    deps = [
+        ":resource_proto",
+        "@com_google_protobuf//:duration_proto",
+    ],
+)
+
 # Go proto rules below here
 go_proto_library(
     name = "prometheus_client_go_proto",
@@ -1994,6 +2003,20 @@ go_proto_library(
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/ociregistry",
     proto = ":ociregistry_proto",
+)
+
+go_proto_library(
+    name = "hit_tracker_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+        "//proto:vtprotobuf_compiler",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker",
+    proto = ":hit_tracker_proto",
+    deps = [
+        ":resource_go_proto",
+    ],
 )
 
 # TypeScript proto rules below here

--- a/proto/hit_tracker.proto
+++ b/proto/hit_tracker.proto
@@ -1,0 +1,41 @@
+
+syntax = "proto3";
+
+import "google/protobuf/duration.proto";
+import "proto/resource.proto";
+
+package hit_tracker;
+
+// Contains information about an artifact that was downloaded from the cache.
+message Download {
+  // The resource that was downloaded. Only digest and compressor are used.
+  resource.ResourceName resource = 1;
+
+  // The number of bytes that were downloaded.
+  int64 size_bytes = 2;
+
+  // The time taken for the download.
+  google.protobuf.Duration duration = 3;
+}
+
+// Information about cache hits for a particular invocation.
+message CacheHits {
+  // The invocation ID associated with this cache hit information.
+  string invocation_id = 1;
+
+  // The number of empty digests that "hit" the cache.
+  int64 empty_hits = 2;
+
+  // Information about cache downloads (size, duration, etc.).
+  repeated Download downloads = 3;
+}
+
+message TrackRequest {
+  repeated CacheHits hits = 1;
+}
+
+message TrackResponse {}
+
+service HitTrackerService {
+  rpc Track(TrackRequest) returns (TrackResponse);
+}

--- a/server/environment/BUILD
+++ b/server/environment/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/environment",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:hit_tracker_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc"
 
+	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -135,5 +136,6 @@ type Env interface {
 	GetAtimeUpdater() interfaces.AtimeUpdater
 	GetCPULeaser() interfaces.CPULeaser
 	GetHitTrackerFactory() interfaces.HitTrackerFactory
+	GetHitTrackerServiceServer() hitpb.HitTrackerServiceServer
 	GetExperimentFlagProvider() interfaces.ExperimentFlagProvider
 }

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//proto:auth_go_proto",
         "//proto:buildbuddy_service_go_proto",
+        "//proto:hit_tracker_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -61,6 +61,7 @@ import (
 	apipb "github.com/buildbuddy-io/buildbuddy/proto/api/v1"
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
+	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -321,6 +322,9 @@ func registerServices(env *real_environment.RealEnv, grpcServer *grpc.Server) {
 	}
 	if auth := env.GetAuthService(); auth != nil {
 		authpb.RegisterAuthServiceServer(grpcServer, auth)
+	}
+	if ht := env.GetHitTrackerServiceServer(); ht != nil {
+		hitpb.RegisterHitTrackerServiceServer(grpcServer, ht)
 	}
 }
 

--- a/server/real_environment/BUILD
+++ b/server/real_environment/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/real_environment",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:hit_tracker_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc"
 
+	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -134,6 +135,7 @@ type RealEnv struct {
 	cpuLeaser                        interfaces.CPULeaser
 	ociRegistry                      interfaces.OCIRegistry
 	hitTrackerFactory                interfaces.HitTrackerFactory
+	hitTrackerServiceServer          hitpb.HitTrackerServiceServer
 	experimentFlagProvider           interfaces.ExperimentFlagProvider
 }
 
@@ -822,6 +824,14 @@ func (r *RealEnv) GetHitTrackerFactory() interfaces.HitTrackerFactory {
 func (r *RealEnv) SetHitTrackerFactory(hitTrackerFactory interfaces.HitTrackerFactory) {
 	r.hitTrackerFactory = hitTrackerFactory
 }
+
+func (r *RealEnv) GetHitTrackerServiceServer() hitpb.HitTrackerServiceServer {
+	return r.hitTrackerServiceServer
+}
+func (r *RealEnv) SetHitTrackerServiceServer(hitTrackerServiceServer hitpb.HitTrackerServiceServer) {
+	r.hitTrackerServiceServer = hitTrackerServiceServer
+}
+
 func (r *RealEnv) GetExperimentFlagProvider() interfaces.ExperimentFlagProvider {
 	return r.experimentFlagProvider
 }


### PR DESCRIPTION
This is https://github.com/buildbuddy-io/buildbuddy/pull/8726/files but without any changes to the hit tracker implementation.

I also removed the `source` field from `TrackRequest` as it's not needed at this time (but would be nice to have in the future).