### PR TITLE
Normalize remote bazel env vars

### DIFF
--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//server/util/git",
         "//server/util/log",
         "//server/util/prefix",
+        "//server/util/rexec",
         "//server/util/status",
         "@com_github_google_uuid//:uuid",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/enterprise/server/hostedrunner/hostedrunner_test.go
+++ b/enterprise/server/hostedrunner/hostedrunner_test.go
@@ -111,62 +111,6 @@ func (*fakeExecuteStream) Recv() (*longrunning.Operation, error) {
 	return &longrunning.Operation{Name: "fake-operation-name", Metadata: metadata}, nil
 }
 
-func TestNormalizePlatform(t *testing.T) {
-	tests := map[string]struct {
-		input          []*repb.Platform_Property
-		expectedOutput []*repb.Platform_Property
-	}{
-		"empty input": {
-			input:          []*repb.Platform_Property{},
-			expectedOutput: []*repb.Platform_Property{},
-		},
-		"sort and dedupe": {
-			input: []*repb.Platform_Property{
-				{
-					Name:  "B",
-					Value: "should get overwritten",
-				},
-				{
-					Name:  "B",
-					Value: "2",
-				},
-				{
-					Name:  "A",
-					Value: "should get overwritten",
-				},
-				{
-					Name:  "A",
-					Value: "1",
-				},
-				{
-					Name:  "C",
-					Value: "3",
-				},
-			},
-			expectedOutput: []*repb.Platform_Property{
-				{
-					Name:  "A",
-					Value: "1",
-				},
-				{
-					Name:  "B",
-					Value: "2",
-				},
-				{
-					Name:  "C",
-					Value: "3",
-				},
-			},
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			o := normalizePlatform(tc.input)
-			require.Equal(t, tc.expectedOutput, o)
-		})
-	}
-}
-
 func TestRemoteHeaders_EnvOverrides(t *testing.T) {
 	te, ctx := getEnv(t)
 

--- a/server/util/rexec/BUILD
+++ b/server/util/rexec/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "rexec",
@@ -18,5 +18,18 @@ go_library(
         "@org_golang_google_genproto//googleapis/longrunning",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "rexec_test",
+    srcs = ["rexec_test.go"],
+    deps = [
+        ":rexec",
+        "//proto:remote_execution_go_proto",
+        "//server/util/proto",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/server/util/rexec/rexec_test.go
+++ b/server/util/rexec/rexec_test.go
@@ -1,0 +1,112 @@
+package rexec_test
+
+import (
+	"testing"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rexec"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestNormalizeCommand(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		command  *repb.Command
+		expected *repb.Command
+	}{
+		{
+			name:     "handles nil command",
+			command:  nil,
+			expected: nil,
+		},
+		{
+			name:     "handles nil platform and env",
+			command:  &repb.Command{},
+			expected: &repb.Command{},
+		},
+		{
+			name: "handles non-nil platform with nil properties",
+			command: &repb.Command{
+				Platform: &repb.Platform{},
+			},
+			expected: &repb.Command{
+				Platform: &repb.Platform{},
+			},
+		},
+		{
+			name: "sorts env vars",
+			command: &repb.Command{
+				EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+					{Name: "B", Value: "2"},
+					{Name: "A", Value: "1"},
+				},
+			},
+			expected: &repb.Command{
+				EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+					{Name: "A", Value: "1"},
+					{Name: "B", Value: "2"},
+				},
+			},
+		},
+		{
+			name: "dedupes env vars",
+			command: &repb.Command{
+				EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+					{Name: "A", Value: "1"},
+					{Name: "A", Value: "2"},
+				},
+			},
+			expected: &repb.Command{
+				EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+					{Name: "A", Value: "2"},
+				},
+			},
+		},
+		{
+			name: "sorts platform properties",
+			command: &repb.Command{
+				Platform: &repb.Platform{
+					Properties: []*repb.Platform_Property{
+						{Name: "B", Value: "2"},
+						{Name: "A", Value: "1"},
+					},
+				},
+			},
+			expected: &repb.Command{
+				Platform: &repb.Platform{
+					Properties: []*repb.Platform_Property{
+						{Name: "A", Value: "1"},
+						{Name: "B", Value: "2"},
+					},
+				},
+			},
+		},
+		{
+			name: "dedupes platform properties",
+			command: &repb.Command{
+				Platform: &repb.Platform{
+					Properties: []*repb.Platform_Property{
+						{Name: "A", Value: "1"},
+						{Name: "A", Value: "2"},
+					},
+				},
+			},
+			expected: &repb.Command{
+				Platform: &repb.Platform{
+					Properties: []*repb.Platform_Property{
+						{Name: "A", Value: "2"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := proto.Clone(test.command).(*repb.Command)
+			rexec.NormalizeCommand(cmd)
+			require.Empty(t, cmp.Diff(test.expected, cmd, protocmp.Transform()))
+		})
+	}
+}


### PR DESCRIPTION
Functionally, this is just a small aesthetic change - makes it easier to compare actions in the UI, since currently the env vars get shuffled around when looking at different remote bazel invocations. It's also good practice though since the REAPI spec says we "MUST" normalize env vars