### PR TITLE
quarantine cli_test.TestParseGlobalFlags

### DIFF
--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -46,6 +46,7 @@ func TestBazelVersion(t *testing.T) {
 }
 
 func TestParseGlobalFlags(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	ws := testcli.NewWorkspace(t)
 	testfs.WriteAllFileContents(t, ws, map[string]string{
 		"BUILD":         `sh_binary(name = "print_args", srcs = ["print_args.sh"])`,


### PR DESCRIPTION
Has [flaked multiple times](https://app.buildbuddy.io/tests/?target=%2F%2Fcli%2Ftest%2Fintegration%2Fcli%3Acli_test&branch=master#flakes) on `master` in the last 7 days.