### PR TITLE
Give cache benchmarks a long timeout

### DIFF
--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -1,7 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_test(
     name = "cache_test",
+    timeout = "long",
     srcs = ["cache_test.go"],
     args = [
         "-test.bench=.",
@@ -25,5 +28,3 @@ go_test(
         "//server/util/testing/flags",
     ],
 )
-
-package(default_visibility = ["//enterprise:__subpackages__"])


### PR DESCRIPTION
Since I added a new benchmark in https://github.com/buildbuddy-io/buildbuddy/pull/9354, they've been timing out.