### PR TITLE
add ability for ActionCacheServer to restrict Get/Update by instance name prefix

### DIFF
--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//server/util/status",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
-        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )
 
@@ -30,10 +29,14 @@ go_test(
     srcs = ["ociregistry_test.go"],
     deps = [
         ":ociregistry",
+        "//enterprise/server/clientidentity",
+        "//server/interfaces",
         "//server/testutil/testcache",
         "//server/testutil/testenv",
         "//server/testutil/testport",
         "//server/testutil/testregistry",
+        "//server/util/random",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/ociregistry/BUILD
+++ b/enterprise/server/ociregistry/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/http/httpclient",
+        "//server/interfaces",
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/http/httpclient"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -39,7 +40,7 @@ const (
 
 	blobOutputFilePath         = "_bb_ociregistry_blob_"
 	blobMetadataOutputFilePath = "_bb_ociregistry_blob_metadata_"
-	actionResultInstanceName   = "_bb_ociregistry_"
+	actionResultInstanceName   = interfaces.OCIImageInstanceNamePrefix
 )
 
 var (

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -379,16 +379,7 @@ func (r *registry) fetchBlobOrManifestFromCache(ctx context.Context, w http.Resp
 		actionResultInstanceName,
 		repb.DigestFunction_SHA256,
 	)
-	acctx := ctx
-	if r.env.GetClientIdentityService() != nil {
-		idctx, err := r.env.GetClientIdentityService().AddIdentityToContext(ctx)
-		if err == nil {
-			acctx = idctx
-		} else {
-			log.CtxWarningf(ctx, "could not add identity to context: %s", err)
-		}
-	}
-	ar, err := cachetools.GetActionResult(acctx, r.env.GetActionCacheClient(), arRN)
+	ar, err := cachetools.GetActionResult(ctx, r.env.GetActionCacheClient(), arRN)
 	if err != nil {
 		return err
 	}
@@ -494,16 +485,7 @@ func (r *registry) writeBlobOrManifestToCacheAndResponse(ctx context.Context, up
 		actionResultInstanceName,
 		repb.DigestFunction_SHA256,
 	)
-	acctx := ctx
-	if r.env.GetClientIdentityService() != nil {
-		idctx, err := r.env.GetClientIdentityService().AddIdentityToContext(ctx)
-		if err == nil {
-			acctx = idctx
-		} else {
-			log.CtxWarningf(ctx, "could not add identity to context: %s", err)
-		}
-	}
-	err = cachetools.UploadActionResult(acctx, r.env.GetActionCacheClient(), arRN, ar)
+	err = cachetools.UploadActionResult(ctx, r.env.GetActionCacheClient(), arRN, ar)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/ociregistry/ociregistry_test.go
+++ b/enterprise/server/ociregistry/ociregistry_test.go
@@ -11,11 +11,15 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/ociregistry"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testregistry"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +37,11 @@ type simplePullTestCase struct {
 
 func TestPull(t *testing.T) {
 	te := testenv.GetTestEnv(t)
+	flags.Set(t, "app.client_identity.client", interfaces.ClientIdentityApp)
+	key, err := random.RandomString(16)
+	require.NoError(t, err)
+	flags.Set(t, "app.client_identity.key", string(key))
+	clientidentity.Register(te)
 
 	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
 	testcache.Setup(t, te, localGRPClis)

--- a/enterprise/server/test/integration/action_cache_server/BUILD
+++ b/enterprise/server/test/integration/action_cache_server/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "action_cache_server_test",
+    srcs = ["action_cache_server_test.go"],
+    deps = [
+        "//enterprise/server/clientidentity",
+        "//server/interfaces",
+        "//server/remote_cache/action_cache_server",
+        "//server/remote_cache/digest",
+        "//server/util/random",
+        "//server/util/status",
+        "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
+        "//server/testutil/testcache",
+        "//server/testutil/testenv",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/test/integration/action_cache_server/BUILD
+++ b/enterprise/server/test/integration/action_cache_server/BUILD
@@ -5,16 +5,16 @@ go_test(
     srcs = ["action_cache_server_test.go"],
     deps = [
         "//enterprise/server/clientidentity",
-        "//server/interfaces",
-        "//server/remote_cache/action_cache_server",
-        "//server/remote_cache/digest",
-        "//server/util/random",
-        "//server/util/status",
         "//proto:remote_execution_go_proto",
-        "//proto:resource_go_proto",
+        "//server/interfaces",
+        "//server/remote_cache/digest",
         "//server/testutil/testcache",
         "//server/testutil/testenv",
+        "//server/util/random",
+        "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/integration/action_cache_server/action_cache_server_test.go
+++ b/enterprise/server/test/integration/action_cache_server/action_cache_server_test.go
@@ -1,0 +1,163 @@
+package action_cache_server_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestRestrictedPrefixes(t *testing.T) {
+	// id service, can NOT write and read restricted instance names from untrusted client
+	for _, tc := range []struct {
+		name          string
+		initIDService bool
+		instanceNames []string
+		clientID      string
+		canWrite      bool
+		canRead       bool
+	}{
+		{
+			name:          "no id service, CAN write and read unrestricted instance names normally",
+			initIDService: false,
+			instanceNames: []string{"normal instance name", "", "another totally normal name"},
+			clientID:      "",
+			canWrite:      true,
+			canRead:       true,
+		},
+		{
+			name:          "id service, CAN write and read unrestricted instance names normally",
+			initIDService: true,
+			instanceNames: []string{"normal instance name", "", "another totally normal name"},
+			clientID:      "",
+			canWrite:      true,
+			canRead:       true,
+		},
+		{
+			name:          "no id service, CANNOT write or read restricted instance names",
+			initIDService: true,
+			instanceNames: []string{interfaces.OCIImageInstanceNamePrefix, interfaces.OCIImageInstanceNamePrefix + "suffix"},
+			clientID:      "",
+			canWrite:      false,
+			canRead:       false,
+		},
+		{
+			name:          "id service, CAN write or read restricted instance names from app",
+			initIDService: true,
+			instanceNames: []string{interfaces.OCIImageInstanceNamePrefix, interfaces.OCIImageInstanceNamePrefix + "suffix"},
+			clientID:      interfaces.ClientIdentityApp,
+			canWrite:      true,
+			canRead:       true,
+		},
+		{
+			name:          "id service, CAN write or read restricted instance names from executor",
+			initIDService: true,
+			instanceNames: []string{interfaces.OCIImageInstanceNamePrefix, interfaces.OCIImageInstanceNamePrefix + "suffix"},
+			clientID:      interfaces.ClientIdentityExecutor,
+			canWrite:      true,
+			canRead:       true,
+		},
+		{
+			name:          "id service, CAN write or read restricted instance names from workflow",
+			initIDService: true,
+			instanceNames: []string{interfaces.OCIImageInstanceNamePrefix, interfaces.OCIImageInstanceNamePrefix + "suffix"},
+			clientID:      interfaces.ClientIdentityWorkflow,
+			canWrite:      true,
+			canRead:       true,
+		},
+		{
+			name:          "id service, CANNOT write or read restricted instance names from untrusted client",
+			initIDService: false,
+			instanceNames: []string{interfaces.OCIImageInstanceNamePrefix, interfaces.OCIImageInstanceNamePrefix + "suffix"},
+			clientID:      "untrusted",
+			canWrite:      false,
+			canRead:       false,
+		},
+		{
+			name:          "id service, CANNOT write or read restricted instance names from empty client",
+			initIDService: false,
+			instanceNames: []string{interfaces.OCIImageInstanceNamePrefix, interfaces.OCIImageInstanceNamePrefix + "suffix"},
+			clientID:      "",
+			canWrite:      false,
+			canRead:       false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			te := testenv.GetTestEnv(t)
+			flags.Set(t, "app.client_identity.client", tc.clientID)
+			if tc.initIDService {
+				key, err := random.RandomString(16)
+				require.NoError(t, err)
+				flags.Set(t, "app.client_identity.key", string(key))
+				clientidentity.Register(te)
+			}
+			_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
+			testcache.Setup(t, te, localGRPClis)
+			go runServer()
+
+			for _, instanceName := range tc.instanceNames {
+				arDigest, err := digest.Compute(bytes.NewReader([]byte(tc.name)), repb.DigestFunction_SHA256)
+				require.NoError(t, err)
+				acClient := te.GetActionCacheClient()
+				{
+					ar := &repb.ActionResult{
+						ExecutionMetadata: &repb.ExecutedActionMetadata{
+							Worker: tc.name,
+						},
+					}
+					ctx := context.Background()
+					if tc.initIDService {
+						ctx, err = te.GetClientIdentityService().AddIdentityToContext(ctx)
+						require.NoError(t, err)
+					}
+					uar, err := acClient.UpdateActionResult(ctx, &repb.UpdateActionResultRequest{
+						InstanceName:   instanceName,
+						DigestFunction: repb.DigestFunction_SHA256,
+						ActionDigest:   arDigest,
+						ActionResult:   ar,
+					})
+					if tc.canWrite {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+						require.Nil(t, uar)
+						require.True(t, status.IsUnauthenticatedError(err))
+					}
+				}
+
+				{
+					ctx := context.Background()
+					if tc.initIDService {
+						ctx, err = te.GetClientIdentityService().AddIdentityToContext(ctx)
+						require.NoError(t, err)
+					}
+					ar, err := acClient.GetActionResult(ctx, &repb.GetActionResultRequest{
+						InstanceName:   instanceName,
+						DigestFunction: repb.DigestFunction_SHA256,
+						ActionDigest:   arDigest,
+					})
+					if tc.canRead {
+						require.NoError(t, err)
+						require.NotNil(t, ar.ExecutionMetadata)
+						require.Equal(t, tc.name, ar.ExecutionMetadata.Worker)
+					} else {
+						require.Error(t, err)
+						require.Nil(t, ar)
+						require.True(t, status.IsUnauthenticatedError(err))
+					}
+				}
+			}
+		})
+	}
+}

--- a/enterprise/server/test/integration/action_cache_server/action_cache_server_test.go
+++ b/enterprise/server/test/integration/action_cache_server/action_cache_server_test.go
@@ -69,12 +69,12 @@ func TestRestrictedPrefixes(t *testing.T) {
 			canRead:       true,
 		},
 		{
-			name:          "id service, CAN write or read restricted instance names from workflow",
+			name:          "id service, CANNOT write or read restricted instance names from workflow",
 			initIDService: true,
 			instanceNames: []string{interfaces.OCIImageInstanceNamePrefix, interfaces.OCIImageInstanceNamePrefix + "suffix"},
 			clientID:      interfaces.ClientIdentityWorkflow,
-			canWrite:      true,
-			canRead:       true,
+			canWrite:      false,
+			canRead:       false,
 		},
 		{
 			name:          "id service, CANNOT write or read restricted instance names from untrusted client",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1655,6 +1655,8 @@ type CPULeaser interface {
 	Acquire(milliCPU int64, taskID string, opts ...any) (int, []int, func())
 }
 
+const OCIImageInstanceNamePrefix = "_bb_ociregistry_"
+
 type OCIRegistry interface {
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
 }

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -324,7 +324,7 @@ func (s *ActionCacheServer) validateRestrictedAccess(ctx context.Context, instan
 		if err != nil {
 			return status.UnauthenticatedErrorf("Could not check identity for restricted instance name prefix: %s", err)
 		}
-		if identity.Client != interfaces.ClientIdentityApp && identity.Client != interfaces.ClientIdentityExecutor && identity.Client != interfaces.ClientIdentityWorkflow {
+		if identity.Client != interfaces.ClientIdentityApp && identity.Client != interfaces.ClientIdentityExecutor {
 			return status.UnauthenticatedError("Cannot write restricted ActionResult from untrusted client")
 		}
 	}

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -31,21 +31,8 @@ import (
 var (
 	checkClientActionResultDigests = flag.Bool("cache.check_client_action_result_digests", false, "If true, the server will check (and honor) the bb-specific cached_action_result_digest field on ActionCache.getActionResult requests to reduce bandwidth")
 
-	restrictedPrefixes []string
-	restrictedOnce     sync.Once
-	restrictedMu       sync.Mutex
+	restrictedPrefixes = []string{interfaces.OCIImageInstanceNamePrefix}
 )
-
-// RestrictPrefix adds an instance name prefix to a list of prefixes that are "restricted":
-// the Action Cache Server will not return an Action Result stored under a restricted instance name
-// prefix unless the request comes from the app, an executor, or a workflow.
-// RestrictPrefix must be only called in init() functions, so that isRestricted(...) does not
-// have to lock a mutex during Action Cache request serving.
-func RestrictPrefix(prefix string) {
-	restrictedMu.Lock()
-	defer restrictedMu.Unlock()
-	restrictedPrefixes = append(restrictedPrefixes, prefix)
-}
 
 func isRestricted(instanceName string) bool {
 	for _, prefix := range restrictedPrefixes {
@@ -229,17 +216,8 @@ func (s *ActionCacheServer) GetActionResult(ctx context.Context, req *repb.GetAc
 	if err != nil {
 		return nil, err
 	}
-	if isRestricted(req.GetInstanceName()) {
-		if s.env.GetClientIdentityService() == nil {
-			return nil, status.UnauthenticatedError("No client ID service available to check restricted instance name prefix")
-		}
-		identity, err := s.env.GetClientIdentityService().IdentityFromContext(ctx)
-		if err != nil {
-			return nil, status.UnauthenticatedErrorf("Could not check identity for restricted instance name prefix: %s", err)
-		}
-		if identity.Client != interfaces.ClientIdentityApp && identity.Client != interfaces.ClientIdentityExecutor && identity.Client != interfaces.ClientIdentityWorkflow {
-			return nil, status.UnauthenticatedError("Cannot fetch restricted ActionResult from untrusted client")
-		}
+	if err := s.validateRestrictedAccess(ctx, req.GetInstanceName()); err != nil {
+		return nil, err
 	}
 
 	ht := s.env.GetHitTrackerFactory().NewACHitTracker(ctx, bazel_request.GetRequestMetadata(ctx))
@@ -302,17 +280,8 @@ func (s *ActionCacheServer) UpdateActionResult(ctx context.Context, req *repb.Up
 		return req.ActionResult, nil
 	}
 
-	if isRestricted(req.GetInstanceName()) {
-		if s.env.GetClientIdentityService() == nil {
-			return nil, status.UnauthenticatedError("No client ID service available to check restricted instance name prefix")
-		}
-		identity, err := s.env.GetClientIdentityService().IdentityFromContext(ctx)
-		if err != nil {
-			return nil, status.UnauthenticatedErrorf("Could not check identity for restricted instance name prefix: %s", err)
-		}
-		if identity.Client != interfaces.ClientIdentityApp && identity.Client != interfaces.ClientIdentityExecutor && identity.Client != interfaces.ClientIdentityWorkflow {
-			return nil, status.UnauthenticatedError("Cannot write restricted ActionResult from untrusted client")
-		}
+	if err := s.validateRestrictedAccess(ctx, req.GetInstanceName()); err != nil {
+		return nil, err
 	}
 
 	ht := s.env.GetHitTrackerFactory().NewACHitTracker(ctx, bazel_request.GetRequestMetadata(ctx))
@@ -339,6 +308,27 @@ func (s *ActionCacheServer) UpdateActionResult(ctx context.Context, req *repb.Up
 		log.Debugf("UpdateActionResult: upload tracker error: %s", err)
 	}
 	return req.ActionResult, nil
+}
+
+// validateRestrictedAccess checks to see if the instance name has a restricted prefix.
+// If it does, validateRestrictedAccess uses the ClientIdentityService to assert that the
+// request comes from a trusted client: the app, an executor, or a workflow.
+// If the client is not trusted, the ClientIdentityService is not available, or there are any other errors,
+// validateRestrictedAccess returns an UnauthenticatedError.
+func (s *ActionCacheServer) validateRestrictedAccess(ctx context.Context, instanceName string) error {
+	if isRestricted(instanceName) {
+		if s.env.GetClientIdentityService() == nil {
+			return status.UnauthenticatedError("No client ID service available to check restricted instance name prefix")
+		}
+		identity, err := s.env.GetClientIdentityService().IdentityFromContext(ctx)
+		if err != nil {
+			return status.UnauthenticatedErrorf("Could not check identity for restricted instance name prefix: %s", err)
+		}
+		if identity.Client != interfaces.ClientIdentityApp && identity.Client != interfaces.ClientIdentityExecutor && identity.Client != interfaces.ClientIdentityWorkflow {
+			return status.UnauthenticatedError("Cannot write restricted ActionResult from untrusted client")
+		}
+	}
+	return nil
 }
 
 // Inlines the contents of output files requested to be inlined as long as the

--- a/server/testutil/testcache/BUILD
+++ b/server/testutil/testcache/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/remote_cache/byte_stream_server",
         "//server/remote_cache/capabilities_server",
         "//server/remote_cache/content_addressable_storage_server",
+        "//server/rpc/interceptors",
         "//server/testutil/testenv",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",

--- a/server/testutil/testcache/testcache.go
+++ b/server/testutil/testcache/testcache.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/capabilities_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
+	"github.com/buildbuddy-io/buildbuddy/server/rpc/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -32,7 +33,12 @@ func Setup(t *testing.T, env *testenv.TestEnv, lis *bufconn.Listener) {
 
 	RegisterServers(t, env)
 
-	conn, err := testenv.LocalGRPCConn(env.GetServerContext(), lis)
+	conn, err := testenv.LocalGRPCConn(
+		env.GetServerContext(),
+		lis,
+		interceptors.GetUnaryClientIdentityInterceptor(env),
+		interceptors.GetStreamClientIdentityInterceptor(env),
+	)
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
 


### PR DESCRIPTION
This change introduces a hardcoded set of AC instance name prefixes. Gets and Updates for an ActionResult with an instance name that starts with one of these prefixes will only be permitted if the request comes from a trusted client: the app, an executor, or a workflow.

This change includes an integration test, as well as changes to the OCI registry to use a restricted prefix.