### PR TITLE
Wire a watchdog timer into healthcheck, configurable via flag

### DIFF
--- a/server/util/healthcheck/BUILD
+++ b/server/util/healthcheck/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "//server/util/statusz",
+        "//server/util/watchdog",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//health/grpc_health_v1",
         "@org_golang_x_sync//errgroup",

--- a/server/util/watchdog/BUILD
+++ b/server/util/watchdog/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "watchdog",
+    srcs = ["watchdog.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/watchdog",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/status",
+        "@com_github_jonboulle_clockwork//:clockwork",
+    ],
+)
+
+go_test(
+    name = "watchdog_test",
+    srcs = ["watchdog_test.go"],
+    deps = [
+        ":watchdog",
+        "//server/util/status",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/watchdog/BUILD
+++ b/server/util/watchdog/BUILD
@@ -5,10 +5,7 @@ go_library(
     srcs = ["watchdog.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/watchdog",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/status",
-        "@com_github_jonboulle_clockwork//:clockwork",
-    ],
+    deps = ["@com_github_jonboulle_clockwork//:clockwork"],
 )
 
 go_test(
@@ -16,7 +13,6 @@ go_test(
     srcs = ["watchdog_test.go"],
     deps = [
         ":watchdog",
-        "//server/util/status",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/watchdog/watchdog.go
+++ b/server/util/watchdog/watchdog.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Timer struct {
-	start time.Time
+	start    time.Time
 	lifetime time.Duration
-	clock clockwork.Clock
+	clock    clockwork.Clock
 }
 
 func New(lifetime time.Duration) *Timer {
@@ -20,8 +20,8 @@ func New(lifetime time.Duration) *Timer {
 
 func NewWithClock(clock clockwork.Clock, lifetime time.Duration) *Timer {
 	wdt := &Timer{
-		clock: clock,
-		start: clock.Now(),
+		clock:    clock,
+		start:    clock.Now(),
 		lifetime: lifetime,
 	}
 	return wdt
@@ -31,7 +31,7 @@ func (t *Timer) nextReset() time.Time {
 	return t.start.Add(t.lifetime)
 }
 func (t *Timer) Reset() {
-	t.start = t.clock.Now().Add(t.lifetime)	
+	t.start = t.clock.Now().Add(t.lifetime)
 }
 
 func (t *Timer) Statusz(ctx context.Context) string {

--- a/server/util/watchdog/watchdog.go
+++ b/server/util/watchdog/watchdog.go
@@ -1,0 +1,52 @@
+package watchdog
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+type Timer struct {
+	start time.Time
+	lifetime time.Duration
+	clock clockwork.Clock
+}
+
+func New(lifetime time.Duration) *Timer {
+	return NewWithClock(clockwork.NewRealClock(), lifetime)
+}
+
+func NewWithClock(clock clockwork.Clock, lifetime time.Duration) *Timer {
+	wdt := &Timer{
+		clock: clock,
+		start: clock.Now(),
+		lifetime: lifetime,
+	}
+	return wdt
+}
+
+func (t *Timer) nextReset() time.Time {
+	return t.start.Add(t.lifetime)
+}
+func (t *Timer) Reset() {
+	t.start = t.clock.Now().Add(t.lifetime)	
+}
+
+func (t *Timer) Statusz(ctx context.Context) string {
+	var remainingTime string
+	if t.lifetime == 0 {
+		remainingTime = "∞"
+	} else {
+		remainingTime = t.nextReset().Sub(t.clock.Now()).String()
+	}
+	return fmt.Sprintf("Time to live: %s", remainingTime)
+}
+
+func (t *Timer) Live() bool {
+	if t.lifetime == 0 {
+		return true
+	}
+	return t.clock.Now().Before(t.nextReset())
+}

--- a/server/util/watchdog/watchdog_test.go
+++ b/server/util/watchdog/watchdog_test.go
@@ -1,0 +1,47 @@
+package watchdog_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/watchdog"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatchdogExpires(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ttl := time.Hour
+
+	wdt := watchdog.NewWithClock(clock, ttl)
+	clock.Advance(time.Minute)
+	require.True(t, wdt.Live())
+
+	clock.Advance(ttl)
+	require.False(t, wdt.Live())
+}
+
+func TestWatchdogReset(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	ttl := time.Hour
+
+	wdt := watchdog.NewWithClock(clock, ttl)
+
+	for range 10 {
+		clock.Advance(59 * time.Minute)
+		require.True(t, wdt.Live())
+		wdt.Reset()
+	}
+	require.True(t, wdt.Live())
+}
+
+func TestDisabledWatchdogIsValidForever(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	wdt := watchdog.NewWithClock(clock, 0)
+
+	for range 100 {
+		clock.Advance(100 * 365 * 24 * time.Hour)
+		require.True(t, wdt.Live())
+	}
+	require.True(t, wdt.Live())
+}


### PR DESCRIPTION
This does not change the default behavior, except to add a new TTL counter in the statusz page.

If the --max_unready_duration flag is set, and the app is unready for longer than 30 seconds, then it will exit.