### PR TITLE
[SS] Respect enable_local_snapshot_sharing flag

### DIFF
--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -35,9 +35,6 @@ go_library(
 go_test(
     name = "snaploader_test",
     srcs = ["snaploader_test.go"],
-    args = [
-        "--executor.enable_local_snapshot_sharing=true",
-    ],
     deps = [
         ":snaploader",
         "//enterprise/server/remote_execution/copy_on_write",

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -35,6 +35,9 @@ go_library(
 go_test(
     name = "snaploader_test",
     srcs = ["snaploader_test.go"],
+    args = [
+        "--executor.enable_local_snapshot_sharing=true",
+    ],
     deps = [
         ":snaploader",
         "//enterprise/server/remote_execution/copy_on_write",

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -41,6 +41,7 @@ func init() {
 }
 
 func setupEnv(t *testing.T) *testenv.TestEnv {
+	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
 	env := testenv.GetTestEnv(t)
 	filecacheDir := testfs.MakeTempDir(t)
 	fc, err := filecache.NewFileCache(filecacheDir, maxFilecacheSizeBytes, false)

--- a/enterprise/server/remote_execution/snaputil/snaputil_test.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil_test.go
@@ -25,6 +25,9 @@ import (
 )
 
 func setupEnv(t *testing.T) *testenv.TestEnv {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
+
 	env := testenv.GetTestEnv(t)
 	fc, err := filecache.NewFileCache(testfs.MakeTempDir(t), 100_000, false)
 	require.NoError(t, err)
@@ -36,8 +39,6 @@ func setupEnv(t *testing.T) *testenv.TestEnv {
 }
 
 func TestCacheAndFetchArtifact(t *testing.T) {
-	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
-
 	env := setupEnv(t)
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env)
 	require.NoError(t, err)
@@ -99,8 +100,6 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 }
 
 func TestCacheAndFetchArtifact_LocalOnly(t *testing.T) {
-	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
-
 	env := setupEnv(t)
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env)
 	require.NoError(t, err)
@@ -136,8 +135,6 @@ func TestCacheAndFetchArtifact_LocalOnly(t *testing.T) {
 }
 
 func TestCacheAndFetchBytes(t *testing.T) {
-	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
-
 	env := setupEnv(t)
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env)
 	require.NoError(t, err)


### PR DESCRIPTION
Previously, there was no way to disable local snapshot sharing, which required more setup for tests and has caused some issues testing locally for me when fast copy performance is not good