### PR TITLE
[raft] remove transfer leadership step from removeZombie

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1759,21 +1759,6 @@ func (j *replicaJanitor) removeZombie(ctx context.Context, task zombieCleanupTas
 			removeDataReq.Range = task.rd
 		}
 	} else if task.action == zombieCleanupRemoveReplica {
-		// In the rare case where the zombie holds the leader, we try to transfer the leader away first.
-		if j.store.isLeader(task.rangeID, task.replicaID) {
-			targetReplicaID := uint64(0)
-			for replicaID := range task.shardInfo.Replicas {
-				if replicaID != task.shardInfo.ReplicaID {
-					targetReplicaID = replicaID
-					if err := j.store.nodeHost.RequestLeaderTransfer(task.rangeID, targetReplicaID); err != nil {
-						return zombieCleanupRemoveReplica, status.InternalErrorf("failed to transfer leader from c%dn%d to c%dn%d", task.shardInfo.ShardID, task.shardInfo.ReplicaID, task.shardInfo.ShardID, targetReplicaID)
-					}
-					log.Debugf("transferred leadership for c%dn%d", task.rangeID, task.replicaID)
-					return zombieCleanupRemoveReplica, nil
-				}
-			}
-		}
-
 		// fetched the up-to-date range from meta range
 		var rd *rfpb.RangeDescriptor
 		var err error

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -284,20 +284,22 @@ func TestCleanupZombieNonVoter(t *testing.T) {
 
 	sf := testutil.NewStoreFactoryWithClock(t, clock)
 	s1 := sf.NewStore(t)
+	s2 := sf.NewStore(t)
+	s3 := sf.NewStore(t)
 	ctx := context.Background()
 
-	stores := []*testutil.TestingStore{s1}
+	stores := []*testutil.TestingStore{s1, s2, s3}
 	sf.StartShard(t, ctx, stores...)
 
-	s2 := sf.NewStore(t)
-	// add a non-voter c2n2
-	addNonVoting(t, s1, ctx, 2, 2, s2.NHID())
+	s4 := sf.NewStore(t)
+	// add a non-voter c2n4
+	addNonVoting(t, s1, ctx, 2, 4, s4.NHID())
 
 	membership, err := s1.GetMembership(ctx, 2)
 	require.NoError(t, err)
-	// Check that c2n2 is a non-voter on raft.
+	// Check that c2n4 is a non-voter on raft.
 	require.Equal(t, 1, len(membership.NonVotings))
-	require.Contains(t, membership.NonVotings, uint64(2))
+	require.Contains(t, membership.NonVotings, uint64(4))
 
 	for {
 		clock.Advance(1 * time.Hour)


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4192

The current code can sometimes causes one zombie stuck in the transfer
leadership step when we remove zombies that are not in the meta range.
This is because, when we determine the target replica id for leader transfer, we
are using task.shardInfo.Replicas, which can be stale when we are removing three
zombies simultaneously on 3 machines.

If we really want to make this work, we probably need to call get membership to
get the current replicas to find a target. This can make the code more
complicated and I don't think explicit leadership transfer is a necessary step 
anyway.

Also, explicitly disable driver in some zombie test. And set up three stores instead of 2 to reduce timeout errors. 
