### PR TITLE
Add and use new parsed args types within the `parser` package

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -78,7 +78,7 @@ func run() (exitCode int, err error) {
 	args = shortcuts.HandleShortcuts(args)
 
 	// Make sure startup args are always in the format --foo=bar.
-	args, err = parser.CanonicalizeStartupArgs(args)
+	args, err = parser.CanonicalizeArgs(args)
 	if err != nil {
 		return -1, err
 	}

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -5,11 +5,11 @@ go_library(
     srcs = ["parser.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser",
     deps = [
-        "//cli/arg",
         "//cli/bazelisk",
         "//cli/log",
         "//cli/parser/arguments",
         "//cli/parser/options",
+        "//cli/parser/parsed",
         "//cli/storage",
         "//cli/workspace",
         "//proto:bazel_flags_go_proto",

--- a/cli/parser/arguments/arguments.go
+++ b/cli/parser/arguments/arguments.go
@@ -30,6 +30,9 @@ func (a *PositionalArgument) Format() []string {
 }
 
 func FromConcrete[T Argument](args []T) []Argument {
+	if args == nil {
+		return nil
+	}
 	argSlice := make([]Argument, 0, len(args))
 	for _, a := range args {
 		// `append(a, b...)` only works if `a` and `b` have exactly the same type,
@@ -40,7 +43,21 @@ func FromConcrete[T Argument](args []T) []Argument {
 	return argSlice
 }
 
+func ToPositionalArguments(args []string) []Argument {
+	if args == nil {
+		return nil
+	}
+	pos := make([]Argument, 0, len(args))
+	for _, arg := range args {
+		pos = append(pos, &PositionalArgument{Value: arg})
+	}
+	return pos
+}
+
 func FormatAll[T Argument](args []T) []string {
+	if args == nil {
+		return nil
+	}
 	s := make([]string, 0, len(args))
 	for _, arg := range args {
 		s = append(s, arg.Format()...)

--- a/cli/parser/arguments/arguments.go
+++ b/cli/parser/arguments/arguments.go
@@ -44,7 +44,7 @@ func FromConcrete[T Argument](args []T) []Argument {
 }
 
 func ToPositionalArguments(args []string) []Argument {
-	if args == nil {
+	if len(args) == 0 {
 		return nil
 	}
 	pos := make([]Argument, 0, len(args))

--- a/cli/parser/arguments/arguments.go
+++ b/cli/parser/arguments/arguments.go
@@ -30,7 +30,7 @@ func (a *PositionalArgument) Format() []string {
 }
 
 func FromConcrete[T Argument](args []T) []Argument {
-	if args == nil {
+	if len(args) == 0 {
 		return nil
 	}
 	argSlice := make([]Argument, 0, len(args))

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -357,7 +357,10 @@ func (o *RequiredValueOption) Normalized() Option {
 	}
 }
 
-type Negatable interface {
+type BoolLike interface {
+	AsBool() (bool, error)
+	Cleared() bool
+	Clear()
 	Negated() bool
 	Negate()
 }
@@ -410,6 +413,15 @@ func (o *BoolOrEnumOption) ClearValue() {
 
 func (o *BoolOrEnumOption) SetValue(value string) {
 	o.Value = &value
+}
+
+func (o *BoolOrEnumOption) Cleared() bool {
+	return o.Value == nil && !o.IsNegative
+}
+
+func (o *BoolOrEnumOption) Clear() {
+	o.Value = nil
+	o.IsNegative = false
 }
 
 func (o *BoolOrEnumOption) Negated() bool {

--- a/cli/parser/parsed/BUILD
+++ b/cli/parser/parsed/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "parsed",
+    srcs = ["parsed.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser/parsed",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/parser/arguments",
+        "//cli/parser/options",
+    ],
+)
+
+package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -1,0 +1,614 @@
+package parsed
+
+import (
+	"fmt"
+	"iter"
+	"slices"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
+)
+
+type Args interface {
+	Format() []string
+	Canonicalized() Args
+	GetStartupOptions() []options.Option
+	GetCommand() string
+	GetCommandOptions() []options.Option
+	GetTargets() []*arguments.PositionalArgument
+	GetExecArgs() []*arguments.PositionalArgument
+	GetOptionsByName(string) []*IndexedOption
+
+	// RemoveOption removes all options whose definitions have names that match
+	// optionName and returns a slice of all removed options, if any, in the order
+	// in which they appeared in the args. The index is the index they were
+	// removed at.
+	RemoveOptions(...string) []*IndexedOption
+
+	// Append appends the given arguments by inserting them in the last valid
+	// location for that type of argument. Startup options
+	Append(...arguments.Argument) error
+
+	// SplitExecutableArgs returns the args split up between the args that bazel
+	// consumes directly and the args that will passed to the executable bazel is
+	// running. This is a concept that only makes sense when using the `run`
+	// command. The arguments that are passed to the executable are all of the
+	// positional arguments that follow the target that is passed to the bazel run
+	// command.
+	SplitExecutableArgs() ([]string, []string)
+}
+
+// Interface for argument classifications to implement
+type Classified interface {
+	arg() arguments.Argument
+}
+
+// Interface for argument classifications to implement if they describe options
+type IsOption interface {
+	AsOption() options.Option
+}
+
+// Argument classifications
+
+type UnsupportedArgument struct{ arguments.Argument }
+
+func (u *UnsupportedArgument) arg() arguments.Argument { return u.Argument }
+
+type StartupOption struct{ options.Option }
+
+func (s *StartupOption) arg() arguments.Argument  { return s.Option }
+func (s *StartupOption) AsOption() options.Option { return s.Option }
+
+type Command struct{ *arguments.PositionalArgument }
+
+func (c *Command) arg() arguments.Argument { return c.PositionalArgument }
+
+type CommandOption struct{ options.Option }
+
+func (c *CommandOption) arg() arguments.Argument  { return c.Option }
+func (c *CommandOption) AsOption() options.Option { return c.Option }
+
+type DoubleDash struct{ *arguments.PositionalArgument }
+
+func (d *DoubleDash) arg() arguments.Argument { return d.PositionalArgument }
+
+type Target struct{ *arguments.PositionalArgument }
+
+func (t *Target) arg() arguments.Argument { return t.PositionalArgument }
+
+type ExecArg struct{ *arguments.PositionalArgument }
+
+func (e *ExecArg) arg() arguments.Argument { return e.PositionalArgument }
+
+// classifier tracks relevant context while iterating over a slice of
+// Arguments in command-line order. It is primarily intended for use
+// by the `Classify` and `Find` functions.
+type classifier struct {
+	command          *string
+	foundDoubleDash  bool
+	foundFirstTarget bool
+}
+
+func (c *classifier) ClassifyAndAccumulate(arg arguments.Argument) Classified {
+	classified := c.Classify(arg)
+	c.Accumulate(classified)
+	return classified
+}
+
+func (c *classifier) Accumulate(classified Classified) {
+	switch v := classified.(type) {
+	case *Command:
+		command := v.Value
+		c.command = &command
+	case *DoubleDash:
+		c.foundDoubleDash = true
+	case *Target:
+		c.foundFirstTarget = true
+	}
+}
+
+func (c *classifier) Classify(arg arguments.Argument) Classified {
+	switch arg := arg.(type) {
+	case *arguments.PositionalArgument:
+		switch {
+		case c.command == nil:
+			return &Command{arg}
+		case !c.foundDoubleDash && arg.Value == "--":
+			return &DoubleDash{arg}
+		case *c.command == "run" && c.foundFirstTarget:
+			return &ExecArg{arg}
+		default:
+			return &Target{arg}
+		}
+	case options.Option:
+		if c.command == nil {
+			return &StartupOption{arg}
+		}
+		return &CommandOption{arg}
+	}
+	return &UnsupportedArgument{arg}
+}
+
+// Classify takes a slice of Arguments and returns a sequence of those Arguments
+// in the same order, wrapped in Classified types. Classify assumes that the
+// Arguments passed in are a full list of arguments in command-line order and
+// has unspecified behavior if they are not. Command-line order looks like:
+func Classify[E arguments.Argument](args []E) iter.Seq2[int, Classified] {
+	return func(yield func(int, Classified) bool) {
+		c := &classifier{}
+		for i, a := range args {
+			if !yield(i, c.ClassifyAndAccumulate(a)) {
+				return
+			}
+		}
+	}
+}
+
+func Find[T Classified, E arguments.Argument](args []E) (int, T) {
+	for i, c := range Classify(args) {
+		if t, ok := c.(T); ok {
+			return i, t
+		}
+	}
+	return -1, *new(T)
+}
+
+// OrderedArgs is a parsed representation of Arguments that will faithfully
+// reproduce the string slice they were generated from if `Format()` is called.
+type OrderedArgs struct {
+	Args []arguments.Argument
+}
+
+// PartitionedArgs is a parsed representation of Arguments that has been
+// partitioned by argument classification (startup options, command, command
+// options, targets, and exec args). It is more performant when adding or
+// removing arguments than OrderedArgs, and `Format()` will always produce
+// args of the form:
+// [startupOptions...] [command [commandOptions...] { [targets... ["--" execArgs...]] | "--" targets... [execArgs] } ]
+// "--" will precede `targets` iff there is at least one negative target (a
+// target prefixed with "-").
+type PartitionedArgs struct {
+	StartupOptions []options.Option
+	Command        *string
+	CommandOptions []options.Option
+	Targets        []*arguments.PositionalArgument
+	ExecArgs       []*arguments.PositionalArgument
+}
+
+func (a *OrderedArgs) Format() []string {
+	tokens := []string{}
+	for _, arg := range a.Args {
+		if arg == nil {
+			tokens = append(tokens, "<nil>")
+			continue
+		}
+		tokens = append(tokens, arg.Format()...)
+	}
+	return tokens
+}
+
+func (a *OrderedArgs) Canonicalized() Args {
+	partitioned := Partition(a.Args)
+	partitioned.StartupOptions = options.Canonicalize(partitioned.StartupOptions)
+	partitioned.CommandOptions = options.Canonicalize(partitioned.CommandOptions)
+	if partitioned.Command == nil {
+		command := "help"
+		partitioned.Command = &command
+	}
+	return partitioned
+}
+
+func (a *OrderedArgs) GetStartupOptions() []options.Option {
+	var startupOptions []options.Option
+	for _, c := range Classify(a.Args) {
+		switch c := c.(type) {
+		case *StartupOption:
+			startupOptions = append(startupOptions, c.Option)
+		case *Command:
+			return startupOptions
+		}
+	}
+	return startupOptions
+}
+
+func (a *OrderedArgs) GetCommand() string {
+	if i, command := Find[*Command](a.Args); i != -1 {
+		return command.Value
+	}
+	// bazel treats no command as a "help" command.
+	return "help"
+}
+
+func (a *OrderedArgs) GetCommandOptions() []options.Option {
+	var commandOptions []options.Option
+	for _, c := range Classify(a.Args) {
+		switch c := c.(type) {
+		case *DoubleDash:
+			return commandOptions
+		case *CommandOption:
+			commandOptions = append(commandOptions, c.Option)
+		}
+	}
+	return commandOptions
+}
+
+func (a *OrderedArgs) GetTargets() []*arguments.PositionalArgument {
+	var targets []*arguments.PositionalArgument
+	command := ""
+	for _, c := range Classify(a.Args) {
+		switch c := c.(type) {
+		case *Command:
+			command = c.Value
+		case *Target:
+			targets = append(targets, c.PositionalArgument)
+			if command == "run" {
+				// "run" command has only one target; return early
+				return targets
+			}
+		}
+	}
+	return targets
+}
+
+func (a *OrderedArgs) GetExecArgs() []*arguments.PositionalArgument {
+	var execArgs []*arguments.PositionalArgument
+	for _, c := range Classify(a.Args) {
+		switch c := c.(type) {
+		case *Command:
+			if c.Value != "run" {
+				// only "run" has ExecArgs; return early
+				return nil
+			}
+		case *ExecArg:
+			execArgs = append(execArgs, c.PositionalArgument)
+		}
+	}
+	return execArgs
+}
+
+func (a *OrderedArgs) SplitExecutableArgs() ([]string, []string) {
+	bazelArgs := []string{}
+	executableArgs := []string{}
+	for _, c := range Classify(a.Args) {
+		switch c := c.(type) {
+		case *Command:
+			if c.Value != "run" {
+				// there are no executable args to split out.
+				return a.Format(), nil
+			}
+			bazelArgs = append(bazelArgs, c.Format()...)
+		case *DoubleDash:
+			continue
+		case *ExecArg:
+			executableArgs = append(executableArgs, c.Format()...)
+		case *Target:
+			if strings.HasPrefix(c.GetValue(), "-") {
+				// This is a negative target to a bazel "run" command; the only way this
+				// can happen is if it was immediately preceded by a double dash. This
+				// command won't run correctly, but restore the double dash to let bazel
+				// output the correct error to the user.
+				bazelArgs = append(bazelArgs, "--")
+			}
+			bazelArgs = append(bazelArgs, c.Format()...)
+		default:
+			bazelArgs = append(bazelArgs, c.arg().Format()...)
+		}
+	}
+	return bazelArgs, executableArgs
+}
+
+type IndexedOption struct {
+	options.Option
+	Index int
+}
+
+func (a *OrderedArgs) GetOptionsByName(optionName string) []*IndexedOption {
+	var matchedOptions []*IndexedOption
+	for i, c := range Classify(a.Args) {
+		if c, ok := c.(IsOption); ok && c.AsOption().Name() == optionName {
+			matchedOptions = append(matchedOptions, &IndexedOption{Option: c.AsOption(), Index: i})
+		}
+	}
+	return matchedOptions
+}
+
+func (a *OrderedArgs) RemoveOptions(optionNames ...string) []*IndexedOption {
+	toRemove := make(map[string]struct{}, len(optionNames))
+	for _, n := range optionNames {
+		toRemove[n] = struct{}{}
+	}
+	var removed []*IndexedOption
+	for i:= 0; i < len(a.Args); i++ {
+		if o, ok := a.Args[i].(options.Option); ok {
+			if _, ok := toRemove[o.Name()]; ok {
+				a.Args = slices.Delete(a.Args, i, i+1)
+				removed = append(removed, &IndexedOption{Option: o, Index: i})
+				// account for the fact that the next element is now at index i instead
+				// of i+1
+				i--
+			}
+		}
+	}
+	return removed
+}
+
+func (a *OrderedArgs) Append(args ...arguments.Argument) error {
+	startupOptionInsertIndex := -1
+	commandOptionInsertIndex := -1
+	for _, arg := range args {
+		switch arg := arg.(type) {
+		case *arguments.PositionalArgument:
+			startupOptionInsertIndex, commandOptionInsertIndex = a.appendPositionalArgument(arg, startupOptionInsertIndex, commandOptionInsertIndex)
+		case options.Option:
+			var err error
+			if startupOptionInsertIndex, commandOptionInsertIndex, err = a.appendOption(arg, startupOptionInsertIndex, commandOptionInsertIndex); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("Append only supports Options and PositionalArguments, but %#v was of type %T.", arg, arg)
+		}
+	}
+	return nil
+}
+
+func (a *OrderedArgs) appendPositionalArgument(arg *arguments.PositionalArgument, startupOptionInsertIndex, commandOptionInsertIndex int) (int, int) {
+	if startupOptionInsertIndex == -1 {
+		if startupOptionInsertIndex, _ = Find[*Command](a.Args); startupOptionInsertIndex == -1 {
+			startupOptionInsertIndex = len(a.Args)
+		}
+	}
+	if startupOptionInsertIndex == len(a.Args) {
+		// We're appending the command
+		a.Args = append(a.Args, arg)
+		return startupOptionInsertIndex, len(a.Args)
+	}
+	if commandOptionInsertIndex == -1 {
+		if commandOptionInsertIndex, _ = Find[*Command](a.Args[startupOptionInsertIndex:]); commandOptionInsertIndex == -1 {
+			commandOptionInsertIndex = len(a.Args)
+		}
+	}
+
+	if commandOptionInsertIndex == len(a.Args) {
+		if strings.HasPrefix(arg.GetValue(), "-") {
+			a.Args = append(a.Args, &arguments.PositionalArgument{Value: "--"})
+		} else {
+			// If there's no double dash, commandOptionInsertIndex needs to be
+			// incremented to still be len(p.Args) afer we append the argument for
+			// when we return.
+			commandOptionInsertIndex += 1
+		}
+	}
+	a.Args = append(a.Args, arg)
+	return startupOptionInsertIndex, commandOptionInsertIndex
+}
+
+func (a *OrderedArgs) appendOption(option options.Option, startupOptionInsertIndex, commandOptionInsertIndex int) (int, int, error) {
+	if startupOptionInsertIndex == -1 {
+		if startupOptionInsertIndex, _ = Find[*Command](a.Args); startupOptionInsertIndex == -1 {
+			startupOptionInsertIndex = len(a.Args)
+		}
+	}
+	command := "startup"
+	if startupOptionInsertIndex < len(a.Args) {
+		command = a.Args[startupOptionInsertIndex].GetValue()
+	}
+	if option.PluginID() == options.UnknownBuiltinPluginID && !option.HasSupportedCommands() {
+		// If this is an unknown option with no listed supported commands, assume it
+		// supports this command (or "startup" in the rare case that no command was
+		// provided.
+		option.GetDefinition().AddSupportedCommand(command)
+	}
+	if option.Supports("startup") {
+		a.Args = slices.Insert(a.Args, startupOptionInsertIndex, arguments.Argument(option))
+		startupOptionInsertIndex += 1
+		if commandOptionInsertIndex != -1 {
+			commandOptionInsertIndex += 1
+		}
+		return startupOptionInsertIndex, commandOptionInsertIndex, nil
+	}
+	if command == "startup" {
+		return startupOptionInsertIndex, commandOptionInsertIndex, fmt.Errorf("Failed to append Option: option '%s' is not a startup option and no command was provided.", option.Name())
+	}
+	if option.Supports(command) {
+		if commandOptionInsertIndex == -1 {
+			if startupOptionInsertIndex == -1 {
+				if startupOptionInsertIndex, _ = Find[*Command](a.Args); startupOptionInsertIndex == -1 {
+					startupOptionInsertIndex = len(a.Args)
+				}
+			}
+			if commandOptionInsertIndex, _ = Find[*Command](a.Args[startupOptionInsertIndex:]); commandOptionInsertIndex == -1 {
+				commandOptionInsertIndex = len(a.Args)
+			}
+		}
+		a.Args = slices.Insert(a.Args, commandOptionInsertIndex, arguments.Argument(option))
+		commandOptionInsertIndex += 1
+		return startupOptionInsertIndex, commandOptionInsertIndex, nil
+	}
+	return startupOptionInsertIndex, commandOptionInsertIndex, fmt.Errorf("Failed to append Option: option '%s' is not a startup option and the command '%s' does not support it.", option.Name(), command)
+}
+
+// Offset exists as a temporary hack while we continue to move away from
+// passing arguments around as strings. It returns the offset in the
+// string-based arg slice where the argument at this index is located.
+func (a *OrderedArgs) Offset(index int) int {
+	offset := 0
+	for _, arg := range a.Args[:index] {
+		offset += len(arg.Format())
+	}
+	return offset
+}
+
+func Partition(args []arguments.Argument) *PartitionedArgs {
+	partitioned := &PartitionedArgs{}
+	for _, c := range Classify(args) {
+		switch c := c.(type) {
+		case *StartupOption:
+			partitioned.StartupOptions = append(partitioned.StartupOptions, c.Option)
+		case *Command:
+			partitioned.Command = &c.Value
+		case *CommandOption:
+			partitioned.CommandOptions = append(partitioned.CommandOptions, c.Option)
+		case *Target:
+			partitioned.Targets = append(partitioned.Targets, c.PositionalArgument)
+		case *ExecArg:
+			partitioned.ExecArgs = append(partitioned.ExecArgs, c.PositionalArgument)
+		}
+	}
+	return partitioned
+}
+
+func (a *PartitionedArgs) Format() []string {
+	formatted := arguments.FormatAll(a.StartupOptions)
+	if a.Command != nil {
+		formatted = append(formatted, *a.Command)
+	}
+	formatted = append(formatted, arguments.FormatAll(a.CommandOptions)...)
+	for _, arg := range a.Targets {
+		if strings.HasPrefix(arg.Value, "-") {
+			formatted = append(formatted, "--")
+			formatted = append(formatted, arguments.FormatAll(a.Targets)...)
+			formatted = append(formatted, arguments.FormatAll(a.ExecArgs)...)
+			return formatted
+		}
+	}
+	formatted = append(formatted, arguments.FormatAll(a.Targets)...)
+	if len(a.ExecArgs) != 0 {
+		formatted = append(formatted, "--")
+		formatted = append(formatted, arguments.FormatAll(a.ExecArgs)...)
+	}
+	return formatted
+}
+
+func (a *PartitionedArgs) Canonicalized() Args {
+	return &PartitionedArgs{
+		StartupOptions: options.Canonicalize(a.StartupOptions),
+		Command:        a.Command,
+		CommandOptions: options.Canonicalize(a.CommandOptions),
+		Targets:        slices.Clone(a.Targets),
+		ExecArgs:       slices.Clone(a.ExecArgs),
+	}
+}
+
+func (a *PartitionedArgs) GetStartupOptions() []options.Option {
+	return a.StartupOptions
+}
+
+func (a *PartitionedArgs) GetCommand() string {
+	if a.Command == nil {
+		return "help"
+	}
+	return *a.Command
+}
+
+func (a *PartitionedArgs) GetCommandOptions() []options.Option {
+	return a.CommandOptions
+}
+
+func (a *PartitionedArgs) GetTargets() []*arguments.PositionalArgument {
+	return a.Targets
+}
+
+func (a *PartitionedArgs) GetExecArgs() []*arguments.PositionalArgument {
+	return a.ExecArgs
+}
+
+func (a *PartitionedArgs) GetOptionsByName(optionName string) []*IndexedOption {
+	var matchedOptions []*IndexedOption
+	for i, o := range a.StartupOptions {
+		if o.Name() == optionName {
+			matchedOptions = append(matchedOptions, &IndexedOption{Option: o, Index: i})
+		}
+	}
+	for i, o := range a.CommandOptions {
+		if o.Name() == optionName {
+			matchedOptions = append(matchedOptions, &IndexedOption{Option: o, Index: i + len(a.StartupOptions) + 1})
+		}
+	}
+	return matchedOptions
+}
+
+func (a *PartitionedArgs) RemoveOptions(optionNames ...string) []*IndexedOption {
+	toRemove := make(map[string]struct{}, len(optionNames))
+	for _, n := range optionNames {
+		toRemove[n] = struct{}{}
+	}
+	var removed []*IndexedOption
+	for i := 0; i < len(a.StartupOptions); {
+		o := a.StartupOptions[i]
+		if _, ok := toRemove[o.Name()]; ok {
+			a.StartupOptions = slices.Delete(a.StartupOptions, i, i+1)
+			removed = append(removed, &IndexedOption{Option: o, Index: i})
+			// account for the fact that the next element is now at index i instead
+			// of i+1
+			i--
+		}
+	}
+	for i := 0; i < len(a.CommandOptions); {
+		o := a.CommandOptions[i]
+		if _, ok := toRemove[o.Name()]; ok {
+			a.CommandOptions = slices.Delete(a.CommandOptions, i, i+1)
+			removed = append(removed, &IndexedOption{Option: o, Index: i + len(a.StartupOptions) + 1})
+			// account for the fact that the next element is now at index i instead
+			// of i+1
+			i--
+		}
+	}
+	return removed
+}
+
+func (a *PartitionedArgs) Append(args ...arguments.Argument) error {
+	for _, arg := range args {
+		switch arg := arg.(type) {
+		case *arguments.PositionalArgument:
+			switch {
+			case a.Command == nil:
+				a.Command = &arg.Value
+			case *a.Command == "run" && len(a.Targets) > 0:
+				a.ExecArgs = append(a.ExecArgs, arg)
+			default:
+				a.Targets = append(a.Targets, arg)
+			}
+		case options.Option:
+			if arg.PluginID() == options.UnknownBuiltinPluginID && !arg.HasSupportedCommands() {
+				// If this is an unknown option with no listed supported commands, assume it
+				// supports this command (or "startup" in the rare case that no command was
+				// provided.
+				command := "startup"
+				if a.Command != nil {
+					command = *a.Command
+				}
+				arg.GetDefinition().AddSupportedCommand(command)
+			}
+			switch {
+			case arg.Supports("startup"):
+				a.StartupOptions = append(a.StartupOptions, arg)
+			case a.Command == nil:
+				return fmt.Errorf("Failed to append Option: option '%s' is not a startup option and no command was provided.", arg.Name())
+			case arg.Supports(*a.Command):
+				a.CommandOptions = append(a.CommandOptions, arg)
+			default:
+				return fmt.Errorf("Failed to append Option: option '%s' is not a startup option and the command '%s' does not support it.", arg.Name(), *a.Command)
+
+			}
+		}
+	}
+	return nil
+}
+
+func (a *PartitionedArgs) SplitExecutableArgs() ([]string, []string) {
+	bazelArgs := arguments.FormatAll(a.StartupOptions)
+	if a.Command != nil {
+		bazelArgs = append(bazelArgs, *a.Command)
+	}
+	bazelArgs = append(bazelArgs, arguments.FormatAll(a.CommandOptions)...)
+	for _, arg := range a.Targets {
+		if strings.HasPrefix(arg.Value, "-") {
+			bazelArgs = append(bazelArgs, "--")
+			bazelArgs = append(bazelArgs, arguments.FormatAll(a.Targets)...)
+			return bazelArgs, arguments.FormatAll(a.ExecArgs)
+		}
+	}
+	bazelArgs = append(bazelArgs, arguments.FormatAll(a.Targets)...)
+	return bazelArgs, arguments.FormatAll(a.ExecArgs)
+}

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -319,7 +319,7 @@ func (a *OrderedArgs) RemoveOptions(optionNames ...string) []*IndexedOption {
 		toRemove[n] = struct{}{}
 	}
 	var removed []*IndexedOption
-	for i:= 0; i < len(a.Args); i++ {
+	for i := 0; i < len(a.Args); i++ {
 		if o, ok := a.Args[i].(options.Option); ok {
 			if _, ok := toRemove[o.Name()]; ok {
 				a.Args = slices.Delete(a.Args, i, i+1)

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -194,18 +194,6 @@ func (p *Parser) ParseArgsForCommand(args []string, command string) (*parsed.Ord
 			}
 			if _, ok := p.BazelCommands[command]; !ok {
 				return nil, fmt.Errorf("Command '%s' not found. Try 'bb help'", command)
-				/*
-					// This isn't a bazel command, but it might be a bb extension.
-					extensionParser := NewParser(nil)
-					extensionParser.BazelCommands[command] = struct{}{}
-					extensionArgs, err := extensionParser.ParseArgsForCommand(next[1:], command)
-					if err != nil {
-						return nil, err
-					}
-					parsedArgs.Args = append(parsedArgs.Args, &arguments.PositionalArgument{Value: next[0]})
-					parsedArgs.Args = append(parsedArgs.Args, extensionArgs.Args...)
-					return parsedArgs, nil
-				*/
 			}
 		}
 		parsedArgs.Args = append(parsedArgs.Args, &arguments.PositionalArgument{Value: next[0]})

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -18,11 +18,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -156,6 +156,100 @@ func (p *Parser) AddOptionDefinition(o *options.Definition) error {
 	return nil
 }
 
+func ParseArgs(args []string) (*parsed.OrderedArgs, error) {
+	p, err := GetParser()
+	if err != nil {
+		return nil, err
+	}
+	return p.ParseArgsForCommand(args, "startup")
+}
+
+func (p *Parser) ParseArgsForCommand(args []string, command string) (*parsed.OrderedArgs, error) {
+	parsedArgs := &parsed.OrderedArgs{}
+	next := args
+	for {
+		opts, argIndex, err := p.ParseOptions(next, command)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s options: %s", command, err)
+		}
+		parsedArgs.Args = append(parsedArgs.Args, arguments.FromConcrete(opts)...)
+		next = next[argIndex:]
+		if len(next) == 0 {
+			break
+		}
+		if next[0] == "--" {
+			if command == "startup" {
+				// Bazel does not recognize `--` until the command has been encountered.
+				return nil, fmt.Errorf("unknown startup option '--'.")
+			}
+			parsedArgs.Args = append(parsedArgs.Args, arguments.ToPositionalArguments(next)...)
+			break
+		}
+		if command == "startup" {
+			command = next[0]
+			if command == "" {
+				// bazel treats a blank command as a help command that halts both option and
+				// argument parsing and ignores all non-startup options in the rc file.
+				break
+			}
+			if _, ok := p.BazelCommands[command]; !ok {
+				return nil, fmt.Errorf("Command '%s' not found. Try 'bb help'", command)
+				/*
+					// This isn't a bazel command, but it might be a bb extension.
+					extensionParser := NewParser(nil)
+					extensionParser.BazelCommands[command] = struct{}{}
+					extensionArgs, err := extensionParser.ParseArgsForCommand(next[1:], command)
+					if err != nil {
+						return nil, err
+					}
+					parsedArgs.Args = append(parsedArgs.Args, &arguments.PositionalArgument{Value: next[0]})
+					parsedArgs.Args = append(parsedArgs.Args, extensionArgs.Args...)
+					return parsedArgs, nil
+				*/
+			}
+		}
+		parsedArgs.Args = append(parsedArgs.Args, &arguments.PositionalArgument{Value: next[0]})
+		next = next[1:]
+	}
+	return parsedArgs, nil
+}
+
+// Parse options until we encounter a positional argument, and return the
+// options and the index of the positional argument that terminated parsing, or
+// the length of the input arguments array if no positional argument was
+// encountered. If no command is provided, options will not be filtered by
+// command.
+func (p *Parser) ParseOptions(args []string, command string) ([]options.Option, int, error) {
+	var parsedOptions []options.Option
+	// Iterate through the args, looking for a terminating token.
+	for i := 0; i < len(args); {
+		token := args[i]
+		if token == "--" {
+			// POSIX-specified (and bazel-supported) delimiter to end option parsing
+			return parsedOptions, i, nil
+		}
+		option, next, err := p.Next(args, i, command == "startup")
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to parse options: %s", err)
+		}
+		if option == nil {
+			// This is a positional argument, return it.
+			return parsedOptions, i, nil
+		}
+		if command != "" {
+			if option.PluginID() == options.UnknownBuiltinPluginID {
+				// If this is an unknown option, assume it's supported by this command.
+				option.GetDefinition().AddSupportedCommand(command)
+			} else if !option.Supports(command) {
+				return nil, 0, fmt.Errorf("failed to parse options: Option '%s' does not support command '%s'", token, command)
+			}
+		}
+		parsedOptions = append(parsedOptions, option)
+		i = next
+	}
+	return parsedOptions, len(args), nil
+}
+
 // Next parses the next option in the args list, starting at the given index. It
 // is intended to be called in a loop that parses an argument list against a
 // Parser.
@@ -192,14 +286,14 @@ func (p *Parser) Next(args []string, start int, startup bool) (option options.Op
 		// Unknown option, possibly a plugin-specific argument. Apply a rough
 		// heuristic to determine whether or not to have it consume the next
 		// argument.
-		if b, ok := unknownOption.Option.(options.Negatable); ok && !option.HasValue() && !b.Negated() {
+		if b, ok := unknownOption.Option.(options.BoolLike); ok && !option.HasValue() && !b.Negated() {
 			// This could actually be a required-value-type option rather than a
 			// boolean option; if the next argument doesn't look like an option or a
 			// bazel command, let's assume that it is.
 			if start+1 < len(args) {
 				if nextArg := args[start+1]; !strings.HasPrefix(nextArg, "-") {
 					if _, ok := p.BazelCommands[nextArg]; !startup || !ok {
-						innerOption, err := options.NewOption(
+						option, err = options.NewOption(
 							strings.TrimLeft(startToken, "-"),
 							nil,
 							options.NewDefinition(
@@ -213,7 +307,6 @@ func (p *Parser) Next(args []string, start int, startup bool) (option options.Op
 						if err != nil {
 							return nil, -1, err
 						}
-						unknownOption.Option = innerOption
 					}
 				}
 			}
@@ -354,11 +447,14 @@ func GenerateParser(flagCollection *bfpb.FlagCollection) (*Parser, error) {
 	parser := NewParser(nil)
 	for _, info := range flagCollection.FlagInfos {
 		d := options.DefinitionFrom(info)
-		for cmd := range d.SupportedCommands() {
-			if cmd != "startup" {
-				// startup is not a real command, just a flag classifier
+		if !d.Supports("startup") {
+			// only add commands from non-startup flags to the bazel commands
+			for cmd := range d.SupportedCommands() {
 				parser.BazelCommands[cmd] = struct{}{}
 			}
+			// non-startup flags support the "common" and "always" bazelrc classifiers
+			d.AddSupportedCommand("common")
+			d.AddSupportedCommand("always")
 		}
 		if err := parser.AddOptionDefinition(d); err != nil {
 			return nil, err
@@ -370,22 +466,6 @@ func GenerateParser(flagCollection *bfpb.FlagCollection) (*Parser, error) {
 func GetParser() (*Parser, error) {
 	once := generateParserOnce()
 	return once.p, once.error
-}
-
-func CanonicalizeStartupArgs(args []string) ([]string, error) {
-	// Check for bazel command prior to running the parser to avoid the
-	// performance cost of generating the parser, which runs bazel.
-	bazelCommand, _ := GetBazelCommandAndIndex(args)
-	if bazelCommand == "" {
-		// Not a bazel command; no startup args to canonicalize.
-		return args, nil
-	}
-
-	p, err := GetParser()
-	if err != nil {
-		return nil, err
-	}
-	return p.canonicalizeArgs(args, true)
 }
 
 func CanonicalizeArgs(args []string) ([]string, error) {
@@ -401,60 +481,21 @@ func CanonicalizeArgs(args []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.canonicalizeArgs(args, false)
+	return p.canonicalizeArgs(args)
 }
 
-func (p *Parser) canonicalizeArgs(args []string, onlyStartupOptions bool) ([]string, error) {
-	args, execArgs := arg.SplitExecutableArgs(args)
-	// First pass: go through args, expanding short names, converting bool
-	// values to 0 or 1, and converting "--name value" args to "--name=value"
-	// form.
-	var processedArgs []arguments.Argument
-	lastOptionIndex := map[string]int{}
-	i := 0
-	command := "startup"
-	for i < len(args) {
-		token := args[i]
-		option, next, err := p.Next(args, i, command == "startup")
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse %s options: %s", command, err)
-		}
-		i = next
-		switch {
-		case option == nil:
-			// This is a positional argument
-			processedArgs = append(processedArgs, &arguments.PositionalArgument{Value: token})
-		case !option.HasSupportedCommands():
-			// This option is unsupported by bazel, assume a plugin option
-			fallthrough
-		case option.Supports(command):
-			lastOptionIndex[option.Name()] = len(processedArgs)
-			processedArgs = append(processedArgs, option.Normalized())
-		default:
-			return nil, fmt.Errorf("option '%s' is not a '%s' option.", option.Name(), command)
-		}
-		if _, ok := p.BazelCommands[token]; ok {
-			if onlyStartupOptions {
-				return arg.JoinExecutableArgs(append(arguments.FormatAll(processedArgs), args[i:]...), execArgs), nil
-			}
-			// When we see the bazel command token, switch to parsing command
-			// options instead of startup options.
-			command = token
+func (p *Parser) canonicalizeArgs(args []string) ([]string, error) {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		if _, ok := p.BazelCommands[args[0]]; !ok {
+			// Not a bazel command; no startup args to canonicalize.
+			return args, nil
 		}
 	}
-	// Second pass: loop through the canonical args so far, and remove any args
-	// which are overridden by a later arg. Note that multi-args cannot be
-	// overriden.
-	var canonical []string
-	for i, arg := range processedArgs {
-		if opt, ok := arg.(options.Option); ok {
-			if opt != nil && !opt.Multi() && lastOptionIndex[opt.Name()] > i {
-				continue
-			}
-		}
-		canonical = append(canonical, arg.Format()...)
+	parsedArgs, err := ParseArgs(args)
+	if err != nil {
+		return nil, err
 	}
-	return arg.JoinExecutableArgs(canonical, execArgs), nil
+	return parsedArgs.Canonicalized().Format(), nil
 }
 
 // runBazelHelpWithCache returns the `bazel help <topic>` output for the version
@@ -721,6 +762,42 @@ func ParseRCFiles(workspaceDir string, filePaths ...string) ([]*RcRule, error) {
 	return opts, nil
 }
 
+// Convenience function to use the singleton parser's MakeOption function.
+func MakeOption(optionName string, value *string) (option options.Option, err error) {
+	p, err := GetParser()
+	if err != nil {
+		return nil, err
+	}
+	o, err := p.MakeOption(optionName, value)
+	if err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+func (p *Parser) MakeOption(optionName string, value *string) (option options.Option, err error) {
+	if len(optionName) == 1 {
+		// assume length 1 is a short name
+		option, err = p.parseShortNameOption(optionName)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		option, err = p.parseLongNameOption(optionName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	option, err = options.NewOption(optionName, value, option.GetDefinition())
+	if err != nil {
+		return nil, err
+	}
+	if option.ExpectsValue() {
+		return nil, fmt.Errorf("Required value option %s must have a value, but none was provided.", optionName)
+	}
+	return option, nil
+}
+
 func ExpandConfigs(args []string) ([]string, error) {
 	p, err := GetParser()
 	if err != nil {
@@ -734,7 +811,7 @@ func ExpandConfigs(args []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.canonicalizeArgs(args, false)
+	return p.canonicalizeArgs(args)
 }
 
 // Mirroring the behavior here:
@@ -811,33 +888,44 @@ func (p *Parser) expandConfigs(workspaceDir string, args []string) ([]string, er
 	args = concat(args[:commandIndex+1], defaultArgs, args[commandIndex+1:])
 	log.Debugf("Args after expanding default rc rules: %v", args)
 
-	enable, enableIndex, enableLength := arg.FindLast(args, enablePlatformSpecificConfigFlag)
-	_, noEnableIndex, _ := arg.FindLast(args, "no"+enablePlatformSpecificConfigFlag)
-	if enableIndex > noEnableIndex {
-		if strings.HasPrefix(enable, "-") {
-			// It's likely that the "enable" value here is just another Bazel flag, such as `--config` or `-c`.
-			// And our --enable_platform_specific_config flag is a standalone flag that does not come with a value.
-			//
-			// In this case, manually fix arg.FindLast results to avoid confusion.
-			// TODO(sluongng): This is a hack. We should fix arg.FindLast to return the correct index.
-			enable = "true"
-			enableLength = 1
-		}
-		if enable == "true" || enable == "yes" || enable == "1" || enable == "" {
-			args = concat(args[:enableIndex], []string{"--config", getBazelOS()}, args[enableIndex+enableLength:])
-			log.Debugf("Args after inserting artificial platform-specific --config argument: %s", args)
+	parsedArgs, err := ParseArgs(args)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace the last occurrence of `--enable_platform_specific_config` with
+	// `--config=<bazelOS>`, so long as the last occurrence evaluates as true.
+	opts := parsedArgs.RemoveOptions(enablePlatformSpecificConfigFlag)
+	if len(opts) > 0 {
+		enable := opts[len(opts)-1].Option
+		index := opts[len(opts)-1].Index
+		if b, ok := enable.(options.BoolLike); ok {
+			if v, err := b.AsBool(); err != nil && v {
+				bazelOS := getBazelOS()
+				o, err := p.MakeOption("config", &bazelOS)
+				if err != nil {
+					return nil, err
+				}
+				parsedArgs.Args = slices.Insert(parsedArgs.Args, index, arguments.Argument(o))
+			}
 		}
 	}
 
-	offset := 0
+	offset := parsedArgs.Offset(len(parsedArgs.GetStartupOptions())) + 1
 	for offset < len(args) {
+		parsedArgs, err := p.ParseArgsForCommand(args[offset:], command)
+		if err != nil {
+			return nil, err
+		}
 		// Find the next --config arg, starting from just after we expanded
 		// the last config arg.
-		config, configIndex, length := arg.Find(args[offset:], "config")
-		if configIndex < 0 {
+		opts := parsedArgs.GetOptionsByName("config")
+		if len(opts) == 0 {
 			break
 		}
-		configIndex = offset + configIndex
+		config := opts[0].GetValue()
+		configIndex := offset + parsedArgs.Offset(opts[0].Index)
+		length := len(opts[0].Format())
 
 		// If the config isn't defined, leave it as-is, and let bazel return
 		// an error.

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -21,16 +21,17 @@ func Setup(args []string, tempDir string) (_ []*plugin.Plugin, bazelArgs []strin
 	}
 
 	// Parse args.
-	bazelArgs, execArgs = arg.SplitExecutableArgs(args)
+
 	// TODO: Expanding configs results in a long explicit command line in the BB
 	// UI. Need to find a way to override the explicit command line in the UI so
 	// that it reflects the args passed to the CLI, not the wrapped Bazel
 	// process.
-	bazelArgs, err = parser.ExpandConfigs(bazelArgs)
+	args, err = parser.ExpandConfigs(args)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
 
+	bazelArgs, execArgs = arg.SplitExecutableArgs(args)
 	// Save some flags from the current invocation for non-Bazel commands such
 	// as `bb ask`.
 	// Args are saved before the sidecar rewrites them as API requests require


### PR DESCRIPTION
This PR primarily adds types to manage parsed args. It additionally removes the need for separating canonicalization of startup args from canonicalization of other args. Many of the methods added are intended for use once we begin passing `ParsedArgs` types around instead of `[]arg` slices. Finally, it adds the `common` and `always` "commands" to non-startup options to make config expansion more straightforward.
