### PR TITLE
Return retryable error if pids.max limit is hit

### DIFF
--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -351,6 +351,13 @@ func ReadMemoryEvents(dir string) (map[string]int64, error) {
 	return readAllInt64Fields(filepath.Join(dir, "memory.events"))
 }
 
+// ReadPidsEvents reads the "pids.events" file under the given cgroup
+// directory and returns the counter values as a map. The directory should be an
+// absolute path, including the /sys/fs/cgroup prefix.
+func ReadPidsEvents(dir string) (map[string]int64, error) {
+	return readAllInt64Fields(filepath.Join(dir, "pids.events"))
+}
+
 // Stats reads all stats from the given cgroup2 directory. The directory should
 // be an absolute path, including the /sys/fs/cgroup prefix.
 func Stats(ctx context.Context, dir string, blockDevice *block_io.Device) (*repb.UsageStats, error) {


### PR DESCRIPTION
When `pids.events` contains a line like `max N` (where `N` is a number >0), this means the container tried to create a process but failed due to the `pids.max` limit.

With this change, we'll start reading this file and return an Unavailable error if the limit is hit. This is similar to how we read the `memory.events` file and return an error if we see an OOM event.

Note: this change depends on https://github.com/buildbuddy-io/buildbuddy/pull/9113, because `pids.events` is only reported to the container cgroup, not the parent cgroup. Prior to that change, `crun` would immediately delete the container cgroup once the task exited, preventing us from detecting these events.