### PR TITLE
Don't write to the invalid index in the chunkstore

### DIFF
--- a/server/backends/chunkstore/BUILD
+++ b/server/backends/chunkstore/BUILD
@@ -22,5 +22,7 @@ go_test(
         "//server/testutil/mockstore",
         "//server/util/status",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/backends/chunkstore/chunkstore.go
+++ b/server/backends/chunkstore/chunkstore.go
@@ -588,11 +588,18 @@ func (l *writeLoop) run(ctx context.Context) {
 			//just wrote data to disk, reset the flushTime.
 			flushTime = time.Now().Add(l.writeTimeoutDuration)
 		}
-		// We report lastWriteSize as the number of bytes written because we may not
-		// flush all the bytes, but they will still be buffered to be written after
-		// we return. Thus, any and all write failures are instead reported in the
-		// error object as opposed to reflected in the number of bytes written.
+		// We normally report lastWriteSize as the number of bytes written because
+		// we may not flush all the bytes, but they will still be buffered to be
+		// written after we return unless we have exhausted the available indices.
+		// Thus, most write errors are instead reported in the error object as
+		// opposed to being reflected in the number of bytes written.
 		result := &WriteResult{Size: lastWriteSize, Err: err, LastChunkIndex: chunkIndex - 1, Timeout: timeout, BytesFlushed: bytesFlushed, Close: !open}
+		if status.IsResourceExhaustedError(err) {
+			// We ran out of indices for chunks, we can no longer write.
+			result.Size = bytesFlushed
+			result.Close = true
+			open = false
+		}
 		l.writeResultChannel <- result
 
 		if l.writeHook != nil {

--- a/server/backends/chunkstore/chunkstore.go
+++ b/server/backends/chunkstore/chunkstore.go
@@ -471,6 +471,9 @@ type writeLoop struct {
 }
 
 func (l *writeLoop) write(ctx context.Context, chunk []byte, chunkIndex uint16, lastWriteSize int) (int, error) {
+	if chunkIndex == EmptyIndex {
+		return 0, status.ResourceExhaustedErrorf("Failed to write to chunkstore; index '%04x' is the invalid index.", chunkIndex)
+	}
 	size := l.writeBlockSize
 	if len(chunk) <= size {
 		size = len(chunk)

--- a/server/backends/chunkstore/chunkstore_test.go
+++ b/server/backends/chunkstore/chunkstore_test.go
@@ -457,6 +457,7 @@ func TestWriteInvalidChunk(t *testing.T) {
 	c := New(m, &ChunkstoreOptions{})
 	mtx := &mockstore.Context{}
 
+	// Write uint16_max chunks.
 	writer := c.Writer(mtx, "test", &ChunkstoreWriterOptions{WriteBlockSize: 1})
 	n, err := writer.Write(mtx, make([]byte, 65535))
 	require.NoError(t, err)

--- a/server/backends/chunkstore/chunkstore_test.go
+++ b/server/backends/chunkstore/chunkstore_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/mockstore"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChunkName(t *testing.T) {
@@ -448,4 +450,20 @@ func TestWriter(t *testing.T) {
 	if !cmp.Equal(m.GetBlobMap(), test_map) {
 		t.Fatalf("Map contents are incorrect for multi-chunk file after close, which should flush the tail:\n\n%v\n\nshould be:\n\n%v", m.GetBlobMap(), test_map)
 	}
+}
+
+func TestWriteInvalidChunk(t *testing.T) {
+	m := mockstore.New()
+	c := New(m, &ChunkstoreOptions{})
+	mtx := &mockstore.Context{}
+
+	writer := c.Writer(mtx, "test", &ChunkstoreWriterOptions{WriteBlockSize: 1})
+	n, err := writer.Write(mtx, make([]byte, 65535))
+	require.NoError(t, err)
+	assert.Equal(t, 65535, n)
+
+	n, err = writer.Write(mtx, []byte{0})
+	assert.Equal(t, 0, n)
+	assert.Error(t, err)
+	assert.ErrorAs(t, err, status.ResourceExhaustedError())
 }

--- a/server/backends/chunkstore/chunkstore_test.go
+++ b/server/backends/chunkstore/chunkstore_test.go
@@ -465,5 +465,5 @@ func TestWriteInvalidChunk(t *testing.T) {
 	n, err = writer.Write(mtx, []byte{0})
 	assert.Equal(t, 0, n)
 	assert.Error(t, err)
-	assert.ErrorAs(t, err, status.ResourceExhaustedError())
+	assert.True(t, status.IsResourceExhaustedError(err))
 }


### PR DESCRIPTION
Fixes a bug where the chunkstore would write a chunk with the invalid index, which ought to be impossible. Adds a test confirming this behavior.
