### PR TITLE
Add rbe-ubuntu24-04 image

### DIFF
--- a/dockerfiles/rbe-ubuntu24-04/Dockerfile
+++ b/dockerfiles/rbe-ubuntu24-04/Dockerfile
@@ -1,0 +1,101 @@
+FROM marketplace.gcr.io/google/ubuntu2404@sha256:f226b52ce8f8365aa0a52fb8f4392ecbe1c215639f73edf16a12e5f3d6765147
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Python 3
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      python3 \
+      python3-dev \
+      python-is-python3 \
+      && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# gpg-agent (for add-apt-repository below)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gpg-agent \
+    && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && \
+    mkdir -p /root/.gnupg
+
+# GCC, make
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Misc. utils
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      software-properties-common \
+      && \
+    add-apt-repository ppa:git-core/ppa -y && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      curl \
+      ed \
+      file \
+      git \
+      less \
+      netcat-traditional \
+      openssh-client \
+      sudo \
+      unzip \
+      wget \
+      zip \
+      zipmerge \
+      && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Docker
+#
+# Note: gnupg is only needed to install Docker, so we uninstall it at the end of
+# this step and also run `apt-get autoremove` to get rid of the unnecessary
+# packages it came with.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gnupg \
+      lsb-release \
+      && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo >/etc/apt/sources.list.d/docker.list "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
+    apt-get update && \
+    apt-get install -y \
+      docker-ce=5:28.1.0-1~ubuntu.24.04~noble \
+      docker-ce-cli=5:28.1.0-1~ubuntu.24.04~noble \
+      containerd.io=1.7.27-1 \
+      && \
+    apt-get remove -y gnupg && \
+    apt-get autoremove -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# en_US.UTF-8 locale
+#
+# Bazel forces the locale to be en_US.UTF-8 (not C.UTF-8) for Java actions.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      locales \
+      && \
+    locale-gen en_US.UTF-8 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# The new iptables requires nft which we haven't yet set up properly in our VM
+# guest kernel configs. This prevents docker network setup from working properly
+# when using docker-in-fireecracker. To work around this, downgrade to
+# iptables-legacy for now.
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Provision a non-root user named "buildbuddy" and set up passwordless sudo.
+# Non-root users are needed for some bazel toolchains, such as hermetic python.
+# Also add them to the docker group so they can use docker.
+RUN useradd --create-home buildbuddy --groups sudo,docker && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+CMD bash

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -42,12 +42,18 @@ var (
 )
 
 const (
+	// BuildBuddy ubuntu images. When adding images here, also update
+	// the image aliases in enterprise/server/workflow/service/service.go
 	Ubuntu16_04Image = "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0"
 	Ubuntu20_04Image = "gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622"
+	Ubuntu22_04Image = "gcr.io/flame-public/rbe-ubuntu22-04@sha256:0d84a80bb0fc36ba5381942adcf6493249594dcc9044845c617b78c9b621cae3"
+	Ubuntu24_04Image = "gcr.io/flame-public/rbe-ubuntu24-04@sha256:f7db0d4791247f032fdb4451b7c3ba90e567923a341cc6dc43abfc283436791a"
 
 	Ubuntu18_04WorkflowsImage = "gcr.io/flame-public/buildbuddy-ci-runner@sha256:8cf614fc4695789bea8321446402e7d6f84f6be09b8d39ec93caa508fa3e3cfc"
 	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:ba28945426fcdf4310f18e8a8e3c47af670bdcf9ba76bd76b269898c0579089e"
-	Ubuntu22_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu22-04@sha256:0d84a80bb0fc36ba5381942adcf6493249594dcc9044845c617b78c9b621cae3"
+	// Images from 22.04+ do not have separate images for workflows.
+	Ubuntu22_04WorkflowsImage = Ubuntu22_04Image
+	Ubuntu24_04WorkflowsImage = Ubuntu24_04Image
 
 	// OverrideHeaderPrefix is a prefix used to override platform props via
 	// remote headers. The property name immediately follows the prefix in the

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1224,6 +1224,9 @@ func (ws *workflowService) resolveImageAliases(value string) string {
 	if value == "ubuntu-22.04" {
 		return platform.DockerPrefix + platform.Ubuntu22_04WorkflowsImage
 	}
+	if value == "ubuntu-24.04" {
+		return platform.DockerPrefix + platform.Ubuntu24_04WorkflowsImage
+	}
 
 	// Otherwise, interpret container_image the same way we treat it for RBE
 	// actions.


### PR DESCRIPTION
Was mostly able to copy the 22.04 image and it "just works." The only thing different is that it's using a newer version of docker, since v24 no longer exists in the repositories for ubuntu 24.04. I pushed and tested the image and made sure docker-in-firecracker still works (using `bb execute --exec_properties=container-image=docker://gcr.io/flame-public/rbe-ubuntu24-04:latest --exec_properties=workload-isolation-type=firecracker --exec_properties=init-dockerd=true -- docker run --rm busybox echo Hello`)