### PR TITLE
Move mutex and block profiling flags into monitoring.go

### DIFF
--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"runtime"
 	"runtime/debug"
 
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore"
@@ -85,9 +84,6 @@ var (
 	appDirectory    = flag.String("app_directory", "", "the directory containing app binary files to host")
 
 	exitWhenReady = flag.Bool("exit_when_ready", false, "If set, the app will exit as soon as it becomes ready (useful for migrations)")
-
-	mutexProfileFraction = flag.Int("mutex_profile_fraction", 0, "The fraction of mutex contention events reported. (1/rate, 0 disables)")
-	blockProfileRate     = flag.Int("block_profile_rate", 0, "The fraction of goroutine blocking events reported. (1/rate, 0 disables)")
 
 	// URL path prefixes that should be handled by serving the app's HTML.
 	appRoutes = []string{
@@ -349,8 +345,6 @@ func registerLocalGRPCClients(env *real_environment.RealEnv) error {
 
 func StartMonitoringHandler(env *real_environment.RealEnv) {
 	env.SetListenAddr(*listen)
-	runtime.SetMutexProfileFraction(*mutexProfileFraction)
-	runtime.SetBlockProfileRate(*blockProfileRate)
 	monitoring.StartMonitoringHandler(env, fmt.Sprintf("%s:%d", *listen, *monitoringPort))
 }
 

--- a/server/util/monitoring/monitoring.go
+++ b/server/util/monitoring/monitoring.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"runtime"
 
 	"github.com/VictoriaMetrics/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -21,6 +22,9 @@ import (
 )
 
 var (
+	mutexProfileFraction = flag.Int("mutex_profile_fraction", 0, "The fraction of mutex contention events reported. (1/rate, 0 disables)")
+	blockProfileRate     = flag.Int("block_profile_rate", 0, "The fraction of goroutine blocking events reported. (1/rate, 0 disables)")
+
 	basicAuthUser = flag.String("monitoring.basic_auth.username", "", "Optional username for basic auth on the monitoring port.")
 	basicAuthPass = flag.String("monitoring.basic_auth.password", "", "Optional password for basic auth on the monitoring port.", flag.Secret)
 )
@@ -67,6 +71,9 @@ func RegisterMonitoringHandlers(env environment.Env, mux *http.ServeMux) {
 // in the same mux on the specified host and port, which should not have
 // anything else running on it.
 func StartMonitoringHandler(env environment.Env, hostPort string) {
+	runtime.SetMutexProfileFraction(*mutexProfileFraction)
+	runtime.SetBlockProfileRate(*blockProfileRate)
+
 	mux := http.NewServeMux()
 	RegisterMonitoringHandlers(env, mux)
 	s := &http.Server{


### PR DESCRIPTION
So that these can be set for binaries that don't use `libmain` (e.g. Cache Proxy).