### PR TITLE
bzlmod: prepare deps for migration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,7 +28,7 @@ single_version_override(
     patches = [
         "@@//buildpatches:bzlmod_googleapis.patch",
     ],
-    version = "0.0.0-20240326-1c8d509c5",
+    version = "0.0.0-20241220-5e258e33",
 )
 
 # Note that this is 'rules_nodejs-core'
@@ -81,13 +81,14 @@ bazel_dep(name = "aspect_rules_js", version = "2.1.3")
 bazel_dep(name = "aspect_rules_swc", version = "2.3.0")
 bazel_dep(name = "aspect_rules_ts", version = "3.5.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_go", version = "0.52.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_oci", version = "2.0.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.3.0")
 bazel_dep(name = "toolchains_musl", version = "0.1.15")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
 
@@ -125,6 +126,25 @@ buildbuddy.msvc_toolchain(
     # From 'Microsoft Visual C++ 2022 Minimum Runtime' for x64 architecture
     # https://github.com/actions/runner-images/blob/win22/20250303.1/images/windows/Windows2022-Readme.md#microsoft-visual-c
     msvc_version = "14.43.34808",
+)
+
+# Explicitly register the toolchains in the order which we want to use.
+#
+# Note: Both rules_cc and toolschains_buildbuddy modules automatically register
+# their respective toolchains automatically. Bazel will prioritize which ever bazel_dep
+# was declared first. By explicitly registering the toolchains here, we can control
+# the prioritization order.
+#
+# If none of the toolchains listed here matched against
+# the target+exec platform combintation, Bazel will pick one from the toolchains that
+# were automatically registered toolchains by these dependencies modules.
+#
+# Reference: https://bazel.build/external/migration#register-toolchains
+register_toolchains(
+    # CC toolchains
+    "@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_x86_64",
+    "@toolchains_buildbuddy//toolchains/cc:ubuntu_gcc_arm64",
+    "@toolchains_buildbuddy//toolchains/cc:windows_msvc_x86_64",
 )
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
@@ -182,13 +202,6 @@ rules_ts_ext.deps(
 # TODO: Remove this after the next aspect_rules_ts update.
 # https://github.com/aspect-build/rules_ts/pull/786
 use_repo(rules_ts_ext, "npm_typescript")
-
-switched_rules = use_extension("@googleapis//:extensions.bzl", "switched_rules")
-switched_rules.use_languages(
-    cc = True,
-    go = True,
-    grpc = True,
-)
 
 toolchains_musl = use_extension("@toolchains_musl//:toolchains_musl.bzl", "toolchains_musl", dev_dependency = True)
 toolchains_musl.config(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,10 +11,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 # Bazel platforms
 http_archive(
     name = "platforms",
-    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
+    integrity = "sha256-KXQuhydYCbXlmNwvBNhpYMx6VbMGfZciHJq7yZJr/w8=",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.11/platforms-0.0.11.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.11/platforms-0.0.11.tar.gz",
     ],
 )
 
@@ -51,9 +51,9 @@ http_archive(
 
 http_archive(
     name = "rules_python",
-    sha256 = "4f7e2aa1eb9aa722d96498f5ef514f426c1f55161c3c9ae628c857a7128ceb07",
-    strip_prefix = "rules_python-1.0.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/1.0.0/rules_python-1.0.0.tar.gz",
+    integrity = "sha256-LMJrvVOFTOt23UKoNLEALNS6f43zVEDPA0guBFr/wkQ=",
+    strip_prefix = "rules_python-1.3.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/1.3.0/rules_python-1.3.0.tar.gz",
 )
 
 http_archive(
@@ -251,18 +251,18 @@ gazelle_dependencies(
 )
 
 # Version taken from
-# https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/googleapis/0.0.0-20240326-1c8d509c5/source.json
+# https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/googleapis/0.0.0-20241220-5e258e33/source.json
 # So that we can use the same version of googleapis as the one used in bzlmod.
 http_archive(
     name = "googleapis",
+    integrity = "sha256-ftfNAEA+XKYX5I+kRRNhXnnfyBert9Rgq1WQ6sJ0Pvk=",
     patch_args = ["-p1"],
     patches = [
         "//buildpatches:googleapis.patch",
     ],
-    sha256 = "b854ae17ddb933c249530f743db8d78df80905dfb42681255564a1d1921dfc3c",
-    strip_prefix = "googleapis-1c8d509c574aeab7478be1bfd4f2e8f0931cfead",
+    strip_prefix = "googleapis-5e258e334154da04dcd0a567a61ac21518cac81b",
     urls = [
-        "https://github.com/googleapis/googleapis/archive/1c8d509c574aeab7478be1bfd4f2e8f0931cfead.tar.gz",
+        "https://github.com/googleapis/googleapis/archive/5e258e334154da04dcd0a567a61ac21518cac81b.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Cleanup MODULE.bazel file to prepare for eventual migration.
The most important change here is that we are explicitly registering our
bb toolchains to override the default auto-registering order, which put
rules_cc local toolchain up top based on the bazel_dep loading order.

In the future we might need to apply the same manual registration to
select the exact Go toolchains that we want to use.

Upgraded googleapis, platforms, rules_python to latest release on central
registry. This let us get rid of the deprecated switched_rules
extensions call.
