### PR TITLE
Fix codesearch DropNamespace and add test

### DIFF
--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -334,7 +334,7 @@ func (w *Writer) DeleteMatchingDocuments(matchField types.Field) error {
 
 // DropNamespace deletes everything in a namespace.
 func (w *Writer) DropNamespace() error {
-	w.batch.RangeKeyDelete(fmt.Appendf(nil, "%s:", w.namespace), fmt.Appendf(nil, "%s:\xff", w.namespace), nil)
+	w.batch.DeleteRange(fmt.Appendf(nil, "%s:", w.namespace), fmt.Appendf(nil, "%s:\xff", w.namespace), nil)
 	return nil
 }
 


### PR DESCRIPTION
This was supposed to have gone in with the initial PR for these tools, but it seems I forgot to push the fix