### PR TITLE
Test that zstd compression and decompression is lossless

### DIFF
--- a/server/util/compression/BUILD
+++ b/server/util/compression/BUILD
@@ -16,6 +16,9 @@ go_library(
 go_test(
     name = "compression_test",
     srcs = ["compression_test.go"],
-    embed = [":compression"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        ":compression",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/server/util/compression/BUILD
+++ b/server/util/compression/BUILD
@@ -18,6 +18,7 @@ go_test(
     srcs = ["compression_test.go"],
     deps = [
         ":compression",
+        "//server/testutil/testdigest",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/compression/compression_test.go
+++ b/server/util/compression/compression_test.go
@@ -1,18 +1,35 @@
-package compression
+package compression_test
 
 import (
 	"io"
 	"strings"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
+// CompressZstd -> DecompressZstd, NewZstdDecompressor, NewZStdDecompressingReader
+// NewZstdCompressingReader -> DecompressZstd, NewZstdDecompressor, NewZStdDecompressingReader
+
+func TestLossless_CompressZstd(t *testing.T) {
+	src := []byte(strings.Repeat("Please compress me.", 1024))
+	dst := make([]byte, len(src))
+	compressed := compression.CompressZstd(dst, src)
+	require.LessOrEqual(t, len(compressed), len(src))
+
+	decompressed := make([]byte, len(src))
+	decompressed, err := compression.DecompressZstd(decompressed, compressed)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(src, decompressed))
+}
+
 func Test_NewZstdDecompressingReader(t *testing.T) {
 	blob := "AAAAAAAAAAAAA"
-	compressedBlob := CompressZstd(nil, []byte(blob))
+	compressedBlob := compression.CompressZstd(nil, []byte(blob))
 	compressedReader := strings.NewReader(string(compressedBlob))
-	decompressedReader, err := NewZstdDecompressingReader(io.NopCloser(compressedReader))
+	decompressedReader, err := compression.NewZstdDecompressingReader(io.NopCloser(compressedReader))
 	require.NoError(t, err)
 
 	b, err := io.ReadAll(decompressedReader)


### PR DESCRIPTION
This change adds a test that takes all the publicly available zstd compressors (`CompressZstd` and `NewZstdCompressingReader`) and zstd decompressors (`DecompressZstd`, `NewZstdDecompressor`, `NewZstdDecompressingReader`) and makes sure that compressing and decompressing through each pair produces the same string.

This change also removes `Test_NewZstdDecompressingReader`, as `TestLossless` is a superset of that test.

I'm about to introduce `NewZstdCompressingWriter` in another change, and I want to be able to test that it too is lossless.