### PR TITLE
Revert changes to make ByteStreamServerProxy call ByteStreamServer directly

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -24,7 +24,7 @@ import (
 type ByteStreamServerProxy struct {
 	atimeUpdater  interfaces.AtimeUpdater
 	authenticator interfaces.Authenticator
-	local         interfaces.ByteStreamServer
+	local         bspb.ByteStreamClient
 	remote        bspb.ByteStreamClient
 }
 
@@ -46,13 +46,13 @@ func New(env environment.Env) (*ByteStreamServerProxy, error) {
 	if authenticator == nil {
 		return nil, fmt.Errorf("An Authenticator is required to enable ByteStreamServerProxy")
 	}
+	local := env.GetLocalByteStreamClient()
+	if local == nil {
+		return nil, fmt.Errorf("A local ByteStreamClient is required to enable ByteStreamServerProxy")
+	}
 	remote := env.GetByteStreamClient()
 	if remote == nil {
 		return nil, fmt.Errorf("A remote ByteStreamClient is required to enable ByteStreamServerProxy")
-	}
-	local := env.GetLocalByteStreamServer()
-	if local == nil {
-		return nil, fmt.Errorf("A local ByteStreamServer is required to enable ByteStreamServerProxy")
 	}
 	return &ByteStreamServerProxy{
 		atimeUpdater:  atimeUpdater,
@@ -62,163 +62,77 @@ func New(env environment.Env) (*ByteStreamServerProxy, error) {
 	}, nil
 }
 
-// Wrapper around a ByteStream_ReadServer that counts the number of frames
-// and bytes read through it.
-type meteredReadServerStream struct {
-	bytes  int64
-	frames int64
-	bspb.ByteStream_ReadServer
-}
-
-func (s *meteredReadServerStream) Send(message *bspb.ReadResponse) error {
-	s.bytes += int64(len(message.GetData()))
-	s.frames++
-	return s.ByteStream_ReadServer.Send(message)
-}
-
 func (s *ByteStreamServerProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
 	ctx, spn := tracing.StartSpan(stream.Context())
 	defer spn.End()
 
-	cacheStatus := "unknown"
-	var err error
+	skipRemote := proxy_util.SkipRemote(ctx)
 	requestTypeLabel := proxy_util.RequestTypeLabelFromContext(ctx)
-	meteredStream := &meteredReadServerStream{ByteStream_ReadServer: stream}
-	stream = meteredStream
 
 	if authutil.EncryptionEnabled(ctx, s.authenticator) {
-		cacheStatus = metrics.UncacheableStatusLabel
-		err = s.readRemoteOnly(ctx, req, stream)
-	} else if proxy_util.SkipRemote(ctx) {
-		err = s.readLocalOnly(req, stream)
-		cacheStatus = metrics.MissStatusLabel
-		if err == nil {
-			cacheStatus = metrics.HitStatusLabel
-		} else {
-			log.CtxInfof(ctx, "Error reading local: %v", err)
-		}
-	} else {
-		localErr := s.local.Read(req, stream)
-		// If some responses were streamed to the client, just return the
-		// error. Otherwise, fall-back to remote. We might be able to continue
-		// streaming to the client by doing an offset read from the remote
-		// cache, but keep it simple for now.
-		if localErr != nil && meteredStream.frames == 0 {
-			// Recover from local error if no frames have been sent
-			cacheStatus = metrics.MissStatusLabel
-			err = s.readRemoteWriteLocal(req, stream)
-		} else if localErr == nil {
-			cacheStatus = metrics.HitStatusLabel
-			s.atimeUpdater.EnqueueByResourceName(ctx, req.ResourceName)
-		}
-	}
-
-	recordReadMetrics(cacheStatus, requestTypeLabel, err, int(meteredStream.bytes))
-	return err
-}
-
-func (s *ByteStreamServerProxy) readRemoteOnly(ctx context.Context, req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
-	remoteReadStream, err := s.remote.Read(ctx, req)
-	if err != nil {
-		log.CtxInfof(ctx, "error reading from remote: %s", err)
+		bytesRead, err := s.readRemote(req, stream)
+		recordReadMetrics(metrics.UncacheableStatusLabel, requestTypeLabel, err, bytesRead)
 		return err
 	}
+
+	localReadStream, err := s.local.Read(ctx, req)
+	if err != nil {
+		if skipRemote {
+			recordReadMetrics(metrics.MissStatusLabel, requestTypeLabel, err, 0)
+			return err
+		}
+
+		// Fall back to reading from the remote cache.
+		if !status.IsNotFoundError(err) {
+			log.CtxInfof(ctx, "Error reading from local bytestream client: %s", err)
+		}
+		bytesRead, err := s.readRemote(req, stream)
+		recordReadMetrics(metrics.MissStatusLabel, requestTypeLabel, err, bytesRead)
+		return err
+	}
+
+	if !skipRemote {
+		s.atimeUpdater.EnqueueByResourceName(ctx, req.ResourceName)
+	}
+
+	responseSent := false
+	bytesRead := 0
 	for {
-		message, err := remoteReadStream.Recv()
-		if err != nil {
-			log.CtxInfof(ctx, "Error streaming from remote for read: %s", err)
-			return err
+		rsp, err := localReadStream.Recv()
+		if rsp != nil {
+			bytesRead += len(rsp.Data)
 		}
-		if err = stream.Send(message); err != nil {
-			return err
-		}
-	}
-}
-
-func (s *ByteStreamServerProxy) readLocalOnly(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
-	return s.local.Read(req, stream)
-}
-
-func writeRequest(resourceName string, data []byte, offset int64, finishWrite bool) *bspb.WriteRequest {
-	return &bspb.WriteRequest{
-		ResourceName: resourceName,
-		Data:         data,
-		WriteOffset:  offset,
-		FinishWrite:  finishWrite,
-	}
-}
-
-func (s *ByteStreamServerProxy) readRemoteWriteLocal(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
-	ctx, spn := tracing.StartSpan(stream.Context())
-	defer spn.End()
-
-	remoteReadStream, err := s.remote.Read(ctx, req)
-	if err != nil {
-		log.CtxInfof(ctx, "error reading from remote: %s", err)
-		return err
-	}
-
-	// Retrieve first frame from read stream
-	rsp, err := remoteReadStream.Recv()
-	if err == io.EOF {
-		return nil
-	}
-	if err != nil {
-		log.CtxInfof(ctx, "Error streaming from remote for read-remote-write-local: %s", err)
-		return err
-	}
-
-	// Rewrite the resource name so we can write to the local server
-	rn, err := digest.ParseDownloadResourceName(req.GetResourceName())
-	if err != nil {
-		return err
-	}
-	uploadRN := rn.NewUploadString()
-
-	// Open the local writer (if possible).
-	localWriteOffset := req.GetReadOffset()
-	var localWriter interfaces.ByteStreamWriteHandler
-	if req.GetReadOffset() == 0 {
-		localWriter, err = s.local.BeginWrite(ctx, writeRequest(uploadRN, rsp.GetData(), localWriteOffset, false))
-		if err != nil {
-			log.CtxDebugf(ctx, "Error opening local ByteStreamServer write stream: %v", err)
-		} else {
-			defer localWriter.Close()
-		}
-	}
-
-	for {
-		// Write to local cache
-		if localWriter != nil {
-			_, err = localWriter.Write(writeRequest(uploadRN, rsp.GetData(), localWriteOffset, false))
-			if err != nil {
-				log.CtxDebugf(ctx, "Error writing to local ByteStreamServer: %v", err)
-				localWriter = nil
-			}
-		}
-
-		// Send frame to client
-		localWriteOffset += int64(len(rsp.GetData()))
-		if err = stream.Send(rsp); err != nil {
-			return err
-		}
-
-		// Retreive the next frame and handle errors
-		rsp, err = remoteReadStream.Recv()
 		if err == io.EOF {
-			if localWriter != nil {
-				_, err = localWriter.Write(writeRequest(uploadRN, []byte{}, localWriteOffset, true))
-				if err != nil {
-					log.CtxDebugf(ctx, "Error writing to local ByteStreamServer: %v", err)
-				}
-			}
-			return nil
+			break
 		}
 		if err != nil {
-			log.CtxInfof(ctx, "Error streaming from remote for read through: %s", err)
+			// If some responses were streamed to the client, just return the
+			// error. Otherwise, fall-back to remote. We might be able to
+			// continue streaming to the client by doing an offset read from
+			// the remote cache, but keep it simple for now.
+			if responseSent {
+				log.CtxInfof(ctx, "error midstream of local read: %s", err)
+				recordReadMetrics(metrics.HitStatusLabel, requestTypeLabel, err, bytesRead)
+				return err
+			} else if skipRemote {
+				recordReadMetrics(metrics.MissStatusLabel, requestTypeLabel, err, bytesRead)
+				return err
+			} else {
+				// Fall back to reading remotely if the local read fails.
+				remoteBytesRead, err := s.readRemote(req, stream)
+				recordReadMetrics(metrics.MissStatusLabel, requestTypeLabel, err, remoteBytesRead)
+				return err
+			}
+		}
+
+		if err := stream.Send(rsp); err != nil {
+			recordReadMetrics(metrics.HitStatusLabel, requestTypeLabel, err, bytesRead)
 			return err
 		}
+		responseSent = true
 	}
+	recordReadMetrics(metrics.HitStatusLabel, requestTypeLabel, nil, bytesRead)
+	return nil
 }
 
 func recordReadMetrics(cacheStatus string, proxyRequestType string, err error, bytesRead int) {
@@ -231,145 +145,221 @@ func recordReadMetrics(cacheStatus string, proxyRequestType string, err error, b
 	metrics.ByteStreamProxiedReadBytes.With(labels).Add(float64(bytesRead))
 }
 
-// Wrapper around a ByteStream_WriteServer that counts the number of bytes
-// written through it.
-type meteredServerSideClientStream struct {
-	bytes int64
-	bspb.ByteStream_WriteServer
-}
-
-func (s *meteredServerSideClientStream) Recv() (*bspb.WriteRequest, error) {
-	message, err := s.ByteStream_WriteServer.Recv()
-	s.bytes += int64(len(message.GetData()))
-	return message, err
-}
-
-func (s *ByteStreamServerProxy) Write(stream bspb.ByteStream_WriteServer) error {
-	ctx, spn := tracing.StartSpan(stream.Context())
-	defer spn.End()
-
-	requestTypeLabel := proxy_util.RequestTypeLabelFromContext(stream.Context())
-	meteredStream := &meteredServerSideClientStream{ByteStream_WriteServer: stream}
-	stream = meteredStream
-	var err error
-	if authutil.EncryptionEnabled(ctx, s.authenticator) {
-		err = s.writeRemoteOnly(ctx, stream)
-	} else if proxy_util.SkipRemote(ctx) {
-		err = s.writeLocalOnly(stream)
-	} else {
-		err = s.dualWrite(ctx, stream)
-	}
-	recordWriteMetrics(meteredStream.bytes, err, requestTypeLabel)
-	return err
-}
-
-func (s *ByteStreamServerProxy) writeRemoteOnly(ctx context.Context, stream bspb.ByteStream_WriteServer) error {
-	remoteStream, err := s.remote.Write(ctx)
-	if err != nil {
-		return err
-	}
-	for {
-		req, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		if err = remoteStream.Send(req); err != nil {
-			return err
-		}
-		if req.GetFinishWrite() {
-			break
-		}
-	}
-	resp, err := remoteStream.CloseAndRecv()
-	if err != nil {
-		return err
-	}
-	return stream.SendAndClose(resp)
-}
-
-func (s *ByteStreamServerProxy) writeLocalOnly(stream bspb.ByteStream_WriteServer) error {
-	return s.local.Write(stream)
-}
-
-// TODO(iain): investigate performance of making the local write async
-func (s *ByteStreamServerProxy) dualWrite(ctx context.Context, stream bspb.ByteStream_WriteServer) error {
-	// Grab the first frame from the client so the local writer can be created
-	req, err := stream.Recv()
-	if err != nil {
-		return err
-	}
-
-	localWriteStream, err := s.local.BeginWrite(ctx, req)
-	if err == nil {
-		defer localWriteStream.Close()
-	} else {
-		log.CtxWarningf(ctx, "Error opening local write stream: %v", err)
-	}
-
-	remoteWriteStream, err := s.remote.Write(ctx)
-	if err != nil {
-		return err
-	}
-
-	for {
-		// Send to the local ByteStreamServer (if available)
-		localDone := req.GetFinishWrite()
-		if localWriteStream != nil {
-			if _, err := localWriteStream.Write(req); err != nil {
-				localWriteStream = nil
-				if err == io.EOF {
-					localDone = true
-				} else {
-					log.CtxInfof(ctx, "error writing to local bytestream server for write: %s", err)
-				}
-			}
-		}
-
-		// Send to the remote ByteStreamServer
-		remoteDone := req.GetFinishWrite()
-		if err := remoteWriteStream.Send(req); err != nil {
-			if err == io.EOF {
-				remoteDone = true
-			} else {
-				return err
-			}
-		}
-
-		// Handle stream-finished cases
-		if remoteDone {
-			if localWriteStream != nil && !localDone {
-				log.CtxInfo(ctx, "remote write done but local write is not")
-			}
-			resp, err := remoteWriteStream.CloseAndRecv()
-			if err != nil {
-				return err
-			}
-			err = stream.SendAndClose(resp)
-			return err
-		} else if localDone {
-			log.CtxInfo(ctx, "local write done but remote write is not")
-		}
-
-		// Finally, receive the next frame from the client
-		req, err = stream.Recv()
-		if err != nil {
-			return err
-		}
-	}
-}
-
-func recordWriteMetrics(bytesWritten int64, err error, proxyRequestType string) {
+func recordWriteMetrics(resp *bspb.WriteResponse, err error, proxyRequestType string) {
 	labels := prometheus.Labels{
 		metrics.StatusLabel:           fmt.Sprintf("%d", gstatus.Code(err)),
 		metrics.CacheHitMissStatus:    metrics.MissStatusLabel,
 		metrics.CacheProxyRequestType: proxyRequestType,
 	}
 	metrics.ByteStreamProxiedWriteRequests.With(labels).Inc()
-	if bytesWritten > 0 {
-		metrics.ByteStreamProxiedWriteBytes.With(labels).Add(float64(bytesWritten))
+	if resp != nil && resp.GetCommittedSize() > 0 {
+		metrics.ByteStreamProxiedWriteBytes.With(labels).Add(float64(resp.GetCommittedSize()))
+	}
+}
+
+// The Write() RPC requires the client keep track of some state. The
+// implementations of this interface take care of that.
+type localWriter interface {
+	send(data []byte) error
+	commit() error
+}
+
+// A localWriter that discards everything sent to it.
+type discardingLocalWriter struct {
+}
+
+func (s *discardingLocalWriter) send(data []byte) error {
+	return nil
+}
+
+func (s *discardingLocalWriter) commit() error {
+	return nil
+}
+
+// A localWriter that writes data to a local ByteStream_WriteClient.
+type realLocalWriter struct {
+	ctx          context.Context
+	local        bspb.ByteStream_WriteClient
+	resourceName string
+	initialized  bool
+	offset       int64
+}
+
+func (s *realLocalWriter) send(data []byte) error {
+	req := &bspb.WriteRequest{WriteOffset: s.offset, Data: data}
+	if !s.initialized {
+		// Rewrite the resource name so we can write to the local server.
+		rn, err := digest.ParseDownloadResourceName(s.resourceName)
+		if err != nil {
+			return err
+		}
+		req.ResourceName = rn.NewUploadString()
+		s.initialized = true
+	}
+	s.offset += int64(len(data))
+	return s.local.Send(req)
+}
+
+func (s *realLocalWriter) commit() error {
+	if err := s.local.Send(&bspb.WriteRequest{WriteOffset: s.offset, FinishWrite: true}); err != nil {
+		return err
+	}
+	// Ignore the local response (but not the error)
+	_, err := s.local.CloseAndRecv()
+	return err
+}
+
+func (s *ByteStreamServerProxy) readRemote(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) (int, error) {
+	ctx, spn := tracing.StartSpan(stream.Context())
+	defer spn.End()
+
+	remoteReadStream, err := s.remote.Read(ctx, req)
+	if err != nil {
+		log.CtxInfof(ctx, "error reading from remote: %s", err)
+		return 0, err
+	}
+
+	var localWriteStream localWriter = &discardingLocalWriter{}
+	if req.ReadOffset == 0 && !authutil.EncryptionEnabled(ctx, s.authenticator) {
+		localStream, err := s.local.Write(ctx)
+		if err == nil {
+			localWriteStream = &realLocalWriter{
+				ctx:          ctx,
+				local:        localStream,
+				resourceName: req.ResourceName,
+				initialized:  false,
+				offset:       int64(0),
+			}
+		} else {
+			log.CtxInfof(ctx, "error opening local bytestream write stream for read through: %s", err)
+		}
+	}
+
+	bytesRead := 0
+	for {
+		rsp, err := remoteReadStream.Recv()
+		if rsp != nil {
+			bytesRead += len(rsp.Data)
+		}
+		if err != nil {
+			if err == io.EOF {
+				if err := localWriteStream.commit(); err != nil {
+					log.CtxInfof(ctx, "error committing local write: %s", err)
+				}
+				break
+			}
+			log.CtxInfof(ctx, "error streaming from remote for read through: %s", err)
+			return bytesRead, err
+		}
+
+		if err := localWriteStream.send(rsp.Data); err != nil {
+			log.CtxInfof(ctx, "Error writing locally for read through: %s", err)
+			localWriteStream = &discardingLocalWriter{}
+		}
+		if err = stream.Send(rsp); err != nil {
+			return bytesRead, err
+		}
+	}
+	return bytesRead, nil
+}
+
+func (s *ByteStreamServerProxy) Write(stream bspb.ByteStream_WriteServer) error {
+	resp, err := s.write(stream)
+	requestTypeLabel := proxy_util.RequestTypeLabelFromContext(stream.Context())
+	recordWriteMetrics(resp, err, requestTypeLabel)
+	return err
+}
+
+func (s *ByteStreamServerProxy) write(stream bspb.ByteStream_WriteServer) (*bspb.WriteResponse, error) {
+	ctx, spn := tracing.StartSpan(stream.Context())
+	defer spn.End()
+
+	var local bspb.ByteStream_WriteClient
+	if !authutil.EncryptionEnabled(ctx, s.authenticator) {
+		localWriter, err := s.local.Write(ctx)
+		if err != nil {
+			log.CtxInfof(ctx, "error opening local bytestream write stream for write: %s", err)
+			localWriter = nil
+		}
+		local = localWriter
+	}
+
+	var remote bspb.ByteStream_WriteClient
+	// `local` can be nil for encrypted requests. The proxy doesn't support encrpytion,
+	// so always write encrypted requests to the remote cache.
+	if !proxy_util.SkipRemote(ctx) || local == nil {
+		var err error
+		remote, err = s.remote.Write(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+
+		// Send to the local ByteStreamServer (if it hasn't errored)
+		localDone := req.GetFinishWrite()
+		if local != nil {
+			if err := local.Send(req); err != nil {
+				if err == io.EOF {
+					localDone = true
+				} else {
+					// Swallow local write errors if we're writing remotely too
+					if remote != nil {
+						log.CtxInfof(ctx, "error writing to local bytestream server for write: %s", err)
+						local = nil
+					} else {
+						return nil, err
+					}
+				}
+			}
+		}
+
+		// Send to the remote ByteStreamServer
+		remoteDone := req.GetFinishWrite()
+		if remote != nil {
+			if err := remote.Send(req); err != nil {
+				if err == io.EOF {
+					remoteDone = true
+				} else {
+					return nil, err
+				}
+			}
+		}
+
+		// If the client or the remote server told us the write is done, send the
+		// response to the client.
+		if remote == nil && localDone {
+			resp, err := local.CloseAndRecv()
+			if err != nil {
+				return nil, err
+			}
+			err = stream.SendAndClose(resp)
+			return resp, err
+		}
+
+		if remote != nil && remoteDone {
+			if local != nil {
+				if !localDone {
+					log.CtxInfo(ctx, "remote write done but local write is not")
+				}
+				if _, err := local.CloseAndRecv(); err != nil {
+					log.CtxInfof(ctx, "error closing local write stream: %s", err)
+				}
+			}
+			resp, err := remote.CloseAndRecv()
+			if err != nil {
+				return nil, err
+			}
+			err = stream.SendAndClose(resp)
+			return resp, err
+		} else if localDone {
+			log.CtxInfo(ctx, "local write done but remote write is not")
+		}
 	}
 }
 

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -98,14 +98,24 @@ func runRemoteServices(ctx context.Context, env *testenv.TestEnv, t testing.TB) 
 	return bspb.NewByteStreamClient(conn), repb.NewContentAddressableStorageClient(conn), &unaryRequestCounter, &streamRequestCounter
 }
 
+func runLocalBSS(ctx context.Context, env *testenv.TestEnv, t testing.TB) bspb.ByteStreamClient {
+	server, err := byte_stream_server.NewByteStreamServer(env)
+	require.NoError(t, err)
+	grpcServer, runFunc, lis := testenv.RegisterLocalInternalGRPCServer(t, env)
+	bspb.RegisterByteStreamServer(grpcServer, server)
+	go runFunc()
+	conn, err := testenv.LocalInternalGRPCConn(ctx, lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return bspb.NewByteStreamClient(conn)
+}
+
 func runBSProxy(ctx context.Context, client bspb.ByteStreamClient, env *testenv.TestEnv, t testing.TB) bspb.ByteStreamClient {
 	if env.GetAtimeUpdater() == nil {
 		env.SetAtimeUpdater(&testenv.NoOpAtimeUpdater{})
 	}
 	env.SetByteStreamClient(client)
-	bss, err := byte_stream_server.NewByteStreamServer(env)
-	require.NoError(t, err)
-	env.SetLocalByteStreamServer(bss)
+	env.SetLocalByteStreamClient(runLocalBSS(ctx, env, t))
 	byteStreamServer, err := New(env)
 	require.NoError(t, err)
 	grpcServer, runFunc, lis := testenv.RegisterLocalGRPCServer(t, env)

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy_test.go
@@ -85,20 +85,26 @@ func runRemoteCASS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (*gr
 	return conn, &unaryRequestCounter, &streamRequestCounter
 }
 
-func runLocalCASS(ctx context.Context, env *testenv.TestEnv, t testing.TB) repb.ContentAddressableStorageServer {
+func runLocalCASS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (bspb.ByteStreamClient, repb.ContentAddressableStorageServer) {
+	bs, err := byte_stream_server.NewByteStreamServer(env)
+	require.NoError(t, err)
 	cas, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
 	require.NoError(t, err)
-	return cas
+	grpcServer, runFunc, lis := testenv.RegisterLocalInternalGRPCServer(t, env)
+	repb.RegisterContentAddressableStorageServer(grpcServer, cas)
+	bspb.RegisterByteStreamServer(grpcServer, bs)
+	go runFunc()
+	conn, err := testenv.LocalInternalGRPCConn(ctx, lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return bspb.NewByteStreamClient(conn), cas
 }
 
 func runCASProxy(ctx context.Context, clientConn *grpc.ClientConn, env *testenv.TestEnv, t testing.TB) *grpc.ClientConn {
 	env.SetByteStreamClient(bspb.NewByteStreamClient(clientConn))
 	env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(clientConn))
-	bss, err := byte_stream_server.NewByteStreamServer(env)
-	require.NoError(t, err)
-	env.SetLocalByteStreamServer(bss)
-	cas, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
-	require.NoError(t, err)
+	bs, cas := runLocalCASS(ctx, env, t)
+	env.SetLocalByteStreamClient(bs)
 	env.SetLocalCASServer(cas)
 	casServer, err := New(env)
 	require.NoError(t, err)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -272,7 +272,7 @@ func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEn
 		proxyEnv.SetActionCacheClient(acClient)
 		proxyEnv.SetByteStreamClient(bsClient)
 		proxyEnv.SetAtimeUpdater(&testenv.NoOpAtimeUpdater{})
-		runProxyServers(ctx, proxyEnv, t)
+		runProxyGrpcServers(ctx, proxyEnv, t)
 
 		acProxy, err := action_cache_server_proxy.NewActionCacheServerProxy(proxyEnv)
 		require.NoError(t, err)
@@ -316,12 +316,19 @@ func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEn
 	return env
 }
 
-func runProxyServers(ctx context.Context, proxyEnv *testenv.TestEnv, t *testing.T) {
+func runProxyGrpcServers(ctx context.Context, proxyEnv *testenv.TestEnv, t *testing.T) {
 	server, err := byte_stream_server.NewByteStreamServer(proxyEnv)
 	require.NoError(t, err)
 	acServer, err := action_cache_server.NewActionCacheServer(proxyEnv)
 	require.NoError(t, err)
-	proxyEnv.SetLocalByteStreamServer(server)
+	grpcServer, runFunc, lis := testenv.RegisterLocalInternalGRPCServer(t, proxyEnv)
+	bspb.RegisterByteStreamServer(grpcServer, server)
+	repb.RegisterActionCacheServer(grpcServer, acServer)
+	go runFunc()
+	conn, err := testenv.LocalInternalGRPCConn(ctx, lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	proxyEnv.SetLocalByteStreamClient(bspb.NewByteStreamClient(conn))
 	proxyEnv.SetLocalActionCacheServer(acServer)
 }
 

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -99,6 +99,7 @@ type Env interface {
 	GetGitHubStatusService() interfaces.GitHubStatusService
 	GetLocalCASServer() repb.ContentAddressableStorageServer
 	GetCASServer() repb.ContentAddressableStorageServer
+	GetLocalByteStreamClient() bspb.ByteStreamClient
 	GetLocalByteStreamServer() interfaces.ByteStreamServer
 	GetByteStreamServer() bspb.ByteStreamServer
 	GetLocalActionCacheServer() repb.ActionCacheServer

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -96,6 +96,7 @@ type RealEnv struct {
 	buildEventServer                 pepb.PublishBuildEventServer
 	localCASServer                   repb.ContentAddressableStorageServer
 	casServer                        repb.ContentAddressableStorageServer
+	localByteStreamClient            bspb.ByteStreamClient
 	localByteStreamServer            interfaces.ByteStreamServer
 	byteStreamServer                 bspb.ByteStreamServer
 	localActionCacheServer           repb.ActionCacheServer
@@ -545,6 +546,13 @@ func (r *RealEnv) GetCASServer() repb.ContentAddressableStorageServer {
 
 func (r *RealEnv) SetCASServer(casServer repb.ContentAddressableStorageServer) {
 	r.casServer = casServer
+}
+
+func (r *RealEnv) GetLocalByteStreamClient() bspb.ByteStreamClient {
+	return r.localByteStreamClient
+}
+func (r *RealEnv) SetLocalByteStreamClient(localByteStreamClient bspb.ByteStreamClient) {
+	r.localByteStreamClient = localByteStreamClient
 }
 
 func (r *RealEnv) GetLocalByteStreamServer() interfaces.ByteStreamServer {


### PR DESCRIPTION
This PR reverts: https://github.com/buildbuddy-io/buildbuddy/pull/9169 and https://github.com/buildbuddy-io/buildbuddy/pull/9106 due to suspected EOF errors writing snapshots from workflows in dev.