### PR TITLE
Move `RunScript` functions to avoid dependency cycle while refactoring option parsing

### DIFF
--- a/cli/bazelisk/BUILD
+++ b/cli/bazelisk/BUILD
@@ -8,7 +8,6 @@ go_library(
     srcs = ["bazelisk.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/bazelisk",
     deps = [
-        "//cli/arg",
         "//cli/log",
         "//cli/workspace",
         "@com_github_bazelbuild_bazelisk//config",

--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -8,12 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/bazelbuild/bazelisk/config"
 	"github.com/bazelbuild/bazelisk/core"
 	"github.com/bazelbuild/bazelisk/repositories"
-	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 )
@@ -76,42 +74,6 @@ func Run(args []string, opts *RunOpts) (exitCode int, err error) {
 		}
 	}
 	return core.RunBazelisk(args, repos)
-}
-
-// ConfigureRunScript adds `--script_path` to a bazel run command so that we can
-// invoke the build and the run separately.
-func ConfigureRunScript(args []string) (newArgs []string, scriptPath string, err error) {
-	if arg.GetCommand(args) != "run" {
-		return args, "", nil
-	}
-	// If --script_path is already set, don't create a run script ourselves,
-	// since the caller probably has the intention to invoke it on their own.
-	existingScript := arg.Get(args, "script_path")
-	if existingScript != "" {
-		return args, "", nil
-	}
-	script, err := os.CreateTemp("", "bb-run-*")
-	if err != nil {
-		return nil, "", err
-	}
-	defer script.Close()
-	scriptPath = script.Name()
-	args = append(args, "--script_path="+scriptPath)
-	return args, scriptPath, nil
-}
-
-func InvokeRunScript(path string) (exitCode int, err error) {
-	if err := os.Chmod(path, 0o755); err != nil {
-		return -1, err
-	}
-	// TODO: Exec() replaces the current process, so it prevents us from running
-	// post-run hooks (if we decide those will be supported). If we want to use
-	// exec.Command() here instead of exec(), then we might need to manually
-	// forward signals from the parent file watcher process.
-	if err := syscall.Exec(path, nil, os.Environ()); err != nil {
-		return -1, err
-	}
-	panic("unreachable")
 }
 
 // IsInvokedByBazelisk returns whether the CLI was invoked by bazelisk itself.

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//cli/parser",
         "//cli/picker",
         "//cli/plugin",
+        "//cli/runscript",
         "//cli/setup",
         "//cli/shortcuts",
         "//cli/watcher",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/picker"
 	"github.com/buildbuddy-io/buildbuddy/cli/plugin"
+	"github.com/buildbuddy-io/buildbuddy/cli/runscript"
 	"github.com/buildbuddy-io/buildbuddy/cli/setup"
 	"github.com/buildbuddy-io/buildbuddy/cli/shortcuts"
 	"github.com/buildbuddy-io/buildbuddy/cli/watcher"
@@ -158,7 +159,7 @@ func handleBazelCommand(start time.Time, args []string, originalArgs []string) (
 
 		// Invoke the run script only if the build succeeded.
 		if exitCode == 0 && scriptPath != "" {
-			exitCode, err = bazelisk.InvokeRunScript(scriptPath)
+			exitCode, err = runscript.Invoke(scriptPath)
 		}
 	}()
 
@@ -181,7 +182,7 @@ func handleBazelCommand(start time.Time, args []string, originalArgs []string) (
 
 	// If this is a `bazel run` command, add a --run_script arg so that
 	// we can execute post-bazel plugins between the build and the run step.
-	bazelArgs, scriptPath, err = bazelisk.ConfigureRunScript(bazelArgs)
+	bazelArgs, scriptPath, err = runscript.Configure(bazelArgs)
 	if err != nil {
 		return 1, err
 	}

--- a/cli/runscript/BUILD
+++ b/cli/runscript/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "runscript",
+    srcs = ["runscript.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/runscript",
+    visibility = ["//visibility:public"],
+    deps = ["//cli/arg"],
+)
+
+package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/runscript/runscript.go
+++ b/cli/runscript/runscript.go
@@ -1,0 +1,45 @@
+package runscript
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+)
+
+
+// Configure adds `--script_path` to a bazel run command so that we can
+// invoke the build and the run separately.
+func Configure(args []string) (newArgs []string, scriptPath string, err error) {
+	if arg.GetCommand(args) != "run" {
+		return args, "", nil
+	}
+	// If --script_path is already set, don't create a run script ourselves,
+	// since the caller probably has the intention to invoke it on their own.
+	existingScript := arg.Get(args, "script_path")
+	if existingScript != "" {
+		return args, "", nil
+	}
+	script, err := os.CreateTemp("", "bb-run-*")
+	if err != nil {
+		return nil, "", err
+	}
+	defer script.Close()
+	scriptPath = script.Name()
+	args = append(args, "--script_path="+scriptPath)
+	return args, scriptPath, nil
+}
+
+func Invoke(path string) (exitCode int, err error) {
+	if err := os.Chmod(path, 0o755); err != nil {
+		return -1, err
+	}
+	// TODO: Exec() replaces the current process, so it prevents us from running
+	// post-run hooks (if we decide those will be supported). If we want to use
+	// exec.Command() here instead of exec(), then we might need to manually
+	// forward signals from the parent file watcher process.
+	if err := syscall.Exec(path, nil, os.Environ()); err != nil {
+		return -1, err
+	}
+	panic("unreachable")
+}


### PR DESCRIPTION
Because the `RunScript` functions manipulate the CLI command line arguments, they will need to depend on `parser.go`, which itself depends on `bazelisk.go` in order to get the `bazel help` output to inform parsing. Fortunately, these functions neither depend on nor are depended on by anything else in `bazelisk.go`. Thus, we can simply move them into their own package.
