### PR TITLE
Reinstate "[SS] Only cache multiple snapshots on the same branch locally" (#9218)

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -947,6 +947,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	vmd.LastExecutedTask = c.getVMTask()
 
 	shouldCacheRemotely := false
+	shouldCacheManifestLocally := true
 	if c.supportsRemoteSnapshots {
 		// Only save a remote snapshot if a remote snapshot for the primary git branch key
 		// doesn't already exist. Otherwise, only save a local snapshot. Workloads
@@ -959,11 +960,15 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		// running on the master snapshot.
 		hasRemoteSnapshotForBranchKey := c.hasRemoteSnapshotForBranchKey(ctx)
 		shouldCacheRemotely = !c.hasFallbackKeys() || !hasRemoteSnapshotForBranchKey || !*snaputil.EnableLocalSnapshotSharing
-		if !shouldCacheRemotely {
-			log.CtxInfof(ctx, "Would not save remote snapshot. Has remote snapshot for branch key: %v. Snapshot keys: %v", hasRemoteSnapshotForBranchKey, c.snapshotKeySet)
-		} else if hasRemoteSnapshotForBranchKey {
+
+		branchKey := c.snapshotKeySet.GetBranchKey()
+		if shouldCacheRemotely && hasRemoteSnapshotForBranchKey && !(branchKey.Ref == "master" || branchKey.Ref == "main") {
 			log.CtxInfof(ctx, "Would save remote snapshot even though one already exists. Snapshot keys: %v", c.snapshotKeySet)
 		}
+
+		// Don't save local snapshot manifests for the master snapshot, so it always
+		// starts from the remote snapshot.
+		shouldCacheManifestLocally = c.hasFallbackKeys()
 	}
 
 	opts := &snaploader.CacheSnapshotOptions{
@@ -976,6 +981,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		Recycled:             c.recycled,
 		Remote:               shouldCacheRemotely,
 		SkippedCacheRemotely: c.supportsRemoteSnapshots && !shouldCacheRemotely,
+		CacheManifestLocally: shouldCacheManifestLocally,
 	}
 	if snapshotSharingEnabled {
 		if c.rootStore != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -958,7 +958,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		// to all executors. `!c.hasFallbackKeys()` is a good proxy for whether we're
 		// running on the master snapshot.
 		hasRemoteSnapshotForBranchKey := c.hasRemoteSnapshotForBranchKey(ctx)
-		shouldCacheRemotely = !c.hasFallbackKeys() || !hasRemoteSnapshotForBranchKey
+		shouldCacheRemotely = !c.hasFallbackKeys() || !hasRemoteSnapshotForBranchKey || !*snaputil.EnableLocalSnapshotSharing
 		if !shouldCacheRemotely {
 			log.CtxInfof(ctx, "Would not save remote snapshot. Has remote snapshot for branch key: %v. Snapshot keys: %v", hasRemoteSnapshotForBranchKey, c.snapshotKeySet)
 		} else if hasRemoteSnapshotForBranchKey {
@@ -967,15 +967,15 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	}
 
 	opts := &snaploader.CacheSnapshotOptions{
-		VMMetadata:                 vmd,
-		VMConfiguration:            c.vmConfig,
-		VMStateSnapshotPath:        filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
-		KernelImagePath:            c.executorConfig.GuestKernelImagePath,
-		InitrdImagePath:            c.executorConfig.InitrdImagePath,
-		ChunkedFiles:               map[string]*copy_on_write.COWStore{},
-		Recycled:                   c.recycled,
-		Remote:                     c.supportsRemoteSnapshots,
-		WouldNotHaveCachedRemotely: !shouldCacheRemotely,
+		VMMetadata:           vmd,
+		VMConfiguration:      c.vmConfig,
+		VMStateSnapshotPath:  filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
+		KernelImagePath:      c.executorConfig.GuestKernelImagePath,
+		InitrdImagePath:      c.executorConfig.InitrdImagePath,
+		ChunkedFiles:         map[string]*copy_on_write.COWStore{},
+		Recycled:             c.recycled,
+		Remote:               shouldCacheRemotely,
+		SkippedCacheRemotely: c.supportsRemoteSnapshots && !shouldCacheRemotely,
 	}
 	if snapshotSharingEnabled {
 		if c.rootStore != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -853,21 +853,6 @@ func TestFirecracker_RemoteSnapshotSharing(t *testing.T) {
 		}
 	})
 
-	workDir := testfs.MakeDirAll(t, rootDir, "work")
-	opts := firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDir,
-		VMConfiguration: &fcpb.VMConfiguration{
-			NumCpus:            1,
-			MemSizeMb:          minMemSizeMB, // small to make snapshotting faster.
-			EnableNetworking:   false,
-			ScratchDiskSizeMb:  100,
-			GuestKernelVersion: cfg.GuestKernelVersion,
-			FirecrackerVersion: cfg.FirecrackerVersion,
-			GuestApiVersion:    cfg.GuestAPIVersion,
-		},
-		ExecutorConfig: cfg,
-	}
 	instanceName := "test-instance-name"
 	task := &repb.ExecutionTask{
 		Command: &repb.Command{
@@ -876,57 +861,62 @@ func TestFirecracker_RemoteSnapshotSharing(t *testing.T) {
 				{Name: "recycle-runner", Value: "true"},
 			}},
 			Arguments: []string{"./buildbuddy_ci_runner"},
+			// Simulate that this is for a PR branch, because master snapshots
+			// are always saved to the remote cache.
+			EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+				{Name: "GIT_REPO_DEFAULT_BRANCH", Value: "master"},
+				{Name: "GIT_BRANCH", Value: "my-pr"},
+			},
 		},
 		ExecuteRequest: &repb.ExecuteRequest{
 			InstanceName: instanceName,
 		},
 	}
