### PR TITLE
[RB] Cleanup ci runner for bare isolation type

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -513,11 +513,10 @@ func (r *taskRunner) RemoveInBackground(ctx context.Context) {
 func (r *taskRunner) isCIRunner() bool {
 	r.p.mu.RLock()
 	task := r.task
-	props := r.PlatformProperties
 	r.p.mu.RUnlock()
 
 	args := task.GetCommand().GetArguments()
-	return props.WorkflowID != "" && len(args) > 0 && args[0] == "./buildbuddy_ci_runner"
+	return len(args) > 0 && args[0] == "./buildbuddy_ci_runner"
 }
 
 func (r *taskRunner) cleanupCIRunner(ctx context.Context) error {


### PR DESCRIPTION
Remote bazel does not set a workflow ID, but we still need to clean up the ci_runner in the bare isolation type

This should also fix some flakiness in remote bazel integration tests