### PR TITLE
use httpclient for /v2/ requests

### DIFF
--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -156,7 +156,7 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 		http.Error(w, fmt.Sprintf("could not make %s request to upstream registry '%s': %s", inreq.Method, u, err), http.StatusNotFound)
 		return
 	}
-	upresp, err := http.DefaultClient.Do(upreq.WithContext(ctx))
+	upresp, err := r.client.Do(upreq.WithContext(ctx))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("transport error making %s request to upstream registry '%s': %s", inreq.Method, u, err), http.StatusNotFound)
 		return


### PR DESCRIPTION
To track metrics (and block requests to non-allowed IPs), use the `httpclient` instead of `http.DefaultClient`.