### PR TITLE
Default --app.enable_write_executions_to_olap_db to true

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -427,7 +427,7 @@ func (s *ExecutionServer) recordExecution(
 			} else {
 				log.CtxInfof(ctx, "appended execution %q to invocation %q in redis", executionID, link.GetInvocationId())
 			}
-		} else {
+		} else if s.env.GetOLAPDBHandle() != nil {
 			err = s.env.GetOLAPDBHandle().FlushExecutionStats(ctx, inv, []*repb.StoredExecution{executionProto})
 			if err != nil {
 				log.CtxErrorf(ctx, "failed to flush execution %q for invocation %q to clickhouse: %s", executionID, link.GetInvocationId(), err)

--- a/server/olapdbconfig/olapdbconfig.go
+++ b/server/olapdbconfig/olapdbconfig.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	writeExecutionsToOLAPDBEnabled = flag.Bool("app.enable_write_executions_to_olap_db", false, "If enabled, complete Executions will be flushed to OLAP DB")
+	writeExecutionsToOLAPDBEnabled = flag.Bool("app.enable_write_executions_to_olap_db", true, "If enabled, complete Executions will be flushed to OLAP DB")
 )
 
 func WriteExecutionsToOLAPDBEnabled() bool {


### PR DESCRIPTION
It's always set to true in our configs. If someone is self-hosting, using clickhouse, and they don't want every execution written when they update buildbuddy, they can still turn the flag off.