### PR TITLE
Add app/executor Node Overview rows that work outside of GCP to main Grafana dashboard

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -80,7 +80,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 241
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 21,
@@ -101,7 +101,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.1",
+          "pluginVersion": "10.1.0",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -187,7 +187,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 248
+            "y": 64
           },
           "hiddenSeries": false,
           "id": 6270,
@@ -208,7 +208,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.1",
+          "pluginVersion": "10.1.0",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -284,7 +284,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 255
+            "y": 71
           },
           "hiddenSeries": false,
           "id": 932,
@@ -304,7 +304,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.3.1",
+          "pluginVersion": "10.1.0",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -384,6 +384,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -420,7 +421,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 255
+            "y": 71
           },
           "id": 5492,
           "options": {
@@ -493,7 +494,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 170
+            "y": 226
           },
           "hiddenSeries": false,
           "id": 348,
@@ -581,7 +582,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 170
+            "y": 226
           },
           "hiddenSeries": false,
           "id": 804,
@@ -701,7 +702,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 43
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 6840,
@@ -794,7 +795,7 @@
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 43
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 25,
@@ -888,7 +889,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 51
+            "y": 107
           },
           "hiddenSeries": false,
           "id": 1232,
@@ -1002,7 +1003,7 @@
             "h": 8,
             "w": 12,
             "x": 9,
-            "y": 51
+            "y": 107
           },
           "hiddenSeries": false,
           "id": 65,
@@ -1096,7 +1097,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 59
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 13,
@@ -1262,7 +1263,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 244
+            "y": 300
           },
           "id": 1182,
           "options": {
@@ -1358,7 +1359,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 244
+            "y": 300
           },
           "id": 1186,
           "options": {
@@ -1451,7 +1452,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 252
+            "y": 308
           },
           "id": 1183,
           "options": {
@@ -1545,7 +1546,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 252
+            "y": 308
           },
           "id": 1187,
           "options": {
@@ -1638,7 +1639,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 260
+            "y": 316
           },
           "id": 1184,
           "options": {
@@ -1732,7 +1733,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 260
+            "y": 316
           },
           "id": 1188,
           "options": {
@@ -1805,7 +1806,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 389
+            "y": 445
           },
           "hiddenSeries": false,
           "id": 230,
@@ -1894,7 +1895,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 389
+            "y": 445
           },
           "hiddenSeries": false,
           "id": 310,
@@ -1993,7 +1994,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 397
+            "y": 453
           },
           "hiddenSeries": false,
           "id": 312,
@@ -2110,7 +2111,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 399
+            "y": 455
           },
           "hiddenSeries": false,
           "id": 254,
@@ -2206,7 +2207,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 399
+            "y": 455
           },
           "hiddenSeries": false,
           "id": 251,
@@ -2331,7 +2332,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 407
+            "y": 463
           },
           "hiddenSeries": false,
           "id": 250,
@@ -2457,7 +2458,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 407
+            "y": 463
           },
           "hiddenSeries": false,
           "id": 252,
@@ -2583,7 +2584,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 415
+            "y": 471
           },
           "hiddenSeries": false,
           "id": 253,
@@ -2737,7 +2738,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 143
+            "y": 199
           },
           "hiddenSeries": false,
           "id": 17,
@@ -2828,7 +2829,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 143
+            "y": 199
           },
           "hiddenSeries": false,
           "id": 19,
@@ -2921,7 +2922,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 151
+            "y": 207
           },
           "hiddenSeries": false,
           "id": 4,
@@ -3031,7 +3032,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 151
+            "y": 207
           },
           "hiddenSeries": false,
           "id": 9,
@@ -3170,7 +3171,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 160
+            "y": 216
           },
           "id": 6656,
           "options": {
@@ -3263,7 +3264,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 160
+            "y": 216
           },
           "id": 6834,
           "options": {
@@ -3318,7 +3319,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 168
+            "y": 224
           },
           "hiddenSeries": false,
           "id": 646,
