### PR TITLE
Remove digest.Is*ResourceName functions

### DIFF
--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -241,14 +241,10 @@ func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests
 }
 
 func (u *atimeUpdater) EnqueueByResourceName(ctx context.Context, downloadString string) {
-	if digest.IsActionCacheResourceName(downloadString) {
-		// ActionCache entries are always read authoritatively, so no need to
-		// enqueue an atime update.
-		return
-	}
 	rn, err := digest.ParseDownloadResourceName(downloadString)
 	if err != nil {
-		log.Warningf("Skipping remote atime update for malformed download resource name: %s [%s]", downloadString, err)
+		// Could be an ActionCache digest, or malformed.
+		log.Debugf("Skipping remote atime update for malformed download resource name: %s [%s]", downloadString, err)
 		return
 	}
 	u.Enqueue(ctx, rn.GetInstanceName(), []*repb.Digest{rn.GetDigest()}, rn.GetDigestFunction())

--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -244,7 +244,7 @@ func (u *atimeUpdater) EnqueueByResourceName(ctx context.Context, downloadString
 	rn, err := digest.ParseDownloadResourceName(downloadString)
 	if err != nil {
 		// Could be an ActionCache digest, or malformed.
-		log.Debugf("Skipping remote atime update for malformed download resource name: %s [%s]", downloadString, err)
+		log.Infof("Skipping remote atime update for malformed download resource name: %s [%s]", downloadString, err)
 		return
 	}
 	u.Enqueue(ctx, rn.GetInstanceName(), []*repb.Digest{rn.GetDigest()}, rn.GetDigestFunction())

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -454,10 +454,6 @@ func ComputeForFile(path string, digestType repb.DigestFunction_Value) (*repb.Di
 	return Compute(f, digestType)
 }
 
-func isResourceName(url string, matcher *regexp.Regexp) bool {
-	return matcher.MatchString(url)
-}
-
 func parseResourceName(resourceName string, matcher *regexp.Regexp, cacheType rspb.CacheType) (*ResourceName, error) {
 	match := matcher.FindStringSubmatch(resourceName)
 	result := make(map[string]string, len(match))
@@ -535,14 +531,6 @@ func ParseActionCacheResourceName(resourceName string) (*ACResourceName, error) 
 		return nil, err
 	}
 	return rn.CheckAC()
-}
-
-func IsDownloadResourceName(url string) bool {
-	return isResourceName(url, downloadRegex)
-}
-
-func IsActionCacheResourceName(url string) bool {
-	return isResourceName(url, actionCacheRegex)
 }
 
 func blobTypeSegment(compressor repb.Compressor_Value) string {


### PR DESCRIPTION
These functions fully parse the digest name, which is kind of expensive, and the only callers later call the corresponding `Parse` function. Change the callers to just call `Parse` and check for errors.