### PR TITLE
Quarantine cache_test tests

### DIFF
--- a/enterprise/server/raft/cache/cache_test.go
+++ b/enterprise/server/raft/cache/cache_test.go
@@ -190,12 +190,14 @@ func startNNodes(t *testing.T, configs []testConfig) []*raft_cache.RaftCache {
 }
 
 func TestAutoBringup(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	configs := getTestConfigs(t, 3)
 	caches := startNNodes(t, configs)
 	waitForShutdown(t, caches...)
 }
 
 func TestReaderAndWriter(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	configs := getTestConfigs(t, 3)
 	caches := startNNodes(t, configs)
 	rc1 := caches[0]
@@ -255,6 +257,7 @@ func TestCacheShutdown(t *testing.T) {
 }
 
 func TestDistributedRanges(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	configs := getTestConfigs(t, 3)
 	caches := startNNodes(t, configs)
 
@@ -286,6 +289,7 @@ func TestDistributedRanges(t *testing.T) {
 }
 
 func TestFindMissingBlobs(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	configs := getTestConfigs(t, 3)
 	caches := startNNodes(t, configs)
 


### PR DESCRIPTION
This change quarantines 4 additional tests in cache_test.
In total, 5 out of 6 tests in this suite will be quarantined.

Tests are selected for quarantine if they
* appear at least twice in [the past 30 days of flakes for the cache_test suite](https://app.buildbuddy.io/tests/?target=%2F%2Fenterprise%2Fserver%2Fraft%2Fcache%3Acache_test&days=30#flakes), or
* fail or timeout once during a run of bazel  test //enterprise/server/raft/cache:cache_test --config=remote --config=race --nocache_test_results --runs_per_test=16.