### PR TITLE
Support SkipRemote in FindMissing for CAS proxy

### DIFF
--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -34,6 +34,7 @@ go_test(
     deps = [
         "//enterprise/server/atime_updater",
         "//enterprise/server/byte_stream_server_proxy",
+        "//enterprise/server/util/proxy_util",
         "//proto:remote_execution_go_proto",
         "//server/remote_cache/byte_stream_server",
         "//server/remote_cache/cachetools",

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -94,7 +94,7 @@ func recordMetrics(op, status string, digestsPerStatus, bytesPerStatus map[strin
 
 func (s *CASServerProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMissingBlobsRequest) (*repb.FindMissingBlobsResponse, error) {
 	if proxy_util.SkipRemote(ctx) {
-		return nil, status.UnimplementedError("Skip remote not implemented")
+		return s.local.FindMissingBlobs(ctx, req)
 	}
 
 	ctx, spn := tracing.StartSpan(ctx)


### PR DESCRIPTION
[Workflows now call CASServer::FindMissing](https://github.com/buildbuddy-io/buildbuddy/pull/9232), so support SkipRemote in the proxy