### PR TITLE
Periodically try to reconnect gRPC client connections that are in TRANSIENT_FAILURE state

### DIFF
--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	poolSize          = flag.Int("grpc_client.pool_size", 15, "Number of connections to create to each target.")
-	reconnectInterval = flag.Duration("grpc_client.transient_failure_reconnect_interval", 30*time.Second, "TODO(iain)")
+	reconnectInterval = flag.Duration("grpc_client.transient_failure_reconnect_interval", 30*time.Second, "Attempt to reconnect gRPC client connections that are in the TRANSIENT_FAILURE state for longer than this duration.")
 )
 
 type clientConn struct {


### PR DESCRIPTION
Sometimes the executors get into a bad state where all of their gRPC client connections to the scheduler are stuck in the TRANSIENT_FAILURE state. This makes the executor fail health checks and receive no traffic, meaning the connection is never re-tried. This PR periodically attempts to reconnect these connections. We could do something smarter here like exponentially backoff or something, but I think this should suffice for the time being.