### PR TITLE
Update execution server to allow storing metadata in Redis

### DIFF
--- a/enterprise/server/util/execution/execution.go
+++ b/enterprise/server/util/execution/execution.go
@@ -19,12 +19,10 @@ import (
 )
 
 func TableExecToProto(in *tables.Execution, invLink *sipb.StoredInvocationLink) *repb.StoredExecution {
-	return &repb.StoredExecution{
+	ex := &repb.StoredExecution{
 		GroupId:                            in.GroupID,
 		UpdatedAtUsec:                      in.UpdatedAtUsec,
 		ExecutionId:                        in.ExecutionID,
-		InvocationUuid:                     strings.Replace(invLink.GetInvocationId(), "-", "", -1),
-		InvocationLinkType:                 int32(invLink.GetType()),
 		CreatedAtUsec:                      in.CreatedAtUsec,
 		UserId:                             in.UserID,
 		Worker:                             in.Worker,
@@ -55,6 +53,13 @@ func TableExecToProto(in *tables.Execution, invLink *sipb.StoredInvocationLink) 
 		DoNotCache:                         in.DoNotCache,
 		CommandSnippet:                     in.CommandSnippet,
 	}
+	SetInvocationLink(ex, invLink)
+	return ex
+}
+
+func SetInvocationLink(ex *repb.StoredExecution, invLink *sipb.StoredInvocationLink) {
+	ex.InvocationUuid = strings.Replace(invLink.GetInvocationId(), "-", "", -1)
+	ex.InvocationLinkType = int32(invLink.GetType())
 }
 
 func TableExecToClientProto(in *tables.Execution) (*espb.Execution, error) {


### PR DESCRIPTION
Introduces 3 flags to the execution server:
- `remote_execution.write_execution_progress_state_to_redis`: if enabled, writes execution updates and invocation-execution links to Redis, using the new methods added in https://github.com/buildbuddy-io/buildbuddy/commit/9b6419d71a3a700873dcd35cdc505755241f6faf
- `remote_execution.write_executions_to_primary_db`: if enabled, writes Execution rows and InvocationExecution rows to mysql. Defaults to true in order to preserve our current behavior.
- `remote_execution.read_final_execution_state_from_redis`: if enabled, read the final execution state from redis instead of mysql when we write executions to clickhouse.

The rollout plan to fully stop writing executions to MySQL would then be:
- Rollout 1: enable `remote_execution.write_execution_progress_state_to_redis`
- Rollout 2: enable `remote_execution.read_final_execution_state_from_redis`
- Rollout 3: disable `remote_execution.write_executions_to_primary_db`

This PR only affects the execution server; the UI endpoint (execution_service) also needs to be updated to read the in-progress execution state from redis, which will be done in a separate PR.