### PR TITLE
Expand digest when no target label

### DIFF
--- a/app/invocation/invocation_execution_table.tsx
+++ b/app/invocation/invocation_execution_table.tsx
@@ -37,7 +37,7 @@ export default class InvocationExecutionTable extends React.Component<Props> {
               <div>
                 <div className="execution-header">
                   {execution.targetLabel && <span className="target-label">{execution.targetLabel}</span>}
-                  <DigestComponent digest={execution.actionDigest} expanded={execution.targetLabel === ''}/>
+                  <DigestComponent digest={execution.actionDigest} expanded={execution.targetLabel === ""} />
                 </div>
                 <div className="command-snippet">$ {execution.commandSnippet}</div>
                 <div className="status">

--- a/app/invocation/invocation_execution_table.tsx
+++ b/app/invocation/invocation_execution_table.tsx
@@ -37,7 +37,7 @@ export default class InvocationExecutionTable extends React.Component<Props> {
               <div>
                 <div className="execution-header">
                   {execution.targetLabel && <span className="target-label">{execution.targetLabel}</span>}
-                  <DigestComponent digest={execution.actionDigest} />
+                  <DigestComponent digest={execution.actionDigest} expanded={execution.targetLabel === ''}/>
                 </div>
                 <div className="command-snippet">$ {execution.commandSnippet}</div>
                 <div className="status">


### PR DESCRIPTION
Expand the action digest in the execution table only when the
associated target label is empty. This should help improve the visual a
little bit when the label is not available.
