### PR TITLE
github/actions: determine cache paths automatically based on runner os

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -131,7 +131,7 @@ common:ci --disk_cache=
 # Configuration used for untrusted GitHub actions-based CI
 common:untrusted-ci --config=remote-minimal
 common:untrusted-ci --remote_instance_name=buildbuddy-io/buildbuddy/untrusted-ci
-common:untrusted-ci --repository_cache=~/repo-cache/untrusted/
+common:untrusted-ci --repository_cache=~/repo-cache/
 common:untrusted-ci --disk_cache=
 common:untrusted-ci --flaky_test_attempts=2
 common:untrusted-ci --remote_executor=grpcs://remote.buildbuddy.io

--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -1,19 +1,17 @@
 name: "Restore download caches"
-description: "Restores external dependencies caches, and outputs cache-hit statuses."
-inputs:
-  repo-cache-dir:
-    description: "The directory where the Bazel Repo cache is stored."
-    required: true
-    default: "$HOME/repo-cache"
-  go-mod-cache-dir:
-    description: "The directory where the Go Mod cache is stored."
-    required: true
-    default: "$HOME/go-mod-cache"
-  yarn-cache-dir:
-    description: "The directory where the Yarn cache is stored."
-    required: true
-    default: "$HOME/.cache/yarn/v6"
+description: "Determines cache paths based on OS using hardcoded paths, restores external dependencies caches, and outputs cache-hit statuses and paths."
 outputs:
+  # Cache paths for each cache
+  repo-cache-dir:
+    description: "Determined Bazel Repo cache directory path"
+    value: ${{ steps.determine-paths-linux.outputs.repo-cache-dir || steps.determine-paths-macos.outputs.repo-cache-dir || steps.determine-paths-windows.outputs.repo-cache-dir }}
+  go-mod-cache-dir:
+    description: "Determined Go Mod cache directory path"
+    value: ${{ steps.determine-paths-linux.outputs.go-mod-cache-dir || steps.determine-paths-macos.outputs.go-mod-cache-dir || steps.determine-paths-windows.outputs.go-mod-cache-dir }}
+  yarn-cache-dir:
+    description: "Determined Yarn cache directory path"
+    value: ${{ steps.determine-paths-linux.outputs.yarn-cache-dir || steps.determine-paths-macos.outputs.yarn-cache-dir || steps.determine-paths-windows.outputs.yarn-cache-dir }}
+  # Cache hit statuses for each cache
   repo-cache-hit:
     description: "Cache hit status for Bazel Repo Cache"
     value: ${{ steps.repo-cache-restore.outputs.cache-hit }}
@@ -25,16 +23,44 @@ outputs:
     value: ${{ steps.yarn-cache-restore.outputs.cache-hit }}
 runs:
   using: composite
-  # Github Actions does not allow overwriting an existing cache key.
-  # So we write a new cache key for each run attempt, while restoring the cache with a prefix match.
-  #
-  # Reference: https://github.com/actions/cache/pull/1452
   steps:
+    # Step to determine paths for Linux using /home/runner
+    - name: Determine Cache Paths (Linux)
+      id: determine-paths-linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "repo-cache-dir=/home/runner/repo-cache" >> $GITHUB_OUTPUT
+        echo "go-mod-cache-dir=/home/runner/go-mod-cache" >> $GITHUB_OUTPUT
+        echo "yarn-cache-dir=/home/runner/.cache/yarn/v6" >> $GITHUB_OUTPUT
+
+    # Step to determine paths for macOS using /Users/runner
+    - name: Determine Cache Paths (macOS)
+      id: determine-paths-macos
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        echo "repo-cache-dir=/Users/runner/repo-cache" >> $GITHUB_OUTPUT
+        echo "go-mod-cache-dir=/Users/runner/go-mod-cache" >> $GITHUB_OUTPUT
+        echo "yarn-cache-dir=/Users/runner/.cache/yarn/v6" >> $GITHUB_OUTPUT
+
+    # Step to determine paths for Windows using D:\
+    - name: Determine Cache Paths (Windows)
+      id: determine-paths-windows
+      if: runner.os == 'Windows'
+      shell: pwsh # PowerShell is default on Windows runners
+      run: |
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "repo-cache-dir=D:/bazel/repo-cache"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "go-mod-cache-dir=D:/go-mod-cache"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "yarn-cache-dir=~\\AppData\\Local\\Yarn\\Cache\\v6"
+
+    # Restore steps now use combined outputs from the determine steps
     - name: Restore Bazel Repo Cache
       uses: actions/cache/restore@v4
       id: repo-cache-restore
       with:
