### PR TITLE
add HTTP client request counts

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -3461,7 +3461,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": false
@@ -4232,7 +4232,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": false
@@ -9381,7 +9381,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -9462,7 +9462,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -12890,7 +12890,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -12971,7 +12971,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -13052,7 +13052,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -13133,7 +13133,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -13214,7 +13214,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -13295,7 +13295,7 @@
               "color": "rgba(255,0,255,0.7)"
             },
             "filterValues": {
-              "le": 1e-9
+              "le": 1e-09
             },
             "legend": {
               "show": true
@@ -16921,6 +16921,5 @@
   "timezone": "",
   "title": "BuildBuddy Metrics",
   "uid": "1rsE5yoGz",
-  "version": 0,
   "weekStart": ""
 }


### PR DESCRIPTION
This change add panels showing HTTP client outgoing requests
* by host (legend is not displayed, hovering reveals host names) and
* by HTTP method
to the HTTP panel on the General dashboard.

<img width="1485" alt="Screenshot 2025-04-22 at 10 19 43 AM" src="https://github.com/user-attachments/assets/fcfa2e7a-0f85-4e3f-9c71-db3331b7e94a" />