### PR TITLE
Add cache methods to oci.Resolver and have OCI mirror use them

### DIFF
--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -8,19 +8,14 @@ go_library(
     deps = [
         "//enterprise/server/util/oci",
         "//proto:ociregistry_go_proto",
-        "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/http/httpclient",
         "//server/real_environment",
-        "//server/remote_cache/cachetools",
-        "//server/remote_cache/digest",
         "//server/util/log",
         "//server/util/prefix",
-        "//server/util/proto",
         "//server/util/status",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
-        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )
 

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/ociregistry",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/util/oci",
         "//proto:ociregistry_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2362,7 +2362,7 @@ func (c *FirecrackerContainer) PullImage(ctx context.Context, creds oci.Credenti
 		log.CtxDebugf(ctx, "PullImage took %s", time.Since(start))
 	}()
 
-	_, err := ociconv.CreateDiskImage(ctx, c.executorConfig.CacheRoot, c.containerImage, creds)
+	_, err := ociconv.CreateDiskImage(ctx, c.env, c.executorConfig.CacheRoot, c.containerImage, creds)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -268,7 +268,7 @@ func NewProvider(env environment.Env, buildRoot, cacheRoot string) (*provider, e
 	if err := cleanStaleImageCacheDirs(imageCacheRoot); err != nil {
 		log.Warningf("Failed to clean up old image cache versions: %s", err)
 	}
-	imageStore, err := NewImageStore(imageCacheRoot)
+	imageStore, err := NewImageStore(env, imageCacheRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -1345,8 +1345,8 @@ type ImageLayer struct {
 	DiffID ctr.Hash
 }
 
-func NewImageStore(layersDir string) (*ImageStore, error) {
-	resolver, err := oci.NewResolver()
+func NewImageStore(env environment.Env, layersDir string) (*ImageStore, error) {
+	resolver, err := oci.NewResolver(env)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -1359,6 +1359,7 @@ func TestFileOwnership(t *testing.T) {
 }
 
 func TestPathSanitization(t *testing.T) {
+	te := testenv.GetTestEnv(t)
 	setupNetworking(t)
 	for _, test := range []struct {
 		Name          string
@@ -1390,7 +1391,7 @@ func TestPathSanitization(t *testing.T) {
 			testfs.WriteAllFileContents(t, cacheRoot, map[string]string{
 				"test-link-target": "Hello",
 			})
-			imageStore, err := ociruntime.NewImageStore(cacheRoot)
+			imageStore, err := ociruntime.NewImageStore(te, cacheRoot)
 			require.NoError(t, err)
 			// Load busybox oci image
 			busyboxImg := testregistry.ImageFromRlocationpath(t, ociBusyboxRlocationpath)
@@ -1631,6 +1632,7 @@ func hasMountPermissions(t *testing.T) bool {
 //	     --test_env=TEST_PULLIMAGE=1 \
 //	     enterprise/server/remote_execution/containers/ociruntime:ociruntime_test
 func TestPullImage(t *testing.T) {
+	te := testenv.GetTestEnv(t)
 	if os.Getenv("TEST_PULLIMAGE") == "" {
 		t.Skip("Skipping integration test..")
 	}
@@ -1666,7 +1668,7 @@ func TestPullImage(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			layerDir := t.TempDir()
-			imgStore, err := ociruntime.NewImageStore(layerDir)
+			imgStore, err := ociruntime.NewImageStore(te, layerDir)
 			require.NoError(t, err)
 
 			ctx := context.Background()

--- a/enterprise/server/sociartifactstore/sociartifactstore.go
+++ b/enterprise/server/sociartifactstore/sociartifactstore.go
@@ -103,7 +103,7 @@ func newSociArtifactStore(env environment.Env) (error, *SociArtifactStore) {
 	if env.GetSingleFlightDeduper() == nil {
 		return status.FailedPreconditionError("soci artifact server requires a single-flight deduper"), nil
 	}
-	resolver, err := oci.NewResolver()
+	resolver, err := oci.NewResolver(env)
 	if err != nil {
 		return err, nil
 	}

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -8,10 +8,16 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci",
     deps = [
         "//enterprise/server/remote_execution/platform",
+        "//proto:ociregistry_go_proto",
         "//proto:registry_go_proto",
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
         "//server/http/httpclient",
+        "//server/remote_cache/cachetools",
+        "//server/remote_cache/digest",
         "//server/util/flag",
         "//server/util/log",
+        "//server/util/proto",
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_docker_distribution//reference",
@@ -21,6 +27,7 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
         "@com_github_google_go_containerregistry//pkg/v1/types",
+        "@org_golang_google_protobuf//types/known/anypb",
     ],
 )
 
@@ -33,6 +40,7 @@ go_test(
         ":oci",
         "//enterprise/server/remote_execution/platform",
         "//proto:registry_go_proto",
+        "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/testutil/testregistry",
         "//server/util/proto",

--- a/enterprise/server/util/ociconv/BUILD
+++ b/enterprise/server/util/ociconv/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/util/ext4",
         "//enterprise/server/util/oci",
+        "//server/environment",
         "//server/util/disk",
         "//server/util/hash",
         "//server/util/log",
@@ -33,6 +34,7 @@ go_test(
     deps = [
         ":ociconv",
         "//enterprise/server/util/oci",
+        "//server/testutil/testenv",
         "//server/testutil/testfs",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/util/ociconv/ociconv_test.go
+++ b/enterprise/server/util/ociconv/ociconv_test.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ociconv"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOciconv(t *testing.T) {
+	te := testenv.GetTestEnv(t)
 	ctx := context.Background()
 	root := testfs.MakeTempDir(t)
 	os.Setenv("REGISTRY_AUTH_FILE", "_null")
@@ -21,7 +23,7 @@ func TestOciconv(t *testing.T) {
 		"mirror.gcr.io/ubuntu:22.04",
 	} {
 		t.Run("image="+img, func(t *testing.T) {
-			_, err := ociconv.CreateDiskImage(ctx, root, img, oci.Credentials{})
+			_, err := ociconv.CreateDiskImage(ctx, te, root, img, oci.Credentials{})
 			require.NoError(t, err)
 		})
 	}

--- a/proto/ociregistry.proto
+++ b/proto/ociregistry.proto
@@ -50,3 +50,9 @@ message OCIActionResultKey {
   // Digest as a hex string.
   string hash_hex = 5;
 }
+
+message OCIManifestContent {
+  bytes raw = 1;
+  int64 content_length = 2;
+  string content_type = 3;
+}


### PR DESCRIPTION
This change introduces functions for fetching OCI manifest metadata and contents from the AC, layer metadata from the AC, and layer contents from the CAS. This change also modifies the OCI mirror registry to use these functions.

#8876 contains working end-to-end for both the OCI mirror registry and `oci.Resolver` using these caching functions.
If requests to the mirror registry fail, the Docker client will fall back to the upstream registry.  So burning in changes to the mirror registry is lower risk than pushing changes to `oci.Resolver`.

Manifest contents, size, and content type are now all written to a field on an `ActionResult` stored in the AC.
Layer contents, size, and content type are stored in the CAS. An `ActionResult` in the AC points to these blobs.