### PR TITLE
invocation/suggestion: skip legacy_important_outputs for 8.0

### DIFF
--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -437,6 +437,9 @@ ${yamlSuggestions.map((s) => `      ${s}`).join("\n")}`}
     if (!capabilities.config.expandedSuggestionsEnabled) return null;
     if (!model.isBazelInvocation()) return null;
 
+    const version = getBazelVersion(model);
+    if (version === null || version.major >= 8) return null;
+
     if (model.optionsMap.get("legacy_important_outputs")) return null;
 
     return {


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/commit/241c21da0739ad2d5b0642690190c14b96dcbae2
flips this to false by default starting from 8.0.
