### PR TITLE
CLI: Refactor config parsing to use the new parsing constructs

### DIFF
--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -164,7 +164,7 @@ func AppendRcRulesFromFile(workspaceDir string, rpath string, namedConfigs map[s
 		if tokens[0] == "import" || tokens[0] == "try-import" {
 			isOptional := tokens[0] == "try-import"
 			path := strings.TrimSpace(strings.TrimPrefix(line, tokens[0]))
-			if err = appendRcRulesFromImport(workspaceDir, path, namedConfigs, defaultConfig, isOptional, importStack); err != nil {
+			if err := appendRcRulesFromImport(workspaceDir, path, namedConfigs, defaultConfig, isOptional, importStack); err != nil {
 				return err
 			}
 			continue

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -548,17 +548,6 @@ func NewConfig() *Config {
 	}
 }
 
-// Offset exists as a temporary hack while we continue to move away from
-// passing arguments around as strings. It returns the offset in the
-// string-based arg slice where the argument at this index is located.
-func (a *OrderedArgs) Offset(index int) int {
-	offset := 0
-	for _, arg := range a.Args[:index] {
-		offset += len(arg.Format())
-	}
-	return offset
-}
-
 func Partition(args []arguments.Argument) *PartitionedArgs {
 	partitioned := &PartitionedArgs{}
 	for _, c := range Classify(args) {

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -538,6 +538,16 @@ func (a *OrderedArgs) appendOption(option options.Option, startupOptionInsertInd
 	return startupOptionInsertIndex, commandOptionInsertIndex, fmt.Errorf("Failed to append Option: option '%s' is not a startup option and the command '%s' does not support it.", option.Name(), command)
 }
 
+type Config struct {
+	ByPhase map[string][]arguments.Argument
+}
+
+func NewConfig() *Config {
+	return &Config{
+		ByPhase: make(map[string][]arguments.Argument),
+	}
+}
+
 // Offset exists as a temporary hack while we continue to move away from
 // passing arguments around as strings. It returns the offset in the
 // string-based arg slice where the argument at this index is located.
@@ -670,6 +680,8 @@ func (a *PartitionedArgs) RemoveOptions(optionNames ...string) []*IndexedOption 
 func (a *PartitionedArgs) Append(args ...arguments.Argument) error {
 	for _, arg := range args {
 		switch arg := arg.(type) {
+		case *arguments.DoubleDash:
+			// skip
 		case *arguments.PositionalArgument:
 			switch {
 			case a.Command == nil:

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -838,7 +838,7 @@ func appendExpansion(
 		case options.Option:
 			// For the common phases, only append the arg if it's supported by
 			// the command.
-			if bazelrc.IsCommonPhase(phase) && !a.Supports(phases[len(phases)-1]) {
+			if bazelrc.IsUnconditionalCommandPhase(phase) && !a.Supports(phases[len(phases)-1]) {
 				if phase == "always" {
 					log.Warnf("Inherited 'always' options: %v", arguments.FormatAll(toExpand))
 					return nil, fmt.Errorf("%[1]s :: Unrecognized option %[1]s", a.Format()[0])

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -21,15 +21,21 @@ func Setup(args []string, tempDir string) (_ []*plugin.Plugin, bazelArgs []strin
 	}
 
 	// Parse args.
+	parsedArgs, err := parser.ParseArgs(args)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	parsedArgs, err = parser.ResolveArgs(parsedArgs)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 
 	// TODO: Expanding configs results in a long explicit command line in the BB
 	// UI. Need to find a way to override the explicit command line in the UI so
 	// that it reflects the args passed to the CLI, not the wrapped Bazel
 	// process.
-	args, err = parser.ExpandConfigs(args)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
+	args = parsedArgs.Format()
 
 	bazelArgs, execArgs = arg.SplitExecutableArgs(args)
 	// Save some flags from the current invocation for non-Bazel commands such


### PR DESCRIPTION
This change is a little odd, since many of the refactored functions in `parser.go` now belong in `parsed.go`, but I elected to make the changes first and then move them in a later PR so as to make viewing the diffs easier when reviewing.

Primarily, this change:
- Directly uses the options-retrieval abilities of parsed.Args to consume the rc file options
- Parses the rc files into `parsed.Config` structs in a map keyed by config name and into a default config struct for unnamed configs (for example, `common` or `build` as opposed to `common:foo` or `build:bar`)
- Uses these config structs to expand config options

Small behavior changes include that `common:` will no longer be equivalent to `common`, which mirrors bazel's bahavior, and that the `always` phase is now supported.

Once this is approved, a follow-on PR will move the functions indicated with the relevant `TODO`s to their appropriate locations with minimal changes as are necessary to move them as described.
