### PR TITLE
Enable the clickhouse datasource in dev grafana

### DIFF
--- a/tools/metrics/grafana/provisioning/deploy/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/deploy/datasources/datasources.yml
@@ -15,7 +15,7 @@ datasources:
     uid: grafana
     jsonData:
       port: 9000
-      host: clickhouse-repl-%{ENV}.clickhouse-operator-dev.svc.cluster.local
+      host: clickhouse-repl-%{ENV}.clickhouse-operator-%{ENV}.svc.cluster.local
       username: buildbuddy_%{ENV}_readonly
     secureJsonData:
       password: ${CLICKHOUSE_PASSWORD}


### PR DESCRIPTION
This depends on https://github.com/buildbuddy-io/buildbuddy-internal/pull/4750