### PR TITLE
Export VM metrics in /metrics endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/GoogleCloudPlatform/cloudsql-proxy v1.35.0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/RoaringBitmap/roaring v1.9.1
+	github.com/VictoriaMetrics/metrics v1.33.1
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/aws/aws-sdk-go-v2 v1.36.3
@@ -194,7 +195,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.3 // indirect
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
-	github.com/VictoriaMetrics/metrics v1.33.1 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect

--- a/go_deps.MODULE.bazel
+++ b/go_deps.MODULE.bazel
@@ -289,6 +289,7 @@ use_repo(
     "com_github_tink_crypto_tink_go_gcpkms_v2",
     "com_github_tink_crypto_tink_go_v2",
     "com_github_tklauser_go_sysconf",
+    "com_github_victoriametrics_metrics",
     "com_github_vishvananda_netlink",
     "com_github_xiam_s_expr",
     "com_github_zeebo_blake3",

--- a/server/util/monitoring/BUILD
+++ b/server/util/monitoring/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
+        "//server/http/interceptors",
         "//server/util/basicauth",
         "//server/util/flag",
         "//server/util/flagz",
@@ -16,5 +17,6 @@ go_library(
         "//server/util/statusz",
         "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_rantav_go_grpc_channelz//:go-grpc-channelz",
+        "@com_github_victoriametrics_metrics//:metrics",
     ],
 )

--- a/server/util/monitoring/monitoring.go
+++ b/server/util/monitoring/monitoring.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/pprof"
 
+	"github.com/VictoriaMetrics/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/util/basicauth"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagz"
@@ -35,7 +37,7 @@ func RegisterMonitoringHandlers(env environment.Env, mux *http.ServeMux) {
 	}
 
 	// Prometheus metrics
-	handle("/metrics", promhttp.Handler())
+	handle("/metrics", metricsHandler())
 
 	// PProf endpoints
 	handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
@@ -95,4 +97,23 @@ func StartSSLMonitoringHandler(env environment.Env, hostPort string) error {
 		s.ListenAndServeTLS("", "")
 	}()
 	return nil
+}
+
+func metricsHandler() http.Handler {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Removes the "Accept-Encoding: gzip" to ensure
+		// promhttp.Handler().ServeHTTP() outputs plaintext, so that we can append the plaintext from victoria metrics.
+		encodingKey := "Accept-Encoding"
+		vals := r.Header.Values(encodingKey)
+		r.Header.Del("Accept-Encoding")
+		promhttp.Handler().ServeHTTP(w, r)
+		metrics.WritePrometheus(w, false)
+
+		// Adding the encoding key back
+		for _, v := range vals {
+			r.Header.Add(encodingKey, v)
+		}
+	})
+
+	return interceptors.Gzip(h)
 }

--- a/server/util/monitoring/monitoring.go
+++ b/server/util/monitoring/monitoring.go
@@ -105,7 +105,7 @@ func StartSSLMonitoringHandler(env environment.Env, hostPort string) error {
 
 func metricsHandler() http.Handler {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Removes the "Accept-Encoding: gzip" to ensure
+		// Remove any "Accept-Encoding" headers to ensure
 		// promhttp.Handler().ServeHTTP() outputs plaintext, so that we can append the plaintext from victoria metrics.
 		vals := r.Header.Values(acceptEncodingKey)
 		r.Header.Del(acceptEncodingKey)


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4736

Export metrics registered with VictoriaMetrics in metrics endpoint too.
Dragonboat library's metrics are registered with VM.

Note: my change dropped support for zstd compression that was supported
in promhttp.Handler(). However, Both [VM's prometheus scraper](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/2f4680d8f39f5e84069dcdabb71c72bc3234c69f/lib/promscrape/client.go#L144) and prometheus's own
[scraper](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go#L812) only set gzip header. 



I pushed this change to raft-dev, and verified /metrics endpoint works and the 
dragonboat metrics were picked by vm scraper.
