### PR TITLE
Don't attempt to delete from dst cache on src failure

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -222,7 +222,7 @@ func TestSet_SrcWriteErr(t *testing.T) {
 	err = mc.Set(ctx, r, buf)
 	require.Error(t, err)
 
-	// Verify data was deleted from the dest cache
+	// Verify data wasn't committed to the dest cache.
 	destData, err := destCache.Get(ctx, r)
 	require.Error(t, err)
 	require.True(t, status.IsNotFoundError(err))


### PR DESCRIPTION
As far as I can tell, this code hasn't been doing anything in a while. If src.Write fails, then Commit is never called on the destination, so there is nothing to delete.

See the discussion in https://github.com/buildbuddy-io/buildbuddy/pull/9336