### PR TITLE
[SS] Always look for a local manifest before remote manifest

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -421,10 +421,13 @@ func (l *FileCacheLoader) getSnapshot(ctx context.Context, key *fcpb.SnapshotKey
 
 	// Always prioritize the local manifest if it exists. It may point to a more
 	// updated snapshot than the remote manifest, which is updated less frequently.
+	// Note that the master snapshot is never cached locally.
 	if *snaputil.EnableLocalSnapshotSharing {
 		manifest, err := l.getLocalManifest(ctx, key)
 		if err == nil || !remoteEnabled || !*snaputil.EnableRemoteSnapshotSharing {
-			log.CtxInfof(ctx, "Using local manifest")
+			if err == nil {
+				log.CtxInfof(ctx, "Using local manifest")
+			}
 			return manifest, err
 		}
 		log.CtxDebugf(ctx, "Fetch local manifest err: %s", err)


### PR DESCRIPTION
In an effort to re-push #9221 , break out some of the changes to make them less risky and easier to review.

With #9221, we will write fewer remote snapshots and should try to use a local snapshot instead. This PR should have no effect until #9221 is merged, because workflows won't write local manifests so we'll always fall back to reading the remote manifest