### PR TITLE
bazelrc: rename platform configs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,12 @@ import %workspace%/shared.bazelrc
 # so OSS / anonymous users can still send events to our server.
 common --config=anon-bes
 
+# Target+Exec platform configurations.
+#
+# We maintain separate configuration for each repo so that we can migrate them to bzlmod independently.
+common:target-linux-x86 --config=workspace-target-linux-x86
+common:target-linux-arm64 --config=workspace-target-linux-arm64
+
 # Don't run Docker and Firecracker tests by default, because they cannot be run on all environments
 # Firecracker tests can only be run on Linux machines with bare execution, and we want to avoid a hard dependency
 # on Docker for development

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -178,11 +178,11 @@ common:cache-dev --remote_cache=grpcs://buildbuddy.buildbuddy.dev
 common:cache --config=cache-shared
 common:cache --remote_cache=grpcs://buildbuddy.buildbuddy.io
 
-common:target-linux-x86 --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
-common:target-linux-x86 --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_x86_64
-common:target-linux-arm64 --platforms=@buildbuddy_toolchain//:platform_linux_arm64
-common:target-linux-arm64 --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_arm64
-
+# Target+Exec Platforms configuration
+common:workspace-target-linux-x86 --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
+common:workspace-target-linux-x86 --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_x86_64
+common:workspace-target-linux-arm64 --platforms=@buildbuddy_toolchain//:platform_linux_arm64
+common:workspace-target-linux-arm64 --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_arm64
 common:bzlmod-target-linux-x86 --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:bzlmod-target-linux-x86 --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:bzlmod-target-linux-arm64 --platforms=@toolchains_buildbuddy//platforms:linux_arm64


### PR DESCRIPTION
Rename the default platform config to indicate that it's specific
to WORKSPACE setup. Move the actual flag back to <repo>/.bazelrc so that
we can migrate each repo to bzlmod independently from each others.
