### PR TITLE
Flush usages data after publishOperation stream is closed

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -673,6 +673,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		SelfHosted:                   test.expectedSelfHosted,
 		Region:                       "test-region",
 		CommandSnippet:               "test",
+		Os:                           "linux",
 		QueuedTimestampUsec:          queuedTime.UnixMicro(),
 		WorkerStartTimestampUsec:     workerStartTime.UnixMicro(),
 		WorkerCompletedTimestampUsec: workerEndTime.UnixMicro(),

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2498,6 +2498,7 @@ message StoredExecution {
   // Executor metadata
   bool self_hosted = 58;
   string region = 59;
+  string os = 63;
 
   // IO Stats
   int64 file_download_count = 9;


### PR DESCRIPTION
Rather than flushing the data when a COMPLETED operation is published, publish when the client requests to close the publishOperation stream. This guarantees that all executions data has been collected (including cleanup data, which may come after an initial COMPLETED operation) before the data is flushed.