### PR TITLE
[raft] use store.GetRange instead of repl.RangeDescriptor()

### DIFF
--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -152,7 +152,6 @@ func (a DriverAction) String() string {
 }
 
 type IReplica interface {
-	RangeDescriptor() *rfpb.RangeDescriptor
 	ReplicaID() uint64
 	RangeID() uint64
 	Usage() (*rfpb.ReplicaUsage, error)
@@ -160,6 +159,7 @@ type IReplica interface {
 
 type IStore interface {
 	GetReplica(rangeID uint64) (*replica.Replica, error)
+	GetRange(rangeID uint64) *rfpb.RangeDescriptor
 	HaveLease(ctx context.Context, rangeID uint64) bool
 	AddReplica(ctx context.Context, req *rfpb.AddReplicaRequest) (*rfpb.AddReplicaResponse, error)
 	RemoveReplica(ctx context.Context, req *rfpb.RemoveReplicaRequest) (*rfpb.RemoveReplicaResponse, error)
@@ -376,9 +376,9 @@ func (rq *Queue) getReplica(rangeID uint64) (IReplica, error) {
 
 // computeAction computes the action needed and its priority.
 func (rq *Queue) computeAction(ctx context.Context, repl IReplica) (DriverAction, float64) {
-	rd := repl.RangeDescriptor()
+	rd := rq.store.GetRange(repl.RangeID())
 	action := DriverNoop
-	if !rq.store.HaveLease(ctx, rd.GetRangeId()) {
+	if rd == nil || !rq.store.HaveLease(ctx, rd.GetRangeId()) {
 		return action, action.Priority()
 	}
 
@@ -1223,8 +1223,12 @@ func (rq *Queue) applyChange(ctx context.Context, change *change) error {
 
 func (rq *Queue) processReplica(ctx context.Context, repl IReplica, action DriverAction) RequeueType {
 	var change *change
-	rd := repl.RangeDescriptor()
 	rangeID := repl.RangeID()
+	rd := rq.store.GetRange(rangeID)
+	if rd == nil {
+		// We might be calling GetRange in the small window between RemoveRange and AddRange
+		return RequeueCheckOtherActions
+	}
 
 	switch action {
 	case DriverNoop:

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -2052,13 +2052,6 @@ func (sm *Replica) RecoverFromSnapshot(r io.Reader, quit <-chan struct{}) error 
 	return sm.loadReplicaState(db)
 }
 
-func (sm *Replica) RangeDescriptor() *rfpb.RangeDescriptor {
-	sm.rangeMu.RLock()
-	rd := sm.rangeDescriptor
-	sm.rangeMu.RUnlock()
-	return rd.CloneVT()
-}
-
 func (sm *Replica) ReplicaID() uint64 {
 	return sm.replicaID
 }

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -166,13 +166,15 @@ func writer(t *testing.T, em *entryMaker, r *replica.Replica, h *rfpb.Header, fi
 	return wc
 }
 
-func writeDefaultRangeDescriptor(t *testing.T, em *entryMaker, r *replica.Replica) {
-	writeLocalRangeDescriptor(t, em, r, &rfpb.RangeDescriptor{
+func writeDefaultRangeDescriptor(t *testing.T, em *entryMaker, r *replica.Replica) *rfpb.RangeDescriptor {
+	rd := &rfpb.RangeDescriptor{
 		Start:      keys.Key{constants.UnsplittableMaxByte},
 		End:        keys.MaxByte,
 		RangeId:    1,
 		Generation: 1,
-	})
+	}
+	writeLocalRangeDescriptor(t, em, r, rd)
+	return rd
 }
 
 func randomRecord(t *testing.T, partition string, sizeBytes int64) (*sgpb.FileRecord, []byte) {
@@ -1000,7 +1002,7 @@ func TestUsage(t *testing.T) {
 	require.NoError(t, err)
 
 	em := newEntryMaker(t)
-	writeDefaultRangeDescriptor(t, em, repl.Replica)
+	rd := writeDefaultRangeDescriptor(t, em, repl.Replica)
 
 	rt := newWriteTester(t, em, repl.Replica)
 
@@ -1012,7 +1014,6 @@ func TestUsage(t *testing.T) {
 	rt.writeRandom(header, anotherPartition, 300)
 
 	repl.DB().Flush()
-	rd := repl.RangeDescriptor()
 	{
 		ru, err := repl.Usage()
 		require.NoError(t, err)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2269,7 +2269,7 @@ func newDeleteSessionsWorker(clock clockwork.Clock, store *Store, clientSessionT
 }
 
 func (w *deleteSessionWorker) deleteSessions(ctx context.Context, repl *replica.Replica) error {
-	rd := repl.RangeDescriptor()
+	rd := w.store.lookupRange(repl.RangeID())
 	lastExecutionTimeI, found := w.lastExecutionTime.Load(rd.GetRangeId())
 	if found {
 		lastExecutionTime, ok := lastExecutionTimeI.(time.Time)
@@ -3103,7 +3103,8 @@ func (s *Store) GetReplicaStates(ctx context.Context, rd *rfpb.RangeDescriptor) 
 			res[r.GetReplicaId()] = constants.ReplicaStateUnknown
 		}
 	}
-	rd = localReplica.RangeDescriptor()
+
+	rd = s.lookupRange(localReplica.RangeID())
 	indicesByReplicaID := s.GetRemoteLastAppliedIndices(ctx, rd, localReplica)
 	for replicaID, index := range indicesByReplicaID {
 		if index >= curIndex {

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1218,7 +1218,8 @@ func TestUpReplicate(t *testing.T) {
 	waitForReplicaToCatchUp(t, ctx, r2, desiredAppliedIndex)
 	waitStart := time.Now()
 	for {
-		l := len(r2.RangeDescriptor().GetReplicas())
+		rd2 := s3.GetRange(2)
+		l := len(rd2.GetReplicas())
 		if l == 3 {
 			break
 		}


### PR DESCRIPTION
repl.RangeDescriptor requires a Clone() which is not as efficient as
store.GetRange().

The downside of using store.GetRange() is that between RemoveRange() and
AddRange() there is a gap where GetRange() can return nil. This is not addressed
in this PR.
