### PR TITLE
Disable commit status reporting in executor arm64 test builds

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -50,6 +50,7 @@ jobs:
           common --flaky_test_attempts=3
           common --local_test_jobs=1
           common --build_metadata=ROLE=CI
+          common --build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true
           common --color=yes
           common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           "


### PR DESCRIPTION
These are polluting the statuses with a bunch of extra invocations for each PR run.