### PR TITLE
Complete action merging cleanup even with a canceled parent context

### DIFF
--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -282,11 +282,6 @@ func DeletePendingExecution(ctx context.Context, rdb redis.UniversalClient, exec
 		return nil
 	}
 
-	// The pending execution should be cleaned up regardless of whether
-	// the original request is canceled or times out.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer cancel()
-
 	pendingExecutionDigestKey := redisKeyForPendingExecutionDigest(executionID)
 	pendingExecutionKey, err := rdb.Get(ctx, pendingExecutionDigestKey).Result()
 	if err == redis.Nil {

--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -278,6 +278,10 @@ func shouldHedge(hash map[string]string) bool {
 
 // Deletes the pending execution with the provided execution ID.
 func DeletePendingExecution(ctx context.Context, rdb redis.UniversalClient, executionID string) error {
+	// The pending execution should be cleaned up regardless of whether
+	// the original request is canceled or times out.
+	ctx = context.WithoutCancel(ctx)
+
 	if !*enableActionMerging {
 		return nil
 	}

--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -278,13 +278,14 @@ func shouldHedge(hash map[string]string) bool {
 
 // Deletes the pending execution with the provided execution ID.
 func DeletePendingExecution(ctx context.Context, rdb redis.UniversalClient, executionID string) error {
-	// The pending execution should be cleaned up regardless of whether
-	// the original request is canceled or times out.
-	ctx = context.WithoutCancel(ctx)
-
 	if !*enableActionMerging {
 		return nil
 	}
+
+	// The pending execution should be cleaned up regardless of whether
+	// the original request is canceled or times out.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
 
 	pendingExecutionDigestKey := redisKeyForPendingExecutionDigest(executionID)
 	pendingExecutionKey, err := rdb.Get(ctx, pendingExecutionDigestKey).Result()

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -57,7 +57,8 @@ import (
 )
 
 const (
-	updateExecutionTimeout = 15 * time.Second
+	updateExecutionTimeout             = 15 * time.Second
+	deletePendingExecutionExtraTimeout = 10 * time.Second
 
 	// When an action finishes, schedule the corresponding pubsub channel to
 	// be discarded after this time. There may be multiple waiters for a single
@@ -691,7 +692,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	}
 
 	if _, err := scheduler.ScheduleTask(ctx, scheduleReq); err != nil {
-		ctx, cancel := background.ExtendContextForFinalization(ctx, 10*time.Second)
+		ctx, cancel := background.ExtendContextForFinalization(ctx, deletePendingExecutionExtraTimeout)
 		defer cancel()
 		if opts.recordActionMergingState {
 			_ = action_merger.DeletePendingExecution(ctx, s.rdb, executionID)
@@ -1069,6 +1070,8 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 		if taskID == "" {
 			return
 		}
+		ctx, cancel := background.ExtendContextForFinalization(ctx, deletePendingExecutionExtraTimeout)
+		defer cancel()
 		if err := action_merger.DeletePendingExecution(ctx, s.rdb, taskID); err != nil {
 			log.CtxWarningf(ctx, "could not delete pending execution %q: %s", taskID, err)
 		}


### PR DESCRIPTION
Speculative fix for a number of cases in which action merging keys went stale because their original execution's context got canceled during the cleanup routine.