### PR TITLE
Add graphs for lookaside cache metrics

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -80,7 +80,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 9
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 21,
@@ -187,7 +187,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 16
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 6270,
@@ -284,7 +284,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 932,
@@ -421,7 +421,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 31
           },
           "id": 5492,
           "options": {
@@ -494,7 +494,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 234
+            "y": 242
           },
           "hiddenSeries": false,
           "id": 348,
@@ -582,7 +582,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 234
+            "y": 242
           },
           "hiddenSeries": false,
           "id": 804,
@@ -702,7 +702,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 107
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 6840,
@@ -795,7 +795,7 @@
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 107
+            "y": 115
           },
           "hiddenSeries": false,
           "id": 25,
@@ -889,7 +889,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 115
+            "y": 123
           },
           "hiddenSeries": false,
           "id": 1232,
@@ -1003,7 +1003,7 @@
             "h": 8,
             "w": 12,
             "x": 9,
-            "y": 115
+            "y": 123
           },
           "hiddenSeries": false,
           "id": 65,
@@ -1097,7 +1097,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 123
+            "y": 131
           },
           "hiddenSeries": false,
           "id": 13,
@@ -1263,7 +1263,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 308
+            "y": 316
           },
           "id": 1182,
           "options": {
@@ -1359,7 +1359,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 308
+            "y": 316
           },
           "id": 1186,
           "options": {
@@ -1452,7 +1452,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 316
+            "y": 324
           },
           "id": 1183,
           "options": {
@@ -1546,7 +1546,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 316
+            "y": 324
           },
           "id": 1187,
           "options": {
@@ -1639,7 +1639,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 324
+            "y": 332
           },
           "id": 1184,
           "options": {
@@ -1733,7 +1733,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 324
+            "y": 332
           },
           "id": 1188,
           "options": {
@@ -1806,7 +1806,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 453
+            "y": 461
           },
           "hiddenSeries": false,
           "id": 230,
@@ -1895,7 +1895,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 453
+            "y": 461
           },
           "hiddenSeries": false,
           "id": 310,
@@ -1994,7 +1994,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 461
+            "y": 469
           },
           "hiddenSeries": false,
           "id": 312,
@@ -2094,607 +2094,7 @@
         "y": 5
       },
       "id": 240,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 14
