### PR TITLE
proto: update bazel protos

### DIFF
--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -575,6 +575,7 @@ message File {
   int64 length = 6;
 }
 
+// BUILDBUDDY-SPECIFIC EVENTS BELOW
 message Tree {
   // Where the tree is to be planted.
   string name = 1;
@@ -627,7 +628,7 @@ message ActionExecuted {
   repeated string command_line = 9;
 
   // List of paths to log files
-  repeated File action_metadata_logs = 10;
+  repeated File action_metadata_logs = 10 [deprecated = true];
 
   // Only populated if success = false, and sometimes not even then.
   failure_details.FailureDetail failure_detail = 11;

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -575,7 +575,7 @@ message File {
   int64 length = 6;
 }
 
-// BUILDBUDDY-SPECIFIC EVENTS BELOW
+// BUILDBUDDY-SPECIFIC EVENT
 message Tree {
   // Where the tree is to be planted.
   string name = 1;

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -575,14 +575,6 @@ message File {
   int64 length = 6;
 }
 
-// BUILDBUDDY-SPECIFIC EVENT
-message Tree {
-  // Where the tree is to be planted.
-  string name = 1;
-  // Bytestream URI for the tree digest.
-  string uri = 2;
-}
-
 // Payload of a message to describe a set of files, usually build artifacts, to
 // be referred to later by their name. In this way, files that occur identically
 // as outputs of several targets have to be named only once.
@@ -1594,6 +1586,13 @@ message ChildInvocationCompleted {
 
   // How long it took for the invocation to complete.
   google.protobuf.Duration duration = 5;
+}
+
+message Tree {
+  // Where the tree is to be planted.
+  string name = 1;
+  // Bytestream URI for the tree digest.
+  string uri = 2;
 }
 
 // Event describing the runtime properties of a runnable target.

--- a/proto/command_line.proto
+++ b/proto/command_line.proto
@@ -16,10 +16,10 @@ syntax = "proto3";
 
 package command_line;
 
+import "proto/option_filters.proto";
+
 // option java_api_version = 2;
 option java_package = "com.google.devtools.build.lib.runtime.proto";
-
-import "proto/option_filters.proto";
 
 // Representation of a Bazel command line.
 message CommandLine {

--- a/proto/command_line.proto
+++ b/proto/command_line.proto
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 syntax = "proto3";
+
 package command_line;
 
 // option java_api_version = 2;
@@ -99,4 +100,8 @@ message Option {
   // Metadata about the flag. See OptionMetadataTag's java documentation for
   // details.
   repeated options.OptionMetadataTag metadata_tags = 5;
+
+  // The source of the flag (i.e. whether is was explicitly passed by the user,
+  // from which .{bazel,blaze}rc it comes, etc).
+  string source = 6;
 }

--- a/proto/execution_graph.proto
+++ b/proto/execution_graph.proto
@@ -25,6 +25,7 @@ package execution_graph;
 option java_package = "com.google.devtools.build.lib.actions";
 
 // Node is one entry in the executed graph.
+// Next ID: 12
 message Node {
   // All nodes should have a description so human debuggers could see what was
   // going on in this step. This should be ActionAnalysisMetadata.prettyPrint().
@@ -62,6 +63,11 @@ message Node {
   // a flaky test would point to the first attempt, and the third attempt would
   // point to the second.
   optional int32 retry_of = 9;
+
+  // An opaque id used by spawn runner to uniquely identify the spawn. Only
+  // available when remote execution, remote cache or disk cache was enabled for
+  // the spawn.
+  string identifier = 11;
 }
 
 // Metrics contains all the timing metrics about a Node.

--- a/proto/failure_details.proto
+++ b/proto/failure_details.proto
@@ -622,7 +622,8 @@ message Command {
     STARLARK_OPTIONS_PARSE_FAILURE = 10 [(metadata) = { exit_code: 2 }];
     ARGUMENTS_NOT_RECOGNIZED = 11 [(metadata) = { exit_code: 2 }];
     NOT_IN_WORKSPACE = 12 [(metadata) = { exit_code: 2 }];
-    SPACES_IN_WORKSPACE_PATH = 13 [(metadata) = { exit_code: 36 }, deprecated = true];
+    SPACES_IN_WORKSPACE_PATH = 13
+        [(metadata) = { exit_code: 36 }, deprecated = true];
     IN_OUTPUT_DIRECTORY = 14 [(metadata) = { exit_code: 2 }];
   }
 

--- a/proto/failure_details.proto
+++ b/proto/failure_details.proto
@@ -622,7 +622,7 @@ message Command {
     STARLARK_OPTIONS_PARSE_FAILURE = 10 [(metadata) = { exit_code: 2 }];
     ARGUMENTS_NOT_RECOGNIZED = 11 [(metadata) = { exit_code: 2 }];
     NOT_IN_WORKSPACE = 12 [(metadata) = { exit_code: 2 }];
-    SPACES_IN_WORKSPACE_PATH = 13 [(metadata) = { exit_code: 36 }];
+    SPACES_IN_WORKSPACE_PATH = 13 [(metadata) = { exit_code: 36 }, deprecated = true];
     IN_OUTPUT_DIRECTORY = 14 [(metadata) = { exit_code: 2 }];
   }
 

--- a/proto/failure_details.proto
+++ b/proto/failure_details.proto
@@ -170,6 +170,8 @@ message FailureDetail {
   reserved 176;         // For internal use
   reserved 178;         // For internal use
   reserved 180;         // For internal use
+  reserved 187;         // For internal use
+  reserved 188;         // For internal use
 }
 
 message Interrupted {
@@ -228,8 +230,7 @@ message Spawn {
     //   refactored to prohibit undetailed failures
     UNSPECIFIED_EXECUTION_FAILURE = 12 [(metadata) = { exit_code: 1 }];
     FORBIDDEN_INPUT = 13 [(metadata) = { exit_code: 1 }];
-    // This also includes other remote cache errors, not just evictions,
-    // if --incompatible_remote_use_new_exit_code_for_lost_inputs is set.
+    // This also includes other remote cache errors, not just evictions.
     // TODO: Rename it to a more general name when
     // --experimental_remote_cache_eviction_retries is moved to
     // non-experimental.
@@ -335,6 +336,30 @@ message Crash {
   // CRASH_OOM was chosen because an OutOfMemoryError was detected prior to the
   // crash.
   bool oom_detector_override = 3;
+
+  enum OomCauseCategory {
+    // This was not an OOM.
+    NONE = 0;
+
+    // Normal OOM noticed in Blaze's app-land code.
+    ORGANIC = 1;
+
+    // Originally a crash, but changed to an OOM because Blaze's native code was
+    // told by the JVM there was an OOM, and then Blaze's app-land code assumed
+    // the crash was a symptom of that OOM.
+    //
+    // Conveys the same thing that the field oom_detector_override does.
+    OOM_DETECTOR_OVERRIDE = 2;
+
+    // Blaze gave up and pretended it OOM'd because its post-full-GC heap size
+    // was too big after a number of full GCs within a time window.
+    //
+    // See --gc_thrashing_threshold and --gc_thrashing_limits.
+    GC_THRASHING = 3;
+  }
+
+  // If Blaze OOM'd (code = CRASH_OOM), the category of cause of that OOM.
+  OomCauseCategory oom_cause_category = 4;
 }
 
 message Throwable {
@@ -541,6 +566,7 @@ message Filesystem {
     DEFAULT_DIGEST_HASH_FUNCTION_INVALID_VALUE = 6
         [(metadata) = { exit_code: 2 }];
     FILESYSTEM_JNI_NOT_AVAILABLE = 8 [(metadata) = { exit_code: 36 }];
+    FAILED_TO_LOCK_INSTALL_BASE = 12 [(metadata) = { exit_code: 36 }];
 
     reserved 7, 9, 10;  // For internal use
   }
@@ -569,7 +595,7 @@ message ExecutionOptions {
     DYNAMIC_STRATEGY_NOT_SANDBOXED = 10 [(metadata) = { exit_code: 2 }];
     MULTIPLE_EXECUTION_LOG_FORMATS = 11 [(metadata) = { exit_code: 2 }];
 
-    reserved 1, 2;  // For internal use
+    reserved 1, 2, 12, 13;  // For internal use
   }
 
   Code code = 1;
@@ -1304,6 +1330,7 @@ message PackageLoading {
     SYMLINK_CYCLE_OR_INFINITE_EXPANSION = 30 [(metadata) = { exit_code: 1 }];
     OTHER_IO_EXCEPTION = 31 [(metadata) = { exit_code: 36 }];
     BAD_REPO_FILE = 32 [(metadata) = { exit_code: 1 }];
+    BAD_IGNORED_DIRECTORIES = 33 [(metadata) = { exit_code: 1 }];
   }
 
   Code code = 1;

--- a/proto/spawn.proto
+++ b/proto/spawn.proto
@@ -213,9 +213,9 @@ message SpawnExec {
 // serialized after all other entries it references by ID. However, entries
 // aren't guaranteed to be serialized in increasing ID order.
 //
-// Entries other than spawns and non-spawn actions may not be assumed to be
-// canonical. For performance reasons, the same file, directory or input set may
-// be serialized multiple times with a different ID.
+// Entries other than Invocation, Spawn and SymlinkSction must not be assumed to
+// be canonical: they may be serialized multiple times with different IDs for
+// performance reasons.
 message ExecLogEntry {
   // Information pertaining to the entire invocation.
   // May appear at most once in the initial position.

--- a/proto/stardoc_output.proto
+++ b/proto/stardoc_output.proto
@@ -71,6 +71,7 @@ enum AttributeType {
   OUTPUT = 12;
   OUTPUT_LIST = 13;
   LABEL_DICT_UNARY = 14;
+  LABEL_LIST_DICT = 15;
 }
 
 // Representation of a Starlark rule definition.
@@ -126,6 +127,9 @@ message MacroInfo {
   // The module where and the name under which the macro was originally
   // declared.
   OriginKey origin_key = 4;
+
+  // True if this macro is a rule finalizer.
+  bool finalizer = 5;
 }
 
 // Representation of a Starlark rule, repository rule, or module extension tag
@@ -161,6 +165,9 @@ message AttributeInfo {
 
   // If true, the attribute is non-configurable.
   bool nonconfigurable = 7;
+
+  // If true, the attribute is defined in Bazel's native code, not in Starlark.
+  bool natively_defined = 8;
 }
 
 // Representation of a set of providers.


### PR DESCRIPTION
Update Bazel protos to get latest fields.

Avoid removing fields by marking them as deprecated instead.

Some minor style fixes to help future updates.
