### PR TITLE
Optimize the migration cache

### DIFF
--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -9,19 +9,20 @@ go_test(
     tags = ["performance"],
     deps = [
         "//enterprise/server/backends/distributed",
+        "//enterprise/server/backends/migration_cache",
         "//enterprise/server/backends/pebble_cache",
         "//proto:resource_go_proto",
         "//server/backends/disk_cache",
         "//server/backends/memory_cache",
         "//server/environment",
         "//server/interfaces",
-        "//server/testutil/testauth",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/testutil/testport",
         "//server/util/log",
         "//server/util/prefix",
+        "//server/util/testing/flags",
     ],
 )
 

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -135,6 +135,9 @@ func getPebbleCache(t testing.TB, te *testenv.TestEnv) interfaces.Cache {
 func benchmarkSet(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, b *testing.B, unique bool) {
 	var digestBufs []*digestBuf
 	if unique {
+		// Create as many digests as benchmark iterations, so the distributed
+		// cache can't benefit from its optimization where it calls FindMissing
+		// before doing writes.
 		digestBufs = makeDigests(b, b.N, digestSizeBytes)
 	} else {
 		digestBufs = makeDigests(b, numDigests, digestSizeBytes)

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -3,46 +3,37 @@ package cache_test
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/distributed"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/migration_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
-	maxSizeBytes = int64(100000000) // 100MB
+	// 100GB should be enough to prevent any eviction
+	maxSizeBytes = int64(100_000_000_000)
 	numDigests   = 100
-)
-
-var (
-	emptyUserMap = testauth.TestUsers()
 )
 
 func init() {
 	*log.LogLevel = "error"
 	*log.IncludeShortFileName = true
 	log.Configure()
-}
-
-func getTestEnv(t testing.TB, users map[string]interfaces.UserInfo) *testenv.TestEnv {
-	te := testenv.GetTestEnv(t)
-	te.SetAuthenticator(testauth.NewTestAuthenticator(users))
-	return te
 }
 
 func getAnonContext(t testing.TB, te *testenv.TestEnv) context.Context {
@@ -95,6 +86,18 @@ func getDiskCache(t testing.TB, env environment.Env) interfaces.Cache {
 	return dc
 }
 
+func getMigrationCache(t testing.TB, env environment.Env, src, dest interfaces.Cache) interfaces.Cache {
+	config := &migration_cache.MigrationConfig{
+		CopyChanBufferSize:             200,
+		MaxCopiesPerSec:                100,
+		NumCopyWorkers:                 1,
+		CopyChanFullWarningIntervalMin: 60,
+		AsyncDestWrites:                false,
+		DoubleReadPercentage:           1,
+	}
+	return migration_cache.NewMigrationCache(env, config, src, dest)
+}
+
 func getDistributedCache(t testing.TB, te *testenv.TestEnv, c interfaces.Cache) interfaces.Cache {
 	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(t))
 	conf := distributed.CacheConfig{
@@ -115,6 +118,7 @@ func getDistributedCache(t testing.TB, te *testenv.TestEnv, c interfaces.Cache) 
 func getPebbleCache(t testing.TB, te *testenv.TestEnv) interfaces.Cache {
 	testRootDir := testfs.MakeTempDir(t)
 	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{
+		Name:          testRootDir,
 		RootDirectory: testRootDir,
 		MaxSizeBytes:  maxSizeBytes,
 	})
@@ -128,13 +132,18 @@ func getPebbleCache(t testing.TB, te *testenv.TestEnv) interfaces.Cache {
 	return pc
 }
 
-func benchmarkSet(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, b *testing.B) {
-	digestBufs := makeDigests(b, numDigests, digestSizeBytes)
+func benchmarkSet(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, b *testing.B, unique bool) {
+	var digestBufs []*digestBuf
+	if unique {
+		digestBufs = makeDigests(b, b.N, digestSizeBytes)
+	} else {
+		digestBufs = makeDigests(b, numDigests, digestSizeBytes)
+	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		dbuf := digestBufs[rand.Intn(len(digestBufs))]
+		dbuf := digestBufs[i%len(digestBufs)]
 		b.SetBytes(dbuf.d.GetDigest().GetSizeBytes())
 		err := c.Set(ctx, dbuf.d, dbuf.buf)
 		if err != nil {
@@ -150,7 +159,7 @@ func benchmarkGet(ctx context.Context, c interfaces.Cache, digestSizeBytes int64
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		dbuf := digestBufs[rand.Intn(len(digestBufs))]
+		dbuf := digestBufs[i%len(digestBufs)]
 		b.SetBytes(dbuf.d.GetDigest().GetSizeBytes())
 		_, err := c.Get(ctx, dbuf.d)
 		if err != nil {
@@ -205,38 +214,43 @@ type namedCache struct {
 }
 
 func getAllCaches(b *testing.B, te *testenv.TestEnv) []*namedCache {
-	dc := getDiskCache(b, te)
-	ddc := getDistributedCache(b, te, dc)
+	flags.Set(b, "cache.distributed_cache.consistent_hash_function", "SHA256")
+	// dc := getDiskCache(b, te)
+	// ddc := getDistributedCache(b, te, dc)
 	pc := getPebbleCache(b, te)
 	dpc := getDistributedCache(b, te, pc)
 
 	time.Sleep(100 * time.Millisecond)
 	caches := []*namedCache{
-		{getMemoryCache(b), "Memory"},
-		{getDiskCache(b, te), "Disk"},
-		{ddc, "DistDisk"},
-		{getPebbleCache(b, te), "Pebble"},
+		// {getMemoryCache(b), "LocalMemory"},
+		// {getDiskCache(b, te), "LocalDisk"},
+		// {ddc, "DistDisk"},
+		{getPebbleCache(b, te), "LocalPebble"},
 		{dpc, "DistPebble"},
+		{getMigrationCache(b, te, getPebbleCache(b, te), getPebbleCache(b, te)), "LocalMigration"},
+		{getDistributedCache(b, te, getMigrationCache(b, te, getPebbleCache(b, te), getPebbleCache(b, te))), "DistMigration"},
 	}
 	return caches
 }
 
 func BenchmarkSet(b *testing.B) {
-	sizes := []int64{10, 100, 1000, 10000}
+	sizes := []int64{10, 100, 1000, 10000, 1_000_000}
 	te := testenv.GetTestEnv(b)
 	ctx := getAnonContext(b, te)
 
 	for _, cache := range getAllCaches(b, te) {
 		for _, size := range sizes {
-			name := fmt.Sprintf("%s%d", cache.Name, size)
-			b.Run(name, func(b *testing.B) {
-				benchmarkSet(ctx, cache, size, b)
-			})
+			for _, unique := range []bool{false, true} {
+				name := fmt.Sprintf("%s%d/unique=%v", cache.Name, size, unique)
+				b.Run(name, func(b *testing.B) {
+					benchmarkSet(ctx, cache, size, b, unique)
+				})
+			}
 		}
 	}
 }
 
-func BenchmarkGet(b *testing.B) {
+func BenchmarkGetSingle(b *testing.B) {
 	sizes := []int64{10, 100, 1000, 10000}
 	te := testenv.GetTestEnv(b)
 	ctx := getAnonContext(b, te)

--- a/server/nullauth/nullauth.go
+++ b/server/nullauth/nullauth.go
@@ -10,6 +10,12 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
+// Create these once so they don't show up in benchmarks that use null auth
+var (
+	anonymouseUserError = authutil.AnonymousUserError("Auth not implemented")
+	unimplementedError  = status.UnimplementedError("Auth not implemented")
+)
+
 func NewNullAuthenticator(anonymousUsageEnabled bool, adminGroupID string) *NullAuthenticator {
 	return &NullAuthenticator{
 		adminGroupID:           adminGroupID,
@@ -47,7 +53,7 @@ func (a *NullAuthenticator) AuthenticatedGRPCContext(ctx context.Context) contex
 }
 
 func (a *NullAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {
-	return nil, authutil.AnonymousUserError("Auth not implemented")
+	return nil, anonymouseUserError
 }
 
 func (a *NullAuthenticator) FillUser(ctx context.Context, user *tables.User) error {
@@ -55,15 +61,15 @@ func (a *NullAuthenticator) FillUser(ctx context.Context, user *tables.User) err
 }
 
 func (a *NullAuthenticator) Login(w http.ResponseWriter, r *http.Request) error {
-	return status.UnimplementedError("Auth not implemented")
+	return unimplementedError
 }
 
 func (a *NullAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error {
-	return status.UnimplementedError("Auth not implemented")
+	return unimplementedError
 }
 
 func (a *NullAuthenticator) Logout(w http.ResponseWriter, r *http.Request) error {
-	return status.UnimplementedError("Auth not implemented")
+	return unimplementedError
 }
 
 func (a *NullAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context {

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -116,16 +116,16 @@ func (d *zstdDecompressor) Close() error {
 	return lastErr
 }
 
-type compressingReader struct {
+type wrappedReader struct {
 	pr          *io.PipeReader
 	inputReader io.ReadCloser
 }
 
-func (r *compressingReader) Read(p []byte) (int, error) {
+func (r *wrappedReader) Read(p []byte) (int, error) {
 	return r.pr.Read(p)
 }
 
-func (r *compressingReader) Close() error {
+func (r *wrappedReader) Close() error {
 	defer r.inputReader.Close()
 	return r.pr.Close()
 }
@@ -167,7 +167,7 @@ func NewZstdCompressingReader(reader io.ReadCloser, readBuf []byte, compressBuf 
 			}
 		}
 	}()
-	return &compressingReader{
+	return &wrappedReader{
 		pr:          pr,
 		inputReader: reader,
 	}, nil


### PR DESCRIPTION
The Get, GetMulti, FindMissing, and Contains methods all follow a similar pattern. Instead of using an errgroup and waiting for the results of both caches, do the destination read completely async. The Reader method is more complicated so I ignored it for now.

Writer is more interesting. The key here is not creating a goroutine for every `Writer.Write` call. Instead, create a single goroutine for the destination writer which handles all writes, comitts, and closes. Also, creating the source and destination writer in parallel actually makes things slower. I guess the errgroup overhead is large enough and creating a pebble Writer is fast enough.

The Get methods are up to 50% faster. FindMissing is up to 10% faster. Set (which uses Writer) is up to 20% faster.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                                          │      base      │              optimized               │
                                          │     sec/op     │    sec/op      vs base               │
Set/LocalMigration10/unique=false-24         34.46µ ±   2%   28.18µ ±   4%  -18.23% (p=0.001 n=7)
Set/LocalMigration10/unique=true-24          37.53µ ±   5%   32.24µ ±   5%  -14.09% (p=0.001 n=7)
Set/LocalMigration100/unique=false-24        47.56µ ±   3%   39.59µ ±   3%  -16.75% (p=0.001 n=7)
Set/LocalMigration100/unique=true-24         54.86µ ±   5%   47.56µ ±  10%  -13.31% (p=0.001 n=7)
Set/LocalMigration1000/unique=false-24       74.28µ ±   4%   67.35µ ±   6%   -9.33% (p=0.001 n=7)
Set/LocalMigration1000/unique=true-24        80.77µ ±   8%   75.20µ ±   4%   -6.90% (p=0.007 n=7)
Set/LocalMigration10000/unique=false-24      291.7µ ±   6%   285.8µ ±   6%        ~ (p=0.209 n=7)
Set/LocalMigration10000/unique=true-24       331.2µ ±   5%   360.1µ ±  17%        ~ (p=0.073 n=7)
Set/LocalMigration1000000/unique=false-24    3.635m ±   1%   3.614m ± 324%        ~ (p=1.000 n=7)
Set/LocalMigration1000000/unique=true-24     3.675m ±  67%   3.614m ±  48%        ~ (p=0.710 n=7)
Set/DistMigration10/unique=false-24         105.95µ ± 841%   99.88µ ±   4%   -5.73% (p=0.002 n=7)
Set/DistMigration10/unique=true-24           174.9µ ±   8%   159.8µ ±   7%   -8.59% (p=0.001 n=7)
Set/DistMigration100/unique=false-24         110.1µ ±   4%   100.7µ ±   2%   -8.57% (p=0.001 n=7)
Set/DistMigration100/unique=true-24          219.1µ ±  12%   207.3µ ±   6%   -5.39% (p=0.017 n=7)
Set/DistMigration1000/unique=false-24        110.5µ ±   4%   106.5µ ±   4%   -3.61% (p=0.001 n=7)
Set/DistMigration1000/unique=true-24         256.2µ ±   5%   257.0µ ±   7%        ~ (p=0.710 n=7)
Set/DistMigration10000/unique=false-24       118.2µ ±   3%   114.9µ ±   3%   -2.79% (p=0.002 n=7)
Set/DistMigration10000/unique=true-24        497.6µ ±   8%   441.5µ ±   9%  -11.26% (p=0.001 n=7)
Set/DistMigration1000000/unique=false-24     884.2µ ±   4%   856.0µ ±   2%   -3.19% (p=0.001 n=7)
Set/DistMigration1000000/unique=true-24      4.270m ±   9%   4.232m ±   6%        ~ (p=1.000 n=7)
GetSingle/LocalMigration10-24               24.891µ ±  10%   6.681µ ±   2%  -73.16% (p=0.001 n=7)
GetSingle/LocalMigration100-24              24.899µ ±   7%   7.031µ ±   2%  -71.76% (p=0.001 n=7)
GetSingle/LocalMigration1000-24             26.139µ ±  10%   8.083µ ±   5%  -69.08% (p=0.001 n=7)
GetSingle/LocalMigration10000-24             43.00µ ±   4%   25.13µ ±   1%  -41.56% (p=0.001 n=7)
GetSingle/DistMigration10-24                 130.4µ ±   2%   129.1µ ±   2%        ~ (p=0.805 n=7)
GetSingle/DistMigration100-24                132.8µ ±   3%   132.9µ ±   3%        ~ (p=0.805 n=7)
GetSingle/DistMigration1000-24               139.7µ ±   4%   137.9µ ±   4%        ~ (p=0.805 n=7)
GetSingle/DistMigration10000-24              196.9µ ±   3%   193.0µ ±   4%        ~ (p=0.318 n=7)
GetMulti/LocalMigration10-24                 753.4µ ±   5%   343.6µ ±   3%  -54.39% (p=0.001 n=7)
GetMulti/LocalMigration100-24                789.8µ ±   4%   375.2µ ±   3%  -52.50% (p=0.001 n=7)
GetMulti/LocalMigration1000-24               927.5µ ±   4%   483.4µ ±   2%  -47.88% (p=0.001 n=7)
GetMulti/LocalMigration10000-24              2.638m ±   1%   2.169m ±   3%  -17.77% (p=0.001 n=7)
GetMulti/DistMigration10-24                  737.1µ ±  10%   430.2µ ±  13%  -41.64% (p=0.001 n=7)
GetMulti/DistMigration100-24                1096.5µ ±   4%   639.2µ ±   2%  -41.71% (p=0.001 n=7)
GetMulti/DistMigration1000-24               1330.5µ ±   5%   853.8µ ±   2%  -35.83% (p=0.001 n=7)
GetMulti/DistMigration10000-24               3.478m ±   2%   3.013m ±   2%  -13.37% (p=0.001 n=7)
FindMissing/LocalMigration10-24              280.6µ ±   3%   253.0µ ±   3%   -9.83% (p=0.001 n=7)
FindMissing/LocalMigration100-24             291.2µ ±   4%   253.9µ ±   6%  -12.80% (p=0.001 n=7)
FindMissing/LocalMigration1000-24            304.6µ ±   3%   269.2µ ±   4%  -11.64% (p=0.001 n=7)
FindMissing/LocalMigration10000-24           303.8µ ±   2%   258.5µ ±   2%  -14.91% (p=0.001 n=7)
FindMissing/DistMigration10-24               389.9µ ±   7%   364.2µ ±   8%   -6.60% (p=0.038 n=7)
FindMissing/DistMigration100-24              512.8µ ±   2%   497.6µ ±   2%   -2.97% (p=0.001 n=7)
FindMissing/DistMigration1000-24             523.5µ ±   1%   508.5µ ±   2%   -2.86% (p=0.001 n=7)
FindMissing/DistMigration10000-24            514.8µ ±   2%   497.0µ ±   2%   -3.46% (p=0.002 n=7)
geomean                                      266.5µ          210.5µ         -21.03%

                                          │     base      │                optimized                 │
                                          │      B/s      │      B/s        vs base                  │
Set/LocalMigration10/unique=false-24        283.2Ki ±  3%    341.8Ki ±  3%   +20.69% (p=0.001 n=7)
Set/LocalMigration10/unique=true-24         263.7Ki ±  7%    302.7Ki ±  6%   +14.81% (p=0.001 n=7)
Set/LocalMigration100/unique=false-24       2.003Mi ±  3%    2.413Mi ±  4%   +20.48% (p=0.001 n=7)
Set/LocalMigration100/unique=true-24        1.736Mi ±  5%    2.003Mi ± 11%   +15.38% (p=0.001 n=7)
Set/LocalMigration1000/unique=false-24      12.84Mi ±  4%    14.16Mi ±  7%   +10.33% (p=0.001 n=7)
Set/LocalMigration1000/unique=true-24       11.81Mi ±  8%    12.68Mi ±  3%    +7.43% (p=0.005 n=7)
Set/LocalMigration10000/unique=false-24     32.69Mi ±  6%    33.37Mi ±  7%         ~ (p=0.209 n=7)
Set/LocalMigration10000/unique=true-24      28.79Mi ±  5%    26.48Mi ± 20%         ~ (p=0.073 n=7)
Set/LocalMigration1000000/unique=false-24   262.4Mi ±  1%    263.9Mi ± 76%         ~ (p=1.000 n=7)
Set/LocalMigration1000000/unique=true-24    259.5Mi ± 40%    263.9Mi ± 32%         ~ (p=0.710 n=7)
Set/DistMigration10/unique=false-24         87.89Ki ± 89%    97.66Ki ±  0%         ~ (p=0.070 n=7)
Set/DistMigration10/unique=true-24          58.59Ki ± 17%    58.59Ki ± 17%         ~ (p=0.269 n=7)
Set/DistMigration100/unique=false-24        888.7Ki ±  3%    966.8Ki ±  2%    +8.79% (p=0.001 n=7)
Set/DistMigration100/unique=true-24         449.2Ki ± 11%    468.8Ki ±  6%    +4.35% (p=0.027 n=7)
Set/DistMigration1000/unique=false-24       8.631Mi ±  4%    8.955Mi ±  4%    +3.76% (p=0.001 n=7)
Set/DistMigration1000/unique=true-24        3.719Mi ±  5%    3.710Mi ±  8%         ~ (p=0.734 n=7)
Set/DistMigration10000/unique=false-24      80.67Mi ±  3%    82.99Mi ±  3%    +2.87% (p=0.002 n=7)
Set/DistMigration10000/unique=true-24       19.17Mi ±  7%    21.60Mi ±  8%   +12.69% (p=0.001 n=7)
Set/DistMigration1000000/unique=false-24    1.053Gi ±  4%    1.088Gi ±  2%    +3.30% (p=0.001 n=7)
Set/DistMigration1000000/unique=true-24     223.3Mi ±  8%    225.3Mi ±  6%         ~ (p=1.000 n=7)
GetSingle/LocalMigration10-24               390.6Ki ± 12%   1464.8Ki ±  2%  +275.00% (p=0.001 n=7)
GetSingle/LocalMigration100-24              3.834Mi ±  7%   13.561Mi ±  2%  +253.73% (p=0.001 n=7)
GetSingle/LocalMigration1000-24             36.49Mi ± 11%   117.98Mi ±  4%  +223.34% (p=0.001 n=7)
GetSingle/LocalMigration10000-24            221.8Mi ±  3%    379.5Mi ±  1%   +71.13% (p=0.001 n=7)
GetSingle/DistMigration10-24                78.12Ki ±  0%    78.12Ki ±  0%         ~ (p=1.000 n=7) ¹
GetSingle/DistMigration100-24               732.4Ki ±  3%    732.4Ki ±  4%         ~ (p=0.739 n=7)
GetSingle/DistMigration1000-24              6.828Mi ±  4%    6.914Mi ±  3%         ~ (p=0.776 n=7)
GetSingle/DistMigration10000-24             48.45Mi ±  3%    49.41Mi ±  4%         ~ (p=0.300 n=7)
GetMulti/LocalMigration10-24                1.268Mi ±  5%    2.775Mi ±  3%  +118.80% (p=0.001 n=7)
GetMulti/LocalMigration100-24               12.07Mi ±  3%    25.42Mi ±  2%  +110.51% (p=0.001 n=7)
GetMulti/LocalMigration1000-24              102.8Mi ±  4%    197.3Mi ±  2%   +91.88% (p=0.001 n=7)
GetMulti/LocalMigration10000-24             361.5Mi ±  1%    439.6Mi ±  2%   +21.61% (p=0.001 n=7)
GetMulti/DistMigration10-24                 1.297Mi ± 10%    2.213Mi ± 11%   +70.59% (p=0.001 n=7)
GetMulti/DistMigration100-24                8.698Mi ±  4%   14.925Mi ±  2%   +71.60% (p=0.001 n=7)
GetMulti/DistMigration1000-24               71.68Mi ±  5%   111.70Mi ±  2%   +55.84% (p=0.001 n=7)
GetMulti/DistMigration10000-24              274.2Mi ±  2%    316.5Mi ±  2%   +15.43% (p=0.001 n=7)
geomean                                     8.340Mi          10.89Mi         +30.58%
¹ all samples are equal

                                          │      base      │               optimized               │
                                          │      B/op      │      B/op       vs base               │
Set/LocalMigration10/unique=false-24         11.95Ki ±  1%   12.01Ki ±   0%   +0.52% (p=0.024 n=7)
Set/LocalMigration10/unique=true-24          11.85Ki ±  1%   11.92Ki ±   1%   +0.56% (p=0.016 n=7)
Set/LocalMigration100/unique=false-24        12.06Ki ±  0%   12.13Ki ±   1%   +0.61% (p=0.001 n=7)
Set/LocalMigration100/unique=true-24         11.82Ki ±  0%   11.89Ki ±   2%   +0.57% (p=0.001 n=7)
Set/LocalMigration1000/unique=false-24       15.15Ki ±  5%   15.25Ki ±   4%        ~ (p=0.128 n=7)
Set/LocalMigration1000/unique=true-24        14.27Ki ±  4%   14.46Ki ±   0%   +1.39% (p=0.023 n=7)
Set/LocalMigration10000/unique=false-24      17.22Ki ±  0%   17.27Ki ±   0%   +0.33% (p=0.001 n=7)
Set/LocalMigration10000/unique=true-24       17.76Ki ±  1%   17.95Ki ±  12%   +1.07% (p=0.007 n=7)
Set/LocalMigration1000000/unique=false-24    30.72Ki ± 31%   36.32Ki ± 127%        ~ (p=0.456 n=7)
Set/LocalMigration1000000/unique=true-24     49.99Ki ± 47%   45.69Ki ±  13%   -8.59% (p=0.001 n=7)
Set/DistMigration10/unique=false-24          32.14Ki ±  1%   31.84Ki ±   0%   -0.93% (p=0.001 n=7)
Set/DistMigration10/unique=true-24           46.02Ki ±  0%   45.81Ki ±   1%   -0.46% (p=0.011 n=7)
Set/DistMigration100/unique=false-24         32.60Ki ±  0%   32.29Ki ±   0%   -0.94% (p=0.001 n=7)
Set/DistMigration100/unique=true-24          53.62Ki ±  0%   53.26Ki ±   0%   -0.67% (p=0.001 n=7)
Set/DistMigration1000/unique=false-24        33.55Ki ±  0%   33.24Ki ±   0%   -0.93% (p=0.001 n=7)
Set/DistMigration1000/unique=true-24         56.37Ki ±  0%   55.80Ki ±   0%   -1.02% (p=0.001 n=7)
Set/DistMigration10000/unique=false-24       42.04Ki ±  0%   41.74Ki ±   0%   -0.71% (p=0.001 n=7)
Set/DistMigration10000/unique=true-24        69.17Ki ±  0%   68.54Ki ±   0%   -0.91% (p=0.001 n=7)
Set/DistMigration1000000/unique=false-24     1.031Mi ±  1%   1.024Mi ±   1%        ~ (p=0.097 n=7)
Set/DistMigration1000000/unique=true-24      1.111Mi ±  2%   1.104Mi ±   1%   -0.67% (p=0.017 n=7)
GetSingle/LocalMigration10-24               10.622Ki ±  1%   7.552Ki ±   0%  -28.91% (p=0.001 n=7)
GetSingle/LocalMigration100-24              10.935Ki ±  0%   7.825Ki ±   0%  -28.44% (p=0.001 n=7)
GetSingle/LocalMigration1000-24              13.66Ki ±  0%   10.23Ki ±   0%  -25.06% (p=0.001 n=7)
GetSingle/LocalMigration10000-24             31.31Ki ±  0%   28.21Ki ±   0%   -9.92% (p=0.001 n=7)
GetSingle/DistMigration10-24                 36.28Ki ±  0%   36.27Ki ±   0%   -0.02% (p=0.010 n=7)
GetSingle/DistMigration100-24                36.89Ki ±  0%   36.88Ki ±   0%        ~ (p=0.053 n=7)
GetSingle/DistMigration1000-24               42.26Ki ±  0%   42.27Ki ±   0%        ~ (p=0.876 n=7)
GetSingle/DistMigration10000-24              66.91Ki ±  0%   66.88Ki ±   0%        ~ (p=0.302 n=7)
GetMulti/LocalMigration10-24                 825.0Ki ±  0%   550.1Ki ±   0%  -33.32% (p=0.001 n=7)
GetMulti/LocalMigration100-24                858.1Ki ±  0%   579.1Ki ±   0%  -32.52% (p=0.001 n=7)
GetMulti/LocalMigration1000-24              1129.3Ki ±  0%   819.4Ki ±   0%  -27.44% (p=0.001 n=7)
GetMulti/LocalMigration10000-24              2.829Mi ±  0%   2.552Mi ±   0%   -9.79% (p=0.001 n=7)
GetMulti/DistMigration10-24                  676.1Ki ± 14%   496.3Ki ±  14%  -26.61% (p=0.001 n=7)
GetMulti/DistMigration100-24                1037.9Ki ±  0%   757.5Ki ±   0%  -27.01% (p=0.001 n=7)
GetMulti/DistMigration1000-24                1.379Mi ±  0%   1.077Mi ±   0%  -21.87% (p=0.001 n=7)
GetMulti/DistMigration10000-24               4.002Mi ±  0%   3.729Mi ±   1%   -6.83% (p=0.001 n=7)
FindMissing/LocalMigration10-24              417.7Ki ±  1%   410.0Ki ±   0%   -1.83% (p=0.001 n=7)
FindMissing/LocalMigration100-24             426.1Ki ±  0%   418.3Ki ±   0%   -1.84% (p=0.001 n=7)
FindMissing/LocalMigration1000-24            488.0Ki ±  0%   481.1Ki ±   0%   -1.40% (p=0.001 n=7)
FindMissing/LocalMigration10000-24           428.7Ki ±  0%   420.9Ki ±   0%   -1.80% (p=0.001 n=7)
FindMissing/DistMigration10-24               388.3Ki ±  8%   391.0Ki ±  12%        ~ (p=0.710 n=7)
FindMissing/DistMigration100-24              572.2Ki ±  1%   564.9Ki ±   0%   -1.27% (p=0.001 n=7)
FindMissing/DistMigration1000-24             634.2Ki ±  0%   626.8Ki ±   0%   -1.17% (p=0.001 n=7)
FindMissing/DistMigration10000-24            574.7Ki ±  0%   567.2Ki ±   0%   -1.30% (p=0.001 n=7)
geomean                                      106.9Ki         99.20Ki          -7.18%

                                          │     base      │               optimized               │
                                          │   allocs/op   │  allocs/op    vs base                 │
Set/LocalMigration10/unique=false-24          198.0 ±  0%    189.0 ±  0%   -4.55% (p=0.001 n=7)
Set/LocalMigration10/unique=true-24           202.0 ±  0%    193.0 ±  0%   -4.46% (p=0.001 n=7)
Set/LocalMigration100/unique=false-24         190.0 ±  0%    181.0 ±  0%   -4.74% (p=0.001 n=7)
Set/LocalMigration100/unique=true-24          196.0 ±  0%    187.0 ±  1%   -4.59% (p=0.001 n=7)
Set/LocalMigration1000/unique=false-24        190.0 ±  1%    181.0 ±  1%   -4.74% (p=0.001 n=7)
Set/LocalMigration1000/unique=true-24         196.0 ±  1%    189.0 ±  0%   -3.57% (p=0.001 n=7)
Set/LocalMigration10000/unique=false-24       245.0 ±  0%    236.0 ±  0%   -3.67% (p=0.001 n=7)
Set/LocalMigration10000/unique=true-24        261.0 ±  0%    253.0 ±  2%   -3.07% (p=0.001 n=7)
Set/LocalMigration1000000/unique=false-24     254.0 ±  0%    244.0 ± 10%   -3.94% (p=0.022 n=7)
Set/LocalMigration1000000/unique=true-24      264.0 ±  7%    255.0 ±  0%   -3.41% (p=0.001 n=7)
Set/DistMigration10/unique=false-24           513.0 ±  1%    504.0 ±  0%   -1.75% (p=0.001 n=7)
Set/DistMigration10/unique=true-24            780.0 ±  1%    759.0 ±  1%   -2.69% (p=0.001 n=7)
Set/DistMigration100/unique=false-24          514.0 ±  0%    506.0 ±  0%   -1.56% (p=0.001 n=7)
Set/DistMigration100/unique=true-24           914.0 ±  0%    885.0 ±  0%   -3.17% (p=0.001 n=7)
Set/DistMigration1000/unique=false-24         509.0 ±  0%    501.0 ±  0%   -1.57% (p=0.001 n=7)
Set/DistMigration1000/unique=true-24          909.0 ±  0%    880.0 ±  0%   -3.19% (p=0.001 n=7)
Set/DistMigration10000/unique=false-24        510.0 ±  0%    502.0 ±  0%   -1.57% (p=0.001 n=7)
Set/DistMigration10000/unique=true-24         978.0 ±  0%    949.0 ±  0%   -2.97% (p=0.001 n=7)
Set/DistMigration1000000/unique=false-24      619.0 ±  1%    612.0 ±  1%   -1.13% (p=0.002 n=7)
Set/DistMigration1000000/unique=true-24      1.054k ±  0%   1.029k ±  0%   -2.37% (p=0.001 n=7)
GetSingle/LocalMigration10-24                 203.0 ±  0%    142.0 ±  1%  -30.05% (p=0.001 n=7)
GetSingle/LocalMigration100-24                203.0 ±  0%    143.0 ±  1%  -29.56% (p=0.001 n=7)
GetSingle/LocalMigration1000-24               203.0 ±  0%    143.0 ±  0%  -29.56% (p=0.001 n=7)
GetSingle/LocalMigration10000-24              205.0 ±  0%    145.0 ±  0%  -29.27% (p=0.001 n=7)
GetSingle/DistMigration10-24                  611.0 ±  0%    611.0 ±  0%        ~ (p=1.000 n=7) ¹
GetSingle/DistMigration100-24                 611.0 ±  0%    611.0 ±  0%        ~ (p=1.000 n=7) ¹
GetSingle/DistMigration1000-24                611.0 ±  0%    611.0 ±  0%        ~ (p=1.000 n=7) ¹
GetSingle/DistMigration10000-24               608.0 ±  0%    608.0 ±  0%        ~ (p=1.000 n=7) ¹
GetMulti/LocalMigration10-24                 15.34k ±  0%   10.23k ±  0%  -33.33% (p=0.001 n=7)
GetMulti/LocalMigration100-24                15.34k ±  0%   10.23k ±  0%  -33.33% (p=0.001 n=7)
GetMulti/LocalMigration1000-24               15.34k ±  0%   10.23k ±  0%  -33.34% (p=0.001 n=7)
GetMulti/LocalMigration10000-24              15.55k ±  0%   10.43k ±  0%  -32.94% (p=0.001 n=7)
GetMulti/DistMigration10-24                 11.569k ± 15%   8.243k ± 16%  -28.75% (p=0.001 n=7)
GetMulti/DistMigration100-24                 17.50k ±  0%   12.39k ±  0%  -29.23% (p=0.001 n=7)
GetMulti/DistMigration1000-24                17.51k ±  0%   12.40k ±  0%  -29.22% (p=0.001 n=7)
GetMulti/DistMigration10000-24               17.80k ±  0%   12.68k ±  0%  -28.74% (p=0.001 n=7)
FindMissing/LocalMigration10-24              8.244k ±  0%   8.226k ±  0%   -0.22% (p=0.001 n=7)
FindMissing/LocalMigration100-24             8.244k ±  0%   8.226k ±  0%   -0.22% (p=0.001 n=7)
FindMissing/LocalMigration1000-24            8.244k ±  0%   8.226k ±  0%   -0.22% (p=0.001 n=7)
FindMissing/LocalMigration10000-24           8.244k ±  0%   8.226k ±  0%   -0.22% (p=0.001 n=7)
FindMissing/DistMigration10-24               6.675k ±  8%   6.849k ± 11%        ~ (p=1.000 n=7)
FindMissing/DistMigration100-24              9.974k ±  1%   9.957k ±  0%   -0.17% (p=0.008 n=7)
FindMissing/DistMigration1000-24             9.973k ±  0%   9.957k ±  0%   -0.16% (p=0.001 n=7)
FindMissing/DistMigration10000-24            9.974k ±  0%   9.957k ±  0%   -0.17% (p=0.001 n=7)
geomean                                      1.315k         1.174k        -10.77%
¹ all samples are equal
```