### PR TITLE
Deflake TestFirecrackerRun_Timeout_DebugOutputIsAvailable

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -2464,7 +2464,7 @@ func TestFirecrackerRun_Timeout_DebugOutputIsAvailable(t *testing.T) {
 		echo output > output.txt
 		sleep infinity
 	`}}
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	res := c.Run(ctx, cmd, opts.ActionWorkingDirectory, oci.Credentials{})
 


### PR DESCRIPTION
It seems that just doubling the timeout helps. It's not a great solution, but it's better than flaking.

100 passing runs: https://app.buildbuddy.io/invocation/1d1ba186-d12c-4288-8965-0f9470336989