### PR TITLE
Parse JWT once in remoteauth and store those Claims (or error) in Context

### DIFF
--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -171,14 +171,9 @@ func TestJwtExpiry(t *testing.T) {
 	barJwt := validJwt(t, "bar")
 	require.NotEqual(t, fooJwt, barJwt)
 
-	// JWTs received from the remote backend are used directly (no validation)
+	// The JWT minted by the backend should be considered to expire too soon
+	// and should not be used.
 	fakeAuth.Reset().setNextJwt(t, fooJwt)
 	ctx := authenticator.AuthenticatedGRPCContext(contextWithApiKey(t, "foo"))
-	require.Equal(t, fooJwt, ctx.Value(authutil.ContextTokenStringKey))
-
-	// fooJwt (which was cached above) should be considered to expire too soon
-	// and should be discarded.
-	fakeAuth.Reset().setNextJwt(t, barJwt)
-	ctx = authenticator.AuthenticatedGRPCContext(contextWithApiKey(t, "foo"))
-	require.Equal(t, barJwt, ctx.Value(authutil.ContextTokenStringKey))
+	require.Nil(t, ctx.Value(authutil.ContextTokenStringKey))
 }


### PR DESCRIPTION
This change makes the RemoteAuthenticator eagerly parse the JWT returned from the cache or AuthService and store the Claims in the context. This lets subsequent code using the same Context use the parsed Claims instead of reparsing the JWT, and saves a bit of CPU due to that.

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4942