### PR TITLE
Clarify InvocationLink naming in execution collector

### DIFF
--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
@@ -66,7 +66,7 @@ func TestCollectExecutionUpdates(t *testing.T) {
 	}
 
 	// Also add an invocation link, associating an invocation with the execution.
-	err := collector.AddInvocationLink(ctx, &sipb.StoredInvocationLink{
+	err := collector.AddExecutionInvocationLink(ctx, &sipb.StoredInvocationLink{
 		ExecutionId:  executionID,
 		InvocationId: invocationID,
 	}, true /*=storeReverseLink*/)
@@ -102,7 +102,7 @@ func TestCollectExecutionUpdates(t *testing.T) {
 
 	// Delete reverse invocation links; should no longer be able to look up
 	// in-progress executions by invocation ID.
-	err = collector.DeleteReverseInvocationLinks(ctx, invocationID)
+	err = collector.DeleteInvocationExecutionLinks(ctx, invocationID)
 	require.NoError(t, err)
 	executions, err = collector.GetInProgressExecutions(ctx, invocationID)
 	require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestGetInProgressExecutionsIgnoresDeletedExecutions(t *testing.T) {
 		Stage:          int64(repb.ExecutionStage_COMPLETED),
 	})
 	require.NoError(t, err)
-	err = collector.AddInvocationLink(ctx, &sipb.StoredInvocationLink{
+	err = collector.AddExecutionInvocationLink(ctx, &sipb.StoredInvocationLink{
 		ExecutionId:  executionID,
 		InvocationId: invocationID,
 	}, true /*=storeReverseLink*/)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -265,7 +265,7 @@ func (s *ExecutionServer) insertInvocationLinkInRedis(ctx context.Context, execu
 		ExecutionId:  executionID,
 		Type:         linkType,
 	}
-	return s.env.GetExecutionCollector().AddInvocationLink(ctx, link, false /*=storeReverseLink*/)
+	return s.env.GetExecutionCollector().AddExecutionInvocationLink(ctx, link, false /*=storeReverseLink*/)
 }
 
 func trimStatus(statusMessage string) string {
@@ -357,12 +357,12 @@ func (s *ExecutionServer) recordExecution(
 	}
 	// Always clean up invocationLinks in Collector because we are not retrying
 	defer func() {
-		err := s.env.GetExecutionCollector().DeleteInvocationLinks(ctx, executionID)
+		err := s.env.GetExecutionCollector().DeleteExecutionInvocationLinks(ctx, executionID)
 		if err != nil {
 			log.CtxErrorf(ctx, "failed to clean up invocation links in collector: %s", err)
 		}
 	}()
-	links, err := s.env.GetExecutionCollector().GetInvocationLinks(ctx, executionID)
+	links, err := s.env.GetExecutionCollector().GetExecutionInvocationLinks(ctx, executionID)
 	if err != nil {
 		return status.InternalErrorf("failed to get invocations for execution %q: %s", executionID, err)
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -423,16 +423,16 @@ type fakeCollector struct {
 	executions      []*repb.StoredExecution
 }
 
-func (fc *fakeCollector) DeleteInvocationLinks(_ context.Context, _ string) error {
+func (fc *fakeCollector) DeleteExecutionInvocationLinks(_ context.Context, _ string) error {
 	return nil
 }
 
-func (fc *fakeCollector) AddInvocationLink(_ context.Context, link *sipb.StoredInvocationLink, _ bool) error {
+func (fc *fakeCollector) AddExecutionInvocationLink(_ context.Context, link *sipb.StoredInvocationLink, _ bool) error {
 	fc.invocationLinks = append(fc.invocationLinks, link)
 	return nil
 }
 
-func (fc *fakeCollector) GetInvocationLinks(_ context.Context, executionID string) ([]*sipb.StoredInvocationLink, error) {
+func (fc *fakeCollector) GetExecutionInvocationLinks(_ context.Context, executionID string) ([]*sipb.StoredInvocationLink, error) {
 	var res []*sipb.StoredInvocationLink
 	for _, link := range fc.invocationLinks {
 		if link.GetExecutionId() == executionID {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1439,9 +1439,9 @@ type ExecutionCollector interface {
 	// behavior, and will not return the deleted execution.
 	DeleteInProgressExecution(ctx context.Context, executionID string) error
 
-	// DeleteReverseInvocationLinks deletes all invocation => []execution links
-	// for the given invocation ID.
-	DeleteReverseInvocationLinks(ctx context.Context, invocationID string) error
+	// DeleteInvocationExecutionLinks deletes all invocation => []execution
+	// links for the given invocation ID.
+	DeleteInvocationExecutionLinks(ctx context.Context, invocationID string) error
 
 	AppendExecution(ctx context.Context, iid string, execution *repb.StoredExecution) error
 	// GetExecutions fetches a range of executions for the given invocation ID.
@@ -1452,9 +1452,9 @@ type ExecutionCollector interface {
 	DeleteExecutions(ctx context.Context, iid string) error
 	AddInvocation(ctx context.Context, inv *sipb.StoredInvocation) error
 	GetInvocation(ctx context.Context, iid string) (*sipb.StoredInvocation, error)
-	AddInvocationLink(ctx context.Context, link *sipb.StoredInvocationLink, storeReverseLink bool) error
-	GetInvocationLinks(ctx context.Context, executionID string) ([]*sipb.StoredInvocationLink, error)
-	DeleteInvocationLinks(ctx context.Context, executionID string) error
+	AddExecutionInvocationLink(ctx context.Context, link *sipb.StoredInvocationLink, bidirectional bool) error
+	GetExecutionInvocationLinks(ctx context.Context, executionID string) ([]*sipb.StoredInvocationLink, error)
+	DeleteExecutionInvocationLinks(ctx context.Context, executionID string) error
 }
 
 // SuggestionService enables fetching of suggestions.


### PR DESCRIPTION
Rename `InvocationLinks` to `ExecutionInvocationLinks` (since it maps execution ID => invocation IDs) and rename `ReverseInvocationLinks` to `InvocationExecutionLinks` (since it maps invocation ID => execution IDs)