### PR TITLE
[raft] Update instead of Remove/Add Range

### DIFF
--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -286,7 +286,7 @@ func (tp *TestingProposer) StaleRead(rangeID uint64, query interface{}) (interfa
 // FakeStore implements replica.IStore without real functionality.
 type FakeStore struct{}
 
-func (fs *FakeStore) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica)    {}
+func (fs *FakeStore) UpdateRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {}
 func (fs *FakeStore) RemoveRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {}
 func (fs *FakeStore) Sender() *sender.Sender {
 	return nil


### PR DESCRIPTION
Fix flaky test for AddRangeBack
  -- add retries for remove replica and remove data call. Occasionally,
  these tests fail with timeout while updating range descriptors b/c
  there are no leaders elected.
  -- add retries for transfer leader because it's a best effort only
  call.
  -- GetReplica call can fail with OutOfRangeError from the test when it is
  called between RemoveRange and AddRange.

Also remove the quarantine on AddRangeBackTest:
https://app.buildbuddy.io/invocation/ce1949ab-259e-4d29-a0ad-1a2a8082b858
https://app.buildbuddy.io/invocation/63e7524a-7414-4184-91b1-b2c199e76a98

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4192