### PR TITLE
[oci resolver] track number of Resolve(...) calls

### DIFF
--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proto:registry_go_proto",
         "//server/environment",
         "//server/http/httpclient",
+        "//server/metrics",
         "//server/util/flag",
         "//server/util/log",
         "//server/util/status",
@@ -24,6 +25,8 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
         "@com_github_google_go_containerregistry//pkg/v1/types",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_x_net//publicsuffix",
     ],
 )
 

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -370,6 +370,7 @@ func updateResolveEventMetric(host string) {
 	metrics.OCIRegistryResolveEvents.With(prometheus.Labels{
 		metrics.HTTPHostLabel: hostLabel,
 	}).Inc()
+	log.Infof("Resolving OCI image for registry %q", hostLabel)
 }
 
 func (r *Resolver) fetchRawManifestFromCacheOrRemote(ctx context.Context, digestOrTagRef gcrname.Reference, remoteOpts []remote.Option) (*gcr.Hash, []byte, bool, error) {

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocicache"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/http/httpclient"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -24,6 +25,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/publicsuffix"
 
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	gcrname "github.com/google/go-containerregistry/pkg/name"
@@ -238,6 +241,7 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image %q", imageName)
 	}
+	updateResolveEventMetric(imageRef.Context().RepositoryStr())
 
 	gcrPlatform := gcr.Platform{
 		Architecture: platform.GetArch(),
@@ -340,6 +344,22 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 		remoteOpts: remoteOpts,
 	}
 	return partial.CompressedToImage(image)
+}
+
+func updateResolveEventMetric(host string) {
+	var hostLabel string
+	if net.ParseIP(host) != nil {
+		hostLabel = "[IP_ADDRESS]"
+	} else {
+		label, err := publicsuffix.EffectiveTLDPlusOne(host)
+		if err != nil {
+			label = "[UNKNOWN]"
+		}
+		hostLabel = label
+	}
+	metrics.OCIRegistryResolveEvents.With(prometheus.Labels{
+		metrics.HTTPHostLabel: hostLabel,
+	}).Inc()
 }
 
 func (r *Resolver) fetchRawManifestFromCacheOrRemote(ctx context.Context, digestOrTagRef gcrname.Reference, remoteOpts []remote.Option) (*gcr.Hash, []byte, bool, error) {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -3306,6 +3306,15 @@ var (
 		CacheTypeLabel,
 		CacheEventTypeLabel,
 	})
+
+	OCIRegistryResolveEvents = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "ociregistry",
+		Name:      "resolve_events",
+		Help:      "Number of cache events handled.",
+	}, []string{
+		HTTPHostLabel,
+	})
 )
 
 // exponentialBucketRange returns prometheus.ExponentialBuckets specified in


### PR DESCRIPTION
I'm trying to see if the code that caches OCI image manifests in the OCI Resolver is working correctly, and would like to see how often `Resolve(...)` is being called at all. This change introduces a metric to track that count.