### PR TITLE
[oci cache] do not set secret on protobuf message

### DIFF
--- a/enterprise/server/util/ocicache/BUILD
+++ b/enterprise/server/util/ocicache/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/flag",
+        "//server/util/hash",
         "//server/util/ioutil",
         "//server/util/log",
         "//server/util/proto",

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
 	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -112,17 +113,16 @@ func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, r
 	return &mc, nil
 }
 
-func manifestACKey(ref gcrname.Reference, hash gcr.Hash) (*digest.ACResourceName, error) {
-	var buf bytes.Buffer
-	buf.Write([]byte(ref.Context().RegistryStr()))
-	buf.Write([]byte(ref.Context().RepositoryStr()))
-	buf.Write([]byte(ocipb.OCIResourceType_MANIFEST.String()))
-	buf.Write([]byte(hash.Algorithm))
-	buf.Write([]byte(hash.Hex))
-	if *cacheSecret != "" {
-		buf.Write([]byte(*cacheSecret))
-	}
-	arDigest, err := digest.Compute(&buf, cacheDigestFunction)
+func manifestACKey(ref gcrname.Reference, refhash gcr.Hash) (*digest.ACResourceName, error) {
+	s := hash.Strings(
+		ref.Context().RegistryStr(),
+		ref.Context().RepositoryStr(),
+		ocipb.OCIResourceType_MANIFEST.String(),
+		refhash.Algorithm,
+		refhash.Hex,
+		*cacheSecret,
+	)
+	arDigest, err := digest.Compute(bytes.NewBufferString(s), cacheDigestFunction)
 	if err != nil {
 		return nil, err
 	}

--- a/proto/ociregistry.proto
+++ b/proto/ociregistry.proto
@@ -51,9 +51,6 @@ message OCIActionResultKey {
 
   // Digest as a hex string.
   string hash_hex = 5;
-
-  // Secret to protect against unauthorized lookups.
-  string secret = 6;
 }
 
 message OCIManifestContent {


### PR DESCRIPTION
To make it clear that the OCI cache secret will never be stored, manually hash the key for looking up manifests in the AC.
Will eventually move to doing the same for OCI image layers, but this is the key change needed for protecting private OCI image manifests.