### PR TITLE
Record network metrics for VMs and OCI containers

### DIFF
--- a/dockerfiles/test_images/defs.bzl
+++ b/dockerfiles/test_images/defs.bzl
@@ -1,0 +1,1 @@
+NET_TOOLS_IMAGE = "gcr.io/flame-public/net-tools@sha256:fdd8b0a391871eaf47664b2f6620b64d2bc4bdf8c86b57c1e0d013935cac1215"

--- a/dockerfiles/test_images/net_tools/Dockerfile
+++ b/dockerfiles/test_images/net_tools/Dockerfile
@@ -6,10 +6,12 @@ RUN apt-get update && \
         conntrack \
         curl \
         dnsutils \
+        file \
         iproute2 \
         iptables \
         iputils-ping \
         net-tools \
+        tcpdump \
         && \
     update-ca-certificates && \
     apt-get clean && \

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2100,7 +2100,7 @@ func (c *FirecrackerContainer) fillNetStats(ctx context.Context, usageStats *rep
 	}
 	netStats, err := c.network.Stats(ctx)
 	if err != nil {
-		log.CtxErrorf(ctx, "Failed to get network stats: %s", err)
+		log.CtxWarningf(ctx, "Failed to get network stats: %s", err)
 		return
 	}
 	usageStats.NetworkStats = netStats

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2081,16 +2081,31 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 	case res := <-resultCh:
 		cancelCgroupPoll()
 		res.UsageStats = combineHostAndGuestStats(hostCgroupStats.TaskStats(), res.UsageStats)
+		c.fillNetStats(ctx, res.UsageStats)
 		return res, true
 	case err := <-healthCheckErrCh:
 		cancelCgroupPoll()
 		res := commandutil.ErrorResult(status.UnavailableErrorf("VM health check failed (possibly crashed?): %s", err))
 		statsMu.Lock()
 		res.UsageStats = combineHostAndGuestStats(hostCgroupStats.TaskStats(), lastGuestStats)
+		c.fillNetStats(ctx, res.UsageStats)
 		statsMu.Unlock()
 		return res, false
 	}
 }
