### PR TITLE
Improve signal handling/logging in healthchecker

### DIFF
--- a/server/util/healthcheck/BUILD
+++ b/server/util/healthcheck/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/util/status",
         "//server/util/statusz",
         "//server/util/watchdog",
+        "@com_github_mattn_go_isatty//:go-isatty",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//health/grpc_health_v1",
         "@org_golang_x_sync//errgroup",

--- a/server/util/healthcheck/healthcheck.go
+++ b/server/util/healthcheck/healthcheck.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"github.com/buildbuddy-io/buildbuddy/server/util/watchdog"
+	"github.com/mattn/go-isatty"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 
@@ -70,12 +71,14 @@ func NewHealthChecker(serverType string) *HealthChecker {
 		lastStatus:    make([]*serviceStatus, 0),
 		watchdogTimer: watchdog.New(*maxUnreadyDuration),
 	}
-	sigTerm := make(chan os.Signal, 1)
-	go func() {
-		<-sigTerm
-		hc.Shutdown()
-	}()
-	signal.Notify(sigTerm, os.Interrupt, syscall.SIGTERM)
+
+	// TODO: don't do this if we're running under a bazel test. Entering Ctrl+C
+	// in a test should just kill it. Tests are sandboxed so it shouldn't be
+	// problematic to force-kill them.
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+	go hc.handleSignals(signalChan)
+
 	go hc.handleShutdownFuncs()
 	go func() {
 		ticker := time.NewTicker(healthCheckPeriod)
@@ -109,6 +112,41 @@ func (h *HealthChecker) Statusz(ctx context.Context) string {
 	return buf
 }
 
+func (h *HealthChecker) handleSignals(signalChan <-chan os.Signal) {
+	// When running in a terminal, the ^C character echoed back to the user
+	// messes up the log output a bit. So, print a newline every time we get
+	// a signal to make the output a little cleaner.
+	isTTY := isatty.IsTerminal(uintptr(os.Stderr.Fd()))
+	sig := <-signalChan
+	if isTTY {
+		fmt.Println()
+	}
+	log.Infof("Caught %s signal; starting graceful shutdown (hard-stopping in %s)", sig, *maxShutdownDuration)
+	hardStopTime := time.Now().Add(*maxShutdownDuration)
+	h.Shutdown()
+	// If we keep getting SIGINT/SIGTERM, the user is probably mashing
+	// Ctrl+C and really wants to kill the server. After 3 signals, exit
+	// immediately. Before then, report the current status so the user knows
+	// we got their request but are just still shutting down.
+	n := 0
+	const ignoreCount = 3
+	for sig := range signalChan {
+		if isTTY {
+			fmt.Println()
+		}
+		n++
+		if n >= ignoreCount {
+			log.Fatalf("Got %d shutdown requests; exiting immediately", n)
+		}
+		d := time.Until(hardStopTime)
+		if d > 0 {
+			log.Infof("Received %s signal; still shutting down; will hard-stop in %s", sig, d)
+		} else {
+			log.Warningf("Server handlers are still running after hard-stop %s ago. Send %d more signal(s) to exit immediately.", -d, ignoreCount-n)
+		}
+	}
+}
+
 func (h *HealthChecker) handleShutdownFuncs() {
 	<-h.quit
 
@@ -117,9 +155,6 @@ func (h *HealthChecker) handleShutdownFuncs() {
 	h.shuttingDown = true
 	h.mu.Unlock()
 
-	// We use fmt here and below because this code is called from the
-	// signal handler and log.Printf can be a little wonky.
-	fmt.Printf("Caught interrupt signal; shutting down...\n")
 	ctx, cancel := context.WithTimeout(context.Background(), *maxShutdownDuration)
 	defer cancel()
 
@@ -134,17 +169,17 @@ func (h *HealthChecker) handleShutdownFuncs() {
 		f := fn
 		eg.Go(func() error {
 			if err := f(egCtx); err != nil {
-				fmt.Printf("Error gracefully shutting down: %s\n", err)
+				log.CtxErrorf(ctx, "Error gracefully shutting down: %s", err)
 			}
 			return nil
 		})
 	}
 	eg.Wait()
 	if err := ctx.Err(); err != nil {
-		fmt.Printf("MaxShutdownDuration exceeded. Non-graceful exit.\n")
+		log.CtxErrorf(ctx, "MaxShutdownDuration exceeded. Non-graceful exit.")
 	}
 	time.Sleep(10 * time.Millisecond)
-	fmt.Printf("Server %q stopped.\n", h.serverType)
+	log.Infof("Server %q stopped.", h.serverType)
 	close(h.done)
 }
 


### PR DESCRIPTION
- Switch from `fmt.Println()` to `log.Infof()` so that shutdown logs are handled consistently, using structured logging if enabled. There is a comment about the log output being wonky due to being called in a signal handler, but using `log.Infof` seems to work just fine when I tested locally, and don't see why the log output would be wonky since the signal handler is just a regular goroutine, but lmk if I'm missing something.
- When running in a terminal, print a newline when receiving a signal to work around the `^C` echoed to the terminal from causing extra indentation and making the logs harder to read. (I suspect the "wonky" comment might have been referring to this echoing behavior, but the same problem happens with `log.Infof` so I'm not sure.)
- If the user presses Ctrl+C several times repeatedly, add more feedback to the logs that we're still shutting down. If the user pressed Ctrl+C more than 3 times, force-quit (I've seen this behavior in a few other apps, e.g. bazel and docker-compose). I often find myself mashing Ctrl+C and it (frustratingly) doesn't work, so I have to open a separate terminal and SIGKILL the app and the executor. One example of this is when running a single app and executor locally, and trying to shut down while an execution is still in progress. The app and executor get deadlocked because they are both trying really really hard to make sure the task gets re-enqueued, so they ignore the context cancellation that happens when the gRPC server is hard-stopped, and become unresponsive to Ctrl+C. Another example is when trying to use the health checker inside a bazel test, since we install the signal handlers even in tests. (Arguably, both of these examples are their own issues that can be addressed separately, but there are other ways I've seen the server get stuck especially while developing features locally - e.g. writing an infinite loop or receiving from a channel without also receiving from `ctx.Done()`. If the user is mashing Ctrl+C it just seems generally sensible to force-kill the app.)
- Add logging of the specific signals that we're receiving, instead of always logging "Caught interrupt signal" (this is inaccurate/confusing if we actually got SIGTERM)