-          },
-          "hiddenSeries": false,
-          "id": 254,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1261",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_started_total{region=\"${region}\", job=\"buildbuddy-app\",grpc_service=\"distributed_cache.DistributedCache\"}[${window}])) by (grpc_method)\n",
-              "interval": "",
-              "legendFormat": "{{grpc_method}}",
-              "queryType": "randomWalk",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Request Mix",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1268",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1269",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 14
-          },
-          "hiddenSeries": false,
-          "id": 251,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1348",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P99",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P95",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P50",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (grpc_service)",
-              "interval": "",
-              "legendFormat": "QPS",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "/GetMulti",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1355",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1356",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 22
-          },
-          "hiddenSeries": false,
-          "id": 250,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:74",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P99",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P95",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P50",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (grpc_service)",
-              "interval": "",
-              "legendFormat": "QPS",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "/FindMissing",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:81",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:82",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 22
-          },
-          "hiddenSeries": false,
-          "id": 252,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1687",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P99",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P95",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P50",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (grpc_service)",
-              "interval": "",
-              "legendFormat": "QPS",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "/Write",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1694",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1695",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 30
-          },
-          "hiddenSeries": false,
-          "id": 253,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1858",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P99",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P95",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P50",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (grpc_service)",
-              "interval": "",
-              "legendFormat": "QPS",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "/Read",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1865",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1866",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
+      "panels": [],
       "targets": [
         {
           "datasource": {
@@ -2708,6 +2108,845 @@
       "type": "row"
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 254,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1261",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_started_total{region=\"${region}\", job=\"buildbuddy-app\",grpc_service=\"distributed_cache.DistributedCache\"}[${window}])) by (grpc_method)\n",
+          "interval": "",
+          "legendFormat": "{{grpc_method}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Request Mix",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1268",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1269",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 251,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1348",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P99",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (grpc_service)",
+          "interval": "",
+          "legendFormat": "QPS",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "/GetMulti",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1355",
+          "format": "s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1356",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 250,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:74",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P99",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (grpc_service)",
+          "interval": "",
+          "legendFormat": "QPS",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "/FindMissing",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:81",
+          "format": "s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:82",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 252,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1687",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P99",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (grpc_service)",
+          "interval": "",
+          "legendFormat": "QPS",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "/Write",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1694",
+          "format": "s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1695",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "hiddenSeries": false,
+      "id": 253,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1858",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P99",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"buildbuddy-app\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (grpc_service)",
+          "interval": "",
+          "legendFormat": "QPS",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "/Read",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1865",
+          "format": "s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1866",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "hiddenSeries": false,
+      "id": 10479,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1261",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum by(status) (rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\"}[${window}])) \n",
+          "interval": "",
+          "legendFormat": "__auto",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Lookaside cache hits and misses",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1268",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1269",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "collapsed": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "hiddenSeries": false,
+      "id": 10604,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1858",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, eviction_reason) (rate(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_bucket{region=\"${region}\", job=\"buildbuddy-app\"}[${window}])))",
+          "interval": "",
+          "legendFormat": "{{eviction_reason}} P99",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, eviction_reason) (rate(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_bucket{region=\"${region}\", job=\"buildbuddy-app\"}[${window}])))",
+          "interval": "",
+          "legendFormat": "{{eviction_reason}} P95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le, eviction_reason) (rate(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_bucket{region=\"${region}\", job=\"buildbuddy-app\"}[${window}])))",
+          "interval": "",
+          "legendFormat": "{{eviction_reason}} P50",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum by(eviction_reason) (increase(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_sum{region=\"${region}\", job=\"buildbuddy-app\"}[${window}])) / sum by(eviction_reason) (increase(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_count{region=\"${region}\", job=\"buildbuddy-app\"}[${window}]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{eviction_reason}} avg",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Lookaside cache eviction age by reason",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1865",
+          "format": "ms",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1866",
+          "format": "reqps",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -2717,7 +2956,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 38
       },
       "id": 15,
       "panels": [
@@ -2738,7 +2977,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 17,
@@ -2829,7 +3068,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 19,
@@ -2922,7 +3161,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 4,
@@ -3032,7 +3271,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 9,
@@ -3171,7 +3410,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 49
           },
           "id": 6656,
           "options": {
@@ -3264,7 +3503,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 49
           },
           "id": 6834,
           "options": {
@@ -3319,7 +3558,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 57
           },
           "hiddenSeries": false,
           "id": 646,
@@ -3433,7 +3672,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 65
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -3584,7 +3823,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 65
+            "y": 73
           },
           "id": 1338,
           "options": {
@@ -3685,7 +3924,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 73
+            "y": 81
           },
           "id": 2135,
           "options": {
@@ -3817,7 +4056,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 89
           },
           "id": 6732,
           "options": {
@@ -3938,7 +4177,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 89
+            "y": 97
           },
           "id": 6422,
           "options": {
@@ -4034,7 +4273,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 97
+            "y": 105
           },
           "id": 6428,
           "options": {
@@ -4132,7 +4371,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 105
+            "y": 113
           },
           "id": 2182,
           "options": {
@@ -4204,7 +4443,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 113
+            "y": 121
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -4309,7 +4548,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 39
       },
       "id": 3680,
       "panels": [
@@ -4374,7 +4613,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 281
+            "y": 289
           },
           "id": 6580,
           "options": {
@@ -4494,7 +4733,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 289
+            "y": 297
           },
           "id": 3763,
           "options": {
@@ -4623,7 +4862,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 297
+            "y": 305
           },
           "id": 5574,
           "options": {
@@ -4777,7 +5016,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 305
+            "y": 313
           },
           "id": 3846,
           "options": {
@@ -4873,7 +5112,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 313
+            "y": 321
           },
           "id": 5160,
           "options": {
@@ -4969,7 +5208,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 321
+            "y": 329
           },
           "id": 5242,
           "options": {
@@ -5064,7 +5303,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 329
+            "y": 337
           },
           "id": 5324,
           "options": {
@@ -5159,7 +5398,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 337
+            "y": 345
           },
           "id": 5406,
           "options": {
@@ -5202,7 +5441,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 40
       },
       "id": 4996,
       "panels": [
@@ -5266,7 +5505,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 317
+            "y": 325
           },
           "id": 3929,
           "options": {
@@ -5358,7 +5597,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 317
+            "y": 325
           },
           "id": 4011,
           "options": {
@@ -5450,7 +5689,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 325
+            "y": 333
           },
           "id": 4093,
           "options": {
@@ -5542,7 +5781,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 325
+            "y": 333
           },
           "id": 4175,
           "options": {
@@ -5634,7 +5873,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 333
+            "y": 341
           },
           "id": 4257,
           "options": {
@@ -5726,7 +5965,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 333
+            "y": 341
           },
           "id": 4339,
           "options": {
@@ -5818,7 +6057,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 341
+            "y": 349
           },
           "id": 4421,
           "options": {
@@ -5910,7 +6149,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 341
+            "y": 349
           },
           "id": 4503,
           "options": {
@@ -6002,7 +6241,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 349
+            "y": 357
           },
           "id": 4585,
           "options": {
@@ -6094,7 +6333,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 349
+            "y": 357
           },
           "id": 4667,
           "options": {
@@ -6186,7 +6425,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 357
+            "y": 365
           },
           "id": 4749,
           "options": {
@@ -6278,7 +6517,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 357
+            "y": 365
           },
           "id": 4831,
           "options": {
@@ -6370,7 +6609,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 365
+            "y": 373
           },
           "id": 4913,
           "options": {
@@ -6417,7 +6656,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 42
       },
       "id": 264,
       "panels": [
@@ -6439,7 +6678,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 74
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 274,
@@ -6552,7 +6791,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 74
+            "y": 82
           },
           "hiddenSeries": false,
           "id": 276,
@@ -6643,7 +6882,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 290,
@@ -6734,7 +6973,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 292,
@@ -6831,7 +7070,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 98
           },
           "hiddenSeries": false,
           "id": 278,
@@ -6928,7 +7167,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 98
           },
           "hiddenSeries": false,
           "id": 280,
@@ -7026,7 +7265,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 45
       },
       "id": 38,
       "panels": [
@@ -7094,7 +7333,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 294
+            "y": 302
           },
           "id": 40,
           "options": {
@@ -7236,7 +7475,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 307
+            "y": 315
           },
           "id": 76,
           "options": {
@@ -7292,7 +7531,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 321
+            "y": 329
           },
           "hiddenSeries": false,
           "id": 42,
@@ -7384,7 +7623,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 321
+            "y": 329
           },
           "hiddenSeries": false,
           "id": 46,
@@ -7476,7 +7715,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329
+            "y": 337
           },
           "hiddenSeries": false,
           "id": 44,
@@ -7573,7 +7812,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 46
       },
       "id": 458,
       "panels": [
@@ -7605,7 +7844,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 313
+            "y": 321
           },
           "hiddenSeries": false,
           "id": 498,
