### PR TITLE
integration/remote_bazel: only include secrets in test actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,8 +24,10 @@ common --config=anon-bes
 # Don't run Docker and Firecracker tests by default, because they cannot be run on all environments
 # Firecracker tests can only be run on Linux machines with bare execution, and we want to avoid a hard dependency
 # on Docker for development
-test --test_tag_filters=-docker,-bare
-build --build_tag_filters=-secrets
+#
+# Exclude tests which require BuildBuddy Secrets from the default unauthenticated builds
+# These often require "include-secrets: true" exec property in their BUILD file.
+test --test_tag_filters=-docker,-bare,-secrets
 
 # Build with --config=local to send build logs to your local server
 common:local --extra_execution_platforms=@buildbuddy_toolchain//:platform

--- a/enterprise/server/test/integration/remote_bazel/BUILD
+++ b/enterprise/server/test/integration/remote_bazel/BUILD
@@ -7,7 +7,7 @@ go_test(
     size = "enormous",
     srcs = ["remote_bazel_test.go"],
     exec_properties = {
-        "include-secrets": "true",
+        "test.include-secrets": "true",
         "test.workload-isolation-type": "firecracker",
         # Use an image with bazelisk installed
         "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:271e5e3704d861159c75b8dd6713dbe5a12272ec8ee73d17f89ed7be8026553f",


### PR DESCRIPTION
The compile and link actions should not need access to BuildBuddy Secret
values. It's an execution time dependency.

Shift the tag exclusion from build -> test.
