### PR TITLE
Make consistent_hash.GetAllReplicas 20 times faster

### DIFF
--- a/server/util/consistent_hash/BUILD
+++ b/server/util/consistent_hash/BUILD
@@ -5,10 +5,7 @@ go_library(
     srcs = ["consistent_hash.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/consistent_hash",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/log",
-        "//server/util/status",
-    ],
+    deps = ["//server/util/status"],
 )
 
 go_test(

--- a/server/util/consistent_hash/consistent_hash.go
+++ b/server/util/consistent_hash/consistent_hash.go
@@ -4,11 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"hash/crc32"
+	"slices"
 	"sort"
 	"strconv"
 	"sync"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
@@ -32,13 +32,15 @@ var (
 	}
 )
 
+const maxSize = 256
+
 type ConsistentHash struct {
-	ring      map[int]uint8
-	keys      []int
-	items     []string
-	numVnodes int
-	hashKey   HashFunction
-	mu        sync.RWMutex
+	keys                []int
+	items               []string
+	keyIndexToItemIndex []uint8
+	numVnodes           int
+	hashKey             HashFunction
+	mu                  sync.RWMutex
 }
 
 // NewConsistentHash returns a new consistent hash ring.
@@ -51,11 +53,11 @@ type ConsistentHash struct {
 // See https://en.wikipedia.org/wiki/Consistent_hashing#Variance_reduction
 func NewConsistentHash(hashFunction HashFunction, vnodes int) *ConsistentHash {
 	return &ConsistentHash{
-		numVnodes: vnodes,
-		hashKey:   hashFunction,
-		keys:      make([]int, 0),
-		ring:      make(map[int]uint8, 0),
-		items:     make([]string, 0),
+		numVnodes:           vnodes,
+		hashKey:             hashFunction,
+		keys:                make([]int, 0),
+		items:               make([]string, 0),
+		keyIndexToItemIndex: make([]uint8, 0),
 	}
 }
 
@@ -66,13 +68,13 @@ func (c *ConsistentHash) GetItems() []string {
 }
 
 func (c *ConsistentHash) Set(items ...string) error {
-	if len(items) > 256 {
+	if len(items) > maxSize {
 		return status.InvalidArgumentError("Too many items in consistent hash, max allowed: 256")
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.keys = make([]int, 0)
-	c.ring = make(map[int]uint8, 0)
+	c.keys = make([]int, 0, len(items)*c.numVnodes)
+	ring := make(map[int]uint8, len(items)*c.numVnodes)
 
 	c.items = items
 	sort.Strings(c.items)
@@ -81,10 +83,16 @@ func (c *ConsistentHash) Set(items ...string) error {
 		for i := 0; i < c.numVnodes; i++ {
 			h := c.hashKey(strconv.Itoa(i) + key)
 			c.keys = append(c.keys, h)
-			c.ring[h] = uint8(itemIndex)
+			ring[h] = uint8(itemIndex)
 		}
 	}
 	sort.Ints(c.keys)
+	// Precompute the mapping from key to item. This doesn't depened on the
+	// keys that are passed to Get or GetAllReplicas.
+	c.keyIndexToItemIndex = make([]uint8, len(c.keys))
+	for i, key := range c.keys {
+		c.keyIndexToItemIndex[i] = ring[key]
+	}
 	return nil
 }
 
@@ -95,22 +103,31 @@ func (c *ConsistentHash) Get(key string) string {
 	if len(c.keys) == 0 {
 		return ""
 	}
-	h := c.hashKey(key)
-	idx := sort.Search(len(c.keys), func(i int) bool {
-		return c.keys[i] >= h
-	})
-	if idx == len(c.keys) {
-		idx = 0
-	}
-	r := c.items[c.ring[c.keys[idx]]]
+	idx := c.firstKey(key)
+	r := c.items[c.keyIndexToItemIndex[idx]]
 	return r
 }
 
-func (c *ConsistentHash) lookupVnodes(idx int, fn func(vnodeIndex uint8) bool) {
+func (c *ConsistentHash) firstKey(key string) int {
+	h := c.hashKey(key)
+	startKeyIdx, _ := slices.BinarySearch(c.keys, h)
+	if startKeyIdx == len(c.keys) {
+		return 0
+	}
+	return startKeyIdx
+}
+
+func (c *ConsistentHash) lookupVnodes(startKeyIdx int, fn func(vnodeIndex uint8) bool) {
 	done := false
 	for offset := 1; offset < len(c.keys) && !done; offset += 1 {
-		newIdx := (idx + offset) % len(c.keys)
-		done = fn(c.ring[c.keys[newIdx]])
+		keyIdx := (startKeyIdx + offset)
+		if keyIdx >= len(c.keyIndexToItemIndex) {
+			// This is 20% faster than always modding by
+			// len(c.keyIndexToItemIndex) every iteration.
+			startKeyIdx -= len(c.keyIndexToItemIndex)
+			keyIdx -= len(c.keyIndexToItemIndex)
+		}
+		done = fn(c.keyIndexToItemIndex[keyIdx])
 	}
 }
 
@@ -120,40 +137,23 @@ func (c *ConsistentHash) GetAllReplicas(key string) []string {
 	if len(c.keys) == 0 {
 		return nil
 	}
-	h := c.hashKey(key)
-	idx := sort.Search(len(c.keys), func(i int) bool {
-		return c.keys[i] >= h
-	})
-	if idx == len(c.keys) {
-		idx = 0
-	}
-	originalIndex := c.ring[c.keys[idx]]
+	startKeyIdx := c.firstKey(key)
+	originalIndex := c.keyIndexToItemIndex[startKeyIdx]
 
 	replicas := make([]string, 0, len(c.items))
 	replicas = append(replicas, c.items[originalIndex])
+	var replicaSet [maxSize]bool // This doesn't allocate since it's on the stack.
+	replicaSet[originalIndex] = true
 
-	c.lookupVnodes(idx, func(vnodeIndex uint8) bool {
-		replica := c.items[vnodeIndex]
+	c.lookupVnodes(startKeyIdx, func(vnodeIndex uint8) bool {
 		// If we already visited this vnode's corresponding replica, skip.
-		for _, r := range replicas {
-			if r == replica {
-				return false
-			}
+		if replicaSet[vnodeIndex] {
+			return false
 		}
-		replicas = append(replicas, replica)
+		replicaSet[vnodeIndex] = true
+		replicas = append(replicas, c.items[vnodeIndex])
 		return len(replicas) == len(c.items)
 	})
 
 	return replicas
-}
-
-// GetNReplicas returns the N "items" responsible for the specified key, in
-// order. It does this by walking the vnodes in the consistent hash ring, in
-// order, until N unique replicas have been found.
-func (c *ConsistentHash) GetNReplicas(key string, n int) []string {
-	replicas := c.GetAllReplicas(key)
-	if len(replicas) < n {
-		log.Warningf("Warning: client requested %d replicas but only %d were available.", n, len(replicas))
-	}
-	return replicas[:n]
 }

--- a/server/util/consistent_hash/consistent_hash.go
+++ b/server/util/consistent_hash/consistent_hash.go
@@ -32,6 +32,11 @@ var (
 	}
 )
 
+// The maximum number of items that can be passed to Set(). This is before they
+// are multiplied by vnodes. Using 256 allows us to use uint8 values in a few
+// places and an array of size 256 instead of a slice for deduplication.
+// Increasing this would require changing all fields with uint8 values, and
+// rethinking the deduplication strategy.
 const maxSize = 256
 
 type ConsistentHash struct {

--- a/server/util/consistent_hash/consistent_hash_test.go
+++ b/server/util/consistent_hash/consistent_hash_test.go
@@ -136,6 +136,18 @@ func TestAgainstReference(t *testing.T) {
 	}
 }
 
+func TestGoldenSet(t *testing.T) {
+	ch := consistent_hash.NewConsistentHash(consistent_hash.SHA256, 10000)
+	require.NoError(t, ch.Set("a", "b", "c", "d"))
+	// NOTE: These values should never change -- if you have to change them it
+	// means the consistent hash is broken and returning results in a different
+	// order than before.
+	assert.Equal(t, []string{"d", "b", "c", "a"}, ch.GetAllReplicas(""))
+	assert.Equal(t, []string{"b", "c", "d", "a"}, ch.GetAllReplicas("1"))
+	assert.Equal(t, []string{"b", "a", "c", "d"}, ch.GetAllReplicas("2"))
+	assert.Equal(t, []string{"a", "c", "d", "b"}, ch.GetAllReplicas("3"))
+}
+
 func BenchmarkGetAllReplicas(b *testing.B) {
 	for _, test := range []struct {
 		Name         string

--- a/server/util/consistent_hash/consistent_hash_test.go
+++ b/server/util/consistent_hash/consistent_hash_test.go
@@ -56,25 +56,29 @@ func TestNodesetOrderIndependence(t *testing.T) {
 }
 
 func TestGetAllReplicas(t *testing.T) {
-	assert := assert.New(t)
 	ch := consistent_hash.NewConsistentHash(consistent_hash.CRC32, numVnodes)
 
-	hosts := make([]string, 0)
-	for i := 0; i < 10; i++ {
-		r, err := random.RandomString(5)
-		assert.Nil(err)
-		hosts = append(hosts, fmt.Sprintf("%s:%d", r, 1000+i))
-	}
+	for _, numHosts := range []int{0, 1, 10} {
+		t.Run(fmt.Sprintf("%vhosts", numHosts), func(t *testing.T) {
+			assert := assert.New(t)
+			hosts := make([]string, 0, numHosts)
+			for i := 0; i < numHosts; i++ {
+				r, err := random.RandomString(5)
+				assert.Nil(err)
+				hosts = append(hosts, fmt.Sprintf("%s:%d", r, 1000+i))
+			}
 
-	if err := ch.Set(hosts...); err != nil {
-		t.Fatal(err)
-	}
+			if err := ch.Set(hosts...); err != nil {
+				t.Fatal(err)
+			}
 
-	for i := 0; i < 100; i++ {
-		k, err := random.RandomString(64)
-		assert.Nil(err)
-		replicas := ch.GetAllReplicas(k)
-		assert.Equal(10, len(replicas))
+			for i := 0; i < 100; i++ {
+				k, err := random.RandomString(64)
+				assert.Nil(err)
+				replicas := ch.GetAllReplicas(k)
+				assert.Equal(numHosts, len(replicas))
+			}
+		})
 	}
 }
 
@@ -123,7 +127,7 @@ func BenchmarkGetAllReplicas(b *testing.B) {
 			ch := consistent_hash.NewConsistentHash(test.HashFunction, test.NumVnodes)
 
 			hosts := make([]string, 0)
-			for i := 0; i < 10; i++ {
+			for i := 0; i < 50; i++ {
 				r, err := random.RandomString(5)
 				assert.Nil(err)
 				hosts = append(hosts, fmt.Sprintf("%s:%d", r, 1000+i))


### PR DESCRIPTION
In benchmarks, this makes distributed FindMissing ~10% faster. GetAllReplicas is also 2.6% of our app CPU, so this will nearly eliminate that.

Benchmark results from `//server/util/consistent_hash:consistent_hash_test`:
```
                                      │    50base     │            50finalnomod2            │
                                      │    sec/op     │   sec/op     vs base                │
GetAllReplicas/CRC32/100_vnodes-24      23560.0n ± 1%   579.5n ± 3%  -97.54% (p=0.000 n=11)
GetAllReplicas/SHA256/10000_vnodes-24   17076.0n ± 3%   759.3n ± 1%  -95.55% (p=0.000 n=11)
geomean                                   20.06µ        663.3n       -96.69%

                                      │   50base   │            50finalnomod2            │
                                      │    B/op    │    B/op     vs base                 │
GetAllReplicas/CRC32/100_vnodes-24      960.0 ± 0%   960.0 ± 0%       ~ (p=1.000 n=11) ¹
GetAllReplicas/SHA256/10000_vnodes-24   960.0 ± 0%   960.0 ± 0%       ~ (p=1.000 n=11) ¹
geomean                                 960.0        960.0       +0.00%

                                      │   50base   │            50finalnomod2            │
                                      │ allocs/op  │ allocs/op   vs base                 │
GetAllReplicas/CRC32/100_vnodes-24      2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=11) ¹
GetAllReplicas/SHA256/10000_vnodes-24   2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=11) ¹
geomean                                 2.000        2.000       +0.00%
```

Benchmark results from `//enterprise/server/test/performance/cache:cache_test`:
```
                               │  cachebase   │           cachefinalnomod           │
                               │    sec/op    │   sec/op     vs base                │
FindMissing/DistDisk10-24        353.8µ ± 12%   293.1µ ± 9%  -17.15% (p=0.000 n=11)
FindMissing/DistDisk100-24       462.3µ ±  4%   417.3µ ± 8%   -9.74% (p=0.000 n=11)
FindMissing/DistDisk1000-24      466.7µ ±  4%   428.9µ ± 3%   -8.10% (p=0.000 n=11)
FindMissing/DistDisk10000-24     480.7µ ±  2%   419.1µ ± 5%  -12.81% (p=0.000 n=11)
FindMissing/DistPebble10-24      459.9µ ±  8%   443.9µ ± 8%        ~ (p=0.088 n=11)
FindMissing/DistPebble100-24     652.7µ ±  1%   599.0µ ± 1%   -8.23% (p=0.000 n=11)
FindMissing/DistPebble1000-24    666.1µ ±  2%   614.5µ ± 3%   -7.74% (p=0.000 n=11)
FindMissing/DistPebble10000-24   653.3µ ±  2%   601.3µ ± 1%   -7.95% (p=0.000 n=11)
geomean                          513.0µ         464.3µ        -9.48%

                               │   cachebase   │           cachefinalnomod            │
                               │     B/op      │     B/op       vs base               │
FindMissing/DistDisk10-24        198.2Ki ±  5%   193.4Ki ± 13%       ~ (p=0.562 n=11)
FindMissing/DistDisk100-24       264.8Ki ±  0%   265.6Ki ±  0%  +0.30% (p=0.035 n=11)
FindMissing/DistDisk1000-24      264.6Ki ±  0%   265.3Ki ±  0%       ~ (p=0.088 n=11)
FindMissing/DistDisk10000-24     264.4Ki ±  0%   264.3Ki ±  0%       ~ (p=0.949 n=11)
FindMissing/DistPebble10-24      314.6Ki ± 10%   335.0Ki ± 12%       ~ (p=0.519 n=11)
FindMissing/DistPebble100-24     462.6Ki ±  0%   462.5Ki ±  0%       ~ (p=0.748 n=11)
FindMissing/DistPebble1000-24    494.0Ki ±  0%   494.1Ki ±  0%       ~ (p=1.000 n=11)
FindMissing/DistPebble10000-24   463.7Ki ±  0%   463.9Ki ±  0%       ~ (p=0.308 n=11)
geomean                          324.3Ki         326.1Ki        +0.55%

                               │  cachebase   │            cachefinalnomod            │
                               │  allocs/op   │  allocs/op    vs base                 │
FindMissing/DistDisk10-24        2.623k ±  5%   2.561k ± 11%       ~ (p=0.573 n=11)
FindMissing/DistDisk100-24       3.590k ±  0%   3.590k ±  0%       ~ (p=0.738 n=11)
FindMissing/DistDisk1000-24      3.590k ±  0%   3.590k ±  0%       ~ (p=0.214 n=11)
FindMissing/DistDisk10000-24     3.590k ±  0%   3.589k ±  0%       ~ (p=0.395 n=11)
FindMissing/DistPebble10-24      5.603k ± 11%   6.003k ± 11%       ~ (p=0.468 n=11)
FindMissing/DistPebble100-24     8.377k ±  0%   8.377k ±  0%       ~ (p=1.000 n=11) ¹
FindMissing/DistPebble1000-24    8.377k ±  0%   8.377k ±  0%       ~ (p=1.000 n=11) ¹
FindMissing/DistPebble10000-24   8.377k ±  0%   8.377k ±  0%       ~ (p=1.000 n=11) ¹
geomean                          5.014k         5.043k        +0.56%
```