### PR TITLE
Send JWT in EnqueueTaskReservationRequest

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/metrics",
         "//server/resources",
         "//server/util/alert",
+        "//server/util/authutil",
         "//server/util/bazel_request",
         "//server/util/log",
         "//server/util/priority_queue",

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/priority_queue"
@@ -805,6 +806,7 @@ func (q *PriorityTaskScheduler) handleTask() {
 	ctx := log.EnrichContext(q.rootContext, log.ExecutionIDKey, reservation.GetTaskId())
 	ctx, cancel := context.WithCancel(ctx)
 	ctx = tracing.ExtractProtoTraceMetadata(ctx, reservation.GetTraceMetadata())
+	ctx = context.WithValue(ctx, authutil.ContextTokenStringKey, reservation.GetJwt())
 	log.CtxInfof(ctx, "Scheduling task of size %s", tasksize.String(nextTask.GetTaskSize()))
 
 	q.trackTask(reservation, &cancel)

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//server/remote_execution/config",
         "//server/resources",
         "//server/scheduling/scheduler_server/config",
+        "//server/util/authutil",
         "//server/util/background",
         "//server/util/bazel_request",
         "//server/util/grpc_client",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -432,6 +433,10 @@ func (h *executorHandle) EnqueueTaskReservation(ctx context.Context, req *scpb.E
 	// We also clone to avoid mutating the proto in adjustTaskSize below.
 	req = req.CloneVT()
 	tracing.InjectProtoTraceMetadata(ctx, req.GetTraceMetadata(), func(m *tpb.Metadata) { req.TraceMetadata = m })
+
+	if tokenString, ok := ctx.Value(authutil.ContextTokenStringKey).(string); ok {
+		req.Jwt = tokenString
+	}
 
 	if req.GetSchedulingMetadata() == nil {
 		return status.InvalidArgumentError("request is missing scheduling metadata")

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -401,6 +401,10 @@ message EnqueueTaskReservationRequest {
   // it can retry the lease.
   google.protobuf.Duration delay = 5;
 
+  // The jwt for this specific task. Can't be propagated via RPC metadata
+  // because this is sent in long-running streaming RPC.
+  string jwt = 6;
+
   // Used to propagate trace information from the initial Execute request.
   // Normally trace information is automatically propagated via RPC metadata but
   // that doesn't work for streamed task reservations since there's one


### PR DESCRIPTION
This allows the executor to set the JWT on outgoing RPCs. Having this on the LeaseTask RPC is necessary to get experiments to trigger by group ID.