### PR TITLE
Avoid analysis cache drop when switching between build and test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,7 +40,7 @@ common:target-linux-arm64 --config=workspace-target-linux-arm64
 #
 # Don't run benchmarks by default; benchmarks should only run if we are
 # explicitly doing performance testing.
-test --test_tag_filters=-docker,-bare,-secrets,-performance
+common --test_tag_filters=-docker,-bare,-secrets,-performance
 
 # CI invocations from public repo should be publicly accessible.
 common:ci-shared --build_metadata=VISIBILITY=PUBLIC

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -63,7 +63,7 @@ common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
 # Add `-test.v` to all Go tests so that each test func is reported as a separate test case
 # in the XML output.  This allows our webUI to display the run time of each test case
 # separately and let us know which tests is slow.
-test --test_env=GO_TEST_WRAP_TESTV=1
+common --test_env=GO_TEST_WRAP_TESTV=1
 
 # In rules_go v0.50.0, nogo static analysis was moved from GoCompilePkg to a couple of
 # actions: RunNogo and ValidateNogo. Among these, ValidateNogo is a validation action*.
@@ -79,7 +79,7 @@ common --experimental_use_validation_aspect=true
 # Don't show cached test results in the test summary
 # We have many tests that can fill up the console with cached results.
 # If you prefer to see cached results, set this to 'short' in user.bazelrc file.
-test --test_summary=terse
+common --test_summary=terse
 
 common:race --@io_bazel_rules_go//go/config:race
 
@@ -87,26 +87,26 @@ common:performance --compilation_mode=opt
 
 # Configurations used to debug flaky tests
 common:quarantine --config=remote-minimal
-test:quarantine --config=race
-test:quarantine --test_env=RUN_QUARANTINED_TESTS=true
+common:quarantine --config=race
+common:quarantine --test_env=RUN_QUARANTINED_TESTS=true
 
 # Configuration used to deflake tests
 common:deflake --config=remote-minimal
-test:deflake --runs_per_test=100
-test:deflake --test_output=errors
-test:deflake --test_runner_fail_fast
-test:deflake --notest_keep_going
-test:deflake --config=quarantine
+common:deflake --runs_per_test=100
+common:deflake --test_output=errors
+common:deflake --test_runner_fail_fast
+common:deflake --notest_keep_going
+common:deflake --config=quarantine
 
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.
-test:webdriver-debug --test_arg=-webdriver_headless=false
-test:webdriver-debug --test_arg=-webdriver_end_of_test_delay=3s
+common:webdriver-debug --test_arg=-webdriver_headless=false
+common:webdriver-debug --test_arg=-webdriver_end_of_test_delay=3s
 # Forward X server display for local webdriver tests.
-test:webdriver-debug --test_env=DISPLAY
+common:webdriver-debug --test_env=DISPLAY
 # When debugging, only run one webdriver test at a time (it's overwhelming
 # otherwise).
-test:webdriver-debug --local_test_jobs=1
+common:webdriver-debug --local_test_jobs=1
 
 
 ###################################


### PR DESCRIPTION
`--test_env` is still a `build` option in Bazel 8 (fixed in https://github.com/bazelbuild/bazel/commit/43ebb95d1b1a66e7d46dc5e573309ace68f471a8) and thus invalidates the analysis cache when it changes between `build` and `test`. Since that's obscure knowledge and there is no downside, migrate all test options to `common`.