### PR TITLE
[Cache Proxy] allow empty values of cache_proxy.remote_hit_tracker.target

### DIFF
--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -36,6 +36,7 @@ var (
 
 func Register(env *real_environment.RealEnv) error {
 	if *remoteHitTrackerTarget == "" || *remoteHitTrackerWorkers < 1 {
+		env.SetHitTrackerFactory(&NoOpHitTrackerFactory{})
 		return nil
 	}
 
@@ -45,6 +46,16 @@ func Register(env *real_environment.RealEnv) error {
 	}
 	env.SetHitTrackerFactory(newHitTrackerClient(env.GetServerContext(), env, conn))
 	return nil
+}
+
+type NoOpHitTrackerFactory struct{}
+
+func (h *NoOpHitTrackerFactory) NewACHitTracker(ctx context.Context, requestMetadata *repb.RequestMetadata) interfaces.HitTracker {
+	return &NoOpHitTracker{}
+}
+
+func (h *NoOpHitTrackerFactory) NewCASHitTracker(ctx context.Context, requestMetadata *repb.RequestMetadata) interfaces.HitTracker {
+	return &NoOpHitTracker{}
 }
 
 func newHitTrackerClient(ctx context.Context, env *real_environment.RealEnv, conn grpc.ClientConnInterface) *HitTrackerFactory {


### PR DESCRIPTION
Without this PR, the hit-tracker-factory is nil if the flag is missing, which causes panics in the cache code that tries to use it. This change registers a no-op hit tracker factory if the flag is missing.