### PR TITLE
Add local-rbe config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,9 +39,6 @@ common:target-linux-arm64 --config=workspace-target-linux-arm64
 # These often require "include-secrets: true" exec property in their BUILD file.
 test --test_tag_filters=-docker,-bare,-secrets
 
-# Build with --config=local to send build logs to your local server
-common:local --extra_execution_platforms=@buildbuddy_toolchain//:platform
-
 # Configuration used for GitHub actions-based CI
 common:ci --config=remote-minimal
 common:ci --build_metadata=ROLE=CI

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -155,6 +155,20 @@ common:authed-bes --bes_backend=grpcs://buildbuddy.buildbuddy.io
 common:local --bes_results_url=http://localhost:8080/invocation/
 common:local --bes_backend=grpc://localhost:1985
 common:local --remote_cache=grpc://localhost:1985
+common:local --config=cache-shared
+
+# Build with --config=local-rbe-linux to target a local linux executor, using
+# BuildBuddy's RBE container image (x86_64 only for now). For this to work, the
+# local executor must have an isolation type enabled which supports
+# containerized execution, such as docker (the default), podman, or oci.
+common:local-rbe-linux --remote_executor=grpc://localhost:1985
+common:local-rbe-linux --config=target-linux-x86
+common:local-rbe-linux --config=local
+
+# Build with --config=local-rbe-mac to target a local executor on macOS.
+common:local-rbe-mac --remote_executor=grpc://localhost:1985
+common:local-rbe-mac --config=local-rbe
+common:local-rbe-mac --config=local
 
 # Build with --config=dev to send build logs to the dev server
 common:dev --bes_results_url=https://buildbuddy.buildbuddy.dev/invocation/


### PR DESCRIPTION
Similar to https://github.com/buildbuddy-io/buildbuddy/pull/8672/files but adds separate configs for macos and linux.

I don't see an easy way to make `--config=local-rbe` "just work" regardless of platform, so the proposed setup in this PR is that we'll run with either `--config=local-rbe-linux` or `--config=local-rbe-mac` if we want to run with local RBE.