### PR TITLE
Add test for InvocationStatService

### DIFF
--- a/enterprise/server/invocation_stat_service/BUILD
+++ b/enterprise/server/invocation_stat_service/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -24,5 +24,29 @@ go_library(
         "//server/util/status",
         "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "invocation_stat_service_test",
+    srcs = ["invocation_stat_service_test.go"],
+    embed = [":invocation_stat_service"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "true",
+        # We don't want different different db tests to be assigned to the samed
+        # recycled runner, because we can't fit all db docker images with the
+        # default disk limit.
+        "test.runner-recycling-key": "clickhouse",
+    },
+    tags = ["docker"],
+    deps = [
+        "//proto:stats_go_proto",
+        "//server/testutil/testauth",
+        "//server/testutil/testenv",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -1204,12 +1204,12 @@ func (i *InvocationStatService) getDrilldownQuery(ctx context.Context, req *stpb
 	if *tagsInDrilldowns {
 		drilldownFields = append(drilldownFields, "tag")
 	}
-	if req.GetDrilldownMetric().Execution != nil {
+	if req.GetDrilldownMetric().GetExecution() != sfpb.ExecutionMetricType_UNKNOWN_EXECUTION_METRIC {
 		drilldownFields = append(drilldownFields, "worker", "target_label", "action_mnemonic")
 	}
 	placeholderQuery := query_builder.NewQuery("")
 
-	if err := i.addWhereClauses(placeholderQuery, req.GetQuery(), req.GetDrilldownMetric().Execution != nil, req.GetRequestContext()); err != nil {
+	if err := i.addWhereClauses(placeholderQuery, req.GetQuery(), req.GetDrilldownMetric().GetExecution() != sfpb.ExecutionMetricType_UNKNOWN_EXECUTION_METRIC, req.GetRequestContext()); err != nil {
 		return "", nil, err
 	}
 

--- a/enterprise/server/invocation_stat_service/invocation_stat_service_test.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service_test.go
@@ -1,0 +1,34 @@
+package invocation_stat_service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/proto/stats"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStatDrilldown(t *testing.T) {
+	flags.Set(t, "testenv.use_clickhouse", true)
+	flags.Set(t, "app.trends_heatmap_enabled", true)
+	te := testenv.GetTestEnv(t)
+
+	ta := testauth.NewTestAuthenticator(testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(ta)
+
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "USER1")
+	require.NoError(t, err)
+
+	reqCtx := testauth.RequestContext("USER1", "GROUP1")
+
+	iss := NewInvocationStatService(te, te.GetDBHandle(), te.GetOLAPDBHandle())
+	_, err = iss.GetStatDrilldown(ctx, &stats.GetStatDrilldownRequest{
+		RequestContext: reqCtx,
+	})
+	require.True(t, status.IsInvalidArgumentError(err))
+	require.Error(t, err, "Empty filter for drilldown.")
+}


### PR DESCRIPTION
Adds a new go_test target for the invocation stat service.
This covers the GetStatDrilldown method with a basic test case.

Also includes a small fix to the drilldown metric check condition,
using protobuf Getter api and compare it against the default value
instead of checking nil field directly.
