### PR TITLE
Fix crash due to thread-unsafe usage of tokenizers in codesearch

### DIFF
--- a/codesearch/schema/BUILD
+++ b/codesearch/schema/BUILD
@@ -19,5 +19,6 @@ go_test(
         ":schema",
         "//codesearch/token",
         "//codesearch/types",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/codesearch/schema/schema_test.go
+++ b/codesearch/schema/schema_test.go
@@ -6,46 +6,30 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/codesearch/schema"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/token"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMakeField(t *testing.T) {
 	fschema, err := schema.NewFieldSchema(types.KeywordField, "test", true)
-	if err != nil {
-		t.Fatalf("Failed to create field schema: %v", err)
-	}
-	if fschema.Type() != types.KeywordField {
-		t.Errorf("Expected field type %v, got %v", types.KeywordField, fschema.Type())
-	}
-	if fschema.Name() != "test" {
-		t.Errorf("Expected field name %q, got %q", "test", fschema.Name())
-	}
-	if fschema.Stored() != true {
-		t.Errorf("Expected field stored %v, got %v", true, fschema.Stored())
-	}
-	if fschema.Tokenizer() == nil {
-		// Tokenizer type mappings covered in other tests below.
-		t.Errorf("Expected field tokenizer %v, got %v", nil, fschema.Tokenizer())
-	}
+	assert.Nil(t, err, "Expected no error creating field schema")
+
+	assert.Equal(t, fschema.Type(), types.KeywordField)
+	assert.Equal(t, fschema.Name(), "test")
+	assert.Equal(t, fschema.Stored(), true)
+	// Tokenizer type mappings covered in other tests below.
+	assert.NotNil(t, fschema.MakeTokenizer())
 }
 
 func testInvalidName(t *testing.T, name string) {
 	fschema, err := schema.NewFieldSchema(types.KeywordField, name, true)
-	if err == nil {
-		t.Fatalf("Expected error for invalid field name %q, got %v", name, fschema)
-	}
-	if fschema != nil {
-		t.Errorf("Expected nil field schema for invalid name %q, got %v", name, fschema)
-	}
+	assert.NotNilf(t, err, "Expected error for invalid field name %q", name)
+	assert.Nil(t, fschema, "Expected nil field schema for invalid name %q", name)
 }
 
 func testValidName(t *testing.T, name string) {
 	fschema, err := schema.NewFieldSchema(types.KeywordField, name, true)
-	if err != nil {
-		t.Fatalf("Expected no error for valid field name %q, got %v", name, err)
-	}
-	if fschema == nil {
-		t.Errorf("Expected non-nil field schema for valid name %q, got %v", name, fschema)
-	}
+	assert.Nil(t, err, "Expected no error creating field schema for valid name %q", name)
+	assert.NotNil(t, fschema, "Expected non-nil field schema for valid name %q", name)
 }
 
 func TestFieldNamePatterns(t *testing.T) {
@@ -61,66 +45,39 @@ func TestFieldNamePatterns(t *testing.T) {
 
 func TestNgramTokenizer(t *testing.T) {
 	fschema, err := schema.NewFieldSchema(types.SparseNgramField, "test", true)
-	if err != nil {
-		t.Fatalf("Failed to create field schema: %v", err)
-	}
-	tok := fschema.Tokenizer()
-	if tok == nil {
-		t.Errorf("Expected non-nil tokenizer, got nil")
-	}
-	// Check that the tokenizer is of the expected type.
-	if _, ok := tok.(*token.SparseNgramTokenizer); !ok {
-		t.Errorf("Expected SparseNgramTokenizer, got %T", tok)
-	}
+	assert.Nil(t, err, "Expected no error creating field schema")
+
+	tok := fschema.MakeTokenizer()
+	assert.NotNil(t, tok, "Expected non-nil tokenizer")
+	assert.IsType(t, &token.SparseNgramTokenizer{}, tok)
 }
 
 func TestTrigramTokenizer(t *testing.T) {
 	fschema, err := schema.NewFieldSchema(types.TrigramField, "test", true)
-	if err != nil {
-		t.Fatalf("Failed to create field schema: %v", err)
-	}
-	tok := fschema.Tokenizer()
-	if tok == nil {
-		t.Errorf("Expected non-nil tokenizer, got nil")
-	}
-	// Check that the tokenizer is of the expected type.
-	if _, ok := tok.(*token.TrigramTokenizer); !ok {
-		t.Errorf("Expected TrigramTokenizer, got %T", tok)
-	}
+	assert.Nil(t, err, "Expected no error creating field schema")
+
+	tok := fschema.MakeTokenizer()
+	assert.NotNil(t, tok, "Expected non-nil tokenizer")
+	assert.IsType(t, &token.TrigramTokenizer{}, tok)
 }
 
 func TestKeywordTokenizer(t *testing.T) {
 	fschema, err := schema.NewFieldSchema(types.KeywordField, "test", true)
-	if err != nil {
-		t.Fatalf("Failed to create field schema: %v", err)
-	}
-	tok := fschema.Tokenizer()
-	if tok == nil {
-		t.Errorf("Expected non-nil tokenizer, got nil")
-	}
-	// Check that the tokenizer is of the expected type.
-	if _, ok := tok.(*token.WhitespaceTokenizer); !ok {
-		t.Errorf("Expected WhitespaceTokenizer, got %T", tok)
-	}
+	assert.Nil(t, err, "Expected no error creating field schema")
+
+	tok := fschema.MakeTokenizer()
+	assert.NotNil(t, tok, "Expected non-nil tokenizer")
+	assert.IsType(t, &token.WhitespaceTokenizer{}, tok)
 }
 
 func TestInvalidTokenizer(t *testing.T) {
 	fschema, err := schema.NewFieldSchema(100, "test", true)
-	if err == nil {
-		t.Fatalf("Expected error for invalid field type, got %v", fschema)
-	}
-	if fschema != nil {
-		t.Errorf("Expected nil field schema for invalid type, got %v", fschema)
-	}
+	assert.NotNil(t, err)
+	assert.Nil(t, fschema)
 }
 
 func TestFieldSchemaString(t *testing.T) {
 	fschema, err := schema.NewFieldSchema(types.KeywordField, "test", true)
-	if err != nil {
-		t.Fatalf("Failed to create field schema: %v", err)
-	}
-	expected := `FieldSchema<type: KeywordToken, name: "test", stored: true>`
-	if fschema.String() != expected {
-		t.Errorf("Expected %q, got %q", expected, fschema.String())
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, `FieldSchema<type: KeywordToken, name: "test", stored: true>`, fschema.String())
 }

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -32,7 +32,7 @@ type FieldSchema interface {
 	Type() FieldType
 	Name() string
 	Stored() bool
-	Tokenizer() Tokenizer
+	MakeTokenizer() Tokenizer
 	MakeField([]byte) Field
 	String() string
 }


### PR DESCRIPTION
Tokenizers are not threadsafe. In this change, Tokenizers are now created on-demand and cached on Writer instances. This avoids reuse of a single tokenizer instance across multiple Writers. Writers themselves are not shared across threads currently. This crash was introduced in #9255.

Note that there is a larger issue here around updating the same document concurrently with multiple writers, but this change is intended to get us back to a non-crashing state before addressing this larger issue.