### PR TITLE
[raft] fix snapshot bug post-split

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -708,29 +708,27 @@ func (sm *Replica) clearInMemoryReplicaState() {
 	sm.partitionMetadataMu.Unlock()
 }
 
-// clearReplica clears in-memory replica state, and data (both in local range and
-// in the range specified by range descriptor) on the disk.
-func (sm *Replica) clearReplica(db ReplicaWriter) error {
-	// Remove range from the store
-	sm.rangeMu.Lock()
-	rangeDescriptor := sm.rangeDescriptor
-	sm.rangeMu.Unlock()
-
-	if sm.store != nil && rangeDescriptor != nil {
-		sm.store.RemoveRange(rangeDescriptor, sm)
+// clearRangeData clears data in range [start, end).
+func (sm *Replica) clearRangeData(db ReplicaWriter, rd *rfpb.RangeDescriptor) error {
+	wb := db.NewBatch()
+	if rd.GetStart() != nil && rd.GetEnd() != nil {
+		if err := wb.DeleteRange(rd.GetStart(), rd.GetEnd(), nil /*ignored write options*/); err != nil {
+			return err
+		}
 	}
+	if err := wb.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	return nil
+}
 
-	wb := db.NewIndexedBatch()
+// clearReplica clears in-memory replica state, and local range data on the disk.
+func (sm *Replica) clearReplica(db ReplicaWriter) error {
+	wb := db.NewBatch()
 
 	start, end := keys.Range(sm.replicaPrefix())
 	if err := wb.DeleteRange(start, end, nil /*ignored write options*/); err != nil {
 		return err
-	}
-	if rangeDescriptor != nil && rangeDescriptor.GetStart() != nil && rangeDescriptor.GetEnd() != nil {
-
-		if err := wb.DeleteRange(rangeDescriptor.GetStart(), rangeDescriptor.GetEnd(), nil /*ignored write options*/); err != nil {
-			return err
-		}
 	}
 	if err := wb.Commit(pebble.Sync); err != nil {
 		return err
@@ -1909,11 +1907,13 @@ func flushBatch(wb pebble.Batch) error {
 	return nil
 }
 
-func (sm *Replica) ApplySnapshotFromReader(r io.Reader, db ReplicaWriter) error {
+func (sm *Replica) applySnapshotFromReader(r io.Reader, db ReplicaWriter) error {
 	wb := db.NewBatch()
 	defer wb.Close()
 
 	readBuf := bufio.NewReader(r)
+
+	inLocalRangeSection := true
 	for {
 		r, count, err := readDataFromReader(readBuf)
 		if err != nil {
@@ -1934,21 +1934,38 @@ func (sm *Replica) ApplySnapshotFromReader(r io.Reader, db ReplicaWriter) error 
 		if err := proto.Unmarshal(protoBytes, kv); err != nil {
 			return err
 		}
-		if isLocalKey(kv.Key) {
-			kv.Key = sm.replicaLocalKey(kv.Key)
+		if inLocalRangeSection {
+			if isLocalKey(kv.Key) {
+				if bytes.Equal(kv.Key, constants.LocalRangeKey) {
+					rangeDescriptor := &rfpb.RangeDescriptor{}
+					if err := proto.Unmarshal(kv.Value, rangeDescriptor); err != nil {
+						return err
+					}
+					if err := sm.clearRangeData(db, rangeDescriptor); err != nil {
+						return err
+					}
+				}
+				kv.Key = sm.replicaLocalKey(kv.Key)
+			} else {
+				inLocalRangeSection = false
+			}
+		} else {
+			if isLocalKey(kv.Key) {
+				return status.InvalidArgumentErrorf("failed to apply snapshot: the snapshot contains non-continuous local range section")
+			}
 		}
 		if err := wb.Set(kv.Key, kv.Value, nil); err != nil {
 			return err
 		}
 		if wb.Len() > 1*gb {
 			// Pebble panics when the batch is greater than ~4GB (or 2GB on 32-bit systems)
-			sm.log.Debugf("ApplySnapshotFromReader: flushed batch of size %s", units.BytesSize(float64(wb.Len())))
+			sm.log.Debugf("applySnapshotFromReader: flushed batch of size %s", units.BytesSize(float64(wb.Len())))
 			if err = flushBatch(wb); err != nil {
 				return err
 			}
 		}
 	}
-	sm.log.Debugf("ApplySnapshotFromReader: flushed batch of size %s", units.BytesSize(float64(wb.Len())))
+	sm.log.Debugf("applySnapshotFromReader: flushed batch of size %s", units.BytesSize(float64(wb.Len())))
 	return flushBatch(wb)
 }
 
@@ -1988,6 +2005,8 @@ func (sm *Replica) ApplySnapshotFromReader(r io.Reader, db ReplicaWriter) error 
 // errors, the IOnDiskStateMachine implementation should only return a non-nil
 // error when the system need to be immediately halted for critical errors,
 // e.g. disk error preventing you from saving the snapshot.
+//
+// Note: we assume that local range will be saved before data in the [start, end).
 func (sm *Replica) SaveSnapshot(preparedSnap interface{}, w io.Writer, quit <-chan struct{}) error {
 	snap, ok := preparedSnap.(*pebble.Snapshot)
 	if !ok {
@@ -2035,7 +2054,7 @@ func (sm *Replica) RecoverFromSnapshot(r io.Reader, quit <-chan struct{}) error 
 	}
 
 	sm.clearReplica(db)
-	err = sm.ApplySnapshotFromReader(r, db)
+	err = sm.applySnapshotFromReader(r, db)
 	db.Close() // close the DB before handling errors or checking keys.
 	if err != nil {
 		return err


### PR DESCRIPTION
Add a unit test to replica to repo the bug: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4965

Delete the range from the range descriptor in the snapshot instead of from the replica.
