### PR TITLE
Introduce SkipQuarantinedTest; quarantine 1 cache_test test and 4 store_test tests

### DIFF
--- a/enterprise/server/raft/cache/BUILD
+++ b/enterprise/server/raft/cache/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//proto:resource_go_proto",
         "//server/gossip",
         "//server/interfaces",
+        "//server/testutil/quarantine",
         "//server/testutil/testauth",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",

--- a/enterprise/server/raft/cache/cache_test.go
+++ b/enterprise/server/raft/cache/cache_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/usagetracker"
 	"github.com/buildbuddy-io/buildbuddy/server/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
@@ -324,6 +325,7 @@ func TestFindMissingBlobs(t *testing.T) {
 }
 
 func TestLRU(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	flags.Set(t, "cache.raft.entries_between_usage_checks", 1)
 	flags.Set(t, "cache.raft.atime_update_threshold", 10*time.Second)
 	flags.Set(t, "cache.raft.atime_write_batch_size", 1)

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -78,6 +78,7 @@ go_test(
         "//enterprise/server/util/pebble",
         "//proto:raft_go_proto",
         "//proto:storage_go_proto",
+        "//server/testutil/quarantine",
         "//server/testutil/testdigest",
         "//server/util/log",
         "//server/util/proto",

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/testutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -97,6 +98,7 @@ func TestAddGetRemoveRange(t *testing.T) {
 }
 
 func TestCleanupZombieReplicaNotInRangeDescriptor(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	// Prevent driver kicks in to add the replica back to the store.
 	flags.Set(t, "cache.raft.enable_driver", false)
 	clock := clockwork.NewFakeClock()
@@ -166,6 +168,7 @@ func TestCleanupZombieReplicaNotInRangeDescriptor(t *testing.T) {
 }
 
 func TestCleanupZombieInitialMembersNotSetUp(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	// Prevent driver kicks in to add the replica back to the store.
 	flags.Set(t, "cache.raft.min_replicas_per_range", 1)
 	flags.Set(t, "cache.raft.min_meta_range_replicas", 3)
@@ -218,6 +221,7 @@ func TestCleanupZombieInitialMembersNotSetUp(t *testing.T) {
 }
 
 func TestCleanupZombieRangeDescriptorNotInMetaRange(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	// Prevent driver kicks in to add the replica back to the store.
 	flags.Set(t, "cache.raft.enable_driver", false)
 
@@ -277,6 +281,7 @@ func TestCleanupZombieRangeDescriptorNotInMetaRange(t *testing.T) {
 }
 
 func TestCleanupZombieNonVoter(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	// Prevent driver kicks in to add the replica back to the store.
 	flags.Set(t, "cache.raft.enable_driver", false)
 

--- a/server/testutil/quarantine/BUILD
+++ b/server/testutil/quarantine/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "quarantine",
+    testonly = 1,
+    srcs = ["quarantine.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine",
+    visibility = ["//visibility:public"],
+)

--- a/server/testutil/quarantine/quarantine.go
+++ b/server/testutil/quarantine/quarantine.go
@@ -1,0 +1,12 @@
+package quarantine
+
+import (
+	"os"
+	"testing"
+)
+
+func SkipQuarantinedTest(t *testing.T) {
+	if os.Getenv("RUN_QUARANTINED_TESTS") != "true" {
+		t.Skip("skipping quarantined test")
+	}
+}

--- a/server/testutil/quarantine/quarantine.go
+++ b/server/testutil/quarantine/quarantine.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+// SkipQuarantinedTest skips the current test unless
+// the RUN_QUARANTINED_TESTS environment variable is set to "true".
 func SkipQuarantinedTest(t *testing.T) {
 	if os.Getenv("RUN_QUARANTINED_TESTS") != "true" {
 		t.Skip("skipping quarantined test")


### PR DESCRIPTION
By default, we want to skip running flakey tests locally and in CI, while preserving the option to choose to run them.
This change introduces `SkipQuarantinedTest`, which will skip the current test unless `RUN_QUARANTINED_TESTS` environment variable is set to `true`.

If people are comfortable with this change and approach, I will quarantine other flakey tests. From that point on, we will have zero tolerance for flakes: either fix them or delete them.