### PR TITLE
Add separate RPC to unlink user-level GH token

### DIFF
--- a/enterprise/app/settings/user_github_link.tsx
+++ b/enterprise/app/settings/user_github_link.tsx
@@ -89,13 +89,9 @@ export default class UserGitHubLink extends React.Component<Props, State> {
   private onConfirmDelete() {
     this.setState({ isDeleting: true });
     rpcService.service
-      .unlinkGitHubAccount(github.UnlinkGitHubAccountRequest.create({ unlinkUserAccount: true }))
+      .unlinkUserGitHubAccount({})
       .then((response) => {
-        if (response.warning.length) {
-          alertService.warning("Warnings encountered while deleting GitHub account:\n" + response.warning.join("\n"));
-        } else {
-          alertService.success("Successfully unlinked GitHub account");
-        }
+        alertService.success("Successfully unlinked GitHub account");
         this.setState({ deleteModalVisible: false });
         this.refreshUser();
       })

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -164,6 +164,8 @@ service BuildBuddyService {
   // Note: GitHub account linking is accomplished via HTTP redirect flow
   rpc UnlinkGitHubAccount(github.UnlinkGitHubAccountRequest)
       returns (github.UnlinkGitHubAccountResponse);
+  rpc UnlinkUserGitHubAccount(github.UnlinkUserGitHubAccountRequest)
+      returns (github.UnlinkUserGitHubAccountResponse);
 
   // GitHub app link API
   rpc GetGitHubAppInstallPath(github.GetGithubAppInstallPathRequest)

--- a/proto/github.proto
+++ b/proto/github.proto
@@ -4,13 +4,25 @@ import "proto/context.proto";
 
 package github;
 
+// UnlinkUserGitHubAccountRequest is a request to unlink the GitHub account
+// associated with the authenticated user.
+message UnlinkUserGitHubAccountRequest {
+  context.RequestContext request_context = 1;
+}
+
+message UnlinkUserGitHubAccountResponse {
+  context.ResponseContext response_context = 1;
+}
+
 // UnlinkGitHubAccountRequest is a request to unlink the GitHub account
 // associated with the group selected in the request context.
 message UnlinkGitHubAccountRequest {
   context.RequestContext request_context = 1;
 
   // Whether to unlink the user-level account.
-  bool unlink_user_account = 2;
+  // DEPRECATED: use UnlinkUserGitHubAccount RPC instead.
+  // TODO(bduffany): delete this after next rollout.
+  bool unlink_user_account = 2 [deprecated = true];
 }
 
 message UnlinkGitHubAccountResponse {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1458,6 +1458,17 @@ func (s *BuildBuddyServer) GetWorkspaceFile(ctx context.Context, req *wspb.GetWo
 	return nil, status.UnimplementedError("Not implemented")
 }
 
+func (s *BuildBuddyServer) UnlinkUserGitHubAccount(ctx context.Context, req *ghpb.UnlinkUserGitHubAccountRequest) (*ghpb.UnlinkUserGitHubAccountResponse, error) {
+	udb := s.env.GetUserDB()
+	if udb == nil {
+		return nil, status.UnimplementedError("Not implemented")
+	}
+	if err := udb.DeleteUserGitHubToken(ctx); err != nil {
+		return nil, err
+	}
+	return &ghpb.UnlinkUserGitHubAccountResponse{}, nil
+}
+
 func (s *BuildBuddyServer) UnlinkGitHubAccount(ctx context.Context, req *ghpb.UnlinkGitHubAccountRequest) (*ghpb.UnlinkGitHubAccountResponse, error) {
 	udb := s.env.GetUserDB()
 	if udb == nil {

--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -54,6 +54,10 @@ var (
 		"GetAction",
 		"GetFile",
 		"DeleteFile",
+
+		// GitHub user-level token management does not require group membership.
+		"UnlinkUserGitHubAccount",
+
 		// GitHub passthrough endpoints use User's linked GitHub account
 		"GetGithubUserInstallations",
 		"GetGithubUser",


### PR DESCRIPTION
The current RPC requires `Admin` role (since it can unlink the account that is linked to the org), which prevents `Developer` users from unlinking their GitHub account. Add a new RPC that only requires an authenticated user to call (since it only affects the User entity).