### PR TITLE
[raft] pushUpdate registry event should not be coalesced

### DIFF
--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -390,7 +390,7 @@ func (d *DynamicNodeRegistry) pushUpdate(req *rfpb.RegistryPushRequest) {
 		d.sReg.log.Errorf("error marshaling proto: %s", err)
 		return
 	}
-	err = d.gossipManager.SendUserEvent(constants.RegistryUpdateEvent, buf, true)
+	err = d.gossipManager.SendUserEvent(constants.RegistryUpdateEvent, buf /*coalesce=*/, false)
 	if err != nil {
 		d.sReg.log.Errorf("error pushing gossip update: %s", err)
 	}


### PR DESCRIPTION
After we removed registry.Add and registry.AddNode call from addNonVoting in https://github.com/buildbuddy-io/buildbuddy/pull/8796,  it causes issues when we try up-replicate meta-range from 3 replicas to 5 replicas.

The issue is that the target:raft_address:grpc_address were not propagated to other nodes as expected through gossip; and as a result, registry.Resolve can't resolve the raft address for the new replica c1n4 or c1n5 even though registry have info for these two replicas.
