### PR TITLE
Optimize migration_cache.Read

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math/rand"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -469,12 +470,11 @@ func (d *doubleReader) Read(p []byte) (n int, err error) {
 
 	if d.dest != nil {
 		eg.Go(func() error {
-			if d.doubleReadBuf == nil || len(d.doubleReadBuf) != len(p) {
-				d.doubleReadBuf = make([]byte, len(p))
-			}
+			// Grow never changes the length, so it will stay 0.
+			d.doubleReadBuf = slices.Grow(d.doubleReadBuf, len(p))
 
 			var dstN int
-			dstN, dstErr = io.ReadFull(d.dest, d.doubleReadBuf)
+			dstN, dstErr = io.ReadFull(d.dest, d.doubleReadBuf[:len(p)])
 			if dstErr == io.ErrUnexpectedEOF {
 				dstErr = io.EOF
 			}


### PR DESCRIPTION
Try harder to avoid allocating a buffer on every double read. This makes it 40% faster, mostly by allocating 50% less.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                            │   read-buf   │             read-grow              │
                            │    sec/op    │   sec/op     vs base               │
Read/LocalMigration10-24       40.16µ ± 1%   34.97µ ± 2%  -12.91% (p=0.001 n=7)
Read/LocalMigration100-24      91.51µ ± 4%   64.45µ ± 2%  -29.57% (p=0.001 n=7)
Read/LocalMigration1000-24     271.9µ ± 3%   148.2µ ± 2%  -45.51% (p=0.001 n=7)
Read/LocalMigration10000-24   1426.6µ ± 7%   542.3µ ± 3%  -61.98% (p=0.001 n=7)
geomean                        194.3µ        116.0µ       -40.30%

                            │   read-buf   │               read-grow               │
                            │     B/s      │      B/s       vs base                │
Read/LocalMigration10-24      244.1Ki ± 0%    283.2Ki ± 3%   +16.00% (p=0.001 n=7)
Read/LocalMigration100-24     1.040Mi ± 4%    1.478Mi ± 2%   +42.20% (p=0.001 n=7)
Read/LocalMigration1000-24    3.510Mi ± 3%    6.437Mi ± 3%   +83.42% (p=0.001 n=7)
Read/LocalMigration10000-24   6.685Mi ± 8%   17.586Mi ± 2%  +163.05% (p=0.001 n=7)
geomean                       1.553Mi         2.608Mi        +67.96%

                            │   read-buf    │              read-grow              │
                            │     B/op      │     B/op      vs base               │
Read/LocalMigration10-24      177.0Ki ±  9%   112.6Ki ± 5%  -36.40% (p=0.001 n=7)
Read/LocalMigration100-24     883.2Ki ±  4%   474.0Ki ± 1%  -46.33% (p=0.001 n=7)
Read/LocalMigration1000-24    3.499Mi ±  0%   1.757Mi ± 0%  -49.77% (p=0.001 n=7)
Read/LocalMigration10000-24   28.70Mi ± 11%   14.41Mi ± 2%  -49.79% (p=0.001 n=7)
geomean                       1.967Mi         1.065Mi       -45.83%

                            │  read-buf  │            read-grow             │
                            │ allocs/op  │ allocs/op   vs base              │
Read/LocalMigration10-24      217.0 ± 0%   216.0 ± 0%  -0.46% (p=0.001 n=7)
Read/LocalMigration100-24     218.0 ± 0%   217.0 ± 0%  -0.46% (p=0.001 n=7)
Read/LocalMigration1000-24    220.0 ± 0%   218.0 ± 0%  -0.91% (p=0.001 n=7)
Read/LocalMigration10000-24   233.0 ± 0%   226.0 ± 0%  -3.00% (p=0.001 n=7)
geomean                       221.9        219.2       -1.21%
```