### PR TITLE
Deflake target_test

### DIFF
--- a/server/target/target.go
+++ b/server/target/target.go
@@ -685,7 +685,7 @@ func readPaginatedTargetsFromOLAPDB(ctx context.Context, env environment.Env, re
 	if branch != "" {
 		q.AddWhereClause("branch_name = ?", branch)
 	}
-	q.SetOrderBy("label", true /*=ascending*/)
+	q.SetOrderBy("label ASC, start_time_usec", false /*=ascending*/)
 	return fetchTargetsFromOLAPDB(ctx, env, q, repo, groupID)
 }
 


### PR DESCRIPTION
We fetch target statuses commit-by-commit, but the returned target statuses within each commit aren't sorted in a stable way which causes the tests to be flaky (I added `label` in a previous PR which partly addressed this; this PR also adds sorting on `start_time_usec`).

I don't believe this should have any impact on query performance since it's applying the ordering to the final results from the inner query (which is filtering on commit_sha and not these other fields) but it would be great if someone could double-check my understanding on this :D