### PR TITLE
[oci resolver] read manifests from cache (disabled by default)

### DIFF
--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -21,7 +21,6 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/authn",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
-        "@com_github_google_go_containerregistry//pkg/v1/match",
         "@com_github_google_go_containerregistry//pkg/v1/partial",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -21,9 +21,11 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/authn",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@com_github_google_go_containerregistry//pkg/v1/partial",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
         "@com_github_google_go_containerregistry//pkg/v1/types",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )
 

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -21,6 +21,7 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/authn",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@com_github_google_go_containerregistry//pkg/v1/match",
         "@com_github_google_go_containerregistry//pkg/v1/partial",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -39,7 +39,7 @@ var (
 	defaultKeychainEnabled = flag.Bool("executor.container_registry_default_keychain_enabled", false, "Enable the default container registry keychain, respecting both docker configs and podman configs.")
 	allowedPrivateIPs      = flag.Slice("executor.container_registry_allowed_private_ips", []string{}, "Allowed private IP ranges for container registries. Private IPs are disallowed by default.")
 
-	useCachePercent        = flag.Int("executor.container_registry.use_cache_percent", 0, "Percentage of image pulls to use the cache (individaul cache flags must also be enabled).")
+	useCachePercent        = flag.Int("executor.container_registry.use_cache_percent", 0, "Percentage of image pulls to use the cache (individual cache flags must also be enabled).")
 	writeManifestsToCache  = flag.Bool("executor.container_registry.write_manifests_to_cache", false, "Write resolved manifests to the cache.")
 	readManifestsFromCache = flag.Bool("executor.container_registry.read_manifests_from_cache", false, "Read manifests from the cache after a HEAD request to the upstream registry.")
 

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -36,8 +36,9 @@ var (
 	defaultKeychainEnabled = flag.Bool("executor.container_registry_default_keychain_enabled", false, "Enable the default container registry keychain, respecting both docker configs and podman configs.")
 	allowedPrivateIPs      = flag.Slice("executor.container_registry_allowed_private_ips", []string{}, "Allowed private IP ranges for container registries. Private IPs are disallowed by default.")
 
-	useCachePercent       = flag.Int("executor.container_registry.use_cache_percent", 0, "Percentage of image pulls to use the cache (individaul cache flags must also be enabled).")
-	writeManifestsToCache = flag.Bool("executor.container_registry.write_manifests_to_cache", false, "Write resolved manifests to the cache.")
+	useCachePercent        = flag.Int("executor.container_registry.use_cache_percent", 0, "Percentage of image pulls to use the cache (individaul cache flags must also be enabled).")
+	writeManifestsToCache  = flag.Bool("executor.container_registry.write_manifests_to_cache", false, "Write resolved manifests to the cache.")
+	readManifestsFromCache = flag.Bool("executor.container_registry.read_manifests_from_cache", false, "Read manifests from the cache after a HEAD request to the upstream registry.")
 )
 
 type MirrorConfig struct {

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -334,7 +334,7 @@ func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef gcrname.Ref
 			desc.Digest,
 		)
 		if err != nil && !status.IsNotFoundError(err) {
-			log.Warningf("Error fetching manifest from cache: %s", err)
+			log.CtxWarningf(ctx, "Error fetching manifest from cache: %s", err)
 		}
 		if mc != nil && err == nil {
 			return imageFromDescriptorAndManifest(

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -696,6 +696,7 @@ func TestResolve_WithCache(t *testing.T) {
 					flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 					flags.Set(t, "executor.container_registry.use_cache_percent", 100)
 					flags.Set(t, "executor.container_registry.write_manifests_to_cache", writeManifests)
+					flags.Set(t, "executor.container_registry.read_manifests_from_cache", readManifests)
 					counter := atomic.Int32{}
 					registry := testregistry.Run(t, testregistry.Opts{
 						HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -438,7 +438,9 @@ func TestResolve_Layers_DiffIDs(t *testing.T) {
 				upstreamCounter := atomic.Int32{}
 				registry := testregistry.Run(t, testregistry.Opts{
 					HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
-						upstreamCounter.Add(1)
+						if r.Method == http.MethodGet && r.URL.Path != "/v2/" {
+							upstreamCounter.Add(1)
+						}
 						return true
 					},
 				})

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -680,75 +680,76 @@ func TestResolve_WithCache(t *testing.T) {
 			},
 		},
 	} {
-		readManifests := false
 		writeLayers := false
 		readLayers := false
 		for _, writeManifests := range []bool{false, true} {
-			name := tc.name + fmt.Sprintf(
-				"/write_manifests_%t_read_manifests_%t_write_layers_%t_read_layers_%t",
-				writeManifests,
-				readManifests,
-				writeLayers,
-				readLayers,
-			)
-			t.Run(name, func(t *testing.T) {
-				te := setupTestEnvWithCache(t)
-				flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
-				flags.Set(t, "executor.container_registry.use_cache_percent", 100)
-				flags.Set(t, "executor.container_registry.write_manifests_to_cache", writeManifests)
-				counter := atomic.Int32{}
-				registry := testregistry.Run(t, testregistry.Opts{
-					HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
-						if r.Method == http.MethodGet && r.URL.Path != "/v2/" {
-							counter.Add(1)
+			for _, readManifests := range []bool{false, true} {
+				name := tc.name + fmt.Sprintf(
+					"/write_manifests_%t_read_manifests_%t_write_layers_%t_read_layers_%t",
+					writeManifests,
+					readManifests,
+					writeLayers,
+					readLayers,
+				)
+				t.Run(name, func(t *testing.T) {
+					te := setupTestEnvWithCache(t)
+					flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
+					flags.Set(t, "executor.container_registry.use_cache_percent", 100)
+					flags.Set(t, "executor.container_registry.write_manifests_to_cache", writeManifests)
+					counter := atomic.Int32{}
+					registry := testregistry.Run(t, testregistry.Opts{
+						HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+							if r.Method == http.MethodGet && r.URL.Path != "/v2/" {
+								counter.Add(1)
+							}
+							return true
+						},
+					})
+					_, pushedImage := registry.PushNamedImageWithFiles(t, tc.imageName+"_image", tc.imageFiles)
+
+					index := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
+						Add: pushedImage,
+						Descriptor: v1.Descriptor{
+							Platform: &tc.imagePlatform,
+						},
+					})
+					registry.PushIndex(t, index, tc.imageName+"_index")
+
+					{
+						imageAddress := registry.ImageAddress(tc.args.imageName + "_image")
+						resolveCount := int32(1)
+						filesCount := int32(1)
+						resolveAndCheck(t, tc, te, imageAddress, &counter, resolveCount, filesCount)
+
+						resolveCount = int32(1)
+						if writeManifests && readManifests {
+							resolveCount = int32(0)
 						}
-						return true
-					},
+						filesCount = int32(1)
+						if writeLayers && readLayers {
+							filesCount = int32(0)
+						}
+						resolveAndCheck(t, tc, te, imageAddress, &counter, resolveCount, filesCount)
+					}
+
+					{
+						indexAddress := registry.ImageAddress(tc.args.imageName + "_index")
+						resolveCount := int32(2)
+						filesCount := int32(1)
+						resolveAndCheck(t, tc, te, indexAddress, &counter, resolveCount, filesCount)
+
+						resolveCount = int32(2)
+						if writeManifests && readManifests {
+							resolveCount = int32(0)
+						}
+						filesCount = int32(1)
+						if writeLayers && readLayers {
+							filesCount = int32(0)
+						}
+						resolveAndCheck(t, tc, te, indexAddress, &counter, resolveCount, filesCount)
+					}
 				})
-				_, pushedImage := registry.PushNamedImageWithFiles(t, tc.imageName+"_image", tc.imageFiles)
-
-				index := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
-					Add: pushedImage,
-					Descriptor: v1.Descriptor{
-						Platform: &tc.imagePlatform,
-					},
-				})
-				registry.PushIndex(t, index, tc.imageName+"_index")
-
-				{
-					imageAddress := registry.ImageAddress(tc.args.imageName + "_image")
-					resolveCount := int32(1)
-					filesCount := int32(1)
-					resolveAndCheck(t, tc, te, imageAddress, &counter, resolveCount, filesCount)
-
-					resolveCount = int32(1)
-					if writeManifests && readManifests {
-						resolveCount = int32(0)
-					}
-					filesCount = int32(1)
-					if writeLayers && readLayers {
-						filesCount = int32(0)
-					}
-					resolveAndCheck(t, tc, te, imageAddress, &counter, resolveCount, filesCount)
-				}
-
-				{
-					indexAddress := registry.ImageAddress(tc.args.imageName + "_index")
-					resolveCount := int32(2)
-					filesCount := int32(1)
-					resolveAndCheck(t, tc, te, indexAddress, &counter, resolveCount, filesCount)
-
-					resolveCount = int32(2)
-					if writeManifests && readManifests {
-						resolveCount = int32(0)
-					}
-					filesCount = int32(1)
-					if writeLayers && readLayers {
-						filesCount = int32(0)
-					}
-					resolveAndCheck(t, tc, te, indexAddress, &counter, resolveCount, filesCount)
-				}
-			})
+			}
 		}
 	}
 }


### PR DESCRIPTION
This change adds the `read_manifests_from_cache` flag and will fetch image and index manifests from the cache when enabled.

In order to avoid pathological behavior wherein `Layer.DiffID()` fetches the entire uncompressed layer in order to compute a checksum, I also implement `layerFromDigest` in this change. A future change will cache the layer on calls to `Compressed()`.