### PR TITLE
Don't render 0x16 bytes from go test logs

### DIFF
--- a/app/terminal/ansi.tsx
+++ b/app/terminal/ansi.tsx
@@ -107,6 +107,13 @@ export default function parseAnsi(text: string): AnsiTextSpan[] {
   const spans: AnsiTextSpan[] = [];
   let code = "";
 
+  // rules_go produces test logs containing 0x16 ("synchronous idle") bytes at
+  // the start of the line for some reason. Just ignore these for now -
+  // terminals seem to ignore these bytes too.
+  if (text.startsWith("\x16")) {
+    text = text.substring(1);
+  }
+
   let inEscapeSequence = false;
   for (let i = 0; i < text.length; i++) {
     const char = text[i];


### PR DESCRIPTION
Context: https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1746566444199369?thread_ts=1746546618.860849&cid=C01D5GHRJ59