### PR TITLE
Codesearch server only processes one update per repo at a time

### DIFF
--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -35,8 +35,6 @@ type postingLists map[string]posting.List
 // Multiple instances can be used concurrently without crashing, however CRUD operations are
 // not atomic, so index corruption can occur if multiple writers are used to modify the same
 // documents at the same time.
-// TODO(jdelfino): The server currently does not guarantee that multiple Writers won't be used to
-// update the same documents at the same time.
 type Writer struct {
 	db  *pebble.DB
 	log log.Logger
@@ -242,6 +240,9 @@ func (w *Writer) DeleteDocument(docID uint64) error {
 }
 
 func (w *Writer) UpdateDocument(matchField types.Field, newDoc types.Document) error {
+	// Note: This implementation does not handle file renames - clients must explicitly
+	// delete the old file and add (or update) the new file when renames happen.
+
 	if matchField.Type() != types.KeywordField {
 		return status.InternalError("match field must be of keyword type")
 	}

--- a/codesearch/server/BUILD
+++ b/codesearch/server/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//server/util/disk",
         "//server/util/flagutil/yaml",
         "//server/util/git",
+        "//server/util/lockmap",
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/status",


### PR DESCRIPTION
There are numerous race conditions that can occur when re-indexing the same repo concurrently - the same files may get added twice in many circumstances. 

This change makes the codesearch server lock on a per-repo basis. On it's own, this is not a scalable change, especially for large repos. However, it is made in preparation for implementing incremental index updates.