### PR TITLE
Pass owner instead of repo url to GetGitHubAppForOwner

### DIFF
--- a/enterprise/server/backends/codesearch/BUILD
+++ b/enterprise/server/backends/codesearch/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/util/claims",
         "//server/util/db",
         "//server/util/flag",
+        "//server/util/git",
         "//server/util/grpc_client",
         "//server/util/status",
     ],

--- a/enterprise/server/backends/codesearch/codesearch.go
+++ b/enterprise/server/backends/codesearch/codesearch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
@@ -60,7 +61,12 @@ func (css *CodesearchService) getGitRepoAccessToken(ctx context.Context, groupId
 		return "", status.InternalError("GitHub App service is not configured")
 	}
 
-	gha, err := ghas.GetGitHubAppForOwner(ctx, repoURL)
+	parsedRepoURL, err := git.ParseGitHubRepoURL(repoURL)
+	if err != nil {
+		return "", status.InvalidArgumentErrorf("invalid repo URL %q: %s", repoURL, err)
+	}
+
+	gha, err := ghas.GetGitHubAppForOwner(ctx, parsedRepoURL.Owner)
 	if err != nil {
 		return "", status.UnavailableErrorf("could not get GitHub app for repo %q: %s", repoURL, err)
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -723,9 +723,9 @@ type GitHubAppService interface {
 	// have an authenticated user context.
 	GetGitHubAppForAuthenticatedUser(ctx context.Context) (GitHubApp, error)
 	// GetGitHubAppForRepoURL returns the BB GitHub app corresponding to the app installation
-	// for the given URL. The installation must be both installed on GitHub and imported
+	// for the given owner. The installation must be both installed on GitHub and imported
 	// to BuildBuddy via (`LinkGitHubAppInstallation`).
-	GetGitHubAppForOwner(ctx context.Context, repoURL string) (GitHubApp, error)
+	GetGitHubAppForOwner(ctx context.Context, owner string) (GitHubApp, error)
 
 	InstallPath(ctx context.Context) (string, error)
 


### PR DESCRIPTION
Also, fix the arg name in `interfaces.go`. The sole implementation of this method does indeed take `owner`, not `repoUrl`: https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/githubapp/githubapp.go#L186