### PR TITLE
CLI: Ignore lines in bazelrc that consist of single shlex tokens

### DIFF
--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -187,6 +187,9 @@ func appendRcRulesFromFile(workspaceDir string, f *os.File, rules []*RcRule, imp
 			log.Debugf("Error parsing bazelrc option: %s", err.Error())
 			continue
 		}
+		if rule == nil {
+			continue
+		}
 		// Bazel doesn't support configs for startup options and ignores them if
 		// they appear in a bazelrc: https://bazel.build/run/bazelrc#config
 		if rule.Phase == "startup" && rule.Config != "" {
@@ -221,6 +224,10 @@ func parseRcRule(line string) (*RcRule, error) {
 	}
 	if len(tokens) == 0 {
 		return nil, fmt.Errorf("unexpected empty line")
+	}
+	if len(tokens) == 1 {
+		// bazel ignores .bazelrc lines consisting of a single shlex token
+		return nil, nil
 	}
 	if strings.HasPrefix(tokens[0], "-") {
 		return &RcRule{

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -110,10 +110,11 @@ startup --startup_flag_1
 startup:config --startup_configs_are_not_supported_so_this_flag_should_be_ignored
 
 # continuations are allowed \
---build_metadata=THIS_IS_NOT_A_FLAG_SINCE_IT_IS_PART_OF_THE_PREVIOUS_LINE=1
+common --build_metadata=THIS_IS_NOT_A_FLAG_SINCE_IT_IS_PART_OF_THE_PREVIOUS_LINE=1
 
---invalid_common_flag_1          # trailing comments are allowed
---build_metadata=VALID_COMMON_FLAG=1
+common --invalid_common_flag_1          # trailing comments are allowed
+--build_metadata=INVALID_COMMON_FLAG=1
+common --build_metadata=VALID_COMMON_FLAG=1
 common --invalid_common_flag_2
 common --build_metadata=VALID_COMMON_FLAG=2
 common:foo --build_metadata=COMMON_CONFIG_FOO=1


### PR DESCRIPTION
This is the behavior bazel does, as well.
