### PR TITLE
CLI: Support positional arguments when parsing `common` configs

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -1090,6 +1090,10 @@ func (p *Parser) appendArgsForConfig(command string, rules *Rules, args []string
 						}
 					} else if strings.HasPrefix(tok, "-") {
 						i += 2
+					} else {
+						// not an option; support positional arguments
+						args = append(args, tok)
+						i++
 					}
 				}
 				continue

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -629,3 +629,30 @@ func TestCommonUndocumentedOption(t *testing.T) {
 	require.NoError(t, err, "error expanding %s", args)
 	assert.Equal(t, expectedExpandedArgs, expandedArgs)
 }
+
+func TestCommonPositionalArgument(t *testing.T) {
+	ws := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"WORKSPACE": "",
+		".bazelrc":  "common foo",
+	})
+
+	args := []string{
+		"build",
+	}
+
+	expectedExpandedArgs := []string{
+		"--ignore_all_rc_files",
+		"build",
+		"foo",
+	}
+	p, err := GetParser()
+	require.NoError(t, err)
+	expandedArgs, err := p.expandConfigs(
+		ws,
+		args,
+	)
+
+	require.NoError(t, err, "error expanding %s", args)
+	assert.Equal(t, expectedExpandedArgs, expandedArgs)
+}


### PR DESCRIPTION
Positional arguments should just be passed through the args when filtering common configs for supported options, but they were causing an infinite loop. This fixes that issue and adds a test for it.
