### PR TITLE
Generalize kythe workflow action 

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -200,6 +200,11 @@ func buildWithKythe(dirName string) string {
 	return fmt.Sprintf(`
 BZL_MAJOR_VERSION=$(bazel version | grep "Build label" | cut -d':' -f 2 | xargs | sed -r "s/([[:digit:]]*).[[:digit:]]*.[[:digit:]]*/\1/"))
 bazel mod graph > /dev/null 2>&1; BZLMOD_ENABLED=$(( $? == 0 ))
+
+KYTHE_ARGS="--inject_repository=kythe_release=$KYTHE_DIR"
+if [ "$BZLMOD_ENABLED" -eq 1 && $BZL_MAJOR_VERSION lt 8 ]; then
+  echo 'bazel_dep(name = "kythe", version = "0.0.74")' >> MODULE.bazel
+  echo '
 if [ "$BZL_MAJOR_VERSION" -lt 8 ]; then
 
 export KYTHE_DIR="$BUILDBUDDY_CI_RUNNER_ROOT_DIR"/%s

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -194,8 +194,6 @@ func buildWithKythe(dirName string) string {
 	// enable Kythe. This means the build will fail or be invalid if the normal build workflow
 	// passes any important flags. While passing flags on the command line is discouraged,
 	// we'll need to handle this eventually.
-	// TODO(jdelfino): DO NOT SUBMIT We need to cut a new release of kythe with bzlmod support
-	// before this can go in - the current buildbuddy-io/kythe release does not support bzlmod.
 	bazelConfigFlags := `--config=buildbuddy_bes_backend --config=buildbuddy_bes_results_url`
 	return fmt.Sprintf(`
 BZL_MAJOR_VERSION=$(bazel --version | cut -d' ' -f2 | xargs | cut -d'.' -f1)

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -194,6 +194,8 @@ func buildWithKythe(dirName string) string {
 	// enable Kythe. This means the build will fail or be invalid if the normal build workflow
 	// passes any important flags. While passing flags on the command line is discouraged,
 	// we'll need to handle this eventually.
+	// TODO(jdelfino): DO NOT SUBMIT We need to cut a new release of kythe with bzlmod support
+	// before this can go in - the current buildbuddy-io/kythe release does not support bzlmod.
 	bazelConfigFlags := `--config=buildbuddy_bes_backend --config=buildbuddy_bes_results_url`
 	return fmt.Sprintf(`
 BZL_MAJOR_VERSION=$(bazel version | grep "Build label" | cut -d':' -f 2 | xargs | cut -d'.' -f1

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -198,7 +198,7 @@ func buildWithKythe(dirName string) string {
 	// before this can go in - the current buildbuddy-io/kythe release does not support bzlmod.
 	bazelConfigFlags := `--config=buildbuddy_bes_backend --config=buildbuddy_bes_results_url`
 	return fmt.Sprintf(`
-BZL_MAJOR_VERSION=$(bazel version | grep "Build label" | cut -d':' -f 2 | xargs | cut -d'.' -f1)
+BZL_MAJOR_VERSION=$(bazel --version | cut -d' ' -f2 | xargs | cut -d'.' -f1)
 
 if [ $BZL_MAJOR_VERSION -lt 7 ]; then
     BZLMOD_DEFAULT=0
@@ -226,7 +226,7 @@ if [ "$BZLMOD_ENABLED" -eq - ]; then
 		echo 'bazel_dep(name = "kythe", version = "0.0.75")' >> MODULE.bazel
 		echo "local_path_override(module_name=\"kythe\", path=\"$KYTHE_DIR\")" >> MODULE.bazel
 	else
-		KYTHE_ARGS="--inject_repository kythe_release=$KYTHE_DIR"
+		KYTHE_ARGS="--inject_repository=kythe_release=$KYTHE_DIR"
 	fi
 else
     # override_repository always works if bzlmod is disabled.


### PR DESCRIPTION
This action should now work on repos with or without bzlmod, and with different versions of bazel (although I've only tested back to 7.5.x)

I don't love putting all this bash into a string in a go file, but I also think that integration testing this script is probably more effort than it is worth right now, because it would involve setting up at least 4 test repos to hit the different cases. 