### PR TITLE
Allow local grafana to connect to clickhouse

### DIFF
--- a/tools/metrics/docker-compose.grafana.yml
+++ b/tools/metrics/docker-compose.grafana.yml
@@ -9,6 +9,10 @@ services:
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/buildbuddy.json
       - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
       - GF_DATASOURCE_URL=${GF_DATASOURCE_URL}
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - CLICKHOUSE_PORT=${CLICKHOUSE_PORT}
+      - CLICKHOUSE_USERNAME=${CLICKHOUSE_USERNAME}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
     volumes:
       - ./grafana/provisioning/local:/etc/grafana/provisioning
       - ${DASHBOARDS_DIR}:/var/lib/grafana/dashboards

--- a/tools/metrics/grafana/grafana.go
+++ b/tools/metrics/grafana/grafana.go
@@ -82,6 +82,7 @@ func run() error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
+		defer cancel() // stop everything else even when docker exits cleanly
 		// Start docker-compose
 		os.Setenv("DASHBOARDS_DIR", filepath.Join(workspaceRoot, dashboardsDir))
 		os.Setenv("GF_DATASOURCE_URL", strings.Replace(datasourceURL(), "localhost", "host.docker.internal", 1))

--- a/tools/metrics/grafana/grafana.go
+++ b/tools/metrics/grafana/grafana.go
@@ -126,18 +126,16 @@ func run() error {
 		return err
 	})
 	eg.Go(func() error {
-		var context, namespace, service string
+		var context string
 		if *clickhouse == "dev" {
 			context = "gke_flame-build_us-west1_dev-nv8eh"
-			namespace = "clickhouse-operator-dev"
-			service = "chi-repl-dev-replicated-0-0-0"
 		} else if *clickhouse == "prod" {
 			context = "gke_flame-build_us-west1_prod-hs6in"
-			namespace = "clickhouse-operator-prod"
-			service = "chi-repl-prod-replicated-0-0-0"
 		} else {
 			return nil
 		}
+		namespace := "clickhouse-operator-" + *clickhouse
+		service := "chi-repl-" + *clickhouse + "-replicated-0-0-0"
 		// Start kubectl port-forward for clickhouse
 		cmd := exec.CommandContext(
 			ctx, "kubectl", "--namespace", namespace, "port-forward", service,

--- a/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
@@ -11,3 +11,12 @@ datasources:
     editable: false
     jsonData:
       timeInterval: 1s
+  - name: ClickHouse
+    type: grafana-clickhouse-datasource
+    uid: clickhouse
+    jsonData:
+      port: ${CLICKHOUSE_PORT}
+      host: host.docker.internal
+      username: ${CLICKHOUSE_USERNAME}
+    secureJsonData:
+      password: ${CLICKHOUSE_PASSWORD}


### PR DESCRIPTION
It can connect to either a locally running clickhouse, or a port-forwarded dev/prod instance.

I also made a few minor improvements to grafana.go:
- if `docker-compose` isn't available, then `docker compose` is used
- Log when port forwarding fails. Since we don't use `exec.CommandContext` for the docker command, it keeps running and logging, so `eg.Wait()` doesn't return which makes it hard to tell that anything went wrong.
- Cancel the context when docker exits cleanly. This cancels all the other goroutines and lets the program exit instead of continuously logging `Failed to list grafana dashboards...`