### PR TITLE
Bugfix: Prevent codesearch from returning matches that don't fully match

### DIFF
--- a/codesearch/query/BUILD
+++ b/codesearch/query/BUILD
@@ -26,7 +26,9 @@ go_test(
     ],
     embed = [":query"],
     deps = [
+        "//codesearch/schema",
         "//codesearch/token",
+        "//codesearch/types",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/codesearch/query/regexp.go
+++ b/codesearch/query/regexp.go
@@ -13,7 +13,6 @@ import (
 	"unicode"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/token"
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
 // A Query is a matching machine, like a regular expression,
@@ -402,18 +401,13 @@ func (q *Query) SQuery(fieldName string) string {
 
 // RegexpQuery returns a Query for the given regexp.
 func RegexpQuery(re *syntax.Regexp, mods ...token.Option) *Query {
-	log.Info(fmt.Sprintf("origianl syntax.Regexp: %s", re.String()))
-
 	opts := token.DefaultOptions()
 	for _, mod := range mods {
 		mod(opts)
 	}
 	info := analyze(re, opts)
-	log.Info(fmt.Sprintf("regexp before simplify: %s", info.match))
 	info.simplify(true)
-	log.Info(fmt.Sprintf("regexp after simplify: %s", info.match))
 	info.addExact()
-	log.Info(fmt.Sprintf("regexp after addExact: %s", info.match))
 	return info.match
 }
 

--- a/codesearch/query/regexp.go
+++ b/codesearch/query/regexp.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/token"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
 // A Query is a matching machine, like a regular expression,
@@ -401,13 +402,18 @@ func (q *Query) SQuery(fieldName string) string {
 
 // RegexpQuery returns a Query for the given regexp.
 func RegexpQuery(re *syntax.Regexp, mods ...token.Option) *Query {
+	log.Info(fmt.Sprintf("origianl syntax.Regexp: %s", re.String()))
+
 	opts := token.DefaultOptions()
 	for _, mod := range mods {
 		mod(opts)
 	}
 	info := analyze(re, opts)
+	log.Info(fmt.Sprintf("regexp before simplify: %s", info.match))
 	info.simplify(true)
+	log.Info(fmt.Sprintf("regexp after simplify: %s", info.match))
 	info.addExact()
+	log.Info(fmt.Sprintf("regexp after addExact: %s", info.match))
 	return info.match
 }
 

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -227,7 +227,12 @@ func expressionToSquery(expr string, fieldName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return RegexpQuery(syn).SQuery(fieldName), nil
+	log.Info(fmt.Sprintf("regexp: %s, top op: %s %v", syn, syn.Op, syn.Sub))
+	r := RegexpQuery(syn)
+	log.Info(fmt.Sprintf("regexp query: %s", r))
+	s := r.SQuery(fieldName)
+	log.Info(fmt.Sprintf("squery: %s", s))
+	return s, nil
 }
 
 func NewReQuery(ctx context.Context, q string) (*ReQuery, error) {
@@ -250,6 +255,8 @@ func NewReQuery(ctx context.Context, q string) (*ReQuery, error) {
 	}
 
 	q, filename := filters.ExtractFilenameFilter(q)
+	log.Info(fmt.Sprintf("filename filter: %s", filename))
+
 	if len(filename) > 0 {
 		subQ, err := expressionToSquery(filename, filenameField)
 		if err != nil {

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -337,6 +337,11 @@ func NewReQuery(ctx context.Context, q string) (*ReQuery, error) {
 			required: true,
 		}
 
+		// TODO(jdelfino): Is this a no-op?
+		// We would use this when: we have short atoms that aren't looked up in the index...
+		// then we get docs back that don't fully match in content, but do match in the
+		// filename... I don't think this is useful. We're not actually also looking up filenames.
+
 		// If there is a content matcher, and there is not already a
 		// filename matcher, allow filenames that match the query too.
 		if _, ok := fieldMatchers[filenameField]; !ok {

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -241,9 +241,7 @@ func expressionToSquery(expr string, fieldName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	r := RegexpQuery(syn)
-	s := r.SQuery(fieldName)
-	return s, nil
+	return RegexpQuery(syn).SQuery(fieldName), nil
 }
 
 func NewReQuery(ctx context.Context, q string) (*ReQuery, error) {

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -110,9 +110,9 @@ func (s *reScorer) Score(docMatch types.DocumentMatch, doc types.Document) float
 		matchingRegions := match(re.Clone(), field.Contents())
 		f_qi_d := float64(len(matchingRegions))
 		if f_qi_d == 0 {
-			// HACK? If any of the field matchers fail entirely, it's not a match.
-			// This is only valid if all the field matchers are required, which
-			// they are in the current implementation.
+			// Important note: If any of the field matchers fail entirely, it's not a match.
+			// This is only valid if all the field matchers are required, which was true at the
+			// time this was added.
 			return 0.0
 		}
 		D := float64(len(strings.Fields(string(field.Contents()))))
@@ -323,6 +323,10 @@ func NewReQuery(ctx context.Context, q string) (*ReQuery, error) {
 		}
 	}
 	subLog.Infof("parsed query: [%s]", q)
+
+	// Here we build the squery as a conjunction of all the clauses.
+	// If we ever add support for OR clauses between query terms, the scoring logic will need
+	// to be updated as well. The scorer currently assumes that all fieldMatchers must match.
 
 	squery := ""
 	if len(sQueries) == 1 {

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testSchema = schema.NewDocumentSchema(
+	[]types.FieldSchema{
+		schema.MustFieldSchema(types.KeywordField, "id", true),
+		schema.MustFieldSchema(types.TrigramField, "filename", true),
+		schema.MustFieldSchema(types.SparseNgramField, "content", true),
+		schema.MustFieldSchema(types.KeywordField, "lang", true),
+	},
+)
+
+func newTestDocument(t *testing.T, fieldMap map[string][]byte) types.Document {
+	doc, err := testSchema.MakeDocument(fieldMap)
+	if err != nil {
+		t.Fatalf("failed to create test document: %v", err)
+	}
+	return doc
+}
+
 func TestCaseSensitive(t *testing.T) {
 	ctx := context.Background()
 	q, err := NewReQuery(ctx, "case:y foo")
@@ -173,27 +190,6 @@ func TestUngroupedTerms(t *testing.T) {
 	fieldMatchers := q.TestOnlyFieldMatchers()
 	require.Contains(t, fieldMatchers, "content")
 	assert.Contains(t, fieldMatchers["content"].String(), "(grp)|(trm)")
-}
-
-// define schema
-// make test doc
-// call score on individual docs
-
-var testSchema = schema.NewDocumentSchema(
-	[]types.FieldSchema{
-		schema.MustFieldSchema(types.KeywordField, "id", true),
-		schema.MustFieldSchema(types.TrigramField, "filename", true),
-		schema.MustFieldSchema(types.SparseNgramField, "content", true),
-		schema.MustFieldSchema(types.KeywordField, "lang", true),
-	},
-)
-
-func newTestDocument(t *testing.T, fieldMap map[string][]byte) types.Document {
-	doc, err := testSchema.MakeDocument(fieldMap)
-	if err != nil {
-		t.Fatalf("failed to create test document: %v", err)
-	}
-	return doc
 }
 
 func TestScoringMatchContentOnly(t *testing.T) {

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -106,3 +106,22 @@ func TestUngroupedTerms(t *testing.T) {
 	require.Contains(t, fieldMatchers, "content")
 	assert.Contains(t, fieldMatchers["content"].String(), "(grp)|(trm)")
 }
+
+// define schema
+// make test doc
+// call score on individual docs
+func TestScoringSingleMatch(t *testing.T) {
+	ctx := context.Background()
+	q, err := NewReQuery(ctx, "foo")
+	require.NoError(t, err)
+
+	scorer := q.Scorer()
+	require.NotNil(t, scorer)
+
+	squery := string(q.SQuery())
+	assert.Contains(t, squery, `(:eq content "foo")`)
+
+	fieldMatchers := q.TestOnlyFieldMatchers()
+	require.Contains(t, fieldMatchers, "content")
+	assert.Contains(t, fieldMatchers["content"].String(), "foo")
+}

--- a/codesearch/searcher/searcher.go
+++ b/codesearch/searcher/searcher.go
@@ -78,6 +78,10 @@ func (c *CodeSearcher) scoreDocs(scorer types.Scorer, matches []types.DocumentMa
 	scoreMap := make(map[uint64]float64, numDocs)
 	var mu sync.Mutex
 
+	// TODO(jdelfino): Rework this - discard docs with 0 score. Estimate
+	// when to stop scoring based on the number of docs scored, stdev of scores
+	// so far, and the number of docs remaining. This is a heuristic, but it should be
+	// better than scoring all docs.
 	// TODO(tylerw): use a priority-queue; stop iteration early.
 	g := new(errgroup.Group)
 	g.SetLimit(runtime.GOMAXPROCS(0))

--- a/codesearch/searcher/searcher.go
+++ b/codesearch/searcher/searcher.go
@@ -51,6 +51,17 @@ func truncate(results []uint64, numResults, offset int) []uint64 {
 	return rest
 }
 
+func dropZeroScores(docIDs []uint64, scoreMap map[uint64]float64) []uint64 {
+	// Precondition: docIDs is sorted in descending order of score.
+	for i, docID := range docIDs {
+		if scoreMap[docID] <= 0.0 {
+			log.Infof("Dropping %d zero scores", len(docIDs)-i)
+			return docIDs[:i]
+		}
+	}
+	return docIDs
+}
+
 func (c *CodeSearcher) scoreDocs(scorer types.Scorer, matches []types.DocumentMatch, numResults, offset int) ([]uint64, error) {
 	start := time.Now()
 
@@ -78,10 +89,6 @@ func (c *CodeSearcher) scoreDocs(scorer types.Scorer, matches []types.DocumentMa
 	scoreMap := make(map[uint64]float64, numDocs)
 	var mu sync.Mutex
 
-	// TODO(jdelfino): Rework this - discard docs with 0 score. Estimate
-	// when to stop scoring based on the number of docs scored, stdev of scores
-	// so far, and the number of docs remaining. This is a heuristic, but it should be
-	// better than scoring all docs.
 	// TODO(tylerw): use a priority-queue; stop iteration early.
 	g := new(errgroup.Group)
 	g.SetLimit(runtime.GOMAXPROCS(0))
@@ -122,7 +129,8 @@ func (c *CodeSearcher) scoreDocs(scorer types.Scorer, matches []types.DocumentMa
 		return scoreMap[docIDs[i]] > scoreMap[docIDs[j]]
 	})
 
-	return truncate(docIDs, numResults, offset), nil
+	docIDs = truncate(docIDs, numResults, offset)
+	return dropZeroScores(docIDs, scoreMap), nil
 }
 
 func (c *CodeSearcher) Search(q types.Query, numResults, offset int) ([]types.Document, error) {

--- a/codesearch/searcher/searcher_test.go
+++ b/codesearch/searcher/searcher_test.go
@@ -48,10 +48,10 @@ var sampleData = []struct {
 	{"eleven", "turn it up to 11"},
 }
 
-type zeroScorer struct{}
+type constantScorer struct{}
 
-func (s zeroScorer) Skip() bool                                                     { return false }
-func (s zeroScorer) Score(docMatch types.DocumentMatch, doc types.Document) float64 { return 0.0 }
+func (s constantScorer) Skip() bool                                                     { return false }
+func (s constantScorer) Score(docMatch types.DocumentMatch, doc types.Document) float64 { return 0.1 }
 
 type sQuery struct {
 	s      string
@@ -88,7 +88,7 @@ func TestBasicSearcher(t *testing.T) {
 	ctx := context.Background()
 	db := createSampleIndex(t)
 	s := searcher.New(ctx, index.NewReader(ctx, db, "testns", testSchema))
-	docs, err := s.Search(sQuery{"(:all)", zeroScorer{}}, 100, 0)
+	docs, err := s.Search(sQuery{"(:all)", constantScorer{}}, 100, 0)
 	require.NoError(t, err)
 	require.Equal(t, len(sampleData), len(docs))
 }
@@ -97,7 +97,7 @@ func TestSearcherOffsetAndLimit(t *testing.T) {
 	ctx := context.Background()
 	db := createSampleIndex(t)
 	s := searcher.New(ctx, index.NewReader(ctx, db, "testns", testSchema))
-	docs, err := s.Search(sQuery{"(:all)", zeroScorer{}}, 11, 8)
+	docs, err := s.Search(sQuery{"(:all)", constantScorer{}}, 11, 8)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(docs))
 
@@ -105,3 +105,7 @@ func TestSearcherOffsetAndLimit(t *testing.T) {
 	assert.Equal(t, "ten", string(docs[1].Field("ident").Contents()))
 	assert.Equal(t, "eleven", string(docs[2].Field("ident").Contents()))
 }
+
+// test search for short tokens alone
+// test search for short tokens combined with other tokens, where short tokens match
+// test search for short tokens combined with other tokens, where short token doesn't always match any docs - e.g. "foo is" or "ind.z"


### PR DESCRIPTION
This change fixes a bug in codesearch where, in certain circumstances, docs that shouldn't match were returned. This happened most often when short tokens were included in the query.

There are 2 relevant phases in a query:
1. Find docs that match according to the n-gram index
2. Post filter and rank (score) these documents

In phase 1, we sometimes over-retrieve documents, because n-gram indices are incapable of filtering on tokens < 3 characters long. For example, searching for "foo ba" will return all documents that have "foo", but will not filter at all on "ba". This also shows up in cases like "foo.ba", where `.` is treated as single-char wildcard. In these cases, post-filtering is needed to trim out all the non-matches.

In phase 2, we score all the documents. Prior to this change, we didn't filter any documents out during this step (aside from honoring limit/offset query parameters). 

In this change, we now drop documents that have a score 0. A score of 0 indicates that the resulting document didn't actually match the full query. So a document with "foo" but not "ba" would receive a score of 0. 

One additional related change is that we used to add an additional matcher on filename for content searches. The ultimate intention here was to match on filename or content when not using a limiter in the query (e.g. "foo" matches files with "foo" in them, but also files with "foo" in the filename). However, this extra matcher didn't cause filenames to match, because the squery didn't include the relevant clauses to retrieve them from the index in the first place. We can revisit supporting this functionality in the future, but that would require a larger change, and also requires a more complex approach to scoring (scoring would need to support disjunctions).

Note that this bug wasn't very visible, because many cases were papered over by the fact that the highlighter filtered out docs with no matching regions. It was visible with filename matches though.