-	baseVM, err := firecracker.NewContainer(ctx, env, task, opts)
-	require.NoError(t, err)
-	containersToCleanup = append(containersToCleanup, baseVM)
-	err = container.PullImageIfNecessary(ctx, env, baseVM, oci.Credentials{}, opts.ContainerImage)
-	require.NoError(t, err)
-	err = baseVM.Create(ctx, opts.ActionWorkingDirectory)
-	require.NoError(t, err)
-	baseSnapshotId := baseVM.SnapshotID()
 
-	// Create a snapshot. Data written to this snapshot should persist
-	// when other VMs reuse the snapshot
-	cmd := appendToLog("Base")
-	res := baseVM.Exec(ctx, cmd, nil /*=stdio*/)
-	require.NoError(t, res.Error)
-	require.Equal(t, "Base\n", string(res.Stdout))
-	require.NotEmpty(t, res.VMMetadata.GetSnapshotId())
-	err = baseVM.Pause(ctx)
-	require.NoError(t, err)
+	runAndSnapshotVM := func(workDir string, stringToLog string, expectedOutput string, snapshotKeyOverride *fcpb.SnapshotKey) string {
+		opts := firecracker.ContainerOpts{
+			ContainerImage:         busyboxImage,
+			ActionWorkingDirectory: workDir,
+			VMConfiguration: &fcpb.VMConfiguration{
+				NumCpus:           1,
+				MemSizeMb:         minMemSizeMB, // small to make snapshotting faster.
+				EnableNetworking:  false,
+				ScratchDiskSizeMb: 100,
+			},
+			ExecutorConfig:      cfg,
+			OverrideSnapshotKey: snapshotKeyOverride,
+		}
+		vm, err := firecracker.NewContainer(ctx, env, task, opts)
+		require.NoError(t, err)
+		containersToCleanup = append(containersToCleanup, vm)
+		err = vm.Create(ctx, workDir)
+		require.NoError(t, err)
+		cmd := appendToLog(stringToLog)
+		res := vm.Exec(ctx, cmd, nil /*=stdio*/)
+		require.NoError(t, res.Error)
+		require.Equal(t, expectedOutput, string(res.Stdout))
+		require.NotEmpty(t, res.VMMetadata.GetSnapshotId())
+		err = vm.Pause(ctx)
+		require.NoError(t, err)
 
-	// Start a VM from the snapshot. Artifacts should be stored locally in the filecache
-	workDirForkLocalFetch := testfs.MakeDirAll(t, rootDir, "work-fork-local-fetch")
-	opts = firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDirForkLocalFetch,
-		VMConfiguration: &fcpb.VMConfiguration{
-			NumCpus:           1,
-			MemSizeMb:         minMemSizeMB, // small to make snapshotting faster.
-			EnableNetworking:  false,
-			ScratchDiskSizeMb: 100,
-		},
-		ExecutorConfig: cfg,
+		return vm.SnapshotID()
 	}
