### PR TITLE
Add ratchet option to migration config

### DIFF
--- a/enterprise/server/backends/migration_cache/config.go
+++ b/enterprise/server/backends/migration_cache/config.go
@@ -64,6 +64,7 @@ type PebbleCacheConfig struct {
 	ActiveKeyVersion            *int64                  `yaml:"active_key_version"`
 	GCSConfig                   GCSConfig               `yaml:"gcs"`
 	IncludeMetadataSize         bool                    `yaml:"include_metadata_size"`
+	EnableAutoRatchet           bool                    `yaml:"enable_auto_ratchet"`
 }
 
 func (cfg *MigrationConfig) SetConfigDefaults() {

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -167,6 +167,7 @@ func pebbleCacheFromConfig(env environment.Env, cfg *PebbleCacheConfig) (*pebble
 		GCSTTLDays:                  cfg.GCSConfig.TTLDays,
 		MinGCSFileSizeBytes:         cfg.GCSConfig.MinGCSFileSizeBytes,
 		IncludeMetadataSize:         cfg.IncludeMetadataSize,
+		EnableAutoRatchet:           cfg.EnableAutoRatchet,
 	}
 
 	c, err := pebble_cache.NewPebbleCache(env, opts)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3019,7 +3019,6 @@ func TestSampling(t *testing.T) {
 }
 
 func TestRatchetDB(t *testing.T) {
-	flags.Set(t, "cache.pebble.enable_auto_ratchet", true)
 	rootDir := testfs.MakeTempDir(t)
 
 	// Init DB with default format
@@ -3034,7 +3033,7 @@ func TestRatchetDB(t *testing.T) {
 	// Create pebble_cache to upgrade the DB
 	te := testenv.GetTestEnv(t)
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes})
+	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes, EnableAutoRatchet: true})
 	require.NoError(t, err)
 	err = pc.Start()
 	require.NoError(t, err)


### PR DESCRIPTION
Add this option which we set in some cells so that migrations can proceed with it set.