### PR TITLE
oci: update distribution reference (#8931)

### DIFF
--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -14,7 +14,7 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "//server/util/tracing",
-        "@com_github_docker_distribution//reference",
+        "@com_github_distribution_reference//:reference",
         "@com_github_google_go_containerregistry//pkg/authn",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/creack/pty v1.1.18
 	github.com/crewjam/saml v0.4.14
-	github.com/docker/distribution v2.8.2+incompatible
+	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v26.1.5+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/dop251/goja v0.0.0-20230626124041-ba8a63e79201
@@ -246,9 +246,9 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/diegoholiveira/jsonlogic/v3 v3.7.4 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/docker/cli v27.5.0+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect

--- a/go_deps.MODULE.bazel
+++ b/go_deps.MODULE.bazel
@@ -213,7 +213,7 @@ use_repo(
     "com_github_coreos_go_oidc_v3",
     "com_github_creack_pty",
     "com_github_crewjam_saml",
-    "com_github_docker_distribution",
+    "com_github_distribution_reference",
     "com_github_docker_docker",
     "com_github_docker_go_units",
     "com_github_dop251_goja",


### PR DESCRIPTION
Replace docker/distribution/reference with a newer version of that
package at distribution/reference.

This helps us avoid potential compilcation error spotted while migrating
to bzlmod:

```
external/gazelle++go_deps+com_github_docker_distribution/reference/reference_deprecated.go:122:19: undefined: reference.SplitHostname
compilepkg: error running subcommand external/rules_go++go_sdk+buildbuddy__download_0/pkg/tool/darwin_arm64/compile: exit status 2
```

Example invocation:
https://buildbuddy.buildbuddy.io/invocation/708b4308-2da8-4cec-8132-c2eb9a038889#@45

`SplitHostname` was deprecated and yanked in the latest version of distribution/reference.

https://pkg.go.dev/github.com/docker/distribution/reference#SplitHostname
https://github.com/distribution/reference/commit/4894124079e525c3c3c5c8aacaa653b5499004e9