-	forkedVM, err := firecracker.NewContainer(ctx, env, task, opts)
-	require.NoError(t, err)
-	containersToCleanup = append(containersToCleanup, forkedVM)
-	err = forkedVM.Unpause(ctx)
-	require.NoError(t, err)
-	cmd = appendToLog("Fork local fetch")
-	res = forkedVM.Exec(ctx, cmd, nil /*=stdio*/)
-	require.NoError(t, res.Error)
+
+	// Create a snapshot. Data written to this snapshot should be cached remotely,
+	// and persist when other VMs reuse the snapshot.
+	workDir := testfs.MakeDirAll(t, rootDir, "work")
+	baseSnapshotId := runAndSnapshotVM(workDir, "Cache Remotely", "Cache Remotely\n", nil)
+
+	// Start a VM from the snapshot. Artifacts should be stored locally in the filecache.
 	// The log should contain data written to the original snapshot
-	// and the current VM
-	require.Equal(t, "Base\nFork local fetch\n", string(res.Stdout))
-	require.NotEmpty(t, res.VMMetadata.GetSnapshotId())
-	err = forkedVM.Pause(ctx)
-	require.NoError(t, err)
+	// and the current VM.
+	workDirForkLocalFetch := testfs.MakeDirAll(t, rootDir, "work-fork-local-fetch")
+	runAndSnapshotVM(workDirForkLocalFetch, "Cache Locally", "Cache Remotely\nCache Locally\n", nil)
+
+	// Start another VM from the locally cached snapshot. The log should contain
+	// data from the most recent run, as well as the current run.
+	workDirForkLocalFetch2 := testfs.MakeDirAll(t, rootDir, "work-fork-local-fetch")
+	runAndSnapshotVM(workDirForkLocalFetch2, "Cache Locally 2", "Cache Remotely\nCache Locally\nCache Locally 2\n", nil)
 
 	// Clear the local filecache. Vms should still be able to unpause the snapshot
 	// by pulling artifacts from the remote cache
@@ -938,65 +928,25 @@ func TestFirecracker_RemoteSnapshotSharing(t *testing.T) {
 	fc2.WaitForDirectoryScanToComplete()
 	env.SetFileCache(fc2)
 
-	// Start a VM from the snapshot.
+	// Start a VM from the remote snapshot. The log should contain data from the
+	// first run, which was saved remotely, but not the two most recent runs which
+	// were only cached locally.
 	workDirForkRemoteFetch := testfs.MakeDirAll(t, rootDir, "work-fork-remote-fetch")
-	opts = firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDirForkRemoteFetch,
-		VMConfiguration: &fcpb.VMConfiguration{
-			NumCpus:           1,
-			MemSizeMb:         minMemSizeMB, // small to make snapshotting faster.
-			EnableNetworking:  false,
-			ScratchDiskSizeMb: 100,
-		},
-		ExecutorConfig: cfg,
-	}
-	forkedVM2, err := firecracker.NewContainer(ctx, env, task, opts)
-	require.NoError(t, err)
-	containersToCleanup = append(containersToCleanup, forkedVM2)
-	err = forkedVM2.Unpause(ctx)
-	require.NoError(t, err)
-	cmd = appendToLog("Fork remote fetch")
-	res = forkedVM2.Exec(ctx, cmd, nil /*=stdio*/)
-	require.NoError(t, res.Error)
-	// The log should contain data written to the most recent snapshot
-	require.Equal(t, "Base\nFork local fetch\nFork remote fetch\n", string(res.Stdout))
-	require.NotEmpty(t, res.VMMetadata.GetSnapshotId())
+	runAndSnapshotVM(workDirForkRemoteFetch, "Cache Locally 3", "Cache Remotely\nCache Locally 3\n", nil)
 
 	// Should still be able to start from the original snapshot if we use
 	// a snapshot key containing the original VM's snapshot ID.
 	// Note that when using a snapshot ID as the key, we only include the
 	// snapshot_id and instance_name fields.
