### PR TITLE
Give saml_test more resources

### DIFF
--- a/enterprise/server/test/webdriver/saml/BUILD
+++ b/enterprise/server/test/webdriver/saml/BUILD
@@ -6,6 +6,7 @@ go_web_test_suite(
     name = "saml_test",
     srcs = ["saml_test.go"],
     exec_properties = {
+        "test.EstimatedComputeUnits": "3",
         "test.workload-isolation-type": "firecracker",
         "test.recycle-runner": "true",
         "test.init-dockerd": "true",


### PR DESCRIPTION
We're seeing a few "session deleted because of page crash" errors, with the VM getting close to its memory limit ([example](https://buildbuddy.buildbuddy.io/invocation/36cd69af-67e4-455f-a857-1d38a90f3658?executionId=buildbuddy-io%2Fbuildbuddy%2Fworkflows%2Fuploads%2F2848ac9b-7ede-45c4-b23f-9b1d0c1f6611%2Fblobs%2Fblake3%2Fbc284fd724b6615ebd311f9c587cd888579740c1e64472b95a6aa284f09d394e%2F476&actionDigest=bc284fd724b6615ebd311f9c587cd888579740c1e64472b95a6aa284f09d394e%2F476&executeResponseDigest=93212d203f7ba4eda6f24b6ab2b42e01c62695cf990526a389b99845bf4a7146%2F161#action))