### PR TITLE
Add task lease RTT metric

### DIFF
--- a/enterprise/server/scheduling/task_leaser/BUILD
+++ b/enterprise/server/scheduling/task_leaser/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proto:scheduler_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/metrics",
         "//server/util/authutil",
         "//server/util/flag",
         "//server/util/log",

--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor_auth"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -99,6 +100,11 @@ func (t *TaskLease) Task() *repb.ExecutionTask {
 }
 
 func (t *TaskLease) sendRequest(req *scpb.LeaseTaskRequest) (*scpb.LeaseTaskResponse, error) {
+	start := time.Now()
+	defer func() {
+		metrics.TaskLeaseRequestDurationUsec.Observe(time.Since(start).Microseconds())
+	}()
+
 	if err := t.stream.Send(req); err != nil {
 		return nil, err
 	}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1546,6 +1546,14 @@ var (
 		GroupID,
 	})
 
+	TaskLeaseRequestDurationUsec = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "task_lease_request_duration_usec",
+		Help:      "Total duration of task lease requests made from the executor to the scheduler, in **microseconds**.",
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 5*time.Minute, 1.2),
+	})
+
 	// ## Blobstore metrics
 	//
 	// "Blobstore" refers to the backing storage that BuildBuddy uses to


### PR DESCRIPTION
Add a metric to measure the duration between the time that the executor sends a request on a LeaseTask stream to the time that it receives a response from the server.