### PR TITLE
Simplify and improve ociruntime cgroup setup

### DIFF
--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -89,9 +89,8 @@ func Setup(ctx context.Context, path string, s *scpb.CgroupSettings, blockDevice
 		controller, _, _ := strings.Cut(name, ".")
 		if !enabledControllers[controller] {
 			// Attempt to enable the controller if it's not already enabled.
-			parent := filepath.Dir(path)
-			if err := WriteSubtreeControl(parent, map[string]bool{controller: true}); err != nil {
-				log.CtxWarningf(ctx, "Failed to enable cgroup controller %q for cgroup parent %q: %s", controller, parent, err)
+			if err := EnableController(path, controller); err != nil {
+				log.CtxWarningf(ctx, "Failed to enable cgroup controller %q for cgroup %q: %s", controller, path, err)
 				continue
 			}
 			enabledControllers[controller] = true
@@ -117,6 +116,48 @@ func EnabledControllers(path string) (map[string]bool, error) {
 		enabled[f] = true
 	}
 	return enabled, nil
+}
+
+// EnableController enables the given controller for the cgroup at the given
+// path. It recursively enables the controller for all ancestor cgroups as
+// needed. Note that this will fail if any non-root ancestors have processes in
+// them, since non-root cgroups cannot have child cgroups if they have
+// processes.
+func EnableController(path string, controller string) error {
+	path = filepath.Clean(path)
+	log.Debugf("Enabling cgroup controller %q for %q", controller, path)
+	// Stack of cgroup paths to enable the controller for.
+	var stack []string
+	for {
+		enabled, err := EnabledControllers(path)
+		if err != nil {
+			return fmt.Errorf("read enabled controllers for %q: %w", path, err)
+		}
+		if enabled[controller] {
+			break
+		}
+		path = ParentPath(path)
+		stack = append(stack, path)
+		if path == RootPath {
+			break
+		}
+	}
+	for i := len(stack) - 1; i >= 0; i-- {
+		log.Infof("Enabling cgroup subtree controller %q for %q", controller, stack[i])
+		if err := WriteSubtreeControl(stack[i], map[string]bool{controller: true}); err != nil {
+			return fmt.Errorf("write subtree control for %q: %w", stack[i], err)
+		}
+	}
+	return nil
+}
+
+// ParentPath returns the parent cgroup path for the given cgroup path.
+func ParentPath(path string) string {
+	path = filepath.Clean(path)
+	if path == RootPath {
+		return RootPath
+	}
+	return filepath.Dir(path)
 }
 
 // WriteSubtreeControl writes to the "cgroup.subtree_control" file under the

--- a/enterprise/server/remote_execution/cgroup/cgroup_test.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup_test.go
@@ -175,29 +175,24 @@ func TestParentPath(t *testing.T) {
 			expected: "/",
 		},
 		{
-			name:     "single level",
-			path:     "/foo",
-			expected: "/",
+			name:     "cgroup root",
+			path:     "/sys/fs/cgroup",
+			expected: "/sys/fs/cgroup",
 		},
 		{
-			name:     "multi level",
-			path:     "/foo/bar",
-			expected: "/foo",
+			name:     "cgroup root with trailing slash",
+			path:     "/sys/fs/cgroup/",
+			expected: "/sys/fs/cgroup",
 		},
 		{
-			name:     "multi level with trailing slash",
-			path:     "/foo/bar/",
-			expected: "/foo",
+			name:     "single level under cgroup root",
+			path:     "/sys/fs/cgroup/foo",
+			expected: "/sys/fs/cgroup",
 		},
 		{
-			name:     "empty string",
-			path:     "",
-			expected: ".",
-		},
-		{
-			name:     "dot",
-			path:     ".",
-			expected: ".",
+			name:     "multi level under cgroup root",
+			path:     "/sys/fs/cgroup/foo/bar",
+			expected: "/sys/fs/cgroup/foo",
 		},
 		{
 			name:     "relative path",
@@ -207,6 +202,16 @@ func TestParentPath(t *testing.T) {
 		{
 			name:     "relative path with dot",
 			path:     "./foo",
+			expected: ".",
+		},
+		{
+			name:     "empty string",
+			path:     "",
+			expected: ".",
+		},
+		{
+			name:     "dot",
+			path:     ".",
 			expected: ".",
 		},
 	} {

--- a/enterprise/server/remote_execution/cgroup/cgroup_test.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup_test.go
@@ -162,3 +162,56 @@ func TestParseIOStats(t *testing.T) {
 		{Maj: 9, Min: 0, Rbytes: 3952640, Wbytes: 0, Rios: 48, Wios: 0, Dbytes: 0, Dios: 0},
 	}, stats, protocmp.Transform()))
 }
+
+func TestParentPath(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "root",
+			path:     "/",
+			expected: "/",
+		},
+		{
+			name:     "single level",
+			path:     "/foo",
+			expected: "/",
+		},
+		{
+			name:     "multi level",
+			path:     "/foo/bar",
+			expected: "/foo",
+		},
+		{
+			name:     "multi level with trailing slash",
+			path:     "/foo/bar/",
+			expected: "/foo",
+		},
+		{
+			name:     "empty string",
+			path:     "",
+			expected: ".",
+		},
+		{
+			name:     "dot",
+			path:     ".",
+			expected: ".",
+		},
+		{
+			name:     "relative path",
+			path:     "foo",
+			expected: ".",
+		},
+		{
+			name:     "relative path with dot",
+			path:     "./foo",
+			expected: ".",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, ParentPath(test.path))
+		})
+	}
+}

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -77,7 +77,6 @@ go_test(
     },
     deps = [
         ":ociruntime",
-        "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/persistentworker",
         "//enterprise/server/remote_execution/platform",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -383,11 +383,7 @@ func (c *ociContainer) rootfsPath() string {
 }
 
 func (c *ociContainer) cgroupRootRelativePath() string {
-	// Each container gets 2 cgroups: a parent cgroup and a child cgroup. We do
-	// this to work around crun deleting the container cgroup after the
-	// containerized process has run, which is inconvenient because we still
-	// want to read from the cgroup after the process has exited.
-	return filepath.Join(c.cgroupParent, c.cid+"_parent", c.cid)
+	return filepath.Join(c.cgroupParent, c.cid)
 }
 
 func (c *ociContainer) cgroupPath() string {
@@ -511,7 +507,9 @@ func (c *ociContainer) Run(ctx context.Context, cmd *repb.Command, workDir strin
 	}
 
 	return c.doWithStatsTracking(ctx, func(ctx context.Context) *interfaces.CommandResult {
-		return c.invokeRuntime(ctx, nil /*=cmd*/, &interfaces.Stdio{}, 0 /*=waitDelay*/, "run", "--bundle="+c.bundlePath(), c.cid)
+		// Use --keep to prevent the cgroup from being deleted when the
+		// container exits.
+		return c.invokeRuntime(ctx, nil /*=cmd*/, &interfaces.Stdio{}, 0 /*=waitDelay*/, "run", "--keep", "--bundle="+c.bundlePath(), c.cid)
 	})
 }
 
@@ -646,13 +644,9 @@ func (c *ociContainer) Remove(ctx context.Context) error {
 		firstErr = status.UnavailableErrorf("remove bundle: %s", err)
 	}
 
-	// Remove child cgroup if crun hasn't deleted it already
+	// Remove the cgroup in case the delete command didn't work as expected.
 	if err := os.Remove(c.cgroupPath()); err != nil && firstErr == nil && !os.IsNotExist(err) {
 		firstErr = status.UnavailableErrorf("remove container cgroup: %s", err)
-	}
-	// Remove parent cgroup
-	if err := os.Remove(filepath.Dir(c.cgroupPath())); err != nil && firstErr == nil && !os.IsNotExist(err) {
-		firstErr = status.UnavailableErrorf("remove parent cgroup: %s", err)
 	}
 
 	if c.releaseCPUs != nil {
@@ -732,7 +726,7 @@ func (c *ociContainer) doWithStatsTracking(ctx context.Context, invokeRuntimeFn 
 	// Check for oom_kill memory events in the cgroup and return a
 	// ResourceExhausted error if found. We read this from the parent cgroup,
 	// because at this point, crun will have deleted the child cgroup.
-	memoryEvents, err := cgroup.ReadMemoryEvents(filepath.Dir(c.cgroupPath()))
+	memoryEvents, err := cgroup.ReadMemoryEvents(c.cgroupPath())
 	if err != nil {
 		log.CtxWarningf(ctx, "Failed to get memory events: %s", err)
 	} else if memoryEvents["oom_kill"] > 0 {
@@ -761,11 +755,6 @@ func (c *ociContainer) setupCgroup(ctx context.Context) error {
 	path := c.cgroupPath()
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return fmt.Errorf("create cgroup: %w", err)
-	}
-	// Propagate enabled controllers to the child cgroup before performing
-	// cgroup setup.
-	if err := cgroup.DelegateControllers(filepath.Dir(path)); err != nil {
-		return fmt.Errorf("delegate controllers: %w", err)
 	}
 	if err := cgroup.Setup(ctx, path, c.cgroupSettings, c.blockDevice); err != nil {
 		return fmt.Errorf("configure cgroup: %w", err)

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -508,7 +508,8 @@ func (c *ociContainer) Run(ctx context.Context, cmd *repb.Command, workDir strin
 
 	return c.doWithStatsTracking(ctx, func(ctx context.Context) *interfaces.CommandResult {
 		// Use --keep to prevent the cgroup from being deleted when the
-		// container exits.
+		// container exits, since we still want to be able to look at stats,
+		// events, etc. after completion.
 		return c.invokeRuntime(ctx, nil /*=cmd*/, &interfaces.Stdio{}, 0 /*=waitDelay*/, "run", "--keep", "--bundle="+c.bundlePath(), c.cid)
 	})
 }

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/bazelbuild/rules_go/go/runfiles"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/ociruntime"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/persistentworker"
@@ -198,14 +197,6 @@ func TestCgroupSettings(t *testing.T) {
 	require.NoError(t, err)
 	wd := testfs.MakeDirAll(t, buildRoot, "work")
 
-	// Enable the cgroup controllers that we're going to test (this test is run
-	// in a firecracker VM which doesn't enable any controllers by default)
-	err = cgroup.WriteSubtreeControl(cgroup.RootPath, map[string]bool{
-		"cpu":  true,
-		"pids": true,
-	})
-	require.NoError(t, err)
-
 	c, err := provider.New(ctx, &container.Init{
 		Task: &repb.ScheduledTask{
 			SchedulingMetadata: &scpb.SchedulingMetadata{
@@ -357,10 +348,6 @@ func TestRunOOM(t *testing.T) {
 	require.NoError(t, err)
 	wd := testfs.MakeDirAll(t, buildRoot, "work")
 
-	// Make sure the memory controller is enabled in the root cgroup; we need it
-	// for this test.
-	err = cgroup.WriteSubtreeControl(cgroup.RootPath, map[string]bool{"memory": true})
-	require.NoError(t, err, "enable memory controller")
 	c, err := provider.New(ctx, &container.Init{
 		Task: &repb.ScheduledTask{
 			SchedulingMetadata: &scpb.SchedulingMetadata{


### PR DESCRIPTION
- Recursively enable ancestor cgroup controllers if they are not already enabled. `crun` effectively does this already, but only after our first failed attempt to enable the controllers. This results in warnings being printed to the logs on executor startup (when it runs the warmup container). Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/4842
- Use `--keep` to prevent the runtime from immediately deleting the container cgroup when the task completes. This removes the need for the parent/child setup and also is a prerequisite for being able to detect when the `pids.max` limit exceeded, since pid events are only reported to the child cgroup which currently is being cleaned up before we have the chance to read from it. This should also let us get more accurate resource usage measurements (in a later PR), since we can now take one final measurement just after the task completes. Today, we're using polling, so we're potentially losing ~50ms of data or more, depending on load.


