### PR TITLE
[servicetest] bump test suite size

### DIFF
--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -55,7 +55,7 @@ go_library(
 
 go_test(
     name = "service_test",
-    size = "small",
+    size = "medium",
     srcs = ["service_test.go"],
     deps = [
         ":service",


### PR DESCRIPTION
The `service_test` suite often times out. This change bumps the test size (and therefore the timeout). Let's see if that reduces flake!