@@ -7704,7 +7943,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 313
+            "y": 321
           },
           "hiddenSeries": false,
           "id": 542,
@@ -7842,7 +8081,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 322
+            "y": 330
           },
           "hideTimeOverride": true,
           "id": 506,
@@ -7907,7 +8146,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 331
+            "y": 339
           },
           "hiddenSeries": false,
           "id": 496,
@@ -8011,7 +8250,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 341
+            "y": 349
           },
           "hiddenSeries": false,
           "id": 500,
@@ -8115,7 +8354,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 341
+            "y": 349
           },
           "hiddenSeries": false,
           "id": 504,
@@ -8218,7 +8457,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 47
       },
       "id": 48,
       "panels": [
@@ -8237,7 +8476,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 128
+            "y": 136
           },
           "hiddenSeries": false,
           "id": 50,
@@ -8328,7 +8567,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 128
+            "y": 136
           },
           "hiddenSeries": false,
           "id": 53,
@@ -8418,7 +8657,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 136
+            "y": 144
           },
           "hiddenSeries": false,
           "id": 51,
@@ -8509,7 +8748,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 136
+            "y": 144
           },
           "hiddenSeries": false,
           "id": 55,
@@ -8606,7 +8845,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 48
       },
       "id": 384,
       "panels": [
@@ -8673,7 +8912,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 225
+            "y": 233
           },
           "id": 742,
           "options": {
@@ -8776,7 +9015,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 225
+            "y": 233
           },
           "id": 422,
           "options": {
@@ -8876,7 +9115,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 233
+            "y": 241
           },
           "id": 420,
           "options": {
@@ -8976,7 +9215,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 233
+            "y": 241
           },
           "id": 6504,
           "options": {
@@ -9125,7 +9364,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 241
+            "y": 249
           },
           "id": 1223,
           "options": {
@@ -9296,7 +9535,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 241
+            "y": 249
           },
           "id": 1224,
           "options": {
@@ -9352,7 +9591,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 249
+            "y": 257
           },
           "id": 6943,
           "options": {
@@ -9444,7 +9683,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 249
+            "y": 257
           },
           "id": 6944,
           "options": {
@@ -9564,7 +9803,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 257
+            "y": 265
           },
           "id": 7133,
           "options": {
@@ -9753,7 +9992,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 257
+            "y": 265
           },
           "id": 7039,
           "options": {
@@ -9880,7 +10119,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 49
       },
       "id": 107,
       "panels": [
@@ -9902,7 +10141,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 122,
@@ -9992,7 +10231,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 116,
@@ -10086,7 +10325,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 98
           },
           "hiddenSeries": false,
           "id": 112,
@@ -10183,7 +10422,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 98
           },
           "hiddenSeries": false,
           "id": 120,
