### PR TITLE
CLI: Move parser-related functions to the files they belong in

### DIFF
--- a/cli/parser/parsed/BUILD
+++ b/cli/parser/parsed/BUILD
@@ -6,7 +6,9 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser/parsed",
     visibility = ["//visibility:public"],
     deps = [
+        "//cli/log",
         "//cli/parser/arguments",
+        "//cli/parser/bazelrc",
         "//cli/parser/options",
     ],
 )

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -10,10 +10,14 @@ package parsed
 import (
 	"fmt"
 	"iter"
+	"os/user"
+	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
 )
 
@@ -538,6 +542,67 @@ func (a *OrderedArgs) appendOption(option options.Option, startupOptionInsertInd
 	return startupOptionInsertIndex, commandOptionInsertIndex, fmt.Errorf("Failed to append Option: option '%s' is not a startup option and the command '%s' does not support it.", option.Name(), command)
 }
 
+// ConsumeRCFileOptions removes all rc-file related options from the provided
+// args and appends an `ignore_all_rc_files` option to the startup options.
+// Returns a slice of all the rc files that should be parsed.
+func (a *OrderedArgs) ConsumeRCFileOptions(workspaceDir string) (rcFiles []string, err error) {
+	if rcOptions := a.RemoveOptions("ignore_all_rc_files"); len(rcOptions) > 0 {
+		o := rcOptions[len(rcOptions)-1].Option
+		if b, ok := o.(options.BoolLike); !ok {
+			return nil, fmt.Errorf("%s must be a boolean option if it is present, but its type was %T", o.Name(), o)
+		} else if v, err := b.AsBool(); err != nil {
+			return nil, fmt.Errorf("%s must have a boolean value if it is present, but its value was %s", o.Name(), o.GetValue())
+		} else if v {
+			// Before we do anything, check whether --ignore_all_rc_files is already
+			// set. If so, return an empty list of RC files, since bazel will do the
+			// same.
+			a.RemoveOptions("system_rc", "workspace_rc", "home_rc")
+			return nil, nil
+		}
+	}
+	// Parse rc files in the order defined here:
+	// https://bazel.build/run/bazelrc#bazelrc-file-locations
+	for _, optName := range []string{"system_rc", "workspace_rc", " home_rc"} {
+		if rcOptions := a.RemoveOptions(optName); len(rcOptions) > 0 {
+			o := rcOptions[len(rcOptions)-1].Option
+			if b, ok := o.(options.BoolLike); !ok {
+				return nil, fmt.Errorf("%s must be a boolean option if it is present, but its type was %T", o.Name(), o)
+			} else if v, err := b.AsBool(); err != nil {
+				return nil, fmt.Errorf("%s must have a boolean value if it is present, but its value was %s", o.Name(), o.GetValue())
+			} else if !v {
+				// When these flags are false, they have no effect on the list of
+				// rcFiles we should parse.
+				continue
+			}
+		}
+		switch optName {
+		case "system_rc":
+			rcFiles = append(rcFiles, "/etc/bazel.bazelrc")
+			rcFiles = append(rcFiles, `%ProgramData%\bazel.bazelrc`)
+		case "workspace_rc":
+			if workspaceDir != "" {
+				rcFiles = append(rcFiles, filepath.Join(workspaceDir, ".bazelrc"))
+			}
+		case "home_rc":
+			usr, err := user.Current()
+			if err == nil {
+				rcFiles = append(rcFiles, filepath.Join(usr.HomeDir, ".bazelrc"))
+			}
+		}
+	}
+	for _, indexedOption := range a.RemoveOptions("bazelrc") {
+		o := indexedOption.Option
+		if o.GetValue() == "/dev/null" {
+			// if we encounter --bazelrc=/dev/null, that means bazel will ignore
+			// subsequent --bazelrc args, so we ignore them as well.
+			break
+		}
+		rcFiles = append(rcFiles, o.GetValue())
+		continue
+	}
+	return rcFiles, nil
+}
+
 type Config struct {
 	ByPhase map[string][]arguments.Argument
 }
