### PR TITLE
Return an error if in progress execution is not found in redis

### DIFF
--- a/enterprise/server/backends/redis_execution_collector/BUILD
+++ b/enterprise/server/backends/redis_execution_collector/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:stored_invocation_go_proto",
         "//server/real_environment",
         "//server/util/proto",
+        "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",
     ],
 )
@@ -23,6 +24,7 @@ go_test(
         "//enterprise/server/testutil/testredis",
         "//proto:remote_execution_go_proto",
         "//proto:stored_invocation_go_proto",
+        "//server/util/status",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-redis/redis/v8"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -211,7 +212,7 @@ func (c *collector) GetInProgressExecution(ctx context.Context, executionID stri
 		return nil, err
 	}
 	if len(serializedResults) == 0 {
-		return nil, nil
+		return nil, status.NotFoundErrorf("in progress execution %s not found", executionID)
 	}
 	return mergeExecutionUpdates(serializedResults)
 }

--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_execution_collector"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,10 +113,9 @@ func TestCollectExecutionUpdates(t *testing.T) {
 	err = collector.DeleteInProgressExecution(ctx, executionID)
 	require.NoError(t, err)
 
-	// Read the updates back again; should return nil.
-	execution, err = collector.GetInProgressExecution(ctx, executionID)
-	require.NoError(t, err)
-	require.Nil(t, execution)
+	// Read the updates back again; should return not found error.
+	_, err = collector.GetInProgressExecution(ctx, executionID)
+	require.True(t, status.IsNotFoundError(err))
 }
 
 func TestGetInProgressExecutionsIgnoresDeletedExecutions(t *testing.T) {


### PR DESCRIPTION
There can be a nil pointer reference [below](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/remote_execution/execution_server/execution_server.go#L454) if executionProto is nil

The execution proto is [cleaned up in redis](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/remote_execution/execution_server/execution_server.go#L448) after it's flushed. This can occur if the flush is attempted twice, for example if the executor retries publishing the COMPLETED event