### PR TITLE
Add `Set` type

### DIFF
--- a/server/util/lib/set/BUILD
+++ b/server/util/lib/set/BUILD
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "set",
+    srcs = ["set.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/lib/set",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "set_test",
+    srcs = ["set_test.go"],
+    deps = [
+        ":set",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -1,0 +1,97 @@
+package set
+
+import (
+	"iter"
+	"maps"
+)
+
+// Set is just a lightweight wrapper around the standard golang stand-in for the
+// set type, map[E]struct{}. It is intended to improve readability and reduce
+// code duplication. An empty Set can be made with `make(Set[E])` or
+// `make(Set[E], cap)`, just like a normal map.
+type Set[E comparable] map[E]struct{}
+
+// From creates a new Set containing all the provided elements.
+func From[E comparable](s ...E) Set[E] {
+	set := make(Set[E], len(s))
+	for _, e := range s {
+		set[e] = struct{}{}
+	}
+	return set
+}
+
+// FromSeq creates a new Set containing all terms in the provided sequence.
+func FromSeq[E comparable](s iter.Seq[E]) Set[E] {
+	set := make(Set[E])
+	for e := range s {
+		set[e] = struct{}{}
+	}
+	return set
+}
+
+// Seq returns a sequence of all the elements in this set.
+func (s Set[E]) Seq() iter.Seq[E] {
+	return maps.Keys(s)
+}
+
+// Add adds the provided element to the set if it is not yet a member of the
+// set.
+func (s Set[E]) Add(e E) {
+	s[e] = struct{}{}
+}
+
+// Remove removes the provided element from the set if it is currently a
+// member of the set.
+func (s Set[E]) Remove(e E) {
+	delete(s, e)
+}
+
+// Contains returns true if the provided element is a member of the set, and
+// false if it is not.
+func (s Set[E]) Contains(e E) bool {
+	_, ok := s[e]
+	return ok
+}
+
+// Intersection returns the intersection of this set and the passed conjunct.
+func (s Set[E]) Intersection(conjunct Set[E]) iter.Seq[E] {
+	return func(yield func(E) bool) {
+		for e := range s {
+			if conjunct.Contains(e) {
+				if !yield(e) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Union returns the union of this set and the passed disjunct.
+func (s Set[E]) Union(disjunct Set[E]) iter.Seq[E] {
+	return func(yield func(E) bool) {
+		for e := range s {
+			if !yield(e) {
+				return
+			}
+		}
+		for e := range disjunct.Difference(s) {
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}
+
+// Difference returns this set with all the elements in the subtrahend removed.
+func (s Set[E]) Difference(subtrahend Set[E]) iter.Seq[E] {
+	return func(yield func(E) bool) {
+		for e := range s {
+			if subtrahend.Contains(e) {
+				continue
+			}
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -44,6 +44,7 @@ func FromSeq[E comparable](s iter.Seq[E]) Set[E] {
 	return set
 }
 
+// AsView returns a View of the keys in the provided map as a set.
 func AsView[E comparable, V any](m map[E]V) View[E] {
 	return mapView[E, V](m)
 }

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -14,14 +14,14 @@ type View[E comparable] interface {
 	Difference(View[E]) iter.Seq[E]
 }
 
-// Nothing is an alias for struct{} for clarity/readability.
-type Nothing = struct{}
+// nothing is an alias for struct{} for clarity/readability.
+type nothing = struct{}
 
 // Set is just a lightweight wrapper around the standard golang stand-in for the
 // set type, map[E]struct{}. It is intended to improve readability and reduce
 // code duplication. An empty Set can be made with `make(Set[E])` or
 // `make(Set[E], cap)`, just like a normal map.
-type Set[E comparable] map[E]Nothing
+type Set[E comparable] map[E]nothing
 
 // mapView is a view of a `map[E]V` as a `View[E] `.
 type mapView[E comparable, V any] map[E]V
@@ -30,7 +30,7 @@ type mapView[E comparable, V any] map[E]V
 func From[E comparable](s ...E) Set[E] {
 	set := make(Set[E], len(s))
 	for _, e := range s {
-		set[e] = Nothing{}
+		set[e] = nothing{}
 	}
 	return set
 }
@@ -39,7 +39,7 @@ func From[E comparable](s ...E) Set[E] {
 func FromSeq[E comparable](s iter.Seq[E]) Set[E] {
 	set := make(Set[E])
 	for e := range s {
-		set[e] = Nothing{}
+		set[e] = nothing{}
 	}
 	return set
 }

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -44,14 +44,14 @@ func FromSeq[E comparable](s iter.Seq[E]) Set[E] {
 	return set
 }
 
-// AsView returns a View of the keys in the provided map as a set.
-func AsView[E comparable, V any](m map[E]V) View[E] {
+// KeyView returns a View of the keys in the provided map as a set.
+func KeyView[E comparable, V any](m map[E]V) View[E] {
 	return mapView[E, V](m)
 }
 
 // All returns a sequence of all the elements in this set.
 func (s Set[E]) All() iter.Seq[E] {
-	return AsView(s).All()
+	return KeyView(s).All()
 }
 
 // All returns a sequence of all the elements in this set.
@@ -74,7 +74,7 @@ func (s Set[E]) Remove(e E) {
 // Contains returns true if the provided element is a member of the set, and
 // false if it is not.
 func (s Set[E]) Contains(e E) bool {
-	return AsView(s).Contains(e)
+	return KeyView(s).Contains(e)
 }
 
 // Contains returns true if the provided element is a member of the set, and
@@ -86,7 +86,7 @@ func (s mapView[E, V]) Contains(e E) bool {
 
 // Intersection returns the intersection of this set and the passed conjunct.
 func (s Set[E]) Intersection(conjunct View[E]) iter.Seq[E] {
-	return AsView(s).Intersection(conjunct)
+	return KeyView(s).Intersection(conjunct)
 }
 
 // Intersection returns the intersection of this set and the passed conjunct.
@@ -104,7 +104,7 @@ func (s mapView[E, V]) Intersection(conjunct View[E]) iter.Seq[E] {
 
 // Union returns the union of this set and the passed disjunct.
 func (s Set[E]) Union(disjunct View[E]) iter.Seq[E] {
-	return AsView(s).Union(disjunct)
+	return KeyView(s).Union(disjunct)
 }
 
 // Union returns the union of this set and the passed disjunct.
@@ -125,7 +125,7 @@ func (s mapView[E, V]) Union(disjunct View[E]) iter.Seq[E] {
 
 // Difference returns this set with all the elements in the subtrahend removed.
 func (s Set[E]) Difference(subtrahend View[E]) iter.Seq[E] {
-	return AsView(s).Difference(subtrahend)
+	return KeyView(s).Difference(subtrahend)
 }
 
 // Difference returns this set with all the elements in the subtrahend removed.

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -30,7 +30,7 @@ type mapView[E comparable, V any] map[E]V
 func From[E comparable](s ...E) Set[E] {
 	set := make(Set[E], len(s))
 	for _, e := range s {
-		set[e] = nothing{}
+		set.Add(e)
 	}
 	return set
 }
@@ -39,7 +39,7 @@ func From[E comparable](s ...E) Set[E] {
 func FromSeq[E comparable](s iter.Seq[E]) Set[E] {
 	set := make(Set[E])
 	for e := range s {
-		set[e] = nothing{}
+		set.Add(e)
 	}
 	return set
 }

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -35,9 +35,7 @@ func From[E comparable](s ...E) Set[E] {
 // FromSeq creates a new Set containing all terms in the provided sequence.
 func FromSeq[E comparable](s iter.Seq[E]) Set[E] {
 	set := make(Set[E])
-	for e := range s {
-		set.Add(e)
-	}
+	set.AddSeq(s)
 	return set
 }
 
@@ -62,10 +60,26 @@ func (s Set[E]) Add(e E) {
 	s[e] = struct{}{}
 }
 
+// AddSeq takes a sequence of elements and, for each element, adds it if it is
+// not yet a member of the set.
+func (s Set[E]) AddSeq(toAdd iter.Seq[E]) {
+	for e := range toAdd {
+		s.Add(e)
+	}
+}
+
 // Remove removes the provided element from the set if it is currently a
 // member of the set.
 func (s Set[E]) Remove(e E) {
 	delete(s, e)
+}
+
+// RemoveSeq takes a sequence of elements and, for each element, removes it if
+// it is currently a member of the set.
+func (s Set[E]) RemoveSeq(toRemove iter.Seq[E]) {
+	for e := range toRemove {
+		s.Remove(e)
+	}
 }
 
 // Contains returns true if the provided element is a member of the set, and

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -29,8 +29,8 @@ func FromSeq[E comparable](s iter.Seq[E]) Set[E] {
 	return set
 }
 
-// Seq returns a sequence of all the elements in this set.
-func (s Set[E]) Seq() iter.Seq[E] {
+// All returns a sequence of all the elements in this set.
+func (s Set[E]) All() iter.Seq[E] {
 	return maps.Keys(s)
 }
 

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -3,6 +3,7 @@ package set
 import (
 	"iter"
 	"maps"
+	"slices"
 )
 
 // View is a (read-only) view of a data structure as a set.
@@ -28,11 +29,7 @@ type mapView[E comparable, V any] map[E]V
 
 // From creates a new Set containing all the provided elements.
 func From[E comparable](s ...E) Set[E] {
-	set := make(Set[E], len(s))
-	for _, e := range s {
-		set.Add(e)
-	}
-	return set
+	return FromSeq(slices.Values(s))
 }
 
 // FromSeq creates a new Set containing all terms in the provided sequence.

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -23,10 +23,7 @@ type Nothing = struct{}
 // `make(Set[E], cap)`, just like a normal map.
 type Set[E comparable] map[E]Nothing
 
-// Set is just a lightweight wrapper around the standard golang stand-in for the
-// set type, map[E]struct{}. It is intended to improve readability and reduce
-// code duplication. An empty Set can be made with `make(Set[E])` or
-// `make(Set[E], cap)`, just like a normal map.
+// mapView is a view of a `map[E]V` as a `View[E] `.
 type mapView[E comparable, V any] map[E]V
 
 // From creates a new Set containing all the provided elements.

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -106,17 +106,13 @@ func (s mapView[E, V]) Len() int {
 
 // Intersection returns the intersection of the passed conjuncts.
 func Intersection[V View[E], E comparable](conjuncts ...V) iter.Seq[E] {
+	if len(conjuncts) == 0 {
+		return slices.Values[[]E](nil)
+	}
+	if len(conjuncts) == 1 {
+		return conjuncts[0].All()
+	}
 	return func(yield func(E) bool) {
-		if len(conjuncts) == 0 {
-			return
-		} else if len(conjuncts) == 1 {
-			for e := range conjuncts[0].All() {
-				if !yield(e) {
-					return
-				}
-			}
-			return
-		}
 		// intersect with the smallest set.
 		smallest := slices.MinFunc(conjuncts, func(a V, b V) int {
 			return cmp.Compare(a.Len(), b.Len())
@@ -141,6 +137,12 @@ func Intersection[V View[E], E comparable](conjuncts ...V) iter.Seq[E] {
 
 // Union returns the union of the passed disjuncts.
 func Union[V View[E], E comparable](disjuncts ...V) iter.Seq[E] {
+	if len(disjuncts) == 0 {
+		return slices.Values[[]E](nil)
+	}
+	if len(disjuncts) == 1 {
+		return disjuncts[0].All()
+	}
 	return func(yield func(E) bool) {
 		if len(disjuncts) == 0 {
 			return
@@ -181,6 +183,9 @@ func Union[V View[E], E comparable](disjuncts ...V) iter.Seq[E] {
 // Difference returns the difference between the passed minuend and the union of
 // the passed subtrahends.
 func Difference[V View[E], E comparable](minuend View[E], subtrahends ...V) iter.Seq[E] {
+	if len(subtrahends) == 0 {
+		return minuend.All()
+	}
 	return func(yield func(E) bool) {
 		for e := range minuend.All() {
 			keep := true

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -104,7 +104,7 @@ func (s mapView[E, V]) Len() int {
 	return len(s)
 }
 
-// Intersection returns the intersection of this set and the passed conjuncts.
+// Intersection returns the intersection of the passed conjuncts.
 func Intersection[V View[E], E comparable](conjuncts ...V) iter.Seq[E] {
 	return func(yield func(E) bool) {
 		if len(conjuncts) == 0 {
@@ -139,7 +139,7 @@ func Intersection[V View[E], E comparable](conjuncts ...V) iter.Seq[E] {
 	}
 }
 
-// Union returns the union of this set and the passed disjuncts.
+// Union returns the union of the passed disjuncts.
 func Union[V View[E], E comparable](disjuncts ...V) iter.Seq[E] {
 	return func(yield func(E) bool) {
 		if len(disjuncts) == 0 {

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -57,7 +57,7 @@ func (s mapView[E, V]) All() iter.Seq[E] {
 // Add adds the provided element to the set if it is not yet a member of the
 // set.
 func (s Set[E]) Add(e E) {
-	s[e] = struct{}{}
+	s[e] = nothing{}
 }
 
 // AddSeq takes a sequence of elements and, for each element, adds it if it is

--- a/server/util/lib/set/set.go
+++ b/server/util/lib/set/set.go
@@ -5,17 +5,35 @@ import (
 	"maps"
 )
 
+// View is a (read-only) view of a data structure as a set.
+type View[E comparable] interface {
+	All() iter.Seq[E]
+	Contains(E) bool
+	Intersection(View[E]) iter.Seq[E]
+	Union(View[E]) iter.Seq[E]
+	Difference(View[E]) iter.Seq[E]
+}
+
+// Nothing is an alias for struct{} for clarity/readability.
+type Nothing = struct{}
+
 // Set is just a lightweight wrapper around the standard golang stand-in for the
 // set type, map[E]struct{}. It is intended to improve readability and reduce
 // code duplication. An empty Set can be made with `make(Set[E])` or
 // `make(Set[E], cap)`, just like a normal map.
-type Set[E comparable] map[E]struct{}
+type Set[E comparable] map[E]Nothing
+
+// Set is just a lightweight wrapper around the standard golang stand-in for the
+// set type, map[E]struct{}. It is intended to improve readability and reduce
+// code duplication. An empty Set can be made with `make(Set[E])` or
+// `make(Set[E], cap)`, just like a normal map.
+type mapView[E comparable, V any] map[E]V
 
 // From creates a new Set containing all the provided elements.
 func From[E comparable](s ...E) Set[E] {
 	set := make(Set[E], len(s))
 	for _, e := range s {
-		set[e] = struct{}{}
+		set[e] = Nothing{}
 	}
 	return set
 }
@@ -24,13 +42,22 @@ func From[E comparable](s ...E) Set[E] {
 func FromSeq[E comparable](s iter.Seq[E]) Set[E] {
 	set := make(Set[E])
 	for e := range s {
-		set[e] = struct{}{}
+		set[e] = Nothing{}
 	}
 	return set
 }
 
+func AsView[E comparable, V any](m map[E]V) View[E] {
+	return mapView[E, V](m)
+}
+
 // All returns a sequence of all the elements in this set.
 func (s Set[E]) All() iter.Seq[E] {
+	return AsView(s).All()
+}
+
+// All returns a sequence of all the elements in this set.
+func (s mapView[E, V]) All() iter.Seq[E] {
 	return maps.Keys(s)
 }
 
@@ -49,12 +76,23 @@ func (s Set[E]) Remove(e E) {
 // Contains returns true if the provided element is a member of the set, and
 // false if it is not.
 func (s Set[E]) Contains(e E) bool {
+	return AsView(s).Contains(e)
+}
+
+// Contains returns true if the provided element is a member of the set, and
+// false if it is not.
+func (s mapView[E, V]) Contains(e E) bool {
 	_, ok := s[e]
 	return ok
 }
 
 // Intersection returns the intersection of this set and the passed conjunct.
-func (s Set[E]) Intersection(conjunct Set[E]) iter.Seq[E] {
+func (s Set[E]) Intersection(conjunct View[E]) iter.Seq[E] {
+	return AsView(s).Intersection(conjunct)
+}
+
+// Intersection returns the intersection of this set and the passed conjunct.
+func (s mapView[E, V]) Intersection(conjunct View[E]) iter.Seq[E] {
 	return func(yield func(E) bool) {
 		for e := range s {
 			if conjunct.Contains(e) {
@@ -67,7 +105,12 @@ func (s Set[E]) Intersection(conjunct Set[E]) iter.Seq[E] {
 }
 
 // Union returns the union of this set and the passed disjunct.
-func (s Set[E]) Union(disjunct Set[E]) iter.Seq[E] {
+func (s Set[E]) Union(disjunct View[E]) iter.Seq[E] {
+	return AsView(s).Union(disjunct)
+}
+
+// Union returns the union of this set and the passed disjunct.
+func (s mapView[E, V]) Union(disjunct View[E]) iter.Seq[E] {
 	return func(yield func(E) bool) {
 		for e := range s {
 			if !yield(e) {
@@ -83,7 +126,12 @@ func (s Set[E]) Union(disjunct Set[E]) iter.Seq[E] {
 }
 
 // Difference returns this set with all the elements in the subtrahend removed.
-func (s Set[E]) Difference(subtrahend Set[E]) iter.Seq[E] {
+func (s Set[E]) Difference(subtrahend View[E]) iter.Seq[E] {
+	return AsView(s).Difference(subtrahend)
+}
+
+// Difference returns this set with all the elements in the subtrahend removed.
+func (s mapView[E, V]) Difference(subtrahend View[E]) iter.Seq[E] {
 	return func(yield func(E) bool) {
 		for e := range s {
 			if subtrahend.Contains(e) {

--- a/server/util/lib/set/set_test.go
+++ b/server/util/lib/set/set_test.go
@@ -678,215 +678,215 @@ func TestIntersection(t *testing.T) {
 			},
 		},
 		{
-			Name:     "Empty intersects empty",
-			Input:    []set.Set[string]{
+			Name: "Empty intersects empty",
+			Input: []set.Set[string]{
 				make(set.Set[string], 0),
 				make(set.Set[string], 0),
 			},
 			Expected: []string{},
 		},
 		{
-			Name:     "Nil intersects nil",
-			Input:    []set.Set[string]{nil,
-			nil,
-		},
-		Expected: []string{},
-	},
-	{
-		Name:     "Empty intersects nil",
-		Input:    []set.Set[string]{
-			make(set.Set[string], 0),
-			nil,
-		},
-		Expected: []string{},
-	},
-	{
-		Name:     "Nil intersects empty",
-		Input:    []set.Set[string]{
-			nil,
-			make(set.Set[string], 0),
-		},
-		Expected: []string{},
-	},
-	{
-		Name:  "Empty intersects non-empty",
-		Input: []set.Set[string]{
-			make(set.Set[string], 0),
-			{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+			Name: "Nil intersects nil",
+			Input: []set.Set[string]{nil,
+				nil,
 			},
+			Expected: []string{},
 		},
-		Expected: []string{},
-	},
-	{
-		Name: "Non-empty intersects empty",
-		Input: []set.Set[string]{
-			{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+		{
+			Name: "Empty intersects nil",
+			Input: []set.Set[string]{
+				make(set.Set[string], 0),
+				nil,
 			},
-			make(set.Set[string], 0),
+			Expected: []string{},
 		},
-		Expected: []string{},
-	},
-	{
-		Name:  "Nil intersects non-empty",
-		Input: []set.Set[string]{
-			nil,
-			{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+		{
+			Name: "Nil intersects empty",
+			Input: []set.Set[string]{
+				nil,
+				make(set.Set[string], 0),
 			},
+			Expected: []string{},
 		},
-		Expected: []string{},
-	},
-	{
-		Name: "Non-empty intersects nil",
-		Input: []set.Set[string]{
-			{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+		{
+			Name: "Empty intersects non-empty",
+			Input: []set.Set[string]{
+				make(set.Set[string], 0),
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
 			},
-			nil,
+			Expected: []string{},
 		},
-		Expected: []string{},
-	},
-	{
-		Name: "Intersect with overlap",
-		Input: []set.Set[string]{
-			{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-				"barfoo": {},
+		{
+			Name: "Non-empty intersects empty",
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
+				make(set.Set[string], 0),
 			},
-			{
-				"bar":    {},
-				"barfoo": {},
-				"barbar": {},
-			},
+			Expected: []string{},
 		},
-		Expected: []string{
-			"bar",
-			"barfoo",
-		},
-	},
-	{
-		Name: "Intersect with no overlap",
-		Input: []set.Set[string]{
-			{
-				"foo":    {},
-				"barfoo": {},
+		{
+			Name: "Nil intersects non-empty",
+			Input: []set.Set[string]{
+				nil,
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
 			},
-			{
-				"bar":    {},
-				"barbar": {},
+			Expected: []string{},
+		},
+		{
+			Name: "Non-empty intersects nil",
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
+				nil,
+			},
+			Expected: []string{},
+		},
+		{
+			Name: "Intersect with overlap",
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+					"barfoo": {},
+				},
+				{
+					"bar":    {},
+					"barfoo": {},
+					"barbar": {},
+				},
+			},
+			Expected: []string{
+				"bar",
+				"barfoo",
 			},
 		},
-		Expected: []string{},
-	},
-	{
-		Name: "Intersect with zero-value overlap",
-		Input: []set.Set[string]{
-			{
-				"":       {},
-				"foo":    {},
-				"barfoo": {},
+		{
+			Name: "Intersect with no overlap",
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"barfoo": {},
+				},
+				{
+					"bar":    {},
+					"barbar": {},
+				},
 			},
-			{
-				"":       {},
-				"bar":    {},
-				"barbar": {},
+			Expected: []string{},
+		},
+		{
+			Name: "Intersect with zero-value overlap",
+			Input: []set.Set[string]{
+				{
+					"":       {},
+					"foo":    {},
+					"barfoo": {},
+				},
+				{
+					"":       {},
+					"bar":    {},
+					"barbar": {},
+				},
+			},
+			Expected: []string{
+				"",
 			},
 		},
-		Expected: []string{
-			"",
-		},
-	},
-	{
-		Name: "Intersect with zero-value no overlap",
-		Input: []set.Set[string]{
-			{
-				"":       {},
-				"foo":    {},
-				"barfoo": {},
+		{
+			Name: "Intersect with zero-value no overlap",
+			Input: []set.Set[string]{
+				{
+					"":       {},
+					"foo":    {},
+					"barfoo": {},
+				},
+				{
+					"foo":    {},
+					"barbar": {},
+				},
 			},
-			{
-				"foo":    {},
-				"barbar": {},
-			},
-		},
-		Expected: []string{
-			"foo",
-		},
-	},
-	{
-		Name: "Intersect with zero-value no overlap 2",
-		Input: []set.Set[string]{
-			{
-				"foo":    {},
-				"barfoo": {},
-			},
-			{
-				"":       {},
-				"foo":    {},
-				"barbar": {},
+			Expected: []string{
+				"foo",
 			},
 		},
-		Expected: []string{
-			"foo",
-		},
-	},
-	{
-		Name: "Complex Intersect with many sets",
-		Input: []set.Set[string]{
-			{
-				"foo":    {},
-				"barfoo": {},
-				"barbar": {},
-				"barbarbar": {},
+		{
+			Name: "Intersect with zero-value no overlap 2",
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"barfoo": {},
+				},
+				{
+					"":       {},
+					"foo":    {},
+					"barbar": {},
+				},
 			},
-			{
-				"":       {},
-				"foo":    {},
-				"foobar": {},
-				"barbar": {},
-			},
-			{
-				"":       {},
-				"foo":    {},
-				"foobar": {},
-				"barbar": {},
-			},
-			{
-				"":       {},
-				"foo":    {},
-				"foobar": {},
-				"barbar": {},
-			},
-			{
-				"":       {},
-				"foo":    {},
-				"barbar": {},
-				"barfoo": {},
+			Expected: []string{
+				"foo",
 			},
 		},
-		Expected: []string{
-			"foo",
-			"barbar",
+		{
+			Name: "Complex Intersect with many sets",
+			Input: []set.Set[string]{
+				{
+					"foo":       {},
+					"barfoo":    {},
+					"barbar":    {},
+					"barbarbar": {},
+				},
+				{
+					"":       {},
+					"foo":    {},
+					"foobar": {},
+					"barbar": {},
+				},
+				{
+					"":       {},
+					"foo":    {},
+					"foobar": {},
+					"barbar": {},
+				},
+				{
+					"":       {},
+					"foo":    {},
+					"foobar": {},
+					"barbar": {},
+				},
+				{
+					"":       {},
+					"foo":    {},
+					"barbar": {},
+					"barfoo": {},
+				},
+			},
+			Expected: []string{
+				"foo",
+				"barbar",
+			},
 		},
-	},
-} {
-	t.Run(tc.Name, func(t *testing.T) {
-		s := set.Intersection(tc.Input...)
-		assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
-	})
-}
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			s := set.Intersection(tc.Input...)
+			assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
+		})
+	}
 }
 
 func TestUnion(t *testing.T) {
@@ -920,39 +920,39 @@ func TestUnion(t *testing.T) {
 			},
 		},
 		{
-			Name:     "Empty union empty",
-			Input:    []set.Set[string]{
+			Name: "Empty union empty",
+			Input: []set.Set[string]{
 				make(set.Set[string], 0),
 				make(set.Set[string], 0),
 			},
 			Expected: []string{},
 		},
 		{
-			Name:     "Nil union nil",
-			Input:    []set.Set[string]{
+			Name: "Nil union nil",
+			Input: []set.Set[string]{
 				nil,
 				nil,
 			},
 			Expected: []string{},
 		},
 		{
-			Name:     "Empty union nil",
-			Input:    []set.Set[string]{
+			Name: "Empty union nil",
+			Input: []set.Set[string]{
 				make(set.Set[string], 0),
 				nil,
 			},
 			Expected: []string{},
 		},
 		{
-			Name:     "Nil union empty",
-			Input:    []set.Set[string]{
+			Name: "Nil union empty",
+			Input: []set.Set[string]{
 				nil,
 				make(set.Set[string], 0),
 			},
 			Expected: []string{},
 		},
 		{
-			Name:  "Empty union non-empty",
+			Name: "Empty union non-empty",
 			Input: []set.Set[string]{
 				make(set.Set[string], 0),
 				{
@@ -984,7 +984,7 @@ func TestUnion(t *testing.T) {
 			},
 		},
 		{
-			Name:  "Nil union non-empty",
+			Name: "Nil union non-empty",
 			Input: []set.Set[string]{
 				nil,
 				{
@@ -1123,30 +1123,30 @@ func TestUnion(t *testing.T) {
 			Name: "Complex union with many sets",
 			Input: []set.Set[string]{
 				{
-					"foo":    {},
-					"barbar": {},
-					"barfoo": {},
+					"foo":       {},
+					"barbar":    {},
+					"barfoo":    {},
 					"barbarbar": {},
 				},
 				{
 					"":       {},
 					"foo":    {},
-					"foobar":    {},
+					"foobar": {},
 					"barbar": {},
 				},
 				nil,
 				{
-					"foo":    {},
+					"foo":       {},
 					"foobar":    {},
-					"barbar": {},
+					"barbar":    {},
 					"foofoofoo": {},
 				},
 				{},
 				{
-					"":       {},
+					"":          {},
 					"foofoo":    {},
-					"bar":    {},
-					"barbar": {},
+					"bar":       {},
+					"barbar":    {},
 					"foofoofoo": {},
 				},
 			},
@@ -1172,19 +1172,19 @@ func TestUnion(t *testing.T) {
 
 func TestDifference(t *testing.T) {
 	for _, tc := range []struct {
-		Name       string
-		Minuend    set.Set[string]
+		Name        string
+		Minuend     set.Set[string]
 		Subtrahends []set.Set[string]
-		Expected   []string
+		Expected    []string
 	}{
 		{
-			Name:     "No subtrahends",
+			Name: "No subtrahends",
 			Minuend: set.Set[string]{
 				"foo":    {},
 				"bar":    {},
 				"foobar": {},
 			},
-			Subtrahends:    make([]set.Set[string], 0),
+			Subtrahends: make([]set.Set[string], 0),
 			Expected: []string{
 				"foo",
 				"bar",
@@ -1192,34 +1192,34 @@ func TestDifference(t *testing.T) {
 			},
 		},
 		{
-			Name:       "Empty subtract empty",
-			Minuend:    make(set.Set[string], 0),
+			Name:    "Empty subtract empty",
+			Minuend: make(set.Set[string], 0),
 			Subtrahends: []set.Set[string]{
 				make(set.Set[string], 0),
 			},
-			Expected:   []string{},
+			Expected: []string{},
 		},
 		{
-			Name:       "Nil subtract nil",
-			Minuend:    nil,
+			Name:    "Nil subtract nil",
+			Minuend: nil,
 			Subtrahends: []set.Set[string]{
 				nil,
 			},
-			Expected:   []string{},
+			Expected: []string{},
 		},
 		{
-			Name:       "Empty subtract nil",
-			Minuend:    make(set.Set[string], 0),
+			Name:        "Empty subtract nil",
+			Minuend:     make(set.Set[string], 0),
 			Subtrahends: nil,
-			Expected:   []string{},
+			Expected:    []string{},
 		},
 		{
-			Name:       "Nil subtract empty",
-			Minuend:    nil,
+			Name:    "Nil subtract empty",
+			Minuend: nil,
 			Subtrahends: []set.Set[string]{
 				make(set.Set[string], 0),
 			},
-			Expected:   []string{},
+			Expected: []string{},
 		},
 		{
 			Name:    "Empty subtract non-empty",
@@ -1408,21 +1408,21 @@ func TestDifference(t *testing.T) {
 		{
 			Name: "Complex difference with many sets",
 			Minuend: set.Set[string]{
-				"": {},
-				"foo": {},
-				"bar": {},
-				"foobar": {},
-				"barfoo": {},
-				"foofoo": {},
-				"barbar": {},
+				"":          {},
+				"foo":       {},
+				"bar":       {},
+				"foobar":    {},
+				"barfoo":    {},
+				"foofoo":    {},
+				"barbar":    {},
 				"foofoofoo": {},
 				"barbarbar": {},
 			},
 			Subtrahends: []set.Set[string]{
 				{
-					"foo":    {},
-					"barbar": {},
-					"barfoo": {},
+					"foo":       {},
+					"barbar":    {},
+					"barfoo":    {},
 					"barbarbar": {},
 				},
 				{
@@ -1434,7 +1434,7 @@ func TestDifference(t *testing.T) {
 				{},
 				{
 					"":       {},
-					"foofoo":    {},
+					"foofoo": {},
 					"bar":    {},
 					"barbar": {},
 				},

--- a/server/util/lib/set/set_test.go
+++ b/server/util/lib/set/set_test.go
@@ -258,7 +258,7 @@ func TestAddSeq(t *testing.T) {
 			},
 		},
 		{
-			Name:  "Add Empty",
+			Name: "Add Empty",
 			Input: set.Set[string]{
 				"foo":    {},
 				"bar":    {},
@@ -274,9 +274,9 @@ func TestAddSeq(t *testing.T) {
 			},
 		},
 		{
-			Name:  "Add Empty to Empty",
-			Input: make(set.Set[string], 0),
-			ToAdd: []string{},
+			Name:     "Add Empty to Empty",
+			Input:    make(set.Set[string], 0),
+			ToAdd:    []string{},
 			Expected: set.Set[string]{},
 		},
 		{
@@ -460,16 +460,16 @@ func TestRemoveSeq(t *testing.T) {
 		Expected set.Set[string]
 	}{
 		{
-			Name:     "Remove from Empty",
-			Input:    make(set.Set[string], 0),
+			Name:  "Remove from Empty",
+			Input: make(set.Set[string], 0),
 			ToRemove: []string{
 				"foo",
 			},
 			Expected: make(set.Set[string], 0),
 		},
 		{
-			Name:     "Remove from nil",
-			Input:    nil,
+			Name:  "Remove from nil",
+			Input: nil,
 			ToRemove: []string{
 				"foo",
 			},
@@ -516,8 +516,8 @@ func TestRemoveSeq(t *testing.T) {
 				"foobar",
 			},
 			Expected: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
+				"foo": {},
+				"bar": {},
 			},
 		},
 		{
@@ -650,196 +650,316 @@ func TestContains(t *testing.T) {
 func TestIntersection(t *testing.T) {
 	for _, tc := range []struct {
 		Name     string
-		Input    set.Set[string]
-		Conjunct set.Set[string]
+		Input    []set.Set[string]
 		Expected []string
 	}{
 		{
-			Name:     "Empty intersects empty",
-			Input:    make(set.Set[string], 0),
-			Conjunct: make(set.Set[string], 0),
+			Name:     "No sets",
+			Input:    make([]set.Set[string], 0),
 			Expected: []string{},
 		},
 		{
-			Name:     "Nil intersects nil",
-			Input:    nil,
-			Conjunct: nil,
-			Expected: []string{},
-		},
-		{
-			Name:     "Empty intersects nil",
-			Input:    make(set.Set[string], 0),
-			Conjunct: nil,
-			Expected: []string{},
-		},
-		{
-			Name:     "Nil intersects empty",
-			Input:    nil,
-			Conjunct: make(set.Set[string], 0),
-			Expected: []string{},
-		},
-		{
-			Name:  "Empty intersects non-empty",
-			Input: make(set.Set[string], 0),
-			Conjunct: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+			Name: "One set",
+			Input: []set.Set[string]{
+				{
+					"":       {},
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+					"barfoo": {},
+				},
 			},
-			Expected: []string{},
-		},
-		{
-			Name: "Non-empty intersects empty",
-			Input: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-			},
-			Conjunct: make(set.Set[string], 0),
-			Expected: []string{},
-		},
-		{
-			Name:  "Nil intersects non-empty",
-			Input: nil,
-			Conjunct: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-			},
-			Expected: []string{},
-		},
-		{
-			Name: "Non-empty intersects nil",
-			Input: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-			},
-			Conjunct: nil,
-			Expected: []string{},
-		},
-		{
-			Name: "Intersect with overlap",
-			Input: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-				"barfoo": {},
-			}),
-			Conjunct: set.Set[string](map[string]struct{}{
-				"bar":    {},
-				"barfoo": {},
-				"barbar": {},
-			}),
 			Expected: []string{
+				"",
+				"foo",
 				"bar",
+				"foobar",
 				"barfoo",
 			},
 		},
 		{
-			Name: "Intersect with no overlap",
-			Input: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"barfoo": {},
-			}),
-			Conjunct: set.Set[string](map[string]struct{}{
-				"bar":    {},
-				"barbar": {},
-			}),
+			Name:     "Empty intersects empty",
+			Input:    []set.Set[string]{
+				make(set.Set[string], 0),
+				make(set.Set[string], 0),
+			},
 			Expected: []string{},
 		},
 		{
-			Name: "Intersect with zero-value overlap",
-			Input: set.Set[string](map[string]struct{}{
+			Name:     "Nil intersects nil",
+			Input:    []set.Set[string]{nil,
+			nil,
+		},
+		Expected: []string{},
+	},
+	{
+		Name:     "Empty intersects nil",
+		Input:    []set.Set[string]{
+			make(set.Set[string], 0),
+			nil,
+		},
+		Expected: []string{},
+	},
+	{
+		Name:     "Nil intersects empty",
+		Input:    []set.Set[string]{
+			nil,
+			make(set.Set[string], 0),
+		},
+		Expected: []string{},
+	},
+	{
+		Name:  "Empty intersects non-empty",
+		Input: []set.Set[string]{
+			make(set.Set[string], 0),
+			{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+			},
+		},
+		Expected: []string{},
+	},
+	{
+		Name: "Non-empty intersects empty",
+		Input: []set.Set[string]{
+			{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+			},
+			make(set.Set[string], 0),
+		},
+		Expected: []string{},
+	},
+	{
+		Name:  "Nil intersects non-empty",
+		Input: []set.Set[string]{
+			nil,
+			{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+			},
+		},
+		Expected: []string{},
+	},
+	{
+		Name: "Non-empty intersects nil",
+		Input: []set.Set[string]{
+			{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+			},
+			nil,
+		},
+		Expected: []string{},
+	},
+	{
+		Name: "Intersect with overlap",
+		Input: []set.Set[string]{
+			{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			},
+			{
+				"bar":    {},
+				"barfoo": {},
+				"barbar": {},
+			},
+		},
+		Expected: []string{
+			"bar",
+			"barfoo",
+		},
+	},
+	{
+		Name: "Intersect with no overlap",
+		Input: []set.Set[string]{
+			{
+				"foo":    {},
+				"barfoo": {},
+			},
+			{
+				"bar":    {},
+				"barbar": {},
+			},
+		},
+		Expected: []string{},
+	},
+	{
+		Name: "Intersect with zero-value overlap",
+		Input: []set.Set[string]{
+			{
 				"":       {},
 				"foo":    {},
 				"barfoo": {},
-			}),
-			Conjunct: set.Set[string](map[string]struct{}{
+			},
+			{
 				"":       {},
 				"bar":    {},
 				"barbar": {},
-			}),
-			Expected: []string{
-				"",
 			},
 		},
-		{
-			Name: "Intersect with zero-value no overlap",
-			Input: set.Set[string](map[string]struct{}{
+		Expected: []string{
+			"",
+		},
+	},
+	{
+		Name: "Intersect with zero-value no overlap",
+		Input: []set.Set[string]{
+			{
 				"":       {},
 				"foo":    {},
 				"barfoo": {},
-			}),
-			Conjunct: set.Set[string](map[string]struct{}{
+			},
+			{
 				"foo":    {},
 				"barbar": {},
-			}),
-			Expected: []string{
-				"foo",
 			},
 		},
-		{
-			Name: "Intersect with zero-value no overlap 2",
-			Input: set.Set[string](map[string]struct{}{
+		Expected: []string{
+			"foo",
+		},
+	},
+	{
+		Name: "Intersect with zero-value no overlap 2",
+		Input: []set.Set[string]{
+			{
 				"foo":    {},
 				"barfoo": {},
-			}),
-			Conjunct: set.Set[string](map[string]struct{}{
+			},
+			{
 				"":       {},
 				"foo":    {},
 				"barbar": {},
-			}),
-			Expected: []string{
-				"foo",
 			},
 		},
-	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			s := tc.Input.Intersection(tc.Conjunct)
-			assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
-		})
-	}
+		Expected: []string{
+			"foo",
+		},
+	},
+	{
+		Name: "Complex Intersect with many sets",
+		Input: []set.Set[string]{
+			{
+				"foo":    {},
+				"barfoo": {},
+				"barbar": {},
+				"barbarbar": {},
+			},
+			{
+				"":       {},
+				"foo":    {},
+				"foobar": {},
+				"barbar": {},
+			},
+			{
+				"":       {},
+				"foo":    {},
+				"foobar": {},
+				"barbar": {},
+			},
+			{
+				"":       {},
+				"foo":    {},
+				"foobar": {},
+				"barbar": {},
+			},
+			{
+				"":       {},
+				"foo":    {},
+				"barbar": {},
+				"barfoo": {},
+			},
+		},
+		Expected: []string{
+			"foo",
+			"barbar",
+		},
+	},
+} {
+	t.Run(tc.Name, func(t *testing.T) {
+		s := set.Intersection(tc.Input...)
+		assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
+	})
+}
 }
 
 func TestUnion(t *testing.T) {
 	for _, tc := range []struct {
 		Name     string
-		Input    set.Set[string]
-		Disjunct set.Set[string]
+		Input    []set.Set[string]
 		Expected []string
 	}{
 		{
+			Name:     "No sets",
+			Input:    make([]set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "One set",
+			Input: []set.Set[string]{
+				{
+					"":       {},
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+					"barfoo": {},
+				},
+			},
+			Expected: []string{
+				"",
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+			},
+		},
+		{
 			Name:     "Empty union empty",
-			Input:    make(set.Set[string], 0),
-			Disjunct: make(set.Set[string], 0),
+			Input:    []set.Set[string]{
+				make(set.Set[string], 0),
+				make(set.Set[string], 0),
+			},
 			Expected: []string{},
 		},
 		{
 			Name:     "Nil union nil",
-			Input:    nil,
-			Disjunct: nil,
+			Input:    []set.Set[string]{
+				nil,
+				nil,
+			},
 			Expected: []string{},
 		},
 		{
 			Name:     "Empty union nil",
-			Input:    make(set.Set[string], 0),
-			Disjunct: nil,
+			Input:    []set.Set[string]{
+				make(set.Set[string], 0),
+				nil,
+			},
 			Expected: []string{},
 		},
 		{
 			Name:     "Nil union empty",
-			Input:    nil,
-			Disjunct: make(set.Set[string], 0),
+			Input:    []set.Set[string]{
+				nil,
+				make(set.Set[string], 0),
+			},
 			Expected: []string{},
 		},
 		{
 			Name:  "Empty union non-empty",
-			Input: make(set.Set[string], 0),
-			Disjunct: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+			Input: []set.Set[string]{
+				make(set.Set[string], 0),
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
 			},
 			Expected: []string{
 				"foo",
@@ -849,12 +969,14 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Non-empty union empty",
-			Input: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
+				make(set.Set[string], 0),
 			},
-			Disjunct: make(set.Set[string], 0),
 			Expected: []string{
 				"foo",
 				"bar",
@@ -863,11 +985,13 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name:  "Nil union non-empty",
-			Input: nil,
-			Disjunct: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+			Input: []set.Set[string]{
+				nil,
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
 			},
 			Expected: []string{
 				"foo",
@@ -877,12 +1001,14 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Non-empty union nil",
-			Input: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
+				nil,
 			},
-			Disjunct: nil,
 			Expected: []string{
 				"foo",
 				"bar",
@@ -891,17 +1017,19 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with overlap",
-			Input: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-				"barfoo": {},
-			}),
-			Disjunct: set.Set[string](map[string]struct{}{
-				"bar":    {},
-				"barfoo": {},
-				"barbar": {},
-			}),
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+					"barfoo": {},
+				},
+				{
+					"bar":    {},
+					"barfoo": {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"foo",
 				"bar",
@@ -912,14 +1040,16 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with no overlap",
-			Input: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"barfoo": {},
-			}),
-			Disjunct: set.Set[string](map[string]struct{}{
-				"bar":    {},
-				"barbar": {},
-			}),
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"barfoo": {},
+				},
+				{
+					"bar":    {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"foo",
 				"bar",
@@ -929,16 +1059,18 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with zero-value overlap",
-			Input: set.Set[string](map[string]struct{}{
-				"":       {},
-				"foo":    {},
-				"barfoo": {},
-			}),
-			Disjunct: set.Set[string](map[string]struct{}{
-				"":       {},
-				"bar":    {},
-				"barbar": {},
-			}),
+			Input: []set.Set[string]{
+				{
+					"":       {},
+					"foo":    {},
+					"barfoo": {},
+				},
+				{
+					"":       {},
+					"bar":    {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"",
 				"foo",
@@ -949,15 +1081,17 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with zero-value no overlap",
-			Input: set.Set[string](map[string]struct{}{
-				"":       {},
-				"foo":    {},
-				"barfoo": {},
-			}),
-			Disjunct: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"barbar": {},
-			}),
+			Input: []set.Set[string]{
+				{
+					"":       {},
+					"foo":    {},
+					"barfoo": {},
+				},
+				{
+					"foo":    {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"",
 				"foo",
@@ -967,15 +1101,17 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with zero-value no overlap 2",
-			Input: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"barfoo": {},
-			}),
-			Disjunct: set.Set[string](map[string]struct{}{
-				"":       {},
-				"foo":    {},
-				"barbar": {},
-			}),
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"barfoo": {},
+				},
+				{
+					"":       {},
+					"foo":    {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"",
 				"foo",
@@ -983,9 +1119,52 @@ func TestUnion(t *testing.T) {
 				"barbar",
 			},
 		},
+		{
+			Name: "Complex union with many sets",
+			Input: []set.Set[string]{
+				{
+					"foo":    {},
+					"barbar": {},
+					"barfoo": {},
+					"barbarbar": {},
+				},
+				{
+					"":       {},
+					"foo":    {},
+					"foobar":    {},
+					"barbar": {},
+				},
+				nil,
+				{
+					"foo":    {},
+					"foobar":    {},
+					"barbar": {},
+					"foofoofoo": {},
+				},
+				{},
+				{
+					"":       {},
+					"foofoo":    {},
+					"bar":    {},
+					"barbar": {},
+					"foofoofoo": {},
+				},
+			},
+			Expected: []string{
+				"",
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+				"foofoo",
+				"barbar",
+				"foofoofoo",
+				"barbarbar",
+			},
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			s := tc.Input.Union(tc.Disjunct)
+			s := set.Union(tc.Input...)
 			assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
 		})
 	}
@@ -994,52 +1173,18 @@ func TestUnion(t *testing.T) {
 func TestDifference(t *testing.T) {
 	for _, tc := range []struct {
 		Name       string
-		Input      set.Set[string]
-		Subtrahend set.Set[string]
+		Minuend    set.Set[string]
+		Subtrahends []set.Set[string]
 		Expected   []string
 	}{
 		{
-			Name:       "Empty subtract empty",
-			Input:      make(set.Set[string], 0),
-			Subtrahend: make(set.Set[string], 0),
-			Expected:   []string{},
-		},
-		{
-			Name:       "Nil subtract nil",
-			Input:      nil,
-			Subtrahend: nil,
-			Expected:   []string{},
-		},
-		{
-			Name:       "Empty subtract nil",
-			Input:      make(set.Set[string], 0),
-			Subtrahend: nil,
-			Expected:   []string{},
-		},
-		{
-			Name:       "Nil subtract empty",
-			Input:      nil,
-			Subtrahend: make(set.Set[string], 0),
-			Expected:   []string{},
-		},
-		{
-			Name:  "Empty subtract non-empty",
-			Input: make(set.Set[string], 0),
-			Subtrahend: set.Set[string]{
+			Name:     "No subtrahends",
+			Minuend: set.Set[string]{
 				"foo":    {},
 				"bar":    {},
 				"foobar": {},
 			},
-			Expected: []string{},
-		},
-		{
-			Name: "Non-empty subtract empty",
-			Input: set.Set[string]{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-			},
-			Subtrahend: make(set.Set[string], 0),
+			Subtrahends:    make([]set.Set[string], 0),
 			Expected: []string{
 				"foo",
 				"bar",
@@ -1047,23 +1192,85 @@ func TestDifference(t *testing.T) {
 			},
 		},
 		{
-			Name:  "Nil subtract non-empty",
-			Input: nil,
-			Subtrahend: set.Set[string]{
+			Name:       "Empty subtract empty",
+			Minuend:    make(set.Set[string], 0),
+			Subtrahends: []set.Set[string]{
+				make(set.Set[string], 0),
+			},
+			Expected:   []string{},
+		},
+		{
+			Name:       "Nil subtract nil",
+			Minuend:    nil,
+			Subtrahends: []set.Set[string]{
+				nil,
+			},
+			Expected:   []string{},
+		},
+		{
+			Name:       "Empty subtract nil",
+			Minuend:    make(set.Set[string], 0),
+			Subtrahends: nil,
+			Expected:   []string{},
+		},
+		{
+			Name:       "Nil subtract empty",
+			Minuend:    nil,
+			Subtrahends: []set.Set[string]{
+				make(set.Set[string], 0),
+			},
+			Expected:   []string{},
+		},
+		{
+			Name:    "Empty subtract non-empty",
+			Minuend: make(set.Set[string], 0),
+			Subtrahends: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
+			},
+			Expected: []string{},
+		},
+		{
+			Name: "Non-empty subtract empty",
+			Minuend: set.Set[string]{
 				"foo":    {},
 				"bar":    {},
 				"foobar": {},
+			},
+			Subtrahends: []set.Set[string]{
+				make(set.Set[string], 0),
+			},
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+			},
+		},
+		{
+			Name:    "Nil subtract non-empty",
+			Minuend: nil,
+			Subtrahends: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+				},
 			},
 			Expected: []string{},
 		},
 		{
 			Name: "Non-empty subtract nil",
-			Input: set.Set[string]{
+			Minuend: set.Set[string]{
 				"foo":    {},
 				"bar":    {},
 				"foobar": {},
 			},
-			Subtrahend: nil,
+			Subtrahends: []set.Set[string]{
+				nil,
+			},
 			Expected: []string{
 				"foo",
 				"bar",
@@ -1072,17 +1279,19 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with overlap",
-			Input: set.Set[string](map[string]struct{}{
+			Minuend: set.Set[string]{
 				"foo":    {},
 				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
-			}),
-			Subtrahend: set.Set[string](map[string]struct{}{
-				"bar":    {},
-				"barfoo": {},
-				"barbar": {},
-			}),
+			},
+			Subtrahends: []set.Set[string]{
+				{
+					"bar":    {},
+					"barfoo": {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"foo",
 				"foobar",
@@ -1090,14 +1299,16 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with no overlap",
-			Input: set.Set[string](map[string]struct{}{
+			Minuend: set.Set[string]{
 				"foo":    {},
 				"barfoo": {},
-			}),
-			Subtrahend: set.Set[string](map[string]struct{}{
-				"bar":    {},
-				"barbar": {},
-			}),
+			},
+			Subtrahends: []set.Set[string]{
+				{
+					"bar":    {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"foo",
 				"barfoo",
@@ -1105,16 +1316,18 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with zero-value overlap",
-			Input: set.Set[string](map[string]struct{}{
+			Minuend: set.Set[string]{
 				"":       {},
 				"foo":    {},
 				"barfoo": {},
-			}),
-			Subtrahend: set.Set[string](map[string]struct{}{
-				"":       {},
-				"bar":    {},
-				"barbar": {},
-			}),
+			},
+			Subtrahends: []set.Set[string]{
+				{
+					"":       {},
+					"bar":    {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"foo",
 				"barfoo",
@@ -1122,15 +1335,17 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with zero-value no overlap",
-			Input: set.Set[string](map[string]struct{}{
+			Minuend: set.Set[string]{
 				"":       {},
 				"foo":    {},
 				"barfoo": {},
-			}),
-			Subtrahend: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"barbar": {},
-			}),
+			},
+			Subtrahends: []set.Set[string]{
+				{
+					"foo":    {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"",
 				"barfoo",
@@ -1138,55 +1353,100 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with zero-value no overlap 2",
-			Input: set.Set[string](map[string]struct{}{
+			Minuend: set.Set[string]{
 				"foo":    {},
 				"barfoo": {},
-			}),
-			Subtrahend: set.Set[string](map[string]struct{}{
-				"":       {},
-				"foo":    {},
-				"barbar": {},
-			}),
+			},
+			Subtrahends: []set.Set[string]{
+				{
+					"":       {},
+					"foo":    {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{
 				"barfoo",
 			},
 		},
 		{
 			Name: "Subtract all",
-			Input: set.Set[string](map[string]struct{}{
+			Minuend: set.Set[string]{
 				"foo":    {},
 				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
-			}),
-			Subtrahend: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-				"barfoo": {},
-			}),
+			},
+			Subtrahends: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+					"barfoo": {},
+				},
+			},
 			Expected: []string{},
 		},
 		{
 			Name: "Subtract more than all",
-			Input: set.Set[string](map[string]struct{}{
+			Minuend: set.Set[string]{
 				"foo":    {},
 				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
-			}),
-			Subtrahend: set.Set[string](map[string]struct{}{
-				"foo":    {},
-				"bar":    {},
-				"foobar": {},
-				"barfoo": {},
-				"barbar": {},
-			}),
+			},
+			Subtrahends: []set.Set[string]{
+				{
+					"foo":    {},
+					"bar":    {},
+					"foobar": {},
+					"barfoo": {},
+					"barbar": {},
+				},
+			},
 			Expected: []string{},
+		},
+		{
+			Name: "Complex difference with many sets",
+			Minuend: set.Set[string]{
+				"": {},
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+				"foofoo": {},
+				"barbar": {},
+				"foofoofoo": {},
+				"barbarbar": {},
+			},
+			Subtrahends: []set.Set[string]{
+				{
+					"foo":    {},
+					"barbar": {},
+					"barfoo": {},
+					"barbarbar": {},
+				},
+				{
+					"":       {},
+					"foo":    {},
+					"barbar": {},
+				},
+				nil,
+				{},
+				{
+					"":       {},
+					"foofoo":    {},
+					"bar":    {},
+					"barbar": {},
+				},
+			},
+			Expected: []string{
+				"foobar",
+				"foofoofoo",
+			},
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			s := tc.Input.Difference(tc.Subtrahend)
+			s := set.Difference(tc.Minuend, tc.Subtrahends...)
 			assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
 		})
 	}

--- a/server/util/lib/set/set_test.go
+++ b/server/util/lib/set/set_test.go
@@ -10,121 +10,119 @@ import (
 )
 
 func TestFrom(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Slice []string
+	for _, tc := range []struct {
+		Name     string
+		Slice    []string
 		Expected set.Set[string]
-	} {
+	}{
 		{
-			Name: "Empty",
-			Slice: []string{},
+			Name:     "Empty",
+			Slice:    []string{},
 			Expected: make(set.Set[string], 0),
 		},
 		{
-			Name: "Distinct elements",
+			Name:  "Distinct elements",
 			Slice: []string{"foo", "bar", "foobar"},
-			Expected: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Expected: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			}),
 		},
 		{
-			Name: "Repeated elements",
+			Name:  "Repeated elements",
 			Slice: []string{"foo", "bar", "foobar", "bar", "foobar", "foobar", "barfoo"},
-			Expected: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Expected: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
 		},
 		{
-			Name: "Contains zero-value element",
+			Name:  "Contains zero-value element",
 			Slice: []string{"", "bar", "foobar"},
-			Expected: set.Set[string](map[string]struct{} {
-				"": {},
-				"bar": {},
+			Expected: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
 				"foobar": {},
 			}),
 		},
-
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			s := set.From(tc.Slice...)
 			if !cmp.Equal(s, tc.Expected) {
 				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, s))
 			}
-		})	
+		})
 	}
 }
 
 func TestFromSeq(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Slice []string
+	for _, tc := range []struct {
+		Name     string
+		Slice    []string
 		Expected set.Set[string]
-	} {
+	}{
 		{
-			Name: "Empty",
-			Slice: []string{},
+			Name:     "Empty",
+			Slice:    []string{},
 			Expected: make(set.Set[string], 0),
 		},
 		{
-			Name: "Distinct elements",
+			Name:  "Distinct elements",
 			Slice: []string{"foo", "bar", "foobar"},
-			Expected: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Expected: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			}),
 		},
 		{
-			Name: "Repeated elements",
+			Name:  "Repeated elements",
 			Slice: []string{"foo", "bar", "foobar", "bar", "foobar", "foobar", "barfoo"},
-			Expected: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Expected: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
 		},
 		{
-			Name: "Contains zero-value element",
+			Name:  "Contains zero-value element",
 			Slice: []string{"", "bar", "foobar"},
-			Expected: set.Set[string](map[string]struct{} {
-				"": {},
-				"bar": {},
+			Expected: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
 				"foobar": {},
 			}),
 		},
-
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			s := set.FromSeq(slices.Values(tc.Slice))
 			if !cmp.Equal(s, tc.Expected) {
 				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, s))
 			}
-		})	
+		})
 	}
 }
 
-func TestSeq(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Input set.Set[string]
+func TestAll(t *testing.T) {
+	for _, tc := range []struct {
+		Name     string
+		Input    set.Set[string]
 		Expected []string
-	} {
+	}{
 		{
-			Name: "Empty",
-			Input: make(set.Set[string], 0),
+			Name:     "Empty",
+			Input:    make(set.Set[string], 0),
 			Expected: []string{},
 		},
 		{
 			Name: "Four elements",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
@@ -137,9 +135,9 @@ func TestSeq(t *testing.T) {
 		},
 		{
 			Name: "Contains zero-value element",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
 				"foobar": {},
 			}),
 			Expected: []string{
@@ -150,39 +148,39 @@ func TestSeq(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			v := slices.Collect(tc.Input.Seq())
+			v := slices.Collect(tc.Input.All())
 			assert.ElementsMatch(t, v, tc.Expected)
 		})
 	}
 }
 
 func TestAdd(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Input set.Set[string]
-		ToAdd string
+	for _, tc := range []struct {
+		Name     string
+		Input    set.Set[string]
+		ToAdd    string
 		Expected set.Set[string]
-	} {
+	}{
 		{
-			Name: "Add to Empty",
+			Name:  "Add to Empty",
 			Input: make(set.Set[string], 0),
 			ToAdd: "foo",
-			Expected: set.Set[string] {
+			Expected: set.Set[string]{
 				"foo": {},
 			},
 		},
 		{
 			Name: "Add distinct elements",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
 			ToAdd: "barbar",
-			Expected: set.Set[string] {
-				"foo": {},
-				"bar": {},
+			Expected: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 				"barbar": {},
@@ -190,45 +188,45 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			Name: "Add repeated element",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
 			ToAdd: "foo",
-			Expected: set.Set[string] {
-				"foo": {},
-				"bar": {},
+			Expected: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			},
 		},
 		{
 			Name: "Contains zero-value element",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
 				"foobar": {},
 			}),
 			ToAdd: "foo",
-			Expected: set.Set[string] {
-				"": {},
-				"foo": {},
-				"bar": {},
+			Expected: set.Set[string]{
+				"":       {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 		},
 		{
 			Name: "Add zero-value element",
-			Input: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"foobar": {},
 			}),
 			ToAdd: "",
-			Expected: set.Set[string] {
-				"": {},
-				"bar": {},
+			Expected: set.Set[string]{
+				"":       {},
+				"bar":    {},
 				"foobar": {},
 			},
 		},
@@ -243,78 +241,78 @@ func TestAdd(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Input set.Set[string]
+	for _, tc := range []struct {
+		Name     string
+		Input    set.Set[string]
 		ToRemove string
 		Expected set.Set[string]
-	} {
+	}{
 		{
-			Name: "Remove from Empty",
-			Input: make(set.Set[string], 0),
+			Name:     "Remove from Empty",
+			Input:    make(set.Set[string], 0),
 			ToRemove: "foo",
 			Expected: make(set.Set[string], 0),
 		},
 		{
-			Name: "Remove from nil",
-			Input: nil,
+			Name:     "Remove from nil",
+			Input:    nil,
 			ToRemove: "foo",
 			Expected: nil,
 		},
 		{
 			Name: "Remove extant element",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
 			ToRemove: "barfoo",
-			Expected: set.Set[string] {
-				"foo": {},
-				"bar": {},
+			Expected: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 		},
 		{
 			Name: "Remove missing element",
-			Input: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
 			ToRemove: "foo",
-			Expected: set.Set[string] {
-				"bar": {},
+			Expected: set.Set[string]{
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			},
 		},
 		{
 			Name: "Contains zero-value element",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			}),
 			ToRemove: "foo",
-			Expected: set.Set[string] {
-				"": {},
-				"bar": {},
+			Expected: set.Set[string]{
+				"":       {},
+				"bar":    {},
 				"foobar": {},
 			},
 		},
 		{
 			Name: "Remove zero-value element",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
 				"foobar": {},
 			}),
 			ToRemove: "",
-			Expected: set.Set[string] {
-				"bar": {},
+			Expected: set.Set[string]{
+				"bar":    {},
 				"foobar": {},
 			},
 		},
@@ -329,29 +327,29 @@ func TestRemove(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Input set.Set[string]
+	for _, tc := range []struct {
+		Name     string
+		Input    set.Set[string]
 		Contains string
 		Expected bool
-	} {
+	}{
 		{
-			Name: "Empty Contains",
-			Input: make(set.Set[string], 0),
+			Name:     "Empty Contains",
+			Input:    make(set.Set[string], 0),
 			Contains: "foo",
 			Expected: false,
 		},
 		{
-			Name: "Nil Contains",
-			Input: nil,
+			Name:     "Nil Contains",
+			Input:    nil,
 			Contains: "foo",
 			Expected: false,
 		},
 		{
 			Name: "Contains extant element",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
@@ -360,8 +358,8 @@ func TestContains(t *testing.T) {
 		},
 		{
 			Name: "Contains missing element",
-			Input: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
@@ -370,10 +368,10 @@ func TestContains(t *testing.T) {
 		},
 		{
 			Name: "Contains extant zero-value element",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			}),
 			Contains: "",
@@ -381,8 +379,8 @@ func TestContains(t *testing.T) {
 		},
 		{
 			Name: "Contains missing zero-value element",
-			Input: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"foobar": {},
 			}),
 			Contains: "",
@@ -396,42 +394,42 @@ func TestContains(t *testing.T) {
 }
 
 func TestIntersection(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Input set.Set[string]
+	for _, tc := range []struct {
+		Name     string
+		Input    set.Set[string]
 		Conjunct set.Set[string]
 		Expected []string
-	} {
+	}{
 		{
-			Name: "Empty intersects empty",
-			Input: make(set.Set[string], 0),
+			Name:     "Empty intersects empty",
+			Input:    make(set.Set[string], 0),
 			Conjunct: make(set.Set[string], 0),
 			Expected: []string{},
 		},
 		{
-			Name: "Nil intersects nil",
-			Input: nil,
+			Name:     "Nil intersects nil",
+			Input:    nil,
 			Conjunct: nil,
 			Expected: []string{},
 		},
 		{
-			Name: "Empty intersects nil",
-			Input: make(set.Set[string], 0),
+			Name:     "Empty intersects nil",
+			Input:    make(set.Set[string], 0),
 			Conjunct: nil,
 			Expected: []string{},
 		},
 		{
-			Name: "Nil intersects empty",
-			Input: nil,
+			Name:     "Nil intersects empty",
+			Input:    nil,
 			Conjunct: make(set.Set[string], 0),
 			Expected: []string{},
 		},
 		{
-			Name: "Empty intersects non-empty",
+			Name:  "Empty intersects non-empty",
 			Input: make(set.Set[string], 0),
 			Conjunct: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Expected: []string{},
@@ -439,19 +437,19 @@ func TestIntersection(t *testing.T) {
 		{
 			Name: "Non-empty intersects empty",
 			Input: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Conjunct: make(set.Set[string], 0),
 			Expected: []string{},
 		},
 		{
-			Name: "Nil intersects non-empty",
+			Name:  "Nil intersects non-empty",
 			Input: nil,
 			Conjunct: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Expected: []string{},
@@ -459,8 +457,8 @@ func TestIntersection(t *testing.T) {
 		{
 			Name: "Non-empty intersects nil",
 			Input: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Conjunct: nil,
@@ -468,14 +466,14 @@ func TestIntersection(t *testing.T) {
 		},
 		{
 			Name: "Intersect with overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
-			Conjunct: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Conjunct: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"barfoo": {},
 				"barbar": {},
 			}),
@@ -486,26 +484,26 @@ func TestIntersection(t *testing.T) {
 		},
 		{
 			Name: "Intersect with no overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Conjunct: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Conjunct: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"barbar": {},
 			}),
 			Expected: []string{},
 		},
 		{
 			Name: "Intersect with zero-value overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Conjunct: set.Set[string](map[string]struct{} {
-				"": {},
-				"bar": {},
+			Conjunct: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -514,13 +512,13 @@ func TestIntersection(t *testing.T) {
 		},
 		{
 			Name: "Intersect with zero-value no overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Conjunct: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Conjunct: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -529,13 +527,13 @@ func TestIntersection(t *testing.T) {
 		},
 		{
 			Name: "Intersect with zero-value no overlap 2",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Conjunct: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Conjunct: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -551,42 +549,42 @@ func TestIntersection(t *testing.T) {
 }
 
 func TestUnion(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Input set.Set[string]
+	for _, tc := range []struct {
+		Name     string
+		Input    set.Set[string]
 		Disjunct set.Set[string]
 		Expected []string
-	} {
+	}{
 		{
-			Name: "Empty union empty",
-			Input: make(set.Set[string], 0),
+			Name:     "Empty union empty",
+			Input:    make(set.Set[string], 0),
 			Disjunct: make(set.Set[string], 0),
 			Expected: []string{},
 		},
 		{
-			Name: "Nil union nil",
-			Input: nil,
+			Name:     "Nil union nil",
+			Input:    nil,
 			Disjunct: nil,
 			Expected: []string{},
 		},
 		{
-			Name: "Empty union nil",
-			Input: make(set.Set[string], 0),
+			Name:     "Empty union nil",
+			Input:    make(set.Set[string], 0),
 			Disjunct: nil,
 			Expected: []string{},
 		},
 		{
-			Name: "Nil union empty",
-			Input: nil,
+			Name:     "Nil union empty",
+			Input:    nil,
 			Disjunct: make(set.Set[string], 0),
 			Expected: []string{},
 		},
 		{
-			Name: "Empty union non-empty",
+			Name:  "Empty union non-empty",
 			Input: make(set.Set[string], 0),
 			Disjunct: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Expected: []string{
@@ -598,8 +596,8 @@ func TestUnion(t *testing.T) {
 		{
 			Name: "Non-empty union empty",
 			Input: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Disjunct: make(set.Set[string], 0),
@@ -610,11 +608,11 @@ func TestUnion(t *testing.T) {
 			},
 		},
 		{
-			Name: "Nil union non-empty",
+			Name:  "Nil union non-empty",
 			Input: nil,
 			Disjunct: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Expected: []string{
@@ -626,8 +624,8 @@ func TestUnion(t *testing.T) {
 		{
 			Name: "Non-empty union nil",
 			Input: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Disjunct: nil,
@@ -639,14 +637,14 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
-			Disjunct: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Disjunct: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"barfoo": {},
 				"barbar": {},
 			}),
@@ -660,12 +658,12 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with no overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Disjunct: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Disjunct: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -677,14 +675,14 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with zero-value overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Disjunct: set.Set[string](map[string]struct{} {
-				"": {},
-				"bar": {},
+			Disjunct: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -697,13 +695,13 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with zero-value no overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Disjunct: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Disjunct: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -715,13 +713,13 @@ func TestUnion(t *testing.T) {
 		},
 		{
 			Name: "Union with zero-value no overlap 2",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Disjunct: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Disjunct: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -740,42 +738,42 @@ func TestUnion(t *testing.T) {
 }
 
 func TestDifference(t *testing.T) {
-	for _, tc := range []struct{
-		Name string
-		Input set.Set[string]
+	for _, tc := range []struct {
+		Name       string
+		Input      set.Set[string]
 		Subtrahend set.Set[string]
-		Expected []string
-	} {
+		Expected   []string
+	}{
 		{
-			Name: "Empty subtract empty",
-			Input: make(set.Set[string], 0),
+			Name:       "Empty subtract empty",
+			Input:      make(set.Set[string], 0),
 			Subtrahend: make(set.Set[string], 0),
-			Expected: []string{},
+			Expected:   []string{},
 		},
 		{
-			Name: "Nil subtract nil",
-			Input: nil,
+			Name:       "Nil subtract nil",
+			Input:      nil,
 			Subtrahend: nil,
-			Expected: []string{},
+			Expected:   []string{},
 		},
 		{
-			Name: "Empty subtract nil",
-			Input: make(set.Set[string], 0),
+			Name:       "Empty subtract nil",
+			Input:      make(set.Set[string], 0),
 			Subtrahend: nil,
-			Expected: []string{},
+			Expected:   []string{},
 		},
 		{
-			Name: "Nil subtract empty",
-			Input: nil,
+			Name:       "Nil subtract empty",
+			Input:      nil,
 			Subtrahend: make(set.Set[string], 0),
-			Expected: []string{},
+			Expected:   []string{},
 		},
 		{
-			Name: "Empty subtract non-empty",
+			Name:  "Empty subtract non-empty",
 			Input: make(set.Set[string], 0),
 			Subtrahend: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Expected: []string{},
@@ -783,8 +781,8 @@ func TestDifference(t *testing.T) {
 		{
 			Name: "Non-empty subtract empty",
 			Input: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Subtrahend: make(set.Set[string], 0),
@@ -795,11 +793,11 @@ func TestDifference(t *testing.T) {
 			},
 		},
 		{
-			Name: "Nil subtract non-empty",
+			Name:  "Nil subtract non-empty",
 			Input: nil,
 			Subtrahend: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Expected: []string{},
@@ -807,8 +805,8 @@ func TestDifference(t *testing.T) {
 		{
 			Name: "Non-empty subtract nil",
 			Input: set.Set[string]{
-				"foo": {},
-				"bar": {},
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 			},
 			Subtrahend: nil,
@@ -820,14 +818,14 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
-			Subtrahend: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Subtrahend: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"barfoo": {},
 				"barbar": {},
 			}),
@@ -838,12 +836,12 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with no overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Subtrahend: set.Set[string](map[string]struct{} {
-				"bar": {},
+			Subtrahend: set.Set[string](map[string]struct{}{
+				"bar":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -853,14 +851,14 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with zero-value overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Subtrahend: set.Set[string](map[string]struct{} {
-				"": {},
-				"bar": {},
+			Subtrahend: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -870,13 +868,13 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with zero-value no overlap",
-			Input: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Subtrahend: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Subtrahend: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -886,13 +884,13 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract with zero-value no overlap 2",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
 				"barfoo": {},
 			}),
-			Subtrahend: set.Set[string](map[string]struct{} {
-				"": {},
-				"foo": {},
+			Subtrahend: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
 				"barbar": {},
 			}),
 			Expected: []string{
@@ -901,15 +899,15 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract all",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
-			Subtrahend: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Subtrahend: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
@@ -917,15 +915,15 @@ func TestDifference(t *testing.T) {
 		},
 		{
 			Name: "Subtract more than all",
-			Input: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 			}),
-			Subtrahend: set.Set[string](map[string]struct{} {
-				"foo": {},
-				"bar": {},
+			Subtrahend: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
 				"foobar": {},
 				"barfoo": {},
 				"barbar": {},

--- a/server/util/lib/set/set_test.go
+++ b/server/util/lib/set/set_test.go
@@ -240,6 +240,132 @@ func TestAdd(t *testing.T) {
 	}
 }
 
+func TestAddSeq(t *testing.T) {
+	for _, tc := range []struct {
+		Name     string
+		Input    set.Set[string]
+		ToAdd    []string
+		Expected set.Set[string]
+	}{
+		{
+			Name:  "Add to Empty",
+			Input: make(set.Set[string], 0),
+			ToAdd: []string{
+				"foo",
+			},
+			Expected: set.Set[string]{
+				"foo": {},
+			},
+		},
+		{
+			Name:  "Add Empty",
+			Input: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			},
+			ToAdd: []string{},
+			Expected: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			},
+		},
+		{
+			Name:  "Add Empty to Empty",
+			Input: make(set.Set[string], 0),
+			ToAdd: []string{},
+			Expected: set.Set[string]{},
+		},
+		{
+			Name: "Add distinct elements",
+			Input: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			},
+			ToAdd: []string{
+				"barbar",
+				"foofoo",
+			},
+			Expected: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"foofoo": {},
+				"barfoo": {},
+				"barbar": {},
+			},
+		},
+		{
+			Name: "Add repeated element",
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			ToAdd: []string{
+				"foo",
+				"bar",
+			},
+			Expected: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			},
+		},
+		{
+			Name: "Contains zero-value element",
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
+				"foobar": {},
+			}),
+			ToAdd: []string{
+				"foo",
+				"barfoo",
+			},
+			Expected: set.Set[string]{
+				"":       {},
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			},
+		},
+		{
+			Name: "Add zero-value element",
+			Input: set.Set[string](map[string]struct{}{
+				"bar":    {},
+				"foobar": {},
+			}),
+			ToAdd: []string{
+				"",
+				"foobar",
+				"barfoo",
+			},
+			Expected: set.Set[string]{
+				"":       {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.Input.AddSeq(slices.Values(tc.ToAdd))
+			if !cmp.Equal(tc.Input, tc.Expected) {
+				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, tc.Input))
+			}
+		})
+	}
+}
+
 func TestRemove(t *testing.T) {
 	for _, tc := range []struct {
 		Name     string
@@ -319,6 +445,134 @@ func TestRemove(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			tc.Input.Remove(tc.ToRemove)
+			if !cmp.Equal(tc.Input, tc.Expected) {
+				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, tc.Input))
+			}
+		})
+	}
+}
+
+func TestRemoveSeq(t *testing.T) {
+	for _, tc := range []struct {
+		Name     string
+		Input    set.Set[string]
+		ToRemove []string
+		Expected set.Set[string]
+	}{
+		{
+			Name:     "Remove from Empty",
+			Input:    make(set.Set[string], 0),
+			ToRemove: []string{
+				"foo",
+			},
+			Expected: make(set.Set[string], 0),
+		},
+		{
+			Name:     "Remove from nil",
+			Input:    nil,
+			ToRemove: []string{
+				"foo",
+			},
+			Expected: nil,
+		},
+		{
+			Name:     "Remove Empty from Empty",
+			Input:    make(set.Set[string], 0),
+			ToRemove: []string{},
+			Expected: make(set.Set[string], 0),
+		},
+		{
+			Name:     "Remove Empty from nil",
+			Input:    nil,
+			ToRemove: []string{},
+			Expected: nil,
+		},
+		{
+			Name: "Remove empty",
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			ToRemove: []string{},
+			Expected: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			},
+		},
+		{
+			Name: "Remove extant elements",
+			Input: set.Set[string](map[string]struct{}{
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			ToRemove: []string{
+				"barfoo",
+				"foobar",
+			},
+			Expected: set.Set[string]{
+				"foo":    {},
+				"bar":    {},
+			},
+		},
+		{
+			Name: "Remove missing element",
+			Input: set.Set[string](map[string]struct{}{
+				"bar":    {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			ToRemove: []string{
+				"foo",
+				"bar",
+			},
+			Expected: set.Set[string]{
+				"foobar": {},
+				"barfoo": {},
+			},
+		},
+		{
+			Name: "Contains zero-value element",
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"foo":    {},
+				"bar":    {},
+				"foobar": {},
+			}),
+			ToRemove: []string{
+				"foo",
+				"bar",
+			},
+			Expected: set.Set[string]{
+				"":       {},
+				"foobar": {},
+			},
+		},
+		{
+			Name: "Remove zero-value element",
+			Input: set.Set[string](map[string]struct{}{
+				"":       {},
+				"bar":    {},
+				"foobar": {},
+				"barbar": {},
+			}),
+			ToRemove: []string{
+				"",
+				"foobar",
+			},
+			Expected: set.Set[string]{
+				"bar":    {},
+				"barbar": {},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.Input.RemoveSeq(slices.Values(tc.ToRemove))
 			if !cmp.Equal(tc.Input, tc.Expected) {
 				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, tc.Input))
 			}

--- a/server/util/lib/set/set_test.go
+++ b/server/util/lib/set/set_test.go
@@ -1,0 +1,941 @@
+package set_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrom(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Slice []string
+		Expected set.Set[string]
+	} {
+		{
+			Name: "Empty",
+			Slice: []string{},
+			Expected: make(set.Set[string], 0),
+		},
+		{
+			Name: "Distinct elements",
+			Slice: []string{"foo", "bar", "foobar"},
+			Expected: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			}),
+		},
+		{
+			Name: "Repeated elements",
+			Slice: []string{"foo", "bar", "foobar", "bar", "foobar", "foobar", "barfoo"},
+			Expected: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+		},
+		{
+			Name: "Contains zero-value element",
+			Slice: []string{"", "bar", "foobar"},
+			Expected: set.Set[string](map[string]struct{} {
+				"": {},
+				"bar": {},
+				"foobar": {},
+			}),
+		},
+
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			s := set.From(tc.Slice...)
+			if !cmp.Equal(s, tc.Expected) {
+				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, s))
+			}
+		})	
+	}
+}
+
+func TestFromSeq(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Slice []string
+		Expected set.Set[string]
+	} {
+		{
+			Name: "Empty",
+			Slice: []string{},
+			Expected: make(set.Set[string], 0),
+		},
+		{
+			Name: "Distinct elements",
+			Slice: []string{"foo", "bar", "foobar"},
+			Expected: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			}),
+		},
+		{
+			Name: "Repeated elements",
+			Slice: []string{"foo", "bar", "foobar", "bar", "foobar", "foobar", "barfoo"},
+			Expected: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+		},
+		{
+			Name: "Contains zero-value element",
+			Slice: []string{"", "bar", "foobar"},
+			Expected: set.Set[string](map[string]struct{} {
+				"": {},
+				"bar": {},
+				"foobar": {},
+			}),
+		},
+
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			s := set.FromSeq(slices.Values(tc.Slice))
+			if !cmp.Equal(s, tc.Expected) {
+				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, s))
+			}
+		})	
+	}
+}
+
+func TestSeq(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Input set.Set[string]
+		Expected []string
+	} {
+		{
+			Name: "Empty",
+			Input: make(set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "Four elements",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+			},
+		},
+		{
+			Name: "Contains zero-value element",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"bar": {},
+				"foobar": {},
+			}),
+			Expected: []string{
+				"",
+				"bar",
+				"foobar",
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			v := slices.Collect(tc.Input.Seq())
+			assert.ElementsMatch(t, v, tc.Expected)
+		})
+	}
+}
+
+func TestAdd(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Input set.Set[string]
+		ToAdd string
+		Expected set.Set[string]
+	} {
+		{
+			Name: "Add to Empty",
+			Input: make(set.Set[string], 0),
+			ToAdd: "foo",
+			Expected: set.Set[string] {
+				"foo": {},
+			},
+		},
+		{
+			Name: "Add distinct elements",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			ToAdd: "barbar",
+			Expected: set.Set[string] {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+				"barbar": {},
+			},
+		},
+		{
+			Name: "Add repeated element",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			ToAdd: "foo",
+			Expected: set.Set[string] {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			},
+		},
+		{
+			Name: "Contains zero-value element",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"bar": {},
+				"foobar": {},
+			}),
+			ToAdd: "foo",
+			Expected: set.Set[string] {
+				"": {},
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+		},
+		{
+			Name: "Add zero-value element",
+			Input: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"foobar": {},
+			}),
+			ToAdd: "",
+			Expected: set.Set[string] {
+				"": {},
+				"bar": {},
+				"foobar": {},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.Input.Add(tc.ToAdd)
+			if !cmp.Equal(tc.Input, tc.Expected) {
+				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, tc.Input))
+			}
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Input set.Set[string]
+		ToRemove string
+		Expected set.Set[string]
+	} {
+		{
+			Name: "Remove from Empty",
+			Input: make(set.Set[string], 0),
+			ToRemove: "foo",
+			Expected: make(set.Set[string], 0),
+		},
+		{
+			Name: "Remove from nil",
+			Input: nil,
+			ToRemove: "foo",
+			Expected: nil,
+		},
+		{
+			Name: "Remove extant element",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			ToRemove: "barfoo",
+			Expected: set.Set[string] {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+		},
+		{
+			Name: "Remove missing element",
+			Input: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			ToRemove: "foo",
+			Expected: set.Set[string] {
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			},
+		},
+		{
+			Name: "Contains zero-value element",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			}),
+			ToRemove: "foo",
+			Expected: set.Set[string] {
+				"": {},
+				"bar": {},
+				"foobar": {},
+			},
+		},
+		{
+			Name: "Remove zero-value element",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"bar": {},
+				"foobar": {},
+			}),
+			ToRemove: "",
+			Expected: set.Set[string] {
+				"bar": {},
+				"foobar": {},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.Input.Remove(tc.ToRemove)
+			if !cmp.Equal(tc.Input, tc.Expected) {
+				t.Errorf("Output did not match expectation.\nexpected: (-), actual: (+):\n%s", cmp.Diff(tc.Expected, tc.Input))
+			}
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Input set.Set[string]
+		Contains string
+		Expected bool
+	} {
+		{
+			Name: "Empty Contains",
+			Input: make(set.Set[string], 0),
+			Contains: "foo",
+			Expected: false,
+		},
+		{
+			Name: "Nil Contains",
+			Input: nil,
+			Contains: "foo",
+			Expected: false,
+		},
+		{
+			Name: "Contains extant element",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Contains: "barfoo",
+			Expected: true,
+		},
+		{
+			Name: "Contains missing element",
+			Input: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Contains: "foo",
+			Expected: false,
+		},
+		{
+			Name: "Contains extant zero-value element",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			}),
+			Contains: "",
+			Expected: true,
+		},
+		{
+			Name: "Contains missing zero-value element",
+			Input: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"foobar": {},
+			}),
+			Contains: "",
+			Expected: false,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.Equal(t, tc.Input.Contains(tc.Contains), tc.Expected)
+		})
+	}
+}
+
+func TestIntersection(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Input set.Set[string]
+		Conjunct set.Set[string]
+		Expected []string
+	} {
+		{
+			Name: "Empty intersects empty",
+			Input: make(set.Set[string], 0),
+			Conjunct: make(set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "Nil intersects nil",
+			Input: nil,
+			Conjunct: nil,
+			Expected: []string{},
+		},
+		{
+			Name: "Empty intersects nil",
+			Input: make(set.Set[string], 0),
+			Conjunct: nil,
+			Expected: []string{},
+		},
+		{
+			Name: "Nil intersects empty",
+			Input: nil,
+			Conjunct: make(set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "Empty intersects non-empty",
+			Input: make(set.Set[string], 0),
+			Conjunct: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Expected: []string{},
+		},
+		{
+			Name: "Non-empty intersects empty",
+			Input: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Conjunct: make(set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "Nil intersects non-empty",
+			Input: nil,
+			Conjunct: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Expected: []string{},
+		},
+		{
+			Name: "Non-empty intersects nil",
+			Input: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Conjunct: nil,
+			Expected: []string{},
+		},
+		{
+			Name: "Intersect with overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Conjunct: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"barfoo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"bar",
+				"barfoo",
+			},
+		},
+		{
+			Name: "Intersect with no overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barfoo": {},
+			}),
+			Conjunct: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"barbar": {},
+			}),
+			Expected: []string{},
+		},
+		{
+			Name: "Intersect with zero-value overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barfoo": {},
+			}),
+			Conjunct: set.Set[string](map[string]struct{} {
+				"": {},
+				"bar": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"",
+			},
+		},
+		{
+			Name: "Intersect with zero-value no overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barfoo": {},
+			}),
+			Conjunct: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"foo",
+			},
+		},
+		{
+			Name: "Intersect with zero-value no overlap 2",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barfoo": {},
+			}),
+			Conjunct: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"foo",
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			s := tc.Input.Intersection(tc.Conjunct)
+			assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
+		})
+	}
+}
+
+func TestUnion(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Input set.Set[string]
+		Disjunct set.Set[string]
+		Expected []string
+	} {
+		{
+			Name: "Empty union empty",
+			Input: make(set.Set[string], 0),
+			Disjunct: make(set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "Nil union nil",
+			Input: nil,
+			Disjunct: nil,
+			Expected: []string{},
+		},
+		{
+			Name: "Empty union nil",
+			Input: make(set.Set[string], 0),
+			Disjunct: nil,
+			Expected: []string{},
+		},
+		{
+			Name: "Nil union empty",
+			Input: nil,
+			Disjunct: make(set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "Empty union non-empty",
+			Input: make(set.Set[string], 0),
+			Disjunct: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+			},
+		},
+		{
+			Name: "Non-empty union empty",
+			Input: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Disjunct: make(set.Set[string], 0),
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+			},
+		},
+		{
+			Name: "Nil union non-empty",
+			Input: nil,
+			Disjunct: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+			},
+		},
+		{
+			Name: "Non-empty union nil",
+			Input: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Disjunct: nil,
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+			},
+		},
+		{
+			Name: "Union with overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Disjunct: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"barfoo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+				"barbar",
+			},
+		},
+		{
+			Name: "Union with no overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barfoo": {},
+			}),
+			Disjunct: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"foo",
+				"bar",
+				"barfoo",
+				"barbar",
+			},
+		},
+		{
+			Name: "Union with zero-value overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barfoo": {},
+			}),
+			Disjunct: set.Set[string](map[string]struct{} {
+				"": {},
+				"bar": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"",
+				"foo",
+				"bar",
+				"barfoo",
+				"barbar",
+			},
+		},
+		{
+			Name: "Union with zero-value no overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barfoo": {},
+			}),
+			Disjunct: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"",
+				"foo",
+				"barfoo",
+				"barbar",
+			},
+		},
+		{
+			Name: "Union with zero-value no overlap 2",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barfoo": {},
+			}),
+			Disjunct: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"",
+				"foo",
+				"barfoo",
+				"barbar",
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			s := tc.Input.Union(tc.Disjunct)
+			assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
+		})
+	}
+}
+
+func TestDifference(t *testing.T) {
+	for _, tc := range []struct{
+		Name string
+		Input set.Set[string]
+		Subtrahend set.Set[string]
+		Expected []string
+	} {
+		{
+			Name: "Empty subtract empty",
+			Input: make(set.Set[string], 0),
+			Subtrahend: make(set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "Nil subtract nil",
+			Input: nil,
+			Subtrahend: nil,
+			Expected: []string{},
+		},
+		{
+			Name: "Empty subtract nil",
+			Input: make(set.Set[string], 0),
+			Subtrahend: nil,
+			Expected: []string{},
+		},
+		{
+			Name: "Nil subtract empty",
+			Input: nil,
+			Subtrahend: make(set.Set[string], 0),
+			Expected: []string{},
+		},
+		{
+			Name: "Empty subtract non-empty",
+			Input: make(set.Set[string], 0),
+			Subtrahend: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Expected: []string{},
+		},
+		{
+			Name: "Non-empty subtract empty",
+			Input: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Subtrahend: make(set.Set[string], 0),
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+			},
+		},
+		{
+			Name: "Nil subtract non-empty",
+			Input: nil,
+			Subtrahend: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Expected: []string{},
+		},
+		{
+			Name: "Non-empty subtract nil",
+			Input: set.Set[string]{
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+			},
+			Subtrahend: nil,
+			Expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+			},
+		},
+		{
+			Name: "Subtract with overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Subtrahend: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"barfoo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"foo",
+				"foobar",
+			},
+		},
+		{
+			Name: "Subtract with no overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barfoo": {},
+			}),
+			Subtrahend: set.Set[string](map[string]struct{} {
+				"bar": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"foo",
+				"barfoo",
+			},
+		},
+		{
+			Name: "Subtract with zero-value overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barfoo": {},
+			}),
+			Subtrahend: set.Set[string](map[string]struct{} {
+				"": {},
+				"bar": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"foo",
+				"barfoo",
+			},
+		},
+		{
+			Name: "Subtract with zero-value no overlap",
+			Input: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barfoo": {},
+			}),
+			Subtrahend: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"",
+				"barfoo",
+			},
+		},
+		{
+			Name: "Subtract with zero-value no overlap 2",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"barfoo": {},
+			}),
+			Subtrahend: set.Set[string](map[string]struct{} {
+				"": {},
+				"foo": {},
+				"barbar": {},
+			}),
+			Expected: []string{
+				"barfoo",
+			},
+		},
+		{
+			Name: "Subtract all",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Subtrahend: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Expected: []string{},
+		},
+		{
+			Name: "Subtract more than all",
+			Input: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+			}),
+			Subtrahend: set.Set[string](map[string]struct{} {
+				"foo": {},
+				"bar": {},
+				"foobar": {},
+				"barfoo": {},
+				"barbar": {},
+			}),
+			Expected: []string{},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			s := tc.Input.Difference(tc.Subtrahend)
+			assert.ElementsMatch(t, slices.Collect(s), tc.Expected)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a formal `Set` type, which is simply defined as a `map[E any]struct{}`

Motivations for this change:
- I find myself very, very frequently needing to turn a slice or sequence into a "set", and writing the same for-loop every time. 
- Inserting a new element into a "set" is not very readable: `set[element] := struct{}{}` is technically understandable, but it is not a very intuitive way to represent what you're doing.
- Determining membership in a "set" is cumbersome. For any conditional, checking membership requires doing `if _, ok := set[element]; ok`. This means both that you cannot combine two checks for set membership in one conditional, and you cannot short-circuit checking set membership in a conditional since the check has to be evaluated before the actual conditional.
- This gives us the opportunity to make some common set operations (`Intersection`, `Union`, `Difference`) readily available and tested instead of re-implementing them every time they are needed.
- We can now get read-only `View`s of the keys in a normal map, allowing us to perform set-operations concisely without making copies.