### PR TITLE
Make config=remote-dev depend on config=dev

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,6 +93,7 @@ common:remote-linux-arm64 --config=target-linux-arm64
 common:remote-linux-arm64 --remote_download_toplevel
 
 # Flags shared for dev RBE and cache
+common:remote-dev-shared --config=dev
 common:remote-dev-shared --config=remote-shared
 common:remote-dev-shared --config=cache-shared
 common:remote-dev-shared --remote_executor=grpcs://buildbuddy.buildbuddy.dev


### PR DESCRIPTION
When running tests against app.buildbuddy.dev, I could not authenticate until I made this change.