### PR TITLE
Use `arg.Append` to append to cli bazel args

### DIFF
--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 )
 
@@ -157,7 +158,9 @@ func JoinExecutableArgs(args, execArgs []string) []string {
 	if len(execArgs) == 0 {
 		return out
 	}
-	out = append(out, "--")
+	if !slices.Contains(args, "--") {
+		out = append(out, "--")
+	}
 	out = append(out, execArgs...)
 	return out
 }
@@ -226,4 +229,16 @@ func SplitOptionValue(arg string) (flag string, value string) {
 	default:
 		return "", ""
 	}
+}
+
+func Append(args []string, arg... string) []string {
+	bazelArgs, execArgs := SplitExecutableArgs(args)
+	for _, a := range arg {
+		if strings.HasPrefix(a, "-") {
+			bazelArgs = append(bazelArgs, a)
+			continue
+		}
+		execArgs = append(execArgs, a)
+	}
+	return JoinExecutableArgs(bazelArgs, execArgs)
 }

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -231,7 +231,7 @@ func SplitOptionValue(arg string) (flag string, value string) {
 	}
 }
 
-func Append(args []string, arg... string) []string {
+func Append(args []string, arg ...string) []string {
 	bazelArgs, execArgs := SplitExecutableArgs(args)
 	for _, a := range arg {
 		if strings.HasPrefix(a, "-") {

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -126,11 +126,7 @@ func handleGlobalCliFlags(args []string) []string {
 			log.Configure(flagVal)
 		}
 	}
-	if len(residual) > 0 {
-		args = append(args, "--")
-		args = append(args, residual...)
-	}
-	return args
+	return arg.JoinExecutableArgs(args, residual)
 }
 
 // handleBazelCommand handles a native bazel command (i.e. commands that are

--- a/cli/flaghistory/BUILD
+++ b/cli/flaghistory/BUILD
@@ -20,5 +20,9 @@ go_test(
     name = "flaghistory_test",
     srcs = ["flaghistory_test.go"],
     embed = [":flaghistory"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//cli/parser",
+        "//cli/parser/test_data",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/cli/flaghistory/BUILD
+++ b/cli/flaghistory/BUILD
@@ -20,9 +20,5 @@ go_test(
     name = "flaghistory_test",
     srcs = ["flaghistory_test.go"],
     embed = [":flaghistory"],
-    deps = [
-        "//cli/parser",
-        "//cli/parser/test_data",
-        "@com_github_stretchr_testify//require",
-    ],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/cli/flaghistory/flaghistory.go
+++ b/cli/flaghistory/flaghistory.go
@@ -70,7 +70,7 @@ func saveFlag(args []string, flag, backup string, maxValues int) []string {
 	if value == "" {
 		value = backup
 	}
-	args = append(args, "--"+flag+"="+value)
+	args = arg.Append(args, "--"+flag+"="+value)
 	path := getPreviousFlagPath(flag)
 	if path == "" {
 		log.Debugf("Failed to get path for flag %q", flag)

--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -344,7 +344,7 @@ func ConfigureAPIKey(args []string) ([]string, error) {
 		return args, nil
 	}
 
-	return append(args, "--"+apiKeyHeader+"="+strings.TrimSpace(apiKey)), nil
+	return arg.Append(args, "--"+apiKeyHeader+"="+strings.TrimSpace(apiKey)), nil
 }
 
 // Commands that support the `--remote_header` bazel flag

--- a/cli/runscript/runscript.go
+++ b/cli/runscript/runscript.go
@@ -25,7 +25,7 @@ func Configure(args []string) (newArgs []string, scriptPath string, err error) {
 	}
 	defer script.Close()
 	scriptPath = script.Name()
-	args = append(args, "--script_path="+scriptPath)
+	args = arg.Append(args, "--script_path="+scriptPath)
 	return args, scriptPath, nil
 }
 

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -235,7 +235,7 @@ func ConfigureSidecar(args []string) ([]string, *Instance) {
 		syncFlag := arg.Get(args, "sync")
 		if !isFlagTrue(syncFlag) {
 			log.Debugf("CI build detected. add --sync=true")
-			args = append(args, "--sync=true")
+			args = arg.Append(args, "--sync=true")
 		}
 	}
 
@@ -291,7 +291,7 @@ func ConfigureSidecar(args []string) ([]string, *Instance) {
 	if synchronousWriteFlag == "1" || synchronousWriteFlag == "true" {
 		sidecarArgs = append(sidecarArgs, "--local_cache_proxy.synchronous_write")
 		sidecarArgs = append(sidecarArgs, "--bes_synchronous")
-		args = append(args, "--bes_upload_mode=wait_for_upload_complete")
+		args = arg.Append(args, "--bes_upload_mode=wait_for_upload_complete")
 	}
 
 	sidecarArgs = append(sidecarArgs, []string{
@@ -329,14 +329,14 @@ func ConfigureSidecar(args []string) ([]string, *Instance) {
 			continue
 		}
 		if sidecarBESEnabled {
-			args = append(args, fmt.Sprintf("--bes_backend=unix://%s", instance.SockPath))
+			args = arg.Append(args, fmt.Sprintf("--bes_backend=unix://%s", instance.SockPath))
 		}
 		if sidecarCacheEnabled {
-			args = append(args, fmt.Sprintf("--remote_cache=unix://%s", instance.SockPath))
+			args = arg.Append(args, fmt.Sprintf("--remote_cache=unix://%s", instance.SockPath))
 			// Set bytestream URI prefix to match the actual remote cache
 			// backend, rather than the sidecar socket.
 			instanceName := arg.Get(args, "remote_instance_name")
-			args = append(args, fmt.Sprintf("--remote_bytestream_uri_prefix=%s", bytestreamURIPrefix(remoteCacheFlag, instanceName)))
+			args = arg.Append(args, fmt.Sprintf("--remote_bytestream_uri_prefix=%s", bytestreamURIPrefix(remoteCacheFlag, instanceName)))
 		}
 		return args, instance
 	}

--- a/cli/tooltag/tooltag.go
+++ b/cli/tooltag/tooltag.go
@@ -16,7 +16,7 @@ func ConfigureToolTag(args []string) []string {
 		v = version.String()
 	}
 	if arg.GetCommand(args) != "" && !arg.Has(args, "tool_tag") {
-		return append(args, "--tool_tag=buildbuddy-cli-"+v)
+		return arg.Append(args, "--tool_tag=buildbuddy-cli-"+v)
 	}
 	return args
 }


### PR DESCRIPTION
Switch to using `arg.Append` instead of `append(args, ...)` to append to bazel args. This helps protect us from cases where there may be a `--` in the args we are appending to, and also abstracts the call so we can use real parsing in the future to do appending.

Also enforces `JoinExecutableArgs` not adding an additional `--` if one already exists.
