### PR TITLE
Optimize distributed.Cache.Get

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1121,7 +1121,7 @@ func (c *Cache) Get(ctx context.Context, rn *rspb.ResourceName) ([]byte, error) 
 	} else {
 		buf = new(bytes.Buffer)
 	}
-	_, err = buf.ReadFrom(r)
+	_, err = io.Copy(buf, r)
 	return buf.Bytes(), err
 }
 

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -214,9 +214,9 @@ func getAllCaches(b *testing.B, te *testenv.TestEnv) []*namedCache {
 	caches := []*namedCache{
 		{getMemoryCache(b), "Memory"},
 		{getDiskCache(b, te), "Disk"},
-		{ddc, "DDisk"},
+		{ddc, "DistDisk"},
 		{getPebbleCache(b, te), "Pebble"},
-		{dpc, "DPebble"},
+		{dpc, "DistPebble"},
 	}
 	return caches
 }

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -509,64 +509,93 @@ func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, isolation *dcpb
 }
 
 func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
-	isolation := &dcpb.Isolation{
-		CacheType:          r.GetCacheType(),
-		RemoteInstanceName: r.GetInstanceName(),
-	}
-	req := &dcpb.ReadRequest{
-		Isolation: isolation,
-		Key:       digestToKey(r.GetDigest()),
-		Offset:    offset,
-		Limit:     limit,
-		Resource:  r,
-	}
-
 	client, err := c.getClient(ctx, peer)
 	if err != nil {
 		return nil, err
 	}
-
+	req := &dcpb.ReadRequest{
+		Isolation: &dcpb.Isolation{
+			CacheType:          r.GetCacheType(),
+			RemoteInstanceName: r.GetInstanceName(),
+		},
+		Key:      digestToKey(r.GetDigest()),
+		Offset:   offset,
+		Limit:    limit,
+		Resource: r,
+	}
 	stream, err := client.Read(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	reader, writer := io.Pipe()
+	return newDistributedCacheReader(stream, r.GetDigest().GetSizeBytes() == offset)
+}
 
