### PR TITLE
Update request context to match invocation owner group ID

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -142,6 +142,20 @@ class RpcService {
     return bestMatch;
   }
 
+  /**
+   * Temporarily re-scopes the requestContext to use the given group ID as the
+   * selected group ID.
+   *
+   * The returned function must be called to restore the original group ID.
+   */
+  overrideGroupId(groupId: string): () => void {
+    const originalGroupId = this.requestContext.groupId;
+    this.requestContext.groupId = groupId;
+    return () => {
+      this.requestContext.groupId = originalGroupId;
+    };
+  }
+
   getDownloadUrl(params: Record<string, string>): string {
     const encodedRequestContext = uint8ArrayToBase64(context.RequestContext.encode(this.requestContext).finish());
     return `/file/download?${new URLSearchParams({


### PR DESCRIPTION
All RPCs and bytestream file downloads that are issued when viewing an invocation should have the `requestContext.groupId` match the invocation owner group ID, so that cache artifact fetches work properly. This PR makes it happen.