### PR TITLE
Fix a bug in distributed.Cache.remoteGetMulti 

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -704,6 +704,8 @@ func (c *Cache) remoteGetMulti(ctx context.Context, peer string, isolation *dcpb
 		}
 	}
 	if len(results) == 0 {
+		// If there weren't any local results, we can just return the remote
+		// ones, instead instead of copying into an empty map.
 		return remoteResults, nil
 	}
 	for k, v := range remoteResults {

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -692,16 +692,22 @@ func (c *Cache) remoteGetMulti(ctx context.Context, peer string, isolation *dcpb
 		return results, nil
 	}
 
-	results, err := c.distributedProxy.RemoteGetMulti(ctx, peer, isolation, stillMissing)
+	remoteResults, err := c.distributedProxy.RemoteGetMulti(ctx, peer, isolation, stillMissing)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, r := range stillMissing {
-		buf, ok := results[r.GetDigest()]
+		buf, ok := remoteResults[r.GetDigest()]
 		if ok {
 			c.addLookasideEntry(r, buf)
 		}
+	}
+	if len(results) == 0 {
+		return remoteResults, nil
+	}
+	for k, v := range remoteResults {
+		results[k] = v
 	}
 	return results, nil
 }


### PR DESCRIPTION
When using a lookaside cache, if some of the digests weren't found in the lookaside cache, we would fail to return all the ones that *were* found.