### PR TITLE
Optimize pebble reads

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1631,6 +1631,7 @@ func (p *PebbleCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, er
 		return nil, err
 	}
 	defer rc.Close()
+	// The median and average AC results are less than 4KiB: go/action-result-size
 	bufSize := 4 * 1024
 	if r.GetCacheType() == rspb.CacheType_CAS {
 		bufSize = int(r.GetDigest().GetSizeBytes())

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1641,9 +1641,9 @@ func bufferSize(r *rspb.ResourceName) int {
 		// The median and average AC results are less than 4KiB: go/action-result-size
 		return 4 * 1024
 	}
-	// Clamp the size between 0 and 100MB, to protect from invalid and
+	// Clamp the size between 0 and 10MB, to protect from invalid and
 	// malicious requests.
-	return min(100_000_000, max(0, int(r.GetDigest().GetSizeBytes())))
+	return min(10_000_000, max(0, int(r.GetDigest().GetSizeBytes())))
 }
 
 func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1886,7 +1886,6 @@ func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompre
 	if err != nil {
 		return nil, err
 	}
-	// return rc, nil
 
 	// Grab another lease and pass the Close function to the reader
 	// so it will be closed when the reader is.

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2742,7 +2742,7 @@ func BenchmarkFindMissing(b *testing.B) {
 }
 
 func benchmarkContains1(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.Context, digestSizeBytes int64) {
-	digestKeys := make([]*rspb.ResourceName, 0, 100000)
+	digestKeys := make([]*rspb.ResourceName, 0, 100)
 	for i := 0; i < 100; i++ {
 		r, buf := testdigest.RandomCASResourceBuf(b, digestSizeBytes)
 		digestKeys = append(digestKeys, r)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -744,7 +744,7 @@ func TestMultiGetSet(t *testing.T) {
 				require.True(t, ok, "Multi-get failed to return expected digest: %q", d.GetHash())
 				d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 				require.NoError(t, err)
-				require.Equal(t, d.GetHash(), d2.GetHash())
+				require.Equal(t, d.GetHash(), d2.GetHash(), "d=%v; d2=%v", d, d2)
 			}
 		})
 	}
