### PR TITLE
Codesearch incremental update extraction tools

### DIFF
--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -225,7 +225,7 @@ func processDiffTreeLine(gc gitClient, line string, commit *inpb.Commit) error {
 	}
 
 	srcFile := parts[5]
-	if fileStatus == "D" || fileStatus[0] == 'R' || fileStatus[0] == 'C' {
+	if fileStatus == "D" || fileStatus[0] == 'R' {
 		if !slices.Contains(commit.DeleteFilepaths, srcFile) {
 			commit.DeleteFilepaths = append(commit.DeleteFilepaths, srcFile)
 		}
@@ -238,6 +238,7 @@ func processDiffTreeLine(gc gitClient, line string, commit *inpb.Commit) error {
 
 	fileToLoad := srcFile
 	if fileStatus[0] == 'R' || fileStatus[0] == 'C' {
+		// renames and copies have a destination file name in index 6
 		if len(parts) < 7 {
 			return status.InternalErrorf("invalid diff-tree line, R/C with no dest file: %s", line)
 		}

--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -283,9 +283,11 @@ func extractCommitDetails(gc gitClient, sha, parentSha string) (*inpb.Commit, er
 	return result, nil
 }
 
-// TODO(jdelfino): Add unit test coverage
-// TODO(jdelfino): manual integration test with incr updates
-func ExtractCommitRange(gc gitClient, firstSha, lastSha string) (*inpb.IncrementalUpdate, error) {
+// ComputeIncrementalUpdate generates an incremental update payload for the codesearch indexer.
+// The information is extracted using the git command line client on a local clone of a repo.
+// The payload contains a list of commits, the file contents for each added/modified file, and a list
+// of deleted filenames.
+func ComputeIncrementalUpdate(gc gitClient, firstSha, lastSha string) (*inpb.IncrementalUpdate, error) {
 	output, err := gc.ExecuteCommand("git", "log", "--first-parent", "--format=%H", fmt.Sprintf("%s..%s", firstSha, lastSha))
 	if err != nil {
 		return nil, err

--- a/codesearch/github/github_test.go
+++ b/codesearch/github/github_test.go
@@ -380,7 +380,7 @@ func (f *fakeGitClient) LoadFileContents(fileToLoad string) ([]byte, error) {
 	return nil, fmt.Errorf("file not found: %s", fileToLoad)
 }
 
-func TestExtractCommitRange_OneCommit(t *testing.T) {
+func TestComputeIncrementalUpdate_OneCommit(t *testing.T) {
 	firstSHA := "abc123"
 	lastSHA := "def456"
 
@@ -410,7 +410,7 @@ func TestExtractCommitRange_OneCommit(t *testing.T) {
 		},
 	}
 
-	result, err := ExtractCommitRange(fakeClient, firstSHA, lastSHA)
+	result, err := ComputeIncrementalUpdate(fakeClient, firstSHA, lastSHA)
 	require.NoError(t, err)
 
 	assert.Equal(t, &inpb.IncrementalUpdate{
@@ -430,7 +430,7 @@ func TestExtractCommitRange_OneCommit(t *testing.T) {
 	}, result)
 }
 
-func TestExtractCommitRange_MultipleCommits(t *testing.T) {
+func TestComputeIncrementalUpdate_MultipleCommits(t *testing.T) {
 	sha1 := "abc123"
 	sha2 := "def456"
 	sha3 := "ghi789"
@@ -451,7 +451,7 @@ func TestExtractCommitRange_MultipleCommits(t *testing.T) {
 		},
 	}
 
-	result, err := ExtractCommitRange(fakeClient, sha1, sha4)
+	result, err := ComputeIncrementalUpdate(fakeClient, sha1, sha4)
 	require.NoError(t, err)
 
 	assert.Equal(t, &inpb.IncrementalUpdate{
@@ -482,7 +482,7 @@ func TestExtractCommitRange_MultipleCommits(t *testing.T) {
 	}, result)
 }
 
-func TestExtractCommitRange_SkipUnindexable(t *testing.T) {
+func TestComputeIncrementalUpdate_SkipUnindexable(t *testing.T) {
 	firstSHA := "abc123"
 	lastSHA := "def456"
 
@@ -499,7 +499,7 @@ func TestExtractCommitRange_SkipUnindexable(t *testing.T) {
 		},
 	}
 
-	result, err := ExtractCommitRange(fakeClient, firstSHA, lastSHA)
+	result, err := ComputeIncrementalUpdate(fakeClient, firstSHA, lastSHA)
 	require.NoError(t, err)
 
 	assert.Equal(t, &inpb.IncrementalUpdate{

--- a/codesearch/github/github_test.go
+++ b/codesearch/github/github_test.go
@@ -363,8 +363,8 @@ type fakeGitClient struct {
 	t        *testing.T
 }
 
-func (f *fakeGitClient) ExecuteCommand(cmd string, args ...string) (string, error) {
-	fullCmd := cmd + " " + strings.Join(args, " ")
+func (f *fakeGitClient) ExecuteCommand(args ...string) (string, error) {
+	fullCmd := strings.Join(args, " ")
 	if output, ok := f.commands[fullCmd]; ok {
 		return output, nil
 	}
@@ -387,16 +387,16 @@ func TestComputeIncrementalUpdate_OneCommit(t *testing.T) {
 	fakeClient := &fakeGitClient{
 		t: t,
 		commands: map[string]string{
-			fmt.Sprintf("git log --first-parent --format=%%H %s..%s", firstSHA, lastSHA): "def456",
+			fmt.Sprintf("log --first-parent --format=%%H %s..%s", firstSHA, lastSHA): "def456",
 			// This sample output is taken directly from the diff-tree documentation, and covers
 			// every modification type.
-			fmt.Sprintf("git diff-tree -r %s..%s", firstSHA, lastSHA): `
-:100644 100644 bcd1234 0123456 M file0
-:100644 100644 abcd123 1234567 C68 file0 file2
-:100644 100644 abcd123 1234567 R86 file1 file3
-:000000 100644 0000000 1234567 A file4
-:100644 000000 1234567 0000000 D file5
-:000000 000000 0000000 0000000 U file6
+			fmt.Sprintf("diff-tree -r %s..%s", firstSHA, lastSHA): `
+:100644 100644 bcd1234 0123456 M	file0
+:100644 100644 abcd123 1234567 C68	file0	file2
+:100644 100644 abcd123 1234567 R86	file1	file3
+:000000 100644 0000000 1234567 A	file4
+:100644 000000 1234567 0000000 D	file5
+:000000 000000 0000000 0000000 U	file6
 `,
 		},
 		files: map[string][]byte{
@@ -439,10 +439,10 @@ func TestComputeIncrementalUpdate_MultipleCommits(t *testing.T) {
 	fakeClient := &fakeGitClient{
 		t: t,
 		commands: map[string]string{
-			fmt.Sprintf("git log --first-parent --format=%%H %s..%s", sha1, sha4): "def456\nghi789\njkl012",
-			fmt.Sprintf("git diff-tree -r %s..%s", sha1, sha2):                    ":100644 100644 bcd1234 0123456 M file0",
-			fmt.Sprintf("git diff-tree -r %s..%s", sha2, sha3):                    ":000000 100644 0000000 1234567 A file1",
-			fmt.Sprintf("git diff-tree -r %s..%s", sha3, sha4):                    ":100644 100644 abcd123 1234567 R86 file1 file2",
+			fmt.Sprintf("log --first-parent --format=%%H %s..%s", sha1, sha4): "jkl012\nghi789\ndef456\n",
+			fmt.Sprintf("diff-tree -r %s..%s", sha1, sha2):                    ":100644 100644 bcd1234 0123456 M	file0",
+			fmt.Sprintf("diff-tree -r %s..%s", sha2, sha3):                    ":000000 100644 0000000 1234567 A	file1",
+			fmt.Sprintf("diff-tree -r %s..%s", sha3, sha4):                    ":100644 100644 abcd123 1234567 R86	file1	file2",
 		},
 		files: map[string][]byte{
 			"file0": []byte("file0 content"),
@@ -489,10 +489,8 @@ func TestComputeIncrementalUpdate_SkipUnindexable(t *testing.T) {
 	fakeClient := &fakeGitClient{
 		t: t,
 		commands: map[string]string{
-			fmt.Sprintf("git log --first-parent --format=%%H %s..%s", firstSHA, lastSHA): "def456",
-			// This sample output is taken directly from the diff-tree documentation, and covers
-			// every modification type.
-			fmt.Sprintf("git diff-tree -r %s..%s", firstSHA, lastSHA): ":100644 100644 bcd1234 0123456 M file0",
+			fmt.Sprintf("log --first-parent --format=%%H %s..%s", firstSHA, lastSHA): "def456",
+			fmt.Sprintf("diff-tree -r %s..%s", firstSHA, lastSHA):                    ":100644 100644 bcd1234 0123456 M	file0",
 		},
 		files: map[string][]byte{
 			"file0": []byte{0x47, 0x49, 0x46, 0x38, 0x39, 0x61}, // GIF file


### PR DESCRIPTION
This change adds some functions that will be used to create incremental update payloads for the codesearch indexer. This will eventually be wired into the BB CLI, and will be run on a local clone of a git repository. 

These functions look at a range of commits on a single branch, and extract the changes from each commit in the range that need to be sent to the indexer: the contents of all added/modified files, and the names of deleted / renamed files.