### PR TITLE
CLI: Fix order of options when no command is present

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -734,7 +734,7 @@ func expandConfigs(
 	commandIndex, command := parsed.Find[*parsed.Command](args.Args)
 	if commandIndex == -1 {
 		// No command is a help command that does not expand anything but the startup config.
-		return &parsed.OrderedArgs{Args: append(args.Args, startupConfig...)}, nil
+		return &parsed.OrderedArgs{Args: slices.Concat(startupConfig, args.Args)}, nil
 	}
 	expanded := slices.Concat(startupConfig, args.Args[:commandIndex])
 	expanded = append(expanded, command.PositionalArgument)


### PR DESCRIPTION
Explicit options should always take precedence over config options, which means, ironically, that config options should always precede explicit options :P

This corrects our behavior when no command is present to be in line with that.
