### PR TITLE
[Cache Proxy] propagate subdomain to AuthService.Authenticate

### DIFF
--- a/enterprise/server/auth_service/BUILD
+++ b/enterprise/server/auth_service/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/real_environment",
         "//server/util/authutil",
         "//server/util/status",
+        "//server/util/subdomain",
     ],
 )
 

--- a/enterprise/server/auth_service/auth_service.go
+++ b/enterprise/server/auth_service/auth_service.go
@@ -22,7 +22,7 @@ func Register(env *real_environment.RealEnv) {
 
 func (a AuthService) Authenticate(ctx context.Context, req *authpb.AuthenticateRequest) (*authpb.AuthenticateResponse, error) {
 	// Override the subdomain with the one for which auth is requested
-	ctx = context.WithValue(ctx, subdomain.Key, req.GetSubdomain())
+	ctx = subdomain.Context(req.GetSubdomain(), ctx)
 	ctx = a.authenticator.AuthenticatedGRPCContext(ctx)
 	err, found := authutil.AuthErrorFromContext(ctx)
 	if found {

--- a/enterprise/server/auth_service/auth_service.go
+++ b/enterprise/server/auth_service/auth_service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
 )
@@ -20,6 +21,8 @@ func Register(env *real_environment.RealEnv) {
 }
 
 func (a AuthService) Authenticate(ctx context.Context, req *authpb.AuthenticateRequest) (*authpb.AuthenticateResponse, error) {
+	// Override the subdomain with the one for which auth is requested
+	ctx = context.WithValue(ctx, subdomain.Key, req.GetSubdomain())
 	ctx = a.authenticator.AuthenticatedGRPCContext(ctx)
 	err, found := authutil.AuthErrorFromContext(ctx)
 	if found {

--- a/enterprise/server/auth_service/auth_service.go
+++ b/enterprise/server/auth_service/auth_service.go
@@ -22,7 +22,7 @@ func Register(env *real_environment.RealEnv) {
 
 func (a AuthService) Authenticate(ctx context.Context, req *authpb.AuthenticateRequest) (*authpb.AuthenticateResponse, error) {
 	// Override the subdomain with the one for which auth is requested
-	ctx = subdomain.Context(req.GetSubdomain(), ctx)
+	ctx = subdomain.Context(ctx, req.GetSubdomain())
 	ctx = a.authenticator.AuthenticatedGRPCContext(ctx)
 	err, found := authutil.AuthErrorFromContext(ctx)
 	if found {

--- a/enterprise/server/remoteauth/BUILD
+++ b/enterprise/server/remoteauth/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/util/log",
         "//server/util/lru",
         "//server/util/status",
+        "//server/util/subdomain",
         "//server/util/tracing",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//metadata",

--- a/enterprise/server/remoteauth/BUILD
+++ b/enterprise/server/remoteauth/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//server/util/authutil",
         "//server/util/claims",
         "//server/util/status",
+        "//server/util/subdomain",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//metadata",

--- a/enterprise/server/remoteauth/remoteauth.go
+++ b/enterprise/server/remoteauth/remoteauth.go
@@ -138,7 +138,7 @@ func (a *RemoteAuthenticator) AuthenticatedGRPCContext(ctx context.Context) cont
 
 	key, err := claimsCacheKey(ctx)
 	if err != nil {
-		return authutil.AuthContextWithError(ctx, status.PermissionDeniedError("Missing API key"))
+		return authutil.AuthContextWithError(ctx, err)
 	}
 
 	// Try to use a locally-cached JWT, if available and valid.
@@ -220,10 +220,6 @@ func (a *RemoteAuthenticator) authenticate(ctx context.Context) (string, error) 
 		return "", status.InternalError("Authenticate succeeded with nil jwt")
 	}
 	return *resp.Jwt, nil
-}
-
-func getAPIKey(ctx context.Context) string {
-	return getLastMetadataValue(ctx, authutil.APIKeyHeader)
 }
 
 // Returns:

--- a/enterprise/server/remoteauth/remoteauth.go
+++ b/enterprise/server/remoteauth/remoteauth.go
@@ -3,7 +3,6 @@ package remoteauth
 import (
 	"context"
 	"flag"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -78,7 +77,7 @@ func claimsCacheKey(ctx context.Context) (string, error) {
 		return "", status.PermissionDeniedError("Missing API key")
 	}
 	sub := subdomain.Get(ctx)
-	return fmt.Sprintf("%s:%s", sub, key), nil
+	return sub + ":" + key, nil
 }
 
 type RemoteAuthenticator struct {
@@ -139,7 +138,7 @@ func (a *RemoteAuthenticator) AuthenticatedGRPCContext(ctx context.Context) cont
 
 	key, err := claimsCacheKey(ctx)
 	if err != nil {
-		authutil.AuthContextWithError(ctx, status.PermissionDeniedError("Missing API key"))
+		return authutil.AuthContextWithError(ctx, status.PermissionDeniedError("Missing API key"))
 	}
 
 	// Try to use a locally-cached JWT, if available and valid.

--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -177,7 +177,7 @@ func TestJwtExpiry(t *testing.T) {
 
 	// The JWT minted by the backend should be considered to expire too soon
 	// and should not be used.
-	fakeAuth.Reset().setNextJwt(t, fooJwt)
+	fakeAuth.Reset().setNextJwt(t, "", fooJwt)
 	ctx := authenticator.AuthenticatedGRPCContext(contextWithApiKey(t, "foo"))
 	require.Nil(t, ctx.Value(authutil.ContextTokenStringKey))
 }

--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -194,19 +194,19 @@ func TestSubdomains(t *testing.T) {
 
 	// Authenticate at foosub.buildbuddy.io with API key foo
 	fakeAuth.Reset().setNextJwt(t, "foosub", fooJwt)
-	ctx := subdomain.Context("foosub", contextWithApiKey(t, "foo"))
+	ctx := subdomain.Context(contextWithApiKey(t, "foo"), "foosub")
 	ctx = authenticator.AuthenticatedGRPCContext(ctx)
 	require.Equal(t, fooJwt, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Ensure that JWT is not cached for a different subdomain
 	fakeAuth.Reset().setNextJwt(t, "barsub", barJwt)
-	ctx = subdomain.Context("barsub", contextWithApiKey(t, "foo"))
+	ctx = subdomain.Context(contextWithApiKey(t, "foo"), "barsub")
 	ctx = authenticator.AuthenticatedGRPCContext(ctx)
 	require.Equal(t, barJwt, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Also ensure API key bar doesn't work for foosub.buildbuddy.io
 	fakeAuth.Reset().setNextJwt(t, "foosub", bazJwt)
-	ctx = subdomain.Context("foosub", contextWithApiKey(t, "bar"))
+	ctx = subdomain.Context(contextWithApiKey(t, "bar"), "foosub")
 	ctx = authenticator.AuthenticatedGRPCContext(ctx)
 	require.Equal(t, bazJwt, ctx.Value(authutil.ContextTokenStringKey))
 }

--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -14,13 +14,14 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"google.golang.org/grpc/metadata"
 )
 
 type fakeAuthService struct {
-	nextJwt string
-	nextErr error
+	nextJwt map[string]string
+	nextErr map[string]error
 
 	mu sync.Mutex
 }
@@ -28,35 +29,35 @@ type fakeAuthService struct {
 func (a *fakeAuthService) Reset() *fakeAuthService {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.nextErr = nil
-	a.nextJwt = ""
+	a.nextErr = map[string]error{}
+	a.nextJwt = map[string]string{}
 	return a
 }
 
-func (a *fakeAuthService) setNextJwt(t *testing.T, jwt string) {
+func (a *fakeAuthService) setNextJwt(t *testing.T, sub, jwt string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	require.NoError(t, a.nextErr)
-	a.nextJwt = jwt
+	require.NoError(t, a.nextErr[sub])
+	a.nextJwt[sub] = jwt
 }
 
-func (a *fakeAuthService) setNextErr(t *testing.T, err error) {
+func (a *fakeAuthService) setNextErr(t *testing.T, sub string, err error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	require.Equal(t, "", a.nextJwt)
-	a.nextErr = err
+	require.Equal(t, "", a.nextJwt[sub])
+	a.nextErr[sub] = err
 }
 
 func (a *fakeAuthService) Authenticate(ctx context.Context, req *authpb.AuthenticateRequest) (*authpb.AuthenticateResponse, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.nextErr != nil {
-		err := a.nextErr
+	if a.nextErr[req.GetSubdomain()] != nil {
+		err := a.nextErr[req.GetSubdomain()]
 		a.nextErr = nil
 		return nil, err
 	}
-	jwt := a.nextJwt
-	a.nextJwt = ""
+	jwt := a.nextJwt[req.GetSubdomain()]
+	a.nextJwt[req.GetSubdomain()] = ""
 	return &authpb.AuthenticateResponse{Jwt: &jwt}, nil
 }
 
@@ -114,49 +115,49 @@ func TestAuthenticatedGRPCContext(t *testing.T) {
 	require.NotEqual(t, barJwt, bazJwt)
 
 	// Fail if there are no auth headers.
-	fakeAuth.setNextJwt(t, validJwt(t, "nothing"))
+	fakeAuth.setNextJwt(t, "", validJwt(t, "nothing"))
 	ctx := authenticator.AuthenticatedGRPCContext(context.Background())
 	require.Equal(t, nil, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Don't cache responses for missing auth headers.
-	fakeAuth.Reset().setNextJwt(t, validJwt(t, "nothing"))
+	fakeAuth.Reset().setNextJwt(t, "", validJwt(t, "nothing"))
 	ctx = authenticator.AuthenticatedGRPCContext(context.Background())
 	require.Equal(t, nil, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Error case.
-	fakeAuth.Reset().setNextErr(t, status.InternalError("error"))
+	fakeAuth.Reset().setNextErr(t, "", status.InternalError("error"))
 	ctx = authenticator.AuthenticatedGRPCContext(context.Background())
 	require.Nil(t, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Error case with API Key.
-	fakeAuth.Reset().setNextErr(t, status.InternalError("error"))
+	fakeAuth.Reset().setNextErr(t, "", status.InternalError("error"))
 	ctx = authenticator.AuthenticatedGRPCContext(contextWithApiKey(t, "foo"))
 	require.Nil(t, ctx.Value(authutil.ContextTokenStringKey))
 	err, _ := authutil.AuthErrorFromContext(ctx)
 	require.True(t, status.IsInternalError(err))
 
 	// Don't cache errors.
-	fakeAuth.Reset().setNextJwt(t, fooJwt)
+	fakeAuth.Reset().setNextJwt(t, "", fooJwt)
 	ctx = authenticator.AuthenticatedGRPCContext(contextWithApiKey(t, "foo"))
 	require.Equal(t, fooJwt, ctx.Value(authutil.ContextTokenStringKey))
 
 	// The next auth attempt should be cached.
-	fakeAuth.Reset().setNextJwt(t, barJwt)
+	fakeAuth.Reset().setNextJwt(t, "", barJwt)
 	ctx = authenticator.AuthenticatedGRPCContext(contextWithApiKey(t, "foo"))
 	require.Equal(t, fooJwt, ctx.Value(authutil.ContextTokenStringKey))
 
 	// But a different API Key should re-remotely-auth
-	fakeAuth.Reset().setNextJwt(t, barJwt)
+	fakeAuth.Reset().setNextJwt(t, "", barJwt)
 	ctx = authenticator.AuthenticatedGRPCContext(contextWithApiKey(t, "bar"))
 	require.Equal(t, barJwt, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Valid JWTs should be passed through
-	fakeAuth.Reset().setNextJwt(t, bazJwt)
+	fakeAuth.Reset().setNextJwt(t, "", bazJwt)
 	ctx = authenticator.AuthenticatedGRPCContext(contextWithJwt(t, bazJwt))
 	require.Equal(t, bazJwt, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Invalid JWTs should return an error
-	fakeAuth.Reset().setNextJwt(t, "invalid")
+	fakeAuth.Reset().setNextJwt(t, "", "invalid")
 	ctx = authenticator.AuthenticatedGRPCContext(contextWithJwt(t, "baz"))
 	require.Nil(t, ctx.Value(authutil.ContextTokenStringKey))
 	err, _ = authutil.AuthErrorFromContext(ctx)
@@ -176,4 +177,30 @@ func TestJwtExpiry(t *testing.T) {
 	fakeAuth.Reset().setNextJwt(t, fooJwt)
 	ctx := authenticator.AuthenticatedGRPCContext(contextWithApiKey(t, "foo"))
 	require.Nil(t, ctx.Value(authutil.ContextTokenStringKey))
+}
+
+func TestSubdomains(t *testing.T) {
+	_, fakeAuth := setup(t)
+
+	fooJwt := validJwt(t, "foo")
+	barJwt := validJwt(t, "bar")
+	bazJwt := validJwt(t, "baz")
+	require.NotEqual(t, fooJwt, barJwt)
+	require.NotEqual(t, fooJwt, bazJwt)
+	require.NotEqual(t, barJwt, bazJwt)
+
+	// Authenticate at foosub.buildbuddy.io with API key foo
+	fakeAuth.Reset().setNextJwt(t, "foosub", fooJwt)
+	ctx := context.WithValue(contextWithApiKey(t, "foo"), subdomain.Key, "foosub")
+	require.Equal(t, fooJwt, ctx.Value(authutil.ContextTokenStringKey))
+
+	// Ensure that JWT is not cached for a different subdomain
+	fakeAuth.Reset().setNextJwt(t, "barsub", barJwt)
+	ctx = context.WithValue(contextWithApiKey(t, "foo"), subdomain.Key, "barsub")
+	require.Equal(t, barJwt, ctx.Value(authutil.ContextTokenStringKey))
+
+	// Also ensure API key bar doesn't work for foosub.buildbuddy.io
+	fakeAuth.Reset().setNextJwt(t, "foosub", bazJwt)
+	ctx = context.WithValue(contextWithApiKey(t, "bar"), subdomain.Key, "foosub")
+	require.Equal(t, bazJwt, ctx.Value(authutil.ContextTokenStringKey))
 }

--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -194,19 +194,19 @@ func TestSubdomains(t *testing.T) {
 
 	// Authenticate at foosub.buildbuddy.io with API key foo
 	fakeAuth.Reset().setNextJwt(t, "foosub", fooJwt)
-	ctx := context.WithValue(contextWithApiKey(t, "foo"), subdomain.Key, "foosub")
+	ctx := subdomain.Context("foosub", contextWithApiKey(t, "foo"))
 	ctx = authenticator.AuthenticatedGRPCContext(ctx)
 	require.Equal(t, fooJwt, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Ensure that JWT is not cached for a different subdomain
 	fakeAuth.Reset().setNextJwt(t, "barsub", barJwt)
-	ctx = context.WithValue(contextWithApiKey(t, "foo"), subdomain.Key, "barsub")
+	ctx = subdomain.Context("barsub", contextWithApiKey(t, "foo"))
 	ctx = authenticator.AuthenticatedGRPCContext(ctx)
 	require.Equal(t, barJwt, ctx.Value(authutil.ContextTokenStringKey))
 
 	// Also ensure API key bar doesn't work for foosub.buildbuddy.io
 	fakeAuth.Reset().setNextJwt(t, "foosub", bazJwt)
-	ctx = context.WithValue(contextWithApiKey(t, "bar"), subdomain.Key, "foosub")
+	ctx = subdomain.Context("foosub", contextWithApiKey(t, "bar"))
 	ctx = authenticator.AuthenticatedGRPCContext(ctx)
 	require.Equal(t, bazJwt, ctx.Value(authutil.ContextTokenStringKey))
 }

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -3,8 +3,11 @@ syntax = "proto3";
 
 package auth;
 
-// Authentication information is passed via headers.
-message AuthenticateRequest {}
+// Most Authentication information (API key, source IP) is passed via headers.
+message AuthenticateRequest {
+  // The subdomain to which the request was sent.
+  optional string subdomain = 1;
+}
 
 message AuthenticateResponse {
   // JWT that may be cached short-term for local authentication.

--- a/server/util/subdomain/subdomain.go
+++ b/server/util/subdomain/subdomain.go
@@ -42,7 +42,7 @@ func SetHost(ctx context.Context, host string) context.Context {
 			return ctx
 		}
 	}
-	return Context(subdomain, ctx)
+	return Context(ctx, subdomain)
 }
 
 func Context(ctx context.Context, subdomain string) context.Context {

--- a/server/util/subdomain/subdomain.go
+++ b/server/util/subdomain/subdomain.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/urlutil"
 )
 
-const subdomainKey = "subdomain"
+const Key = "subdomain"
 
 var (
 	enableSubdomainMatching = flag.Bool("app.enable_subdomain_matching", false, "If true, request subdomain will be taken into account when determining what request restrictions should be applied.")
@@ -42,13 +42,13 @@ func SetHost(ctx context.Context, host string) context.Context {
 			return ctx
 		}
 	}
-	return context.WithValue(ctx, subdomainKey, subdomain)
+	return context.WithValue(ctx, Key, subdomain)
 }
 
 // Get returns the subdomain restriction that should be applied or an empty
 // string if no subdomain restrictions should be applied.
 func Get(ctx context.Context) string {
-	v, _ := ctx.Value(subdomainKey).(string)
+	v, _ := ctx.Value(Key).(string)
 	return v
 }
 

--- a/server/util/subdomain/subdomain.go
+++ b/server/util/subdomain/subdomain.go
@@ -45,7 +45,7 @@ func SetHost(ctx context.Context, host string) context.Context {
 	return Context(subdomain, ctx)
 }
 
-func Context(subdomain string, ctx context.Context) context.Context {
+func Context(ctx context.Context, subdomain string) context.Context {
 	return context.WithValue(ctx, key, subdomain)
 }
 

--- a/server/util/subdomain/subdomain.go
+++ b/server/util/subdomain/subdomain.go
@@ -13,7 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/urlutil"
 )
 
-const Key = "subdomain"
+const key = "subdomain"
 
 var (
 	enableSubdomainMatching = flag.Bool("app.enable_subdomain_matching", false, "If true, request subdomain will be taken into account when determining what request restrictions should be applied.")
@@ -42,13 +42,17 @@ func SetHost(ctx context.Context, host string) context.Context {
 			return ctx
 		}
 	}
-	return context.WithValue(ctx, Key, subdomain)
+	return Context(subdomain, ctx)
+}
+
+func Context(subdomain string, ctx context.Context) context.Context {
+	return context.WithValue(ctx, key, subdomain)
 }
 
 // Get returns the subdomain restriction that should be applied or an empty
 // string if no subdomain restrictions should be applied.
 func Get(ctx context.Context) string {
-	v, _ := ctx.Value(Key).(string)
+	v, _ := ctx.Value(key).(string)
 	return v
 }
 


### PR DESCRIPTION
This is a no-op without `--app.enable_subdomain_matching` which is false by default and in production Cache Proxies. But this makes it possible (with that flag and a couple others) to authenticate against a subdomain.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4870