### PR TITLE
Fix a race condition in remote_execution_test

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -50,7 +50,7 @@ var (
 	defaultPoolName              = flag.String("remote_execution.default_pool_name", "", "The default executor pool to use if one is not specified.")
 	sharedExecutorPoolGroupID    = flag.String("remote_execution.shared_executor_pool_group_id", "", "Group ID that owns the shared executor pool.")
 	requireExecutorAuthorization = flag.Bool("remote_execution.require_executor_authorization", false, "If true, executors connecting to this server must provide a valid executor API key.")
-	leaseInterval                = flag.Duration("remote_execution.lease_duration", 10*time.Second, "How long before a task lease must be renewed by the executor client.")
+	leaseDuration                = flag.Duration("remote_execution.lease_duration", 10*time.Second, "How long before a task lease must be renewed by the executor client.")
 	leaseGracePeriod             = flag.Duration("remote_execution.lease_grace_period", 10*time.Second, "How long to wait for the executor to renew the lease after the TTL duration has elapsed.")
 	leaseReconnectGracePeriod    = flag.Duration("remote_execution.lease_reconnect_grace_period", 1*time.Second, "How long to delay re-enqueued tasks in order to allow the previous lease holder to renew its lease (following a server shutdown).")
 	maxSchedulingDelay           = flag.Duration("remote_execution.max_scheduling_delay", 5*time.Second, "Max duration that actions can sit in a non-preferred executor's queue before they are executed.")
@@ -981,10 +981,11 @@ func (c *schedulerClientCache) get(hostPort string) (schedulerClient, error) {
 
 // Options for overriding server behavior needed for testing.
 type Options struct {
-	LocalPortOverride             int32
-	RequireExecutorAuthorization  bool
-	Clock                         clockwork.Clock
-	ActionMergingLeaseTTLOverride time.Duration
+	LocalPortOverride               int32
+	RequireExecutorAuthorization    bool
+	Clock                           clockwork.Clock
+	ActionMergingLeaseTTLOverride   time.Duration
+	LeaseDuration, LeaseGracePeriod time.Duration
 }
 
 type SchedulerServer struct {
@@ -1014,6 +1015,8 @@ type SchedulerServer struct {
 
 	mu    sync.RWMutex
 	pools map[nodePoolKey]*nodePool
+
+	leaseDuration, leaseGracePeriod time.Duration
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -1070,6 +1073,12 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 		actionMergingLeaseTTL = options.ActionMergingLeaseTTLOverride
 	}
 
+	if options.LeaseGracePeriod == 0 {
+		options.LeaseGracePeriod = *leaseGracePeriod
+	}
+	if options.LeaseDuration == 0 {
+		options.LeaseDuration = *leaseDuration
+	}
 	s := &SchedulerServer{
 		env:                               env,
 		pools:                             make(map[nodePoolKey]*nodePool),
@@ -1084,6 +1093,8 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 		enableRedisAvailabilityMonitoring: remote_execution_config.RemoteExecutionEnabled() && env.GetRemoteExecutionService().RedisAvailabilityMonitoringEnabled(),
 		ownHostPort:                       fmt.Sprintf("%s:%d", ownHostname, ownPort),
 		actionMergingLeaseTTL:             actionMergingLeaseTTL,
+		leaseDuration:                     options.LeaseDuration,
+		leaseGracePeriod:                  options.LeaseGracePeriod,
 	}
 	s.schedulerClientCache = newSchedulerClientCache(env, s.ownHostPort, s)
 	return s, nil
@@ -1615,7 +1626,7 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 		}
 	}()
 
-	livenessTicker := s.clock.NewTicker(*leaseInterval)
+	livenessTicker := s.clock.NewTicker(s.leaseDuration)
 	defer livenessTicker.Stop()
 	for {
 		var req *scpb.LeaseTaskRequest
@@ -1625,7 +1636,7 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 			req = msg.req
 			err = msg.err
 		case <-livenessTicker.Chan():
-			if s.clock.Since(lastCheckin) > (*leaseInterval + *leaseGracePeriod) {
+			if s.clock.Since(lastCheckin) > (s.leaseDuration + s.leaseGracePeriod) {
 				err = status.DeadlineExceededErrorf("lease was not renewed by executor and expired (last renewal: %s)", lastCheckin)
 			} else {
 				continue
@@ -1652,7 +1663,7 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 			ctx = log.EnrichContext(ctx, log.ExecutionIDKey, req.GetTaskId())
 		}
 		rsp := &scpb.LeaseTaskResponse{
-			LeaseDurationSeconds: int64(leaseInterval.Seconds()),
+			LeaseDurationSeconds: int64(s.leaseDuration.Seconds()),
 		}
 		if !claimed {
 			log.CtxInfof(ctx, "LeaseTask attempt (reconnect=%t) from executor %q", req.GetReconnectToken() != "", executorID)

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -86,9 +86,9 @@ func (f *fakeTaskRouter) MarkFailed(ctx context.Context, action *repb.Action, cm
 }
 
 type schedulerOpts struct {
+	options            Options
 	userOwnedEnabled   bool
 	groupOwnedEnabled  bool
-	clock              clockwork.Clock
 	preferredExecutors []string
 }
 
@@ -104,7 +104,7 @@ func getEnv(t *testing.T, opts *schedulerOpts, user string) (*testenv.TestEnv, c
 	err := execution_server.Register(env)
 	require.NoError(t, err)
 	env.SetTaskRouter(&fakeTaskRouter{opts.preferredExecutors})
-	s, err := NewSchedulerServerWithOptions(env, &Options{Clock: opts.clock})
+	s, err := NewSchedulerServerWithOptions(env, &opts.options)
 	require.NoError(t, err)
 	env.SetSchedulerService(s)
 
@@ -639,11 +639,12 @@ func TestExecutorReEnqueue_RetriesDisabled(t *testing.T) {
 }
 
 func TestLeaseExpiration(t *testing.T) {
-	flags.Set(t, "remote_execution.lease_duration", 10*time.Second)
-	flags.Set(t, "remote_execution.lease_grace_period", 10*time.Second)
-
 	fakeClock := clockwork.NewFakeClock()
-	env, ctx := getEnv(t, &schedulerOpts{clock: fakeClock}, "user1")
+	env, ctx := getEnv(t, &schedulerOpts{options: Options{
+		Clock:            fakeClock,
+		LeaseDuration:    10 * time.Second,
+		LeaseGracePeriod: 10 * time.Second,
+	}}, "user1")
 
 	fe := newFakeExecutor(ctx, t, env.GetSchedulerClient())
 	fe.Register()

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -797,7 +797,7 @@ func TestEnqueueTaskReservation_Exists(t *testing.T) {
 
 func TestAskForMoreWorkOnlyEnqueuesTasksThatFitOnNode(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	env, ctx := getEnv(t, &schedulerOpts{clock: clock}, "user1")
+	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
 
 	// Register two nodes with different capacities.
 	largeExecutor := newFakeExecutorWithId(ctx, t, "large", env.GetSchedulerClient())


### PR DESCRIPTION
Setting flags that are read in goroutines often causes race condition failures like https://buildbuddy.buildbuddy.dev/invocation/230df744-1163-4fa7-9be2-4b55a0bd090e?target=%2F%2Fenterprise%2Fserver%2Ftest%2Fintegration%2Fremote_execution%3Aremote_execution_test&targetStatus=6#10@10