### PR TITLE
[raft] allow the replica to lock the entire range

### DIFF
--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -137,6 +137,11 @@ func (bb *BatchBuilder) SetSession(session *rfpb.Session) *BatchBuilder {
 	return bb
 }
 
+func (bb *BatchBuilder) SetLockMappedRange(lock bool) *BatchBuilder {
+	bb.cmd.LockMappedRange = lock
+	return bb
+}
+
 func (bb *BatchBuilder) AddPostCommitHook(m proto.Message) *BatchBuilder {
 	switch value := m.(type) {
 	case *rfpb.SnapshotClusterHook:

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -244,6 +244,11 @@ message BatchCmdRequest {
 
   // Session is used to guarantee idempotency for writes on the state machine.
   optional Session session = 6;
+
+  // If set, the mapped_range will be locked when we prepare a transaction, no
+  // writes will be allowed; it will be unlocked when the transaction is 
+  // committed or rolled back.
+  bool lock_mapped_range = 7;
 }
 
 message BatchCmdResponse {

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -246,7 +246,7 @@ message BatchCmdRequest {
   optional Session session = 6;
 
   // If set, the mapped_range will be locked when we prepare a transaction, no
-  // writes will be allowed; it will be unlocked when the transaction is 
+  // writes will be allowed; it will be unlocked when the transaction is
   // committed or rolled back.
   bool lock_mapped_range = 7;
 }


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4843

I added a boolean in BatchCmdRequest to indicate if the entire mapped range should be locked. This is because we don't need to lock the entire range when we prepare every transaction; we only need to do that for the left range during the split transaction. 