### PR TITLE
Update `@babel/runtime` to `v7.26.10` for dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "react-slider": {
         "//": "Fixes an issue that esbuild can't build react-slider because it implicitly depends on @babel/runtime.",
         "dependencies": {
-          "@babel/runtime": "7.19.0"
+          "@babel/runtime": "7.26.10"
         }
       }
     }


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy/security/dependabot/202
