### PR TITLE
Check for concurrent mutations while uploading

### DIFF
--- a/server/remote_cache/cachetools/BUILD
+++ b/server/remote_cache/cachetools/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//server/testutil/testcache",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
+        "//server/util/rpcutil",
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -591,6 +591,11 @@ func String(d *repb.Digest) string {
 	return fmt.Sprintf("%s/%d", d.Hash, d.SizeBytes)
 }
 
+// Equal returns whether two digests are exactly equal, including the size.
+func Equal(d1 *repb.Digest, d2 *repb.Digest) bool {
+	return d1.GetHash() == d2.GetHash() && d1.GetSizeBytes() == d2.GetSizeBytes()
+}
+
 // ElementsMatch returns whether two slices contain the same digests, ignoring the order of the elements.
 // If there are duplicate elements, the number of appearances of each of them in both lists should match.
 func ElementsMatch(s1 []*repb.Digest, s2 []*repb.Digest) bool {


### PR DESCRIPTION
If we get a DataLoss error, re-hash the file to diagnose whether it was due to a concurrent mutation, and if there is a hash mismatch, report a clearer error message instead of DataLoss.

Context: https://buildbuddy-corp.slack.com/archives/C0495TM9UUE/p1747332726948839?thread_ts=1747332576.080259&cid=C0495TM9UUE