### PR TITLE
Refactor code to split out code specifically for dealing with rc files from the core parser code

### DIFF
--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -8,6 +8,7 @@ go_library(
         "//cli/bazelisk",
         "//cli/log",
         "//cli/parser/arguments",
+        "//cli/parser/bazelrc",
         "//cli/parser/options",
         "//cli/parser/parsed",
         "//cli/storage",
@@ -17,7 +18,6 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/disk",
         "//server/util/proto",
-        "@com_github_google_shlex//:shlex",
     ],
 )
 

--- a/cli/parser/bazelrc/BUILD
+++ b/cli/parser/bazelrc/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "bazelrc",
+    srcs = ["bazelrc.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/log",
+        "//server/util/shlex",
+    ],
+)
+
+package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -16,9 +16,8 @@ import (
 
 const (
 	EnablePlatformSpecificConfigFlag = "enable_platform_specific_config"
-	workspacePrefix = `%workspace%/`
+	workspacePrefix                  = `%workspace%/`
 )
-
 
 var (
 	bazelCommands = map[string]struct{}{
@@ -282,8 +281,6 @@ func ParseRCFiles(workspaceDir string, filePaths ...string) ([]*RcRule, error) {
 	}
 	return opts, nil
 }
-
-
 
 // Mirroring the behavior here:
 // https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java#L41

--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -3,7 +3,6 @@ package bazelrc
 import (
 	"bufio"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -59,24 +58,14 @@ var (
 		"coverage": "test",
 	}
 
-	CommonPhases = map[string]struct{}{
-		"common": {},
-		"always": {},
+	StartupFlagNoRc = map[string]struct{}{
+		"ignore_all_rc_files": {},
+		"home_rc":             {},
+		"workspace_rc":        {},
+		"system_rc":           {},
+		"bazelrc":             {},
 	}
-
-	allPhases = func() map[string]struct{} {
-		v := maps.Clone(bazelCommands)
-		maps.Insert(v, maps.All(CommonPhases))
-		v["startup"] = struct{}{}
-		return v
-	}()
 )
-
-func BazelCommands() (map[string]struct{}, error) {
-	// TODO(zoey): figure out if we can get bazel help output without starting a
-	// bazel server at any point.
-	return bazelCommands, nil
-}
 
 // RcRule is a rule parsed from a bazelrc file.
 type RcRule struct {
@@ -299,6 +288,11 @@ func GetBazelOS() string {
 	default:
 		return runtime.GOOS
 	}
+}
+
+func IsBazelCommand(command string) bool {
+	_, ok := bazelCommands[command]
+	return ok
 }
 
 func Parent(command string) (string, bool) {

--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -1,0 +1,310 @@
+package bazelrc
+
+import (
+	"bufio"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/shlex"
+)
+
+const (
+	EnablePlatformSpecificConfigFlag = "enable_platform_specific_config"
+	workspacePrefix = `%workspace%/`
+)
+
+
+var (
+	bazelCommands = map[string]struct{}{
+		"analyze-profile":    {},
+		"aquery":             {},
+		"build":              {},
+		"canonicalize-flags": {},
+		"clean":              {},
+		"coverage":           {},
+		"cquery":             {},
+		"dump":               {},
+		"fetch":              {},
+		"help":               {},
+		"info":               {},
+		"license":            {},
+		"mobile-install":     {},
+		"print_action":       {},
+		"query":              {},
+		"run":                {},
+		"shutdown":           {},
+		"sync":               {},
+		"test":               {},
+		"version":            {},
+	}
+
+	// Inheritance hierarchy: https://bazel.build/run/bazelrc#option-defaults
+	// All commands inherit from "common".
+	parentCommand = map[string]string{
+		"test":           "build",
+		"run":            "build",
+		"clean":          "build",
+		"mobile-install": "build",
+		"info":           "build",
+		"print_action":   "build",
+		"config":         "build",
+		"cquery":         "build",
+		"aquery":         "build",
+
+		"coverage": "test",
+	}
+
+	CommonPhases = map[string]struct{}{
+		"common": {},
+		"always": {},
+	}
+
+	allPhases = func() map[string]struct{} {
+		v := maps.Clone(bazelCommands)
+		maps.Insert(v, maps.All(CommonPhases))
+		v["startup"] = struct{}{}
+		return v
+	}()
+)
+
+func BazelCommands() (map[string]struct{}, error) {
+	// TODO(zoey): figure out if we can get bazel help output without starting a
+	// bazel server at any point.
+	return bazelCommands, nil
+}
+
+// RcRule is a rule parsed from a bazelrc file.
+type RcRule struct {
+	Phase  string
+	Config string
+	// Tokens contains the raw (non-canonicalized) tokens in the rule.
+	Tokens []string
+}
+
+type Rules struct {
+	All              []*RcRule
+	ByPhaseAndConfig map[string]map[string][]*RcRule
+}
+
+func StructureRules(rules []*RcRule) *Rules {
+	r := &Rules{
+		All:              rules,
+		ByPhaseAndConfig: map[string]map[string][]*RcRule{},
+	}
+	for _, rule := range rules {
+		byConfig := r.ByPhaseAndConfig[rule.Phase]
+		if byConfig == nil {
+			byConfig = map[string][]*RcRule{}
+			r.ByPhaseAndConfig[rule.Phase] = byConfig
+		}
+		byConfig[rule.Config] = append(byConfig[rule.Config], rule)
+	}
+	return r
+}
+
+func (r *Rules) ForPhaseAndConfig(phase, config string) []*RcRule {
+	byConfig := r.ByPhaseAndConfig[phase]
+	if byConfig == nil {
+		return nil
+	}
+	return byConfig[config]
+}
+
+func (r *RcRule) String() string {
+	return fmt.Sprintf("phase=%q,config=%q,tokens=%v", r.Phase, r.Config, r.Tokens)
+}
+
+// getPhases returns the command's inheritance hierarchy in increasing order of
+// precedence.
+//
+// Examples:
+//
+//	getPhases("run")      // {"always", "common", "build", "run"}
+//	getPhases("coverage") // {"always", "common", "build", "test", "coverage"}
+func GetPhases(command string) (out []string) {
+	for {
+		if command == "" {
+			out = append(out, "common", "always")
+			break
+		}
+		out = append(out, command)
+		command = parentCommand[command]
+	}
+	slices.Reverse(out)
+	return
+}
+
+func appendRcRulesFromImport(workspaceDir, path string, opts []*RcRule, optional bool, importStack []string) ([]*RcRule, error) {
+	if strings.HasPrefix(path, workspacePrefix) {
+		path = filepath.Join(workspaceDir, path[len(workspacePrefix):])
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		if optional {
+			return opts, nil
+		}
+		return nil, err
+	}
+	defer file.Close()
+	return appendRcRulesFromFile(workspaceDir, file, opts, importStack)
+}
+
+func appendRcRulesFromFile(workspaceDir string, f *os.File, rules []*RcRule, importStack []string) ([]*RcRule, error) {
+	rpath, err := realpath(f.Name())
+	if err != nil {
+		return nil, fmt.Errorf("could not determine real path of bazelrc file: %s", err)
+	}
+	for _, path := range importStack {
+		if path == rpath {
+			return nil, fmt.Errorf("circular import detected: %s -> %s", strings.Join(importStack, " -> "), rpath)
+		}
+	}
+	importStack = append(importStack, rpath)
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Handle line continuations (lines can end with "\" to effectively
+		// continue the same line)
+		for strings.HasSuffix(line, `\`) && scanner.Scan() {
+			line = line[:len(line)-1] + scanner.Text()
+		}
+
+		line = stripCommentsAndWhitespace(line)
+
+		tokens := strings.Fields(line)
+		if len(tokens) == 0 {
+			// blank line
+			continue
+		}
+		if tokens[0] == "import" || tokens[0] == "try-import" {
+			isOptional := tokens[0] == "try-import"
+			path := strings.TrimSpace(strings.TrimPrefix(line, tokens[0]))
+			rules, err = appendRcRulesFromImport(workspaceDir, path, rules, isOptional, importStack)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		rule, err := parseRcRule(line)
+		if err != nil {
+			log.Debugf("Error parsing bazelrc option: %s", err.Error())
+			continue
+		}
+		// Bazel doesn't support configs for startup options and ignores them if
+		// they appear in a bazelrc: https://bazel.build/run/bazelrc#config
+		if rule.Phase == "startup" && rule.Config != "" {
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	log.Debugf("Adding rc rules from %q: %v", rpath, rules)
+	return rules, scanner.Err()
+}
+
+func realpath(path string) (string, error) {
+	directPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(directPath)
+}
+
+func stripCommentsAndWhitespace(line string) string {
+	index := strings.Index(line, "#")
+	if index >= 0 {
+		line = line[:index]
+	}
+	return strings.TrimSpace(line)
+}
+
+func parseRcRule(line string) (*RcRule, error) {
+	tokens, err := shlex.Split(line)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("unexpected empty line")
+	}
+	if strings.HasPrefix(tokens[0], "-") {
+		return &RcRule{
+			Phase:  "common",
+			Tokens: tokens,
+		}, nil
+	}
+	if !strings.Contains(tokens[0], ":") {
+		return &RcRule{
+			Phase:  tokens[0],
+			Tokens: tokens[1:],
+		}, nil
+	}
+	phaseConfig := strings.Split(tokens[0], ":")
+	if len(phaseConfig) != 2 {
+		return nil, fmt.Errorf("invalid bazelrc syntax: %s", phaseConfig)
+	}
+	return &RcRule{
+		Phase:  phaseConfig[0],
+		Config: phaseConfig[1],
+		Tokens: tokens[1:],
+	}, nil
+}
+
+func ParseRCFiles(workspaceDir string, filePaths ...string) ([]*RcRule, error) {
+	opts := make([]*RcRule, 0)
+	seen := map[string]bool{}
+	for _, filePath := range filePaths {
+		r, err := realpath(filePath)
+		if err != nil {
+			continue
+		}
+		if seen[r] {
+			continue
+		}
+		seen[r] = true
+
+		file, err := os.Open(filePath)
+		if err != nil {
+			continue
+		}
+		defer file.Close()
+		opts, err = appendRcRulesFromFile(workspaceDir, file, opts, nil /*=importStack*/)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
+}
+
+
+
+// Mirroring the behavior here:
+// https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java#L41
+func GetBazelOS() string {
+	switch runtime.GOOS {
+	case "linux":
+		return "linux"
+	case "darwin":
+		return "macos"
+	case "windows":
+		return "windows"
+	case "freebsd":
+		return "freebsd"
+	case "openbsd":
+		return "openbsd"
+	default:
+		return runtime.GOOS
+	}
+}
+
+func Parent(command string) (string, bool) {
+	parent, ok := parentCommand[command]
+	return parent, ok
+}

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -913,12 +913,8 @@ func asStartupBoolFlag(arg, name string) (value, ok bool) {
 // that passing `bazel --output_base build test ...` returns "build" as the
 // bazel command, even though "build" is the argument to --output_base.
 func GetBazelCommandAndIndex(args []string) (string, int) {
-	commands, err := bazelrc.BazelCommands()
-	if err != nil {
-		return "", -1
-	}
 	for i, a := range args {
-		if _, ok := commands[a]; ok {
+		if bazelrc.IsBazelCommand(a) {
 			return a, i
 		}
 	}


### PR DESCRIPTION
Moves this code out so that we can depend on some of this stuff from files `parser.go` will depend on in the future.

Part of the larger overall refactoring effort for parser.go
