### PR TITLE
bazelrc: fix wrong config on local-rbe-mac

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -28,6 +28,7 @@ common --config=anon-bes
 # Target+Exec platform configurations.
 #
 # We maintain separate configuration for each repo so that we can migrate them to bzlmod independently.
+common:target-darwin-arm64 --config=workspace-target-darwin-arm64
 common:target-linux-x86 --config=workspace-target-linux-x86
 common:target-linux-arm64 --config=workspace-target-linux-arm64
 

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -172,7 +172,7 @@ common:local-rbe-linux --config=local
 
 # Build with --config=local-rbe-mac to target a local executor on macOS.
 common:local-rbe-mac --remote_executor=grpc://localhost:1985
-common:local-rbe-mac --config=local-rbe
+common:local-rbe-mac --config=target-darwin-arm64
 common:local-rbe-mac --config=local
 
 # Build with --config=dev to send build logs to the dev server
@@ -193,10 +193,14 @@ common:cache --config=cache-shared
 common:cache --remote_cache=grpcs://buildbuddy.buildbuddy.io
 
 # Target+Exec Platforms configuration
+common:workspace-target-darwin-arm64 --platforms=@buildbuddy_toolchain//:platform_darwin_arm64
+common:workspace-target-darwin-arm64 --extra_execution_platforms=@buildbuddy_toolchain//:platform_darwin_arm64
 common:workspace-target-linux-x86 --platforms=@buildbuddy_toolchain//:platform_linux_x86_64
 common:workspace-target-linux-x86 --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_x86_64
 common:workspace-target-linux-arm64 --platforms=@buildbuddy_toolchain//:platform_linux_arm64
 common:workspace-target-linux-arm64 --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux_arm64
+common:bzlmod-target-darwin-arm64 --platforms=@buildbuddy_toolchain//:platform_darwin_arm64
+common:bzlmod-target-darwin-arm64 --extra_execution_platforms=@buildbuddy_toolchain//:platform_darwin_arm64
 common:bzlmod-target-linux-x86 --platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:bzlmod-target-linux-x86 --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64
 common:bzlmod-target-linux-arm64 --platforms=@toolchains_buildbuddy//platforms:linux_arm64


### PR DESCRIPTION
The config local-rbe does not exist.
Replace it with target-darwin-arm64 instead, since it's pretty safe to
assume that nobody on our team will be using an Intel Mac for
development.
