### PR TITLE
Add port mapping for Prometheus metrics to docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -17,7 +17,7 @@ If you're running BuildBuddy in a Docker image - you can use Docker's [-v flag](
 Be sure to replace `PATH_TO_YOUR_LOCAL_CONFIG ` with the path to your custom config file:
 
 ```bash
-docker pull gcr.io/flame-public/buildbuddy-app-onprem:latest && docker run -p 1985:1985 -p 8080:8080 -v /PATH_TO_YOUR_LOCAL_CONFIG/config.yaml:/config.yaml gcr.io/flame-public/buildbuddy-app-onprem:latest
+docker pull gcr.io/flame-public/buildbuddy-app-onprem:latest && docker run -p 1985:1985 -p 9090:9090 -p 8080:8080 -v /PATH_TO_YOUR_LOCAL_CONFIG/config.yaml:/config.yaml gcr.io/flame-public/buildbuddy-app-onprem:latest
 ```
 
 Note: If you're using BuildBuddy's Docker image locally and a third party gRPC cache, you'll likely need to add the `--network=host` [flag](https://docs.docker.com/network/host/) to your `docker run` command in order for BuildBuddy to be able to pull test logs and timing information from the external cache.

--- a/docs/on-prem.md
+++ b/docs/on-prem.md
@@ -50,7 +50,7 @@ We publish a [Docker](https://www.docker.com/) image with every release that con
 To run it, use the following command:
 
 ```bash
-docker pull gcr.io/flame-public/buildbuddy-app-onprem:latest && docker run -p 1985:1985 -p 8080:8080 gcr.io/flame-public/buildbuddy-app-onprem:latest
+docker pull gcr.io/flame-public/buildbuddy-app-onprem:latest && docker run -p 1985:1985 -p 9090:9090 -p 8080:8080 gcr.io/flame-public/buildbuddy-app-onprem:latest
 ```
 
 If you'd like to pass a custom configuration file to BuildBuddy running in a Docker image - see the [configuration docs](config.md) on using Docker's [-v flag](https://docs.docker.com/storage/volumes/).


### PR DESCRIPTION
This burned me as I spent time figuring out why the Prometheus metrics `/metrics` wasn't loading. Because monitoring is enabled by default, I believe it should work out of the box.