@@ -3432,7 +3433,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 176
+            "y": 232
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -3583,7 +3584,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 184
+            "y": 240
           },
           "id": 1338,
           "options": {
@@ -3684,7 +3685,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 192
+            "y": 248
           },
           "id": 2135,
           "options": {
@@ -3816,7 +3817,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 192
+            "y": 248
           },
           "id": 6732,
           "options": {
@@ -3937,7 +3938,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 200
+            "y": 256
           },
           "id": 6422,
           "options": {
@@ -4033,7 +4034,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 208
+            "y": 264
           },
           "id": 6428,
           "options": {
@@ -4131,7 +4132,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 216
+            "y": 272
           },
           "id": 2182,
           "options": {
@@ -4203,7 +4204,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 224
+            "y": 280
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -4373,7 +4374,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 217
+            "y": 273
           },
           "id": 6580,
           "options": {
@@ -4493,7 +4494,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 225
+            "y": 281
           },
           "id": 3763,
           "options": {
@@ -4622,7 +4623,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 233
+            "y": 289
           },
           "id": 5574,
           "options": {
@@ -4776,7 +4777,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 241
+            "y": 297
           },
           "id": 3846,
           "options": {
@@ -4872,7 +4873,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 249
+            "y": 305
           },
           "id": 5160,
           "options": {
@@ -4968,7 +4969,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 257
+            "y": 313
           },
           "id": 5242,
           "options": {
@@ -5063,7 +5064,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 265
+            "y": 321
           },
           "id": 5324,
           "options": {
@@ -5158,7 +5159,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 273
+            "y": 329
           },
           "id": 5406,
           "options": {
@@ -5265,7 +5266,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 253
+            "y": 309
           },
           "id": 3929,
           "options": {
@@ -5357,7 +5358,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 253
+            "y": 309
           },
           "id": 4011,
           "options": {
@@ -5449,7 +5450,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 261
+            "y": 317
           },
           "id": 4093,
           "options": {
@@ -5541,7 +5542,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 261
+            "y": 317
           },
           "id": 4175,
           "options": {
@@ -5633,7 +5634,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 269
+            "y": 325
           },
           "id": 4257,
           "options": {
@@ -5725,7 +5726,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 269
+            "y": 325
           },
           "id": 4339,
           "options": {
@@ -5817,7 +5818,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 277
+            "y": 333
           },
           "id": 4421,
           "options": {
@@ -5909,7 +5910,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 277
+            "y": 333
           },
           "id": 4503,
           "options": {
@@ -6001,7 +6002,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 285
+            "y": 341
           },
           "id": 4585,
           "options": {
@@ -6093,7 +6094,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 285
+            "y": 341
           },
           "id": 4667,
           "options": {
@@ -6185,7 +6186,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 293
+            "y": 349
           },
           "id": 4749,
           "options": {
@@ -6277,7 +6278,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 293
+            "y": 349
           },
           "id": 4831,
           "options": {
@@ -6369,7 +6370,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 301
+            "y": 357
           },
           "id": 4913,
           "options": {
@@ -6416,7 +6417,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 9
       },
       "id": 264,
       "panels": [
@@ -6438,7 +6439,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 274,
@@ -6551,7 +6552,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 276,
@@ -6642,7 +6643,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 290,
@@ -6733,7 +6734,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 292,
@@ -6830,7 +6831,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 278,
@@ -6927,7 +6928,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 280,
@@ -7025,7 +7026,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 10
       },
       "id": 38,
       "panels": [
@@ -7093,7 +7094,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 230
+            "y": 286
           },
           "id": 40,
           "options": {
@@ -7235,7 +7236,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 243
+            "y": 299
           },
           "id": 76,
           "options": {
@@ -7291,7 +7292,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 257
+            "y": 313
           },
           "hiddenSeries": false,
           "id": 42,
@@ -7383,7 +7384,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 257
+            "y": 313
           },
           "hiddenSeries": false,
           "id": 46,
@@ -7475,7 +7476,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 265
+            "y": 321
           },
           "hiddenSeries": false,
           "id": 44,
@@ -7572,7 +7573,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 11
       },
       "id": 458,
       "panels": [
@@ -7604,7 +7605,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 249
+            "y": 305
           },
           "hiddenSeries": false,
           "id": 498,
@@ -7703,7 +7704,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 249
+            "y": 305
           },
           "hiddenSeries": false,
           "id": 542,
@@ -7841,7 +7842,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 258
+            "y": 314
           },
           "hideTimeOverride": true,
           "id": 506,