@@ -10278,7 +10517,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 118,
@@ -10368,7 +10607,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 124,
@@ -10458,7 +10697,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 106
+            "y": 114
           },
           "hiddenSeries": false,
           "id": 9138,
@@ -10554,7 +10793,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 106
+            "y": 114
           },
           "hiddenSeries": false,
           "id": 9139,
@@ -10650,7 +10889,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 114
+            "y": 122
           },
           "hiddenSeries": false,
           "id": 9266,
@@ -10749,7 +10988,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 50
       },
       "id": 28,
       "panels": [
@@ -10772,7 +11011,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 89
           },
           "hiddenSeries": false,
           "id": 190,
@@ -11035,7 +11274,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 89
           },
           "id": 159,
           "options": {
@@ -11138,7 +11377,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 97
           },
           "hiddenSeries": false,
           "id": 210,
@@ -11277,7 +11516,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 97
           },
           "id": 1209,
           "options": {
@@ -11372,7 +11611,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 97
+            "y": 105
           },
           "id": 31,
           "options": {
@@ -11422,7 +11661,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 105
           },
           "hiddenSeries": false,
           "id": 178,
@@ -11572,7 +11811,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 105
+            "y": 113
           },
           "id": 8505,
           "options": {
@@ -11689,7 +11928,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 105
+            "y": 113
           },
           "id": 8606,
           "options": {
@@ -11828,7 +12067,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 113
+            "y": 121
           },
           "id": 1216,
           "options": {
@@ -11958,7 +12197,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 113
+            "y": 121
           },
           "id": 1231,
           "options": {
@@ -12044,7 +12283,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 121
+            "y": 129
           },
           "hiddenSeries": false,
           "id": 33,
@@ -12136,7 +12375,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 121
+            "y": 129
           },
           "hiddenSeries": false,
           "id": 35,
@@ -12226,7 +12465,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 129
+            "y": 137
           },
           "hiddenSeries": false,
           "id": 129,
@@ -12319,7 +12558,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 129
+            "y": 137
           },
           "hiddenSeries": false,
           "id": 102,
@@ -12525,7 +12764,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 137
+            "y": 145
           },
           "id": 1195,
           "options": {
@@ -12613,7 +12852,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 137
+            "y": 145
           },
           "hiddenSeries": false,
           "id": 180,
@@ -12755,7 +12994,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 145
+            "y": 153
           },
           "id": 1202,
           "options": {
@@ -12914,7 +13153,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 145
+            "y": 153
           },
           "id": 1196,
           "options": {
@@ -12972,7 +13211,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 153
+            "y": 161
           },
           "id": 7139,
           "options": {
@@ -13053,7 +13292,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 153
+            "y": 161
           },
           "id": 7145,
           "options": {
@@ -13134,7 +13373,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 161
+            "y": 169
           },
           "id": 7151,
           "options": {
@@ -13215,7 +13454,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 161
+            "y": 169
           },
           "id": 7157,
           "options": {
@@ -13296,7 +13535,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 169
+            "y": 177
           },
           "id": 7163,
           "options": {
@@ -13377,7 +13616,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 169
+            "y": 177
           },
           "id": 7169,
           "options": {
@@ -13457,7 +13696,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 53
       },
       "id": 83,
       "panels": [
@@ -13477,7 +13716,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 223
+            "y": 231
           },
           "hiddenSeries": false,
           "id": 85,
@@ -13580,7 +13819,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 223
+            "y": 231
           },
           "hiddenSeries": false,
           "id": 87,
@@ -13674,7 +13913,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 232
+            "y": 240
           },
           "hiddenSeries": false,
           "id": 91,
@@ -13767,7 +14006,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 232
+            "y": 240
           },
           "hiddenSeries": false,
           "id": 93,
@@ -13870,7 +14109,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 57
       },
       "id": 71,
       "panels": [
@@ -13906,7 +14145,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 146
+            "y": 154
           },
           "hiddenSeries": false,
           "id": 73,
@@ -13999,7 +14238,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 146
+            "y": 154
           },
           "hiddenSeries": false,
           "id": 79,
