### PR TITLE
Unquarantine TestFirecrackerRun_Timeout_DebugOutputIsAvailable

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -172,7 +172,6 @@ go_test(
         "//server/remote_cache/digest",
         "//server/resources",
         "//server/rpc/interceptors",
-        "//server/testutil/quarantine",
         "//server/testutil/testauth",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/rpc/interceptors"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
@@ -2456,7 +2455,6 @@ func TestFirecrackerExecWithDockerFromSnapshot(t *testing.T) {
 // test, or figure out some way to determine that the VM has started the
 // `sleep` command.
 func TestFirecrackerRun_Timeout_DebugOutputIsAvailable(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	rootDir := testfs.MakeTempDir(t)


### PR DESCRIPTION
I can't reproduce the flakiness, so let it run in CI until we have some flaky examples.