### PR TITLE
[raft] fix TestDownReplicate

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1241,7 +1241,6 @@ func TestUpReplicate(t *testing.T) {
 }
 
 func TestDownReplicate(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	flags.Set(t, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
 	// disable txn cleanup and zombie scan, because advance the fake clock can
 	// prematurely trigger txn cleanup and zombie cleanup
@@ -1319,7 +1318,7 @@ func TestDownReplicate(t *testing.T) {
 
 		if len(replicas) == 0 {
 			// It's possible that between the function call GetStoreWithRangeLease
-			// and getMembership, the replica is removed from the store s and the
+			// and getMembership, the replica is removed from the stores and the
 			// range lease is deleted. In this case, we want to continue the
 			// for loop.
 			continue
@@ -1345,6 +1344,7 @@ func TestDownReplicate(t *testing.T) {
 	db = removed.DB()
 
 	for i := 0; ; i++ {
+		clock.Advance(3 * time.Second)
 		db.Flush()
 		iter2, err := db.NewIter(&pebble.IterOptions{
 			LowerBound: rd.GetStart(),


### PR DESCRIPTION
This PR https://github.com/buildbuddy-io/buildbuddy/pull/8941 changed the driver
so that remove replica as an raft cluster member and remove data becomes two
driver action. This introduced the flakiness in the test; because some times,
when we verify whether the data is removed, the remove data action has not been
run.

The test passes with --runs_per_test=500 on top of the change to decrease raft disk usage in test:
https://app.buildbuddy.io/invocation/1ab84174-781d-4709-927d-83f9ff233d7b
https://app.buildbuddy.io/invocation/fc3d6700-8f4d-4530-aedb-a133184069ae

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4192