@@ -14138,7 +14377,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 155
+            "y": 163
           },
           "id": 2087,
           "options": {
@@ -14240,7 +14479,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 155
+            "y": 163
           },
           "id": 2039,
           "options": {
@@ -14307,7 +14546,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 61
       },
       "id": 9283,
       "panels": [
@@ -14374,7 +14613,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 35
           },
           "id": 9300,
           "options": {
@@ -14471,7 +14710,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 35
           },
           "id": 9301,
           "options": {
@@ -14581,7 +14820,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 43
           },
           "id": 9303,
           "options": {
@@ -14638,7 +14877,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 62
       },
       "id": 9320,
       "panels": [
@@ -14705,7 +14944,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 36
           },
           "id": 9337,
           "options": {
@@ -14802,7 +15041,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 36
           },
           "id": 9462,
           "options": {
@@ -14912,7 +15151,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 44
           },
           "id": 9587,
           "options": {
@@ -14973,7 +15212,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 63
       },
       "id": 1088,
       "panels": [
@@ -15040,7 +15279,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 60
           },
           "id": 1127,
           "options": {
@@ -15137,7 +15376,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 60
           },
           "id": 1166,
           "options": {
@@ -15247,7 +15486,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 68
           },
           "id": 1168,
           "options": {
@@ -15319,7 +15558,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 68
       },
       "id": 8,
       "panels": [
@@ -15341,7 +15580,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 412
+            "y": 420
           },
           "hiddenSeries": false,
           "id": 2,
@@ -15454,7 +15693,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 412
+            "y": 420
           },
           "hiddenSeries": false,
           "id": 578,
@@ -15551,7 +15790,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 69
       },
       "id": 1346,
       "panels": [
@@ -15571,7 +15810,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 457
+            "y": 465
           },
           "hiddenSeries": false,
           "id": 2556,
@@ -15678,7 +15917,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 470
+            "y": 478
           },
           "hiddenSeries": false,
           "id": 2840,
@@ -15777,7 +16016,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 484
+            "y": 492
           },
           "hiddenSeries": false,
           "id": 2890,
@@ -15871,7 +16110,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 484
+            "y": 492
           },
           "hiddenSeries": false,
           "id": 2940,
@@ -16009,7 +16248,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 492
+            "y": 500
           },
           "id": 1353,
           "links": [
@@ -16065,7 +16304,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 70
       },
       "id": 5641,
       "panels": [
@@ -16131,7 +16370,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 241
+            "y": 249
           },
           "id": 5595,
           "options": {
@@ -16224,7 +16463,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 241
+            "y": 249
           },
           "id": 5608,
           "options": {
@@ -16318,7 +16557,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 249
+            "y": 257
           },
           "id": 5622,
           "options": {
@@ -16412,7 +16651,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 249
+            "y": 257
           },
           "id": 5629,
           "options": {
@@ -16505,7 +16744,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 257
+            "y": 265
           },
           "id": 5615,
           "options": {
@@ -16546,7 +16785,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 71
       },
       "id": 7275,
       "panels": [
@@ -16614,7 +16853,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 157
+            "y": 165
           },
           "id": 7381,
           "options": {
@@ -16735,7 +16974,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 157
+            "y": 165
           },
           "id": 7382,
           "options": {
@@ -16834,7 +17073,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 165
+            "y": 173
           },
           "id": 7489,
           "options": {
@@ -16933,7 +17172,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 165
+            "y": 173
           },
           "id": 7488,
           "options": {
@@ -17029,7 +17268,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 173
+            "y": 181
           },
           "id": 7595,
           "options": {
@@ -17125,7 +17364,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 173
+            "y": 181
           },
           "id": 8743,
           "options": {
@@ -17221,7 +17460,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 181
+            "y": 189
           },
           "id": 8880,
           "options": {
@@ -17317,7 +17556,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 181
+            "y": 189
           },
           "id": 9017,
           "options": {
@@ -17359,7 +17598,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 72
       },
       "id": 9846,
       "panels": [
@@ -17425,7 +17664,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 56
           },
           "id": 10100,
           "options": {
@@ -17519,7 +17758,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 56
           },
           "id": 10227,
           "options": {
@@ -17568,7 +17807,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 64
           },
           "hiddenSeries": false,
           "id": 10354,

--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -2756,7 +2756,7 @@
       "seriesOverrides": [
         {
           "$$hashKey": "object:1261",
-          "alias": "QPS",
+          "alias": "hit_ratio",
           "yaxis": 2
         }
       ],
@@ -2770,12 +2770,26 @@
             "uid": "vm"
           },
           "editorMode": "code",
-          "expr": "sum by(status) (rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\"}[${window}])) \n",
+          "expr": "sum by(status) (rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\"}[${window}]))",
           "interval": "",
           "legendFormat": "__auto",
           "queryType": "randomWalk",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\", status=\"hit\"}[${window}])) / sum(rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\"}[${window}]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "hit_ratio",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -2801,7 +2815,7 @@
         },
         {
           "$$hashKey": "object:1269",
-          "format": "reqps",
+          "format": "none",
           "logBase": 1,
           "show": true
         }
@@ -2852,13 +2866,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1858",
-          "alias": "QPS",
-          "yaxis": 2
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,

