### PR TITLE
Test redacting passwords in URLs in a single function

### DIFF
--- a/server/util/redact/BUILD
+++ b/server/util/redact/BUILD
@@ -26,8 +26,10 @@ go_test(
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
         "//server/testutil/testenv",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -17,7 +17,7 @@ import (
 	clpb "github.com/buildbuddy-io/buildbuddy/proto/command_line"
 )
 
-func TestRedactURLSecrets(t *testing.T) {
+func TestRedactPasswordsInURLs(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		event    *bespb.BuildEvent


### PR DESCRIPTION
This change groups the tests for redacting passwords in URLs into a single test function with multiple test cases. It also uses the `protocmp` and `go-cmp` packages to compare BuildEvents.

In general, I'd like one test function per _kind_ of secret we're redacting (such as passwords in URLs, non-allowed environment variables, or repo credentials) with one test case per _place_ where a secret could appear.

This way, if we find we're failing to redact a particular _kind_ of secret, we can add or modify the test cases for that _kind_ of secret and know we've covered it. Same goes for cases where we're over-redacting.

If people approve of this approach, I'll keep going!