### PR TITLE
[raft] put metadata_test on firecracker

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -86,6 +86,8 @@ type Config struct {
 
 	Partitions        []disk.Partition
 	PartitionMappings []disk.PartitionMapping
+
+	LogDBConfigType store.LogDBConfigType
 }
 
 // data needed to update last access time.
@@ -180,6 +182,7 @@ func Register(env *real_environment.RealEnv) error {
 		GRPCPort:          *gRPCPort,
 		Partitions:        ps,
 		PartitionMappings: *partitionMappings,
+		LogDBConfigType:   store.LargeMemLogDBConfigType,
 	}
 	rc, err := NewRaftCache(env, rcConfig)
 	if err != nil {
@@ -222,7 +225,7 @@ func NewRaftCache(env environment.Env, conf *Config) (*RaftCache, error) {
 	rc.grpcAddr = fmt.Sprintf("%s:%d", conf.Hostname, conf.GRPCPort)
 	grpcListeningAddr := fmt.Sprintf("%s:%d", conf.ListenAddr, conf.GRPCPort)
 
-	store, err := store.New(rc.env, conf.RootDir, rc.raftAddr, rc.grpcAddr, grpcListeningAddr, rc.conf.Partitions)
+	store, err := store.New(rc.env, conf.RootDir, rc.raftAddr, rc.grpcAddr, grpcListeningAddr, rc.conf.Partitions, rc.conf.LogDBConfigType)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/metadata/BUILD
+++ b/enterprise/server/raft/metadata/BUILD
@@ -36,9 +36,14 @@ go_library(
 go_test(
     name = "metadata_test",
     srcs = ["metadata_test.go"],
+    exec_properties = {
+        "test.EstimatedComputeUnits": "8",
+        "test.workload-isolation-type": "firecracker",
+    },
     deps = [
         ":metadata",
         "//enterprise/server/filestore",
+        "//enterprise/server/raft/store",
         "//enterprise/server/raft/usagetracker",
         "//proto:metadata_go_proto",
         "//proto:storage_go_proto",

--- a/enterprise/server/raft/metadata/metadata.go
+++ b/enterprise/server/raft/metadata/metadata.go
@@ -80,6 +80,8 @@ type Config struct {
 
 	Partitions        []disk.Partition
 	PartitionMappings []disk.PartitionMapping
+
+	LogDBConfigType store.LogDBConfigType
 }
 
 // data needed to update last access time.
@@ -174,6 +176,7 @@ func NewFromFlags(env *real_environment.RealEnv) (*Server, error) {
 		GRPCPort:          *gRPCPort,
 		Partitions:        ps,
 		PartitionMappings: *partitionMappings,
+		LogDBConfigType:   store.LargeMemLogDBConfigType,
 	}
 	return New(env, rcConfig)
 }
@@ -202,7 +205,7 @@ func New(env environment.Env, conf *Config) (*Server, error) {
 	rc.grpcAddr = fmt.Sprintf("%s:%d", conf.Hostname, conf.GRPCPort)
 	grpcListeningAddr := fmt.Sprintf("%s:%d", conf.ListenAddr, conf.GRPCPort)
 
-	store, err := store.New(rc.env, conf.RootDir, rc.raftAddr, rc.grpcAddr, grpcListeningAddr, rc.conf.Partitions)
+	store, err := store.New(rc.env, conf.RootDir, rc.raftAddr, rc.grpcAddr, grpcListeningAddr, rc.conf.Partitions, rc.conf.LogDBConfigType)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -223,7 +223,6 @@ func TestAutoBringup(t *testing.T) {
 }
 
 func TestGetAndSet(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	configs := getTestConfigs(t, 3)
 	caches := startNodes(t, configs)
 	rc1 := caches[0]

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -185,7 +185,6 @@ func (rc *registryHolder) Create(nhid string, streamConnections uint64, v dbConf
 }
 
 func getLogDbConfig(t LogDBConfigType) dbConfig.LogDBConfig {
-	log.Infof("getlogdbconfig")
 	switch t {
 	case SmallMemLogDBConfigType:
 		return dbConfig.GetSmallMemLogDBConfig()

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -90,6 +90,13 @@ const (
 	listenerID = "replicaStatusWaiter"
 )
 
+type LogDBConfigType int
+
+const (
+	SmallMemLogDBConfigType LogDBConfigType = iota
+	LargeMemLogDBConfigType
+)
+
 type Store struct {
 	env        environment.Env
 	rootDir    string
@@ -177,7 +184,20 @@ func (rc *registryHolder) Create(nhid string, streamConnections uint64, v dbConf
 	return r, nil
 }
 
-func New(env environment.Env, rootDir, raftAddr, grpcAddr, grpcListeningAddr string, partitions []disk.Partition) (*Store, error) {
+func getLogDbConfig(t LogDBConfigType) dbConfig.LogDBConfig {
+	log.Infof("getlogdbconfig")
+	switch t {
+	case SmallMemLogDBConfigType:
+		return dbConfig.GetSmallMemLogDBConfig()
+	case LargeMemLogDBConfigType:
+		return dbConfig.GetLargeMemLogDBConfig()
+	default:
+		alert.UnexpectedEvent("unknown-raft-log-db-config-type", "unknown type: %d", t)
+	}
+	return dbConfig.GetDefaultLogDBConfig()
+}
+
+func New(env environment.Env, rootDir, raftAddr, grpcAddr, grpcListeningAddr string, partitions []disk.Partition, logDBConfigType LogDBConfigType) (*Store, error) {
 	rangeCache := rangecache.New()
 	raftListener := listener.NewRaftListener()
 	gossipManager := env.GetGossipService()
@@ -189,6 +209,7 @@ func New(env environment.Env, rootDir, raftAddr, grpcAddr, grpcListeningAddr str
 		RaftAddress:    raftAddr,
 		Expert: dbConfig.ExpertConfig{
 			NodeRegistryFactory: regHolder,
+			LogDB:               getLogDbConfig(logDBConfigType),
 		},
 		RaftEventListener:   raftListener,
 		SystemEventListener: raftListener,


### PR DESCRIPTION
Fix TestGetAndSet:
1. put metadata_test on firecracker. Refactor the store so that we can use small
memory LogDBConfig option in test.
2. Remove the timeout context in TestGetAndSet. We used one context with 1 second
for both get and set so the test sometimes failed with deadline exceeded.

