### PR TITLE
[Macs] Clean up the System Status row of the Mac Grafana dashboard

### DIFF
--- a/tools/metrics/grafana/dashboards/mac.json
+++ b/tools/metrics/grafana/dashboards/mac.json
@@ -51,22 +51,21 @@
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
+          "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 7,
-            "w": 24,
+            "h": 8,
+            "w": 12,
             "x": 0,
-            "y": 49
+            "y": 1
           },
           "hiddenSeries": false,
-          "id": 21,
+          "id": 6279,
           "legend": {
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
-            "rightSide": false,
             "show": true,
             "total": false,
             "values": false
@@ -82,115 +81,6 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeat": "job",
-          "repeatDirection": "h",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(up{region=\"${region}\", job=\"${job}\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Up",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "exemplar": true,
-              "expr": "sum(kube_pod_status_ready{region=\"${region}\", pod=~\"${job}-([0-9a-f]{8,10}-.*|[0-9]+)$\"})",
-              "interval": "",
-              "legendFormat": "Ready",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "${job} instances",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:365",
-              "decimals": 0,
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:366",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 56
-          },
-          "hiddenSeries": false,
-          "id": 6270,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "repeat": "job",
-          "repeatDirection": "h",
           "seriesOverrides": [],
           "spaceLength": 10,
           "stack": false,
@@ -202,10 +92,10 @@
                 "uid": "vm"
               },
               "editorMode": "code",
-              "expr": "sum by (version)(buildbuddy_version{region=\"${region}\", job=\"${job}\"})",
-              "hide": false,
+              "exemplar": true,
+              "expr": "sum(up{region=\"${region}\", job=\"${job}\"})",
               "interval": "",
-              "legendFormat": "{{version}}",
+              "legendFormat": "up",
               "queryType": "randomWalk",
               "range": true,
               "refId": "A"
@@ -213,7 +103,7 @@
           ],
           "thresholds": [],
           "timeRegions": [],
-          "title": "${job} versions",
+          "title": "${job} Instances",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -227,18 +117,16 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:365",
-              "decimals": 0,
+              "$$hashKey": "object:137",
               "format": "short",
               "logBase": 1,
-              "min": "0",
               "show": true
             },
             {
-              "$$hashKey": "object:366",
+              "$$hashKey": "object:138",
               "format": "short",
               "logBase": 1,
-              "show": false
+              "show": true
             }
           ],
           "yaxis": {
@@ -260,8 +148,100 @@
           "gridPos": {
             "h": 8,
             "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 6280,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.1.0",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (version) (buildbuddy_version{region=\"${region}\", job=\"${job}\"})",
+              "interval": "",
+              "legendFormat": "{{version}}",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "${job} Versions",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:137",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:138",
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "collapsed": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
             "x": 0,
-            "y": 63
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 932,
@@ -336,6 +316,101 @@
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "collapsed": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 6281,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.1.0",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "1 - (1 - up{region=\"${region}\", job=\"${job}\"})",
+              "interval": "",
+              "legendFormat": "{{inventory_hostname}}",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "${job} Instance States",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:137",
+              "decimals": 0,
+              "format": "bool_on_off",
+              "logBase": 1,
+              "max": "1",
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:138",
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
           "collapsed": true,
           "datasource": {
             "type": "prometheus",
@@ -396,9 +471,9 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 63
+            "w": 8,
+            "x": 16,
+            "y": 9
           },
           "id": 5492,
           "options": {
@@ -421,7 +496,7 @@
               },
               "editorMode": "code",
               "expr": "sum(1 - (buildbuddy_health_check_status{region=\"${region}\"} == 0)) by (pod_name, health_check_name)",
-              "legendFormat": "__auto",
+              "legendFormat": "{{pod_name}}",
               "range": true,
               "refId": "A"
             }
@@ -560,7 +635,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 10
           },
           "id": 6272,
           "options": {
@@ -707,7 +782,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 10
           },
           "id": 6273,
           "options": {
@@ -800,7 +875,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 18
           },
           "id": 6274,
           "options": {
@@ -893,7 +968,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 18
           },
           "id": 6275,
           "options": {
@@ -1002,7 +1077,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 26
           },
           "id": 6276,
           "options": {
@@ -1122,7 +1197,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 26
           },
           "id": 6277,
           "options": {
@@ -1203,7 +1278,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 274,
@@ -1316,7 +1391,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 58
           },
           "hiddenSeries": false,
           "id": 276,
@@ -1407,7 +1482,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 290,
@@ -1498,7 +1573,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 66
           },
           "hiddenSeries": false,
           "id": 292,
@@ -1589,7 +1664,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 66
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 278,
@@ -1680,7 +1755,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 66
+            "y": 74
           },
           "hiddenSeries": false,
           "id": 280,
@@ -1800,7 +1875,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 190,
@@ -1905,7 +1980,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 159,
@@ -2026,7 +2101,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 59
+            "y": 67
           },
           "hiddenSeries": false,
           "id": 210,
@@ -2163,7 +2238,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 59
+            "y": 67
           },
           "id": 1209,
           "options": {
@@ -2256,7 +2331,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 75
           },
           "id": 31,
           "options": {
@@ -2305,7 +2380,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 67
+            "y": 75
           },
           "hiddenSeries": false,
           "id": 178,
