### PR TITLE
Set dockerInit=true on remote bazel commands that don't use firecracker

### DIFF
--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -242,6 +242,15 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		})
 	}
 
+	if isolationType != string(platform.FirecrackerContainerType) {
+		// If not running with Firecracker, run an init process so that the
+		// bazel process can be reaped.
+		cmd.Platform.Properties = append(cmd.Platform.Properties, &repb.Platform_Property{
+			Name:  platform.DockerInitPropertyName,
+			Value: "true",
+		})
+	}
+
 	cmd.Platform.Properties = append(cmd.Platform.Properties, req.GetExecProperties()...)
 
 	// Normalize to adhere to the REAPI spec.


### PR DESCRIPTION
Context: https://buildbuddy-corp.slack.com/archives/C04S4M5U3BK/p1746470513290689?thread_ts=1746470374.153659&cid=C04S4M5U3BK