### PR TITLE
[compression] NewZstdCompressor

### DIFF
--- a/server/util/compression/compression_test.go
+++ b/server/util/compression/compression_test.go
@@ -112,18 +112,6 @@ func compressWithNewZstdCompressor(t *testing.T, src []byte) []byte {
 	return w.Bytes()
 }
 
-type testCommittedWriteCloser struct {
-	io.Writer
-}
-
-func (w *testCommittedWriteCloser) Commit() error {
-	return nil
-}
-
-func (w *testCommittedWriteCloser) Close() error {
-	return nil
-}
-
 func decompressWithDecompressZstd(t *testing.T, srclen int, compressed []byte) []byte {
 	decompressed := make([]byte, srclen)
 	decompressed, err := compression.DecompressZstd(decompressed, compressed)


### PR DESCRIPTION
This change introduce `NewZstdCompressor(...)` (copied and adapted from `pebble_cache.NewZstdCompressor(...)`.

A follow-on change will wrap a `cachetools.UploadWriter` with this compressor when zstd compression is requested.