### PR TITLE
Only set skip-resaving-action-snapshots on firecracker actions

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -82,7 +82,7 @@ const (
 	persistentWorkerKeyPropertyName         = "persistentWorkerKey"
 	persistentWorkerProtocolPropertyName    = "persistentWorkerProtocol"
 	WorkflowIDPropertyName                  = "workflow-id"
-	workloadIsolationPropertyName           = "workload-isolation-type"
+	WorkloadIsolationPropertyName           = "workload-isolation-type"
 	initDockerdPropertyName                 = "init-dockerd"
 	enableDockerdTCPPropertyName            = "enable-dockerd-tcp"
 	enableVFSPropertyName                   = "enable-vfs"
@@ -297,7 +297,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		pool = ""
 	}
 	recycleRunner := boolProp(m, RecycleRunnerPropertyName, false)
-	isolationType := stringProp(m, workloadIsolationPropertyName, "")
+	isolationType := stringProp(m, WorkloadIsolationPropertyName, "")
 
 	// Only Enable VFS if it is also enabled via flags.
 	vfsEnabled := boolProp(m, enableVFSPropertyName, false) && *enableVFS

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1786,10 +1786,14 @@ func (s *SchedulerServer) modifyTaskForExperiments(ctx context.Context, executor
 	// We need the bazel RequestMetadata to make experiment decisions. The Lease
 	// RPC doesn't get this metadata, because the executor doesn't get it until
 	// the lease returns. Instead of piping it all the way through, create a new
-	// gRPC incoming context, from the serialized task's metadata.
+	// gRPC incoming context from the serialized task's metadata.
 	taskProto := &repb.ExecutionTask{}
 	if err := proto.Unmarshal(task, taskProto); err != nil {
 		log.CtxWarningf(ctx, "Failed to unmarshal ExecutionTask: %s", err)
+		return task
+	}
+	isolationType := platform.FindEffectiveValue(taskProto, platform.WorkloadIsolationPropertyName)
+	if isolationType != string(platform.FirecrackerContainerType) {
 		return task
 	}
 	md, found := metadata.FromIncomingContext(ctx)


### PR DESCRIPTION
This skips most of modifyTaskForExperiments for OCI actions, and it will make it a bit easier to analyze the experiment.