### PR TITLE
Refactor runnerPool.TryRecycle in the executor

### DIFF
--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -37,5 +37,27 @@ go_library(
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)
+
+go_test(
+    name = "executor_test",
+    srcs = ["executor_test.go"],
+    deps = [
+        ":executor",
+        "//enterprise/server/remote_execution/operation",
+        "//enterprise/server/test/integration/remote_execution/rbetest",
+        "//enterprise/server/testutil/enterprise_testenv",
+        "//proto:remote_execution_go_proto",
+        "//proto:scheduler_go_proto",
+        "//server/interfaces",
+        "//server/remote_cache/digest",
+        "//server/testutil/testauth",
+        "//server/testutil/testcache",
+        "//server/testutil/testenv",
+        "//server/testutil/testfs",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto//googleapis/longrunning",
     ],
 )

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -227,8 +227,8 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	md := &repb.ExecutedActionMetadata{
 		Worker:                   s.hostID,
 		QueuedTimestamp:          task.QueuedTimestamp,
-		WorkerStartTimestamp:     timestamppb.Now(),
-		WorkerCompletedTimestamp: timestamppb.Now(),
+		WorkerStartTimestamp:     timestamppb.New(s.env.GetClock().Now()),
+		WorkerCompletedTimestamp: timestamppb.New(s.env.GetClock().Now()),
 		ExecutorId:               s.id,
 		IoStats:                  &repb.IOStats{},
 		EstimatedTaskSize:        st.GetSchedulingMetadata().GetTaskSize(),
@@ -239,7 +239,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 			return true, finalErr
 		}
 		resp := operation.ErrorResponse(finalErr)
-		md.WorkerCompletedTimestamp = timestamppb.Now()
+		md.WorkerCompletedTimestamp = timestamppb.New(s.env.GetClock().Now())
 		if err := appendAuxiliaryMetadata(md, auxMetadata); err != nil {
 			log.CtxWarningf(ctx, "Failed to append ExecutionAuxiliaryMetadata: %s", err)
 		}
@@ -303,7 +303,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		return finishWithErrFn(err)
 	}
 
-	md.InputFetchStartTimestamp = timestamppb.Now()
+	md.InputFetchStartTimestamp = timestamppb.New(s.env.GetClock().Now())
 
 	log.CtxDebugf(ctx, "Downloading inputs.")
 	stage.Set("input_fetch")
@@ -312,8 +312,8 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		return finishWithErrFn(err)
 	}
 
-	md.InputFetchCompletedTimestamp = timestamppb.Now()
-	md.ExecutionStartTimestamp = timestamppb.Now()
+	md.InputFetchCompletedTimestamp = timestamppb.New(s.env.GetClock().Now())
+	md.ExecutionStartTimestamp = timestamppb.New(s.env.GetClock().Now())
 	execTimeouts, err := parseTimeouts(task)
 	if err != nil {
 		// These errors are failure-specific. Pass through unchanged.
@@ -321,7 +321,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	}
 	auxMetadata.Timeout = durationpb.New(execTimeouts.TerminateAfter)
 
-	now := time.Now()
+	now := s.env.GetClock().Now()
 	terminateAt := now.Add(execTimeouts.TerminateAfter)
 	forceShutdownAt := now.Add(execTimeouts.ForceKillAfter)
 
@@ -419,8 +419,8 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 			return finishWithErrFn(status.InternalErrorf("append auxiliary metadata: %s", err))
 		}
 	}
-	md.ExecutionCompletedTimestamp = timestamppb.Now()
-	md.OutputUploadStartTimestamp = timestamppb.Now()
+	md.ExecutionCompletedTimestamp = timestamppb.New(s.env.GetClock().Now())
+	md.OutputUploadStartTimestamp = timestamppb.New(s.env.GetClock().Now())
 
 	actionResult := &repb.ActionResult{}
 	actionResult.ExitCode = int32(cmdResult.ExitCode)
@@ -433,8 +433,8 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	if err := r.UploadOutputs(ctx, md.IoStats, executeResponse, cmdResult); err != nil {
 		return finishWithErrFn(status.UnavailableErrorf("Error uploading outputs: %s", err.Error()))
 	}
