### PR TITLE
[cachetools] add NewUploadWriter and tests

### DIFF
--- a/server/remote_cache/cachetools/BUILD
+++ b/server/remote_cache/cachetools/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
+        "//server/util/bytebufferpool",
         "//server/util/compression",
         "//server/util/ioutil",
         "//server/util/log",

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -1182,6 +1182,9 @@ func (uw *UploadWriter) Write(p []byte) (int, error) {
 		uw.bytesBuffered += n
 		written += n
 		if err := uw.flush(false /* finish */); err != nil {
+			if err == io.EOF {
+				return written, io.ErrShortWrite
+			}
 			return written, err
 		}
 		p = p[n:]
@@ -1219,7 +1222,7 @@ func (uw *UploadWriter) Commit() error {
 	if uw.committed {
 		return nil
 	}
-	if uw.sendErr != nil {
+	if uw.sendErr != nil && uw.sendErr != io.EOF {
 		return status.WrapError(uw.sendErr, "UploadWriter already encountered send error, cannot commit")
 	}
 

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -810,30 +810,6 @@ func TestCancelSend(t *testing.T) {
 	err = sender.SendWithTimeoutCause(req, 1*time.Minute, status.DeadlineExceededError("second write timed out"))
 	require.Error(t, err)
 	require.ErrorContains(t, err, "context canceled")
-
-	// req = &bspb.WriteRequest{
-	// 	Data:         []byte{},
-	// 	ResourceName: uploadString,
-	// 	WriteOffset:  1024,
-	// 	FinishWrite:  true,
-	// }
-	// err = sender.SendWithTimeoutCause(req, 1*time.Minute, status.DeadlineExceededError("last write timed out"))
-	// require.NoError(t, err)
-
-	// resp, err := stream.CloseAndRecv()
-	// require.NoError(t, err)
-	// require.Equal(t, int64(1024), resp.CommittedSize)
-
-	// {
-	// 	out := &bytes.Buffer{}
-	// 	err := cachetools.GetBlob(ctx, te.GetByteStreamClient(), casRN, out)
-
-	// 	require.NoError(t, err)
-	// 	require.Equal(t, len(buf), out.Len())
-	// 	require.Empty(t, cmp.Diff(buf[:9], out.Bytes()[:9]))
-	// 	require.Empty(t, cmp.Diff(buf[len(buf)-9:], out.Bytes()[out.Len()-9:]))
-	// }
-
 }
 
 func TestUploadWriter_NoWritesAfterCommit(t *testing.T) {

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -876,9 +876,9 @@ func TestUploadWriter_NoWritesAfterCommit(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, 0, written)
 
-	// Cannot commit again after commit
+	// Committing after commit is a no-op
 	err = uw.Commit()
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	err = uw.Close()
 	require.NoError(t, err)
@@ -938,8 +938,7 @@ func TestUploadWriter_CancelContext(t *testing.T) {
 
 	cancel()
 
-	written, err = uw.Write(buf[half:])
+	_, err = uw.Write(buf[half:])
 	require.Error(t, err)
 	require.ErrorContains(t, err, "context canceled")
-	require.Zero(t, written)
 }


### PR DESCRIPTION
This change introduces `NewUploadWriter` and tests for `UploadWriter`. It leaves the `UploadFromReader` path untouched, since my first need for `UploadWriter` is as a best-effort writer for caching OCI image layers. A later change will have `UploadFromReader` use `UploadWriter`.