### PR TITLE
coverage_card: fix sorting logic

### DIFF
--- a/app/invocation/invocation_coverage_card.tsx
+++ b/app/invocation/invocation_coverage_card.tsx
@@ -6,7 +6,7 @@ import Button from "../components/button/button";
 import { ListChecks } from "lucide-react";
 import errorService from "../errors/error_service";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
-import { parseLcov } from "../util/lcov";
+import { LcovItem, parseLcov } from "../util/lcov";
 import format from "../format/format";
 import { percentageColor } from "../util/color";
 import { TextLink } from "../components/link/link";
@@ -16,7 +16,7 @@ interface Props {
 }
 
 interface State {
-  report: any[] | null;
+  report: Array<LcovItem> | null;
   loading: boolean;
   sort: "file" | "most" | "least";
 }
@@ -128,12 +128,14 @@ export default class InvocationCoverageCardComponent extends React.Component<Pro
     this.setState({ sort: sort });
   }
 
-  sort(a: any, b: any) {
+  sort(a: LcovItem, b: LcovItem) {
+    let aratio = a.numLinesFound === 0 ? 0 : a.numLinesHit / a.numLinesFound;
+    let bratio = b.numLinesFound === 0 ? 0 : b.numLinesHit / b.numLinesFound;
     if (this.state.sort == "most") {
-      return b.numLinesHit / b.numLinesFound - a.numLinesHit / a.numLinesFound;
+      return bratio - aratio;
     }
     if (this.state.sort == "least") {
-      return a.numLinesHit / a.numLinesFound - b.numLinesHit / b.numLinesFound;
+      return aratio - bratio;
     }
 
     return a.sourceFile.localeCompare(b.sourceFile);

--- a/app/util/lcov.ts
+++ b/app/util/lcov.ts
@@ -1,11 +1,26 @@
 /**
  * Takes an lcov file an input and returns a structured lcov object
  */
-export function parseLcov(input: string) {
+
+export interface LcovItem {
+  sourceFile: string;
+  testName: string;
+  functionName: string;
+  numFunctionsFound: number;
+  numFunctionsHit: number;
+  branchData: string[];
+  branchesFound: number;
+  branchesHit: number;
+  data: string[];
+  numLinesFound: number;
+  numLinesHit: number;
+}
+
+export function parseLcov(input: string): Array<LcovItem> {
   const records = input.split("end_of_record");
-  let items = [];
+  let items: Array<LcovItem> = [];
   for (let record of records) {
-    let item = {
+    let item: LcovItem = {
       sourceFile: "",
       testName: "",
       functionName: "",


### PR DESCRIPTION
Sorting was not working properly if there are files with zero lines
found. That caused a divided-by-zero bug, which is now shortcuted by a
zero check.

Also added proper typing for lcov entries parsed from the coverage
report file.
