### PR TITLE
Revert "[SS] Skip accessing the remote cache when proxy is enabled"

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -129,8 +129,6 @@ go_test(
     ],
     deps = [
         ":firecracker",
-        "//enterprise/server/action_cache_server_proxy",
-        "//enterprise/server/byte_stream_server_proxy",
         "//enterprise/server/clientidentity",
         "//enterprise/server/ociregistry",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/snaputil",
-        "//enterprise/server/util/proxy_util",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -17,7 +17,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/proxy_util"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
@@ -116,7 +115,6 @@ func (l *FileCacheLoader) currentSnapshotVersion(ctx context.Context, key *fcpb.
 		return "", err
 	}
 	rn := digest.NewACResourceName(versionKey, key.InstanceName, repb.DigestFunction_BLAKE3)
-	ctx = proxy_util.SetSkipRemote(ctx)
 	acResult, err := cachetools.GetActionResult(ctx, l.env.GetActionCacheClient(), rn)
 	if status.IsNotFoundError(err) {
 		// Version metadata might not exist in the cache if:
@@ -439,12 +437,6 @@ func (l *FileCacheLoader) fetchRemoteManifest(ctx context.Context, key *fcpb.Sna
 		return nil, err
 	}
 	rn := digest.NewACResourceName(manifestKey, key.InstanceName, repb.DigestFunction_BLAKE3)
-
-	// If the proxy is enabled, skip writing snapshots to the remote cache to minimize
-	// high network transfer. Snapshots can't be shared across different machine
-	// types, so there's no reason to support snapshot sharing across clusters.
-	ctx = proxy_util.SetSkipRemote(ctx)
-
 	acResult, err := cachetools.GetActionResult(ctx, l.env.GetActionCacheClient(), rn)
 	if err != nil {
 		return nil, err
@@ -724,7 +716,6 @@ func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotK
 func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.SnapshotKey, ar *repb.ActionResult, opts *CacheSnapshotOptions) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
-	ctx = proxy_util.SetSkipRemote(ctx)
 	b, err := proto.Marshal(ar)
 	if err != nil {
 		return err
@@ -1072,8 +1063,6 @@ func (l *SnapshotService) InvalidateSnapshot(ctx context.Context, key *fcpb.Snap
 	}
 
 	acDigest := digest.NewACResourceName(versionKey, key.InstanceName, repb.DigestFunction_BLAKE3)
-
-	ctx = proxy_util.SetSkipRemote(ctx)
 	if err := cachetools.UploadActionResult(ctx, l.env.GetActionCacheClient(), acDigest, versionMetadataActionResult); err != nil {
 		return "", err
 	}

--- a/enterprise/server/remote_execution/snaputil/BUILD
+++ b/enterprise/server/remote_execution/snaputil/BUILD
@@ -7,7 +7,6 @@ go_library(
     srcs = ["snaputil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil",
     deps = [
-        "//enterprise/server/util/proxy_util",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/metrics",

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/proxy_util"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
@@ -99,12 +98,6 @@ func GetArtifact(ctx context.Context, localCache interfaces.FileCache, bsClient 
 		return 0, err
 	}
 	defer f.Close()
-
-	// If the proxy is enabled, snapshots are not saved to the remote cache to minimize
-	// high network transfer. Snapshots can't be shared across different machine
-	// types, so there's no reason to support snapshot sharing across clusters.
-	ctx = proxy_util.SetSkipRemote(ctx)
-
 	r := digest.NewCASResourceName(d, instanceName, repb.DigestFunction_BLAKE3)
 	r.SetCompressor(repb.Compressor_ZSTD)
 	if err := cachetools.GetBlob(ctx, bsClient, r, f); err != nil {
@@ -170,12 +163,6 @@ func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytest
 		return 0, err
 	}
 	defer file.Close()
-
-	// If the proxy is enabled, skip writing snapshots to the remote cache to minimize
-	// high network transfer. Snapshots can't be shared across different machine
-	// types, so there's no reason to support snapshot sharing across clusters.
-	ctx = proxy_util.SetSkipRemote(ctx)
-
 	_, bytesUploaded, err := cachetools.UploadFromReader(ctx, bsClient, rn, file)
 	if err == nil && bytesUploaded > 0 {
 		metrics.SnapshotRemoteCacheUploadSizeBytes.With(prometheus.Labels{


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#9000

When looking at the metrics, I was surprised to see "local-only" requests already being made. This was only intended for snapshots, but is currently being applied to FC RBE actions run on proxies. I'll re-apply the PR to only add the header for workflows / remote bazel