### PR TITLE
[SS] Fix skipped bytes metric

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -1078,7 +1078,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 	if cacheOpts.SkippedCacheRemotely {
 		metrics.COWSnapshotSkippedRemoteBytes.With(prometheus.Labels{
 			metrics.FileName: name,
-		}).Add(float64(compressedBytesWrittenRemotely))
+		}).Add(float64(dirtyBytes))
 	}
 
 	for chunkSrc, count := range chunkSourceCounter {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1458,7 +1458,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",
 		Name:      "cow_snapshot_skipped_remote_bytes",
-		Help:      "The number of compressed bytes that would not be written to the remote cache if stricter remote write logic was applied.",
+		Help:      "The number of uncompressed bytes that were not written to the remote cache due to only writing locally.",
 	}, []string{
 		FileName,
 	})


### PR DESCRIPTION
If we don't write data to the remote cache, `compressedBytesWrittenRemotely` is 0. Track `dirtyBytes` instead, as a proxy for how much data we would've written (though it's the uncompressed value).