### PR TITLE
CLI: Error out when attempting to expand unrecognized config option

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -698,11 +698,8 @@ func (p *Parser) expandConfigs(workspaceDir string, args []string) ([]string, er
 		configIndex := offset + parsedArgs.Offset(opts[0].Index)
 		length := len(opts[0].Format())
 
-		// If the config isn't defined, leave it as-is, and let bazel return
-		// an error.
 		if !isConfigDefined(rules, config, phases) {
-			offset = configIndex + length
-			continue
+			return nil, fmt.Errorf("config value '%s' is not defined in any .rc file", config)
 		}
 
 		var configArgs []string


### PR DESCRIPTION
It is clearer to fail early, and means we do not need to create a potentially confusing partially-expanded list of command-line arguments to pass to bazel. The goal is that any command line that is actually passed to bazel is fully expanded and free from any `rc` options, save the single `ignore_all_rc` option we add when consuming the rc files.
