### PR TITLE
Don't alert.UnexpectedEvent for dropped hit-tracker-client hits

### DIFF
--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -3,7 +3,6 @@ package hit_tracker_client
 import (
 	"context"
 	"flag"
-	"fmt"
 	"sync"
 	"time"
 
@@ -242,7 +241,6 @@ func (h *HitTrackerFactory) enqueue(ctx context.Context, requestMetadata *repb.R
 		return
 	}
 
-	alert.UnexpectedEvent(fmt.Sprintf("Exceeded maximum number of pending cache hits for group %s, dropping some.", string(groupID)))
 	metrics.RemoteHitTrackerUpdates.With(
 		prometheus.Labels{
 			metrics.GroupID:              string(groupID),


### PR DESCRIPTION
I added a separate alert for the dropped-hits metric in https://github.com/buildbuddy-io/buildbuddy-internal/pull/5092

I modified the existing benchmark to set the flags so the hit-tracker-client drops hits after the first one and then set the number of hits-to-enqueue to 1,000 to measure the impact of this when the client is full. Here are the results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 7 5800X 8-Core Processor             
           │ /home/iain/old.txt │          /home/iain/new.txt           │
           │       sec/op       │   sec/op     vs base                  │
Enqueue-16       3064.1µ ± 262%   474.7µ ± 8%  -84.51% (p=0.000 n=7+10)

           │ /home/iain/old.txt │           /home/iain/new.txt           │
           │        B/op        │     B/op      vs base                  │
Enqueue-16         4.535Mi ± 1%   1.375Mi ± 2%  -69.69% (p=0.000 n=7+10)

           │ /home/iain/old.txt │          /home/iain/new.txt           │
           │     allocs/op      │  allocs/op   vs base                  │
Enqueue-16          66.35k ± 0%   19.61k ± 1%  -70.45% (p=0.000 n=7+10)
```