### PR TITLE
Unquarantine distributed_test.TestReadWriteWithFailedNode

### DIFF
--- a/enterprise/server/backends/distributed/BUILD
+++ b/enterprise/server/backends/distributed/BUILD
@@ -50,7 +50,6 @@ go_test(
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/content_addressable_storage_server",
-        "//server/testutil/quarantine",
         "//server/testutil/testauth",
         "//server/testutil/testcompression",
         "//server/testutil/testdigest",

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcompression"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
@@ -475,7 +474,6 @@ func TestReadOffsetLimit(t *testing.T) {
 }
 
 func TestReadWriteWithFailedNode(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	env, _, ctx := getEnvAuthAndCtx(t)
 	singleCacheSizeBytes := int64(1000000)
 	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
@@ -522,10 +520,7 @@ func TestReadWriteWithFailedNode(t *testing.T) {
 	// or distributedCaches so they should not be referenced
 	// below when reading / writing, although the running nodes
 	// still have reference to them via the Nodes list.
-	shutdownCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	err := dc3.Shutdown(shutdownCtx)
-	cancel()
-	assert.Nil(t, err)
+	waitForShutdown(dc3)
 
 	for i := 0; i < 100; i++ {
 		// Do a write, and ensure it was written to all nodes.


### PR DESCRIPTION
The problem was that the "failing" cache didn't finish shutting down before distributed_client.RemoteWriter returned a client for it. Giving the failing cache more time to shut down fixes this.

200 runs: https://app.buildbuddy.io/invocation/2aad935b-9719-4c08-9ea6-e37791ed8836