### PR TITLE
capabilities_server: Limit priority range

### DIFF
--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/action_cache_server",
         "//server/remote_cache/cachetools",
+        "//server/remote_cache/capabilities_server",
         "//server/remote_cache/digest",
         "//server/remote_execution/config",
         "//server/tables",

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/action_cache_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/capabilities_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
@@ -707,8 +708,8 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) error {
 	// Enforce a priority range of -1000 to 1000 for now so that we have some
 	// flexibility to assign different meanings to priority values later on.
-	if req.GetExecutionPolicy().GetPriority() > 1000 || req.GetExecutionPolicy().GetPriority() < -1000 {
-		return status.InvalidArgumentErrorf("invalid execution priority %d; priority values must be between -1000 and 1000 (inclusive)", req.GetExecutionPolicy().GetPriority())
+	if req.GetExecutionPolicy().GetPriority() > capabilities_server.MaxExecutionPriority || req.GetExecutionPolicy().GetPriority() < capabilities_server.MinExecutionPriority {
+		return status.InvalidArgumentErrorf("invalid execution priority %d; priority values must be between %d and %d (inclusive)", req.GetExecutionPolicy().GetPriority(), capabilities_server.MinExecutionPriority, capabilities_server.MaxExecutionPriority)
 	}
 
 	adInstanceDigest := digest.NewCASResourceName(req.GetActionDigest(), req.GetInstanceName(), req.GetDigestFunction())

--- a/server/remote_cache/capabilities_server/capabilities_server.go
+++ b/server/remote_cache/capabilities_server/capabilities_server.go
@@ -2,7 +2,6 @@ package capabilities_server
 
 import (
 	"context"
-	"math"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
@@ -13,6 +12,11 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	smpb "github.com/buildbuddy-io/buildbuddy/proto/semver"
 	remote_cache_config "github.com/buildbuddy-io/buildbuddy/server/remote_cache/config"
+)
+
+const (
+	MinExecutionPriority = -1000
+	MaxExecutionPriority = 1000
 )
 
 var (
@@ -84,7 +88,10 @@ func (s *CapabilitiesServer) GetCapabilities(ctx context.Context, req *repb.GetC
 			ExecEnabled:    true,
 			ExecutionPriorityCapabilities: &repb.PriorityCapabilities{
 				Priorities: []*repb.PriorityCapabilities_PriorityRange{
-					{MinPriority: math.MinInt32, MaxPriority: math.MaxInt32},
+					{
+						MinPriority: MinExecutionPriority,
+						MaxPriority: MaxExecutionPriority,
+					},
 				},
 			},
 			DigestFunctions: digest.SupportedDigestFunctions(),


### PR DESCRIPTION
We are currently enforcing this limit in ExecutionServer.execute.
Let's make sure that we advertise the correct value through
GetCapabilities rpc.
