### PR TITLE
CLI: Add function to get the accumulated value from a slice of `Option`s

### DIFF
--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -797,8 +797,8 @@ func AccumulateValues[ T string | []string | bool | BoolOrEnum ](acc T, opts...O
 			}
 			*p = v
 		case *BoolOrEnum:
-			b, ok := opt.(BoolLike)
-			if !ok {
+			b := opt.BoolLike()
+			if b == nil {
 				p.SetEnum(opt.GetValue())
 				continue
 			}

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -288,6 +288,11 @@ type Option interface {
 	GetDefinition() *Definition
 	UseShortName(bool)
 	Normalized() Option
+
+	// Because Options wrap other Options sometimes, we cannot depend on being
+	// able to use type assertion to get a BoolLike from an Option that should
+	// support it. This problem could theoretically be alleviated by embedding
+	// types defined in type parameters, but that is explicitly disallowed by go.
 	BoolLike() BoolLike
 }
 

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -758,26 +758,12 @@ func (b *BoolOrEnum) Set(value any) {
 	}
 }
 
-func FromConcrete[T Option](opts []T) []Option {
-	if len(opts) == 0 {
-		return nil
-	}
-	optSlice := make([]Option, 0, len(opts))
-	for _, a := range opts {
-		// `append(a, b...)` only works if `a` and `b` have exactly the same type,
-		// even if the slice element types are the same. So we use a loop and append
-		// one-by-one, converting each element to `Option` with each append.
-		optSlice = append(optSlice, a)
-	}
-	return optSlice
-}
-
 // AccumulateValues accepts an initial value, acc, and a variadic Option
 // parameter, opts, and returns the resulting value of evaluating all of those
 // options in order. It should only be called with opts that all share the same
 // definition, and an inital value that matches the type of value that
 // definition implies. Otherwise, its output will be nonsensical.
