### PR TITLE
Don't get a stack trace for every missing result in FindMissing

### DIFF
--- a/enterprise/server/util/pebble/BUILD
+++ b/enterprise/server/util/pebble/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "pebble",
     srcs = ["pebble.go"],
@@ -15,6 +17,8 @@ go_library(
         "@com_github_cockroachdb_pebble//bloom",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )
 
@@ -29,5 +33,3 @@ go_test(
         "@org_golang_x_sync//errgroup",
     ],
 )
-
-package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/util/pebble/pebble.go
+++ b/enterprise/server/util/pebble/pebble.go
@@ -22,6 +22,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/bloom"
+
+	"google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
 )
 
 const (
@@ -604,13 +607,13 @@ func GetCopy(b Reader, key []byte) ([]byte, error) {
 	buf, closer, err := b.Get(key)
 	if err != nil {
 		if err == pebble.ErrNotFound {
-			return nil, status.NotFoundErrorf("key %q not found", key)
+			return nil, gstatus.Errorf(codes.NotFound, "key %q not found", key)
 		}
 		return nil, err
 	}
 	defer closer.Close()
 	if len(buf) == 0 {
-		return nil, status.NotFoundErrorf("key %q not found (empty value)", key)
+		return nil, gstatus.Errorf(codes.NotFound, "key %q not found (empty value)", key)
 	}
 
 	// We need to copy the value before closer is closed.
@@ -623,13 +626,13 @@ func GetProto(b Reader, key []byte, pb proto.Message) error {
 	buf, closer, err := b.Get(key)
 	if err != nil {
 		if err == pebble.ErrNotFound {
-			return status.NotFoundErrorf("key %q not found", key)
+			return gstatus.Errorf(codes.NotFound, "key %q not found", key)
 		}
 		return err
 	}
 	defer closer.Close()
 	if len(buf) == 0 {
-		return status.NotFoundErrorf("key %q not found (empty value)", key)
+		return gstatus.Errorf(codes.NotFound, "key %q not found (empty value)", key)
 	}
 	if err := proto.Unmarshal(buf, pb); err != nil {
 		return status.InternalErrorf("error parsing value for %q: %s", key, err)
@@ -639,7 +642,7 @@ func GetProto(b Reader, key []byte, pb proto.Message) error {
 
 func LookupProto(iter Iterator, key []byte, pb proto.Message) error {
 	if !iter.SeekGE(key) || !bytes.Equal(iter.Key(), key) {
-		return status.NotFoundErrorf("key %q not found", key)
+		return gstatus.Errorf(codes.NotFound, "key %q not found", key)
 	}
 	if err := proto.Unmarshal(iter.Value(), pb); err != nil {
 		return status.InternalErrorf("error parsing value for %q: %s", key, err)


### PR DESCRIPTION
status.NotFoundError allocates a stack trace. This might be useful for some errors, but NOT_FOUND is a frequent and expected error in our service, so I think we should avoid allocating a stack trace in common and unexceptional situations.

This makes pebble_cache.FindMissing with all missing keys 20% faster. Note that before, FindMissing was much faster when keys were present.
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                                       │    base     │                final                │
                                       │   sec/op    │   sec/op     vs base                │
FindMissing/size=1KiB/insert=false-24    457.0µ ± 3%   359.1µ ± 2%  -21.42% (p=0.000 n=11)
FindMissing/size=1MiB/insert=false-24    454.0µ ± 1%   368.2µ ± 2%  -18.90% (p=0.000 n=11)
FindMissing/size=10MiB/insert=false-24   457.7µ ± 2%   367.5µ ± 1%  -19.71% (p=0.000 n=11)
FindMissing/size=1KiB/insert=true-24     322.2µ ± 3%   325.5µ ± 3%        ~ (p=0.847 n=11)
FindMissing/size=1MiB/insert=true-24     330.8µ ± 3%   329.3µ ± 2%        ~ (p=0.847 n=11)
FindMissing/size=10MiB/insert=true-24    338.0µ ± 2%   337.8µ ± 2%        ~ (p=0.151 n=11)
geomean                                  388.2µ        347.4µ       -10.49%

                                       │     base     │                final                │
                                       │     B/op     │     B/op      vs base               │
FindMissing/size=1KiB/insert=false-24    282.2Ki ± 0%   269.6Ki ± 0%  -4.45% (p=0.000 n=11)
FindMissing/size=1MiB/insert=false-24    282.2Ki ± 0%   269.7Ki ± 0%  -4.44% (p=0.000 n=11)
FindMissing/size=10MiB/insert=false-24   282.2Ki ± 0%   269.7Ki ± 0%  -4.44% (p=0.000 n=11)
FindMissing/size=1KiB/insert=true-24     299.0Ki ± 0%   299.0Ki ± 0%       ~ (p=0.782 n=11)
FindMissing/size=1MiB/insert=true-24     722.2Ki ± 3%   718.4Ki ± 3%       ~ (p=0.606 n=11)
FindMissing/size=10MiB/insert=true-24    728.2Ki ± 1%   719.5Ki ± 1%  -1.20% (p=0.005 n=11)
geomean                                  390.3Ki        380.4Ki       -2.53%

                                       │    base     │                final                 │
                                       │  allocs/op  │  allocs/op   vs base                 │
FindMissing/size=1KiB/insert=false-24    6.717k ± 0%   6.417k ± 0%  -4.47% (p=0.000 n=11)
FindMissing/size=1MiB/insert=false-24    6.717k ± 0%   6.417k ± 0%  -4.47% (p=0.000 n=11)
FindMissing/size=10MiB/insert=false-24   6.717k ± 0%   6.417k ± 0%  -4.47% (p=0.000 n=11)
FindMissing/size=1KiB/insert=true-24     6.108k ± 0%   6.108k ± 0%       ~ (p=1.000 n=11) ¹
FindMissing/size=1MiB/insert=true-24     13.20k ± 2%   13.13k ± 2%       ~ (p=0.606 n=11)
FindMissing/size=10MiB/insert=true-24    13.30k ± 1%   13.15k ± 1%  -1.10% (p=0.005 n=11)
geomean                                  8.291k        8.082k       -2.52%
```