### PR TITLE
Recreate atime-updater/hit-tracker-client in benchmarks

### DIFF
--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -588,6 +588,8 @@ func BenchmarkEnqueue(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
+		// The updater discards updates and logs stuff if too many updates are
+		// enqueued. Recreate for each benchmark to prevent this.
 		b.StopTimer()
 		_, updater, _, _ := setup(b)
 		b.StartTimer()

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -585,10 +585,12 @@ func BenchmarkEnqueue(b *testing.B) {
 
 	flags.Set(b, "cache_proxy.remote_atime_max_digests_per_update", b.N*len(instances)*len(digests)*numToEnqueue)
 	flags.Set(b, "cache_proxy.remote_atime_max_updates_per_group", b.N*len(instances)*len(digests)*numToEnqueue)
-	_, updater, _, _ := setup(b)
 
 	b.ReportAllocs()
 	for b.Loop() {
+		b.StopTimer()
+		_, updater, _, _ := setup(b)
+		b.StartTimer()
 		wg := sync.WaitGroup{}
 		for i := 0; i < 10_000; i++ {
 			for _, instance := range instances {

--- a/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
@@ -300,10 +300,12 @@ func BenchmarkEnqueue(b *testing.B) {
 	numToEnqueue := 1_000_000
 	flags.Set(b, "cache_proxy.remote_hit_tracker.max_hits_per_update", b.N*numToEnqueue)
 	flags.Set(b, "cache_proxy.remote_hit_tracker.max_pending_hits_per_group", b.N*numToEnqueue)
-	_, hitTrackerFactory, _ := setup(b)
 
 	b.ReportAllocs()
 	for b.Loop() {
+		b.StopTimer()
+		_, hitTrackerFactory, _ := setup(b)
+		b.StartTimer()
 		hitTracker := hitTrackerFactory.NewCASHitTracker(b.Context(), &repb.RequestMetadata{})
 		wg := sync.WaitGroup{}
 		for i := 0; i < numToEnqueue; i++ {

--- a/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
@@ -303,6 +303,8 @@ func BenchmarkEnqueue(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
+		// The client discards hits and logs stuff if too many hits are
+		// enqueued. Recreate for each benchmark to prevent this.
 		b.StopTimer()
 		_, hitTrackerFactory, _ := setup(b)
 		b.StartTimer()


### PR DESCRIPTION
Both of these have logic in them that discards entries and logs stuff if they have too many. The benchmarks could hit that, making the results unreliable.