@@ -546,6 +611,193 @@ func NewConfig() *Config {
 	return &Config{
 		ByPhase: make(map[string][]arguments.Argument),
 	}
+}
+
+// ExpandConfigs expands all the config options in the args, using the
+// provided config parameters to resolve them. It also expands the
+// `enable_platform_specific_config` option, if it exists.
+func (a *OrderedArgs) ExpandConfigs(
+	namedConfigs map[string]*Config,
+	defaultConfig *Config,
+) (*OrderedArgs, error) {
+	command := a.GetCommand()
+	expanded, err := a.expandConfigs(namedConfigs, defaultConfig)
+	if err != nil {
+		return nil, err
+	}
+	// Replace the last occurrence of `--enable_platform_specific_config` with
+	// `--config=<bazelOS>`, so long as the last occurrence evaluates as true.
+	opts := expanded.RemoveOptions(bazelrc.EnablePlatformSpecificConfigFlag)
+	if len(opts) > 0 {
+		enable := opts[len(opts)-1].Option
+		index := opts[len(opts)-1].Index
+		if b, ok := enable.(options.BoolLike); ok {
+			if v, err := b.AsBool(); err == nil && v {
+				bazelOS := bazelrc.GetBazelOS()
+				if platformConfig, ok := namedConfigs[bazelOS]; ok {
+					phases := bazelrc.GetPhases(command)
+					expansion, err := platformConfig.appendArgsForConfig(nil, namedConfigs, phases, []string{bazelOS}, true)
+					if err != nil {
+						return nil, err
+					}
+					expanded.Args = slices.Insert(expanded.Args, index, expansion...)
+					// Remove all occurrences of the enable platform-specific config flag
+					// that may have been added when expanding the platform-specific config.
+					expanded.RemoveOptions(bazelrc.EnablePlatformSpecificConfigFlag)
+				}
+			}
+		}
+	}
+	return expanded, nil
+}
+
+// expandConfigs expands all the config options in the args, using the
+// provided config parameters to resolve them.
+func (a *OrderedArgs) expandConfigs(
+	namedConfigs map[string]*Config,
+	defaultConfig *Config,
+) (*OrderedArgs, error) {
+	// Expand startup args first, before any other args (including explicit
+	// startup args).
+	//
+	// startup config is guaranteed to only be startup options.
+	startupConfig := defaultConfig.ByPhase["startup"]
+
+	commandIndex, command := Find[*Command](a.Args)
+	if commandIndex == -1 {
+		// No command is a help command that does not expand anything but the startup config.
+		return &OrderedArgs{Args: slices.Concat(startupConfig, a.Args)}, nil
+	}
+	expanded := slices.Concat(startupConfig, a.Args[:commandIndex])
+	expanded = append(expanded, command.PositionalArgument)
+
+	// Always apply bazelrc rules in order of the precedence hierarchy. For
+	// example, for the "test" command, apply options in order of "always",
+	// then "common", then "build", then "test".
+	phases := bazelrc.GetPhases(command.GetValue())
+	log.Debugf("Bazel command: %q, rc rule classes: %v", command, phases)
+
+	// We'll refer to args in bazelrc which aren't expanded from a --config
+	// option as "default" args, like a .bazelrc line that just says
+	// "common -c dbg" or "build -c dbg" as opposed to something qualified like
+	// "build:dbg -c dbg".
+	//
+	// These default args take lower precedence than explicit command line args
+	// so we expand those first just after the command.
+	log.Debugf("Args before expanding default rc rules: %#v", arguments.FormatAll(expanded))
+	var err error
+	expanded, err = defaultConfig.appendArgsForConfig(expanded, namedConfigs, phases, []string{}, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate bazelrc configuration: %s", err)
+	}
+	log.Debugf("Args after expanding default rc rules: %v", arguments.FormatAll(expanded))
+	expanded, err = appendExpansion(expanded, a.Args[commandIndex+1:], command.Value, namedConfigs, phases, []string{}, false)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Fully expanded args: %+v", arguments.FormatAll(expanded))
+
+	// Append to new OrderedArgs to make sure `--` is handled correctly.
+	expandedArgs := &OrderedArgs{}
+	if err := expandedArgs.Append(expanded...); err != nil {
+		return nil, err
+	}
+	return expandedArgs, err
+}
+
+// Expands and appends all applicable args from the provided Config to the
+// provided argument slice and returns it.
+func (c *Config) appendArgsForConfig(
+	expanded []arguments.Argument,
+	namedConfigs map[string]*Config,
+	phases []string,
+	configStack []string,
+	allowEmpty bool,
+) ([]arguments.Argument, error) {
+	empty := true
+	for _, phase := range phases {
+		toExpand, ok := c.ByPhase[phase]
+		if !ok {
+			continue
+		}
+		empty = false
+		var err error
+		expanded, err = appendExpansion(
+			expanded,
+			toExpand,
+			phase,
+			namedConfigs,
+			phases,
+			configStack,
+			true,
+		)
+		if err != nil {
+			return nil, err
+		}
+		log.Debugf("Expanded for phase %s: %#v", phase, arguments.FormatAll(expanded))
+	}
+	if empty && !allowEmpty {
+		// empty config names do not require supported phases
+		return nil, fmt.Errorf("config value not defined in any .rc file")
+	}
+	return expanded, nil
+}
+
+// appendExpansion expands and appends all args in `toExpand` to `expanded`.
+func appendExpansion(
+	expanded []arguments.Argument,
+	toExpand []arguments.Argument,
+	phase string,
+	namedConfigs map[string]*Config,
+	phases []string,
+	configStack []string,
+	removeDoubleDash bool,
+) ([]arguments.Argument, error) {
+	for _, a := range toExpand {
+		log.Debugf("Expanding '%+v'", a.Format())
+		switch a := a.(type) {
+		case *arguments.DoubleDash:
+			if removeDoubleDash {
+				continue
+			}
+			expanded = append(expanded, &arguments.DoubleDash{})
+		case options.Option:
+			// For the unconditional phases, only append the arg if it's supported by
+			// the command.
+			if bazelrc.IsUnconditionalCommandPhase(phase) && !a.Supports(phases[len(phases)-1]) {
+				if phase == bazelrc.AlwaysPhase {
+					log.Warnf("Inherited '%s' options: %v", bazelrc.AlwaysPhase, arguments.FormatAll(toExpand))
+					return nil, fmt.Errorf("%[1]s :: Unrecognized option %[1]s", a.Format()[0])
+				}
+				// TODO(zoey): return an error here if the option does not support any
+				// command; unknown options are disallowed in rc files.
+				log.Debugf("common rc rule: opt %q is unsupported by command %q; skipping", a.Name(), phases[len(phases)-1])
+				continue
+			}
+			if a.Name() != "config" {
+				expanded = append(expanded, a)
+				continue
+			}
+			// This is a config option; expand it.
+			if _, ok := a.(*options.RequiredValueOption); !ok {
+				return nil, fmt.Errorf("config options must be of '*RequiredValueOption', but was of type '%T'.", a)
+			}
+			config, ok := namedConfigs[a.GetValue()]
+			if !ok {
+				return nil, fmt.Errorf("config value '%s' is not defined in any .rc file", a.GetValue())
+			}
+			if slices.Index(configStack, a.GetValue()) != -1 {
+				return nil, fmt.Errorf("circular --config reference detected: %s", strings.Join(append(configStack, a.GetValue()), " -> "))
+			}
+			var err error
+			if expanded, err = config.appendArgsForConfig(expanded, namedConfigs, phases, append(configStack, a.GetValue()), false); err != nil {
+				return nil, fmt.Errorf("error expanding config '%s': %s", a.GetValue(), err)
+			}
+		case *arguments.PositionalArgument:
+			expanded = append(expanded, a)
+		}
+	}
+	return expanded, nil
 }
 
 func Partition(args []arguments.Argument) *PartitionedArgs {

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"maps"
 	"os"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -555,7 +554,7 @@ func resolveArgs(parsedArgs *parsed.OrderedArgs, ws string) (*parsed.OrderedArgs
 	if err != nil {
 		return nil, err
 	}
-	return ExpandConfigs(parsedArgs, configs, defaultConfig)
+	return parsedArgs.ExpandConfigs(configs, defaultConfig)
 }
 
 // ParseRCFiles parses the provided rc files in the given workspace into Configs
@@ -673,207 +672,6 @@ func (p *Parser) MakeOption(optionName string, value *string) (option options.Op
 	return option, nil
 }
 
-// ExpandConfigs expands all the config options in the args, using the
-// provided config parameters to resolve them. It also expands the
-// `enable_platform_specific_config` option, if it exists.
-//
-// TODO(zoey): move this function into `parsed.go` and make it a method
-// of `OrderedArgs`.
-func ExpandConfigs(
-	args *parsed.OrderedArgs,
-	namedConfigs map[string]*parsed.Config,
-	defaultConfig *parsed.Config,
-) (*parsed.OrderedArgs, error) {
-	command := args.GetCommand()
-	expanded, err := expandConfigs(args, namedConfigs, defaultConfig)
-	if err != nil {
-		return nil, err
-	}
-	// Replace the last occurrence of `--enable_platform_specific_config` with
-	// `--config=<bazelOS>`, so long as the last occurrence evaluates as true.
-	opts := expanded.RemoveOptions(bazelrc.EnablePlatformSpecificConfigFlag)
-	if len(opts) > 0 {
-		enable := opts[len(opts)-1].Option
-		index := opts[len(opts)-1].Index
-		if b, ok := enable.(options.BoolLike); ok {
-			if v, err := b.AsBool(); err == nil && v {
-				bazelOS := bazelrc.GetBazelOS()
-				if platformConfig, ok := namedConfigs[bazelOS]; ok {
-					phases := bazelrc.GetPhases(command)
-					expansion, err := appendArgsForConfig(platformConfig, nil, namedConfigs, phases, []string{bazelOS}, true)
-					if err != nil {
-						return nil, err
-					}
-					expanded.Args = slices.Insert(expanded.Args, index, expansion...)
-					// Remove all occurrences of the enable platform-specific config flag
-					// that may have been added when expanding the platform-specific config.
-					expanded.RemoveOptions(bazelrc.EnablePlatformSpecificConfigFlag)
-				}
-			}
-		}
-	}
-	return expanded, nil
-}
-
-// expandConfigs expands all the config options in the args, using the
-// provided config parameters to resolve them.
-//
-// TODO(zoey): move this function into `parsed.go` and make it a method
-// of `OrderedArgs`.
-func expandConfigs(
-	args *parsed.OrderedArgs,
-	namedConfigs map[string]*parsed.Config,
-	defaultConfig *parsed.Config,
-) (*parsed.OrderedArgs, error) {
-	// Expand startup args first, before any other args (including explicit
-	// startup args).
-	//
-	// startup config is guaranteed to only be startup options.
-	startupConfig := defaultConfig.ByPhase["startup"]
-
-	commandIndex, command := parsed.Find[*parsed.Command](args.Args)
-	if commandIndex == -1 {
-		// No command is a help command that does not expand anything but the startup config.
-		return &parsed.OrderedArgs{Args: slices.Concat(startupConfig, args.Args)}, nil
-	}
-	expanded := slices.Concat(startupConfig, args.Args[:commandIndex])
-	expanded = append(expanded, command.PositionalArgument)
-
-	// Always apply bazelrc rules in order of the precedence hierarchy. For
-	// example, for the "test" command, apply options in order of "always",
-	// then "common", then "build", then "test".
-	phases := bazelrc.GetPhases(command.GetValue())
-	log.Debugf("Bazel command: %q, rc rule classes: %v", command, phases)
-
-	// We'll refer to args in bazelrc which aren't expanded from a --config
-	// option as "default" args, like a .bazelrc line that just says
-	// "common -c dbg" or "build -c dbg" as opposed to something qualified like
-	// "build:dbg -c dbg".
-	//
-	// These default args take lower precedence than explicit command line args
-	// so we expand those first just after the command.
-	log.Debugf("Args before expanding default rc rules: %#v", arguments.FormatAll(expanded))
-	var err error
-	expanded, err = appendArgsForConfig(defaultConfig, expanded, namedConfigs, phases, []string{}, true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to evaluate bazelrc configuration: %s", err)
-	}
-	log.Debugf("Args after expanding default rc rules: %v", arguments.FormatAll(expanded))
-	expanded, err = appendExpansion(expanded, args.Args[commandIndex+1:], command.Value, namedConfigs, phases, []string{}, false)
-	if err != nil {
-		return nil, err
-	}
-	log.Debugf("Fully expanded args: %+v", arguments.FormatAll(expanded))
-
-	// Append to new OrderedArgs to make sure `--` is handled correctly.
-	expandedArgs := &parsed.OrderedArgs{}
-	if err := expandedArgs.Append(expanded...); err != nil {
-		return nil, err
-	}
-	return expandedArgs, err
-}
-
-// Expands and appends all applicable args from the provided Config to the
-// provided argument slice and returns it.
-//
-// TODO(zoey): move this function into `parsed.go` and make it a method of
-// `Config`.
-func appendArgsForConfig(
-	config *parsed.Config,
-	expanded []arguments.Argument,
-	namedConfigs map[string]*parsed.Config,
-	phases []string,
-	configStack []string,
-	allowEmpty bool,
-) ([]arguments.Argument, error) {
-	empty := true
-	for _, phase := range phases {
-		toExpand, ok := config.ByPhase[phase]
-		if !ok {
-			continue
-		}
-		empty = false
-		var err error
-		expanded, err = appendExpansion(
-			expanded,
-			toExpand,
-			phase,
-			namedConfigs,
-			phases,
-			configStack,
-			true,
-		)
-		if err != nil {
-			return nil, err
-		}
-		log.Debugf("Expanded for phase %s: %#v", phase, arguments.FormatAll(expanded))
-	}
-	if empty && !allowEmpty {
-		// empty config names do not require supported phases
-		return nil, fmt.Errorf("config value not defined in any .rc file")
-	}
-	return expanded, nil
-}
-
-// appendExpansion expands and appends all args in `toExpand` to `expanded`.
-//
-// TODO(zoey): move  this function into `parsed.go`.
-func appendExpansion(
-	expanded []arguments.Argument,
-	toExpand []arguments.Argument,
-	phase string,
-	namedConfigs map[string]*parsed.Config,
-	phases []string,
-	configStack []string,
-	removeDoubleDash bool,
-) ([]arguments.Argument, error) {
-	for _, a := range toExpand {
-		log.Debugf("Expanding '%+v'", a.Format())
-		switch a := a.(type) {
-		case *arguments.DoubleDash:
-			if removeDoubleDash {
-				continue
-			}
-			expanded = append(expanded, &arguments.DoubleDash{})
-		case options.Option:
-			// For the common phases, only append the arg if it's supported by
-			// the command.
-			if bazelrc.IsUnconditionalCommandPhase(phase) && !a.Supports(phases[len(phases)-1]) {
-				if phase == "always" {
-					log.Warnf("Inherited 'always' options: %v", arguments.FormatAll(toExpand))
-					return nil, fmt.Errorf("%[1]s :: Unrecognized option %[1]s", a.Format()[0])
-				}
-				// TODO(zoey): return an error here if the option does not support any
-				// command; unknown options are disallowed in rc files.
-				log.Debugf("common rc rule: opt %q is unsupported by command %q; skipping", a.Name(), phases[len(phases)-1])
-				continue
-			}
-			if a.Name() != "config" {
-				expanded = append(expanded, a)
-				continue
-			}
-			// This is a config option; expand it.
-			if _, ok := a.(*options.RequiredValueOption); !ok {
-				return nil, fmt.Errorf("config options must be of '*RequiredValueOption', but was of type '%T'.", a)
-			}
-			config, ok := namedConfigs[a.GetValue()]
-			if !ok {
-				return nil, fmt.Errorf("config value '%s' is not defined in any .rc file", a.GetValue())
-			}
-			if slices.Index(configStack, a.GetValue()) != -1 {
-				return nil, fmt.Errorf("circular --config reference detected: %s", strings.Join(append(configStack, a.GetValue()), " -> "))
-			}
-			var err error
-			if expanded, err = appendArgsForConfig(config, expanded, namedConfigs, phases, append(configStack, a.GetValue()), false); err != nil {
-				return nil, fmt.Errorf("error expanding config '%s': %s", a.GetValue(), err)
-			}
-		case *arguments.PositionalArgument:
-			expanded = append(expanded, a)
-		}
-	}
-	return expanded, nil
-}
-
 // ConsumeAndParseRCFiles removes all rc-file related options from the provided
 // args and appends an `ignore_all_rc_files` option to the startup options.
 // Returns a map of all the named configs in those files and the default
@@ -891,7 +689,7 @@ func (p *Parser) ConsumeAndParseRCFiles(args *parsed.OrderedArgs) (map[string]*p
 // Returns a map of all the named configs in those files and the default
 // (unnamed) config from those files.
 func (p *Parser) consumeAndParseRCFiles(args *parsed.OrderedArgs, workspaceDir string) (map[string]*parsed.Config, *parsed.Config, error) {
-	rcFiles, err := ConsumeRCFileOptions(args, workspaceDir)
+	rcFiles, err := args.ConsumeRCFileOptions(workspaceDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -914,70 +712,6 @@ func (p *Parser) consumeAndParseRCFiles(args *parsed.OrderedArgs, workspaceDir s
 		return nil, nil, err
 	}
 	return parsedNamedConfigs, defaultConfig, nil
-}
-
-// ConsumeRCFileOptions removes all rc-file related options from the provided
-// args and appends an `ignore_all_rc_files` option to the startup options.
-// Returns a slice of all the rc files that should be parsed.
-//
-// TODO(zoey): move this function into `parsed.go` and make it a method of
-// `OrderedArgs`.
-func ConsumeRCFileOptions(parsedArgs *parsed.OrderedArgs, workspaceDir string) (rcFiles []string, err error) {
-	if rcOptions := parsedArgs.RemoveOptions("ignore_all_rc_files"); len(rcOptions) > 0 {
-		o := rcOptions[len(rcOptions)-1].Option
-		if b, ok := o.(options.BoolLike); !ok {
-			return nil, fmt.Errorf("%s must be a boolean option if it is present, but its type was %T", o.Name(), o)
-		} else if v, err := b.AsBool(); err != nil {
-			return nil, fmt.Errorf("%s must have a boolean value if it is present, but its value was %s", o.Name(), o.GetValue())
-		} else if v {
-			// Before we do anything, check whether --ignore_all_rc_files is already
-			// set. If so, return an empty list of RC files, since bazel will do the
-			// same.
-			parsedArgs.RemoveOptions("system_rc", "workspace_rc", "home_rc")
-			return nil, nil
-		}
-	}
-	// Parse rc files in the order defined here:
-	// https://bazel.build/run/bazelrc#bazelrc-file-locations
-	for _, optName := range []string{"system_rc", "workspace_rc", " home_rc"} {
-		if rcOptions := parsedArgs.RemoveOptions(optName); len(rcOptions) > 0 {
-			o := rcOptions[len(rcOptions)-1].Option
-			if b, ok := o.(options.BoolLike); !ok {
-				return nil, fmt.Errorf("%s must be a boolean option if it is present, but its type was %T", o.Name(), o)
-			} else if v, err := b.AsBool(); err != nil {
-				return nil, fmt.Errorf("%s must have a boolean value if it is present, but its value was %s", o.Name(), o.GetValue())
-			} else if !v {
-				// When these flags are false, they have no effect on the list of
-				// rcFiles we should parse.
-				continue
-			}
-		}
-		switch optName {
-		case "system_rc":
-			rcFiles = append(rcFiles, "/etc/bazel.bazelrc")
-			rcFiles = append(rcFiles, `%ProgramData%\bazel.bazelrc`)
-		case "workspace_rc":
-			if workspaceDir != "" {
-				rcFiles = append(rcFiles, filepath.Join(workspaceDir, ".bazelrc"))
-			}
-		case "home_rc":
-			usr, err := user.Current()
-			if err == nil {
-				rcFiles = append(rcFiles, filepath.Join(usr.HomeDir, ".bazelrc"))
-			}
-		}
-	}
-	for _, indexedOption := range parsedArgs.RemoveOptions("bazelrc") {
-		o := indexedOption.Option
-		if o.GetValue() == "/dev/null" {
-			// if we encounter --bazelrc=/dev/null, that means bazel will ignore
-			// subsequent --bazelrc args, so we ignore them as well.
-			break
-		}
-		rcFiles = append(rcFiles, o.GetValue())
-		continue
-	}
-	return rcFiles, nil
 }
 
 // TODO: Return an empty string if the subcommand happens to come after


### PR DESCRIPTION
This PR moves the functions to the places specified by their TODOs and modifies them only the minimal amount necessary to make them work in the file they were moved to.
