### PR TITLE
[raft] TestRemoveNodeFromCluster: add one more node

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -427,7 +427,6 @@ func TestAddNodeToCluster(t *testing.T) {
 }
 
 func TestRemoveNodeFromCluster(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	// disable txn cleanup and zombie scan, because advance the fake clock can
 	// prematurely trigger txn cleanup and zombie cleanup.
 	flags.Set(t, "cache.raft.enable_txn_cleanup", false)

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -435,9 +435,10 @@ func TestRemoveNodeFromCluster(t *testing.T) {
 	sf := testutil.NewStoreFactory(t)
 	s1 := sf.NewStore(t)
 	s2 := sf.NewStore(t)
+	s3 := sf.NewStore(t)
 	ctx := context.Background()
 
-	stores := []*testutil.TestingStore{s1, s2}
+	stores := []*testutil.TestingStore{s1, s2, s3}
 	sf.StartShard(t, ctx, stores...)
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
@@ -460,9 +461,9 @@ func TestRemoveNodeFromCluster(t *testing.T) {
 
 	s = testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	replicas := getMembership(t, s, ctx, 2)
-	require.Equal(t, 1, len(replicas))
+	require.Equal(t, 2, len(replicas))
 	rd = s.GetRange(2)
-	require.Equal(t, 1, len(rd.GetReplicas()))
+	require.Equal(t, 2, len(rd.GetReplicas()))
 }
 
 func TestAddRangeBack(t *testing.T) {


### PR DESCRIPTION
- add one more store to avoid split brain
- When we check the number of members, we don't want to check the store where
  the replica is removed. Most of time this won't happen because
    - we call remove the replica on the store with the lease
	- we don't remove the replica that's the leader
  In some cases, however we did end up remove the leader replica (when there is
  a leader transfer after we call RemoveReplica) and when we try to verify the
  membership, the store we get is the one with the removed replica and the
  getmembership will return 0 instead of 2.  

- Remove the test from quarantine. 
I ran this test twice with --runs_per_test=500
https://app.buildbuddy.io/invocation/df9817b1-09f6-4d6c-b171-bd63dc3ba506
https://app.buildbuddy.io/invocation/8d842a5c-5d10-437b-87c5-60a40353e0b7
