### PR TITLE
Remove hover styling for non-clickable cards

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -455,8 +455,7 @@ body {
   background-color: #fff;
 }
 
-.card.card-hovered,
-.card:hover {
+a.card:hover {
   box-shadow: var(--shadow-6);
 }
 
@@ -562,11 +561,11 @@ body {
   display: none;
 }
 
-.card-hovered.card-success {
+.card.card-success:hover {
   border-left: 6px solid #7cb342;
 }
 
-.card-hovered.card-failure {
+.card.card-failure:hover {
   border-left: 6px solid #e53935;
 }
 

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -56,7 +56,6 @@ interface State {
   aggregateStats?: invocation.InvocationStat[];
   loadingAggregateStats?: boolean;
 
-  hoveredInvocationId?: string;
   pageToken?: string;
   invocationIdToCompare?: string;
 
@@ -394,16 +393,6 @@ export default class HistoryComponent extends React.Component<Props, State> {
     router.clearFilters();
   }
 
-  handleMouseOver(invocation: invocation.Invocation) {
-    this.setState({
-      hoveredInvocationId: invocation.invocationId,
-    });
-  }
-
-  handleMouseOut(invocation: invocation.IInvocation) {
-    this.setState({ hoveredInvocationId: undefined });
-  }
-
   handleLoadNextPageClicked() {
     this.getInvocations(true);
   }
@@ -659,9 +648,6 @@ export default class HistoryComponent extends React.Component<Props, State> {
           <div className="container nopadding-dense">
             {this.state.invocations?.map((invocation) => (
               <InvocationCardComponent
-                className={this.state.hoveredInvocationId == invocation.invocationId ? "card-hovered" : ""}
-                onMouseOver={this.handleMouseOver.bind(this, invocation)}
-                onMouseOut={this.handleMouseOut.bind(this, invocation)}
                 invocation={invocation}
                 isSelectedForCompare={invocation.invocationId === this.state.invocationIdToCompare}
                 isSelectedWithKeyboard={invocation.invocationId === this.state.selectedInvocationId}


### PR DESCRIPTION
Also simplify hover state logic a bit (we were previously using JS to track mouse movements to compute a `card-hovered` class, but can just use `:hover` in CSS instead)