### PR TITLE
vfs: refresh attrs in Lookup if needed

### DIFF
--- a/enterprise/server/remote_execution/vfs/vfs_unix.go
+++ b/enterprise/server/remote_execution/vfs/vfs_unix.go
@@ -421,7 +421,7 @@ func (n *Node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (nod
 	// a refresh if necessary as it already handles this case for the GetAttr call.
 	attrs, err := n.getattr()
 	if err != nil {
-		return nil, 0
+		return nil, rpcErrToSyscallErrno(err)
 	}
 	fillFuseAttr(&out.Attr, attrs)
 

--- a/enterprise/server/remote_execution/vfs/vfs_unix.go
+++ b/enterprise/server/remote_execution/vfs/vfs_unix.go
@@ -338,6 +338,25 @@ func (vfs *VFS) startOP(pathFn func() string, op string) {
 	stats[op]++
 }
 
+func (vfs *VFS) getattr(inode uint64) (*vfspb.Attrs, error) {
+	attrs, ok := vfs.inodeCache.getCachedAttrs(inode)
+
+	if !ok {
+		rsp, err := vfs.vfsClient.GetAttr(vfs.getRPCContext(), &vfspb.GetAttrRequest{Id: inode})
+		if err != nil {
+			return nil, err
+		}
+		attrs = rsp.GetAttrs()
+		vfs.inodeCache.cacheAttrs(inode, attrs)
+	} else {
+		if vfs.verbose {
+			log.CtxInfof(vfs.getRPCContext(), "using cached attributes for inode %d", inode)
+		}
+	}
+
+	return attrs, nil
+}
+
 type Node struct {
 	fs.Inode
 
@@ -419,7 +438,7 @@ func (n *Node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (nod
 	// a very frequently performed operation. If a file has been modified
 	// but not yet closed it may return stale attributes. We defer to getAttr to trigger
 	// a refresh if necessary as it already handles this case for the GetAttr call.
-	attrs, err := n.getattr()
+	attrs, err := n.vfs.getattr(rsp.Id)
 	if err != nil {
 		return nil, rpcErrToSyscallErrno(err)
 	}
@@ -889,25 +908,6 @@ func modeDebugString(mode uint32) string {
 	return fmt.Sprintf("%s %#o", typ, mode & ^uint32(unix.S_IFMT))
 }
 
-func (n *Node) getattr() (*vfspb.Attrs, error) {
-	attrs, ok := n.vfs.inodeCache.getCachedAttrs(n.StableAttr().Ino)
-
-	if !ok {
-		rsp, err := n.vfs.vfsClient.GetAttr(n.vfs.getRPCContext(), &vfspb.GetAttrRequest{Id: n.StableAttr().Ino})
-		if err != nil {
-			return nil, err
-		}
-		attrs = rsp.GetAttrs()
-		n.vfs.inodeCache.cacheAttrs(n.StableAttr().Ino, attrs)
-	} else {
-		if n.vfs.verbose {
-			log.CtxInfof(n.vfs.getRPCContext(), "using cached attributes for inode %d", n.StableAttr().Ino)
-		}
-	}
-
-	return attrs, nil
-}
-
 func (n *Node) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) (errno syscall.Errno) {
 	n.startOP("Getattr")
 	if n.vfs.verbose {
@@ -921,7 +921,7 @@ func (n *Node) Getattr(ctx context.Context, f fs.FileHandle, out *fuse.AttrOut) 
 		}()
 	}
 
-	attrs, err := n.getattr()
+	attrs, err := n.vfs.getattr(n.StableAttr().Ino)
 	if err != nil {
 		return rpcErrToSyscallErrno(err)
 	}
@@ -981,7 +981,7 @@ func (n *Node) Getxattr(ctx context.Context, attr string, dest []byte) (uint32, 
 		log.CtxDebugf(n.vfs.rpcCtx, "Getxattr %q", n.relativePath())
 	}
 
-	attrs, err := n.getattr()
+	attrs, err := n.vfs.getattr(n.StableAttr().Ino)
 	if err != nil {
 		return 0, rpcErrToSyscallErrno(err)
 	}
@@ -1005,7 +1005,7 @@ func (n *Node) Getxattr(ctx context.Context, attr string, dest []byte) (uint32, 
 }
 
 func (n *Node) Listxattr(ctx context.Context, dest []byte) (uint32, syscall.Errno) {
-	attrs, err := n.getattr()
+	attrs, err := n.vfs.getattr(n.StableAttr().Ino)
 	if err != nil {
 		return 0, rpcErrToSyscallErrno(err)
 	}


### PR DESCRIPTION
I don't know how to write a simple test for this. There doesn't seem to be a way for user space code to exercise Lookup w/o also calling GetAttr.

overlayfs is likely able to do it because it's running in the kernel and is able to use lower-level APIs. Perhaps the only option is to add an overlayfs test to vfs_test?