-	md.OutputUploadCompletedTimestamp = timestamppb.Now()
-	md.WorkerCompletedTimestamp = timestamppb.Now()
+	md.OutputUploadCompletedTimestamp = timestamppb.New(s.env.GetClock().Now())
+	md.WorkerCompletedTimestamp = timestamppb.New(s.env.GetClock().Now())
 	actionResult.ExecutionMetadata = md
 
 	// If there's an error that we know the client won't retry, return an error

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -1,0 +1,157 @@
+package executor_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/longrunning"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
+)
+
+type mockExecutionServer struct {
+	repb.UnimplementedExecutionServer
+	operations []*longrunning.Operation
+	finished   chan struct{}
+}
+
+func (s *mockExecutionServer) Execute(req *repb.ExecuteRequest, stream repb.Execution_ExecuteServer) error {
+	return nil
+}
+
+func (s *mockExecutionServer) WaitExecution(req *repb.WaitExecutionRequest, stream repb.Execution_WaitExecutionServer) error {
+	return nil
+}
+
+func (s *mockExecutionServer) PublishOperation(stream repb.Execution_PublishOperationServer) error {
+	for {
+		op, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		s.operations = append(s.operations, op)
+		stage := operation.ExtractStage(op)
+		if stage == repb.ExecutionStage_COMPLETED {
+			close(s.finished)
+		}
+	}
+}
+
+type counters struct {
+	countFinishedCleanly int
+	countRecycled        int
+}
+
+func getExecutor(t *testing.T) (*executor.Executor, repb.ExecutionClient, *mockExecutionServer, *counters) {
+	env := enterprise_testenv.New(t)
+	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	clock := clockwork.NewFakeClock()
+	env.SetClock(clock)
+	_, runServer, lis := testenv.RegisterLocalGRPCServer(t, env)
+	testcache.Setup(t, env, lis)
+	mockServer := &mockExecutionServer{operations: make([]*longrunning.Operation, 0), finished: make(chan struct{})}
+	repb.RegisterExecutionServer(env.GetGRPCServer(), mockServer)
+	go runServer()
+
+	c := &counters{}
+	cacheRoot := testfs.MakeTempDir(t)
+	runnerPool := rbetest.NewTestRunnerPool(t, env, cacheRoot, rbetest.TestRunnerOverrides{
+		RunInterceptor:     rbetest.RunNoop(),
+		DownloadInputsMock: rbetest.DownloadInputsNoop(),
+		RecycleInterceptor: func(ctx context.Context, r interfaces.Runner, finishedCleanly bool, original rbetest.TryRecycleFunc) {
+			// Simulate that recycling takes 1min.
+			clock.Advance(1 * time.Minute)
+			c.countRecycled++
+			if finishedCleanly {
+				c.countFinishedCleanly++
+			}
+		},
+	})
+	exec, err := executor.NewExecutor(env, "executor-id", "host-id", "hostname", runnerPool)
+	require.NoError(t, err)
+
+	conn, err := testenv.LocalGRPCConn(context.Background(), lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	client := repb.NewExecutionClient(conn)
+
+	return exec, client, mockServer, c
+}
+
+func getTask() *repb.ScheduledTask {
+	r := digest.NewCASResourceName(&repb.Digest{Hash: strings.Repeat("a", 64), SizeBytes: 1}, "", repb.DigestFunction_SHA256)
+	executionID := r.NewUploadString()
+	return &repb.ScheduledTask{
+		ExecutionTask: &repb.ExecutionTask{
+			ExecutionId: executionID,
+			ExecuteRequest: &repb.ExecuteRequest{
+				ActionDigest: &repb.Digest{
+					Hash:      strings.Repeat("b", 64),
+					SizeBytes: 123,
+				},
+				InstanceName:   "",
+				DigestFunction: repb.DigestFunction_SHA256,
+			},
+			Action: &repb.Action{},
+			Command: &repb.Command{
+				Arguments: []string{"echo", "hello"},
+			},
+		},
+		SchedulingMetadata: &scpb.SchedulingMetadata{
+			TaskSize: &scpb.TaskSize{
+				EstimatedMemoryBytes: 100,
+				EstimatedMilliCpu:    100,
+			},
+		},
+	}
+}
+
+func TestExecuteTaskAndStreamResults(t *testing.T) {
+	ctx := context.Background()
+	exec, execClient, mockServer, mockCounter := getExecutor(t)
+	task := getTask()
+
+	publisher, err := operation.Publish(ctx, execClient, task.ExecutionTask.ExecutionId)
+	require.NoError(t, err)
+
+	retry, err := exec.ExecuteTaskAndStreamResults(ctx, task, publisher)
+	require.NoError(t, err)
+	require.False(t, retry)
+
+	// Wait until all progress updates have finished sending.
+	require.Eventually(t, func() bool {
+		<-mockServer.finished
+		return true
+	}, 15*time.Second, 50*time.Millisecond)
+
+	require.Equal(t, 1, mockCounter.countRecycled)
+	require.Equal(t, 1, mockCounter.countFinishedCleanly)
+
+	operationStageCount := make(map[repb.ExecutionStage_Value]int, len(mockServer.operations))
+	for _, op := range mockServer.operations {
+		stage := operation.ExtractStage(op)
+		operationStageCount[stage]++
+	}
+
+	require.GreaterOrEqual(t, len(mockServer.operations), 3)
+	require.GreaterOrEqual(t, operationStageCount[repb.ExecutionStage_EXECUTING], 1)
+	require.Equal(t, 1, operationStageCount[repb.ExecutionStage_COMPLETED])
+
+	completedOp := mockServer.operations[len(mockServer.operations)-1]
+	require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
+}


### PR DESCRIPTION
To de-risk a PR to track cleanup time for executions, this is a small change to move `TryRecycle` out of a defer. This should be a no-op.