+
+func (c *FirecrackerContainer) fillNetStats(ctx context.Context, usageStats *repb.UsageStats) {
+	if c.network == nil {
+		return
+	}
+	netStats, err := c.network.Stats(ctx)
+	if err != nil {
+		log.CtxErrorf(ctx, "Failed to get network stats: %s", err)
+		return
+	}
+	usageStats.NetworkStats = netStats
+}
+
 func (c *FirecrackerContainer) vmExecConn(ctx context.Context) (*grpc.ClientConn, error) {
 	if c.vmExec.conn == nil && c.vmExec.err == nil {
 		c.vmExec.conn, c.vmExec.err = c.dialVMExecServer(ctx)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1593,8 +1593,9 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 	env := getTestEnv(ctx, t, envOpts{})
 	rootDir := testfs.MakeTempDir(t)
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
+	flags.Set(t, "executor.network_stats_enabled", true)
 
-	// Make sure the container can send packets to something external of the VM
+	// Make sure the container can send packets to something external to the VM
 	googleDNS := "8.8.8.8"
 	cmd := &repb.Command{Arguments: []string{"ping", "-c1", googleDNS}}
 
@@ -1622,6 +1623,8 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Contains(t, string(res.Stdout), "64 bytes from "+googleDNS)
+	assert.GreaterOrEqual(t, res.UsageStats.GetNetworkStats().GetBytesSent(), int64(100))
+	assert.GreaterOrEqual(t, res.UsageStats.GetNetworkStats().GetBytesReceived(), int64(100))
 }
 
 func TestSnapshotAndResumeWithNetwork(t *testing.T) {
@@ -1629,6 +1632,7 @@ func TestSnapshotAndResumeWithNetwork(t *testing.T) {
 	env := getTestEnv(ctx, t, envOpts{})
 	rootDir := testfs.MakeTempDir(t)
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
+	flags.Set(t, "executor.network_stats_enabled", true)
 
 	// Make sure the container can send packets to something external of the VM
 	googleDNS := "8.8.8.8"
@@ -1658,6 +1662,8 @@ func TestSnapshotAndResumeWithNetwork(t *testing.T) {
 	require.NoError(t, res.Error)
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Contains(t, string(res.Stdout), "64 bytes from "+googleDNS)
+	assert.GreaterOrEqual(t, res.UsageStats.GetNetworkStats().GetBytesSent(), int64(100))
+	assert.GreaterOrEqual(t, res.UsageStats.GetNetworkStats().GetBytesReceived(), int64(100))
 
 	err = c.Pause(ctx)
 	require.NoError(t, err)
@@ -1669,6 +1675,8 @@ func TestSnapshotAndResumeWithNetwork(t *testing.T) {
 	require.NoError(t, res.Error)
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Contains(t, string(res.Stdout), "64 bytes from "+googleDNS)
+	assert.GreaterOrEqual(t, res.UsageStats.GetNetworkStats().GetBytesSent(), int64(100))
+	assert.GreaterOrEqual(t, res.UsageStats.GetNetworkStats().GetBytesReceived(), int64(100))
 
 	err = c.Pause(ctx)
 	require.NoError(t, err)

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//dockerfiles/test_images:defs.bzl", "NET_TOOLS_IMAGE")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -64,7 +65,7 @@ go_test(
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:e904e2149194b94f4504fdfb3c7b2b71afa130708feb482fe9a9d557453fa8fd",
+        "test.container-image": "docker://" + NET_TOOLS_IMAGE,
         "test.EstimatedComputeUnits": "2",
         "test.EstimatedFreeDiskBytes": "10GB",
     },
@@ -86,6 +87,7 @@ go_test(
         "busyboxRlocationpath": "$(rlocationpath :busybox)",
         "ociBusyboxRlocationpath": "$(rlocationpath @busybox)",
         "testworkerRlocationpath": "$(rlocationpath //enterprise/server/remote_execution/runner/testworker)",
+        "netToolsImageRef": NET_TOOLS_IMAGE,
     },
     deps = [
         ":ociruntime",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -765,6 +765,13 @@ func (c *ociContainer) doWithStatsTracking(ctx context.Context, invokeRuntimeFn 
 		log.CtxWarning(ctx, status.Message(err))
 	}
 
+	networkStats, err := c.network.Stats(ctx)
+	if err != nil {
+		log.CtxWarningf(ctx, "Failed to get network stats: %s", err)
+	} else {
+		res.UsageStats.NetworkStats = networkStats
+	}
+
 	return res
 }
 

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2349,6 +2349,17 @@ message UsageStats {
   // IO stats for the block device where all action IO happened (action inputs
   // and outputs, overlayfs temporary files, etc.)
   CgroupIOStats cgroup_io_stats = 9;
+
+  // Network statistics for the network interface assigned to the action.
+  NetworkStats network_stats = 10;
+}
+
+// Network statistics for an action.
+message NetworkStats {
+  int64 bytes_received = 1;
+  int64 packets_received = 2;
+  int64 bytes_sent = 3;
+  int64 packets_sent = 4;
 }
 
 // Structured representation of the cgroup2 "io.stat" file.
@@ -2514,6 +2525,10 @@ message StoredExecution {
   int64 disk_bytes_written = 35;
   int64 disk_read_operations = 36;
   int64 disk_write_operations = 37;
+  int64 network_bytes_sent = 63;
+  int64 network_bytes_received = 64;
+  int64 network_packets_sent = 65;
+  int64 network_packets_received = 66;
 
   // Effective task sizing
   int64 estimated_memory_bytes = 17;

--- a/server/testutil/testnetworking/BUILD
+++ b/server/testutil/testnetworking/BUILD
@@ -7,6 +7,8 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testnetworking",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/util/lockingbuffer",
+        "//server/util/log",
         "//server/util/networking",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/testutil/testnetworking/testnetworking.go
+++ b/server/testutil/testnetworking/testnetworking.go
@@ -1,12 +1,19 @@
 package testnetworking
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/lockingbuffer"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
 	"github.com/stretchr/testify/require"
 )
@@ -39,4 +46,80 @@ func Setup(t *testing.T) {
 	// Set up default hostNetAllocator
 	err = networking.Configure(context.Background())
 	require.NoError(t, err)
+}
+
+// PacketCapture represents a packet capture process. A packet capture can be
+// started with StartPacketCapture, and stopped by calling Stop and Wait on the
+// returned instance. The resulting packet capture can be viewed with a program
+// like wireshark.
+//
+// NOTE: this is intended for debugging purposes only and should not be used in
+// production.
+type PacketCapture struct {
+	cmd    *exec.Cmd
+	stderr *bytes.Buffer
+	done   chan struct{}
+	err    error
+}
+
+// StartPacketCapture starts a packet capture on the given device, writing
+// captured packets to the given writer. The resulting packet capture can be
+// viewed with a program like wireshark.
+//
+// Requires tcpdump to be available on $PATH.
+func StartPacketCapture(device string, w io.Writer) (*PacketCapture, error) {
+	stderr := &bytes.Buffer{}
+	args := []string{"tcpdump", "-i", device, "-w", "-"}
+	if os.Getuid() != 0 {
+		args = append([]string{"sudo", "-A"}, args...)
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = w
+	lockbuf := lockingbuffer.New()
+	cmd.Stderr = io.MultiWriter(stderr, lockbuf)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	pcap := &PacketCapture{
+		cmd:    cmd,
+		stderr: stderr,
+		done:   make(chan struct{}),
+	}
+	go func() {
+		err := cmd.Wait()
+		pcap.err = err
+		close(pcap.done)
+	}()
+	for !strings.Contains(lockbuf.String(), "listening on") {
+		select {
+		case <-time.After(10 * time.Millisecond):
+		case <-pcap.done:
+			return nil, pcap.Wait()
+		}
+	}
+	return pcap, nil
+}
+
+// Stop stops packet capture.
+// Call Wait() to wait for the packet capture to finish.
+func (p *PacketCapture) Stop() error {
+	// Wait a bit for packets to be captured - it takes some time for tcpdump
+	// to actually capture the packets even if they have already been sent.
+	// TODO: there has to be a better way to do this...
+	time.Sleep(1 * time.Second)
+	return p.cmd.Process.Signal(os.Interrupt)
+}
+
+func (p *PacketCapture) Wait() error {
+	<-p.done
+	// Ignore SIGINT triggered by Stop()
+	if ws, ok := p.cmd.ProcessState.Sys().(syscall.WaitStatus); ok && ws.Signaled() && ws.Signal() == syscall.SIGINT {
+		log.Debugf("Stopped packet capture. tcpdump stderr: %q", p.stderr)
+		return nil
+	}
+	if p.err != nil {
+		return fmt.Errorf("packet capture failed: %w: %q", p.err, p.stderr)
+	}
+	log.Debugf("Stopped packet capture. tcpdump stderr: %q", p.stderr)
+	return nil
 }

--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//dockerfiles/test_images:defs.bzl", "NET_TOOLS_IMAGE")
 
 go_library(
     name = "networking",
@@ -6,10 +7,12 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/networking",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:remote_execution_go_proto",
         "//server/metrics",
         "//server/util/alert",
         "//server/util/background",
         "//server/util/flag",
+        "//server/util/lockingbuffer",
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",
@@ -27,9 +30,10 @@ go_test(
     srcs = ["networking_test.go"],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
-        "test.container-image": "docker://gcr.io/flame-public/net-tools@sha256:e904e2149194b94f4504fdfb3c7b2b71afa130708feb482fe9a9d557453fa8fd",
-        "test.EstimatedComputeUnits": "2",
+        "test.container-image": "docker://" + NET_TOOLS_IMAGE,
+        "test.EstimatedComputeUnits": "4",
     },
+    shard_count = 2,
     tags = [
         "docker",
         "no-sandbox",
@@ -37,6 +41,7 @@ go_test(
     deps = [
         ":networking",
         "//server/testutil/testnetworking",
+        "//server/testutil/testshell",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//server/util/alert",
         "//server/util/background",
         "//server/util/flag",
-        "//server/util/lockingbuffer",
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",

--- a/server/util/networking/networking_test.go
+++ b/server/util/networking/networking_test.go
@@ -359,11 +359,11 @@ func TestNetworkStats(t *testing.T) {
 			require.Equal(t, int64(0), stats.GetPacketsSent(), "%s (attempt %d): should have sent 0 packets initially", tc.name, attemptNumber)
 		}
 
-		var pcap *networking.PacketCapture
+		var pcap *testnetworking.PacketCapture
 		pcapBuf := &bytes.Buffer{}
 		hostDevice := cn.HostDevice()
 		if enablePcap && !tc.loopbackOnly {
-			p, err := networking.StartPacketCapture(hostDevice, pcapBuf)
+			p, err := testnetworking.StartPacketCapture(hostDevice, pcapBuf)
 			require.NoError(t, err)
 			pcap = p
 		}

--- a/server/util/networking/networking_test.go
+++ b/server/util/networking/networking_test.go
@@ -1,18 +1,24 @@
 package networking_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testnetworking"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testshell"
 	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
@@ -225,6 +231,283 @@ func TestContainerNetworkPool(t *testing.T) {
 	netnsExec(t, cn.NamespacePath(), `ping -c 1 -W 3 8.8.8.8`)
 }
 
+func TestNetworkStats(t *testing.T) {
+	// Set this to true to enable packet capture for debugging. If an assertion
+	// fails about metrics for a given interface, a packet capture from that
+	// interface will be written as test output, which can be viewed with
+	// wireshark to diagnose the unexpected behavior.
+	//
+	// NOTE: Set back to false before merging, since this adds overhead.
+	const enablePcap = false
+
+	// Max number of test cases that can be run concurrently (this test runs
+	// each test case in serial, then runs all test cases concurrently).
+	const maxConcurrency = 8
+
+	testnetworking.Setup(t)
+	// Start a tx/rx test server listening on the default interface since we
+	// need an IP to be able to reach it from within the netns.
+	server := httptest.NewUnstartedServer(http.HandlerFunc(trafficTestHandler))
+	server.Listener = defaultInterfaceListener(t)
+	server.Start()
+	defer server.Close()
+	// Allow traffic on the default interface.
+	flags.Set(t, "executor.task_allowed_private_ips", []string{"default"})
+	// Enable stats.
+	flags.Set(t, "executor.network_stats_enabled", true)
+
+	overrideSysctlsForTest(t, map[string]string{
+		// Set large network buffer sizes to help reduce TCP re-transmissions,
+		// which throw off stats.
+		"net.core.rmem_max": "134217728",
+		"net.core.wmem_max": "134217728",
+		"net.ipv4.tcp_rmem": "4096 16384 67108864",
+		"net.ipv4.tcp_wmem": "4096 16384 67108864",
+	})
+
+	type testCase struct {
+		name         string
+		tx           int64
+		rx           int64
+		pool         bool
+		loopbackOnly bool
+	}
+	testCases := []testCase{
+		{
+			name: "no traffic",
+			tx:   0,
+			rx:   0,
+		},
+		{
+			name: "no traffic with pooling",
+			tx:   0,
+			rx:   0,
+			pool: true,
+		},
+		{
+			name: "tx traffic",
+			tx:   100_000,
+			rx:   0,
+		},
+		{
+			name: "tx traffic with pooling",
+			tx:   0,
+			rx:   0,
+			pool: true,
+		},
+		{
+			name: "rx traffic",
+			tx:   0,
+			rx:   100_000,
+		},
+		{
+			name: "rx traffic pooled",
+			tx:   0,
+			rx:   100_000,
+		},
+		{
+			name: "tx and rx traffic",
+			tx:   50_000,
+			rx:   100_000,
+		},
+		{
+			name: "tx and rx traffic with pooling",
+			tx:   50_000,
+			rx:   100_000,
+			pool: true,
+		},
+		{
+			name:         "loopback only",
+			tx:           0,
+			rx:           0,
+			loopbackOnly: true,
+		},
+	}
+
+	getPool := func(ctx context.Context, t *testing.T) *networking.ContainerNetworkPool {
+		pool := networking.NewContainerNetworkPool(maxConcurrency /*=poolSize*/)
+		t.Cleanup(func() {
+			err := pool.Shutdown(ctx)
+			require.NoError(t, err)
+		})
+		return pool
+	}
+
+	runTestCase := func(ctx context.Context, t *testing.T, pool *networking.ContainerNetworkPool, tc testCase, attemptNumber int) {
+		// We don't pool loopback-only networks in practice - sanity check that
+		// we're not inadvertently testing this.
+		require.False(t, tc.loopbackOnly && tc.pool, "loopback-only networks should not be pooled")
+
+		var cn *networking.ContainerNetwork
+		if tc.pool {
+			cn = pool.Get(ctx)
+		}
+		if cn == nil {
+			n, err := networking.CreateContainerNetwork(ctx, tc.loopbackOnly)
+			require.NoError(t, err)
+			cn = n
+		}
+
+		// Read stats initially; should be 0, even if we just took from
+		// the pool.
+		{
+			stats, err := cn.Stats(ctx)
+			require.NoError(t, err)
+			require.Equal(t, int64(0), stats.GetBytesReceived(), "%s (attempt %d): should have received 0 bytes initially", tc.name, attemptNumber)
+			require.Equal(t, int64(0), stats.GetBytesSent(), "%s (attempt %d): should have sent 0 bytes initially", tc.name, attemptNumber)
+			require.Equal(t, int64(0), stats.GetPacketsReceived(), "%s (attempt %d): should have received 0 packets initially", tc.name, attemptNumber)
+			require.Equal(t, int64(0), stats.GetPacketsSent(), "%s (attempt %d): should have sent 0 packets initially", tc.name, attemptNumber)
+		}
+
+		var pcap *networking.PacketCapture
+		pcapBuf := &bytes.Buffer{}
+		hostDevice := cn.HostDevice()
+		if enablePcap && !tc.loopbackOnly {
+			p, err := networking.StartPacketCapture(hostDevice, pcapBuf)
+			require.NoError(t, err)
+			pcap = p
+		}
+
+		// If external networking is enabled, make a request to the test
+		// server from within the namespace, sending and/or receiving
+		// the expected amount of traffic.
+		if !tc.loopbackOnly && (tc.tx > 0 || tc.rx > 0) {
+			netnsExec(t, cn.NamespacePath(), `
+				yes | head -c `+fmt.Sprint(tc.tx)+` |
+					curl --data-binary @- `+server.URL+`?rx=`+fmt.Sprint(tc.rx)+`
+			`)
+		}
+
+		// Get stats and verify that they match the expected values
+		// within a reasonable tolerance.
+		stats, err := cn.Stats(ctx)
+		require.NoError(t, err)
+		ok := true
+		ok = ok && assert.GreaterOrEqual(t, stats.GetBytesReceived(), tc.rx, "%s (attempt %d): should have received at least %d bytes", tc.name, attemptNumber, tc.rx)
+		ok = ok && assert.GreaterOrEqual(t, stats.GetBytesSent(), tc.tx, "%s (attempt %d): should have sent at least %d bytes", tc.name, attemptNumber, tc.tx)
+		// Note: these tolerances are somewhat large to account for protocol
+		// overhead (HTTP headers, TCP/IP headers, TCP acks, etc.) as well as
+		// TCP re-transmissions which can happen if the machine is under heavy
+		// load. If these assertions fail, consider setting enablePcap to true
+		// to confirm whether it's a real issue, or just due to something like
+		// TCP re-transmissions.
+		ok = ok && assert.InDelta(t, tc.rx, stats.GetBytesReceived(), 16*1024, "%s (attempt %d): bytes received should be within 4KB of expected", tc.name, attemptNumber)
+		ok = ok && assert.InDelta(t, tc.tx, stats.GetBytesSent(), 16*1024, "%s (attempt %d): bytes sent should be within 4KB of expected", tc.name, attemptNumber)
+		if tc.tx > 0 {
+			// Transmitted some bytes; should have sent several packets.
+			ok = ok && assert.GreaterOrEqual(t, stats.GetPacketsSent(), int64(10), "%s (attempt %d): packets sent should be at least 1", tc.name, attemptNumber)
+		} else if tc.rx > 0 {
+			// Received some bytes; should have sent several ACK packets.
+			ok = ok && assert.GreaterOrEqual(t, stats.GetPacketsSent(), int64(10), "%s (attempt %d): packets sent should be at least 1", tc.name, attemptNumber)
+		} else {
+			// No traffic; should have very few packets sent (might have some
+			// ARP packets etc.)
+			ok = ok && assert.LessOrEqual(t, stats.GetPacketsSent(), int64(10), "%s (attempt %d): packets sent should be smaller than 10", tc.name, attemptNumber)
+		}
+		if tc.rx > 0 {
+			// Received some bytes; should have received several packets.
+			ok = ok && assert.GreaterOrEqual(t, stats.GetPacketsReceived(), int64(10), "%s (attempt %d): packets received should be at least 1", tc.name, attemptNumber)
+		} else if tc.tx > 0 {
+			// Sent some bytes; should have received several ACK packets.
+			ok = ok && assert.GreaterOrEqual(t, stats.GetPacketsReceived(), int64(10), "%s (attempt %d): packets received should be at least 1", tc.name, attemptNumber)
+		} else {
+			// No traffic; should have very few packets received (might have
+			// some ARP packets etc.)
+			ok = ok && assert.LessOrEqual(t, stats.GetPacketsReceived(), int64(10), "%s (attempt %d): packets received should be smaller than 10", tc.name, attemptNumber)
+		}
+
+		if pcap != nil {
+			err = pcap.Stop()
+			require.NoError(t, err)
+			err = pcap.Wait()
+			require.NoError(t, err)
+		}
+		// Write packet capture for the interface (for debugging purposes) if
+		// the reported stats don't match the expected values.
+		if pcap != nil && !ok {
+			pcapPath := os.Getenv("TEST_UNDECLARED_OUTPUTS_DIR") + "/" + fmt.Sprintf("%s-%d-%s.pcap", strings.ReplaceAll(tc.name, " ", "_"), attemptNumber, hostDevice)
+			err := os.WriteFile(pcapPath, pcapBuf.Bytes(), 0644)
+			require.NoError(t, err)
+			t.Logf("Wrote pcap to %s", pcapPath)
+		}
+
+		// Release the network.
+		if !tc.loopbackOnly {
+			if ok := pool.Add(ctx, cn); !ok {
+				err := cn.Cleanup(ctx)
+				require.NoError(t, err)
+			}
+		} else {
+			err := cn.Cleanup(ctx)
+			require.NoError(t, err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			pool := getPool(ctx, t)
+			// Run each test case multiple times. If pooling is enabled, then
+			// this is testing that we're only reporting incremental metrics
+			// rather than cumulative. If pooling is disabled, this is just
+			// exercising the code a bit more.
+			for attemptNumber := 1; attemptNumber <= 3; attemptNumber++ {
+				runTestCase(ctx, t, pool, tc, attemptNumber)
+			}
+		})
+	}
+
+	// Run all tests again, this time running all test cases concurrently. This
+	// is testing that traffic from one test case doesn't pollute the results
+	// for other test cases, which could conceivably happen if our packet
+	// routing isn't set up correctly.
+	t.Run("all test cases concurrently", func(t *testing.T) {
+		ctx := context.Background()
+		pool := getPool(ctx, t)
+		var eg errgroup.Group
+		eg.SetLimit(maxConcurrency)
+		for attemptNumber := 1; attemptNumber < 10; attemptNumber++ {
+			rand.Shuffle(len(testCases), func(i, j int) {
+				testCases[i], testCases[j] = testCases[j], testCases[i]
+			})
+			for _, tc := range testCases {
+				eg.Go(func() error {
+					runTestCase(ctx, t, pool, tc, attemptNumber)
+					return nil
+				})
+			}
+		}
+		err := eg.Wait()
+		require.NoError(t, err)
+	})
+}
+
+func overrideSysctlsForTest(t *testing.T, values map[string]string) {
+	oldValues := map[string]string{}
+	for k, v := range values {
+		out := testshell.Run(t, "" /*=workDir*/, fmt.Sprintf("sysctl -n %s", k))
+		oldValues[k] = strings.TrimSpace(out)
+		testshell.Run(t, "" /*=workDir*/, fmt.Sprintf("sysctl -w %s=%q", k, v))
+	}
+	t.Cleanup(func() {
+		for k, v := range oldValues {
+			testshell.Run(t, "" /*=workDir*/, fmt.Sprintf("sysctl -w %s=%q", k, v))
+		}
+	})
+}
+
+func defaultInterfaceIP(t *testing.T) net.IP {
+	ip, err := networking.DefaultIP(context.Background())
+	require.NoError(t, err)
+	return ip
+}
+
+func defaultInterfaceListener(t *testing.T) net.Listener {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", defaultInterfaceIP(t)))
+	require.NoError(t, err)
+	return listener
+}
+
 func BenchmarkCreateContainerNetwork_Unpooled(b *testing.B) {
 	ctx := context.Background()
 	var eg errgroup.Group
@@ -287,4 +570,36 @@ func netnsExec(t *testing.T, nsPath, script string) string {
 	b, err := exec.Command("ip", "netns", "exec", filepath.Base(nsPath), "sh", "-eu", "-c", script).CombinedOutput()
 	require.NoError(t, err, "%s", string(b))
 	return string(b)
+}
+
+// Handler that allows testing tx/rx traffic. Spin it up using httptest from
+// stdlib. To test the send direction, make a request with a body payload of the
+// desired size, and the handler will fully consume the request body. To test
+// the receive direction, send a request with the "rx" query parameter set to
+// the desired size, and the handler will respond with arbitrary response data
+// of the same size.
+func trafficTestHandler(w http.ResponseWriter, r *http.Request) {
+	buf := bytes.Repeat([]byte{'x'}, 1024)
+	// Fully consume the request body.
+	io.Copy(io.Discard, r.Body)
+
+	// If the request has a "rx" query parameter, respond with the specified
+	// number of bytes.
+	b := r.URL.Query().Get("rx")
+	if b == "" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	n, err := strconv.Atoi(b)
+	if err != nil {
+		http.Error(w, "Invalid response_bytes", http.StatusBadRequest)
+		return
+	}
+	w.Header().Add("Content-Length", strconv.Itoa(n))
+	w.WriteHeader(http.StatusOK)
+	for i := 0; i < n; i += len(buf) {
+		if _, err := w.Write(buf[:min(len(buf), n-i)]); err != nil {
+			return
+		}
+	}
 }


### PR DESCRIPTION
Depends on https://github.com/buildbuddy-io/buildbuddy/pull/9500

Captures `{tx,rx}_{bytes,packets}` and populates the UsageStats proto with this information (behind a flag).

Stats are collected from the host side of the veth pair to avoid having to enter a netns to collect stats from the namespaced side, which has too much overhead (especially since we probably want to poll these and show a chart, similar to disk usage). This means that we have to swap the tx/rx traffic for it to reflect the container's perspective, which is a bit of a hack, but IMO an OK tradeoff for now.