### PR TITLE
[raft] call sync propose to set up the new shard in a separate call

### DIFF
--- a/enterprise/server/raft/bringup/BUILD
+++ b/enterprise/server/raft/bringup/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
+        "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
         "//server/interfaces",
         "//server/util/log",

--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -333,7 +333,9 @@ func StartShard(ctx context.Context, store IStore, bootstrapInfo *ClusterBootstr
 	if err != nil {
 		return err
 	}
-	//
+	// This range descriptor is only used in sender and is not being stored.
+	// The generation is intentionally not set, so we won't accidentally
+	// overwrite the stored range descriptor.
 	rd := &rfpb.RangeDescriptor{
 		RangeId:  bootstrapInfo.rangeID,
 		Replicas: bootstrapInfo.Replicas,

--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -29,6 +30,7 @@ type IStore interface {
 	ConfiguredClusters() int
 	APIClient() *client.APIClient
 	NodeHost() *dragonboat.NodeHost
+	Sender() *sender.Sender
 }
 
 type ClusterStarter struct {
@@ -199,9 +201,6 @@ func (cs *ClusterStarter) attemptQueryAndBringupOnce() error {
 	if err != nil {
 		return err
 	}
-	nodeHost := cs.store.NodeHost()
-	apiClient := cs.store.APIClient()
-
 	bootstrapInfo := make(map[string]string, 0)
 	for nodeRsp := range rsp.ResponseCh() {
 		if nodeRsp.Payload == nil {
@@ -217,7 +216,7 @@ func (cs *ClusterStarter) attemptQueryAndBringupOnce() error {
 		bootstrapInfo[br.GetNhid()] = br.GetGrpcAddress()
 		if len(bootstrapInfo) == len(cs.join) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			err = SendStartShardRequests(ctx, cs.session, nodeHost, apiClient, bootstrapInfo)
+			err = SendStartShardRequests(ctx, cs.session, cs.store, bootstrapInfo)
 			cancel()
 			return err
 		}
@@ -292,33 +291,21 @@ func MakeBootstrapInfo(rangeID, firstReplicaID uint64, nodeGrpcAddrs map[string]
 	return bi
 }
 
-func StartShard(ctx context.Context, apiClient *client.APIClient, bootstrapInfo *ClusterBootstrapInfo, batch *rbuilder.BatchBuilder) error {
+func StartShard(ctx context.Context, store IStore, bootstrapInfo *ClusterBootstrapInfo, batch *rbuilder.BatchBuilder) error {
 	log.Debugf("StartShard called with bootstrapInfo: %+v", bootstrapInfo)
-	rangeSetupTime := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
-		Kv: &rfpb.KV{
-			Key:   constants.LocalRangeSetupTimeKey,
-			Value: []byte(fmt.Sprintf("%d", time.Now().UnixNano())),
-		},
-	})
-	batch = batch.Merge(rangeSetupTime)
-	batchProto, err := batch.ToProto()
-	if err != nil {
-		return err
-	}
 
-	eg, ctx := errgroup.WithContext(ctx)
+	eg, egCtx := errgroup.WithContext(ctx)
 	for _, node := range bootstrapInfo.nodes {
 		node := node
 		eg.Go(func() error {
-			apiClient, err := apiClient.Get(ctx, node.grpcAddress)
+			apiClient, err := store.APIClient().Get(egCtx, node.grpcAddress)
 			if err != nil {
 				return err
 			}
-			_, err = apiClient.StartShard(ctx, &rfpb.StartShardRequest{
+			_, err = apiClient.StartShard(egCtx, &rfpb.StartShardRequest{
 				RangeId:       bootstrapInfo.rangeID,
 				ReplicaId:     node.index,
 				InitialMember: bootstrapInfo.initialMembers,
-				Batch:         batchProto,
 			})
 			if err != nil {
 				if !status.IsAlreadyExistsError(err) {
@@ -331,12 +318,40 @@ func StartShard(ctx context.Context, apiClient *client.APIClient, bootstrapInfo 
 		})
 	}
 
-	return eg.Wait()
+	err := eg.Wait()
+	if err != nil {
+		return err
+	}
+	rangeSetupTime := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   constants.LocalRangeSetupTimeKey,
+			Value: []byte(fmt.Sprintf("%d", time.Now().UnixNano())),
+		},
+	})
+	batch = batch.Merge(rangeSetupTime)
+	batchProto, err := batch.ToProto()
+	if err != nil {
+		return err
+	}
+	//
+	rd := &rfpb.RangeDescriptor{
+		RangeId:  bootstrapInfo.rangeID,
+		Replicas: bootstrapInfo.Replicas,
+	}
+	syncRsp, err := store.Sender().SyncProposeWithRangeDescriptor(ctx, rd, batchProto)
+	if err != nil {
+		return err
+	}
+	rsp := rbuilder.NewBatchResponseFromProto(syncRsp.GetBatch())
+	if err := rsp.AnyError(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // This function is called to send RPCs to the other nodes listed in the Join
 // list requesting that they bring up initial cluster(s).
-func SendStartShardRequests(ctx context.Context, session *client.Session, nodeHost *dragonboat.NodeHost, apiClient *client.APIClient, nodeGrpcAddrs map[string]string) error {
+func SendStartShardRequests(ctx context.Context, session *client.Session, store IStore, nodeGrpcAddrs map[string]string) error {
 	startingRanges := []*rfpb.RangeDescriptor{
 		&rfpb.RangeDescriptor{
 			Start:      constants.MetaRangePrefix,
@@ -349,10 +364,10 @@ func SendStartShardRequests(ctx context.Context, session *client.Session, nodeHo
 			Generation: 1,
 		},
 	}
-	return SendStartShardRequestsWithRanges(ctx, session, nodeHost, apiClient, nodeGrpcAddrs, startingRanges)
+	return SendStartShardRequestsWithRanges(ctx, session, store, nodeGrpcAddrs, startingRanges)
 }
 
-func SendStartShardRequestsWithRanges(ctx context.Context, session *client.Session, nodeHost *dragonboat.NodeHost, apiClient *client.APIClient, nodeGrpcAddrs map[string]string, startingRanges []*rfpb.RangeDescriptor) error {
+func SendStartShardRequestsWithRanges(ctx context.Context, session *client.Session, store IStore, nodeGrpcAddrs map[string]string, startingRanges []*rfpb.RangeDescriptor) error {
 	replicaID := uint64(constants.InitialReplicaID)
 	rangeID := uint64(constants.InitialRangeID)
 
@@ -387,7 +402,7 @@ func SendStartShardRequestsWithRanges(ctx context.Context, session *client.Sessi
 			})
 		}
 		log.Debugf("Attempting to start cluster %d on: %+v", rangeID, bootstrapInfo)
-		if err := StartShard(ctx, apiClient, bootstrapInfo, batch); err != nil {
+		if err := StartShard(ctx, store, bootstrapInfo, batch); err != nil {
 			return err
 		}
 		log.Debugf("Cluster %d started on: %+v", rangeID, bootstrapInfo)
@@ -413,7 +428,7 @@ func SendStartShardRequestsWithRanges(ctx context.Context, session *client.Sessi
 		if err != nil {
 			return err
 		}
-		batchRsp, err := session.SyncProposeLocal(ctx, nodeHost, constants.InitialRangeID, batchProto)
+		batchRsp, err := session.SyncProposeLocal(ctx, store.NodeHost(), constants.InitialRangeID, batchProto)
 		if err != nil {
 			return err
 		}

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -528,6 +528,8 @@ func (s *Sender) SyncPropose(ctx context.Context, key []byte, batchCmd *rfpb.Bat
 	return rsp.GetBatch(), nil
 }
 
+// SyncProposeWithRangeDescriptor calls SyncPropose on different replicas
+// specified in the given range descriptor, until one of the replica succeeds.
 func (s *Sender) SyncProposeWithRangeDescriptor(ctx context.Context, rd *rfpb.RangeDescriptor, batchCmd *rfpb.BatchCmdRequest) (*rfpb.SyncProposeResponse, error) {
 	var syncRsp *rfpb.SyncProposeResponse
 	runFn := func(ctx context.Context, c rfspb.ApiClient, h *rfpb.Header) error {

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -528,6 +528,25 @@ func (s *Sender) SyncPropose(ctx context.Context, key []byte, batchCmd *rfpb.Bat
 	return rsp.GetBatch(), nil
 }
 
+func (s *Sender) SyncProposeWithRangeDescriptor(ctx context.Context, rd *rfpb.RangeDescriptor, batchCmd *rfpb.BatchCmdRequest) (*rfpb.SyncProposeResponse, error) {
+	var syncRsp *rfpb.SyncProposeResponse
+	runFn := func(ctx context.Context, c rfspb.ApiClient, h *rfpb.Header) error {
+		r, err := c.SyncPropose(ctx, &rfpb.SyncProposeRequest{
+			Header: h,
+			Batch:  batchCmd,
+		})
+		if err != nil {
+			return err
+		}
+		syncRsp = r
+		return nil
+	}
+	_, err := s.TryReplicas(ctx, rd, runFn, func(rd *rfpb.RangeDescriptor, replicaIdx int) *rfpb.Header {
+		return header.NewWithoutRangeInfo(rd, replicaIdx, rfpb.Header_LINEARIZABLE)
+	})
+	return syncRsp, err
+}
+
 func (s *Sender) SyncRead(ctx context.Context, key []byte, batchCmd *rfpb.BatchCmdRequest, mods ...Option) (*rfpb.BatchCmdResponse, error) {
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
 	defer spn.End()

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1075,7 +1075,7 @@ func TestSplitAcrossClusters(t *testing.T) {
 	})
 
 	bootstrapInfo := bringup.MakeBootstrapInfo(2, 1, poolB)
-	err = bringup.StartShard(ctx, s2.APIClient(), bootstrapInfo, initalRDBatch)
+	err = bringup.StartShard(ctx, s2, bootstrapInfo, initalRDBatch)
 	require.NoError(t, err)
 
 	metaRDBatch, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{

--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -196,13 +196,13 @@ func (ts *TestingStore) Stop() {
 
 func (sf *StoreFactory) StartShard(t *testing.T, ctx context.Context, stores ...*TestingStore) {
 	require.Greater(t, len(stores), 0)
-	err := bringup.SendStartShardRequests(ctx, client.NewSessionWithClock(sf.clock), stores[0].NodeHost(), stores[0].APIClient(), MakeNodeGRPCAddressesMap(stores...))
+	err := bringup.SendStartShardRequests(ctx, client.NewSessionWithClock(sf.clock), stores[0], MakeNodeGRPCAddressesMap(stores...))
 	require.NoError(t, err)
 }
 
 func (sf *StoreFactory) StartShardWithRanges(t *testing.T, ctx context.Context, startingRanges []*rfpb.RangeDescriptor, stores ...*TestingStore) {
 	require.Greater(t, len(stores), 0)
-	err := bringup.SendStartShardRequestsWithRanges(ctx, client.NewSessionWithClock(sf.clock), stores[0].NodeHost(), stores[0].APIClient(), MakeNodeGRPCAddressesMap(stores...), startingRanges)
+	err := bringup.SendStartShardRequestsWithRanges(ctx, client.NewSessionWithClock(sf.clock), stores[0], MakeNodeGRPCAddressesMap(stores...), startingRanges)
 	require.NoError(t, err)
 }
 

--- a/enterprise/server/raft/txn/BUILD
+++ b/enterprise/server/raft/txn/BUILD
@@ -8,12 +8,10 @@ go_library(
     deps = [
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
-        "//enterprise/server/raft/header",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
-        "//proto:raft_service_go_proto",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/status",

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -480,7 +480,7 @@ message StartShardRequest {
 }
 
 message StartShardResponse {
-	reserved 1;
+  reserved 1;
 }
 
 message RemoveDataRequest {

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -467,9 +467,7 @@ message StartShardRequest {
   uint64 replica_id = 2;
   map<uint64, string> initial_member = 3;
 
-  // The following commands will be SyncProposed on the local
-  // nodehost after the cluster has been created.
-  BatchCmdRequest batch = 4;
+  reserved 4;
 
   bool join = 5;
 
@@ -482,7 +480,7 @@ message StartShardRequest {
 }
 
 message StartShardResponse {
-  BatchCmdResponse batch = 1;
+	reserved 1;
 }
 
 message RemoveDataRequest {


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4832

Refactor to reduce the number of arguments passed into some functions in bringup
code.

Call SyncPropose after the startShard requests finished.
