### PR TITLE
[oci cache] test writing and fetching blobs

### DIFF
--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -406,7 +406,7 @@ func fetchFromCacheWriteToResponse(ctx context.Context, w http.ResponseWriter, b
 	if !writeBody {
 		return nil
 	}
-	return ocicache.FetchBlobFromCache(ctx, w, bsClient, acClient, hash, blobMetadata.GetContentLength())
+	return ocicache.FetchBlobFromCache(ctx, w, bsClient, hash, blobMetadata.GetContentLength())
 }
 
 func isDigest(identifier string) bool {

--- a/enterprise/server/util/ocicache/BUILD
+++ b/enterprise/server/util/ocicache/BUILD
@@ -42,6 +42,7 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_containerregistry//pkg/crane",
         "@com_github_google_go_containerregistry//pkg/name",
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -194,7 +194,7 @@ func FetchBlobMetadataFromCache(ctx context.Context, bsClient bspb.ByteStreamCli
 	return blobMetadata, nil
 }
 
-func FetchBlobFromCache(ctx context.Context, w io.Writer, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, hash gcr.Hash, contentLength int64) error {
+func FetchBlobFromCache(ctx context.Context, w io.Writer, bsClient bspb.ByteStreamClient, hash gcr.Hash, contentLength int64) error {
 	blobCASDigest := &repb.Digest{
 		Hash:      hash.Hex,
 		SizeBytes: contentLength,


### PR DESCRIPTION
This change tests the WriteBlob and FetchBlob[Metadata] paths.

I'll want the same exact test when I introduce `ocicache.NewBlobUploader`, so landing it now!