### PR TITLE
Make org join requests unambiguous

### DIFF
--- a/enterprise/app/org/BUILD
+++ b/enterprise/app/org/BUILD
@@ -82,6 +82,7 @@ ts_library(
         "//app/service:rpc_service",
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",
+        "//proto:user_ts_proto",
     ],
 )
 

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -227,7 +227,7 @@
   align-items: center;
 }
 
-.org-join-requests .email {
+.org-join-requests .account {
   font-weight: 600;
 }
 

--- a/proto/user_id.proto
+++ b/proto/user_id.proto
@@ -10,7 +10,6 @@ message UserId {
 // The user's name, usually pulled (initially) from the authentication provider.
 message Name {
   string full = 1;
-
   string first = 2;
   string last = 3;
 }
@@ -23,6 +22,8 @@ message DisplayUser {
   string profile_image_url = 3;
   string email = 4;
   AccountType account_type = 5;
+  // Username provided by the authentication provider, if known.
+  string username = 6;
 }
 
 enum AccountType {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -316,9 +316,10 @@ func (u *User) TableName() string {
 
 func (u *User) ToProto() *uspb.DisplayUser {
 	name := strings.TrimSpace(u.FirstName + " " + u.LastName)
-	// Use the github username as the name, if no name is set.
-	if name == "" && strings.HasPrefix(u.SubID, "https://github.com/") {
-		name = strings.TrimPrefix(u.SubID, "https://github.com/")
+	// Parse username from subscriber ID (for known providers).
+	username := ""
+	if strings.HasPrefix(u.SubID, "https://github.com/") {
+		username = strings.TrimPrefix(u.SubID, "https://github.com/")
 	}
 	return &uspb.DisplayUser{
 		UserId: &uspb.UserId{
@@ -332,6 +333,7 @@ func (u *User) ToProto() *uspb.DisplayUser {
 		ProfileImageUrl: u.ImageURL,
 		Email:           u.Email,
 		AccountType:     subIDToAccountType(u.SubID),
+		Username:        username,
 	}
 }
 


### PR DESCRIPTION
- Fix an issue that we're still showing an empty user name.
- Render the account type (google, github, etc.), so it's clear whether an OIDC or SSO user is being added.

Before:

![image](https://github.com/user-attachments/assets/9cc315e3-7ad7-4342-9247-6fbbd5287fe9)

After:

![image](https://github.com/user-attachments/assets/474d78ba-6db5-4593-a9e0-471b7fad078d)
