### PR TITLE
[raft] increase events chan size and add monitoring

### DIFF
--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -149,7 +149,11 @@ func (la *leaseAgent) sendRangeEvent(eventType events.EventType) {
 	case la.broadcast <- ev:
 		break
 	default:
-		la.log.Warningf("Dropping range event: %+v", ev)
+		metrics.RaftStoreEventBroadcastDropped.With(prometheus.Labels{
+			metrics.RaftEventBroadcaster: "leasekeeper",
+			metrics.RaftEventType:        ev.EventType().String(),
+		}).Inc()
+		la.log.Warningf("leaseAgent dropped range event: %+v", ev)
 	}
 }
 

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -226,7 +226,11 @@ func (sm *Replica) notifyListenersOfUsage(rd *rfpb.RangeDescriptor, usage *rfpb.
 	case sm.broadcast <- up:
 		break
 	default:
-		sm.log.Warningf("dropped usage update: %+v", up)
+		metrics.RaftStoreEventBroadcastDropped.With(prometheus.Labels{
+			metrics.RaftEventBroadcaster: "replica",
+			metrics.RaftEventType:        up.EventType().String(),
+		}).Inc()
+		sm.log.Warningf("replica dropped usage update: %+v", up)
 	}
 }
 

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -130,7 +130,7 @@ type Store struct {
 
 	eventsMu       sync.Mutex
 	events         chan events.Event
-	eventListeners []chan events.Event
+	eventListeners map[string]chan events.Event
 
 	usages *usagetracker.Tracker
 
@@ -219,7 +219,7 @@ func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeH
 	nodeLiveness := nodeliveness.New(env.GetServerContext(), nodeHost.ID(), sender)
 
 	nhLog := log.NamedSubLogger(nodeHost.ID())
-	eventsChan := make(chan events.Event, 100)
+	eventsChan := make(chan events.Event, 1000)
 
 	clock := env.GetClock()
 	session := client.NewSessionWithClock(clock)
@@ -253,7 +253,7 @@ func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeH
 
 		eventsMu:       sync.Mutex{},
 		events:         eventsChan,
-		eventListeners: make([]chan events.Event, 0),
+		eventListeners: make(map[string]chan events.Event),
 
 		metaRangeMu:   sync.Mutex{},
 		metaRangeData: make([]byte, 0),
@@ -587,12 +587,16 @@ func (s *Store) handleEvents(ctx context.Context) {
 		select {
 		case e := <-s.events:
 			s.eventsMu.Lock()
-			for _, ch := range s.eventListeners {
+			for id, ch := range s.eventListeners {
 				select {
 				case ch <- e:
 					continue
 				default:
-					s.log.Warningf("Dropped event: %s", e)
+					metrics.RaftStoreEventListenerDropped.With(prometheus.Labels{
+						metrics.RaftListenerID: id,
+						metrics.RaftEventType:  e.EventType().String(),
+					}).Inc()
+					s.log.Warningf("EventListener(%s) dropped event: %s", id, e)
 				}
 			}
 			s.eventsMu.Unlock()
@@ -602,12 +606,12 @@ func (s *Store) handleEvents(ctx context.Context) {
 	}
 }
 
-func (s *Store) AddEventListener() <-chan events.Event {
+func (s *Store) AddEventListener(id string) <-chan events.Event {
 	s.eventsMu.Lock()
 	defer s.eventsMu.Unlock()
 
-	ch := make(chan events.Event, 100)
-	s.eventListeners = append(s.eventListeners, ch)
+	ch := make(chan events.Event, 1000)
+	s.eventListeners[id] = ch
 	return ch
 }
 
@@ -1811,7 +1815,7 @@ func (j *replicaJanitor) removeZombie(ctx context.Context, task zombieCleanupTas
 }
 
 func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context, maxRangeSizeBytes int64) {
-	eventsCh := s.AddEventListener()
+	eventsCh := s.AddEventListener("splitRanges")
 	for {
 		select {
 		case <-ctx.Done():
@@ -1848,7 +1852,7 @@ func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context, maxRangeSizeBy
 }
 
 func (s *Store) updateStoreUsageTag(ctx context.Context) {
-	eventsCh := s.AddEventListener()
+	eventsCh := s.AddEventListener("updateTags")
 	for {
 		select {
 		case <-ctx.Done():
@@ -3140,6 +3144,7 @@ func (s *Store) refreshMetrics(ctx context.Context) {
 				metrics.DiskCacheFilesystemTotalBytes.With(prometheus.Labels{metrics.CacheNameLabel: constants.CacheName}).Set(float64(fsu.Total))
 				metrics.DiskCacheFilesystemAvailBytes.With(prometheus.Labels{metrics.CacheNameLabel: constants.CacheName}).Set(float64(fsu.Avail))
 			}
+			metrics.RaftStoreEventsChanSize.Set(float64(len(s.events)))
 		}
 	}
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -194,11 +194,18 @@ const (
 	// Raft RangeCache event type: `hit`, `miss`, or `update`.
 	RaftRangeCacheEventTypeLabel = "rangecache_event_type"
 
-	// Raft Listener Event Type
+	// Raft Listener Event Type, such as "LeaderUpdated". These are events sent
+	// by dragonboat library.
 	RaftListenerEventType = "listener_event"
 
 	// The ID of a raft listener
 	RaftListenerID = "listener_id"
+
+	// The source of the event broadcase
+	RaftEventBroadcaster = "event_broadcast_source"
+
+	// Raft Event Type, such as "range-removed", "range-usage-updated"
+	RaftEventType = "raft_event"
 
 	// Binary version. Example: `v2.0.0`.
 	VersionLabel = "version"
@@ -2454,6 +2461,33 @@ var (
 	}, []string{
 		RaftListenerID,
 		RaftListenerEventType,
+	})
+
+	RaftStoreEventsChanSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "store_events",
+		Help:      "Number of events in the queue",
+	})
+
+	RaftStoreEventBroadcastDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "store_event_broadcast_dropped",
+		Help:      "The total number of dropped events to broadcast",
+	}, []string{
+		RaftEventBroadcaster,
+		RaftEventType,
+	})
+
+	RaftStoreEventListenerDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "store_event_listener_dropped",
+		Help:      "The total number of dropped events in store",
+	}, []string{
+		RaftListenerID,
+		RaftEventType,
 	})
 
 	RaftLeaseActionCount = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -201,7 +201,7 @@ const (
 	// The ID of a raft listener
 	RaftListenerID = "listener_id"
 
-	// The source of the event broadcase
+	// The source of the event broadcast.
 	RaftEventBroadcaster = "event_broadcast_source"
 
 	// Raft Event Type, such as "range-removed", "range-usage-updated"


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/3602

increased event size to 1000. We have ~180 ranges per machine. When replica and
leasekeeper broadcasting events at the same time, we will drop events.

add monitoring to monitor the size of the broadcast chan and the num of dropped
events
