### PR TITLE
[raft] preload registry: only load those addresses for the ranges the machine has

### DIFF
--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -278,7 +278,9 @@ message RegistryQueryResponse {
   string raft_address = 3;
 }
 
-message GetRegistryRequest {}
+message GetRegistryRequest {
+  repeated uint64 range_ids = 1;
+}
 
 message ConnectionInfo {
   string nhid = 1;


### PR DESCRIPTION
If app doesn't have range 2 for example, it doesn't need to load registry entry
for replicas of range 2. Right now, when we preload registries, we load
everything. This is not only unnecessary, but also make removing entries from
the registry difficult.
