### PR TITLE
[testserver] increase server start timeout to 60s

### DIFF
--- a/server/testutil/testserver/testserver.go
+++ b/server/testutil/testserver/testserver.go
@@ -20,7 +20,7 @@ const (
 	// readyCheckTimeout determines how long to wait until giving up on waiting for
 	// BuildBuddy server to become ready. If this timeout is reached, the test case
 	// running the server will fail with a timeout error.
-	readyCheckTimeout = 30 * time.Second
+	readyCheckTimeout = 60 * time.Second
 )
 
 type Server struct {


### PR DESCRIPTION
An experiment to see if `ci_runner_test` flake decreases.