### PR TITLE
bazelrc: remove remote-minimal from deflake

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -91,12 +91,11 @@ common:quarantine --config=race
 common:quarantine --test_env=RUN_QUARANTINED_TESTS=true
 
 # Configuration used to deflake tests
-common:deflake --config=remote-minimal
+common:deflake --config=quarantine
 common:deflake --runs_per_test=100
 common:deflake --test_output=errors
 common:deflake --test_runner_fail_fast
 common:deflake --notest_keep_going
-common:deflake --config=quarantine
 
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.


### PR DESCRIPTION
Deflake uses quarantine which already included remote-minimal.
Avoid expanding the same config multiple times.

Closes https://github.com/buildbuddy-io/buildbuddy-internal/issues/5082
