### PR TITLE
Populate status_message column in ClickHouse

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -638,6 +638,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		InvocationUuid:         strings.ReplaceAll(invocationID, "-", ""),
 		Stage:                  4,
 		StatusCode:             int32(gstatus.Code(test.status)),
+		StatusMessage:          gstatus.Convert(test.status).Proto().GetMessage(),
 		ExitCode:               test.exitCode,
 		DoNotCache:             test.doNotCache,
 		CachedResult:           test.cachedResult,

--- a/enterprise/server/util/execution/execution.go
+++ b/enterprise/server/util/execution/execution.go
@@ -48,6 +48,7 @@ func TableExecToProto(in *tables.Execution, invLink *sipb.StoredInvocationLink) 
 		OutputUploadStartTimestampUsec:     in.OutputUploadStartTimestampUsec,
 		OutputUploadCompletedTimestampUsec: in.OutputUploadCompletedTimestampUsec,
 		StatusCode:                         in.StatusCode,
+		StatusMessage:                      in.StatusMessage,
 		ExitCode:                           in.ExitCode,
 		CachedResult:                       in.CachedResult,
 		DoNotCache:                         in.DoNotCache,

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -243,6 +243,7 @@ func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *schem
 		OutputUploadStartTimestampUsec:     in.GetOutputUploadStartTimestampUsec(),
 		OutputUploadCompletedTimestampUsec: in.GetOutputUploadCompletedTimestampUsec(),
 		StatusCode:                         in.GetStatusCode(),
+		StatusMessage:                      in.GetStatusMessage(),
 		ExitCode:                           in.GetExitCode(),
 		CachedResult:                       in.GetCachedResult(),
 		DoNotCache:                         in.GetDoNotCache(),


### PR DESCRIPTION
This is a blocker for migrating from MySQL => ClickHouse for the Executions page, since we currently render this column on that page.