### PR TITLE
CLI: Fix errant negation when expanding `--enable_platform_specific_config`

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -696,7 +696,7 @@ func ExpandConfigs(
 		enable := opts[len(opts)-1].Option
 		index := opts[len(opts)-1].Index
 		if b, ok := enable.(options.BoolLike); ok {
-			if v, err := b.AsBool(); err != nil && v {
+			if v, err := b.AsBool(); err == nil && v {
 				bazelOS := bazelrc.GetBazelOS()
 				if platformConfig, ok := namedConfigs[bazelOS]; ok {
 					phases := bazelrc.GetPhases(command)


### PR DESCRIPTION
We should be checking that there is no error when evaluating the flag as a bool, not that there is one.
