### PR TITLE
Fix invocation execution cancellation when mysql is disabled

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -1484,9 +1485,9 @@ func setExecutionDuration(counts *tables.UsageCounts, duration time.Duration, po
 }
 
 func (s *ExecutionServer) Cancel(ctx context.Context, invocationID string) error {
-	ids, err := s.executionIDs(ctx, invocationID)
+	ids, err := s.getInProgressExecutionIDsForInvocation(ctx, invocationID)
 	if err != nil {
-		return status.InternalErrorf("failed to lookup execution IDs for invocation %q: %s", invocationID, err)
+		return status.InternalErrorf("get in-progress execution IDs for invocation %q: %s", invocationID, err)
 	}
 	numCancelled := 0
 	for _, id := range ids {
@@ -1550,13 +1551,32 @@ func (s *ExecutionServer) markInvocationAsDisconnected(ctx context.Context, invo
 	return inv, nil
 }
 
-func (s *ExecutionServer) executionIDs(ctx context.Context, invocationID string) ([]string, error) {
+func (s *ExecutionServer) getInProgressExecutionIDsForInvocation(ctx context.Context, invocationID string) ([]string, error) {
+	var ids []string
+
+	if *writeExecutionProgressStateToRedis {
+		executions, err := s.env.GetExecutionCollector().GetInProgressExecutions(ctx, invocationID)
+		if err != nil {
+			log.CtxWarningf(ctx, "Failed to get in-progress executions for invocation %q: %s", invocationID, err)
+		} else {
+			for _, e := range executions {
+				ids = append(ids, e.GetExecutionId())
+			}
+		}
+	}
+
+	if !*writeExecutionsToPrimaryDB {
+		if *writeExecutionProgressStateToRedis {
+			return ids, nil
+		}
+		return nil, status.UnimplementedErrorf("could not get in-progress execution IDs for invocation: in-progressexecution storage is not configured")
+	}
+
 	dbh := s.env.GetDBHandle()
 	rq := dbh.NewQuery(ctx, "execution_server_get_executions_for_invocation").Raw(
 		`SELECT execution_id FROM "Executions" WHERE invocation_id = ? AND stage != ?`,
 		invocationID,
 		repb.ExecutionStage_COMPLETED)
-	ids := make([]string, 0)
 	err := db.ScanEach(rq, func(ctx context.Context, e *tables.Execution) error {
 		ids = append(ids, e.ExecutionID)
 		return nil
@@ -1564,5 +1584,7 @@ func (s *ExecutionServer) executionIDs(ctx context.Context, invocationID string)
 	if err != nil {
 		return nil, err
 	}
+	slices.Sort(ids)
+	ids = slices.Compact(ids)
 	return ids, nil
 }

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1700,7 +1700,39 @@ func TestRedisRestart(t *testing.T) {
 	)
 }
 
+type cancelInvocationTestCase struct {
+	name  string
+	flags map[string]any
+}
+
 func TestInvocationCancellation(t *testing.T) {
+	for _, tc := range []cancelInvocationTestCase{
+		{
+			name: "executions stored in redis",
+			flags: map[string]any{
+				"remote_execution.write_execution_progress_state_to_redis": true,
+				"remote_execution.write_executions_to_primary_db":          false,
+			},
+		},
+		{
+			name: "executions stored in DB",
+			flags: map[string]any{
+				"remote_execution.write_execution_progress_state_to_redis": false,
+				"remote_execution.write_executions_to_primary_db":          true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testInvocationCancellation(t, tc)
+		})
+	}
+}
+
+func testInvocationCancellation(t *testing.T, tc cancelInvocationTestCase) {
+	for k, v := range tc.flags {
+		flags.Set(t, k, v)
+	}
+
 	rbe := rbetest.NewRBETestEnv(t)
 
 	bbServer := rbe.AddBuildBuddyServer()


### PR DESCRIPTION
Realized that the cancellation codepath was still reading the in-progress execution IDs from mysql.