### PR TITLE
Make digest parsing faster by manually parsing the string

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -722,7 +722,7 @@ func TestMarkFailed(t *testing.T) {
 
 	require.Equal(t, int64(repb.ExecutionStage_COMPLETED), ex.Stage)
 
-	err = s.MarkExecutionFailed(ctx, "blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/1", status.InternalError("It didn't work"))
+	err = s.MarkExecutionFailed(ctx, "uploads/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/1", status.InternalError("It didn't work"))
 	require.True(t, status.IsNotFoundError(err), "error should be NotFoundError, but was %s", err)
 }
 

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -523,7 +523,7 @@ func parseResourceName(resourceName string, cacheType rspb.CacheType, resourceTy
 	if pieceIdx >= 0 {
 		piece = pieces[pieceIdx]
 	}
-	if compressor == repb.Compressor_ZSTD {
+	if compressor != repb.Compressor_IDENTITY {
 		if piece != "compressed-blobs" {
 			return nil, status.InvalidArgumentErrorf("Unparseable resource name, invalid compressed blob type: %s", resourceName)
 		}

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -475,17 +475,18 @@ func parseResourceName(resourceName string, cacheType rspb.CacheType, resourceTy
 	// The next piece may be the digest function
 	pieceIdx--
 	piece := pieces[pieceIdx]
-	if piece == "blake3" {
+	switch piece {
+	case "blake3":
 		digestFunction = repb.DigestFunction_BLAKE3
-	} else if piece == "sha1" {
+	case "sha1":
 		digestFunction = repb.DigestFunction_SHA1
-	} else if piece == "sha512" {
+	case "sha512":
 		digestFunction = repb.DigestFunction_SHA512
-	} else if piece == "sha384" {
+	case "sha384":
 		digestFunction = repb.DigestFunction_SHA384
-	} else if piece == "sha256" {
+	case "sha256":
 		digestFunction = repb.DigestFunction_SHA256
-	} else {
+	default:
 		pieceIdx++
 	}
 	if len(hash) != hashLength(digestFunction) {

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -55,6 +55,18 @@ func TestParseDownloadResourceName(t *testing.T) {
 			resourceName: "/compressed-blobs/unknownCompressionType/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			wantError:    status.InvalidArgumentError(""),
 		},
+		{ // Missing blob-type
+			resourceName: "blake3/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			wantError:    status.InvalidArgumentError(""),
+		},
+		{ // Valid, but incorrect hash length
+			resourceName: "/blobs/sha256/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac/1234",
+			wantError:    status.InvalidArgumentError(""),
+		},
+		{ // SHA1 hardcoded
+			resourceName: "/blobs/sha1/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac/1234",
+			wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac", SizeBytes: 1234}, "", repb.DigestFunction_SHA1),
+		},
 		{ // SHA1
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac/1234",
 			wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac", SizeBytes: 1234}, "", repb.DigestFunction_SHA1),
@@ -289,6 +301,10 @@ func TestParseActionCacheResourceName(t *testing.T) {
 		},
 		{ // Not enough pieces
 			resourceName: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			wantError:    status.InvalidArgumentError(""),
+		},
+		{ // Missing blob-type
+			resourceName: "ac/blake3/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			wantError:    status.InvalidArgumentError(""),
 		},
 		{ // SHA256 AC resource name with instance name

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -71,9 +71,9 @@ func TestParseDownloadResourceName(t *testing.T) {
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac/1234",
 			wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac", SizeBytes: 1234}, "", repb.DigestFunction_SHA1),
 		},
-		{ // MD5
-			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b51/1234",
-			wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b51", SizeBytes: 1234}, "", repb.DigestFunction_MD5),
+		{ // MD5 -- shortest possible resource name
+			resourceName: "blobs/072d9dd55aacaa829d7d1cc9ec8c4b51/1",
+			wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b51", SizeBytes: 1}, "", repb.DigestFunction_MD5),
 		},
 		{ // SHA256
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -43,16 +43,14 @@ func TestParseDownloadResourceName(t *testing.T) {
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/",
 			wantError:    status.InvalidArgumentError(""),
 		},
-		// TODO(iain): fix
-		// { // Invalid size
-		// 	resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234b",
-		// 	wantError:    status.InvalidArgumentError(""),
-		// },
-		// TODO(iain): fix
-		// { // Trailing slashes
-		// 	resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234////////",
-		// 	wantError:    status.InvalidArgumentError(""),
-		// },
+		{ // Invalid size
+			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234b",
+			wantError:    status.InvalidArgumentError(""),
+		},
+		{ // Trailing slashes
+			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234////////",
+			wantError:    status.InvalidArgumentError(""),
+		},
 		{ // Bad compression type
 			resourceName: "/compressed-blobs/unknownCompressionType/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			wantError:    status.InvalidArgumentError(""),
@@ -61,11 +59,10 @@ func TestParseDownloadResourceName(t *testing.T) {
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac/1234",
 			wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49ac", SizeBytes: 1234}, "", repb.DigestFunction_SHA1),
 		},
-		// TODO(iain): fix
-		// { // MD5
-		// 	resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b51/1234",
-		// 	wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b51", SizeBytes: 1234}, "", repb.DigestFunction_MD5),
-		// },
+		{ // MD5
+			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b51/1234",
+			wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b51", SizeBytes: 1234}, "", repb.DigestFunction_MD5),
+		},
 		{ // SHA256
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			wantDRN:      digest.NewCASResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "", repb.DigestFunction_SHA256),


### PR DESCRIPTION
This does away with the regular expression parsing in digest.go in favor of splitting the provided resource name on `/` and validating the individual pieces. There is probably still lots of room for improvement here, but according to the benchmark in https://github.com/buildbuddy-io/buildbuddy/pull/9405, this is a bit over 10x faster:

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 7 5800X 8-Core Processor             
                       │ /home/iain/old.txt │         /home/iain/new.txt          │
                       │       sec/op       │   sec/op     vs base                │
ParseDownloadString-16         57.675µ ± 3%   4.821µ ± 1%  -91.64% (p=0.000 n=40)

                       │ /home/iain/old.txt │          /home/iain/new.txt          │
                       │        B/op        │     B/op      vs base                │
ParseDownloadString-16         3.835Ki ± 0%   2.641Ki ± 0%  -31.14% (p=0.000 n=40)

                       │ /home/iain/old.txt │     /home/iain/new.txt     │
                       │     allocs/op      │ allocs/op   vs base        │
ParseDownloadString-16           69.00 ± 0%   56.00 ± 0%  -18.84% (n=40)
```

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5015