@@ -2634,6 +2634,7 @@ func benchmarkGetMulti(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.C
 
 	b.ReportAllocs()
 	b.StopTimer()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		keys := randomDigests(100)
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2614,7 +2614,7 @@ func TestEncryptionAndCompression(t *testing.T) {
 }
 
 func benchmarkGetMulti(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.Context, digestSizeBytes int64) {
-	digestKeys := make([]*rspb.ResourceName, 0, 100000)
+	digestKeys := make([]*rspb.ResourceName, 0, 100)
 	for i := 0; i < 100; i++ {
 		r, buf := testdigest.NewRandomResourceAndBuf(b, digestSizeBytes, rspb.CacheType_CAS, "" /*instanceName*/)
 		digestKeys = append(digestKeys, r)
@@ -2678,7 +2678,7 @@ func BenchmarkGetMulti(b *testing.B) {
 }
 
 func benchmarkFindMissing(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.Context, digestSizeBytes int64) {
-	digestKeys := make([]*rspb.ResourceName, 0, 100000)
+	digestKeys := make([]*rspb.ResourceName, 0, 100)
 	for i := 0; i < 100; i++ {
 		r, buf := testdigest.RandomCASResourceBuf(b, digestSizeBytes)
 		digestKeys = append(digestKeys, r)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2698,6 +2698,7 @@ func benchmarkFindMissing(b *testing.B, pc *pebble_cache.PebbleCache, ctx contex
 
 	b.ReportAllocs()
 	b.StopTimer()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		keys := randomDigests(100)
 
@@ -2752,6 +2753,7 @@ func benchmarkContains1(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.
 
 	b.ReportAllocs()
 	b.StopTimer()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		d := digestKeys[randIntN(b, len(digestKeys))]
 		b.StartTimer()
@@ -2795,6 +2797,7 @@ func BenchmarkContains1(b *testing.B) {
 func benchmarkSet(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.Context, digestSizeBytes int64) {
 	b.ReportAllocs()
 	b.StopTimer()
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		r, buf := testdigest.RandomCASResourceBuf(b, digestSizeBytes)
 		b.StartTimer()

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -1,6 +1,7 @@
 package compression
 
 import (
+	"errors"
 	"io"
 	"runtime"
 	"sync"
@@ -180,23 +181,47 @@ func NewZstdDecompressingReader(reader io.ReadCloser) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	pr, pw := io.Pipe()
-	go func() {
-		// Write decoded bytes to pw and pipe to pr
-		n, err := decoder.WriteTo(pw)
-		pw.CloseWithError(err)
-		metrics.BytesDecompressed.With(prometheus.Labels{metrics.CompressionType: "zstd"}).Add(float64(n))
-
-		if err := zstdDecoderPool.Put(decoder); err != nil {
-			log.Errorf("Failed to return zstd decoder to pool: %s", err.Error())
-		}
-	}()
-
-	return &wrappedReader{
-		pr:          pr,
+	return &decoderReader{
+		decoder:     decoder,
 		inputReader: reader,
 	}, nil
+}
+
+type decoderReader struct {
+	decoder     *DecoderRef
+	inputReader io.ReadCloser
+	read        int
+	closed      bool
+}
+
+func (r *decoderReader) Read(p []byte) (int, error) {
+	if r.closed {
+		return 0, errors.New("decoderReader.Read used after Close")
+	}
+	n, err := r.decoder.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *decoderReader) WriteTo(w io.Writer) (int64, error) {
+	if r.closed {
+		return 0, errors.New("decoderReader.WriteTo used after Close")
+	}
+	n, err := r.decoder.WriteTo(w)
+	r.read += int(n)
+	return n, err
+}
+
+func (r *decoderReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	metrics.BytesDecompressed.With(prometheus.Labels{metrics.CompressionType: "zstd"}).Add(float64(r.read))
+	if err := zstdDecoderPool.Put(r.decoder); err != nil {
+		log.Errorf("Failed to return zstd decoder to pool: %s", err.Error())
+	}
+	return r.inputReader.Close()
 }
 
 // DecoderRef wraps a *zstd.Decoder. Since it does not directly start any

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -174,7 +174,10 @@ func NewZstdCompressingReader(reader io.ReadCloser, readBuf []byte, compressBuf 
 }
 
 // NewZstdDecompressingReader reads zstd-compressed data from the input
-// reader and makes the decompressed data available on the output reader
+// reader and makes the decompressed data available on the output reader. The
+// output reader is also an io.WriterTo, which can often prevent allocations
+// when used with io.Copy to write into a bytes.Buffer. If you wrap the output
+// reader, you probably want to maintain that property.
 func NewZstdDecompressingReader(reader io.ReadCloser) (io.ReadCloser, error) {
 	// Stream data from reader to decoder
 	decoder, err := zstdDecoderPool.Get(reader)


### PR DESCRIPTION
The changes to compression.NewZstdDecompressingReader get most of the benefit here, making small reads in benchmarks 20% faster. This is because io.Pipe() causes every read and write to block on a channel, and it requires creating another goroutine.

Using io.ReadFull instead of io.Copy is mostly about reducing allocations and memory copying. This improves performance by 2-4%.

I'm not sure if real world impact of these changes will be as high, since the pebble parts of the code seem relatively more heavy weight in the real world profiles compared to benchmark profiles.

Here are the benchmarks from `//enterprise/server/backends/pebble_cache:pebble_cache_test`:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                       │ /tmp/getmulti/base │      /tmp/getmulti/zstdreader       │  /tmp/getmulti/zstdreader-readfull  │
                       │       sec/op       │   sec/op     vs base                │   sec/op     vs base                │
GetMulti/size=1KiB-24           1.961m ± 1%   1.523m ± 0%  -22.36% (p=0.000 n=50)   1.501m ± 0%  -23.48% (p=0.000 n=50)
GetMulti/size=1MiB-24           67.31m ± 1%   64.43m ± 0%   -4.28% (p=0.000 n=50)   63.79m ± 0%   -5.24% (p=0.000 n=50)
GetMulti/size=10MiB-24          898.6m ± 1%   891.6m ± 1%        ~ (p=0.063 n=50)   874.4m ± 1%   -2.70% (p=0.000 n=50)
geomean                         49.14m        44.39m        -9.66%                  43.74m       -10.98%

                       │ /tmp/getmulti/base │      /tmp/getmulti/zstdreader       │  /tmp/getmulti/zstdreader-readfull  │
                       │        B/op        │     B/op      vs base               │     B/op      vs base               │
GetMulti/size=1KiB-24          780.1Ki ± 0%   734.4Ki ± 0%  -5.86% (n=50)           709.8Ki ± 0%  -9.01% (n=50)
GetMulti/size=1MiB-24          193.5Mi ± 0%   186.7Mi ± 0%  -3.54% (p=0.000 n=50)   182.1Mi ± 0%  -5.90% (p=0.000 n=50)
GetMulti/size=10MiB-24         2.093Gi ± 0%   2.065Gi ± 0%  -1.33% (p=0.000 n=50)   2.010Gi ± 0%  -3.97% (p=0.000 n=50)
geomean                        68.11Mi        65.66Mi       -3.59%                  63.81Mi       -6.32%

                       │ /tmp/getmulti/base │      /tmp/getmulti/zstdreader       │ /tmp/getmulti/zstdreader-readfull  │
                       │     allocs/op      │  allocs/op    vs base               │  allocs/op   vs base               │
GetMulti/size=1KiB-24          10.619k ± 0%   10.117k ± 0%  -4.73% (n=50)           9.815k ± 0%  -7.58% (n=50)
GetMulti/size=1MiB-24           1.498M ± 1%    1.441M ± 0%  -3.80% (p=0.000 n=50)   1.397M ± 1%  -6.72% (p=0.000 n=50)
GetMulti/size=10MiB-24          18.65M ± 1%    18.25M ± 1%  -2.16% (p=0.000 n=50)   18.05M ± 1%  -3.20% (p=0.000 n=50)
geomean                         666.9k         643.1k       -3.57%                  627.9k       -5.85%
```

Here are the benchmarks from `//enterprise/server/test/performance/cache:cache_test`:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                         │ /tmp/cache/base │        /tmp/cache/zstdreader        │   /tmp/cache/zstdreader-readfull    │
                         │     sec/op      │    sec/op     vs base               │    sec/op     vs base               │
Get/Pebble10-24               8.935µ ±  2%   6.641µ ±  2%  -25.67% (p=0.001 n=7)   6.027µ ±  2%  -32.55% (p=0.001 n=7)
Get/Pebble100-24             10.564µ ±  2%   7.038µ ±  2%  -33.38% (p=0.001 n=7)   6.554µ ±  2%  -37.96% (p=0.001 n=7)
Get/Pebble1000-24            12.588µ ±  1%   8.305µ ±  1%  -34.02% (p=0.001 n=7)   7.550µ ±  1%  -40.02% (p=0.001 n=7)
Get/Pebble10000-24            34.78µ ±  1%   27.46µ ±  2%  -21.04% (p=0.001 n=7)   23.80µ ±  1%  -31.58% (p=0.001 n=7)
Get/DPebble10-24              124.0µ ±  2%   121.6µ ±  7%   -1.97% (p=0.004 n=7)   121.9µ ±  4%        ~ (p=0.209 n=7)
Get/DPebble100-24             127.3µ ±  4%   122.9µ ±  6%   -3.41% (p=0.026 n=7)   124.4µ ±  1%        ~ (p=0.165 n=7)
Get/DPebble1000-24            131.5µ ±  4%   124.9µ ±  5%   -5.01% (p=0.002 n=7)   126.3µ ±  7%   -3.95% (p=0.007 n=7)
Get/DPebble10000-24           169.8µ ±  2%   165.1µ ±  3%   -2.78% (p=0.004 n=7)   167.8µ ±  3%   -1.22% (p=0.017 n=7)
GetMulti/Pebble10-24          640.8µ ±  3%   416.5µ ±  2%  -35.00% (p=0.001 n=7)   406.5µ ±  2%  -36.56% (p=0.001 n=7)
GetMulti/Pebble100-24         772.5µ ±  2%   451.2µ ±  3%  -41.59% (p=0.001 n=7)   446.7µ ±  3%  -42.18% (p=0.001 n=7)
GetMulti/Pebble1000-24        872.8µ ±  3%   557.7µ ±  2%  -36.11% (p=0.001 n=7)   537.1µ ±  3%  -38.46% (p=0.001 n=7)
GetMulti/Pebble10000-24       2.682m ±  2%   2.208m ±  3%  -17.67% (p=0.001 n=7)   2.193m ±  2%  -18.23% (p=0.001 n=7)
GetMulti/DPebble10-24         750.1µ ± 16%   537.6µ ± 14%  -28.33% (p=0.001 n=7)   594.5µ ± 11%  -20.74% (p=0.001 n=7)
GetMulti/DPebble100-24       1179.5µ ±  2%   862.9µ ±  2%  -26.85% (p=0.001 n=7)   865.7µ ±  3%  -26.61% (p=0.001 n=7)
GetMulti/DPebble1000-24       1.438m ±  2%   1.139m ±  3%  -20.82% (p=0.001 n=7)   1.131m ±  4%  -21.38% (p=0.001 n=7)
GetMulti/DPebble10000-24      3.877m ±  3%   3.433m ±  2%  -11.46% (p=0.001 n=7)   3.363m ±  1%  -13.25% (p=0.001 n=7)

                         │ /tmp/cache/base │          /tmp/cache/zstdreader          │     /tmp/cache/zstdreader-readfull      │
                         │       B/s       │      B/s        vs base                 │      B/s        vs base                 │
Get/Pebble10-24              1.068Mi ±  2%    1.440Mi ±  2%  +34.82% (p=0.001 n=7)      1.583Mi ±  2%  +48.21% (p=0.001 n=7)
Get/Pebble100-24             9.031Mi ±  2%   13.552Mi ±  2%  +50.05% (p=0.001 n=7)     14.553Mi ±  2%  +61.14% (p=0.001 n=7)
Get/Pebble1000-24            75.76Mi ±  1%   114.82Mi ±  1%  +51.56% (p=0.001 n=7)     126.31Mi ±  1%  +66.73% (p=0.001 n=7)
Get/Pebble10000-24           274.2Mi ±  1%    347.3Mi ±  2%  +26.65% (p=0.001 n=7)      400.8Mi ±  1%  +46.15% (p=0.001 n=7)
Get/DPebble10-24             78.12Ki ±  0%    78.12Ki ± 12%        ~ (p=0.462 n=7)      78.12Ki ± 12%        ~ (p=1.000 n=7)
Get/DPebble100-24            771.5Ki ±  4%    791.0Ki ±  6%        ~ (p=0.054 n=7)      781.2Ki ±  1%        ~ (p=0.152 n=7)
Get/DPebble1000-24           7.248Mi ±  4%    7.639Mi ±  5%   +5.39% (p=0.002 n=7)      7.553Mi ±  7%   +4.21% (p=0.007 n=7)
Get/DPebble10000-24          56.15Mi ±  2%    57.75Mi ±  3%   +2.85% (p=0.004 n=7)      56.84Mi ±  3%   +1.22% (p=0.020 n=7)
GetMulti/Pebble10-24         1.488Mi ±  3%    2.289Mi ±  2%  +53.85% (p=0.001 n=7)      2.346Mi ±  2%  +57.69% (p=0.001 n=7)
GetMulti/Pebble100-24        12.34Mi ±  2%    21.13Mi ±  3%  +71.25% (p=0.001 n=7)      21.35Mi ±  3%  +73.03% (p=0.001 n=7)
GetMulti/Pebble1000-24       109.3Mi ±  3%    171.0Mi ±  2%  +56.50% (p=0.001 n=7)      177.6Mi ±  3%  +62.50% (p=0.001 n=7)
GetMulti/Pebble10000-24      355.6Mi ±  2%    432.0Mi ±  3%  +21.47% (p=0.001 n=7)      434.9Mi ±  2%  +22.29% (p=0.001 n=7)
GetMulti/DPebble10-24        1.268Mi ± 14%    1.774Mi ± 16%  +39.85% (p=0.001 n=7)      1.602Mi ± 12%  +26.32% (p=0.001 n=7)
GetMulti/DPebble100-24       8.087Mi ±  2%   11.053Mi ±  2%  +36.67% (p=0.001 n=7)     11.015Mi ±  3%  +36.20% (p=0.001 n=7)
GetMulti/DPebble1000-24      66.30Mi ±  2%    83.73Mi ±  3%  +26.29% (p=0.001 n=7)      84.32Mi ±  4%  +27.19% (p=0.001 n=7)
GetMulti/DPebble10000-24     246.0Mi ±  3%    277.8Mi ±  2%  +12.94% (p=0.001 n=7)      283.5Mi ±  1%  +15.28% (p=0.001 n=7)

                         │ /tmp/cache/base │        /tmp/cache/zstdreader         │     /tmp/cache/zstdreader-readfull     │
                         │      B/op       │     B/op       vs base               │     B/op       vs base                 │
Get/Pebble10-24              6.348Ki ±  0%   5.915Ki ±  0%   -6.82% (p=0.001 n=7)   4.383Ki ±  0%  -30.95% (p=0.001 n=7)
Get/Pebble100-24             6.393Ki ±  0%   5.961Ki ±  0%   -6.75% (p=0.001 n=7)   4.521Ki ±  0%  -29.27% (p=0.001 n=7)
Get/Pebble1000-24            8.712Ki ±  0%   8.278Ki ±  0%   -4.98% (p=0.001 n=7)   5.726Ki ±  0%  -34.28% (p=0.001 n=7)
Get/Pebble10000-24           38.94Ki ±  0%   38.48Ki ±  0%   -1.18% (p=0.001 n=7)   16.66Ki ±  0%  -57.21% (p=0.001 n=7)
Get/DPebble10-24             24.94Ki ±  0%   24.54Ki ±  0%   -1.64% (p=0.001 n=7)   24.53Ki ±  0%   -1.65% (p=0.001 n=7)
Get/DPebble100-24            25.28Ki ±  0%   24.86Ki ±  0%   -1.68% (p=0.001 n=7)   24.88Ki ±  0%   -1.60% (p=0.001 n=7)
Get/DPebble1000-24           28.76Ki ±  0%   28.37Ki ±  0%   -1.38% (p=0.001 n=7)   28.37Ki ±  0%   -1.36% (p=0.001 n=7)
Get/DPebble10000-24          56.25Ki ±  0%   55.79Ki ±  0%   -0.80% (p=0.001 n=7)   55.82Ki ±  0%   -0.76% (p=0.001 n=7)
GetMulti/Pebble10-24         404.9Ki ±  0%   360.7Ki ±  0%  -10.92% (p=0.001 n=7)   359.8Ki ±  0%  -11.14% (p=0.001 n=7)
GetMulti/Pebble100-24        418.6Ki ±  0%   374.6Ki ±  0%  -10.51% (p=0.001 n=7)   374.3Ki ±  0%  -10.58% (p=0.001 n=7)
GetMulti/Pebble1000-24       541.3Ki ±  0%   495.9Ki ±  0%   -8.39% (p=0.001 n=7)   494.6Ki ±  0%   -8.63% (p=0.001 n=7)
GetMulti/Pebble10000-24      1.647Mi ±  0%   1.584Mi ±  0%   -3.84% (p=0.001 n=7)   1.551Mi ±  0%   -5.83% (p=0.001 n=7)
GetMulti/DPebble10-24        424.9Ki ± 16%   353.5Ki ± 15%  -16.80% (p=0.001 n=7)   394.1Ki ± 13%   -7.25% (p=0.007 n=7)
GetMulti/DPebble100-24       615.7Ki ±  0%   571.7Ki ±  1%   -7.14% (p=0.001 n=7)   571.7Ki ±  0%   -7.15% (p=0.001 n=7)
GetMulti/DPebble1000-24      868.5Ki ±  2%   819.6Ki ±  1%   -5.63% (p=0.001 n=7)   822.2Ki ±  1%   -5.34% (p=0.001 n=7)
GetMulti/DPebble10000-24     2.899Mi ±  1%   2.829Mi ±  1%   -2.39% (p=0.001 n=7)   2.793Mi ±  1%   -3.65% (p=0.001 n=7)

                         │ /tmp/cache/base │         /tmp/cache/zstdreader         │    /tmp/cache/zstdreader-readfull     │
                         │    allocs/op    │  allocs/op    vs base                 │  allocs/op    vs base                 │
Get/Pebble10-24                95.00 ±  0%    90.00 ±  0%   -5.26% (p=0.001 n=7)      88.00 ±  0%   -7.37% (p=0.001 n=7)
Get/Pebble100-24               95.00 ±  0%    90.00 ±  0%   -5.26% (p=0.001 n=7)      88.00 ±  0%   -7.37% (p=0.001 n=7)
Get/Pebble1000-24              96.00 ±  0%    91.00 ±  0%   -5.21% (p=0.001 n=7)      88.00 ±  0%   -8.33% (p=0.001 n=7)
Get/Pebble10000-24             127.0 ±  0%    122.0 ±  0%   -3.94% (p=0.001 n=7)      113.0 ±  0%  -11.02% (p=0.001 n=7)
Get/DPebble10-24               438.0 ±  0%    434.0 ±  0%   -0.91% (p=0.001 n=7)      434.0 ±  0%   -0.91% (p=0.001 n=7)
Get/DPebble100-24              438.0 ±  0%    434.0 ±  0%   -0.91% (p=0.001 n=7)      434.0 ±  0%   -0.91% (p=0.001 n=7)
Get/DPebble1000-24             437.0 ±  0%    433.0 ±  0%   -0.92% (p=0.001 n=7)      433.0 ±  0%   -0.92% (p=0.001 n=7)
Get/DPebble10000-24            460.0 ±  0%    456.0 ±  0%   -0.87% (p=0.001 n=7)      456.0 ±  0%   -0.87% (p=0.001 n=7)
GetMulti/Pebble10-24          7.516k ±  0%   7.015k ±  0%   -6.67% (p=0.001 n=7)     7.013k ±  0%   -6.69% (p=0.001 n=7)
GetMulti/Pebble100-24         7.517k ±  0%   7.015k ±  0%   -6.68% (p=0.001 n=7)     7.013k ±  0%   -6.70% (p=0.001 n=7)
GetMulti/Pebble1000-24        7.518k ±  0%   7.015k ±  0%   -6.69% (p=0.001 n=7)     7.013k ±  0%   -6.72% (p=0.001 n=7)
GetMulti/Pebble10000-24      10.327k ±  0%   9.821k ±  0%   -4.90% (p=0.001 n=7)     9.519k ±  0%   -7.82% (p=0.001 n=7)
GetMulti/DPebble10-24         7.099k ± 18%   6.106k ± 14%  -13.99% (p=0.001 n=7)     6.756k ± 12%        ~ (p=0.097 n=7)
GetMulti/DPebble100-24       10.219k ±  0%   9.717k ±  1%   -4.91% (p=0.001 n=7)     9.716k ±  0%   -4.92% (p=0.001 n=7)
GetMulti/DPebble1000-24      10.232k ±  0%   9.729k ±  0%   -4.92% (p=0.001 n=7)     9.725k ±  0%   -4.96% (p=0.001 n=7)
GetMulti/DPebble10000-24      13.12k ±  0%   12.62k ±  0%   -3.79% (p=0.001 n=7)     12.32k ±  0%   -6.07% (p=0.001 n=7)
```