### PR TITLE
Revert "Tag benchmark tests `manual`"

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -64,10 +64,7 @@ go_test(
         # costs, so run a fixed number instead of using time-based estimation.
         "-test.benchtime=16x",
     ],
-    tags = [
-        "manual",
-        "performance",
-    ],
+    tags = ["performance"],
     deps = [
         ":copy_on_write",
         "//enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil",

--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -9,10 +9,7 @@ go_test(
     args = [
         "-test.bench=.",
     ],
-    tags = [
-        "manual",
-        "performance",
-    ],
+    tags = ["performance"],
     deps = [
         "//enterprise/server/backends/distributed",
         "//enterprise/server/backends/migration_cache",


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#9368

This stopped the benchmarks workflow from running.