### PR TITLE
Reduce noise from WaitExecution logs

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -821,15 +821,14 @@ type InProgressExecution struct {
 
 func (e *InProgressExecution) processOpUpdate(ctx context.Context, op *longrunning.Operation) (done bool, err error) {
 	stage := operation.ExtractStage(op)
-	log.CtxInfof(ctx, "WaitExecution: %q in stage: %s", e.opName, stage)
-	if stage < e.lastStage {
-		return false, nil
-	}
 	// Log only on stage transitions or if it's been a while since we last
 	// logged.
 	if stage != e.lastStage || time.Since(e.lastLogTime) > 30*time.Second {
 		log.CtxInfof(ctx, "WaitExecution: %q in stage: %s", e.opName, stage)
 		e.lastLogTime = time.Now()
+	}
+	if stage < e.lastStage {
+		return false, nil
 	}
 	e.lastStage = stage
 	err = e.clientStream.Send(op)


### PR DESCRIPTION
Since we added finer-grained updates in WaitExecution (PULLING_CONTAINER_IMAGE, DOWNLOADING_INPUTS etc.) we're doing a lot more "WaitExecution" logs which add a lot of noise. This PR attempts to denoise the logs a bit.