### PR TITLE
Add several codesearch index utilities

### DIFF
--- a/codesearch/posting/posting.go
+++ b/codesearch/posting/posting.go
@@ -9,6 +9,7 @@ import (
 type List interface {
 	Or(List)
 	And(List)
+	AndNot(List)
 	Add(uint64)
 	Remove(uint64)
 	GetCardinality() uint64
@@ -33,6 +34,15 @@ func (w *roaringWrapper) And(l List) {
 		panic("not roaringWrapper")
 	}
 	w.Bitmap.And(bm.Bitmap)
+}
+
+// AndNot is the same as set difference, equivalent to w - l
+func (w *roaringWrapper) AndNot(l List) {
+	bm, ok := l.(*roaringWrapper)
+	if !ok {
+		panic("not roaringWrapper")
+	}
+	w.Bitmap.AndNot(bm.Bitmap)
 }
 
 func NewList(ids ...uint64) List {

--- a/codesearch/posting/posting_test.go
+++ b/codesearch/posting/posting_test.go
@@ -49,6 +49,21 @@ func TestAnd(t *testing.T) {
 	assert.Equal(t, []uint64{3}, pl.ToArray())
 }
 
+func TestAndNot(t *testing.T) {
+	pl := posting.NewList()
+	pl.Add(1)
+	pl.Add(2)
+	pl.Add(3)
+
+	pl2 := posting.NewList()
+	pl2.Add(3)
+	pl2.Add(4)
+	pl2.Add(5)
+
+	pl.AndNot(pl2)
+	assert.Equal(t, []uint64{1, 2}, pl.ToArray())
+}
+
 func TestRemove(t *testing.T) {
 	pl := posting.NewList()
 	pl.Add(1)


### PR DESCRIPTION
Adds 3 functions:
- `DropNamespace`, which drops an entire namespace
- `DeleteMatchingDocuments`, which deletes all docs that match a given field. Intended to be used to delete an entire repository at once
- `CompactDeletes`, which removes deleted doc ids from all posting lists in a namespace. Note that this is a potentially very expensive operation for large indices, but it will keep the index size proportional to the size of the repo, rather than the number of updates that have been applied.

None of these are used or exposed anywhere yet.