### PR TITLE
Represent resource name cache types in the type system

### DIFF
--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -156,7 +156,7 @@ func execute(cmdArgs []string) error {
 		return err
 	}
 	log.Debugf("Uploaded inputs in %s", time.Since(stageStart))
-	acrn, err := digest.ResourceNameFromProto(arn).ToCAS()
+	acrn, err := digest.ResourceNameFromProto(arn).CheckCAS()
 	if err == nil {
 		actionStr, err := acrn.DownloadString()
 		if err != nil {

--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -156,7 +156,7 @@ func execute(cmdArgs []string) error {
 		return err
 	}
 	log.Debugf("Uploaded inputs in %s", time.Since(stageStart))
-	acrn, err := digest.ResourceNameFromProto(arn).CheckCAS()
+	acrn, err := digest.CASResourceNameFromProto(arn)
 	if err == nil {
 		actionStr, err := acrn.DownloadString()
 		if err != nil {

--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -156,11 +156,16 @@ func execute(cmdArgs []string) error {
 		return err
 	}
 	log.Debugf("Uploaded inputs in %s", time.Since(stageStart))
-	actionStr, err := digest.ResourceNameFromProto(arn).DownloadString()
-	if err != nil {
-		log.Debugf("Failed to compute action resource name: %s", err)
+	acrn, err := digest.ResourceNameFromProto(arn).ToCAS()
+	if err == nil {
+		actionStr, err := acrn.DownloadString()
+		if err != nil {
+			log.Debugf("Failed to compute action resource name: %s", err)
+		} else {
+			log.Debugf("Action resource name: %s", actionStr)
+		}
 	} else {
-		log.Debugf("Action resource name: %s", actionStr)
+		log.Debugf("Failed to compute action resource name: %s", err)
 	}
 	stageStart = time.Now()
 	log.Debug("Starting /Execute request")

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -236,7 +236,7 @@ func openLog(pathOrId string) (io.ReadCloser, error) {
 	return in, err
 }
 
-func getExecLogResource(ctx context.Context, conn *grpc_client.ClientConnPool, invocationId string) (*digest.ResourceName, error) {
+func getExecLogResource(ctx context.Context, conn *grpc_client.ClientConnPool, invocationId string) (*digest.CASResourceName, error) {
 	resp, err := bbspb.NewBuildBuddyServiceClient(conn).GetInvocation(ctx, &invocation.GetInvocationRequest{
 		Lookup: &invocation.InvocationLookup{InvocationId: invocationId},
 	})

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -669,7 +669,7 @@ func printLogs(ctx context.Context, bbClient bbspb.BuildBuddyServiceClient, invo
 	return nil
 }
 
-func downloadFile(ctx context.Context, bsClient bspb.ByteStreamClient, resourceName *digest.ResourceName, outFile string) error {
+func downloadFile(ctx context.Context, bsClient bspb.ByteStreamClient, resourceName *digest.CASResourceName, outFile string) error {
 	if err := os.MkdirAll(filepath.Dir(outFile), 0755); err != nil {
 		return err
 	}
@@ -710,7 +710,7 @@ func lookupBazelInvocationOutputs(ctx context.Context, bbClient bbspb.BuildBuddy
 	return outputs, nil
 }
 
-func bytestreamURIToResourceName(uri string) (*digest.ResourceName, error) {
+func bytestreamURIToResourceName(uri string) (*digest.CASResourceName, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err

--- a/cli/upload/BUILD
+++ b/cli/upload/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//cli/login",
         "//cli/storage",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/grpc_client",

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -103,7 +102,7 @@ func uploadFile(args []string) error {
 	if err != nil {
 		return err
 	}
-	ind := digest.NewResourceName(d, *remoteInstanceName, rspb.CacheType_CAS, digestFunction)
+	ind := digest.NewCASResourceName(d, *remoteInstanceName, digestFunction)
 	if *compress {
 		ind.SetCompressor(repb.Compressor_ZSTD)
 	}

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -416,7 +416,7 @@ func (css *codesearchServer) syncIngestAnnotations(ctx context.Context, req *inp
 		os.Remove(fileName)
 	}()
 
-	sstableName, err := digest.ResourceNameFromProto(req.GetSstableName()).ToCAS()
+	sstableName, err := digest.ResourceNameFromProto(req.GetSstableName()).CheckCAS()
 	if err != nil {
 		return nil, err
 	}

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -416,7 +416,10 @@ func (css *codesearchServer) syncIngestAnnotations(ctx context.Context, req *inp
 		os.Remove(fileName)
 	}()
 
-	sstableName := digest.ResourceNameFromProto(req.GetSstableName())
+	sstableName, err := digest.ResourceNameFromProto(req.GetSstableName()).ToCAS()
+	if err != nil {
+		return nil, err
+	}
 	if err := cachetools.GetBlob(ctx, css.env.GetByteStreamClient(), sstableName, tmpFile); err != nil {
 		return nil, err
 	}

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -416,7 +416,7 @@ func (css *codesearchServer) syncIngestAnnotations(ctx context.Context, req *inp
 		os.Remove(fileName)
 	}()
 
-	sstableName, err := digest.ResourceNameFromProto(req.GetSstableName()).CheckCAS()
+	sstableName, err := digest.CASResourceNameFromProto(req.GetSstableName())
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/atime_updater/BUILD
+++ b/enterprise/server/atime_updater/BUILD
@@ -28,7 +28,6 @@ go_test(
     embed = [":atime_updater"],
     deps = [
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/interfaces",
         "//server/remote_cache/digest",
         "//server/testutil/testauth",

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -22,7 +22,6 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
@@ -488,14 +487,14 @@ func TestEnqueueByResourceName_ActionCache(t *testing.T) {
 	_, updater, cas, ticker := setup(t)
 	ctx := ctxWithClientIdentity()
 
-	rn, err := digest.NewResourceName(aDigest, "instance-1", rspb.CacheType_AC, repb.DigestFunction_SHA256).ActionCacheString()
+	rn, err := digest.NewACResourceName(aDigest, "instance-1", repb.DigestFunction_SHA256).ActionCacheString()
 	require.NoError(t, err)
 	updater.EnqueueByResourceName(ctx, rn)
 	expectNoMoreUpdates(t, ticker, cas)
 }
 
 func casResourceName(t *testing.T, d *repb.Digest, instanceName string) string {
-	rn, err := digest.NewResourceName(d, instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256).DownloadString()
+	rn, err := digest.NewCASResourceName(d, instanceName, repb.DigestFunction_SHA256).DownloadString()
 	require.NoError(t, err)
 	return rn
 }

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -343,9 +343,17 @@ func lookasideKey(r *rspb.ResourceName) (string, error) {
 		// These are OK to put in the lookaside cache because even
 		// though they are technically AC entries, they are based on CAS
 		// content that does not change.
-		return digest.ResourceNameFromProto(r).ActionCacheString()
+		rn, err := digest.ResourceNameFromProto(r).ToAC()
+		if err != nil {
+			return "", err
+		}
+		return rn.ActionCacheString()
 	} else {
-		return digest.ResourceNameFromProto(r).DownloadString()
+		rn, err := digest.ResourceNameFromProto(r).ToCAS()
+		if err != nil {
+			return "", err
+		}
+		return rn.DownloadString()
 	}
 }
 

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -343,13 +343,13 @@ func lookasideKey(r *rspb.ResourceName) (string, error) {
 		// These are OK to put in the lookaside cache because even
 		// though they are technically AC entries, they are based on CAS
 		// content that does not change.
-		rn, err := digest.ResourceNameFromProto(r).CheckAC()
+		rn, err := digest.ACResourceNameFromProto(r)
 		if err != nil {
 			return "", err
 		}
 		return rn.ActionCacheString()
 	} else {
-		rn, err := digest.ResourceNameFromProto(r).CheckCAS()
+		rn, err := digest.CASResourceNameFromProto(r)
 		if err != nil {
 			return "", err
 		}

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -343,13 +343,13 @@ func lookasideKey(r *rspb.ResourceName) (string, error) {
 		// These are OK to put in the lookaside cache because even
 		// though they are technically AC entries, they are based on CAS
 		// content that does not change.
-		rn, err := digest.ResourceNameFromProto(r).ToAC()
+		rn, err := digest.ResourceNameFromProto(r).CheckAC()
 		if err != nil {
 			return "", err
 		}
 		return rn.ActionCacheString()
 	} else {
-		rn, err := digest.ResourceNameFromProto(r).ToCAS()
+		rn, err := digest.ResourceNameFromProto(r).CheckCAS()
 		if err != nil {
 			return "", err
 		}

--- a/enterprise/server/bes_artifacts/BUILD
+++ b/enterprise/server/bes_artifacts/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//enterprise/server/build_event_publisher",
         "//proto:build_event_stream_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/grpc_client",

--- a/enterprise/server/bes_artifacts/bes_artifacts.go
+++ b/enterprise/server/bes_artifacts/bes_artifacts.go
@@ -18,7 +18,6 @@ import (
 
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -114,7 +113,7 @@ func (u *Uploader) uploadDirectory(namedSetID, root string) error {
 	var files []*bespb.File
 	for _, uploadChan := range uploadChans {
 		r := <-uploadChan
-		rn := digest.NewResourceName(r.Digest, u.instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+		rn := digest.NewCASResourceName(r.Digest, u.instanceName, repb.DigestFunction_SHA256)
 		rnString, err := rn.DownloadString()
 		if err != nil {
 			return err

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -145,7 +145,7 @@ func waitContains(ctx context.Context, env *testenv.TestEnv, rn *rspb.ResourceNa
 		}
 		time.Sleep(time.Duration(i) * time.Millisecond)
 	}
-	casrn, err := digest.ResourceNameFromProto(rn).ToCAS()
+	casrn, err := digest.ResourceNameFromProto(rn).CheckCAS()
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func TestRead(t *testing.T) {
 		// it's only read from the remote byestream server the first time.
 		for i := 1; i < 4; i++ {
 			var buf bytes.Buffer
-			r, err := digest.ResourceNameFromProto(rn).ToCAS()
+			r, err := digest.ResourceNameFromProto(rn).CheckCAS()
 			require.NoError(t, err)
 			gotErr := byte_stream.ReadBlob(ctx, proxy, r, &buf, tc.offset)
 			if gstatus.Code(gotErr) != gstatus.Code(tc.wantError) {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -145,7 +145,7 @@ func waitContains(ctx context.Context, env *testenv.TestEnv, rn *rspb.ResourceNa
 		}
 		time.Sleep(time.Duration(i) * time.Millisecond)
 	}
-	casrn, err := digest.ResourceNameFromProto(rn).CheckCAS()
+	casrn, err := digest.CASResourceNameFromProto(rn)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func TestRead(t *testing.T) {
 		// it's only read from the remote byestream server the first time.
 		for i := 1; i < 4; i++ {
 			var buf bytes.Buffer
-			r, err := digest.ResourceNameFromProto(rn).CheckCAS()
+			r, err := digest.CASResourceNameFromProto(rn)
 			require.NoError(t, err)
 			gotErr := byte_stream.ReadBlob(ctx, proxy, r, &buf, tc.offset)
 			if gstatus.Code(gotErr) != gstatus.Code(tc.wantError) {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -145,7 +145,11 @@ func waitContains(ctx context.Context, env *testenv.TestEnv, rn *rspb.ResourceNa
 		}
 		time.Sleep(time.Duration(i) * time.Millisecond)
 	}
-	s, err := digest.ResourceNameFromProto(rn).DownloadString()
+	casrn, err := digest.ResourceNameFromProto(rn).ToCAS()
+	if err != nil {
+		return err
+	}
+	s, err := casrn.DownloadString()
 	if err != nil {
 		return err
 	}
@@ -165,42 +169,36 @@ func TestRead(t *testing.T) {
 
 	cases := []struct {
 		wantError error
-		cacheType rspb.CacheType
 		size      int64
 		offset    int64
 		remotes   remoteReadExpectation
 	}{
 		{ // Simple Read
 			wantError: nil,
-			cacheType: rspb.CacheType_CAS,
 			size:      1234,
 			offset:    0,
 			remotes:   once,
 		},
 		{ // Large Read
 			wantError: nil,
-			cacheType: rspb.CacheType_CAS,
 			size:      1000 * 1000 * 100,
 			offset:    0,
 			remotes:   once,
 		},
 		{ // 0 length read
 			wantError: nil,
-			cacheType: rspb.CacheType_CAS,
 			size:      0,
 			offset:    0,
 			remotes:   never,
 		},
 		{ // Offset
 			wantError: nil,
-			cacheType: rspb.CacheType_CAS,
 			size:      1234,
 			offset:    1,
 			remotes:   always,
 		},
 		{ // Max offset
 			wantError: nil,
-			cacheType: rspb.CacheType_CAS,
 			size:      1234,
 			offset:    1234,
 			remotes:   always,
@@ -213,7 +211,7 @@ func TestRead(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		rn, data := testdigest.NewRandomResourceAndBuf(t, tc.size, tc.cacheType, "")
+		rn, data := testdigest.NewRandomResourceAndBuf(t, tc.size, rspb.CacheType_CAS, "")
 		// Set the value in the remote cache.
 		err := remoteEnv.GetCache().Set(ctx, rn, data)
 		require.NoError(t, err)
@@ -222,7 +220,9 @@ func TestRead(t *testing.T) {
 		// it's only read from the remote byestream server the first time.
 		for i := 1; i < 4; i++ {
 			var buf bytes.Buffer
-			gotErr := byte_stream.ReadBlob(ctx, proxy, digest.ResourceNameFromProto(rn), &buf, tc.offset)
+			r, err := digest.ResourceNameFromProto(rn).ToCAS()
+			require.NoError(t, err)
+			gotErr := byte_stream.ReadBlob(ctx, proxy, r, &buf, tc.offset)
 			if gstatus.Code(gotErr) != gstatus.Code(tc.wantError) {
 				t.Errorf("got %v; want %v", gotErr, tc.wantError)
 			}

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:runner_go_proto",
         "//server/real_environment",
         "//server/remote_cache/cachetools",

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -52,7 +52,6 @@ import (
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	clpb "github.com/buildbuddy-io/buildbuddy/proto/command_line"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
 	backendLog "github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -1398,7 +1397,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 		if err != nil {
 			return nil, nil, err
 		}
-		downloadString, err := digest.NewResourceName(d.ToDigest(), *remoteInstanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256).DownloadString()
+		downloadString, err := digest.NewCASResourceName(d.ToDigest(), *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1457,7 +1456,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 			if err != nil {
 				return err
 			}
-			downloadString, err := digest.NewResourceName(td, *remoteInstanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256).DownloadString()
+			downloadString, err := digest.NewCASResourceName(td, *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
 			if err != nil {
 				return err
 			}

--- a/enterprise/server/cmd/smash/BUILD
+++ b/enterprise/server/cmd/smash/BUILD
@@ -8,7 +8,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/smash",
     deps = [
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/grpc_client",

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -22,7 +22,6 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -142,7 +141,7 @@ func newRandomDigestBuf(sizeBytes int64) (*repb.Digest, []byte) {
 
 func writeDataFunc(cd *runner.CallData) ([]*dynamic.Message, error) {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName, err := digest.NewResourceName(d, *instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256).UploadString()
+	resourceName, err := digest.NewCASResourceName(d, *instanceName, repb.DigestFunction_SHA256).UploadString()
 	if err != nil {
 		log.Fatalf("Error computing upload resource name: %s", err)
 	}
@@ -181,7 +180,7 @@ func writeDataFunc(cd *runner.CallData) ([]*dynamic.Message, error) {
 func readDataFunc(cd *runner.CallData) ([]*dynamic.Message, error) {
 	randomDigest := preWrittenDigests[rand.Intn(len(preWrittenDigests))]
 
-	downloadString, err := digest.NewResourceName(randomDigest, *instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256).DownloadString()
+	downloadString, err := digest.NewCASResourceName(randomDigest, *instanceName, repb.DigestFunction_SHA256).DownloadString()
 	if err != nil {
 		log.Fatalf("Error computing download string: %s", err)
 	}

--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//enterprise/server/util/ci_runner_util",
         "//enterprise/server/workflow/config",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:runner_go_proto",
         "//server/endpoint_urls/build_buddy_url",
         "//server/endpoint_urls/cache_api_url",

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -34,7 +34,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	gstatus "google.golang.org/grpc/status"
 )
@@ -97,7 +96,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		if err != nil {
 			return nil, status.WrapError(err, "upload patch")
 		}
-		rn := digest.NewResourceName(patchDigest, req.GetInstanceName(), rspb.CacheType_CAS, repb.DigestFunction_BLAKE3)
+		rn := digest.NewCASResourceName(patchDigest, req.GetInstanceName(), repb.DigestFunction_BLAKE3)
 		uri, err := rn.DownloadString()
 		if err != nil {
 			return nil, status.WrapError(err, "patch download string")

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//proto:ociregistry_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/environment",
         "//server/real_environment",
         "//server/remote_cache/cachetools",

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -8,9 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
-
 	"regexp"
+	"strconv"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
@@ -23,7 +22,6 @@ import (
 
 	ocipb "github.com/buildbuddy-io/buildbuddy/proto/ociregistry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	gcrname "github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
@@ -373,10 +371,9 @@ func fetchBlobOrManifestFromCache(ctx context.Context, w http.ResponseWriter, bs
 	if err != nil {
 		return err
 	}
-	arRN := digest.NewResourceName(
+	arRN := digest.NewACResourceName(
 		arDigest,
 		actionResultInstanceName,
-		rspb.CacheType_AC,
 		repb.DigestFunction_SHA256,
 	)
 	ar, err := cachetools.GetActionResult(ctx, acClient, arRN)
@@ -399,10 +396,9 @@ func fetchBlobOrManifestFromCache(ctx context.Context, w http.ResponseWriter, bs
 	if blobMetadataCASDigest == nil || blobCASDigest == nil {
 		return fmt.Errorf("missing blob metadata digest or blob digest for %s", ref)
 	}
-	blobMetadataRN := digest.NewResourceName(
+	blobMetadataRN := digest.NewCASResourceName(
 		blobMetadataCASDigest,
 		"",
-		rspb.CacheType_CAS,
 		repb.DigestFunction_SHA256,
 	)
 	blobMetadata := &ocipb.OCIBlobMetadata{}
@@ -416,10 +412,9 @@ func fetchBlobOrManifestFromCache(ctx context.Context, w http.ResponseWriter, bs
 	w.WriteHeader(http.StatusOK)
 
 	if writeBody {
-		blobRN := digest.NewResourceName(
+		blobRN := digest.NewCASResourceName(
 			blobCASDigest,
 			"",
-			rspb.CacheType_CAS,
 			repb.DigestFunction_SHA256,
 		)
 		blobRN.SetCompressor(repb.Compressor_ZSTD)
@@ -434,10 +429,9 @@ func writeBlobOrManifestToCacheAndResponse(ctx context.Context, upstream io.Read
 		Hash:      hash.Hex,
 		SizeBytes: contentLength,
 	}
-	blobRN := digest.NewResourceName(
+	blobRN := digest.NewCASResourceName(
 		blobCASDigest,
 		"",
-		rspb.CacheType_CAS,
 		repb.DigestFunction_SHA256,
 	)
 	blobRN.SetCompressor(repb.Compressor_ZSTD)
@@ -483,10 +477,9 @@ func writeBlobOrManifestToCacheAndResponse(ctx context.Context, upstream io.Read
 	if err != nil {
 		return err
 	}
-	arRN := digest.NewResourceName(
+	arRN := digest.NewACResourceName(
 		arDigest,
 		actionResultInstanceName,
-		rspb.CacheType_AC,
 		repb.DigestFunction_SHA256,
 	)
 	err = cachetools.UploadActionResult(ctx, acClient, arRN, ar)

--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -58,7 +58,7 @@ var (
 // Returns the redis key pointing to the hash storing action merging state. The
 // value stored here is a hash containing the canonical (first-submitted)
 // execution ID and the count of executions run for this action (for hedging).
-func redisKeyForPendingExecutionID(ctx context.Context, adResource *digest.ResourceName) (string, error) {
+func redisKeyForPendingExecutionID(ctx context.Context, adResource *digest.CASResourceName) (string, error) {
 	userPrefix, err := prefix.UserPrefixFromContext(ctx)
 	if err != nil {
 		return "", err
@@ -88,7 +88,7 @@ func redisKeyForPendingExecutionDigest(executionID string) string {
 // quickly.
 //
 // This function records a queued execution in Redis.
-func RecordQueuedExecution(ctx context.Context, rdb redis.UniversalClient, executionID string, adResource *digest.ResourceName) error {
+func RecordQueuedExecution(ctx context.Context, rdb redis.UniversalClient, executionID string, adResource *digest.CASResourceName) error {
 	if !*enableActionMerging {
 		return nil
 	}
@@ -136,7 +136,7 @@ func RecordClaimedExecution(ctx context.Context, rdb redis.UniversalClient, exec
 }
 
 // This function records a hedged execution in Redis.
-func RecordHedgedExecution(ctx context.Context, rdb redis.UniversalClient, adResource *digest.ResourceName, groupIdForMetrics string) error {
+func RecordHedgedExecution(ctx context.Context, rdb redis.UniversalClient, adResource *digest.CASResourceName, groupIdForMetrics string) error {
 	key, err := redisKeyForPendingExecutionID(ctx, adResource)
 	if err != nil {
 		return err
@@ -150,7 +150,7 @@ func RecordHedgedExecution(ctx context.Context, rdb redis.UniversalClient, adRes
 }
 
 // This function records a merged execution in Redis.
-func RecordMergedExecution(ctx context.Context, rdb redis.UniversalClient, adResource *digest.ResourceName, groupIdForMetrics string) error {
+func RecordMergedExecution(ctx context.Context, rdb redis.UniversalClient, adResource *digest.CASResourceName, groupIdForMetrics string) error {
 	key, err := redisKeyForPendingExecutionID(ctx, adResource)
 	if err != nil {
 		return err
@@ -208,7 +208,7 @@ func recordSubmitTimeOffsetMetric(hash map[string]string, groupIdForMetrics stri
 // the provided action digest, or an empty string, as well as a boolean if the
 // provided action should be run additionally in the background ("hedged"), or
 // an error if no pending execution was found.
-func FindPendingExecution(ctx context.Context, rdb redis.UniversalClient, schedulerService interfaces.SchedulerService, adResource *digest.ResourceName) (string, bool, error) {
+func FindPendingExecution(ctx context.Context, rdb redis.UniversalClient, schedulerService interfaces.SchedulerService, adResource *digest.CASResourceName) (string, bool, error) {
 	if !*enableActionMerging {
 		return "", false, nil
 	}

--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//proto:execution_stats_go_proto",
         "//proto:invocation_status_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:scheduler_go_proto",
         "//proto:stored_invocation_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -49,7 +49,6 @@ import (
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	sipb "github.com/buildbuddy-io/buildbuddy/proto/stored_invocation"
 	remote_execution_config "github.com/buildbuddy-io/buildbuddy/server/remote_execution/config"
@@ -437,8 +436,8 @@ func (s *ExecutionServer) recordExecution(
 // not validate it.
 // N.B. This should only be used if the calling code has already ensured the
 // action is valid and may be returned.
-func (s *ExecutionServer) getUnvalidatedActionResult(ctx context.Context, r *digest.ResourceName) (*repb.ActionResult, error) {
-	cacheResource := digest.NewResourceName(r.GetDigest(), r.GetInstanceName(), rspb.CacheType_AC, r.GetDigestFunction())
+func (s *ExecutionServer) getUnvalidatedActionResult(ctx context.Context, r *digest.CASResourceName) (*repb.ActionResult, error) {
+	cacheResource := digest.NewACResourceName(r.GetDigest(), r.GetInstanceName(), r.GetDigestFunction())
 	data, err := s.cache.Get(ctx, cacheResource.ToProto())
 	if err != nil {
 		if status.IsNotFoundError(err) {
@@ -453,7 +452,7 @@ func (s *ExecutionServer) getUnvalidatedActionResult(ctx context.Context, r *dig
 	return actionResult, nil
 }
 
-func (s *ExecutionServer) getActionResultFromCache(ctx context.Context, d *digest.ResourceName) (*repb.ActionResult, error) {
+func (s *ExecutionServer) getActionResultFromCache(ctx context.Context, d *digest.CASResourceName) (*repb.ActionResult, error) {
 	actionResult, err := s.getUnvalidatedActionResult(ctx, d)
 	if err != nil {
 		return nil, err
@@ -544,7 +543,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	r := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS, req.GetDigestFunction())
+	r := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
 	executionID, err := r.UploadString()
 	if err != nil {
 		return "", nil, err
@@ -566,7 +565,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		log.CtxInfof(ctx, "Execution %q is missing invocation ID metadata. Request metadata: %+v", executionID, rmd)
 	}
 
-	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS, req.GetDigestFunction())
+	adInstanceDigest := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
 	action, command, err := s.fetchActionAndCommand(ctx, adInstanceDigest)
 	if err != nil {
 		return "", nil, err
@@ -711,7 +710,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 		return status.InvalidArgumentErrorf("invalid execution priority %d; priority values must be between -1000 and 1000 (inclusive)", req.GetExecutionPolicy().GetPriority())
 	}
 
-	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS, req.GetDigestFunction())
+	adInstanceDigest := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
 	ctx, err := prefix.AttachUserPrefixToContext(stream.Context(), s.env)
 	if err != nil {
 		return err
@@ -727,14 +726,14 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	executionID := ""
 	if !req.GetSkipCacheLookup() {
 		if actionResult, err := s.getActionResultFromCache(ctx, adInstanceDigest); err == nil {
-			r := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS, req.GetDigestFunction())
+			r := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
 			executionID, err := r.UploadString()
 			if err != nil {
 				return err
 			}
 			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_result", "cached")
 			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_id", executionID)
-			stateChangeFn := operation.GetStateChangeFunc(stream, executionID, adInstanceDigest)
+			stateChangeFn := operation.GetStateChangeFunc(stream, executionID, &adInstanceDigest.ResourceName)
 			if err := stateChangeFn(repb.ExecutionStage_COMPLETED, operation.ExecuteResponseWithCachedResult(actionResult)); err != nil {
 				return err // CHECK (these errors should not happen).
 			}
@@ -901,7 +900,7 @@ func (s *ExecutionServer) waitExecution(ctx context.Context, req *repb.WaitExecu
 		// Send a best-effort initial "in progress" update to client.
 		// Once Bazel receives the initial update, it will use WaitExecution to handle retry on error instead of
 		// requesting a new execution via Execute.
-		stateChangeFn := operation.GetStateChangeFunc(stream, req.GetName(), actionResource)
+		stateChangeFn := operation.GetStateChangeFunc(stream, req.GetName(), &actionResource.ResourceName)
 		err = stateChangeFn(repb.ExecutionStage_QUEUED, operation.InProgressExecuteResponse())
 		if err != nil && err != io.EOF {
 			log.CtxWarningf(stream.Context(), "Could not send initial update: %s", err)
@@ -926,7 +925,7 @@ func (s *ExecutionServer) waitExecution(ctx context.Context, req *repb.WaitExecu
 		if msg.Err != nil {
 			op, err := operation.Assemble(
 				req.GetName(),
-				operation.Metadata(repb.ExecutionStage_COMPLETED, actionResource),
+				operation.Metadata(repb.ExecutionStage_COMPLETED, &actionResource.ResourceName),
 				operation.ErrorResponse(msg.Err))
 			if err != nil {
 				return err
@@ -984,7 +983,7 @@ func (s *ExecutionServer) MarkExecutionFailed(ctx context.Context, taskID string
 		return err
 	}
 	rsp := operation.ErrorResponse(reason)
-	op, err := operation.Assemble(taskID, operation.Metadata(repb.ExecutionStage_COMPLETED, r), rsp)
+	op, err := operation.Assemble(taskID, operation.Metadata(repb.ExecutionStage_COMPLETED, &r.ResourceName), rsp)
 	if err != nil {
 		return err
 	}
@@ -1107,13 +1106,13 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			} else if !ok {
 				log.CtxInfof(ctx, "Failed to find ExecutionAuxiliaryMetadata. Executor is probably self-hosted and not updated since 2024-12-13.")
 			}
-			actionRN, err := digest.ParseUploadResourceName(taskID)
+			actionCASRN, err := digest.ParseUploadResourceName(taskID)
 			if err != nil {
 				return status.WrapErrorf(err, "Failed to parse taskID")
 			}
-			actionRN = digest.NewResourceName(actionRN.GetDigest(), actionRN.GetInstanceName(), rspb.CacheType_AC, actionRN.GetDigestFunction())
+			actionRN := digest.NewACResourceName(actionCASRN.GetDigest(), actionCASRN.GetInstanceName(), actionCASRN.GetDigestFunction())
 			var cmd *repb.Command
-			action, cmd, err = s.fetchActionAndCommand(ctx, actionRN)
+			action, cmd, err = s.fetchActionAndCommand(ctx, actionCASRN)
 			if err != nil {
 				return status.UnavailableErrorf("Failed to fetch action and command: %s", err)
 			}
@@ -1184,7 +1183,7 @@ func (s *ExecutionServer) cacheExecuteResponse(ctx context.Context, taskID strin
 	if err != nil {
 		return err
 	}
-	arn := digest.NewResourceName(d, taskRN.GetInstanceName(), rspb.CacheType_AC, taskRN.GetDigestFunction())
+	arn := digest.NewACResourceName(d, taskRN.GetInstanceName(), taskRN.GetDigestFunction())
 
 	redactCachedExecuteResponse(ctx, response)
 	b, err := proto.Marshal(response)
@@ -1196,7 +1195,7 @@ func (s *ExecutionServer) cacheExecuteResponse(ctx context.Context, taskID strin
 	return cachetools.UploadActionResult(ctx, s.env.GetActionCacheClient(), arn, ar)
 }
 
-func (s *ExecutionServer) cacheActionResult(ctx context.Context, actionResourceName *digest.ResourceName, response *repb.ExecuteResponse, action *repb.Action) error {
+func (s *ExecutionServer) cacheActionResult(ctx context.Context, actionResourceName *digest.ACResourceName, response *repb.ExecuteResponse, action *repb.Action) error {
 	if response.GetCachedResult() || action.GetDoNotCache() || response.GetStatus().GetCode() != 0 || response.GetResult().GetExitCode() != 0 {
 		return nil
 	}
@@ -1205,7 +1204,7 @@ func (s *ExecutionServer) cacheActionResult(ctx context.Context, actionResourceN
 
 // markTaskComplete contains logic to be run when the task is complete but
 // before letting the client know that the task has completed.
-func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceName *digest.ResourceName, executeResponse *repb.ExecuteResponse, action *repb.Action, cmd *repb.Command, properties *platform.Properties) error {
+func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceName *digest.ACResourceName, executeResponse *repb.ExecuteResponse, action *repb.Action, cmd *repb.Command, properties *platform.Properties) error {
 	execErr := gstatus.ErrorProto(executeResponse.GetStatus())
 	router := s.env.GetTaskRouter()
 	if router != nil && !executeResponse.GetCachedResult() {
@@ -1275,14 +1274,14 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb
 	return ut.Increment(ctx, labels, counts)
 }
 
-func (s *ExecutionServer) fetchActionAndCommand(ctx context.Context, actionResourceName *digest.ResourceName) (*repb.Action, *repb.Command, error) {
+func (s *ExecutionServer) fetchActionAndCommand(ctx context.Context, actionResourceName *digest.CASResourceName) (*repb.Action, *repb.Command, error) {
 	action := &repb.Action{}
 	if err := cachetools.ReadProtoFromCAS(ctx, s.cache, actionResourceName, action); err != nil {
 		log.CtxWarningf(ctx, "Error fetching action: %s", err.Error())
 		return nil, nil, err
 	}
 	cmdDigest := action.GetCommandDigest()
-	cmdInstanceNameDigest := digest.NewResourceName(cmdDigest, actionResourceName.GetInstanceName(), rspb.CacheType_CAS, actionResourceName.GetDigestFunction())
+	cmdInstanceNameDigest := digest.NewCASResourceName(cmdDigest, actionResourceName.GetInstanceName(), actionResourceName.GetDigestFunction())
 	cmd := &repb.Command{}
 	if err := cachetools.ReadProtoFromCAS(ctx, s.cache, cmdInstanceNameDigest, cmd); err != nil {
 		log.CtxWarningf(ctx, "Error fetching command: %s", err.Error())

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -597,7 +597,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 
 	// Check that the action cache contains the right entry, if any.
 	arn.ToProto().CacheType = rspb.CacheType_AC
-	arnAC, err := arn.ToAC()
+	arnAC, err := arn.CheckAC()
 	require.NoError(t, err)
 	cachedActionResult, err := cachetools.GetActionResult(ctx, env.GetActionCacheClient(), arnAC)
 	if !test.doNotCache && test.exitCode == 0 && test.status == nil && !test.cachedResult {

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -597,7 +597,9 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 
 	// Check that the action cache contains the right entry, if any.
 	arn.ToProto().CacheType = rspb.CacheType_AC
-	cachedActionResult, err := cachetools.GetActionResult(ctx, env.GetActionCacheClient(), arn)
+	arnAC, err := arn.ToAC()
+	require.NoError(t, err)
+	cachedActionResult, err := cachetools.GetActionResult(ctx, env.GetActionCacheClient(), arnAC)
 	if !test.doNotCache && test.exitCode == 0 && test.status == nil && !test.cachedResult {
 		require.NoError(t, err)
 		assert.Empty(t, cmp.Diff(trimmedExecuteResponse.GetResult(), cachedActionResult, protocmp.Transform()))

--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//enterprise/server/remote_execution/platform",
         "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:scheduler_go_proto",
         "//server/environment",
         "//server/interfaces",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -39,7 +39,6 @@ import (
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 )
 
@@ -202,7 +201,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	task := st.GetExecutionTask()
 	req := task.GetExecuteRequest()
 	taskID := task.GetExecutionId()
-	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_AC, req.GetDigestFunction())
+	adInstanceDigest := digest.NewACResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
 	digestFunction := adInstanceDigest.GetDigestFunction()
 	task.ExecuteRequest.DigestFunction = digestFunction
 	acClient := s.env.GetActionCacheClient()
@@ -213,7 +212,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		SchedulingMetadata: st.GetSchedulingMetadata(),
 		ExecutorHostname:   s.hostname,
 	}
-	opStateChangeFn := operation.GetStateChangeFunc(stream, taskID, adInstanceDigest)
+	opStateChangeFn := operation.GetStateChangeFunc(stream, taskID, &adInstanceDigest.ResourceName)
 	stateChangeFn := operation.StateChangeFunc(func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {
 		if stage == repb.ExecutionStage_COMPLETED {
 			if err := appendAuxiliaryMetadata(execResponse.GetResult().GetExecutionMetadata(), auxMetadata); err != nil {

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -33,7 +33,7 @@ const (
 // is broken.
 type Publisher struct {
 	taskID           string
-	taskResourceName *digest.ResourceName
+	taskResourceName *digest.CASResourceName
 
 	// Execution stage as defined by the remote execution API.
 	executionStage repb.ExecutionStage_Value
@@ -47,7 +47,7 @@ type Publisher struct {
 	stream *retryingClient
 }
 
-func newPublisher(stream *retryingClient, taskID string, taskResourceName *digest.ResourceName) *Publisher {
+func newPublisher(stream *retryingClient, taskID string, taskResourceName *digest.CASResourceName) *Publisher {
 	return &Publisher{
 		stream:           stream,
 		taskID:           taskID,
@@ -331,8 +331,8 @@ func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest *dige
 	}
 }
 
-func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest *digest.ResourceName, er *repb.ExecuteResponse) error {
-	op, err := Assemble(taskID, Metadata(repb.ExecutionStage_COMPLETED, adInstanceDigest), er)
+func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest *digest.ACResourceName, er *repb.ExecuteResponse) error {
+	op, err := Assemble(taskID, Metadata(repb.ExecutionStage_COMPLETED, &adInstanceDigest.ResourceName), er)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//enterprise/server/util/ci_runner_util",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:runner_go_proto",
         "//proto:scheduler_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -44,7 +44,6 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 )
@@ -249,10 +248,10 @@ func (r *taskRunner) PrepareForTask(ctx context.Context) error {
 }
 
 func (r *taskRunner) DownloadInputs(ctx context.Context, ioStats *repb.IOStats) error {
-	rootInstanceDigest := digest.NewResourceName(
+	rootInstanceDigest := digest.NewCASResourceName(
 		r.task.GetAction().GetInputRootDigest(),
 		r.task.GetExecuteRequest().GetInstanceName(),
-		rspb.CacheType_CAS, r.task.GetExecuteRequest().GetDigestFunction())
+		r.task.GetExecuteRequest().GetDigestFunction())
 	inputTree, err := cachetools.GetAndMaybeCacheTreeFromRootDirectoryDigest(
 		ctx, r.env.GetContentAddressableStorageClient(), rootInstanceDigest, r.env.GetFileCache(), r.env.GetByteStreamClient())
 	if err != nil {

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//enterprise/server/remote_execution/snaputil",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/environment",
         "//server/metrics",
         "//server/remote_cache/cachetools",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -36,7 +36,6 @@ import (
 
 	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
@@ -115,7 +114,7 @@ func (l *FileCacheLoader) currentSnapshotVersion(ctx context.Context, key *fcpb.
 	if err != nil {
 		return "", err
 	}
-	rn := digest.NewResourceName(versionKey, key.InstanceName, rspb.CacheType_AC, repb.DigestFunction_BLAKE3)
+	rn := digest.NewACResourceName(versionKey, key.InstanceName, repb.DigestFunction_BLAKE3)
 	acResult, err := cachetools.GetActionResult(ctx, l.env.GetActionCacheClient(), rn)
 	if status.IsNotFoundError(err) {
 		// Version metadata might not exist in the cache if:
@@ -428,7 +427,7 @@ func (l *FileCacheLoader) fetchRemoteManifest(ctx context.Context, key *fcpb.Sna
 	if err != nil {
 		return nil, err
 	}
-	rn := digest.NewResourceName(manifestKey, key.InstanceName, rspb.CacheType_AC, repb.DigestFunction_BLAKE3)
+	rn := digest.NewACResourceName(manifestKey, key.InstanceName, repb.DigestFunction_BLAKE3)
 	acResult, err := cachetools.GetActionResult(ctx, l.env.GetActionCacheClient(), rn)
 	if err != nil {
 		return nil, err
@@ -718,7 +717,7 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 		if err != nil {
 			return err
 		}
-		acDigest := digest.NewResourceName(d, key.InstanceName, rspb.CacheType_AC, repb.DigestFunction_BLAKE3)
+		acDigest := digest.NewACResourceName(d, key.InstanceName, repb.DigestFunction_BLAKE3)
 		if err := cachetools.UploadActionResult(ctx, l.env.GetActionCacheClient(), acDigest, ar); err != nil {
 			return err
 		}
@@ -736,7 +735,7 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 				log.Warningf("Failed to generate snapshot specific remote manifest key for snapshot ID %s: %s", snapshotID, err)
 				return nil
 			}
-			snapshotSpecificAcDigest := digest.NewResourceName(snapshotSpecificManifestKey, key.InstanceName, rspb.CacheType_AC, repb.DigestFunction_BLAKE3)
+			snapshotSpecificAcDigest := digest.NewACResourceName(snapshotSpecificManifestKey, key.InstanceName, repb.DigestFunction_BLAKE3)
 			if err := cachetools.UploadActionResult(ctx, l.env.GetActionCacheClient(), snapshotSpecificAcDigest, ar); err != nil {
 				log.Warningf("Failed to cache remote snapshot specific manifest for snapshot ID %s: %s", snapshotID, err)
 				return nil
@@ -1054,7 +1053,7 @@ func (l *SnapshotService) InvalidateSnapshot(ctx context.Context, key *fcpb.Snap
 		return "", err
 	}
 
-	acDigest := digest.NewResourceName(versionKey, key.InstanceName, rspb.CacheType_AC, repb.DigestFunction_BLAKE3)
+	acDigest := digest.NewACResourceName(versionKey, key.InstanceName, repb.DigestFunction_BLAKE3)
 	if err := cachetools.UploadActionResult(ctx, l.env.GetActionCacheClient(), acDigest, versionMetadataActionResult); err != nil {
 		return "", err
 	}

--- a/enterprise/server/remote_execution/snaputil/BUILD
+++ b/enterprise/server/remote_execution/snaputil/BUILD
@@ -8,7 +8,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil",
     deps = [
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/cachetools",

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/genproto/googleapis/bytestream"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 var EnableLocalSnapshotSharing = flag.Bool("executor.enable_local_snapshot_sharing", false, "Enables local snapshot sharing for firecracker VMs.")
@@ -93,7 +92,7 @@ func GetArtifact(ctx context.Context, localCache interfaces.FileCache, bsClient 
 		return 0, err
 	}
 	defer f.Close()
-	r := digest.NewResourceName(d, instanceName, rspb.CacheType_CAS, repb.DigestFunction_BLAKE3)
+	r := digest.NewCASResourceName(d, instanceName, repb.DigestFunction_BLAKE3)
 	r.SetCompressor(repb.Compressor_ZSTD)
 	if err := cachetools.GetBlob(ctx, bsClient, r, f); err != nil {
 		return 0, status.WrapError(err, "remote fetch snapshot artifact")
@@ -143,7 +142,7 @@ func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytest
 		defer func() { log.CtxDebugf(ctx, "Uploaded snapshot artifact in %s", time.Since(start)) }()
 	}
 
-	rn := digest.NewResourceName(d, remoteInstanceName, rspb.CacheType_CAS, repb.DigestFunction_BLAKE3)
+	rn := digest.NewCASResourceName(d, remoteInstanceName, repb.DigestFunction_BLAKE3)
 	rn.SetCompressor(repb.Compressor_ZSTD)
 	file, err := os.Open(path)
 	if err != nil {

--- a/enterprise/server/remote_execution/soci_store/BUILD
+++ b/enterprise/server/remote_execution/soci_store/BUILD
@@ -17,7 +17,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//proto:registry_go_proto",
             "//proto:remote_execution_go_proto",
-            "//proto:resource_go_proto",
             "//proto:soci_go_proto",
             "//server/interfaces",
             "//server/metrics",

--- a/enterprise/server/remote_execution/soci_store/soci_store_linux.go
+++ b/enterprise/server/remote_execution/soci_store/soci_store_linux.go
@@ -29,7 +29,6 @@ import (
 	sspb "github.com/awslabs/soci-snapshotter/proto"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	socipb "github.com/buildbuddy-io/buildbuddy/proto/soci"
 	godigest "github.com/opencontainers/go-digest"
 )
@@ -333,7 +332,7 @@ func getArtifacts(ctx context.Context, client socipb.SociArtifactStoreClient, en
 			return err
 		}
 		defer blobFile.Close()
-		resourceName := digest.NewResourceName(artifact.Digest, "" /*=instanceName -- not used */, rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+		resourceName := digest.NewCASResourceName(artifact.Digest, "" /*=instanceName -- not used */, repb.DigestFunction_SHA256)
 		if err = cachetools.GetBlob(ctx, env.GetByteStreamClient(), resourceName, blobFile); err != nil {
 			return err
 		}

--- a/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
@@ -8,7 +8,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbeclient",
     deps = [
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/cache/dirtools",
         "//server/environment",
         "//server/remote_cache/cachetools",

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -36,7 +36,6 @@ go_library(
         "//proto:context_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:scheduler_go_proto",
         "//server/build_event_protocol/build_event_handler",
         "//server/build_event_protocol/build_event_server",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -80,7 +80,6 @@ import (
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -924,7 +923,7 @@ func (r *Env) DownloadOutputsToNewTempDir(res *CommandResult) string {
 func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionResult, instanceName string) (string, string, error) {
 	stdout := ""
 	if actionResult.GetStdoutDigest() != nil {
-		d := digest.NewResourceName(actionResult.GetStdoutDigest(), instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+		d := digest.NewCASResourceName(actionResult.GetStdoutDigest(), instanceName, repb.DigestFunction_SHA256)
 		buf := bytes.NewBuffer(make([]byte, 0, d.GetDigest().GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {
@@ -935,7 +934,7 @@ func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionR
 
 	stderr := ""
 	if actionResult.GetStderrDigest() != nil {
-		d := digest.NewResourceName(actionResult.GetStderrDigest(), instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+		d := digest.NewCASResourceName(actionResult.GetStderrDigest(), instanceName, repb.DigestFunction_SHA256)
 		buf := bytes.NewBuffer(make([]byte, 0, d.GetDigest().GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {

--- a/enterprise/server/util/vfs_server/BUILD
+++ b/enterprise/server/util/vfs_server/BUILD
@@ -23,7 +23,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//enterprise/server/remote_execution/container",
             "//proto:remote_execution_go_proto",
-            "//proto:resource_go_proto",
             "//proto:vfs_go_proto",
             "//server/cache/dirtools",
             "//server/environment",

--- a/enterprise/server/util/vfs_server/vfs_server.go
+++ b/enterprise/server/util/vfs_server/vfs_server.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/codes"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	vfspb "github.com/buildbuddy-io/buildbuddy/proto/vfs"
 	fusefs "github.com/hanwen/go-fuse/v2/fs"
 	gstatus "google.golang.org/grpc/status"
@@ -778,7 +777,7 @@ func newCASFetcher(env environment.Env, remoteInstanceName string, digestFunctio
 
 func (cf *casFetcher) downloadToFileCache(ctx context.Context, node *fsNode) error {
 	bsClient := cf.env.GetByteStreamClient()
-	rn := digest.NewResourceName(node.fileNode.GetDigest(), cf.remoteInstanceName, rspb.CacheType_CAS, cf.digestFunction)
+	rn := digest.NewCASResourceName(node.fileNode.GetDigest(), cf.remoteInstanceName, cf.digestFunction)
 	rn.SetCompressor(repb.Compressor_ZSTD)
 	w, err := cf.env.GetFileCache().Writer(ctx, node.fileNode, cf.digestFunction)
 	if err != nil {

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -65,7 +65,6 @@ go_test(
         "//proto:buildbuddy_service_go_proto",
         "//proto:git_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:workflow_go_proto",
         "//server/backends/repo_downloader",
         "//server/buildbuddy_server",

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -38,7 +38,6 @@ import (
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	gitpb "github.com/buildbuddy-io/buildbuddy/proto/git"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	wfpb "github.com/buildbuddy-io/buildbuddy/proto/workflow"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -149,12 +148,12 @@ type execution struct {
 // getExecution fetches digest contents of an ExecuteRequest.
 func getExecution(t *testing.T, ctx context.Context, te *testenv.TestEnv, executeRequest *repb.ExecuteRequest) *execution {
 	instanceName := executeRequest.GetInstanceName()
-	ar := digest.NewResourceName(executeRequest.GetActionDigest(), instanceName, rspb.CacheType_CAS, repb.DigestFunction_BLAKE3)
+	ar := digest.NewCASResourceName(executeRequest.GetActionDigest(), instanceName, repb.DigestFunction_BLAKE3)
 	action := &repb.Action{}
 	err := cachetools.GetBlobAsProto(ctx, te.GetByteStreamClient(), ar, action)
 	require.NoError(t, err)
 	command := &repb.Command{}
-	cr := digest.NewResourceName(action.GetCommandDigest(), instanceName, rspb.CacheType_CAS, repb.DigestFunction_BLAKE3)
+	cr := digest.NewCASResourceName(action.GetCommandDigest(), instanceName, repb.DigestFunction_BLAKE3)
 	err = cachetools.GetBlobAsProto(ctx, te.GetByteStreamClient(), cr, command)
 	require.NoError(t, err)
 	return &execution{

--- a/enterprise/tools/mount_vfs/BUILD
+++ b/enterprise/tools/mount_vfs/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//enterprise/server/remote_execution/vfs",
         "//enterprise/server/util/vfs_server",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/enterprise/tools/replay_action/BUILD
+++ b/enterprise/tools/replay_action/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//proto:buildbuddy_service_go_proto",
         "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/bazel_request",

--- a/enterprise/tools/upload_local_snapshot/BUILD
+++ b/enterprise/tools/upload_local_snapshot/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//enterprise/server/remote_execution/snaploader",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/environment",
         "//server/nullauth",
         "//server/real_environment",

--- a/enterprise/tools/upload_local_snapshot/upload_local_snapshot.go
+++ b/enterprise/tools/upload_local_snapshot/upload_local_snapshot.go
@@ -28,7 +28,6 @@ import (
 
 	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -254,7 +253,7 @@ func uploadDigestsRemoteCache(ctx context.Context, ctxWithClaims context.Context
 			}
 			defer os.Remove(path)
 
-			rn := digest.NewResourceName(d, remoteInstanceName, rspb.CacheType_CAS, repb.DigestFunction_BLAKE3)
+			rn := digest.NewCASResourceName(d, remoteInstanceName, repb.DigestFunction_BLAKE3)
 			rn.SetCompressor(repb.Compressor_ZSTD)
 			file, err := os.Open(path)
 			if err != nil {
@@ -279,7 +278,7 @@ func uploadManifestRemoteCache(ctx context.Context, env environment.Env, key *fc
 	if err != nil {
 		log.Fatalf("Error generating digest for snapshot key: %s", err)
 	}
-	acDigest := digest.NewResourceName(remoteManifestKey, remoteInstanceName, rspb.CacheType_AC, repb.DigestFunction_BLAKE3)
+	acDigest := digest.NewACResourceName(remoteManifestKey, remoteInstanceName, repb.DigestFunction_BLAKE3)
 	if err := cachetools.UploadActionResult(ctx, env.GetActionCacheClient(), acDigest, localACResult); err != nil {
 		log.Fatalf("Error uploading manifest to remote cache: %s", err)
 	}

--- a/enterprise/tools/vmstart/BUILD
+++ b/enterprise/tools/vmstart/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//enterprise/server/util/oci",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:vmvfs_go_proto",
         "//server/environment",
         "//server/interfaces",

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -82,7 +82,6 @@ go_test(
         "//proto:invocation_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:user_id_go_proto",
         "//server/backends/invocationdb",
         "//server/build_event_protocol/build_event_handler",

--- a/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/server/buildbuddy_server/buildbuddy_server_test.go
@@ -313,7 +313,7 @@ func TestFileDownloadEndpoint(t *testing.T) {
 	{
 		// Upload CAS resource
 		rn, b := testdigest.RandomCASResourceBuf(t, 100)
-		casrn, err := digest.ResourceNameFromProto(rn).CheckCAS()
+		casrn, err := digest.CASResourceNameFromProto(rn)
 		require.NoError(t, err)
 		_, _, err = cachetools.UploadFromReader(ctx, te.GetByteStreamClient(), casrn, bytes.NewReader(b))
 		require.NoError(t, err)

--- a/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/server/buildbuddy_server/buildbuddy_server_test.go
@@ -39,7 +39,6 @@ import (
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
@@ -313,8 +312,10 @@ func TestFileDownloadEndpoint(t *testing.T) {
 
 	{
 		// Upload CAS resource
-		rn, b := testdigest.NewRandomResourceAndBuf(t, 100, rspb.CacheType_CAS, "")
-		_, _, err = cachetools.UploadFromReader(ctx, te.GetByteStreamClient(), digest.ResourceNameFromProto(rn), bytes.NewReader(b))
+		rn, b := testdigest.RandomCASResourceBuf(t, 100)
+		casrn, err := digest.ResourceNameFromProto(rn).ToCAS()
+		require.NoError(t, err)
+		_, _, err = cachetools.UploadFromReader(ctx, te.GetByteStreamClient(), casrn, bytes.NewReader(b))
 		require.NoError(t, err)
 
 		// Fetch it from /file/download endpoint
@@ -336,7 +337,7 @@ func TestFileDownloadEndpoint(t *testing.T) {
 			Hash:      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
 			SizeBytes: 111,
 		}
-		rn := digest.NewResourceName(key, "", rspb.CacheType_AC, repb.DigestFunction_SHA256)
+		rn := digest.NewACResourceName(key, "", repb.DigestFunction_SHA256)
 		ar := &repb.ActionResult{
 			StdoutRaw: []byte("test-stdout"),
 			ExecutionMetadata: &repb.ExecutedActionMetadata{

--- a/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/server/buildbuddy_server/buildbuddy_server_test.go
@@ -313,7 +313,7 @@ func TestFileDownloadEndpoint(t *testing.T) {
 	{
 		// Upload CAS resource
 		rn, b := testdigest.RandomCASResourceBuf(t, 100)
-		casrn, err := digest.ResourceNameFromProto(rn).ToCAS()
+		casrn, err := digest.ResourceNameFromProto(rn).CheckCAS()
 		require.NoError(t, err)
 		_, _, err = cachetools.UploadFromReader(ctx, te.GetByteStreamClient(), casrn, bytes.NewReader(b))
 		require.NoError(t, err)

--- a/server/cache/dirtools/BUILD
+++ b/server/cache/dirtools/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//server/util/rpcutil",
         "//server/util/status",
         "//third_party/singleflight",
-        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_x_sync//errgroup",
     ],

--- a/server/cache_proxy/BUILD
+++ b/server/cache_proxy/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/cache_proxy",
     deps = [
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//proto:semver_go_proto",
         "//server/environment",
         "//server/interfaces",

--- a/server/cache_proxy/cache_proxy.go
+++ b/server/cache_proxy/cache_proxy.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	smpb "github.com/buildbuddy-io/buildbuddy/proto/semver"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -218,7 +217,7 @@ func (p *CacheProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServ
 		if err != nil {
 			if err == io.EOF {
 				if localFile != nil {
-					resourceName := digest.NewResourceName(d, instanceName, rspb.CacheType_CAS, resourceName.GetDigestFunction())
+					resourceName := digest.NewCASResourceName(d, instanceName, resourceName.GetDigestFunction())
 					if _, _, err := cachetools.UploadFromReader(ctx, p.localBSSClient, resourceName, localFile); err != nil {
 						log.Errorf("error uploading from reader: %s", err.Error())
 					}

--- a/server/remote_asset/fetch_server/BUILD
+++ b/server/remote_asset/fetch_server/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/environment",
         "//server/real_environment",
         "//server/remote_cache/cachetools",

--- a/server/remote_cache/byte_stream_server/BUILD
+++ b/server/remote_cache/byte_stream_server/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//proto:api_key_go_proto",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/real_environment",
@@ -35,7 +34,6 @@ go_test(
     embed = [":byte_stream_server"],
     deps = [
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/backends/memory_metrics_collector",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -23,7 +23,6 @@ import (
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	remote_cache_config "github.com/buildbuddy-io/buildbuddy/server/remote_cache/config"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -112,7 +111,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 	}
 	downloadTracker := ht.TrackDownload(r.GetDigest())
 
-	cacheRN := digest.NewResourceName(r.GetDigest(), r.GetInstanceName(), rspb.CacheType_CAS, r.GetDigestFunction())
+	cacheRN := digest.NewCASResourceName(r.GetDigest(), r.GetInstanceName(), r.GetDigestFunction())
 	passthroughCompressionEnabled := s.cache.SupportsCompressor(r.GetCompressor()) && req.ReadOffset == 0 && req.ReadLimit == 0
 	if passthroughCompressionEnabled {
 		cacheRN.SetCompressor(r.GetCompressor())
@@ -211,7 +210,7 @@ type writeState struct {
 	cacheCloser        io.Closer
 
 	checksum           *Checksum
-	resourceName       *digest.ResourceName
+	resourceName       *digest.CASResourceName
 	resourceNameString string
 	offset             int64
 }
@@ -256,7 +255,7 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 		resourceNameString: req.ResourceName,
 	}
 
-	casRN := digest.NewResourceName(r.GetDigest(), r.GetInstanceName(), rspb.CacheType_CAS, r.GetDigestFunction())
+	casRN := digest.NewCASResourceName(r.GetDigest(), r.GetInstanceName(), r.GetDigestFunction())
 	if s.cache.SupportsCompressor(r.GetCompressor()) {
 		casRN.SetCompressor(r.GetCompressor())
 	}
@@ -557,7 +556,7 @@ func (s *Checksum) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-func (s *Checksum) Check(r *digest.ResourceName) error {
+func (s *Checksum) Check(r *digest.CASResourceName) error {
 	d := r.GetDigest()
 	computedDigest := fmt.Sprintf("%x", s.hash.Sum(nil))
 	if computedDigest != d.GetHash() {

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	guuid "github.com/google/uuid"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gstatus "google.golang.org/grpc/status"
@@ -72,55 +71,55 @@ func TestRPCRead(t *testing.T) {
 	}
 	cases := []struct {
 		wantError    error
-		resourceName *digest.ResourceName
+		resourceName *digest.CASResourceName
 		wantData     string
 		offset       int64
 	}{
 		{ // Simple Read
-			resourceName: digest.NewResourceName(&repb.Digest{
+			resourceName: digest.NewCASResourceName(&repb.Digest{
 				Hash:      "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d",
 				SizeBytes: 1234,
-			}, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256),
+			}, "", repb.DigestFunction_SHA256),
 
 			wantData:  randStr(1234),
 			wantError: nil,
 			offset:    0,
 		},
 		{ // Large Read
-			resourceName: digest.NewResourceName(&repb.Digest{
+			resourceName: digest.NewCASResourceName(&repb.Digest{
 				Hash:      "ffd14ebb6c1b2701ac793ea1aff6dddf8540e734bd6d051ac2a24aa3ec062781",
 				SizeBytes: 1000 * 1000 * 100,
-			}, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256),
+			}, "", repb.DigestFunction_SHA256),
 
 			wantData:  randStr(1000 * 1000 * 100),
 			wantError: nil,
 			offset:    0,
 		},
 		{ // 0 length read
-			resourceName: digest.NewResourceName(&repb.Digest{
+			resourceName: digest.NewCASResourceName(&repb.Digest{
 				Hash:      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 				SizeBytes: 0,
-			}, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256),
+			}, "", repb.DigestFunction_SHA256),
 
 			wantData:  "",
 			wantError: nil,
 			offset:    0,
 		},
 		{ // Offset
-			resourceName: digest.NewResourceName(&repb.Digest{
+			resourceName: digest.NewCASResourceName(&repb.Digest{
 				Hash:      "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d",
 				SizeBytes: 1234,
-			}, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256),
+			}, "", repb.DigestFunction_SHA256),
 
 			wantData:  randStr(1234),
 			wantError: nil,
 			offset:    1,
 		},
 		{ // Max offset
-			resourceName: digest.NewResourceName(&repb.Digest{
+			resourceName: digest.NewCASResourceName(&repb.Digest{
 				Hash:      "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d",
 				SizeBytes: 1234,
-			}, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256),
+			}, "", repb.DigestFunction_SHA256),
 
 			wantData:  randStr(1234),
 			wantError: nil,
@@ -161,7 +160,7 @@ func TestRPCWrite(t *testing.T) {
 
 	// Test that a regular bytestream upload works.
 	d, readSeeker := testdigest.NewReader(t, 1000)
-	instanceNameDigest := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+	instanceNameDigest := digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256)
 	_, _, err := cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, readSeeker)
 	if err != nil {
 		t.Fatal(err)
@@ -177,7 +176,7 @@ func TestRPCWriteWithDirectWrite(t *testing.T) {
 
 	// This file is small enough that we'll skip the Contains check.
 	d, readSeeker := testdigest.NewReader(t, 1000)
-	instanceNameDigest := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+	instanceNameDigest := digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256)
 	_, _, err := cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, readSeeker)
 	if err != nil {
 		t.Fatal(err)
@@ -199,7 +198,11 @@ func TestRPCMalformedWrite(t *testing.T) {
 	buf[0] = ^buf[0] // flip bits in byte to corrupt digest.
 
 	readSeeker := bytes.NewReader(buf)
-	_, _, err := cachetools.UploadFromReader(ctx, bsClient, digest.ResourceNameFromProto(instanceNameDigest), readSeeker)
+	rn, err := digest.ResourceNameFromProto(instanceNameDigest).ToCAS()
+	if err != nil {
+		t.Fatalf("failed to create resource name: %v", err)
+	}
+	_, _, err = cachetools.UploadFromReader(ctx, bsClient, rn, readSeeker)
 	if !status.IsDataLossError(err) {
 		t.Fatalf("Expected data loss error but got %s", err)
 	}
@@ -214,10 +217,13 @@ func TestRPCTooLongWrite(t *testing.T) {
 	// Test that a malformed upload (wrong bytesize) is rejected.
 	rnProto, buf := testdigest.RandomCASResourceBuf(t, 1000)
 	rnProto.Digest.SizeBytes += 1 // increment expected byte count by 1 to trigger mismatch.
-	instanceNameDigest := digest.ResourceNameFromProto(rnProto)
+	instanceNameDigest, err := digest.ResourceNameFromProto(rnProto).ToCAS()
+	if err != nil {
+		t.Fatalf("failed to create resource name: %v", err)
+	}
 
 	readSeeker := bytes.NewReader(buf)
-	_, _, err := cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, readSeeker)
+	_, _, err = cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, readSeeker)
 	if !status.IsDataLossError(err) {
 		t.Fatalf("Expected data loss error but got %s", err)
 	}
@@ -234,7 +240,7 @@ func TestRPCReadWriteLargeBlob(t *testing.T) {
 	require.NoError(t, err)
 	d, err := digest.Compute(strings.NewReader(blob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
-	instanceNameDigest := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+	instanceNameDigest := digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256)
 
 	// Write
 	_, _, err = cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, strings.NewReader(blob))

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -198,7 +198,7 @@ func TestRPCMalformedWrite(t *testing.T) {
 	buf[0] = ^buf[0] // flip bits in byte to corrupt digest.
 
 	readSeeker := bytes.NewReader(buf)
-	rn, err := digest.ResourceNameFromProto(instanceNameDigest).CheckCAS()
+	rn, err := digest.CASResourceNameFromProto(instanceNameDigest)
 	if err != nil {
 		t.Fatalf("failed to create resource name: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestRPCTooLongWrite(t *testing.T) {
 	// Test that a malformed upload (wrong bytesize) is rejected.
 	rnProto, buf := testdigest.RandomCASResourceBuf(t, 1000)
 	rnProto.Digest.SizeBytes += 1 // increment expected byte count by 1 to trigger mismatch.
-	instanceNameDigest, err := digest.ResourceNameFromProto(rnProto).CheckCAS()
+	instanceNameDigest, err := digest.CASResourceNameFromProto(rnProto)
 	if err != nil {
 		t.Fatalf("failed to create resource name: %v", err)
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -198,7 +198,7 @@ func TestRPCMalformedWrite(t *testing.T) {
 	buf[0] = ^buf[0] // flip bits in byte to corrupt digest.
 
 	readSeeker := bytes.NewReader(buf)
-	rn, err := digest.ResourceNameFromProto(instanceNameDigest).ToCAS()
+	rn, err := digest.ResourceNameFromProto(instanceNameDigest).CheckCAS()
 	if err != nil {
 		t.Fatalf("failed to create resource name: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestRPCTooLongWrite(t *testing.T) {
 	// Test that a malformed upload (wrong bytesize) is rejected.
 	rnProto, buf := testdigest.RandomCASResourceBuf(t, 1000)
 	rnProto.Digest.SizeBytes += 1 // increment expected byte count by 1 to trigger mismatch.
-	instanceNameDigest, err := digest.ResourceNameFromProto(rnProto).ToCAS()
+	instanceNameDigest, err := digest.ResourceNameFromProto(rnProto).CheckCAS()
 	if err != nil {
 		t.Fatalf("failed to create resource name: %v", err)
 	}

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -979,7 +979,7 @@ func getSubtree(ctx context.Context, subtree *digest.CASResourceName, fc interfa
 		var stMutex sync.Mutex
 		for _, child := range treeCache.GetTreeCacheChildren() {
 			subtreeEG.Go(func() error {
-				r, err := digest.ResourceNameFromProto(child).CheckCAS()
+				r, err := digest.CASResourceNameFromProto(child)
 				if err != nil {
 					return err
 				}

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -61,7 +61,7 @@ type nopCloser struct {
 
 func (nopCloser) Close() error { return nil }
 
-func getBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, out io.Writer) error {
+func getBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASResourceName, out io.Writer) error {
 	if bsClient == nil {
 		return status.FailedPreconditionError("ByteStreamClient not configured")
 	}
@@ -127,7 +127,7 @@ func getBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.Reso
 	return nil
 }
 
-func GetBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, out io.Writer) error {
+func GetBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASResourceName, out io.Writer) error {
 	// We can only retry if we can rewind the writer back to the beginning.
 	seeker, retryable := out.(io.Seeker)
 	if retryable {
@@ -230,15 +230,15 @@ func batchReadBlobs(ctx context.Context, casClient repb.ContentAddressableStorag
 	return results, nil
 }
 
-func computeDigest(in io.ReadSeeker, instanceName string, digestFunction repb.DigestFunction_Value) (*digest.ResourceName, error) {
+func computeDigest(in io.ReadSeeker, instanceName string, digestFunction repb.DigestFunction_Value) (*digest.CASResourceName, error) {
 	d, err := digest.Compute(in, digestFunction)
 	if err != nil {
 		return nil, err
 	}
-	return digest.NewResourceName(d, instanceName, rspb.CacheType_CAS, digestFunction), nil
+	return digest.NewCASResourceName(d, instanceName, digestFunction), nil
 }
 
-func ComputeFileDigest(fullFilePath, instanceName string, digestFunction repb.DigestFunction_Value) (*digest.ResourceName, error) {
+func ComputeFileDigest(fullFilePath, instanceName string, digestFunction repb.DigestFunction_Value) (*digest.CASResourceName, error) {
 	f, err := os.Open(fullFilePath)
 	if err != nil {
 		return nil, err
@@ -247,7 +247,7 @@ func ComputeFileDigest(fullFilePath, instanceName string, digestFunction repb.Di
 	return computeDigest(f, instanceName, digestFunction)
 }
 
-func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, in io.Reader) (*repb.Digest, int64, error) {
+func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASResourceName, in io.Reader) (*repb.Digest, int64, error) {
 	if bsClient == nil {
 		return nil, 0, status.FailedPreconditionError("ByteStreamClient not configured")
 	}
@@ -339,7 +339,7 @@ type uploadRetryResult = struct {
 	uploadedBytes int64
 }
 
-func UploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, in io.Reader) (*repb.Digest, int64, error) {
+func UploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASResourceName, in io.Reader) (*repb.Digest, int64, error) {
 	// We can only retry if we can rewind the reader back to the beginning.
 	seeker, retryable := in.(io.Seeker)
 	if retryable {
@@ -359,12 +359,9 @@ func UploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 	}
 }
 
-func GetActionResult(ctx context.Context, acClient repb.ActionCacheClient, ar *digest.ResourceName) (*repb.ActionResult, error) {
+func GetActionResult(ctx context.Context, acClient repb.ActionCacheClient, ar *digest.ACResourceName) (*repb.ActionResult, error) {
 	if acClient == nil {
 		return nil, status.FailedPreconditionError("ActionCacheClient not configured")
-	}
-	if ar.GetCacheType() != rspb.CacheType_AC {
-		return nil, status.InvalidArgumentError("Cannot download non-AC resource from action cache")
 	}
 	req := &repb.GetActionResultRequest{
 		ActionDigest:   ar.GetDigest(),
@@ -382,12 +379,9 @@ func GetActionResult(ctx context.Context, acClient repb.ActionCacheClient, ar *d
 	})
 }
 
-func UploadActionResult(ctx context.Context, acClient repb.ActionCacheClient, r *digest.ResourceName, ar *repb.ActionResult) error {
+func UploadActionResult(ctx context.Context, acClient repb.ActionCacheClient, r *digest.ACResourceName, ar *repb.ActionResult) error {
 	if acClient == nil {
 		return status.FailedPreconditionError("ActionCacheClient not configured")
-	}
-	if r.GetCacheType() != rspb.CacheType_AC {
-		return status.InvalidArgumentError("Cannot upload non-AC resource to action cache")
 	}
 
 	req := &repb.UpdateActionResultRequest{
@@ -456,10 +450,7 @@ func UploadFile(ctx context.Context, bsClient bspb.ByteStreamClient, instanceNam
 	return result, err
 }
 
-func GetBlobAsProto(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, out proto.Message) error {
-	if r.GetCacheType() != rspb.CacheType_CAS {
-		return status.InvalidArgumentError("Cannot download non-CAS resource from CAS cache")
-	}
+func GetBlobAsProto(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASResourceName, out proto.Message) error {
 	buf := bytes.NewBuffer(make([]byte, 0, r.GetDigest().GetSizeBytes()))
 	if err := GetBlob(ctx, bsClient, r, buf); err != nil {
 		return err
@@ -467,7 +458,7 @@ func GetBlobAsProto(ctx context.Context, bsClient bspb.ByteStreamClient, r *dige
 	return proto.Unmarshal(buf.Bytes(), out)
 }
 
-func readProtoFromCache(ctx context.Context, cache interfaces.Cache, r *digest.ResourceName, out proto.Message) error {
+func readProtoFromCache(ctx context.Context, cache interfaces.Cache, r *digest.CASResourceName, out proto.Message) error {
 	data, err := cache.Get(ctx, r.ToProto())
 	if err != nil {
 		if gstatus.Code(err) == gcodes.NotFound {
@@ -475,17 +466,13 @@ func readProtoFromCache(ctx context.Context, cache interfaces.Cache, r *digest.R
 		}
 		return err
 	}
-	return proto.Unmarshal([]byte(data), out)
+	return proto.Unmarshal(data, out)
 }
 
-func ReadProtoFromCAS(ctx context.Context, cache interfaces.Cache, d *digest.ResourceName, out proto.Message) error {
-	casRN := digest.NewResourceName(d.GetDigest(), d.GetInstanceName(), rspb.CacheType_CAS, d.GetDigestFunction())
+func ReadProtoFromCAS(ctx context.Context, cache interfaces.Cache, d *digest.CASResourceName, out proto.Message) error {
+	// TODO: Check whether this is intentionally creating a partial copy of d.
+	casRN := digest.NewCASResourceName(d.GetDigest(), d.GetInstanceName(), d.GetDigestFunction())
 	return readProtoFromCache(ctx, cache, casRN, out)
-}
-
-func ReadProtoFromAC(ctx context.Context, cache interfaces.Cache, d *digest.ResourceName, out proto.Message) error {
-	acRN := digest.NewResourceName(d.GetDigest(), d.GetInstanceName(), rspb.CacheType_AC, d.GetDigestFunction())
-	return readProtoFromCache(ctx, cache, acRN, out)
 }
 
 func UploadBytesToCache(ctx context.Context, cache interfaces.Cache, cacheType rspb.CacheType, remoteInstanceName string, digestFunction repb.DigestFunction_Value, in io.ReadSeeker) (*repb.Digest, error) {
@@ -528,7 +515,7 @@ func UploadBlobToCAS(ctx context.Context, bsClient bspb.ByteStreamClient, instan
 	if err != nil {
 		return nil, err
 	}
-	resourceName := digest.NewResourceName(d, instanceName, rspb.CacheType_CAS, digestFunction)
+	resourceName := digest.NewCASResourceName(d, instanceName, digestFunction)
 	if resourceName.IsEmpty() {
 		return d, nil
 	}
@@ -643,7 +630,7 @@ func (ul *BatchCASUploader) Upload(d *repb.Digest, rsc io.ReadSeekCloser) error 
 	}
 
 	if d.GetSizeBytes() > rpcutil.GRPCMaxSizeBytes {
-		resourceName := digest.NewResourceName(d, ul.instanceName, rspb.CacheType_CAS, ul.digestFunction)
+		resourceName := digest.NewCASResourceName(d, ul.instanceName, ul.digestFunction)
 		resourceName.SetCompressor(compressor)
 
 		byteStreamClient := ul.env.GetByteStreamClient()
@@ -870,9 +857,9 @@ func isExecutable(info os.FileInfo) bool {
 	return info.Mode()&0100 != 0
 }
 
-func streamTree(ctx context.Context, casClient repb.ContentAddressableStorageClient, root *digest.ResourceName, sendCachedSubtreeDigests bool) ([]*repb.Directory, []*digest.ResourceName, error) {
+func streamTree(ctx context.Context, casClient repb.ContentAddressableStorageClient, root *digest.CASResourceName, sendCachedSubtreeDigests bool) ([]*repb.Directory, []*digest.CASResourceName, error) {
 	var dirs []*repb.Directory
-	var subtrees []*digest.ResourceName
+	var subtrees []*digest.CASResourceName
 	nextPageToken := ""
 	for {
 		stream, err := casClient.GetTree(ctx, &repb.GetTreeRequest{
@@ -896,7 +883,7 @@ func streamTree(ctx context.Context, casClient repb.ContentAddressableStorageCli
 			nextPageToken = rsp.GetNextPageToken()
 			dirs = append(dirs, rsp.GetDirectories()...)
 			for _, st := range rsp.GetSubtrees() {
-				subtrees = append(subtrees, digest.NewResourceName(st.GetDigest(), st.GetInstanceName(), rspb.CacheType_CAS, st.GetDigestFunction()))
+				subtrees = append(subtrees, digest.NewCASResourceName(st.GetDigest(), st.GetInstanceName(), st.GetDigestFunction()))
 			}
 		}
 		if nextPageToken == "" {
@@ -913,7 +900,7 @@ func streamTree(ctx context.Context, casClient repb.ContentAddressableStorageCli
 // the salt so that we can invalidate the entire filecache-based treecache
 // if needed.
 // Exposed for testing--no reason to use outside of this package.
-func MakeFileNode(r *digest.ResourceName) (*repb.FileNode, error) {
+func MakeFileNode(r *digest.CASResourceName) (*repb.FileNode, error) {
 	buf := strings.NewReader(fmt.Sprintf("%s/%d", r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()) + r.GetInstanceName() + "_treecache_" + *filecacheTreeSalt)
 	d, err := digest.Compute(buf, r.GetDigestFunction())
 	if err != nil {
@@ -922,7 +909,7 @@ func MakeFileNode(r *digest.ResourceName) (*repb.FileNode, error) {
 	return &repb.FileNode{Digest: &repb.Digest{Hash: d.GetHash(), SizeBytes: 0}}, nil
 }
 
-func getTreeCacheFromFilecache(ctx context.Context, r *digest.ResourceName, fc interfaces.FileCache) (*capb.TreeCache, int, error) {
+func getTreeCacheFromFilecache(ctx context.Context, r *digest.CASResourceName, fc interfaces.FileCache) (*capb.TreeCache, int, error) {
 	file, err := MakeFileNode(r)
 	if err != nil {
 		return nil, 0, err
@@ -939,7 +926,7 @@ func getTreeCacheFromFilecache(ctx context.Context, r *digest.ResourceName, fc i
 	return out, len(buf), nil
 }
 
-func writeTreeCacheToFilecache(ctx context.Context, r *digest.ResourceName, data *capb.TreeCache, fc interfaces.FileCache) (int, error) {
+func writeTreeCacheToFilecache(ctx context.Context, r *digest.CASResourceName, data *capb.TreeCache, fc interfaces.FileCache) (int, error) {
 	file, err := MakeFileNode(r)
 	if err != nil {
 		return 0, err
@@ -952,7 +939,7 @@ func writeTreeCacheToFilecache(ctx context.Context, r *digest.ResourceName, data
 	return fc.Write(ctx, file, contents)
 }
 
-func getSubtree(ctx context.Context, subtree *digest.ResourceName, fc interfaces.FileCache, bs bspb.ByteStreamClient) ([]*capb.DirectoryWithDigest, error) {
+func getSubtree(ctx context.Context, subtree *digest.CASResourceName, fc interfaces.FileCache, bs bspb.ByteStreamClient) ([]*capb.DirectoryWithDigest, error) {
 	// First, check the filecache.
 	treeCache, bytesRead, err := getTreeCacheFromFilecache(ctx, subtree, fc)
 	if err == nil {
@@ -992,7 +979,11 @@ func getSubtree(ctx context.Context, subtree *digest.ResourceName, fc interfaces
 		var stMutex sync.Mutex
 		for _, child := range treeCache.GetTreeCacheChildren() {
 			subtreeEG.Go(func() error {
-				childDirs, err := getSubtree(subtreeCtx, digest.ResourceNameFromProto(child), fc, bs)
+				r, err := digest.ResourceNameFromProto(child).ToCAS()
+				if err != nil {
+					return err
+				}
+				childDirs, err := getSubtree(subtreeCtx, r, fc, bs)
 				if err != nil {
 					return err
 				}
@@ -1011,7 +1002,7 @@ func getSubtree(ctx context.Context, subtree *digest.ResourceName, fc interfaces
 	return treeCache.Children, nil
 }
 
-func getAndCacheTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.ContentAddressableStorageClient, r *digest.ResourceName, fc interfaces.FileCache, bs bspb.ByteStreamClient) ([]*repb.Directory, error) {
+func getAndCacheTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.ContentAddressableStorageClient, r *digest.CASResourceName, fc interfaces.FileCache, bs bspb.ByteStreamClient) ([]*repb.Directory, error) {
 	dirs, subtrees, err := streamTree(ctx, casClient, r, true && fc != nil)
 	if err != nil {
 		return nil, err
@@ -1055,7 +1046,7 @@ func getAndCacheTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.
 	return dirs, nil
 }
 
-func GetAndMaybeCacheTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.ContentAddressableStorageClient, r *digest.ResourceName, fc interfaces.FileCache, bs bspb.ByteStreamClient) (*repb.Tree, error) {
+func GetAndMaybeCacheTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.ContentAddressableStorageClient, r *digest.CASResourceName, fc interfaces.FileCache, bs bspb.ByteStreamClient) (*repb.Tree, error) {
 	var dirs []*repb.Directory
 	if fc != nil && bs != nil && *requestCachedSubtreeDigests {
 		out, err := getAndCacheTreeFromRootDirectoryDigest(ctx, casClient, r, fc, bs)
@@ -1084,6 +1075,6 @@ func GetAndMaybeCacheTreeFromRootDirectoryDigest(ctx context.Context, casClient 
 	}, nil
 }
 
-func GetTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.ContentAddressableStorageClient, r *digest.ResourceName) (*repb.Tree, error) {
+func GetTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.ContentAddressableStorageClient, r *digest.CASResourceName) (*repb.Tree, error) {
 	return GetAndMaybeCacheTreeFromRootDirectoryDigest(ctx, casClient, r, nil, nil)
 }

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -979,7 +979,7 @@ func getSubtree(ctx context.Context, subtree *digest.CASResourceName, fc interfa
 		var stMutex sync.Mutex
 		for _, child := range treeCache.GetTreeCacheChildren() {
 			subtreeEG.Go(func() error {
-				r, err := digest.ResourceNameFromProto(child).ToCAS()
+				r, err := digest.ResourceNameFromProto(child).CheckCAS()
 				if err != nil {
 					return err
 				}

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -54,7 +54,7 @@ func setUpFakeData(getTreeResponse *repb.GetTreeResponse, fileCacheContents []*r
 	}
 	for _, f := range fileCacheContents {
 		fileData, _ := f.data.MarshalVT()
-		rn, err := digest.ResourceNameFromProto(f.rn).ToCAS()
+		rn, err := digest.ResourceNameFromProto(f.rn).CheckCAS()
 		if err != nil {
 			panic(fmt.Sprintf("failed to convert resource name to CAS: %s", err))
 		}
@@ -66,7 +66,7 @@ func setUpFakeData(getTreeResponse *repb.GetTreeResponse, fileCacheContents []*r
 	bsDataMap := make(map[string][]byte)
 	for _, f := range remoteContents {
 		bsData, _ := f.data.MarshalVT()
-		rn, err := digest.ResourceNameFromProto(f.rn).ToCAS()
+		rn, err := digest.ResourceNameFromProto(f.rn).CheckCAS()
 		if err != nil {
 			panic(fmt.Sprintf("failed to convert resource name to CAS: %s", err))
 		}
@@ -78,7 +78,7 @@ func setUpFakeData(getTreeResponse *repb.GetTreeResponse, fileCacheContents []*r
 		data: bsDataMap,
 	}
 
-	rn, err := digest.ResourceNameFromProto(&fakeTreeRoot).ToCAS()
+	rn, err := digest.ResourceNameFromProto(&fakeTreeRoot).CheckCAS()
 	if err != nil {
 		panic(fmt.Sprintf("failed to convert resource name to CAS: %s", err))
 	}

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -54,7 +54,7 @@ func setUpFakeData(getTreeResponse *repb.GetTreeResponse, fileCacheContents []*r
 	}
 	for _, f := range fileCacheContents {
 		fileData, _ := f.data.MarshalVT()
-		rn, err := digest.ResourceNameFromProto(f.rn).CheckCAS()
+		rn, err := digest.CASResourceNameFromProto(f.rn)
 		if err != nil {
 			panic(fmt.Sprintf("failed to convert resource name to CAS: %s", err))
 		}
@@ -66,7 +66,7 @@ func setUpFakeData(getTreeResponse *repb.GetTreeResponse, fileCacheContents []*r
 	bsDataMap := make(map[string][]byte)
 	for _, f := range remoteContents {
 		bsData, _ := f.data.MarshalVT()
-		rn, err := digest.ResourceNameFromProto(f.rn).CheckCAS()
+		rn, err := digest.CASResourceNameFromProto(f.rn)
 		if err != nil {
 			panic(fmt.Sprintf("failed to convert resource name to CAS: %s", err))
 		}
@@ -78,7 +78,7 @@ func setUpFakeData(getTreeResponse *repb.GetTreeResponse, fileCacheContents []*r
 		data: bsDataMap,
 	}
 
-	rn, err := digest.ResourceNameFromProto(&fakeTreeRoot).CheckCAS()
+	rn, err := digest.CASResourceNameFromProto(&fakeTreeRoot)
 	if err != nil {
 		panic(fmt.Sprintf("failed to convert resource name to CAS: %s", err))
 	}

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -34,6 +34,7 @@ var (
 		},
 		InstanceName:   testInstance,
 		DigestFunction: repb.DigestFunction_BLAKE3,
+		CacheType:      rspb.CacheType_CAS,
 	}
 )
 

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -747,13 +747,9 @@ func TestGetTreeWithSubtrees(t *testing.T) {
 	assert.Equal(t, 1, len(subtrees))
 
 	subtree := &capb.TreeCache{}
-	err = cachetools.GetBlobAsProto(ctx, bsClient, digest.ResourceNameFromProto(&rspb.ResourceName{
-		Digest:         subtrees[0].GetDigest(),
-		InstanceName:   subtrees[0].GetInstanceName(),
-		Compressor:     subtrees[0].GetCompressor(),
-		DigestFunction: subtrees[0].GetDigestFunction(),
-		CacheType:      rspb.CacheType_CAS,
-	}), subtree)
+	rn := digest.NewCASResourceName(subtrees[0].GetDigest(), instanceName, subtrees[0].GetDigestFunction())
+	rn.SetCompressor(subtrees[0].GetCompressor())
+	err = cachetools.GetBlobAsProto(ctx, bsClient, rn, subtree)
 	assert.NoError(t, err)
 
 	uploadedFiles2 := append(nodeModulesFiles, child3Files...)

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -116,6 +116,7 @@ func ResourceNameFromProto(in *rspb.ResourceName) *ResourceName {
 	}
 }
 
+// Prefer either NewCASResourceName or NewACResourceName.
 func NewResourceName(d *repb.Digest, instanceName string, cacheType rspb.CacheType, digestFunction repb.DigestFunction_Value) *ResourceName {
 	if digestFunction == repb.DigestFunction_UNKNOWN {
 		digestFunction = InferOldStyleDigestFunctionInDesperation(d)
@@ -129,6 +130,28 @@ func NewResourceName(d *repb.Digest, instanceName string, cacheType rspb.CacheTy
 			DigestFunction: digestFunction,
 		},
 	}
+}
+
+func NewCASResourceName(d *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value) *CASResourceName {
+	return &CASResourceName{*NewResourceName(d, instanceName, rspb.CacheType_CAS, digestFunction)}
+}
+
+func NewACResourceName(d *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value) *ACResourceName {
+	return &ACResourceName{*NewResourceName(d, instanceName, rspb.CacheType_AC, digestFunction)}
+}
+
+func (r *ResourceName) ToCAS() (*CASResourceName, error) {
+	if r.rn.GetCacheType() != rspb.CacheType_CAS {
+		return nil, status.FailedPreconditionErrorf("ResourceName is not a CAS resource name: %s", r.rn)
+	}
+	return &CASResourceName{*r}, nil
+}
+
+func (r *ResourceName) ToAC() (*ACResourceName, error) {
+	if r.rn.GetCacheType() != rspb.CacheType_AC {
+		return nil, status.FailedPreconditionErrorf("ResourceName is not an AC resource name: %s", r.rn)
+	}
+	return &ACResourceName{*r}, nil
 }
 
 func (r *ResourceName) ToProto() *rspb.ResourceName {
@@ -183,12 +206,14 @@ func (r *ResourceName) Validate() error {
 	return nil
 }
 
+type CASResourceName struct {
+	ResourceName
+}
+
 // DownloadString returns a string representing the resource name for download
 // purposes.
-func (r *ResourceName) DownloadString() (string, error) {
-	if r.rn.GetCacheType() != rspb.CacheType_CAS {
-		return "", status.FailedPreconditionError("Cannot compute bytestream download string for non-CAS resource name")
-	}
+// TODO: Drop the error return value, which is always nil.
+func (r *CASResourceName) DownloadString() (string, error) {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
@@ -205,40 +230,13 @@ func (r *ResourceName) DownloadString() (string, error) {
 	}
 }
 
-// ActionCacheString returns a string representing the resource name for in
-// the action cache. This is BuildBuddy specific.
-func (r *ResourceName) ActionCacheString() (string, error) {
-	if r.rn.GetCacheType() != rspb.CacheType_AC {
-		return "", status.FailedPreconditionError("Cannot compute bytestream download string for non-CAS resource name")
-	}
-	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
-	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
-	if isOldStyleDigestFunction(r.rn.DigestFunction) {
-		return fmt.Sprintf(
-			"%s/%s/ac/%s/%d",
-			instanceName, blobTypeSegment(r.GetCompressor()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()), nil
-	} else {
-		return fmt.Sprintf(
-			"%s/%s/ac/%s/%s/%d",
-			instanceName, blobTypeSegment(r.GetCompressor()),
-			strings.ToLower(r.rn.DigestFunction.String()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()), nil
-	}
-}
-
 // UploadString returns a string representing the resource name for upload
 // purposes.
-func (r *ResourceName) UploadString() (string, error) {
-	if r.rn.GetCacheType() != rspb.CacheType_CAS {
-		return "", status.FailedPreconditionError("Cannot compute bytestream upload string for non-CAS resource name")
-	}
+// TODO: Drop the error return value, which is always nil.
+func (r *CASResourceName) UploadString() (string, error) {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
-	u, err := guuid.NewRandom()
-	if err != nil {
-		return "", err
-	}
+	u := guuid.New()
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
 		return fmt.Sprintf(
 			"%s/uploads/%s/%s/%s/%d",
@@ -252,6 +250,30 @@ func (r *ResourceName) UploadString() (string, error) {
 			strings.ToLower(r.rn.DigestFunction.String()),
 			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes(),
 		), nil
+	}
+}
+
+type ACResourceName struct {
+	ResourceName
+}
+
+// ActionCacheString returns a string representing the resource name for in
+// the action cache. This is BuildBuddy specific.
+// TODO: Drop the error return value, which is always nil.
+func (r *ACResourceName) ActionCacheString() (string, error) {
+	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
+	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
+	if isOldStyleDigestFunction(r.rn.DigestFunction) {
+		return fmt.Sprintf(
+			"%s/%s/ac/%s/%d",
+			instanceName, blobTypeSegment(r.GetCompressor()),
+			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()), nil
+	} else {
+		return fmt.Sprintf(
+			"%s/%s/ac/%s/%s/%d",
+			instanceName, blobTypeSegment(r.GetCompressor()),
+			strings.ToLower(r.rn.DigestFunction.String()),
+			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()), nil
 	}
 }
 
@@ -474,16 +496,28 @@ func parseResourceName(resourceName string, matcher *regexp.Regexp, cacheType rs
 	return r, nil
 }
 
-func ParseUploadResourceName(resourceName string) (*ResourceName, error) {
-	return parseResourceName(resourceName, uploadRegex, rspb.CacheType_CAS)
+func ParseUploadResourceName(resourceName string) (*CASResourceName, error) {
+	rn, err := parseResourceName(resourceName, uploadRegex, rspb.CacheType_CAS)
+	if err != nil {
+		return nil, err
+	}
+	return rn.ToCAS()
 }
 
-func ParseDownloadResourceName(resourceName string) (*ResourceName, error) {
-	return parseResourceName(resourceName, downloadRegex, rspb.CacheType_CAS)
+func ParseDownloadResourceName(resourceName string) (*CASResourceName, error) {
+	rn, err := parseResourceName(resourceName, downloadRegex, rspb.CacheType_CAS)
+	if err != nil {
+		return nil, err
+	}
+	return rn.ToCAS()
 }
 
-func ParseActionCacheResourceName(resourceName string) (*ResourceName, error) {
-	return parseResourceName(resourceName, actionCacheRegex, rspb.CacheType_AC)
+func ParseActionCacheResourceName(resourceName string) (*ACResourceName, error) {
+	rn, err := parseResourceName(resourceName, actionCacheRegex, rspb.CacheType_AC)
+	if err != nil {
+		return nil, err
+	}
+	return rn.ToAC()
 }
 
 func IsDownloadResourceName(url string) bool {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -140,14 +140,14 @@ func NewACResourceName(d *repb.Digest, instanceName string, digestFunction repb.
 	return &ACResourceName{*NewResourceName(d, instanceName, rspb.CacheType_AC, digestFunction)}
 }
 
-func (r *ResourceName) ToCAS() (*CASResourceName, error) {
+func (r *ResourceName) CheckCAS() (*CASResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_CAS {
 		return nil, status.FailedPreconditionErrorf("ResourceName is not a CAS resource name: %s", r.rn)
 	}
 	return &CASResourceName{*r}, nil
 }
 
-func (r *ResourceName) ToAC() (*ACResourceName, error) {
+func (r *ResourceName) CheckAC() (*ACResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_AC {
 		return nil, status.FailedPreconditionErrorf("ResourceName is not an AC resource name: %s", r.rn)
 	}
@@ -501,7 +501,7 @@ func ParseUploadResourceName(resourceName string) (*CASResourceName, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rn.ToCAS()
+	return rn.CheckCAS()
 }
 
 func ParseDownloadResourceName(resourceName string) (*CASResourceName, error) {
@@ -509,7 +509,7 @@ func ParseDownloadResourceName(resourceName string) (*CASResourceName, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rn.ToCAS()
+	return rn.CheckCAS()
 }
 
 func ParseActionCacheResourceName(resourceName string) (*ACResourceName, error) {
@@ -517,7 +517,7 @@ func ParseActionCacheResourceName(resourceName string) (*ACResourceName, error) 
 	if err != nil {
 		return nil, err
 	}
-	return rn.ToAC()
+	return rn.CheckAC()
 }
 
 func IsDownloadResourceName(url string) bool {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -105,6 +105,7 @@ type ResourceName struct {
 	rn *rspb.ResourceName
 }
 
+// TODO: Introduce typed variants that return *CASResourceName or *ACResourceName.
 func ResourceNameFromProto(in *rspb.ResourceName) *ResourceName {
 	rn := in.CloneVT()
 	// TODO(tylerw): remove once digest function is explicit everywhere.

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -105,7 +105,7 @@ type ResourceName struct {
 	rn *rspb.ResourceName
 }
 
-// TODO: Introduce typed variants that return *CASResourceName or *ACResourceName.
+// Prefer either CASResourceNameFromProto or ACResourceNameFromProto.
 func ResourceNameFromProto(in *rspb.ResourceName) *ResourceName {
 	rn := in.CloneVT()
 	// TODO(tylerw): remove once digest function is explicit everywhere.
@@ -115,6 +115,16 @@ func ResourceNameFromProto(in *rspb.ResourceName) *ResourceName {
 	return &ResourceName{
 		rn: rn,
 	}
+}
+
+func CASResourceNameFromProto(in *rspb.ResourceName) (*CASResourceName, error) {
+	rn := ResourceNameFromProto(in)
+	return rn.CheckCAS()
+}
+
+func ACResourceNameFromProto(in *rspb.ResourceName) (*ACResourceName, error) {
+	rn := ResourceNameFromProto(in)
+	return rn.CheckAC()
 }
 
 // Prefer either NewCASResourceName or NewACResourceName.

--- a/server/testutil/byte_stream/byte_stream.go
+++ b/server/testutil/byte_stream/byte_stream.go
@@ -25,7 +25,7 @@ func WithBazelVersion(t *testing.T, ctx context.Context, version string) context
 	return ctx
 }
 
-func ReadBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, out io.Writer, offset int64) error {
+func ReadBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASResourceName, out io.Writer, offset int64) error {
 	downloadString, err := r.DownloadString()
 	if err != nil {
 		return err

--- a/server/util/rexec/rexec.go
+++ b/server/util/rexec/rexec.go
@@ -116,7 +116,7 @@ func Prepare(ctx context.Context, env environment.Env, instanceName string, dige
 	if err != nil {
 		return nil, err
 	}
-	actionResourceName := digest.NewResourceName(actionDigest, instanceName, rspb.CacheType_CAS, digestFunction).ToProto()
+	actionResourceName := digest.NewCASResourceName(actionDigest, instanceName, digestFunction).ToProto()
 	return actionResourceName, nil
 }
 
@@ -156,13 +156,13 @@ func GetResult(ctx context.Context, env environment.Env, instanceName string, di
 	eg, egctx := errgroup.WithContext(ctx)
 	if res.GetStdoutDigest() != nil {
 		eg.Go(func() error {
-			rn := digest.NewResourceName(res.GetStdoutDigest(), instanceName, rspb.CacheType_CAS, digestFunction)
+			rn := digest.NewCASResourceName(res.GetStdoutDigest(), instanceName, digestFunction)
 			return cachetools.GetBlob(egctx, env.GetByteStreamClient(), rn, &stdout)
 		})
 	}
 	if res.GetStderrDigest() != nil {
 		eg.Go(func() error {
-			rn := digest.NewResourceName(res.GetStderrDigest(), instanceName, rspb.CacheType_CAS, digestFunction)
+			rn := digest.NewCASResourceName(res.GetStderrDigest(), instanceName, digestFunction)
 			return cachetools.GetBlob(egctx, env.GetByteStreamClient(), rn, &stderr)
 		})
 	}

--- a/tools/cacheload/BUILD
+++ b/tools/cacheload/BUILD
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
         "//server/metrics",
         "//server/real_environment",
         "//server/remote_cache/cachetools",

--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -129,7 +128,7 @@ func incrementPromErrorMetric(err error) {
 
 func writeBlob(ctx context.Context, client bspb.ByteStreamClient) (*repb.Digest, error) {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName := digest.NewResourceName(d, *instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+	resourceName := digest.NewCASResourceName(d, *instanceName, repb.DigestFunction_SHA256)
 	if *writeCompressed {
 		resourceName.SetCompressor(repb.Compressor_ZSTD)
 	}
@@ -146,7 +145,7 @@ func writeBlob(ctx context.Context, client bspb.ByteStreamClient) (*repb.Digest,
 }
 
 func readBlob(ctx context.Context, client bspb.ByteStreamClient, casClient repb.ContentAddressableStorageClient, d *repb.Digest) error {
-	resourceName := digest.NewResourceName(d, *instanceName, rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+	resourceName := digest.NewCASResourceName(d, *instanceName, repb.DigestFunction_SHA256)
 	if *readCompressed {
 		resourceName.SetCompressor(repb.Compressor_ZSTD)
 	}
@@ -167,7 +166,7 @@ func readBlob(ctx context.Context, client bspb.ByteStreamClient, casClient repb.
 	})
 }
 
-func batchReadSingleBlob(ctx context.Context, casClient repb.ContentAddressableStorageClient, rn *digest.ResourceName) ([]byte, error) {
+func batchReadSingleBlob(ctx context.Context, casClient repb.ContentAddressableStorageClient, rn *digest.CASResourceName) ([]byte, error) {
 	responses, err := cachetools.BatchReadBlobs(ctx, casClient, &repb.BatchReadBlobsRequest{
 		InstanceName:          rn.GetInstanceName(),
 		AcceptableCompressors: []repb.Compressor_Value{rn.GetCompressor()},

--- a/tools/cas/cas.go
+++ b/tools/cas/cas.go
@@ -130,7 +130,7 @@ func main() {
 	// Handle raw string types
 	if *blobType == "stdout" || *blobType == "stderr" || *blobType == "file" {
 		var out bytes.Buffer
-		r, err := ind.ToCAS()
+		r, err := ind.CheckCAS()
 		if err != nil {
 			log.Fatalf("Failed to convert resource name to CAS: %s", err)
 		}
@@ -143,7 +143,7 @@ func main() {
 
 	// Handle ActionResults (these are stored in the action cache)
 	if *blobType == "ActionResult" {
-		r, err := ind.ToAC()
+		r, err := ind.CheckAC()
 		if err != nil {
 			log.Fatalf("Failed to convert resource name to AC: %s", err)
 		}
@@ -157,7 +157,7 @@ func main() {
 
 	// Handle Trees (these are stored in the CAS)
 	if *blobType == "Tree" {
-		r, err := ind.ToCAS()
+		r, err := ind.CheckCAS()
 		if err != nil {
 			log.Fatalf("Failed to convert resource name to CAS: %s", err)
 		}
@@ -179,7 +179,7 @@ func main() {
 	default:
 		log.Fatalf(`Invalid --type: %q (allowed values: Action, ActionResult, Command, Tree, file, stderr, stdout)`, *blobType)
 	}
-	r, err := ind.ToCAS()
+	r, err := ind.CheckCAS()
 	if err != nil {
 		log.Fatalf("Failed to convert resource name to CAS: %s", err)
 	}

--- a/tools/cas/cas.go
+++ b/tools/cas/cas.go
@@ -70,12 +70,15 @@ func main() {
 		digestString = "/blobs/" + digestString
 	}
 
-	ind, err := digest.ParseDownloadResourceName(digestString)
-	if err != nil {
-		log.Fatal(status.Message(err))
-	}
+	var ind *digest.ResourceName
 	if *blobType == "ActionResult" {
 		ind = digest.NewResourceName(ind.GetDigest(), ind.GetInstanceName(), rspb.CacheType_AC, ind.GetDigestFunction())
+	} else {
+		indDownload, err := digest.ParseDownloadResourceName(digestString)
+		if err != nil {
+			log.Fatal(status.Message(err))
+		}
+		ind = &indDownload.ResourceName
 	}
 
 	// For backwards compatibility with the existing behavior of this code:
@@ -127,7 +130,11 @@ func main() {
 	// Handle raw string types
 	if *blobType == "stdout" || *blobType == "stderr" || *blobType == "file" {
 		var out bytes.Buffer
-		if err := cachetools.GetBlob(ctx, bsClient, ind, &out); err != nil {
+		r, err := ind.ToCAS()
+		if err != nil {
+			log.Fatalf("Failed to convert resource name to CAS: %s", err)
+		}
+		if err := cachetools.GetBlob(ctx, bsClient, r, &out); err != nil {
 			log.Fatal(err.Error())
 		}
 		writeToStdout(out.Bytes())
@@ -136,7 +143,11 @@ func main() {
 
 	// Handle ActionResults (these are stored in the action cache)
 	if *blobType == "ActionResult" {
-		ar, err := cachetools.GetActionResult(ctx, acClient, ind)
+		r, err := ind.ToAC()
+		if err != nil {
+			log.Fatalf("Failed to convert resource name to AC: %s", err)
+		}
+		ar, err := cachetools.GetActionResult(ctx, acClient, r)
 		if err != nil {
 			log.Fatal(err.Error())
 		}
@@ -146,7 +157,11 @@ func main() {
 
 	// Handle Trees (these are stored in the CAS)
 	if *blobType == "Tree" {
-		inputTree, err := cachetools.GetTreeFromRootDirectoryDigest(ctx, casClient, ind)
+		r, err := ind.ToCAS()
+		if err != nil {
+			log.Fatalf("Failed to convert resource name to CAS: %s", err)
+		}
+		inputTree, err := cachetools.GetTreeFromRootDirectoryDigest(ctx, casClient, r)
 		if err != nil {
 			log.Fatal(err.Error())
 		}
@@ -164,7 +179,11 @@ func main() {
 	default:
 		log.Fatalf(`Invalid --type: %q (allowed values: Action, ActionResult, Command, Tree, file, stderr, stdout)`, *blobType)
 	}
-	if err := cachetools.GetBlobAsProto(ctx, bsClient, ind, msg); err != nil {
+	r, err := ind.ToCAS()
+	if err != nil {
+		log.Fatalf("Failed to convert resource name to CAS: %s", err)
+	}
+	if err := cachetools.GetBlobAsProto(ctx, bsClient, r, msg); err != nil {
 		log.Fatal(err.Error())
 	}
 	printMessage(msg)


### PR DESCRIPTION
This makes method signatures accepting resource names more descriptive and avoids runtime failures in the various `*String()` methods. Previously, these errors made it difficult to distinguish between violations of invariants (programming errors) and legitimately unexpected cache types (user errors).

Since this PR is already large enough, removing the `error` return values from these methods is left to a follow-up PR. It is currently always `nil`. Further cleanups are also possible now that most callers have migrated to typed signatures.