### PR TITLE
vfs: don't try to add files to filecache when vfs is enabled

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -387,8 +387,11 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, cmd *repb.Command, execu
 				return status.WrapError(err, "apply overlay upperdir changes")
 			}
 		}
+		// Don't try to add files to the filecache if VFS is enabled. We use hard links to store data in the file
+		// cache and hard links across filesystems are not possible.
+		addToFileCache := ws.vfs == nil
 		var err error
-		txInfo, err = dirtools.UploadTree(egCtx, ws.env, ws.dirHelper, instanceName, digestFunction, ws.inputRoot(), cmd, executeResponse.Result)
+		txInfo, err = dirtools.UploadTree(egCtx, ws.env, ws.dirHelper, instanceName, digestFunction, ws.inputRoot(), cmd, executeResponse.Result, addToFileCache)
 		return err
 	})
 	var logsMu sync.Mutex

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -653,7 +653,7 @@ func TestUploadTree(t *testing.T) {
 			dirHelper := dirtools.NewDirHelper(rootDir, tc.cmd, fs.FileMode(0o755))
 
 			actionResult := &repb.ActionResult{}
-			txInfo, err := dirtools.UploadTree(ctx, env, dirHelper, "", repb.DigestFunction_SHA256, rootDir, tc.cmd, actionResult)
+			txInfo, err := dirtools.UploadTree(ctx, env, dirHelper, "", repb.DigestFunction_SHA256, rootDir, tc.cmd, actionResult, true /*=addToFileCache*/)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedInfo.FileCount, txInfo.FileCount)


### PR DESCRIPTION
This fixes some log spam since these adds can never succeed.