### PR TITLE
deps: upgrade protobufjs (#8922)

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6605,8 +6605,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
 def install_static_dependencies(workspace_name = "buildbuddy"):
     http_archive(
         name = "com_github_buildbuddy_io_protoc_gen_protobufjs",
-        sha256 = "81ce501fdcc10a08c84b8c9d9d1900ca35b62f581deaba8168bed2b96e7696b0",
-        urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.12/protoc-gen-protobufjs-v0.0.12.tar.gz"],
+        integrity = "sha256-VL3iXrCZj9OiYrads5Ve6uHjppfc5i8mHexOrVvpOI4=",
+        urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.13/protoc-gen-protobufjs-v0.0.13.tar.gz"],
     )
 
     http_archive(


### PR DESCRIPTION
Upgrade protoc-gen-protobufjs to v0.0.13 and
update the integrity checksum.

Include this change that should help aid bzlmod migration.
https://github.com/buildbuddy-io/protoc-gen-protobufjs/pull/3
