### PR TITLE
Fix 2 codesearch incremental bugs

### DIFF
--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -295,13 +295,13 @@ func ComputeIncrementalUpdate(gc GitClient, firstSha, lastSha string) (*inpb.Inc
 	var currentCommit *inpb.Commit
 	sha := firstSha
 
+	regexpSha := regexp.MustCompile("^[0-9a-f]{5,40}$")
+	filepathSha := regexp.MustCompile("^:[0-9]{6} [0-9]{6}")
+
 	for _, line := range changes {
 		line := strings.TrimSpace(line)
-		if len(line) == 0 {
-			continue
-		}
 
-		if line[0] != ':' {
+		if regexpSha.MatchString(line) {
 			// Commit line
 			currentCommit = &inpb.Commit{
 				Sha:       line,
@@ -309,10 +309,10 @@ func ComputeIncrementalUpdate(gc GitClient, firstSha, lastSha string) (*inpb.Inc
 			}
 			result.Commits = append(result.Commits, currentCommit)
 			sha = line
-		} else {
+		} else if filepathSha.MatchString(line) {
 			// Diff line
 			processDiffTreeLine(gc, line, currentCommit)
-		}
+		} // else: ignore other lines
 	}
 	return result, nil
 }

--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -38,9 +38,11 @@ const (
 	maxAllowedChanges = 1000
 )
 
-// TODO(tylerw): this should come from a flag?
 var (
-	skipMime = regexp.MustCompile(`^audio/.*|video/.*|image/.*|application/gzip$`)
+	// TODO(tylerw): this should come from a flag?
+	skipMime    = regexp.MustCompile(`^audio/.*|video/.*|image/.*|application/gzip$`)
+	regexpSha   = regexp.MustCompile("^[0-9a-f]{5,40}$")
+	filepathSha = regexp.MustCompile("^:[0-9]{6} [0-9]{6}")
 )
 
 func lastIndexedDocKey(repoURL *git.RepoURL) []byte {
@@ -294,9 +296,6 @@ func ComputeIncrementalUpdate(gc GitClient, firstSha, lastSha string) (*inpb.Inc
 	}
 	var currentCommit *inpb.Commit
 	sha := firstSha
-
-	regexpSha := regexp.MustCompile("^[0-9a-f]{5,40}$")
-	filepathSha := regexp.MustCompile("^:[0-9]{6} [0-9]{6}")
 
 	for _, line := range changes {
 		line := strings.TrimSpace(line)

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -291,6 +291,7 @@ func sendIncrementalUpdate(apiTarget, repoURL string) string {
 	// TODO(jdelfino): Remove explicit CLI installation once buildbuddy-internal/#5060 is resolved
 	buf := fmt.Sprintf(`
 curl -fsSL https://install.buildbuddy.io | bash
+git fetch --force --filter=blob:none --unshallow origin
 bb index --target %s --repo-url %s`, apiTarget, repoURL)
 	return buf
 }


### PR DESCRIPTION
1. When we clone repos for workflows, we clone with `depth=1`, which makes history unavailable. This change adds an `--unshallow` fetch to the codesearch incremental update action, which fetches history (but still avoids fetching blobs from history). Note we might be able to do this entire thing slightly more cheaply with a treeless clone (`--filter=tree:0`), as opposed to a blobless clone, but I'm sticking with the current blobless clone that's used already for now.

2. The parsing of `git whatchanged` is made more robust. The git output in the workflows included a warning about forced updates not being shown, probably due to some bit of config from the workflow setup. This output was breaking the parsing. We now parse the rows with regexes to be more resilient. The next most resilient step here would probably be trying to work programmatically with the git repo directly, rather than through the command line client, but this would be a step up in complexity, so we'll see how this does.