### PR TITLE
Don't generate .list.sum file

### DIFF
--- a/rules/sha/BUILD
+++ b/rules/sha/BUILD
@@ -4,11 +4,9 @@ sh_test(
     name = "sha_test",
     srcs = ["sha_test.sh"],
     data = [
-        ":testdata_sha.list.sum",
         ":testdata_sha.sum",
     ],
     env = {
-        "TESTDATA_LIST_SUM": "$(location :testdata_sha.list.sum)",
         "TESTDATA_SUM": "$(location :testdata_sha.sum)",
     },
 )

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -4,23 +4,28 @@ def sha(name, srcs, **kwargs):
     native.genrule(
         name = name,
         srcs = srcs,
-        outs = [
-            name + ".sum",
-            name + ".list.sum",
-        ],
+        outs = [name + ".sum"],
         cmd_bash = """
         # Replaces host config paths like "bazel-out/{k8-opt,k8-fastbuild,k8-opt-ST-abc123}" etc.
         # with just "bazel-out/CONFIG"
         normalize_config_paths() {
             perl -p -e 's@ bazel-out/.*?/@ bazel-out/CONFIG/@'
         }
+        _debug() {
+            if [ "$${BB_RULES_SHA_DEBUG:-0}" -eq 1 ]; then
+                tee /dev/stderr
+                echo >&2 "rules/sha: BB_RULES_SHA_DEBUG=1; exiting (see file hashes above)"
+                exit 1
+            fi
+            cat
+        }
         find -L $(SRCS) -type f |
             sort |
             xargs shasum |
             normalize_config_paths |
-            tee $(location :%s.list.sum) |
+            _debug |
             shasum |
-            awk '{ print $$1 }' > $(location :%s.sum)
-        """ % (name, name),
+            awk '{ print $$1 }' > $@
+        """,
         **kwargs
     )

--- a/rules/sha/sha_test.sh
+++ b/rules/sha/sha_test.sh
@@ -9,15 +9,6 @@ EXPECTED_HASHES=$(cat <<EOF
 797f24c0a77095eb03f5a1f183245eb371d6db00  rules/sha/testdata/dir.ln/child.txt
 EOF
 )
-ACTUAL_HASHES=$(cat "$TESTDATA_LIST_SUM")
-if [ "$ACTUAL_HASHES" != "$EXPECTED_HASHES" ]; then
-  echo >&2 "Unexpected .list.sum contents:"
-  echo >&2 "$ACTUAL_HASHES"
-  echo >&2 "Expected:"
-  echo >&2 "$EXPECTED_HASHES"
-  exit 1
-fi
-
 # This expected hash was computed by copying the "EXPECTED_HASHES" declaration
 # above, then running:
 # echo "$EXPECTED_HASHES" | shasum
@@ -25,5 +16,6 @@ EXPECTED_HASH='1c385057a72428ea0499c51856a90e638c9dd7df'
 ACTUAL_HASH=$(cat "$TESTDATA_SUM")
 if [ "$ACTUAL_HASH" != "$EXPECTED_HASH" ]; then
   echo >&2 "Unexpected .sum contents: '$ACTUAL_HASH' does not match expected hash '$EXPECTED_HASH'"
+  echo >&2 "Re-run with --action_env=BB_RULES_SHA_DEBUG=1 to see the intermediate file hashes."
   exit 1
 fi


### PR DESCRIPTION
This breaks the gcs deployment because the target label is now ambiguous as to which sum file it refers to.

The .list.sum file was only needed for debugging. Instead add an env var that prints out the .list.sum file contents to stderr and fails.