### PR TITLE
invocation_target_group_card: show cache status

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -150,6 +150,21 @@
   color: #212121;
 }
 
+.invocation-targets-card .target-cache-status {
+  border-radius: 16px;
+  color: #212121ad;
+  background: #eee;
+  line-height: 1;
+  flex-shrink: 0;
+
+  font-size: 0.8em;
+  word-break: break-word;
+  white-space: nowrap;
+  margin-left: auto;
+  margin-right: 8px;
+  padding: 2px 6px;
+}
+
 .invocation-targets-card .root-cause-badge {
   background: #eee;
   flex-shrink: 0;

--- a/app/invocation/invocation_target_group_card.tsx
+++ b/app/invocation/invocation_target_group_card.tsx
@@ -229,6 +229,9 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
                         <ChevronRight className="icon" />
                       </span>
                       <span className="target-label">{target.metadata?.label}</span>{" "}
+                      {target.testSummary && target.testSummary.totalNumCached === target.testSummary.totalRunCount && (
+                        <span className="target-cache-status">Cached</span>
+                      )}
                       {target.rootCause && <span className="root-cause-badge">Root cause</span>}
                     </div>
                     <div className="target-duration">{!!target.timing?.duration && renderDuration(target.timing)}</div>

--- a/app/target/target.tsx
+++ b/app/target/target.tsx
@@ -263,22 +263,29 @@ export default class TargetComponent extends React.Component<Props> {
         <div className="container nopadding-dense">
           {resultEvents.length > 1 && (
             <div className={`runs ${resultEvents.length > 9 && "run-grid"}`}>
-              {resultEvents.map((result, index) => (
-                <a
-                  href={`#${index + 1}`}
-                  title={this.generateRunName(result.buildEvent?.id?.testResult ?? {})}
-                  className={`run ${this.getStatusClass(
-                    result.buildEvent?.testResult?.status ?? build_event_stream.TestStatus.NO_STATUS
-                  )} ${(this.props.tab || "#1") == `#${index + 1}` ? "selected" : ""}`}>
-                  Run {result.buildEvent?.id?.testResult?.run ?? 0} (Attempt{" "}
-                  {result.buildEvent?.id?.testResult?.attempt ?? 0}, Shard{" "}
-                  {result.buildEvent?.id?.testResult?.shard ?? 0})
-                </a>
-              ))}
+              {resultEvents
+                .map((result) => result.buildEvent)
+                .map((buildEvent, index) => (
+                  <a
+                    href={`#${index + 1}`}
+                    title={this.generateRunName(buildEvent?.id?.testResult ?? {})}
+                    className={`run ${this.getStatusClass(
+                      buildEvent?.testResult?.status ?? build_event_stream.TestStatus.NO_STATUS
+                    )} ${(this.props.tab || "#1") == `#${index + 1}` ? "selected" : ""}`}>
+                    Run {buildEvent?.id?.testResult?.run ?? 0} (Attempt {buildEvent?.id?.testResult?.attempt ?? 0},
+                    Shard {buildEvent?.id?.testResult?.shard ?? 0}
+                    {buildEvent?.testResult?.cachedLocally
+                      ? ", Cached locally"
+                      : buildEvent?.testResult?.executionInfo?.cachedRemotely
+                        ? ", Cached remotely"
+                        : ""}
+                    )
+                  </a>
+                ))}
             </div>
           )}
           {resultEvents
-            .filter((value, index) => `#${index + 1}` == (this.props.tab || "#1"))
+            .filter((_, index) => `#${index + 1}` == (this.props.tab || "#1"))
             .map((result) => (
               <span>
                 <TargetTestDocumentCardComponent
@@ -318,12 +325,13 @@ export default class TargetComponent extends React.Component<Props> {
               (value, index) =>
                 `#${index + 1}` == (this.props.tab || "#1") && value.buildEvent?.testResult?.testActionOutput
             )
-            .map((result) => (
+            .map((result) => result.buildEvent)
+            .map((buildEvent) => (
               <div>
                 <TargetArtifactsCardComponent
-                  name={this.generateRunName(result.buildEvent?.id?.testResult ?? {})}
+                  name={this.generateRunName(buildEvent?.id?.testResult ?? {})}
                   invocationId={this.props.invocationId}
-                  files={result.buildEvent?.testResult?.testActionOutput as build_event_stream.File[]}
+                  files={buildEvent?.testResult?.testActionOutput as build_event_stream.File[]}
                 />
               </div>
             ))}

--- a/app/target/target_test_document_card.tsx
+++ b/app/target/target_test_document_card.tsx
@@ -106,7 +106,9 @@ export default class TargetTestDocumentCardComponent extends React.Component<Pro
                       <div className="stat">Run {this.props.buildEvent.id.testResult.run}</div>
                       <div className="stat-label">
                         (Attempt {this.props.buildEvent.id.testResult.attempt}, Shard{" "}
-                        {this.props.buildEvent.id.testResult.shard})
+                        {this.props.buildEvent.id.testResult.shard}
+                        {this.props.buildEvent?.testResult?.cachedLocally && <>, Cached Locally</>}
+                        {this.props.buildEvent?.testResult?.executionInfo?.cachedRemotely && <>, Cached Remotely</>})
                       </div>
                     </div>
                   )}

--- a/app/target/target_v2.tsx
+++ b/app/target/target_v2.tsx
@@ -355,13 +355,19 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
                     event.testResult?.status ?? build_event_stream.TestStatus.NO_STATUS
                   )} ${this.getTab() == `#${index + 1}` ? "selected" : ""}`}>
                   Run {event.id?.testResult?.run ?? 0} (Attempt {event.id?.testResult?.attempt ?? 0}, Shard{" "}
-                  {event.id?.testResult?.shard ?? 0})
+                  {event.id?.testResult?.shard ?? 0}
+                  {event.testResult?.cachedLocally
+                    ? ", Cached locally"
+                    : event.testResult?.executionInfo?.cachedRemotely
+                      ? ", Cached remotely"
+                      : ""}
+                  )
                 </a>
               ))}
             </div>
           )}
           {resultEvents
-            .filter((value, index) => `#${index + 1}` == this.getTab())
+            .filter((_, index) => `#${index + 1}` == this.getTab())
             .map((buildEvent) => (
               <span>
                 <TargetTestDocumentCardComponent


### PR DESCRIPTION
Adds a badge next to the target label in the invocation targets
list to display test cache status information.

The badge shows "Cached" if all runs were served from cache.
Nothing is displayed if only some of the runs, or none were cached.

Note that we are not currently using test cache status to sort the
target group. Such logic can be added later in a future change. Also,
there is insufficient information from Build Event Stream to indicate
whether a build target was cached or not, so all build targets are being
shown without the badge, which could be misinterpreted as no-cache.
