### PR TITLE
Add loader when changing scorecard query

### DIFF
--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -151,7 +151,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
   }
 
   private fetchResults(pageToken = this.state.nextPageToken) {
-    this.setState({ loading: true });
+    this.setState({ loading: true, nextPageToken: pageToken });
 
     const filterFields: string[] = [];
 
@@ -889,6 +889,15 @@ fi
           onRequestClose={() => this.setState({ isLinkRepoModalOpen: false })}
         />
         <div debug-id="cache-results-table" className="results-table">
+          {/* When the results are being replaced, show an overlay indicating that the
+              current results are stale. */}
+          {this.state.loading && !this.state.nextPageToken && (
+            <>
+              <div className="loading-overlay" />
+              <div className="loading loading-slim results-updating" />
+            </>
+          )}
+
           <div className="row column-headers">
             {this.getGroupBy() !== cache.GetCacheScoreCardRequest.GroupBy.GROUP_BY_ACTION && (
               <div className="name-column">Name</div>

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -219,6 +219,11 @@
   margin-top: 24px;
 }
 
+.cache-requests-card.card {
+  /* 'overflow: hidden' styling prevents sticky spinner from working properly. */
+  overflow: initial;
+}
+
 .cache-requests-card .action-id {
   font-weight: 600;
 }
@@ -317,6 +322,28 @@
 .cache-requests-card .results-table {
   border: 1px solid #eee;
   border-radius: 4px;
+  position: relative;
+}
+
+.cache-requests-card .loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: grayscale(100%);
+}
+
+.cache-requests-card .loading.results-updating {
+  position: sticky;
+  top: 0;
+  height: 0;
+  overflow: visible;
+  z-index: 1;
+  transform: translateY(32px);
 }
 
 .cache-requests-card .column-headers {


### PR DESCRIPTION
For some invocations recently I've noticed that when changing the scorecard query, there is a significant delay before the results are updated, with no loading indicator shown. This PR fixes that.

https://github.com/user-attachments/assets/7fdc5cb1-4ac8-43b3-b369-85e0ddf91d84

