### PR TITLE
[SS] Add logs to test reducing remote snapshot writes

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1453,6 +1453,16 @@ var (
 		ChunkSource,
 	})
 
+	// TODO(Maggie): Delete after evaluating the results
+	COWSnapshotSkippedRemoteBytes = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "cow_snapshot_skipped_remote_bytes",
+		Help:      "The number of compressed bytes that would not be written to the remote cache if stricter remote write logic was applied.",
+	}, []string{
+		FileName,
+	})
+
 	COWSnapshotMemoryMappedBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",


### PR DESCRIPTION
Before applying the [change to only cache multiple snapshots on the same branch locally](https://github.com/buildbuddy-io/buildbuddy/pull/9084), add some logging and metrics to evaluate if this would be impactful, or if any modifications to the logic are necessary

The implemented logic is:
* If a given branch does not have a remote snapshot, we will write one remotely
* If it already has a remote snapshot, we will only write subsequent snapshots locally
* For the default/master snapshot, we will always write remotely
