### PR TITLE
[grafana] do not restrict OCI registry cache events by workload

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -6665,7 +6665,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 9
       },
       "id": 264,
       "panels": [
@@ -7274,7 +7274,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 12
       },
       "id": 38,
       "panels": [
@@ -7821,7 +7821,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 13
       },
       "id": 458,
       "panels": [
@@ -8466,7 +8466,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 14
       },
       "id": 48,
       "panels": [
@@ -8854,7 +8854,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 15
       },
       "id": 384,
       "panels": [
@@ -10128,7 +10128,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 16
       },
       "id": 107,
       "panels": [
@@ -10150,7 +10150,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 122,
@@ -10240,7 +10240,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 116,
@@ -10334,7 +10334,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 112,
@@ -10431,7 +10431,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 120,
@@ -10526,7 +10526,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 106
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 118,
@@ -10616,7 +10616,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 106
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 124,
@@ -10706,7 +10706,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 114
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 9138,
@@ -10802,7 +10802,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 114
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 9139,
@@ -10898,7 +10898,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 122
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 9266,
@@ -10997,7 +10997,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 17
       },
       "id": 28,
       "panels": [
@@ -13705,7 +13705,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 20
       },
       "id": 83,
       "panels": [
@@ -14118,7 +14118,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 24
       },
       "id": 71,
       "panels": [
@@ -14555,7 +14555,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 28
       },
       "id": 9283,
       "panels": [
@@ -14886,7 +14886,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 29
       },
       "id": 9320,
       "panels": [
@@ -15221,7 +15221,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 30
       },
       "id": 1088,
       "panels": [
@@ -15567,7 +15567,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 39
       },
       "id": 8,
       "panels": [
@@ -15799,7 +15799,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 40
       },
       "id": 1346,
       "panels": [
@@ -16313,7 +16313,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 41
       },
       "id": 5641,
       "panels": [
@@ -16794,7 +16794,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 42
       },
       "id": 7275,
       "panels": [
@@ -17607,7 +17607,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 43
       },
       "id": 9846,
       "panels": [
@@ -17673,7 +17673,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 44
           },
           "id": 10100,
           "options": {
@@ -17695,7 +17695,7 @@
                 "uid": "vm"
               },
               "editorMode": "code",
-              "expr": "sum by (cache_event_type) (rate(buildbuddy_ociregistry_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_type=\"action_cache\"}[${window}]))",
+              "expr": "sum by (cache_event_type) (rate(buildbuddy_ociregistry_cache_events{region=\"${region}\", cache_type=\"action_cache\"}[${window}]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -17767,7 +17767,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 44
           },
           "id": 10227,
           "options": {
@@ -17789,7 +17789,7 @@
                 "uid": "vm"
               },
               "editorMode": "code",
-              "expr": "sum by (cache_event_type) (rate(buildbuddy_ociregistry_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_type=\"cas\"}[${window}]))",
+              "expr": "sum by (cache_event_type) (rate(buildbuddy_ociregistry_cache_events{region=\"${region}\", cache_type=\"cas\"}[${window}]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -17816,7 +17816,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 52
           },
           "hiddenSeries": false,
           "id": 10354,
@@ -17851,7 +17851,7 @@
                 "uid": "vm"
               },
               "editorMode": "code",
-              "expr": "sum(rate(buildbuddy_ociregistry_cache_download_size_bytes_sum{region=\"${region}\", job=\"buildbuddy-app\"}[${window}]))",
+              "expr": "sum(rate(buildbuddy_ociregistry_cache_download_size_bytes_sum{region=\"${region}\"}[${window}]))",
               "interval": "",
               "legendFormat": "",
               "queryType": "randomWalk",


### PR DESCRIPTION
Now that `oci.Resolver.Resolve(...)` writes to and reads from the cache, there are OCI registry events (should probably rename to OCI cache events) on both the app and executors. Change the metrics dashboard to plot events from any workload.