### PR TITLE
[Cache Proxy] Use AC/CAS RPC server interfaces directly instead of invoking client interfaces via self RPC

### DIFF
--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -34,7 +34,7 @@ type ActionCacheServerProxy struct {
 	authenticator  interfaces.Authenticator
 	localCache     interfaces.Cache
 	remoteACClient repb.ActionCacheClient
-	localACClient  repb.ActionCacheClient
+	localACServer  repb.ActionCacheServer
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -56,7 +56,7 @@ func NewActionCacheServerProxy(env environment.Env) (*ActionCacheServerProxy, er
 		authenticator:  env.GetAuthenticator(),
 		localCache:     env.GetCache(),
 		remoteACClient: remoteCache,
-		localACClient:  env.GetLocalActionCacheClient(),
+		localACServer:  env.GetLocalActionCacheServer(),
 	}, nil
 }
 
@@ -150,7 +150,7 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 	}
 
 	if proxy_util.SkipRemote(ctx) {
-		rsp, err := s.localACClient.GetActionResult(ctx, req)
+		rsp, err := s.localACServer.GetActionResult(ctx, req)
 
 		cacheStatus := metrics.MissStatusLabel
 		if err == nil {
@@ -221,7 +221,7 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 func (s *ActionCacheServerProxy) UpdateActionResult(ctx context.Context, req *repb.UpdateActionResultRequest) (*repb.ActionResult, error) {
 	// Only if it's explicitly requested do we cache AC results locally.
 	if proxy_util.SkipRemote(ctx) && !authutil.EncryptionEnabled(ctx, s.authenticator) {
-		resp, err := s.localACClient.UpdateActionResult(ctx, req)
+		resp, err := s.localACServer.UpdateActionResult(ctx, req)
 
 		labels := prometheus.Labels{
 			metrics.StatusLabel:           fmt.Sprintf("%d", gstatus.Code(err)),

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -258,12 +258,12 @@ func registerInternalGRPCServices(grpcServer *grpc.Server, env *real_environment
 	if err != nil {
 		return status.InternalErrorf("CacheProxy: error starting local contentaddressablestorage server: %s", err.Error())
 	}
-	env.SetLocalCASClient(localCAS)
+	env.SetLocalCASServer(localCAS)
 
 	localAC, err := action_cache_server.NewActionCacheServer(env)
 	if err != nil {
 		return status.InternalErrorf("CacheProxy: error starting local actioncache server: %s", err.Error())
 	}
-	env.SetLocalActionCacheClient(localAC)
+	env.SetLocalActionCacheServer(localAC)
 	return nil
 }

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -187,8 +187,6 @@ func startGRPCServers(env *real_environment.RealEnv) error {
 		return status.InternalErrorf("CacheProxy: error starting local bytestream gRPC server: %s", err.Error())
 	}
 	env.SetLocalByteStreamClient(bspb.NewByteStreamClient(conn))
-	env.SetLocalActionCacheClient(repb.NewActionCacheClient(conn))
-	env.SetLocalCASClient(repb.NewContentAddressableStorageClient(conn))
 
 	s, err := grpc_server.New(env, grpc_server.GRPCPort(), false, grpcServerConfig)
 	if err != nil {
@@ -260,12 +258,12 @@ func registerInternalGRPCServices(grpcServer *grpc.Server, env *real_environment
 	if err != nil {
 		return status.InternalErrorf("CacheProxy: error starting local contentaddressablestorage server: %s", err.Error())
 	}
-	repb.RegisterContentAddressableStorageServer(grpcServer, localCAS)
+	env.SetLocalCASClient(localCAS)
 
 	localAC, err := action_cache_server.NewActionCacheServer(env)
 	if err != nil {
 		return status.InternalErrorf("CacheProxy: error starting local actioncache server: %s", err.Error())
 	}
-	repb.RegisterActionCacheServer(grpcServer, localAC)
+	env.SetLocalActionCacheClient(localAC)
 	return nil
 }

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -31,7 +31,7 @@ var enableGetTreeCaching = flag.Bool("cache_proxy.enable_get_tree_caching", fals
 type CASServerProxy struct {
 	atimeUpdater  interfaces.AtimeUpdater
 	authenticator interfaces.Authenticator
-	local         repb.ContentAddressableStorageClient
+	local         repb.ContentAddressableStorageServer
 	remote        repb.ContentAddressableStorageClient
 }
 
@@ -53,7 +53,7 @@ func New(env environment.Env) (*CASServerProxy, error) {
 	if authenticator == nil {
 		return nil, fmt.Errorf("An Authenticator is required to enable the ContentAddressableStorageServerProxy")
 	}
-	local := env.GetLocalCASClient()
+	local := env.GetLocalCASServer()
 	if local == nil {
 		return nil, fmt.Errorf("A local ContentAddressableStorageClient is required to enable the ContentAddressableStorageServerProxy")
 	}

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
@@ -85,7 +85,7 @@ func runRemoteCASS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (*gr
 	return conn, &unaryRequestCounter, &streamRequestCounter
 }
 
-func runLocalCASS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (bspb.ByteStreamClient, repb.ContentAddressableStorageClient) {
+func runLocalCASS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (bspb.ByteStreamClient, repb.ContentAddressableStorageServer) {
 	bs, err := byte_stream_server.NewByteStreamServer(env)
 	require.NoError(t, err)
 	cas, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
@@ -97,7 +97,7 @@ func runLocalCASS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (bspb
 	conn, err := testenv.LocalInternalGRPCConn(ctx, lis)
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
-	return bspb.NewByteStreamClient(conn), repb.NewContentAddressableStorageClient(conn)
+	return bspb.NewByteStreamClient(conn), cas
 }
 
 func runCASProxy(ctx context.Context, clientConn *grpc.ClientConn, env *testenv.TestEnv, t testing.TB) *grpc.ClientConn {
@@ -105,7 +105,7 @@ func runCASProxy(ctx context.Context, clientConn *grpc.ClientConn, env *testenv.
 	env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(clientConn))
 	bs, cas := runLocalCASS(ctx, env, t)
 	env.SetLocalByteStreamClient(bs)
-	env.SetLocalCASClient(cas)
+	env.SetLocalCASServer(cas)
 	casServer, err := New(env)
 	require.NoError(t, err)
 	bsServer, err := byte_stream_server_proxy.New(env)

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -97,11 +97,11 @@ type Env interface {
 	GetSSLService() interfaces.SSLService
 	GetBuildEventServer() pepb.PublishBuildEventServer
 	GetGitHubStatusService() interfaces.GitHubStatusService
-	GetLocalCASClient() repb.ContentAddressableStorageClient
+	GetLocalCASServer() repb.ContentAddressableStorageServer
 	GetCASServer() repb.ContentAddressableStorageServer
 	GetLocalByteStreamClient() bspb.ByteStreamClient
 	GetByteStreamServer() bspb.ByteStreamServer
-	GetLocalActionCacheClient() repb.ActionCacheClient
+	GetLocalActionCacheServer() repb.ActionCacheServer
 	GetActionCacheServer() repb.ActionCacheServer
 	GetPushServer() rapb.PushServer
 	GetFetchServer() rapb.FetchServer

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -94,11 +94,11 @@ type RealEnv struct {
 	sslService                       interfaces.SSLService
 	quotaManager                     interfaces.QuotaManager
 	buildEventServer                 pepb.PublishBuildEventServer
-	localCASClient                   repb.ContentAddressableStorageClient
+	localCASServer                   repb.ContentAddressableStorageServer
 	casServer                        repb.ContentAddressableStorageServer
 	localByteStreamClient            bspb.ByteStreamClient
 	byteStreamServer                 bspb.ByteStreamServer
-	localActionCacheClient           repb.ActionCacheClient
+	localActionCacheServer           repb.ActionCacheServer
 	actionCacheServer                repb.ActionCacheServer
 	pushServer                       rapb.PushServer
 	fetchServer                      rapb.FetchServer
@@ -532,11 +532,11 @@ func (r *RealEnv) SetBuildEventServer(buildEventServer pepb.PublishBuildEventSer
 	r.buildEventServer = buildEventServer
 }
 
-func (r *RealEnv) GetLocalCASClient() repb.ContentAddressableStorageClient {
-	return r.localCASClient
+func (r *RealEnv) GetLocalCASServer() repb.ContentAddressableStorageServer {
+	return r.localCASServer
 }
-func (r *RealEnv) SetLocalCASClient(localCASClient repb.ContentAddressableStorageClient) {
-	r.localCASClient = localCASClient
+func (r *RealEnv) SetLocalCASServer(localCASServer repb.ContentAddressableStorageServer) {
+	r.localCASServer = localCASServer
 }
 
 func (r *RealEnv) GetCASServer() repb.ContentAddressableStorageServer {
@@ -561,11 +561,11 @@ func (r *RealEnv) SetByteStreamServer(byteStreamServer bspb.ByteStreamServer) {
 	r.byteStreamServer = byteStreamServer
 }
 
-func (r *RealEnv) GetLocalActionCacheClient() repb.ActionCacheClient {
-	return r.localActionCacheClient
+func (r *RealEnv) GetLocalActionCacheServer() repb.ActionCacheServer {
+	return r.localActionCacheServer
 }
-func (r *RealEnv) SetLocalActionCacheClient(localClient repb.ActionCacheClient) {
-	r.localActionCacheClient = localClient
+func (r *RealEnv) SetLocalActionCacheServer(localServer repb.ActionCacheServer) {
+	r.localActionCacheServer = localServer
 }
 
 func (r *RealEnv) GetActionCacheServer() repb.ActionCacheServer {


### PR DESCRIPTION
Benchmark results on my local machine (from `benchstat`):

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 7 5800X 8-Core Processor             
                    │   old.txt   │               new.txt               │
                    │   sec/op    │   sec/op     vs base                │
FindMissingBlobs-16   313.4µ ± 8%   301.1µ ± 9%        ~ (p=0.280 n=10)
BatchReadBlobs-16     377.9µ ± 4%   236.6µ ± 7%  -37.39% (p=0.000 n=10)
BatchUpdateBlobs-16   601.8µ ± 6%   461.1µ ± 6%  -23.38% (p=0.000 n=10)
GetTree-16            744.4µ ± 7%   256.3µ ± 6%  -65.56% (p=0.000 n=10)
geomean               479.9µ        302.9µ       -36.88%

                    │    old.txt    │               new.txt                │
                    │     B/op      │     B/op      vs base                │
FindMissingBlobs-16    46.50Ki ± 0%   46.52Ki ± 0%        ~ (p=0.590 n=10)
BatchReadBlobs-16      74.90Ki ± 0%   51.95Ki ± 0%  -30.64% (p=0.000 n=10)
BatchUpdateBlobs-16    127.6Ki ± 0%   104.2Ki ± 0%  -18.34% (p=0.000 n=10)
GetTree-16            122.01Ki ± 0%   61.37Ki ± 0%  -49.70% (p=0.000 n=10)
geomean                85.82Ki        62.70Ki       -26.94%

                    │   old.txt   │               new.txt               │
                    │  allocs/op  │  allocs/op   vs base                │
FindMissingBlobs-16    810.0 ± 0%    809.0 ± 0%        ~ (p=0.370 n=10)
BatchReadBlobs-16     1104.0 ± 0%    710.0 ± 0%  -35.69% (p=0.000 n=10)
BatchUpdateBlobs-16   1.866k ± 0%   1.468k ± 0%  -21.33% (p=0.000 n=10)
GetTree-16            2052.0 ± 0%    989.0 ± 0%  -51.80% (p=0.000 n=10)
geomean               1.360k         955.6       -29.75%
```

Not sure exactly how this will translate to prod load, but results look promising. Will do ByteStream next it's just more work because the server/client interfaces differ more significantly than for unary RPCs.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4782