### PR TITLE
Fix error logged when removing docker container that is already removed

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -700,8 +700,11 @@ func (r *dockerCommandContainer) Pause(ctx context.Context) error {
 
 func (r *dockerCommandContainer) Remove(ctx context.Context) error {
 	r.removed = true
-	if err := r.client.ContainerRemove(ctx, r.id, dockercontainer.RemoveOptions{Force: true}); err != nil {
-		return wrapDockerErr(err, fmt.Sprintf("failed to remove docker container %s", r.id))
+	if r.id != "" {
+		if err := r.client.ContainerRemove(ctx, r.id, dockercontainer.RemoveOptions{Force: true}); err != nil {
+			return wrapDockerErr(err, fmt.Sprintf("failed to remove docker container %s", r.id))
+		}
+		r.id = ""
 	}
 	return nil
 }


### PR DESCRIPTION
A while back, the contract of the `Remove` method (from the `CommandContainer` interface) was changed so that (a) it must be idempotent ("removes **any** resources asociated with the container"), and (b) it is called even for the `Run` codepath (non-recycling case). But we never updated the `docker` impl to account for this, so it now tries to remove the container unconditionally, even though the current implementation in `Run` removes the container in the background. This PR fixes the `Remove` implementation to only remove if the container exists and has not yet been removed.

Side note: the current (ancient) implementation of `Run` spawns a background process to remove the container after the action finishes running, which is not great - in a follow up PR, I would like to remove that code, and let the cleanup happen in the `Remove` method instead.