### PR TITLE
Automatically report statuses for CI builds

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -1522,12 +1522,16 @@ func TestBuildStatusReportingDisabled(t *testing.T) {
 			dbh := te.GetDBHandle()
 			require.NotNil(t, dbh)
 			gh := &tables.GitHubAppInstallation{
-				GroupID:                         "GROUP1",
-				Owner:                           "testowner",
-				ReportCommitStatusesForCIBuilds: test.enableReportingForRepo,
+				GroupID: "GROUP1",
+				Owner:   "testowner",
 			}
 			err = dbh.NewQuery(context.Background(), "create_github_app_installation_for_test").Create(gh)
 			require.NoError(t, err)
+			// Gorm `Create` will ignore the value of `report_commit_statuses_for_ci_builds`
+			// if it is set to false in the struct. To override its default value of true,
+			// you have to explicitly update the value of the field.
+			rsp := dbh.NewQuery(context.Background(), "create_github_app_installation_for_test").Raw(`UPDATE "GitHubAppInstallations" SET report_commit_statuses_for_ci_builds = ?`, test.enableReportingForRepo).Exec()
+			require.NoError(t, rsp.Error)
 
 			buildEvents := []*bspb.BuildEvent{
 				{

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -596,7 +596,7 @@ type GitHubAppInstallation struct {
 	// report commit statuses to GitHub for all builds where role is CI or CI_RUNNER.
 	// Even if enabled, this setting can be overridden by setting
 	// `--build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true` on a build.
-	ReportCommitStatusesForCIBuilds bool `gorm:"not null;default:0"`
+	ReportCommitStatusesForCIBuilds bool `gorm:"not null;default:1"`
 }
 
 func (gh *GitHubAppInstallation) TableName() string {


### PR DESCRIPTION
After thinking about this more, I wonder if we should just change the default for now.

I see your reasoning that most people with workflows will always want a CI status, but from a code maintainability perspective it seems simplest to just enable this by default, and ask users who don't want statuses to disable the toggle or set `--build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true`. Wdyt? We've already been asking users to do that up until this point, so doesn't seem like too heavy of a lift. Otherwise users may start relying on these subtle nuances in the code, which will make this column hyper-specific