+	// The log should contain data written to the original snapshot
+	// and the current VM, but not from any of the other VMs, including the master
+	// snapshot
 	workDirForkOriginalSnapshot := testfs.MakeDirAll(t, rootDir, "work-fork-og-snapshot")
 	originalSnapshotKey := &fcpb.SnapshotKey{
 		InstanceName: instanceName,
 		SnapshotId:   baseSnapshotId,
 	}
-	opts = firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDirForkOriginalSnapshot,
-		VMConfiguration: &fcpb.VMConfiguration{
-			NumCpus:           1,
-			MemSizeMb:         minMemSizeMB, // small to make snapshotting faster.
-			EnableNetworking:  false,
-			ScratchDiskSizeMb: 100,
-		},
-		ExecutorConfig:      cfg,
-		OverrideSnapshotKey: originalSnapshotKey,
-	}
-	ogFork, err := firecracker.NewContainer(ctx, env, task, opts)
-	require.NoError(t, err)
-	containersToCleanup = append(containersToCleanup, ogFork)
-	err = ogFork.Unpause(ctx)
-	require.NoError(t, err)
-	cmd = appendToLog("Fork from original vm")
-	res = ogFork.Exec(ctx, cmd, nil /*=stdio*/)
-	require.NoError(t, res.Error)
-	// The log should contain data written to the original snapshot
-	// and the current VM, but not from any of the other VMs, including the master
-	// snapshot
-	require.Equal(t, "Base\nFork from original vm\n", string(res.Stdout))
-	require.NotEmpty(t, res.VMMetadata.GetSnapshotId())
+	runAndSnapshotVM(workDirForkOriginalSnapshot, "Fork from original vm", "Cache Remotely\nFork from original vm\n", originalSnapshotKey)
 }
 
 func TestFirecracker_RemoteSnapshotSharing_RemoteInstanceName(t *testing.T) {

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -339,9 +339,8 @@ type CacheSnapshotOptions struct {
 	// Whether to save the snapshot to the remote cache (in addition to locally)
 	Remote bool
 
-	// Whether we would've cached this snapshot remotely if our remote snapshot
-	// limits were applied.
-	WouldNotHaveCachedRemotely bool
+	// Whether we skipped caching remotely due to newly applied remote snapshot limits.
+	SkippedCacheRemotely bool
 }
 
 type UnpackedSnapshot struct {
@@ -418,19 +417,20 @@ func (l *FileCacheLoader) GetSnapshot(ctx context.Context, keys *fcpb.SnapshotKe
 func (l *FileCacheLoader) getSnapshot(ctx context.Context, key *fcpb.SnapshotKey, remoteEnabled bool) (*fcpb.SnapshotManifest, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
-	if *snaputil.EnableRemoteSnapshotSharing && remoteEnabled {
-		manifest, err := l.fetchRemoteManifest(ctx, key)
-		if err != nil {
-			return nil, status.WrapError(err, "fetch remote manifest")
+
+	// Always prioritize the local manifest if it exists. It may point to a more
+	// updated snapshot than the remote manifest, which is updated less frequently.
+	if *snaputil.EnableLocalSnapshotSharing {
+		manifest, err := l.getLocalManifest(ctx, key)
+		if err == nil || !remoteEnabled || !*snaputil.EnableRemoteSnapshotSharing {
+			return manifest, err
 		}
-		return manifest, nil
+	} else if !remoteEnabled {
+		return nil, status.InternalErrorf("invalid state: EnableLocalSnapshotSharing=false and remoteEnabled=false")
 	}
 
-	manifest, err := l.getLocalManifest(ctx, key)
-	if err != nil {
-		return nil, status.WrapError(err, "get local manifest")
-	}
-	return manifest, nil
+	// Fall back to fetching remote manifest.
+	return l.fetchRemoteManifest(ctx, key)
 }
 
 // fetchRemoteManifest fetches the most recent snapshot manifest from the remote
@@ -1042,7 +1042,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 		metrics.FileName: name,
 	}).Observe(float64(emptyChunkCount) / float64(len(chunks)))
 
-	if cacheOpts.Remote && cacheOpts.WouldNotHaveCachedRemotely {
+	if cacheOpts.SkippedCacheRemotely {
 		metrics.COWSnapshotSkippedRemoteBytes.With(prometheus.Labels{
 			metrics.FileName: name,
 		}).Add(float64(compressedBytesWrittenRemotely))

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -339,6 +339,9 @@ type CacheSnapshotOptions struct {
 	// Whether to save the snapshot to the remote cache (in addition to locally)
 	Remote bool
 
+	// Whether to save the snapshot manifest to the local cache
+	CacheManifestLocally bool
+
 	// Whether we skipped caching remotely due to newly applied remote snapshot limits.
 	SkippedCacheRemotely bool
 }
@@ -764,7 +767,7 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 		}
 	}
 
-	if *snaputil.EnableLocalSnapshotSharing {
+	if *snaputil.EnableLocalSnapshotSharing && opts.CacheManifestLocally {
 		gid, err := groupID(ctx, l.env)
 		if err != nil {
 			return err

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -760,45 +760,45 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 			}
 			log.CtxInfof(ctx, "Cached remote snapshot manifest %s", snapshotDebugString(ctx, l.env, snapshotSpecificKey, true /*remote*/, snapshotID))
 		}
-
-		return nil
 	}
 
-	gid, err := groupID(ctx, l.env)
-	if err != nil {
-		return err
-	}
-	d, err := LocalManifestKey(gid, key)
-	if err != nil {
-		return err
-	}
-	manifestNode := &repb.FileNode{Digest: d}
-	if _, err := l.env.GetFileCache().Write(ctx, manifestNode, b); err != nil {
-		return err
-	}
-	log.CtxInfof(ctx, "Updated local master snapshot manifest %s", snapshotDebugString(ctx, l.env, key, false /*remote*/, "" /*=snapshotID*/))
-
-	// Cache snapshot manifest for this specific snapshot ID
-	if opts.VMMetadata.GetSnapshotId() != "" {
-		snapshotID := opts.VMMetadata.GetSnapshotId()
-		snapshotSpecificKey := &fcpb.SnapshotKey{
-			InstanceName: key.InstanceName,
-			SnapshotId:   snapshotID,
-		}
-
-		snapshotSpecificManifestKey, err := LocalManifestKey(gid, snapshotSpecificKey)
+	if *snaputil.EnableLocalSnapshotSharing {
+		gid, err := groupID(ctx, l.env)
 		if err != nil {
-			log.Warningf("Failed to generate snapshot specific local manifest key for snapshot ID %s: %s", snapshotID, err)
-			return nil
+			return err
 		}
-
-		snapshotSpecificManifestNode := &repb.FileNode{Digest: snapshotSpecificManifestKey}
-		if _, err := l.env.GetFileCache().Write(ctx, snapshotSpecificManifestNode, b); err != nil {
-			log.Warningf("Failed to cache local snapshot specific manifest for snapshot ID %s: %s", snapshotID, err)
-			return nil
+		d, err := LocalManifestKey(gid, key)
+		if err != nil {
+			return err
 		}
+		manifestNode := &repb.FileNode{Digest: d}
+		if _, err := l.env.GetFileCache().Write(ctx, manifestNode, b); err != nil {
+			return err
+		}
+		log.CtxInfof(ctx, "Updated local master snapshot manifest %s", snapshotDebugString(ctx, l.env, key, false /*remote*/, "" /*=snapshotID*/))
 
-		log.CtxInfof(ctx, "Cached local snapshot manifest %s", snapshotDebugString(ctx, l.env, snapshotSpecificKey, false /*remote*/, snapshotID))
+		// Cache snapshot manifest for this specific snapshot ID
+		if opts.VMMetadata.GetSnapshotId() != "" {
+			snapshotID := opts.VMMetadata.GetSnapshotId()
+			snapshotSpecificKey := &fcpb.SnapshotKey{
+				InstanceName: key.InstanceName,
+				SnapshotId:   snapshotID,
+			}
+
+			snapshotSpecificManifestKey, err := LocalManifestKey(gid, snapshotSpecificKey)
+			if err != nil {
+				log.Warningf("Failed to generate snapshot specific local manifest key for snapshot ID %s: %s", snapshotID, err)
+				return nil
+			}
+
+			snapshotSpecificManifestNode := &repb.FileNode{Digest: snapshotSpecificManifestKey}
+			if _, err := l.env.GetFileCache().Write(ctx, snapshotSpecificManifestNode, b); err != nil {
+				log.Warningf("Failed to cache local snapshot specific manifest for snapshot ID %s: %s", snapshotID, err)
+				return nil
+			}
+
+			log.CtxInfof(ctx, "Cached local snapshot manifest %s", snapshotDebugString(ctx, l.env, snapshotSpecificKey, false /*remote*/, snapshotID))
+		}
 	}
 
 	return nil

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -537,6 +537,78 @@ func TestGetSnapshot_CacheIsolation(t *testing.T) {
 	}
 }
 
+// TODO: Test with instance name and no instance name
+func TestGetSnapshot_MixOfLocalAndRemoteChunks(t *testing.T) {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+	flags.Set(t, "executor.snaploader_max_eager_fetches_per_sec", 0)
+
+	env := setupEnv(t)
+	ctx := context.Background()
+	loader, err := snaploader.New(env)
+	require.NoError(t, err)
+	workDir := testfs.MakeTempDir(t)
+
+	// Save a snapshot remotely. Should also cache chunks and manifest locally.
+	workDirA := testfs.MakeDirAll(t, workDir, "VM-A")
+	const chunkSize = 1
+	const fileSize = chunkSize * 10
+	originalImagePath := makeRandomFile(t, workDirA, "test-file", fileSize)
+	cowA, err := copy_on_write.ConvertFileToCOW(ctx, env, originalImagePath, chunkSize, workDirA, "", true /*remoteEnabled*/)
+	require.NoError(t, err)
+	// Initialize snapshot.
+	originalWriteBuf := []byte("0123456789")
+	_, err = cowA.WriteAt(originalWriteBuf, 0)
+	require.NoError(t, err)
+	optsA := makeFakeSnapshot(t, workDirA, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+		"scratchfs": cowA,
+	}, "")
+	keyset := keysWithInstanceName(t, ctx, loader, "")
+	// Write the snapshot remotely only.
+	flags.Set(t, "executor.enable_local_snapshot_sharing", false)
+	err = loader.CacheSnapshot(ctx, keyset.GetBranchKey(), optsA)
+	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
+	require.NoError(t, err)
+
+	// Read chunks 1-3 from the remote snapshot. Modify chunk 3 and save the
+	// snapshot locally only.
+	workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
+	// Use local manifest.
+	snap, err := loader.GetSnapshot(ctx, keyset, true /*enableRemote*/)
+	require.NoError(t, err)
+	unpacked, err := loader.UnpackSnapshot(ctx, snap, workDirB)
+	require.NoError(t, err)
+	readBuf := make([]byte, 3)
+	disk := unpacked.ChunkedFiles["scratchfs"]
+	_, err = disk.ReadAt(readBuf, 1)
+	require.NoError(t, err)
+	require.ElementsMatch(t, originalWriteBuf[1:4], readBuf)
+	readBuf[2] = '6'
+	_, err = disk.WriteAt(readBuf, 1)
+	require.NoError(t, err)
+	// Write snapshot locally only.
+	optsB := makeFakeSnapshot(t, workDirB, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+		"scratchfs": disk,
+	}, "")
+	err = loader.CacheSnapshot(ctx, keyset.GetBranchKey(), optsB)
+	require.NoError(t, err)
+
+	// Use the local snapshot manifest. Read chunks 2-5. Should read the modified chunk 3
+	// that was written locally only. Should be able to fetch chunks 4-5 from the
+	// remote snapshot, even though they were not cached locally by VM-B.
+	workDirC := testfs.MakeDirAll(t, workDir, "VM-C")
+	// Use local manifest with remote fallback.
+	snap, err = loader.GetSnapshot(ctx, keyset, true /*enableRemote*/)
+	require.NoError(t, err)
+	unpackedC, err := loader.UnpackSnapshot(ctx, snap, workDirC)
+	require.NoError(t, err)
+	readBufC := make([]byte, 4)
+	diskC := unpackedC.ChunkedFiles["scratchfs"]
+	_, err = diskC.ReadAt(readBufC, 2)
+	require.NoError(t, err)
+	expectedBuf := []byte("2645")
+	require.ElementsMatch(t, expectedBuf, readBufC)
+}
+
 func TestMergeQueueBranch(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 


### PR DESCRIPTION
This reverts commit 0e350491cc29ea89c81c73c6ab20c660dbdf3e93.

TODO: Before merging, add SkipRemote support in the cacheproxy for FindMissingBlobs in the CAS server