### PR TITLE
Track and expose the most recently indexed commit per repository in codesearch

### DIFF
--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -184,7 +184,7 @@ func handleIndex(args []string) {
 					log.Info(err.Error())
 					return nil
 				}
-				doc, err := schema.DefaultSchema().MakeDocument(fields)
+				doc, err := schema.CodeSchema().MakeDocument(fields)
 				if err != nil {
 					log.Fatal(err.Error())
 				}
@@ -195,7 +195,7 @@ func handleIndex(args []string) {
 			}
 			return nil
 		})
-		iw.SetLastIndexedCommitSha(repoURL.String(), commitSHA)
+		github.SetLastIndexedCommitSha(iw, repoURL, commitSHA)
 	}
 
 	if err := iw.Flush(); err != nil {
@@ -212,7 +212,7 @@ func handleSearch(ctx context.Context, args []string) {
 	}
 	defer db.Close()
 
-	codesearcher := searcher.New(ctx, index.NewReader(ctx, db, getNamespace(), schema.DefaultSchema()))
+	codesearcher := searcher.New(ctx, index.NewReader(ctx, db, getNamespace(), schema.CodeSchema()))
 	q, err := query.NewReQuery(ctx, pat)
 	if err != nil {
 		log.Fatal(err.Error())
@@ -281,7 +281,7 @@ func handleSquery(ctx context.Context, args []string) {
 	}
 	defer db.Close()
 
-	ir := index.NewReader(ctx, db, getNamespace(), schema.DefaultSchema())
+	ir := index.NewReader(ctx, db, getNamespace(), schema.CodeSchema())
 	matches, err := ir.RawQuery(pat)
 	if err != nil {
 		log.Fatal(err.Error())

--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -184,7 +184,7 @@ func handleIndex(args []string) {
 					log.Info(err.Error())
 					return nil
 				}
-				doc, err := schema.CodeSchema().MakeDocument(fields)
+				doc, err := schema.GitHubFileSchema().MakeDocument(fields)
 				if err != nil {
 					log.Fatal(err.Error())
 				}
@@ -212,7 +212,7 @@ func handleSearch(ctx context.Context, args []string) {
 	}
 	defer db.Close()
 
-	codesearcher := searcher.New(ctx, index.NewReader(ctx, db, getNamespace(), schema.CodeSchema()))
+	codesearcher := searcher.New(ctx, index.NewReader(ctx, db, getNamespace(), schema.GitHubFileSchema()))
 	q, err := query.NewReQuery(ctx, pat)
 	if err != nil {
 		log.Fatal(err.Error())
@@ -281,7 +281,7 @@ func handleSquery(ctx context.Context, args []string) {
 	}
 	defer db.Close()
 
-	ir := index.NewReader(ctx, db, getNamespace(), schema.CodeSchema())
+	ir := index.NewReader(ctx, db, getNamespace(), schema.GitHubFileSchema())
 	matches, err := ir.RawQuery(pat)
 	if err != nil {
 		log.Fatal(err.Error())

--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -195,6 +195,7 @@ func handleIndex(args []string) {
 			}
 			return nil
 		})
+		iw.SetLastIndexedCommitSha(repoURL.String(), commitSHA)
 	}
 
 	if err := iw.Flush(); err != nil {

--- a/codesearch/github/BUILD
+++ b/codesearch/github/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "github",
@@ -7,9 +7,25 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//codesearch/schema",
+        "//codesearch/types",
         "//server/util/git",
         "@com_github_cespare_xxhash_v2//:xxhash",
         "@com_github_gabriel_vasile_mimetype//:mimetype",
         "@com_github_go_enry_go_enry_v2//:go-enry",
+    ],
+)
+
+go_test(
+    name = "github_test",
+    srcs = ["github_test.go"],
+    embed = [":github"],
+    deps = [
+        "//codesearch/index",
+        "//codesearch/schema",
+        "//server/testutil/testfs",
+        "//server/util/git",
+        "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/codesearch/github/BUILD
+++ b/codesearch/github/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//codesearch/types",
         "//server/util/git",
         "@com_github_cespare_xxhash_v2//:xxhash",
-        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_gabriel_vasile_mimetype//:mimetype",
         "@com_github_go_enry_go_enry_v2//:go-enry",
     ],

--- a/codesearch/github/BUILD
+++ b/codesearch/github/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//codesearch/types",
         "//server/util/git",
         "@com_github_cespare_xxhash_v2//:xxhash",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_gabriel_vasile_mimetype//:mimetype",
         "@com_github_go_enry_go_enry_v2//:go-enry",
     ],

--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/schema"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
 	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 
+	"github.com/cockroachdb/pebble"
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/go-enry/go-enry/v2"
 

--- a/codesearch/github/github_test.go
+++ b/codesearch/github/github_test.go
@@ -1,0 +1,82 @@
+package github
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/codesearch/index"
+	"github.com/buildbuddy-io/buildbuddy/codesearch/schema"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/git"
+	"github.com/cockroachdb/pebble"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLastIndexedCommit(t *testing.T) {
+	ctx := context.Background()
+	indexDir := testfs.MakeTempDir(t)
+	db, err := pebble.Open(indexDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	commitSHA := "abc123"
+	repoURL, err := git.ParseGitHubRepoURL("github.com/buildbuddy-io/buildbuddy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w, err := index.NewWriter(db, "testing-namespace")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NoError(t, SetLastIndexedCommitSha(w, repoURL, commitSHA))
+	require.NoError(t, w.Flush())
+
+	r := index.NewReader(ctx, db, "testing-namespace", schema.MetadataSchema())
+	lastRev, err := GetLastIndexedCommitSha(r, repoURL)
+	require.NoError(t, err)
+	assert.Equal(t, commitSHA, lastRev)
+}
+
+func TestLastIndexedCommitUnset(t *testing.T) {
+	ctx := context.Background()
+	indexDir := testfs.MakeTempDir(t)
+	db, err := pebble.Open(indexDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	commitSHA := "abc123"
+	repoURL1, err := git.ParseGitHubRepoURL("github.com/buildbuddy-io/buildbuddy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repoURL2, err := git.ParseGitHubRepoURL("github.com/buildbuddy-io/buildbuddy-internal")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := index.NewReader(ctx, db, "testing-namespace", schema.MetadataSchema())
+	lastRev, err := GetLastIndexedCommitSha(r, repoURL2)
+	require.NoError(t, err)
+	assert.Empty(t, lastRev)
+
+	// Set a different repo, and make sure we still don't find repo2
+	w, err := index.NewWriter(db, "testing-namespace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NoError(t, SetLastIndexedCommitSha(w, repoURL1, commitSHA))
+	require.NoError(t, w.Flush())
+
+	r = index.NewReader(ctx, db, "testing-namespace", schema.MetadataSchema())
+	lastRev, err = GetLastIndexedCommitSha(r, repoURL2)
+	require.NoError(t, err)
+	assert.Empty(t, lastRev)
+}

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -30,7 +30,6 @@ var (
 const (
 	batchFlushSizeBytes = 1_000_000_000 // flush batch every 1G
 	generationKey       = "__generation__"
-	revisionPrefix      = "__revision__"
 )
 
 type postingLists map[string]posting.List

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -324,22 +324,6 @@ func (w *Writer) AddDocument(doc types.Document) error {
 	return nil
 }
 
-/*
-func (w *Writer) SetLastIndexedCommitSha(repoURL, commitSHA string) error {
-	if repoURL == "" {
-		return status.InvalidArgumentError("repoURL cannot be empty")
-	}
-	if commitSHA == "" {
-		return status.InvalidArgumentError("commitSHA cannot be empty")
-	}
-	if err := w.db.Set(commitShaKey(w.namespace, repoURL), []byte(commitSHA), pebble.Sync); err != nil {
-		return err
-	}
-	w.log.Infof("Set last indexed commit to %s for namespace: %s, repo: %s", commitSHA, w.namespace, repoURL)
-	return nil
-}
-*/
-
 func (w *Writer) flushBatch() error {
 	if w.batch.Empty() {
 		return nil
@@ -865,19 +849,3 @@ func (r *Reader) RawQuery(squery string) ([]types.DocumentMatch, error) {
 	}
 	return matches, nil
 }
-
-/*
-func (r *Reader) LastIndexedCommitSha(repoURL string) (string, error) {
-	value, closer, err := r.db.Get(commitShaKey(r.namespace, repoURL))
-	if err != nil {
-		if err == pebble.ErrNotFound {
-			// Unset is not an error
-			return "", nil
-		}
-		return "", err
-	}
-	defer closer.Close()
-
-	return string(value), nil
-}
-*/

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -246,8 +246,8 @@ func lookupDocId(db pebble.Reader, namespace string, matchField types.Field) (ui
 	return postingList.ToArray()[0], nil
 }
 
-func commitShaKey(namespace string) []byte {
-	return []byte(fmt.Sprintf("%s:%s", namespace, revisionPrefix))
+func commitShaKey(namespace, repoURL string) []byte {
+	return []byte(fmt.Sprintf("%s:%s:%s", namespace, repoURL, revisionPrefix))
 }
 
 func (w *Writer) DeleteDocument(docID uint64) error {
@@ -329,14 +329,14 @@ func (w *Writer) AddDocument(doc types.Document) error {
 	return nil
 }
 
-func (w *Writer) SetLastIndexedCommitSha(revision string) error {
-	if revision == "" {
+func (w *Writer) SetLastIndexedCommitSha(repoURL, commitSHA string) error {
+	if commitSHA == "" {
 		return status.InvalidArgumentError("revision cannot be empty")
 	}
-	if err := w.db.Set(commitShaKey(w.namespace), []byte(revision), pebble.Sync); err != nil {
+	if err := w.db.Set(commitShaKey(w.namespace, repoURL), []byte(commitSHA), pebble.Sync); err != nil {
 		return err
 	}
-	w.log.Infof("Set last indexed revision to %q", revision)
+	w.log.Infof("Set last indexed revision to %q", commitSHA)
 	return nil
 }
 
@@ -858,8 +858,8 @@ func (r *Reader) RawQuery(squery string) ([]types.DocumentMatch, error) {
 	return matches, nil
 }
 
-func (r *Reader) LastIndexedCommitSha() (string, error) {
-	value, closer, err := r.db.Get(commitShaKey(r.namespace))
+func (r *Reader) LastIndexedCommitSha(repoURL string) (string, error) {
+	value, closer, err := r.db.Get(commitShaKey(r.namespace, repoURL))
 	if err != nil {
 		if err == pebble.ErrNotFound {
 			return "", status.NotFoundErrorf("no last indexed revision found")

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -516,14 +516,6 @@ func (r *Reader) GetStoredDocument(docID uint64) (types.Document, error) {
 	return r.newLazyDoc(docID), nil
 }
 
-func (r *Reader) GetStoredDocumentByMatchField(matchField types.Field) (types.Document, error) {
-	docID, err := lookupDocId(r.db, r.namespace, matchField)
-	if err != nil {
-		return nil, err
-	}
-	return r.GetStoredDocument(docID)
-}
-
 // postingList looks up the set of docIDs matching the provided ngram.
 // If `field` is set to a non-empty value, matches are restricted to just the
 // specified field. Otherwise, all fields are searched.

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -246,10 +246,6 @@ func lookupDocId(db pebble.Reader, namespace string, matchField types.Field) (ui
 	return postingList.ToArray()[0], nil
 }
 
-func commitShaKey(namespace, repoURL string) []byte {
-	return []byte(fmt.Sprintf("%s:%s:%s", namespace, repoURL, revisionPrefix))
-}
-
 func (w *Writer) DeleteDocument(docID uint64) error {
 	fieldsStart := w.storedFieldKey(docID, "")
 	fieldsEnd := w.storedFieldKey(docID, "\xff")
@@ -329,6 +325,7 @@ func (w *Writer) AddDocument(doc types.Document) error {
 	return nil
 }
 
+/*
 func (w *Writer) SetLastIndexedCommitSha(repoURL, commitSHA string) error {
 	if repoURL == "" {
 		return status.InvalidArgumentError("repoURL cannot be empty")
@@ -342,6 +339,7 @@ func (w *Writer) SetLastIndexedCommitSha(repoURL, commitSHA string) error {
 	w.log.Infof("Set last indexed commit to %s for namespace: %s, repo: %s", commitSHA, w.namespace, repoURL)
 	return nil
 }
+*/
 
 func (w *Writer) flushBatch() error {
 	if w.batch.Empty() {
@@ -533,6 +531,14 @@ func (r *Reader) getStoredFields(docID uint64, fieldNames ...string) (map[string
 
 func (r *Reader) GetStoredDocument(docID uint64) (types.Document, error) {
 	return r.newLazyDoc(docID), nil
+}
+
+func (r *Reader) GetStoredDocumentByMatchField(matchField types.Field) (types.Document, error) {
+	docID, err := lookupDocId(r.db, r.namespace, matchField)
+	if err != nil {
+		return nil, err
+	}
+	return r.GetStoredDocument(docID)
 }
 
 // postingList looks up the set of docIDs matching the provided ngram.
@@ -861,6 +867,7 @@ func (r *Reader) RawQuery(squery string) ([]types.DocumentMatch, error) {
 	return matches, nil
 }
 
+/*
 func (r *Reader) LastIndexedCommitSha(repoURL string) (string, error) {
 	value, closer, err := r.db.Get(commitShaKey(r.namespace, repoURL))
 	if err != nil {
@@ -874,3 +881,4 @@ func (r *Reader) LastIndexedCommitSha(repoURL string) (string, error) {
 
 	return string(value), nil
 }
+*/

--- a/codesearch/index/index_test.go
+++ b/codesearch/index/index_test.go
@@ -321,6 +321,31 @@ func TestSQuery(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLastIndexedCommitSha(t *testing.T) {
+	ctx := context.Background()
+	indexDir := testfs.MakeTempDir(t)
+	db, err := pebble.Open(indexDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	commitSha := "abc123"
+
+	w, err := NewWriter(db, "testing-namespace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.SetLastIndexedCommitSha(commitSha)
+	require.NoError(t, w.Flush())
+
+	r := NewReader(ctx, db, "testing-namespace", testSchema)
+	readCommitSha, err := r.LastIndexedCommitSha()
+	require.NoError(t, err)
+
+	assert.Equal(t, commitSha, readCommitSha)
+}
+
 func printDB(t testing.TB, db *pebble.DB) {
 	iter, err := db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte{0},

--- a/codesearch/schema/schema.go
+++ b/codesearch/schema/schema.go
@@ -30,10 +30,20 @@ var (
 		MustFieldSchema(types.KeywordField, RepoField, true),
 		MustFieldSchema(types.KeywordField, SHAField, true),
 	})
+	metadataSchema = NewDocumentSchema([]types.FieldSchema{
+		// Repository URL
+		MustFieldSchema(types.KeywordField, RepoField, true),
+		// Last indexed commit SHA
+		MustFieldSchema(types.KeywordField, SHAField, true),
+	})
 )
 
-func DefaultSchema() types.DocumentSchema {
+func CodeSchema() types.DocumentSchema {
 	return defaultSchema
+}
+
+func MetadataSchema() types.DocumentSchema {
+	return metadataSchema
 }
 
 // Satisfies the types.FieldSchema interface.

--- a/codesearch/schema/schema.go
+++ b/codesearch/schema/schema.go
@@ -13,15 +13,16 @@ var (
 	fieldNameRegex = regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9_]*)$`)
 
 	// The following field names are used in the indexed docs.
-	IDField       = "id"
-	FilenameField = "filename"
-	ContentField  = "content"
-	LanguageField = "language"
-	OwnerField    = "owner"
-	RepoField     = "repo"
-	SHAField      = "sha"
+	IDField        = "id"
+	FilenameField  = "filename"
+	ContentField   = "content"
+	LanguageField  = "language"
+	OwnerField     = "owner"
+	RepoField      = "repo"
+	SHAField       = "sha"
+	LatestSHAField = "latest_sha"
 
-	defaultSchema = NewDocumentSchema([]types.FieldSchema{
+	gitHubFileSchema = NewDocumentSchema([]types.FieldSchema{
 		MustFieldSchema(types.KeywordField, IDField, false),
 		MustFieldSchema(types.TrigramField, FilenameField, true),
 		MustFieldSchema(types.SparseNgramField, ContentField, true),
@@ -32,14 +33,14 @@ var (
 	})
 	metadataSchema = NewDocumentSchema([]types.FieldSchema{
 		// Repository URL
-		MustFieldSchema(types.KeywordField, RepoField, true),
+		MustFieldSchema(types.KeywordField, IDField, false),
 		// Last indexed commit SHA
-		MustFieldSchema(types.KeywordField, SHAField, true),
+		MustFieldSchema(types.KeywordField, LatestSHAField, true),
 	})
 )
 
-func CodeSchema() types.DocumentSchema {
-	return defaultSchema
+func GitHubFileSchema() types.DocumentSchema {
+	return gitHubFileSchema
 }
 
 func MetadataSchema() types.DocumentSchema {

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -231,7 +231,7 @@ func (css *codesearchServer) syncIndex(_ context.Context, req *inpb.IndexRequest
 		}
 	}
 
-	iw.SetLastIndexedCommitSha(commitSHA)
+	iw.SetLastIndexedCommitSha(repoURLString, commitSHA)
 
 	if err := iw.Flush(); err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (css *codesearchServer) Index(ctx context.Context, req *inpb.IndexRequest) 
 	return rsp, nil
 }
 
-func (css *codesearchServer) IndexStatus(ctx context.Context, req *inpb.IndexStatusRequest) (*inpb.IndexStatusResponse, error) {
+func (css *codesearchServer) RepoStatus(ctx context.Context, req *inpb.RepoStatusRequest) (*inpb.RepoStatusResponse, error) {
 	// TODO(jdelfino): where does namespace come from? middleware? It's not set in githubapp.go, but shows up here...
 	namespace, err := css.getUserNamespace(ctx, req.GetNamespace())
 	if err != nil {
@@ -293,12 +293,12 @@ func (css *codesearchServer) IndexStatus(ctx context.Context, req *inpb.IndexSta
 
 	r := index.NewReader(ctx, css.db, namespace, schema.DefaultSchema())
 
-	lastIndexedRevision, err := r.LastIndexedCommitSha()
+	lastIndexedRevision, err := r.LastIndexedCommitSha(req.GetRepoUrl())
 	if err != nil {
 		return nil, err
 	}
 
-	return &inpb.IndexStatusResponse{
+	return &inpb.RepoStatusResponse{
 		LastIndexedCommitSha: lastIndexedRevision,
 	}, nil
 }

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -218,7 +218,7 @@ func (css *codesearchServer) syncIndex(_ context.Context, req *inpb.IndexRequest
 			log.Debug(err.Error())
 			continue
 		}
-		doc, err := schema.CodeSchema().MakeDocument(fields)
+		doc, err := schema.GitHubFileSchema().MakeDocument(fields)
 		if err != nil {
 			log.Debug(err.Error())
 			continue
@@ -299,7 +299,7 @@ func (css *codesearchServer) RepoStatus(ctx context.Context, req *inpb.RepoStatu
 	if err != nil {
 		return nil, err
 	}
-	r := index.NewReader(ctx, css.db, namespace, schema.CodeSchema())
+	r := index.NewReader(ctx, css.db, namespace, schema.GitHubFileSchema())
 
 	rev, err := github.GetLastIndexedCommitSha(r, repoURL)
 	if err != nil {
@@ -324,7 +324,7 @@ func (css *codesearchServer) Search(ctx context.Context, req *srpb.SearchRequest
 	if req.GetNumResults() > 0 && req.GetNumResults() < maxNumResults {
 		numResults = int(req.GetNumResults())
 	}
-	codesearcher := searcher.New(ctx, index.NewReader(ctx, css.db, namespace, schema.CodeSchema()))
+	codesearcher := searcher.New(ctx, index.NewReader(ctx, css.db, namespace, schema.GitHubFileSchema()))
 	q, err := query.NewReQuery(ctx, req.GetQuery().GetTerm())
 	if err != nil {
 		return nil, err

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -85,7 +85,6 @@ type IndexWriter interface {
 
 type IndexReader interface {
 	GetStoredDocument(docID uint64) (Document, error)
-	GetStoredDocumentByMatchField(matchField Field) (Document, error)
 	RawQuery(squery string) ([]DocumentMatch, error)
 }
 

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -85,6 +85,7 @@ type IndexWriter interface {
 
 type IndexReader interface {
 	GetStoredDocument(docID uint64) (Document, error)
+	GetStoredDocumentByMatchField(matchField Field) (Document, error)
 	RawQuery(squery string) ([]DocumentMatch, error)
 }
 

--- a/proto/codesearch_service.proto
+++ b/proto/codesearch_service.proto
@@ -9,7 +9,7 @@ option go_package = "codesearch_service";
 
 service CodesearchService {
   rpc Index(index.IndexRequest) returns (index.IndexResponse);
-  rpc IndexStatus(index.IndexStatusRequest) returns (index.IndexStatusResponse);
+  rpc RepoStatus(index.RepoStatusRequest) returns (index.RepoStatusResponse);
   rpc Search(search.SearchRequest) returns (search.SearchResponse);
   rpc IngestAnnotations(index.IngestAnnotationsRequest)
       returns (index.IngestAnnotationsResponse);

--- a/proto/codesearch_service.proto
+++ b/proto/codesearch_service.proto
@@ -9,8 +9,10 @@ option go_package = "codesearch_service";
 
 service CodesearchService {
   rpc Index(index.IndexRequest) returns (index.IndexResponse);
+  rpc IndexStatus(index.IndexStatusRequest) returns (index.IndexStatusResponse);
   rpc Search(search.SearchRequest) returns (search.SearchResponse);
   rpc IngestAnnotations(index.IngestAnnotationsRequest)
       returns (index.IngestAnnotationsResponse);
   rpc KytheProxy(search.KytheRequest) returns (search.KytheResponse);
+
 }

--- a/proto/codesearch_service.proto
+++ b/proto/codesearch_service.proto
@@ -14,5 +14,4 @@ service CodesearchService {
   rpc IngestAnnotations(index.IngestAnnotationsRequest)
       returns (index.IngestAnnotationsResponse);
   rpc KytheProxy(search.KytheRequest) returns (search.KytheResponse);
-
 }

--- a/proto/index.proto
+++ b/proto/index.proto
@@ -41,11 +41,12 @@ message IndexResponse {
   context.ResponseContext response_context = 1;
 }
 
-message IndexStatusRequest {
+message RepoStatusRequest {
   string namespace = 1;
+  string repo_url = 2;
 }
 
-message IndexStatusResponse {
+message RepoStatusResponse {
   string last_indexed_commit_sha = 1;
 }
 

--- a/proto/index.proto
+++ b/proto/index.proto
@@ -50,7 +50,6 @@ message RepoStatusResponse {
   string last_indexed_commit_sha = 1;
 }
 
-
 message IngestAnnotationsRequest {
   context.RequestContext request_context = 1;
 

--- a/proto/index.proto
+++ b/proto/index.proto
@@ -42,12 +42,20 @@ message IndexResponse {
 }
 
 message RepoStatusRequest {
-  string namespace = 1;
-  string repo_url = 2;
+  context.RequestContext request_context = 1;
+
+  // Required. See namespace field on IndexRequest above.
+  string namespace = 2;
+
+  // The URL of the repo
+  string repo_url = 3;
 }
 
 message RepoStatusResponse {
-  string last_indexed_commit_sha = 1;
+  context.ResponseContext response_context = 1;
+
+  // The SHA of the most recently indexed commit
+  string last_indexed_commit_sha = 2;
 }
 
 message IngestAnnotationsRequest {

--- a/proto/index.proto
+++ b/proto/index.proto
@@ -41,6 +41,15 @@ message IndexResponse {
   context.ResponseContext response_context = 1;
 }
 
+message IndexStatusRequest {
+  string namespace = 1;
+}
+
+message IndexStatusResponse {
+  string last_indexed_commit_sha = 1;
+}
+
+
 message IngestAnnotationsRequest {
   context.RequestContext request_context = 1;
 


### PR DESCRIPTION
This change adds the ability for index.Writer and index.Reader to record and produce the most recently indexed commit, per repository.

It also exposes this via a `RepoStatus` rpc in the codeearch service.

This is in support of a near-future change which will enable incremental updates of the codesearch index as individual commits are created on the indexed branch.

The factoring here could be improved in the future - all the core codesearch types (e.g. IndexReader/IndexWriter) should probably remain completely ignorant of anything git-specific, such as commits. Additionally, the logic for tracking commits is duplicated across the CLI tool and the server, and doesn't really belong directly in either of them. This should probably be addressed by introducing a more explicit git-specific layer in between the clients (server, CLI) and the core codesearch implementation.