### PR TITLE
[raft] use firecracker for store_test

### DIFF
--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -60,7 +60,7 @@ go_test(
     srcs = ["store_test.go"],
     exec_properties = {
         "test.EstimatedComputeUnits": "8",
-		"test.workload-isolation-type": "firecracker",
+        "test.workload-isolation-type": "firecracker",
     },
     shard_count = 8,
     tags = ["block-network"],

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -60,6 +60,7 @@ go_test(
     srcs = ["store_test.go"],
     exec_properties = {
         "test.EstimatedComputeUnits": "8",
+		"test.workload-isolation-type": "firecracker",
     },
     shard_count = 8,
     tags = ["block-network"],


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4192

store_test sometimes failed with shard is not ready. When I turned on the logs for dragonboat, there are LocalTicks warnings that indicates that nodes are overloaded. The execution page showed high IO pressure stall duration. 