### PR TITLE
compute and log pebble cache partition space used by group ID.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2787,7 +2787,10 @@ func (e *partitionEvictor) updateSize(cacheType rspb.CacheType, groupID string, 
 	}
 
 	if groupID != "" {
-		e.sizeByGroup[groupID] += deltaSize
+		// When this is first turned on, we will be evicting stuff that we
+		// weren't previously tracking.  Rather than letting ourselves go
+		// negative, we limit at zero.
+		e.sizeByGroup[groupID] = max(0, e.sizeByGroup[groupID]+deltaSize)
 	}
 
 	switch cacheType {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1381,9 +1381,7 @@ func (p *PebbleCache) Statusz(ctx context.Context) string {
 	for _, e := range evictors {
 		sizeBytes, sbg, casCount, acCount := e.Counts()
 		for g, s := range sbg {
-			if g != "" {
-				sizeByGroup[g] += s
-			}
+			sizeByGroup[g] += s
 		}
 		totalSizeBytes += sizeBytes
 		totalCASCount += casCount
@@ -1392,7 +1390,7 @@ func (p *PebbleCache) Statusz(ctx context.Context) string {
 	buf += fmt.Sprintf("Min DB version: %d, Max DB version: %d, Active version: %d\n", p.minDatabaseVersion(), p.maxDatabaseVersion(), p.activeDatabaseVersion())
 	buf += fmt.Sprintf("[All Partitions] Total Size: %d bytes\n", totalSizeBytes)
 	for g, s := range sizeByGroup {
-		buf += fmt.Sprintf("[All Partitions] %s: %d bytes\n", g, s)
+		buf += fmt.Sprintf("[All Partitions] (Group %s): %d bytes\n", g, s)
 	}
 	buf += fmt.Sprintf("[All Partitions] CAS total: %d items\n", totalCASCount)
 	buf += fmt.Sprintf("[All Partitions] AC total: %d items\n", totalACCount)
@@ -2772,9 +2770,6 @@ func (e *partitionEvictor) updateMetrics() {
 		metrics.CacheNameLabel: e.cacheName,
 		metrics.CacheTypeLabel: "cas"}).Set(float64(e.casCount))
 	for g, sizeBytes := range e.sizeByGroup {
-		if g == "" {
-			continue
-		}
 		metrics.DiskCachePartitionSizeBytes.With(prometheus.Labels{
 			metrics.PartitionID:    e.part.ID,
 			metrics.CacheNameLabel: e.cacheName,

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2714,7 +2714,6 @@ func (e *partitionEvictor) generateSamplesForEviction(quitChan chan struct{}) er
 		}
 
 		e.maybeAddToSampleChan(iter, fileMetadata, quitChan, timer)
-		fileMetadata.GetFileRecord().GetIsolation().GetGroupId()
 
 		iter.Next()
 		fileMetadata.ResetVT()

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2837,7 +2837,7 @@ func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, map[str
 
 		sizeBytes := getSizeOnLocalDisk(iter.Key(), fileMetadata, true)
 		totalSizeBytes += sizeBytes
-		if groupID := fileMetadata.GetFileRecord().GetIsolation().GetGroupId(); groupID != nil {
+		if groupID := fileMetadata.GetFileRecord().GetIsolation().GetGroupId(); groupID != "" {
 			totalSizeByGroup[groupID] += sizeBytes
 		}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2716,7 +2716,6 @@ func (e *partitionEvictor) generateSamplesForEviction(quitChan chan struct{}) er
 		e.maybeAddToSampleChan(iter, fileMetadata, quitChan, timer)
 		fileMetadata.GetFileRecord().GetIsolation().GetGroupId()
 
-
 		iter.Next()
 		fileMetadata.ResetVT()
 	}
@@ -2770,9 +2769,9 @@ func (e *partitionEvictor) updateMetrics() {
 		metrics.CacheTypeLabel: "cas"}).Set(float64(e.casCount))
 	for g, sizeBytes := range e.sizeByGroup {
 		metrics.DiskCachePartitionSizeBytes.With(prometheus.Labels{
-			metrics.PartitionID: e.part.ID,
+			metrics.PartitionID:    e.part.ID,
 			metrics.CacheNameLabel: e.cacheName,
-			metrics.GroupID: g}).Set(float64(sizeBytes))
+			metrics.GroupID:        g}).Set(float64(sizeBytes))
 	}
 }
 
@@ -2824,7 +2823,7 @@ func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, map[str
 		if err := proto.Unmarshal(iter.Value(), fileMetadata); err != nil {
 			return 0, nil, 0, 0, err
 		}
-		
+
 		sizeBytes := getSizeOnLocalDisk(iter.Key(), fileMetadata, true)
 		totalSizeBytes += sizeBytes
 		totalSizeByGroup[fileMetadata.GetFileRecord().GetIsolation().GetGroupId()] += sizeBytes
@@ -2880,10 +2879,10 @@ func (e *partitionEvictor) writePartitionMetadata(db pebble.IPebbleDB, md *sgpb.
 func (e *partitionEvictor) flushPartitionMetadata(db pebble.IPebbleDB) error {
 	sizeBytes, sizeByGroup, casCount, acCount := e.Counts()
 	return e.writePartitionMetadata(db, &sgpb.PartitionMetadata{
-		SizeBytes: sizeBytes,
+		SizeBytes:   sizeBytes,
 		SizeByGroup: sizeByGroup,
-		CasCount:  casCount,
-		AcCount:   acCount,
+		CasCount:    casCount,
+		AcCount:     acCount,
 	})
 }
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1395,22 +1395,22 @@ func (p *PebbleCache) Statusz(ctx context.Context) string {
 	buf += fmt.Sprintf("[All Partitions] CAS total: %d items\n", totalCASCount)
 	buf += fmt.Sprintf("[All Partitions] AC total: %d items\n", totalACCount)
 	if len(sizeByGroup) > 0 {
-		extra := totalSizeBytes;
+		extra := totalSizeBytes
 		sortedKeys := make([]string, 0, len(sizeByGroup))
 		for k, _ := range sizeByGroup {
 			sortedKeys = append(sortedKeys, k)
 		}
 		sort.Strings(sortedKeys)
 		buf += "\n[All partitions] Size by group:\n"
-			for _, g := range sortedKeys {
-				if s, ok := sizeByGroup[g]; ok {
-					buf += fmt.Sprintf("  %s: %d bytes\n", g, s)
-					extra -= s
-				}
+		for _, g := range sortedKeys {
+			if s, ok := sizeByGroup[g]; ok {
+				buf += fmt.Sprintf("  %s: %d bytes\n", g, s)
+				extra -= s
 			}
+		}
 		buf += fmt.Sprintf("Extra space (from before counting began): %d bytes\n", extra)
 	}
-	
+
 	buf += "</pre>"
 	for _, e := range evictors {
 		buf += e.Statusz(ctx)

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"math"
 	"math/rand"
 	"os"
@@ -2930,8 +2931,7 @@ func (e *partitionEvictor) computeSize() (int64, map[string]int64, int64, int64,
 func (e *partitionEvictor) Counts() (int64, map[string]int64, int64, int64) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	// XXX: copy sizeByGroup.
-	return e.sizeBytes, e.sizeByGroup, e.casCount, e.acCount
+	return e.sizeBytes, maps.Clone(e.sizeByGroup), e.casCount, e.acCount
 }
 
 func (e *partitionEvictor) Statusz(ctx context.Context) string {

--- a/proto/storage.proto
+++ b/proto/storage.proto
@@ -108,6 +108,7 @@ message PartitionMetadata {
   int64 ac_count = 3;
   int64 total_count = 4;
   string partition_id = 5;
+  map<string, int64> size_by_group = 6;
 }
 
 message PartitionMetadatas {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -684,6 +684,17 @@ var (
 		CacheNameLabel,
 	})
 
+	DiskCachePartitionGroupSizeBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "disk_cache_partition_group_size_bytes",
+		Help:      "Number of bytes in the partition, by group ID.",
+	}, []string{
+		PartitionID,
+		CacheNameLabel,
+		GroupID,
+	})
+
 	DiskCachePartitionCapacityBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",


### PR DESCRIPTION
this approach only counts bytes that were written after a specified timestamp--without a "start" time, the byte count can go negative as items are evicted.  limiting the byte count to be positive would have similar issues: so long as a user's share of the cache isn't increasing, we would expect their byte count to stay near zero.

happy to hear other suggestions, but i kind of like how this one ties into our existing counting methods, so i'll take not knowing where some bytes came from as a starting point--if the "permanent" cache size (stuff that never gets evicted) is large enough that we care, we can try to figure out a sampling-based approach.