### PR TITLE
Tag benchmark tests `manual`

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -64,7 +64,10 @@ go_test(
         # costs, so run a fixed number instead of using time-based estimation.
         "-test.benchtime=16x",
     ],
-    tags = ["performance"],
+    tags = [
+        "manual",
+        "performance",
+    ],
     deps = [
         ":copy_on_write",
         "//enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil",

--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -9,7 +9,10 @@ go_test(
     args = [
         "-test.bench=.",
     ],
-    tags = ["performance"],
+    tags = [
+        "manual",
+        "performance",
+    ],
     deps = [
         "//enterprise/server/backends/distributed",
         "//enterprise/server/backends/migration_cache",


### PR DESCRIPTION
Benchmarks should only run in isolation, and only when explicitly invoked. It doesn't make much sense to run a benchmark as part of a wildcard target.
