### PR TITLE
Move `-performance` filter to the default `test_tag_filters` in `.bazelrc`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,7 +37,10 @@ common:target-linux-arm64 --config=workspace-target-linux-arm64
 #
 # Exclude tests which require BuildBuddy Secrets from the default unauthenticated builds
 # These often require "include-secrets: true" exec property in their BUILD file.
-test --test_tag_filters=-docker,-bare,-secrets
+#
+# Don't run benchmarks by default; benchmarks should only run if we are
+# explicitly donig performance testing.
+test --test_tag_filters=-docker,-bare,-secrets,-performance
 
 # CI invocations from public repo should be publicly accessible.
 common:ci-shared --build_metadata=VISIBILITY=PUBLIC

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -212,20 +212,12 @@ common:remote-shared --verbose_failures
 # Flags shared for prod RBE and cache
 common:remote-prod-shared --config=remote-shared
 common:remote-prod-shared --remote_executor=grpcs://buildbuddy.buildbuddy.io
-# Tests tagged with "docker" or "bare" can be run if using authenticated RBE,
-# but performance tests should not be run remotely since the environment
-# is not consistent or stable.
-common:remote-prod-shared --test_tag_filters=-performance
 
 # Flags shared for dev BES, RBE and cache
 # Note: Dev BES needed to override the default prod BES urls.
 common:remote-dev-shared --config=dev
 common:remote-dev-shared --config=remote-shared
 common:remote-dev-shared --remote_executor=grpcs://buildbuddy.buildbuddy.dev
-# Tests tagged with "docker" or "bare" can be run if using authenticated RBE,
-# but performance tests should not be run remotely since the environment
-# is not consistent or stable.
-common:remote-dev-shared --test_tag_filters=-performance
 
 # Build with --config=remote to use BuildBuddy RBE, generally as a human from
 # the command line. Other configs shoudn't embed this.


### PR DESCRIPTION
Performance tests should not be run by default, they should instead be run specifically when we are trying to get benchmarks (for example, in the benchmark workflow).
