### PR TITLE
Retry internal errors on task lease stream

### DIFF
--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -131,7 +131,7 @@ func (t *TaskLease) pingServer(ctx context.Context) (b []byte, err error) {
 		if err == nil {
 			break
 		}
-		if !*enableReconnect || !status.IsUnavailableError(err) {
+		if !*enableReconnect || !(status.IsUnavailableError(err) || status.IsInternalError(err)) {
 			return nil, err
 		}
 		originalErr := err
@@ -181,7 +181,7 @@ func (t *TaskLease) keepLease(ctx context.Context) {
 				return
 			case <-time.After(t.ttl):
 				if _, err := t.pingServer(ctx); err != nil {
-					log.CtxWarningf(ctx, "Error updating lease for task: %q: %s", t.taskID, err.Error())
+					log.CtxErrorf(ctx, "Error updating lease for task: %q: %s", t.taskID, err)
 					t.cancelFunc()
 					return
 				}


### PR DESCRIPTION
We saw an instance of `Error updating lease for task: "TASK_ID": rpc error: code = Internal desc = stream terminated by RST_STREAM with error code: INTERNAL_ERROR`. Make sure to retry these. Also, elevate these errors to ERROR level to make them stand out more in the logs, since these errors are the root cause if a task is canceled.