### PR TITLE
Consolidate driver.priorityQueue and priorityQueue.innerPQ

### DIFF
--- a/enterprise/server/util/cpuset/cpuset.go
+++ b/enterprise/server/util/cpuset/cpuset.go
@@ -211,7 +211,7 @@ func (l *CPULeaser) Acquire(milliCPU int64, taskID string, opts ...any) (int, []
 		numTasks := l.load[cpuInfo.processor]
 		// we want the least loaded cpus first, so give the
 		// cpus with more tasks a more negative score.
-		pq.Push(cpuInfo, -1*numTasks)
+		pq.Push(cpuInfo, float64(-1*numTasks))
 	}
 
 	// Get the set of CPUs, in order of load (incr).

--- a/server/util/priority_queue/priority_queue.go
+++ b/server/util/priority_queue/priority_queue.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// A Item is the element managed by a priority queue.
+// Item is an element managed by a priority queue.
 type Item[V any] struct {
 	value      V
 	index      int // The index of the item in the heap
@@ -64,11 +64,17 @@ func (pq *PriorityQueue[V]) Update(item *Item[V], priority float64) {
 func (pq *PriorityQueue[V]) RemoveItemWithMinPriority() *Item[V] {
 	old := *pq
 	n := len(old)
-	item := old[n-1]
-	if item != nil && item.index >= 0 {
-		heap.Remove(pq, item.index)
+
+	// The min item can only be at the leaf nodes; so we only need to scan the
+	// right half of the array.
+	minIndex := n / 2
+
+	for i := n/2 + 1; i < n; i++ {
+		if pq.Less(minIndex, i) {
+			minIndex = i
+		}
 	}
-	return item
+	return heap.Remove(pq, minIndex).(*Item[V])
 }
 
 // ThreadSafePriorityQueue implements a thread safe priority queue for type V.

--- a/server/util/priority_queue/priority_queue.go
+++ b/server/util/priority_queue/priority_queue.go
@@ -7,83 +7,112 @@ import (
 	"time"
 )
 
-// A pqItem is the element managed by a priority queue.
-type pqItem[V any] struct {
+// A Item is the element managed by a priority queue.
+type Item[V any] struct {
 	value      V
-	priority   int
+	index      int // The index of the item in the heap
+	priority   float64
 	insertTime time.Time
 }
 
-// innerPQ implements heap.Interface and holds pqItems.
-type innerPQ[V any] []*pqItem[V]
+func (i *Item[V]) Value() V {
+	return i.value
+}
+func NewItem[V any](v V, priority float64) *Item[V] {
+	return &Item[V]{
+		value:      v,
+		insertTime: time.Now(),
+		priority:   priority,
+	}
+}
 
-func (pq innerPQ[V]) Len() int { return len(pq) }
-func (pq innerPQ[V]) Less(i, j int) bool {
+// PriorityQueue implements heap.Interface and holds items.
+type PriorityQueue[V any] []*Item[V]
+
+func (pq PriorityQueue[V]) Len() int { return len(pq) }
+func (pq PriorityQueue[V]) Less(i, j int) bool {
 	return pq[i].priority > pq[j].priority ||
 		(pq[i].priority == pq[j].priority && pq[i].insertTime.Before(pq[j].insertTime))
 }
-func (pq innerPQ[V]) Swap(i, j int) {
+func (pq PriorityQueue[V]) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
 }
-func (pq *innerPQ[V]) Push(x any) {
-	item := x.(*pqItem[V])
+func (pq *PriorityQueue[V]) Push(x any) {
+	n := len(*pq)
+	item := x.(*Item[V])
+	item.index = n
 	*pq = append(*pq, item)
 }
-func (pq *innerPQ[V]) Pop() any {
+func (pq *PriorityQueue[V]) Pop() any {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
-	old[n-1] = nil // avoid memory leak
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
 	*pq = old[0 : n-1]
 	return item
 }
+func (pq *PriorityQueue[V]) Update(item *Item[V], priority float64) {
+	item.priority = priority
+	heap.Fix(pq, item.index)
+}
 
-// PriorityQueue implements a thread safe priority queue for type V.
+// RemoveItemWithMinPriority removes the item with the minimum priority and
+// returns the removed item's value.
+func (pq *PriorityQueue[V]) RemoveItemWithMinPriority() *Item[V] {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	if item != nil && item.index >= 0 {
+		heap.Remove(pq, item.index)
+	}
+	return item
+}
+
+// ThreadSafePriorityQueue implements a thread safe priority queue for type V.
 // If the queue is empty, calling Pop() or Peek() will return a zero value of
 // type V, or a specific empty value configured via options.
-type PriorityQueue[V any] struct {
+type ThreadSafePriorityQueue[V any] struct {
 	mu    sync.Mutex // protects inner
-	inner innerPQ[V]
+	inner PriorityQueue[V]
 }
 
-func New[V any]() *PriorityQueue[V] {
-	return &PriorityQueue[V]{}
+func New[V any]() *ThreadSafePriorityQueue[V] {
+	return &ThreadSafePriorityQueue[V]{}
 }
 
-func (pq *PriorityQueue[V]) Clone() *PriorityQueue[V] {
+func (pq *ThreadSafePriorityQueue[V]) Clone() *ThreadSafePriorityQueue[V] {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	return &PriorityQueue[V]{
+	return &ThreadSafePriorityQueue[V]{
 		inner: slices.Clone(pq.inner),
 	}
 }
 
-func (pq *PriorityQueue[V]) zeroValue() V {
+func (pq *ThreadSafePriorityQueue[V]) zeroValue() V {
 	var zero V
 	return zero
 }
 
-func (pq *PriorityQueue[V]) Push(v V, priority int) {
+func (pq *ThreadSafePriorityQueue[V]) Push(v V, priority float64) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	heap.Push(&pq.inner, &pqItem[V]{
-		value:      v,
-		insertTime: time.Now(),
-		priority:   priority,
-	})
+	heap.Push(&pq.inner, NewItem(v, priority))
 }
 
-func (pq *PriorityQueue[V]) Pop() (V, bool) {
+func (pq *ThreadSafePriorityQueue[V]) Pop() (V, bool) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	if len(pq.inner) == 0 {
 		return pq.zeroValue(), false
 	}
-	item := heap.Pop(&pq.inner).(*pqItem[V])
+	item := heap.Pop(&pq.inner).(*Item[V])
 	return item.value, true
 }
 
-func (pq *PriorityQueue[V]) Peek() (V, bool) {
+func (pq *ThreadSafePriorityQueue[V]) Peek() (V, bool) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	if len(pq.inner) == 0 {
@@ -101,7 +130,7 @@ func (pq *PriorityQueue[V]) Peek() (V, bool) {
 //
 // It has complexity O(index * log(n)) where n is the number of elements in the
 // queue.
-func (pq *PriorityQueue[V]) RemoveAt(index int) (V, bool) {
+func (pq *ThreadSafePriorityQueue[V]) RemoveAt(index int) (V, bool) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	if index >= len(pq.inner) {
@@ -122,10 +151,10 @@ func (pq *PriorityQueue[V]) RemoveAt(index int) (V, bool) {
 		heap.Push(&pq.inner, v)
 	}
 
-	return item.(*pqItem[V]).value, true
+	return item.(*Item[V]).value, true
 }
 
-func (pq *PriorityQueue[V]) GetAll() []V {
+func (pq *ThreadSafePriorityQueue[V]) GetAll() []V {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	allValues := make([]V, len(pq.inner))
@@ -135,7 +164,7 @@ func (pq *PriorityQueue[V]) GetAll() []V {
 	return allValues
 }
 
-func (pq *PriorityQueue[V]) Len() int {
+func (pq *ThreadSafePriorityQueue[V]) Len() int {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	return len(pq.inner)

--- a/server/util/priority_queue/priority_queue_test.go
+++ b/server/util/priority_queue/priority_queue_test.go
@@ -1,6 +1,7 @@
 package priority_queue_test
 
 import (
+	"container/heap"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/priority_queue"
@@ -101,4 +102,18 @@ func TestRemoveAt(t *testing.T) {
 	// Queue should now be empty
 	_, ok = q.RemoveAt(0)
 	require.False(t, ok)
+}
+
+func TestRemoveItemWithMinPriority(t *testing.T) {
+	pq := &priority_queue.PriorityQueue[string]{}
+	heap.Push(pq, priority_queue.NewItem("A", 1))
+	heap.Push(pq, priority_queue.NewItem("B", 2))
+
+	item := pq.RemoveItemWithMinPriority()
+	require.Equal(t, "A", item.Value())
+
+	heap.Push(pq, priority_queue.NewItem("C", 3))
+	heap.Push(pq, priority_queue.NewItem("D", 4))
+	item = pq.RemoveItemWithMinPriority()
+	require.Equal(t, "B", item.Value())
 }


### PR DESCRIPTION
driver.priorityQueue and priority_queue.innerPQ share almost the same code.

The main difference is that 
- in driver, we want to be able to remove the item with the min priority when the
queue is full. 
- in driver, we want to update the priority, when we push the task with the same
range id instead of adding a new item onto the queue.
