### PR TITLE
Use WithLabelValues instead of With for metrics in atime_updater

### DIFF
--- a/enterprise/server/atime_updater/BUILD
+++ b/enterprise/server/atime_updater/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/authutil",
         "//server/util/log",
-        "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -579,6 +579,9 @@ func TestEnqueueByResourceName_CAS(t *testing.T) {
 }
 
 func BenchmarkEnqueue(b *testing.B) {
+	*log.LogLevel = "error"
+	log.Configure()
+
 	numToEnqueue := 10_000
 	instances := []string{"instance-1", "instance-2", "instance-3"}
 	digests := []*repb.Digest{digest0, digest1, digest2, digest3, digest4, digest5, digest6, digest7, digest8, digest9}


### PR DESCRIPTION
This should save a bit of CPU in the cache proxy.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
           │    base     │               values               │
           │   sec/op    │   sec/op     vs base               │
Enqueue-24   146.6m ± 4%   138.0m ± 3%  -5.86% (p=0.005 n=11)

           │     base     │                values                │
           │     B/op     │     B/op      vs base                │
Enqueue-24   689.3Mi ± 0%   400.9Mi ± 0%  -41.84% (p=0.000 n=11)

           │    base     │               values                │
           │  allocs/op  │  allocs/op   vs base                │
Enqueue-24   7.531M ± 0%   5.730M ± 0%  -23.90% (p=0.000 n=11)
```