### PR TITLE
Fix potential nil dereference in firecracker.getVMMetadata

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1023,7 +1023,7 @@ func (c *FirecrackerContainer) getVMMetadata() *fcpb.VMMetadata {
 		return &fcpb.VMMetadata{
 			VmId:        c.id,
 			SnapshotId:  c.snapshotID,
-			SnapshotKey: c.SnapshotKeySet().BranchKey,
+			SnapshotKey: c.SnapshotKeySet().GetBranchKey(),
 		}
 	}
 	return c.snapshot.GetVMMetadata()


### PR DESCRIPTION
Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/4905