### PR TITLE
Several cs fixes

### DIFF
--- a/codesearch/README.md
+++ b/codesearch/README.md
@@ -68,7 +68,7 @@ Some example queries:
   $ grpc_cli call --metadata x-buildbuddy-api-key:YOUR_DEV_API_KEY localhost:2633 codesearch.service.CodesearchService.Index 'git_repo:<repo_url:"https://github.com/buildbuddy-io/buildbuddy"> repo_state:<commit_sha:"master">'
   #
   # grpcurl version:
-  $ grpcurl -plaintext -H "x-buildbuddy-api-key:YOUR_DEV_API_KEY" -d '{"git_repo": {"repo_url":"https://github.com/buildbuddy-io/buildbuddy"}, "repo_state": {"commit_sha":"master"}}' localhost:2633 codesearch.service.CodesearchService.Index
+  $ grpcurl -plaintext -H "x-buildbuddy-api-key:YOUR_DEV_API_KEY" -d '{"git_repo": {"repo_url":"https://github.com/buildbuddy-io/buildbuddy"}, "repo_state": {"commit_sha":"master"}, "replacement_strategy": 1}' localhost:2633 codesearch.service.CodesearchService.Index
 ```
 
 ## Perform a Search (server)

--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -181,7 +181,7 @@ func handleIndex(args []string) {
 				}
 
 				if err := github.AddFileToIndex(iw, repoURL, commitSHA, path, buf); err != nil {
-					log.Fatalf("failed to add file %s: %s", path, err)
+					log.Infof("Skipping file %s: %s", path, err)
 				}
 			}
 			return nil

--- a/codesearch/github/github_test.go
+++ b/codesearch/github/github_test.go
@@ -519,3 +519,20 @@ def456
 		},
 	}, result)
 }
+
+func TestComputeIncrementalUpdate_NoChanges(t *testing.T) {
+	firstSHA := "abc123"
+	lastSHA := "def456"
+
+	fakeClient := &fakeGitClient{
+		t: t,
+		commands: map[string]string{
+			fmt.Sprintf("whatchanged --first-parent --format=%%H --reverse %s..%s", firstSHA, lastSHA): "\n",
+		},
+		files: map[string][]byte{},
+	}
+
+	result, err := ComputeIncrementalUpdate(fakeClient, firstSHA, lastSHA)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -327,7 +327,7 @@ func (css *codesearchServer) Index(ctx context.Context, req *inpb.IndexRequest) 
 		unlockFn := css.repoLocks.Lock(lockKey)
 		defer unlockFn()
 
-		log.Infof("Starting indexing %q@%s", repoURL, commitSHA)
+		log.Infof("Starting indexing %s@%s", repoURL, commitSHA)
 
 		var err error
 		switch req.GetReplacementStrategy() {


### PR DESCRIPTION
- Fix grpcurl example in the README to reflect now-required replacement strategy arg
- Make incremental update computation properly return an error when no changes found
- Don't crash the CS CLI when failing to add a document
- Expose the GitClient from github.go, it will be used by the BB CLI in a change shortly