### PR TITLE
[raft] remove rd from lease

### DIFF
--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -171,7 +171,7 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 	valid := la.l.Valid(ctx)
 	start := time.Now()
 
-	rangeID := la.l.GetRangeDescriptor().GetRangeId()
+	rangeID := la.l.GetRangeID()
 
 	switch instruction.action {
 	case Acquire:
@@ -194,7 +194,7 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 		la.log.Debugf("Acquired lease [%s] %s after callback (%s)", la.l.Desc(ctx), dur, instruction)
 		la.sendRangeEvent(events.EventRangeLeaseAcquired)
 		metrics.RaftLeases.With(prometheus.Labels{
-			metrics.RaftRangeIDLabel: strconv.Itoa(int(la.l.GetRangeDescriptor().GetRangeId())),
+			metrics.RaftRangeIDLabel: strconv.Itoa(int(la.l.GetRangeID())),
 		}).Inc()
 		metrics.RaftLeaseActionDurationMsec.With(prometheus.Labels{
 			metrics.RaftLeaseActionLabel: leaseAction,
@@ -269,7 +269,7 @@ func (lk *LeaseKeeper) newLeaseAgent(rd *rfpb.RangeDescriptor, r *replica.Replic
 	return &leaseAgent{
 		replicaID: r.ReplicaID(),
 		log:       lk.log,
-		l:         rangelease.New(lk.nodeHost, lk.session, lk.log, lk.liveness, rd, r),
+		l:         rangelease.New(lk.nodeHost, lk.session, lk.log, lk.liveness, rd.GetRangeId(), r),
 		ctx:       gctx,
 		cancel:    cancel,
 		eg:        eg,

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -87,7 +87,7 @@ func TestAcquireAndRelease(t *testing.T) {
 			{RangeId: 1, ReplicaId: 3},
 		},
 	}
-	l := rangelease.New(proposer, session, log.NamedSubLogger("test"), liveness, rd, rep)
+	l := rangelease.New(proposer, session, log.NamedSubLogger("test"), liveness, rd.GetRangeId(), rep)
 
 	// Should be able to get a rangelease.
 	err := l.Lease(ctx)
@@ -128,7 +128,7 @@ func TestAcquireAndReleaseMetaRange(t *testing.T) {
 			{RangeId: 1, ReplicaId: 3},
 		},
 	}
-	l := rangelease.New(proposer, session, log.NamedSubLogger("test"), liveness, rd, rep)
+	l := rangelease.New(proposer, session, log.NamedSubLogger("test"), liveness, rd.GetRangeId(), rep)
 
 	// Should be able to get a rangelease.
 	err := l.Lease(ctx)
@@ -170,7 +170,7 @@ func TestMetaRangeLeaseKeepalive(t *testing.T) {
 	}
 	leaseDuration := 100 * time.Millisecond
 	gracePeriod := 50 * time.Millisecond
-	l := rangelease.New(proposer, session, log.NamedSubLogger("test"), liveness, rd, rep).WithTimeouts(leaseDuration, gracePeriod)
+	l := rangelease.New(proposer, session, log.NamedSubLogger("test"), liveness, rd.GetRangeId(), rep).WithTimeouts(leaseDuration, gracePeriod)
 
 	// Should be able to get a rangelease.
 	err := l.Lease(ctx)


### PR DESCRIPTION
We only use rangeID.

Now that we don't call RemoveRange when we update the range, the rd in the lease
is not updated. Remove it from Lease b/c (1) the [start, end) in logs are confusing (2) can cause future bugs if rd is used.
