### PR TITLE
SCIM: fix user creation if user exists but not in SCIM group

### DIFF
--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -58,6 +58,10 @@ var (
 	samlSubjectAttributes   = append([]string{"urn:oasis:names:tc:SAML:attribute:subject-id", "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent", "user_id", "username"}, samlEmailAttributes...)
 )
 
+func SubIDForUserName(userName string, g *tables.Group) string {
+	return fmt.Sprintf("%s/%s", build_buddy_url.WithPath("saml/metadata").String()+"?slug="+g.URLIdentifier, userName)
+}
+
 // CookieRequestTracker tracks requests by setting a uniquely named
 // cookie for each request.
 //

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -58,8 +58,12 @@ var (
 	samlSubjectAttributes   = append([]string{"urn:oasis:names:tc:SAML:attribute:subject-id", "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent", "user_id", "username"}, samlEmailAttributes...)
 )
 
+func SubIDPrefixForGroup(slug string) string {
+	return build_buddy_url.WithPath("saml/metadata").String() + "?slug=" + slug + "/"
+}
+
 func SubIDForUserName(userName string, g *tables.Group) string {
-	return fmt.Sprintf("%s/%s", build_buddy_url.WithPath("saml/metadata").String()+"?slug="+g.URLIdentifier, userName)
+	return SubIDPrefixForGroup(g.URLIdentifier) + userName
 }
 
 // CookieRequestTracker tracks requests by setting a uniquely named
