### PR TITLE
Fix for line-wrap bug

### DIFF
--- a/server/util/terminal/terminal.go
+++ b/server/util/terminal/terminal.go
@@ -14,7 +14,7 @@ const (
 	// it as the `cap` parameter when making slices to represent lines, which
 	// means we are actually allocating space for slices of this length.
 	// TODO: patch the library to make the cap for slices and the max columns two
-  // different numbers, ideally as a PR.
+	// different numbers, ideally as a PR.
 	columns = 256
 )
 

--- a/server/util/terminal/terminal.go
+++ b/server/util/terminal/terminal.go
@@ -37,10 +37,14 @@ func NewScreenWriter(windowHeight int) (*ScreenWriter, error) {
 	w := &ScreenWriter{Screen: s}
 	if windowHeight > 0 {
 		s.ScrollOutFunc = func(line string) { _, w.WriteErr = w.OutputAccumulator.WriteString(line) }
-		s.SetSize(columns, windowHeight)
+		if err := s.SetSize(columns, windowHeight); err != nil {
+			return nil, err
+		}
 	} else {
 		// 100 is the default number of lines.
-		s.SetSize(columns, 100)
+		if err := s.SetSize(columns, 100); err != nil {
+			return nil, err
+		}
 	}
 	return w, nil
 }

--- a/server/util/terminal/terminal.go
+++ b/server/util/terminal/terminal.go
@@ -6,6 +6,18 @@ import (
 	bkterminal "github.com/buildkite/terminal-to-html/v3"
 )
 
+const (
+	// The number of columns to use for the terminal-to-html ANSI state machine.
+	// All lines that fit in this number of columns (characters) will not wrap to
+	// the next line.
+	// We cannot make this number arbitrarily large because the state machine uses
+	// it as the `cap` parameter when making slices to represent lines, which
+	// means we are actually allocating space for slices of this length.
+	// TODO: patch the library to make the cap for slices and the max columns two
+  // different numbers, ideally as a PR.
+	columns = 256
+)
+
 type ScreenWriter struct {
 	*bkterminal.Screen
 	OutputAccumulator strings.Builder
@@ -25,6 +37,10 @@ func NewScreenWriter(windowHeight int) (*ScreenWriter, error) {
 	w := &ScreenWriter{Screen: s}
 	if windowHeight > 0 {
 		s.ScrollOutFunc = func(line string) { _, w.WriteErr = w.OutputAccumulator.WriteString(line) }
+		s.SetSize(columns, windowHeight)
+	} else {
+		// 100 is the default number of lines.
+		s.SetSize(columns, 100)
 	}
 	return w, nil
 }


### PR DESCRIPTION
This "fixes" the annoying bug where bazel progress lines get scrolled up above the line where curses believes them to be, effectively freezing those lines in time and then beginning the progress lines below. I discovered that what was happening was that particulary long lines (>100 characters) would wrap in the ANSI state machine we use, which would cause any lines above it to move up. That means any lines above that line would no longer be where curses believed them to be, so the lines above the window curses modifies would never be changed again, resulting in the behavior we were seeing.

I increased the number of columns in the state machine from 160 to 256 via the `SetSize` function, which at least makes this much less common. I am open to suggestions as to what this value ought to be; I selected 256 arbitrarily and then tested it on our repo and saw that the bug did not occur. The _correct_ solution to this is to decouple the maximum columns and the cap size of line slices in the `terminal-to-html` library, which would allow us to use an arbitrarily large number (like `math.MaxInt`) as the column size, at which point this bug would never occur again instead of just being less common. However, this is very low-hanging fruit that fixes the 95% case and does not make the remaining cases any worse.
