### PR TITLE
testcli: Ignore system and home rc files

### DIFF
--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -51,7 +51,7 @@ func TestParseGlobalFlags(t *testing.T) {
 		"print_args.sh": `echo $@`,
 	})
 	testfs.MakeExecutable(t, ws, "print_args.sh")
-	cmd := testcli.Command(t, ws, "run", ":print_args", "--", "--before", "--verbose", "hello", "--after")
+	cmd := testcli.BazelCommand(t, ws, "run", ":print_args", "--", "--before", "--verbose", "hello", "--after")
 	b, err := testcli.Output(cmd)
 	require.NoError(t, err, "output: %s", string(b))
 	require.Equal(t, "--before --verbose hello --after\n", string(b))
@@ -129,7 +129,7 @@ func TestBazelBuildWithLocalPlugin(t *testing.T) {
 
 	testfs.WriteAllFileContents(t, ws, map[string]string{"BUILD": ``})
 
-	cmd = testcli.Command(t, ws, "build", "//...", "--build_metadata", "FOO=bar")
+	cmd = testcli.BazelCommand(t, ws, "build", "//...", "--build_metadata", "FOO=bar")
 
 	b, err = testcli.CombinedOutput(cmd)
 
@@ -186,7 +186,7 @@ func TestBazelRunWithLocalPlugin(t *testing.T) {
 	args = append(args, "--")
 	args = append(args, "Hello")
 
-	cmd = testcli.Command(t, ws, args...)
+	cmd = testcli.BazelCommand(t, ws, args...)
 
 	b, err = testcli.CombinedOutput(cmd)
 
@@ -211,7 +211,7 @@ func TestBazelRunWithLocalPlugin(t *testing.T) {
 	iid = uid.String()
 	args = append(args, "--invocation_id="+iid)
 
-	cmd = testcli.Command(t, ws, args...)
+	cmd = testcli.BazelCommand(t, ws, args...)
 
 	b, err = testcli.CombinedOutput(cmd)
 
@@ -245,7 +245,7 @@ func TestBazelBuildWithBuildBuddyServices(t *testing.T) {
 	iid := uid.String()
 	args = append(args, "--invocation_id="+iid)
 
-	cmd := testcli.Command(t, ws, args...)
+	cmd := testcli.BazelCommand(t, ws, args...)
 
 	b, err := testcli.CombinedOutput(cmd)
 	require.NoErrorf(t, err, "output: %s", string(b))
@@ -307,7 +307,7 @@ func TestTerminalOutput(t *testing.T) {
 	})
 
 	term := testcli.PTY(t)
-	term.Run(testcli.Command(t, ws, "test", "...", "--test_output=streamed"))
+	term.Run(testcli.BazelCommand(t, ws, "test", "...", "--test_output=streamed"))
 
 	// Make sure Bazel's progress output doesn't get interspersed with the test
 	// output.
@@ -332,17 +332,17 @@ sh_test(name = "fail", srcs = ["fail.sh"])
 		"targets.txt": "//:pass",
 	})
 
-	b, err := testcli.CombinedOutput(testcli.Command(t, ws, "build", "--target_pattern_file=targets.txt"))
+	b, err := testcli.CombinedOutput(testcli.BazelCommand(t, ws, "build", "--target_pattern_file=targets.txt"))
 	require.NoErrorf(t, err, "output: %s", string(b))
 
-	b, err = testcli.CombinedOutput(testcli.Command(t, ws, "test", "--target_pattern_file=targets.txt"))
+	b, err = testcli.CombinedOutput(testcli.BazelCommand(t, ws, "test", "--target_pattern_file=targets.txt"))
 	require.NoErrorf(t, err, "output: %s", string(b))
 
-	b, err = testcli.CombinedOutput(testcli.Command(t, ws, "test", "--config=pattern-file"))
+	b, err = testcli.CombinedOutput(testcli.BazelCommand(t, ws, "test", "--config=pattern-file"))
 	require.NoErrorf(t, err, "output: %s", string(b))
 
 	// "test" should expand to "test //..." and the tests should fail.
-	b, err = testcli.CombinedOutput(testcli.Command(t, ws, "test"))
+	b, err = testcli.CombinedOutput(testcli.BazelCommand(t, ws, "test"))
 	require.Errorf(t, err, "output: %s", string(b))
 }
 
@@ -354,7 +354,7 @@ func TestQueryFile(t *testing.T) {
 		"targets.txt": "//:nop",
 	})
 
-	b, err := testcli.CombinedOutput(testcli.Command(t, ws, "query", "--query_file=targets.txt"))
+	b, err := testcli.CombinedOutput(testcli.BazelCommand(t, ws, "query", "--query_file=targets.txt"))
 	require.NoErrorf(t, err, "output: %s", string(b))
 }
 
@@ -376,7 +376,7 @@ startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 `,
 	})
 
-	cmd := testcli.Command(t, ws, "query", "//...")
+	cmd := testcli.BazelCommand(t, ws, "query", "//...")
 	b, err := testcli.CombinedOutput(cmd)
 	require.NoErrorf(t, err, "output: %s", string(b))
 	require.NotContains(t, string(b), "Running Bazel server needs to be killed")

--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -41,6 +41,9 @@ func BinaryPath(t *testing.T) string {
 }
 
 // Command returns an *exec.Cmd for the CLI binary.
+//
+// Prefer using BazelCommand for bazel-specific commands, such as build, test, query
+// as the additional flags will help improve hermeticity of the tests.
 func Command(t *testing.T, workspacePath string, args ...string) *exec.Cmd {
 	initEnvOnce.Do(func() {
 		// Need a HOME dir for .cache and .config dirs.
@@ -71,7 +74,7 @@ func BazelCommand(t *testing.T, workspacePath string, args ...string) *exec.Cmd 
 
 // BazeliskCommand returns a bazelisk command to invoke the CLI via the
 // .bazelversion trick.
-// It's usually preferable to use Command() except when specifically
+// It's usually preferable to use BazelCommand() except when specifically
 // testing bazelisk integration.
 func BazeliskCommand(t *testing.T, workspacePath string, args ...string) *exec.Cmd {
 	cmd := Command(t, workspacePath, args...)

--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -63,6 +63,12 @@ func Command(t *testing.T, workspacePath string, args ...string) *exec.Cmd {
 	return cmd
 }
 
+// BazelCommand returns a bazel-specific command with system and home bazelrc ignored
+// to ensure hermetic testing result.
+func BazelCommand(t *testing.T, workspacePath string, args ...string) *exec.Cmd {
+	return Command(t, workspacePath, append([]string{"--nosystem_rc", "--nohome_rc"}, args...)...)
+}
+
 // BazeliskCommand returns a bazelisk command to invoke the CLI via the
 // .bazelversion trick.
 // It's usually preferable to use Command() except when specifically


### PR DESCRIPTION
Introduce a new BazelCommand wrapper around existing Command func so
that we can inject the 2 --nosystem_rc and --nohome_rc flags.

This enable us to run these tests locally on MacOS while having a
$HOME/.bazelrc file setup.

