### PR TITLE
[SS] Don't cache snapshot version remotely for RBE actions

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -695,13 +695,12 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		if snaputil.IsChunkedSnapshotSharingEnabled() {
 			runnerID = ""
 		}
-		c.snapshotKeySet, err = loader.SnapshotKeySet(ctx, task, cd.GetHash(), runnerID)
+		c.snapshotKeySet, err = loader.SnapshotKeySet(ctx, task, cd.GetHash(), runnerID, c.supportsRemoteSnapshots)
 		if err != nil {
 			return nil, err
 		}
 		// If recycling is enabled and a snapshot exists, then when calling
 		// Create(), load the snapshot instead of creating a new VM.
-
 		recyclingEnabled := platform.IsTrue(platform.FindValue(platform.GetProto(task.GetAction(), task.GetCommand()), platform.RecycleRunnerPropertyName))
 		c.recyclingEnabled = recyclingEnabled
 		if recyclingEnabled && snaputil.IsChunkedSnapshotSharingEnabled() {
@@ -2464,7 +2463,7 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 		log.CtxWarningf(ctx, "Failed to check existence of %s: %s", invalidateSnapshotMarkerFile, err)
 	} else if exists {
 		log.CtxInfof(ctx, "Action created %s file in workspace root; invalidating snapshot for key %v", invalidateSnapshotMarkerFile, c.SnapshotKeySet().GetBranchKey())
-		_, err = snaploader.NewSnapshotService(c.env).InvalidateSnapshot(ctx, c.SnapshotKeySet().GetBranchKey())
+		_, err = snaploader.NewSnapshotService(c.env).InvalidateSnapshot(ctx, c.SnapshotKeySet().GetBranchKey(), c.supportsRemoteSnapshots)
 		if err != nil {
 			log.CtxWarningf(ctx, "Failed to invalidate snapshot despite existence of %s: %s", invalidateSnapshotMarkerFile, err)
 		}

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1650,7 +1650,8 @@ func (s *BuildBuddyServer) InvalidateSnapshot(ctx context.Context, request *wfpb
 			al.LogForGroup(ctx, u.GetGroupID(), alpb.Action_INVALIDATE_VM_SNAPSHOT, request)
 		}
 
-		if _, err := ss.InvalidateSnapshot(ctx, request.SnapshotKey); err != nil {
+		remoteEnabled := request.GetIsCiRunnerTask()
+		if _, err := ss.InvalidateSnapshot(ctx, request.SnapshotKey, remoteEnabled); err != nil {
 			return nil, err
 		}
 		return &wfpb.InvalidateSnapshotResponse{}, nil

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -639,7 +639,7 @@ type WorkspaceService interface {
 }
 
 type SnapshotService interface {
-	InvalidateSnapshot(ctx context.Context, key *fcpb.SnapshotKey) (string, error)
+	InvalidateSnapshot(ctx context.Context, key *fcpb.SnapshotKey, remoteEnabled bool) (string, error)
 }
 
 // GitHubApp represents a specific instance of either the read-only or read-write


### PR DESCRIPTION
Currently we only save snapshots locally for RBE actions. I realized we're still storing the version metadata remotely. There's more latency with remote caching, so only cache the version locally as well. (Realized when looking into [this](https://github.com/buildbuddy-io/buildbuddy/commit/fd32eb407b14cdeb56dad1b004965b52ccb51958))

DNM: https://github.com/buildbuddy-io/buildbuddy/pull/9112 is a pre-requisite to merging