### PR TITLE
Fix panic when auth fails

### DIFF
--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -643,7 +643,7 @@ func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Re
 	// the token below.
 	if ut, err := auth.verifyTokenAndExtractUser(ctx, jwt, true /*=checkExpiry*/); err == nil {
 		claims, err := claims.ClaimsFromSubID(ctx, a.env, ut.GetSubID())
-		if auth.getSlug() != "" {
+		if claims != nil && auth.getSlug() != "" {
 			claims.CustomerSSO = true
 		}
 		return claims, ut, err
@@ -689,7 +689,7 @@ func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Re
 
 	cookie.SetLoginCookie(w, jwt, issuer, sessionID, newToken.Expiry.Unix())
 	claims, err := claims.ClaimsFromSubID(ctx, a.env, ut.GetSubID())
-	if auth.getSlug() != "" {
+	if claims != nil && auth.getSlug() != "" {
 		claims.CustomerSSO = true
 	}
 	return claims, ut, err


### PR DESCRIPTION
I think this was introduced in https://github.com/buildbuddy-io/buildbuddy/pull/9465. Not sure whether this would happen in practice, but I hit this while trying to test Entra + OIDC locally.