### PR TITLE
Disable locking in VFS implementation.

### DIFF
--- a/enterprise/server/remote_execution/vfs/vfs_unix.go
+++ b/enterprise/server/remote_execution/vfs/vfs_unix.go
@@ -132,7 +132,6 @@ func (vfs *VFS) Mount() error {
 			DirectMountStrict: true,
 			FsName:            "bbvfs",
 			MaxWrite:          fuse.MAX_KERNEL_WRITE,
-			EnableLocks:       true,
 		},
 	}
 	nodeFS := fs.NewNodeFS(vfs.root, opts)


### PR DESCRIPTION
There are different types of locks (POSIX/OFD) with different semantics and the fuse implementation does not have enough information to know which one is being used (!).

Thankfully if locking is not enabled in the FUSE implementation it is handled entirely by the kernel which is able to properly handle different lock types.

I'll rip out the rest of the locking code after I'm satisfied that it won't be needed anymore.