### PR TITLE
More lookaside cache optimizations

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -344,7 +344,6 @@ func (t *teeReadCloser) Read(p []byte) (int, error) {
 	return read, t.lastReadErr
 }
 
-
 func (t *teeReadCloser) Close() error {
 	err := t.rc.Close()
 	if err == nil && t.lastReadErr != nil && t.lastReadErr != io.EOF {

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -232,13 +232,20 @@ func (c *Proxy) Metadata(ctx context.Context, req *dcpb.MetadataRequest) (*dcpb.
 	}, nil
 }
 
-// ResourceIsolationString returns a compact representation of a resource's isolation that is suitable for logging.
-func ResourceIsolationString(r *rspb.ResourceName) string {
+type resourceIsolationStringer struct{ *rspb.ResourceName }
+
+func (r resourceIsolationStringer) String() string {
 	rep := filepath.Join(r.GetInstanceName(), digest.CacheTypeToPrefix(r.GetCacheType()), r.GetDigest().GetHash())
 	if !strings.HasSuffix(rep, "/") {
 		rep += "/"
 	}
 	return rep
+}
+
+// ResourceIsolationString lazily returns a compact representation of a
+// resource's isolation that is suitable for logging.
+func ResourceIsolationString(r *rspb.ResourceName) fmt.Stringer {
+	return resourceIsolationStringer{r}
 }
 
 func (c *Proxy) Delete(ctx context.Context, req *dcpb.DeleteRequest) (*dcpb.DeleteResponse, error) {

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -243,7 +243,9 @@ func (r resourceIsolationStringer) String() string {
 }
 
 // ResourceIsolationString lazily returns a compact representation of a
-// resource's isolation that is suitable for logging.
+// resource's isolation that is suitable for logging. This returns a
+// fmt.Stringer instead of a string because it avoids actual formatting if we
+// never log a message (maybe because the log level isn't enabled).
 func ResourceIsolationString(r *rspb.ResourceName) fmt.Stringer {
 	return resourceIsolationStringer{r}
 }

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -217,17 +217,22 @@ func (r *CASResourceName) DownloadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
-		return fmt.Sprintf(
-			"%s/%s/%s/%d",
-			instanceName, blobTypeSegment(r.GetCompressor()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
-	} else {
-		return fmt.Sprintf(
-			"%s/%s/%s/%s/%d",
-			instanceName, blobTypeSegment(r.GetCompressor()),
-			strings.ToLower(r.rn.DigestFunction.String()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
+		return strings.Join(
+			[]string{
+				instanceName,
+				blobTypeSegment(r.GetCompressor()),
+				r.GetDigest().GetHash(),
+				strconv.Itoa(int(r.GetDigest().GetSizeBytes()))},
+			"/")
 	}
+	return strings.Join(
+		[]string{
+			instanceName,
+			blobTypeSegment(r.GetCompressor()),
+			strings.ToLower(r.rn.DigestFunction.String()),
+			r.GetDigest().GetHash(),
+			strconv.Itoa(int(r.GetDigest().GetSizeBytes()))},
+		"/")
 }
 
 // NewUploadString returns a new string representing the resource name for
@@ -235,21 +240,26 @@ func (r *CASResourceName) DownloadString() string {
 func (r *CASResourceName) NewUploadString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
-	u := guuid.New()
+	u := guuid.New().String()
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
-		return fmt.Sprintf(
-			"%s/uploads/%s/%s/%s/%d",
-			instanceName, u.String(), blobTypeSegment(r.GetCompressor()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes(),
-		)
-	} else {
-		return fmt.Sprintf(
-			"%s/uploads/%s/%s/%s/%s/%d",
-			instanceName, u.String(), blobTypeSegment(r.GetCompressor()),
-			strings.ToLower(r.rn.DigestFunction.String()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes(),
-		)
+		return strings.Join(
+			[]string{
+				instanceName,
+				"uploads",
+				u,
+				blobTypeSegment(r.GetCompressor()),
+				r.GetDigest().GetHash(),
+				strconv.Itoa(int(r.GetDigest().GetSizeBytes()))}, "/")
 	}
+	return strings.Join(
+		[]string{
+			instanceName,
+			"uploads",
+			u,
+			blobTypeSegment(r.GetCompressor()),
+			strings.ToLower(r.rn.DigestFunction.String()),
+			r.GetDigest().GetHash(),
+			strconv.Itoa(int(r.GetDigest().GetSizeBytes()))}, "/")
 }
 
 type ACResourceName struct {
@@ -262,17 +272,24 @@ func (r *ACResourceName) ActionCacheString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
-		return fmt.Sprintf(
-			"%s/%s/ac/%s/%d",
-			instanceName, blobTypeSegment(r.GetCompressor()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
-	} else {
-		return fmt.Sprintf(
-			"%s/%s/ac/%s/%s/%d",
-			instanceName, blobTypeSegment(r.GetCompressor()),
-			strings.ToLower(r.rn.DigestFunction.String()),
-			r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
+		return strings.Join(
+			[]string{
+				instanceName,
+				blobTypeSegment(r.GetCompressor()),
+				"ac",
+				r.GetDigest().GetHash(),
+				strconv.Itoa(int(r.GetDigest().GetSizeBytes()))},
+			"/")
 	}
+	return strings.Join(
+		[]string{
+			instanceName,
+			blobTypeSegment(r.GetCompressor()),
+			"ac",
+			strings.ToLower(r.rn.DigestFunction.String()),
+			r.GetDigest().GetHash(),
+			strconv.Itoa(int(r.GetDigest().GetSizeBytes()))},
+		"/")
 }
 
 func CacheTypeToPrefix(cacheType rspb.CacheType) string {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -222,7 +222,7 @@ func (r *CASResourceName) DownloadString() string {
 				instanceName,
 				blobTypeSegment(r.GetCompressor()),
 				r.GetDigest().GetHash(),
-				strconv.Itoa(int(r.GetDigest().GetSizeBytes()))},
+				strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)},
 			"/")
 	}
 	return strings.Join(
@@ -231,7 +231,7 @@ func (r *CASResourceName) DownloadString() string {
 			blobTypeSegment(r.GetCompressor()),
 			strings.ToLower(r.rn.DigestFunction.String()),
 			r.GetDigest().GetHash(),
-			strconv.Itoa(int(r.GetDigest().GetSizeBytes()))},
+			strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)},
 		"/")
 }
 
@@ -249,7 +249,7 @@ func (r *CASResourceName) NewUploadString() string {
 				u,
 				blobTypeSegment(r.GetCompressor()),
 				r.GetDigest().GetHash(),
-				strconv.Itoa(int(r.GetDigest().GetSizeBytes()))}, "/")
+				strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)}, "/")
 	}
 	return strings.Join(
 		[]string{
@@ -259,7 +259,7 @@ func (r *CASResourceName) NewUploadString() string {
 			blobTypeSegment(r.GetCompressor()),
 			strings.ToLower(r.rn.DigestFunction.String()),
 			r.GetDigest().GetHash(),
-			strconv.Itoa(int(r.GetDigest().GetSizeBytes()))}, "/")
+			strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)}, "/")
 }
 
 type ACResourceName struct {
@@ -278,7 +278,7 @@ func (r *ACResourceName) ActionCacheString() string {
 				blobTypeSegment(r.GetCompressor()),
 				"ac",
 				r.GetDigest().GetHash(),
-				strconv.Itoa(int(r.GetDigest().GetSizeBytes()))},
+				strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)},
 			"/")
 	}
 	return strings.Join(
@@ -288,7 +288,7 @@ func (r *ACResourceName) ActionCacheString() string {
 			"ac",
 			strings.ToLower(r.rn.DigestFunction.String()),
 			r.GetDigest().GetHash(),
-			strconv.Itoa(int(r.GetDigest().GetSizeBytes()))},
+			strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)},
 		"/")
 }
 

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -206,6 +206,9 @@ func (l *Logger) Debugf(format string, args ...interface{}) {
 // (e.g. invocation_id, request_id)
 func (l *Logger) CtxDebugf(ctx context.Context, format string, args ...interface{}) {
 	e := l.zl.Debug()
+	if e == nil {
+		return
+	}
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)
 }