@@ -2452,7 +2527,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 83
           },
           "id": 1216,
           "options": {
@@ -2580,7 +2655,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 75
+            "y": 83
           },
           "id": 1231,
           "options": {
@@ -2663,7 +2738,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 83
+            "y": 91
           },
           "hiddenSeries": false,
           "id": 33,
@@ -2754,7 +2829,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 83
+            "y": 91
           },
           "hiddenSeries": false,
           "id": 35,
@@ -2843,7 +2918,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 91
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 129,
@@ -2935,7 +3010,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 91
+            "y": 99
           },
           "hiddenSeries": false,
           "id": 102,
@@ -3074,7 +3149,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 99
+            "y": 107
           },
           "id": 1195,
           "options": {
@@ -3120,7 +3195,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 99
+            "y": 107
           },
           "hiddenSeries": false,
           "id": 180,
@@ -3260,7 +3335,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 107
+            "y": 115
           },
           "id": 1202,
           "options": {
@@ -3417,7 +3492,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 107
+            "y": 115
           },
           "id": 1196,
           "options": {
@@ -3494,7 +3569,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 60
           },
           "hiddenSeries": false,
           "id": 85,
@@ -3592,7 +3667,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 60
           },
           "hiddenSeries": false,
           "id": 87,
@@ -3683,7 +3758,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 69
           },
           "hiddenSeries": false,
           "id": 93,
@@ -3850,7 +3925,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 61
           },
           "id": 1127,
           "options": {
@@ -3946,7 +4021,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 61
           },
           "id": 1166,
           "options": {
@@ -4055,7 +4130,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 69
           },
           "id": 1168,
           "options": {
@@ -4226,7 +4301,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 54
+            "y": 62
           },
           "id": 992,
           "options": {
@@ -4482,7 +4557,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 55
+            "y": 63
           },
           "id": 1257,
           "maxPerRow": 2,
@@ -4664,7 +4739,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 64
           },
           "id": 1991,
           "options": {
@@ -4819,7 +4894,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 65
           },
           "id": 1261,
           "options": {


### PR DESCRIPTION
- Remove unnecessary second query from 'up' graph
- Make the up and version graphs narrower
- Add a graph showing which specific machines are up/down
- Fix label of healthcheck graph

Looks like this now:
<img width="1540" alt="Screenshot 2025-05-16 at 9 40 33 AM" src="https://github.com/user-attachments/assets/39071d22-488d-45c3-9dcd-8968d35dd61d" />