### PR TITLE
[raft] fix TestCleanupZombieInitialMemberNotSetUp

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1116,12 +1116,12 @@ func (s *Store) StartShard(ctx context.Context, req *rfpb.StartShardRequest) (*r
 			}
 			return nil, status.InternalErrorf("cannot start c%dn%d because c%dn%d already exists", nu.ShardID(), nu.ReplicaID(), req.GetRangeId(), req.GetReplicaId())
 		}
-		return nil, err
+		return nil, status.WrapErrorf(err, "failed to start node c%dn%d on dragonboat", req.GetRangeId(), req.GetReplicaId())
 	}
 
 	if req.GetLastAppliedIndex() > 0 {
 		if err := s.waitForReplicaToCatchUp(ctx, req.GetRangeId(), req.GetLastAppliedIndex()); err != nil {
-			return nil, err
+			return nil, status.WrapErrorf(err, "failed to wait for c%dn%d to catch up", req.GetRangeId(), req.GetReplicaId())
 		}
 	}
 
@@ -1139,7 +1139,7 @@ func (s *Store) StartShard(ctx context.Context, req *rfpb.StartShardRequest) (*r
 	if req.GetReplicaId() == replicaIDs[len(replicaIDs)-1] {
 		batchResponse, err := s.shardStarterSession.SyncProposeLocal(ctx, s.nodeHost, req.GetRangeId(), req.GetBatch())
 		if err != nil {
-			return nil, err
+			return nil, status.WrapErrorf(err, "faile to sync propose batch request on c%dn%d", req.GetRangeId(), req.GetReplicaId())
 		}
 		rsp.Batch = batchResponse
 	}

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -193,21 +193,6 @@ func TestCleanupZombieInitialMembersNotSetUp(t *testing.T) {
 	c1, err := s1.APIClient().Get(ctx, s1.GRPCAddress)
 	require.NoError(t, err)
 	bootstrapInfo := bringup.MakeBootstrapInfo(2, 1, poolB)
-	rd := &rfpb.RangeDescriptor{
-		Start:      keys.MakeKey([]byte("a")),
-		End:        keys.MakeKey([]byte("z")),
-		RangeId:    2,
-		Generation: 1,
-	}
-	protoBytes, err := proto.Marshal(rd)
-	require.NoError(t, err)
-	batchProto, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   constants.LocalRangeKey,
-			Value: protoBytes,
-		},
-	}).ToProto()
-	require.NoError(t, err)
 
 	replicaID := uint64(0)
 	for _, repl := range bootstrapInfo.Replicas {
@@ -219,7 +204,6 @@ func TestCleanupZombieInitialMembersNotSetUp(t *testing.T) {
 		RangeId:       2,
 		ReplicaId:     replicaID,
 		InitialMember: bootstrapInfo.InitialMembersForTesting(),
-		Batch:         batchProto,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This test sometimes failed with the "the shard is not ready".

Upon investigation, this happens with the step in StartShard when we try to call
sync propose the batch request because we only set up one replica of the shard
when there are three initial members.

I removed the batch request from the StartShardRequest because this is not 
necessary for the test.

Also add more context in the returned errors in StartShard.
