### PR TITLE
cli/printlog: vibe coding

### DIFF
--- a/cli/printlog/compact/compact.go
+++ b/cli/printlog/compact/compact.go
@@ -9,6 +9,10 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -79,6 +83,9 @@ func PrintCompactExecLog(path string, raw bool, sort bool) error {
 		if err != nil {
 			return fmt.Errorf("failed getting spawn exec: %s", err)
 		}
+		if s == nil { // Skip non-spawn entries after processing
+			continue
+		}
 		if sort {
 			spawns = append(spawns, s)
 			continue
@@ -119,7 +126,7 @@ func StableSortExec(spawns []*spb.SpawnExec, forEachFn func(*spb.SpawnExec) erro
 	blockedBy := newSpawnSetMultiMap()
 	blocking := newSpawnSetMultiMap()
 
-	queue := make(priorityQueue, 0, len(spawns))
+	queue := make(PriorityQueue, 0, len(spawns))
 
 	for _, s := range spawns {
 		blocked := false
@@ -152,14 +159,25 @@ func StableSortExec(spawns []*spb.SpawnExec, forEachFn func(*spb.SpawnExec) erro
 	return nil
 }
 
-// priorityQueue implements container/heap.PriorityQueue
-type priorityQueue []*spb.SpawnExec
+// RelPath calculates the relative path from base to target.
+// It uses filepath.Rel for potentially better cross-platform handling,
+// although Bazel paths typically use '/'.
+func RelPath(basepath, targpath string) (string, error) {
+	// Ensure forward slashes for consistency before using filepath.Rel,
+	// as filepath.Rel might behave differently based on OS separators.
+	basepath = filepath.ToSlash(basepath)
+	targpath = filepath.ToSlash(targpath)
+	return filepath.Rel(basepath, targpath)
+}
 
-func (q priorityQueue) Len() int {
+// priorityQueue implements container/heap.PriorityQueue
+type PriorityQueue []*spb.SpawnExec
+
+func (q PriorityQueue) Len() int {
 	return len(q)
 }
 
-func (q priorityQueue) Less(i, j int) bool {
+func (q PriorityQueue) Less(i, j int) bool {
 	return toCompareString(q[i]) < toCompareString(q[j])
 }
 
@@ -179,22 +197,28 @@ func toCompareString(s *spb.SpawnExec) string {
 		Inputs:               s.GetInputs(),
 		Mnemonic:             s.GetMnemonic(),
 	}
+	// Sort inputs by path for stability when comparing stripped proto strings
+	inputFiles := make([]*spb.File, len(stripped.Inputs))
+	copy(inputFiles, stripped.Inputs)
+
+	sort.Slice(inputFiles, func(i, j int) bool {
+		return inputFiles[i].GetPath() < inputFiles[j].GetPath()
+	})
+	stripped.Inputs = inputFiles
+
 	return "2_" + stripped.String()
 }
 
-func (q priorityQueue) Swap(i, j int) {
+func (q PriorityQueue) Swap(i, j int) {
 	q[i], q[j] = q[j], q[i]
 }
 
-func (q *priorityQueue) Push(s any) {
-	if len(*q) == 0 {
-		*q = []*spb.SpawnExec{s.(*spb.SpawnExec)}
-		return
-	}
-	*q = append(*q, s.(*spb.SpawnExec))
+func (q *PriorityQueue) Push(s any) {
+	item := s.(*spb.SpawnExec)
+	*q = append(*q, item)
 }
 
-func (q *priorityQueue) Pop() any {
+func (q *PriorityQueue) Pop() any {
 	old := *q
 	n := len(old)
 	s := old[n-1]
@@ -247,11 +271,18 @@ func (ismm spawnSetMultiMap) remove(key *spb.SpawnExec, val *spb.SpawnExec) {
 type SpawnLogReconstructor struct {
 	input protodelim.Reader
 
-	hashFunc string
-	files    map[uint32]*spb.File
-	dirs     map[uint32]*reconstructedDir
-	symlinks map[uint32]*spb.File
-	sets     map[uint32]*spb.ExecLogEntry_InputSet
+	// Invocation info
+	hashFunc             string
+	workspaceRunfilesDir string
+	siblingRepoLayout    bool
+
+	// Stored entries by ID
+	files            map[uint32]*spb.File
+	dirs             map[uint32]*reconstructedDir
+	symlinks         map[uint32]*spb.File
+	sets             map[uint32]*spb.ExecLogEntry_InputSet
+	symlinkEntrySets map[uint32]*spb.ExecLogEntry_SymlinkEntrySet
+	runfilesTrees    map[uint32]*reconstructedDir // Store reconstructed RunfilesTree as a directory
 }
 
 type reconstructedDir struct {
@@ -259,17 +290,26 @@ type reconstructedDir struct {
 	files []*spb.File
 }
 
+// SymlinkConsumer is a callback function to process reconstructed symlink entries.
+// It receives the path relative to the runfiles tree root and the reconstructed target files. Return error to stop processing.
+type SymlinkConsumer func(rootRelativePath string, targetFiles []*spb.File) error
+
 func NewSpawnLogReconstructor(input protodelim.Reader) *SpawnLogReconstructor {
 	return &SpawnLogReconstructor{
-		input:    input,
-		hashFunc: "",
-		files:    make(map[uint32]*spb.File),
-		dirs:     make(map[uint32]*reconstructedDir),
-		symlinks: make(map[uint32]*spb.File),
-		sets:     make(map[uint32]*spb.ExecLogEntry_InputSet),
+		input:            input,
+		hashFunc:         "", // Will be set by Invocation message
+		files:            make(map[uint32]*spb.File),
+		dirs:             make(map[uint32]*reconstructedDir),
+		symlinks:         make(map[uint32]*spb.File),
+		sets:             make(map[uint32]*spb.ExecLogEntry_InputSet),
+		symlinkEntrySets: make(map[uint32]*spb.ExecLogEntry_SymlinkEntrySet),
+		runfilesTrees:    make(map[uint32]*reconstructedDir),
 	}
 }
 
+// GetSpawnExec reads the next log entry. If it's a Spawn, it reconstructs and
+// returns it. If it's another entry type, it stores it for future reference and
+// returns nil. Returns io.EOF when the log ends.
 func (slr *SpawnLogReconstructor) GetSpawnExec() (*spb.SpawnExec, error) {
 	entry := &spb.ExecLogEntry{}
 	for {
@@ -284,24 +324,54 @@ func (slr *SpawnLogReconstructor) GetSpawnExec() (*spb.SpawnExec, error) {
 		switch e := entry.GetType().(type) {
 		case *spb.ExecLogEntry_Invocation_:
 			slr.hashFunc = e.Invocation.GetHashFunctionName()
+			slr.workspaceRunfilesDir = e.Invocation.GetWorkspaceRunfilesDirectory()
+			slr.siblingRepoLayout = e.Invocation.GetSiblingRepositoryLayout()
 		case *spb.ExecLogEntry_File_:
-			slr.files[entry.GetId()] = reconstructFile(nil, e.File)
+			// Store file, applying hash function if digest exists
+			fileEntry := reconstructFile(nil, e.File)
+			if fileEntry.GetDigest() != nil && fileEntry.GetDigest().GetHashFunctionName() == "" {
+				fileEntry.Digest.HashFunctionName = slr.hashFunc
+			}
+			slr.files[entry.GetId()] = fileEntry
 		case *spb.ExecLogEntry_Directory_:
-			slr.dirs[entry.GetId()] = reconstructDir(e.Directory)
+			// Store reconstructed directory, applying hash function to contained files
+			dirEntry := reconstructDir(e.Directory)
+			for _, f := range dirEntry.files {
+				if f.GetDigest() != nil && f.GetDigest().GetHashFunctionName() == "" {
+					f.Digest.HashFunctionName = slr.hashFunc
+				}
+			}
+			slr.dirs[entry.GetId()] = dirEntry
 		case *spb.ExecLogEntry_UnresolvedSymlink_:
 			slr.symlinks[entry.GetId()] = reconstructSymlink(e.UnresolvedSymlink)
 		case *spb.ExecLogEntry_InputSet_:
 			slr.sets[entry.GetId()] = e.InputSet
 		case *spb.ExecLogEntry_Spawn_:
-			return slr.reconstructSpawn(e.Spawn), nil
+			// Reconstruct and return the SpawnExec
+			spawnExec := slr.reconstructSpawn(e.Spawn)
+			// Apply hash function to action digest if present
+			if spawnExec.GetDigest() != nil && spawnExec.GetDigest().GetHashFunctionName() == "" {
+				spawnExec.Digest.HashFunctionName = slr.hashFunc
+			}
+			return spawnExec, nil // Return the reconstructed spawn
 		case *spb.ExecLogEntry_SymlinkAction_:
-			// TODO: Handle symlink actions
+			// Symlink actions are not represented in the expanded SpawnExec format.
+			log.Debugf("Skipping SymlinkAction entry ID %d", entry.GetId())
 		case *spb.ExecLogEntry_SymlinkEntrySet_:
-			// TODO: Handle symlink entry sets
+			// Store the set for potential use by RunfilesTree reconstruction
+			slr.symlinkEntrySets[entry.GetId()] = e.SymlinkEntrySet
+			log.Debugf("Stored SymlinkEntrySet entry ID %d", entry.GetId())
 		case *spb.ExecLogEntry_RunfilesTree_:
-			// TODO: Handle runfiles trees
+			// Reconstruct the RunfilesTree into a directory representation
+			reconstructed, err := slr.reconstructRunfilesDir(e.RunfilesTree)
+			if err != nil {
+				log.Warnf("Failed to reconstruct RunfilesTree entry ID %d: %v. Skipping.", entry.GetId(), err)
+				continue // Skip storing if reconstruction fails
+			}
+			slr.runfilesTrees[entry.GetId()] = reconstructed
+			log.Debugf("Reconstructed and stored RunfilesTree entry ID %d as directory %s", entry.GetId(), reconstructed.path)
 		default:
-			log.Warnf("unknown exec log entry: %v", entry)
+			log.Warnf("Unknown exec log entry type: %T (ID: %d)", entry.GetType(), entry.GetId())
 		}
 	}
 }
@@ -322,59 +392,105 @@ func (slr *SpawnLogReconstructor) reconstructSpawn(s *spb.ExecLogEntry_Spawn) *s
 		TimeoutMillis:        s.GetTimeoutMillis(),
 		Metrics:              s.GetMetrics(),
 		Platform:             s.GetPlatform(),
-		Digest:               s.GetDigest(),
+		Digest:               s.GetDigest(), // Hash function name applied in GetSpawnExec
 	}
 
-	// Handle inputs
+	// Handle inputs (including deprecated fields)
 	order, inputs := slr.reconstructInputs(s.GetInputSetId())
 	_, toolInputs := slr.reconstructInputs(s.GetToolSetId())
 	var spawnInputs []*spb.File
+	visitedInputPaths := make(map[string]struct{}) // Avoid duplicates from different IDs mapping to same effective input
 	for _, path := range order {
-		file := inputs[path]
+		if _, visited := visitedInputPaths[path]; visited {
+			continue
+		}
+		file := proto.Clone(inputs[path]).(*spb.File) // Clone to safely modify IsTool
 		if _, ok := toolInputs[path]; ok {
 			file.IsTool = true
 		}
 		spawnInputs = append(spawnInputs, file)
+		visitedInputPaths[path] = struct{}{}
 	}
 	se.Inputs = spawnInputs
 
-	// Handle outputs
+	// Handle outputs (including deprecated fields)
 	var listedOutputs []string
 	var actualOutputs []*spb.File
+	outputPaths := make(map[string]struct{}) // Track paths added to avoid duplicates
+
+	addOutput := func(f *spb.File) {
+		if _, exists := outputPaths[f.GetPath()]; !exists {
+			actualOutputs = append(actualOutputs, f)
+			outputPaths[f.GetPath()] = struct{}{}
+		}
+	}
+
 	for _, output := range s.GetOutputs() {
 		switch o := output.GetType().(type) {
+		// Modern field first
 		case *spb.ExecLogEntry_Output_OutputId:
+			listedPath := ""
 			if f, ok := slr.files[o.OutputId]; ok {
-				listedOutputs = append(listedOutputs, f.GetPath())
-				actualOutputs = append(actualOutputs, f)
-				continue
+				listedPath = f.GetPath()
+				addOutput(f)
+			} else if d, ok := slr.dirs[o.OutputId]; ok {
+				listedPath = d.path
+				for _, df := range d.files {
+					addOutput(df)
+				}
+			} else if symlink, ok := slr.symlinks[o.OutputId]; ok {
+				listedPath = symlink.GetPath()
+				addOutput(symlink)
+			} else if rft, ok := slr.runfilesTrees[o.OutputId]; ok {
+				listedPath = rft.path
+				for _, rfFile := range rft.files {
+					addOutput(rfFile)
+				}
+			} else {
+				log.Warnf("Output ID %d referenced in spawn not found in stored entries.", o.OutputId)
+				continue // Skip if ID is invalid
 			}
-			if d, ok := slr.dirs[o.OutputId]; ok {
-				listedOutputs = append(listedOutputs, d.path)
-				actualOutputs = append(actualOutputs, d.files...)
-				continue
-			}
-			if symlink, ok := slr.symlinks[o.OutputId]; ok {
-				listedOutputs = append(listedOutputs, symlink.GetPath())
-				actualOutputs = append(actualOutputs, symlink)
-				continue
-			}
+			listedOutputs = append(listedOutputs, listedPath)
+
+		// Deprecated fields (handle if modern field wasn't used)
 		case *spb.ExecLogEntry_Output_FileId:
-			f := slr.files[o.FileId]
-			listedOutputs = append(listedOutputs, f.GetPath())
-			actualOutputs = append(actualOutputs, f)
+			if f, ok := slr.files[o.FileId]; ok {
+				listedOutputs = append(listedOutputs, f.GetPath())
+				addOutput(f)
+			} else {
+				log.Warnf("Deprecated Output FileId %d referenced in spawn not found.", o.FileId)
+			}
 		case *spb.ExecLogEntry_Output_DirectoryId:
-			d := slr.dirs[o.DirectoryId]
-			listedOutputs = append(listedOutputs, d.path)
-			actualOutputs = append(actualOutputs, d.files...)
+			if d, ok := slr.dirs[o.DirectoryId]; ok {
+				listedOutputs = append(listedOutputs, d.path)
+				for _, df := range d.files {
+					addOutput(df)
+				}
+			} else {
+				// Check if it's a RunfilesTree (handled similar to Directory for outputs)
+				if rft, ok := slr.runfilesTrees[o.DirectoryId]; ok {
+					listedOutputs = append(listedOutputs, rft.path)
+					for _, rfFile := range rft.files {
+						addOutput(rfFile)
+					}
+				} else {
+					log.Warnf("Deprecated Output DirectoryId %d referenced in spawn not found.", o.DirectoryId)
+				}
+			}
 		case *spb.ExecLogEntry_Output_UnresolvedSymlinkId:
-			symlink := slr.symlinks[o.UnresolvedSymlinkId]
-			listedOutputs = append(listedOutputs, symlink.GetPath())
-			actualOutputs = append(actualOutputs, symlink)
+			if symlink, ok := slr.symlinks[o.UnresolvedSymlinkId]; ok {
+				listedOutputs = append(listedOutputs, symlink.GetPath())
+				addOutput(symlink)
+			} else {
+				log.Warnf("Deprecated Output UnresolvedSymlinkId %d referenced in spawn not found.", o.UnresolvedSymlinkId)
+			}
+
+		// Invalid path
 		case *spb.ExecLogEntry_Output_InvalidOutputPath:
 			listedOutputs = append(listedOutputs, o.InvalidOutputPath)
+
 		default:
-			log.Warnf("unknown output type: %v", output)
+			log.Warnf("Unknown output type in spawn: %T", output.GetType())
 		}
 	}
 	se.ListedOutputs = listedOutputs
@@ -384,94 +500,597 @@ func (slr *SpawnLogReconstructor) reconstructSpawn(s *spb.ExecLogEntry_Spawn) *s
 }
 
 func (slr *SpawnLogReconstructor) reconstructInputs(setID uint32) ([]string, map[string]*spb.File) {
-	var order []string
+	// This function retains support for deprecated fields `file_ids`, etc.
+	order := []string{}
 	inputs := make(map[string]*spb.File)
-	var setsToVisit []uint32
-	visited := make(map[uint32]struct{})
+	setsToVisit := []uint32{} // Acts like a stack for the first pass
+	visitedSets := make(map[uint32]struct{})
+	visitedInputs := make(map[uint32]struct{}) // Track individual input IDs
+
 	if setID != 0 {
 		setsToVisit = append(setsToVisit, setID)
-		visited[setID] = struct{}{}
+		visitedSets[setID] = struct{}{}
 	}
+
+	postOrderSets := []uint32{}                    // To store the set IDs in post-order
+	processedForPostOrder := make(map[uint32]bool) // Track sets added to post-order list
+
+	// Iterative approach similar to Java's first pass (building post-order list)
 	for len(setsToVisit) > 0 {
-		currentID := setsToVisit[0]
-		setsToVisit = setsToVisit[1:]
-		set := slr.sets[currentID]
+		currentSetID := setsToVisit[len(setsToVisit)-1] // Peek top of stack
 
-		for _, setID := range set.GetTransitiveSetIds() {
-			if _, ok := visited[setID]; ok {
-				continue
+		set, ok := slr.sets[currentSetID]
+		// Handle missing set gracefully during post-order construction
+		if !ok {
+			if !processedForPostOrder[currentSetID] { // Avoid adding multiple times if referenced multiple times
+				log.Warnf("InputSet ID %d referenced but not found during post-order build.", currentSetID)
+				postOrderSets = append(postOrderSets, currentSetID) // Add to post-order to maintain structure
+				processedForPostOrder[currentSetID] = true
 			}
-			visited[setID] = struct{}{}
-			setsToVisit = append(setsToVisit, setID)
-		}
-
-		// The input_id is a relatively new field that combines
-		// files, directories, unresolved symlinks or runfiles trees.
-		if len(set.GetInputIds()) > 0 {
-			for _, inputIds := range set.GetInputIds() {
-				if _, ok := visited[inputIds]; ok {
-					continue
-				}
-
-				visited[inputIds] = struct{}{}
-				if f, ok := slr.files[inputIds]; ok {
-					order = append(order, f.GetPath())
-					inputs[f.GetPath()] = f
-					continue
-				}
-				if d, ok := slr.dirs[inputIds]; ok {
-					for _, f := range d.files {
-						order = append(order, f.GetPath())
-						inputs[f.GetPath()] = f
-					}
-					continue
-				}
-				if symlink, ok := slr.symlinks[inputIds]; ok {
-					order = append(order, symlink.GetPath())
-					inputs[symlink.GetPath()] = symlink
-					continue
-				}
-			}
+			setsToVisit = setsToVisit[:len(setsToVisit)-1] // Pop
 			continue
 		}
 
-		// Handle deprecated fields
-		for _, fileID := range set.GetFileIds() {
-			if _, ok := visited[fileID]; ok {
+		// Check if already processed for post-order
+		if processedForPostOrder[currentSetID] {
+			setsToVisit = setsToVisit[:len(setsToVisit)-1] // Pop
+			continue
+		}
+
+		// Check transitive dependencies
+		allTransitiveProcessed := true
+		// Process in reverse to push dependencies onto stack in the correct order for post-order
+		for i := len(set.GetTransitiveSetIds()) - 1; i >= 0; i-- {
+			transitiveSetID := set.GetTransitiveSetIds()[i]
+			if _, visited := visitedSets[transitiveSetID]; !visited {
+				allTransitiveProcessed = false
+				visitedSets[transitiveSetID] = struct{}{}
+				setsToVisit = append(setsToVisit, transitiveSetID) // Push dependency
+			} else if !processedForPostOrder[transitiveSetID] {
+				// Dependency visited but not yet added to post-order list
+				allTransitiveProcessed = false
+			}
+		}
+
+		if allTransitiveProcessed {
+			// All dependencies processed, add this set to post-order list
+			postOrderSets = append(postOrderSets, currentSetID)
+			processedForPostOrder[currentSetID] = true
+			setsToVisit = setsToVisit[:len(setsToVisit)-1] // Pop
+		}
+	}
+
+	// Second pass: Process direct inputs in the calculated post-order
+	for _, currentSetID := range postOrderSets {
+		set, ok := slr.sets[currentSetID]
+		if !ok {
+			// Already warned during post-order build, skip processing direct inputs
+			continue
+		}
+
+		// --- Handle Modern `input_ids` Field ---
+		for _, inputID := range set.GetInputIds() {
+			if _, visited := visitedInputs[inputID]; visited {
 				continue
 			}
-			visited[fileID] = struct{}{}
-			f := slr.files[fileID]
-			order = append(order, f.GetPath())
-			inputs[f.GetPath()] = f
+			visitedInputs[inputID] = struct{}{}
+
+			if f, ok := slr.files[inputID]; ok {
+				if _, exists := inputs[f.GetPath()]; !exists { // Avoid duplicates in map/order
+					order = append(order, f.GetPath())
+					inputs[f.GetPath()] = f
+				}
+			} else if d, ok := slr.dirs[inputID]; ok {
+				// Add directory contents
+				for _, df := range d.files {
+					if _, exists := inputs[df.GetPath()]; !exists {
+						order = append(order, df.GetPath())
+						inputs[df.GetPath()] = df
+					}
+				}
+			} else if symlink, ok := slr.symlinks[inputID]; ok {
+				if _, exists := inputs[symlink.GetPath()]; !exists {
+					order = append(order, symlink.GetPath())
+					inputs[symlink.GetPath()] = symlink
+				}
+			} else if rft, ok := slr.runfilesTrees[inputID]; ok {
+				// If input is a RunfilesTree, add all its files
+				for _, rfFile := range rft.files {
+					if _, exists := inputs[rfFile.GetPath()]; !exists {
+						order = append(order, rfFile.GetPath())
+						inputs[rfFile.GetPath()] = rfFile
+					}
+				}
+			} else if _, ok := slr.symlinkEntrySets[inputID]; ok {
+				// InputSet can contain SymlinkEntrySet, but it doesn't directly contribute files here.
+				// RunfilesTree reconstruction handles these.
+			} else if _, ok := slr.sets[inputID]; ok {
+				// InputSet can contain InputSet, handled by transitive logic.
+			} else {
+				log.Debugf("Input ID %d in InputSet %d is not a File, Directory, Symlink, RunfilesTree or Set. Skipping for direct input list.", inputID, currentSetID)
+			}
+		}
+
+		// --- Handle Deprecated Fields (if modern field was empty or for back compat) ---
+		// Process regardless for safety, respecting visitedInputs.
+		for _, fileID := range set.GetFileIds() {
+			if _, visited := visitedInputs[fileID]; visited {
+				continue
+			}
+			visitedInputs[fileID] = struct{}{}
+			if f, ok := slr.files[fileID]; ok {
+				if _, exists := inputs[f.GetPath()]; !exists {
+					order = append(order, f.GetPath())
+					inputs[f.GetPath()] = f
+				}
+			}
 		}
 		for _, dirID := range set.GetDirectoryIds() {
-			if _, ok := visited[dirID]; ok {
+			if _, visited := visitedInputs[dirID]; visited {
 				continue
 			}
-			visited[dirID] = struct{}{}
-			d := slr.dirs[dirID]
-			for _, f := range d.files {
-				order = append(order, f.GetPath())
-				inputs[f.GetPath()] = f
+			visitedInputs[dirID] = struct{}{}
+			if d, ok := slr.dirs[dirID]; ok {
+				for _, df := range d.files {
+					if _, exists := inputs[df.GetPath()]; !exists {
+						order = append(order, df.GetPath())
+						inputs[df.GetPath()] = df
+					}
+				}
+			} else {
+				// Check if it's a RunfilesTree (handled similar to Directory for inputs)
+				if rft, ok := slr.runfilesTrees[dirID]; ok {
+					for _, rfFile := range rft.files {
+						if _, exists := inputs[rfFile.GetPath()]; !exists {
+							order = append(order, rfFile.GetPath())
+							inputs[rfFile.GetPath()] = rfFile
+						}
+					}
+				}
 			}
 		}
 		for _, symlinkID := range set.GetUnresolvedSymlinkIds() {
-			if _, ok := visited[symlinkID]; ok {
+			if _, visited := visitedInputs[symlinkID]; visited {
 				continue
 			}
-			visited[symlinkID] = struct{}{}
-			s := slr.symlinks[symlinkID]
-			order = append(order, s.GetPath())
-			inputs[s.GetPath()] = s
+			visitedInputs[symlinkID] = struct{}{}
+			if s, ok := slr.symlinks[symlinkID]; ok {
+				if _, exists := inputs[s.GetPath()]; !exists {
+					order = append(order, s.GetPath())
+					inputs[s.GetPath()] = s
+				}
+			}
 		}
 	}
+
 	return order, inputs
+}
+
+// reconstructRunfilesDir reconstructs the directory structure represented by a RunfilesTree entry.
+func (slr *SpawnLogReconstructor) reconstructRunfilesDir(runfilesTree *spb.ExecLogEntry_RunfilesTree) (*reconstructedDir, error) {
+	// Use a slice to maintain insertion order (for correct overrides) and a map for quick lookups.
+	orderedPaths := []string{}
+	runfiles := make(map[string]*spb.File)
+	hasWorkspaceRunfilesDirectory := runfilesTree.GetLegacyExternalRunfiles()
+
+	// Helper to add a file, respecting override order.
+	addFile := func(file *spb.File) {
+		if _, exists := runfiles[file.GetPath()]; !exists {
+			orderedPaths = append(orderedPaths, file.GetPath())
+		}
+		runfiles[file.GetPath()] = file
+	}
+
+	// 1. Symlinks
+	visitedSymlinkSets := make(map[uint32]struct{})
+	err := slr.reconstructSymlinkEntries(
+		runfilesTree,
+		runfilesTree.GetSymlinksId(),
+		false, // rootSymlinks = false
+		func(rootRelativePath string, targetFiles []*spb.File) error {
+			if strings.HasPrefix(rootRelativePath, slr.workspaceRunfilesDir+"/") {
+				hasWorkspaceRunfilesDirectory = true
+			}
+			for _, f := range targetFiles {
+				addFile(f)
+			}
+			return nil
+		},
+		visitedSymlinkSets,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("processing runfiles symlinks: %w", err)
+	}
+
+	// 2. Artifacts at canonical locations
+	artifactOrder, artifacts := slr.reconstructInputs(runfilesTree.GetInputSetId())
+	for _, execPath := range artifactOrder {
+		file := artifacts[execPath]
+		// Determine if the original exec path implies the workspace directory exists
+		rPathInfo, err := extractRunfilesPath(execPath, slr.siblingRepoLayout)
+		if err != nil {
+			log.Warnf("Could not extract runfiles path info from artifact exec path '%s' in runfiles tree %s: %v", execPath, runfilesTree.GetPath(), err)
+			// Attempt to add anyway, might be missing info but better than nothing
+		} else if rPathInfo.repo == "" { // Artifact in the main repo implies workspace dir presence
+			hasWorkspaceRunfilesDirectory = true
+		}
+
+		runfilesPaths, err := slr.getRunfilesPaths(execPath, runfilesTree.GetLegacyExternalRunfiles())
+		if err != nil {
+			log.Warnf("Could not determine runfiles paths for artifact exec path '%s' in runfiles tree %s: %v", execPath, runfilesTree.GetPath(), err)
+			continue // Skip this artifact if paths can't be determined
+		}
+		for _, relativePath := range runfilesPaths {
+			newFile := proto.Clone(file).(*spb.File)
+			newFile.Path = path.Join(runfilesTree.GetPath(), relativePath)
+			// Make sure digest hash function is set
+			if newFile.Digest != nil && newFile.Digest.HashFunctionName == "" {
+				newFile.Digest.HashFunctionName = slr.hashFunc
+			}
+			addFile(newFile)
+		}
+	}
+
+	// 3. Empty files
+	for _, emptyFileRelative := range runfilesTree.GetEmptyFiles() {
+		var newPath string
+		if strings.HasPrefix(emptyFileRelative, "../") {
+			// Relative to sibling directory (e.g., ../repo/foo)
+			// Note: Go's path.Join cleans "../", need careful construction
+			if len(runfilesTree.GetPath()) > 0 {
+				// Base path + relative path without "../"
+				newPath = path.Join(path.Dir(runfilesTree.GetPath()), emptyFileRelative[3:])
+			} else {
+				// If runfiles tree path is empty (unlikely), just use relative path
+				newPath = emptyFileRelative[3:]
+			}
+		} else {
+			// Relative to workspace directory inside runfiles tree (e.g., pkg/foo)
+			newPath = path.Join(runfilesTree.GetPath(), slr.workspaceRunfilesDir, emptyFileRelative)
+		}
+		// Empty files don't inherently create the workspace dir if it wouldn't exist otherwise.
+		addFile(&spb.File{Path: newPath}) // Digest is implicitly nil (empty file)
+	}
+
+	// 4. Root symlinks
+	visitedSymlinkSets = make(map[uint32]struct{}) // Reset visited sets for root symlinks
+	err = slr.reconstructSymlinkEntries(
+		runfilesTree,
+		runfilesTree.GetRootSymlinksId(),
+		true, // rootSymlinks = true
+		func(rootRelativePath string, targetFiles []*spb.File) error {
+			if strings.HasPrefix(rootRelativePath, slr.workspaceRunfilesDir+"/") {
+				hasWorkspaceRunfilesDirectory = true
+			}
+			for _, f := range targetFiles {
+				addFile(f)
+			}
+			return nil
+		},
+		visitedSymlinkSets,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("processing runfiles root symlinks: %w", err)
+	}
+
+	// 5. Repo mapping manifest
+	if runfilesTree.GetRepoMappingManifest() != nil && runfilesTree.GetRepoMappingManifest().GetDigest() != nil {
+		repoMappingPath := path.Join(runfilesTree.GetPath(), "_repo_mapping")
+		repoMappingFile := &spb.File{
+			Path:   repoMappingPath,
+			Digest: proto.Clone(runfilesTree.GetRepoMappingManifest().GetDigest()).(*spb.Digest),
+		}
+		// Ensure hash function name is set
+		if repoMappingFile.Digest.GetHashFunctionName() == "" {
+			repoMappingFile.Digest.HashFunctionName = slr.hashFunc
+		}
+		addFile(repoMappingFile)
+		// Presence of repo mapping doesn't imply workspace dir existence itself.
+	}
+
+	// 6. .runfile marker
+	if !runfilesTree.GetLegacyExternalRunfiles() && !hasWorkspaceRunfilesDirectory && slr.workspaceRunfilesDir != "" {
+		dotRunfilePath := path.Join(runfilesTree.GetPath(), slr.workspaceRunfilesDir, ".runfile")
+		addFile(&spb.File{Path: dotRunfilePath}) // Implicitly empty
+	}
+
+	// Collect final files in the correct order
+	finalFiles := make([]*spb.File, 0, len(orderedPaths))
+	for _, p := range orderedPaths {
+		finalFiles = append(finalFiles, runfiles[p])
+	}
+
+	return &reconstructedDir{
+		path:  runfilesTree.GetPath(),
+		files: finalFiles,
+	}, nil
+}
+
+// reconstructSymlinkEntries traverses a SymlinkEntrySet (transitively, in post-order) and calls the consumer for each direct entry.
+// This function is prepared for use by RunfilesTree reconstruction.
+func (slr *SpawnLogReconstructor) reconstructSymlinkEntries(
+	runfilesTree *spb.ExecLogEntry_RunfilesTree, // Context needed for paths
+	symlinkEntrySetID uint32,
+	rootSymlinks bool, // Determines relative path calculation
+	consumer SymlinkConsumer,
+	visitedSetIDs map[uint32]struct{}, // Track visited sets to avoid cycles and redundant work
+) error {
+
+	// Iterative post-order traversal (similar to reconstructInputs)
+	setsToVisit := []uint32{}                   // Stack for traversal
+	setsInPostOrder := []uint32{}               // Stores IDs in post-order
+	locallyVisited := make(map[uint32]struct{}) // Track visits within *this* call
+
+	// First pass: Build the post-order list
+	if symlinkEntrySetID != 0 {
+		// Check global visited set first before starting traversal
+		if _, visited := visitedSetIDs[symlinkEntrySetID]; !visited {
+			setsToVisit = append(setsToVisit, symlinkEntrySetID)
+			locallyVisited[symlinkEntrySetID] = struct{}{}
+		}
+	}
+
+	processedForPostOrder := make(map[uint32]bool) // Track sets added to post-order list
+
+	for len(setsToVisit) > 0 {
+		currentSetID := setsToVisit[len(setsToVisit)-1] // Peek top
+
+		// Check if already processed for post-order in *this* traversal
+		if processedForPostOrder[currentSetID] {
+			setsToVisit = setsToVisit[:len(setsToVisit)-1] // Pop
+			continue
+		}
+
+		set, ok := slr.symlinkEntrySets[currentSetID]
+		if !ok {
+			// Log warning but continue traversal if possible
+			log.Warnf("SymlinkEntrySet ID %d referenced but not found during traversal.", currentSetID)
+			processedForPostOrder[currentSetID] = true // Mark as processed to avoid infinite loop
+			setsInPostOrder = append(setsInPostOrder, currentSetID)
+			setsToVisit = setsToVisit[:len(setsToVisit)-1] // Pop
+			continue
+		}
+
+		// Check transitive dependencies
+		allTransitiveProcessed := true
+		// Iterate reverse to push dependencies onto stack in intended order
+		for i := len(set.GetTransitiveSetIds()) - 1; i >= 0; i-- {
+			transitiveSetID := set.GetTransitiveSetIds()[i]
+			// Check global visited set first (passed in)
+			if _, globalVisited := visitedSetIDs[transitiveSetID]; globalVisited {
+				continue
+			}
+			// Check if visited/processed within this specific traversal run
+			if _, localVisited := locallyVisited[transitiveSetID]; !localVisited {
+				allTransitiveProcessed = false
+				locallyVisited[transitiveSetID] = struct{}{}
+				setsToVisit = append(setsToVisit, transitiveSetID) // Push dependency
+			} else if !processedForPostOrder[transitiveSetID] {
+				allTransitiveProcessed = false // Dependency visited but not yet post-ordered
+			}
+		}
+
+		if allTransitiveProcessed {
+			// All dependencies handled, process this node
+			processedForPostOrder[currentSetID] = true
+			setsInPostOrder = append(setsInPostOrder, currentSetID)
+			setsToVisit = setsToVisit[:len(setsToVisit)-1] // Pop
+		}
+	}
+
+	// Second pass: Process direct entries in post-order
+	for _, currentSetID := range setsInPostOrder {
+		// Check global visited set - if visited by a prior call, skip entire processing for this ID
+		if _, visited := visitedSetIDs[currentSetID]; visited {
+			continue
+		}
+		visitedSetIDs[currentSetID] = struct{}{} // Mark globally visited now
+
+		set, ok := slr.symlinkEntrySets[currentSetID]
+		if !ok {
+			// Already warned in first pass
+			continue
+		}
+
+		// Process direct entries (sort map keys for deterministic order)
+		directPaths := make([]string, 0, len(set.GetDirectEntries()))
+		for p := range set.GetDirectEntries() {
+			directPaths = append(directPaths, p)
+		}
+		sort.Strings(directPaths)
+
+		for _, entryPath := range directPaths {
+			targetID := set.GetDirectEntries()[entryPath]
+			err := slr.processSingleSymlinkEntry(runfilesTree, rootSymlinks, entryPath, targetID, consumer)
+			if err != nil {
+				return err // Propagate error
+			}
+		}
+	}
+
+	return nil
+}
+
+// processSingleSymlinkEntry handles the path calculation and target reconstruction for one entry.
+func (slr *SpawnLogReconstructor) processSingleSymlinkEntry(
+	runfilesTree *spb.ExecLogEntry_RunfilesTree,
+	rootSymlinks bool,
+	entryPath string, // Path from the SymlinkEntrySet map key
+	targetID uint32,
+	consumer SymlinkConsumer,
+) error {
+	var runfilesTreeRelativePath string
+	if rootSymlinks {
+		runfilesTreeRelativePath = entryPath
+	} else if strings.HasPrefix(entryPath, "../") {
+		// Path is relative to runfiles root sibling (e.g., ../repo/file)
+		runfilesTreeRelativePath = entryPath[3:] // Remove "../"
+	} else {
+		// Path is relative to workspace dir inside runfiles (e.g., pkg/file)
+		if slr.workspaceRunfilesDir == "" {
+			// This case might indicate an issue if non-root, non-../ symlinks exist without a workspace dir defined.
+			// The Java code implicitly joins with workspaceRunfilesDirectory. We replicate this, potentially joining with "".
+			log.Debugf("Workspace runfiles directory is empty, joining symlink path '%s' directly under runfiles root %s", entryPath, runfilesTree.GetPath())
+		}
+		runfilesTreeRelativePath = path.Join(slr.workspaceRunfilesDir, entryPath)
+	}
+
+	// Calculate the final absolute path within the execution root
+	symlinkPath := path.Join(runfilesTree.GetPath(), runfilesTreeRelativePath)
+
+	// Reconstruct the target(s) based on the ID
+	targetFiles, err := slr.reconstructRunfilesSymlinkTarget(symlinkPath, targetID)
+	if err != nil {
+		log.Warnf("Error reconstructing target for symlink %s (targetID %d): %v", symlinkPath, targetID, err)
+		return nil // Don't fail the whole process, just skip this entry
+	}
+
+	// Call the consumer with the primary path
+	if err := consumer(runfilesTreeRelativePath, targetFiles); err != nil {
+		return err // Propagate consumer errors
+	}
+
+	// Handle legacy external runfiles path if needed
+	// Condition: legacy enabled, AND NOT root symlinks, AND relative path is NOT under workspace dir (or ws dir is empty), AND workspace dir exists
+	isExternal := false
+	if slr.workspaceRunfilesDir == "" {
+		// If no workspace dir, any non-root symlink not starting with ../ is considered "external" for legacy purposes if legacy is on.
+		isExternal = !rootSymlinks && !strings.HasPrefix(entryPath, "../")
+	} else {
+		isExternal = !rootSymlinks && !strings.HasPrefix(runfilesTreeRelativePath, slr.workspaceRunfilesDir+"/")
+	}
+
+	if runfilesTree.GetLegacyExternalRunfiles() && isExternal && slr.workspaceRunfilesDir != "" {
+		// Determine the original repo-relative path to join with "external/"
+		originalRepoRelativePath := ""
+		if strings.HasPrefix(entryPath, "../") {
+			originalRepoRelativePath = entryPath[3:] // e.g., "my_repo/path/to/file"
+		} else if rootSymlinks {
+			// This case should not happen based on the 'isExternal' check above
+		} else {
+			// Path was relative to workspace dir, e.g., "pkg/file", but isExternal was true.
+			// This implies wsDir was empty OR relative path didn't start with it.
+			// If wsDir was empty, runfilesTreeRelativePath is "pkg/file".
+			// If wsDir was not empty, but path didn't start with it (e.g. path.Join("", "pkg/file")),
+			// runfilesTreeRelativePath is still "pkg/file".
+			// The Java logic seems to rely on the relative path *not* containing wsDir when external.
+			// Let's assume the relative path computed is the one to be prefixed.
+			originalRepoRelativePath = runfilesTreeRelativePath
+		}
+
+		legacyRelativePath := path.Join(slr.workspaceRunfilesDir, "external", originalRepoRelativePath)
+		legacySymlinkPath := path.Join(runfilesTree.GetPath(), legacyRelativePath)
+
+		// Reconstruct target again with the legacy path
+		legacyTargetFiles, err := slr.reconstructRunfilesSymlinkTarget(legacySymlinkPath, targetID)
+		if err != nil {
+			log.Warnf("Error reconstructing target for legacy symlink %s (targetID %d): %v", legacySymlinkPath, targetID, err)
+			// Continue without failing
+		} else if err := consumer(legacyRelativePath, legacyTargetFiles); err != nil {
+			return err // Propagate consumer error
+		}
+	}
+
+	return nil
+}
+
+// reconstructRunfilesSymlinkTarget finds the target entry (File, Symlink, Dir) for a runfiles symlink
+// and returns the corresponding File protos with their paths adjusted to the new symlink location.
+func (slr *SpawnLogReconstructor) reconstructRunfilesSymlinkTarget(newPath string, targetId uint32) ([]*spb.File, error) {
+	if targetId == 0 {
+		// Target ID 0 likely represents an empty file or directory created implicitly.
+		// Represent it as an empty file at the new path.
+		return []*spb.File{{Path: newPath}}, nil
+	}
+
+	if f, ok := slr.files[targetId]; ok {
+		// Target is a file
+		newFile := proto.Clone(f).(*spb.File)
+		newFile.Path = newPath
+		// Ensure hash function name is set
+		if newFile.Digest != nil && newFile.Digest.HashFunctionName == "" {
+			newFile.Digest.HashFunctionName = slr.hashFunc
+		}
+		return []*spb.File{newFile}, nil
+	}
+	if sym, ok := slr.symlinks[targetId]; ok {
+		// Target is another symlink
+		newSymlink := proto.Clone(sym).(*spb.File)
+		newSymlink.Path = newPath
+		// Keep original SymlinkTargetPath
+		return []*spb.File{newSymlink}, nil
+	}
+	if d, ok := slr.dirs[targetId]; ok {
+		// Target is a directory
+		reconstructedFiles := make([]*spb.File, 0, len(d.files))
+		for _, fileInDir := range d.files {
+			// Calculate the file's path relative to the original directory root
+			// Use path.Rel for robustness, handle potential errors
+			relativePath, err := RelPath(d.path, fileInDir.GetPath())
+			if err != nil {
+				// Fallback to simple TrimPrefix if Rel fails
+				log.Warnf("path.Rel failed for dir '%s' and file '%s': %v. Falling back to TrimPrefix.", d.path, fileInDir.GetPath(), err)
+				if strings.HasPrefix(fileInDir.GetPath(), d.path+"/") {
+					relativePath = strings.TrimPrefix(fileInDir.GetPath(), d.path+"/")
+				} else if fileInDir.GetPath() == d.path {
+					// Should not happen if file is *in* dir, but handle defensively
+					relativePath = "."
+				} else {
+					// Cannot determine relative path, skip this file
+					log.Warnf("Cannot determine relative path for file '%s' within directory '%s'. Skipping.", fileInDir.GetPath(), d.path)
+					continue
+				}
+			}
+
+			// Construct the new path relative to the symlink location
+			finalPath := path.Join(newPath, relativePath)
+
+			newFile := proto.Clone(fileInDir).(*spb.File)
+			newFile.Path = finalPath
+			// Ensure hash function name is set
+			if newFile.Digest != nil && newFile.Digest.HashFunctionName == "" {
+				newFile.Digest.HashFunctionName = slr.hashFunc
+			}
+			reconstructedFiles = append(reconstructedFiles, newFile)
+		}
+		return reconstructedFiles, nil
+	}
+	// Check RunfilesTree last, as it's represented as a directory
+	if rft, ok := slr.runfilesTrees[targetId]; ok {
+		// Target is a runfiles tree (treat like a directory)
+		reconstructedFiles := make([]*spb.File, 0, len(rft.files))
+		for _, fileInTree := range rft.files {
+			relativePath, err := RelPath(rft.path, fileInTree.GetPath())
+			if err != nil {
+				log.Warnf("path.Rel failed for runfiles tree '%s' and file '%s': %v. Falling back to TrimPrefix.", rft.path, fileInTree.GetPath(), err)
+				if strings.HasPrefix(fileInTree.GetPath(), rft.path+"/") {
+					relativePath = strings.TrimPrefix(fileInTree.GetPath(), rft.path+"/")
+				} else if fileInTree.GetPath() == rft.path {
+					relativePath = "."
+				} else {
+					log.Warnf("Cannot determine relative path for file '%s' within runfiles tree '%s'. Skipping.", fileInTree.GetPath(), rft.path)
+					continue
+				}
+			}
+			finalPath := path.Join(newPath, relativePath)
+			newFile := proto.Clone(fileInTree).(*spb.File)
+			newFile.Path = finalPath
+			// Ensure hash function name is set (already done during tree reconstruction, but double check)
+			if newFile.Digest != nil && newFile.Digest.HashFunctionName == "" {
+				newFile.Digest.HashFunctionName = slr.hashFunc
+			}
+			reconstructedFiles = append(reconstructedFiles, newFile)
+		}
+		return reconstructedFiles, nil
+	}
+
+	return nil, fmt.Errorf("symlink target ID %d not found or is not a file, symlink, directory, or runfiles tree", targetId)
 }
 
 func reconstructDir(d *spb.ExecLogEntry_Directory) *reconstructedDir {
 	filesInDir := make([]*spb.File, 0, len(d.GetFiles()))
 	for _, file := range d.GetFiles() {
+		// Note: Hash function applied later in the main loop
 		filesInDir = append(filesInDir, reconstructFile(d, file))
 	}
 	return &reconstructedDir{
@@ -481,7 +1100,7 @@ func reconstructDir(d *spb.ExecLogEntry_Directory) *reconstructedDir {
 }
 
 func reconstructFile(parentDir *spb.ExecLogEntry_Directory, file *spb.ExecLogEntry_File) *spb.File {
-	f := &spb.File{Digest: file.GetDigest()}
+	f := &spb.File{Digest: file.GetDigest()} // Note: Hash function applied later
 	if parentDir != nil {
 		f.Path = path.Join(parentDir.GetPath(), file.GetPath())
 	} else {
@@ -494,5 +1113,122 @@ func reconstructSymlink(s *spb.ExecLogEntry_UnresolvedSymlink) *spb.File {
 	return &spb.File{
 		Path:              s.GetPath(),
 		SymlinkTargetPath: s.GetTargetPath(),
+	}
+}
+
+// --- Runfiles Path Calculation Logic (Mirrors Java) ---
+
+// Define patterns similar to Java (using Go's regexp syntax)
+var (
+	// Non-sibling layout patterns
+	defaultGeneratedFileRunfilesPathPattern = regexp.MustCompile(`^(?:bazel|blaze)-out/[^/]+/[^/]+/(?:external/(?P<repo>[^/]+)/)?(?P<path>.+)$`)
+	defaultSourceFileRunfilesPathPattern    = regexp.MustCompile(`^(?:external/(?P<repo>[^/]+)/)?(?P<path>.+)$`)
+
+	// Sibling layout patterns
+	// Go doesn't support lookaheads directly in the standard regexp. We simplify.
+	// This might misinterpret some edge cases involving hyphens in output dirs vs repo names.
+	// The Java lookahead `(?=/[^/]+-[^/]+/)(?!/coverage-metadata/)` checks if the *next* segment
+	// looks like a configuration mnemonic (contains a hyphen) but isn't "coverage-metadata".
+	// We approximate this by checking if the segment *after* the potential repo name contains a hyphen.
+	// This is less precise but captures the common case.
+	siblingLayoutGeneratedFileRunfilesPathPattern = regexp.MustCompile(`^(?:bazel|blaze)-out/(?P<repo>[^/]+)/(?P<config>[^/]+(?:-[^/]+)?)/[^/]+/(?P<path>.+)$`) // Tries to capture config
+	siblingLayoutSourceFileRunfilesPathPattern    = regexp.MustCompile(`^(?:\.\./(?P<repo>[^/]+)/)?(?P<path>.+)$`)
+
+	// Need a pattern to *try* matching the sibling layout generated file *without* a repo first
+	siblingLayoutGeneratedFileNoRepoPattern = regexp.MustCompile(`^(?:bazel|blaze)-out/(?P<config>[^/]+(?:-[^/]+)?)/[^/]+/(?P<path>.+)$`) // Includes config check
+)
+
+type runfilesPathInfo struct {
+	repo string // "" if main repository
+	path string // Path relative to the repository root
+}
+
+func extractRunfilesPath(execPath string, siblingRepositoryLayout bool) (*runfilesPathInfo, error) {
+	var matcher []string
+	var groupNames []string
+
+	findMatch := func(p *regexp.Regexp) bool {
+		matcher = p.FindStringSubmatch(execPath)
+		if matcher != nil {
+			groupNames = p.SubexpNames()
+			return true
+		}
+		return false
+	}
+
+	getGroup := func(name string) string {
+		for i, n := range groupNames {
+			if n == name && i < len(matcher) && i < len(matcher) { // Check bounds
+				return matcher[i]
+			}
+		}
+		return ""
+	}
+
+	if siblingRepositoryLayout {
+		// Try generated pattern with repo first
+		if findMatch(siblingLayoutGeneratedFileRunfilesPathPattern) {
+			// Check if the 'config' segment looks like a config (contains hyphen, not just repo name)
+			configSegment := getGroup("config")
+			if strings.Contains(configSegment, "-") && configSegment != "coverage-metadata" {
+				// Looks like repo/config/..., so repo is correct
+				return &runfilesPathInfo{repo: getGroup("repo"), path: getGroup("path")}, nil
+			}
+			// If it doesn't look like config, maybe the first segment WAS the config, not the repo. Fall through.
+		}
+		// Try generated pattern without repo (higher precedence than source)
+		if findMatch(siblingLayoutGeneratedFileNoRepoPattern) {
+			// Check if the 'config' segment looks like a config
+			configSegment := getGroup("config")
+			if strings.Contains(configSegment, "-") && configSegment != "coverage-metadata" {
+				// Looks like config/bin/..., so no repo
+				return &runfilesPathInfo{repo: "", path: getGroup("path")}, nil
+			}
+			// If not, this pattern matched but didn't represent the no-repo case correctly. Fall through.
+		}
+		// Try source pattern
+		if findMatch(siblingLayoutSourceFileRunfilesPathPattern) {
+			return &runfilesPathInfo{repo: getGroup("repo"), path: getGroup("path")}, nil
+		}
+	} else { // Default layout
+		if findMatch(defaultGeneratedFileRunfilesPathPattern) || findMatch(defaultSourceFileRunfilesPathPattern) {
+			return &runfilesPathInfo{repo: getGroup("repo"), path: getGroup("path")}, nil
+		}
+	}
+
+	// Fallback/Error: If sibling layout was true, but generated patterns didn't definitively identify repo/no-repo based on config segment,
+	// we might have misparsed. The default patterns might still work if the structure resembles them.
+	if siblingRepositoryLayout {
+		if findMatch(defaultGeneratedFileRunfilesPathPattern) || findMatch(defaultSourceFileRunfilesPathPattern) {
+			log.Warnf("Exec path '%s' with sibling layout enabled matched default pattern after failing sibling patterns. Using default interpretation.", execPath)
+			return &runfilesPathInfo{repo: getGroup("repo"), path: getGroup("path")}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not match execPath '%s' to any known runfiles pattern (siblingLayout: %v)", execPath, siblingRepositoryLayout)
+}
+
+func (slr *SpawnLogReconstructor) getRunfilesPaths(execPath string, legacyExternalRunfiles bool) ([]string, error) {
+	info, err := extractRunfilesPath(execPath, slr.siblingRepoLayout)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.repo == "" { // Main repository
+		// Should not be empty if pattern matched correctly
+		if slr.workspaceRunfilesDir == "" {
+			log.Warnf("Workspace runfiles directory is empty, but needed for main repo path calculation for %s", execPath)
+		}
+		// Use path.Join, it handles empty workspaceRunfilesDir correctly (joins with just info.path)
+		return []string{path.Join(slr.workspaceRunfilesDir, info.path)}, nil
+	} else { // External repository
+		paths := []string{}
+		// Default path (repo name relative to runfiles root)
+		paths = append(paths, path.Join(info.repo, info.path))
+		// Legacy path (under workspace dir/external)
+		if legacyExternalRunfiles && slr.workspaceRunfilesDir != "" {
+			paths = append(paths, path.Join(slr.workspaceRunfilesDir, "external", info.repo, info.path))
+		}
+		return paths, nil
 	}
 }

--- a/cli/test/integration/compact/BUILD
+++ b/cli/test/integration/compact/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
+package(default_visibility = ["//cli:__subpackages__"])
+
 go_test(
     name = "compact_test",
     srcs = ["compact_test.go"],
@@ -10,5 +12,3 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
-
-package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/test/integration/compact/testdata/1.json
+++ b/cli/test/integration/compact/testdata/1.json
@@ -16,21 +16,24 @@
       "path": "external/bazel_tools/tools/genrule/genrule-setup.sh",
       "digest": {
         "hash": "ecbd7e347af9b7a4ddc4ea397b195bd0c794e1dbfd666ee29ef98dd779cf8439",
-        "sizeBytes": "858"
+        "sizeBytes": "858",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/stable-status.txt",
       "digest": {
         "hash": "360e2eaf3ae813baac4904bed231da9bb12bcd785832e6438229df0920c37188",
-        "sizeBytes": "154"
+        "sizeBytes": "154",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/volatile-status.txt",
       "digest": {
         "hash": "5215d4bcddbfbcff78cbbb9efe08b37461eaa73fba42651f520a76dc0f94b40a",
-        "sizeBytes": "226"
+        "sizeBytes": "226",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -44,7 +47,8 @@
     {
       "path": "bazel-out/darwin_arm64-fastbuild/bin/server/version/commit.txt",
       "digest": {
-        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -74,21 +78,24 @@
       "path": "external/bazel_tools/tools/genrule/genrule-setup.sh",
       "digest": {
         "hash": "ecbd7e347af9b7a4ddc4ea397b195bd0c794e1dbfd666ee29ef98dd779cf8439",
-        "sizeBytes": "858"
+        "sizeBytes": "858",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/stable-status.txt",
       "digest": {
         "hash": "360e2eaf3ae813baac4904bed231da9bb12bcd785832e6438229df0920c37188",
-        "sizeBytes": "154"
+        "sizeBytes": "154",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/volatile-status.txt",
       "digest": {
         "hash": "5215d4bcddbfbcff78cbbb9efe08b37461eaa73fba42651f520a76dc0f94b40a",
-        "sizeBytes": "226"
+        "sizeBytes": "226",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -102,7 +109,8 @@
     {
       "path": "bazel-out/darwin_arm64-fastbuild/bin/server/version/version.txt",
       "digest": {
-        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],

--- a/cli/test/integration/compact/testdata/1.sorted.json
+++ b/cli/test/integration/compact/testdata/1.sorted.json
@@ -16,21 +16,24 @@
       "path": "external/bazel_tools/tools/genrule/genrule-setup.sh",
       "digest": {
         "hash": "ecbd7e347af9b7a4ddc4ea397b195bd0c794e1dbfd666ee29ef98dd779cf8439",
-        "sizeBytes": "858"
+        "sizeBytes": "858",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/stable-status.txt",
       "digest": {
         "hash": "360e2eaf3ae813baac4904bed231da9bb12bcd785832e6438229df0920c37188",
-        "sizeBytes": "154"
+        "sizeBytes": "154",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/volatile-status.txt",
       "digest": {
         "hash": "5215d4bcddbfbcff78cbbb9efe08b37461eaa73fba42651f520a76dc0f94b40a",
-        "sizeBytes": "226"
+        "sizeBytes": "226",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -44,7 +47,8 @@
     {
       "path": "bazel-out/darwin_arm64-fastbuild/bin/server/version/commit.txt",
       "digest": {
-        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -74,21 +78,24 @@
       "path": "external/bazel_tools/tools/genrule/genrule-setup.sh",
       "digest": {
         "hash": "ecbd7e347af9b7a4ddc4ea397b195bd0c794e1dbfd666ee29ef98dd779cf8439",
-        "sizeBytes": "858"
+        "sizeBytes": "858",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/stable-status.txt",
       "digest": {
         "hash": "360e2eaf3ae813baac4904bed231da9bb12bcd785832e6438229df0920c37188",
-        "sizeBytes": "154"
+        "sizeBytes": "154",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/volatile-status.txt",
       "digest": {
         "hash": "5215d4bcddbfbcff78cbbb9efe08b37461eaa73fba42651f520a76dc0f94b40a",
-        "sizeBytes": "226"
+        "sizeBytes": "226",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -102,7 +109,8 @@
     {
       "path": "bazel-out/darwin_arm64-fastbuild/bin/server/version/version.txt",
       "digest": {
-        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],

--- a/cli/test/integration/compact/testdata/2.json
+++ b/cli/test/integration/compact/testdata/2.json
@@ -16,21 +16,24 @@
       "path": "external/bazel_tools/tools/genrule/genrule-setup.sh",
       "digest": {
         "hash": "ecbd7e347af9b7a4ddc4ea397b195bd0c794e1dbfd666ee29ef98dd779cf8439",
-        "sizeBytes": "858"
+        "sizeBytes": "858",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/stable-status.txt",
       "digest": {
         "hash": "aaca31393fa0043ba63c61b6240f4f81da3708143863107ffc1167a49b9add6e",
-        "sizeBytes": "154"
+        "sizeBytes": "154",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/volatile-status.txt",
       "digest": {
         "hash": "4a326985aed96c4155b057cf0375f1a5fa564501b059301face13e18eb9369cc",
-        "sizeBytes": "226"
+        "sizeBytes": "226",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -44,7 +47,8 @@
     {
       "path": "bazel-out/darwin_arm64-fastbuild/bin/server/version/version.txt",
       "digest": {
-        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -74,21 +78,24 @@
       "path": "external/bazel_tools/tools/genrule/genrule-setup.sh",
       "digest": {
         "hash": "ecbd7e347af9b7a4ddc4ea397b195bd0c794e1dbfd666ee29ef98dd779cf8439",
-        "sizeBytes": "858"
+        "sizeBytes": "858",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/stable-status.txt",
       "digest": {
         "hash": "aaca31393fa0043ba63c61b6240f4f81da3708143863107ffc1167a49b9add6e",
-        "sizeBytes": "154"
+        "sizeBytes": "154",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/volatile-status.txt",
       "digest": {
         "hash": "4a326985aed96c4155b057cf0375f1a5fa564501b059301face13e18eb9369cc",
-        "sizeBytes": "226"
+        "sizeBytes": "226",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -102,7 +109,8 @@
     {
       "path": "bazel-out/darwin_arm64-fastbuild/bin/server/version/commit.txt",
       "digest": {
-        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],

--- a/cli/test/integration/compact/testdata/2.sorted.json
+++ b/cli/test/integration/compact/testdata/2.sorted.json
@@ -16,21 +16,24 @@
       "path": "external/bazel_tools/tools/genrule/genrule-setup.sh",
       "digest": {
         "hash": "ecbd7e347af9b7a4ddc4ea397b195bd0c794e1dbfd666ee29ef98dd779cf8439",
-        "sizeBytes": "858"
+        "sizeBytes": "858",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/stable-status.txt",
       "digest": {
         "hash": "aaca31393fa0043ba63c61b6240f4f81da3708143863107ffc1167a49b9add6e",
-        "sizeBytes": "154"
+        "sizeBytes": "154",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/volatile-status.txt",
       "digest": {
         "hash": "4a326985aed96c4155b057cf0375f1a5fa564501b059301face13e18eb9369cc",
-        "sizeBytes": "226"
+        "sizeBytes": "226",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -44,7 +47,8 @@
     {
       "path": "bazel-out/darwin_arm64-fastbuild/bin/server/version/commit.txt",
       "digest": {
-        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -74,21 +78,24 @@
       "path": "external/bazel_tools/tools/genrule/genrule-setup.sh",
       "digest": {
         "hash": "ecbd7e347af9b7a4ddc4ea397b195bd0c794e1dbfd666ee29ef98dd779cf8439",
-        "sizeBytes": "858"
+        "sizeBytes": "858",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/stable-status.txt",
       "digest": {
         "hash": "aaca31393fa0043ba63c61b6240f4f81da3708143863107ffc1167a49b9add6e",
-        "sizeBytes": "154"
+        "sizeBytes": "154",
+        "hashFunctionName": "BLAKE3"
       }
     },
     {
       "path": "bazel-out/volatile-status.txt",
       "digest": {
         "hash": "4a326985aed96c4155b057cf0375f1a5fa564501b059301face13e18eb9369cc",
-        "sizeBytes": "226"
+        "sizeBytes": "226",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],
@@ -102,7 +109,8 @@
     {
       "path": "bazel-out/darwin_arm64-fastbuild/bin/server/version/version.txt",
       "digest": {
-        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+        "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+        "hashFunctionName": "BLAKE3"
       }
     }
   ],


### PR DESCRIPTION
Use Gemini 2.5 to implement support for RunfilesTree reconstruction.

Fully implement support for SymlinkAction, SymlinkEntrySet and
RunfilesTree log entries.