@@ -7906,7 +7907,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 267
+            "y": 323
           },
           "hiddenSeries": false,
           "id": 496,
@@ -8010,7 +8011,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 277
+            "y": 333
           },
           "hiddenSeries": false,
           "id": 500,
@@ -8114,7 +8115,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 277
+            "y": 333
           },
           "hiddenSeries": false,
           "id": 504,
@@ -8217,7 +8218,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 12
       },
       "id": 48,
       "panels": [
@@ -8236,7 +8237,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 120
           },
           "hiddenSeries": false,
           "id": 50,
@@ -8327,7 +8328,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 120
           },
           "hiddenSeries": false,
           "id": 53,
@@ -8417,7 +8418,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 128
           },
           "hiddenSeries": false,
           "id": 51,
@@ -8508,7 +8509,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 72
+            "y": 128
           },
           "hiddenSeries": false,
           "id": 55,
@@ -8605,7 +8606,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 13
       },
       "id": 384,
       "panels": [
@@ -8672,7 +8673,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 161
+            "y": 217
           },
           "id": 742,
           "options": {
@@ -8775,7 +8776,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 161
+            "y": 217
           },
           "id": 422,
           "options": {
@@ -8875,7 +8876,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 169
+            "y": 225
           },
           "id": 420,
           "options": {
@@ -8975,7 +8976,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 169
+            "y": 225
           },
           "id": 6504,
           "options": {
@@ -9124,7 +9125,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 177
+            "y": 233
           },
           "id": 1223,
           "options": {
@@ -9295,7 +9296,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 177
+            "y": 233
           },
           "id": 1224,
           "options": {
@@ -9351,7 +9352,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 185
+            "y": 241
           },
           "id": 6943,
           "options": {
@@ -9443,7 +9444,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 185
+            "y": 241
           },
           "id": 6944,
           "options": {
@@ -9563,7 +9564,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 193
+            "y": 249
           },
           "id": 7133,
           "options": {
@@ -9752,7 +9753,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 193
+            "y": 249
           },
           "id": 7039,
           "options": {
@@ -9879,7 +9880,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 14
       },
       "id": 107,
       "panels": [
@@ -9901,7 +9902,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 122,
@@ -9991,7 +9992,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 116,
@@ -10085,7 +10086,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 112,
@@ -10182,7 +10183,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 120,
@@ -10277,7 +10278,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 118,
@@ -10367,7 +10368,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 124,
@@ -10457,7 +10458,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 98
           },
           "hiddenSeries": false,
           "id": 9138,
@@ -10553,7 +10554,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 98
           },
           "hiddenSeries": false,
           "id": 9139,
@@ -10649,7 +10650,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 9266,
@@ -10748,7 +10749,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 15
       },
       "id": 28,
       "panels": [
@@ -10771,7 +10772,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 73
           },
           "hiddenSeries": false,
           "id": 190,
@@ -11034,7 +11035,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 73
           },
           "id": 159,
           "options": {
@@ -11137,7 +11138,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 81
           },
           "hiddenSeries": false,
           "id": 210,
@@ -11276,7 +11277,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 81
           },
           "id": 1209,
           "options": {
@@ -11371,7 +11372,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 89
           },
           "id": 31,
           "options": {
@@ -11421,7 +11422,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 89
           },
           "hiddenSeries": false,
           "id": 178,
@@ -11571,7 +11572,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 97
           },
           "id": 8505,
           "options": {
@@ -11688,7 +11689,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 97
           },
           "id": 8606,
           "options": {
@@ -11827,7 +11828,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 105
           },
           "id": 1216,
           "options": {
@@ -11957,7 +11958,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 105
           },
           "id": 1231,
           "options": {
@@ -12043,7 +12044,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 113
           },
           "hiddenSeries": false,
           "id": 33,
@@ -12135,7 +12136,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 113
           },
           "hiddenSeries": false,
           "id": 35,
@@ -12225,7 +12226,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 121
           },
           "hiddenSeries": false,
           "id": 129,
@@ -12318,7 +12319,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 121
           },
           "hiddenSeries": false,
           "id": 102,
@@ -12524,7 +12525,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 73
+            "y": 129
           },
           "id": 1195,
           "options": {
@@ -12612,7 +12613,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 73
+            "y": 129
           },
           "hiddenSeries": false,
           "id": 180,