@@ -345,14 +349,6 @@ func (a *SAMLAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error {
 
 	sp.ServeHTTP(w, r)
 	return nil
-}
-
-func SubIDPrefixForGroup(slug string) string {
-	return build_buddy_url.WithPath("saml/metadata").String() + "?slug=" + slug + "/"
-}
-
-func SubIDForUserName(userName string, g *tables.Group) string {
-	return SubIDPrefixForGroup(g.URLIdentifier) + userName
 }
 
 func (a *SAMLAuthenticator) serviceProviderFromRequest(r *http.Request) (*samlsp.Middleware, error) {

--- a/enterprise/server/scim/BUILD
+++ b/enterprise/server/scim/BUILD
@@ -32,6 +32,8 @@ go_test(
         "//enterprise/server/testutil/enterprise_testauth",
         "//enterprise/server/testutil/enterprise_testenv",
         "//proto:api_key_go_proto",
+        "//proto:group_go_proto",
+        "//proto:user_id_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/tables",

--- a/enterprise/server/scim/scim.go
+++ b/enterprise/server/scim/scim.go
@@ -504,8 +504,10 @@ func (s *SCIMServer) createUser(ctx context.Context, r *http.Request, g *tables.
 		return nil, err
 	}
 	if updateExistingUser {
-		// Need to add the user to the group first in order to get past the
-		// permission check in UpdateUser.
+		// UpdateUser performs a permission check that allows the update only
+		// if the caller is an admin of any groups of which the target user is a
+		// member of. That means we need to add the user to the group first
+		// before performing the update.
 		if err := s.env.GetUserDB().UpdateGroupUsers(ctx, g.GroupID, roleUpdate); err != nil {
 			return nil, err
 		}

--- a/enterprise/server/scim/scim.go
+++ b/enterprise/server/scim/scim.go
@@ -418,15 +418,32 @@ func mapRole(ur *UserResource) (role.Role, error) {
 	return role.Parse(roleName)
 }
 
-func roleUpdateRequest(userID string, userRole role.Role) ([]*grpb.UpdateGroupUsersRequest_Update, error) {
+func roleUpdateRequest(userID string, userRole role.Role, addUserToGroup bool) ([]*grpb.UpdateGroupUsersRequest_Update, error) {
 	r, err := role.ToProto(userRole)
 	if err != nil {
 		return nil, err
 	}
-	return []*grpb.UpdateGroupUsersRequest_Update{{
+	update := &grpb.UpdateGroupUsersRequest_Update{
 		UserId: &uidpb.UserId{Id: userID},
 		Role:   r,
-	}}, nil
+	}
+	if addUserToGroup {
+		update.MembershipAction = grpb.UpdateGroupUsersRequest_Update_ADD
+	}
+	return []*grpb.UpdateGroupUsersRequest_Update{update}, nil
+}
+
+func fillUserFromResource(u *tables.User, ur UserResource, g *tables.Group) error {
+	userRole, err := mapRole(&ur)
+	if err != nil {
+		return err
+	}
+	u.SubID = saml.SubIDForUserName(ur.UserName, g)
+	u.FirstName = ur.Name.GivenName
+	u.LastName = ur.Name.FamilyName
+	u.Email = ur.UserName
+	u.Groups = []*tables.GroupRole{{Group: *g, Role: uint32(userRole)}}
+	return nil
 }
 
 func (s *SCIMServer) createUser(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
@@ -434,41 +451,67 @@ func (s *SCIMServer) createUser(ctx context.Context, r *http.Request, g *tables.
 	if err != nil {
 		return nil, err
 	}
-	log.CtxDebugf(ctx, "SCIM create user request: %s", string(req))
+	log.CtxInfof(ctx, "SCIM create user request:\n%s", string(req))
 	ur := UserResource{}
 	if err := json.Unmarshal(req, &ur); err != nil {
 		return nil, err
 	}
 
-	pk, err := tables.PrimaryKeyForTable("Users")
-	if err != nil {
-		return nil, err
-	}
 	userRole, err := mapRole(&ur)
 	if err != nil {
 		return nil, err
 	}
-	roleUpdate, err := roleUpdateRequest(pk, userRole)
+
+	// If the user exists in our system, but is not currently part of the group
+	// managed by SCIM then all the SCIM query APIs will not return information
+	// about this user.
+	// From the perspective of the upstream system the user effectively does not
+	// exist in our system. If we get a create request for such a user then
+	// we need to translate it to an update request.
+	updateExistingUser := false
+	user, err := s.env.GetAuthDB().LookupUserFromSubID(ctx, saml.SubIDForUserName(ur.UserName, g))
+	if err != nil && !status.IsNotFoundError(err) {
+		return nil, err
+	}
+	if err == nil {
+		for _, eg := range user.Groups {
+			if eg.GroupID == g.GroupID {
+				return status.AlreadyExistsErrorf("user %q already exists", ur.UserName), nil
+			}
+		}
+		updateExistingUser = true
+	} else {
+		pk, err := tables.PrimaryKeyForTable("Users")
+		if err != nil {
+			return nil, err
+		}
+		user = &tables.User{UserID: pk}
+	}
+
+	if err := fillUserFromResource(user, ur, g); err != nil {
+		return nil, err
+	}
+
+	roleUpdate, err := roleUpdateRequest(user.UserID, userRole, updateExistingUser)
 	if err != nil {
 		return nil, err
 	}
-	u := &tables.User{
-		UserID:    pk,
-		SubID:     saml.SubIDForUserName(ur.UserName, g),
-		FirstName: ur.Name.GivenName,
-		LastName:  ur.Name.FamilyName,
-		Email:     ur.UserName,
-		Groups: []*tables.GroupRole{
-			{Group: *g, Role: uint32(userRole)},
-		},
+	if updateExistingUser {
+		if err := s.env.GetUserDB().UpdateGroupUsers(ctx, g.GroupID, roleUpdate); err != nil {
+			return nil, err
+		}
+		if err := s.env.GetUserDB().UpdateUser(ctx, user); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := s.env.GetUserDB().InsertUser(ctx, user); err != nil {
+			return nil, err
+		}
+		if err := s.env.GetUserDB().UpdateGroupUsers(ctx, g.GroupID, roleUpdate); err != nil {
+			return nil, err
+		}
 	}
-	if err := s.env.GetUserDB().InsertUser(ctx, u); err != nil {
-		return nil, err
-	}
-	if err := s.env.GetUserDB().UpdateGroupUsers(ctx, g.GroupID, roleUpdate); err != nil {
-		return nil, err
-	}
-	return newUserResource(u, g)
+	return newUserResource(user, g)
 }
 
 // Azure AD incorrectly sends "active" field as a string instead of a native
@@ -586,7 +629,7 @@ func (s *SCIMServer) patchUser(ctx context.Context, r *http.Request, g *tables.G
 			if err != nil {
 				return nil, err
 			}
-			roleUpdate, err := roleUpdateRequest(id, userRole)
+			roleUpdate, err := roleUpdateRequest(id, userRole, false /*=addUserToGroup*/)
 			if err != nil {
 				return nil, err
 			}
@@ -640,7 +683,7 @@ func (s *SCIMServer) updateUser(ctx context.Context, r *http.Request, g *tables.
 		if err != nil {
 			return nil, err
 		}
-		roleUpdate, err := roleUpdateRequest(id, userRole)
+		roleUpdate, err := roleUpdateRequest(id, userRole, false /*=addUserToGroup*/)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/scim/scim_test.go
+++ b/enterprise/server/scim/scim_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
+	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 )
 
 func getEnv(t *testing.T) *testenv.TestEnv {
@@ -43,7 +45,7 @@ func authUserCtx(ctx context.Context, env environment.Env, t *testing.T, userID 
 	return ctx
 }
 
-func prepareGroup(t *testing.T, ctx context.Context, env environment.Env) (string, *tables.Group) {
+func prepareGroup(t *testing.T, ctx context.Context, env environment.Env) (string, string) {
 	u, err := env.GetUserDB().GetUser(ctx)
 	require.NoError(t, err)
 	g := u.Groups[0].Group
@@ -67,7 +69,7 @@ func prepareGroup(t *testing.T, ctx context.Context, env environment.Env) (strin
 	_, err = env.GetUserDB().UpdateGroup(ctx, &gr)
 	require.NoError(t, err)
 
-	return apiKey.Value, &gr
+	return apiKey.Value, gr.GroupID
 }
 
 type testClient struct {
@@ -144,7 +146,7 @@ func TestGetUsers(t *testing.T) {
 	require.NoError(t, err)
 
 	userCtx := authUserCtx(ctx, env, t, "US100")
-	apiKey, gr := prepareGroup(t, userCtx, env)
+	apiKey := prepareGroup(t, userCtx, env)
 	updateUserSubID(t, userCtx, udb, "US100", gr)
 
 	// Add another user to the group with the same e-mail but non-matching
@@ -318,7 +320,7 @@ func TestCreateUser(t *testing.T) {
 	require.NoError(t, err)
 
 	userCtx := authUserCtx(ctx, env, t, "US100")
-	apiKey, _ := prepareGroup(t, userCtx, env)
+	apiKey := prepareGroup(t, userCtx, env)
 
 	ss := scim.NewSCIMServer(env)
 	mux := http.NewServeMux()
@@ -377,6 +379,7 @@ func TestCreateUser(t *testing.T) {
 	}
 
 	// Create admin user.
+	user501ID := ""
 	{
 		newUser := &scim.UserResource{
 			Schemas:  []string{scim.UserResourceSchema},
@@ -421,6 +424,64 @@ func TestCreateUser(t *testing.T) {
 		require.Equal(t, "user501@org1.io", ur.UserName)
 		verifyRole(t, ur, role.Admin.String())
 		require.True(t, ur.Active)
+
+		user501ID = createdUser.ID
+	}
+
+	// Remove a user manually from the SCIM-managed group and try creating the
+	// user through the SCIM API. The user should be added to the target group.
+	{
+		err = udb.UpdateGroupUsers(userCtx, groupID, []*grpb.UpdateGroupUsersRequest_Update{{
+			UserId:           &uidpb.UserId{Id: user501ID},
+			MembershipAction: grpb.UpdateGroupUsersRequest_Update_REMOVE,
+		}})
+		require.NoError(t, err)
+
+		newUser := &scim.UserResource{
+			Schemas:  []string{scim.UserResourceSchema},
+			UserName: "user501@org1.io",
+			Name: scim.NameResource{
+				GivenName:  "User",
+				FamilyName: "Doe",
+			},
+			Emails: []scim.EmailResource{
+				{
+					Primary: true,
+					Value:   "user501@org1.io",
+				},
+			},
+			Active: true,
+		}
+		body, err := json.Marshal(newUser)
+		require.NoError(t, err)
+
+		code, body := tc.Post(baseURL+"/scim/Users", body)
+		require.Equal(tc.t, http.StatusOK, code, "body: %s", string(body))
+		createdUser := scim.UserResource{}
+		err = json.Unmarshal(body, &createdUser)
+		require.NoError(t, err)
+		require.Equal(t, "User", createdUser.Name.GivenName)
+		require.Equal(t, "Doe", createdUser.Name.FamilyName)
+		require.Equal(t, "user501@org1.io", createdUser.UserName)
+		require.True(t, createdUser.Active)
+
+		code, body = tc.Get(baseURL + "/scim/Users/" + createdUser.ID)
+		require.Equal(tc.t, http.StatusOK, code, "body: %s", string(body))
+		ur := scim.UserResource{}
+		err = json.Unmarshal(body, &ur)
+		require.NoError(t, err)
+		require.Len(t, ur.Schemas, 1)
+		require.Equal(t, scim.UserResourceSchema, ur.Schemas[0])
+		require.Equal(t, createdUser.ID, ur.ID)
+		require.Equal(t, "User", ur.Name.GivenName)
+		require.Equal(t, "Doe", ur.Name.FamilyName)
+		require.Equal(t, "user501@org1.io", ur.UserName)
+		verifyRole(t, ur, role.Developer.String())
+		require.True(t, ur.Active)
+
+		u, err := udb.GetUserByID(userCtx, createdUser.ID)
+		require.NoError(t, err)
+		require.Equal(t, "http://localhost:8080/saml/metadata?slug=gr100-slug/user501@org1.io", u.SubID)
 	}
 }
 


### PR DESCRIPTION
From the perspective of an external system, a user does not exist if it's not a member of the SCIM-managed group. We do not return such users via the query APIs.

If a user is manually removed via the UI, but is still mapped in the external system then the external system will send a "create user" request to bring the systems in sync. Prior to this fix, this would fail since the internal create call would fail due to the existence of a user with the same SubID.