### PR TITLE
replay_invocation: allow replaying build_event_json_file

### DIFF
--- a/tools/replay_invocation/BUILD
+++ b/tools/replay_invocation/BUILD
@@ -28,7 +28,9 @@ go_library(
         "@com_github_google_uuid//:uuid",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
 


### PR DESCRIPTION
This is useful for replaying the exact BES contents as they were originally streamed, which matters for things like logs / ANSI parsing debugging, and redaction debugging.

Context: https://buildbuddy-corp.slack.com/archives/C03JL0YT6G5/p1747426991216539?thread_ts=1747424427.201779&cid=C03JL0YT6G5