### PR TITLE
[raft] Remove TestSplitMetaRange from quarantine

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -734,7 +734,6 @@ func writeNRecordsAndFlush(ctx context.Context, t *testing.T, store *testutil.Te
 }
 
 func TestSplitMetaRange(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	flags.Set(t, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
 	sf := testutil.NewStoreFactory(t)
 	s1 := sf.NewStore(t)


### PR DESCRIPTION
Successes over 2 500 runs:
https://app.buildbuddy.io/invocation/50e0b294-d1f8-4f28-9f3f-6e79485c31bf
https://app.buildbuddy.io/invocation/ac4ee557-5569-4cc0-9542-70e679d1f0f0

https://github.com/buildbuddy-io/buildbuddy-internal/issues/4192
