### PR TITLE
Separate option behavior by option type

### DIFF
--- a/cli/parser/arguments/arguments.go
+++ b/cli/parser/arguments/arguments.go
@@ -29,10 +29,44 @@ func (a *PositionalArgument) Format() []string {
 	return []string{a.Value}
 }
 
+func AsArguments[T Argument](args []T) []Argument {
+	argSlice := make([]Argument, 0, len(args))
+	for _, a := range args {
+		// Obviously this looks wrong and one would want to just write
+		// `argSlice = append(argSlice, args...)` instead of this verbose loop, but
+		// `append(s, e)` is actually just syntactic sugar for `append(s, []E{e})`
+		// (where `E` is the type of the element in `s`), which means that this
+		// works because a `T` is being used as an `Argument` in a
+		// newly-instantiated Argument slice, whereas `append(argSlice, args)`
+		// would be attempting to satisfy the  second argument of the function
+		// signature `append(s []Argument, els...Argument)` with a value of type
+		// `[]T`, while `els` is of type []Argument. And while a `T` is an
+		// `Argument`, a `[]T` is not a `[]Argument`. Hence, the loop.
+		argSlice = append(argSlice, a)
+	}
+	return argSlice
+}
+
+func AsPositionalArguments(args []string) []Argument {
+	pos := make([]Argument, 0, len(args))
+	for _, arg := range args {
+		pos = append(pos, &PositionalArgument{Value: arg})
+	}
+	return pos
+}
+
 func AsFormatted[T Argument](args []T) []string {
 	s := make([]string, 0, len(args))
 	for _, arg := range args {
 		s = append(s, arg.Format()...)
+	}
+	return s
+}
+
+func AsValues[T Argument](args []T) []string {
+	s := make([]string, 0, len(args))
+	for _, arg := range args {
+		s = append(s, arg.GetValue())
 	}
 	return s
 }

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -593,9 +593,9 @@ func NewOption(optName string, v *string, d *Definition) (Option, error) {
 			// and remove the value ourselves, we should output the warning instead.
 			log.Warnf("option '%s' is an expansion option. It does not accept values, and does not change its expansion based on the value provided. Value '%s' will be ignored.", d.name, v)
 		}
-		if form == negativeForm {
+		if form == negativeForm && d.pluginID != StarlarkBuiltinPluginID {
 			// This is a negative boolean value (of the form "--noNAME") with a
-			// specified value, which is unsupported.
+			// specified value, which is only supported for starlark.
 			return nil, fmt.Errorf("Unexpected value after boolean option: %s", optName)
 		}
 	}

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -536,6 +536,7 @@ func Canonicalize(opts []Option) []Option {
 			continue
 		}
 		if opt.PluginID() != UnknownBuiltinPluginID {
+			// don't normalize unknown options
 			opt = opt.Normalized()
 		}
 		canonical = append(canonical, opt)
@@ -574,7 +575,7 @@ func NewOption(optName string, v *string, d *Definition) (Option, error) {
 		return nil, fmt.Errorf("option name '%s' cannot specify an option with definition '%#v'", optName, d)
 	}
 
-	if d.requiresValue {
+	if d.RequiresValue() {
 		return &RequiredValueOption{Definition: d, Value: v, UsesShortName: form == shortForm, Joined: v != nil}, nil
 	}
 	if v != nil {


### PR DESCRIPTION
This PR primarily seeks to break all the conditional branching we were doing in GeneralOption out into specific types to improve overall readability and debuggability, as well as to use the type system to help enforce flags not being misinterpreted when changing them, reading from them, or inspecting them.
