### PR TITLE
Update app and executor images

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -143,7 +143,7 @@ container_pull = use_repo_rule("@io_bazel_rules_docker//container:pull.bzl", "co
 
 container_pull(
     name = "buildbuddy_go_image_base",
-    digest = "sha256:dc7acdb6300eaa99ae93621b0f033237ae1284fdd5ab323b4d90ba8359c55854",
+    digest = "sha256:e20cc14ff3d02fa6f2dfc7820a65c58fd43ec6f7a1a5882f1475d3c786676685",
     registry = "gcr.io",
     repository = "distroless/cc-debian12",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -563,7 +563,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
     name = "buildbuddy_go_image_base",
-    digest = "sha256:dc7acdb6300eaa99ae93621b0f033237ae1284fdd5ab323b4d90ba8359c55854",
+    digest = "sha256:e20cc14ff3d02fa6f2dfc7820a65c58fd43ec6f7a1a5882f1475d3c786676685",
     registry = "gcr.io",
     repository = "distroless/cc-debian12",
 )

--- a/deps.bzl
+++ b/deps.bzl
@@ -6,9 +6,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 # When changing this version, a new release of podman-static may be needed.
 # See dockerfiles/executor_image/README.md for instructions.
 # The checksums below will also need to be updated.
-PODMAN_VERSION = "v5.4.1"
-PODMAN_STATIC_SHA256_AMD64 = "d00a72a6eefd46f48d1dfc35857e9553053635294ce896dd8ac8e4d47bb43be2"
-PODMAN_STATIC_SHA256_ARM64 = "f07f67d96b858293f32a1ad63b44ada74abc03e8f45a006592fe0f657743ffd7"
+PODMAN_VERSION = "v5.5.0"
+PODMAN_STATIC_SHA256_AMD64 = "8ce959cd2b0ea68ae8ac7ccbb181cad59504086d54d4c9521954ee49dae013eb"
+PODMAN_STATIC_SHA256_ARM64 = "ef1e84ab80ee5d78d4d2e59e128ff963038f39e1e4259a83e08d7c8f85faf90d"
 
 # bazelisk run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%install_go_mod_dependencies -prune
 def install_go_mod_dependencies(workspace_name = "buildbuddy"):
@@ -6919,8 +6919,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             # 'filegroup(name = "rootlessctl.bin", srcs = ["rootlessctl"])',
             'filegroup(name = "rootlesskit.bin", srcs = ["rootlesskit"])',
         ]),
-        urls = ["https://github.com/rootless-containers/rootlesskit/releases/download/v2.3.2/rootlesskit-x86_64.tar.gz"],
-        sha256 = "5d402d7995f1e2c369240de3c6f8eb4cc2a3d1f0f4877ac5362044b2e83962e9",
+        urls = ["https://github.com/rootless-containers/rootlesskit/releases/download/v2.3.5/rootlesskit-x86_64.tar.gz"],
+        sha256 = "118208e25becd144ee7317c172fc9decce7b16174d5c1bbf80f1d1d0eacc6b5f",
     )
     http_archive(
         name = "com_github_rootless_containers_rootlesskit-linux-arm64",
@@ -6929,8 +6929,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             # 'filegroup(name = "rootlessctl.bin", srcs = ["rootlessctl"])',
             'filegroup(name = "rootlesskit.bin", srcs = ["rootlesskit"])',
         ]),
-        urls = ["https://github.com/rootless-containers/rootlesskit/releases/download/v2.3.2/rootlesskit-aarch64.tar.gz"],
-        sha256 = "0a4ed18c6794bfe5821cc6548f52b26b3b2296170f05df194c2073545200d968",
+        urls = ["https://github.com/rootless-containers/rootlesskit/releases/download/v2.3.5/rootlesskit-aarch64.tar.gz"],
+        sha256 = "478c14c3195bf989cd9a8e6bd129d227d5d88f1c11418967ffdc84a0072cc7a2",
     )
 
     http_archive(
@@ -6942,8 +6942,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             'filegroup(name = "containerd-shim-runc-v2.bin", srcs = ["containerd-shim-runc-v2"])',
             'filegroup(name = "ctr.bin", srcs = ["ctr"])',
         ]),
-        urls = ["https://github.com/containerd/containerd/releases/download/v2.0.4/containerd-2.0.4-linux-amd64.tar.gz"],
-        sha256 = "e1c64c5fd60ecd555e750744eaef150b6f78d7f750da5c08c52825aa6b791737",
+        urls = ["https://github.com/containerd/containerd/releases/download/v2.1.1/containerd-2.1.1-linux-amd64.tar.gz"],
+        sha256 = "918e88fd393c28c89424e6535df0546ca36c1dfa7d8a5d685dee70b449380a9b",
     )
     http_archive(
         name = "com_github_containerd_containerd-linux-arm64",
@@ -6954,21 +6954,21 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             'filegroup(name = "containerd-shim-runc-v2.bin", srcs = ["containerd-shim-runc-v2"])',
             'filegroup(name = "ctr.bin", srcs = ["ctr"])',
         ]),
