### PR TITLE
Respect min/max duration filters in invocation aggregate/summary queries

### DIFF
--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -1070,6 +1070,13 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 		q.AddWhereClause("updated_at_usec < ?", end.AsTime().UnixMicro())
 	}
 
+	if minDuration := req.GetQuery().GetMinimumDuration().AsDuration(); minDuration > 0 {
+		q.AddWhereClause(`duration_usec >= ?`, minDuration.Microseconds())
+	}
+	if maxDuration := req.GetQuery().GetMaximumDuration().AsDuration(); maxDuration > 0 {
+		q.AddWhereClause(`duration_usec <= ?`, maxDuration.Microseconds())
+	}
+
 	for _, f := range req.GetQuery().GetFilter() {
 		str, args, err := filter.GenerateFilterStringAndArgs(f)
 		if err != nil {

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -452,6 +452,12 @@ message InvocationStatQuery {
   // Stat filters (duration_usec, cas_cache_misses, etc.)
   repeated stat_filter.StatFilter filter = 12;
 
+  // The minimum invocation duration.
+  google.protobuf.Duration minimum_duration = 17;
+
+  // The maximum invocation duration.
+  google.protobuf.Duration maximum_duration = 18;
+
   // String-based dimensional filters (execution worker, branch, etc.)
   repeated stat_filter.DimensionFilter dimension_filter = 15;
 


### PR DESCRIPTION
Was trying to filter the UI to show only prober invocations > 1 minute and noticed the invocation list was being updated but not the summary at the top which shows the total invocation count / duration etc. This PR fixes that.

Also simplify some of the server-side query logic and fix some TS type issues (we were using the `InvocationQuery` message for the `GetInvocationStatRequest.query` field but should be using `InvocationStatQuery`).