### PR TITLE
track full response size in action_cache_server even for client-side cache hits.

### DIFF
--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -71,6 +71,9 @@ func getACKeyForGetActionResultRequest(req *repb.GetActionResultRequest) (*diges
 }
 
 func (s *ActionCacheServerProxy) getLocallyCachedActionResult(ctx context.Context, key *digest.ACResourceName) (*repb.Digest, *repb.ActionResult, error) {
+	// NOTE: To avoid double-counting AC hits, we deliberately don't track
+	// download for these reads.  The remote server will count the full response
+	// size when checking the cached value.
 	ptr := &rspb.ResourceName{}
 	if err := cachetools.ReadProtoFromAC(ctx, s.localCache, key, ptr); err != nil {
 		return nil, nil, err

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -130,24 +130,24 @@ func setWorkerMetadata(ar *repb.ActionResult) error {
 	return nil
 }
 
-func (s *ActionCacheServer) fetchActionResult(ctx context.Context, rn *digest.ACResourceName, req *repb.GetActionResultRequest) (*repb.ActionResult, bool, int64, error) {
+func (s *ActionCacheServer) fetchActionResult(ctx context.Context, rn *digest.ACResourceName, req *repb.GetActionResultRequest) (*repb.ActionResult, int64, error) {
 	blob, err := s.cache.Get(ctx, rn.ToProto())
 	if err != nil {
-		return nil, false, 0, status.NotFoundErrorf("ActionResult (%s) not found: %s", req.GetActionDigest(), err)
+		return nil, 0, status.NotFoundErrorf("ActionResult (%s) not found: %s", req.GetActionDigest(), err)
 	}
 
 	rsp := &repb.ActionResult{}
 	if err := proto.Unmarshal(blob, rsp); err != nil {
-		return nil, false, 0, err
+		return nil, 0, err
 	}
 
 	if err := ValidateActionResult(ctx, s.cache, req.GetInstanceName(), req.GetDigestFunction(), rsp); err != nil {
-		return nil, false, 0, status.NotFoundErrorf("ActionResult (%s) not found: %s", req.GetActionDigest(), err)
+		return nil, 0, status.NotFoundErrorf("ActionResult (%s) not found: %s", req.GetActionDigest(), err)
 	}
 	// The default limit on incoming gRPC messages is 4MB and Bazel doesn't
 	// change it.
 	if err := s.maybeInlineOutputFiles(ctx, req, rsp, 4*1024*1024); err != nil {
-		return nil, false, 0, err
+		return nil, 0, err
 	}
 
 	if !req.GetIncludeTimelineData() && rsp.GetExecutionMetadata().GetUsageStats() != nil {
@@ -160,7 +160,7 @@ func (s *ActionCacheServer) fetchActionResult(ctx context.Context, rn *digest.AC
 	if *checkClientActionResultDigests && req.GetCachedActionResultDigest().GetHash() != "" {
 		d, err := digest.ComputeForMessage(rsp, req.GetDigestFunction())
 		if err != nil {
-			return nil, false, 0, err
+			return nil, 0, err
 		}
 
 		// NOTE: To avoid double-counting AC hits, callers that specify a
@@ -173,10 +173,10 @@ func (s *ActionCacheServer) fetchActionResult(ctx context.Context, rn *digest.AC
 				ActionResultDigest: d,
 			}
 		}
-		return rsp, true, originalResultSize, nil
+		return rsp, originalResultSize, nil
 	}
 
-	return rsp, true, int64(proto.Size(rsp)), nil
+	return rsp, int64(proto.Size(rsp)), nil
 }
 
 // Retrieve a cached execution result.
@@ -209,14 +209,14 @@ func (s *ActionCacheServer) GetActionResult(ctx context.Context, req *repb.GetAc
 	d := req.GetActionDigest()
 	downloadTracker := ht.TrackDownload(d)
 
-	rsp, isCacheHit, downloadSizeBytes, err := s.fetchActionResult(ctx, rn, req)
+	rsp, downloadSizeBytes, err := s.fetchActionResult(ctx, rn, req)
 	ht.SetExecutedActionMetadata(rsp.GetExecutionMetadata())
-	if isCacheHit {
-		if trackerErr := downloadTracker.CloseWithBytesTransferred(downloadSizeBytes, downloadSizeBytes, repb.Compressor_IDENTITY, "ac_server"); err != nil {
+	if err == nil {
+		if trackerErr := downloadTracker.CloseWithBytesTransferred(downloadSizeBytes, downloadSizeBytes, repb.Compressor_IDENTITY, "ac_server"); trackerErr != nil {
 			log.Debugf("GetActionResult: download tracker error: %s", trackerErr)
 		}
 	} else {
-		if trackerErr := ht.TrackMiss(d); err != nil {
+		if trackerErr := ht.TrackMiss(d); trackerErr != nil {
 			log.Debugf("GetActionResult: hit tracker error: %s", trackerErr)
 		}
 	}

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -130,6 +130,55 @@ func setWorkerMetadata(ar *repb.ActionResult) error {
 	return nil
 }
 
+func (s *ActionCacheServer) fetchActionResult(ctx context.Context, rn *digest.ACResourceName, req *repb.GetActionResultRequest) (*repb.ActionResult, bool, int64, error) {
+	blob, err := s.cache.Get(ctx, rn.ToProto())
+	if err != nil {
+		return nil, false, 0, status.NotFoundErrorf("ActionResult (%s) not found: %s", req.GetActionDigest(), err)
+	}
+
+	rsp := &repb.ActionResult{}
+	if err := proto.Unmarshal(blob, rsp); err != nil {
+		return nil, false, 0, err
+	}
+
+	if err := ValidateActionResult(ctx, s.cache, req.GetInstanceName(), req.GetDigestFunction(), rsp); err != nil {
+		return nil, false, 0, status.NotFoundErrorf("ActionResult (%s) not found: %s", req.GetActionDigest(), err)
+	}
+	// The default limit on incoming gRPC messages is 4MB and Bazel doesn't
+	// change it.
+	if err := s.maybeInlineOutputFiles(ctx, req, rsp, 4*1024*1024); err != nil {
+		return nil, false, 0, err
+	}
+
+	if !req.GetIncludeTimelineData() && rsp.GetExecutionMetadata().GetUsageStats() != nil {
+		rsp.GetExecutionMetadata().GetUsageStats().Timeline = nil
+	}
+
+	// See if the caller specified a cached value.  If they did and it matches
+	// the full response that we just computed, then we won't bother sending the
+	// data, and instead just tell the caller that their cache is correct.
+	if *checkClientActionResultDigests && req.GetCachedActionResultDigest().GetHash() != "" {
+		d, err := digest.ComputeForMessage(rsp, req.GetDigestFunction())
+		if err != nil {
+			return nil, false, 0, err
+		}
+
+		// NOTE: To avoid double-counting AC hits, callers that specify a
+		// cached_action_result_digest don't do hit tracking on their own.  This
+		// means we need to track the full response size here instead.
+		originalResultSize := int64(proto.Size(rsp))
+		// Now that we've tracked size, wipe out the response.
+		if proto.Equal(req.GetCachedActionResultDigest(), d) {
+			rsp = &repb.ActionResult{
+				ActionResultDigest: d,
+			}
+		}
+		return rsp, true, originalResultSize, nil
+	}
+
+	return rsp, true, int64(proto.Size(rsp)), nil
+}
+
 // Retrieve a cached execution result.
 //
 // Implementations SHOULD ensure that any blobs referenced from the
@@ -146,7 +195,7 @@ func (s *ActionCacheServer) GetActionResult(ctx context.Context, req *repb.GetAc
 	if req.ActionDigest == nil {
 		return nil, status.InvalidArgumentError("ActionDigest is a required field")
 	}
-	rn := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_AC, req.GetDigestFunction())
+	rn := digest.NewACResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())
 	if err := rn.Validate(); err != nil {
 		return nil, err
 	}
@@ -158,73 +207,20 @@ func (s *ActionCacheServer) GetActionResult(ctx context.Context, req *repb.GetAc
 	ht := s.env.GetHitTrackerFactory().NewACHitTracker(ctx, bazel_request.GetRequestMetadata(ctx))
 	// Fetch the "ActionResult" object which enumerates all the files in the action.
 	d := req.GetActionDigest()
-
 	downloadTracker := ht.TrackDownload(d)
-	isCacheHit := false
-	var uncompressedResultSizeBytes int64
-	defer func() {
-		if isCacheHit {
-			if err := downloadTracker.CloseWithBytesTransferred(uncompressedResultSizeBytes, uncompressedResultSizeBytes, repb.Compressor_IDENTITY, "ac_server"); err != nil {
-				log.Debugf("GetActionResult: download tracker error: %s", err)
-			}
-		} else {
-			if err := ht.TrackMiss(d); err != nil {
-				log.Debugf("GetActionResult: hit tracker error: %s", err)
-			}
-		}
-	}()
 
-	blob, err := s.cache.Get(ctx, rn.ToProto())
-	if err != nil {
-		return nil, status.NotFoundErrorf("ActionResult (%s) not found: %s", d, err)
-	}
-
-	rsp := &repb.ActionResult{}
-	if err := proto.Unmarshal(blob, rsp); err != nil {
-		return nil, err
-	}
+	rsp, isCacheHit, downloadSizeBytes, err := s.fetchActionResult(ctx, rn, req)
 	ht.SetExecutedActionMetadata(rsp.GetExecutionMetadata())
-	if err := ValidateActionResult(ctx, s.cache, req.GetInstanceName(), req.GetDigestFunction(), rsp); err != nil {
-		return nil, status.NotFoundErrorf("ActionResult (%s) not found: %s", d, err)
-	}
-	// The default limit on incoming gRPC messages is 4MB and Bazel doesn't
-	// change it.
-	if err := s.maybeInlineOutputFiles(ctx, req, rsp, 4*1024*1024); err != nil {
-		return nil, err
-	}
-
-	if !req.GetIncludeTimelineData() && rsp.GetExecutionMetadata().GetUsageStats() != nil {
-		rsp.GetExecutionMetadata().GetUsageStats().Timeline = nil
-	}
-
-	// See if the caller specified a cached value.  If they did and it matches
-	// the full response that we just computed, then we won't bother sending the
-	// data, and instead just tell the caller that their cache is correct.
-	if *checkClientActionResultDigests && req.GetCachedActionResultDigest().GetHash() != "" {
-		d, err := digest.ComputeForMessage(rsp, req.GetDigestFunction())
-		if err != nil {
-			return nil, err
-		}
-
-		// NOTE: To avoid double-counting AC hits, callers that specify a
-		// cached_action_result_digest don't do hit tracking on their own.  This
-		// means we need to track the full response size here instead.
-		uncompressedResultSizeBytes = int64(proto.Size(rsp))
-		isCacheHit = true
-		// Now that we've tracked size, wipe out the response.
-		if proto.Equal(req.GetCachedActionResultDigest(), d) {
-			rsp = &repb.ActionResult{
-				ActionResultDigest: d,
-			}
+	if isCacheHit {
+		if trackerErr := downloadTracker.CloseWithBytesTransferred(downloadSizeBytes, downloadSizeBytes, repb.Compressor_IDENTITY, "ac_server"); err != nil {
+			log.Debugf("GetActionResult: download tracker error: %s", trackerErr)
 		}
 	} else {
-		// If the client didn't specify a cached value, just track usage the way
-		// you would expect.
-		uncompressedResultSizeBytes = int64(proto.Size(rsp))
-		isCacheHit = true
+		if trackerErr := ht.TrackMiss(d); err != nil {
+			log.Debugf("GetActionResult: hit tracker error: %s", trackerErr)
+		}
 	}
-
-	return rsp, nil
+	return rsp, err
 }
 
 // Upload a new execution result.


### PR DESCRIPTION
this is admittedly a little weird.  there are two options here that i see:
1. track size in the cache proxy when the value is in the cache proxy's cache, track size in the apps when it's there instead.  this is a little weird, because we don't know if the value will match until we've actually read it, at which point we've already initialized a tracker in the app server, yada yada.
2. do what's in this pr: never track download for ac requests in the cache proxy.  this is also a little weird, but the net result is that we run no risk of double-tracking hits.  i considered this more reasonable because we literally always perform the reads in the apps under the current implementation--we _never_ put ac entries in the lookaside cache, and cut around the hit-tracking service implementations when looking up values in the cache.