### PR TITLE
vfs: add some stuff neededed by overlayfs

### DIFF
--- a/enterprise/server/remote_execution/vfs/BUILD
+++ b/enterprise/server/remote_execution/vfs/BUILD
@@ -25,6 +25,7 @@ go_library(
             "@com_github_hanwen_go_fuse_v2//fs",
             "@com_github_hanwen_go_fuse_v2//fuse",
             "@org_golang_google_grpc//status",
+            "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:darwin_arm64": [
             "//proto:vfs_go_proto",
@@ -34,6 +35,7 @@ go_library(
             "@com_github_hanwen_go_fuse_v2//fs",
             "@com_github_hanwen_go_fuse_v2//fuse",
             "@org_golang_google_grpc//status",
+            "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:linux_amd64": [
             "//proto:vfs_go_proto",
@@ -43,6 +45,7 @@ go_library(
             "@com_github_hanwen_go_fuse_v2//fs",
             "@com_github_hanwen_go_fuse_v2//fuse",
             "@org_golang_google_grpc//status",
+            "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:linux_arm64": [
             "//proto:vfs_go_proto",
@@ -52,6 +55,7 @@ go_library(
             "@com_github_hanwen_go_fuse_v2//fs",
             "@com_github_hanwen_go_fuse_v2//fuse",
             "@org_golang_google_grpc//status",
+            "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:windows_amd64": [
             "//proto:vfs_go_proto",

--- a/enterprise/server/remote_execution/vfs/vfs_test.go
+++ b/enterprise/server/remote_execution/vfs/vfs_test.go
@@ -379,6 +379,8 @@ func TestSymlinks(t *testing.T) {
 
 type rawStats struct {
 	Ino       uint64
+	Mode      uint32
+	Rdev      uint64
 	Nlink     uint64
 	Atime     time.Time
 	Mtime     time.Time
@@ -391,6 +393,8 @@ func toRawStats(fi fs.FileInfo) *rawStats {
 	rs := fi.Sys().(*syscall.Stat_t)
 	return &rawStats{
 		Ino:       rs.Ino,
+		Mode:      rs.Mode,
+		Rdev:      rs.Rdev,
 		Nlink:     uint64(rs.Nlink),
 		Mtime:     time.Unix(rs.Mtim.Sec, rs.Mtim.Nsec),
 		Atime:     time.Unix(rs.Atim.Sec, rs.Atim.Nsec),
@@ -852,4 +856,40 @@ func TestComputeStats(t *testing.T) {
 	require.EqualValues(t, 1, stats.FileDownloadCount)
 	require.EqualValues(t, 100, stats.FileDownloadSizeBytes)
 	require.Greater(t, stats.FileDownloadDurationUsec, int64(0))
+}
+
+func TestRenameWhiteout(t *testing.T) {
+	fsPath := setupVFS(t)
+
+	testFile := filepath.Join(fsPath, "hello.txt")
+	f, err := os.Create(testFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	newPath := filepath.Join(fsPath, "bye.txt")
+	err = unix.Renameat2(0, testFile, 0, newPath, unix.RENAME_WHITEOUT)
+	require.NoError(t, err)
+
+	rs := rawStat(t, testFile)
+	require.EqualValues(t, unix.S_IFCHR, rs.Mode&unix.S_IFMT)
+	require.EqualValues(t, 0, rs.Rdev)
+
+	rs = rawStat(t, newPath)
+	require.EqualValues(t, unix.S_IFREG, rs.Mode&unix.S_IFMT)
+}
+
+func TestMknod(t *testing.T) {
+	fsPath := setupVFS(t)
+
+	testFile := filepath.Join(fsPath, "hello.txt")
+	err := unix.Mknod(testFile, unix.S_IFREG, 0)
+	require.NoError(t, err)
+	rs := rawStat(t, testFile)
+	require.EqualValues(t, unix.S_IFREG, rs.Mode&unix.S_IFMT)
+
+	testCharDevice := filepath.Join(fsPath, "char")
+	err = unix.Mknod(testCharDevice, unix.S_IFCHR, 0)
+	require.NoError(t, err)
+	rs = rawStat(t, testCharDevice)
+	require.EqualValues(t, unix.S_IFCHR, rs.Mode&unix.S_IFMT)
 }

--- a/enterprise/server/remote_execution/vfs/vfs_unix.go
+++ b/enterprise/server/remote_execution/vfs/vfs_unix.go
@@ -5,6 +5,7 @@ package vfs
 import (
 	"context"
 	"fmt"
+	"golang.org/x/sys/unix"
 	"os"
 	"path/filepath"
 	"slices"
@@ -738,6 +739,37 @@ func (n *Node) Create(ctx context.Context, name string, flags uint32, mode uint3
 	return inode, rf, 0, 0
 }
 
+func (n *Node) Mknod(ctx context.Context, name string, mode uint32, dev uint32, out *fuse.EntryOut) (node *fs.Inode, errno syscall.Errno) {
+	if n.vfs.verbose {
+		newPath := filepath.Join(n.relativePath(), name)
+		log.CtxDebugf(n.vfs.rpcCtx, "Mknod %q mode %s dev %d", newPath, modeDebugString(mode), dev)
+		defer func() {
+			if errno == 0 {
+				log.CtxDebugf(n.vfs.rpcCtx, "Mknod %q: %s", newPath, attrDebugString(node, &out.Attr))
+			} else {
+				log.CtxDebugf(n.vfs.rpcCtx, "Mknod %q: %s", newPath, errno)
+			}
+		}()
+	}
+
+	rsp, err := n.vfs.vfsClient.Mknod(n.vfs.getRPCContext(), &vfspb.MknodRequest{
+		ParentId: n.StableAttr().Ino,
+		Name:     name,
+		Mode:     mode,
+		Dev:      dev,
+	})
+	if err != nil {
+		return nil, rpcErrToSyscallErrno(err)
+	}
+
+	fillFuseAttr(&out.Attr, rsp.GetAttrs())
+
+	child := &Node{vfs: n.vfs}
+	inode := n.vfs.root.NewInode(ctx, child, fs.StableAttr{Mode: mode, Ino: rsp.GetId()})
+
+	return inode, 0
+}
+
 func (n *Node) CopyFileRange(ctx context.Context, fhIn fs.FileHandle, offIn uint64, out *fs.Inode, fhOut fs.FileHandle, offOut uint64, len uint64, flags uint64) (uint32, syscall.Errno) {
 	n.startOP("CopyFileRange")
 	n.resetCachedAttrs()
@@ -770,7 +802,7 @@ func (n *Node) CopyFileRange(ctx context.Context, fhIn fs.FileHandle, offIn uint
 	return rsp.GetNumBytesCopied(), fs.OK
 }
 
-func (n *Node) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
+func (n *Node) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) (errno syscall.Errno) {
 	n.startOP("Rename")
 	newParentNode, ok := newParent.EmbeddedInode().Operations().(*Node)
 	if !ok {
@@ -778,7 +810,16 @@ func (n *Node) Rename(ctx context.Context, name string, newParent fs.InodeEmbedd
 		return syscall.EINVAL
 	}
 	if n.vfs.verbose {
-		log.CtxDebugf(n.vfs.rpcCtx, "Rename %q => %q", filepath.Join(n.relativePath(), name), filepath.Join(newParentNode.relativePath(), newName))
+		oldPath := filepath.Join(n.relativePath(), name)
+		newPath := filepath.Join(newParentNode.relativePath(), newName)
+		log.CtxDebugf(n.vfs.getRPCContext(), "Rename %q => %q (flags %x)", oldPath, newPath, flags)
+		defer func() {
+			if errno == 0 {
+				log.CtxDebugf(n.vfs.getRPCContext(), "Rename %q => %q: OK", oldPath, newPath)
+			} else {
+				log.CtxDebugf(n.vfs.getRPCContext(), "Rename %q => %q: %s", oldPath, newPath, errno)
+			}
+		}()
 	}
 
 	_, err := n.vfs.vfsClient.Rename(n.vfs.getRPCContext(), &vfspb.RenameRequest{
@@ -786,6 +827,7 @@ func (n *Node) Rename(ctx context.Context, name string, newParent fs.InodeEmbedd
 		OldName:     name,
 		NewParentId: newParent.EmbeddedInode().StableAttr().Ino,
 		NewName:     newName,
+		Flags:       flags,
 	})
 	if err != nil {
 		return rpcErrToSyscallErrno(err)
@@ -810,7 +852,29 @@ func fillFuseAttr(out *fuse.Attr, attr *vfspb.Attrs) {
 }
 
 func attrDebugString(n *fs.Inode, attr *fuse.Attr) string {
-	return fmt.Sprintf("ino %d size %d mode %#o num links %d", n.StableAttr().Ino, attr.Size, attr.Mode, attr.Nlink)
+	return fmt.Sprintf("ino %d size %d mode %s num links %d", n.StableAttr().Ino, attr.Size, modeDebugString(attr.Mode), attr.Nlink)
+}
+
+func modeDebugString(mode uint32) string {
+	typ := "<UNKNOWN %d>"
+	switch mode & unix.S_IFMT {
+	case unix.S_IFBLK:
+		typ = "S_IFBLK"
+	case unix.S_IFCHR:
+		typ = "S_IFCHR"
+	case unix.S_IFIFO:
+		typ = "S_IFIFO"
+	case unix.S_IFREG:
+		typ = "S_IFREG"
+	case unix.S_IFSOCK:
+		typ = "S_IFSOCK"
+	case unix.S_IFDIR:
+		typ = "S_IFDIR"
+	default:
+		typ = fmt.Sprintf("<UNKNOWN TYPE %d>", mode&unix.S_IFMT)
+	}
+
+	return fmt.Sprintf("%s %#o", typ, mode & ^uint32(unix.S_IFMT))
 }
 
 func (n *Node) getattr() (*vfspb.Attrs, error) {
@@ -1257,5 +1321,6 @@ func (n *Node) Statfs(ctx context.Context, out *fuse.StatfsOut) syscall.Errno {
 	out.Blocks = rsp.TotalBlocks
 	out.Bavail = rsp.BlocksAvailable
 	out.Bfree = rsp.BlocksFree
+	out.NameLen = 255
 	return fs.OK
 }

--- a/enterprise/server/remote_execution/vfs/vfs_unix.go
+++ b/enterprise/server/remote_execution/vfs/vfs_unix.go
@@ -5,7 +5,6 @@ package vfs
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sys/unix"
 	"os"
 	"path/filepath"
 	"slices"
@@ -14,6 +13,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"

--- a/proto/vfs.proto
+++ b/proto/vfs.proto
@@ -81,6 +81,18 @@ message GetDirectoryContentsResponse {
   repeated Node nodes = 1;
 }
 
+message MknodRequest {
+  uint64 parent_id = 1;
+  string name = 2;
+  uint32 mode = 3;
+  uint32 dev = 4;
+}
+
+message MknodResponse {
+  uint64 id = 1;
+  Attrs attrs = 2;
+}
+
 message CreateRequest {
   uint64 parent_id = 1;
   string name = 2;
@@ -227,6 +239,7 @@ message RenameRequest {
   string old_name = 2;
   uint64 new_parent_id = 3;
   string new_name = 4;
+  uint32 flags = 5;
 }
 
 message RenameResponse {}
@@ -318,6 +331,9 @@ service FileSystem {
   rpc Lookup(LookupRequest) returns (LookupResponse);
   rpc GetDirectoryContents(GetDirectoryContentsRequest)
       returns (GetDirectoryContentsResponse);
+
+  // Mknod creates a file system node of a specific type.
+  rpc Mknod(MknodRequest) returns (MknodResponse);
 
   // Create creates a file and returns a file handle.
   rpc Create(CreateRequest) returns (CreateResponse);


### PR DESCRIPTION
overlayfs uses Mknod to create regular files and character files for "whiteouts". It also uses the rename flag RENAME_WHITEOUT to leave a whiteout marker on renames.