### PR TITLE
Add a disk fullness healthchecker + statusz widget and add it to the executor

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -54,6 +54,7 @@ go_library(
         "//server/util/log",
         "//server/util/monitoring",
         "//server/util/status",
+        "//server/util/statusz",
         "//server/util/tracing",
         "//server/util/usageutil",
         "//server/util/vtprotocodec",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -45,6 +45,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/buildbuddy-io/buildbuddy/server/util/usageutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
@@ -74,6 +75,7 @@ var (
 	localCacheDirectory       = flag.String("executor.local_cache_directory", "/tmp/buildbuddy/filecache", "A local on-disk cache directory. Must be on the same device (disk partition, Docker volume, etc.) as the configured root_directory, since files are hard-linked to this cache for performance reasons. Otherwise, 'Invalid cross-device link' errors may result.")
 	localCacheSizeBytes       = flag.Int64("executor.local_cache_size_bytes", 1_000_000_000 /* 1 GB */, "The maximum size, in bytes, to use for the local on-disk cache")
 	startupWarmupMaxWaitSecs  = flag.Int64("executor.startup_warmup_max_wait_secs", 0, "Maximum time to block startup while waiting for default image to be pulled. Default is no wait.")
+	maximumDiskFullness       = flag.Float64("executor.maximum_disk_fullness", 1.01, "Fail health check if device containing executor.local_cache_directory is more than this full")
 
 	listen            = flag.String("listen", "0.0.0.0", "The interface to listen on (default: 0.0.0.0)")
 	port              = flag.Int("port", 8080, "The port to listen for HTTP traffic on")
@@ -287,6 +289,10 @@ func main() {
 	cacheRoot := filepath.Join(*localCacheDirectory, getExecutorHostID())
 	healthChecker := healthcheck.NewHealthChecker(*serverType)
 	env := GetConfiguredEnvironmentOrDie(cacheRoot, healthChecker)
+
+	dshc := disk.NewUsageMonitor(cacheRoot, *maximumDiskFullness)
+	healthChecker.AddHealthCheck("executor_disk_usage", dshc)
+	statusz.AddSection("executor_disk_usage", "Executor disk usage", dshc)
 
 	if err := tracing.Configure(env); err != nil {
 		log.Fatalf("Could not configure tracing: %s", err)

--- a/server/util/healthcheck/healthcheck.go
+++ b/server/util/healthcheck/healthcheck.go
@@ -234,7 +234,7 @@ func (h *HealthChecker) runHealthChecks(ctx context.Context) {
 		h.watchdogTimer.Reset()
 	} else {
 		if !h.watchdogTimer.Live() {
-			log.Infof("Watchdog timer expired; triggering shutdown!")
+			log.Warningf("Watchdog timer expired; triggering shutdown!")
 			go func() {
 				h.Shutdown()
 			}()


### PR DESCRIPTION
This adds a disk fullness healthchecker (disabled by default) and statusz page.

By enabling the disk fullness health check in conjunction with max_unready_duration, you can force executors to restart themselves if their disk is full.

Example:
```
--executor.maximum_disk_fullness=.95 --max_unready_duration=30s
```