### PR TITLE
Don't write to lookaside cache on abandoned reads

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -316,22 +316,32 @@ func (c *Cache) Check(ctx context.Context) error {
 }
 
 type teeReadCloser struct {
-	rc  io.ReadCloser
-	cwc interfaces.CommittedWriteCloser
+	rc          io.ReadCloser
+	cwc         interfaces.CommittedWriteCloser
+	lastReadErr error
+	failedWrite bool
 }
 
-func (t *teeReadCloser) Read(p []byte) (n int, err error) {
-	n, err = t.rc.Read(p)
-	if n > 0 {
-		if n, err := t.cwc.Write(p[:n]); err != nil {
-			return n, err
+func (t *teeReadCloser) Read(p []byte) (int, error) {
+	var read int
+	read, t.lastReadErr = t.rc.Read(p)
+	if read > 0 {
+		written, err := t.cwc.Write(p[:read])
+		if written < read || err != nil {
+			t.failedWrite = true
+		}
+		if err != nil {
+			return written, err
 		}
 	}
-	return
+	return read, t.lastReadErr
 }
 func (t *teeReadCloser) Close() error {
 	err := t.rc.Close()
-	if err == nil {
+	if err == nil && t.lastReadErr != nil && t.lastReadErr != io.EOF {
+		log.Warningf("teeReadCloser Close succeeded but Read failed with: %s", t.lastReadErr)
+	}
+	if err == nil && t.lastReadErr == io.EOF && !t.failedWrite {
 		_ = t.cwc.Commit()
 		_ = t.cwc.Close()
 	}
@@ -450,7 +460,7 @@ func (c *Cache) teeReadCloser(r *rspb.ResourceName, rc io.ReadCloser) io.ReadClo
 	if err != nil {
 		return rc
 	}
-	return &teeReadCloser{rc, lwc}
+	return &teeReadCloser{rc: rc, cwc: lwc}
 }
 
 func (c *Cache) recvHeartbeatCallback(ctx context.Context, peer string) {

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -327,11 +327,13 @@ func (t *teeReadCloser) Read(p []byte) (int, error) {
 	read, t.lastReadErr = t.rc.Read(p)
 	if read > 0 {
 		written, err := t.cwc.Write(p[:read])
-		if written < read || err != nil {
-			t.failedWrite = true
-		}
 		if err != nil {
+			t.failedWrite = true
 			return written, err
+		}
+		if written < read {
+			t.failedWrite = true
+			return written, io.ErrShortWrite
 		}
 	}
 	return read, t.lastReadErr


### PR DESCRIPTION
Currently, if the reader stops for any reason, we will write whatever we read to the lookaside cache. Instead, only write to the lookaside cache when the reader gets an EOF.