### PR TITLE
Use runtime.AddCleanup instead of SetFinalizer

### DIFF
--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -247,9 +247,7 @@ func NewZstdDecoderPool() *ZstdDecoderPool {
 					return err
 				}
 				ref := &DecoderRef{dc}
-				runtime.SetFinalizer(ref, func(ref *DecoderRef) {
-					ref.Decoder.Close()
-				})
+				runtime.AddCleanup(ref, (*zstd.Decoder).Close, dc)
 				return ref
 			},
 		},


### PR DESCRIPTION
See https://go.dev/blog/cleanups-and-weak#cleanups for the benefits, but in short:
- AddCleanup is less error prone.
- AddCleanup will allow the reference to be collected 1 GC cycle earlier.