### PR TITLE
Use ReadTryFillBuffer in cachetools.uploadFromReader

### DIFF
--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -292,7 +292,7 @@ func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 	sender := rpcutil.NewSender[*bspb.WriteRequest](ctx, stream)
 	resourceName := r.NewUploadString()
 	for {
-		n, err := rc.Read(buf)
+		n, err := ioutil.ReadTryFillBuffer(rc, buf)
 		if err != nil && err != io.EOF {
 			return nil, 0, err
 		}


### PR DESCRIPTION
This prevents sending small batches to ByteStream.Write when the reader has more data.