### PR TITLE
[raft] Remove TestRebalance from quarantine

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1539,7 +1539,6 @@ func TestRemoveDeadReplica(t *testing.T) {
 }
 
 func TestRebalance(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	flags.Set(t, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
 	// disable txn cleanup and zombie scan, because advance the fake clock can
 	// prematurely trigger txn cleanup and zombie cleanup


### PR DESCRIPTION
Succeeds on two 500 runs including changes from https://github.com/buildbuddy-io/buildbuddy/pull/9302
https://app.buildbuddy.io/invocation/62b93d75-31a9-4731-8fca-3ad9aff21d5e and https://app.buildbuddy.io/invocation/493bd37e-acb0-4e78-9989-a66177d11aee