### PR TITLE
reduce ci_runner_test flakes

### DIFF
--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -5,13 +5,13 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 go_test(
     name = "ci_runner_test",
     size = "medium",
-    exec_properties = {
-        "test.EstimatedComputeUnits": "3",
-    },
     srcs = ["ci_runner_test.go"],
     data = [
         "//enterprise/server/cmd/ci_runner",
     ],
+    exec_properties = {
+        "test.EstimatedComputeUnits": "3",
+    },
     shard_count = 31,
     tags = ["block-network"],
     x_defs = {

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -4,7 +4,10 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_test(
     name = "ci_runner_test",
-    size = "small",
+    size = "medium",
+    exec_properties = {
+        "test.EstimatedComputeUnits": "3",
+    },
     srcs = ["ci_runner_test.go"],
     data = [
         "//enterprise/server/cmd/ci_runner",

--- a/server/testutil/testserver/testserver.go
+++ b/server/testutil/testserver/testserver.go
@@ -20,7 +20,7 @@ const (
 	// readyCheckTimeout determines how long to wait until giving up on waiting for
 	// BuildBuddy server to become ready. If this timeout is reached, the test case
 	// running the server will fail with a timeout error.
-	readyCheckTimeout = 60 * time.Second
+	readyCheckTimeout = 30 * time.Second
 )
 
 type Server struct {

--- a/server/testutil/testserver/testserver.go
+++ b/server/testutil/testserver/testserver.go
@@ -20,7 +20,7 @@ const (
 	// readyCheckTimeout determines how long to wait until giving up on waiting for
 	// BuildBuddy server to become ready. If this timeout is reached, the test case
 	// running the server will fail with a timeout error.
-	readyCheckTimeout = 30 * time.Second
+	readyCheckTimeout = 60 * time.Second
 )
 
 type Server struct {


### PR DESCRIPTION
This change
* gives the `ci_runner_test` suite 3 compute units
* bumps the size to medium (meaning more RAM and a default timeout of 5 minutes)

Either change made alone still produces flakes with
```
bazel test //enterprise/server/test/integration/ci_runner:ci_runner_test --config=remote --config=race --nocache_test_results --runs_per_test=16
```