### PR TITLE
Read execution data from Redis to flush to Clickhouse

### DIFF
--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
@@ -294,10 +294,18 @@ func unmarshalStoredInvocationLinks(serializedResults []string) ([]*sipb.StoredI
 // (exit code, stats, etc.)
 func mergeExecutionUpdates(serializedResults []string) (*repb.StoredExecution, error) {
 	out := &repb.StoredExecution{}
+	lastStage := int64(repb.ExecutionStage_UNKNOWN)
 	for _, serializedResult := range serializedResults {
 		event := &repb.StoredExecution{}
 		if err := proto.Unmarshal([]byte(serializedResult), event); err != nil {
 			return nil, err
+		}
+
+		// The scheduler attempts to prevent concurrent execution updates via
+		// task leasing, but this is not currently 100% reliable. If execution
+		// progress appears to restart, ignore any future updates.
+		if lastStage == int64(repb.ExecutionStage_COMPLETED) && event.GetStage() != int64(repb.ExecutionStage_COMPLETED) {
+			break
 		}
 		// Copy fields from the latest event to the output proto. proto.Merge()
 		// is a convenient way to do this.
@@ -307,12 +315,7 @@ func mergeExecutionUpdates(serializedResults []string) (*repb.StoredExecution, e
 		// the last value win.
 		out.Experiments = event.Experiments
 
-		// The scheduler attempts to prevent concurrent execution updates via
-		// task leasing, but this is not currently 100% reliable. So we ignore
-		// updates that happen after the initial attempt.
-		if event.GetStage() == int64(repb.ExecutionStage_COMPLETED) {
-			break
-		}
+		lastStage = event.GetStage()
 	}
 	return out, nil
 }

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -3,6 +3,7 @@ package execution_server_test
 import (
 	"context"
 	"io"
+	"strings"
 	"testing"
 	"time"
 

--- a/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
+++ b/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
@@ -31,7 +31,6 @@ func TestInvocationWithRemoteExecutionWithClickHouse_StoreMetadataInRedisAndClic
 		flags: []string{
 			"--remote_execution.write_execution_progress_state_to_redis=true",
 			"--remote_execution.write_executions_to_primary_db=false",
-			"--remote_execution.read_final_execution_state_from_redis=true",
 			"--remote_execution.primary_db_reads_enabled=false",
 			"--remote_execution.olap_reads_enabled=true",
 		},
@@ -43,7 +42,6 @@ func TestInvocationWithRemoteExecutionWithClickHouse_StoreMetadataInPrimaryDBAnd
 		flags: []string{
 			"--remote_execution.write_execution_progress_state_to_redis=false",
 			"--remote_execution.write_executions_to_primary_db=true",
-			"--remote_execution.read_final_execution_state_from_redis=false",
 			"--remote_execution.primary_db_reads_enabled=true",
 			"--remote_execution.olap_reads_enabled=false",
 		},


### PR DESCRIPTION
Currently when an executor has finished execution, it sends a payload to the execution server which immediately flushes the data to clickhouse

In order to track runner recycling time in clickhouse, which may occur after the requested execution has finished, this PR first stores execution data in Redis. It then reads the data from Redis and flushes it to Clickhouse. In itself this PR should functionally be a no-op.

Next, my plan is to 
1. Move flushing data to clickhouse to after the client closes the PublishOperation stream
2. Executor publishes another update with runner recycling time. The execution server updates the in-progress execution data in Redis. Now, when the data is read in step 1, it will include the runner recycling time