### PR TITLE
rules_k8s: upgrade to latest commit on master

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -458,13 +458,13 @@ _go_image_repos()
 
 http_archive(
     name = "io_bazel_rules_k8s",
+    integrity = "sha256-51xa8wL5mhoGlsvgTEm4NRXsfCVgX5lR8a1/evO/pBY=",
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:rules_k8s.patch",
     ],
-    sha256 = "ce5b9bc0926681e2e7f2147b49096f143e6cbc783e71bc1d4f36ca76b00e6f4a",
-    strip_prefix = "rules_k8s-0.7",
-    urls = ["https://github.com/bazelbuild/rules_k8s/archive/refs/tags/v0.7.tar.gz"],
+    strip_prefix = "rules_k8s-554dc69933461ae2fa4fefcc46d09d5784832e6c",
+    urls = ["https://github.com/bazelbuild/rules_k8s/archive/554dc69933461ae2fa4fefcc46d09d5784832e6c.tar.gz"],
 )
 
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_defaults", "k8s_repositories")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -33,13 +33,13 @@ container_repositories()
 
 http_archive(
     name = "io_bazel_rules_k8s",
+    integrity = "sha256-51xa8wL5mhoGlsvgTEm4NRXsfCVgX5lR8a1/evO/pBY=",
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:rules_k8s.patch",
     ],
-    sha256 = "ce5b9bc0926681e2e7f2147b49096f143e6cbc783e71bc1d4f36ca76b00e6f4a",
-    strip_prefix = "rules_k8s-0.7",
-    urls = ["https://github.com/bazelbuild/rules_k8s/archive/refs/tags/v0.7.tar.gz"],
+    strip_prefix = "rules_k8s-554dc69933461ae2fa4fefcc46d09d5784832e6c",
+    urls = ["https://github.com/bazelbuild/rules_k8s/archive/554dc69933461ae2fa4fefcc46d09d5784832e6c.tar.gz"],
 )
 
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_defaults", "k8s_repositories")


### PR DESCRIPTION
Upgrade rules_k8s to latest commit on master branch.

Prepatory change for bzlmod and oci support in the future.
