### PR TITLE
Allow setting TMPDIR for bare executions

### DIFF
--- a/enterprise/server/remote_execution/containers/bare/BUILD
+++ b/enterprise/server/remote_execution/containers/bare/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//enterprise/server/util/procstats",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
+        "//server/util/rexec",
         "//server/util/status",
     ],
 )
@@ -23,10 +24,12 @@ go_test(
     srcs = ["bare_test.go"],
     deps = [
         ":bare",
+        "//enterprise/server/remote_execution/container",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
         "//server/testutil/testfs",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/rexec/rexec.go
+++ b/server/util/rexec/rexec.go
@@ -63,6 +63,18 @@ func MakePlatform(pairs ...string) (*repb.Platform, error) {
 	return p, nil
 }
 
+// LookupEnv returns the value of the environment variable with the given name,
+// or an empty string if the variable is not present. The second return value
+// indicates whether the variable was found.
+func LookupEnv(envs []*repb.Command_EnvironmentVariable, name string) (string, bool) {
+	for _, e := range envs {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
 // NormalizeCommand produces a canonicalized version of the given command
 // that is suitable for caching, without altering the semantics of the command.
 func NormalizeCommand(cmd *repb.Command) {


### PR DESCRIPTION
Some actions on macOS are creating temporary files in system temporary directories, which we don't clean up, causing disk usage to increase over time. Setting TMPDIR to a path that the executor cleans up should solve this.

Context: https://buildbuddy-corp.slack.com/archives/C03JL0YT6G5/p1744654261022149?thread_ts=1744401999.823709&cid=C03JL0YT6G5