### PR TITLE
Add debugging to codesearch workflow

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -249,10 +249,10 @@ func KytheIndexingAction(targetRepoDefaultBranch string) *Action {
 }
 
 func sendIncrementalUpdate(apiTarget, repoURL string) string {
+	// TODO(jdelfino): Remove explicit CLI installation once buildbuddy-internal/#5060 is resolved
 	buf := fmt.Sprintf(`
-export USE_BAZEL_VERSION=buildbuddy-io/latest
-bazel version
-bazel index --target %s --repo-url %s`, apiTarget, repoURL)
+curl -fsSL https://install.buildbuddy.io | bash
+bb index --target %s --repo-url %s`, apiTarget, repoURL)
 	return buf
 }
 


### PR DESCRIPTION
Latest failure is: https://buildbuddy.buildbuddy.dev/invocation/ff14271a-1c3b-4213-921e-dc208c31a769?role=CI_RUNNER&pattern=Codesearch+Incremental+Update#@28

It is claiming `index` is not a command. However, running `USE_BAZEL_VERSION=buildbuddy-io/latest bazelisk index` from a local command line does work. I'd like to see what version it thinks it's using to narrow down what is going on.