### PR TITLE
[ci_runner] Add explicit logs when starting from a clean runner vs snapshot

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1738,6 +1738,7 @@ func (ws *workspace) setup(ctx context.Context) error {
 		return status.WrapErrorf(err, "stat %q", repoDirName)
 	}
 	if repoDirInfo != nil {
+		writeCommandSummary(ws.log, "Starting from a recycled runner")
 		writeCommandSummary(ws.log, "Syncing existing repo...")
 		if err := os.Chdir(repoDirName); err != nil {
 			return status.WrapError(err, "cd")
@@ -1761,6 +1762,8 @@ func (ws *workspace) setup(ctx context.Context) error {
 			return status.WrapErrorf(err, "rm -rf %q", repoDirName)
 		}
 	}
+
+	writeCommandSummary(ws.log, "Starting from a clean runner")
 
 	if err := os.Mkdir(repoDirName, 0777); err != nil {
 		return status.WrapErrorf(err, "mkdir %q", repoDirName)

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1737,8 +1737,14 @@ func (ws *workspace) setup(ctx context.Context) error {
 	if err != nil && !os.IsNotExist(err) {
 		return status.WrapErrorf(err, "stat %q", repoDirName)
 	}
-	if repoDirInfo != nil {
+	repoAlreadyCloned := repoDirInfo != nil
+	if repoAlreadyCloned {
 		writeCommandSummary(ws.log, "Starting from a recycled runner")
+	} else {
+		writeCommandSummary(ws.log, "Starting from a clean runner")
+	}
+
+	if repoAlreadyCloned {
 		writeCommandSummary(ws.log, "Syncing existing repo...")
 		if err := os.Chdir(repoDirName); err != nil {
 			return status.WrapError(err, "cd")
@@ -1762,8 +1768,6 @@ func (ws *workspace) setup(ctx context.Context) error {
 			return status.WrapErrorf(err, "rm -rf %q", repoDirName)
 		}
 	}
-
-	writeCommandSummary(ws.log, "Starting from a clean runner")
 
 	if err := os.Mkdir(repoDirName, 0777); err != nil {
 		return status.WrapErrorf(err, "mkdir %q", repoDirName)


### PR DESCRIPTION
Follow up from https://github.com/buildbuddy-io/buildbuddy/pull/9037