### PR TITLE
Switch incremental update computation to use "git whatchanged"

### DIFF
--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -304,7 +304,7 @@ func ComputeIncrementalUpdate(gc gitClient, firstSha, lastSha string) (*inpb.Inc
 		}
 
 		if line[0] != ':' {
-			// This is a commit line, not a diff line.
+			// Commit line
 			currentCommit = &inpb.Commit{
 				Sha:       line,
 				ParentSha: sha,
@@ -312,7 +312,7 @@ func ComputeIncrementalUpdate(gc gitClient, firstSha, lastSha string) (*inpb.Inc
 			result.Commits = append(result.Commits, currentCommit)
 			sha = line
 		} else {
-			// This is a diff line.
+			// Diff line
 			processDiffTreeLine(gc, line, currentCommit)
 		}
 	}

--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -33,6 +33,8 @@ const (
 	// mimetype detection.
 	detectionBufferSize = 1000
 
+	// The maximum number of changes to process in a single incremental update.
+	// 1000 was an arbitrary choice, and could be adjusted if needed.
 	maxAllowedChanges = 1000
 )
 


### PR DESCRIPTION
Why, what a nifty command this is! `git whatchanged ...` does the same thing as the combination of the previous `git log ...` and `git diff-tree ...` commands.

This change also imposes an arbitrary limit of ~1000 modified files for a single incremental update.