### PR TITLE
Allow reading in-progress executions from Redis

### DIFF
--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -101,11 +101,29 @@ func (es *ExecutionService) getInvocationExecutionsFromPrimaryDB(ctx context.Con
 func (es *ExecutionService) getInvocationExecutionsFromOLAPDB(ctx context.Context, invocationID, actionDigestHash string) ([]*olaptables.Execution, error) {
 	var eg errgroup.Group
 
-	// If the invocation is still in progress, completed executions will be
+	// If executions.write_execution_progress_state_to_redis is enabled,
+	// executions that are still in progress will be buffered in Redis.
+	//
+	// If the invocation is still in progress, completed executions will also be
 	// buffered, waiting to be flushed to the OLAP database as part of a batch
-	// of writes. So we read both buffered and flushed executions here.
+	// of writes. So, we read both buffered and flushed executions here.
+	var inProgressExecutions []*olaptables.Execution
 	var bufferedExecutions []*olaptables.Execution
 	var flushedExecutions []*olaptables.Execution
+	eg.Go(func() error {
+		ex, err := es.env.GetExecutionCollector().GetInProgressExecutions(ctx, invocationID)
+		if err != nil {
+			return err
+		}
+		// Convert buffered representation to OLAP table representation.
+		inProgressExecutions = make([]*olaptables.Execution, len(ex))
+		for i, e := range ex {
+			// Note: invocation metadata is not needed in this case (since this
+			// RPC only returns the execution metadata).
+			inProgressExecutions[i] = clickhouse.ExecutionFromProto(e, nil /*=invocation*/)
+		}
+		return nil
+	})
 	eg.Go(func() error {
 		ex, err := es.env.GetExecutionCollector().GetExecutions(ctx, invocationID, 0, -1)
 		if err != nil {
@@ -118,7 +136,7 @@ func (es *ExecutionService) getInvocationExecutionsFromOLAPDB(ctx context.Contex
 				return len(parts) < 2 || parts[len(parts)-2] != actionDigestHash
 			})
 		}
-		// Converted buffered representation to OLAP table representation.
+		// Convert buffered representation to OLAP table representation.
 		bufferedExecutions = make([]*olaptables.Execution, len(ex))
 		for i, e := range ex {
 			// Note: invocation metadata is not needed in this case (since this
@@ -200,11 +218,10 @@ func (es *ExecutionService) getInvocationExecutionsFromOLAPDB(ctx context.Contex
 		return nil, err
 	}
 
-	// Combine the buffered and flushed executions. Dedupe by execution ID,
-	// since the concurrent reads from Redis and OLAP might occur during an
-	// in-progress flush, in which case the Redis executions might not've been
-	// cleaned up yet.
-	executions := append(flushedExecutions, bufferedExecutions...)
+	// Combine the in-progress, buffered and flushed executions. Dedupe by
+	// execution ID, since an execution's transitions between these lists are
+	// not atomic. Prefer flushed executions, then buffered, then in-progress.
+	executions := slices.Concat(flushedExecutions, bufferedExecutions, inProgressExecutions)
 	executionIDs := make(map[string]bool)
 	dedupedExecutions := make([]*olaptables.Execution, 0, len(executions))
 	for _, e := range executions {


### PR DESCRIPTION
Today, if we were to start storing in-progress execution metadata in Redis instead of MySQL, the UI would not be able to view in-progress executions. We do already read execution state from Redis, but only for executions that have completed (and are sitting in Redis waiting for the invocation to complete).

This PR makes it so we read the in-progress execution state from Redis as well, so that in-progress executions can be displayed in the executions page.