### PR TITLE
[raft] rangelease_test: move ctx close to lease

### DIFF
--- a/enterprise/server/raft/rangelease/BUILD
+++ b/enterprise/server/raft/rangelease/BUILD
@@ -36,7 +36,6 @@ go_test(
         "//enterprise/server/raft/sender",
         "//enterprise/server/raft/testutil",
         "//proto:raft_go_proto",
-        "//server/testutil/quarantine",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/random",

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/testutil"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
@@ -68,7 +67,6 @@ func newTestingProposerAndSenderAndReplica(t testing.TB) (*testutil.TestingPropo
 }
 
 func TestAcquireAndRelease(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	bgCtx := context.Background()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
@@ -109,7 +107,6 @@ func TestAcquireAndRelease(t *testing.T) {
 }
 
 func TestAcquireAndReleaseMetaRange(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	bgCtx := context.Background()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -70,8 +70,6 @@ func newTestingProposerAndSenderAndReplica(t testing.TB) (*testutil.TestingPropo
 func TestAcquireAndRelease(t *testing.T) {
 	quarantine.SkipQuarantinedTest(t)
 	bgCtx := context.Background()
-	ctx, cancel := context.WithTimeout(bgCtx, 3*time.Second)
-	defer cancel()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
 	liveness := nodeliveness.New(bgCtx, "replicaID-1", sender)
@@ -89,6 +87,8 @@ func TestAcquireAndRelease(t *testing.T) {
 	}
 	l := rangelease.New(proposer, session, log.NamedSubLogger("test"), liveness, rd.GetRangeId(), rep)
 
+	ctx, cancel := context.WithTimeout(bgCtx, 3*time.Second)
+	defer cancel()
 	// Should be able to get a rangelease.
 	err := l.Lease(ctx)
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestAcquireAndRelease(t *testing.T) {
 	valid := l.Valid(ctx)
 	require.True(t, valid)
 
-	log.Printf("RangeLease: %s", l.Desc(ctx))
+	log.Infof("RangeLease: %s", l.Desc(ctx))
 
 	// Should be able to release a rangelease.
 	err = l.Release(ctx)
@@ -111,8 +111,6 @@ func TestAcquireAndRelease(t *testing.T) {
 func TestAcquireAndReleaseMetaRange(t *testing.T) {
 	quarantine.SkipQuarantinedTest(t)
 	bgCtx := context.Background()
-	ctx, cancel := context.WithTimeout(bgCtx, 3*time.Second)
-	defer cancel()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
 	liveness := nodeliveness.New(bgCtx, "replicaID-2", sender)
@@ -131,6 +129,8 @@ func TestAcquireAndReleaseMetaRange(t *testing.T) {
 	l := rangelease.New(proposer, session, log.NamedSubLogger("test"), liveness, rd.GetRangeId(), rep)
 
 	// Should be able to get a rangelease.
+	ctx, cancel := context.WithTimeout(bgCtx, 3*time.Second)
+	defer cancel()
 	err := l.Lease(ctx)
 	require.NoError(t, err)
 
@@ -138,7 +138,7 @@ func TestAcquireAndReleaseMetaRange(t *testing.T) {
 	valid := l.Valid(ctx)
 	require.True(t, valid)
 
-	log.Printf("RangeLease: %s", l.Desc(ctx))
+	log.Infof("RangeLease: %s", l.Desc(ctx))
 
 	// Should be able to release a rangelease.
 	err = l.Release(ctx)
@@ -180,9 +180,9 @@ func TestMetaRangeLeaseKeepalive(t *testing.T) {
 	valid := l.Valid(ctx)
 	require.True(t, valid)
 
-	log.Printf("RangeLease: %s", l.Desc(ctx))
+	log.Infof("RangeLease: %s", l.Desc(ctx))
 	time.Sleep(2 * leaseDuration)
-	log.Printf("RangeLease: %s", l.Desc(ctx))
+	log.Infof("RangeLease: %s", l.Desc(ctx))
 
 	// Rangelease should have auto-renewed itself and should still be valid.
 	valid = l.Valid(ctx)


### PR DESCRIPTION
unquarantine rangelease test.

Right now some tests failed with deadline exceeded errors. The deadline is
reached before the renewLease is actually called.

The test passes with 4500 runs. 
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4192