### PR TITLE
reset cache-size-by-group-id map when tracking start time is in the future.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2894,7 +2894,7 @@ func (e *partitionEvictor) lookupPartitionMetadata() (*sgpb.PartitionMetadata, e
 	// which we started tracking.  If we have to reset that to a new time
 	// in the future for whatever reason, we need to clear past tracking
 	// data (or else it may never get removed from the "total size").
-	if *groupTrackingMinTimeUsec > e.clock.Now().UnixMicro() {
+	if partitionMD.GetSizeByGroup() == nil || *groupTrackingMinTimeUsec > e.clock.Now().UnixMicro() {
 		partitionMD.SizeByGroup = make(map[string]int64)
 	}
 
@@ -2926,9 +2926,6 @@ func (e *partitionEvictor) computeSize() (int64, map[string]int64, int64, int64,
 		partitionMD, err := e.lookupPartitionMetadata()
 		if err == nil {
 			log.Infof("[%s] Loaded partition %q metadata from cache: %+v", e.cacheName, e.part.ID, partitionMD)
-			if partitionMD.GetSizeByGroup() == nil {
-				partitionMD.SizeByGroup = make(map[string]int64)
-			}
 			return partitionMD.GetSizeBytes(), partitionMD.GetSizeByGroup(), partitionMD.GetCasCount(), partitionMD.GetAcCount(), nil
 		} else if !status.IsNotFoundError(err) {
 			return 0, nil, 0, 0, err

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2888,6 +2888,9 @@ func (e *partitionEvictor) lookupPartitionMetadata() (*sgpb.PartitionMetadata, e
 	if err != nil {
 		return nil, err
 	}
+	if *groupTrackingMinTimeUsec > e.clock.Now().UnixMicro() {
+		partitionMD.SizeByGroup = make(map[string]int64)
+	}
 
 	return partitionMD, nil
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2888,6 +2888,12 @@ func (e *partitionEvictor) lookupPartitionMetadata() (*sgpb.PartitionMetadata, e
 	if err != nil {
 		return nil, err
 	}
+
+	// Because we enabled group ID-based tracking in the cache without
+	// performing a migration, we had to set an arbitrary timestamp after
+	// which we started tracking.  If we have to reset that to a new time
+	// in the future for whatever reason, we need to clear past tracking
+	// data (or else it may never get removed from the "total size").
 	if *groupTrackingMinTimeUsec > e.clock.Now().UnixMicro() {
 		partitionMD.SizeByGroup = make(map[string]int64)
 	}


### PR DESCRIPTION
this effectively adds reset functionality