### PR TITLE
Add a GROUP_ACCESS capability.

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -761,7 +761,7 @@ func (d *AuthDB) CreateUserAPIKey(ctx context.Context, groupID, userID, label st
 		return nil, status.InvalidArgumentError("missing user ID")
 	}
 
-	if err := authutil.AuthorizeGroupAccess(ctx, d.env, groupID); err != nil {
+	if err := authutil.AuthorizeTargetGroupAccess(ctx, d.env, groupID); err != nil {
 		return nil, err
 	}
 
@@ -936,7 +936,7 @@ func (d *AuthDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIK
 	if err != nil {
 		return nil, err
 	}
-	if err := authutil.AuthorizeGroupAccess(ctx, d.env, groupID); err != nil {
+	if err := authutil.AuthorizeTargetGroupAccess(ctx, d.env, groupID); err != nil {
 		return nil, err
 	}
 	q := query_builder.NewQuery(`SELECT * FROM "APIKeys"`)
@@ -1056,7 +1056,7 @@ func (d *AuthDB) GetUserAPIKeys(ctx context.Context, userID, groupID string) ([]
 	if err != nil {
 		return nil, err
 	}
-	if err := authutil.AuthorizeGroupAccess(ctx, d.env, groupID); err != nil {
+	if err := authutil.AuthorizeTargetGroupAccess(ctx, d.env, groupID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -190,12 +190,13 @@ func TestGetAPIKeyGroupFromAPIKey(t *testing.T) {
 			c, err := claims.APIKeyGroupClaims(ctx, akg)
 			require.NoError(t, err)
 			assert.Equal(t, randKey.GroupID, c.GetGroupID())
-			assert.Equal(t, capabilities.FromInt(randKey.Capabilities), c.GetCapabilities())
+			expectedCaps := append(capabilities.FromInt(randKey.Capabilities), cappb.Capability_GROUP_ACCESS)
+			assert.Equal(t, expectedCaps, c.GetCapabilities())
 			require.Len(t, c.GetGroupMemberships(), 1)
 			assert.Equal(t, []*interfaces.GroupMembership{
 				{
 					GroupID:      randKey.GroupID,
-					Capabilities: capabilities.FromInt(randKey.Capabilities),
+					Capabilities: expectedCaps,
 					// TODO(bduffany): API keys should not have roles - just
 					// capabilities.
 					Role: role.Developer,

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -502,7 +502,7 @@ func (d *UserDB) GetGroupUsers(ctx context.Context, groupID string, opts *interf
 	if len(opts.Statuses) == 0 {
 		return nil, status.InvalidArgumentError("A valid status or statuses are required")
 	}
-	if err := authutil.AuthorizeGroupAccess(ctx, d.env, groupID); err != nil {
+	if err := authutil.AuthorizeTargetGroupAccess(ctx, d.env, groupID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -1808,6 +1808,7 @@ func TestCapabilitiesForUserRole(t *testing.T) {
 			UserRole: role.Developer,
 			ExpectedCapabilities: []cappb.Capability{
 				cappb.Capability_CAS_WRITE,
+				cappb.Capability_GROUP_ACCESS,
 			},
 		},
 		{
@@ -1817,6 +1818,7 @@ func TestCapabilitiesForUserRole(t *testing.T) {
 				cappb.Capability_CAS_WRITE,
 				cappb.Capability_CACHE_WRITE,
 				cappb.Capability_ORG_ADMIN,
+				cappb.Capability_GROUP_ACCESS,
 			},
 		},
 		{
@@ -1825,12 +1827,15 @@ func TestCapabilitiesForUserRole(t *testing.T) {
 			ExpectedCapabilities: []cappb.Capability{
 				cappb.Capability_CAS_WRITE,
 				cappb.Capability_CACHE_WRITE,
+				cappb.Capability_GROUP_ACCESS,
 			},
 		},
 		{
-			Name:                 "Reader",
-			UserRole:             role.Reader,
-			ExpectedCapabilities: nil,
+			Name:     "Reader",
+			UserRole: role.Reader,
+			ExpectedCapabilities: []cappb.Capability{
+				cappb.Capability_GROUP_ACCESS,
+			},
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -606,7 +606,7 @@ func (a *GitHubApp) GetInstallationTokenForStatusReportingOnly(ctx context.Conte
 }
 
 func (a *GitHubApp) GetRepositoryInstallationToken(ctx context.Context, repo *tables.GitRepository) (string, error) {
-	if err := authutil.AuthorizeGroupAccess(ctx, a.env, repo.GroupID); err != nil {
+	if err := authutil.AuthorizeTargetGroupAccess(ctx, a.env, repo.GroupID); err != nil {
 		return "", err
 	}
 	repoURL, err := gitutil.ParseGitHubRepoURL(repo.RepoURL)

--- a/enterprise/server/secrets/secrets.go
+++ b/enterprise/server/secrets/secrets.go
@@ -223,7 +223,7 @@ func (s *SecretService) DeleteSecret(ctx context.Context, req *skpb.DeleteSecret
 }
 
 func (s *SecretService) GetSecretEnvVars(ctx context.Context, groupID string) ([]*repb.Command_EnvironmentVariable, error) {
-	if err := authutil.AuthorizeGroupAccess(ctx, s.env, groupID); err != nil {
+	if err := authutil.AuthorizeTargetGroupAccess(ctx, s.env, groupID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -632,7 +632,7 @@ func (ws *workflowService) getRepositoryWorkflow(ctx context.Context, groupID st
 	if err != nil {
 		return nil, err
 	}
-	if err := authutil.AuthorizeGroupAccess(ctx, ws.env, groupID); err != nil {
+	if err := authutil.AuthorizeTargetGroupAccess(ctx, ws.env, groupID); err != nil {
 		return nil, err
 	}
 	gitRepository := &tables.GitRepository{}

--- a/proto/capability.proto
+++ b/proto/capability.proto
@@ -16,4 +16,7 @@ enum Capability {
   ORG_ADMIN = 8;  // 2^3
   // Allows read-only access to audit logs.
   AUDIT_LOG_READ = 16;  // 2^4
+  // This is an implicit capability granted through group membership, except
+  // for certain API keys with more limited access.
+  GROUP_ACCESS = 32; // 2^5
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1097,7 +1097,7 @@ func (s *BuildBuddyServer) getAPIKeysForAuthorizedGroup(ctx context.Context) ([]
 	if groupID == "" {
 		return []*akpb.ApiKey{}, nil
 	}
-	if err := authutil.AuthorizeGroupAccess(ctx, s.env, groupID); err != nil {
+	if err := authutil.AuthorizeTargetGroupAccess(ctx, s.env, groupID); err != nil {
 		return nil, err
 	}
 	authDB := s.env.GetAuthDB()

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -67,10 +67,34 @@ func AuthorizeOrgAdmin(u interfaces.UserInfo, groupID string) error {
 	return status.PermissionDeniedError("you are not a member of the requested organization")
 }
 
-// AuthorizeGroupAccess checks whether the user is a member of the given group.
+// AuthorizeGroupAccess checks whether the user identified in the context is
+// authorized to access the group identified in the context.
+//
+// This serves as a minimum authorization check on user actions.
+// Where applicable, make sure to check additional capabilities.
+//
+// API requests automatically go through interceptors that populate
+// the user and selected group information into the context. If you need
+// to retrieve the target group ID of the API request, call GetGroupID()
+// on the returned UserInfo.
+func AuthorizeGroupAccess(ctx context.Context, env environment.Env) (interfaces.UserInfo, error) {
+	user, err := env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if user.HasCapability(cappb.Capability_GROUP_ACCESS) {
+		return user, nil
+	}
+	return nil, status.PermissionDeniedError("You do not have access to the requested group")
+}
+
+// AuthorizeTargetGroupAccess checks whether the user identified in the context
+// is a member of the given group.
 // Where applicable, make sure to check the user's capabilities within the group
 // as well.
-func AuthorizeGroupAccess(ctx context.Context, env environment.Env, groupID string) error {
+//
+// In most cases AuthorizeGroupAccess should be used instead.
+func AuthorizeTargetGroupAccess(ctx context.Context, env environment.Env, groupID string) error {
 	if groupID == "" {
 		return status.InvalidArgumentError("group ID is required")
 	}
@@ -80,14 +104,16 @@ func AuthorizeGroupAccess(ctx context.Context, env environment.Env, groupID stri
 	}
 	for _, gm := range user.GetGroupMemberships() {
 		if gm.GroupID == groupID {
-			return nil
+			if slices.Contains(gm.Capabilities, cappb.Capability_GROUP_ACCESS) {
+				return nil
+			}
 		}
 	}
 	return status.PermissionDeniedError("You do not have access to the requested group")
 }
 
 func AuthorizeGroupAccessForStats(ctx context.Context, env environment.Env, groupID string) error {
-	if err := AuthorizeGroupAccess(ctx, env, groupID); err != nil {
+	if err := AuthorizeTargetGroupAccess(ctx, env, groupID); err != nil {
 		return err
 	}
 	if blocklist.IsBlockedForStatsQuery(groupID) {

--- a/server/util/claims/BUILD
+++ b/server/util/claims/BUILD
@@ -28,8 +28,11 @@ go_test(
     srcs = ["claims_test.go"],
     deps = [
         ":claims",
+        "//proto:capability_go_proto",
         "//proto:context_go_proto",
+        "//proto:group_go_proto",
         "//server/interfaces",
+        "//server/tables",
         "//server/util/authutil",
         "//server/util/capabilities",
         "//server/util/request_context",

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -144,16 +144,25 @@ func APIKeyGroupClaims(ctx context.Context, akg interfaces.APIKeyGroup) (*Claims
 		keyRole = role.Admin
 	}
 	allowedGroups := []string{akg.GetGroupID()}
+	caps := capabilities.FromInt(akg.GetCapabilities())
+	// "audit log read" is a limited capability that does not grant any of
+	// the access granted implicitly through group membership.
+	for _, c := range caps {
+		if c != cappb.Capability_AUDIT_LOG_READ && c != cappb.Capability_UNKNOWN_CAPABILITY {
+			caps = append(caps, cappb.Capability_GROUP_ACCESS)
+			break
+		}
+	}
 	groupMemberships := []*interfaces.GroupMembership{{
 		GroupID:      akg.GetGroupID(),
-		Capabilities: capabilities.FromInt(akg.GetCapabilities()),
+		Capabilities: caps,
 		Role:         keyRole,
 	}}
 	for _, cg := range akg.GetChildGroupIDs() {
 		allowedGroups = append(allowedGroups, cg)
 		groupMemberships = append(groupMemberships, &interfaces.GroupMembership{
 			GroupID:      cg,
-			Capabilities: capabilities.FromInt(akg.GetCapabilities()),
+			Capabilities: caps,
 			Role:         keyRole,
 		})
 	}
@@ -174,7 +183,7 @@ func APIKeyGroupClaims(ctx context.Context, akg interfaces.APIKeyGroup) (*Claims
 		GroupID:                effectiveGroup,
 		AllowedGroups:          allowedGroups,
 		GroupMemberships:       groupMemberships,
-		Capabilities:           capabilities.FromInt(akg.GetCapabilities()),
+		Capabilities:           caps,
 		UseGroupOwnedExecutors: akg.GetUseGroupOwnedExecutors(),
 		CacheEncryptionEnabled: akg.GetCacheEncryptionEnabled(),
 		EnforceIPRules:         akg.GetEnforceIPRules(),
@@ -210,7 +219,7 @@ func ClaimsFromSubID(ctx context.Context, env environment.Env, subID string) (*C
 		}
 	}
 
-	claims, err := userClaims(u, eg)
+	claims, err := UserClaims(u, eg)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +248,7 @@ func ClaimsFromSubID(ctx context.Context, env environment.Env, subID string) (*C
 				Group: *ig,
 				Role:  uint32(role.Admin),
 			}}
-			claims, err := userClaims(u, requestContext.GetImpersonatingGroupId())
+			claims, err := UserClaims(u, requestContext.GetImpersonatingGroupId())
 			if err != nil {
 				return nil, err
 			}
@@ -252,15 +261,18 @@ func ClaimsFromSubID(ctx context.Context, env environment.Env, subID string) (*C
 	return claims, nil
 }
 
-func userClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
+func UserClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
 	allowedGroups := make([]string, 0, len(u.Groups))
 	groupMemberships := make([]*interfaces.GroupMembership, 0, len(u.Groups))
 	cacheEncryptionEnabled := false
 	enforceIPRules := false
-	var capabilities []cappb.Capability
+	// Users always have the implicit GROUP_ACCESS capability.
+	capabilities := []cappb.Capability{cappb.Capability_GROUP_ACCESS}
 	for _, g := range u.Groups {
 		allowedGroups = append(allowedGroups, g.Group.GroupID)
 		c, err := role.ToCapabilities(role.Role(g.Role))
+		// Users always have the implicit GROUP_ACCESS capability.
+		c = append(c, cappb.Capability_GROUP_ACCESS)
 		if err != nil {
 			return nil, err
 		}

--- a/server/util/claims/claims_test.go
+++ b/server/util/claims/claims_test.go
@@ -2,9 +2,12 @@ package claims_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
@@ -13,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
 
+	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 )
@@ -116,7 +120,7 @@ func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {
 	require.NoError(t, err)
 	expectedBaseMembership := &interfaces.GroupMembership{
 		GroupID:      baseGroupID,
-		Capabilities: caps,
+		Capabilities: append(caps, cappb.Capability_GROUP_ACCESS),
 		Role:         role.Default,
 	}
 	require.Equal(t, baseGroupID, c.GetGroupID())
@@ -151,7 +155,7 @@ func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {
 	require.NoError(t, err)
 	expectedChildMembership := &interfaces.GroupMembership{
 		GroupID:      childGroupID,
-		Capabilities: caps,
+		Capabilities: append(caps, cappb.Capability_GROUP_ACCESS),
 		Role:         role.Default,
 	}
 	require.Equal(t, baseGroupID, c.GetGroupID())
@@ -171,4 +175,61 @@ func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {
 	_, err = claims.APIKeyGroupClaims(rctx, akg)
 	require.Error(t, err)
 	require.True(t, status.IsPermissionDeniedError(err))
+}
+
+// This test checks whether a given capability implicitly grants the
+// GROUP_ACCESS capability, which grants access to a broad range of access
+// to various resources.
+//
+// When adding a new capability, decide whether that type of API key should
+// have broad access to retrieve invocation information, artifacts, group membership, etc.
+func TestAPIKeyImplicitGroupAccessCaps(t *testing.T) {
+	implicitGroupAccess := map[cappb.Capability]bool{
+		cappb.Capability_UNKNOWN_CAPABILITY: false,
+		cappb.Capability_CACHE_WRITE:        true,
+		cappb.Capability_REGISTER_EXECUTOR:  true,
+		cappb.Capability_CAS_WRITE:          true,
+		cappb.Capability_ORG_ADMIN:          true,
+		cappb.Capability_AUDIT_LOG_READ:     false,
+		cappb.Capability_GROUP_ACCESS:       true,
+	}
+	ctx := context.Background()
+	for name, val := range cappb.Capability_value {
+		baseGroupID := "GR9000"
+		caps := []cappb.Capability{cappb.Capability(val)}
+		akg := &fakeAPIKeyGroup{groupID: baseGroupID, capabilities: capabilities.ToInt(caps)}
+		c, err := claims.APIKeyGroupClaims(ctx, akg)
+		require.NoError(t, err)
+		expected, ok := implicitGroupAccess[cappb.Capability(val)]
+		require.True(t, ok, "expectation for %q needs to be specified", name)
+		actual := slices.Contains(c.Capabilities, cappb.Capability_GROUP_ACCESS)
+		if !expected && actual {
+			require.FailNow(t, "capability should not grant implicit group access", name)
+		} else if expected && !actual {
+			require.FailNow(t, "capability should grant implicit group access", name)
+		}
+	}
+}
+
+// Tests that users always have implicit GROUP_ACCESS capability.
+func TestUserImplicitGroupAccessCaps(t *testing.T) {
+	for name, val := range grpb.Group_Role_value {
+		if grpb.Group_Role(val) == grpb.Group_UNKNOWN_ROLE {
+			continue
+		}
+		groupID := "GR9000"
+		r, err := role.FromProto(grpb.Group_Role(val))
+		require.NoError(t, err, "could not convert proto role %s", name)
+		u := &tables.User{
+			Groups: []*tables.GroupRole{
+				{
+					Group: tables.Group{GroupID: groupID},
+					Role:  uint32(r),
+				},
+			},
+		}
+		c, err := claims.UserClaims(u, groupID)
+		require.NoError(t, err)
+		require.Contains(t, c.Capabilities, cappb.Capability_GROUP_ACCESS, "role %s should grant implicit group access", name)
+	}
 }


### PR DESCRIPTION
Today users and API keys in a group have broad access to various APIs by virtue of group membership. This PR makes this access more explicit by modeling it as its own capability.

Users always have the GROUP_ACCESS capability and most API key types have this capability as well, except the freshly added "audit log reader" capability.

This PR introduces the `AuthorizeGroupAccess` function which is meant to be a drop-in replacement for `authenticator.AuthenticatedUser` with the addition of checking the GROUP_ACCESS capability.
The existing `AuthorizeGroupAccess` is renamed to `AuthorizeTargetGroupAccess` as the existing function is not frequently used and in most cases can be replaced by a call to the new function.