+type distributedCacheReader struct {
+	stream dcpb.DistributedCache_ReadClient
+	rsp    *dcpb.ReadResponse
+	err    error
+}
+
+func newDistributedCacheReader(stream dcpb.DistributedCache_ReadClient, expectEOF bool) (*distributedCacheReader, error) {
+	r := &distributedCacheReader{
+		stream: stream,
+		rsp:    dcpb.ReadResponseFromVTPool(),
+	}
 	// Bit annoying here -- the gRPC stream won't give us an error until
 	// we've called Recv on it. But we don't want to return a reader that
 	// we know will error on first read with NotFound -- we want to return
-	// that error now. So we'll wait for our goroutine to call Recv once
-	// and return any error it gets in the main thread.
-	firstError := make(chan error)
-	go func() {
-		readOnce := false
-		rsp := dcpb.ReadResponseFromVTPool()
-		defer rsp.ReturnToVTPool()
-		for {
-			err := stream.RecvMsg(rsp)
-			if !readOnce {
-				firstError <- err
-				readOnce = true
-			}
-			if err == io.EOF {
-				writer.Close()
-				break
-			}
-			if err != nil {
-				writer.CloseWithError(err)
-				break
-			}
-			writer.Write(rsp.Data)
-			rsp.ResetVT()
-		}
-	}()
-	err = <-firstError
-
-	// If we get an EOF, and we're expecting one - don't return an error.
-	if err == io.EOF && r.GetDigest().GetSizeBytes() == offset {
-		return reader, nil
+	// that error now. So read the first message here and return any unexpected
+	// error.
+	r.ensureMoreData()
+	if r.err == nil || (r.err == io.EOF && expectEOF) {
+		return r, nil
 	}
-	return reader, err
+	return nil, r.err
+}
+
+func (r *distributedCacheReader) ensureMoreData() {
+	if r.err == nil && len(r.rsp.GetData()) == 0 {
+		r.err = r.stream.RecvMsg(r.rsp)
+	}
+}
+
+func (r *distributedCacheReader) hasMore() bool { return r.err == nil || len(r.rsp.GetData()) > 0 }
+
+func (r *distributedCacheReader) Read(out []byte) (int, error) {
+	if !r.hasMore() {
+		return 0, r.err
+	}
+	n := copy(out, r.rsp.GetData())
+	r.rsp.Data = r.rsp.Data[n:]
+	r.ensureMoreData()
+	if len(r.rsp.GetData()) == 0 {
+		// If there is no more data, allow returning a possible EOF. This lets
+		// the client skip making another Read call just to get EOF.
+		return n, r.err
+	}
+	return n, nil
+}
+
+func (r *distributedCacheReader) WriteTo(w io.Writer) (int64, error) {
+	var total int64
+	for r.hasMore() {
+		n, err := w.Write(r.rsp.GetData())
+		total += int64(n)
+		if err != nil {
+			return total, err
+		}
+		r.rsp.Data = r.rsp.Data[n:]
+		r.ensureMoreData()
+	}
+	if r.err == io.EOF {
+		return total, nil
+	}
+	return total, r.err
+}
+
+func (r *distributedCacheReader) Close() error {
+	r.rsp.ReturnToVTPool()
+	return r.stream.CloseSend()
 }
 
 type streamWriteCloser struct {


### PR DESCRIPTION
Implement an io.WriterTo instead of using io.Pipe., which is pretty much the same strategy as https://github.com/buildbuddy-io/buildbuddy/pull/8887.

I renamed the distributed benchmarks so it's easier to just run them with `-test.bench=Benchmark/Dist`.

Reduces CPU usage by 1%-7% and memory allocations by 5%-20%:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                            │     base     │            writetocopy             │
                            │    sec/op    │   sec/op     vs base               │
Get/DistDisk10-24              98.92µ ± 3%   91.90µ ± 2%  -7.10% (p=0.000 n=11)
Get/DistDisk100-24             98.39µ ± 2%   92.34µ ± 3%  -6.14% (p=0.000 n=11)
Get/DistDisk1000-24           100.29µ ± 1%   95.15µ ± 1%  -5.13% (p=0.000 n=11)
Get/DistDisk10000-24           111.1µ ± 1%   104.4µ ± 1%  -6.01% (p=0.000 n=11)
Get/DistPebble10-24           102.62µ ± 1%   95.57µ ± 1%  -6.87% (p=0.000 n=11)
Get/DistPebble100-24          103.28µ ± 1%   97.74µ ± 1%  -5.36% (p=0.000 n=11)
Get/DistPebble1000-24          106.2µ ± 1%   101.9µ ± 1%  -4.04% (p=0.000 n=11)
Get/DistPebble10000-24         138.2µ ± 1%   136.2µ ± 2%  -1.46% (p=0.000 n=11)

                            │     base     │              writetocopy               │
                            │     B/s      │      B/s        vs base                │
Get/DistDisk10-24             97.66Ki ± 0%   107.42Ki ±  0%  +10.00% (p=0.000 n=11)
Get/DistDisk100-24            996.1Ki ± 2%   1054.7Ki ±  1%   +5.88% (p=0.000 n=11)
Get/DistDisk1000-24           9.508Mi ± 1%   10.023Mi ±  1%   +5.42% (p=0.000 n=11)
Get/DistDisk10000-24          85.82Mi ± 2%    91.31Mi ±  1%   +6.40% (p=0.000 n=11)
Get/DistPebble10-24           97.66Ki ± 0%    97.66Ki ± 10%        ~ (p=0.214 n=11)
Get/DistPebble100-24          947.3Ki ± 1%    996.1Ki ±  1%   +5.15% (p=0.000 n=11)
Get/DistPebble1000-24         8.984Mi ± 1%    9.356Mi ±  1%   +4.14% (p=0.000 n=11)
Get/DistPebble10000-24        69.02Mi ± 0%    70.04Mi ±  1%   +1.48% (p=0.000 n=11)

                            │     base      │             writetocopy              │
                            │     B/op      │     B/op      vs base                │
Get/DistDisk10-24             24.10Ki ±  0%   22.02Ki ± 0%   -8.63% (p=0.000 n=11)
Get/DistDisk100-24            24.37Ki ±  0%   22.38Ki ± 1%   -8.16% (p=0.000 n=11)
Get/DistDisk1000-24           27.68Ki ±  0%   26.15Ki ± 0%   -5.53% (p=0.000 n=11)
Get/DistDisk10000-24          54.24Ki ±  0%   43.11Ki ± 0%  -20.53% (p=0.000 n=11)
Get/DistPebble10-24           24.76Ki ±  0%   22.73Ki ± 0%   -8.20% (p=0.000 n=11)
Get/DistPebble100-24          25.11Ki ±  0%   23.19Ki ± 0%   -7.66% (p=0.000 n=11)
Get/DistPebble1000-24         28.62Ki ±  0%   27.16Ki ± 0%   -5.10% (p=0.000 n=11)
Get/DistPebble10000-24        56.61Ki ±  0%   45.82Ki ± 0%  -19.07% (p=0.000 n=11)

                            │    base     │            writetocopy             │
                            │  allocs/op  │  allocs/op   vs base               │
Get/DistDisk10-24              386.0 ± 0%    381.0 ± 0%  -1.30% (p=0.000 n=11)
Get/DistDisk100-24             386.0 ± 0%    381.0 ± 0%  -1.30% (p=0.000 n=11)
Get/DistDisk1000-24            385.0 ± 0%    381.0 ± 0%  -1.04% (p=0.000 n=11)
Get/DistDisk10000-24           380.0 ± 0%    376.0 ± 0%  -1.05% (p=0.000 n=11)
Get/DistPebble10-24            435.0 ± 0%    430.0 ± 0%  -1.15% (p=0.000 n=11)
Get/DistPebble100-24           435.0 ± 0%    430.0 ± 0%  -1.15% (p=0.000 n=11)
Get/DistPebble1000-24          434.0 ± 0%    430.0 ± 0%  -0.92% (p=0.000 n=11)
Get/DistPebble10000-24         457.0 ± 0%    453.0 ± 0%  -0.88% (p=0.000 n=11)
```