### PR TITLE
Make ByteStreamServerProxy call ByteStreamServer directly

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -16,10 +16,12 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/authutil",
         "//server/util/log",
+        "//server/util/proto",
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -16,12 +16,10 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/authutil",
         "//server/util/log",
-        "//server/util/proto",
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
-        "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync/atomic"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/proxy_util"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -13,9 +14,11 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/metadata"
 
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gstatus "google.golang.org/grpc/status"
@@ -24,7 +27,7 @@ import (
 type ByteStreamServerProxy struct {
 	atimeUpdater  interfaces.AtimeUpdater
 	authenticator interfaces.Authenticator
-	local         bspb.ByteStreamClient
+	local         interfaces.ByteStreamServer
 	remote        bspb.ByteStreamClient
 }
 
@@ -46,13 +49,13 @@ func New(env environment.Env) (*ByteStreamServerProxy, error) {
 	if authenticator == nil {
 		return nil, fmt.Errorf("An Authenticator is required to enable ByteStreamServerProxy")
 	}
-	local := env.GetLocalByteStreamClient()
-	if local == nil {
-		return nil, fmt.Errorf("A local ByteStreamClient is required to enable ByteStreamServerProxy")
-	}
 	remote := env.GetByteStreamClient()
 	if remote == nil {
 		return nil, fmt.Errorf("A remote ByteStreamClient is required to enable ByteStreamServerProxy")
+	}
+	local := env.GetLocalByteStreamServer()
+	if local == nil {
+		return nil, fmt.Errorf("A local ByteStreamServer is required to enable ByteStreamServerProxy")
 	}
 	return &ByteStreamServerProxy{
 		atimeUpdater:  atimeUpdater,
@@ -62,77 +65,185 @@ func New(env environment.Env) (*ByteStreamServerProxy, error) {
 	}, nil
 }
 
+// Wrapper around a ByteStream_ReadServer that counts the number of frames
+// and bytes read through it.
+type meteredReadServerStream struct {
+	bytes  *atomic.Int64
+	frames *atomic.Int64
+	proxy  bspb.ByteStream_ReadServer
+}
+
+func (s *meteredReadServerStream) GetByteCount() int64 {
+	return s.bytes.Load()
+}
+
+func (s *meteredReadServerStream) GetFrameCount() int64 {
+	return s.frames.Load()
+}
+
+func (s meteredReadServerStream) Send(message *bspb.ReadResponse) error {
+	s.bytes.Add(int64(proto.Size(message)))
+	s.frames.Add(1)
+	return s.proxy.Send(message)
+}
+
+func (s meteredReadServerStream) SetHeader(header metadata.MD) error {
+	return s.proxy.SetHeader(header)
+}
+
+func (s meteredReadServerStream) SendHeader(header metadata.MD) error {
+	return s.proxy.SendHeader(header)
+}
+
+func (s meteredReadServerStream) SetTrailer(trailer metadata.MD) {
+	s.proxy.SetTrailer(trailer)
+}
+
+func (s meteredReadServerStream) Context() context.Context {
+	return s.proxy.Context()
+}
+
+func (s meteredReadServerStream) SendMsg(message any) error {
+	return s.proxy.SendMsg(message)
+}
+
+func (s meteredReadServerStream) RecvMsg(message any) error {
+	return s.proxy.RecvMsg(message)
+}
+
 func (s *ByteStreamServerProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
 	ctx, spn := tracing.StartSpan(stream.Context())
 	defer spn.End()
 
-	skipRemote := proxy_util.SkipRemote(ctx)
+	cacheStatus := "unknown"
+	var err error
 	requestTypeLabel := proxy_util.RequestTypeLabelFromContext(ctx)
+	meteredStream := &meteredReadServerStream{
+		bytes:  &atomic.Int64{},
+		frames: &atomic.Int64{},
+		proxy:  stream,
+	}
+	stream = nil // use meteredStream
 
 	if authutil.EncryptionEnabled(ctx, s.authenticator) {
-		bytesRead, err := s.readRemote(req, stream)
-		recordReadMetrics(metrics.UncacheableStatusLabel, requestTypeLabel, err, bytesRead)
+		cacheStatus = metrics.UncacheableStatusLabel
+		err = s.readRemoteOnly(ctx, req, meteredStream)
+	} else if proxy_util.SkipRemote(ctx) {
+		err = s.readLocalOnly(req, meteredStream)
+		cacheStatus = metrics.MissStatusLabel
+		if err == nil {
+			cacheStatus = metrics.HitStatusLabel
+		}
+	} else {
+		localErr := s.local.Read(req, meteredStream)
+		if localErr != nil && meteredStream.GetFrameCount() == 0 {
+			// Recover from local error if no frames have been sent
+			cacheStatus = metrics.MissStatusLabel
+			err = s.readRemoteWriteLocal(req, meteredStream)
+		} else {
+			cacheStatus = metrics.HitStatusLabel
+			s.atimeUpdater.EnqueueByResourceName(ctx, req.ResourceName)
+		}
+	}
+
+	recordReadMetrics(cacheStatus, requestTypeLabel, err, int(meteredStream.GetByteCount()))
+	return err
+}
+
+func (s *ByteStreamServerProxy) readRemoteOnly(ctx context.Context, req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
+	remoteReadStream, err := s.remote.Read(ctx, req)
+	if err != nil {
+		return err
+	}
+	for {
+		message, err := remoteReadStream.Recv()
+		if err != nil {
+			return err
+		}
+		if err = stream.Send(message); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *ByteStreamServerProxy) readLocalOnly(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
+	return s.local.Read(req, stream)
+}
+
+func writeRequest(resourceName string, data []byte, offset int64, finishWrite bool) *bspb.WriteRequest {
+	return &bspb.WriteRequest{
+		ResourceName: resourceName,
+		Data:         data,
+		WriteOffset:  offset,
+		FinishWrite:  finishWrite,
+	}
+}
+
+func (s *ByteStreamServerProxy) readRemoteWriteLocal(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
+	ctx, spn := tracing.StartSpan(stream.Context())
+	defer spn.End()
+
+	remoteReadStream, err := s.remote.Read(ctx, req)
+	if err != nil {
+		log.CtxInfof(ctx, "error reading from remote: %s", err)
 		return err
 	}
 
-	localReadStream, err := s.local.Read(ctx, req)
-	if err != nil {
-		if skipRemote {
-			recordReadMetrics(metrics.MissStatusLabel, requestTypeLabel, err, 0)
+	uploadRN := ""
+	localWriteOffset := req.ReadOffset
+	var localWriter interfaces.ByteStreamWriteHandler
+
+	for {
+		rsp, err := remoteReadStream.Recv()
+
+		if err == io.EOF {
+			if localWriter != nil {
+				_, err = localWriter.Write(writeRequest(uploadRN, []byte{}, localWriteOffset, true))
+				if err != nil {
+					log.CtxDebugf(ctx, "Error writing to local ByteStreamServer: %v", err)
+				}
+			}
+			return nil
+		}
+		if err != nil {
+			log.CtxInfof(ctx, "Error streaming from remote for read through: %s", err)
 			return err
 		}
 
-		// Fall back to reading from the remote cache.
-		if !status.IsNotFoundError(err) {
-			log.CtxInfof(ctx, "Error reading from local bytestream client: %s", err)
-		}
-		bytesRead, err := s.readRemote(req, stream)
-		recordReadMetrics(metrics.MissStatusLabel, requestTypeLabel, err, bytesRead)
-		return err
-	}
-
-	if !skipRemote {
-		s.atimeUpdater.EnqueueByResourceName(ctx, req.ResourceName)
-	}
-
-	responseSent := false
-	bytesRead := 0
-	for {
-		rsp, err := localReadStream.Recv()
-		if rsp != nil {
-			bytesRead += len(rsp.Data)
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			// If some responses were streamed to the client, just return the
-			// error. Otherwise, fall-back to remote. We might be able to
-			// continue streaming to the client by doing an offset read from
-			// the remote cache, but keep it simple for now.
-			if responseSent {
-				log.CtxInfof(ctx, "error midstream of local read: %s", err)
-				recordReadMetrics(metrics.HitStatusLabel, requestTypeLabel, err, bytesRead)
+		if uploadRN == "" {
+			// Rewrite the resource name so we can write to the local server.
+			rn, err := digest.ParseDownloadResourceName(req.GetResourceName())
+			if err != nil {
 				return err
-			} else if skipRemote {
-				recordReadMetrics(metrics.MissStatusLabel, requestTypeLabel, err, bytesRead)
-				return err
+			}
+			uploadRN = rn.NewUploadString()
+		}
+
+		// Initialize local cache writer if necessary
+		if localWriteOffset == 0 && localWriter == nil {
+			localWriter, err = s.local.BeginWrite(ctx, writeRequest(uploadRN, rsp.GetData(), localWriteOffset, false))
+			if err != nil {
+				log.CtxDebugf(ctx, "Error opening local ByteStreamServer write stream: %v", err)
 			} else {
-				// Fall back to reading remotely if the local read fails.
-				remoteBytesRead, err := s.readRemote(req, stream)
-				recordReadMetrics(metrics.MissStatusLabel, requestTypeLabel, err, remoteBytesRead)
-				return err
+				defer localWriter.Close()
 			}
 		}
 
-		if err := stream.Send(rsp); err != nil {
-			recordReadMetrics(metrics.HitStatusLabel, requestTypeLabel, err, bytesRead)
+		// Write to local cache
+		if localWriter != nil {
+			_, err = localWriter.Write(writeRequest(uploadRN, rsp.GetData(), localWriteOffset, false))
+			if err != nil {
+				log.CtxDebugf(ctx, "Error writing to local ByteStreamServer: %v", err)
+				localWriter = nil
+			}
+		}
+
+		// Send frame to client
+		localWriteOffset += int64(len(rsp.GetData()))
+		if err = stream.Send(rsp); err != nil {
 			return err
 		}
-		responseSent = true
 	}
-	recordReadMetrics(metrics.HitStatusLabel, requestTypeLabel, nil, bytesRead)
-	return nil
 }
 
 func recordReadMetrics(cacheStatus string, proxyRequestType string, err error, bytesRead int) {
@@ -145,221 +256,180 @@ func recordReadMetrics(cacheStatus string, proxyRequestType string, err error, b
 	metrics.ByteStreamProxiedReadBytes.With(labels).Add(float64(bytesRead))
 }
 
-func recordWriteMetrics(resp *bspb.WriteResponse, err error, proxyRequestType string) {
-	labels := prometheus.Labels{
-		metrics.StatusLabel:           fmt.Sprintf("%d", gstatus.Code(err)),
-		metrics.CacheHitMissStatus:    metrics.MissStatusLabel,
-		metrics.CacheProxyRequestType: proxyRequestType,
-	}
-	metrics.ByteStreamProxiedWriteRequests.With(labels).Inc()
-	if resp != nil && resp.GetCommittedSize() > 0 {
-		metrics.ByteStreamProxiedWriteBytes.With(labels).Add(float64(resp.GetCommittedSize()))
-	}
+// Wrapper around a ByteStream_WriteServer that counts the number of bytes
+// written through it.
+type meteredServerSideClientStream struct {
+	bytes *atomic.Int64
+	proxy bspb.ByteStream_WriteServer
 }
 
-// The Write() RPC requires the client keep track of some state. The
-// implementations of this interface take care of that.
-type localWriter interface {
-	send(data []byte) error
-	commit() error
+func (s *meteredServerSideClientStream) GetByteCount() int64 {
+	return s.bytes.Load()
 }
 
-// A localWriter that discards everything sent to it.
-type discardingLocalWriter struct {
+func (s meteredServerSideClientStream) SendAndClose(message *bspb.WriteResponse) error {
+	return s.proxy.SendAndClose(message)
 }
 
-func (s *discardingLocalWriter) send(data []byte) error {
-	return nil
+func (s meteredServerSideClientStream) Recv() (*bspb.WriteRequest, error) {
+	message, err := s.proxy.Recv()
+	s.bytes.Add(int64(proto.Size(message)))
+	return message, err
 }
 
-func (s *discardingLocalWriter) commit() error {
-	return nil
+func (s meteredServerSideClientStream) SetHeader(header metadata.MD) error {
+	return s.proxy.SetHeader(header)
 }
 
-// A localWriter that writes data to a local ByteStream_WriteClient.
-type realLocalWriter struct {
-	ctx          context.Context
-	local        bspb.ByteStream_WriteClient
-	resourceName string
-	initialized  bool
-	offset       int64
+func (s meteredServerSideClientStream) SendHeader(header metadata.MD) error {
+	return s.proxy.SendHeader(header)
 }
 
-func (s *realLocalWriter) send(data []byte) error {
-	req := &bspb.WriteRequest{WriteOffset: s.offset, Data: data}
-	if !s.initialized {
-		// Rewrite the resource name so we can write to the local server.
-		rn, err := digest.ParseDownloadResourceName(s.resourceName)
-		if err != nil {
-			return err
-		}
-		req.ResourceName = rn.NewUploadString()
-		s.initialized = true
-	}
-	s.offset += int64(len(data))
-	return s.local.Send(req)
+func (s meteredServerSideClientStream) SetTrailer(trailer metadata.MD) {
+	s.proxy.SetTrailer(trailer)
 }
 
-func (s *realLocalWriter) commit() error {
-	if err := s.local.Send(&bspb.WriteRequest{WriteOffset: s.offset, FinishWrite: true}); err != nil {
-		return err
-	}
-	// Ignore the local response (but not the error)
-	_, err := s.local.CloseAndRecv()
-	return err
+func (s meteredServerSideClientStream) Context() context.Context {
+	return s.proxy.Context()
 }
 
-func (s *ByteStreamServerProxy) readRemote(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) (int, error) {
-	ctx, spn := tracing.StartSpan(stream.Context())
-	defer spn.End()
+func (s meteredServerSideClientStream) SendMsg(message any) error {
+	return s.proxy.SendMsg(message)
+}
 
-	remoteReadStream, err := s.remote.Read(ctx, req)
-	if err != nil {
-		log.CtxInfof(ctx, "error reading from remote: %s", err)
-		return 0, err
-	}
-
-	var localWriteStream localWriter = &discardingLocalWriter{}
-	if req.ReadOffset == 0 && !authutil.EncryptionEnabled(ctx, s.authenticator) {
-		localStream, err := s.local.Write(ctx)
-		if err == nil {
-			localWriteStream = &realLocalWriter{
-				ctx:          ctx,
-				local:        localStream,
-				resourceName: req.ResourceName,
-				initialized:  false,
-				offset:       int64(0),
-			}
-		} else {
-			log.CtxInfof(ctx, "error opening local bytestream write stream for read through: %s", err)
-		}
-	}
-
-	bytesRead := 0
-	for {
-		rsp, err := remoteReadStream.Recv()
-		if rsp != nil {
-			bytesRead += len(rsp.Data)
-		}
-		if err != nil {
-			if err == io.EOF {
-				if err := localWriteStream.commit(); err != nil {
-					log.CtxInfof(ctx, "error committing local write: %s", err)
-				}
-				break
-			}
-			log.CtxInfof(ctx, "error streaming from remote for read through: %s", err)
-			return bytesRead, err
-		}
-
-		if err := localWriteStream.send(rsp.Data); err != nil {
-			log.CtxInfof(ctx, "Error writing locally for read through: %s", err)
-			localWriteStream = &discardingLocalWriter{}
-		}
-		if err = stream.Send(rsp); err != nil {
-			return bytesRead, err
-		}
-	}
-	return bytesRead, nil
+func (s meteredServerSideClientStream) RecvMsg(message any) error {
+	return s.proxy.RecvMsg(message)
 }
 
 func (s *ByteStreamServerProxy) Write(stream bspb.ByteStream_WriteServer) error {
-	resp, err := s.write(stream)
-	requestTypeLabel := proxy_util.RequestTypeLabelFromContext(stream.Context())
-	recordWriteMetrics(resp, err, requestTypeLabel)
-	return err
-}
-
-func (s *ByteStreamServerProxy) write(stream bspb.ByteStream_WriteServer) (*bspb.WriteResponse, error) {
 	ctx, spn := tracing.StartSpan(stream.Context())
 	defer spn.End()
 
-	var local bspb.ByteStream_WriteClient
-	if !authutil.EncryptionEnabled(ctx, s.authenticator) {
-		localWriter, err := s.local.Write(ctx)
-		if err != nil {
-			log.CtxInfof(ctx, "error opening local bytestream write stream for write: %s", err)
-			localWriter = nil
+	requestTypeLabel := proxy_util.RequestTypeLabelFromContext(stream.Context())
+	meteredStream := &meteredServerSideClientStream{
+		bytes: &atomic.Int64{},
+		proxy: stream,
+	}
+	stream = nil // use meteredStream
+	var err error
+	if authutil.EncryptionEnabled(ctx, s.authenticator) {
+		err = s.writeRemoteOnly(ctx, meteredStream)
+	} else if proxy_util.SkipRemote(ctx) {
+		err = s.writeLocalOnly(meteredStream)
+	} else {
+		err = s.dualWrite(ctx, meteredStream)
+	}
+	recordWriteMetrics(meteredStream.GetByteCount(), err, requestTypeLabel)
+	return err
+}
+
+func (s *ByteStreamServerProxy) writeRemoteOnly(ctx context.Context, stream bspb.ByteStream_WriteServer) error {
+	remoteStream, err := s.remote.Write(ctx)
+	if err != nil {
+		return err
+	}
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			break
 		}
-		local = localWriter
+		if err != nil {
+			return err
+		}
+		if err = remoteStream.Send(req); err != nil {
+			return err
+		}
+		if req.GetFinishWrite() {
+			break
+		}
+	}
+	resp, err := remoteStream.CloseAndRecv()
+	if err != nil {
+		return err
+	}
+	return stream.SendAndClose(resp)
+}
+
+func (s *ByteStreamServerProxy) writeLocalOnly(stream bspb.ByteStream_WriteServer) error {
+	return s.local.Write(stream)
+}
+
+// TODO(iain): investigate performance of making the local write async
+func (s *ByteStreamServerProxy) dualWrite(ctx context.Context, stream bspb.ByteStream_WriteServer) error {
+	// Grab the first frame from the client so the local writer can be created
+	req, err := stream.Recv()
+	if err != nil {
+		return err
 	}
 
-	var remote bspb.ByteStream_WriteClient
-	// `local` can be nil for encrypted requests. The proxy doesn't support encrpytion,
-	// so always write encrypted requests to the remote cache.
-	if !proxy_util.SkipRemote(ctx) || local == nil {
-		var err error
-		remote, err = s.remote.Write(ctx)
-		if err != nil {
-			return nil, err
-		}
+	localWriteStream, err := s.local.BeginWrite(ctx, req)
+	if err == nil {
+		defer localWriteStream.Close()
+	} else {
+		log.CtxDebugf(ctx, "Error opening local write stream: %v", err)
+	}
+
+	remoteWriteStream, err := s.remote.Write(ctx)
+	if err != nil {
+		return err
 	}
 
 	for {
-		req, err := stream.Recv()
-		if err != nil {
-			return nil, err
-		}
-
-		// Send to the local ByteStreamServer (if it hasn't errored)
+		// Send to the local ByteStreamServer (if available)
 		localDone := req.GetFinishWrite()
-		if local != nil {
-			if err := local.Send(req); err != nil {
+		if localWriteStream != nil {
+			if _, err := localWriteStream.Write(req); err != nil {
+				localWriteStream = nil
 				if err == io.EOF {
 					localDone = true
 				} else {
-					// Swallow local write errors if we're writing remotely too
-					if remote != nil {
-						log.CtxInfof(ctx, "error writing to local bytestream server for write: %s", err)
-						local = nil
-					} else {
-						return nil, err
-					}
+					log.CtxInfof(ctx, "error writing to local bytestream server for write: %s", err)
 				}
 			}
 		}
 
 		// Send to the remote ByteStreamServer
 		remoteDone := req.GetFinishWrite()
-		if remote != nil {
-			if err := remote.Send(req); err != nil {
-				if err == io.EOF {
-					remoteDone = true
-				} else {
-					return nil, err
-				}
+		if err := remoteWriteStream.Send(req); err != nil {
+			if err == io.EOF {
+				remoteDone = true
+			} else {
+				return err
 			}
 		}
 
-		// If the client or the remote server told us the write is done, send the
-		// response to the client.
-		if remote == nil && localDone {
-			resp, err := local.CloseAndRecv()
+		// Handle stream-finished cases
+		if remoteDone {
+			if localWriteStream != nil && !localDone {
+				log.CtxDebug(ctx, "remote write done but local write is not")
+			}
+			resp, err := remoteWriteStream.CloseAndRecv()
 			if err != nil {
-				return nil, err
+				return err
 			}
 			err = stream.SendAndClose(resp)
-			return resp, err
-		}
-
-		if remote != nil && remoteDone {
-			if local != nil {
-				if !localDone {
-					log.CtxInfo(ctx, "remote write done but local write is not")
-				}
-				if _, err := local.CloseAndRecv(); err != nil {
-					log.CtxInfof(ctx, "error closing local write stream: %s", err)
-				}
-			}
-			resp, err := remote.CloseAndRecv()
-			if err != nil {
-				return nil, err
-			}
-			err = stream.SendAndClose(resp)
-			return resp, err
+			return err
 		} else if localDone {
-			log.CtxInfo(ctx, "local write done but remote write is not")
+			log.CtxDebug(ctx, "local write done but remote write is not")
 		}
+
+		// Finally, receive the next frame from the client
+		req, err = stream.Recv()
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func recordWriteMetrics(bytesWritten int64, err error, proxyRequestType string) {
+	labels := prometheus.Labels{
+		metrics.StatusLabel:           fmt.Sprintf("%d", gstatus.Code(err)),
+		metrics.CacheHitMissStatus:    metrics.MissStatusLabel,
+		metrics.CacheProxyRequestType: proxyRequestType,
+	}
+	metrics.ByteStreamProxiedWriteRequests.With(labels).Inc()
+	if bytesWritten > 0 {
+		metrics.ByteStreamProxiedWriteBytes.With(labels).Add(float64(bytesWritten))
 	}
 }
 

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -98,24 +98,14 @@ func runRemoteServices(ctx context.Context, env *testenv.TestEnv, t testing.TB) 
 	return bspb.NewByteStreamClient(conn), repb.NewContentAddressableStorageClient(conn), &unaryRequestCounter, &streamRequestCounter
 }
 
-func runLocalBSS(ctx context.Context, env *testenv.TestEnv, t testing.TB) bspb.ByteStreamClient {
-	server, err := byte_stream_server.NewByteStreamServer(env)
-	require.NoError(t, err)
-	grpcServer, runFunc, lis := testenv.RegisterLocalInternalGRPCServer(t, env)
-	bspb.RegisterByteStreamServer(grpcServer, server)
-	go runFunc()
-	conn, err := testenv.LocalInternalGRPCConn(ctx, lis)
-	require.NoError(t, err)
-	t.Cleanup(func() { conn.Close() })
-	return bspb.NewByteStreamClient(conn)
-}
-
 func runBSProxy(ctx context.Context, client bspb.ByteStreamClient, env *testenv.TestEnv, t testing.TB) bspb.ByteStreamClient {
 	if env.GetAtimeUpdater() == nil {
 		env.SetAtimeUpdater(&testenv.NoOpAtimeUpdater{})
 	}
 	env.SetByteStreamClient(client)
-	env.SetLocalByteStreamClient(runLocalBSS(ctx, env, t))
+	bss, err := byte_stream_server.NewByteStreamServer(env)
+	require.NoError(t, err)
+	env.SetLocalByteStreamServer(bss)
 	byteStreamServer, err := New(env)
 	require.NoError(t, err)
 	grpcServer, runFunc, lis := testenv.RegisterLocalGRPCServer(t, env)

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -169,24 +169,11 @@ func startGRPCServers(env *real_environment.RealEnv) error {
 		},
 	}
 
-	// Start and register services on the internal gRPC server first because
-	// the external proxy services rely on the internal services.
-	is, err := grpc_server.New(env, grpc_server.InternalGRPCPort(), false, grpcServerConfig)
-	if err != nil {
+	// Start and register internal servers first because the external proxy
+	// services rely on the internal servers.
+	if err := registerInternalServices(env); err != nil {
 		return err
 	}
-	if err := registerInternalGRPCServices(is.GetServer(), env); err != nil {
-		return err
-	}
-	if err := is.Start(); err != nil {
-		return err
-	}
-
-	conn, err := grpc_client.DialInternal(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.InternalGRPCPort()))
-	if err != nil {
-		return status.InternalErrorf("CacheProxy: error starting local bytestream gRPC server: %s", err.Error())
-	}
-	env.SetLocalByteStreamClient(bspb.NewByteStreamClient(conn))
 
 	s, err := grpc_server.New(env, grpc_server.GRPCPort(), false, grpcServerConfig)
 	if err != nil {
@@ -247,12 +234,12 @@ func registerGRPCServices(grpcServer *grpc.Server, env *real_environment.RealEnv
 	log.Infof("Cache proxy proxying requests to %s", *remoteCache)
 }
 
-func registerInternalGRPCServices(grpcServer *grpc.Server, env *real_environment.RealEnv) error {
+func registerInternalServices(env *real_environment.RealEnv) error {
 	localBSS, err := byte_stream_server.NewByteStreamServer(env)
 	if err != nil {
 		return status.InternalErrorf("CacheProxy: error starting local bytestream server: %s", err.Error())
 	}
-	bspb.RegisterByteStreamServer(grpcServer, localBSS)
+	env.SetLocalByteStreamServer(localBSS)
 
 	localCAS, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
 	if err != nil {

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -99,7 +99,6 @@ type Env interface {
 	GetGitHubStatusService() interfaces.GitHubStatusService
 	GetLocalCASServer() repb.ContentAddressableStorageServer
 	GetCASServer() repb.ContentAddressableStorageServer
-	GetLocalByteStreamClient() bspb.ByteStreamClient
 	GetLocalByteStreamServer() interfaces.ByteStreamServer
 	GetByteStreamServer() bspb.ByteStreamServer
 	GetLocalActionCacheServer() repb.ActionCacheServer

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -96,7 +96,6 @@ type RealEnv struct {
 	buildEventServer                 pepb.PublishBuildEventServer
 	localCASServer                   repb.ContentAddressableStorageServer
 	casServer                        repb.ContentAddressableStorageServer
-	localByteStreamClient            bspb.ByteStreamClient
 	localByteStreamServer            interfaces.ByteStreamServer
 	byteStreamServer                 bspb.ByteStreamServer
 	localActionCacheServer           repb.ActionCacheServer
@@ -546,13 +545,6 @@ func (r *RealEnv) GetCASServer() repb.ContentAddressableStorageServer {
 
 func (r *RealEnv) SetCASServer(casServer repb.ContentAddressableStorageServer) {
 	r.casServer = casServer
-}
-
-func (r *RealEnv) GetLocalByteStreamClient() bspb.ByteStreamClient {
-	return r.localByteStreamClient
-}
-func (r *RealEnv) SetLocalByteStreamClient(localByteStreamClient bspb.ByteStreamClient) {
-	r.localByteStreamClient = localByteStreamClient
 }
 
 func (r *RealEnv) GetLocalByteStreamServer() interfaces.ByteStreamServer {


### PR DESCRIPTION
This changes the ByteStreamServerProxy to use the `Read()`, `BeginWrite()`, and `WriteState.Write()` functions directly, the latter two of which were introduced in https://github.com/buildbuddy-io/buildbuddy/pull/9105.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 7 5800X 8-Core Processor             
         │ /home/iain/old.txt │         /home/iain/new.txt          │
         │       sec/op       │   sec/op     vs base                │
Read-16          404.2µ ±  7%   226.6µ ± 5%  -43.94% (p=0.000 n=25)
Write-16         665.7µ ± 10%   477.9µ ± 6%  -28.22% (p=0.000 n=25)
geomean          518.8µ         329.1µ       -36.56%

         │ /home/iain/old.txt │          /home/iain/new.txt          │
         │        B/op        │     B/op      vs base                │
Read-16          149.2Ki ± 0%   104.7Ki ± 0%  -29.78% (p=0.000 n=25)
Write-16         175.7Ki ± 0%   130.8Ki ± 0%  -25.54% (p=0.000 n=25)
geomean          161.9Ki        117.0Ki       -27.69%

         │ /home/iain/old.txt │         /home/iain/new.txt         │
         │     allocs/op      │ allocs/op   vs base                │
Read-16            782.0 ± 0%   439.0 ± 0%  -43.86% (p=0.000 n=25)
Write-16          1267.0 ± 0%   928.0 ± 0%  -26.76% (p=0.000 n=25)
geomean            995.4        638.3       -35.88%
```

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4782