### PR TITLE
[oci cache] ref -> repo

### DIFF
--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -267,7 +267,7 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 
 	if *writeManifestsToCache {
 		contentType := string(remoteDesc.MediaType)
-		err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, r.env.GetActionCacheClient(), imageRef, remoteDesc.Digest, contentType)
+		err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, r.env.GetActionCacheClient(), imageRef.Context(), remoteDesc.Digest, contentType)
 		if err != nil {
 			log.CtxWarningf(ctx, "Could not write manifest for %q to the cache: %s", imageRef.Context(), err)
 		}

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -64,11 +64,11 @@ func TestCacheSecret(t *testing.T) {
 			require.NoError(t, err)
 
 			flags.Set(t, "oci.cache.secret", tc.writeSecret)
-			err = ocicache.WriteManifestToAC(ctx, raw, acClient, ref, hash, contentType)
+			err = ocicache.WriteManifestToAC(ctx, raw, acClient, ref.Context(), hash, contentType)
 			require.NoError(t, err)
 
 			flags.Set(t, "oci.cache.secret", tc.fetchSecret)
-			mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref, hash)
+			mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref.Context(), hash)
 			if !tc.canFetch {
 				require.Error(t, err)
 				require.Nil(t, mc)
@@ -131,7 +131,7 @@ func TestManifestWrittenOnlyToAC(t *testing.T) {
 		&out,
 		nil, // explicitly pass nil bytestream client
 		acClient,
-		ref,
+		ref.Context(),
 		ocipb.OCIResourceType_MANIFEST,
 		hash,
 		contentType,
@@ -141,7 +141,7 @@ func TestManifestWrittenOnlyToAC(t *testing.T) {
 	require.Equal(t, len(raw), out.Len())
 	require.Empty(t, cmp.Diff(raw, out.Bytes()))
 
-	mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref, hash)
+	mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref.Context(), hash)
 	require.NoError(t, err)
 	require.NotNil(t, mc)
 


### PR DESCRIPTION
Pass a Repository (includes the registry hostname and the image name) and a Hash (digest) to OCI cache functions.
This change eliminates redundant information (we were already only using the Repository part of References) and makes some follow-on changes smaller.