### PR TITLE
Flush executions data to clickhouse after publishOperation stream is closed

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1151,10 +1151,9 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 	for {
 		op, err := stream.Recv()
 		if err == io.EOF {
-			// TODO(Maggie): Flush execution data to DB when the stream is closed
-			//if err := s.flushExecutionToOLAP(ctx, taskID); err != nil {
-			//	log.CtxErrorf(ctx, "failed to flush execution %q to clickhouse: %s", taskID, err)
-			//}
+			if err := s.flushExecutionToOLAP(ctx, taskID); err != nil {
+				log.CtxErrorf(ctx, "failed to flush execution %q to clickhouse: %s", taskID, err)
+			}
 			return stream.SendAndClose(&repb.PublishOperationResponse{})
 		}
 		if err != nil {
@@ -1251,11 +1250,6 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 				}
 				lastWrite = time.Now()
 				// TODO(Maggie): After receiving cleanup stats, update execution in OLAP again.
-				// TODO(Maggie): Flush execution data to DB when the stream is closed.
-				// Don't flush early here.
-				if err := s.flushExecutionToOLAP(ctx, taskID); err != nil {
-					log.CtxErrorf(ctx, "failed to flush execution %q to clickhouse: %s", taskID, err)
-				}
 				return nil
 			}()
 			if err != nil {


### PR DESCRIPTION
Rather than flushing the data when a COMPLETED operation is published, publish when the client requests to close the publishOperation stream. This guarantees that all executions data has been collected (including cleanup data, which may come after an initial COMPLETED operation) before the data is flushed.