### PR TITLE
Show execution local queue time in trace viewer

### DIFF
--- a/enterprise/server/execution_service/BUILD
+++ b/enterprise/server/execution_service/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/util/log",
         "//server/util/perms",
         "//server/util/query_builder",
+        "//server/util/rexec",
         "//server/util/status",
         "//server/util/timeseries",
         "//server/util/trace_events",


### PR DESCRIPTION
Screenshot (from a local execution with artificial `time.Sleep(100 * time.Millisecond)` after we record each timestamp)

![image](https://github.com/user-attachments/assets/e44691d9-8617-4d6e-a2d5-cb03d74487e2)
