### PR TITLE
Remove timeout parameter from httpclient.

### DIFF
--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/http/httpclient"
@@ -242,7 +241,7 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 		}))
 	}
 
-	tr := httpclient.NewWithAllowedPrivateIPs(60*time.Minute, r.allowedPrivateIPs).Transport
+	tr := httpclient.NewWithAllowedPrivateIPs(r.allowedPrivateIPs).Transport
 	if len(*mirrors) > 0 {
 		remoteOpts = append(remoteOpts, remote.WithTransport(newMirrorTransport(tr, *mirrors)))
 	} else {


### PR DESCRIPTION
Rely solely on context for timeouts.