### PR TITLE
Trim usage timelines from cached ActionResults

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1071,10 +1071,17 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 
 		response := operation.ExtractExecuteResponse(op)
 		trimmedResponse := response.CloneVT()
-		if trimmedResponse.GetResult().GetExecutionMetadata() != nil {
+		if trimmedMetadata := trimmedResponse.GetResult().GetExecutionMetadata(); trimmedMetadata != nil {
 			// Auxiliary metadata shouldn't be sent to bazel or saved in
 			// the action cache.
-			trimmedResponse.GetResult().GetExecutionMetadata().AuxiliaryMetadata = nil
+			trimmedMetadata.AuxiliaryMetadata = nil
+			// Don't send execution timelines to bazel or save them in the
+			// action cache either.
+			// TODO(bduffany): move these timelines to auxiliary metadata
+			// and clean this up.
+			if trimmedUsageStats := trimmedMetadata.GetUsageStats(); trimmedUsageStats != nil {
+				trimmedUsageStats.Timeline = nil
+			}
 			if err := op.GetResponse().MarshalFrom(trimmedResponse); err != nil {
 				return status.InternalErrorf("Failed to marshall trimmed response: %s", err)
 			}

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -521,6 +521,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		executorGroupID = selfHostedPoolGroupID
 	}
 
+	usageStats := &repb.UsageStats{}
 	if test.publishMoreMetadata {
 		aux.IsolationType = "firecracker"
 		aux.Timeout = &durationpb.Duration{Seconds: 11}
@@ -542,6 +543,9 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 			},
 			ExecutorGroupId: executorGroupID,
 		}
+		usageStats.Timeline = &repb.UsageTimeline{
+			StartTime: tspb.New(workerStartTime),
+		}
 	} else {
 		aux.SchedulingMetadata = &scpb.SchedulingMetadata{
 			ExecutorGroupId: executorGroupID,
@@ -558,6 +562,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 			WorkerCompletedTimestamp: tspb.New(workerEndTime),
 			AuxiliaryMetadata:        []*anypb.Any{auxAny},
 			DoNotCache:               test.doNotCache,
+			UsageStats:               usageStats,
 		},
 	}
 	expectedExecuteResponse := &repb.ExecuteResponse{
@@ -578,6 +583,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 
 	trimmedExecuteResponse := expectedExecuteResponse.CloneVT()
 	trimmedExecuteResponse.GetResult().GetExecutionMetadata().AuxiliaryMetadata = nil
+	trimmedExecuteResponse.GetResult().GetExecutionMetadata().GetUsageStats().Timeline = nil
 
 	// Wait for the execute response to be streamed back on our initial
 	// /Execute stream.


### PR DESCRIPTION
The timeline data adds a lot of noise when using tools like `replay_action` which print out the ExecutedActionMetadata. The timeline data can also be somewhat big, and bazel doesn't care about it, so it's adding unnecesary network transfer.