### PR TITLE
[raft] implement registry.Remove/RemoveShard

### DIFF
--- a/enterprise/server/raft/registry/BUILD
+++ b/enterprise/server/raft/registry/BUILD
@@ -30,6 +30,7 @@ go_test(
         "//server/gossip",
         "//server/testutil/testport",
         "//server/util/log",
+        "//server/util/status",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -131,6 +131,7 @@ func (n *StaticRegistry) Remove(rangeID uint64, replicaID uint64) {
 		delete(s, key)
 	}
 	delete(n.nodeTargets, key)
+	log.Debugf("removed targets for c%dn%d", rangeID, replicaID)
 }
 
 // RemoveCluster removes all nodes info associated with the specified cluster
@@ -145,6 +146,7 @@ func (n *StaticRegistry) RemoveShard(rangeID uint64) {
 		}
 	}
 	delete(n.shards, rangeID)
+	log.Debugf("removed targets for range", rangeID)
 }
 
 // ResolveRaft returns the raft address and the connection key of the specified node.

--- a/enterprise/server/raft/registry/registry_test.go
+++ b/enterprise/server/raft/registry/registry_test.go
@@ -47,14 +47,14 @@ func requireResolves(t testing.TB, dnr registry.NodeRegistry, rangeID, replicaID
 }
 
 func TestStaticRegistryAdd(t *testing.T) {
-	nr := registry.NewStaticNodeRegistry(1, nil)
+	nr := registry.NewStaticNodeRegistry(1, nil, log.Logger{})
 	nr.Add(1, 1, "nhid-1")
 	nr.AddNode("nhid-1", "raftaddress:1", "grpcaddress:1")
 	requireResolves(t, nr, 1, 1, "raftaddress:1", "grpcaddress:1")
 }
 
 func TestStaticRegistryRemove(t *testing.T) {
-	nr := registry.NewStaticNodeRegistry(1, nil)
+	nr := registry.NewStaticNodeRegistry(1, nil, log.Logger{})
 	nr.Add(1, 1, "nhid-1")
 	nr.Add(2, 1, "nhid-1")
 	nr.Add(1, 2, "nhid-2")
@@ -72,7 +72,7 @@ func TestStaticRegistryRemove(t *testing.T) {
 }
 
 func TestStaticRegistryRemoveShard(t *testing.T) {
-	nr := registry.NewStaticNodeRegistry(1, nil)
+	nr := registry.NewStaticNodeRegistry(1, nil, log.Logger{})
 	nr.Add(1, 1, "nhid-1")
 	nr.Add(2, 1, "nhid-1")
 	nr.Add(1, 2, "nhid-2")
@@ -93,7 +93,7 @@ func TestStaticRegistryRemoveShard(t *testing.T) {
 func TestDynamicRegistryAdd(t *testing.T) {
 	nodeAddr := localAddr(t)
 	gm := newGossipManager(t, nodeAddr, nil)
-	dnr := registry.NewDynamicNodeRegistry(gm, 1, nil)
+	dnr := registry.NewDynamicNodeRegistry(gm, 1, nil, log.Logger{})
 	dnr.Add(1, 1, "nhid-1")
 	dnr.AddNode("nhid-1", "raftaddress:1", "grpcaddress:1")
 	requireResolves(t, dnr, 1, 1, "raftaddress:1", "grpcaddress:1")
@@ -107,7 +107,7 @@ func TestDynamicRegistryAdd(t *testing.T) {
 func TestDynamicRegistryRemove(t *testing.T) {
 	nodeAddr := localAddr(t)
 	gm := newGossipManager(t, nodeAddr, nil)
-	dnr := registry.NewDynamicNodeRegistry(gm, 1, nil)
+	dnr := registry.NewDynamicNodeRegistry(gm, 1, nil, log.Logger{})
 	dnr.Add(1, 1, "nhid-1")
 	dnr.Add(2, 1, "nhid-1")
 	dnr.Add(1, 2, "nhid-2")
@@ -127,7 +127,7 @@ func TestDynamicRegistryRemove(t *testing.T) {
 func TestDynamicRegistryRemoveShard(t *testing.T) {
 	nodeAddr := localAddr(t)
 	gm := newGossipManager(t, nodeAddr, nil)
-	dnr := registry.NewDynamicNodeRegistry(gm, 1, nil)
+	dnr := registry.NewDynamicNodeRegistry(gm, 1, nil, log.Logger{})
 	dnr.Add(1, 1, "nhid-1")
 	dnr.Add(2, 1, "nhid-1")
 	dnr.Add(1, 2, "nhid-2")
@@ -155,9 +155,9 @@ func TestDynamicRegistryResolution(t *testing.T) {
 	gm2 := newGossipManager(t, node2Addr, seeds)
 	gm3 := newGossipManager(t, node3Addr, seeds)
 
-	dnr1 := registry.NewDynamicNodeRegistry(gm1, 1, nil)
-	dnr2 := registry.NewDynamicNodeRegistry(gm2, 1, nil)
-	dnr3 := registry.NewDynamicNodeRegistry(gm3, 1, nil)
+	dnr1 := registry.NewDynamicNodeRegistry(gm1, 1, nil, log.Logger{})
+	dnr2 := registry.NewDynamicNodeRegistry(gm2, 1, nil, log.Logger{})
+	dnr3 := registry.NewDynamicNodeRegistry(gm3, 1, nil, log.Logger{})
 
 	dnr1.Add(1, 1, "nhid-1")
 	dnr1.AddNode("nhid-1", "raftaddress:1", "grpcaddress:1")

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -168,7 +168,8 @@ type registryHolder struct {
 }
 
 func (rc *registryHolder) Create(nhid string, streamConnections uint64, v dbConfig.TargetValidator) (raftio.INodeRegistry, error) {
-	r := registry.NewDynamicNodeRegistry(rc.g, streamConnections, v)
+	nhLog := log.NamedSubLogger(nhid)
+	r := registry.NewDynamicNodeRegistry(rc.g, streamConnections, v, nhLog)
 	rc.r = r
 	r.AddNode(nhid, rc.raftAddr, rc.grpcAddr)
 	return r, nil
@@ -1815,6 +1816,7 @@ func (j *replicaJanitor) removeZombie(ctx context.Context, task zombieCleanupTas
 	}
 
 	_, err = j.store.RemoveData(ctx, removeDataReq)
+	j.store.log.Infof("removed data for c%dn%d", removeDataReq.RangeId, removeDataReq.ReplicaId)
 	if err != nil {
 		return zombieCleanupRemoveData, status.InternalErrorf("failed to remove data: %s", err)
 	}

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1816,7 +1816,6 @@ func (j *replicaJanitor) removeZombie(ctx context.Context, task zombieCleanupTas
 	}
 
 	_, err = j.store.RemoveData(ctx, removeDataReq)
-	j.store.log.Infof("removed data for c%dn%d", removeDataReq.RangeId, removeDataReq.ReplicaId)
 	if err != nil {
 		return zombieCleanupRemoveData, status.InternalErrorf("failed to remove data: %s", err)
 	}

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -656,7 +656,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 	rd := s.GetRange(2)
 	// Veirfy that nhid in the range descriptor matches the registry.
 	for _, repl := range rd.GetReplicas() {
-		nhid, _, err := sf.Registry().ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
+		nhid, _, err := s.Registry.ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
 		require.NoError(t, err)
 		require.Equal(t, repl.GetNhid(), nhid)
 	}
@@ -675,7 +675,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 	rd = s.GetRange(3)
 	// Veirfy that nhid in the rangea descriptor matches the registry.
 	for _, repl := range rd.GetReplicas() {
-		nhid, _, err := sf.Registry().ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
+		nhid, _, err := s.Registry.ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
 		require.NoError(t, err)
 		require.Equal(t, repl.GetNhid(), nhid)
 	}

--- a/enterprise/server/raft/testutil/BUILD
+++ b/enterprise/server/raft/testutil/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//server/testutil/testfs",
         "//server/testutil/testport",
         "//server/util/disk",
+        "//server/util/log",
         "//server/util/status",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_lni_dragonboat_v4//:dragonboat",


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4573

dragonboat calls Remove/RemoveShard when it applies RemoveNode
membership change.

I changed the nodeTargets to a regular map, added a new map to keep track of all replicas for a single shard. These two maps are protected by a mutex since they need to be in sync. 

Also fix the test. Previously in testutil, we share a single registry among different stores created StoreFactory and this can cause test to fail now we are removing entries from registries. 