@@ -12754,7 +12755,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 137
           },
           "id": 1202,
           "options": {
@@ -12913,7 +12914,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 137
           },
           "id": 1196,
           "options": {
@@ -12971,7 +12972,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 145
           },
           "id": 7139,
           "options": {
@@ -13052,7 +13053,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 145
           },
           "id": 7145,
           "options": {
@@ -13133,7 +13134,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 97
+            "y": 153
           },
           "id": 7151,
           "options": {
@@ -13214,7 +13215,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 153
           },
           "id": 7157,
           "options": {
@@ -13295,7 +13296,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 105
+            "y": 161
           },
           "id": 7163,
           "options": {
@@ -13376,7 +13377,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 105
+            "y": 161
           },
           "id": 7169,
           "options": {
@@ -13456,7 +13457,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 16
       },
       "id": 83,
       "panels": [
@@ -13476,7 +13477,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 159
+            "y": 215
           },
           "hiddenSeries": false,
           "id": 85,
@@ -13579,7 +13580,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 159
+            "y": 215
           },
           "hiddenSeries": false,
           "id": 87,
@@ -13673,7 +13674,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 168
+            "y": 224
           },
           "hiddenSeries": false,
           "id": 91,
@@ -13766,7 +13767,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 168
+            "y": 224
           },
           "hiddenSeries": false,
           "id": 93,
@@ -13869,7 +13870,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 17
       },
       "id": 71,
       "panels": [
@@ -13905,7 +13906,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 138
           },
           "hiddenSeries": false,
           "id": 73,
@@ -13998,7 +13999,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 138
           },
           "hiddenSeries": false,
           "id": 79,
@@ -14137,7 +14138,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 91
+            "y": 147
           },
           "id": 2087,
           "options": {
@@ -14239,7 +14240,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 91
+            "y": 147
           },
           "id": 2039,
           "options": {
@@ -14302,17 +14303,13 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 18
       },
-      "id": 1088,
+      "id": 9283,
       "panels": [
         {
           "datasource": {
@@ -14338,6 +14335,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -14376,9 +14374,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 267
+            "y": 19
           },
-          "id": 1127,
+          "id": 9300,
           "options": {
             "legend": {
               "calcs": [],
@@ -14399,7 +14397,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "1 - (avg by (mode, nodename) ((rate(node_cpu_seconds_total{mode=\"idle\"}[1m])) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${kubepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"})))",
+              "expr": "1 - (avg by (mode, nodename) ((rate(node_cpu_seconds_total{mode=\"idle\"}[1m])) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${appnode}\"})))",
               "hide": false,
               "interval": "",
               "legendFormat": "{{nodename}}",
@@ -14435,6 +14433,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -14472,9 +14471,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 267
+            "y": 19
           },
-          "id": 1166,
+          "id": 9301,
           "options": {
             "legend": {
               "calcs": [],
@@ -14495,7 +14494,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "max by (nodename) (rate(node_disk_read_bytes_total[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${kubepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"}))",
+              "expr": "max by (nodename) (rate(node_disk_read_bytes_total[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${appnode}\"}))",
               "interval": "",
               "legendFormat": "reads {{nodename}}",
               "range": true,
@@ -14508,7 +14507,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "max by (nodename) (rate(node_disk_written_bytes_total[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${kubepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"}))\n",
+              "expr": "max by (nodename) (rate(node_disk_written_bytes_total[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${appnode}\"}))\n",
               "hide": false,
               "interval": "",
               "legendFormat": "writes {{nodename}}",
