### PR TITLE
Use real execution collector in test

### DIFF
--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -60,6 +60,7 @@ go_test(
     srcs = ["execution_server_test.go"],
     deps = [
         ":execution_server",
+        "//enterprise/server/backends/redis_execution_collector",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/tasksize",
         "//enterprise/server/testutil/testredis",
@@ -70,7 +71,6 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//proto:scheduler_go_proto",
-        "//proto:stored_invocation_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/real_environment",


### PR DESCRIPTION
Split out from https://github.com/buildbuddy-io/buildbuddy/pull/9357/files

Use a real collector to avoid having to mock out the new methods that were added.

The real collector is cheap to run, since it only depends on Redis, which is pretty lightweight.