### PR TITLE
[raft] use less disk in test

### DIFF
--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -86,6 +86,7 @@ func (sf *StoreFactory) RecreateStore(t *testing.T, ts *TestingStore) {
 		RaftAddress:    ts.RaftAddress,
 		Expert: dbConfig.ExpertConfig{
 			NodeRegistryFactory: nrf,
+			LogDB:               dbConfig.GetSmallMemLogDBConfig(),
 		},
 		DefaultNodeRegistryEnabled: false,
 		RaftEventListener:          raftListener,


### PR DESCRIPTION
After I switched to use firecracker_test for the store_test, the test
encountered "no space left on device" error.

Dragonboat by default uses `GetLargeMemLogDbConfig` which is set
`KVWriteBufferSize` to 128MB; this value is passed to `MemTableSize` when it
opens pebble. Pebble preallocates WAL files for performance, so the WAL can grow
up to `MemTableSize`. Also, by default, dragonboat created 16 shards.

Before this change, right after we started the shard, before we even right any
data, WAL dir for one store in the test can be 287M including 2 log files that
are 141M big.