@@ -430,6 +433,9 @@ func Debugf(format string, args ...interface{}) {
 // (e.g. invocation_id, request_id)
 func CtxDebug(ctx context.Context, message string) {
 	e := log.Debug()
+	if e == nil {
+		return
+	}
 	enrichEventFromContext(ctx, e)
 	e.Msg(message)
 }
@@ -440,6 +446,9 @@ func CtxDebug(ctx context.Context, message string) {
 // (e.g. invocation_id, request_id)
 func CtxDebugf(ctx context.Context, format string, args ...interface{}) {
 	e := log.Debug()
+	if e == nil {
+		return
+	}
 	enrichEventFromContext(ctx, e)
 	e.Msgf(format, args...)
 }


### PR DESCRIPTION
These make lookaside cache hits 30% faster, by removing some overheads.

The log.go change is only about 1-2%. There's no point to enriching the log message from the context when we won't debug log.

The rest of the improvement is split roughly evenly between:
- pre-evaluating metrics with labels in getLookasideEntry
- lazy string formatting in distributed_client.ResourceIsolationString. This is only used in log statements, and mostly debug ones, so we avoid the formatting if we don't have debug logging enabled.
- using strings.Join instead of fmt.Sprintf in digest.*String functions.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                                          │   base-look   │             after-look             │
                                          │    sec/op     │   sec/op     vs base               │
Set/LookasideDistPebble10/AC-24              124.5µ ±  1%   123.3µ ± 1%        ~ (p=0.050 n=9)
Set/LookasideDistPebble10/CAS-24             96.49µ ±  1%   95.11µ ± 1%   -1.43% (p=0.008 n=9)
Set/LookasideDistPebble100/AC-24             132.6µ ±  1%   132.4µ ± 1%        ~ (p=0.796 n=9)
Set/LookasideDistPebble100/CAS-24            96.56µ ±  1%   95.54µ ± 2%   -1.06% (p=0.024 n=9)
Set/LookasideDistPebble1000/AC-24            146.1µ ±  2%   145.5µ ± 1%        ~ (p=0.297 n=9)
Set/LookasideDistPebble1000/CAS-24           98.38µ ±  1%   97.49µ ± 1%        ~ (p=0.077 n=9)
Set/LookasideDistPebble10000/AC-24           284.8µ ±  4%   289.1µ ± 3%        ~ (p=0.113 n=9)
Set/LookasideDistPebble10000/CAS-24          104.8µ ±  1%   102.4µ ± 1%   -2.31% (p=0.000 n=9)
Set/LookasideDistPebble1000000/AC-24         3.973m ±  2%   3.947m ± 2%        ~ (p=0.297 n=9)
Set/LookasideDistPebble1000000/CAS-24        825.3µ ±  9%   806.4µ ± 8%        ~ (p=0.387 n=9)
Read/LookasideDistPebble10-24               1214.0n ±  3%   825.4n ± 2%  -32.01% (p=0.000 n=9)
Read/LookasideDistPebble100-24              1345.0n ±  3%   921.2n ± 1%  -31.51% (p=0.000 n=9)
Read/LookasideDistPebble1000-24              110.4µ ±  3%   109.5µ ± 3%        ~ (p=0.136 n=9)
Read/LookasideDistPebble10000-24             145.3µ ±  2%   144.8µ ± 4%        ~ (p=0.730 n=9)
GetSingle/LookasideDistPebble10/AC-24        106.1µ ±  2%   105.8µ ± 2%        ~ (p=0.796 n=9)
GetSingle/LookasideDistPebble10/CAS-24      1245.0n ±  4%   860.5n ± 4%  -30.88% (p=0.000 n=9)
GetSingle/LookasideDistPebble100/AC-24       108.3µ ±  2%   105.8µ ± 3%        ~ (p=0.222 n=9)
GetSingle/LookasideDistPebble100/CAS-24     1274.0n ±  4%   912.6n ± 3%  -28.37% (p=0.000 n=9)
GetSingle/LookasideDistPebble1000/AC-24      110.7µ ±  3%   108.2µ ± 1%   -2.28% (p=0.048 n=9)
GetSingle/LookasideDistPebble1000/CAS-24     110.2µ ±  2%   110.2µ ± 3%        ~ (p=1.000 n=9)
GetSingle/LookasideDistPebble10000/AC-24     133.7µ ±  2%   132.4µ ± 1%        ~ (p=0.546 n=9)
GetSingle/LookasideDistPebble10000/CAS-24    136.2µ ±  8%   134.8µ ± 3%        ~ (p=0.489 n=9)
GetMulti/LookasideDistPebble10-24            75.23µ ± 11%   56.47µ ± 5%  -24.93% (p=0.000 n=9)
GetMulti/LookasideDistPebble100-24          100.87µ ±  2%   73.88µ ± 3%  -26.75% (p=0.000 n=9)
GetMulti/LookasideDistPebble1000-24          228.2µ ±  3%   206.3µ ± 2%   -9.62% (p=0.000 n=9)
GetMulti/LookasideDistPebble10000-24         2.725m ±  3%   2.679m ± 2%        ~ (p=0.050 n=9)
FindMissing/LookasideDistPebble10-24         377.0µ ± 11%   355.6µ ± 8%        ~ (p=0.050 n=9)
FindMissing/LookasideDistPebble100-24        495.4µ ±  2%   475.9µ ± 3%   -3.95% (p=0.004 n=9)
FindMissing/LookasideDistPebble1000-24       513.7µ ±  5%   490.7µ ± 4%        ~ (p=0.050 n=9)
FindMissing/LookasideDistPebble10000-24      488.0µ ±  2%   474.2µ ± 3%   -2.84% (p=0.003 n=9)
geomean                                      105.6µ         97.04µ        -8.07%

                                          │   base-look    │               after-look                │
                                          │      B/s       │      B/s        vs base                 │
Set/LookasideDistPebble10/AC-24              78.12Ki ±  0%    78.12Ki ±  0%        ~ (p=1.000 n=9) ¹
Set/LookasideDistPebble10/CAS-24             97.66Ki ±  0%   107.42Ki ±  9%        ~ (p=0.131 n=9)
Set/LookasideDistPebble100/AC-24             732.4Ki ±  1%    742.2Ki ±  1%        ~ (p=0.710 n=9)
Set/LookasideDistPebble100/CAS-24           1015.6Ki ±  2%   1025.4Ki ±  2%        ~ (p=0.085 n=9)
Set/LookasideDistPebble1000/AC-24            6.533Mi ±  1%    6.552Mi ±  1%        ~ (p=0.287 n=9)
Set/LookasideDistPebble1000/CAS-24           9.689Mi ±  1%    9.785Mi ±  1%        ~ (p=0.081 n=9)
Set/LookasideDistPebble10000/AC-24           33.49Mi ±  4%    32.99Mi ±  3%        ~ (p=0.113 n=9)
Set/LookasideDistPebble10000/CAS-24          91.01Mi ±  1%    93.15Mi ±  1%   +2.36% (p=0.000 n=9)
Set/LookasideDistPebble1000000/AC-24         240.0Mi ±  2%    241.6Mi ±  2%        ~ (p=0.297 n=9)
Set/LookasideDistPebble1000000/CAS-24        1.128Gi ±  9%    1.155Gi ±  9%        ~ (p=0.387 n=9)
Read/LookasideDistPebble10-24                7.849Mi ±  3%   11.549Mi ±  2%  +47.14% (p=0.000 n=9)
Read/LookasideDistPebble100-24               70.90Mi ±  3%   103.52Mi ±  1%  +46.02% (p=0.000 n=9)
Read/LookasideDistPebble1000-24              8.640Mi ±  3%    8.707Mi ±  3%        ~ (p=0.142 n=9)
Read/LookasideDistPebble10000-24             65.65Mi ±  2%    65.85Mi ±  4%        ~ (p=0.730 n=9)
GetSingle/LookasideDistPebble10/AC-24        87.89Ki ± 11%    87.89Ki ± 11%        ~ (p=0.620 n=9)
GetSingle/LookasideDistPebble10/CAS-24       7.658Mi ±  4%   11.082Mi ±  4%  +44.71% (p=0.000 n=9)
GetSingle/LookasideDistPebble100/AC-24       898.4Ki ±  2%    927.7Ki ±  3%        ~ (p=0.133 n=9)
GetSingle/LookasideDistPebble100/CAS-24      74.83Mi ±  4%   104.49Mi ±  3%  +39.65% (p=0.000 n=9)
GetSingle/LookasideDistPebble1000/AC-24      8.612Mi ±  3%    8.821Mi ±  1%        ~ (p=0.062 n=9)
GetSingle/LookasideDistPebble1000/CAS-24     8.659Mi ±  2%    8.659Mi ±  3%        ~ (p=1.000 n=9)
GetSingle/LookasideDistPebble10000/AC-24     71.35Mi ±  2%    72.01Mi ±  1%        ~ (p=0.546 n=9)
GetSingle/LookasideDistPebble10000/CAS-24    70.04Mi ±  7%    70.76Mi ±  3%        ~ (p=0.489 n=9)
GetMulti/LookasideDistPebble10-24            12.67Mi ± 13%    16.89Mi ±  5%  +33.26% (p=0.000 n=9)
GetMulti/LookasideDistPebble100-24           94.55Mi ±  2%   129.08Mi ±  3%  +36.52% (p=0.000 n=9)
GetMulti/LookasideDistPebble1000-24          417.9Mi ±  3%    462.4Mi ±  2%  +10.64% (p=0.000 n=9)
GetMulti/LookasideDistPebble10000-24         349.9Mi ±  3%    355.9Mi ±  2%        ~ (p=0.050 n=9)
geomean                                      13.50Mi          14.83Mi         +9.84%
¹ all samples are equal

                                          │   base-look    │              after-look              │
                                          │      B/op      │     B/op       vs base               │
Set/LookasideDistPebble10/AC-24              37.54Ki ±  0%   37.03Ki ±  0%   -1.34% (p=0.003 n=9)
Set/LookasideDistPebble10/CAS-24             28.47Ki ±  0%   28.31Ki ±  0%   -0.57% (p=0.000 n=9)
Set/LookasideDistPebble100/AC-24             37.88Ki ±  0%   37.39Ki ±  0%   -1.29% (p=0.000 n=9)
Set/LookasideDistPebble100/CAS-24            28.87Ki ±  0%   28.68Ki ±  0%   -0.63% (p=0.000 n=9)
Set/LookasideDistPebble1000/AC-24            39.75Ki ±  0%   39.25Ki ±  0%   -1.24% (p=0.000 n=9)
Set/LookasideDistPebble1000/CAS-24           29.50Ki ±  0%   29.34Ki ±  0%   -0.55% (p=0.000 n=9)
Set/LookasideDistPebble10000/AC-24           50.16Ki ±  0%   49.61Ki ±  0%   -1.10% (p=0.000 n=9)
Set/LookasideDistPebble10000/CAS-24          38.35Ki ±  0%   38.18Ki ±  0%   -0.45% (p=0.000 n=9)
Set/LookasideDistPebble1000000/AC-24         1.056Mi ±  0%   1.055Mi ±  1%        ~ (p=0.546 n=9)
Set/LookasideDistPebble1000000/CAS-24        1.016Mi ±  0%   1.017Mi ±  0%        ~ (p=0.931 n=9)
Read/LookasideDistPebble10-24                 1376.0 ±  0%     918.0 ±  0%  -33.28% (p=0.000 n=9)
Read/LookasideDistPebble100-24               1.688Ki ±  1%   1.113Ki ±  0%  -34.03% (p=0.000 n=9)
Read/LookasideDistPebble1000-24              36.15Ki ±  0%   35.57Ki ±  0%   -1.60% (p=0.000 n=9)
Read/LookasideDistPebble10000-24             70.99Ki ±  2%   70.23Ki ± 25%        ~ (p=0.387 n=9)
GetSingle/LookasideDistPebble10/AC-24        29.68Ki ±  0%   29.34Ki ±  0%   -1.13% (p=0.003 n=9)
GetSingle/LookasideDistPebble10/CAS-24        1418.0 ±  0%     953.0 ±  0%  -32.79% (p=0.000 n=9)
GetSingle/LookasideDistPebble100/AC-24       30.05Ki ±  0%   29.72Ki ±  0%   -1.12% (p=0.000 n=9)
GetSingle/LookasideDistPebble100/CAS-24      1.479Ki ±  0%   1.028Ki ±  0%  -30.50% (p=0.000 n=9)
GetSingle/LookasideDistPebble1000/AC-24      33.93Ki ±  0%   33.59Ki ±  0%   -1.00% (p=0.000 n=9)
GetSingle/LookasideDistPebble1000/CAS-24     35.16Ki ±  0%   34.57Ki ±  0%   -1.67% (p=0.000 n=9)
GetSingle/LookasideDistPebble10000/AC-24     49.91Ki ±  0%   49.57Ki ±  0%   -0.68% (p=0.000 n=9)
GetSingle/LookasideDistPebble10000/CAS-24    60.22Ki ±  0%   59.61Ki ±  0%   -1.02% (p=0.000 n=9)
GetMulti/LookasideDistPebble10-24            94.51Ki ± 10%   69.35Ki ±  8%  -26.62% (p=0.000 n=9)
GetMulti/LookasideDistPebble100-24          119.14Ki ±  0%   83.48Ki ±  0%  -29.93% (p=0.000 n=9)
GetMulti/LookasideDistPebble1000-24          151.6Ki ±  0%   115.2Ki ±  0%  -24.03% (p=0.000 n=9)
GetMulti/LookasideDistPebble10000-24         2.375Mi ±  1%   2.334Mi ±  0%   -1.74% (p=0.000 n=9)
FindMissing/LookasideDistPebble10-24         293.2Ki ± 11%   268.9Ki ± 11%        ~ (p=0.063 n=9)
FindMissing/LookasideDistPebble100-24        412.3Ki ±  0%   376.7Ki ±  0%   -8.65% (p=0.000 n=9)
FindMissing/LookasideDistPebble1000-24       444.2Ki ±  0%   407.7Ki ±  0%   -8.21% (p=0.000 n=9)
FindMissing/LookasideDistPebble10000-24      414.2Ki ±  0%   378.0Ki ±  0%   -8.73% (p=0.000 n=9)
geomean                                      54.19Ki         48.94Ki         -9.69%

                                          │  base-look   │             after-look              │
                                          │  allocs/op   │  allocs/op    vs base               │
Set/LookasideDistPebble10/AC-24              580.0 ±  0%    571.0 ±  0%   -1.55% (p=0.000 n=9)
Set/LookasideDistPebble10/CAS-24             441.0 ±  0%    437.0 ±  0%   -0.91% (p=0.000 n=9)
Set/LookasideDistPebble100/AC-24             576.0 ±  0%    567.0 ±  0%   -1.56% (p=0.000 n=9)
Set/LookasideDistPebble100/CAS-24            442.0 ±  0%    438.0 ±  0%   -0.90% (p=0.000 n=9)
Set/LookasideDistPebble1000/AC-24            571.0 ±  0%    562.0 ±  0%   -1.58% (p=0.000 n=9)
Set/LookasideDistPebble1000/CAS-24           437.0 ±  0%    433.0 ±  0%   -0.92% (p=0.000 n=9)
Set/LookasideDistPebble10000/AC-24           602.0 ±  0%    593.0 ±  0%   -1.50% (p=0.000 n=9)
Set/LookasideDistPebble10000/CAS-24          438.0 ±  0%    434.0 ±  0%   -0.91% (p=0.000 n=9)
Set/LookasideDistPebble1000000/AC-24         686.0 ±  1%    679.0 ±  1%   -1.02% (p=0.007 n=9)
Set/LookasideDistPebble1000000/CAS-24        522.0 ±  1%    522.0 ±  0%        ~ (p=0.198 n=9)
Read/LookasideDistPebble10-24                21.00 ±  0%    15.00 ±  0%  -28.57% (p=0.000 n=9)
Read/LookasideDistPebble100-24               21.00 ±  0%    16.00 ±  0%  -23.81% (p=0.000 n=9)
Read/LookasideDistPebble1000-24              486.0 ±  0%    476.0 ±  0%   -2.06% (p=0.000 n=9)
Read/LookasideDistPebble10000-24             482.0 ±  0%    472.0 ±  0%   -2.07% (p=0.000 n=9)
GetSingle/LookasideDistPebble10/AC-24        477.0 ±  0%    471.0 ±  0%   -1.26% (p=0.000 n=9)
GetSingle/LookasideDistPebble10/CAS-24       23.00 ±  0%    17.00 ±  0%  -26.09% (p=0.000 n=9)
GetSingle/LookasideDistPebble100/AC-24       477.0 ±  0%    471.0 ±  0%   -1.26% (p=0.000 n=9)
GetSingle/LookasideDistPebble100/CAS-24      23.00 ±  0%    18.00 ±  0%  -21.74% (p=0.000 n=9)
GetSingle/LookasideDistPebble1000/AC-24      477.0 ±  0%    471.0 ±  0%   -1.26% (p=0.000 n=9)
GetSingle/LookasideDistPebble1000/CAS-24     488.0 ±  0%    478.0 ±  0%   -2.05% (p=0.000 n=9)
GetSingle/LookasideDistPebble10000/AC-24     473.0 ±  0%    467.0 ±  0%   -1.27% (p=0.000 n=9)
GetSingle/LookasideDistPebble10000/CAS-24    484.0 ±  0%    474.0 ±  0%   -2.07% (p=0.000 n=9)
GetMulti/LookasideDistPebble10-24           1122.0 ± 13%    842.0 ± 12%  -24.96% (p=0.000 n=9)
GetMulti/LookasideDistPebble100-24          1.548k ±  0%   1.248k ±  0%  -19.38% (p=0.000 n=9)
GetMulti/LookasideDistPebble1000-24         2.103k ±  0%   1.700k ±  0%  -19.16% (p=0.000 n=9)
GetMulti/LookasideDistPebble10000-24        8.796k ±  0%   8.212k ±  0%   -6.64% (p=0.000 n=9)
FindMissing/LookasideDistPebble10-24        4.493k ± 10%   4.225k ± 10%        ~ (p=0.190 n=9)
FindMissing/LookasideDistPebble100-24       6.437k ±  0%   6.137k ±  0%   -4.66% (p=0.000 n=9)
FindMissing/LookasideDistPebble1000-24      6.537k ±  0%   6.137k ±  0%   -6.12% (p=0.000 n=9)
FindMissing/LookasideDistPebble10000-24     6.537k ±  0%   6.137k ±  0%   -6.12% (p=0.000 n=9)
geomean                                      566.9          523.0         -7.75%
```