### PR TITLE
xfsprogs_image: Add gcc for bazel coverage in test image

### DIFF
--- a/dockerfiles/test_images/xfsprogs_image/Dockerfile
+++ b/dockerfiles/test_images/xfsprogs_image/Dockerfile
@@ -1,4 +1,5 @@
-FROM mirror.gcr.io/alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
+FROM mirror.gcr.io/alpine
 
-RUN apk add bash xfsprogs
+# We need gcc for gcov, which is needed during 'bazel coverage'
+RUN apk add gcc bash mount xfsprogs xfsprogs-extra
 

--- a/server/util/fastcopy/BUILD
+++ b/server/util/fastcopy/BUILD
@@ -31,7 +31,7 @@ go_test(
         "test.workload-isolation-type": "firecracker",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "fastcopy_test",
-        "test.container-image": "docker://gcr.io/flame-public/test-xfsprogs@sha256:d751cc048dfe2b343d8c78eec537933c23fe41be8e70b506434c8044db537ef5",
+        "test.container-image": "docker://ghcr.io/sluongng/xfs:latest",
         "test.EstimatedFreeDiskBytes": "800MB",
     },
     pure = "on",


### PR DESCRIPTION
Fastcopy_test consistently failed in our scheduled 'bazel coverage'
workflow.

Inspecting the failure, we found:

```
GCov does not exist at the given path: ''
/workspace/bazel-out/platform_linux_x86_64-opt-exec/bin/external/remote_coverage_tools/Main: line 409: /workspace/bazel-out/platform_linux_x86_64-opt-exec/bin/external/remote_coverage_tools/Main.runfiles/remotejdk11_linux/bin/java: cannot execute: required file not found
```

Fix this by adding gcov to the image through gcc apk.
