### PR TITLE
Make ByteStream WriteHandler an interface and put in Environment

### DIFF
--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -100,6 +100,7 @@ type Env interface {
 	GetLocalCASServer() repb.ContentAddressableStorageServer
 	GetCASServer() repb.ContentAddressableStorageServer
 	GetLocalByteStreamClient() bspb.ByteStreamClient
+	GetLocalByteStreamServer() interfaces.ByteStreamServer
 	GetByteStreamServer() bspb.ByteStreamServer
 	GetLocalActionCacheServer() repb.ActionCacheServer
 	GetActionCacheServer() repb.ActionCacheServer

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -48,6 +48,7 @@ go_library(
         "@com_github_google_go_github_v59//github",
         "@com_github_hashicorp_serf//serf",
         "@io_gorm_gorm//:gorm",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//health/grpc_health_v1",
     ],

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -54,6 +54,7 @@ import (
 	wspb "github.com/buildbuddy-io/buildbuddy/proto/workspace"
 	zipb "github.com/buildbuddy-io/buildbuddy/proto/zip"
 	dto "github.com/prometheus/client_model/go"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
 	hlpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -1719,4 +1720,31 @@ type ExperimentFlagProvider interface {
 	String(ctx context.Context, flagName string, defaultValue string, opts ...any) string
 	Float64(ctx context.Context, flagName string, defaultValue float64, opts ...any) float64
 	Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64
+}
+
+// ByteStreamWriteHandler enapsulates an on-going ByteStream write to a cache,
+// freeing the caller of having to manage writing and committing-to the cache
+// tracking cache hits, verifying checksums, etc. Here is how it must be used:
+//   - A new WriteHandler may be obtained by providing the first frame of the
+//     stream to the ByteStreamServer.BeginWrite() function. This function will
+//     return a new ByteStreamWriteHandler, or an error.
+//   - If a ByteStreamWriteHandler is returned from BeginWrite(),
+//     ByteStreamWriteHandler.Close() must be called to free system resources
+//     when the write is finished.
+//   - Each subsequent frame should be passed to
+//     ByteStreamWriteHandler.Write(), which will return an error on error
+//     (note: io.EOF indicates the cache believes the write is finished), or an
+//     optional WriteResponse that should be sent to the client if the client
+//     indicated the write is finished. This function will return (nil, nil) if
+//     the frame was processed successfully, but the write is not finished yet.
+type ByteStreamWriteHandler interface {
+	Write(req *bspb.WriteRequest) (*bspb.WriteResponse, error)
+	Close() error
+}
+
+// Wrapper around a bspb.ByteStreamServer that exposes a ByteStreamWriteHandler
+// in addition to the gRPC streaming interfaces.
+type ByteStreamServer interface {
+	bspb.ByteStreamServer
+	BeginWrite(ctx context.Context, req *bspb.WriteRequest) (ByteStreamWriteHandler, error)
 }

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -97,6 +97,7 @@ type RealEnv struct {
 	localCASServer                   repb.ContentAddressableStorageServer
 	casServer                        repb.ContentAddressableStorageServer
 	localByteStreamClient            bspb.ByteStreamClient
+	localByteStreamServer            interfaces.ByteStreamServer
 	byteStreamServer                 bspb.ByteStreamServer
 	localActionCacheServer           repb.ActionCacheServer
 	actionCacheServer                repb.ActionCacheServer
@@ -552,6 +553,13 @@ func (r *RealEnv) GetLocalByteStreamClient() bspb.ByteStreamClient {
 }
 func (r *RealEnv) SetLocalByteStreamClient(localByteStreamClient bspb.ByteStreamClient) {
 	r.localByteStreamClient = localByteStreamClient
+}
+
+func (r *RealEnv) GetLocalByteStreamServer() interfaces.ByteStreamServer {
+	return r.localByteStreamServer
+}
+func (r *RealEnv) SetLocalByteStreamServer(localByteStreamServer interfaces.ByteStreamServer) {
+	r.localByteStreamServer = localByteStreamServer
 }
 
 func (r *RealEnv) GetByteStreamServer() bspb.ByteStreamServer {


### PR DESCRIPTION
This is just some cleanup to try and make https://github.com/buildbuddy-io/buildbuddy/pull/9106 a bit smaller and easier to digest.

I also realized I moved the big ole comment about `Write()` to the wrong place in https://github.com/buildbuddy-io/buildbuddy/pull/9105, so fixed that here.