### PR TITLE
Factor the auth-header preservation out of atime_updater

### DIFF
--- a/enterprise/server/atime_updater/BUILD
+++ b/enterprise/server/atime_updater/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//server/util/authutil",
         "//server/util/log",
         "@com_github_prometheus_client_golang//prometheus",
-        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -62,7 +62,7 @@ func (u *atimeUpdate) toProto() *repb.FindMissingBlobsRequest {
 // discard additional digests until it's flushed.
 type atimeUpdates struct {
 	mu          sync.Mutex // protects jwt, updates, and atimeUpdate.digests.
-	authHeaders map[string]string
+	authHeaders map[string][]string
 	updates     []*atimeUpdate
 	numDigests  int
 }
@@ -259,7 +259,7 @@ func (u *atimeUpdater) sendUpdates(ctx context.Context) int {
 	// Remove updates to send and release the mutex before sending RPCs.
 	updatesToSend := map[string]*repb.FindMissingBlobsRequest{}
 	updatesSent := 0
-	authHeaders := map[string]map[string]string{}
+	authHeaders := map[string]map[string][]string{}
 	u.mu.Lock()
 	for groupID, updates := range u.updates {
 		updates.mu.Lock()
@@ -324,7 +324,7 @@ func (u *atimeUpdater) getUpdate(updates *atimeUpdates) *repb.FindMissingBlobsRe
 	return &req
 }
 
-func (u *atimeUpdater) update(ctx context.Context, groupID string, authHeaders map[string]string, req *repb.FindMissingBlobsRequest) {
+func (u *atimeUpdater) update(ctx context.Context, groupID string, authHeaders map[string][]string, req *repb.FindMissingBlobsRequest) {
 	log.CtxDebugf(ctx, "Asynchronously processing %d atime updates for group %s", len(req.BlobDigests), groupID)
 
 	ctx = authutil.AddAuthHeadersToContext(ctx, authHeaders, u.authenticator)

--- a/server/util/authutil/BUILD
+++ b/server/util/authutil/BUILD
@@ -11,9 +11,11 @@ go_library(
         "//server/interfaces",
         "//server/util/alert",
         "//server/util/blocklist",
+        "//server/util/log",
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",
         "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -10,9 +10,11 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/blocklist"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	gstatus "google.golang.org/grpc/status"
@@ -166,4 +168,39 @@ func EncryptionEnabled(ctx context.Context, authenticator interfaces.Authenticat
 		return false
 	}
 	return u.GetCacheEncryptionEnabled()
+}
+
+// Extracts auth headers from the provided context and returns them as a map.
+// This function is intended for use along with AddAuthHeadersToContext when
+// auth headers must be copied between contexts.
+func GetAuthHeaders(ctx context.Context, authenticator interfaces.Authenticator) map[string]string {
+	headers := map[string]string{}
+
+	keys := metadata.ValueFromIncomingContext(ctx, ClientIdentityHeaderName)
+	if len(keys) > 1 {
+		log.Warningf("Expected at most 1 client-identity header (found %d)", len(keys))
+	} else if len(keys) == 1 {
+		headers[ClientIdentityHeaderName] = keys[0]
+	}
+
+	if jwt := authenticator.TrustedJWTFromAuthContext(ctx); jwt != "" {
+		headers[ContextTokenStringKey] = jwt
+	}
+	return headers
+}
+
+// Adds the provided auth headers into the provided context and returns a new
+// context containng them. This function is intended for use along with
+// GetAuthHeaders when auth headers must be copied between contexts.
+func AddAuthHeadersToContext(ctx context.Context, headers map[string]string, authenticator interfaces.Authenticator) context.Context {
+	for key, value := range headers {
+		if key == ClientIdentityHeaderName {
+			ctx = metadata.AppendToOutgoingContext(ctx, ClientIdentityHeaderName, value)
+		} else if key == ContextTokenStringKey {
+			ctx = authenticator.AuthContextFromTrustedJWT(ctx, value)
+		} else {
+			log.Warningf("Ignoring unrecognized auth header: %s", key)
+		}
+	}
+	return ctx
 }


### PR DESCRIPTION
I'd like to reuse this logic in the hit-tracker-client implementation.