### PR TITLE
Store command_snippet in ClickHouse

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -652,6 +652,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		ActionMnemonic:         "TestRunner",
 		SelfHosted:             test.expectedSelfHosted,
 		Region:                 "test-region",
+		CommandSnippet:         "test",
 	}
 	if test.publishMoreMetadata {
 		expectedExecution.ExecutionPriority = 999

--- a/enterprise/server/util/execution/execution.go
+++ b/enterprise/server/util/execution/execution.go
@@ -52,6 +52,7 @@ func TableExecToProto(in *tables.Execution, invLink *sipb.StoredInvocationLink) 
 		ExitCode:                           in.ExitCode,
 		CachedResult:                       in.CachedResult,
 		DoNotCache:                         in.DoNotCache,
+		CommandSnippet:                     in.CommandSnippet,
 	}
 }
 

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2539,6 +2539,7 @@ message StoredExecution {
 
   string output_path = 31;
   string status_message = 32;
+  string command_snippet = 62;
 
   // TODO(sluongng): add configuration.
   string target_label = 33;

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -266,7 +266,8 @@ func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *schem
 		Tags:                               invocation_format.ConvertDBTagsToOLAP(inv.GetTags()),
 		TargetLabel:                        in.GetTargetLabel(),
 		ActionMnemonic:                     in.GetActionMnemonic(),
-		Experiments:                        in.Experiments,
+		Experiments:                        in.GetExperiments(),
+		CommandSnippet:                     in.GetCommandSnippet(),
 	}
 }
 

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -227,8 +227,9 @@ type Execution struct {
 	Experiments []string `gorm:"type:Array(LowCardinality(String))"`
 
 	// Long string fields
-	OutputPath    string
-	StatusMessage string
+	OutputPath     string
+	StatusMessage  string
+	CommandSnippet string
 
 	// Fields from Invocations
 	User             string
@@ -258,7 +259,6 @@ func (e *Execution) ExcludedFields() []string {
 		"Perms",
 		"SerializedOperation",
 		"SerializedStatusDetails",
-		"CommandSnippet",
 	}
 }
 


### PR DESCRIPTION
This is a blocker for MySQL => ClickHouse migration since we currently show this data in the UI and it's driven by the command_snippet field that we store in MySQL but not ClickHouse.

Longer-term we discussed using `output_paths[0]` instead of command snippet for display in the UI, but I think we should decouple that from the MySQL => ClickHouse migration. If we switch to `output_paths[0]` later, we can always come back and delete this `command_snippet` column.