### PR TITLE
redact sensitive env vars from action_env

### DIFF
--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	envVarOptionNames      = []string{"client_env", "repo_env", "test_env"}
+	envVarOptionNames      = []string{"action_env", "client_env", "repo_env", "test_env"}
 	envVarOptionNamesRegex = regexp.MustCompile(`(--(?:` + strings.Join(envVarOptionNames, "|") + `)=\w+=).*`)
 
 	urlSecretRegex      = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://[^:@]+:)[^@]*(@[^"\s<>{}|\\^[\]]+)`)

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	envVarOptionNames      = []string{"action_env", "client_env", "repo_env", "test_env"}
+	envVarOptionNames      = []string{"action_env", "client_env", "host_action_env", "repo_env", "test_env"}
 	envVarOptionNamesRegex = regexp.MustCompile(`(--(?:` + strings.Join(envVarOptionNames, "|") + `)=\w+=).*`)
 
 	urlSecretRegex      = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://[^:@]+:)[^@]*(@[^"\s<>{}|\\^[\]]+)`)

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -392,6 +392,8 @@ func TestRedactMetadata_StructuredCommandLine(t *testing.T) {
 		{"host_platform", "@buildbuddy_toolchain//:platform", "@buildbuddy_toolchain//:platform"},
 		{"action_env", "AWS_ACCESS_KEY_ID=super_secret_access_key_id", "AWS_ACCESS_KEY_ID=<REDACTED>"},
 		{"action_env", "AWS_SECRET_ACCESS_KEY=super_secret_access_key", "AWS_SECRET_ACCESS_KEY=<REDACTED>"},
+		{"host_action_env", "AWS_ACCESS_KEY_ID=super_secret_access_key_id", "AWS_ACCESS_KEY_ID=<REDACTED>"},
+		{"host_action_env", "AWS_SECRET_ACCESS_KEY=super_secret_access_key", "AWS_SECRET_ACCESS_KEY=<REDACTED>"},
 	} {
 		option := &clpb.Option{
 			OptionName:   testCase.optionName,

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -390,6 +390,8 @@ func TestRedactMetadata_StructuredCommandLine(t *testing.T) {
 		{"remote_default_exec_properties", "container-registry-username=SECRET_USERNAME", "container-registry-username=<REDACTED>"},
 		{"remote_default_exec_properties", "container-registry-password=SECRET_PASSWORD", "container-registry-password=<REDACTED>"},
 		{"host_platform", "@buildbuddy_toolchain//:platform", "@buildbuddy_toolchain//:platform"},
+		{"action_env", "AWS_ACCESS_KEY_ID=super_secret_access_key_id", "AWS_ACCESS_KEY_ID=<REDACTED>"},
+		{"action_env", "AWS_SECRET_ACCESS_KEY=super_secret_access_key", "AWS_SECRET_ACCESS_KEY=<REDACTED>"},
 	} {
 		option := &clpb.Option{
 			OptionName:   testCase.optionName,


### PR DESCRIPTION
Fixes [internal issue 4912](https://github.com/buildbuddy-io/buildbuddy-internal/issues/4912)