### PR TITLE
Add gitserver util

### DIFF
--- a/server/testutil/testshell/testshell.go
+++ b/server/testutil/testshell/testshell.go
@@ -1,17 +1,33 @@
 package testshell
 
 import (
+	"bytes"
 	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// Run runs the given shell script in the given working directory.
+// Run runs the given shell script in the given working directory,
+// returning the combined output. It fails the test if the script fails.
 func Run(t testing.TB, workDir, script string) string {
 	cmd := exec.Command("/usr/bin/env", "bash", "-e", "-c", script)
 	cmd.Dir = workDir
 	b, err := cmd.CombinedOutput()
 	require.NoError(t, err, "script %q failed: %s", script, string(b))
 	return string(b)
+}
+
+// Try runs the given shell script in the given working directory, and does not
+// fail the test if the script fails. Instead, it returns stdout, stderr, and an
+// error as separate values, which allow tests to assert on the values
+// separately.
+func Try(t testing.TB, workDir, script string) (string, string, error) {
+	cmd := exec.Command("/usr/bin/env", "bash", "-e", "-c", script)
+	cmd.Dir = workDir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
 }

--- a/server/util/mockgitserver/BUILD
+++ b/server/util/mockgitserver/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "mockgitserver",
+    srcs = ["mockgitserver.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/mockgitserver",
+    visibility = ["//visibility:public"],
+    deps = ["//server/util/log"],
+)
+
+go_test(
+    name = "mockgitserver_test",
+    srcs = ["mockgitserver_test.go"],
+    deps = [
+        ":mockgitserver",
+        "//server/testutil/testfs",
+        "//server/testutil/testshell",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/mockgitserver/mockgitserver.go
+++ b/server/util/mockgitserver/mockgitserver.go
@@ -1,0 +1,281 @@
+// mockgitserver provides a simple git server that can be accessed via HTTP.
+//
+// The git server hosts a number of "projects" which are all stored under a
+// single project root directory. Each project is located under an OWNER/REPO
+// subdirectory within the root directory.
+//
+// Before pushing a local repository to a project, the project must first be
+// created with the server using CreateProject.
+//
+// Each project directory is a "bare" git repository with a few additional
+// special files: - git-daemon-export-ok: a marker file indicating that the
+// project can be
+//   served. This is a standard git file.
+// - project.json: a JSON file containing access controls for the project.
+//   This is nonstandard, and specific to the mockgitserver implementation.
+
+// Example usage:
+//
+//	func main() {
+//		projectRoot := "/tmp/.gitprojects"
+//		// Add a new project.
+//		err := mockgitserver.CreateProject(projectRoot, "testorg", "testrepo", nil)
+//		// Run the server.
+//		server := mockgitserver.NewHandler(projectRoot, mockgitserver.Options{AccessToken: "test-token"})
+//		http.ListenAndServe(":8999", server)
+//	}
+//
+// The above example will create an empty project named "testorg/testrepo"
+// in the project root directory, /tmp/.gitprojects. The repository can then
+// be accessed using the token "test-token". For example:
+//
+// $ git clone http://x-token:test-token@localhost:8999/testorg/testrepo /tmp/testrepo
+// $ cd /tmp/testrepo
+// $ touch README.md && git add README.md && git commit -m "add README"
+// $ git push -u origin master
+
+package mockgitserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cgi"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+const (
+	// File name of the project settings file within each project directory.
+	// This file contains a JSON-encoded ProjectSettings struct.
+	projectSettingsFileName = "project.json"
+)
+
+// ProjectSettings contains settings for a remote git repository.
+type ProjectSettings struct {
+	// Public indicates whether the repo is readable by anyone who knows the
+	// repo URL, without needing to provide any authentication or authorization.
+	Public bool `json:"public"`
+}
+
+// CreateProject creates a new bare git repository to be served by the mockgitserver
+// serving from the given gitProjectRoot directory.
+//
+// The repository will be initialized as a bare repository without a working
+// tree.
+func CreateProject(gitProjectRoot, owner, repo string, settings *ProjectSettings) error {
+	repoPath := filepath.Join(gitProjectRoot, owner, repo)
+	if err := os.MkdirAll(repoPath, 0755); err != nil {
+		return fmt.Errorf("failed to create repo path %q: %w", repoPath, err)
+	}
+	// Init as bare repository.
+	cmd := exec.Command("git", "init", "--bare", repoPath)
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git init --bare failed: %q (%w)", strings.TrimSpace(stderr.String()), err)
+	}
+	// Create git-daemon-export-ok file to make it available for serving.
+	if err := os.WriteFile(filepath.Join(repoPath, "git-daemon-export-ok"), nil, 0644); err != nil {
+		return fmt.Errorf("create git-daemon-export-ok: %w", err)
+	}
+	// Write project settings.
+	configPath := filepath.Join(repoPath, projectSettingsFileName)
+	b, err := json.Marshal(settings)
+	if err != nil {
+		return fmt.Errorf("marshal project settings: %w", err)
+	}
+	if err := os.WriteFile(configPath, b, 0644); err != nil {
+		return fmt.Errorf("write project settings: %w", err)
+	}
+	return nil
+}
+
+// ProjectExists returns whether a project exists.
+func ProjectExists(gitProjectRoot, owner, repo string) (bool, error) {
+	repoPath := filepath.Join(gitProjectRoot, owner, repo)
+	_, err := os.Stat(repoPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat: %w", err)
+	}
+	return true, nil
+}
+
+// ReadProjectSettings reads the project settings for the given project.
+func ReadProjectSettings(gitProjectRoot, owner, repo string) (*ProjectSettings, error) {
+	repoPath := filepath.Join(gitProjectRoot, owner, repo)
+	configPath := filepath.Join(repoPath, projectSettingsFileName)
+	b, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	settings := &ProjectSettings{}
+	if err := json.Unmarshal(b, settings); err != nil {
+		return nil, fmt.Errorf("unmarshal config: %w", err)
+	}
+	return settings, nil
+}
+
+// Options contains configuration for the mockgitserver.
+type Options struct {
+	// AccessToken specifies a global access token that grants access to all
+	// repositories. It is intended for testing basic authentication scenarios
+	// without having to explicitly configure access controls for each repo.
+	AccessToken string
+
+	// LogWriter handles output from the git-http-backend CGI program.
+	//
+	// If nil, logs are written using log.Info. To explicitly ignore logs, use
+	// io.Discard.
+	LogWriter io.Writer
+
+	// GitHTTPBackendPath is the path to the git-http-backend executable.
+	//
+	// If empty, the path is resolved using `git --exec-path`.
+	GitHTTPBackendPath string
+}
+
+// NewHandler returns an HTTP handler that serves requests on / from the given
+// projectRoot.
+//
+// All repositories use the "owner/repo" format. To set up static repository
+// credentials, use BasicAuthHandler, and wrap this handler with it.
+//
+// If the projectRoot is non-empty, then it must only contain bare repositories.
+// Typically, it's easiest to start with projectRoot as an empty directory, then
+// populate it by pushing repositories to the server. It's possible to use an
+// existing projectRoot but the repositories have to be "bare" repositories,
+// without any commits checked out.
+func NewHandler(projectRoot string, opts Options) http.Handler {
+	logWriter := opts.LogWriter
+	if logWriter == nil {
+		logWriter = &infoLogger{}
+	}
+	gitHTTPBackendPath := opts.GitHTTPBackendPath
+	var gitHTTPBackendPathErr error
+	if gitHTTPBackendPath == "" {
+		gitHTTPBackendPath, gitHTTPBackendPathErr = findGitHTTPBackend()
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteUser, ok := auth(w, r, projectRoot, opts.AccessToken)
+		if !ok {
+			return
+		}
+		if gitHTTPBackendPathErr != nil {
+			log.CtxErrorf(r.Context(), "Failed to find git-http-backend: %s", gitHTTPBackendPathErr)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		// Note: we don't set GIT_HTTP_EXPORT_ALL. Instead, the file
+		// git-daemon-export-ok is used to export each repo separately.
+		env := []string{"GIT_PROJECT_ROOT=" + projectRoot}
+		if remoteUser != nil {
+			env = append(env, "REMOTE_USER="+*remoteUser)
+		}
+		cgiHandler := &cgi.Handler{
+			Path:   gitHTTPBackendPath,
+			Root:   "/",
+			Env:    env,
+			Stderr: logWriter,
+		}
+		cgiHandler.ServeHTTP(w, r)
+	})
+}
+
+func findGitHTTPBackend() (string, error) {
+	execPathOutput, err := exec.Command("git", "--exec-path").Output()
+	if err != nil {
+		return "", fmt.Errorf("git --exec-path: %w", err)
+	}
+	execPath := strings.TrimSpace(string(execPathOutput))
+	if execPath == "" {
+		return "", fmt.Errorf("git --exec-path returned an empty path")
+	}
+	backendPath := filepath.Join(execPath, "git-http-backend")
+	if _, err := os.Stat(backendPath); err != nil {
+		return "", fmt.Errorf("stat git-http-backend %q: %w", backendPath, err)
+	}
+	return backendPath, nil
+}
+
+// auth authenticates and authorizes a git HTTP request.
+//
+// The first return value indicates the authenticated and authorized user, or
+// nil if unauthenticated or unauthorized.
+//
+// The second return value 'ok' indicates whether request processing should
+// proceed. If it is false, auth will have written an error response to
+// the response writer, and the caller should not perform further writes.
+func auth(w http.ResponseWriter, r *http.Request, gitProjectRoot, globalAccessToken string) (remoteUser *string, ok bool) {
+	// git-receive-pack (e.g. git push) requires auth. If we don't set
+	// REMOTE_USER for git-receive-pack requests, then the request will be
+	// rejected by git-http-backend, returning an unstructured error message. So
+	// we proactively check for this case here and return a 401 if appropriate.
+	isUpload := r.URL.Query().Get("service") == "git-receive-pack"
+
+	owner, repo, err := parseOwnerRepo(r)
+	if err != nil {
+		http.Error(w, "invalid URL: failed to parse owner/repo", 400)
+		return nil, false
+	}
+
+	// If the basic auth password matches the global access token, skip
+	// repo-specific access controls.
+	if globalAccessToken != "" {
+		if _, token, ok := r.BasicAuth(); ok && token == globalAccessToken {
+			remoteUser = &owner
+			return remoteUser, true
+		}
+	}
+
+	project, err := ReadProjectSettings(gitProjectRoot, owner, repo)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.Error(w, "Repository not found", http.StatusNotFound)
+			return nil, false
+		}
+		log.CtxErrorf(r.Context(), "Failed to read project settings: %s", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return nil, false
+	}
+
+	// If the repo is public and this is not a write request, then access is
+	// granted.
+	if project.Public && !isUpload {
+		return nil, true
+	}
+
+	// If the repo is not public or this is a write request, then we need to
+	// authenticate.
+	w.Header().Set("WWW-Authenticate", "Basic")
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	return nil, false
+}
+
+func parseOwnerRepo(r *http.Request) (string, string, error) {
+	p := r.URL.Path
+	p = path.Clean(p)
+	p = strings.TrimPrefix(p, "/")
+	parts := strings.Split(p, "/")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("invalid number of path components")
+	}
+	return parts[0], parts[1], nil
+}
+
+type infoLogger struct{}
+
+func (l *infoLogger) Write(p []byte) (n int, err error) {
+	log.Infof("git-http-backend: %s", string(p))
+	return len(p), nil
+}

