### PR TITLE
[raft] fix the issue where we use the lease agent for the removed replica instead of the newly added one

### DIFF
--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -135,7 +135,7 @@ func (l *Lease) verifyLease(ctx context.Context, rl *rfpb.RangeLeaseRecord) (ret
 
 	replicaRL := l.replica.GetRangeLease()
 	if !proto.Equal(replicaRL, rl) {
-		return status.FailedPreconditionErrorf("rangeLease %v does not match replica %v", rl, replicaRL)
+		return status.FailedPreconditionErrorf("rangeLease %v does not match replica(c%dn%d) %v", rl, l.replica.RangeID(), l.replica.ReplicaID(), replicaRL)
 	}
 
 	// This is a node epoch based lease, so check node and epoch.


### PR DESCRIPTION
- add a test to reproduce the issue where when a replica is removed from
  a nodehost, and then we add a new replica of the same range, and then when the
  leadership is transfered to the new replica, we cannot acquire lease.
  https://github.com/buildbuddy-io/buildbuddy-internal/issues/4528

- add the replica name when rangeLease does not match replica's in-memory
  rangelease.

To fix the issue:
- store replica id in lease agent
- use a regular map to store lease agents in leasekeeper, and protect it by the
  existing mu in leasekeeper. 
- in AddRange, we will check if the store lease agent matches the r.ReplicaID.
  If not, we will create a new lease agent and store it. 
- In raft/listener, implement Add(Remove)NodeUnloadedListener; so that
  leasekeeper can listen on it.
- When leasekeeper receives NodeUnload, it will try to delete the lease agent if
  the replica id matches.