--- a/tools/metrics/grafana/dashboards/cache-proxy.json
+++ b/tools/metrics/grafana/dashboards/cache-proxy.json
@@ -3375,7 +3375,7 @@
       "seriesOverrides": [
         {
           "$$hashKey": "object:1261",
-          "alias": "QPS",
+          "alias": "hit_ratio",
           "yaxis": 2
         }
       ],
@@ -3391,10 +3391,24 @@
           "editorMode": "code",
           "expr": "sum(rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"cache-proxy\"}[${window}])) by (status)\n",
           "interval": "",
-          "legendFormat": "{{grpc_method}}",
+          "legendFormat": "__auto",
           "queryType": "randomWalk",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"cache-proxy\", status=\"hit\"}[${window}])) / sum(rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"cache-proxy\"}[${window}]))\n",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "hit_ratio",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -3420,7 +3434,7 @@
         },
         {
           "$$hashKey": "object:1269",
-          "format": "reqps",
+          "format": "none",
           "logBase": 1,
           "show": true
         }
@@ -3470,13 +3484,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1858",
-          "alias": "QPS",
-          "yaxis": 2
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,

--- a/tools/metrics/grafana/dashboards/cache-proxy.json
+++ b/tools/metrics/grafana/dashboards/cache-proxy.json
@@ -80,7 +80,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 129
+            "y": 137
           },
           "hiddenSeries": false,
           "id": 21,
@@ -187,7 +187,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 129
+            "y": 137
           },
           "hiddenSeries": false,
           "id": 6270,
@@ -331,7 +331,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 136
+            "y": 144
           },
           "id": 5492,
           "options": {
@@ -378,7 +378,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 136
+            "y": 144
           },
           "hiddenSeries": false,
           "id": 932,
@@ -495,7 +495,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 8754,
@@ -592,7 +592,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 8755,
@@ -689,7 +689,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 8756,
@@ -799,7 +799,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 8757,
@@ -909,7 +909,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 8022,
@@ -1019,7 +1019,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 8751,
@@ -1129,7 +1129,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 26
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 8128,
@@ -1243,7 +1243,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 26
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 8752,
@@ -1363,7 +1363,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 26
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 8753,
@@ -1483,7 +1483,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 34
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 8758,
@@ -1584,7 +1584,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 34
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 8759,
@@ -1691,7 +1691,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 34
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 8760,
@@ -1792,7 +1792,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 42
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 8761,
@@ -1893,7 +1893,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 42
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 8762,
@@ -2000,7 +2000,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 42
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 8763,
@@ -2132,7 +2132,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 11
           },
           "hiddenSeries": false,
           "id": 8749,
@@ -2254,7 +2254,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 11
           },
           "hiddenSeries": false,
           "id": 8750,
@@ -2384,7 +2384,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 4
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 8773,
@@ -2506,7 +2506,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 4
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 8779,
@@ -2622,7 +2622,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 4
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 8774,
@@ -2706,7 +2706,7 @@
       "type": "row"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": {
         "type": "prometheus",
         "uid": "vm"
@@ -2718,607 +2718,7 @@
         "y": 4
       },
       "id": 240,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 132
