### PR TITLE
Make typed resource names more ergonomic

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -730,7 +730,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 			executionID := adInstanceDigest.NewUploadString()
 			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_result", "cached")
 			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_id", executionID)
-			stateChangeFn := operation.GetStateChangeFunc(stream, executionID, adInstanceDigest)
+			stateChangeFn := operation.GetStateChangeFunc(stream, executionID, adInstanceDigest.GetDigest())
 			if err := stateChangeFn(repb.ExecutionStage_COMPLETED, operation.ExecuteResponseWithCachedResult(actionResult)); err != nil {
 				return err // CHECK (these errors should not happen).
 			}
@@ -897,7 +897,7 @@ func (s *ExecutionServer) waitExecution(ctx context.Context, req *repb.WaitExecu
 		// Send a best-effort initial "in progress" update to client.
 		// Once Bazel receives the initial update, it will use WaitExecution to handle retry on error instead of
 		// requesting a new execution via Execute.
-		stateChangeFn := operation.GetStateChangeFunc(stream, req.GetName(), actionResource)
+		stateChangeFn := operation.GetStateChangeFunc(stream, req.GetName(), actionResource.GetDigest())
 		err = stateChangeFn(repb.ExecutionStage_QUEUED, operation.InProgressExecuteResponse())
 		if err != nil && err != io.EOF {
 			log.CtxWarningf(stream.Context(), "Could not send initial update: %s", err)
@@ -922,7 +922,7 @@ func (s *ExecutionServer) waitExecution(ctx context.Context, req *repb.WaitExecu
 		if msg.Err != nil {
 			op, err := operation.Assemble(
 				req.GetName(),
-				operation.Metadata(repb.ExecutionStage_COMPLETED, actionResource),
+				operation.Metadata(repb.ExecutionStage_COMPLETED, actionResource.GetDigest()),
 				operation.ErrorResponse(msg.Err))
 			if err != nil {
 				return err
@@ -980,7 +980,7 @@ func (s *ExecutionServer) MarkExecutionFailed(ctx context.Context, taskID string
 		return err
 	}
 	rsp := operation.ErrorResponse(reason)
-	op, err := operation.Assemble(taskID, operation.Metadata(repb.ExecutionStage_COMPLETED, r), rsp)
+	op, err := operation.Assemble(taskID, operation.Metadata(repb.ExecutionStage_COMPLETED, r.GetDigest()), rsp)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1107,7 +1107,6 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			if err != nil {
 				return status.WrapErrorf(err, "Failed to parse taskID")
 			}
-			actionRN := digest.NewACResourceName(actionCASRN.GetDigest(), actionCASRN.GetInstanceName(), actionCASRN.GetDigestFunction())
 			var cmd *repb.Command
 			action, cmd, err = s.fetchActionAndCommand(ctx, actionCASRN)
 			if err != nil {
@@ -1117,6 +1116,7 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			if err != nil {
 				return status.InternalErrorf("Failed to parse platform properties: %s", err)
 			}
+			actionRN := digest.NewACResourceName(actionCASRN.GetDigest(), actionCASRN.GetInstanceName(), actionCASRN.GetDigestFunction())
 			if err := s.cacheActionResult(ctx, actionRN, trimmedResponse, action); err != nil {
 				return status.UnavailableErrorf("Error uploading action result: %s", err.Error())
 			}
@@ -1273,14 +1273,14 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb
 
 func (s *ExecutionServer) fetchActionAndCommand(ctx context.Context, actionResourceName *digest.CASResourceName) (*repb.Action, *repb.Command, error) {
 	action := &repb.Action{}
-	if err := cachetools.ReadProtoFromCAS(ctx, s.cache, actionResourceName, action); err != nil {
+	if err := cachetools.ReadProtoFromCache(ctx, s.cache, actionResourceName, action); err != nil {
 		log.CtxWarningf(ctx, "Error fetching action: %s", err.Error())
 		return nil, nil, err
 	}
 	cmdDigest := action.GetCommandDigest()
 	cmdInstanceNameDigest := digest.NewCASResourceName(cmdDigest, actionResourceName.GetInstanceName(), actionResourceName.GetDigestFunction())
 	cmd := &repb.Command{}
-	if err := cachetools.ReadProtoFromCAS(ctx, s.cache, cmdInstanceNameDigest, cmd); err != nil {
+	if err := cachetools.ReadProtoFromCache(ctx, s.cache, cmdInstanceNameDigest, cmd); err != nil {
 		log.CtxWarningf(ctx, "Error fetching command: %s", err.Error())
 		return nil, nil, err
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -566,7 +566,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 	}
 	op, err = operation.Assemble(
 		taskID,
-		operation.Metadata(repb.ExecutionStage_COMPLETED, arn),
+		operation.Metadata(repb.ExecutionStage_COMPLETED, arn.GetDigest()),
 		expectedExecuteResponse,
 	)
 	require.NoError(t, err)

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -212,7 +212,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		SchedulingMetadata: st.GetSchedulingMetadata(),
 		ExecutorHostname:   s.hostname,
 	}
-	opStateChangeFn := operation.GetStateChangeFunc(stream, taskID, adInstanceDigest)
+	opStateChangeFn := operation.GetStateChangeFunc(stream, taskID, adInstanceDigest.GetDigest())
 	stateChangeFn := operation.StateChangeFunc(func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {
 		if stage == repb.ExecutionStage_COMPLETED {
 			if err := appendAuxiliaryMetadata(execResponse.GetResult().GetExecutionMetadata(), auxMetadata); err != nil {
@@ -243,7 +243,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		resp.Result = &repb.ActionResult{
 			ExecutionMetadata: md,
 		}
-		if err := operation.PublishOperationDone(stream, taskID, adInstanceDigest, resp); err != nil {
+		if err := operation.PublishOperationDone(stream, taskID, adInstanceDigest.GetDigest(), resp); err != nil {
 			return true, err
 		}
 		return false, finalErr

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -212,7 +212,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		SchedulingMetadata: st.GetSchedulingMetadata(),
 		ExecutorHostname:   s.hostname,
 	}
-	opStateChangeFn := operation.GetStateChangeFunc(stream, taskID, &adInstanceDigest.ResourceName)
+	opStateChangeFn := operation.GetStateChangeFunc(stream, taskID, adInstanceDigest)
 	stateChangeFn := operation.StateChangeFunc(func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {
 		if stage == repb.ExecutionStage_COMPLETED {
 			if err := appendAuxiliaryMetadata(execResponse.GetResult().GetExecutionMetadata(), auxMetadata); err != nil {

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -253,10 +253,10 @@ func (c *retryingClient) CloseAndRecv() (*repb.PublishOperationResponse, error) 
 
 // Metadata creates the ExecuteOperationMetadata object that goes in the
 // Operation.metadata field.
-func Metadata(stage repb.ExecutionStage_Value, r digest.HasResourceName) *repb.ExecuteOperationMetadata {
+func Metadata(stage repb.ExecutionStage_Value, d *repb.Digest) *repb.ExecuteOperationMetadata {
 	return &repb.ExecuteOperationMetadata{
 		Stage:        stage,
-		ActionDigest: r.GetResourceName().GetDigest(),
+		ActionDigest: d,
 	}
 }
 
@@ -298,7 +298,7 @@ type StreamLike interface {
 type StateChangeFunc func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error
 type FinishWithErrorFunc func(finalErr error) error
 
-func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest digest.HasResourceName) StateChangeFunc {
+func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest *repb.Digest) StateChangeFunc {
 	return func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {
 		if stage == repb.ExecutionStage_COMPLETED {
 			if target, err := flagutil.GetDereferencedValue[string]("executor.app_target"); err == nil {
@@ -331,7 +331,7 @@ func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest diges
 	}
 }
 
-func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest digest.HasResourceName, er *repb.ExecuteResponse) error {
+func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest *repb.Digest, er *repb.ExecuteResponse) error {
 	op, err := Assemble(taskID, Metadata(repb.ExecutionStage_COMPLETED, adInstanceDigest), er)
 	if err != nil {
 		return err

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -253,10 +253,10 @@ func (c *retryingClient) CloseAndRecv() (*repb.PublishOperationResponse, error) 
 
 // Metadata creates the ExecuteOperationMetadata object that goes in the
 // Operation.metadata field.
-func Metadata(stage repb.ExecutionStage_Value, r *digest.ResourceName) *repb.ExecuteOperationMetadata {
+func Metadata(stage repb.ExecutionStage_Value, r digest.HasResourceName) *repb.ExecuteOperationMetadata {
 	return &repb.ExecuteOperationMetadata{
 		Stage:        stage,
-		ActionDigest: r.GetDigest(),
+		ActionDigest: r.GetResourceName().GetDigest(),
 	}
 }
 
@@ -298,7 +298,7 @@ type StreamLike interface {
 type StateChangeFunc func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error
 type FinishWithErrorFunc func(finalErr error) error
 
-func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest *digest.ResourceName) StateChangeFunc {
+func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest digest.HasResourceName) StateChangeFunc {
 	return func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {
 		if stage == repb.ExecutionStage_COMPLETED {
 			if target, err := flagutil.GetDereferencedValue[string]("executor.app_target"); err == nil {
@@ -331,8 +331,8 @@ func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest *dige
 	}
 }
 
-func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest *digest.ACResourceName, er *repb.ExecuteResponse) error {
-	op, err := Assemble(taskID, Metadata(repb.ExecutionStage_COMPLETED, &adInstanceDigest.ResourceName), er)
+func PublishOperationDone(stream StreamLike, taskID string, adInstanceDigest digest.HasResourceName, er *repb.ExecuteResponse) error {
+	op, err := Assemble(taskID, Metadata(repb.ExecutionStage_COMPLETED, adInstanceDigest), er)
 	if err != nil {
 		return err
 	}

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -451,7 +451,7 @@ func GetBlobAsProto(ctx context.Context, bsClient bspb.ByteStreamClient, r *dige
 	return proto.Unmarshal(buf.Bytes(), out)
 }
 
-func readProtoFromCache(ctx context.Context, cache interfaces.Cache, r *digest.CASResourceName, out proto.Message) error {
+func ReadProtoFromCache(ctx context.Context, cache interfaces.Cache, r *digest.CASResourceName, out proto.Message) error {
 	data, err := cache.Get(ctx, r.ToProto())
 	if err != nil {
 		if gstatus.Code(err) == gcodes.NotFound {
@@ -460,12 +460,6 @@ func readProtoFromCache(ctx context.Context, cache interfaces.Cache, r *digest.C
 		return err
 	}
 	return proto.Unmarshal(data, out)
-}
-
-func ReadProtoFromCAS(ctx context.Context, cache interfaces.Cache, d *digest.CASResourceName, out proto.Message) error {
-	// TODO: Check whether this is intentionally creating a partial copy of d.
-	casRN := digest.NewCASResourceName(d.GetDigest(), d.GetInstanceName(), d.GetDigestFunction())
-	return readProtoFromCache(ctx, cache, casRN, out)
 }
 
 func UploadBytesToCache(ctx context.Context, cache interfaces.Cache, cacheType rspb.CacheType, remoteInstanceName string, digestFunction repb.DigestFunction_Value, in io.ReadSeeker) (*repb.Digest, error) {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -151,18 +151,18 @@ func NewACResourceName(d *repb.Digest, instanceName string, digestFunction repb.
 	return &ACResourceName{*NewResourceName(d, instanceName, rspb.CacheType_AC, digestFunction)}
 }
 
-func (r *ResourceName) CheckCAS() (*CASResourceName, error) {
+func (r ResourceName) CheckCAS() (*CASResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_CAS {
 		return nil, status.FailedPreconditionErrorf("ResourceName is not a CAS resource name: %s", r.rn)
 	}
-	return &CASResourceName{*r}, nil
+	return &CASResourceName{r}, nil
 }
 
-func (r *ResourceName) CheckAC() (*ACResourceName, error) {
+func (r ResourceName) CheckAC() (*ACResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_AC {
 		return nil, status.FailedPreconditionErrorf("ResourceName is not an AC resource name: %s", r.rn)
 	}
-	return &ACResourceName{*r}, nil
+	return &ACResourceName{r}, nil
 }
 
 func (r *ResourceName) ToProto() *rspb.ResourceName {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -217,14 +217,6 @@ func (r *ResourceName) Validate() error {
 	return nil
 }
 
-type HasResourceName interface {
-	GetResourceName() *ResourceName
-}
-
-func (r ResourceName) GetResourceName() *ResourceName {
-	return &r
-}
-
 type CASResourceName struct {
 	ResourceName
 }

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -221,8 +221,8 @@ type HasResourceName interface {
 	GetResourceName() *ResourceName
 }
 
-func (r *ResourceName) GetResourceName() *ResourceName {
-	return r
+func (r ResourceName) GetResourceName() *ResourceName {
+	return &r
 }
 
 type CASResourceName struct {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -165,39 +165,39 @@ func (r ResourceName) CheckAC() (*ACResourceName, error) {
 	return &ACResourceName{r}, nil
 }
 
-func (r *ResourceName) ToProto() *rspb.ResourceName {
+func (r ResourceName) ToProto() *rspb.ResourceName {
 	return r.rn
 }
 
-func (r *ResourceName) GetDigest() *repb.Digest {
+func (r ResourceName) GetDigest() *repb.Digest {
 	return r.rn.GetDigest()
 }
 
-func (r *ResourceName) GetDigestFunction() repb.DigestFunction_Value {
+func (r ResourceName) GetDigestFunction() repb.DigestFunction_Value {
 	return r.rn.GetDigestFunction()
 }
 
-func (r *ResourceName) GetInstanceName() string {
+func (r ResourceName) GetInstanceName() string {
 	return r.rn.GetInstanceName()
 }
 
-func (r *ResourceName) GetCacheType() rspb.CacheType {
+func (r ResourceName) GetCacheType() rspb.CacheType {
 	return r.rn.GetCacheType()
 }
 
-func (r *ResourceName) GetCompressor() repb.Compressor_Value {
+func (r ResourceName) GetCompressor() repb.Compressor_Value {
 	return r.rn.GetCompressor()
 }
 
-func (r *ResourceName) SetCompressor(compressor repb.Compressor_Value) {
+func (r ResourceName) SetCompressor(compressor repb.Compressor_Value) {
 	r.rn.Compressor = compressor
 }
 
-func (r *ResourceName) IsEmpty() bool {
+func (r ResourceName) IsEmpty() bool {
 	return IsEmptyHash(r.rn.GetDigest(), r.rn.GetDigestFunction())
 }
 
-func (r *ResourceName) Validate() error {
+func (r ResourceName) Validate() error {
 	d := r.rn.GetDigest()
 	if d == nil {
 		return status.InvalidArgumentError("Invalid (nil) Digest")
@@ -223,7 +223,7 @@ type CASResourceName struct {
 
 // DownloadString returns a string representing the resource name for download
 // purposes.
-func (r *CASResourceName) DownloadString() string {
+func (r CASResourceName) DownloadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
@@ -242,7 +242,7 @@ func (r *CASResourceName) DownloadString() string {
 
 // NewUploadString returns a new string representing the resource name for
 // upload purposes each time it is called.
-func (r *CASResourceName) NewUploadString() string {
+func (r CASResourceName) NewUploadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	u := guuid.New()
@@ -268,7 +268,7 @@ type ACResourceName struct {
 
 // ActionCacheString returns a string representing the resource name for in
 // the action cache. This is BuildBuddy specific.
-func (r *ACResourceName) ActionCacheString() string {
+func (r ACResourceName) ActionCacheString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -217,6 +217,14 @@ func (r *ResourceName) Validate() error {
 	return nil
 }
 
+type HasResourceName interface {
+	GetResourceName() *ResourceName
+}
+
+func (r *ResourceName) GetResourceName() *ResourceName {
+	return r
+}
+
 type CASResourceName struct {
 	ResourceName
 }

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -151,53 +151,53 @@ func NewACResourceName(d *repb.Digest, instanceName string, digestFunction repb.
 	return &ACResourceName{*NewResourceName(d, instanceName, rspb.CacheType_AC, digestFunction)}
 }
 
-func (r ResourceName) CheckCAS() (*CASResourceName, error) {
+func (r *ResourceName) CheckCAS() (*CASResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_CAS {
 		return nil, status.FailedPreconditionErrorf("ResourceName is not a CAS resource name: %s", r.rn)
 	}
-	return &CASResourceName{r}, nil
+	return &CASResourceName{*r}, nil
 }
 
-func (r ResourceName) CheckAC() (*ACResourceName, error) {
+func (r *ResourceName) CheckAC() (*ACResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_AC {
 		return nil, status.FailedPreconditionErrorf("ResourceName is not an AC resource name: %s", r.rn)
 	}
-	return &ACResourceName{r}, nil
+	return &ACResourceName{*r}, nil
 }
 
-func (r ResourceName) ToProto() *rspb.ResourceName {
+func (r *ResourceName) ToProto() *rspb.ResourceName {
 	return r.rn
 }
 
-func (r ResourceName) GetDigest() *repb.Digest {
+func (r *ResourceName) GetDigest() *repb.Digest {
 	return r.rn.GetDigest()
 }
 
-func (r ResourceName) GetDigestFunction() repb.DigestFunction_Value {
+func (r *ResourceName) GetDigestFunction() repb.DigestFunction_Value {
 	return r.rn.GetDigestFunction()
 }
 
-func (r ResourceName) GetInstanceName() string {
+func (r *ResourceName) GetInstanceName() string {
 	return r.rn.GetInstanceName()
 }
 
-func (r ResourceName) GetCacheType() rspb.CacheType {
+func (r *ResourceName) GetCacheType() rspb.CacheType {
 	return r.rn.GetCacheType()
 }
 
-func (r ResourceName) GetCompressor() repb.Compressor_Value {
+func (r *ResourceName) GetCompressor() repb.Compressor_Value {
 	return r.rn.GetCompressor()
 }
 
-func (r ResourceName) SetCompressor(compressor repb.Compressor_Value) {
+func (r *ResourceName) SetCompressor(compressor repb.Compressor_Value) {
 	r.rn.Compressor = compressor
 }
 
-func (r ResourceName) IsEmpty() bool {
+func (r *ResourceName) IsEmpty() bool {
 	return IsEmptyHash(r.rn.GetDigest(), r.rn.GetDigestFunction())
 }
 
-func (r ResourceName) Validate() error {
+func (r *ResourceName) Validate() error {
 	d := r.rn.GetDigest()
 	if d == nil {
 		return status.InvalidArgumentError("Invalid (nil) Digest")
@@ -223,7 +223,7 @@ type CASResourceName struct {
 
 // DownloadString returns a string representing the resource name for download
 // purposes.
-func (r CASResourceName) DownloadString() string {
+func (r *CASResourceName) DownloadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
@@ -242,7 +242,7 @@ func (r CASResourceName) DownloadString() string {
 
 // NewUploadString returns a new string representing the resource name for
 // upload purposes each time it is called.
-func (r CASResourceName) NewUploadString() string {
+func (r *CASResourceName) NewUploadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	u := guuid.New()
@@ -268,7 +268,7 @@ type ACResourceName struct {
 
 // ActionCacheString returns a string representing the resource name for in
 // the action cache. This is BuildBuddy specific.
-func (r ACResourceName) ActionCacheString() string {
+func (r *ACResourceName) ActionCacheString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {


### PR DESCRIPTION
Addresses the comments in https://github.com/buildbuddy-io/buildbuddy/pull/8761#pullrequestreview-2715109056 by:

* Refactor `Metadata` functions to accept digests, which avoids unwrapping `CASResourceName`s.
* Inline a confusing wrapper method.