### PR TITLE
[oci registry] track AC and CAS hits, misses, and uploads

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -3277,6 +3277,16 @@ var (
 	}, []string{
 		CacheTypeLabel,
 	})
+
+	OCIRegistryCacheEvents = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "ociregistry",
+		Name:      "cache_events",
+		Help:      "Number of cache events handled.",
+	}, []string{
+		CacheTypeLabel,
+		CacheEventTypeLabel,
+	})
 )
 
 // exponentialBucketRange returns prometheus.ExponentialBuckets specified in


### PR DESCRIPTION
Each time the OCI registry fetches a manifest or layer from the cache, it can perform up to three fetches:
1. Fetch an ActionResult from the AC
2. Fetch metadata from the CAS
3. (Only needed for serving GET requests) Fetch contents from the CAS

When the OCI registry uploads a manifest or layer to the cache, it always performs three uploads:
1. Upload metadata to CAS
2. Upload contents to CAS
3. Upload an ActionResult to AC

This change counts hits, misses, and uploads for all AC and CAS fetches and uploads.