### PR TITLE
bazelutil: Add mod and vendor commands

### DIFF
--- a/server/util/bazel/bazel.go
+++ b/server/util/bazel/bazel.go
@@ -115,12 +115,14 @@ var bazelCommands = map[string]struct{}{
 	"info":               {},
 	"license":            {},
 	"mobile-install":     {},
+	"mod":                {},
 	"print_action":       {},
 	"query":              {},
 	"run":                {},
 	"shutdown":           {},
 	"sync":               {},
 	"test":               {},
+	"vendor":             {},
 	"version":            {},
 }
 


### PR DESCRIPTION
Add the "mod" and "vendor" commands to the list of recognized
Bazel commands in `server/util/bazel.go`.
