### PR TITLE
Revert "[SS] Only cache multiple snapshots on the same branch locally"

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -958,7 +958,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		// to all executors. `!c.hasFallbackKeys()` is a good proxy for whether we're
 		// running on the master snapshot.
 		hasRemoteSnapshotForBranchKey := c.hasRemoteSnapshotForBranchKey(ctx)
-		shouldCacheRemotely = !c.hasFallbackKeys() || !hasRemoteSnapshotForBranchKey || !*snaputil.EnableLocalSnapshotSharing
+		shouldCacheRemotely = !c.hasFallbackKeys() || !hasRemoteSnapshotForBranchKey
 		if !shouldCacheRemotely {
 			log.CtxInfof(ctx, "Would not save remote snapshot. Has remote snapshot for branch key: %v. Snapshot keys: %v", hasRemoteSnapshotForBranchKey, c.snapshotKeySet)
 		} else if hasRemoteSnapshotForBranchKey {
@@ -967,15 +967,15 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	}
 
 	opts := &snaploader.CacheSnapshotOptions{
-		VMMetadata:           vmd,
-		VMConfiguration:      c.vmConfig,
-		VMStateSnapshotPath:  filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
-		KernelImagePath:      c.executorConfig.GuestKernelImagePath,
-		InitrdImagePath:      c.executorConfig.InitrdImagePath,
-		ChunkedFiles:         map[string]*copy_on_write.COWStore{},
-		Recycled:             c.recycled,
-		Remote:               shouldCacheRemotely,
-		SkippedCacheRemotely: c.supportsRemoteSnapshots && !shouldCacheRemotely,
+		VMMetadata:                 vmd,
+		VMConfiguration:            c.vmConfig,
+		VMStateSnapshotPath:        filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
+		KernelImagePath:            c.executorConfig.GuestKernelImagePath,
+		InitrdImagePath:            c.executorConfig.InitrdImagePath,
+		ChunkedFiles:               map[string]*copy_on_write.COWStore{},
+		Recycled:                   c.recycled,
+		Remote:                     c.supportsRemoteSnapshots,
+		WouldNotHaveCachedRemotely: !shouldCacheRemotely,
 	}
 	if snapshotSharingEnabled {
 		if c.rootStore != nil {


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#9084

Seeing some unexpected behavior when testing locally - I think I know the fix, but don't want to rush it into the release