-        urls = ["https://github.com/containerd/containerd/releases/download/v2.0.4/containerd-2.0.4-linux-arm64.tar.gz"],
-        sha256 = "0fde98b24bb55363a54150732e0ac99a43bccf2a9711371bd5470f32790316f2",
+        urls = ["https://github.com/containerd/containerd/releases/download/v2.1.1/containerd-2.1.1-linux-arm64.tar.gz"],
+        sha256 = "4e3c8c0c2e61438bb393a9ea6bb94f8f56b559ec3243d7b1a2943117bca4dcb4",
     )
 
     http_file(
         name = "com_github_opencontainers_runc_runc-linux-amd64",
-        urls = ["https://github.com/opencontainers/runc/releases/download/v1.2.5/runc.amd64"],
-        sha256 = "fbd851fce6a8e0d67a9d184ea544c2abf67c9fd29b80fcc1adf67dfe9eb036a1",
+        urls = ["https://github.com/opencontainers/runc/releases/download/v1.3.0/runc.amd64"],
+        sha256 = "028986516ab5646370edce981df2d8e8a8d12188deaf837142a02097000ae2f2",
         downloaded_file_path = "runc",
         executable = True,
     )
     http_file(
         name = "com_github_opencontainers_runc_runc-linux-arm64",
-        urls = ["https://github.com/opencontainers/runc/releases/download/v1.2.5/runc.arm64"],
-        sha256 = "bfc6575f4c601740539553b639ad6f635c23f76695ed484171bd864df6a23f76",
+        urls = ["https://github.com/opencontainers/runc/releases/download/v1.3.0/runc.arm64"],
+        sha256 = "85c5e4e4f72e442c8c17bac07527cd4f961ee48e4f2b71797f7533c94f4a52b9",
         downloaded_file_path = "runc",
         executable = True,
     )

--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -2,7 +2,7 @@
 # See README for details.
 
 # debian 12
-FROM mirror.gcr.io/debian@sha256:723a457777ce1b4bebda7c1252131e9779dd775f9b536ed35175a2ba57f2f23f
+FROM mirror.gcr.io/debian@sha256:7ca9335a5953654f8feb8b846ad3dd78309a838d62b090c785d1f5908c2d59d2
 
 RUN apt-get update && \
     apt-get install -y \
@@ -19,10 +19,10 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/* && apt-get clean
 
-RUN DOCKER_VERSION="5:28.0.4-1~debian.12~bookworm" && \
+RUN DOCKER_VERSION="5:28.2.2-1~debian.12~bookworm" && \
     CONTAINERD_DEB_VERSION="1.7.27-1" && \
-    DOCKER_BUILDX_VERSION="0.22.0-1~debian.12~bookworm" && \
-    DOCKER_COMPOSE_VERSION="2.34.0-1~debian.12~bookworm" && \
+    DOCKER_BUILDX_VERSION="0.24.0-1~debian.12~bookworm" && \
+    DOCKER_COMPOSE_VERSION="2.36.2-1~debian.12~bookworm" && \
     apt-get update && \
     apt-get install -y \
     curl ca-certificates apt-transport-https && \
@@ -53,8 +53,7 @@ RUN DOCKER_VERSION="5:28.0.4-1~debian.12~bookworm" && \
     /usr/bin/containerd-shim \
     /usr/bin/containerd-shim-runc-v1 \
     /usr/bin/ctr \
-    # Not currently updating these binaries manually, so leave them in.
     # rootlesskit
-    # /usr/bin/rootlesskit \
+    /usr/bin/rootlesskit \
     # runc
-    # /usr/bin/runc
+    /usr/bin/runc

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -241,10 +241,10 @@ container_image(
         ":docker_credential_gcr_layer",
         ":docker_credential_gcr_docker_config_layer",
         ":containerd_layer",
-        # Updating these layers does not currently afford is any vulnerability
+        # Updating these layers does not currently afford us any vulnerability
         # fixes; leave them out for now.
-        # ":runc_layer",
-        # ":rootlesskit_layer",
+        ":runc_layer",
+        ":rootlesskit_layer",
         ":executor_tools_layer",
         ":podman_static_layer",
     ],


### PR DESCRIPTION
This PR updates the base images as well as some individual binaries installed on them to pick up fixes for security vulnerabilities.

The updates include:
- distroless image for the app
- debian image for the executor
- docker, docker-buildx-plugin, and docker compose plugin versions in apt
- containerd, runc, rootless, and podman binaries
