### PR TITLE
[raft] haveLease should return false when it shoudn't have lease

### DIFF
--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -494,5 +494,5 @@ func (lk *LeaseKeeper) HaveLease(ctx context.Context, rid uint64) bool {
 			action:  Drop,
 		})
 	}
-	return valid
+	return valid && shouldHaveLease
 }


### PR DESCRIPTION
This can cause test-flakiness.

In tests, we often want to find the store with the range leases. There are small
windows of time where two stores both hold leases, with one of them should not
have it hold. In these cases, if we grab the store which should hold the lease,
it can cause the test to fail.
