### PR TITLE
Improve lockmap write benchmark

### DIFF
--- a/server/util/lockmap/lockmap_test.go
+++ b/server/util/lockmap/lockmap_test.go
@@ -1,6 +1,8 @@
 package lockmap
 
 import (
+	"math/rand/v2"
+	"strconv"
 	"testing"
 	"time"
 
@@ -72,19 +74,34 @@ func TestRLock(t *testing.T) {
 	}
 }
 
-func BenchmarkLockQPS(b *testing.B) {
+func benchmarkLock(b *testing.B, keyCount int) {
 	l := New()
 	defer l.Close()
 
+	keys := make([]string, keyCount)
+	var err error
+	for i := range keys {
+		keys[i], err = random.RandomString(64)
+		require.NoError(b, err)
+	}
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
+		i := rand.IntN(len(keys))
 		for pb.Next() {
-			r, err := random.RandomString(64)
-			require.Nil(b, err)
-			unlock := l.Lock(r)
+			unlock := l.Lock(keys[i])
 			unlock()
+			i = (i + 1) % len(keys)
 		}
 	})
+}
+
+func BenchmarkLockQPS(b *testing.B) {
+	// Fewer unique keys should have more contention.
+	for _, keyCount := range []int{1, 10, 1000, 1000000} {
+		b.Run(strconv.Itoa(keyCount), func(b *testing.B) {
+			benchmarkLock(b, keyCount)
+		})
+	}
 }
 
 func BenchmarkRLockQPS(b *testing.B) {
@@ -93,6 +110,7 @@ func BenchmarkRLockQPS(b *testing.B) {
 
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
+		// Each goroutine gets a unique key, so there should be no contention.
 		r, err := random.RandomString(64)
 		require.Nil(b, err)
 

--- a/server/util/lockmap/lockmap_test.go
+++ b/server/util/lockmap/lockmap_test.go
@@ -97,7 +97,7 @@ func benchmarkLock(b *testing.B, keyCount int) {
 
 func BenchmarkLockQPS(b *testing.B) {
 	// Fewer unique keys should have more contention.
-	for _, keyCount := range []int{1, 10, 1000, 1000000} {
+	for _, keyCount := range []int{1, 10, 1000, 10000} {
 		b.Run(strconv.Itoa(keyCount), func(b *testing.B) {
 			benchmarkLock(b, keyCount)
 		})


### PR DESCRIPTION
Previously, it was mostly benchmarking `random.String(64)`. I pulled that out of the loop by pre-creating keys. I also made the number of keys variable, so we can have benchmarks for high and low contention.

I didn't modify the read benchmark because I think it's good to have one benchmark that has no contention.

Current results on my machine:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                 │  /tmp/base  │
                 │   sec/op    │
LockQPS/1-24       138.2n ± 7%
LockQPS/10-24      48.45n ± 5%
LockQPS/1000-24    24.97n ± 1%
LockQPS/10000-24   17.18n ± 1%
RLockQPS-24        17.33n ± 1%
geomean            34.63n

                 │ /tmp/base  │
                 │    B/op    │
LockQPS/1-24       64.00 ± 0%
LockQPS/10-24      64.00 ± 0%
LockQPS/1000-24    64.00 ± 0%
LockQPS/10000-24   64.00 ± 0%
RLockQPS-24        64.00 ± 0%
geomean            64.00

                 │ /tmp/base  │
                 │ allocs/op  │
LockQPS/1-24       3.000 ± 0%
LockQPS/10-24      3.000 ± 0%
LockQPS/1000-24    3.000 ± 0%
LockQPS/10000-24   3.000 ± 0%
RLockQPS-24        3.000 ± 0%
geomean            3.000
```