### PR TITLE
bzlmod: patch rules_webtesting and force stricter go_dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,6 +58,10 @@ bazel_dep(name = "rules_webtesting")
 archive_override(
     module_name = "rules_webtesting",
     integrity = "sha256-wJV/ZIAEYtzoEynx+f6NYA1ilAIrK6ppbUuaeI0+j3Y=",
+    patch_strip = 1,
+    patches = [
+        "@@//buildpatches:rules_webtesting.patch",
+    ],
     strip_prefix = "rules_webtesting-7a1c88f61e35ee5ce0892ae24e2aa2a3106cbfed",
     urls = [
         "https://github.com/bazelbuild/rules_webtesting/archive/7a1c88f61e35ee5ce0892ae24e2aa2a3106cbfed.tar.gz",

--- a/buildpatches/rules_webtesting.patch
+++ b/buildpatches/rules_webtesting.patch
@@ -1,0 +1,12 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 1775465..d307718 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "rules_webtesting",
+-    version = "0.4.0",
++    version = "0.2.1-0.20250212231324-7a1c88f61e35",
+ )
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/go_deps.MODULE.bazel
+++ b/go_deps.MODULE.bazel
@@ -1,4 +1,5 @@
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.config(check_direct_dependencies = "error")
 go_deps.from_file(go_mod = "//:go.mod")
 
 # Non-Go repos referenced by Go repos


### PR DESCRIPTION
rules_webtesting does not have a valid git tag for Go modules, so the
version we are using in go.mod and the actual version would mismatch
each others.

This mismatch would result in several warning in the past, which we have
ignored. However, we do want to elevate this class of issue to error so
that we can catch mismatched Go dependencies earlier.

Patch the bzlmod version of rules_webtesting to be consistent with the
go.mod version. Increase the strictness of go_dep extension to fail when
transitive go deps use a different version than the one in our go.mod.

Ref: https://github.com/bazelbuild/rules_webtesting/issues/452
