### PR TITLE
use vtpool for StorageMetadata and FileRecord

### DIFF
--- a/proto/storage.proto
+++ b/proto/storage.proto
@@ -19,6 +19,7 @@ message Encryption {
 }
 
 message FileRecord {
+  option (vtproto.mempool) = true;
   Isolation isolation = 1;
   build.bazel.remote.execution.v2.Digest digest = 2;
   build.bazel.remote.execution.v2.Compressor.Value compressor = 3;
@@ -27,6 +28,7 @@ message FileRecord {
 }
 
 message StorageMetadata {
+  option (vtproto.mempool) = true;
   message FileMetadata {
     string filename = 1;
   }


### PR DESCRIPTION
When mempool is enabled for StorageMetadata and FileRecord,
FileMetadata.UnmarshalVT will not call &StorageMetadata{} and &FileRecord{} and
instead it will try to grab the objects from VTPool
