### PR TITLE
[raft] change ResolveGRPC to take in nhid

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -57,8 +57,8 @@ type NodeHost interface {
 }
 
 type IRegistry interface {
-	// Lookup the grpc address given a replica's rangeID and replicaID
-	ResolveGRPC(ctx context.Context, rangeID uint64, replicaID uint64) (string, string, error)
+	// Lookup the grpc address given a replica's nhid
+	ResolveGRPC(ctx context.Context, nhid string) (string, error)
 }
 
 type APIClient struct {
@@ -112,7 +112,7 @@ func (c *APIClient) GetForReplica(ctx context.Context, rd *rfpb.ReplicaDescripto
 		tracing.RecordErrorToSpan(spn, returnedErr)
 		spn.End()
 	}()
-	addr, _, err := c.registry.ResolveGRPC(ctx, rd.GetRangeId(), rd.GetReplicaId())
+	addr, err := c.registry.ResolveGRPC(ctx, rd.GetNhid())
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c *APIClient) haveReadyConnections(ctx context.Context, peer string) bool 
 }
 
 func (c *APIClient) HaveReadyConnections(ctx context.Context, rd *rfpb.ReplicaDescriptor) (bool, error) {
-	addr, _, err := c.registry.ResolveGRPC(ctx, rd.GetRangeId(), rd.GetReplicaId())
+	addr, err := c.registry.ResolveGRPC(ctx, rd.GetNhid())
 	if err != nil {
 		return false, status.WrapError(err, "failed to resolve GRPC address")
 	}

--- a/enterprise/server/raft/nodeliveness/nodeliveness.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness.go
@@ -91,10 +91,10 @@ func (h *Liveness) Lease(ctx context.Context) error {
 }
 
 func (h *Liveness) Stop() error {
-	log.Debugf("Liveness shutdown started")
+	log.Debugf("Liveness (nhid=%s) shutdown started", h.nhid)
 	now := time.Now()
 	defer func() {
-		log.Debugf("Liveness shutdown finished in %s", time.Since(now))
+		log.Debugf("Liveness (nhid=%s) shutdown finished in %s", h.nhid, time.Since(now))
 	}()
 	h.cancelFn()
 	h.egMu.Lock()

--- a/enterprise/server/raft/registry/BUILD
+++ b/enterprise/server/raft/registry/BUILD
@@ -17,7 +17,6 @@ go_library(
         "@com_github_hashicorp_serf//serf",
         "@com_github_lni_dragonboat_v4//config",
         "@com_github_lni_dragonboat_v4//raftio",
-        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -388,8 +388,9 @@ func (d *DynamicNodeRegistry) pushUpdate(req *rfpb.RegistryPushRequest) {
 	}
 }
 
-// queryPeers queries the gossip network for node that hold the specified range
-// id and replcia id.
+// queryPeers queries the gossip network to get the (nhid, raft address, grpc
+// address) of the node that holds the specified rangeID and replicaID or the
+// node with the specified NHID.
 // If any nodes are found, they are added to the static registry.
 func (d *DynamicNodeRegistry) queryPeers(ctx context.Context, req *rfpb.RegistryQueryRequest) {
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006

--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -15,7 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/hashicorp/serf/serf"
 	"github.com/lni/dragonboat/v4/raftio"
-	"go.opentelemetry.io/otel/attribute"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	dbConfig "github.com/lni/dragonboat/v4/config"
@@ -31,11 +30,10 @@ type NodeRegistry interface {
 	raftio.INodeRegistry
 
 	// Used by store.go and sender.go.
-	ResolveGRPC(ctx context.Context, rangeID uint64, replicaID uint64) (string, string, error)
+	ResolveGRPC(ctx context.Context, nhid string) (string, error)
 
 	// Used by store.go only.
 	AddNode(target, raftAddress, grpcAddress string)
-	ResolveNHID(ctx context.Context, rangeID uint64, replicaID uint64) (string, string, error)
 	String() string
 	ListNodes() []*rfpb.ConnectionInfo
 }
@@ -154,11 +152,15 @@ func (n *StaticRegistry) RemoveShard(rangeID uint64) {
 
 // ResolveRaft returns the raft address and the connection key of the specified node.
 func (n *StaticRegistry) Resolve(rangeID uint64, replicaID uint64) (string, string, error) {
-	return n.ResolveRaft(rangeID, replicaID)
+	ci, err := n.Lookup(rangeID, replicaID)
+	if err != nil {
+		return "", "", err
+	}
+	return ci.GetRaftAddress(), n.getConnectionKey(ci.GetRaftAddress(), rangeID), nil
 }
 
 // ResolveRaft returns the raft address and the connection key of the specified node.
-func (n *StaticRegistry) ResolveRaft(rangeID uint64, replicaID uint64) (string, string, error) {
+func (n *StaticRegistry) Lookup(rangeID uint64, replicaID uint64) (*rfpb.ConnectionInfo, error) {
 	key := raftio.GetNodeInfo(rangeID, replicaID)
 	n.mu.Lock()
 	target, ok := n.nodeTargets[key]
@@ -166,52 +168,43 @@ func (n *StaticRegistry) ResolveRaft(rangeID uint64, replicaID uint64) (string, 
 
 	if ok {
 		if a, ok := n.targetAddresses.Load(target); ok {
-			raftAddr := a.(addresses).raft
-			return raftAddr, n.getConnectionKey(raftAddr, rangeID), nil
+			addr := a.(addresses)
+			return &rfpb.ConnectionInfo{
+				Nhid:        target,
+				RaftAddress: addr.raft,
+				GrpcAddress: addr.grpc,
+			}, nil
 		}
 	}
-	return "", "", targetAddressUnknownError(rangeID, replicaID)
+	return nil, targetAddressUnknownError(rangeID, replicaID)
+}
+
+func (s *StaticRegistry) LookupByNHID(nhid string) (*rfpb.ConnectionInfo, error) {
+	if a, ok := s.targetAddresses.Load(nhid); ok {
+		addr := a.(addresses)
+		return &rfpb.ConnectionInfo{
+			Nhid:        nhid,
+			RaftAddress: addr.raft,
+			GrpcAddress: addr.grpc,
+		}, nil
+	}
+	return nil, status.NotFoundErrorf("%s: %s", targetAddressUnknownErrorMsg, nhid)
 }
 
 // ResolveGRPC returns the gRPC address and the connection key of the specified node.
-func (n *StaticRegistry) ResolveGRPC(ctx context.Context, rangeID uint64, replicaID uint64) (returnedAddr string, returnedKey string, returnedErr error) {
+func (n *StaticRegistry) ResolveGRPC(ctx context.Context, nhid string) (returnedAddr string, returnedErr error) {
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
-	rangeIDAttr := attribute.Int64("range_id", int64(rangeID))
-	replicaIDAttr := attribute.Int64("replica_id", int64(replicaID))
-	spn.SetAttributes(rangeIDAttr, replicaIDAttr)
 
 	defer func() {
 		tracing.RecordErrorToSpan(spn, returnedErr)
 		spn.End()
 	}()
 
-	key := raftio.GetNodeInfo(rangeID, replicaID)
-
-	n.mu.Lock()
-	target, ok := n.nodeTargets[key]
-	n.mu.Unlock()
-
-	if ok {
-		if a, ok := n.targetAddresses.Load(target); ok {
-			grpcAddr := a.(addresses).grpc
-			return grpcAddr, n.getConnectionKey(grpcAddr, rangeID), nil
-		}
+	if a, ok := n.targetAddresses.Load(nhid); ok {
+		grpcAddr := a.(addresses).grpc
+		return grpcAddr, nil
 	}
-	return "", "", targetAddressUnknownError(rangeID, replicaID)
-}
-
-// ResolveNHID returns the NodeHost ID (NHID) and the connection key of the
-// specified node.
-func (n *StaticRegistry) ResolveNHID(ctx context.Context, rangeID uint64, replicaID uint64) (string, string, error) {
-	key := raftio.GetNodeInfo(rangeID, replicaID)
-	n.mu.Lock()
-	target, ok := n.nodeTargets[key]
-	n.mu.Unlock()
-
-	if ok {
-		return target, n.getConnectionKey(target, rangeID), nil
-	}
-	return "", "", targetAddressUnknownError(rangeID, replicaID)
+	return "", status.NotFoundErrorf("%s: %s", targetAddressUnknownErrorMsg, nhid)
 }
 
 // AddNode adds the raftAddress and grpcAddr for the specified target to the
@@ -221,7 +214,7 @@ func (n *StaticRegistry) AddNode(target, raftAddress, grpcAddress string) {
 		log.Errorf("invalid target %s", target)
 		return
 	}
-	if raftAddress == "" && grpcAddress == "" {
+	if raftAddress == "" || grpcAddress == "" {
 		return
 	}
 	a := addresses{
@@ -318,7 +311,7 @@ func (d *DynamicNodeRegistry) handleEvent(event *serf.UserEvent) {
 		d.sReg.log.Warningf("Ignoring malformed registry push request: %+v", req)
 		return
 	}
-	if req.GetGrpcAddress() != "" || req.GetRaftAddress() != "" {
+	if req.GetGrpcAddress() != "" && req.GetRaftAddress() != "" {
 		d.sReg.AddNode(req.GetNhid(), req.GetRaftAddress(), req.GetGrpcAddress())
 	}
 }
@@ -337,26 +330,28 @@ func (d *DynamicNodeRegistry) handleQuery(ctx context.Context, query *serf.Query
 	if err := proto.Unmarshal(query.Payload, req); err != nil {
 		return
 	}
-	if req.GetRangeId() == 0 || req.GetReplicaId() == 0 {
+
+	var ci *rfpb.ConnectionInfo
+	var err error
+
+	if req.GetNhid() != "" {
+		ci, err = d.sReg.LookupByNHID(req.GetNhid())
+		if err != nil {
+			return
+		}
+	} else if req.GetRangeId() != 0 && req.GetReplicaId() != 0 {
+		ci, err = d.sReg.Lookup(req.GetRangeId(), req.GetReplicaId())
+		if err != nil {
+			return
+		}
+	} else {
 		d.sReg.log.Warningf("Ignoring malformed registry query: %+v", req)
 		return
 	}
-	n, _, err := d.sReg.ResolveNHID(ctx, req.GetRangeId(), req.GetReplicaId())
-	if err != nil {
-		return
-	}
-	r, _, err := d.sReg.ResolveRaft(req.GetRangeId(), req.GetReplicaId())
-	if err != nil {
-		return
-	}
-	g, _, err := d.sReg.ResolveGRPC(ctx, req.GetRangeId(), req.GetReplicaId())
-	if err != nil {
-		return
-	}
 	rsp := &rfpb.RegistryQueryResponse{
-		Nhid:        n,
-		RaftAddress: r,
-		GrpcAddress: g,
+		Nhid:        ci.GetNhid(),
+		RaftAddress: ci.GetRaftAddress(),
+		GrpcAddress: ci.GetGrpcAddress(),
 	}
 	buf, err := proto.Marshal(rsp)
 	if err != nil {
@@ -393,23 +388,18 @@ func (d *DynamicNodeRegistry) pushUpdate(req *rfpb.RegistryPushRequest) {
 	}
 }
 
-// queryPeers queries the gossip network for node that hold the specified rangeID
-// and replicaID. If any nodes are found, they are added to the static registry.
-func (d *DynamicNodeRegistry) queryPeers(ctx context.Context, rangeID uint64, replicaID uint64) {
+// queryPeers queries the gossip network for node that hold the specified range
+// id and replcia id.
+// If any nodes are found, they are added to the static registry.
+func (d *DynamicNodeRegistry) queryPeers(ctx context.Context, req *rfpb.RegistryQueryRequest) {
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
-	rangeIDAttr := attribute.Int64("range_id", int64(rangeID))
-	replicaIDAttr := attribute.Int64("replica_id", int64(replicaID))
-	spn.SetAttributes(rangeIDAttr, replicaIDAttr)
 	defer spn.End()
 
-	req := &rfpb.RegistryQueryRequest{
-		RangeId:   rangeID,
-		ReplicaId: replicaID,
-	}
 	buf, err := proto.Marshal(req)
 	if err != nil {
 		return
 	}
+
 	stream, err := d.gossipManager.Query(constants.RegistryQueryEvent, buf, nil)
 	if err != nil {
 		d.sReg.log.Warningf("queryPeers failed: gossip Query returned err: %s", err)
@@ -420,12 +410,15 @@ func (d *DynamicNodeRegistry) queryPeers(ctx context.Context, rangeID uint64, re
 		if err := proto.Unmarshal(p.Payload, rsp); err != nil {
 			continue
 		}
-		if rsp.GetNhid() == "" {
+		if rsp.GetGrpcAddress() == "" || rsp.GetRaftAddress() == "" {
 			d.sReg.log.Warningf("queryPeers ignoring malformed query response: %+v", rsp)
 			continue
 		}
-		d.sReg.Add(rangeID, replicaID, rsp.GetNhid())
 		d.sReg.AddNode(rsp.GetNhid(), rsp.GetRaftAddress(), rsp.GetGrpcAddress())
+
+		if req.GetRangeId() != 0 && req.GetReplicaId() != 0 {
+			d.sReg.Add(req.GetRangeId(), req.GetReplicaId(), rsp.GetNhid())
+		}
 		// Since only one nodehost can be identified by the specified rangeID and
 		// replicaID. We can close the query after found one nodehost.
 		stream.Close()
@@ -460,47 +453,46 @@ func (d *DynamicNodeRegistry) ListNodes() []*rfpb.ConnectionInfo {
 
 // Resolve returns the raft address and the connection key of the specified node.
 func (d *DynamicNodeRegistry) Resolve(rangeID uint64, replicaID uint64) (string, string, error) {
-	return d.ResolveRaft(context.TODO(), rangeID, replicaID)
+	ci, err := d.Lookup(context.TODO(), rangeID, replicaID)
+	if err != nil {
+		return "", "", err
+	}
+	return ci.GetRaftAddress(), d.sReg.getConnectionKey(ci.GetRaftAddress(), rangeID), nil
 }
 
-// ResolveRaft returns the raft address and the connection key of the specified node.
-func (d *DynamicNodeRegistry) ResolveRaft(ctx context.Context, rangeID uint64, replicaID uint64) (string, string, error) {
-	r, k, err := d.sReg.ResolveRaft(rangeID, replicaID)
-	if strings.HasPrefix(status.Message(err), targetAddressUnknownErrorMsg) {
-		d.queryPeers(ctx, rangeID, replicaID)
-		return d.sReg.ResolveRaft(rangeID, replicaID)
+// Lookup returns the connectionInfo of the specified node
+func (d *DynamicNodeRegistry) Lookup(ctx context.Context, rangeID uint64, replicaID uint64) (*rfpb.ConnectionInfo, error) {
+	ci, err := d.sReg.Lookup(rangeID, replicaID)
+	if err == nil {
+		return ci, err
 	}
-	return r, k, err
+	if strings.HasPrefix(status.Message(err), targetAddressUnknownErrorMsg) {
+		req := &rfpb.RegistryQueryRequest{
+			RangeId:   rangeID,
+			ReplicaId: replicaID,
+		}
+		d.queryPeers(ctx, req)
+		return d.sReg.Lookup(rangeID, replicaID)
+	}
+	return nil, err
 }
 
 // ResolveGRPC returns the gRPC address and the connection key of the specified node.
-func (d *DynamicNodeRegistry) ResolveGRPC(ctx context.Context, rangeID uint64, replicaID uint64) (addr string, key string, returnedErr error) {
+func (d *DynamicNodeRegistry) ResolveGRPC(ctx context.Context, nhid string) (addr string, returnedErr error) {
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
-	rangeIDAttr := attribute.Int64("range_id", int64(rangeID))
-	replicaIDAttr := attribute.Int64("replica_id", int64(replicaID))
-	spn.SetAttributes(rangeIDAttr, replicaIDAttr)
-
 	defer func() {
 		tracing.RecordErrorToSpan(spn, returnedErr)
 		spn.End()
 	}()
-	g, k, err := d.sReg.ResolveGRPC(ctx, rangeID, replicaID)
+	g, err := d.sReg.ResolveGRPC(ctx, nhid)
 	if strings.HasPrefix(status.Message(err), targetAddressUnknownErrorMsg) {
-		d.queryPeers(ctx, rangeID, replicaID)
-		return d.sReg.ResolveGRPC(ctx, rangeID, replicaID)
+		req := &rfpb.RegistryQueryRequest{
+			Nhid: nhid,
+		}
+		d.queryPeers(ctx, req)
+		return d.sReg.ResolveGRPC(ctx, nhid)
 	}
-	return g, k, err
-}
-
-// ResolveNHID returns the NodeHost ID (NHID) and the connection key of the
-// specified node.
-func (d *DynamicNodeRegistry) ResolveNHID(ctx context.Context, rangeID uint64, replicaID uint64) (string, string, error) {
-	n, k, err := d.sReg.ResolveNHID(ctx, rangeID, replicaID)
-	if strings.HasPrefix(status.Message(err), targetAddressUnknownErrorMsg) {
-		d.queryPeers(ctx, rangeID, replicaID)
-		return d.sReg.ResolveNHID(ctx, rangeID, replicaID)
-	}
-	return n, k, err
+	return g, err
 }
 
 // AddNode adds the raftAddress and grpcAddr for the specified target to the

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -601,7 +601,6 @@ func (s *Store) handleEvents(ctx context.Context) {
 			}
 			s.eventsMu.Unlock()
 		case <-ctx.Done():
-			s.log.Debug("handleEvents done")
 			return
 		}
 	}
@@ -653,25 +652,21 @@ func (s *Store) Start() error {
 	if *enableTxnCleanup {
 		s.eg.Go(func() error {
 			s.txnCoordinator.Start(s.egCtx)
-			s.log.Debug("txCoordinator stopped")
 			return nil
 		})
 	}
 	if scanInterval := *replicaScanInterval; scanInterval != 0 {
 		s.eg.Go(func() error {
 			s.scanReplicas(s.egCtx, scanInterval)
-			s.log.Debug("scan replicas stopped")
 			return nil
 		})
 	}
 	s.eg.Go(func() error {
 		s.deleteSessionWorker.Start(s.egCtx)
-		s.log.Debug("delete sessions stopped")
 		return nil
 	})
 	s.eg.Go(func() error {
 		s.nonVoterZombieJanitor.Start(s.egCtx)
-		s.log.Debug("nonvoter janitor stopped")
 		return nil
 	})
 	return nil
@@ -1404,7 +1399,6 @@ func (s *Store) acquireNodeLiveness(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			s.log.Debug("acquireNodeLiveness done")
 			return
 		case <-ticker.Chan():
 			s.metaRangeMu.Lock()
@@ -1619,7 +1613,6 @@ func (j *replicaJanitor) Start(ctx context.Context) {
 		for {
 			select {
 			case <-ctx.Done():
-				j.store.log.Debug("replicaJanitor loop stopped")
 				return nil
 			case task := <-j.tasks:
 				action, err := j.removeZombie(ctx, task)
@@ -1647,7 +1640,6 @@ func (j *replicaJanitor) Start(ctx context.Context) {
 	for len(j.tasks) > 0 {
 		<-j.tasks
 	}
-	j.store.log.Debug("replicaJanitor stopped")
 }
 
 func (j *replicaJanitor) scan(ctx context.Context) {
@@ -1836,7 +1828,6 @@ func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context, maxRangeSizeBy
 	for {
 		select {
 		case <-ctx.Done():
-			s.log.Debug("check if replicas need splitting done")
 			return
 		case e := <-eventsCh:
 			switch e.EventType() {
@@ -1874,7 +1865,6 @@ func (s *Store) updateStoreUsageTag(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			s.log.Debug("update store usage done")
 			return
 		case e := <-eventsCh:
 			switch e.EventType() {
@@ -3151,7 +3141,6 @@ func (s *Store) refreshMetrics(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			s.log.Debug("refresh metrics done")
 			return
 		case <-ticker.Chan():
 			if err := s.updatePebbleMetrics(); err != nil {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2392,7 +2392,7 @@ func (s *Store) SplitRange(ctx context.Context, req *rfpb.SplitRangeRequest) (*r
 		if r.GetNhid() == "" {
 			return nil, status.InternalErrorf("empty nhid in ReplicaDescriptor %+v", r)
 		}
-		grpcAddr, _, err := s.registry.ResolveGRPC(ctx, r.GetRangeId(), r.GetReplicaId())
+		grpcAddr, err := s.registry.ResolveGRPC(ctx, r.GetNhid())
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -772,7 +772,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 
 	s = testutil.GetStoreWithRangeLease(t, ctx, stores, 3)
 	rd = s.GetRange(3)
-	// Veirfy that nhid in the rangea descriptor matches the registry.
+	// Veirfy that nhid in the range descriptor matches the registry.
 	for _, repl := range rd.GetReplicas() {
 		raftAddr, _, err := s.Registry.Resolve(repl.GetRangeId(), repl.GetReplicaId())
 		require.NoError(t, err)

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -742,15 +742,22 @@ func TestSplitNonMetaRange(t *testing.T) {
 	ctx := context.Background()
 
 	stores := []*testutil.TestingStore{s1, s2, s3}
+	storemap := map[string]*testutil.TestingStore{
+		s1.NHID(): s1,
+		s2.NHID(): s2,
+		s3.NHID(): s3,
+	}
 	sf.StartShard(t, ctx, stores...)
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	rd := s.GetRange(2)
 	// Veirfy that nhid in the range descriptor matches the registry.
 	for _, repl := range rd.GetReplicas() {
-		nhid, _, err := s.Registry.ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
+		raftAddr, _, err := s.Registry.Resolve(repl.GetRangeId(), repl.GetReplicaId())
 		require.NoError(t, err)
-		require.Equal(t, repl.GetNhid(), nhid)
+		replStore := storemap[repl.GetNhid()]
+		require.NotNil(t, replStore)
+		require.Equal(t, replStore.RaftAddress, raftAddr)
 	}
 	header := headerFromRangeDescriptor(rd)
 
@@ -767,9 +774,11 @@ func TestSplitNonMetaRange(t *testing.T) {
 	rd = s.GetRange(3)
 	// Veirfy that nhid in the rangea descriptor matches the registry.
 	for _, repl := range rd.GetReplicas() {
-		nhid, _, err := s.Registry.ResolveNHID(ctx, repl.GetRangeId(), repl.GetReplicaId())
+		raftAddr, _, err := s.Registry.Resolve(repl.GetRangeId(), repl.GetReplicaId())
 		require.NoError(t, err)
-		require.Equal(t, repl.GetNhid(), nhid)
+		replStore := storemap[repl.GetNhid()]
+		require.NotNil(t, replStore)
+		require.Equal(t, replStore.RaftAddress, raftAddr)
 	}
 	header = headerFromRangeDescriptor(rd)
 	require.Equal(t, 3, len(rd.GetReplicas()))

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -265,8 +265,10 @@ message BatchCmdResponse {
 // which has knowledge of the queried node may respond with a
 // RegistryQueryResponse.
 message RegistryQueryRequest {
+  // Either (range_id, replica_Id) or nhid needs to be specified
   uint64 range_id = 1;
   uint64 replica_id = 2;
+  string nhid = 3;
 }
 
 message RegistryQueryResponse {


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/3336

- Remove unused ResolveNHID in registry.
- Change ResolveGRPC to take in NHID instead of (shard_id, replica_id).
- Allow us to query peers by NHID.

