### PR TITLE
Optimize distributed.Cache.getLookasideEntry

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -383,7 +383,7 @@ func (c *Cache) addLookasideEntry(r *rspb.ResourceName, data []byte) {
 
 // getLookasideEntry returns the resource and if it was found in the lookaside
 // cache.
-func (c *Cache) getLookasideEntry(r *rspb.ResourceName) (data []byte, found bool) {
+func (c *Cache) getLookasideEntry(r *rspb.ResourceName) ([]byte, bool) {
 	if !c.lookasideCacheEnabled() {
 		return nil, false
 	}
@@ -394,6 +394,7 @@ func (c *Cache) getLookasideEntry(r *rspb.ResourceName) (data []byte, found bool
 	}
 
 	c.lookasideMu.Lock()
+	found := false
 	entry, ok := c.lookaside.Get(k)
 	if ok {
 		if time.Since(time.UnixMilli(entry.createdAtMillis)) > *lookasideCacheTTL {

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -381,7 +381,9 @@ func (c *Cache) addLookasideEntry(r *rspb.ResourceName, data []byte) {
 	c.log.Debugf("Set %q in lookaside cache", k)
 }
 
-func (c *Cache) getLookasideEntry(r *rspb.ResourceName) ([]byte, bool) {
+// getLookasideEntry returns the resource and if it was found in the lookaside
+// cache.
+func (c *Cache) getLookasideEntry(r *rspb.ResourceName) (data []byte, found bool) {
 	if !c.lookasideCacheEnabled() {
 		return nil, false
 	}
@@ -392,7 +394,6 @@ func (c *Cache) getLookasideEntry(r *rspb.ResourceName) ([]byte, bool) {
 	}
 
 	c.lookasideMu.Lock()
-	found := false
 	entry, ok := c.lookaside.Get(k)
 	if ok {
 		if time.Since(time.UnixMilli(entry.createdAtMillis)) > *lookasideCacheTTL {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -153,14 +153,14 @@ func NewACResourceName(d *repb.Digest, instanceName string, digestFunction repb.
 
 func (r *ResourceName) CheckCAS() (*CASResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_CAS {
-		return nil, status.FailedPreconditionErrorf("ResourceName is not a CAS resource name: %s", r.rn)
+		return nil, fmt.Errorf("ResourceName (%s/%s) should have CAS cache_type but has: %s", r.GetInstanceName(), r.GetDigest().GetHash(), r.GetCacheType())
 	}
 	return &CASResourceName{*r}, nil
 }
 
 func (r *ResourceName) CheckAC() (*ACResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_AC {
-		return nil, status.FailedPreconditionErrorf("ResourceName is not an AC resource name: %s", r.rn)
+		return nil, fmt.Errorf("ResourceName (%s/%s) should have AC cache_type but has: %s", r.GetInstanceName(), r.GetDigest().GetHash(), r.GetCacheType())
 	}
 	return &ACResourceName{*r}, nil
 }
@@ -209,7 +209,7 @@ func (r *ResourceName) Validate() error {
 		if r.IsEmpty() {
 			return nil
 		}
-		return status.InvalidArgumentError("Invalid (zero-length) SHA256 hash")
+		return status.InvalidArgumentError("Invalid (zero-length) hash")
 	}
 	if !hashKeyRegex.MatchString(d.Hash) {
 		return status.InvalidArgumentError("Malformed hash")

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -153,14 +153,14 @@ func NewACResourceName(d *repb.Digest, instanceName string, digestFunction repb.
 
 func (r *ResourceName) CheckCAS() (*CASResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_CAS {
-		return nil, fmt.Errorf("ResourceName (%s/%s) should have CAS cache_type but has: %s", r.GetInstanceName(), r.GetDigest().GetHash(), r.GetCacheType())
+		return nil, status.FailedPreconditionErrorf("ResourceName is not a CAS resource name: %s", r.rn)
 	}
 	return &CASResourceName{*r}, nil
 }
 
 func (r *ResourceName) CheckAC() (*ACResourceName, error) {
 	if r.rn.GetCacheType() != rspb.CacheType_AC {
-		return nil, fmt.Errorf("ResourceName (%s/%s) should have AC cache_type but has: %s", r.GetInstanceName(), r.GetDigest().GetHash(), r.GetCacheType())
+		return nil, status.FailedPreconditionErrorf("ResourceName is not an AC resource name: %s", r.rn)
 	}
 	return &ACResourceName{*r}, nil
 }


### PR DESCRIPTION
Currently, it spends most of its time creating errors that are never returned or logged: 
![image](https://github.com/user-attachments/assets/9aaa775b-21e9-4a1e-83c0-cc093b83fcde)


There's no benchmarks that currently use this code, and I could add them, but these changes are trivial so I think it's safe to assume they won't make things slower.