### PR TITLE
[oci cache] add NewBlobReadThroughCacher

### DIFF
--- a/enterprise/server/util/ocicache/BUILD
+++ b/enterprise/server/util/ocicache/BUILD
@@ -39,6 +39,7 @@ go_test(
         "//server/testutil/testcache",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
+        "//server/util/random",
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_containerregistry//pkg/crane",

--- a/enterprise/server/util/ocicache/BUILD
+++ b/enterprise/server/util/ocicache/BUILD
@@ -37,6 +37,7 @@ go_test(
         "//proto:ociregistry_go_proto",
         "//server/interfaces",
         "//server/testutil/testcache",
+        "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -292,8 +292,8 @@ func WriteBlobToCache(ctx context.Context, r io.Reader, bsClient bspb.ByteStream
 
 // NewBlobUploader creates a WriteCloser that writes OCI blobs to the CAS.
 //
-// On Close, the BlobUploader will attempt to commit the OCI blob to the CAS (relying on the Byte Stream Server to detect and reject blobs that
-// do not match the given digest). It will also write blob metadata to the CAS and an AC entry pointing to the blob and its metadata.
+// Once contentLength bytes have been written, the blobUploader will commit the blob.
+// It is an error to attempt to Write after commit, and to write more than contentLength bytes.
 func NewBlobUploader(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) (io.WriteCloser, error) {
 	blobCASDigest := &repb.Digest{
 		Hash:      hash.Hex,

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -390,9 +390,6 @@ type readThroughCacher struct {
 
 func (r *readThroughCacher) Read(p []byte) (int, error) {
 	n, err := r.rc.Read(p)
-	if err != nil && err != io.EOF {
-		return n, err
-	}
 	if n <= 0 {
 		return n, err
 	}
@@ -408,6 +405,7 @@ func (r *readThroughCacher) Read(p []byte) (int, error) {
 	if written < n {
 		r.writeErr = io.ErrShortWrite
 	}
+
 	return n, err
 }
 

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -390,25 +390,25 @@ type readThroughCacher struct {
 
 func (r *readThroughCacher) Read(p []byte) (int, error) {
 	n, err := r.rc.Read(p)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return n, err
 	}
 	if n <= 0 {
-		return n, nil
+		return n, err
 	}
 	if r.writeErr != nil {
-		return n, nil
+		return n, err
 	}
-	written, err := r.wc.Write(p[:n])
-	if err != nil {
-		log.Warningf("Error writing to cache: %s", err)
-		r.writeErr = err
-		return n, nil
+	written, writeErr := r.wc.Write(p[:n])
+	if writeErr != nil {
+		log.Warningf("Error writing to cache: %s", writeErr)
+		r.writeErr = writeErr
+		return n, err
 	}
 	if written < n {
 		r.writeErr = io.ErrShortWrite
 	}
-	return n, nil
+	return n, err
 }
 
 func (r *readThroughCacher) Close() error {

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -12,14 +12,15 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/require"
 
 	ocipb "github.com/buildbuddy-io/buildbuddy/proto/ociregistry"
+	gcr "github.com/google/go-containerregistry/pkg/v1"
 )
 
 func TestCacheSecret(t *testing.T) {


### PR DESCRIPTION
This change introduces `ocicache.NewBlobReadThroughCacher`, which will be necessary to cache layers on read.