### PR TITLE
use in-memory sqlite db for tests

### DIFF
--- a/server/testutil/app/app.go
+++ b/server/testutil/app/app.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -51,7 +53,10 @@ func Run(t *testing.T, commandPath string, commandArgs []string, configFilePath 
 func RunWithApp(t *testing.T, app *App, commandPath string, commandArgs []string, configFilePath string) *App {
 	dataDir := testfs.MakeTempDir(t)
 	app.t = t
-	app.dbFilePath = filepath.Join(dataDir, "buildbuddy.db")
+	app.dbFilePath = "/dev/shm/buildbuddy.db"
+	if _, err := os.Stat("/dev/shm"); errors.Is(err, os.ErrNotExist) {
+		app.dbFilePath = filepath.Join(dataDir, "buildbuddy.db")
+	}
 	args := []string{
 		"--app.log_level=debug",
 		"--app.log_include_short_file_name",

--- a/server/testutil/app/app.go
+++ b/server/testutil/app/app.go
@@ -54,7 +54,7 @@ func createMemoryBackedDB(t testing.TB) *os.File {
 	if _, err := os.Stat("/dev/shm"); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
-	f, err := os.CreateTemp("/dev/shm", "buildbuddy.db")
+	f, err := os.CreateTemp("/dev/shm", "buildbuddy-test-*.db")
 	require.NoError(t, err)
 	path := f.Name()
 	t.Cleanup(func() {


### PR DESCRIPTION
Several integration tests flake due to a failure to start the BuildBuddy server process.
On those same runs, I see warnings about slow queries.
I have also seen 5s+ IO stalls.
This change uses in-memory sqlite db for tests to avoid tests being bottlenecked on disk IO.