### PR TITLE
Use inline loading components for invocation tabs

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -1251,6 +1251,10 @@ svg.invocation-query-graph .nodes rect {
   background: transparent;
 }
 
+.invocation .invocation-tab-loading {
+  margin-top: 32px;
+}
+
 .invocation .more-buttons button {
   margin-top: 16px;
   margin-right: 16px;

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -571,6 +571,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
               mode="failing"
               filter={this.props.search.get("targetFilter") ?? ""}
               pageSize={activeTab === "all" ? smallPageSize : largePageSize}
+              showLoader
             />
           )}
 

--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -79,7 +79,7 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
       if (!artifactListingGroup) return null;
 
       if (this.state.searchLoading) {
-        return <div className="loading" />;
+        return <div className="loading loading-slim invocation-tab-loading" />;
       }
 
       const group = this.state.searchResponse?.targetGroups[0] ?? artifactListingGroup;

--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -185,7 +185,7 @@ export default class SpawnCardComponent extends React.Component<Props, State> {
 
   render() {
     if (this.state.loading) {
-      return <div className="loading" />;
+      return <div className="loading loading-slim invocation-tab-loading" />;
     }
 
     let completedCount = 0;

--- a/app/invocation/invocation_targets.tsx
+++ b/app/invocation/invocation_targets.tsx
@@ -13,6 +13,15 @@ interface Props {
   pageSize: number;
   filter: string;
   mode: "passing" | "failing";
+
+  /**
+   * Whether to show a loading indicator when the targets are loading. Should
+   * only be set for the first card.
+   *
+   * TODO: Restructure these components to avoid this - maybe show the loader in
+   * the filter component instead.
+   */
+  showLoader?: boolean;
 }
 
 interface State {
@@ -93,7 +102,7 @@ export default class TargetsComponent extends React.Component<Props, State> {
 
   render() {
     if (this.state.searchLoading) {
-      return <div className="loading" />;
+      return this.props.showLoader ? <div className="loading loading-slim invocation-tab-loading" /> : null;
     }
 
     if (this.props.model.invocation.targetGroups.length) {


### PR DESCRIPTION
The `.loading` class includes `height: 100%` - use `loading-slim` for a few places where we don't want this.