### PR TITLE
Fix startup options cache error message when not running a bazel command

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2570,7 +2570,7 @@ func runBazelWrapper() error {
 	// We apply these on future bazel cleanup commands to make sure the running
 	// Bazel server isn't restarted.
 	if err := cacheStartupOptions(bazelArgs, rootPath); err != nil {
-		backendLog.Errorf("Failed to cache startup options for bazel command %v: %v", originalArgs, err)
+		backendLog.Warningf("Failed to cache startup options for bazel command %v: %v", originalArgs, err)
 	}
 
 	// Replace the process running the bazel wrapper with the process running bazel,
@@ -2584,6 +2584,11 @@ func runBazelWrapper() error {
 // the existing bazel server, we must make sure to apply the last used startup
 // options when running bazel commands.
 func cacheStartupOptions(bazelCmd []string, rootDir string) error {
+	// If not a bazel command (e.g. a CLI command like 'bazel index'),
+	// there won't be startup options. Do nothing.
+	if _, idx := bazel.GetBazelCommandAndIndex(bazelCmd); idx < 0 {
+		return nil
+	}
 	startupOptions, err := bazel.GetStartupOptions(bazelCmd)
 	if err != nil {
 		return status.WrapErrorf(err, "parse startup options from bazel command")


### PR DESCRIPTION
Example invocation (from @jdelfino) https://buildbuddy.buildbuddy.dev/invocation/8d5bc845-ba49-499c-b3e9-b9dc5fde6878?role=CI_RUNNER&pattern=Codesearch+Incremental+Update#@31

We failed to cache startup options when running `bazel index`, where `bazel` is actually running the CLI via the USE_BAZEL_VERSION trick. This printed a misleading error message

