### PR TITLE
[oci] explicitly lay out oci.Resolver.Resolve(...) test cases

### DIFF
--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -39,7 +39,6 @@ go_test(
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",
-        "@com_github_google_go_containerregistry//pkg/crane",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/empty",
         "@com_github_google_go_containerregistry//pkg/v1/mutate",

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//server/util/proto",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_containerregistry//pkg/crane",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/empty",

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -213,7 +213,7 @@ func newResolver(t *testing.T) *oci.Resolver {
 }
 
 func TestResolve(t *testing.T) {
-	flags.Set(t, "http.client.allow_localhost", true)
+	// flags.Set(t, "http.client.allow_localhost", true)
 	registry := testregistry.Run(t, testregistry.Opts{})
 	imageName, _ := registry.PushRandomImage(t)
 	_, err := newResolver(t).Resolve(
@@ -435,10 +435,13 @@ func TestAllowPrivateIPs(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			flags.Set(t, "executor.container_registry_allowed_private_ips", tc.allowedIPs)
 			registry := testregistry.Run(t, testregistry.Opts{})
 			err := pushAndFetchRandomImage(t, registry)
 			if tc.expectError {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			if tc.errorContains != "" {
 				require.ErrorContains(t, err, tc.errorContains)

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -213,7 +213,7 @@ func newResolver(t *testing.T) *oci.Resolver {
 }
 
 func TestResolve(t *testing.T) {
-	// flags.Set(t, "http.client.allow_localhost", true)
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 	registry := testregistry.Run(t, testregistry.Opts{})
 	imageName, _ := registry.PushRandomImage(t)
 	_, err := newResolver(t).Resolve(
@@ -240,7 +240,7 @@ func TestResolve_InvalidImage(t *testing.T) {
 }
 
 func TestResolve_Unauthorized(t *testing.T) {
-	flags.Set(t, "http.client.allow_localhost", true)
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 	registry := testregistry.Run(t, testregistry.Opts{
 		HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
 			if r.Method == "GET" {
@@ -276,7 +276,7 @@ func TestResolve_Arm64VariantIsOptional(t *testing.T) {
 		{name: "linux/arm64", platform: v1.Platform{Architecture: "arm64", OS: "linux"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			flags.Set(t, "http.client.allow_localhost", true)
+			flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 			ctx := context.Background()
 
 			registry := testregistry.Run(t, testregistry.Opts{})
@@ -334,7 +334,7 @@ func layerContents(t *testing.T, layer v1.Layer) map[string]string {
 }
 
 func TestResolve_FallsBackToOriginalWhenMirrorFails(t *testing.T) {
-	flags.Set(t, "http.client.allow_localhost", true)
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 	// Track requests to original and mirror registries.
 	var originalReqCount, mirrorReqCount atomic.Int32
 

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -199,7 +199,7 @@ func creds(username, password string) oci.Credentials {
 	return oci.Credentials{Username: username, Password: password}
 }
 
-func TestToProto(t *testing.T) {
+func TestCredentialsToProto(t *testing.T) {
 	assert.True(t,
 		proto.Equal(
 			&rgpb.Credentials{Username: "foo", Password: "bar"},

--- a/server/testutil/testregistry/testregistry.go
+++ b/server/testutil/testregistry/testregistry.go
@@ -134,6 +134,12 @@ func (r *Registry) PushNamedImage(t *testing.T, imageName string) (string, gcr.I
 	return r.Push(t, image, imageName), image
 }
 
+func (r *Registry) PushNamedImageWithFiles(t *testing.T, imageName string, files map[string][]byte) (string, gcr.Image) {
+	image, err := crane.Image(files)
+	require.NoError(t, err)
+	return r.Push(t, image, imageName), image
+}
+
 func (r *Registry) Shutdown(ctx context.Context) error {
 	if r.server != nil {
 		return r.server.Shutdown(ctx)


### PR DESCRIPTION
As I add read-through caching to `oci.Resolver.Resolve(...)`, the grid of test cases will expand:
* nothing for the image is cached
* image index is cached, individual manifest is not, layers may or may not be
* image index is cached, individual manifest is cached, layers may or may not be
* ...
* everything is cached

I'd like to enumerate specific inputs and outputs, and then make sure we get the expected outputs under all paths. This change enumerates specific inputs and outputs. It also tests resolving a manifest directly and through an index for each input/output combination.

It also uses the `executor.container_registry_allowed_private_ips` in favor of `http.client.allow_localhost`, since the `executor.container_registry_allowed_private_ips` is part of the public interface of the `oci` package.

I also broke `TestAllowPrivateIPs` into separate test cases because I couldn't help myself.