-func AccumulateValues[ T string | []string | bool | BoolOrEnum ](acc T, opts...Option) (T, error) {
+func AccumulateValues[ T string | []string | bool | BoolOrEnum, O Option ](acc T, opts...O) (T, error) {
 	p := any(&acc)
 	for _, opt := range opts {
 		log.Printf("Accumulating %v...", opt.Format())

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -767,6 +767,11 @@ func FromConcrete[T Option](opts []T) []Option {
 	return optSlice
 }
 
+// AccumulateValues accepts an initial value, acc, and a variadic Option
+// parameter, opts, and returns the resulting value of evaluating all of those
+// options in order. It should only be called with opts that all share the same
+// definition, and an inital value that matches the type of value that
+// definition implies. Otherwise, its output will be nonsensical.
 func AccumulateValues[ T string | []string | bool | BoolOrEnum ](acc T, opts...Option) (T, error) {
 	p := any(&acc)
 	for _, opt := range opts {

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -546,34 +546,25 @@ func (a *OrderedArgs) appendOption(option options.Option, startupOptionInsertInd
 // args and appends an `ignore_all_rc_files` option to the startup options.
 // Returns a slice of all the rc files that should be parsed.
 func (a *OrderedArgs) ConsumeRCFileOptions(workspaceDir string) (rcFiles []string, err error) {
-	if rcOptions := a.RemoveOptions("ignore_all_rc_files"); len(rcOptions) > 0 {
-		o := rcOptions[len(rcOptions)-1].Option
-		if b, ok := o.(options.BoolLike); !ok {
-			return nil, fmt.Errorf("%s must be a boolean option if it is present, but its type was %T", o.Name(), o)
-		} else if v, err := b.AsBool(); err != nil {
-			return nil, fmt.Errorf("%s must have a boolean value if it is present, but its value was %s", o.Name(), o.GetValue())
-		} else if v {
-			// Before we do anything, check whether --ignore_all_rc_files is already
-			// set. If so, return an empty list of RC files, since bazel will do the
-			// same.
-			a.RemoveOptions("system_rc", "workspace_rc", "home_rc")
-			return nil, nil
-		}
+	if ignore, err := options.AccumulateValues(false, options.FromConcrete(a.RemoveOptions("ignore_all_rc_files"))...); err != nil {
+		return nil, fmt.Errorf("Failed to get value from 'ignore_all_rc_files' option: %s", err)
+	} else if ignore {
+		// Before we do anything, check whether --ignore_all_rc_files is already
+		// set. If so, return an empty list of RC files, since bazel will do the
+		// same.
+		a.RemoveOptions("system_rc", "workspace_rc", "home_rc")
+		return nil, nil
 	}
+
 	// Parse rc files in the order defined here:
 	// https://bazel.build/run/bazelrc#bazelrc-file-locations
 	for _, optName := range []string{"system_rc", "workspace_rc", " home_rc"} {
-		if rcOptions := a.RemoveOptions(optName); len(rcOptions) > 0 {
-			o := rcOptions[len(rcOptions)-1].Option
-			if b, ok := o.(options.BoolLike); !ok {
-				return nil, fmt.Errorf("%s must be a boolean option if it is present, but its type was %T", o.Name(), o)
-			} else if v, err := b.AsBool(); err != nil {
-				return nil, fmt.Errorf("%s must have a boolean value if it is present, but its value was %s", o.Name(), o.GetValue())
-			} else if !v {
-				// When these flags are false, they have no effect on the list of
-				// rcFiles we should parse.
-				continue
-			}
+		if v, err := options.AccumulateValues(true, options.FromConcrete(a.RemoveOptions(optName))...); err != nil {
+			return nil, fmt.Errorf("Failed to get value from '%s' option: %s", optName, err)
+		} else if !v {
+			// When these flags are false, they have no effect on the list of
+			// rcFiles we should parse.
+			continue
 		}
 		switch optName {
 		case "system_rc":
@@ -628,24 +619,21 @@ func (a *OrderedArgs) ExpandConfigs(
 	// Replace the last occurrence of `--enable_platform_specific_config` with
 	// `--config=<bazelOS>`, so long as the last occurrence evaluates as true.
 	opts := expanded.RemoveOptions(bazelrc.EnablePlatformSpecificConfigFlag)
-	if len(opts) > 0 {
-		enable := opts[len(opts)-1].Option
+	if v, err := options.AccumulateValues(false, options.FromConcrete(opts)...); err != nil {
+		return nil, fmt.Errorf("Failed to get value from '%s' option: %s", bazelrc.EnablePlatformSpecificConfigFlag, err)
+	} else if v {
 		index := opts[len(opts)-1].Index
-		if b, ok := enable.(options.BoolLike); ok {
-			if v, err := b.AsBool(); err == nil && v {
-				bazelOS := bazelrc.GetBazelOS()
-				if platformConfig, ok := namedConfigs[bazelOS]; ok {
-					phases := bazelrc.GetPhases(command)
-					expansion, err := platformConfig.appendArgsForConfig(nil, namedConfigs, phases, []string{bazelOS}, true)
-					if err != nil {
-						return nil, err
-					}
-					expanded.Args = slices.Insert(expanded.Args, index, expansion...)
-					// Remove all occurrences of the enable platform-specific config flag
-					// that may have been added when expanding the platform-specific config.
-					expanded.RemoveOptions(bazelrc.EnablePlatformSpecificConfigFlag)
-				}
+		bazelOS := bazelrc.GetBazelOS()
+		if platformConfig, ok := namedConfigs[bazelOS]; ok {
+			phases := bazelrc.GetPhases(command)
+			expansion, err := platformConfig.appendArgsForConfig(nil, namedConfigs, phases, []string{bazelOS}, true)
+			if err != nil {
+				return nil, err
 			}
+			expanded.Args = slices.Insert(expanded.Args, index, expansion...)
+			// Remove all occurrences of the enable platform-specific config flag
+			// that may have been added when expanding the platform-specific config.
+			expanded.RemoveOptions(bazelrc.EnablePlatformSpecificConfigFlag)
 		}
 	}
 	return expanded, nil

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -546,7 +546,7 @@ func (a *OrderedArgs) appendOption(option options.Option, startupOptionInsertInd
 // args and appends an `ignore_all_rc_files` option to the startup options.
 // Returns a slice of all the rc files that should be parsed.
 func (a *OrderedArgs) ConsumeRCFileOptions(workspaceDir string) (rcFiles []string, err error) {
-	if ignore, err := options.AccumulateValues(false, options.FromConcrete(a.RemoveOptions("ignore_all_rc_files"))...); err != nil {
+	if ignore, err := options.AccumulateValues(false, a.RemoveOptions("ignore_all_rc_files")...); err != nil {
 		return nil, fmt.Errorf("Failed to get value from 'ignore_all_rc_files' option: %s", err)
 	} else if ignore {
 		// Before we do anything, check whether --ignore_all_rc_files is already
@@ -559,7 +559,7 @@ func (a *OrderedArgs) ConsumeRCFileOptions(workspaceDir string) (rcFiles []strin
 	// Parse rc files in the order defined here:
 	// https://bazel.build/run/bazelrc#bazelrc-file-locations
 	for _, optName := range []string{"system_rc", "workspace_rc", " home_rc"} {
-		if v, err := options.AccumulateValues(true, options.FromConcrete(a.RemoveOptions(optName))...); err != nil {
+		if v, err := options.AccumulateValues(true, a.RemoveOptions(optName)...); err != nil {
 			return nil, fmt.Errorf("Failed to get value from '%s' option: %s", optName, err)
 		} else if !v {
 			// When these flags are false, they have no effect on the list of
@@ -619,7 +619,7 @@ func (a *OrderedArgs) ExpandConfigs(
 	// Replace the last occurrence of `--enable_platform_specific_config` with
 	// `--config=<bazelOS>`, so long as the last occurrence evaluates as true.
 	opts := expanded.RemoveOptions(bazelrc.EnablePlatformSpecificConfigFlag)
-	if v, err := options.AccumulateValues(false, options.FromConcrete(opts)...); err != nil {
+	if v, err := options.AccumulateValues(false, opts...); err != nil {
 		return nil, fmt.Errorf("Failed to get value from '%s' option: %s", bazelrc.EnablePlatformSpecificConfigFlag, err)
 	} else if v {
 		index := opts[len(opts)-1].Index

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -228,12 +228,12 @@ func (p *Parser) Next(args []string, start int, startup bool) (option options.Op
 		// positional argument
 		return nil, start + 1, nil
 	}
-	if unknownOption, ok := option.(*options.UnknownOption); ok {
+	if _, ok := option.(*options.UnknownOption); ok {
 		log.Debugf("Unknown option %s", startToken)
 		// Unknown option, possibly a plugin-specific argument. Apply a rough
 		// heuristic to determine whether or not to have it consume the next
 		// argument.
-		if b, ok := unknownOption.Option.(options.BoolLike); ok && !option.HasValue() && !b.Negated() {
+		if b := option.BoolLike(); b != nil && !option.HasValue() && !b.Negated() {
 			// This could actually be a required-value-type option rather than a
 			// boolean option; if the next argument doesn't look like an option or a
 			// bazel command, let's assume that it is.


### PR DESCRIPTION
Adds a function that takes an initial value (the default value for the option) and then some `Option`s, and returns the resulting value of processing all of those options in that order.
