### PR TITLE
rules_docker: upgrade to latest master

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -422,12 +422,13 @@ googletest_deps()
 
 http_archive(
     name = "io_bazel_rules_docker",
+    integrity = "sha256-ZIUZu2mLsls7gXUqLObaGizFZlNDa0jGkdzpuNahgGE=",
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:rules_docker.patch",
     ],
-    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+    strip_prefix = "rules_docker-b44cc958e61c3192c57fed7aef78c8567d757a70",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/b44cc958e61c3192c57fed7aef78c8567d757a70.tar.gz"],
 )
 
 load(

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -4,12 +4,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 http_archive(
     name = "io_bazel_rules_docker",
+    integrity = "sha256-ZIUZu2mLsls7gXUqLObaGizFZlNDa0jGkdzpuNahgGE=",
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:rules_docker.patch",
     ],
-    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+    strip_prefix = "rules_docker-b44cc958e61c3192c57fed7aef78c8567d757a70",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/b44cc958e61c3192c57fed7aef78c8567d757a70.tar.gz"],
 )
 
 load(


### PR DESCRIPTION
Upgrade to the latest commit in master branch of rules_docker.
The 2 years worth of diff could be found here
https://github.com/bazelbuild/rules_docker/compare/v0.25.0...b44cc958e61c3192c57fed7aef78c8567d757a70

In a future PR, we will attempt to use a fork of rules_docker which
enable bzlmod support. This should help lifting to that version a bit
easier.
