### PR TITLE
Avoid a global lock and reference counting in `lockmap`

### DIFF
--- a/server/util/lockmap/BUILD
+++ b/server/util/lockmap/BUILD
@@ -10,8 +10,8 @@ go_library(
 go_test(
     name = "lockmap_test",
     srcs = ["lockmap_test.go"],
+    embed = [":lockmap"],
     deps = [
-        ":lockmap",
         "//server/util/random",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",

--- a/server/util/lockmap/lockmap.go
+++ b/server/util/lockmap/lockmap.go
@@ -2,38 +2,12 @@ package lockmap
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
-type refCount struct {
-	i *int64
-}
-
-func (c *refCount) Inc() int64 {
-	j := atomic.AddInt64(c.i, 1)
-	return j
-}
-func (c *refCount) Dec() int64 {
-	j := atomic.AddInt64(c.i, -1)
-	return j
-}
-func (c *refCount) Val() int64 {
-	j := atomic.LoadInt64(c.i)
-	return j
-}
-
 type refCountedMutex struct {
 	sync.RWMutex
-	count refCount
-}
-
-func newRefCountedMutex() *refCountedMutex {
-	var i int64
-	return &refCountedMutex{
-		RWMutex: sync.RWMutex{},
-		count:   refCount{&i},
-	}
+	collected bool
 }
 
 // Locker implements a per-key mutex. This can be useful when protecting access
@@ -65,7 +39,6 @@ type Locker interface {
 
 type perKeyMutex struct {
 	mutexes sync.Map
-	bigLock sync.RWMutex
 	closed  chan struct{}
 }
 
@@ -87,46 +60,72 @@ func (p *perKeyMutex) gc() {
 		case <-t.C:
 		}
 		p.mutexes.Range(func(key, value any) bool {
-			p.bigLock.Lock()
 			rcm := value.(*refCountedMutex)
-			if rcm.count.Val() == 0 {
-				p.mutexes.Delete(key)
+			if !rcm.TryLock() {
+				// The mutex is in use and thus shouldn't be collected.
+				return true
 			}
-			p.bigLock.Unlock()
+			// At this point we hold the exclusive lock, so there are two cases:
+			// * There were no other goroutines waiting to acquire a lock, which
+			//   means that the mutex should be collected.
+			// * There were other goroutines waiting to acquire a lock, but they
+			//   failed to acquire it in the short period of time between it
+			//   becoming available and us acquiring it. As GC only rarely runs,
+			//   this case is expected to be very uncommon. All waiting
+			//   goroutines will need to refetch from the map.
+			//
+			// Mark the mutex as unusable before removing it from the map so
+			// that there are never two active mutexes for the same key.
+			rcm.collected = true
+			rcm.Unlock()
+			p.mutexes.Delete(key)
 			return true
 		})
 	}
 }
 
 func (p *perKeyMutex) Lock(key string) func() {
-	p.bigLock.Lock()
-	value, _ := p.mutexes.LoadOrStore(key, newRefCountedMutex())
-	rcm := value.(*refCountedMutex)
-	rcm.count.Inc()
-	p.bigLock.Unlock()
-
-	rcm.Lock()
-	return func() {
+	var rcm *refCountedMutex
+	for {
+		val, _ := p.mutexes.LoadOrStore(key, &refCountedMutex{})
+		rcm = val.(*refCountedMutex)
+		rcm.Lock()
+		if !rcm.collected {
+			break
+		}
+		// We hit the window between rcm.Unlock() and p.mutexes.Delete(key) in
+		// the gc() method. Busy wait for the map slot to be cleared.
 		rcm.Unlock()
-		rcm.count.Dec()
 	}
+	return func() { rcm.Unlock() }
 }
 
 func (p *perKeyMutex) RLock(key string) func() {
-	p.bigLock.Lock()
-	value, _ := p.mutexes.LoadOrStore(key, newRefCountedMutex())
-	rcm := value.(*refCountedMutex)
-	rcm.count.Inc()
-	p.bigLock.Unlock()
-
-	rcm.RLock()
-	return func() {
+	var rcm *refCountedMutex
+	for {
+		val, _ := p.mutexes.LoadOrStore(key, &refCountedMutex{})
+		rcm = val.(*refCountedMutex)
+		rcm.RLock()
+		if !rcm.collected {
+			break
+		}
+		// See comment in Lock().
 		rcm.RUnlock()
-		rcm.count.Dec()
 	}
+	return func() { rcm.RUnlock() }
 }
 
 func (p *perKeyMutex) Close() error {
 	close(p.closed)
 	return nil
+}
+
+// For testing only.
+func (p *perKeyMutex) count() int {
+	count := 0
+	p.mutexes.Range(func(key, value any) bool {
+		count++
+		return true
+	})
+	return count
 }

--- a/server/util/lockmap/lockmap_test.go
+++ b/server/util/lockmap/lockmap_test.go
@@ -26,9 +26,14 @@ func TestLock(t *testing.T) {
 	eg.Wait()
 	require.Equal(t, 100, m["samekey"])
 
-	// Wait for gc
-	time.Sleep(200 * time.Millisecond)
-	require.Equal(t, 0, l.count())
+	// Wait for gc. This test will time out if the single entry isn't cleaned
+	// up eventually.
+	for {
+		if l.count() == 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 func TestRLock(t *testing.T) {
@@ -57,9 +62,14 @@ func TestRLock(t *testing.T) {
 	eg.Wait()
 	require.Equal(t, 20, m["samekey"])
 
-	// Wait for gc
-	time.Sleep(200 * time.Millisecond)
-	require.Equal(t, 0, l.count())
+	// Wait for gc. This test will time out if the single entry isn't cleaned
+	// up eventually.
+	for {
+		if l.count() == 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 func BenchmarkLockQPS(b *testing.B) {


### PR DESCRIPTION
Instead of using a global lock on the entire `sync.Map` to avoid races with the custom GC routine, mark them as unusuable under their own write lock and have the `(R)Lock` function spin when it encounters such a mutex. This should only occur very rarely (GCs are performed at most once every 100ms) and the period of spinning should be short (as long as it takes to delete a key in the map). 

Reference counting is replaced with a call to `TryLock` for a particular entry, which combines a check for approximate unusedness with an acquire of the lock needed to mark the mutex as unusuable in a single atomic operation. This may succeed even though other goroutines were waiting on the lock, in which case they all have to refetch the new mutex from the map. This should also be a rare case since it requires GC to be performed at the exact time where the lock becomes available.

Benchmark:
```
goos: darwin
goarch: arm64
cpu: Apple M3 Max

before:
BenchmarkLockQPS-16     	 1000000	      1145.0 ns/op	     304 B/op	       7 allocs/op
BenchmarkRLockQPS-16    	 5469183	       210.8 ns/op	      72 B/op	       4 allocs/op

after:
BenchmarkLockQPS-16     	 1423785	       841.8 ns/op	     302 B/op	       6 allocs/op
BenchmarkRLockQPS-16    	62436318	        20.4 ns/op	      64 B/op	       3 allocs/op

            │   old.txt    │               new.txt               │
            │    sec/op    │   sec/op     vs base                │
LockQPS-16    1074.0n ± 2%   848.0n ± 1%  -21.05% (p=0.000 n=10)
RLockQPS-16   214.00n ± 4%   18.04n ± 3%  -91.57% (p=0.000 n=10)
geomean        479.4n        123.7n       -74.21%

            │  old.txt   │              new.txt               │
            │    B/op    │    B/op     vs base                │
LockQPS-16    305.0 ± 0%   302.0 ± 0%   -0.98% (p=0.000 n=10)
RLockQPS-16   72.00 ± 0%   64.00 ± 0%  -11.11% (p=0.000 n=10)
geomean       148.2        139.0        -6.18%

            │  old.txt   │              new.txt               │
            │ allocs/op  │ allocs/op   vs base                │
LockQPS-16    7.000 ± 0%   6.000 ± 0%  -14.29% (p=0.000 n=10)
RLockQPS-16   4.000 ± 0%   3.000 ± 0%  -25.00% (p=0.000 n=10)
geomean       5.292        4.243       -19.82%
```