### PR TITLE
[cachetools] Re-introduce UploadWriter; use in UploadFromReader

### DIFF
--- a/server/remote_cache/cachetools/BUILD
+++ b/server/remote_cache/cachetools/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
+        "//server/util/bytebufferpool",
         "//server/util/compression",
         "//server/util/ioutil",
         "//server/util/log",

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -734,3 +734,140 @@ func TestUploadReader_BlobExists(t *testing.T) {
 		})
 	}
 }
+
+func TestUploadWriter_InterleaveWritesReadFrom(t *testing.T) {
+	quarter := (2 * 1024 * 1024) / 4
+	rn, buf := testdigest.RandomCASResourceBuf(t, int64(4*quarter))
+	te := testenv.GetTestEnv(t)
+	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
+	testcache.Setup(t, te, localGRPClis)
+	go runServer()
+	ctx := context.Background()
+	casrn := digest.NewCASResourceName(rn.Digest, rn.InstanceName, rn.DigestFunction)
+	uw, err := cachetools.NewUploadWriter(ctx, te.GetByteStreamClient(), casrn)
+	require.NoError(t, err)
+	{
+		n, err := uw.Write(buf[:quarter])
+		require.NoError(t, err)
+		require.Equal(t, quarter, n)
+	}
+	{
+		n, err := uw.ReadFrom(bytes.NewReader(buf[quarter : 2*quarter]))
+		require.NoError(t, err)
+		require.Equal(t, int64(quarter), n)
+	}
+	{
+		n, err := uw.Write(buf[2*quarter : 3*quarter])
+		require.NoError(t, err)
+		require.Equal(t, quarter, n)
+	}
+	{
+		n, err := uw.ReadFrom(bytes.NewReader(buf[3*quarter:]))
+		require.NoError(t, err)
+		require.Equal(t, int64(quarter), n)
+	}
+
+	err = uw.Commit()
+	require.NoError(t, err)
+
+	err = uw.Close()
+	require.NoError(t, err)
+
+	out := &bytes.Buffer{}
+	err = cachetools.GetBlob(ctx, te.GetByteStreamClient(), casrn, out)
+	require.NoError(t, err)
+	require.Equal(t, 4*quarter, out.Len())
+	require.Empty(t, cmp.Diff(buf[0:9], out.Bytes()[0:9]))
+	require.Empty(t, cmp.Diff(buf[len(buf)-9:], out.Bytes()[len(buf)-9:]))
+}
+
+func TestUploadWriter_NoWritesReadFromsAfterCommit(t *testing.T) {
+	rn, buf := testdigest.RandomCASResourceBuf(t, 2*1024*1024)
+	te := testenv.GetTestEnv(t)
+	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
+	testcache.Setup(t, te, localGRPClis)
+	go runServer()
+	ctx := context.Background()
+	casrn := digest.NewCASResourceName(rn.Digest, rn.InstanceName, rn.DigestFunction)
+
+	uw, err := cachetools.NewUploadWriter(ctx, te.GetByteStreamClient(), casrn)
+	require.NoError(t, err)
+	written, err := uw.Write(buf)
+	require.NoError(t, err)
+	require.Equal(t, len(buf), written)
+
+	// The blob is not available before commit
+	{
+		out := &bytes.Buffer{}
+		err = cachetools.GetBlob(ctx, te.GetByteStreamClient(), casrn, out)
+		require.Error(t, err)
+	}
+
+	err = uw.Commit()
+	require.NoError(t, err)
+
+	// The blob is available post commit
+	{
+		out := &bytes.Buffer{}
+		err = cachetools.GetBlob(ctx, te.GetByteStreamClient(), casrn, out)
+		require.NoError(t, err)
+		require.Equal(t, len(buf), out.Len())
+		require.Empty(t, cmp.Diff(buf[0:9], out.Bytes()[0:9]))
+		require.Empty(t, cmp.Diff(buf[len(buf)-9:], out.Bytes()[len(buf)-9:]))
+	}
+
+	// Cannot Write after commit
+	written, err = uw.Write(buf)
+	require.Error(t, err)
+	require.Equal(t, 0, written)
+
+	// Cannot ReadFrom after commit
+	n, err := uw.ReadFrom(bytes.NewReader(buf))
+	require.Error(t, err)
+	require.Equal(t, int64(0), n)
+
+	// Cannot commit again after commit
+	err = uw.Commit()
+	require.Error(t, err)
+
+	err = uw.Close()
+	require.NoError(t, err)
+
+	// Cannot Write after close
+	written, err = uw.Write(buf)
+	require.Error(t, err)
+	require.Equal(t, 0, written)
+
+	// Cannot ReadFrom after close
+	n, err = uw.ReadFrom(bytes.NewReader(buf))
+	require.Error(t, err)
+	require.Equal(t, int64(0), n)
+
+	// Cannot close again after close
+	err = uw.Close()
+	require.Error(t, err)
+}
+
+func TestUploadWriter_CanCloseBeforeCommit(t *testing.T) {
+	rn, buf := testdigest.RandomCASResourceBuf(t, 2*1024*1024)
+	te := testenv.GetTestEnv(t)
+	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
+	testcache.Setup(t, te, localGRPClis)
+	go runServer()
+	ctx := context.Background()
+	casrn := digest.NewCASResourceName(rn.Digest, rn.InstanceName, rn.DigestFunction)
+
+	uw, err := cachetools.NewUploadWriter(ctx, te.GetByteStreamClient(), casrn)
+	require.NoError(t, err)
+	written, err := uw.Write(buf)
+	require.NoError(t, err)
+	require.Equal(t, len(buf), written)
+
+	err = uw.Close()
+	require.NoError(t, err)
+
+	// Blob is not available since we did not commit
+	out := &bytes.Buffer{}
+	err = cachetools.GetBlob(ctx, te.GetByteStreamClient(), casrn, out)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Now that we have tests for calling `UploadFromReader` on a blob that already exists in the CAS, this change re-introduces `UploadWriter`.