### PR TITLE
tweak deflake settings

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -93,7 +93,6 @@ common:quarantine --test_env=RUN_QUARANTINED_TESTS=true
 # Configuration used to deflake tests
 common:deflake --config=remote-minimal
 common:deflake --runs_per_test=100
-common:deflake --test_output=errors
 common:deflake --test_runner_fail_fast
 common:deflake --notest_keep_going
 common:deflake --config=quarantine


### PR DESCRIPTION
I found test_output=errors a bit inconvenient when working with tests with a lot
of logs like raft tests. To investigate these errors, I ususally open the test
log files with an editor. But the file is shown before all the log lines. And
sometimes, when there are a lot of logs, I cannot get to the file. 
