### PR TITLE
Add auth to context for index template

### DIFF
--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -423,10 +423,10 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 
 	mux := env.GetMux()
 	// Register all of our HTTP handlers on the default mux.
-	mux.Handle("/", interceptors.WrapExternalHandler(env, staticFileServer))
+	mux.Handle("/", interceptors.WrapAuthenticatedExternalHandler(env, staticFileServer))
 	for _, appRoute := range appRoutes {
 		// this causes the muxer to handle redirects from e. g. /path -> /path/
-		mux.Handle(appRoute, interceptors.WrapExternalHandler(env, staticFileServer))
+		mux.Handle(appRoute, interceptors.WrapAuthenticatedExternalHandler(env, staticFileServer))
 	}
 	mux.Handle("/app/", interceptors.WrapExternalHandler(env, http.StripPrefix("/app", afs)))
 	mux.Handle("/rpc/BuildBuddyService/", interceptors.WrapAuthenticatedExternalProtoletHandler(env, "/rpc/BuildBuddyService/", protoletHandler))

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -222,7 +222,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 	if efp := env.GetExperimentFlagProvider(); efp != nil {
 		config.FlipLogoOnHover = efp.Boolean(ctx, "flip-logo-on-hover", false /*=default*/)
 		if *codeSearchEnabled {
-			config.CodeSearchEnabled = efp.Boolean(ctx, "codesearch-enabled", false /*=default*/)
+			config.CodeSearchEnabled = efp.Boolean(ctx, "codesearch-allowed", false /*=default*/)
 		}
 	}
 

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -128,8 +128,7 @@ func handleRootPaths(env environment.Env, rootPaths []string, template *template
 		}
 
 		if r.URL.Path == "/" {
-			ctx := env.GetAuthenticator().AuthenticatedHTTPContext(w, r)
-			serveIndexTemplate(ctx, env, template, version, jsPath, stylePath, appBundleHash, w)
+			serveIndexTemplate(r.Context(), env, template, version, jsPath, stylePath, appBundleHash, w)
 			return
 		}
 

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -128,7 +128,8 @@ func handleRootPaths(env environment.Env, rootPaths []string, template *template
 		}
 
 		if r.URL.Path == "/" {
-			serveIndexTemplate(r.Context(), env, template, version, jsPath, stylePath, appBundleHash, w)
+			ctx := env.GetAuthenticator().AuthenticatedHTTPContext(w, r)
+			serveIndexTemplate(ctx, env, template, version, jsPath, stylePath, appBundleHash, w)
 			return
 		}
 
@@ -221,7 +222,11 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 
 	if efp := env.GetExperimentFlagProvider(); efp != nil {
 		config.FlipLogoOnHover = efp.Boolean(ctx, "flip-logo-on-hover", false /*=default*/)
+		if *codeSearchEnabled {
+			config.CodeSearchEnabled = efp.Boolean(ctx, "codesearch-enabled", false /*=default*/)
+		}
 	}
+
 	configJSON, err := protojson.Marshal(&config)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
This will allow experiment flags to be resolved correctly. The auth information is included in the request, but wasn't being added to the context, and so wasn't available to the experiment flag evaluator.

This PR also adds processing of the codesearch_enabled experiment, which will control whether the "Enable Code Search" check box is shown on the settings page. I'll add the flag definition separately to buildbuddy-internal.