### PR TITLE
quarantine ociruntime_test

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -89,6 +89,7 @@ go_test(
         "//proto:worker_go_proto",
         "//server/interfaces",
         "//server/real_environment",
+        "//server/testutil/quarantine",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/testutil/testnetworking",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testnetworking"
@@ -775,6 +776,7 @@ func TestCreateExecPauseUnpause(t *testing.T) {
 }
 
 func TestCreateFailureHasStderr(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	setupNetworking(t)
 
 	image := manuallyProvisionedBusyboxImage(t)
@@ -865,6 +867,7 @@ func TestDevices(t *testing.T) {
 }
 
 func TestSignal(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	setupNetworking(t)
 
 	image := manuallyProvisionedBusyboxImage(t)
@@ -914,6 +917,7 @@ func TestSignal(t *testing.T) {
 }
 
 func TestNetwork_Enabled(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	setupNetworking(t)
 
 	// Note: busybox has ping, but it fails with 'permission denied (are you


### PR DESCRIPTION
I'm a little hesitant on this one, since this is such a critical path.
TestSignal has a clear race condition -- both Signal() and Run() touch c.cid. If we expect to be able to call those functions from separate goroutines, we need to synchronize access.