### PR TITLE
Add E2E webdriver test for executions + clickhouse

### DIFF
--- a/app/errors/error_service.ts
+++ b/app/errors/error_service.ts
@@ -5,6 +5,8 @@ import alertService from "../alert/alert_service";
 const ERROR_SEARCH_PARAM = "error";
 
 export class ErrorService {
+  isWindowUnloading = false;
+
   register() {
     let searchParams = new URLSearchParams(window.location.search);
     if (searchParams.has(ERROR_SEARCH_PARAM)) {
@@ -12,19 +14,32 @@ export class ErrorService {
       searchParams.delete(ERROR_SEARCH_PARAM);
       router.replaceParams(Object.fromEntries(searchParams.entries()));
     }
+    // Once the user starts unloading the page, ignore errors, to avoid a brief
+    // window where we display the error banner due to errors that happen when
+    // RPCs are disconnected due to the browser closing the connection.
+    window.addEventListener(
+      "beforeunload",
+      () => {
+        this.isWindowUnloading = true;
+      },
+      { once: true }
+    );
   }
 
   handleError(e: any, options?: { ignoreErrorCodes: ErrorCode[] }) {
-    // NOTE: keep this string in sync with webtester.go -
-    // web tests check for this message and fail the test if it's logged.
-    console.error(new Error("Displaying error banner"));
-
+    if (this.isWindowUnloading) {
+      console.debug("Ignoring error due to page unload:", e);
+      return;
+    }
     console.error(e);
     const error = e instanceof BuildBuddyError ? e : BuildBuddyError.parse(e);
     if (options?.ignoreErrorCodes?.includes(error.code)) {
       console.log("Ignoring error code: " + error.code);
       return;
     }
+    // NOTE: keep this string in sync with webtester.go -
+    // web tests check for this message and fail the test if it's logged.
+    console.error(new Error("Displaying error banner"));
     alertService.error(String(error));
     window.opener?.postMessage(
       { type: "buildbuddy_message", error: String(error), success: false },

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -426,7 +426,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
 
   render() {
     if (this.state.loading) {
-      return <div className="loading"></div>;
+      return <div className="loading" debug-id="invocation-loading"></div>;
     }
 
     // If we don't have an invocation but we have an execution error, show just

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -945,7 +945,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
                   <div className="details">
                     <div className="action-section">
                       <div className="action-property-title">Execution ID</div>
-                      <div>{executionId}</div>
+                      <div debug-id="execution-id">{executionId}</div>
                     </div>
                     <div className="action-section">
                       <div className="action-property-title">Stage</div>

--- a/app/invocation/invocation_not_found.tsx
+++ b/app/invocation/invocation_not_found.tsx
@@ -68,7 +68,7 @@ export default class InvocationNotFoundComponent extends React.Component<Props, 
     }
 
     return (
-      <div className="state-page">
+      <div className="state-page" debug-id="invocation-not-found">
         <div className="shelf">
           <div className="container">
             <div className="breadcrumbs">Invocation {this.props.invocationId}</div>

--- a/enterprise/app/trends/heatmap.tsx
+++ b/enterprise/app/trends/heatmap.tsx
@@ -559,20 +559,22 @@ class HeatmapComponentInternal extends React.Component<ResizableHeatmapProps, St
               ref={this.svgRef}>
               <g transform={`translate(${CHART_MARGINS.left}, ${CHART_MARGINS.top})`} ref={this.chartGroupRef}>
                 <rect fill="#f3f3f3" x="0" y="0" width={width} height={height}></rect>
-                {this.props.heatmapData.column.map((column, xIndex) => (
-                  <>
-                    {column.value.map((value, yIndex) =>
-                      +value <= 0 ? null : (
-                        <rect
-                          x={this.xScaleBand(+column.timestampUsec) || 0}
-                          y={this.yScaleBand(+this.props.heatmapData.bucketBracket[yIndex]) || 0}
-                          width={this.xScaleBand.bandwidth() || 0}
-                          height={this.yScaleBand.bandwidth() || 0}
-                          fill={this.getCellColor(xIndex, yIndex, +value, interpolator, selection)}></rect>
-                      )
-                    )}
-                  </>
-                ))}
+                <g debug-id="heatmap-cells">
+                  {this.props.heatmapData.column.map((column, xIndex) => (
+                    <>
+                      {column.value.map((value, yIndex) =>
+                        +value <= 0 ? null : (
+                          <rect
+                            x={this.xScaleBand(+column.timestampUsec) || 0}
+                            y={this.yScaleBand(+this.props.heatmapData.bucketBracket[yIndex]) || 0}
+                            width={this.xScaleBand.bandwidth() || 0}
+                            height={this.yScaleBand.bandwidth() || 0}
+                            fill={this.getCellColor(xIndex, yIndex, +value, interpolator, selection)}></rect>
+                        )
+                      )}
+                    </>
+                  ))}
+                </g>
               </g>
               {this.renderXAxis(width)}
               {this.renderYAxis(height)}

--- a/enterprise/server/test/webdriver/executions_clickhouse/BUILD
+++ b/enterprise/server/test/webdriver/executions_clickhouse/BUILD
@@ -1,0 +1,29 @@
+load("//rules/webdriver:index.bzl", "go_web_test_suite")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_web_test_suite(
+    name = "executions_clickhouse_test",
+    srcs = ["executions_clickhouse_test.go"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "true",
+        "test.runner-recycling-key": "clickhouse",
+        "test.EstimatedComputeUnits": "4",
+    },
+    shard_count = 1,
+    tags = ["docker"],
+    deps = [
+        "//enterprise/server/testutil/buildbuddy_enterprise",
+        "//enterprise/server/testutil/testexecutor",
+        "//server/testutil/testbazel",
+        "//server/testutil/testclickhouse",
+        "//server/testutil/testfs",
+        "//server/testutil/webtester",
+        "//server/util/shlex",
+        "//server/util/uuid",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
+    ],
+)

--- a/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
+++ b/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
@@ -1,0 +1,252 @@
+package executions_clickhouse_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testexecutor"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testclickhouse"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
+	"github.com/buildbuddy-io/buildbuddy/server/util/shlex"
+	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestInvocationWithRemoteExecutionWithClickHouse(t *testing.T) {
+	// This test can't run against cloud yet, since we depend on the test
+	// running on the same filesystem as the executor to coordinate action
+	// execution via fifo pipes.
+	buildbuddy_enterprise.MarkTestLocalOnly(t)
+	ctx := t.Context()
+	clickhouseDSN := testclickhouse.Start(t, true /*=reuseServer*/)
+	target := buildbuddy_enterprise.SetupWebTarget(
+		t,
+		"--remote_execution.enable_remote_exec=true",
+		"--olap_database.data_source="+clickhouseDSN,
+		// TODO(#8900): set flags to read Executions from ClickHouse.
+	)
+	// Register an executor so that we can test RBE end-to-end.
+	_ = testexecutor.Run(t, "--executor.app_target="+target.GRPCAddress())
+	// Log in and get the flags needed to run an authenticated, RBE-enabled
+	// Bazel invocation.
+	wt := webtester.New(t)
+	webtester.Login(wt, target)
+	buildbuddyBuildFlags := webtester.GetBazelBuildFlags(
+		wt, target.HTTPURL(),
+		webtester.WithEnableCache,
+		webtester.WithEnableRemoteExecution,
+	)
+
+	controllerDir := testfs.MakeTempDir(t)
+	genrule := NewControlledGenrule(t, controllerDir, "target1")
+	workspaceContents := map[string]string{
+		"WORKSPACE": "",
+		"BUILD":     genrule.String(),
+		".bazelrc": `
+# Execution should not be flaky in this test; disable retries.
+common --remote_retries=0
+# Target the local buildbuddy server.
+common ` + shlex.Quote(buildbuddyBuildFlags...) + `
+common --incompatible_strict_action_env=true
+`,
+	}
+	workspace1Path := testbazel.MakeTempWorkspace(t, workspaceContents)
+	iid1 := uuid.New()
+	buildArgs := []string{"//...", "--invocation_id=" + iid1}
+
+	// Start the invocation in the background. It won't complete until we
+	// signal the genrule to exit.
+	var eg errgroup.Group
+	t.Cleanup(func() {
+		err := eg.Wait()
+		require.NoError(t, err)
+	})
+	eg.Go(func() error {
+		t.Log("Starting invocation " + iid1)
+		return testbazel.Invoke(ctx, t, workspace1Path, "build", buildArgs...).Error
+	})
+
+	err := genrule.WaitStarted(ctx)
+	require.NoError(t, err)
+
+	// Before we complete the action, start an identical action in a new
+	// invocation, which should get merged against the first execution.
+	workspace2Path := testbazel.MakeTempWorkspace(t, workspaceContents)
+	iid2 := uuid.New()
+	buildArgs2 := []string{"//...", "--invocation_id=" + iid2}
+	eg.Go(func() error {
+		t.Log("Starting invocation " + iid2)
+		return testbazel.Invoke(ctx, t, workspace2Path, "build", buildArgs2...).Error
+	})
+
+	// Now we've got two invocations running in parallel, each waiting on
+	// the same action to complete.
+
+	goToInvocationPage(t, wt, target.HTTPURL(), iid1)
+	// Go to executions tab.
+	wt.Find(`[href="#execution"]`).Click()
+	waitForExecutionsToAppear(t, wt)
+
+	// There should be one execution in in-progress state.
+	execution := wt.Find(".invocation-execution-row")
+	require.Regexp(t, "(Executing|Starting)", execution.Text())
+	execution.Click()
+	originalExecutionID := wt.Find(`[debug-id="execution-id"]`).Text()
+
+	// Go to the second invocation page and load its executions.
+	// We should see the original execution, still in progress.
+	goToInvocationPage(t, wt, target.HTTPURL(), iid2)
+	wt.Find(`[href="#execution"]`).Click()
+	t.Log("Clicked executions tab; waiting for executions to appear")
+	waitForExecutionsToAppear(t, wt)
+	execution = wt.Find(".invocation-execution-row")
+	require.Regexp(t, "(Executing|Starting)", execution.Text())
+
+	// Now signal the action to exit.
+	genrule.Eval("exit 0")
+
+	// Still in the second invocation page, wait until we can see the successful
+	// execution.
+	waitForExecutionToSucceed(t, wt)
+
+	// Click the execution and make sure the execution ID matches the original.
+	execution = wt.Find(".invocation-execution-row")
+	execution.Click()
+	executionID2 := wt.Find(`[debug-id="execution-id"]`).Text()
+	require.Equal(t, originalExecutionID, executionID2)
+
+	// Now go to Drilldowns, drilldown by execution wall time, and click the
+	// rectangle shown in the heatmap. This should select the invocations
+	// we just performed.
+	wt.Find(`[href="/trends/#drilldown"]`).Click()
+	wt.Find(`.drilldown-page-select`).SendKeys("Execution total wall time")
+	wt.Find(`[debug-id="heatmap-cells"] > *`).Click()
+	// There should be two identical executions shown.
+	waitForExecutionsToAppear(t, wt)
+	require.Contains(t, wt.Find(`body`).Text(), "Selected executions (2)")
+	executions := wt.FindAll(".invocation-execution-row")
+	require.Len(t, executions, 2)
+	require.Equal(t, executions[0].Text(), executions[1].Text())
+}
+
+func goToInvocationPage(t *testing.T, wt *webtester.WebTester, baseURL, iid string) {
+	require.Eventually(t, func() bool {
+		wt.Get(baseURL + "/invocation/" + iid)
+		// Wait for either the invocation view or the empty state page to
+		// appear. If it was the empty state page that appeared, keep retrying.
+		wt.Find(`.invocation, .state-page, [debug-id="invocation-loading"]`)
+		return len(wt.FindAll(`.invocation`)) > 0
+	}, 1*time.Minute, 500*time.Millisecond, "go to invocation page")
+}
+
+func waitForExecutionsToAppear(t *testing.T, wt *webtester.WebTester) {
+	require.Eventually(t, func() bool {
+		executions := wt.Find(".invocation-execution-table, .invocation-execution-empty-actions").FindAll(".invocation-execution-row")
+		return len(executions) > 0
+	}, 1*time.Minute, 500*time.Millisecond, "wait for executions to appear")
+}
+
+func waitForExecutionToSucceed(t *testing.T, wt *webtester.WebTester) {
+	require.Eventually(t, func() bool {
+		executions := wt.Find(".invocation-execution-table").FindAll(".invocation-execution-row")
+		require.Len(t, executions, 1)
+		if strings.Contains(executions[0].Text(), "Succeeded") {
+			return true
+		}
+		wt.Refresh()
+		return false
+	}, 1*time.Minute, 500*time.Millisecond, "wait for execution to succeed")
+}
+
+// ControlledGenrule represents a genrule action whose execution can be
+// controlled by the test. This allows us to test in-progress invocation and
+// execution state.
+//
+// Each ControlledGenrule is only good for one invocation.
+type ControlledGenrule struct {
+	t            *testing.T
+	evalPipePath string
+	started      chan struct{}
+	buildRule    string
+}
+
+func NewControlledGenrule(t *testing.T, controllerDir, name string) *ControlledGenrule {
+	// Create pipes for the build action to communicate with the test.
+	startedPipePath := filepath.Join(controllerDir, name+".started.pipe")
+	err := syscall.Mkfifo(startedPipePath, 0666)
+	require.NoError(t, err)
+	evalPipePath := filepath.Join(controllerDir, name+".eval.pipe")
+	err = syscall.Mkfifo(evalPipePath, 0666)
+	require.NoError(t, err)
+
+	// Add a genrule that writes its pid to the "started" pipe when it starts,
+	// then reads and executes commands from the "eval" pipe.
+	script := `
+echo $$ > ` + startedPipePath + `
+while true; do eval "$(cat ` + evalPipePath + `)"; done
+`
+	// Escape Bazel's "make" variable syntax.
+	escapedScript := strings.ReplaceAll(script, "$", "$$")
+	ruleContents := fmt.Sprintf(
+		"genrule(name = %q, outs = [%q], cmd_bash = %q)",
+		name, name+".out", "touch $@\n"+escapedScript)
+	c := &ControlledGenrule{
+		t:            t,
+		evalPipePath: evalPipePath,
+		started:      make(chan struct{}),
+		buildRule:    ruleContents,
+	}
+	waiterDone := make(chan struct{})
+	startedPipe, err := os.OpenFile(startedPipePath, os.O_RDWR, 0)
+	require.NoError(t, err)
+	go func() {
+		defer close(waiterDone)
+		defer startedPipe.Close()
+		// Read started process PID from the started pipe.
+		var pid int
+		_, err = fmt.Fscanf(startedPipe, "%d", &pid)
+		if t.Context().Err() != nil { // Test is exiting.
+			return
+		}
+		require.NoError(t, err, "read PID of started action")
+		close(c.started)
+	}()
+	// Ensure the goroutine stops execution before returning from the test.
+	t.Cleanup(func() {
+		_ = startedPipe.Close()
+		<-waiterDone
+	})
+	return c
+}
+
+// String returns the genrule() target definition for the controlled genrule.
+func (c *ControlledGenrule) String() string {
+	return c.buildRule
+}
+
+// WaitStarted blocks until the genrule has started execution or the context is
+// done.
+func (c *ControlledGenrule) WaitStarted(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.started:
+		return nil
+	}
+}
+
+// Eval writes a command to the genrule's eval pipe.
+func (c *ControlledGenrule) Eval(command string) {
+	err := os.WriteFile(c.evalPipePath, []byte(fmt.Sprintf("%s\n", command)), 0)
+	require.NoError(c.t, err)
+}

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//server/util/alert",
         "//server/util/authutil",
         "//server/util/background",
+        "//server/util/db",
         "//server/util/git",
         "//server/util/log",
         "//server/util/paging",

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
+	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/paging"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
@@ -1423,6 +1424,9 @@ func LookupInvocation(env environment.Env, ctx context.Context, iid string) (*in
 func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid string, cb invocationEventCB) (*inpb.Invocation, error) {
 	ti, err := env.GetInvocationDB().LookupInvocation(ctx, iid)
 	if err != nil {
+		if db.IsRecordNotFound(err) {
+			return nil, status.NotFoundError("invocation not found")
+		}
 		return nil, err
 	}
 

--- a/server/eventlog/BUILD
+++ b/server/eventlog/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/backends/chunkstore",
         "//server/environment",
         "//server/interfaces",
+        "//server/util/db",
         "//server/util/keyval",
         "//server/util/proto",
         "//server/util/status",

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/backends/chunkstore"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/keyval"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -61,6 +62,9 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 	// TODO(zoey): this function is way too long; split it up.
 	inv, err := env.GetInvocationDB().LookupInvocation(ctx, req.GetInvocationId())
 	if err != nil {
+		if db.IsRecordNotFound(err) {
+			return nil, status.NotFoundError("invocation not found")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Both the UI state and backend state for executions is very complex (especially for in-progress executions), and the UI/backend have complex interactions (streaming w/ retries, special loading state, periodic refreshing). So it seems like a basic webdriver test exercising the real code can help us catch lots of bugs here.

While writing the test I hit various test failures/flakes due to how we're handling certain types of errors (mostly NotFound errors), which seem like legitimate issues - e.g. we're directly returning the "record not found" DB-level error to the UI, instead of returning a gRPC NotFound status. Fixed those bugs in this PR as well.