-        path: ${{ inputs.repo-cache-dir }}
+        # Use the path determined in the conditional steps
+        path: ${{ steps.determine-paths-linux.outputs.repo-cache-dir || steps.determine-paths-macos.outputs.repo-cache-dir || steps.determine-paths-windows.outputs.repo-cache-dir }}
         key: repo-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'deps.bzl') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           repo-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'deps.bzl') }}-
@@ -44,7 +70,8 @@ runs:
       uses: actions/cache/restore@v4
       id: go-mod-cache-restore
       with:
-        path: ${{ inputs.go-mod-cache-dir }}
+        # Use the path determined in the conditional steps
+        path: ${{ steps.determine-paths-linux.outputs.go-mod-cache-dir || steps.determine-paths-macos.outputs.go-mod-cache-dir || steps.determine-paths-windows.outputs.go-mod-cache-dir }}
         key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}-
@@ -54,7 +81,8 @@ runs:
       uses: actions/cache/restore@v4
       id: yarn-cache-restore
       with:
-        path: ${{ inputs.yarn-cache-dir }}
+        # Use the path determined in the conditional steps
+        path: ${{ steps.determine-paths-linux.outputs.yarn-cache-dir || steps.determine-paths-macos.outputs.yarn-cache-dir || steps.determine-paths-windows.outputs.yarn-cache-dir }}
         key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}-

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -1,51 +1,44 @@
 name: "Save download caches conditionally"
-description: "Conditionally saves external dependencies caches based on cache-hit status."
+description: "Conditionally saves external dependencies caches based on cache-hit status, using provided paths."
 inputs:
-  repo-cache-hit:
-    description: 'Cache hit status for Bazel Repo Cache'
-    required: true
   repo-cache-dir:
-    description: 'The Bazel Repo cache directory path'
-    required: true
-    default: "$HOME/repo-cache"
-  go-mod-cache-hit:
-    description: 'Cache hit status for Go Mod Cache'
+    description: 'The Bazel Repo cache directory path (determined by cache-restore)'
     required: true
   go-mod-cache-dir:
-    description: 'The Go Mod cache directory path'
-    required: true
-    default: "$HOME/go-mod-cache"
-  yarn-cache-hit:
-    description: 'Cache hit status for Yarn Cache'
+    description: 'The Go Mod cache directory path (determined by cache-restore)'
     required: true
   yarn-cache-dir:
-    description: 'The Yarn cache directory path'
+    description: 'The Yarn cache directory path (determined by cache-restore)'
     required: true
-    default: "$HOME/.cache/yarn/v6"
 runs:
   using: "composite"
-  # Github Actions does not allow overwriting an existing cache key.
-  # So we write a new cache key for each run attempt, while restoring the cache with a prefix match.
-  #
-  # Reference: https://github.com/actions/cache/pull/1452
   steps:
+    # Github Actions does not allow overwriting an existing cache key.
+    # So we write a new cache key for each run attempt, while restoring the cache with a prefix match.
+    # Reference: https://github.com/actions/cache/pull/1452
+
     - name: Save Bazel Repo Cache
       uses: actions/cache/save@v4
-      if: always() && ${{ inputs.repo-cache-hit != 'true' }}
+      # Use always() to ensure this step runs, then check the input hit status
+      if: always()
       with:
+        # Use the input path
         path: ${{ inputs.repo-cache-dir }}
         key: repo-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'deps.bzl') }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     - name: Save Go Mod Cache
       uses: actions/cache/save@v4
-      if: always() && ${{ inputs.go-mod-cache-hit != 'true' }}
+      if: always()
       with:
