### PR TITLE
Add experimental host tmpdir support

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/util/oci",
         "//enterprise/server/util/ociconv",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -1759,3 +1759,51 @@ func TestMounts(t *testing.T) {
 	assert.Empty(t, string(res.Stderr))
 	assert.Equal(t, 0, res.ExitCode)
 }
+
+func TestHostTmpdir(t *testing.T) {
+	setupNetworking(t)
+	image := manuallyProvisionedBusyboxImage(t)
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	installLeaserInEnv(t, env)
+	runtimeRoot := testfs.MakeTempDir(t)
+	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
+	buildRoot := testfs.MakeTempDir(t)
+	cacheRoot := testfs.MakeTempDir(t)
+	provider, err := ociruntime.NewProvider(env, buildRoot, cacheRoot)
+	require.NoError(t, err)
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+	testfs.WriteAllFileContents(t, wd, map[string]string{})
+	c, err := provider.New(ctx, &container.Init{
+		Props: &platform.Properties{
+			ContainerImage: image,
+		},
+		Task: &repb.ScheduledTask{ExecutionTask: &repb.ExecutionTask{
+			Action: &repb.Action{
+				Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+					{
+						Name:  "experimental-host-tmpdir",
+						Value: "true",
+					},
+				}},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := c.Remove(ctx)
+		require.NoError(t, err)
+
+		require.NoDirExists(t, wd+".tmp", "host tmpdir should be cleaned up")
+	})
+
+	// Run
+	cmd := &repb.Command{Arguments: []string{"touch", "/tmp/foo.txt"}}
+	res := c.Run(ctx, cmd, wd, oci.Credentials{})
+
+	assert.Empty(t, string(res.Stdout))
+	assert.Empty(t, string(res.Stderr))
+	assert.Equal(t, 0, res.ExitCode)
+	require.NoError(t, res.Error)
+	require.FileExists(t, wd+".tmp/foo.txt", "file should be created in host tmpdir")
+}


### PR DESCRIPTION
This PR introduces a new `experimental-host-tmpdir` platform property that mounts `/tmp/` from a directory on the host, in order to avoid I/O overhead from overlayfs. It is intended to help diagnose whether `/tmp/` FS operations are causing test timeouts. If setting this property reliably fixes test timeouts, we can consider making this an official platform property and/or executor flag. A benchmark writing 10K files under `/tmp/` with `touch` then reading them back with `cat` (in batches of 100 files) is 1.5X faster with this property enabled.

Separately, it would be nice if we had a way to trace FS operations to answer this question more directly. I think an eBPF-based solution probably makes the most sense here, since cgroups do not provide any way to track FS operations.