### PR TITLE
[oci cache] Make WriteBlobToCacheAndResponse use newBlobUploader

### DIFF
--- a/enterprise/server/util/ocicache/BUILD
+++ b/enterprise/server/util/ocicache/BUILD
@@ -34,7 +34,6 @@ go_test(
     deps = [
         ":ocicache",
         "//enterprise/server/clientidentity",
-        "//proto:ociregistry_go_proto",
         "//server/interfaces",
         "//server/testutil/testcache",
         "//server/testutil/testenv",
@@ -43,6 +42,7 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_containerregistry//pkg/crane",
         "@com_github_google_go_containerregistry//pkg/name",
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -194,7 +194,7 @@ func FetchBlobMetadataFromCache(ctx context.Context, bsClient bspb.ByteStreamCli
 	return blobMetadata, nil
 }
 
-func FetchBlobFromCache(ctx context.Context, w io.Writer, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, hash gcr.Hash, contentLength int64) error {
+func FetchBlobFromCache(ctx context.Context, w io.Writer, bsClient bspb.ByteStreamClient, hash gcr.Hash, contentLength int64) error {
 	blobCASDigest := &repb.Digest{
 		Hash:      hash.Hex,
 		SizeBytes: contentLength,
@@ -220,39 +220,85 @@ func FetchBlobFromCache(ctx context.Context, w io.Writer, bsClient bspb.ByteStre
 	return nil
 }
 
-func WriteBlobToCache(ctx context.Context, r io.Reader, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) error {
-	blobCASDigest := &repb.Digest{
-		Hash:      hash.Hex,
-		SizeBytes: contentLength,
+// WriteManifestToCacheAndResponse reads the entire manifest from the upstream remote registry,
+// and writes the contents to both the response and to the AC.
+func WriteManifestToCacheAndResponse(ctx context.Context, upstream io.Reader, response io.Writer, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) error {
+	if contentLength > maxManifestSize {
+		return status.FailedPreconditionErrorf("manifest too large (%d bytes) to write to cache (limit %d bytes)", contentLength, maxManifestSize)
 	}
-	blobRN := digest.NewCASResourceName(
-		blobCASDigest,
-		"",
-		cacheDigestFunction,
-	)
-	blobRN.SetCompressor(repb.Compressor_ZSTD)
-	updateCacheEventMetric(casLabel, uploadLabel)
-	_, _, err := cachetools.UploadFromReader(ctx, bsClient, blobRN, r)
+	buf := bytes.NewBuffer(make([]byte, 0, contentLength))
+	mw := io.MultiWriter(response, buf)
+	written, err := io.Copy(mw, io.LimitReader(upstream, contentLength))
 	if err != nil {
+		return err
+	}
+	if written != contentLength {
+		return status.DataLossErrorf("expected manifest of length %d, only able to write %d bytes", contentLength, written)
+	}
+	return WriteManifestToAC(ctx, buf.Bytes(), acClient, repo, hash, contentType)
+}
+
+// WriteBlobToCacheAndResponse reads an OCI blob (an OCI image layer) from the upstream remote registry
+// and writes those bytes to the response. It also makes a best-effort attempt to write the blob to the CAS.
+// Failure to write the blob to the CAS should not impact writing the blob to the response.
+func WriteBlobToCacheAndResponse(ctx context.Context, upstream io.Reader, response io.Writer, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) error {
+	uploader, err := NewBlobUploader(ctx, bsClient, acClient, repo, hash, contentType, contentLength)
+	if err != nil {
+		return err
+	}
+	defer uploader.Close()
+	dst := &writeThroughCacher{
+		primary: response,
+		cacher:  uploader,
+	}
+	if _, err := io.Copy(dst, upstream); err != nil {
+		return err
+	}
+	return uploader.Commit()
+}
+
+type blobUploader struct {
+	repo          gcrname.Repository
+	hash          gcr.Hash
+	contentType   string
+	contentLength int64
+
+	writer *cachetools.UploadWriter
+
+	ctx      context.Context
+	bsClient bspb.ByteStreamClient
+	acClient repb.ActionCacheClient
+}
+
+func (up *blobUploader) Write(p []byte) (int, error) {
+	return up.writer.Write(p)
+}
+
+func (up *blobUploader) Commit() error {
+	if err := up.writer.Commit(); err != nil {
 		return err
 	}
 
 	blobMetadata := &ocipb.OCIBlobMetadata{
-		ContentLength: contentLength,
-		ContentType:   contentType,
+		ContentLength: up.contentLength,
+		ContentType:   up.contentType,
 	}
 	updateCacheEventMetric(casLabel, uploadLabel)
-	blobMetadataCASDigest, err := cachetools.UploadProto(ctx, bsClient, "", cacheDigestFunction, blobMetadata)
+	blobMetadataCASDigest, err := cachetools.UploadProto(up.ctx, up.bsClient, "", cacheDigestFunction, blobMetadata)
 	if err != nil {
 		return err
 	}
 
 	arKey := &ocipb.OCIActionResultKey{
-		Registry:      repo.RegistryStr(),
-		Repository:    repo.RepositoryStr(),
+		Registry:      up.repo.RegistryStr(),
+		Repository:    up.repo.RepositoryStr(),
 		ResourceType:  ocipb.OCIResourceType_BLOB,
-		HashAlgorithm: hash.Algorithm,
-		HashHex:       hash.Hex,
+		HashAlgorithm: up.hash.Algorithm,
+		HashHex:       up.hash.Hex,
+	}
+	blobCASDigest := &repb.Digest{
+		Hash:      up.hash.Hex,
+		SizeBytes: up.contentLength,
 	}
 	ar := &repb.ActionResult{
 		OutputFiles: []*repb.OutputFile{
@@ -280,29 +326,52 @@ func WriteBlobToCache(ctx context.Context, r io.Reader, bsClient bspb.ByteStream
 		cacheDigestFunction,
 	)
 	updateCacheEventMetric(actionCacheLabel, uploadLabel)
-	err = cachetools.UploadActionResult(ctx, acClient, arRN, ar)
-	if err != nil {
-		return err
-	}
-	return nil
+	return cachetools.UploadActionResult(up.ctx, up.acClient, arRN, ar)
 }
 
-func WriteBlobOrManifestToCacheAndWriter(ctx context.Context, upstream io.Reader, w io.Writer, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, ociResourceType ocipb.OCIResourceType, hash gcr.Hash, contentType string, contentLength int64) error {
-	if ociResourceType == ocipb.OCIResourceType_MANIFEST {
-		if contentLength > maxManifestSize {
-			return status.FailedPreconditionErrorf("manifest too large (%d bytes) to write to cache (limit %d bytes)", contentLength, maxManifestSize)
-		}
-		buf := bytes.NewBuffer(make([]byte, 0, contentLength))
-		mw := io.MultiWriter(w, buf)
-		written, err := io.Copy(mw, io.LimitReader(upstream, contentLength))
-		if err != nil {
-			return err
-		}
-		if written != contentLength {
-			return status.DataLossErrorf("expected manifest of length %d, only able to write %d bytes", contentLength, written)
-		}
-		return WriteManifestToAC(ctx, buf.Bytes(), acClient, repo, hash, contentType)
+func (up *blobUploader) Close() error {
+	return up.writer.Close()
+}
+
+func NewBlobUploader(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) (interfaces.CommittedWriteCloser, error) {
+	blobCASDigest := &repb.Digest{
+		Hash:      hash.Hex,
+		SizeBytes: contentLength,
 	}
-	tr := io.TeeReader(upstream, w)
-	return WriteBlobToCache(ctx, tr, bsClient, acClient, repo, hash, contentType, contentLength)
+	blobRN := digest.NewCASResourceName(
+		blobCASDigest,
+		"",
+		cacheDigestFunction,
+	)
+	blobRN.SetCompressor(repb.Compressor_ZSTD)
+	updateCacheEventMetric(casLabel, uploadLabel)
+	uw, err := cachetools.NewUploadWriter(ctx, bsClient, blobRN)
+	if err != nil {
+		return nil, err
+	}
+	return &blobUploader{
+		repo:          repo,
+		hash:          hash,
+		contentType:   contentType,
+		contentLength: contentLength,
+
+		writer: uw,
+
+		ctx:      ctx,
+		bsClient: bsClient,
+		acClient: acClient,
+	}, nil
+}
+
+type writeThroughCacher struct {
+	primary io.Writer
+	cacher  io.Writer
+}
+
+func (w *writeThroughCacher) Write(p []byte) (int, error) {
+	n, err := w.primary.Write(p)
+	if n > 0 {
+		w.cacher.Write(p[:n]) // Writing to the cache is best-effort, so ignore any errors.
+	}
+	return n, err
 }

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -242,7 +242,7 @@ func WriteManifestToCacheAndResponse(ctx context.Context, upstream io.Reader, re
 // and writes those bytes to the response. It also makes a best-effort attempt to write the blob to the CAS.
 // Failure to write the blob to the CAS should not impact writing the blob to the response.
 func WriteBlobToCacheAndResponse(ctx context.Context, upstream io.Reader, response io.Writer, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) error {
-	uploader, err := NewBlobUploader(ctx, bsClient, acClient, repo, hash, contentType, contentLength)
+	uploader, err := newBlobUploader(ctx, bsClient, acClient, repo, hash, contentType, contentLength)
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func (up *blobUploader) Close() error {
 	return up.writer.Close()
 }
 
-func NewBlobUploader(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) (interfaces.CommittedWriteCloser, error) {
+func newBlobUploader(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) (interfaces.CommittedWriteCloser, error) {
 	blobCASDigest := &repb.Digest{
 		Hash:      hash.Hex,
 		SizeBytes: contentLength,

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -125,6 +125,7 @@ func TestWriteBlobToCacheAndResponse(t *testing.T) {
 		contentLength,
 	)
 	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(layerBuf, out.Bytes()))
 
 	fetchAndCheckBlob(t, te, layerBuf, layerRef, hash, contentType)
 }

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -3,11 +3,11 @@ package ocicache_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocicache"
-	ocipb "github.com/buildbuddy-io/buildbuddy/proto/ociregistry"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
@@ -17,6 +17,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/stretchr/testify/require"
+
+	gcr "github.com/google/go-containerregistry/pkg/v1"
 )
 
 func TestCacheSecret(t *testing.T) {
@@ -100,51 +102,73 @@ func setupTestEnv(t *testing.T) *testenv.TestEnv {
 	return te
 }
 
-// TestManifestWrittenOnlyToAC sets the byte stream server and client to nil,
-// writes a manifest to the AC, and fetches it. If that path were to touch the CAS
-// at all, there would be an error trying to write to a nil client or server.
-func TestManifestWrittenOnlyToAC(t *testing.T) {
+func TestUploadAndFetchBlob(t *testing.T) {
 	te := setupTestEnv(t)
 
-	imageName := "test_manifest_written_only_to_ac"
+	layerBuf, layerRef, hash, contentType := createLayer(t)
+	contentLength := int64(len(layerBuf))
+
+	ctx := context.Background()
+	bsClient := te.GetByteStreamClient()
+	acClient := te.GetActionCacheClient()
+
+	uploader, err := ocicache.NewBlobUploader(ctx, bsClient, acClient, layerRef.Context(), hash, contentType, contentLength)
+	require.NoError(t, err)
+
+	written, err := io.Copy(uploader, bytes.NewReader(layerBuf))
+	require.NoError(t, err)
+	require.Equal(t, contentLength, written)
+
+	err = uploader.Commit()
+	require.NoError(t, err)
+
+	err = uploader.Close()
+	require.NoError(t, err)
+
+	fetchAndCheckBlob(t, te, layerBuf, layerRef, hash, contentType)
+}
+
+func createLayer(t *testing.T) ([]byte, name.Reference, gcr.Hash, string) {
+	imageName := "create_layer"
 	image, err := crane.Image(map[string][]byte{
 		"/tmp/" + imageName: []byte(imageName),
 	})
 	require.NoError(t, err)
-	raw, err := image.RawManifest()
+	imageRef, err := name.ParseReference("buildbuddy.io/" + imageName)
 	require.NoError(t, err)
-
-	ctx := context.Background()
-	mediaType, err := image.MediaType()
+	layers, err := image.Layers()
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+	layer := layers[0]
+	hash, err := layer.Digest()
+	require.NoError(t, err)
+	layerRef := imageRef.Context().Digest(hash.String())
+	mediaType, err := layer.MediaType()
 	require.NoError(t, err)
 	contentType := string(mediaType)
-	hash, err := image.Digest()
+	rc, err := layer.Compressed()
+	require.NoError(t, err)
+	defer rc.Close()
+	layerBuf, err := io.ReadAll(rc)
 	require.NoError(t, err)
 
+	return layerBuf, layerRef, hash, contentType
+}
+
+func fetchAndCheckBlob(t *testing.T, te *testenv.TestEnv, layerBuf []byte, layerRef name.Reference, hash gcr.Hash, contentType string) {
+	contentLength := int64(len(layerBuf))
+	ctx := context.Background()
+	bsClient := te.GetByteStreamClient()
 	acClient := te.GetActionCacheClient()
-	ref, err := name.ParseReference("buildbuddy.io/" + imageName)
+	blobMetadata, err := ocicache.FetchBlobMetadataFromCache(ctx, bsClient, acClient, layerRef.Context(), hash)
+	require.NoError(t, err)
+	require.NotNil(t, blobMetadata)
+	require.Equal(t, contentLength, blobMetadata.ContentLength)
+	require.Equal(t, contentType, blobMetadata.ContentType)
+
+	out := &bytes.Buffer{}
+	err = ocicache.FetchBlobFromCache(ctx, out, bsClient, hash, contentLength)
 	require.NoError(t, err)
 
-	var out bytes.Buffer
-	err = ocicache.WriteBlobOrManifestToCacheAndWriter(ctx,
-		bytes.NewReader(raw),
-		&out,
-		nil, // explicitly pass nil bytestream client
-		acClient,
-		ref.Context(),
-		ocipb.OCIResourceType_MANIFEST,
-		hash,
-		contentType,
-		int64(len(raw)),
-	)
-	require.NoError(t, err)
-	require.Equal(t, len(raw), out.Len())
-	require.Empty(t, cmp.Diff(raw, out.Bytes()))
-
-	mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref.Context(), hash)
-	require.NoError(t, err)
-	require.NotNil(t, mc)
-
-	require.Equal(t, contentType, mc.ContentType)
-	require.Empty(t, cmp.Diff(raw, mc.Raw))
+	require.Empty(t, cmp.Diff(layerBuf, out.Bytes()))
 }


### PR DESCRIPTION
This change re-lands #9438 (which was reverted in response to  a customer incident last week).

This change eliminates the use of `io.TeeReader` for uploading to the CAS and writing to the response. A short read during CAS upload (whether due to an error or the blob already existing) would short-circuit writing to the response.

This change also tests out `cachetools.NewUploadWriter` in just the OCI registry mirror (where failure causes the client to fallback to the upstream remote registry) instead of more widely-used paths.