### PR TITLE
Support tracking AC and upload requests in hit tracker service

### DIFF
--- a/enterprise/server/hit_tracker_service/BUILD
+++ b/enterprise/server/hit_tracker_service/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["hit_tracker_service.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/hit_tracker_service",
     deps = [
+        "//proto:cache_go_proto",
         "//proto:hit_tracker_go_proto",
         "//proto:resource_go_proto",
         "//server/interfaces",

--- a/enterprise/server/hit_tracker_service/BUILD
+++ b/enterprise/server/hit_tracker_service/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/hit_tracker_service",
     deps = [
         "//proto:hit_tracker_go_proto",
+        "//proto:resource_go_proto",
         "//server/interfaces",
         "//server/real_environment",
         "//server/util/log",

--- a/enterprise/server/hit_tracker_service/hit_tracker_service.go
+++ b/enterprise/server/hit_tracker_service/hit_tracker_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 type HitTrackerService struct {
@@ -28,8 +29,18 @@ func Register(env *real_environment.RealEnv) error {
 // TODO(iain): record a source (e.g. Cache Proxy).
 func (h HitTrackerService) Track(ctx context.Context, req *hitpb.TrackRequest) (*hitpb.TrackResponse, error) {
 	for _, hit := range req.GetHits() {
-		hitTracker := h.hitTrackerFactory.NewCASHitTracker(ctx, hit.GetRequestMetadata())
-		transferTimer := hitTracker.TrackDownload(hit.GetResource().GetDigest())
+		var hitTracker interfaces.HitTracker
+		if hit.GetResource().GetCacheType() == rspb.CacheType_AC {
+			hitTracker = h.hitTrackerFactory.NewACHitTracker(ctx, hit.GetRequestMetadata())
+		} else {
+			hitTracker = h.hitTrackerFactory.NewCASHitTracker(ctx, hit.GetRequestMetadata())
+		}
+		var transferTimer interfaces.TransferTimer
+		if hit.GetCacheRequestType() == hitpb.CacheRequestType_UPLOAD {
+			transferTimer = hitTracker.TrackUpload(hit.GetResource().GetDigest())
+		} else {
+			transferTimer = hitTracker.TrackDownload(hit.GetResource().GetDigest())
+		}
 		duration := hit.GetDuration().AsDuration()
 		err := transferTimer.Record(hit.GetSizeBytes(), duration, hit.GetResource().GetCompressor())
 		if err != nil {

--- a/enterprise/server/hit_tracker_service/hit_tracker_service.go
+++ b/enterprise/server/hit_tracker_service/hit_tracker_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
+	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
@@ -36,7 +37,7 @@ func (h HitTrackerService) Track(ctx context.Context, req *hitpb.TrackRequest) (
 			hitTracker = h.hitTrackerFactory.NewCASHitTracker(ctx, hit.GetRequestMetadata())
 		}
 		var transferTimer interfaces.TransferTimer
-		if hit.GetCacheRequestType() == hitpb.CacheRequestType_UPLOAD {
+		if hit.GetCacheRequestType() == capb.RequestType_WRITE {
 			transferTimer = hitTracker.TrackUpload(hit.GetResource().GetDigest())
 		} else {
 			transferTimer = hitTracker.TrackDownload(hit.GetResource().GetDigest())

--- a/enterprise/server/hit_tracker_service/hit_tracker_service_test.go
+++ b/enterprise/server/hit_tracker_service/hit_tracker_service_test.go
@@ -28,87 +28,129 @@ import (
 func TestHitTrackerService_DetailedStats(t *testing.T) {
 	flags.Set(t, "cache.detailed_stats_enabled", true)
 
-	env := testenv.GetTestEnv(t)
-	mc, err := memory_metrics_collector.NewMemoryMetricsCollector()
-	require.NoError(t, err)
-	env.SetMetricsCollector(mc)
-	hit_tracker.Register(env)
-	require.NoError(t, hit_tracker_service.Register(env))
-	ctx := context.Background()
+	for _, tc := range []struct {
+		name        string
+		cacheType   rspb.CacheType
+		requestType capb.RequestType
+	}{
+		{
+			name:        "CAS upload",
+			cacheType:   rspb.CacheType_CAS,
+			requestType: capb.RequestType_WRITE,
+		},
+		{
+			name:        "CAS download",
+			cacheType:   rspb.CacheType_CAS,
+			requestType: capb.RequestType_READ,
+		},
+		{
+			name:        "AC upload",
+			cacheType:   rspb.CacheType_AC,
+			requestType: capb.RequestType_WRITE,
+		},
+		{
+			name:        "AC download",
+			cacheType:   rspb.CacheType_AC,
+			requestType: capb.RequestType_READ,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testenv.GetTestEnv(t)
+			mc, err := memory_metrics_collector.NewMemoryMetricsCollector()
+			require.NoError(t, err)
+			env.SetMetricsCollector(mc)
+			hit_tracker.Register(env)
+			require.NoError(t, hit_tracker_service.Register(env))
+			ctx := context.Background()
 
-	iid := "d42f4cd1-6963-4a5a-9680-cb77cfaad9bd"
+			iid := "d42f4cd1-6963-4a5a-9680-cb77cfaad9bd"
 
-	// Track one cache hit using the hit_tracker directly.
-	emptyRmd := &repb.RequestMetadata{
-		ToolInvocationId: iid,
-		ActionId:         "4bcc407e49739ff0ea6394ba83efe63ad934c65bb4655db3fe5282d6e005894f",
-		ActionMnemonic:   "EmptyAction",
-		TargetId:         "//empty",
+			// Track one cache hit using the hit_tracker directly.
+			emptyRmd := &repb.RequestMetadata{
+				ToolInvocationId: iid,
+				ActionId:         "4bcc407e49739ff0ea6394ba83efe63ad934c65bb4655db3fe5282d6e005894f",
+				ActionMnemonic:   "EmptyAction",
+				TargetId:         "//empty",
+			}
+			rmd := &repb.RequestMetadata{
+				ToolInvocationId: iid,
+				ActionId:         "f498500e6d2825ef3bd5564bb56c439da36efe38ab4936ae0ff93794e704ccb4",
+				ActionMnemonic:   "GoCompile",
+				TargetId:         "//foo:bar",
+			}
+			d1 := &repb.Digest{
+				Hash:      "c9c111006b30ffe6ce309fd64c44da651bffa068d530c7b1898698186b4afe2b",
+				SizeBytes: 1234,
+			}
+			compressedSize := int64(123)
+
+			var ht interfaces.HitTracker
+			if tc.cacheType == rspb.CacheType_AC {
+				ht = env.GetHitTrackerFactory().NewACHitTracker(ctx, rmd)
+			} else {
+				ht = env.GetHitTrackerFactory().NewCASHitTracker(ctx, rmd)
+			}
+
+			var dl interfaces.TransferTimer
+			if tc.requestType == capb.RequestType_READ {
+				dl = ht.TrackDownload(d1)
+			} else {
+				dl = ht.TrackUpload(d1)
+			}
+			dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD, "test")
+
+			// Track two more cache hits using the hit_tracker_service.
+			emptyDigest := repb.Digest{Hash: digest.EmptySha256, SizeBytes: 0}
+			emptyRn := digest.NewResourceName(&emptyDigest, "", tc.cacheType, repb.DigestFunction_SHA256)
+			emptyHit := hitpb.CacheHit{
+				RequestMetadata:  emptyRmd,
+				Resource:         emptyRn.ToProto(),
+				CacheRequestType: tc.requestType,
+			}
+			d := repb.Digest{
+				Hash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				SizeBytes: 456,
+			}
+			rn := digest.NewResourceName(&d, "", tc.cacheType, repb.DigestFunction_SHA256)
+			hit := hitpb.CacheHit{
+				RequestMetadata:  rmd,
+				Resource:         rn.ToProto(),
+				SizeBytes:        456,
+				Duration:         durationpb.New(time.Minute),
+				CacheRequestType: tc.requestType,
+			}
+			req := hitpb.TrackRequest{Hits: []*hitpb.CacheHit{&emptyHit, &hit}}
+
+			_, err = env.GetHitTrackerServiceServer().Track(ctx, &req)
+			require.NoError(t, err)
+
+			sc := hit_tracker.ScoreCard(ctx, env, iid)
+			require.Len(t, sc.Results, 3, "expected exactly three cache results")
+			actual1 := sc.Results[0]
+			require.Equal(t, tc.cacheType, actual1.CacheType)
+			require.Equal(t, tc.requestType, actual1.RequestType)
+			require.Equal(t, d1.Hash, actual1.GetDigest().GetHash())
+			require.Equal(t, d1.SizeBytes, actual1.GetDigest().GetSizeBytes())
+			require.Equal(t, repb.Compressor_ZSTD, actual1.GetCompressor())
+			require.Equal(t, compressedSize, actual1.GetTransferredSizeBytes())
+
+			actual2 := sc.Results[1]
+			require.Equal(t, tc.cacheType, actual2.CacheType)
+			require.Equal(t, tc.requestType, actual2.RequestType)
+			require.Equal(t, digest.EmptySha256, actual2.GetDigest().GetHash())
+			require.Equal(t, int64(0), actual2.GetDigest().GetSizeBytes())
+			require.Equal(t, repb.Compressor_IDENTITY, actual2.GetCompressor())
+			require.Equal(t, int64(0), actual2.GetTransferredSizeBytes())
+
+			actual3 := sc.Results[2]
+			require.Equal(t, tc.cacheType, actual3.CacheType)
+			require.Equal(t, tc.requestType, actual3.RequestType)
+			require.Equal(t, d.Hash, actual3.GetDigest().GetHash())
+			require.Equal(t, d.SizeBytes, actual3.GetDigest().GetSizeBytes())
+			require.Equal(t, repb.Compressor_IDENTITY, actual3.GetCompressor())
+			require.Equal(t, int64(456), actual3.GetTransferredSizeBytes())
+		})
 	}
-	rmd := &repb.RequestMetadata{
-		ToolInvocationId: iid,
-		ActionId:         "f498500e6d2825ef3bd5564bb56c439da36efe38ab4936ae0ff93794e704ccb4",
-		ActionMnemonic:   "GoCompile",
-		TargetId:         "//foo:bar",
-	}
-	d1 := &repb.Digest{
-		Hash:      "c9c111006b30ffe6ce309fd64c44da651bffa068d530c7b1898698186b4afe2b",
-		SizeBytes: 1234,
-	}
-	compressedSize := int64(123)
-	ht := env.GetHitTrackerFactory().NewCASHitTracker(ctx, rmd)
-
-	dl := ht.TrackDownload(d1)
-	dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD, "test")
-
-	// Track two more cache hits using the hit_tracker_service.
-	emptyDigest := repb.Digest{Hash: digest.EmptySha256, SizeBytes: 0}
-	emptyRn := digest.NewResourceName(&emptyDigest, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256)
-	emptyHit := hitpb.CacheHit{
-		RequestMetadata: emptyRmd,
-		Resource:        emptyRn.ToProto(),
-	}
-	d := repb.Digest{
-		Hash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		SizeBytes: 456,
-	}
-	rn := digest.NewResourceName(&d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256)
-	hit := hitpb.CacheHit{
-		RequestMetadata: rmd,
-		Resource:        rn.ToProto(),
-		SizeBytes:       456,
-		Duration:        durationpb.New(time.Minute),
-	}
-	req := hitpb.TrackRequest{Hits: []*hitpb.CacheHit{&emptyHit, &hit}}
-
-	_, err = env.GetHitTrackerServiceServer().Track(ctx, &req)
-	require.NoError(t, err)
-
-	sc := hit_tracker.ScoreCard(ctx, env, iid)
-	require.Len(t, sc.Results, 3, "expected exactly three cache results")
-	actual1 := sc.Results[0]
-	require.Equal(t, rspb.CacheType_CAS, actual1.CacheType)
-	require.Equal(t, capb.RequestType_READ, actual1.RequestType)
-	require.Equal(t, d1.Hash, actual1.GetDigest().GetHash())
-	require.Equal(t, d1.SizeBytes, actual1.GetDigest().GetSizeBytes())
-	require.Equal(t, repb.Compressor_ZSTD, actual1.GetCompressor())
-	require.Equal(t, compressedSize, actual1.GetTransferredSizeBytes())
-
-	actual2 := sc.Results[1]
-	require.Equal(t, rspb.CacheType_CAS, actual2.CacheType)
-	require.Equal(t, capb.RequestType_READ, actual2.RequestType)
-	require.Equal(t, digest.EmptySha256, actual2.GetDigest().GetHash())
-	require.Equal(t, int64(0), actual2.GetDigest().GetSizeBytes())
-	require.Equal(t, repb.Compressor_IDENTITY, actual2.GetCompressor())
-	require.Equal(t, int64(0), actual2.GetTransferredSizeBytes())
-
-	actual3 := sc.Results[2]
-	require.Equal(t, rspb.CacheType_CAS, actual3.CacheType)
-	require.Equal(t, capb.RequestType_READ, actual3.RequestType)
-	require.Equal(t, d.Hash, actual3.GetDigest().GetHash())
-	require.Equal(t, d.SizeBytes, actual3.GetDigest().GetSizeBytes())
-	require.Equal(t, repb.Compressor_IDENTITY, actual3.GetCompressor())
-	require.Equal(t, int64(456), actual3.GetTransferredSizeBytes())
 }
 
 type fakeUsageTracker struct {
@@ -124,60 +166,106 @@ func (ut *fakeUsageTracker) Increment(ctx context.Context, labels *tables.UsageL
 func TestHitTrackerService_Usage(t *testing.T) {
 	flags.Set(t, "cache.detailed_stats_enabled", true)
 
-	env := testenv.GetTestEnv(t)
-	mc, err := memory_metrics_collector.NewMemoryMetricsCollector()
-	require.NoError(t, err)
-	env.SetMetricsCollector(mc)
-	ut := &fakeUsageTracker{}
-	env.SetUsageTracker(ut)
-	hit_tracker.Register(env)
-	require.NoError(t, hit_tracker_service.Register(env))
-	require.NotNil(t, env.GetHitTrackerServiceServer())
-
-	ctx := context.Background()
-	iid := "d42f4cd1-6963-4a5a-9680-cb77cfaad9bd"
-	emptyRmd := &repb.RequestMetadata{
-		ToolInvocationId: iid,
-		ActionId:         "4bcc407e49739ff0ea6394ba83efe63ad934c65bb4655db3fe5282d6e005894f",
-		ActionMnemonic:   "EmptyAction",
-		TargetId:         "//empty",
-	}
-	rmd := &repb.RequestMetadata{
-		ToolInvocationId: iid,
-		ActionId:         "f498500e6d2825ef3bd5564bb56c439da36efe38ab4936ae0ff93794e704ccb4",
-		ActionMnemonic:   "GoCompile",
-		TargetId:         "//foo:bar",
-	}
-
-	emptyDigest := repb.Digest{Hash: digest.EmptySha256, SizeBytes: 0}
-	emptyRn := digest.NewResourceName(&emptyDigest, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256)
-	emptyHit := hitpb.CacheHit{
-		RequestMetadata: emptyRmd,
-		Resource:        emptyRn.ToProto(),
-	}
-	d := repb.Digest{
-		Hash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		SizeBytes: 456,
-	}
-	rn := digest.NewResourceName(&d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256)
-	hit := hitpb.CacheHit{
-		RequestMetadata: rmd,
-		Resource:        rn.ToProto(),
-		SizeBytes:       456,
-		Duration:        durationpb.New(time.Minute),
-	}
-	req := hitpb.TrackRequest{Hits: []*hitpb.CacheHit{&emptyHit, &hit}}
-	_, err = env.GetHitTrackerServiceServer().Track(ctx, &req)
-	require.NoError(t, err)
-
-	require.Len(t, ut.Increments, 2)
-	require.Equal(t, []*tables.UsageCounts{
-		{CASCacheHits: 1},
+	for _, tc := range []struct {
+		name          string
+		cacheType     rspb.CacheType
+		requestType   capb.RequestType
+		expectedUsage []*tables.UsageCounts
+	}{
 		{
-			CASCacheHits:           1,
-			TotalDownloadSizeBytes: 456,
-		}}, ut.Increments)
-	ut.Increments = nil
+			name:        "CAS upload",
+			cacheType:   rspb.CacheType_CAS,
+			requestType: capb.RequestType_WRITE,
+			expectedUsage: []*tables.UsageCounts{
+				{},
+				{TotalUploadSizeBytes: 456},
+			},
+		},
+		{
+			name:        "CAS download",
+			cacheType:   rspb.CacheType_CAS,
+			requestType: capb.RequestType_READ,
+			expectedUsage: []*tables.UsageCounts{
+				{CASCacheHits: 1},
+				{
+					CASCacheHits:           1,
+					TotalDownloadSizeBytes: 456,
+				},
+			},
+		},
+		{
+			name:        "AC upload",
+			cacheType:   rspb.CacheType_AC,
+			requestType: capb.RequestType_WRITE,
+			expectedUsage: []*tables.UsageCounts{
+				{},
+				{TotalUploadSizeBytes: 456},
+			},
+		},
+		{
+			name:        "AC download",
+			cacheType:   rspb.CacheType_AC,
+			requestType: capb.RequestType_READ,
+			expectedUsage: []*tables.UsageCounts{
+				{ActionCacheHits: 1},
+				{ActionCacheHits: 1, TotalDownloadSizeBytes: 456},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testenv.GetTestEnv(t)
+			mc, err := memory_metrics_collector.NewMemoryMetricsCollector()
+			require.NoError(t, err)
+			env.SetMetricsCollector(mc)
+			ut := &fakeUsageTracker{}
+			env.SetUsageTracker(ut)
+			hit_tracker.Register(env)
+			require.NoError(t, hit_tracker_service.Register(env))
+			require.NotNil(t, env.GetHitTrackerServiceServer())
+
+			ctx := context.Background()
+			iid := "d42f4cd1-6963-4a5a-9680-cb77cfaad9bd"
+			emptyRmd := &repb.RequestMetadata{
+				ToolInvocationId: iid,
+				ActionId:         "4bcc407e49739ff0ea6394ba83efe63ad934c65bb4655db3fe5282d6e005894f",
+				ActionMnemonic:   "EmptyAction",
+				TargetId:         "//empty",
+			}
+			rmd := &repb.RequestMetadata{
+				ToolInvocationId: iid,
+				ActionId:         "f498500e6d2825ef3bd5564bb56c439da36efe38ab4936ae0ff93794e704ccb4",
+				ActionMnemonic:   "GoCompile",
+				TargetId:         "//foo:bar",
+			}
+
+			emptyDigest := repb.Digest{Hash: digest.EmptySha256, SizeBytes: 0}
+			emptyRn := digest.NewResourceName(&emptyDigest, "", tc.cacheType, repb.DigestFunction_SHA256)
+			emptyHit := hitpb.CacheHit{
+				RequestMetadata:  emptyRmd,
+				Resource:         emptyRn.ToProto(),
+				CacheRequestType: tc.requestType,
+			}
+			d := repb.Digest{
+				Hash:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				SizeBytes: 456,
+			}
+			rn := digest.NewResourceName(&d, "", tc.cacheType, repb.DigestFunction_SHA256)
+			hit := hitpb.CacheHit{
+				RequestMetadata:  rmd,
+				Resource:         rn.ToProto(),
+				SizeBytes:        456,
+				Duration:         durationpb.New(time.Minute),
+				CacheRequestType: tc.requestType,
+			}
+			req := hitpb.TrackRequest{Hits: []*hitpb.CacheHit{&emptyHit, &hit}}
+			_, err = env.GetHitTrackerServiceServer().Track(ctx, &req)
+			require.NoError(t, err)
+
+			require.Len(t, ut.Increments, 2)
+			require.Equal(t, tc.expectedUsage, ut.Increments)
+			ut.Increments = nil
+		})
+	}
 }
 
 // Note: Can't use bazel_request.WithRequestMetadata here since it sets the

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -857,6 +857,7 @@ proto_library(
     name = "hit_tracker_proto",
     srcs = ["hit_tracker.proto"],
     deps = [
+        ":cache_proto",
         ":remote_execution_proto",
         ":resource_proto",
         "@com_google_protobuf//:duration_proto",
@@ -2016,6 +2017,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker",
     proto = ":hit_tracker_proto",
     deps = [
+        ":cache_go_proto",
         ":remote_execution_go_proto",
         ":resource_go_proto",
     ],

--- a/proto/hit_tracker.proto
+++ b/proto/hit_tracker.proto
@@ -1,6 +1,7 @@
 
 syntax = "proto3";
 
+import "proto/cache.proto";
 import "google/protobuf/duration.proto";
 import "proto/remote_execution.proto";
 import "proto/resource.proto";
@@ -21,13 +22,7 @@ message CacheHit {
   // The time taken for the download.
   google.protobuf.Duration duration = 4;
 
-  CacheRequestType cache_request_type = 5;
-}
-
-enum CacheRequestType {
-  UNKNOWN = 0;
-  UPLOAD = 1;
-  DOWNLOAD = 2;
+  cache.RequestType cache_request_type = 5;
 }
 
 message TrackRequest {

--- a/proto/hit_tracker.proto
+++ b/proto/hit_tracker.proto
@@ -20,6 +20,14 @@ message CacheHit {
 
   // The time taken for the download.
   google.protobuf.Duration duration = 4;
+
+  CacheRequestType cache_request_type = 5;
+}
+
+enum CacheRequestType {
+  UNKNOWN = 0;
+  UPLOAD = 1;
+  DOWNLOAD = 2;
 }
 
 message TrackRequest {


### PR DESCRIPTION
To prepare for tracking local AC requests in the proxy when we skip the remote cache