### PR TITLE
cli/fix: avoid using langs.go twice

### DIFF
--- a/cli/fix/BUILD
+++ b/cli/fix/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//cli/add",
         "//cli/arg",
         "//cli/bazelisk",
-        "//cli/fix/langs",
         "//cli/fix/langs:gazelle",
         "//cli/fix/language",
         "//cli/log",

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -15,8 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 
-	langs "github.com/buildbuddy-io/buildbuddy/cli/fix/langs"
-
 	gazelle "github.com/bazelbuild/bazel-gazelle/cmd/gazelle"
 	buildifier "github.com/bazelbuild/buildtools/buildifier"
 )
@@ -177,7 +175,7 @@ func walk(moduleOrWorkspaceFile string) error {
 // Collect the languages that support auto-generating WORKSPACE files.
 func getLanguages() []language.Language {
 	var languages []language.Language
-	for _, l := range langs.Languages {
+	for _, l := range gazelle.Languages {
 		if l, ok := l.(language.Language); ok {
 			languages = append(languages, l)
 		}

--- a/cli/fix/langs/BUILD
+++ b/cli/fix/langs/BUILD
@@ -1,5 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//cli:__subpackages__"])
+
+# gazelle:ignore
+
 go_library(
     name = "gazelle",
     # keep
@@ -38,19 +42,3 @@ go_library(
         "@com_github_pmezard_go_difflib//difflib",
     ],
 )
-
-go_library(
-    name = "langs",
-    srcs = ["langs.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/cli/fix/langs",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//cli/fix/golang",
-        "//cli/fix/typescript",
-        "@bazel_gazelle//language",
-        "@bazel_gazelle//language/bazel/visibility",
-        "@bazel_gazelle//language/proto",
-    ],
-)
-
-package(default_visibility = ["//cli:__subpackages__"])


### PR DESCRIPTION
Replace #9472.

We observed that cli/test/integration/compact:compact_test failed
consistently in our 'bazel coverage' scheduled pipeline. There are a few
layers to this onion which we need to peel:

First, the error was that our testcli.CombinedOutput was printing an
extra line at the beginning of the stdout:

```
Diff:
--- Expected
+++ Actual
@@ -1 +1,2 @@
+Already covered cli/fix/langs/langs.go
{
```

This line came from @rules_go//go/tools/coverdata/coverdata.go
through the RegisterFile func. This suggests that our testcli was built
under coverage-enabled mode, which is definitely unintended (!).

However, that's not the problem we are fixing here. We are fixing the
fact that `cli/fix/langs/langs.go` is being used twice in our build: one
for the //cli/fix/langs:langs package and one for the
//cli/fix/langs:gazelle package. Achieve this by fully replacing :langs
with :gazelle and switch the BUILD file of cli/fix/langs to manually
managed.
