### PR TITLE
cache proxy: dont include cached digest key when hashing GetActionResultRequest

### DIFF
--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy_test.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy_test.go
@@ -234,6 +234,9 @@ func TestActionCacheProxy_CachingEnabled(t *testing.T) {
 	require.Equal(t, int32(2), get(ctx, proxy, digestA, t).GetExitCode())
 	// That should _not_ be a cache hit.
 	require.Equal(t, 1, countingClient.cacheHitCount)
+	// But reading from the proxy again _should_ be a cache hit.
+	require.Equal(t, int32(2), get(ctx, proxy, digestA, t).GetExitCode())
+	require.Equal(t, 2, countingClient.cacheHitCount)
 
 	countingClient.cacheHitCount = 0
 	// DigestB shouldn't be present initially,


### PR DESCRIPTION
Previously, if we requested a proxy-cached ActionResult and the remote server has a _different_ ActionResult, we would use a modified GetActionResultRequest that included cached_action_result_digest as a key when saving the ActionResult to the cacheproxy cache.  This meant that the cacheproxy-cached ActionResult was never getting overwritten!

This change computes the AC key for the request prior to setting cached_action_result_digest.