### PR TITLE
[raft] Add staging replica descriptors in range descriptor

### DIFF
--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -271,7 +271,7 @@ func (s *Sender) tryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 	})
 }
 
-// tryReplica tries the this fn on the replica and return whether to try a different replica
+// tryReplica tries the fn on the replica and returns whether to try a different replica
 func (s *Sender) tryReplica(ctx context.Context, rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor, fn runFunc, makeHeaderFn makeHeaderFunc) (bool, error) {
 	select {
 	case <-ctx.Done():
@@ -301,8 +301,7 @@ func (s *Sender) tryReplica(ctx context.Context, rd *rfpb.RangeDescriptor, repli
 		return false, nil
 	}
 	if status.IsOutOfRangeError(err) {
-		m := status.Message(err)
-		switch {
+		switch m := status.Message(err); {
 		// range not found, no replicas are likely to have it; bail.
 		case strings.HasPrefix(m, constants.RangeNotCurrentMsg):
 			return false, status.OutOfRangeErrorf("failed to TryReplicas on c%dn%d: no replicas are likely to have it: %s", replica.GetRangeId(), replica.GetReplicaId(), m)

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -466,8 +466,8 @@ message RangeDescriptor {
   // this list.
   repeated ReplicaDescriptor removed = 8;
 
-  // Replicas marked as staging are going to be added to the raft system. Once 
-  // they are successfully added to raft, we will move the replica descriptor 
+  // Replicas marked as staging are going to be added to the raft system. Once
+  // they are successfully added to raft, we will move the replica descriptor
   // from staging to the replicas field above.
   repeated ReplicaDescriptor staging = 9;
 }

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -465,6 +465,12 @@ message RangeDescriptor {
   // a replica is removed from the system successfully, it will be removed from
   // this list.
   repeated ReplicaDescriptor removed = 8;
+
+  // Replicas marked as staging are going to be added 
+  // to the raft system. Once they are successfully
+  // added to the raft, we will remove the replica descriptor from staging to
+  // the replicas field above.
+  repeated ReplicaDescriptor staging = 9;
 }
 
 // SyncPropose, in proto form.

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -466,10 +466,9 @@ message RangeDescriptor {
   // this list.
   repeated ReplicaDescriptor removed = 8;
 
-  // Replicas marked as staging are going to be added
-  // to the raft system. Once they are successfully
-  // added to the raft, we will remove the replica descriptor from staging to
-  // the replicas field above.
+  // Replicas marked as staging are going to be added to the raft system. Once 
+  // they are successfully added to raft, we will move the replica descriptor 
+  // from staging to the replicas field above.
   repeated ReplicaDescriptor staging = 9;
 }
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -466,7 +466,7 @@ message RangeDescriptor {
   // this list.
   repeated ReplicaDescriptor removed = 8;
 
-  // Replicas marked as staging are going to be added 
+  // Replicas marked as staging are going to be added
   // to the raft system. Once they are successfully
   // added to the raft, we will remove the replica descriptor from staging to
   // the replicas field above.


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4910

Added a staging field in range descriptor.

When we add a replica, we will 
1. add to the staging field in range descriptor
2. start the shard as a non-voter, catch up, promote to voter
3. move the replica descriptor from staging to regular replica descriptors

In the sender, when we try replicas, we will also try staging replicas, so that 
we won't ended up fail the writes with no lease found for replicas when the
leader is moved to the newly added replica before the range descriptor is
updated.

Also, fixed some issues with AddNodeToCluster tests:
- disable driver
- add s3 to the candidate stores when we try to get the store with range lease.

The AddNodeToCluster tested succeeded with 2 500 runs:
https://app.buildbuddy.io/invocation/b5d1949d-63ab-42f1-b772-b7323065b41f
https://app.buildbuddy.io/invocation/0a847409-42c3-41e1-b7e0-8e23d401c072

Note: this change doesn't change zombie janitor yet. With the staging replica descriptor, we can remove the janitor to check for non-voters, and instead let zombie janitor check staging replica descriptor. Also, zombie janitor needs to clean up staging replica after it removes zombie shards. I will accomplish these in a future PR. 