### PR TITLE
Add incremental indexing to codesearch-enabled workflows

### DIFF
--- a/enterprise/server/workflow/config/config_test.go
+++ b/enterprise/server/workflow/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"bytes"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -149,4 +150,22 @@ func TestGetGitFetchFilters(t *testing.T) {
 			require.Equal(t, test.Filters, cfg.Actions[0].GetGitFetchFilters())
 		})
 	}
+}
+
+func TestCodeSearchAction(t *testing.T) {
+	apiURL, err := url.Parse("grpcs://example.com")
+	require.NoError(t, err)
+	ghURL := "https://github.com/buildbuddy-io/buildbuddy"
+
+	action := config.CodesearchIncrementalUpdateAction(apiURL, ghURL, "master")
+
+	require.NotNil(t, action)
+	assert.Equal(t, config.CSIncrementalUpdateName, action.Name)
+	require.NotNil(t, action.Triggers)
+	require.NotNil(t, action.Triggers.Push)
+	assert.Equal(t, []string{"master"}, action.Triggers.Push.Branches)
+	require.NotNil(t, action.Steps)
+	assert.Len(t, action.Steps, 1)
+	assert.Contains(t, action.Steps[0].Run, apiURL.String())
+	assert.Contains(t, action.Steps[0].Run, ghURL)
 }

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -766,7 +766,7 @@ func TestAPIDispatch_ActionFiltering(t *testing.T) {
 			name:            "no action filter, kythe enabled",
 			actionFilter:    nil,
 			kytheEnabled:    true,
-			expectedActions: []string{"Test all targets", config.KytheActionName},
+			expectedActions: []string{"Test all targets", config.CSIncrementalUpdateName, config.KytheActionName},
 		},
 		{
 			name:            "action filter, kythe disabled",
@@ -781,10 +781,16 @@ func TestAPIDispatch_ActionFiltering(t *testing.T) {
 			expectedActions: []string{"Test all targets"},
 		},
 		{
-			name:            "kythe action filter",
+			name:            "kythe-only action filter",
 			actionFilter:    []string{config.KytheActionName},
 			kytheEnabled:    true,
 			expectedActions: []string{config.KytheActionName},
+		},
+		{
+			name:            "all codesearch action filter",
+			actionFilter:    []string{config.CSIncrementalUpdateName, config.KytheActionName},
+			kytheEnabled:    true,
+			expectedActions: []string{config.CSIncrementalUpdateName, config.KytheActionName},
 		},
 	}
 


### PR DESCRIPTION
This PR adds a new action to workflows from codesearch-enabled organizations. This new action uses the `bb index` command to compute and send an incremental update to the codesearch server.