### PR TITLE
[raft] fix TestCleanupZombieRangeDescriptorNotInMetaRange

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -261,10 +261,6 @@ func TestCleanupZombieRangeDescriptorNotInMetaRange(t *testing.T) {
 	err = rbuilder.NewBatchResponseFromProto(writeRsp).AnyError()
 	require.NoError(t, err)
 
-	log.Infof("deleted key: %q, rd2.GetEnd=%q", keys.RangeMetaKey(rd2.GetEnd()), rd2.GetEnd())
-
-	log.Info("====set up complete")
-
 	for {
 		clock.Advance(11 * time.Second)
 		list1, err := s1.ListReplicas(ctx, &rfpb.ListReplicasRequest{})

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -222,7 +222,6 @@ func TestCleanupZombieInitialMembersNotSetUp(t *testing.T) {
 }
 
 func TestCleanupZombieRangeDescriptorNotInMetaRange(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	// Prevent driver kicks in to add the replica back to the store.
 	flags.Set(t, "cache.raft.enable_driver", false)
 
@@ -237,7 +236,18 @@ func TestCleanupZombieRangeDescriptorNotInMetaRange(t *testing.T) {
 	stores := []*testutil.TestingStore{s1, s2, s3}
 	sf.StartShard(t, ctx, stores...)
 
-	rd2 := s1.GetRange(2)
+	var rd2 *rfpb.RangeDescriptor
+	start := time.Now()
+	for {
+		rd2 = s1.GetRange(2)
+		if len(rd2.GetEnd()) > 0 {
+			break
+		}
+		if time.Since(start) > 30*time.Second {
+			require.Fail(t, "failed to get non-empty range descriptor for range 2")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	deleteRDBatch, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectDeleteRequest{
 		Key: keys.RangeMetaKey(rd2.GetEnd()),
@@ -250,6 +260,10 @@ func TestCleanupZombieRangeDescriptorNotInMetaRange(t *testing.T) {
 	require.NoError(t, err)
 	err = rbuilder.NewBatchResponseFromProto(writeRsp).AnyError()
 	require.NoError(t, err)
+
+	log.Infof("deleted key: %q, rd2.GetEnd=%q", keys.RangeMetaKey(rd2.GetEnd()), rd2.GetEnd())
+
+	log.Info("====set up complete")
 
 	for {
 		clock.Advance(11 * time.Second)


### PR DESCRIPTION
buildbuddy-io/buildbuddy-internal#4192

Sometimes GetRange will return empty start and end for range 2 in the test.
Added a for loop to make sure we get an non empty range.

https://app.buildbuddy.io/invocation/0d435d29-5e59-49a6-ac12-a83390265b8d