### PR TITLE
[FC] Fix a potential bug when finding the cached image path

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1914,7 +1914,7 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 		return status.UnavailableErrorf("container image is unavailable: %s", err)
 	}
 	if imageExt4Path == "" {
-		return status.UnavailableErrorf("container image not found ")
+		return status.UnavailableErrorf("container image not found: %s", c.containerImage)
 	}
 	if err := os.Link(imageExt4Path, containerFSPath); err != nil {
 		return err


### PR DESCRIPTION
We weren't checking the return value, which can be an empty string even when there is no error.

I didn't see any cases of this in the wild, but I stumbled onto it while deflaking tests.