+        # Use the input path
         path: ${{ inputs.go-mod-cache-dir }}
         key: go-mod-cache-${{ runner.os }}-${{ hashFiles('MODULE.bazel', 'WORKSPACE.bzlmod', 'WORKSPACE', 'go.mod', 'go.sum', 'deps.bzl') }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     - name: Save Yarn Cache
       uses: actions/cache/save@v4
-      if: always() && ${{ inputs.yarn-cache-hit != 'true' }}
+      if: always()
       with:
+        # Use the input path
         path: ${{ inputs.yarn-cache-dir }}
-        key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        # Ensure hashFiles matches the restore key hashFiles for consistency
+        key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -14,12 +14,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
-        with:
-          repo-cache-dir: "D:/bazel/repo-cache"
-          go-mod-cache-dir: "D:/go-mod-cache"
-          yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"
 
       # This step would list out all files under $vs2022Path for debugging purposes.
       # - name: "Find CL"
@@ -60,6 +56,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-dir: "D:/bazel/repo-cache"
-          go-mod-cache-dir: "D:/go-mod-cache"
-          yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
 
       - name: Build and Upload Artifacts
@@ -60,6 +60,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
@@ -52,7 +52,7 @@ jobs:
           && sudo apt install gh -y
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
 
       - name: Build and Upload Artifacts
@@ -69,6 +69,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/build-mac-intel-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-intel-github-release-artifacts.yaml
@@ -36,12 +36,8 @@ jobs:
           fetch-depth: 0
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
-        with:
-          repo-cache-dir: /Users/runner/repo-cache
-          go-mod-cache-dir: /Users/runner/go-mod-cache
-          yarn-cache-dir: /Users/runner/.cache/yarn/v6
 
       - name: Build and Upload Artifacts
         env:
@@ -65,9 +61,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-dir: /Users/runner/repo-cache
-          go-mod-cache-dir: /Users/runner/go-mod-cache
-          yarn-cache-dir: /Users/runner/.cache/yarn/v6
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/build-mac-m1-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-m1-github-release-artifacts.yaml
@@ -47,12 +47,8 @@ jobs:
           fetch-depth: 0
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
-        with:
-          repo-cache-dir: /Users/runner/repo-cache
-          go-mod-cache-dir: /Users/runner/go-mod-cache
-          yarn-cache-dir: /Users/runner/.cache/yarn/v6
 
       - name: Build and Upload Artifacts
         env:
@@ -69,9 +65,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-dir: /Users/runner/repo-cache
-          go-mod-cache-dir: /Users/runner/go-mod-cache
-          yarn-cache-dir: /Users/runner/.cache/yarn/v6
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -36,12 +36,8 @@ jobs:
           fetch-depth: 0
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
-        with:
-          repo-cache-dir: "D:/bazel/repo-cache"
-          go-mod-cache-dir: "D:/go-mod-cache"
-          yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"
 
       - name: Build and Upload Artifacts
         env:
@@ -60,9 +56,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          repo-cache-dir: "D:/bazel/repo-cache"
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          go-mod-cache-dir: "D:/go-mod-cache"
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
-          yarn-cache-dir: "~\\AppData\\Local\\Yarn\\Cache\\v6"
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
 
       - name: Test
@@ -35,9 +35,9 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}
 
       - name: Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,10 +15,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
-        with:
-          repo-cache-dir: ~/repo-cache/untrusted
 
       - name: Test
         env:
@@ -34,7 +32,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-dir: ~/repo-cache/untrusted
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -157,18 +157,8 @@ jobs:
         with:
           path: buildbuddy
 
-      - name: Restore MacOS caches
-        if: runner.os == 'macOS'
-        id: restore-caches
-        uses: ./buildbuddy/.github/actions/cache-restore
-        with:
-          repo-cache-dir: /Users/runner/repo-cache
-          go-mod-cache-dir: /Users/runner/go-mod-cache
-          yarn-cache-dir: /Users/runner/.cache/yarn/v6
-
-      - name: Restore Linux caches
-        if: runner.os == 'Linux'
-        id: restore-caches
+      - name: Restore caches
+        id: cache-restore
         uses: ./buildbuddy/.github/actions/cache-restore
 
       - name: Build Artifacts
@@ -217,24 +207,12 @@ jobs:
             "${{ steps.build.outputs.BINARY }}" \
             "${{ steps.build.outputs.BINARY }}.sha256"
 
-      - name: Save MacOS cache
+      - name: Save cache
         uses: ./buildbuddy/.github/actions/cache-save
-        if: runner.os == 'macOS'
         with:
-          repo-cache-dir: /Users/runner/repo-cache
-          go-mod-cache-dir: /Users/runner/go-mod-cache
-          yarn-cache-dir: /Users/runner/.cache/yarn/v6
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
-
-      - name: Save Linux caches
-        uses: ./buildbuddy/.github/actions/cache-save
-        if: runner.os == 'Linux'
-        with:
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}
 
   publish-release:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install -y gcc g++
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
 
       - name: Run tests
@@ -70,6 +70,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/website-pr.yaml
+++ b/.github/workflows/website-pr.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
 
       - name: Build Website
@@ -39,6 +39,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restore caches
-        id: restore-caches
+        id: cache-restore
         uses: ./.github/actions/cache-restore
 
       - name: Build Website
@@ -45,6 +45,6 @@ jobs:
         uses: ./.github/actions/cache-save
         if: always()
         with:
-          repo-cache-hit: ${{ steps.restore-caches.outputs.repo-cache-hit }}
-          go-mod-cache-hit: ${{ steps.restore-caches.outputs.go-mod-cache-hit }}
-          yarn-cache-hit: ${{ steps.restore-caches.outputs.yarn-cache-hit }}
+          repo-cache-dir: ${{ steps.cache-restore.outputs.repo-cache-dir }}
+          go-mod-cache-dir: ${{ steps.cache-restore.outputs.go-mod-cache-dir }}
+          yarn-cache-dir: ${{ steps.cache-restore.outputs.yarn-cache-dir }}


### PR DESCRIPTION
Make our cache path more consistent by stop relying on $HOME variable,

which does not resolve in some cases
