### PR TITLE
Fix memory leak in "exec" redis key

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -221,6 +221,13 @@ func (s *ExecutionServer) insertExecution(ctx context.Context, executionID, invo
 }
 
 func (s *ExecutionServer) insertInvocationLink(ctx context.Context, executionID, invocationID string, linkType sipb.StoredInvocationLink_Type) error {
+	// Don't insert invocation links for empty invocation IDs, which can happen
+	// when performing an execution using build tools that don't send
+	// an invocation ID in RequestMetadata.
+	if invocationID == "" {
+		return nil
+	}
+
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 


### PR DESCRIPTION
If the invocation ID is missing from the execution request metadata, we'll keep appending executions to the "exec" key and refreshing the expiration on that key.

Context: https://buildbuddy-corp.slack.com/archives/C06N9AHA4JX/p1742936173184879?thread_ts=1742926682.004709&cid=C06N9AHA4JX