### PR TITLE
Make the hostname sent to PublishOperation use the resources package

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -167,7 +167,7 @@ func getExecutorHostID() string {
 }
 
 func getExecutorHostName() string {
-	name, err := os.Hostname()
+	name, err := resources.GetMyHostname()
 	if err != nil {
 		log.Warningf("Failed to get hostname: %s", err)
 	}


### PR DESCRIPTION
This is the hostname that is sent to the scheduler when the executor registers itself. This only matters if the MY_HOSTNAME env variable is set.