### PR TITLE
Fix cache fetches from UI when invocation owner group is not selected

### DIFF
--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -54,6 +54,7 @@ go_library(
         "//server/util/authutil",
         "//server/util/canary",
         "//server/util/capabilities",
+        "//server/util/claims",
         "//server/util/flagutil",
         "//server/util/git",
         "//server/util/log",


### PR DESCRIPTION
Planning to add tests and such, just wanted to send this out to see if the `claims.SelectGroupID` looks reasonable or not.