### PR TITLE
Lock less aggressively in hit-tracker-client

### DIFF
--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -295,6 +295,7 @@ func (h *HitTrackerFactory) sendTrackRequest(ctx context.Context) int {
 	}
 	hitsToSend := h.hitsQueue[0]
 	h.hitsQueue = h.hitsQueue[1:]
+	hitsToSend.mu.Lock()
 	if len(hitsToSend.hits) <= h.maxHitsPerUpdate {
 		delete(h.hitsByGroup, hitsToSend.gid)
 	} else {
@@ -309,7 +310,6 @@ func (h *HitTrackerFactory) sendTrackRequest(ctx context.Context) int {
 	}
 	h.mu.Unlock()
 
-	hitsToSend.mu.Lock()
 	ctx = authutil.AddAuthHeadersToContext(ctx, hitsToSend.authHeaders, h.authenticator)
 	trackRequest := hitpb.TrackRequest{Hits: hitsToSend.hits}
 	groupID := hitsToSend.gid

--- a/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
@@ -137,7 +137,7 @@ func TestCASHitTracker_SplitsUpdates(t *testing.T) {
 
 	// Pause the hit-tracker RPC service and send an RPC that'll block the
 	// hit-tracker-client worker so updates are queued.
-	hitTrackerService.mu.Lock()
+	hitTrackerService.wg.Add(1)
 	group1Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user1)
 	hitTracker := hitTrackerFactory.NewCASHitTracker(group1Ctx, &repb.RequestMetadata{})
 	hitTracker.TrackDownload(fDigest).CloseWithBytesTransferred(1_000_000, 2_000_000, repb.Compressor_IDENTITY, "test")
@@ -155,7 +155,7 @@ func TestCASHitTracker_SplitsUpdates(t *testing.T) {
 
 	hitTracker = hitTrackerFactory.NewCASHitTracker(group1Ctx, &repb.RequestMetadata{})
 	hitTracker.TrackDownload(fDigest).CloseWithBytesTransferred(1_000_000, 2_000_000, repb.Compressor_IDENTITY, "test")
-	hitTrackerService.mu.Unlock()
+	hitTrackerService.wg.Done()
 
 	// Expect 10x [A, B, C, D, E] for ANON.
 	expectToEqual(t, 50, hitTrackerService.downloads[interfaces.AuthAnonymousUser], "Expected 10 updates for group ANON")

--- a/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
@@ -44,7 +44,7 @@ func digestProto(hash string, sizeBytes int64) *repb.Digest {
 type testHitTracker struct {
 	t               *testing.T
 	authenticator   interfaces.Authenticator
-	mu              sync.Mutex
+	wg              sync.WaitGroup
 	downloads       map[string]*atomic.Int64
 	bytesDownloaded map[string]*atomic.Int64
 }
@@ -65,8 +65,8 @@ func newTestHitTracker(t *testing.T, authenticator interfaces.Authenticator) *te
 }
 
 func (ht *testHitTracker) Track(ctx context.Context, req *hitpb.TrackRequest) (*hitpb.TrackResponse, error) {
-	ht.mu.Lock()
-	defer ht.mu.Unlock()
+	ht.wg.Wait()
+
 	groupID := interfaces.AuthAnonymousUser
 	user, err := ht.authenticator.AuthenticatedUser(ctx)
 	if err == nil {
@@ -74,13 +74,7 @@ func (ht *testHitTracker) Track(ctx context.Context, req *hitpb.TrackRequest) (*
 	}
 
 	for _, hit := range req.GetHits() {
-		if _, ok := ht.bytesDownloaded[groupID]; !ok {
-			ht.bytesDownloaded[groupID] = &atomic.Int64{}
-		}
 		ht.bytesDownloaded[groupID].Add(hit.GetSizeBytes())
-	}
-	if _, ok := ht.downloads[groupID]; !ok {
-		ht.downloads[groupID] = &atomic.Int64{}
 	}
 	ht.downloads[groupID].Add(int64(len(req.GetHits())))
 	return &hitpb.TrackResponse{}, nil
@@ -179,7 +173,7 @@ func TestCASHitTracker_DropsUpdates(t *testing.T) {
 
 	// Pause the hit-tracker RPC service and send an RPC that'll block the
 	// hit-tracker-client worker so updates are queued.
-	hitTrackerService.mu.Lock()
+	hitTrackerService.wg.Add(1)
 	group1Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user1)
 	hitTracker := hitTrackerFactory.NewCASHitTracker(group1Ctx, &repb.RequestMetadata{})
 	hitTracker.TrackDownload(fDigest).CloseWithBytesTransferred(1_000_000, 2_000_000, repb.Compressor_IDENTITY, "test")
@@ -197,7 +191,7 @@ func TestCASHitTracker_DropsUpdates(t *testing.T) {
 
 	hitTracker = hitTrackerFactory.NewCASHitTracker(group1Ctx, &repb.RequestMetadata{})
 	hitTracker.TrackDownload(fDigest).CloseWithBytesTransferred(1_000_000, 2_000_000, repb.Compressor_IDENTITY, "test")
-	hitTrackerService.mu.Unlock()
+	hitTrackerService.wg.Done()
 
 	// Expect A, B, C, D, E, A, B, C, D, E to be sent for ANON.
 	expectToEqual(t, 10, hitTrackerService.downloads[interfaces.AuthAnonymousUser], "Expected 10 updates for group ANON")


### PR DESCRIPTION
I added a small benchmark in the test that enqueues 1,000,000 hits (all for the same group) asynchronously in batches of 100,000, waiting for each enqueue() call in a batch to return before proceeding to the next batch. Before this change, that took 7.26 seconds, with this change it takes 2.67 seconds (63% faster) with `--config=race --config=remote`. With `-c opt` it took 3.1 seconds before this change and about 500ms after. Interestingly, I implemented the channel approach we discussed a week or so ago and that took about the same amount of time, so there may be some other resource contention in the benchmark that's limiting further speedup in the benchmark. For now, this is at least a fair bit faster than the old approach.