### PR TITLE
Add a local-readthrough mode to distributed.go

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -49,6 +49,7 @@ var (
 	replicationFactor            = flag.Int("cache.distributed_cache.replication_factor", 1, "How many total servers the data should be replicated to. Must be >= 1. ** Enterprise only **")
 	clusterSize                  = flag.Int("cache.distributed_cache.cluster_size", 0, "The total number of nodes in this cluster. Required for health checking. ** Enterprise only **")
 	enableLocalWrites            = flag.Bool("cache.distributed_cache.enable_local_writes", false, "If enabled, shortcuts distributed writes that belong to the local shard to local cache instead of making an RPC.")
+	readThroughLocalCache        = flag.Bool("cache.distributed_cache.read_through_local_cache", false, "If enabled, all data read will be written to the local cache node if not already present")
 	enableBackfill               = flag.Bool("cache.distributed_cache.enable_backfill", true, "If enabled, digests written to avoid unavailable nodes will be backfilled when those nodes return")
 	enableLocalCompressionLookup = flag.Bool("cache.distributed_cache.enable_local_compression_lookup", true, "If enabled, checks the local cache for compression support. If not set, distributed compression defaults to off.")
 	newNodes                     = flag.Slice("cache.distributed_cache.new_nodes", []string{}, "The new nodeset to add data too. Useful for migrations. ** Enterprise only **")
@@ -75,6 +76,7 @@ type CacheConfig struct {
 	DisableLocalLookup           bool
 	EnableLocalWrites            bool
 	EnableLocalCompressionLookup bool
+	ReadThroughLocalCache        bool
 }
 
 type hintedHandoffOrder struct {
@@ -138,6 +140,7 @@ func Register(env *real_environment.RealEnv) error {
 		EnableLocalWrites:            *enableLocalWrites,
 		EnableLocalCompressionLookup: *enableLocalCompressionLookup,
 		LookasideCacheSizeBytes:      *lookasideCacheSizeBytes,
+		ReadThroughLocalCache:        *readThroughLocalCache,
 	}
 	log.Infof("Enabling distributed cache with config: %+v", dcConfig)
 	if len(dcConfig.Nodes) == 0 {
@@ -468,22 +471,60 @@ func (c *Cache) lookasideCacheEnabled() bool {
 	return c.config.LookasideCacheSizeBytes > 0
 }
 
-func (c *Cache) teeReadCloser(r *rspb.ResourceName, rc io.ReadCloser) io.ReadCloser {
-	if !c.lookasideCacheEnabled() {
+func (c *Cache) localReadthroughEnabled() bool {
+	return c.config.ReadThroughLocalCache
+}
+
+func combineCommittedWriteClosers(a, b interfaces.CommittedWriteCloser) interfaces.CommittedWriteCloser {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+
+	c := io.MultiWriter(a, b)
+	cwc := ioutil.NewCustomCommitWriteCloser(c)
+	cwc.CommitFn = func(n int64) error {
+		if err := a.Commit(); err != nil {
+			return err
+		}
+		return b.Commit()
+	}
+	cwc.CloseFn = func() error {
+		a.Close()
+		b.Close()
+		return nil
+	}
+	return cwc
+}
+
+func (c *Cache) teeReadCloser(ctx context.Context, r *rspb.ResourceName, rc io.ReadCloser) io.ReadCloser {
+	if !c.lookasideCacheEnabled() && !c.localReadthroughEnabled() {
 		return rc
 	}
-	if r.GetDigest().GetSizeBytes() > *maxLookasideEntryBytes {
+
+	var lookasideWriter, localWriter interfaces.CommittedWriteCloser
+	if c.lookasideCacheEnabled() {
+		if r.GetDigest().GetSizeBytes() <= *maxLookasideEntryBytes {
+			if k, ok := lookasideKey(r); ok {
+				if lwc, err := c.lookasideWriter(r, k); err == nil {
+					lookasideWriter = lwc
+				}
+			}
+		}
+	}
+	if c.localReadthroughEnabled() {
+		if local, err := c.local.Writer(ctx, r); err == nil {
+			localWriter = local
+		}
+	}
+	if lookasideWriter == nil && localWriter == nil {
 		return rc
 	}
-	k, ok := lookasideKey(r)
-	if !ok {
-		return rc
-	}
-	lwc, err := c.lookasideWriter(r, k)
-	if err != nil {
-		return rc
-	}
-	return &teeReadCloser{rc: rc, cwc: lwc}
+
+	cwc := combineCommittedWriteClosers(lookasideWriter, localWriter)
+	return &teeReadCloser{rc: rc, cwc: cwc}
 }
 
 func (c *Cache) recvHeartbeatCallback(ctx context.Context, peer string) {
@@ -756,18 +797,30 @@ func (c *Cache) remoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 	if !c.config.DisableLocalLookup && peer == c.config.ListenAddr {
 		return c.local.Reader(ctx, r, offset, limit)
 	}
-	lookasideCacheable := offset == 0 && limit == 0
-	if lookasideCacheable {
+	cacheable := offset == 0 && limit == 0
+	if cacheable {
+		// See if this object is in the lookaside cache already.
 		if buf, found := c.getLookasideEntry(r); found {
 			return io.NopCloser(bytes.NewReader(buf)), nil
+		}
+
+		// If localReadThrough is enabled, see if we've cached this
+		// locally.
+		if c.localReadthroughEnabled() {
+			if rc, err := c.local.Reader(ctx, r, 0, 0); err == nil {
+				c.log.CtxDebugf(ctx, "Reader(%q) found locally", distributed_client.ResourceIsolationString(r))
+				return rc, nil
+			}
 		}
 	}
 	rc, err := c.distributedProxy.RemoteReader(ctx, peer, r, offset, limit)
 	if err != nil {
 		return nil, err
 	}
-	if offset == 0 && limit == 0 {
-		return c.teeReadCloser(r, rc), nil
+	c.log.CtxDebugf(ctx, "Reader(%q) found on peer %s", distributed_client.ResourceIsolationString(r), peer)
+	if cacheable {
+		// Attempt to write this object to any other caches.
+		return c.teeReadCloser(ctx, r, rc), nil
 	}
 	return rc, nil
 }
@@ -1105,7 +1158,6 @@ func (c *Cache) distributedReader(ctx context.Context, rn *rspb.ResourceName, of
 		lookups++
 		r, err := c.remoteReader(ctx, peer, rn, offset, limit)
 		if err == nil {
-			c.log.CtxDebugf(ctx, "Reader(%q) found on peer %s", distributed_client.ResourceIsolationString(rn), peer)
 			backfill()
 			metrics.DistributedCachePeerLookups.With(prometheus.Labels{
 				metrics.DistributedCacheOperation: metricsLabel,

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -2234,6 +2234,89 @@ func TestTreeCacheLookaside(t *testing.T) {
 	assert.NotEqual(t, opCountBefore[peer3], len(memoryCache3.ops))
 }
 
+func TestReadThroughLocalCache(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer3 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := CacheConfig{
+		ReplicationFactor:     1,
+		Nodes:                 []string{peer1, peer2, peer3},
+		DisableLocalLookup:    true,
+		ReadThroughLocalCache: true,
+	}
+
+	// Setup a distributed cache, 3 nodes, R = 1.
+	memoryCache1 := traceCache(newMemoryCache(t, singleCacheSizeBytes))
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := traceCache(newMemoryCache(t, singleCacheSizeBytes))
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	dc2 := startNewDCache(t, env, config2, memoryCache2)
+
+	memoryCache3 := traceCache(newMemoryCache(t, singleCacheSizeBytes))
+	config3 := baseConfig
+	config3.ListenAddr = peer3
+	dc3 := startNewDCache(t, env, config3, memoryCache3)
+
+	waitForReady(t, config1.ListenAddr)
+	waitForReady(t, config2.ListenAddr)
+	waitForReady(t, config3.ListenAddr)
+
+	baseCaches := []interfaces.Cache{
+		memoryCache1,
+		memoryCache2,
+		memoryCache3,
+	}
+	distributedCaches := []interfaces.Cache{dc1, dc2, dc3}
+	allResources := make([]*rspb.ResourceName, 0)
+
+	for i := 0; i < 100; i++ {
+		// Do a write, and ensure we can read it back from each node,
+		// both via the base cache and distributed cache for each node.
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		if err := distributedCaches[i%3].Set(ctx, rn, buf); err != nil {
+			t.Fatal(err)
+		}
+		allResources = append(allResources, rn)
+		for _, distributedCache := range distributedCaches {
+			exists, err := distributedCache.Contains(ctx, rn)
+			assert.Nil(t, err)
+			assert.True(t, exists)
+			readAndCompareDigest(t, ctx, distributedCache, rn)
+		}
+		for _, baseCache := range baseCaches {
+			exists, err := baseCache.Contains(ctx, rn)
+			assert.Nil(t, err)
+			assert.True(t, exists)
+			readAndCompareDigest(t, ctx, baseCache, rn)
+		}
+	}
+
+	opCountBefore := map[string]int{
+		peer1: len(memoryCache1.ops),
+		peer2: len(memoryCache2.ops),
+		peer3: len(memoryCache3.ops),
+	}
+
+	// Now read all of the digests again -- all should be served
+	// directly from the local cache.
+	for _, rn := range allResources {
+		for _, distributedCache := range distributedCaches {
+			readAndCompareDigest(t, ctx, distributedCache, rn)
+		}
+	}
+
+	assert.Equal(t, opCountBefore[peer1]+len(allResources), len(memoryCache1.ops))
+	assert.Equal(t, opCountBefore[peer2]+len(allResources), len(memoryCache2.ops))
+	assert.Equal(t, opCountBefore[peer3]+len(allResources), len(memoryCache3.ops))
+
+}
+
 type Op int
 
 const (


### PR DESCRIPTION
Allow cache proxy to read-through into the local cache, to prevent cross-zone transfers from happening more than once.