### PR TITLE
Print the logs from the remote bazel run in the remote bazel integration tests

### DIFF
--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -141,7 +141,7 @@ func runRemoteBazelInSeparateProcess(t *testing.T, workDir string, serverAddress
 		},
 		args...)...)
 	b, err := cmd.CombinedOutput()
-	fmt.Println(string(b))
+	t.Log(string(b))
 	require.NoError(t, err)
 }
 

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -140,7 +140,8 @@ func runRemoteBazelInSeparateProcess(t *testing.T, workDir string, serverAddress
 			"--runner_exec_properties=container-image=",
 		},
 		args...)...)
-	err := cmd.Run()
+	b, err := cmd.CombinedOutput()
+	fmt.Println(string(b))
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This will make debugging failures easier