### PR TITLE
In GetTree, don't copy proto just to get the digest size

### DIFF
--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -759,17 +759,16 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		defer mu.Unlock()
 
 		dir := dirWithDigest.Directory
-		rn := digest.ResourceNameFromProto(dirWithDigest.ResourceName)
-		d := rn.GetDigest()
+		size := dirWithDigest.GetResourceName().GetDigest().GetSizeBytes()
 
-		if rspSizeBytes+d.GetSizeBytes() > rpcutil.GRPCMaxSizeBytes {
+		if rspSizeBytes+size > rpcutil.GRPCMaxSizeBytes {
 			if err := stream.Send(rsp); err != nil {
 				return err
 			}
 			rsp = &repb.GetTreeResponse{}
 			rspSizeBytes = 0
 		}
-		rspSizeBytes += d.GetSizeBytes()
+		rspSizeBytes += size
 		rsp.Directories = append(rsp.Directories, dir)
 		dirCount += 1
 		return nil


### PR DESCRIPTION
Maybe `digest.ResourceNameFromProto` used to do more, but right now it just clones the input and maybe sets the digest function.