### PR TITLE
Actually use the `starlarkOption` type

### DIFF
--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -641,6 +641,11 @@ func newOptionImpl(optName string, v *string, d *Definition) (Option, error) {
 		return nil, fmt.Errorf("option name '%s' cannot specify an option with definition '%#v'", optName, d)
 	}
 
+	if d.PluginID() == StarlarkBuiltinPluginID {
+		return &starlarkOption{
+			BoolOrEnumOption: BoolOrEnumOption{Definition: d, Value: v, UsesShortName: form == shortForm, IsNegative: form == negativeForm},
+		}, nil
+	}
 	if d.RequiresValue() {
 		return &RequiredValueOption{Definition: d, Value: v, UsesShortName: form == shortForm, Joined: v != nil}, nil
 	}

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -26,8 +26,8 @@ func TestNegativeStarlarkFlagWithValue(t *testing.T) {
 		Expanded []string
 	}{
 		{
-			Name:    "ExpandStarlarkFlagsFromCommonConfig",
-			Args:    []string{"build", "--no@io_bazel_rules_docker//transitions:enable=foo"},
+			Name: "ExpandStarlarkFlagsFromCommonConfig",
+			Args: []string{"build", "--no@io_bazel_rules_docker//transitions:enable=foo"},
 			Expanded: []string{
 				"--ignore_all_rc_files",
 				"build",

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -18,6 +18,42 @@ func init() {
 	SetBazelHelpForTesting(test_data.BazelHelpFlagsAsProtoOutput)
 }
 
+func TestNegativeStarlarkFlagWithValue(t *testing.T) {
+	for _, test := range []struct {
+		Name     string
+		Bazelrc  string
+		Args     []string
+		Expanded []string
+	}{
+		{
+			Name:    "ExpandStarlarkFlagsFromCommonConfig",
+			Args:    []string{"build", "--no@io_bazel_rules_docker//transitions:enable=foo"},
+			Expanded: []string{
+				"--ignore_all_rc_files",
+				"build",
+				"--no@io_bazel_rules_docker//transitions:enable=foo",
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			ws := testfs.MakeTempDir(t)
+			testfs.WriteAllFileContents(t, ws, map[string]string{
+				"WORKSPACE": "",
+				"BUILD":     "",
+				".bazelrc":  test.Bazelrc,
+			})
+
+			p, err := GetParser()
+			require.NoError(t, err)
+			defer delete(p.ByName, "@io_bazel_rules_docker//transitions:enable")
+			expandedArgs, err := p.expandConfigs(ws, test.Args)
+
+			require.NoError(t, err, "error expanding %s", test.Args)
+			assert.Equal(t, test.Expanded, expandedArgs)
+		})
+	}
+}
+
 func TestParseBazelrc_Simple(t *testing.T) {
 	for _, test := range []struct {
 		Name     string


### PR DESCRIPTION
This was just falling through to a `BoolOrEnumOption`, which works in most cases, but not all.