@@ -14544,6 +14543,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -14581,7 +14581,673 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 275
+            "y": 27
+          },
+          "id": 9303,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(node_network_receive_bytes_total{device=~\"(ens|eth).*\"}[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${appnode}\"})\n",
+              "interval": "",
+              "legendFormat": "rx {{nodename}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(node_network_transmit_bytes_total{device=~\"(ens|eth).*\"}[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${appnode}\"})\n",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "tx {{nodename}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Network",
+          "type": "timeseries"
+        }
+      ],
+      "title": "App Nodes Overview (${appnode})",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 9320,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 9337,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "1 - (avg by (mode, nodename) ((rate(node_cpu_seconds_total{mode=\"idle\"}[1m])) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${executornode}\"})))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{nodename}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100000000,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 9462,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max by (nodename) (rate(node_disk_read_bytes_total[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${executornode}\"}))",
+              "interval": "",
+              "legendFormat": "reads {{nodename}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max by (nodename) (rate(node_disk_written_bytes_total[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${executornode}\"}))\n",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "writes {{nodename}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Disk",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100000000,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 9587,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(node_network_receive_bytes_total{device=~\"(ens|eth).*\"}[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${executornode}\"})\n",
+              "interval": "",
+              "legendFormat": "rx {{nodename}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "rate(node_network_transmit_bytes_total{device=~\"(ens|eth).*\"}[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${executornode}\"})\n",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "tx {{nodename}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Network",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Executor Nodes Overview (${executornode})",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 1088,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 1127,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "1 - (avg by (mode, nodename) ((rate(node_cpu_seconds_total{mode=\"idle\"}[1m])) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${gkepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"})))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{nodename}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100000000,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 1166,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max by (nodename) (rate(node_disk_read_bytes_total[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${gkepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"}))",
+              "interval": "",
+              "legendFormat": "reads {{nodename}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max by (nodename) (rate(node_disk_written_bytes_total[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${gkepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"}))\n",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "writes {{nodename}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Disk",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMax": 100000000,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
           },
           "id": 1168,
           "options": {
@@ -14604,7 +15270,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(node_network_receive_bytes_total{device=~\"(ens|eth).*\"}[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${kubepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"})\n",
+              "expr": "rate(node_network_receive_bytes_total{device=~\"(ens|eth).*\"}[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${gkepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"})\n",
               "interval": "",
               "legendFormat": "rx {{nodename}}",
               "range": true,
@@ -14617,7 +15283,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(node_network_transmit_bytes_total{device=~\"(ens|eth).*\"}[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${kubepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"})\n",
+              "expr": "rate(node_network_transmit_bytes_total{device=~\"(ens|eth).*\"}[1m]) * on(instance) group_left(nodename) (node_uname_info{region=\"${region}\", nodename=~\"^${gkepool}-([0-9a-f]{8})-(grp-)?[0-9a-z]{4}$\"})\n",
               "hide": false,
               "interval": "",
               "legendFormat": "tx {{nodename}}",
@@ -14629,7 +15295,8 @@
           "type": "timeseries"
         }
       ],
-      "repeat": "kubepool",
+      "repeat": "gkepool",
+      "repeatDirection": "h",
       "targets": [
         {
           "datasource": {
@@ -14639,7 +15306,7 @@
           "refId": "A"
         }
       ],
-      "title": "Nodes Overview (${kubepool})",
+      "title": "GKE Nodepool Overview (${gkepool})",
       "type": "row"
     },
     {
@@ -14652,7 +15319,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 25
       },
       "id": 8,
       "panels": [
@@ -14674,7 +15341,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 348
+            "y": 404
           },
           "hiddenSeries": false,
           "id": 2,
@@ -14787,7 +15454,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 348
+            "y": 404
           },
           "hiddenSeries": false,
           "id": 578,
@@ -14884,7 +15551,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 26
       },
       "id": 1346,
       "panels": [
@@ -14904,7 +15571,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 393
+            "y": 449
           },
           "hiddenSeries": false,
           "id": 2556,
@@ -15011,7 +15678,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 406
+            "y": 462
           },
           "hiddenSeries": false,
           "id": 2840,
@@ -15110,7 +15777,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 420
+            "y": 476
           },
           "hiddenSeries": false,
           "id": 2890,
@@ -15204,7 +15871,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 420
+            "y": 476
           },
           "hiddenSeries": false,
           "id": 2940,
