### PR TITLE
Don't re-assemble JWTs in RemoteAuthenticator

### DIFF
--- a/enterprise/server/experiments/experiments_test.go
+++ b/enterprise/server/experiments/experiments_test.go
@@ -149,7 +149,7 @@ func TestSelection(t *testing.T) {
 }
 
 func contextWithUnverifiedJWT(c *claims.Claims) context.Context {
-	authCtx := claims.AuthContextFromClaims(context.Background(), c, nil)
+	authCtx := claims.AuthContextWithJWT(context.Background(), c, nil)
 	jwt := authCtx.Value(authutil.ContextTokenStringKey).(string)
 	return context.WithValue(context.Background(), authutil.ContextTokenStringKey, jwt)
 }

--- a/enterprise/server/githubauth/githubauth.go
+++ b/enterprise/server/githubauth/githubauth.go
@@ -161,7 +161,7 @@ func (a *githubAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r 
 	if err != nil {
 		return authutil.AuthContextWithError(ctx, err)
 	}
-	return claims.AuthContextFromClaims(ctx, c, err)
+	return claims.AuthContextWithJWT(ctx, c, err)
 }
 
 func (a *githubAuthenticator) FillUser(ctx context.Context, user *tables.User) error {

--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -469,7 +469,7 @@ func (a *OpenIDAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey 
 	}
 	ctx = context.WithValue(ctx, authutil.APIKeyHeader, apiKey)
 	c, err := a.claimsFromAPIKey(ctx, apiKey)
-	return claims.AuthContextFromClaims(ctx, c, err)
+	return claims.AuthContextWithJWT(ctx, c, err)
 }
 
 func (a *OpenIDAuthenticator) TrustedJWTFromAuthContext(ctx context.Context) string {
@@ -567,7 +567,7 @@ func (a *OpenIDAuthenticator) authenticateGRPCRequest(ctx context.Context, accep
 // `contextUserErrorKey` context value.
 func (a *OpenIDAuthenticator) AuthenticatedGRPCContext(ctx context.Context) context.Context {
 	c, err := a.authenticateGRPCRequest(ctx, true /* acceptJWT= */)
-	return claims.AuthContextFromClaims(ctx, c, err)
+	return claims.AuthContextWithJWT(ctx, c, err)
 }
 
 func (a *OpenIDAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *http.Request) context.Context {
@@ -581,7 +581,7 @@ func (a *OpenIDAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r 
 	if err != nil {
 		return authutil.AuthContextWithError(ctx, err)
 	}
-	return claims.AuthContextFromClaims(ctx, c, err)
+	return claims.AuthContextWithJWT(ctx, c, err)
 }
 
 func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Request) (*claims.Claims, *userToken, error) {

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -111,7 +111,7 @@ func TestFileCacheGroupIsolation(t *testing.T) {
 	ctx := context.TODO()
 	fcDir := testfs.MakeTempDir(t)
 	baseDir := testfs.MakeTempDir(t)
-	authedCtx := claims.AuthContextFromClaims(ctx, &claims.Claims{GroupID: "GR12345"}, nil)
+	authedCtx := claims.AuthContextWithJWT(ctx, &claims.Claims{GroupID: "GR12345"}, nil)
 
 	{
 		// Create a filecache and add a couple files.
@@ -502,7 +502,7 @@ func TestFileCacheWriter(t *testing.T) {
 
 func BenchmarkFilecacheLink(b *testing.B) {
 	// Use a simple Claims to speed up filecache.groupIDStringFromContext()
-	ctx := claims.AuthContextFromClaims(context.Background(), &claims.Claims{}, nil)
+	ctx := claims.AuthContextWithJWT(context.Background(), &claims.Claims{}, nil)
 	flags.Set(b, "app.log_level", "warn")
 	log.Configure()
 
@@ -583,7 +583,7 @@ func BenchmarkFilecacheLink(b *testing.B) {
 
 func BenchmarkContainsAdd(b *testing.B) {
 	// Use a simple Claims to speed up filecache.groupIDStringFromContext()
-	ctx := claims.AuthContextFromClaims(context.Background(), &claims.Claims{}, nil)
+	ctx := claims.AuthContextWithJWT(context.Background(), &claims.Claims{}, nil)
 	flags.Set(b, "app.log_level", "warn")
 	log.Configure()
 

--- a/enterprise/server/remoteauth/remoteauth.go
+++ b/enterprise/server/remoteauth/remoteauth.go
@@ -263,5 +263,5 @@ func getLastMetadataValue(ctx context.Context, key string) string {
 
 func authContext(ctx context.Context, jwt string, c *claims.Claims) context.Context {
 	ctx = context.WithValue(ctx, authutil.ContextTokenStringKey, jwt)
-	return claims.AuthContextFromClaims(ctx, c, nil)
+	return claims.AuthContextWithClaims(ctx, c)
 }

--- a/enterprise/server/remoteauth/remoteauth.go
+++ b/enterprise/server/remoteauth/remoteauth.go
@@ -263,5 +263,5 @@ func getLastMetadataValue(ctx context.Context, key string) string {
 
 func authContext(ctx context.Context, jwt string, c *claims.Claims) context.Context {
 	ctx = context.WithValue(ctx, authutil.ContextTokenStringKey, jwt)
-	return claims.AuthContextWithClaims(ctx, c)
+	return claims.AuthContext(ctx, c)
 }

--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -100,7 +100,7 @@ func contextWith(t *testing.T, key string, value string) context.Context {
 }
 
 func validJwt(t *testing.T, uid string) string {
-	authctx := claims.AuthContextFromClaims(context.Background(), &claims.Claims{UserID: uid}, nil)
+	authctx := claims.AuthContextWithJWT(context.Background(), &claims.Claims{UserID: uid}, nil)
 	jwt, ok := authctx.Value(authutil.ContextTokenStringKey).(string)
 	require.True(t, ok)
 	require.NotEqual(t, "", jwt)

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -284,7 +284,7 @@ func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *h
 			}
 			c.SAML = true
 
-			return claims.AuthContextFromClaims(ctx, c, err)
+			return claims.AuthContextWithJWT(ctx, c, err)
 		}
 	} else if slug := cookie.GetCookie(r, slugCookie); slug != "" {
 		return authutil.AuthContextWithError(ctx, status.PermissionDeniedErrorf("Error getting service provider for slug %s: %s", slug, err.Error()))

--- a/enterprise/tools/upload_local_snapshot/upload_local_snapshot.go
+++ b/enterprise/tools/upload_local_snapshot/upload_local_snapshot.go
@@ -123,7 +123,7 @@ func main() {
 		// The filecache reads the groupID from the claims on the context,
 		// so set that here. However this isn't a valid Claims object, so for
 		// API calls to the remote cache, you will not be able to use this context
-		ctxWithHackyClaims = claims.AuthContextFromClaims(ctx, &claims.Claims{
+		ctxWithHackyClaims = claims.AuthContextWithJWT(ctx, &claims.Claims{
 			GroupID: snapshotGroupID,
 		}, nil)
 	}

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -105,7 +105,7 @@ func (a *TestAuthenticator) AuthenticatedGRPCContext(ctx context.Context) contex
 	if u != nil {
 		c = u.(*claims.Claims)
 	}
-	return claims.AuthContextFromClaims(ctx, c, err)
+	return claims.AuthContextWithJWT(ctx, c, err)
 }
 
 func (a *TestAuthenticator) AuthenticateGRPCRequest(ctx context.Context) (interfaces.UserInfo, error) {
@@ -178,12 +178,12 @@ func (a *TestAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey st
 	ctx = context.WithValue(ctx, authutil.APIKeyHeader, apiKey)
 	u, err := a.APIKeyProvider(ctx, apiKey)
 	if err != nil {
-		return claims.AuthContextFromClaims(ctx, nil, err)
+		return claims.AuthContextWithJWT(ctx, nil, err)
 	}
 	if u == nil {
-		return claims.AuthContextFromClaims(ctx, nil, status.UnauthenticatedErrorf("API key %s is unknown to TestAuthenticator", apiKey))
+		return claims.AuthContextWithJWT(ctx, nil, status.UnauthenticatedErrorf("API key %s is unknown to TestAuthenticator", apiKey))
 	}
-	return claims.AuthContextFromClaims(ctx, u.(*claims.Claims), nil)
+	return claims.AuthContextWithJWT(ctx, u.(*claims.Claims), nil)
 }
 
 func (a *TestAuthenticator) TrustedJWTFromAuthContext(ctx context.Context) string {

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -303,6 +303,10 @@ func AssembleJWT(c *Claims) (string, error) {
 	return tokenString, err
 }
 
+// Returns a Context containing auth state for the the provided Claims and auth
+// error. Note that this function assembles a JWT out of the provided Claims
+// and sets that in the context, so it should only be used in cases where that
+// is necessary.
 func AuthContextFromClaims(ctx context.Context, c *Claims, err error) context.Context {
 	if err != nil {
 		return authutil.AuthContextWithError(ctx, err)
@@ -312,6 +316,11 @@ func AuthContextFromClaims(ctx context.Context, c *Claims, err error) context.Co
 		return authutil.AuthContextWithError(ctx, err)
 	}
 	ctx = context.WithValue(ctx, authutil.ContextTokenStringKey, tokenString)
+	return AuthContextWithClaims(ctx, c)
+}
+
+// Returns a Context containing auth state for the the provided Claims.
+func AuthContextWithClaims(ctx context.Context, c *Claims) context.Context {
 	ctx = context.WithValue(ctx, contextClaimsKey, c)
 	// Note: we clear the error here in case it was set initially by the
 	// authentication handler, but then we want to re-authenticate later on in the

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -316,11 +316,11 @@ func AuthContextWithJWT(ctx context.Context, c *Claims, err error) context.Conte
 		return authutil.AuthContextWithError(ctx, err)
 	}
 	ctx = context.WithValue(ctx, authutil.ContextTokenStringKey, tokenString)
-	return AuthContextWithClaims(ctx, c)
+	return AuthContext(ctx, c)
 }
 
 // Returns a Context containing auth state for the the provided Claims.
-func AuthContextWithClaims(ctx context.Context, c *Claims) context.Context {
+func AuthContext(ctx context.Context, c *Claims) context.Context {
 	ctx = context.WithValue(ctx, contextClaimsKey, c)
 	// Note: we clear the error here in case it was set initially by the
 	// authentication handler, but then we want to re-authenticate later on in the

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -303,11 +303,11 @@ func AssembleJWT(c *Claims) (string, error) {
 	return tokenString, err
 }
 
-// Returns a Context containing auth state for the the provided Claims and auth
+// Returns a context containing auth state for the provided Claims and auth
 // error. Note that this function assembles a JWT out of the provided Claims
-// and sets that in the context, so it should only be used in cases where that
-// is necessary.
-func AuthContextFromClaims(ctx context.Context, c *Claims, err error) context.Context {
+// and sets that in the context as well, so it should only be used in cases
+// where that is necessary.
+func AuthContextWithJWT(ctx context.Context, c *Claims, err error) context.Context {
 	if err != nil {
 		return authutil.AuthContextWithError(ctx, err)
 	}

--- a/server/util/claims/claims_test.go
+++ b/server/util/claims/claims_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func contextWithUnverifiedJWT(c *claims.Claims) context.Context {
-	authCtx := claims.AuthContextFromClaims(context.Background(), c, nil)
+	authCtx := claims.AuthContextWithJWT(context.Background(), c, nil)
 	jwt := authCtx.Value(authutil.ContextTokenStringKey).(string)
 	return context.WithValue(context.Background(), authutil.ContextTokenStringKey, jwt)
 }


### PR DESCRIPTION
[`RemoteAuthenticator.AuthenticatedGRPCContext`](https://github.com/buildbuddy-io/buildbuddy/blob/a171606c4fa589c2fe83d28712a547d92f83d19d/enterprise/server/remoteauth/remoteauth.go#L126-L171
) obtains a JWT for the incoming request, parses the `claims.Claims` out of it, and then sets those in the incoming context. It uses [`claims.AuthContextFromClaims`](https://github.com/buildbuddy-io/buildbuddy/blob/a171606c4fa589c2fe83d28712a547d92f83d19d/server/util/claims/claims.go#L306-L321
) to do that last step, which always re-assembles the JWT from the provided Claims and sets that JWT in the context. This is inefficient, because the RemoteAuthenticator already had a valid JWT! The Cache Proxy is spending about 2.5% of its CPU doing this right now:
![Screenshot 2025-05-22 at 2 16 02 PM](https://github.com/user-attachments/assets/1f304f83-d78e-4455-bfa7-b42f97d3cc57)
