### PR TITLE
Remove RBE config from --config=release

### DIFF
--- a/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04-16cpu-arm64
+    runs-on: ubuntu-22.04-16cpu-arm64-arm-limited
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,22 +34,6 @@ jobs:
           # We need to fetch git tags to obtain the latest version tag to report
           # the version of the running binary.
           fetch-depth: 0
-
-      # GitHub's arm64 runners do not have the same pre-installed software as
-      # the amd64 runners so we have to install a few things here.
-      - name: Install bazelisk
-        run: |
-          curl -L --output /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64
-          chmod +x /tmp/bazelisk
-          sudo mv /tmp/bazelisk /usr/bin/bazelisk
-
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-          && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-          && sudo apt update \
-          && sudo apt install gh -y
 
       - name: Restore caches
         id: cache-restore

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -286,11 +286,8 @@ common:release-shared --strip=always
 
 # Configuration used for Linux releases
 common:release --config=release-shared
-common:release --config=remote-prod-shared
-common:release --config=target-linux-x86
 common:release --repository_cache=~/repo-cache/
 common:release --remote_instance_name=buildbuddy-io/buildbuddy/release
-common:release --remote_download_toplevel
 
 # Configuration used for release-mac workflow
 common:release-mac --config=release-shared


### PR DESCRIPTION
The executor arm64 release binaries are being built for x86; this should fix that.