### PR TITLE
Add execution collector methods needed to replace MySQL

### DIFF
--- a/enterprise/server/backends/redis_execution_collector/BUILD
+++ b/enterprise/server/backends/redis_execution_collector/BUILD
@@ -24,6 +24,7 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//proto:stored_invocation_go_proto",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//testing/protocmp",
     ],

--- a/enterprise/server/backends/redis_execution_collector/BUILD
+++ b/enterprise/server/backends/redis_execution_collector/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -12,5 +12,19 @@ go_library(
         "//server/real_environment",
         "//server/util/proto",
         "@com_github_go_redis_redis_v8//:redis",
+    ],
+)
+
+go_test(
+    name = "redis_execution_collector_test",
+    srcs = ["redis_execution_collector_test.go"],
+    deps = [
+        ":redis_execution_collector",
+        "//enterprise/server/testutil/testredis",
+        "//proto:remote_execution_go_proto",
+        "//proto:stored_invocation_go_proto",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
@@ -25,9 +25,27 @@ const (
 	// Redis key prefix for mapping execution ID to invocation-execution links.
 	redisInvocationLinkKeyPrefix = "invocationLink"
 
-	invocationExpiration     = 24 * time.Hour
-	invocationLinkExpiration = 24 * time.Hour
-	executionExpiration      = 24 * time.Hour
+	// Redis key prefix for mapping invocation ID to invocation-execution links.
+	redisReverseInvocationLinkKeyPrefix = "reverseInvocationLink"
+
+	// Redis key prefix for mapping execution ID to a list of execution updates,
+	// which are just partial StoredExecution protos. This list will contain the
+	// initial execution metadata as well as changes to the "stage" field as the
+	// execution progresses. It also contains the final execution state once the
+	// execution is complete, but only for a short duration, since the execution
+	// is normally moved to the ClickHouse flush queue shortly after completion.
+	redisExecutionUpdatesKeyPrefix = "executionUpdates"
+
+	invocationExpiration            = 24 * time.Hour
+	invocationLinkExpiration        = 24 * time.Hour
+	reverseInvocationLinkExpiration = 24 * time.Hour
+	executionExpiration             = 24 * time.Hour
+	executionUpdatesExpiration      = 24 * time.Hour
+)
+
+var (
+	// Whether to write invocation => execution links.
+	writeReverseInvocationLinks bool
 )
 
 type collector struct {
@@ -61,6 +79,14 @@ func getInvocationLinkKey(executionID string) string {
 	return strings.Join([]string{redisInvocationLinkKeyPrefix, executionID}, "/")
 }
 
+func getReverseInvocationLinkKey(invocationID string) string {
+	return strings.Join([]string{redisReverseInvocationLinkKeyPrefix, invocationID}, "/")
+}
+
+func getExecutionUpdatesKey(executionID string) string {
+	return strings.Join([]string{redisExecutionUpdatesKeyPrefix, executionID}, "/")
+}
+
 func (c *collector) AddInvocation(ctx context.Context, inv *sipb.StoredInvocation) error {
 	b, err := proto.Marshal(inv)
 	if err != nil {
@@ -85,15 +111,21 @@ func (c *collector) GetInvocation(ctx context.Context, iid string) (*sipb.Stored
 	return res, nil
 }
 
-func (c *collector) AddInvocationLink(ctx context.Context, link *sipb.StoredInvocationLink) error {
+func (c *collector) AddInvocationLink(ctx context.Context, link *sipb.StoredInvocationLink, storeReverseLink bool) error {
 	b, err := proto.Marshal(link)
 	if err != nil {
 		return err
 	}
 	key := getInvocationLinkKey(link.GetExecutionId())
 	pipe := c.rdb.TxPipeline()
-	pipe.SAdd(ctx, key, string(b))
+	s := string(b)
+	pipe.SAdd(ctx, key, s)
 	pipe.Expire(ctx, key, invocationLinkExpiration)
+	if storeReverseLink {
+		key := getReverseInvocationLinkKey(link.GetInvocationId())
+		pipe.SAdd(ctx, key, s)
+		pipe.Expire(ctx, key, reverseInvocationLinkExpiration)
+	}
 	_, err = pipe.Exec(ctx)
 	return err
 }
@@ -103,15 +135,97 @@ func (c *collector) GetInvocationLinks(ctx context.Context, executionID string) 
 	if err != nil {
 		return nil, err
 	}
-	res := make([]*sipb.StoredInvocationLink, 0)
-	for _, serializedResult := range serializedResults {
-		link := &sipb.StoredInvocationLink{}
-		if err := proto.Unmarshal([]byte(serializedResult), link); err != nil {
+	return unmarshalStoredInvocationLinks(serializedResults)
+}
+
+func (c *collector) getReverseInvocationLinks(ctx context.Context, invocationID string) ([]*sipb.StoredInvocationLink, error) {
+	serializedResults, err := c.rdb.SMembers(ctx, getReverseInvocationLinkKey(invocationID)).Result()
+	if err != nil {
+		return nil, err
+	}
+	return unmarshalStoredInvocationLinks(serializedResults)
+}
+
+func (c *collector) GetInProgressExecutions(ctx context.Context, invocationID string) ([]*repb.StoredExecution, error) {
+	links, err := c.getReverseInvocationLinks(ctx, invocationID)
+	if err != nil {
+		return nil, err
+	}
+	pipe := c.rdb.Pipeline()
+	cmds := make([]*redis.StringSliceCmd, len(links))
+	for i, link := range links {
+		cmds[i] = pipe.LRange(ctx, getExecutionUpdatesKey(link.GetExecutionId()), 0, -1)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, err
+	}
+	// For each execution, combine the events into a single StoredExecution
+	// proto.
+	var executions []*repb.StoredExecution
+	for _, cmd := range cmds {
+		serializedResults, err := cmd.Result()
+		if len(serializedResults) == 0 || err == redis.Nil {
+			continue
+		}
+		if err != nil {
 			return nil, err
 		}
-		res = append(res, link)
+		execution, err := mergeExecutionUpdates(serializedResults)
+		if err != nil {
+			return nil, err
+		}
+		executions = append(executions, execution)
 	}
-	return res, nil
+	return executions, nil
+}
+
+// UpdateInProgressExecution updates the given in-progress execution in Redis.
+// The completed execution state is also written using this method, but should
+// be followed by a call to AppendExecution which queues the execution to be
+// flushed to ClickHouse.
+func (c *collector) UpdateInProgressExecution(ctx context.Context, execution *repb.StoredExecution) error {
+	b, err := proto.Marshal(execution)
+	if err != nil {
+		return err
+	}
+	// To avoid having to read the current execution, just push the update to a
+	// list; we can merge updates when reading them back. The updates are mostly
+	// orthogonal except for in-progress updates (which are usually only written
+	// once), so this approach should be comparable to a read-modify-write
+	// approach in terms of data stored.
+	pipe := c.rdb.TxPipeline()
+	pipe.RPush(ctx, getExecutionUpdatesKey(execution.GetExecutionId()), string(b))
+	pipe.Expire(ctx, getExecutionUpdatesKey(execution.GetExecutionId()), executionUpdatesExpiration)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+// GetInProgressExecution reads the current state of an in-progress execution.
+func (c *collector) GetInProgressExecution(ctx context.Context, executionID string) (*repb.StoredExecution, error) {
+	serializedResults, err := c.rdb.LRange(ctx, getExecutionUpdatesKey(executionID), 0, -1).Result()
+	if err != nil {
+		return nil, err
+	}
+	if len(serializedResults) == 0 {
+		return nil, nil
+	}
+	return mergeExecutionUpdates(serializedResults)
+}
+
+// DeleteInProgressExecution deletes the given in-progress execution.
+func (c *collector) DeleteInProgressExecution(ctx context.Context, executionID string) error {
+	// TODO: maybe also proactively delete the reverse invocation links for this
+	// execution, since reverse links are only used to point back to the
+	// in-progress executions for an invocation. Those links will get cleaned up
+	// when the invocation is complete, but cleaning them up here would reduce
+	// the amount of unnecessary data fetched in the invocation page for
+	// executions that have already been completed. For now, this is probably
+	// not a big enough issue to justify the additional reads from redis and
+	// additional complexity.
+	pipe := c.rdb.Pipeline()
+	pipe.Del(ctx, getExecutionUpdatesKey(executionID)).Err()
+	_, err := pipe.Exec(ctx)
+	return err
 }
 
 func (c *collector) AppendExecution(ctx context.Context, iid string, execution *repb.StoredExecution) error {
@@ -149,4 +263,43 @@ func (c *collector) DeleteExecutions(ctx context.Context, iid string) error {
 
 func (c *collector) DeleteInvocationLinks(ctx context.Context, executionID string) error {
 	return c.rdb.Del(ctx, getInvocationLinkKey(executionID)).Err()
+}
+
+func (c *collector) DeleteReverseInvocationLinks(ctx context.Context, invocationID string) error {
+	return c.rdb.Del(ctx, getReverseInvocationLinkKey(invocationID)).Err()
+}
+
+func unmarshalStoredInvocationLinks(serializedResults []string) ([]*sipb.StoredInvocationLink, error) {
+	res := make([]*sipb.StoredInvocationLink, 0)
+	for _, serializedResult := range serializedResults {
+		link := &sipb.StoredInvocationLink{}
+		if err := proto.Unmarshal([]byte(serializedResult), link); err != nil {
+			return nil, err
+		}
+		res = append(res, link)
+	}
+	return res, nil
+}
+
+func mergeExecutionUpdates(serializedResults []string) (*repb.StoredExecution, error) {
+	out := &repb.StoredExecution{}
+	for _, serializedResult := range serializedResults {
+		event := &repb.StoredExecution{}
+		if err := proto.Unmarshal([]byte(serializedResult), event); err != nil {
+			return nil, err
+		}
+		// Copy fields from the latest event to the output proto. proto.Merge()
+		// is a convenient way to do this. Note that this will concatenate
+		// repeated fields, which is fine for now since repeated fields are not
+		// currently populated as execution events.
+		proto.Merge(out, event)
+
+		// The scheduler attempts to prevent concurrent execution updates via
+		// task leasing, but this is not currently 100% reliable. So we ignore
+		// updates that happen after the initial attempt.
+		if event.GetStage() == int64(repb.ExecutionStage_COMPLETED) {
+			break
+		}
+	}
+	return out, nil
 }

--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
@@ -2,11 +2,13 @@ package redis_execution_collector_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_execution_collector"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -147,4 +149,56 @@ func TestGetInProgressExecutionsIgnoresDeletedExecutions(t *testing.T) {
 	executions, err := collector.GetInProgressExecutions(ctx, invocationID)
 	require.NoError(t, err)
 	require.Empty(t, executions)
+}
+
+func TestMergeExecutionUpdatesWithRepeatedFields(t *testing.T) {
+	rdb := testredis.Start(t)
+	collector := redis_execution_collector.New(rdb.Client())
+
+	executionID := "execution-123"
+	updates := []*repb.StoredExecution{
+		{
+			ExecutionId: executionID,
+			Stage:       int64(repb.ExecutionStage_EXECUTING),
+		},
+		{
+			ExecutionId: executionID,
+			Stage:       int64(repb.ExecutionStage_COMPLETED),
+		},
+	}
+
+	// Iterate over the fields of the StoredExecution proto and look for
+	// slice-valued fields.
+	sliceFields := map[string]struct{}{}
+	val := reflect.ValueOf(updates[0]).Elem()
+	for i := range val.NumField() {
+		field := val.Field(i)
+		if field.Kind() == reflect.Slice && field.CanSet() {
+			sliceFields[val.Type().Field(i).Name] = struct{}{}
+			// Allocate a new slice with the same type as the field, then set
+			// both the initial and updated values to the same slice (containing
+			// a single element with a zero value).
+			slice := reflect.MakeSlice(field.Type(), 1, 1)
+			field.Set(slice)
+			reflect.ValueOf(updates[1]).Elem().Field(i).Set(slice)
+		}
+	}
+
+	// Store all the updates then read them back.
+	ctx := context.Background()
+	for _, update := range updates {
+		err := collector.UpdateInProgressExecution(ctx, update)
+		require.NoError(t, err)
+	}
+	execution, err := collector.GetInProgressExecution(ctx, executionID)
+	require.NoError(t, err)
+
+	// Verify that the slice fields are merged correctly.
+	executionValue := reflect.ValueOf(execution).Elem()
+	for fieldName := range sliceFields {
+		// Make sure the slice has length 1.
+		if executionValue.FieldByName(fieldName).Len() != 1 {
+			assert.Failf(t, "unhandled slice field", "StoredExecution field %q was concatenated instead of overwritten by mergeExecutionUpdates - method needs updating?", fieldName)
+		}
+	}
 }

--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
@@ -1,0 +1,150 @@
+package redis_execution_collector_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_execution_collector"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	sipb "github.com/buildbuddy-io/buildbuddy/proto/stored_invocation"
+)
+
+func TestCollectExecutionUpdates(t *testing.T) {
+	rdb := testredis.Start(t)
+	collector := redis_execution_collector.New(rdb.Client())
+
+	executionID := "execution-123"
+	invocationID := "invocation-123"
+	invocationUUID := "invocation123"
+	updates := []*repb.StoredExecution{
+		{
+			ExecutionId:    executionID,
+			InvocationUuid: invocationUUID,
+			Stage:          int64(repb.ExecutionStage_QUEUED),
+			CommandSnippet: "echo Hello",
+		},
+		{
+			ExecutionId: executionID,
+			Stage:       int64(repb.ExecutionStage_EXECUTING),
+		},
+		{
+			ExecutionId:                  executionID,
+			Stage:                        int64(repb.ExecutionStage_COMPLETED),
+			ExitCode:                     1,
+			WorkerStartTimestampUsec:     1e6,
+			WorkerCompletedTimestampUsec: 2e6,
+		},
+		// Updates from duplicate attempts should be ignored. This can happen
+		// since the scheduler currently doesn't provide a guarantee that each
+		// execution is only completed once, though task leasing provides
+		// best-effort protection against duplicates.
+		{
+			ExecutionId: executionID,
+			Stage:       int64(repb.ExecutionStage_EXECUTING),
+		},
+		{
+			ExecutionId:                  executionID,
+			Stage:                        int64(repb.ExecutionStage_COMPLETED),
+			ExitCode:                     2,
+			WorkerStartTimestampUsec:     10e6,
+			WorkerCompletedTimestampUsec: 20e6,
+		},
+	}
+
+	// Add all updates to the collector.
+	ctx := context.Background()
+	for _, update := range updates {
+		err := collector.UpdateInProgressExecution(ctx, update)
+		require.NoError(t, err)
+	}
+
+	// Also add an invocation link, associating an invocation with the execution.
+	err := collector.AddInvocationLink(ctx, &sipb.StoredInvocationLink{
+		ExecutionId:  executionID,
+		InvocationId: invocationID,
+	}, true /*=storeReverseLink*/)
+	require.NoError(t, err)
+
+	// Read the updates back, using the execution ID.
+	execution, err := collector.GetInProgressExecution(ctx, executionID)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(&repb.StoredExecution{
+		ExecutionId:                  executionID,
+		InvocationUuid:               invocationUUID,
+		Stage:                        int64(repb.ExecutionStage_COMPLETED),
+		CommandSnippet:               "echo Hello",
+		ExitCode:                     1,
+		WorkerStartTimestampUsec:     1e6,
+		WorkerCompletedTimestampUsec: 2e6,
+	}, execution, protocmp.Transform()))
+
+	// Read the updates back, using the invocation ID (via the reverse link).
+	executions, err := collector.GetInProgressExecutions(ctx, invocationID)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*repb.StoredExecution{
+		{
+			ExecutionId:                  executionID,
+			InvocationUuid:               invocationUUID,
+			Stage:                        int64(repb.ExecutionStage_COMPLETED),
+			CommandSnippet:               "echo Hello",
+			ExitCode:                     1,
+			WorkerStartTimestampUsec:     1e6,
+			WorkerCompletedTimestampUsec: 2e6,
+		},
+	}, executions, protocmp.Transform()))
+
+	// Delete reverse invocation links; should no longer be able to look up
+	// in-progress executions by invocation ID.
+	err = collector.DeleteReverseInvocationLinks(ctx, invocationID)
+	require.NoError(t, err)
+	executions, err = collector.GetInProgressExecutions(ctx, invocationID)
+	require.NoError(t, err)
+	require.Nil(t, executions)
+
+	// Delete the in-progress execution.
+	err = collector.DeleteInProgressExecution(ctx, executionID)
+	require.NoError(t, err)
+
+	// Read the updates back again; should return nil.
+	execution, err = collector.GetInProgressExecution(ctx, executionID)
+	require.NoError(t, err)
+	require.Nil(t, execution)
+}
+
+func TestGetInProgressExecutionsIgnoresDeletedExecutions(t *testing.T) {
+	rdb := testredis.Start(t)
+	collector := redis_execution_collector.New(rdb.Client())
+
+	executionID := "execution-123"
+	invocationID := "invocation-123"
+	invocationUUID := "invocation123"
+
+	// Create an in-progress execution and add an invocation link.
+	ctx := context.Background()
+	err := collector.UpdateInProgressExecution(ctx, &repb.StoredExecution{
+		ExecutionId:    executionID,
+		InvocationUuid: invocationUUID,
+		Stage:          int64(repb.ExecutionStage_COMPLETED),
+	})
+	require.NoError(t, err)
+	err = collector.AddInvocationLink(ctx, &sipb.StoredInvocationLink{
+		ExecutionId:  executionID,
+		InvocationId: invocationID,
+	}, true /*=storeReverseLink*/)
+	require.NoError(t, err)
+
+	// Delete the in-progress execution.
+	err = collector.DeleteInProgressExecution(ctx, executionID)
+	require.NoError(t, err)
+
+	// Get the in-progress executions for the invocation; should return nil
+	// rather than a list with an empty/nil execution.
+	executions, err := collector.GetInProgressExecutions(ctx, invocationID)
+	require.NoError(t, err)
+	require.Empty(t, executions)
+}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -264,7 +264,7 @@ func (s *ExecutionServer) insertInvocationLinkInRedis(ctx context.Context, execu
 		ExecutionId:  executionID,
 		Type:         linkType,
 	}
-	return s.env.GetExecutionCollector().AddInvocationLink(ctx, link)
+	return s.env.GetExecutionCollector().AddInvocationLink(ctx, link, false /*=storeReverseLink*/)
 }
 
 func trimStatus(statusMessage string) string {

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -427,7 +427,7 @@ func (fc *fakeCollector) DeleteInvocationLinks(_ context.Context, _ string) erro
 	return nil
 }
 
-func (fc *fakeCollector) AddInvocationLink(_ context.Context, link *sipb.StoredInvocationLink) error {
+func (fc *fakeCollector) AddInvocationLink(_ context.Context, link *sipb.StoredInvocationLink, _ bool) error {
 	fc.invocationLinks = append(fc.invocationLinks, link)
 	return nil
 }


### PR DESCRIPTION
Split out from #9211 but added tests and cleaned things up slightly.

Currently, only completed executions are stored in Redis, and only while they are waiting for the invocation to be completed.

This PR adds the functionality needed to store in-progress[^1] executions as well, which would allow us to replace MySQL reads/writes with redis reads/writes. Once each execution is completed and moved to the existing list of completed executions (for each invocation), we'll delete the in-progress execution state in favor of the per-invocation execution lists (or the ClickHouse executions for the invocation, if the invocation is complete).

The new functionality is not used anywhere yet.

Context: https://docs.google.com/document/d/1qf-veFLjAVbXMCtAn1a5IVymWIAaqOBpoQiUO5EOPyk/view

[^1]: One potentially confusing thing is that we write the COMPLETED execution state to this entry in redis, even though it's referred to as the "in-progress" execution state. I wanted some way to differentiate this new list from the per-invocation execution lists which _also_ contain completed executions, but are just waiting for the invocation to complete (so that we can fill out the invocation-specific fields before flushing to ClickHouse). I figured since we move the execution from this "in-progress" list to the per-invocation "waiting to be flushed" lists immediately after it's complete, the "in-progress" naming almost always reflects the actual data that we're storing there, so this naming should hopefully be intuitive enough, but I'm open to better suggestions here :)