### PR TITLE
Remove list of options disallowed in `startup` in rc files from `parser.go`

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -70,14 +70,6 @@ func SetBazelHelpForTesting(encodedProto string) {
 	}
 }
 
-var StartupFlagNoRc = map[string]struct{}{
-	"ignore_all_rc_files": {},
-	"home_rc":             {},
-	"workspace_rc":        {},
-	"system_rc":           {},
-	"bazelrc":             {},
-}
-
 // Parser contains a set of OptionDefinitions (indexed for ease of parsing) and
 // the known bazel commands.
 type Parser struct {


### PR DESCRIPTION
We moved this to `bazelrc.go`
