### PR TITLE
Set a self hosted bit in the experiment context

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1823,14 +1823,13 @@ func (s *SchedulerServer) modifyTaskForExperiments(ctx context.Context, executor
 	expOptions := make([]any, 0, 2)
 	expOptions = append(expOptions, experiments.WithContext("executor_hostname", executorHostname))
 
+	selfHosted := false
 	if is := s.env.GetClientIdentityService(); is != nil {
 		identity, err := is.IdentityFromContext(ctx)
 		// Client identity is only set on managed executors.
-		selfHosted := err != nil || identity.Client != interfaces.ClientIdentityExecutor
-		expOptions = append(expOptions, experiments.WithContext("self_hosted_executor", selfHosted))
-	} else {
-		expOptions = append(expOptions, experiments.WithContext("self_hosted_executor", true))
+		selfHosted = err != nil || identity.Client != interfaces.ClientIdentityExecutor
 	}
+	expOptions = append(expOptions, experiments.WithContext("self_hosted_executor", selfHosted))
 
 	// We need the bazel RequestMetadata to make experiment decisions. The Lease
 	// RPC doesn't get this metadata, because the executor doesn't get it until


### PR DESCRIPTION
This will allow us to limit experiments to only self-hosted executors.