@@ -15342,7 +16009,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 428
+            "y": 484
           },
           "id": 1353,
           "links": [
@@ -15398,7 +16065,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 27
       },
       "id": 5641,
       "panels": [
@@ -15464,7 +16131,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 177
+            "y": 233
           },
           "id": 5595,
           "options": {
@@ -15557,7 +16224,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 177
+            "y": 233
           },
           "id": 5608,
           "options": {
@@ -15651,7 +16318,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 185
+            "y": 241
           },
           "id": 5622,
           "options": {
@@ -15745,7 +16412,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 185
+            "y": 241
           },
           "id": 5629,
           "options": {
@@ -15838,7 +16505,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 193
+            "y": 249
           },
           "id": 5615,
           "options": {
@@ -15879,7 +16546,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 28
       },
       "id": 7275,
       "panels": [
@@ -15947,7 +16614,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 97
           },
           "id": 7381,
           "options": {
@@ -16068,7 +16735,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 97
           },
           "id": 7382,
           "options": {
@@ -16167,7 +16834,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 105
           },
           "id": 7489,
           "options": {
@@ -16266,7 +16933,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 105
           },
           "id": 7488,
           "options": {
@@ -16362,7 +17029,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 113
           },
           "id": 7595,
           "options": {
@@ -16458,7 +17125,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 113
           },
           "id": 8743,
           "options": {
@@ -16554,7 +17221,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 65
+            "y": 121
           },
           "id": 8880,
           "options": {
@@ -16650,7 +17317,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 65
+            "y": 121
           },
           "id": 9017,
           "options": {
@@ -16697,9 +17364,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "us-west1",
-          "value": "us-west1"
+          "selected": true,
+          "text": "us-west2",
+          "value": "us-west2"
         },
         "datasource": {
           "type": "prometheus",
@@ -16890,32 +17557,6 @@
       {
         "current": {
           "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "vm"
-        },
-        "definition": "label_values(node_uname_info{region=\"$region\"}, nodename)",
-        "hide": 0,
-        "includeAll": true,
-        "multi": false,
-        "name": "kubepool",
-        "options": [],
-        "query": {
-          "query": "label_values(node_uname_info{region=\"$region\"}, nodename)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 2,
-        "regex": "^(gke-.*)-([0-9a-f]{8})-(grp-)?([0-9a-z]{4})$",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": true,
           "text": "0.5",
           "value": "0.5"
         },
@@ -16995,11 +17636,97 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "vm"
+        },
+        "definition": "label_values(node_uname_info{region=\"$region\"}, nodename)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "gkepool",
+        "options": [],
+        "query": {
+          "query": "label_values(node_uname_info{region=\"$region\"}, nodename)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "^(gke-.*)-([0-9a-f]{8})-(grp-)?([0-9a-z]{4})$",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "vm"
+        },
+        "definition": "label_values(kube_pod_info{pod=~\"buildbuddy-app-.*\", region=\"$region\"}, node)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "appnode",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info{pod=~\"buildbuddy-app-.*\", region=\"$region\"}, node)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "gke-prod-dtib7-spot-executor-c2-6ee8decb-grp-2t72"
+          ],
+          "value": [
+            "gke-prod-dtib7-spot-executor-c2-6ee8decb-grp-2t72"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "vm"
+        },
+        "definition": "label_values(kube_pod_info{pod=~\"executor-.*\", region=\"$region\"}, node)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "executornode",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info{pod=~\"executor-.*\", region=\"$region\"}, node)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {

--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -17697,10 +17697,10 @@
         "current": {
           "selected": true,
           "text": [
-            "gke-prod-dtib7-spot-executor-c2-6ee8decb-grp-2t72"
+            "All"
           ],
           "value": [
-            "gke-prod-dtib7-spot-executor-c2-6ee8decb-grp-2t72"
+            "$__all"
           ]
         },
         "datasource": {

--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -17365,8 +17365,8 @@
       {
         "current": {
           "selected": true,
-          "text": "us-west2",
-          "value": "us-west2"
+          "text": "us-west1",
+          "value": "us-west1"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
This PR introduces two new template variables: `appnode` and `executornode` that contains the names of all nodes running `buildbuddy-app-.*` or `executor-.*` pods respectively, and adds rows plotting the per-node metrics for those nodes. It also moves the existing "Node Overview" repeated rows to be called "GKE Nodepool Overview". They are still useful because the new node row doesn't work for cluster with lots of nodes.

Example (US-SJC):
<img width="1513" alt="Screenshot 2025-05-01 at 5 45 16 PM" src="https://github.com/user-attachments/assets/658ce157-8daa-471a-b156-ba0efe2b9b21" />

Related Issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4851