### PR TITLE
Fix oci.Resolve metric

### DIFF
--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -245,7 +245,7 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image %q", imageName)
 	}
-	updateResolveEventMetric(imageRef.Context().RepositoryStr())
+	updateResolveEventMetric(imageRef.Context().RegistryStr())
 
 	gcrPlatform := gcr.Platform{
 		Architecture: platform.GetArch(),


### PR DESCRIPTION
I spun up a local executor and saw several log messages like `Resolving OCI image for registry "[UNKNOWN]"` which seemed unexpected since `gcr.io` is a known registry. This PR fixes that.