### PR TITLE
Close DistributedCache.Write stream in a cleanup function

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -752,6 +752,7 @@ func (c *Proxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *r
 	// possible memory leak. If it does, figure out which caller isn't closing
 	// the stream.
 	runtime.AddCleanup(wc, func(stream dcpb.DistributedCache_WriteClient) {
+		// This is safe to do multiple times.
 		stream.CloseAndRecv()
 	}, stream)
 	return c.newBufferedStreamWriteCloser(wc), nil

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -747,6 +748,12 @@ func (c *Proxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *r
 		stream:      stream,
 		r:           r,
 	}
+	// TODO(vanja) figure out if this fixes the in-flight RPCs metric and the
+	// possible memory leak. If it does, figure out which caller isn't closing
+	// the stream.
+	runtime.AddCleanup(wc, func(stream dcpb.DistributedCache_WriteClient) {
+		stream.CloseAndRecv()
+	}, stream)
 	return c.newBufferedStreamWriteCloser(wc), nil
 }
 


### PR DESCRIPTION
This should be temporary, but I think it will fix the in-flight client RPC metric growing continuously.

It might also fix our memory leak.

If either is fixed, we should figure out which caller isn't closing the stream.