### PR TITLE
Fix how the scheduler overrides RequestMetadata for experiments

### DIFF
--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -112,7 +112,7 @@ func (fp *FlagProvider) getEvaluationContext(ctx context.Context, opts ...any) o
 		options.attributes["group_id"] = claims.GetGroupID()
 		options.attributes["user_id"] = claims.GetUserID()
 	}
-	rmd := bazel_request.GetRequestMetadata(ctx))
+	rmd := bazel_request.GetRequestMetadata(ctx)
 	if iid := rmd.GetToolInvocationId(); len(iid) > 0 {
 		options.attributes["invocation_id"] = iid
 	}

--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -112,7 +112,7 @@ func (fp *FlagProvider) getEvaluationContext(ctx context.Context, opts ...any) o
 		options.attributes["group_id"] = claims.GetGroupID()
 		options.attributes["user_id"] = claims.GetUserID()
 	}
-	rmd := bazel_request.GetRequestMetadata(ctx)
+	rmd := bazel_request.GetRequestMetadata(ctx))
 	if iid := rmd.GetToolInvocationId(); len(iid) > 0 {
 		options.attributes["invocation_id"] = iid
 	}

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -37,7 +37,6 @@ go_library(
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
-        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//peer",
         "@org_golang_google_protobuf//encoding/prototext",
         "@org_golang_google_protobuf//types/known/durationpb",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1807,14 +1807,14 @@ func (s *SchedulerServer) modifyTaskForExperiments(ctx context.Context, executor
 	if isolationType != string(platform.FirecrackerContainerType) {
 		return task
 	}
-	md, found := metadata.FromIncomingContext(ctx)
-	if !found {
-		md = make(metadata.MD)
-	}
 	metaBytes, err := proto.Marshal(taskProto.GetRequestMetadata())
 	if err != nil {
 		log.CtxWarningf(ctx, "Failed to marshal request metadata: %s", err)
 		return task
+	}
+	md, found := metadata.FromIncomingContext(ctx)
+	if !found {
+		md = make(metadata.MD)
 	}
 	md.Append(bazel_request.RequestMetadataKey, string(metaBytes))
 	ctx = metadata.NewIncomingContext(ctx, md)

--- a/server/util/bazel_request/bazel_request.go
+++ b/server/util/bazel_request/bazel_request.go
@@ -36,6 +36,9 @@ func GetRequestMetadataBytes(ctx context.Context) []byte {
 
 func ParseRequestMetadataOnce(ctx context.Context) context.Context {
 	rmd := GetRequestMetadata(ctx)
+	if rmd == nil {
+		return ctx
+	}
 
 	// Set the parsed request metadata on the context. By doing this once
 	// and saving the value on the context, we save a bunch of work when

--- a/server/util/bazel_request/bazel_request.go
+++ b/server/util/bazel_request/bazel_request.go
@@ -26,12 +26,19 @@ const (
 	requestMetadataContextKey = "bazel_request.request_metadata"
 )
 
-func GetRequestMetadataBytes(ctx context.Context) []byte {
+func getRequestMetadataBytes(ctx context.Context) []byte {
 	vals := metadata.ValueFromIncomingContext(ctx, RequestMetadataKey)
 	if len(vals) == 0 {
 		return nil
 	}
 	return []byte(vals[0])
+}
+
+// OverrideRequestMetadata returns a context such that
+// `GetRequestMetadata(OverrideRequestMetadata(md))` will always return `md`
+// regardless of what is in gRPC context.
+func OverrideRequestMetadata(ctx context.Context, md *repb.RequestMetadata) context.Context {
+	return context.WithValue(ctx, requestMetadataContextKey, md)
 }
 
 func ParseRequestMetadataOnce(ctx context.Context) context.Context {
@@ -51,7 +58,7 @@ func GetRequestMetadata(ctx context.Context) *repb.RequestMetadata {
 		return rmd
 	}
 
-	b := GetRequestMetadataBytes(ctx)
+	b := getRequestMetadataBytes(ctx)
 	if len(b) == 0 {
 		return nil
 	}


### PR DESCRIPTION
The previous version of this didn't work because `GetRequestMetadata` in `experiments.FlagProvider.getEvaluationContext` would return nil. This is because the server interceptor calls ParseRequestMetadataOnce, it doesn't find the metadata bytes, but it puts a nil proto in the context.

Instead, just allow override the parsed RequestMetadata.