### PR TITLE
Use itoa instead of Sprinf("%d,"... ) in byte_stream_server_proxy

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -44,6 +44,7 @@ go_test(
         "//server/testutil/testenv",
         "//server/util/authutil",
         "//server/util/compression",
+        "//server/util/log",
         "//server/util/prefix",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/proxy_util"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -223,7 +224,7 @@ func (s *ByteStreamServerProxy) readRemoteWriteLocal(req *bspb.ReadRequest, stre
 
 func recordReadMetrics(cacheStatus string, proxyRequestType string, err error, bytesRead int) {
 	labels := prometheus.Labels{
-		metrics.StatusLabel:           fmt.Sprintf("%d", gstatus.Code(err)),
+		metrics.StatusLabel:           strconv.Itoa(int(gstatus.Code(err))),
 		metrics.CacheHitMissStatus:    cacheStatus,
 		metrics.CacheProxyRequestType: proxyRequestType,
 	}
@@ -373,7 +374,7 @@ func (s *ByteStreamServerProxy) dualWrite(ctx context.Context, stream bspb.ByteS
 
 func recordWriteMetrics(bytesWritten int64, err error, proxyRequestType string) {
 	labels := prometheus.Labels{
-		metrics.StatusLabel:           fmt.Sprintf("%d", gstatus.Code(err)),
+		metrics.StatusLabel:           strconv.Itoa(int(gstatus.Code(err))),
 		metrics.CacheHitMissStatus:    metrics.MissStatusLabel,
 		metrics.CacheProxyRequestType: proxyRequestType,
 	}

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
@@ -516,6 +517,8 @@ func TestSkipRemote(t *testing.T) {
 }
 
 func BenchmarkRead(b *testing.B) {
+	*log.LogLevel = "error"
+	log.Configure()
 	// Disable the atime updater as it can interfere with the request counter.
 	flags.Set(b, "cache_proxy.remote_atime_max_digests_per_group", 0)
 
@@ -569,6 +572,8 @@ func BenchmarkRead(b *testing.B) {
 }
 
 func BenchmarkWrite(b *testing.B) {
+	*log.LogLevel = "error"
+	log.Configure()
 	ctx := testContext()
 	remoteEnv := testenv.GetTestEnv(b)
 	proxyEnv := testenv.GetTestEnv(b)


### PR DESCRIPTION
This should save about 0.2% of CPU for the cache proxy.

using metric.WithLabelValues here didn't help for some reason.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
        │    base     │                itoa                │
        │   sec/op    │   sec/op     vs base               │
Read-24   65.22µ ± 4%   61.90µ ± 3%  -5.10% (p=0.025 n=30)

        │     base     │              itoa              │
        │     B/op     │     B/op      vs base          │
Read-24   110.4Ki ± 0%   110.5Ki ± 0%  ~ (p=0.143 n=30)

        │    base    │             itoa             │
        │ allocs/op  │ allocs/op   vs base          │
Read-24   418.0 ± 0%   418.0 ± 0%  ~ (p=0.334 n=30)
```