-          },
-          "hiddenSeries": false,
-          "id": 254,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1261",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_started_total{region=\"${region}\", job=\"cache-proxy\",grpc_service=\"distributed_cache.DistributedCache\"}[${window}])) by (grpc_method)\n",
-              "interval": "",
-              "legendFormat": "{{grpc_method}}",
-              "queryType": "randomWalk",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Request Mix",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1268",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1269",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 132
-          },
-          "hiddenSeries": false,
-          "id": 251,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1348",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P99",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P95",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P50",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (grpc_service)",
-              "interval": "",
-              "legendFormat": "QPS",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "/GetMulti",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1355",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1356",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 140
-          },
-          "hiddenSeries": false,
-          "id": 250,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:74",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P99",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P95",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P50",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (grpc_service)",
-              "interval": "",
-              "legendFormat": "QPS",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "/FindMissing",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:81",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:82",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 140
-          },
-          "hiddenSeries": false,
-          "id": 252,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1687",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P99",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P95",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P50",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (grpc_service)",
-              "interval": "",
-              "legendFormat": "QPS",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "/Write",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1694",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1695",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 148
-          },
-          "hiddenSeries": false,
-          "id": 253,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1858",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P99",
-              "queryType": "randomWalk",
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P95",
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
-              "interval": "",
-              "legendFormat": "P50",
-              "refId": "C"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (grpc_service)",
-              "interval": "",
-              "legendFormat": "QPS",
-              "refId": "D"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "/Read",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1865",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1866",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
+      "panels": [],
       "targets": [
         {
           "datasource": {
@@ -3332,6 +2732,839 @@
       "type": "row"
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 254,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1261",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_started_total{region=\"${region}\", job=\"cache-proxy\",grpc_service=\"distributed_cache.DistributedCache\"}[${window}])) by (grpc_method)\n",
+          "interval": "",
+          "legendFormat": "{{grpc_method}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Request Mix",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1268",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1269",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 251,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1348",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P99",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"GetMulti\"}[${window}])) by (grpc_service)",
+          "interval": "",
+          "legendFormat": "QPS",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "/GetMulti",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1355",
+          "format": "s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1356",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 250,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:74",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P99",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"FindMissing\"}[${window}])) by (grpc_service)",
+          "interval": "",
+          "legendFormat": "QPS",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "/FindMissing",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:81",
+          "format": "s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:82",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 252,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1687",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P99",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Write\"}[${window}])) by (grpc_service)",
+          "interval": "",
+          "legendFormat": "QPS",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "/Write",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1694",
+          "format": "s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1695",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 253,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1858",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P99",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grpc_server_handling_seconds_bucket{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (le)\n)",
+          "interval": "",
+          "legendFormat": "P50",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{region=\"${region}\", job=\"cache-proxy\", grpc_service=\"distributed_cache.DistributedCache\", grpc_method=\"Read\"}[${window}])) by (grpc_service)",
+          "interval": "",
+          "legendFormat": "QPS",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "/Read",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1865",
+          "format": "s",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1866",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 8780,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1261",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(buildbuddy_remote_cache_lookaside_cache_lookup_count{region=\"${region}\", job=\"cache-proxy\"}[${window}])) by (status)\n",
+          "interval": "",
+          "legendFormat": "{{grpc_method}}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Lookaside cache hits and misses",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1268",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1269",
+          "format": "reqps",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "description": "",
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "hiddenSeries": false,
+      "id": 8781,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "10.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1858",
+          "alias": "QPS",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, eviction_reason) (rate(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_bucket{region=\"${region}\", job=\"cache-proxy\"}[${window}])))",
+          "interval": "",
+          "legendFormat": "{{eviction_reason}} P99",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, eviction_reason) (rate(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_bucket{region=\"${region}\", job=\"cache-proxy\"}[${window}])))",
+          "interval": "",
+          "legendFormat": "{{eviction_reason}} P95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le, eviction_reason) (rate(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_bucket{region=\"${region}\", job=\"cache-proxy\"}[${window}])))",
+          "interval": "",
+          "legendFormat": "{{eviction_reason}} P50",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum by(eviction_reason) (increase(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_sum{region=\"${region}\", job=\"cache-proxy\"}[${window}])) / sum by(eviction_reason) (increase(buildbuddy_remote_cache_lookaside_cache_eviction_age_msec_count{region=\"${region}\", job=\"cache-proxy\"}[${window}]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{eviction_reason}} avg",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Lookaside cache eviction age by reason",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1865",
+          "format": "ms",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1866",
+          "format": "reqps",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -3341,7 +3574,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 37
       },
       "id": 15,
       "panels": [
@@ -3362,7 +3595,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 133
+            "y": 141
           },
           "hiddenSeries": false,
           "id": 17,
@@ -3453,7 +3686,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 133
+            "y": 141
           },
           "hiddenSeries": false,
           "id": 19,
@@ -3546,7 +3779,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 141
+            "y": 149
           },
           "hiddenSeries": false,
           "id": 4,
@@ -3656,7 +3889,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 141
+            "y": 149
           },
           "hiddenSeries": false,
           "id": 9,
@@ -3795,7 +4028,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 150
+            "y": 158
           },
           "id": 6656,
           "options": {
@@ -3888,7 +4121,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 150
+            "y": 158
           },
           "id": 6834,
           "options": {
@@ -3943,7 +4176,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 158
+            "y": 166
           },
           "hiddenSeries": false,
           "id": 646,
@@ -4057,7 +4290,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 166
+            "y": 174
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -4208,7 +4441,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 174
+            "y": 182
           },
           "id": 1338,
           "options": {
@@ -4309,7 +4542,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 182
+            "y": 190
           },
           "id": 2135,
           "options": {
@@ -4405,7 +4638,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 190
+            "y": 198
           },
           "id": 6422,
           "options": {
@@ -4501,7 +4734,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 198
+            "y": 206
           },
           "id": 6428,
           "options": {
@@ -4633,7 +4866,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 206
+            "y": 214
           },
           "id": 6732,
           "options": {
@@ -4756,7 +4989,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 214
+            "y": 222
           },
           "id": 2182,
           "options": {
@@ -4828,7 +5061,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 222
+            "y": 230
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -4933,7 +5166,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 38
       },
       "id": 3680,
       "panels": [
@@ -4998,7 +5231,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 337
+            "y": 345
           },
           "id": 6580,
           "options": {
@@ -5118,7 +5351,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 345
+            "y": 353
           },
           "id": 3763,
           "options": {
@@ -5247,7 +5480,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 353
+            "y": 361
           },
           "id": 5574,
           "options": {
@@ -5401,7 +5634,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 361
+            "y": 369
           },
           "id": 3846,
           "options": {
@@ -5497,7 +5730,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 369
+            "y": 377
           },
           "id": 5160,
           "options": {
@@ -5593,7 +5826,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 377
+            "y": 385
           },
           "id": 5242,
           "options": {
@@ -5688,7 +5921,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 385
+            "y": 393
           },
           "id": 5324,
           "options": {
@@ -5783,7 +6016,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 393
+            "y": 401
           },
           "id": 5406,
           "options": {
@@ -5826,7 +6059,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 39
       },
       "id": 4996,
       "panels": [
@@ -5891,7 +6124,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 135
+            "y": 143
           },
           "id": 3929,
           "options": {
@@ -5984,7 +6217,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 135
+            "y": 143
           },
           "id": 4011,
           "options": {
@@ -6077,7 +6310,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 143
+            "y": 151
           },
           "id": 4093,
           "options": {
@@ -6170,7 +6403,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 143
+            "y": 151
           },
           "id": 4175,
           "options": {
@@ -6263,7 +6496,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 151
+            "y": 159
           },
           "id": 4257,
           "options": {
@@ -6356,7 +6589,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 151
+            "y": 159
           },
           "id": 4339,
           "options": {
@@ -6449,7 +6682,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 159
+            "y": 167
           },
           "id": 4421,
           "options": {
@@ -6542,7 +6775,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 159
+            "y": 167
           },
           "id": 4503,
           "options": {
@@ -6635,7 +6868,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 167
+            "y": 175
           },
           "id": 4585,
           "options": {
@@ -6728,7 +6961,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 167
+            "y": 175
           },
           "id": 4667,
           "options": {
@@ -6821,7 +7054,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 175
+            "y": 183
           },
           "id": 4749,
           "options": {
@@ -6914,7 +7147,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 175
+            "y": 183
           },
           "id": 4831,
           "options": {
@@ -7007,7 +7240,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 183
+            "y": 191
           },
           "id": 4913,
           "options": {
@@ -7054,7 +7287,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 40
       },
       "id": 71,
       "panels": [
@@ -7090,7 +7323,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 192
+            "y": 200
           },
           "hiddenSeries": false,
           "id": 73,
@@ -7183,7 +7416,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 192
+            "y": 200
           },
           "hiddenSeries": false,
           "id": 79,
@@ -7322,7 +7555,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 201
+            "y": 209
           },
           "id": 2087,
           "options": {
@@ -7424,7 +7657,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 201
+            "y": 209
           },
           "id": 2039,
           "options": {
@@ -7495,7 +7728,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 41
       },
       "id": 83,
       "panels": [
@@ -7515,7 +7748,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 137
+            "y": 145
           },
           "hiddenSeries": false,
           "id": 85,
@@ -7618,7 +7851,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 137
+            "y": 145
           },
           "hiddenSeries": false,
           "id": 87,
@@ -7712,7 +7945,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 146
+            "y": 154
           },
           "hiddenSeries": false,
           "id": 91,
@@ -7805,7 +8038,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 146
+            "y": 154
           },
           "hiddenSeries": false,
           "id": 93,
@@ -7908,7 +8141,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 42
       },
       "id": 1088,
       "panels": [
@@ -7975,7 +8208,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 19
           },
           "id": 1127,
           "options": {
@@ -8072,7 +8305,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 19
           },
           "id": 1166,
           "options": {
@@ -8182,7 +8415,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 27
           },
           "id": 1168,
           "options": {
@@ -8254,7 +8487,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 43
       },
       "id": 8,
       "panels": [
@@ -8273,7 +8506,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 139
+            "y": 147
           },
           "hiddenSeries": false,
           "id": 578,


### PR DESCRIPTION
I added them for both the app and the cache-proxy. The buckets are broken for the eviction age metric, so I'm fixing them in https://github.com/buildbuddy-io/buildbuddy/pull/9432.

App: 
![image](https://github.com/user-attachments/assets/eb4d8e01-f282-4f9c-b1e0-9efc24dcee91)


Cache proxy: 
![image](https://github.com/user-attachments/assets/2e6acdbc-05f7-4248-b7c4-131004736150)

