### PR TITLE
[SS] Support starting from a local manifest but fetching chunks remotely

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -430,7 +430,9 @@ func (l *FileCacheLoader) getSnapshot(ctx context.Context, key *fcpb.SnapshotKey
 			}
 			return manifest, err
 		}
-		log.CtxDebugf(ctx, "Fetch local manifest err: %s", err)
+		if !status.IsNotFoundError(err) {
+			log.CtxWarningf(ctx, "Fetch local manifest err: %s", err)
+		}
 	} else if !remoteEnabled {
 		return nil, status.InternalErrorf("invalid state: EnableLocalSnapshotSharing=false and remoteEnabled=false")
 	}

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -537,6 +537,80 @@ func TestGetSnapshot_CacheIsolation(t *testing.T) {
 	}
 }
 
+func TestGetSnapshot_MixOfLocalAndRemoteChunks(t *testing.T) {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+	flags.Set(t, "executor.snaploader_max_eager_fetches_per_sec", 0)
+
+	env := setupEnv(t)
+	ctx := context.Background()
+	loader, err := snaploader.New(env)
+	require.NoError(t, err)
+
+	for _, instanceName := range []string{"", "instance-name"} {
+		workDir := testfs.MakeTempDir(t)
+
+		// Save a snapshot remotely.
+		workDirA := testfs.MakeDirAll(t, workDir, "VM-A")
+		const chunkSize = 1
+		const fileSize = chunkSize * 10
+		originalImagePath := makeRandomFile(t, workDirA, "test-file", fileSize)
+		cowA, err := copy_on_write.ConvertFileToCOW(ctx, env, originalImagePath, chunkSize, workDirA, instanceName, true /*remoteEnabled*/)
+		require.NoError(t, err)
+		originalWriteBuf := []byte("0123456789")
+		_, err = cowA.WriteAt(originalWriteBuf, 0)
+		require.NoError(t, err)
+		optsA := makeFakeSnapshot(t, workDirA, true /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+			"scratchfs": cowA,
+		}, "")
+		keyset := keysWithInstanceName(t, ctx, loader, instanceName)
+		// Write the snapshot remotely only.
+		flags.Set(t, "executor.enable_local_snapshot_sharing", false)
+		err = loader.CacheSnapshot(ctx, keyset.GetBranchKey(), optsA)
+		flags.Set(t, "executor.enable_local_snapshot_sharing", true)
+		require.NoError(t, err)
+
+		// Read chunks 1-3 from the remote snapshot. Modify one chunk and save the
+		// snapshot locally only.
+		workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
+		snap, err := loader.GetSnapshot(ctx, keyset, true /*enableRemote*/)
+		require.NoError(t, err)
+		unpacked, err := loader.UnpackSnapshot(ctx, snap, workDirB)
+		require.NoError(t, err)
+		readBuf := make([]byte, 3)
+		disk := unpacked.ChunkedFiles["scratchfs"]
+		_, err = disk.ReadAt(readBuf, 1)
+		require.NoError(t, err)
+		require.ElementsMatch(t, originalWriteBuf[1:4], readBuf)
+		// Update one chunk of the snapshot.
+		readBuf[2] = '6'
+		_, err = disk.WriteAt(readBuf, 1)
+		require.NoError(t, err)
+		// Write snapshot locally only.
+		optsB := makeFakeSnapshot(t, workDirB, false /*remoteEnabled*/, map[string]*copy_on_write.COWStore{
+			"scratchfs": disk,
+		}, "")
+		err = loader.CacheSnapshot(ctx, keyset.GetBranchKey(), optsB)
+		require.NoError(t, err)
+
+		// Read chunks 2-5. Should read the modified chunk 3
+		// that was written locally only by VM-B. Should be able to fetch chunks 4-5 from the
+		// remote snapshot, even though they were not cached locally by VM-B.
+		workDirC := testfs.MakeDirAll(t, workDir, "VM-C")
+		// GetSnapshot should use the local snapshot manifest, but fallback to the
+		// remote cache for any missing chunks.
+		snap, err = loader.GetSnapshot(ctx, keyset, true /*enableRemote*/)
+		require.NoError(t, err)
+		unpackedC, err := loader.UnpackSnapshot(ctx, snap, workDirC)
+		require.NoError(t, err)
+		readBufC := make([]byte, 4)
+		diskC := unpackedC.ChunkedFiles["scratchfs"]
+		_, err = diskC.ReadAt(readBufC, 2)
+		require.NoError(t, err)
+		expectedBuf := []byte("2645")
+		require.ElementsMatch(t, expectedBuf, readBufC)
+	}
+}
+
 func TestMergeQueueBranch(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 


### PR DESCRIPTION
I had to rollback #9084 because it made an assumption that if a snapshot was cached locally, all the chunks existed locally as well. This assumption does not hold true, because we lazily load snapshot chunks. So the following situation is possible:

1. [Executor A] Write snapshot chunks { 0 1 2 3 4 } to the remote cache
2. [Executor B] Fetch the remote snapshot. Only lazily load { 2 4 }. Now only { 2 4} will be cached locally, but the local manifest will still reference all chunks { 0 1 2 3 4}
3. [Executor B] Try to start from the local snapshot from # 2. We fail to use the local snapshot, because `checkAllArtifactsExist` reports that we don't have chunks {0 1 3} in the local filecache. 

After this PR, in # 3 we will allow you to start from the local snapshot, fetching {2 4} from the local cache and {0 1 3} from the remote cache. This fallback behavior is already supported in `copy_on_write::fetch`