--- a/server/util/mockgitserver/mockgitserver_test.go
+++ b/server/util/mockgitserver/mockgitserver_test.go
@@ -1,0 +1,138 @@
+package mockgitserver_test
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testshell"
+	"github.com/buildbuddy-io/buildbuddy/server/util/mockgitserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockGitServerPushAndPull(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		repoIsPublic bool
+		repoTokens   []string
+		userToken    string
+
+		wantCloneError string
+		wantPushError  string
+	}{
+		{
+			name:          "can pull public repo as unauthenticated user",
+			repoIsPublic:  true,
+			wantPushError: "remote: Unauthorized",
+		},
+		{
+			name:          "can pull but not push public repo with invalid access token",
+			repoIsPublic:  true,
+			userToken:     "invalid-test-token",
+			wantPushError: "remote: Unauthorized",
+		},
+		{
+			name:         "can pull and push public repo if authenticated as repo owner",
+			repoIsPublic: true,
+			userToken:    "test-token",
+		},
+		{
+			name:           "cannot pull private repo as unauthenticated user",
+			repoIsPublic:   false,
+			wantCloneError: "remote: Unauthorized",
+		},
+		{
+			name:           "cannot pull private repo with invalid access token",
+			repoIsPublic:   false,
+			userToken:      "invalid-test-token",
+			wantCloneError: "remote: Unauthorized",
+		},
+		{
+			name:         "can pull and push private repo if authenticated as repo owner",
+			repoIsPublic: false,
+			userToken:    "test-token",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// For the purposes of this test, set GIT_ASKPASS to a no-op
+			// executable to prevent "No such device or address" errors, and
+			// instead just tell git to send empty credentials to the server
+			// when the server asks for them.
+			t.Setenv("GIT_ASKPASS", "/usr/bin/true")
+			t.Setenv("GIT_TERMINAL_PROMPT", "0")
+			// Disable credential helpers so macOS keychain prompts do not hang
+			// the test when a remote URL contains credentials.
+			t.Setenv("GIT_CONFIG_COUNT", "1")
+			t.Setenv("GIT_CONFIG_KEY_0", "credential.helper")
+			t.Setenv("GIT_CONFIG_VALUE_0", "")
+
+			remoteRoot := testfs.MakeTempDir(t)
+
+			// Provision a bare repository for testorg/testrepo.
+			err := mockgitserver.CreateProject(remoteRoot, "testorg", "testrepo", &mockgitserver.ProjectSettings{
+				Public: test.repoIsPublic,
+			})
+			require.NoError(t, err)
+
+			// Serve the repository.
+			server := httptest.NewServer(mockgitserver.NewHandler(remoteRoot, mockgitserver.Options{
+				AccessToken: "test-token",
+			}))
+			t.Cleanup(server.Close)
+
+			// Try cloning. Note, we need to add the server's TLS certificate,
+			// otherwise we cannot use auth.
+			remoteURL := server.URL
+			if test.userToken != "" {
+				u, err := url.Parse(server.URL)
+				require.NoError(t, err)
+				u.User = url.UserPassword("x-token", test.userToken)
+				remoteURL = u.String()
+			}
+			localRoot := testfs.MakeTempDir(t)
+			_, stderr, err := testshell.Try(t, localRoot, `
+				git clone `+remoteURL+`/testorg/testrepo clonedir
+			`)
+			if test.wantCloneError != "" {
+				assert.Contains(t, stderr, test.wantCloneError)
+				require.Error(t, err, "stderr: %s", stderr)
+				return
+			} else {
+				require.NoError(t, err, "stderr: %s", stderr)
+			}
+
+			// Try pushing a commit.
+			_, stderr, err = testshell.Try(t, localRoot, `
+				cd clonedir
+				git config user.name 'Test'
+				git config user.email test@test.com
+				echo "test-readme-content" > README
+				git add .
+				git commit -m "Initial commit"
+				git push
+			`)
+			if test.wantPushError != "" {
+				assert.Contains(t, stderr, test.wantPushError)
+				require.Error(t, err, "stderr: %s", stderr)
+				return
+			} else {
+				require.NoError(t, err, "stderr: %s", stderr)
+			}
+
+			// If we got this far, we can both pull and push. Try cloning again
+			// and make sure the clone contains our new file.
+			stdout, stderr, err := testshell.Try(t, localRoot, `
+				mkdir clonedir2
+				cd clonedir2
+				git init >&2
+				cp ../clonedir/.git/config .git/config
+				git pull
+				cat README
+			`)
+			assert.Equal(t, string("test-readme-content\n"), stdout)
+			require.NoError(t, err, "stderr: %s", stderr)
+		})
+	}
+}


### PR DESCRIPTION
Add a "gitserver" implementation which will let us mock out GitHub as well as run a git http server for local testing (just the basic git operations - not the GH APIs). In a follow-up, I'm planning to integrate this with remote_bazel_test to remove the dependency on GitHub and make the test work offline.

The git server is backed by `git-http-backend` which is a [CGI](https://en.wikipedia.org/wiki/Common_Gateway_Interface) program distributed with git. golang has a nice `net/http/cgi` library in stdlib for running CGI programs in HTTP servers, which makes integration relatively straightforward.

One thing that is slightly non-trivial is auth. The only concept of auth supported by `git-http-backend` is that repos cannot be written to unless `REMOTE_USER` is set in the environment, otherwise all repos can be both read and written. To make this work more like GitHub, there is a little bit of basic auth middleware to make public/private visibility work as we'd expect. The gitserver can be configured with a single access token, which grants read/write access to all repos if set. Otherwise, if the token is unset, only public repos can be accessed, and only in readonly mode.