### PR TITLE
Allow filtering tests and flakes by branch name

### DIFF
--- a/enterprise/app/tap/BUILD
+++ b/enterprise/app/tap/BUILD
@@ -12,6 +12,7 @@ ts_library(
         "//:node_modules/react",
         "//app/auth:auth_service",
         "//app/capabilities",
+        "//app/components/input",
         "//app/components/select",
         "//app/errors:error_service",
         "//app/format",

--- a/enterprise/app/tap/flakes.tsx
+++ b/enterprise/app/tap/flakes.tsx
@@ -175,6 +175,7 @@ export default class FlakesComponent extends React.Component<Props, State> {
       const flakeSamplesRequest = rpc_service.service.getTargetFlakeSamples({
         label,
         repo: this.props.repo,
+        branchName: this.props.search.get("branch") || "",
         startedAfter: params.updatedAfter,
         startedBefore: params.updatedBefore,
       });
@@ -271,6 +272,7 @@ export default class FlakesComponent extends React.Component<Props, State> {
     const flakeSamplesRequest = rpc_service.service.getTargetFlakeSamples({
       label,
       repo: this.props.repo,
+      branchName: this.props.search.get("branch") || "",
       pageToken: this.state.flakeSamples.nextPageToken,
     });
 

--- a/enterprise/app/tap/flakes.tsx
+++ b/enterprise/app/tap/flakes.tsx
@@ -78,7 +78,12 @@ export default class FlakesComponent extends React.Component<Props, State> {
     const prevEnd = timestampToDateWithFallback(prevProtoParams.updatedBefore, 0).getTime();
 
     const dateChanged = currentStart != prevStart || currentEnd != prevEnd;
-    if (currentTarget !== prevTarget || this.props.repo !== prevProps.repo || dateChanged) {
+    if (
+      currentTarget !== prevTarget ||
+      this.props.repo !== prevProps.repo ||
+      this.props.search.get("branch") !== prevProps.search.get("branch") ||
+      dateChanged
+    ) {
       this.fetch();
     }
   }
@@ -110,12 +115,14 @@ export default class FlakesComponent extends React.Component<Props, State> {
     const chartRequest = rpc_service.service.getDailyTargetStats({
       labels,
       repo: this.props.repo,
+      branchName: this.props.search.get("branch") || "",
       startedAfter: params.updatedAfter,
       startedBefore: params.updatedBefore,
     });
     const tableRequest = rpc_service.service.getTargetStats({
       labels,
       repo: this.props.repo,
+      branchName: this.props.search.get("branch") || "",
       startedAfter: params.updatedAfter,
       startedBefore: params.updatedBefore,
     });

--- a/enterprise/app/tap/grid.tsx
+++ b/enterprise/app/tap/grid.tsx
@@ -121,8 +121,8 @@ export default class TestGridComponent extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (this.props.repo !== prevProps.repo) {
-      // Repo-changed; re-fetch targets starting from scratch.
+    if (this.props.repo !== prevProps.repo || this.props.search.get("branch") !== prevProps.search.get("branch")) {
+      // Repo or branch filter changed; re-fetch targets starting from scratch.
       this.fetchTargets(/*initial=*/ true);
     }
   }
@@ -141,6 +141,7 @@ export default class TestGridComponent extends React.Component<Props, State> {
       this.updateState(new target.GetTargetHistoryResponse(), initial);
       return;
     }
+    const branchName = this.props.search.get("branch") || "";
 
     let request = new target.GetTargetHistoryRequest();
 
@@ -149,7 +150,7 @@ export default class TestGridComponent extends React.Component<Props, State> {
     request.serverSidePagination = this.isV2;
     request.pageToken = initial ? "" : this.state.nextPageToken;
     if (this.isV2) {
-      request.query = target.TargetQuery.create({ repoUrl });
+      request.query = target.TargetQuery.create({ repoUrl, branchName });
     }
 
     this.setState({ loading: true });

--- a/enterprise/app/tap/tap.tsx
+++ b/enterprise/app/tap/tap.tsx
@@ -37,6 +37,7 @@ export default class TapComponent extends React.Component<Props, State> {
   };
 
   isV2 = Boolean(capabilities.config.testGridV2Enabled);
+  branchInputRef = React.createRef<HTMLInputElement>();
 
   componentWillMount() {
     document.title = `Tests | BuildBuddy`;
@@ -112,7 +113,6 @@ export default class TapComponent extends React.Component<Props, State> {
     router.replaceParams({ repo });
   }
 
-  branchInputRef = React.createRef<HTMLInputElement>();
   handleBranchInputKeyPress(event: React.KeyboardEvent<HTMLInputElement>) {
     if (event.key === "Enter") {
       router.replaceParams({ branch: (event.target as HTMLInputElement).value });

--- a/enterprise/app/tap/tap.tsx
+++ b/enterprise/app/tap/tap.tsx
@@ -13,6 +13,7 @@ import FlakesComponent from "./flakes";
 import GridSortControlsComponent from "./grid_sort_controls";
 import DatePickerButton from "../filter/date_picker_button";
 import { getProtoFilterParams } from "../filter/filter_util";
+import TextInput from "../../../app/components/input/input";
 
 interface Props {
   user: User;
@@ -42,8 +43,15 @@ export default class TapComponent extends React.Component<Props, State> {
     this.fetchRepos();
   }
 
+  componentDidMount() {
+    if (this.branchInputRef.current) {
+      this.branchInputRef.current.value = this.props.search.get("branch") || "";
+    }
+  }
   componentDidUpdate() {
-    localStorage[LAST_SELECTED_REPO_LOCALSTORAGE_KEY] = this.selectedRepo();
+    if (this.branchInputRef.current) {
+      this.branchInputRef.current.value = this.props.search.get("branch") || "";
+    }
   }
 
   getSelectedTab(): Tab {
@@ -104,6 +112,13 @@ export default class TapComponent extends React.Component<Props, State> {
     router.replaceParams({ repo });
   }
 
+  branchInputRef = React.createRef<HTMLInputElement>();
+  handleBranchInputKeyPress(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      router.replaceParams({ branch: (event.target as HTMLInputElement).value });
+    }
+  }
+
   render() {
     const tab = this.getSelectedTab();
     let tabContent;
@@ -127,16 +142,24 @@ export default class TapComponent extends React.Component<Props, State> {
                 <div className="tap-header-left-section">
                   <div className="tap-title">{title}</div>
                   {this.isV2 && this.state.repos.length > 0 && (
-                    <Select
-                      onChange={this.handleRepoChange.bind(this)}
-                      value={this.selectedRepo()}
-                      className="repo-picker">
-                      {this.state.repos.map((repo) => (
-                        <Option key={repo} value={repo}>
-                          {format.formatGitUrl(repo)}
-                        </Option>
-                      ))}
-                    </Select>
+                    <>
+                      <Select
+                        onChange={this.handleRepoChange.bind(this)}
+                        value={this.selectedRepo()}
+                        className="repo-picker">
+                        {this.state.repos.map((repo) => (
+                          <Option key={repo} value={repo}>
+                            {format.formatGitUrl(repo)}
+                          </Option>
+                        ))}
+                      </Select>
+                      <TextInput
+                        placeholder="Branch"
+                        // Use uncontrolled input to avoid re-rendering.
+                        ref={this.branchInputRef}
+                        onKeyPress={(e) => this.handleBranchInputKeyPress(e)}
+                      />
+                    </>
                   )}
                 </div>
                 <div className="controls">

--- a/proto/target.proto
+++ b/proto/target.proto
@@ -325,6 +325,9 @@ message GetTargetFlakeSamplesRequest {
   // If specified, all flaky invocations must match this repo.
   string repo = 3;
 
+  // If specified, all flaky invocations must match this branch.
+  string branch_name = 7;
+
   // A token for fetching another page of flaky runs.
   string page_token = 4;
 

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -775,7 +775,7 @@ func TestTrackTargetsForEventsAborted(t *testing.T) {
 
 func assertTestTargetStatusesMatchOLAPDB(t *testing.T, te *testenv.TestEnv, expected []Row) {
 	var got []Row
-	query := `SELECT group_id, commit_sha, rule_type, label, repo_url, role, command, test_size, status, cached, target_type FROM "TestTargetStatuses"`
+	query := `SELECT group_id, commit_sha, rule_type, label, repo_url, branch_name, role, command, test_size, status, cached, target_type FROM "TestTargetStatuses"`
 	err := te.GetOLAPDBHandle().NewQuery(context.Background(), "get_target_status").Raw(query).Take(&got)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, got, expected)
@@ -793,7 +793,7 @@ func assertTestTargetStatusesMatchPrimaryDB(t *testing.T, ctx context.Context, t
 		Command:        "test",
 	})
 	var got []Row
-	query := `SELECT i.group_id, i.commit_sha, t.rule_type, t.label, i.repo_url,
+	query := `SELECT i.group_id, i.commit_sha, t.rule_type, t.label, i.repo_url, i.branch_name,
       i.role, i.command, ts.test_size, ts.status, ts.cached, ts.target_type 
 	  FROM "Targets" as t 
 	  JOIN "TargetStatuses" as ts ON ts.target_id = t.target_id 

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -655,6 +655,9 @@ func readPaginatedTargetsFromOLAPDB(ctx context.Context, env environment.Env, re
 		FROM "TestTargetStatuses"`)
 	innerCommitQuery.AddWhereClause("group_id = ?", groupID)
 	innerCommitQuery.AddWhereClause("repo_url = ?", repo)
+	if branch := req.GetQuery().GetBranchName(); branch != "" {
+		innerCommitQuery.AddWhereClause("branch_name = ?", branch)
+	}
 	innerCommitQuery.SetGroupBy("commit_sha")
 	innerCommitQuery.SetOrderBy("latest_created_at_usec DESC, commit_sha", true /*=ascending*/)
 
@@ -678,6 +681,9 @@ func readPaginatedTargetsFromOLAPDB(ctx context.Context, env environment.Env, re
 	q.AddWhereInClause("commit_sha", outerCommitQuery)
 	q.AddWhereClause("group_id = ?", groupID)
 	q.AddWhereClause("repo_url = ?", repo)
+	if branch := req.GetQuery().GetBranchName(); branch != "" {
+		q.AddWhereClause("branch_name = ?", branch)
+	}
 	q.SetOrderBy("label", true /*=ascending*/)
 	return fetchTargetsFromOLAPDB(ctx, env, q, repo, groupID)
 }
@@ -781,6 +787,10 @@ func GetDailyTargetStats(ctx context.Context, env environment.Env, req *trpb.Get
 		innerWhereClause = innerWhereClause + " AND repo_url = ?"
 		qArgs = append(qArgs, req.GetRepo())
 	}
+	if req.GetBranchName() != "" {
+		innerWhereClause = innerWhereClause + " AND branch_name = ?"
+		qArgs = append(qArgs, req.GetBranchName())
+	}
 	if len(req.GetLabels()) > 0 {
 		innerWhereClause = innerWhereClause + " AND label IN ?"
 		qArgs = append(qArgs, req.GetLabels())
@@ -790,30 +800,30 @@ func GetDailyTargetStats(ctx context.Context, env environment.Env, req *trpb.Get
 
 	dateSelectorString := env.GetOLAPDBHandle().DateFromUsecTimestamp("invocation_start_time_usec", req.GetRequestContext().GetTimezoneOffsetMinutes())
 
-	qStr := fmt.Sprintf(`SELECT stats.date AS date, total_runs, successful_runs, flaky_runs,
+	qStr := `SELECT stats.date AS date, total_runs, successful_runs, flaky_runs,
 	    failed_runs, likely_flaky_runs, flaky_runs + likely_flaky_runs as total_flakes
 	FROM (SELECT
-		%s AS date,
+		` + dateSelectorString + ` AS date,
 		count(*) AS total_runs,
 		countIf(status = 1) AS successful_runs,
 		countIf(status = 2) AS flaky_runs,
 		countIf(status > 2) AS failed_runs
-		FROM "TestTargetStatuses" WHERE (%s) GROUP BY date) stats
+		FROM "TestTargetStatuses" WHERE (` + innerWhereClause + `) GROUP BY date) stats
 	LEFT JOIN (SELECT date, count(*) AS likely_flaky_runs
 		FROM (
 			SELECT
-			    %s AS date,
+			    ` + dateSelectorString + ` AS date,
 				first_value(status) OVER win AS first_status,
 				status,
 				last_value(status) OVER win AS last_status
 			FROM "TestTargetStatuses"
-			WHERE (%s AND (status BETWEEN 1 AND 4))
+			WHERE (` + innerWhereClause + ` AND (status BETWEEN 1 AND 4))
 			WINDOW win AS (
 				PARTITION BY label
 				ORDER BY invocation_start_time_usec ASC
 				ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING))
 		WHERE (first_status BETWEEN 1 AND 2) AND (last_status BETWEEN 1 AND 2) AND status IN (3, 4) GROUP BY date) lf
-	ON lf.date=stats.date ORDER BY date ASC`, dateSelectorString, innerWhereClause, dateSelectorString, innerWhereClause)
+	ON lf.date=stats.date ORDER BY date ASC`
 
 	rq := env.GetOLAPDBHandle().NewQuery(ctx, "get_target_stats").Raw(qStr, qArgs...)
 
@@ -868,13 +878,17 @@ func GetTargetStats(ctx context.Context, env environment.Env, req *trpb.GetTarge
 		innerWhereClause = innerWhereClause + " AND repo_url = ?"
 		qArgs = append(qArgs, req.GetRepo())
 	}
+	if req.GetBranchName() != "" {
+		innerWhereClause = innerWhereClause + " AND branch_name = ?"
+		qArgs = append(qArgs, req.GetBranchName())
+	}
 	if len(req.GetLabels()) > 0 {
 		innerWhereClause = innerWhereClause + " AND label IN ?"
 		qArgs = append(qArgs, req.GetLabels())
 	}
 
 	qArgs = append(qArgs, qArgs...)
-	qStr := fmt.Sprintf(`SELECT stats.label AS label, total_runs, successful_runs, flaky_runs,
+	qStr := `SELECT stats.label AS label, total_runs, successful_runs, flaky_runs,
 	    failed_runs, likely_flaky_runs, (flaky_duration_usec + likely_flaky_duration_usec) AS total_flake_runtime_usec, flaky_runs + likely_flaky_runs as total_flakes
 	FROM (
 		SELECT label,
@@ -883,7 +897,7 @@ func GetTargetStats(ctx context.Context, env environment.Env, req *trpb.GetTarge
 		countIf(status = 2) AS flaky_runs,
 		countIf(status > 2) AS failed_runs,
 		sumIf(duration_usec, status = 2) AS flaky_duration_usec
-		FROM "TestTargetStatuses" WHERE (%s) GROUP BY label) stats
+		FROM "TestTargetStatuses" WHERE (` + innerWhereClause + `) GROUP BY label) stats
 	LEFT JOIN (SELECT label, sum(duration_usec) AS likely_flaky_duration_usec, count(*) AS likely_flaky_runs
 		FROM (
 			SELECT
@@ -893,13 +907,13 @@ func GetTargetStats(ctx context.Context, env environment.Env, req *trpb.GetTarge
 				duration_usec,
 				last_value(status) OVER win AS last_status
 			FROM "TestTargetStatuses"
-			WHERE (%s AND (status BETWEEN 1 AND 4))
+			WHERE (` + innerWhereClause + ` AND (status BETWEEN 1 AND 4))
 			WINDOW win AS (
 				PARTITION BY label
 				ORDER BY invocation_start_time_usec ASC
 				ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING))
 		WHERE (first_status BETWEEN 1 AND 2) AND (last_status BETWEEN 1 AND 2) AND status IN (3, 4) GROUP BY label) lf
-	ON lf.label=stats.label ORDER BY total_flakes DESC LIMIT 500`, innerWhereClause, innerWhereClause)
+	ON lf.label=stats.label ORDER BY total_flakes DESC LIMIT 500`
 
 	rq := env.GetOLAPDBHandle().NewQuery(ctx, "get_target_stats").Raw(qStr, qArgs...)
 	type qRow struct {

--- a/server/target/target_test.go
+++ b/server/target/target_test.go
@@ -167,6 +167,53 @@ func TestGetTargetHistory(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "GR1 repo1, feature-1 branch",
+			request: &trpb.GetTargetHistoryRequest{
+				RequestContext:       &ctxpb.RequestContext{GroupId: "GR1"},
+				StartTimeUsec:        0,
+				EndTimeUsec:          10e6,
+				ServerSidePagination: true,
+				Query: &trpb.TargetQuery{
+					RepoUrl:    "https://github.com/gr1/repo1",
+					BranchName: "feature-1",
+				},
+			},
+			expectedResponse: &trpb.GetTargetHistoryResponse{
+				InvocationTargets: []*trpb.TargetHistory{
+					{
+						Target: &trpb.TargetMetadata{
+							Label: "//:flaky_test",
+						},
+						RepoUrl: "https://github.com/gr1/repo1",
+						TargetStatus: []*trpb.TargetStatus{
+							{
+								InvocationId:            iid2,
+								InvocationCreatedAtUsec: 2e6,
+								Timing:                  timingUsec(2e6+1, 0),
+								CommitSha:               "commit2",
+								Status:                  common.Status_PASSED,
+							},
+						},
+					},
+					{
+						Target: &trpb.TargetMetadata{
+							Label: "//:passing_test",
+						},
+						RepoUrl: "https://github.com/gr1/repo1",
+						TargetStatus: []*trpb.TargetStatus{
+							{
+								InvocationId:            iid2,
+								InvocationCreatedAtUsec: 2e6,
+								Timing:                  timingUsec(2e6, 0),
+								CommitSha:               "commit2",
+								Status:                  common.Status_PASSED,
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			gr1Ctx, err := testAuth.WithAuthenticatedUser(ctx, "US1")

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -75,11 +75,11 @@ type query struct {
 }
 
 func (q *query) Create(val interface{}) error {
-	return status.UnimplementedError("not supported for clickhouse")
+	return status.UnimplementedError("Create is not supported for clickhouse")
 }
 
 func (q *query) Update(val interface{}) error {
-	return status.UnimplementedError("not supported for clickhouse")
+	return status.UnimplementedError("Update is not supported for clickhouse")
 }
 
 type rawQuery struct {


### PR DESCRIPTION
We already store branch name in the DB but don't allow filtering on it. This PR allows us to filter by branch.

Queries with branch filters enabled should be roughly as fast as what we've got today since we're scanning the same number of rows. We could speed these up in the future by adding a data-skipping index on branch name.

https://github.com/user-attachments/assets/14cc4c42-2b6e-42e2-9f8a-0ffaecc71a28
