### PR TITLE
Make urlutil.Domain 10x faster

### DIFF
--- a/server/util/urlutil/urlutil.go
+++ b/server/util/urlutil/urlutil.go
@@ -28,11 +28,14 @@ func GetDomain(host string) string {
 	}
 	i = strings.LastIndexByte(host, '.')
 	if i < 0 {
+		// If there aren't any periods, return the whole host.
 		return host
 	}
 	i = strings.LastIndexByte(host[:i], '.')
 	if i < 0 {
+		// If there's only 1 period, also return the whole host.
 		return host
 	}
+	// Everything after the second to last period.
 	return host[i+1:]
 }

--- a/server/util/urlutil/urlutil.go
+++ b/server/util/urlutil/urlutil.go
@@ -22,11 +22,17 @@ func SameHostname(urlStringA, urlStringB string) bool {
 // something that works for arbitrary domains.
 func GetDomain(host string) string {
 	// If there is a port number, remove it.
-	host, _, _ = strings.Cut(host, ":")
-
-	pts := strings.Split(host, ".")
-	if len(pts) < 2 {
+	i := strings.IndexByte(host, ':')
+	if i >= 0 {
+		host = host[:i]
+	}
+	i = strings.LastIndexByte(host, '.')
+	if i < 0 {
 		return host
 	}
-	return strings.Join(pts[len(pts)-2:], ".")
+	i = strings.LastIndexByte(host[:i], '.')
+	if i < 0 {
+		return host
+	}
+	return host[i+1:]
 }

--- a/server/util/urlutil/urlutil_test.go
+++ b/server/util/urlutil/urlutil_test.go
@@ -30,6 +30,7 @@ func BenchmarkGetDomain(b *testing.B) {
 		{host: "app.buildbuddy.io", domain: "buildbuddy.io"},
 		{host: "foo.app.buildbuddy.io", domain: "buildbuddy.io"},
 		{host: "app.localhost.io:8080", domain: "localhost.io"},
+		{host: "localhost:8080", domain: "localhost"},
 	} {
 		b.Run(test.host, func(b *testing.B) {
 			for b.Loop() {

--- a/server/util/urlutil/urlutil_test.go
+++ b/server/util/urlutil/urlutil_test.go
@@ -11,10 +11,30 @@ func TestGetDomain(t *testing.T) {
 	for _, test := range []struct {
 		host, domain string
 	}{
+		{host: "buildbuddy.io", domain: "buildbuddy.io"},
 		{host: "app.buildbuddy.io", domain: "buildbuddy.io"},
+		{host: "foo.app.buildbuddy.io", domain: "buildbuddy.io"},
 		{host: "app.localhost.io:8080", domain: "localhost.io"},
+		{host: "localhost:8080", domain: "localhost"},
 	} {
 		domain := urlutil.GetDomain(test.host)
 		assert.Equal(t, test.domain, domain, "GetDomain(%q)", test.host)
+	}
+}
+
+func BenchmarkGetDomain(b *testing.B) {
+	for _, test := range []struct {
+		host, domain string
+	}{
+		{host: "buildbuddy.io", domain: "buildbuddy.io"},
+		{host: "app.buildbuddy.io", domain: "buildbuddy.io"},
+		{host: "foo.app.buildbuddy.io", domain: "buildbuddy.io"},
+		{host: "app.localhost.io:8080", domain: "localhost.io"},
+	} {
+		b.Run(test.host, func(b *testing.B) {
+			for b.Loop() {
+				_ = urlutil.GetDomain(test.host)
+			}
+		})
 	}
 }


### PR DESCRIPTION
It's currently 0.5% of app CPU.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                                   │  domainbase   │            domainindex             │
                                   │    sec/op     │   sec/op     vs base               │
GetDomain/buildbuddy.io-24           68.030n ± 21%   6.869n ± 1%  -89.90% (p=0.000 n=9)
GetDomain/app.buildbuddy.io-24       83.770n ± 14%   6.023n ± 3%  -92.81% (p=0.000 n=9)
GetDomain/foo.app.buildbuddy.io-24   89.880n ± 30%   5.944n ± 3%  -93.39% (p=0.000 n=9)
GetDomain/app.localhost.io:8080-24   57.740n ± 28%   8.331n ± 3%  -85.57% (p=0.000 n=9)
geomean                               73.74n         6.728n       -90.88%

                                   │ domainbase │              domainindex              │
                                   │    B/op    │   B/op     vs base                    │
GetDomain/buildbuddy.io-24           48.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=9)
GetDomain/app.buildbuddy.io-24       64.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=9)
GetDomain/foo.app.buildbuddy.io-24   80.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=9)
GetDomain/app.localhost.io:8080-24   64.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=9)
geomean                              62.98                   ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                   │ domainbase │              domainindex               │
                                   │ allocs/op  │ allocs/op   vs base                    │
GetDomain/buildbuddy.io-24           2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=9)
GetDomain/app.buildbuddy.io-24       2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=9)
GetDomain/foo.app.buildbuddy.io-24   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=9)
GetDomain/app.localhost.io:8080-24   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=9)
geomean                              2.000                    ?                      ¹ ²
```