### PR TITLE
Fix the uid of the clickhouse datasource in grafana

### DIFF
--- a/tools/metrics/grafana/provisioning/deploy/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/deploy/datasources/datasources.yml
@@ -12,7 +12,7 @@ datasources:
     editable: false
   - name: ClickHouse
     type: grafana-clickhouse-datasource
-    uid: grafana
+    uid: clickhouse
     jsonData:
       port: 9000
       host: clickhouse-repl-%{ENV}.clickhouse-operator-%{ENV}.svc.cluster.local


### PR DESCRIPTION
Using the "grafana" uid seems to collide with the builtin grafana data source, making this not work. Either way, I wanted to call this "clickhouse" instead.