### PR TITLE
docs: recommend 600 seconds timeout

### DIFF
--- a/app/docs/setup_code.tsx
+++ b/app/docs/setup_code.tsx
@@ -122,7 +122,7 @@ export default class SetupCodeComponent extends React.Component<Props, State> {
   }
 
   getRemoteOptions() {
-    return <span>build --remote_timeout=3600</span>;
+    return <span>build --remote_timeout=10m</span>;
   }
 
   getRemoteExecution() {

--- a/docs/rbe-setup.md
+++ b/docs/rbe-setup.md
@@ -172,7 +172,7 @@ This determines the number of parallel actions Bazel will remotely execute at on
 This determines the maximum time Bazel will spend on any single remote call, including cache writes. The default value is 60s. We recommend setting this high to avoid timeouts when uploading large cache artifacts.
 
 ```bash
---remote_timeout=600
+--remote_timeout=10m
 ```
 
 [Bazel docs](https://docs.bazel.build/versions/master/command-line-reference.html#flag--remote_timeout)
@@ -401,7 +401,7 @@ build:remote --remote_executor=grpcs://remote.buildbuddy.io
 build:remote --incompatible_strict_action_env=true
 
 # Set a higher timeout value, just in case.
-build:remote --remote_timeout=3600
+build:remote --remote_timeout=10m
 ```
 
 And then run:

--- a/docs/troubleshooting-rbe.md
+++ b/docs/troubleshooting-rbe.md
@@ -11,7 +11,7 @@ This error is often a sign that a cache write is timing out. By default, bazel's
 We recommend using the following flag to increase this remote timeout:
 
 ```bash
---remote_timeout=600
+--remote_timeout=10m
 ```
 
 These expensive writes should only happen once when artifacts are initially written to the cache, and shouldn't happen on subsequent builds.
@@ -23,7 +23,7 @@ This error is a sign that a cache write is timing out. By default, bazel's `remo
 We recommend using the following flag to increase this remote timeout:
 
 ```bash
---remote_timeout=600
+--remote_timeout=10m
 ```
 
 ## exec user process caused "exec format error"


### PR DESCRIPTION
This has been a recurring theme for a while now that Bazel can wait for
an action for a full hour before issuing a retry.

Let's recommend a moderate timeout value of 10 minutes (600 seconds)
instead. This does mean that larger blob transfers may fail in slow
network conditions. But that's relatively rarer and easier to
troubleshoot.
