### PR TITLE
[oci cache] Add `oci.cache.secret` flag

### DIFF
--- a/enterprise/server/util/ocicache/BUILD
+++ b/enterprise/server/util/ocicache/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -23,5 +23,24 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_protobuf//types/known/anypb",
+    ],
+)
+
+go_test(
+    name = "ocicache_test",
+    timeout = "short",
+    srcs = ["ocicache_test.go"],
+    deps = [
+        ":ocicache",
+        "//enterprise/server/clientidentity",
+        "//server/interfaces",
+        "//server/testutil/testcache",
+        "//server/testutil/testenv",
+        "//server/util/random",
+        "//server/util/testing/flags",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_containerregistry//pkg/crane",
+        "@com_github_google_go_containerregistry//pkg/name",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/util/ocicache/BUILD
+++ b/enterprise/server/util/ocicache/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/metrics",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
+        "//server/util/flag",
         "//server/util/ioutil",
         "//server/util/log",
         "//server/util/proto",

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -21,6 +22,10 @@ import (
 	gcrname "github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+var (
+	cacheSecret = flag.String("oci.cache.secret", "", "Secret to add to OCI image cache keys.")
 )
 
 const (
@@ -42,26 +47,10 @@ const (
 )
 
 func WriteManifestToAC(ctx context.Context, raw []byte, acClient repb.ActionCacheClient, ref gcrname.Reference, hash gcr.Hash, contentType string) error {
-	arKey := &ocipb.OCIActionResultKey{
-		Registry:      ref.Context().RegistryStr(),
-		Repository:    ref.Context().RepositoryStr(),
-		ResourceType:  ocipb.OCIResourceType_MANIFEST,
-		HashAlgorithm: hash.Algorithm,
-		HashHex:       hash.Hex,
-	}
-	arKeyBytes, err := proto.Marshal(arKey)
+	arRN, err := manifestACKey(ref, hash)
 	if err != nil {
 		return err
 	}
-	arDigest, err := digest.Compute(bytes.NewReader(arKeyBytes), cacheDigestFunction)
-	if err != nil {
-		return err
-	}
-	arRN := digest.NewACResourceName(
-		arDigest,
-		manifestContentInstanceName,
-		cacheDigestFunction,
-	)
 
 	m := &ocipb.OCIManifestContent{
 		Raw:         raw,
@@ -90,29 +79,11 @@ func updateCacheEventMetric(cacheType, eventType string) {
 }
 
 func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, ref gcrname.Reference, hash gcr.Hash) (*ocipb.OCIManifestContent, error) {
-	arKey := &ocipb.OCIActionResultKey{
-		Registry:      ref.Context().RegistryStr(),
-		Repository:    ref.Context().RepositoryStr(),
-		ResourceType:  ocipb.OCIResourceType_MANIFEST,
-		HashAlgorithm: hash.Algorithm,
-		HashHex:       hash.Hex,
-	}
-	arKeyBytes, err := proto.Marshal(arKey)
+	arRN, err := manifestACKey(ref, hash)
 	if err != nil {
 		updateCacheEventMetric(actionCacheLabel, missLabel)
 		return nil, err
 	}
-	arDigest, err := digest.Compute(bytes.NewReader(arKeyBytes), cacheDigestFunction)
-	if err != nil {
-		updateCacheEventMetric(actionCacheLabel, missLabel)
-		return nil, err
-	}
-	arRN := digest.NewACResourceName(
-		arDigest,
-		manifestContentInstanceName,
-		cacheDigestFunction,
-	)
-
 	ar, err := cachetools.GetActionResult(ctx, acClient, arRN)
 	if err != nil {
 		updateCacheEventMetric(actionCacheLabel, missLabel)
@@ -139,6 +110,32 @@ func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, r
 	}
 	updateCacheEventMetric(actionCacheLabel, hitLabel)
 	return &mc, nil
+}
+
+func manifestACKey(ref gcrname.Reference, hash gcr.Hash) (*digest.ACResourceName, error) {
+	arKey := &ocipb.OCIActionResultKey{
+		Registry:      ref.Context().RegistryStr(),
+		Repository:    ref.Context().RepositoryStr(),
+		ResourceType:  ocipb.OCIResourceType_MANIFEST,
+		HashAlgorithm: hash.Algorithm,
+		HashHex:       hash.Hex,
+	}
+	if *cacheSecret != "" {
+		arKey.Secret = *cacheSecret
+	}
+	arKeyBytes, err := proto.Marshal(arKey)
+	if err != nil {
+		return nil, err
+	}
+	arDigest, err := digest.Compute(bytes.NewReader(arKeyBytes), cacheDigestFunction)
+	if err != nil {
+		return nil, err
+	}
+	return digest.NewACResourceName(
+		arDigest,
+		manifestContentInstanceName,
+		cacheDigestFunction,
+	), nil
 }
 
 func FetchBlobMetadataFromCache(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, ref gcrname.Reference) (*ocipb.OCIBlobMetadata, error) {

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -1,0 +1,61 @@
+package ocicache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocicache"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheSecret(t *testing.T) {
+	image, err := crane.Image(map[string][]byte{
+		"/tmp/TestCacheSecret": []byte("TestCacheSecret"),
+	})
+	require.NoError(t, err)
+	raw, err := image.RawManifest()
+	require.NoError(t, err)
+
+	te := testenv.GetTestEnv(t)
+	flags.Set(t, "app.client_identity.client", interfaces.ClientIdentityApp)
+	key, err := random.RandomString(16)
+	require.NoError(t, err)
+	flags.Set(t, "app.client_identity.key", string(key))
+	require.NoError(t, err)
+	err = clientidentity.Register(te)
+	require.NoError(t, err)
+	require.NotNil(t, te.GetClientIdentityService())
+
+	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
+	testcache.Setup(t, te, localGRPClis)
+	go runServer()
+
+	ctx := context.Background()
+	mediaType, err := image.MediaType()
+	require.NoError(t, err)
+	contentType := string(mediaType)
+	hash, err := image.Digest()
+	require.NoError(t, err)
+
+	acClient := te.GetActionCacheClient()
+	ref := name.MustParseReference("buildbuddy.io/test_cache_secret")
+
+	err = ocicache.WriteManifestToAC(ctx, raw, acClient, ref, hash, contentType)
+	require.NoError(t, err)
+
+	mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref, hash)
+	require.NoError(t, err)
+	require.NotNil(t, mc)
+
+	require.Equal(t, contentType, mc.ContentType)
+	require.Empty(t, cmp.Diff(raw, mc.Raw))
+}

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -18,44 +18,77 @@ import (
 )
 
 func TestCacheSecret(t *testing.T) {
-	image, err := crane.Image(map[string][]byte{
-		"/tmp/TestCacheSecret": []byte("TestCacheSecret"),
-	})
-	require.NoError(t, err)
-	raw, err := image.RawManifest()
-	require.NoError(t, err)
+	for _, tc := range []struct {
+		name        string
+		imageName   string
+		writeSecret string
+		fetchSecret string
+		canFetch    bool
+	}{
+		{
+			name:        "secrets match, can fetch",
+			imageName:   "secrets_match_can_fetch",
+			writeSecret: "not very secret secret",
+			fetchSecret: "not very secret secret",
+			canFetch:    true,
+		},
+		{
+			name:        "secrets do not match, cannot fetch",
+			imageName:   "secrets_do_not_match_cannot_fetch",
+			writeSecret: "not very secret secret",
+			fetchSecret: "completey different not very secret secret",
+			canFetch:    false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			image, err := crane.Image(map[string][]byte{
+				"/tmp/" + tc.imageName: []byte(tc.imageName),
+			})
+			require.NoError(t, err)
+			raw, err := image.RawManifest()
+			require.NoError(t, err)
 
-	te := testenv.GetTestEnv(t)
-	flags.Set(t, "app.client_identity.client", interfaces.ClientIdentityApp)
-	key, err := random.RandomString(16)
-	require.NoError(t, err)
-	flags.Set(t, "app.client_identity.key", string(key))
-	require.NoError(t, err)
-	err = clientidentity.Register(te)
-	require.NoError(t, err)
-	require.NotNil(t, te.GetClientIdentityService())
+			te := testenv.GetTestEnv(t)
+			flags.Set(t, "app.client_identity.client", interfaces.ClientIdentityApp)
+			key, err := random.RandomString(16)
+			require.NoError(t, err)
+			flags.Set(t, "app.client_identity.key", string(key))
+			require.NoError(t, err)
+			err = clientidentity.Register(te)
+			require.NoError(t, err)
+			require.NotNil(t, te.GetClientIdentityService())
 
-	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
-	testcache.Setup(t, te, localGRPClis)
-	go runServer()
+			_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
+			testcache.Setup(t, te, localGRPClis)
+			go runServer()
 
-	ctx := context.Background()
-	mediaType, err := image.MediaType()
-	require.NoError(t, err)
-	contentType := string(mediaType)
-	hash, err := image.Digest()
-	require.NoError(t, err)
+			ctx := context.Background()
+			mediaType, err := image.MediaType()
+			require.NoError(t, err)
+			contentType := string(mediaType)
+			hash, err := image.Digest()
+			require.NoError(t, err)
 
-	acClient := te.GetActionCacheClient()
-	ref := name.MustParseReference("buildbuddy.io/test_cache_secret")
+			acClient := te.GetActionCacheClient()
+			ref, err := name.ParseReference("buildbuddy.io/" + tc.imageName)
+			require.NoError(t, err)
 
-	err = ocicache.WriteManifestToAC(ctx, raw, acClient, ref, hash, contentType)
-	require.NoError(t, err)
+			flags.Set(t, "oci.cache.secret", tc.writeSecret)
+			err = ocicache.WriteManifestToAC(ctx, raw, acClient, ref, hash, contentType)
+			require.NoError(t, err)
 
-	mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref, hash)
-	require.NoError(t, err)
-	require.NotNil(t, mc)
+			flags.Set(t, "oci.cache.secret", tc.fetchSecret)
+			mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref, hash)
+			if !tc.canFetch {
+				require.Error(t, err)
+				require.Nil(t, mc)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, mc)
 
-	require.Equal(t, contentType, mc.ContentType)
-	require.Empty(t, cmp.Diff(raw, mc.Raw))
+			require.Equal(t, contentType, mc.ContentType)
+			require.Empty(t, cmp.Diff(raw, mc.Raw))
+		})
+	}
 }

--- a/proto/ociregistry.proto
+++ b/proto/ociregistry.proto
@@ -51,6 +51,9 @@ message OCIActionResultKey {
 
   // Digest as a hex string.
   string hash_hex = 5;
+
+  // Secret to protect against unauthorized lookups.
+  string secret = 6;
 }
 
 message OCIManifestContent {


### PR DESCRIPTION
This change adds a `secret` field to OCI image AC keys and an `oci.cache.secret` flag to protect manifest entries in the AC.
The secret is not set in the AC key unless the flag is set to a non-empty string.