### PR TITLE
[testserver] add logging

### DIFF
--- a/server/testutil/testserver/BUILD
+++ b/server/testutil/testserver/BUILD
@@ -5,5 +5,8 @@ go_library(
     srcs = ["testserver.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testserver",
     visibility = ["//visibility:public"],
-    deps = ["@io_bazel_rules_go//go/runfiles"],
+    deps = [
+        "//server/util/log",
+        "@io_bazel_rules_go//go/runfiles",
+    ],
 )

--- a/server/testutil/testserver/testserver.go
+++ b/server/testutil/testserver/testserver.go
@@ -86,7 +86,7 @@ func isOK(resp *http.Response) (bool, error) {
 
 func (s *Server) waitForReady() error {
 	start := time.Now()
-	log.Debugf("testserver waitForReady start %s", start.Format(time.DateTime))
+	log.Debug("testserver waitForReady start")
 	for i := 0; ; i++ {
 		s.mu.Lock()
 		exited := s.exited


### PR DESCRIPTION
We're still seeing
```
    testserver.go:73: binary failed to start within 30s: /readyz err: Get "http://localhost:38589/readyz?server-type=buildbuddy-server": dial tcp 127.0.0.1:38589: connect: connection refused
```
in tests, causing them to flake.

This change logs the time at which `waitForReady` starts waiting for the server to respond to `/readyz`. It also clearly marks the testserver stdout and stderr.