### PR TITLE
[testfs] log failure to cleanup test dir, but do not fail test

### DIFF
--- a/server/testutil/testfs/testfs.go
+++ b/server/testutil/testfs/testfs.go
@@ -58,7 +58,7 @@ func MakeTempDir(t testing.TB) string {
 	}
 	t.Cleanup(func() {
 		if err := os.RemoveAll(tmpDir); err != nil && !os.IsNotExist(err) {
-			assert.FailNow(t, "failed to clean up temp dir", err)
+			t.Logf("failed to clean up temp dir: %s", err)
 		}
 	})
 	return tmpDir


### PR DESCRIPTION
Failing to clean up the temporary test directory current fails the test. This is a common source of flake for `remote_bazel_test.TestCancel`.

This change logs an error message if cleanup fails, but does not fail the test.
Since `os.RemoveAll` returns the first error it encounters, this cleanup function has always been best-effort. It remains best-effort.

There is probably more cleanup to add for the servers started in the `remote_bazel_test` suite, but let's do the easy thing first.