### PR TITLE
Reinstate "[SS] Skip accessing the remote cache when proxy is enabled" (#9072)

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -129,6 +129,8 @@ go_test(
     ],
     deps = [
         ":firecracker",
+        "//enterprise/server/action_cache_server_proxy",
+        "//enterprise/server/byte_stream_server_proxy",
         "//enterprise/server/clientidentity",
         "//enterprise/server/ociregistry",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/action_cache_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/ociregistry"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
@@ -192,6 +194,7 @@ type envOpts struct {
 	cacheRootDir     string
 	cacheSize        int64
 	filecacheRootDir string
+	runProxy         bool
 }
 
 func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEnv {
@@ -255,10 +258,40 @@ func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEn
 	if err != nil {
 		t.Error(err)
 	}
+	t.Cleanup(func() { conn.Close() })
 
-	env.SetByteStreamClient(bspb.NewByteStreamClient(conn))
-	env.SetActionCacheClient(repb.NewActionCacheClient(conn))
+	bsClient := bspb.NewByteStreamClient(conn)
+	env.SetByteStreamClient(bsClient)
+	acClient := repb.NewActionCacheClient(conn)
+	env.SetActionCacheClient(acClient)
 	env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
+
+	if opts.runProxy {
+		// Initialize proxies in their own env.
+		proxyEnv := testenv.GetTestEnv(t)
+		proxyEnv.SetActionCacheClient(acClient)
+		proxyEnv.SetByteStreamClient(bsClient)
+		proxyEnv.SetAtimeUpdater(&testenv.NoOpAtimeUpdater{})
+		runProxyGrpcServers(ctx, proxyEnv, t)
+
+		acProxy, err := action_cache_server_proxy.NewActionCacheServerProxy(proxyEnv)
+		require.NoError(t, err)
+		bsProxy, err := byte_stream_server_proxy.New(proxyEnv)
+		require.NoError(t, err)
+
+		proxyGrpcServer, proxyRunFunc, proxyLis := testenv.RegisterLocalGRPCServer(t, proxyEnv)
+		repb.RegisterActionCacheServer(proxyGrpcServer, acProxy)
+		bspb.RegisterByteStreamServer(proxyGrpcServer, bsProxy)
+		go proxyRunFunc()
+
+		proxyConn, err := testenv.LocalGRPCConn(ctx, proxyLis)
+		require.NoError(t, err)
+		t.Cleanup(func() { proxyConn.Close() })
+
+		// Point cache clients on primary env towards proxies.
+		env.SetActionCacheClient(repb.NewActionCacheClient(proxyConn))
+		env.SetByteStreamClient(bspb.NewByteStreamClient(proxyConn))
+	}
 
 	fcDir := opts.filecacheRootDir
 	if *filecacheDir != "" {
@@ -281,6 +314,22 @@ func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEn
 	})
 
 	return env
+}
+
+func runProxyGrpcServers(ctx context.Context, proxyEnv *testenv.TestEnv, t *testing.T) {
+	server, err := byte_stream_server.NewByteStreamServer(proxyEnv)
+	require.NoError(t, err)
+	acServer, err := action_cache_server.NewActionCacheServer(proxyEnv)
+	require.NoError(t, err)
+	grpcServer, runFunc, lis := testenv.RegisterLocalInternalGRPCServer(t, proxyEnv)
+	bspb.RegisterByteStreamServer(grpcServer, server)
+	repb.RegisterActionCacheServer(grpcServer, acServer)
+	go runFunc()
+	conn, err := testenv.LocalInternalGRPCConn(ctx, lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	proxyEnv.SetLocalByteStreamClient(bspb.NewByteStreamClient(conn))
+	proxyEnv.SetLocalActionCacheClient(repb.NewActionCacheClient(conn))
 }
 
 func executorRootDir(t *testing.T) string {
@@ -1219,6 +1268,84 @@ func TestFirecrackerSnapshotVersioning(t *testing.T) {
 	c3, err := firecracker.NewContainer(ctx, env, task, opts)
 	require.NoError(t, err)
 	require.NotEmpty(t, cmp.Diff(c1.SnapshotKeySet(), c3.SnapshotKeySet(), protocmp.Transform()))
+}
+
+func TestFirecracker_RemoteSnapshotSharing_CacheProxy(t *testing.T) {
+	// Disable local snapshot sharing with filecache to simplify the setup.
+	flags.Set(t, "executor.enable_local_snapshot_sharing", false)
+
+	ctx := context.Background()
+	env := getTestEnv(ctx, t, envOpts{runProxy: true})
+	rootDir := testfs.MakeTempDir(t)
+	cfg := getExecutorConfig(t)
+
+	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	filecacheRoot := testfs.MakeDirAll(t, cfg.JailerRoot, "filecache")
+	fc, err := filecache.NewFileCache(filecacheRoot, fileCacheSize, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+	env.SetFileCache(fc)
+
+	workDir := testfs.MakeDirAll(t, rootDir, "work")
+	opts := firecracker.ContainerOpts{
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		VMConfiguration: &fcpb.VMConfiguration{
+			NumCpus:            1,
+			MemSizeMb:          minMemSizeMB, // small to make snapshotting faster.
+			EnableNetworking:   false,
+			ScratchDiskSizeMb:  100,
+			GuestKernelVersion: cfg.GuestKernelVersion,
+			FirecrackerVersion: cfg.FirecrackerVersion,
+			GuestApiVersion:    cfg.GuestAPIVersion,
+		},
+		ExecutorConfig: cfg,
+	}
+	instanceName := "test-instance-name"
+	task := &repb.ExecutionTask{
+		Command: &repb.Command{
+			// Note: platform must match in order to share snapshots
+			Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+				{Name: "recycle-runner", Value: "true"},
+			}},
+			Arguments: []string{"./buildbuddy_ci_runner"},
+		},
+		ExecuteRequest: &repb.ExecuteRequest{
+			InstanceName: instanceName,
+		},
+	}
+
+	vm, err := firecracker.NewContainer(ctx, env, task, opts)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := vm.Remove(ctx)
+		assert.NoError(t, err)
+	})
+	err = container.PullImageIfNecessary(ctx, env, vm, oci.Credentials{}, opts.ContainerImage)
+	require.NoError(t, err)
+	err = vm.Create(ctx, opts.ActionWorkingDirectory)
+	require.NoError(t, err)
+
+	// Create a snapshot.
+	cmd := appendToLog("Base")
+	res := vm.Exec(ctx, cmd, nil /*=stdio*/)
+	require.NoError(t, res.Error)
+	require.Equal(t, "Base\n", string(res.Stdout))
+	err = vm.Pause(ctx)
+	require.NoError(t, err)
+
+	// No snapshot data should've been saved to the remote cache. It should only
+	// be cached in the proxy.
+	remoteCacheStats := env.GetCache().(*disk_cache.DiskCache).Statusz(ctx)
+	require.Contains(t, remoteCacheStats, "Items: 0")
+
+	// Make sure we can start from a snapshot fetched from the proxy
+	err = vm.Unpause(ctx)
+	require.NoError(t, err)
+	cmd = appendToLog("Child")
+	res = vm.Exec(ctx, cmd, nil /*=stdio*/)
+	require.NoError(t, res.Error)
+	require.Equal(t, "Base\nChild\n", string(res.Stdout))
 }
 
 func TestFirecrackerBalloon(t *testing.T) {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -329,7 +329,7 @@ func runProxyGrpcServers(ctx context.Context, proxyEnv *testenv.TestEnv, t *test
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
 	proxyEnv.SetLocalByteStreamClient(bspb.NewByteStreamClient(conn))
-	proxyEnv.SetLocalActionCacheClient(repb.NewActionCacheClient(conn))
+	proxyEnv.SetLocalActionCacheServer(acServer)
 }
 
 func executorRootDir(t *testing.T) string {
@@ -1334,10 +1334,10 @@ func TestFirecracker_RemoteSnapshotSharing_CacheProxy(t *testing.T) {
 	err = vm.Pause(ctx)
 	require.NoError(t, err)
 
-	// No snapshot data should've been saved to the remote cache. It should only
-	// be cached in the proxy.
+	// Only the snapshot version should've been saved to the remote cache. All
+	// other shapsnot artifacts should only be cached in the proxy.
 	remoteCacheStats := env.GetCache().(*disk_cache.DiskCache).Statusz(ctx)
-	require.Contains(t, remoteCacheStats, "Items: 0")
+	require.Contains(t, remoteCacheStats, "Items: 1")
 
 	// Make sure we can start from a snapshot fetched from the proxy
 	err = vm.Unpause(ctx)

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/snaputil",
+        "//enterprise/server/util/proxy_util",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -117,7 +117,9 @@ func (l *FileCacheLoader) currentSnapshotVersion(ctx context.Context, key *fcpb.
 		return "", err
 	}
 	rn := digest.NewACResourceName(versionKey, key.InstanceName, repb.DigestFunction_BLAKE3)
-	ctx = proxy_util.SetSkipRemote(ctx)
+	// NOTE: We don't use `proxy_util.SetSkipRemote` here because the snapshot
+	// version data should always live in the authoritative cache, to ensure that
+	// any updates are applied universally.
 	acResult, err := cachetools.GetActionResult(ctx, l.env.GetActionCacheClient(), rn)
 	if status.IsNotFoundError(err) {
 		// Version metadata might not exist in the cache if:
@@ -1075,7 +1077,9 @@ func (l *SnapshotService) InvalidateSnapshot(ctx context.Context, key *fcpb.Snap
 
 	acDigest := digest.NewACResourceName(versionKey, key.InstanceName, repb.DigestFunction_BLAKE3)
 
-	ctx = proxy_util.SetSkipRemote(ctx)
+	// NOTE: We don't use `proxy_util.SetSkipRemote` here because the snapshot
+	// version data should always live in the authoritative cache, to ensure that
+	// any updates are applied universally.
 	if err := cachetools.UploadActionResult(ctx, l.env.GetActionCacheClient(), acDigest, versionMetadataActionResult); err != nil {
 		return "", err
 	}

--- a/enterprise/server/remote_execution/snaputil/BUILD
+++ b/enterprise/server/remote_execution/snaputil/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["snaputil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil",
     deps = [
+        "//enterprise/server/util/proxy_util",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/metrics",


### PR DESCRIPTION
This reverts commit fd32eb407b14cdeb56dad1b004965b52ccb51958.

Last week, I noticed in the metrics we had some SkipRemote requests recorded in the cacheproxy. I only expected to see SkipRemote requests coming from workflows, which are currently not running with the proxy, so I reverted the PR out of caution.

After looking into it more, I think those are coming from requests for the snapshot version. Firecracker RBE actions only save snapshots locally, but they still request version data from the remote cache.

The first commit in this PR is the change that was reverted. In the second commit, I remove SkipRemote from requests for the snapshot version, so we'll always save that in the remote cache. This will guarantee that any version invalidations are applied universally