### PR TITLE
invocation/error_card: don't show NO_BUILD abort events with cquery

### DIFF
--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -178,6 +178,8 @@ function getModel(props: Props): CardModel {
   for (const event of props.model.aborted) {
     if (event.aborted) {
       if (
+        // Bazel always include "--nobuild" in a "cquery" command, which results in
+        // many "NO_BUILD" aborted events. We ignore those.
         props.model.invocation.command === "cquery" &&
         event.aborted.reason === build_event_stream.Aborted.AbortReason.NO_BUILD
       )

--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -182,8 +182,9 @@ function getModel(props: Props): CardModel {
         // many "NO_BUILD" aborted events. We ignore those.
         props.model.invocation.command === "cquery" &&
         event.aborted.reason === build_event_stream.Aborted.AbortReason.NO_BUILD
-      )
+      ) {
         continue;
+      }
       model.errors.push({ aborted: event });
     }
   }

--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -177,7 +177,11 @@ function getModel(props: Props): CardModel {
   }
   for (const event of props.model.aborted) {
     if (event.aborted) {
-      if (props.model.invocation.command === "cquery" && event.aborted.reason === build_event_stream.Aborted.AbortReason.NO_BUILD) continue;
+      if (
+        props.model.invocation.command === "cquery" &&
+        event.aborted.reason === build_event_stream.Aborted.AbortReason.NO_BUILD
+      )
+        continue;
       model.errors.push({ aborted: event });
     }
   }

--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -176,8 +176,10 @@ function getModel(props: Props): CardModel {
     model.errors.push({ action: props.model.failedAction.action });
   }
   for (const event of props.model.aborted) {
-    if (!event.aborted) continue;
-    model.errors.push({ aborted: event });
+    if (event.aborted) {
+      if (props.model.invocation.command === "cquery" && event.aborted.reason === build_event_stream.Aborted.AbortReason.NO_BUILD) continue;
+      model.errors.push({ aborted: event });
+    }
   }
   if (props.model.finished?.failureDetail?.message) {
     model.errors.push({ finished: props.model.finished });


### PR DESCRIPTION
cquery would always include the --nobuild flag automatically.

This causes Bazel to generate a handful of aborted events despite the
user running a valid query.

Silence the error card by excluding this particular case.
