### PR TITLE
bazelrc: move bzlmod flags out of shared file

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,10 @@ import %workspace%/shared.bazelrc
 # PUBLIC REPO EXCLUSIVE CONFIGS #
 #################################
 
+# TODO(sluongng): Remove this when we migrate to bzlmod
+common --noenable_bzlmod
+common --enable_workspace
+
 # By default, build logs get sent to the production server
 #
 # Note: Use remote.buildbuddy.io and NOT buildbuddy.buildbuddy.io

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -14,8 +14,6 @@ startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 # COMMON FLAGS #
 ################
 
-common --noenable_bzlmod
-common --enable_workspace
 # Avoid being broken by version requirement changes in transitive deps.
 common --check_direct_dependencies=error
 


### PR DESCRIPTION
Move this to repo-specific file so that we can enable bzlmod for each
repo separately.
