### PR TITLE
[raft] store_test: remove out-of-range check from getReplica

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -785,7 +785,6 @@ func getReplica(t testing.TB, s *testutil.TestingStore, rangeID uint64) *replica
 		if err == nil {
 			return res
 		}
-		require.False(t, status.IsOutOfRangeError(err))
 		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
We will get out of range error when we call getReplica when we add a replica and
try to get the replica between 1) the time when the config change is committed at raft, the replica is created and the replica is caught up. This can cause TestUpReplicate to fail even when the replica is added successfully. 

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4192


