### PR TITLE
[oci resolver] fetch config layer the same way we fetch other layers

### DIFF
--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -427,11 +427,24 @@ func (i *imageFromManifest) RawConfigFile() ([]byte, error) {
 	}
 
 	configDigest := i.digest.Digest(i.manifest.Config.Digest.String())
-	rl, err := remote.Layer(configDigest, i.remoteOpts...)
+	remoteLayer, err := remote.Layer(configDigest, i.remoteOpts...)
 	if err != nil {
 		return nil, err
 	}
-	rc, err := rl.Uncompressed()
+	partialLayer := &cacheAwareLayer{
+		hash:      i.manifest.Config.Digest,
+		ocidigest: configDigest,
+
+		remoteLayer: remoteLayer,
+		ctx:         i.ctx,
+		acClient:    i.acClient,
+		bsClient:    i.bsClient,
+	}
+	layer, err := partial.CompressedToLayer(partialLayer)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := layer.Uncompressed()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
OCI image config files are stored as layers.
This change fetches the config file layer the same way we fetch other layers.
Once I add caching upon layer read (coming soon!), config files will benefit from that caching.