### PR TITLE
Set platform in Action as well as command for workflow actions

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1185,6 +1185,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		// once the timeout has elapsed, but if the CI runner takes too long to
 		// finalize, we can still kill the action.
 		Timeout: durationpb.New(timeout + timeoutGracePeriod),
+		Platform: cmd.GetPlatform(),
 	}
 
 	actionDigest, err := cachetools.UploadProtoToCAS(ctx, cache, instanceName, repb.DigestFunction_BLAKE3, action)

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1184,7 +1184,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		// that we allow the CI runner to finalize the outer workflow invocation
 		// once the timeout has elapsed, but if the CI runner takes too long to
 		// finalize, we can still kill the action.
-		Timeout: durationpb.New(timeout + timeoutGracePeriod),
+		Timeout:  durationpb.New(timeout + timeoutGracePeriod),
 		Platform: cmd.GetPlatform(),
 	}
 


### PR DESCRIPTION
Saw a warning log about this. Context: https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L551