### PR TITLE
[raft] remove registry.Add call when we add non-voting replicas

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2613,10 +2613,6 @@ func (s *Store) addNonVoting(ctx context.Context, rangeID uint64, newReplicaID u
 		return status.InternalErrorf("failed to get config change ID: %s", err)
 	}
 
-	// Gossip the address of the node that is about to be added.
-	s.registry.Add(rangeID, newReplicaID, node.GetNhid())
-	s.registry.AddNode(node.GetNhid(), node.GetRaftAddress(), node.GetGrpcAddress())
-
 	// Propose the config change (this adds the node as a non-voter to the raft cluster).
 	err = client.RunNodehostFn(ctx, func(ctx context.Context) error {
 		return s.nodeHost.SyncRequestAddNonVoting(ctx, rangeID, newReplicaID, node.GetNhid(), configChangeID)


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4573

When we start the shard in AddReplica, dragonboat will call registry.Add on our
behalf so we don't need to call it. Sometimes, a non-voter can be a zombie, and the shard is never started. If we don't call registry.Add here, we don't need to clean up.

The node info is either added during preload Registry; or through RegistryPush
gossip requests.
