### PR TITLE
Remove `error` return value of typed `ResourceName` `*String` functions

### DIFF
--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -158,12 +158,7 @@ func execute(cmdArgs []string) error {
 	log.Debugf("Uploaded inputs in %s", time.Since(stageStart))
 	acrn, err := digest.CASResourceNameFromProto(arn)
 	if err == nil {
-		actionStr, err := acrn.DownloadString()
-		if err != nil {
-			log.Debugf("Failed to compute action resource name: %s", err)
-		} else {
-			log.Debugf("Action resource name: %s", actionStr)
-		}
+		log.Debugf("Action resource name: %s", acrn.DownloadString())
 	} else {
 		log.Debugf("Failed to compute action resource name: %s", err)
 	}

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -227,8 +227,7 @@ func openLog(pathOrId string) (io.ReadCloser, error) {
 		defer conn.Close()
 		err := cachetools.GetBlob(ctx, bsClient, resource, out)
 		if err != nil {
-			rs, _ := resource.DownloadString()
-			out.CloseWithError(fmt.Errorf("failed to download %s for invocation %s: %v", rs, invocationId, err))
+			out.CloseWithError(fmt.Errorf("failed to download %s for invocation %s: %v", resource.DownloadString(), invocationId, err))
 		} else {
 			out.Close()
 		}

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -115,11 +115,7 @@ func uploadFile(args []string) error {
 		return err
 	}
 
-	ds, err := ind.DownloadString()
-	if err != nil {
-		return err
-	}
-	log.Print(ds)
+	log.Print(ind.DownloadString())
 	return nil
 }
 

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -494,9 +494,7 @@ func TestEnqueueByResourceName_ActionCache(t *testing.T) {
 }
 
 func casResourceName(t *testing.T, d *repb.Digest, instanceName string) string {
-	rn, err := digest.NewCASResourceName(d, instanceName, repb.DigestFunction_SHA256).DownloadString()
-	require.NoError(t, err)
-	return rn
+	return digest.NewCASResourceName(d, instanceName, repb.DigestFunction_SHA256).DownloadString()
 }
 
 func TestEnqueueByResourceName_CAS(t *testing.T) {

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -487,8 +487,7 @@ func TestEnqueueByResourceName_ActionCache(t *testing.T) {
 	_, updater, cas, ticker := setup(t)
 	ctx := ctxWithClientIdentity()
 
-	rn, err := digest.NewACResourceName(aDigest, "instance-1", repb.DigestFunction_SHA256).ActionCacheString()
-	require.NoError(t, err)
+	rn := digest.NewACResourceName(aDigest, "instance-1", repb.DigestFunction_SHA256).ActionCacheString()
 	updater.EnqueueByResourceName(ctx, rn)
 	expectNoMoreUpdates(t, ticker, cas)
 }

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -347,7 +347,7 @@ func lookasideKey(r *rspb.ResourceName) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return rn.ActionCacheString()
+		return rn.ActionCacheString(), nil
 	} else {
 		rn, err := digest.CASResourceNameFromProto(r)
 		if err != nil {

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -353,7 +353,7 @@ func lookasideKey(r *rspb.ResourceName) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return rn.DownloadString()
+		return rn.DownloadString(), nil
 	}
 }
 

--- a/enterprise/server/bes_artifacts/bes_artifacts.go
+++ b/enterprise/server/bes_artifacts/bes_artifacts.go
@@ -114,11 +114,7 @@ func (u *Uploader) uploadDirectory(namedSetID, root string) error {
 	for _, uploadChan := range uploadChans {
 		r := <-uploadChan
 		rn := digest.NewCASResourceName(r.Digest, u.instanceName, repb.DigestFunction_SHA256)
-		rnString, err := rn.DownloadString()
-		if err != nil {
-			return err
-		}
-		uri := fmt.Sprintf("%s/%s", u.bytestreamURIPrefix, rnString)
+		uri := fmt.Sprintf("%s/%s", u.bytestreamURIPrefix, rn.DownloadString())
 		f := &bespb.File{
 			Name:   r.Name,
 			File:   &bespb.File_Uri{Uri: uri},

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -175,11 +175,7 @@ func (s *realLocalWriter) send(data []byte) error {
 		if err != nil {
 			return err
 		}
-		urn, err := rn.UploadString()
-		if err != nil {
-			return err
-		}
-		req.ResourceName = urn
+		req.ResourceName = rn.UploadString()
 		s.initialized = true
 	}
 	s.offset += int64(len(data))

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -175,7 +175,7 @@ func (s *realLocalWriter) send(data []byte) error {
 		if err != nil {
 			return err
 		}
-		req.ResourceName = rn.UploadString()
+		req.ResourceName = rn.NewUploadString()
 		s.initialized = true
 	}
 	s.offset += int64(len(data))

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -149,10 +149,7 @@ func waitContains(ctx context.Context, env *testenv.TestEnv, rn *rspb.ResourceNa
 	if err != nil {
 		return err
 	}
-	s, err := casrn.DownloadString()
-	if err != nil {
-		return err
-	}
+	s := casrn.DownloadString()
 	return status.NotFoundErrorf("Timed out waiting for cache to contain %s", s)
 }
 

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1397,10 +1397,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 		if err != nil {
 			return nil, nil, err
 		}
-		downloadString, err := digest.NewCASResourceName(d.ToDigest(), *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
-		if err != nil {
-			return nil, nil, err
-		}
+		downloadString := digest.NewCASResourceName(d.ToDigest(), *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
 
 		runfiles = append(runfiles, &bespb.File{
 			Name: relPath,
@@ -1456,10 +1453,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 			if err != nil {
 				return err
 			}
-			downloadString, err := digest.NewCASResourceName(td, *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
-			if err != nil {
-				return err
-			}
+			downloadString := digest.NewCASResourceName(td, *remoteInstanceName, repb.DigestFunction_SHA256).DownloadString()
 			mu.Lock()
 			runfileDirs = append(runfileDirs, &bespb.Tree{
 				Name: relPath,

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -141,7 +141,7 @@ func newRandomDigestBuf(sizeBytes int64) (*repb.Digest, []byte) {
 
 func writeDataFunc(cd *runner.CallData) ([]*dynamic.Message, error) {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName := digest.NewCASResourceName(d, *instanceName, repb.DigestFunction_SHA256).UploadString()
+	resourceName := digest.NewCASResourceName(d, *instanceName, repb.DigestFunction_SHA256).NewUploadString()
 	r := bytes.NewReader(buf)
 
 	var messages []*dynamic.Message

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -141,10 +141,7 @@ func newRandomDigestBuf(sizeBytes int64) (*repb.Digest, []byte) {
 
 func writeDataFunc(cd *runner.CallData) ([]*dynamic.Message, error) {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName, err := digest.NewCASResourceName(d, *instanceName, repb.DigestFunction_SHA256).UploadString()
-	if err != nil {
-		log.Fatalf("Error computing upload resource name: %s", err)
-	}
+	resourceName := digest.NewCASResourceName(d, *instanceName, repb.DigestFunction_SHA256).UploadString()
 	r := bytes.NewReader(buf)
 
 	var messages []*dynamic.Message

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -180,10 +180,7 @@ func writeDataFunc(cd *runner.CallData) ([]*dynamic.Message, error) {
 func readDataFunc(cd *runner.CallData) ([]*dynamic.Message, error) {
 	randomDigest := preWrittenDigests[rand.Intn(len(preWrittenDigests))]
 
-	downloadString, err := digest.NewCASResourceName(randomDigest, *instanceName, repb.DigestFunction_SHA256).DownloadString()
-	if err != nil {
-		log.Fatalf("Error computing download string: %s", err)
-	}
+	downloadString := digest.NewCASResourceName(randomDigest, *instanceName, repb.DigestFunction_SHA256).DownloadString()
 
 	rr := &bspb.ReadRequest{
 		ResourceName: downloadString,

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -97,11 +97,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 			return nil, status.WrapError(err, "upload patch")
 		}
 		rn := digest.NewCASResourceName(patchDigest, req.GetInstanceName(), repb.DigestFunction_BLAKE3)
-		uri, err := rn.DownloadString()
-		if err != nil {
-			return nil, status.WrapError(err, "patch download string")
-		}
-		patchURIs = append(patchURIs, uri)
+		patchURIs = append(patchURIs, rn.DownloadString())
 	}
 
 	repoURL := req.GetGitRepo().GetRepoUrl()

--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -63,10 +63,7 @@ func redisKeyForPendingExecutionID(ctx context.Context, adResource *digest.CASRe
 	if err != nil {
 		return "", err
 	}
-	downloadString, err := adResource.DownloadString()
-	if err != nil {
-		return "", err
-	}
+	downloadString := adResource.DownloadString()
 	return fmt.Sprintf("pendingExecution/%d/%s%s", keyVersion, userPrefix, downloadString), nil
 }
 

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -551,10 +551,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	defer span.End()
 
 	r := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
-	executionID, err := r.UploadString()
-	if err != nil {
-		return "", nil, err
-	}
+	executionID := r.UploadString()
 	tracing.AddStringAttributeToCurrentSpan(ctx, "task_id", executionID)
 	ctx = log.EnrichContext(ctx, log.ExecutionIDKey, executionID)
 
@@ -731,10 +728,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	if !req.GetSkipCacheLookup() {
 		if actionResult, err := s.getActionResultFromCache(ctx, adInstanceDigest); err == nil {
 			r := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
-			executionID, err := r.UploadString()
-			if err != nil {
-				return err
-			}
+			executionID := r.UploadString()
 			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_result", "cached")
 			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_id", executionID)
 			stateChangeFn := operation.GetStateChangeFunc(stream, executionID, &adInstanceDigest.ResourceName)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -723,10 +723,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 		return err
 	}
 
-	downloadString, err := adInstanceDigest.DownloadString()
-	if err != nil {
-		return err
-	}
+	downloadString := adInstanceDigest.DownloadString()
 	invocationID := bazel_request.GetInvocationID(stream.Context())
 
 	hedge := false

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -551,7 +551,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	defer span.End()
 
 	r := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
-	executionID := r.UploadString()
+	executionID := r.NewUploadString()
 	tracing.AddStringAttributeToCurrentSpan(ctx, "task_id", executionID)
 	ctx = log.EnrichContext(ctx, log.ExecutionIDKey, executionID)
 
@@ -727,8 +727,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	executionID := ""
 	if !req.GetSkipCacheLookup() {
 		if actionResult, err := s.getActionResultFromCache(ctx, adInstanceDigest); err == nil {
-			r := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
-			executionID := r.UploadString()
+			executionID := adInstanceDigest.NewUploadString()
 			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_result", "cached")
 			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_id", executionID)
 			stateChangeFn := operation.GetStateChangeFunc(stream, executionID, &adInstanceDigest.ResourceName)

--- a/enterprise/tools/replay_action/replay_action.go
+++ b/enterprise/tools/replay_action/replay_action.go
@@ -353,7 +353,7 @@ func (r *Replayer) replay(ctx, srcCtx, targetCtx context.Context, sourceExecutio
 }
 
 func (r *Replayer) upload(ctx, srcCtx, targetCtx context.Context, action *repb.Action, sourceExecutionRN *digest.CASResourceName) error {
-	s, _ := sourceExecutionRN.DownloadString()
+	s := sourceExecutionRN.DownloadString()
 	log.Infof("Uploading Action, Command, and inputs for execution %q", s)
 	eg, targetCtx := errgroup.WithContext(targetCtx)
 	eg.Go(func() error {

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -69,12 +69,8 @@ func getBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASR
 		return nil
 	}
 
-	downloadString, err := r.DownloadString()
-	if err != nil {
-		return err
-	}
 	req := &bspb.ReadRequest{
-		ResourceName: downloadString,
+		ResourceName: r.DownloadString(),
 	}
 	stream, err := bsClient.Read(ctx, req)
 	if err != nil {

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -270,6 +270,7 @@ func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 	buf := make([]byte, uploadBufSizeBytes)
 	bytesUploaded := int64(0)
 	sender := rpcutil.NewSender[*bspb.WriteRequest](ctx, stream)
+	resourceName := r.NewUploadString()
 	for {
 		n, err := rc.Read(buf)
 		if err != nil && err != io.EOF {
@@ -279,7 +280,7 @@ func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 
 		req := &bspb.WriteRequest{
 			Data:         buf[:n],
-			ResourceName: r.UploadString(),
+			ResourceName: resourceName,
 			WriteOffset:  bytesUploaded,
 			FinishWrite:  readDone,
 		}

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -250,10 +250,6 @@ func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 	if r.IsEmpty() {
 		return r.GetDigest(), 0, nil
 	}
-	resourceName, err := r.UploadString()
-	if err != nil {
-		return nil, 0, err
-	}
 	stream, err := bsClient.Write(ctx)
 	if err != nil {
 		return nil, 0, err
@@ -283,7 +279,7 @@ func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 
 		req := &bspb.WriteRequest{
 			Data:         buf[:n],
-			ResourceName: resourceName,
+			ResourceName: r.UploadString(),
 			WriteOffset:  bytesUploaded,
 			FinishWrite:  readDone,
 		}

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -70,7 +70,7 @@ func setUpFakeData(getTreeResponse *repb.GetTreeResponse, fileCacheContents []*r
 		if err != nil {
 			panic(fmt.Sprintf("failed to convert resource name to CAS: %s", err))
 		}
-		dlString, _ := rn.DownloadString()
+		dlString := rn.DownloadString()
 		bsDataMap[dlString] = bsData
 	}
 	bs := &fakeBytestreamClient{

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -240,9 +240,9 @@ func (r *CASResourceName) DownloadString() string {
 	}
 }
 
-// UploadString returns a string representing the resource name for upload
-// purposes.
-func (r *CASResourceName) UploadString() string {
+// NewUploadString returns a new string representing the resource name for
+// upload purposes each time it is called.
+func (r *CASResourceName) NewUploadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	u := guuid.New()

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -224,20 +224,20 @@ type CASResourceName struct {
 // DownloadString returns a string representing the resource name for download
 // purposes.
 // TODO: Drop the error return value, which is always nil.
-func (r *CASResourceName) DownloadString() (string, error) {
+func (r *CASResourceName) DownloadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
 		return fmt.Sprintf(
 			"%s/%s/%s/%d",
 			instanceName, blobTypeSegment(r.GetCompressor()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()), nil
+			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
 	} else {
 		return fmt.Sprintf(
 			"%s/%s/%s/%s/%d",
 			instanceName, blobTypeSegment(r.GetCompressor()),
 			strings.ToLower(r.rn.DigestFunction.String()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()), nil
+			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
 	}
 }
 

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -223,7 +223,6 @@ type CASResourceName struct {
 
 // DownloadString returns a string representing the resource name for download
 // purposes.
-// TODO: Drop the error return value, which is always nil.
 func (r *CASResourceName) DownloadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
@@ -243,7 +242,6 @@ func (r *CASResourceName) DownloadString() string {
 
 // UploadString returns a string representing the resource name for upload
 // purposes.
-// TODO: Drop the error return value, which is always nil.
 func (r *CASResourceName) UploadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
@@ -270,21 +268,20 @@ type ACResourceName struct {
 
 // ActionCacheString returns a string representing the resource name for in
 // the action cache. This is BuildBuddy specific.
-// TODO: Drop the error return value, which is always nil.
-func (r *ACResourceName) ActionCacheString() (string, error) {
+func (r *ACResourceName) ActionCacheString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
 		return fmt.Sprintf(
 			"%s/%s/ac/%s/%d",
 			instanceName, blobTypeSegment(r.GetCompressor()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()), nil
+			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
 	} else {
 		return fmt.Sprintf(
 			"%s/%s/ac/%s/%s/%d",
 			instanceName, blobTypeSegment(r.GetCompressor()),
 			strings.ToLower(r.rn.DigestFunction.String()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes()), nil
+			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
 	}
 }
 

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -244,7 +244,7 @@ func (r *CASResourceName) DownloadString() string {
 // UploadString returns a string representing the resource name for upload
 // purposes.
 // TODO: Drop the error return value, which is always nil.
-func (r *CASResourceName) UploadString() (string, error) {
+func (r *CASResourceName) UploadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	u := guuid.New()
@@ -253,14 +253,14 @@ func (r *CASResourceName) UploadString() (string, error) {
 			"%s/uploads/%s/%s/%s/%d",
 			instanceName, u.String(), blobTypeSegment(r.GetCompressor()),
 			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes(),
-		), nil
+		)
 	} else {
 		return fmt.Sprintf(
 			"%s/uploads/%s/%s/%s/%s/%d",
 			instanceName, u.String(), blobTypeSegment(r.GetCompressor()),
 			strings.ToLower(r.rn.DigestFunction.String()),
 			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes(),
-		), nil
+		)
 	}
 }
 

--- a/server/testutil/byte_stream/byte_stream.go
+++ b/server/testutil/byte_stream/byte_stream.go
@@ -26,12 +26,8 @@ func WithBazelVersion(t *testing.T, ctx context.Context, version string) context
 }
 
 func ReadBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASResourceName, out io.Writer, offset int64) error {
-	downloadString, err := r.DownloadString()
-	if err != nil {
-		return err
-	}
 	req := &bspb.ReadRequest{
-		ResourceName: downloadString,
+		ResourceName: r.DownloadString(),
 		ReadOffset:   offset,
 		ReadLimit:    r.GetDigest().GetSizeBytes(),
 	}


### PR DESCRIPTION
These functions always return `nil` errors since https://github.com/buildbuddy-io/buildbuddy/pull/8761.