### PR TITLE
[raft] remove ListReplicas API

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1077,18 +1077,16 @@ func (s *Store) SnapshotCluster(ctx context.Context, rangeID uint64) error {
 	}
 }
 
-func (s *Store) ListReplicas(ctx context.Context, req *rfpb.ListReplicasRequest) (*rfpb.ListReplicasResponse, error) {
-	rsp := &rfpb.ListReplicasResponse{
-		Node: s.NodeDescriptor(),
-	}
+func (s *Store) ListReplicasForTest() []*rfpb.ReplicaDescriptor {
+	replicas := []*rfpb.ReplicaDescriptor{}
 	nhInfo := s.nodeHost.GetNodeHostInfo(dragonboat.DefaultNodeHostInfoOption)
 	for _, shardInfo := range nhInfo.ShardInfoList {
-		rsp.Replicas = append(rsp.Replicas, &rfpb.ReplicaDescriptor{
+		replicas = append(replicas, &rfpb.ReplicaDescriptor{
 			RangeId:   shardInfo.ShardID,
 			ReplicaId: shardInfo.ReplicaID,
 		})
 	}
-	return rsp, nil
+	return replicas
 }
 
 func (s *Store) getLeasedReplicas(ctx context.Context) []*replica.Replica {

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -569,13 +569,6 @@ message SplitRangeResponse {
   RangeDescriptor right = 2;
 }
 
-message ListReplicasRequest {}
-
-message ListReplicasResponse {
-  NodeDescriptor node = 1;
-  repeated ReplicaDescriptor replicas = 2;
-}
-
 message CreateSnapshotRequest {
   Header header = 1;
   bytes start = 2;

--- a/proto/raft_service.proto
+++ b/proto/raft_service.proto
@@ -13,8 +13,6 @@ service Api {
   rpc AddReplica(raft.AddReplicaRequest) returns (raft.AddReplicaResponse);
   rpc RemoveReplica(raft.RemoveReplicaRequest)
       returns (raft.RemoveReplicaResponse);
-  rpc ListReplicas(raft.ListReplicasRequest)
-      returns (raft.ListReplicasResponse);
   rpc TransferLeadership(TransferLeadershipRequest)
       returns (TransferLeadershipResponse);
 


### PR DESCRIPTION
ListReplicas is only used in test. Renamed it to ListReplicasForTest.
Removed ListReplicasTest
