### PR TITLE
invocation_error_card: ignore nobuild and noanalyze

### DIFF
--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -178,10 +178,10 @@ function getModel(props: Props): CardModel {
   for (const event of props.model.aborted) {
     if (event.aborted) {
       if (
-        // Bazel always include "--nobuild" in a "cquery" command, which results in
-        // many "NO_BUILD" aborted events. We ignore those.
-        props.model.invocation.command === "cquery" &&
-        event.aborted.reason === build_event_stream.Aborted.AbortReason.NO_BUILD
+        // Ignore aborted events caused by --nobuild and --noanalyze flags.
+        // Note: 'bazel cquery' includes --nobuild automatically.
+        event.aborted.reason === build_event_stream.Aborted.AbortReason.NO_BUILD ||
+        event.aborted.reason === build_event_stream.Aborted.AbortReason.NO_ANALYZE
       ) {
         continue;
       }


### PR DESCRIPTION
Ignore all nobuild and noanalyze aborted events during error tracking.
