### PR TITLE
Use environment variable to identify if the bb binary is running as the sidecar

### DIFF
--- a/cli/cmd/sidecar/BUILD
+++ b/cli/cmd/sidecar/BUILD
@@ -7,7 +7,7 @@ go_library(
     srcs = ["sidecar.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/cmd/sidecar",
     deps = [
-        "//cli/arg",
+        "//cli/config",
         "//cli/devnull",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_execution_go_proto",

--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/config"
 	"github.com/buildbuddy-io/buildbuddy/cli/devnull"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_proxy"
@@ -201,12 +201,10 @@ func initializeDiskCache(env *real_environment.RealEnv) {
 }
 
 func Handle() {
-	sc, args := arg.Pop(os.Args, "sidecar")
-	if sc != "1" {
+	if os.Getenv(config.BbIsSidecar) != "1" {
 		return
 	}
 	defer os.Exit(0)
-	os.Args = args
 
 	flag.Parse()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -23,6 +23,9 @@ const (
 	// Path where we expect to find the user's plugin configuration, relative
 	// to the user's home directory.
 	HomeRelativeUserConfigPath = "buildbuddy.yaml"
+
+	// Environment variable that is set to "1" if we are a sidecar.
+	BbIsSidecar = "_BB_IS_SIDECAR"
 )
 
 // File represents a decoded config file along with its metadata.

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -137,7 +137,7 @@ func restartSidecarIfNecessary(ctx context.Context, bbCacheDir string, args []st
 	// This is where we'll listen for bazel traffic
 	args = append(args, fmt.Sprintf("--listen_addr=unix://%s", sockPath))
 	// Re-invoke ourselves in sidecar mode.
-	c := exec.Command(os.Args[0], append(args)...)
+	c := exec.Command(os.Args[0], args...)
 	c.Env = append(os.Environ(), config.BbIsSidecar+"=1")
 	// Start the sidecar in its own process group so that when we send Ctrl+C,
 	// the sidecar can keep running in the background.

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -138,7 +138,7 @@ func restartSidecarIfNecessary(ctx context.Context, bbCacheDir string, args []st
 	args = append(args, fmt.Sprintf("--listen_addr=unix://%s", sockPath))
 	// Re-invoke ourselves in sidecar mode.
 	c := exec.Command(os.Args[0], append(args)...)
-	c.Env = append(os.Environ(), config.BbIsSidecar + "=1")
+	c.Env = append(os.Environ(), config.BbIsSidecar+"=1")
 	// Start the sidecar in its own process group so that when we send Ctrl+C,
 	// the sidecar can keep running in the background.
 	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -137,7 +137,8 @@ func restartSidecarIfNecessary(ctx context.Context, bbCacheDir string, args []st
 	// This is where we'll listen for bazel traffic
 	args = append(args, fmt.Sprintf("--listen_addr=unix://%s", sockPath))
 	// Re-invoke ourselves in sidecar mode.
-	c := exec.Command(os.Args[0], append(args, "--sidecar=1")...)
+	c := exec.Command(os.Args[0], append(args)...)
+	c.Env = append(os.Environ(), config.BbIsSidecar + "=1")
 	// Start the sidecar in its own process group so that when we send Ctrl+C,
 	// the sidecar can keep running in the background.
 	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}


### PR DESCRIPTION
Switch from searching the os args to try to remove a flag indicating the sidecar, if it exists, to using an environment variable. This avoids having to modify os args without parsing them, which is brittle, as well as parsing the os args, which we would prefer not to do if we are not the sidecar.
