### PR TITLE
Refactor bytestream proxy to use byte_stream_server.Write

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -516,7 +517,7 @@ func TestSkipRemote(t *testing.T) {
 	requestCounter.Store(0)
 }
 
-func BenchmarkRead(b *testing.B) {
+func BenchmarkReadAlwaysPresent(b *testing.B) {
 	*log.LogLevel = "error"
 	log.Configure()
 	// Disable the atime updater as it can interfere with the request counter.
@@ -571,7 +572,89 @@ func BenchmarkRead(b *testing.B) {
 	}
 }
 
-func BenchmarkWrite(b *testing.B) {
+func BenchmarkReadThroughCache(b *testing.B) {
+	*log.LogLevel = "error"
+	log.Configure()
+	// Disable the atime updater as it can interfere with the request counter.
+	flags.Set(b, "cache_proxy.remote_atime_max_digests_per_group", 0)
+
+	ctx := testContext()
+	remoteEnv := testenv.GetTestEnv(b)
+	proxyEnv := testenv.GetTestEnv(b)
+	bs, _, _, requestCounter := runRemoteServices(ctx, remoteEnv, b)
+	proxy := runBSProxy(ctx, bs, proxyEnv, b)
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
+	if err != nil {
+		b.Errorf("error attaching user prefix: %v", err)
+	}
+
+	for _, zstd := range []bool{false, true} {
+		// The largest size is such after compression, it's bigger than 5MiB.
+		for _, size := range []int64{10_000, 3_000_000, 20_000_000} {
+			b.Run(fmt.Sprintf("zstd=%v/size=%v", zstd, size), func(b *testing.B) {
+				b.ReportAllocs()
+				requestCounter.Store(0)
+				i := 0
+				for b.Loop() {
+					i++
+					b.StopTimer()
+					rnProto, data := testdigest.RandomCASResourceBuf(b, size)
+					if zstd {
+						data = compression.CompressZstd(nil, data)
+						rnProto.Compressor = repb.Compressor_ZSTD
+					}
+					rn, err := digest.CASResourceNameFromProto(rnProto)
+					require.NoError(b, err)
+					writeStream, err := bs.Write(ctx)
+					require.NoError(b, err)
+					require.NoError(b, writeStream.Send(&bspb.WriteRequest{
+						ResourceName: rn.NewUploadString(),
+						WriteOffset:  0,
+						Data:         data,
+						FinishWrite:  true,
+					}))
+					resp, err := writeStream.CloseAndRecv()
+					require.NoError(b, err)
+					if !zstd {
+						require.Equal(b, int64(len(data)), resp.GetCommittedSize())
+					} else {
+						// With compression, the committed size won't be equal
+						// to the input size. It can even be bigger when the
+						// input is small.
+						require.Less(b, int64(0), resp.GetCommittedSize())
+					}
+					b.StartTimer()
+
+					downloadBuf := make([]byte, 0, len(data))
+					downloadStream, err := proxy.Read(ctx, &bspb.ReadRequest{ResourceName: rn.DownloadString()})
+					require.NoError(b, err)
+					for {
+						res, err := downloadStream.Recv()
+						if err == io.EOF {
+							break
+						}
+						require.NoError(b, err)
+						downloadBuf = append(downloadBuf, res.Data...)
+					}
+					b.StopTimer()
+					if zstd {
+						data, err = compression.DecompressZstd(nil, data)
+						require.NoError(b, err)
+						downloadBuf, err = compression.DecompressZstd(nil, downloadBuf)
+						require.NoError(b, err)
+					}
+					require.Equal(b, data, downloadBuf)
+					require.Equal(b, int32(i*2), requestCounter.Load())
+					b.StartTimer()
+
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkWriteAlreadyExists(b *testing.B) {
 	*log.LogLevel = "error"
 	log.Configure()
 	ctx := testContext()
@@ -607,5 +690,74 @@ func BenchmarkWrite(b *testing.B) {
 		require.Equal(b, int64(len(dataString)), resp.GetCommittedSize())
 		require.Equal(b, int32(i), requestCounter.Load())
 		i++
+	}
+}
+
+func BenchmarkWriteUnique(b *testing.B) {
+	*log.LogLevel = "error"
+	log.Configure()
+	ctx := testContext()
+	remoteEnv := testenv.GetTestEnv(b)
+	proxyEnv := testenv.GetTestEnv(b)
+	bs, _, _, requestCounter := runRemoteServices(ctx, remoteEnv, b)
+	proxy := runBSProxy(ctx, bs, proxyEnv, b)
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
+	if err != nil {
+		b.Errorf("error attaching user prefix: %v", err)
+	}
+
+	i := 1
+	for _, zstd := range []bool{false, true} {
+		// The largest size is such after compression, it's bigger than 5MiB,
+		// which is the batchSize below.
+		for _, size := range []int64{10_000, 3_000_000, 20_000_000} {
+			b.Run(fmt.Sprintf("zstd=%v/size=%v", zstd, size), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					b.StopTimer()
+					rnProto, data := testdigest.NewRandomResourceAndBuf(b, size, rspb.CacheType_CAS, strconv.Itoa(i))
+					if zstd {
+						data = compression.CompressZstd(nil, data)
+						rnProto.Compressor = repb.Compressor_ZSTD
+					}
+					rn, err := digest.CASResourceNameFromProto(rnProto)
+					require.NoError(b, err)
+					uploadString := rn.NewUploadString()
+					b.StartTimer()
+
+					writeStream, err := proxy.Write(ctx)
+					require.NoError(b, err)
+
+					// Use a batch size bigger than 4MiB, which we often use
+					// for the max buffer size,
+					batchSize := 5_000_000
+					written := int64(0)
+					for len(data) > 0 {
+						batch := min(len(data), batchSize)
+						require.NoError(b, writeStream.Send(&bspb.WriteRequest{
+							ResourceName: uploadString,
+							WriteOffset:  written,
+							Data:         data[:batch],
+							FinishWrite:  batch == len(data),
+						}))
+						written += int64(batch)
+						data = data[batch:]
+					}
+					resp, err := writeStream.CloseAndRecv()
+					require.NoError(b, err)
+					require.Equal(b, int32(i), requestCounter.Load())
+					i++
+					if !zstd {
+						require.Equal(b, int64(size), resp.GetCommittedSize())
+					} else {
+						// With compression, the committed size won't be equal
+						// to the input size. It can even be bigger when the
+						// input is small.
+						require.Less(b, int64(0), resp.GetCommittedSize())
+					}
+				}
+			})
+		}
 	}
 }

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -99,7 +99,7 @@ type Env interface {
 	GetGitHubStatusService() interfaces.GitHubStatusService
 	GetLocalCASServer() repb.ContentAddressableStorageServer
 	GetCASServer() repb.ContentAddressableStorageServer
-	GetLocalByteStreamServer() interfaces.ByteStreamServer
+	GetLocalByteStreamServer() bspb.ByteStreamServer
 	GetByteStreamServer() bspb.ByteStreamServer
 	GetLocalActionCacheServer() repb.ActionCacheServer
 	GetActionCacheServer() repb.ActionCacheServer

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -54,7 +54,6 @@ import (
 	wspb "github.com/buildbuddy-io/buildbuddy/proto/workspace"
 	zipb "github.com/buildbuddy-io/buildbuddy/proto/zip"
 	dto "github.com/prometheus/client_model/go"
-	bspb "google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/genproto/googleapis/longrunning"
 	hlpb "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -1758,31 +1757,4 @@ type ExperimentFlagProvider interface {
 	String(ctx context.Context, flagName string, defaultValue string, opts ...any) string
 	Float64(ctx context.Context, flagName string, defaultValue float64, opts ...any) float64
 	Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64
-}
-
-// ByteStreamWriteHandler enapsulates an on-going ByteStream write to a cache,
-// freeing the caller of having to manage writing and committing-to the cache
-// tracking cache hits, verifying checksums, etc. Here is how it must be used:
-//   - A new WriteHandler may be obtained by providing the first frame of the
-//     stream to the ByteStreamServer.BeginWrite() function. This function will
-//     return a new ByteStreamWriteHandler, or an error.
-//   - If a ByteStreamWriteHandler is returned from BeginWrite(),
-//     ByteStreamWriteHandler.Close() must be called to free system resources
-//     when the write is finished.
-//   - Each subsequent frame should be passed to
-//     ByteStreamWriteHandler.Write(), which will return an error on error
-//     (note: io.EOF indicates the cache believes the write is finished), or an
-//     optional WriteResponse that should be sent to the client if the client
-//     indicated the write is finished. This function will return (nil, nil) if
-//     the frame was processed successfully, but the write is not finished yet.
-type ByteStreamWriteHandler interface {
-	Write(req *bspb.WriteRequest) (*bspb.WriteResponse, error)
-	Close() error
-}
-
-// Wrapper around a bspb.ByteStreamServer that exposes a ByteStreamWriteHandler
-// in addition to the gRPC streaming interfaces.
-type ByteStreamServer interface {
-	bspb.ByteStreamServer
-	BeginWrite(ctx context.Context, req *bspb.WriteRequest) (ByteStreamWriteHandler, error)
 }

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -96,7 +96,7 @@ type RealEnv struct {
 	buildEventServer                 pepb.PublishBuildEventServer
 	localCASServer                   repb.ContentAddressableStorageServer
 	casServer                        repb.ContentAddressableStorageServer
-	localByteStreamServer            interfaces.ByteStreamServer
+	localByteStreamServer            bspb.ByteStreamServer
 	byteStreamServer                 bspb.ByteStreamServer
 	localActionCacheServer           repb.ActionCacheServer
 	actionCacheServer                repb.ActionCacheServer
@@ -547,10 +547,10 @@ func (r *RealEnv) SetCASServer(casServer repb.ContentAddressableStorageServer) {
 	r.casServer = casServer
 }
 
-func (r *RealEnv) GetLocalByteStreamServer() interfaces.ByteStreamServer {
+func (r *RealEnv) GetLocalByteStreamServer() bspb.ByteStreamServer {
 	return r.localByteStreamServer
 }
-func (r *RealEnv) SetLocalByteStreamServer(localByteStreamServer interfaces.ByteStreamServer) {
+func (r *RealEnv) SetLocalByteStreamServer(localByteStreamServer bspb.ByteStreamServer) {
 	r.localByteStreamServer = localByteStreamServer
 }
 

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -179,6 +179,21 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 	return err
 }
 
+// ByteStreamWriteHandler enapsulates an on-going ByteStream write to a cache,
+// freeing the caller of having to manage writing and committing-to the cache
+// tracking cache hits, verifying checksums, etc. Here is how it must be used:
+//   - A new WriteHandler may be obtained by providing the first frame of the
+//     stream to the ByteStreamServer.BeginWrite() function. This function will
+//     return a new ByteStreamWriteHandler, or an error.
+//   - If a ByteStreamWriteHandler is returned from BeginWrite(),
+//     ByteStreamWriteHandler.Close() must be called to free system resources
+//     when the write is finished.
+//   - Each subsequent frame should be passed to
+//     ByteStreamWriteHandler.Write(), which will return an error on error
+//     (note: io.EOF indicates the cache believes the write is finished), or an
+//     optional WriteResponse that should be sent to the client if the client
+//     indicated the write is finished. This function will return (nil, nil) if
+//     the frame was processed successfully, but the write is not finished yet.
 type writeHandler struct {
 	// Top-level writer that handles incoming bytes.
 	writer io.Writer
@@ -218,7 +233,7 @@ func checkSubsequentPreconditions(req *bspb.WriteRequest, ws *writeHandler) erro
 	return nil
 }
 
-func (s *ByteStreamServer) BeginWrite(ctx context.Context, req *bspb.WriteRequest) (interfaces.ByteStreamWriteHandler, error) {
+func (s *ByteStreamServer) BeginWrite(ctx context.Context, req *bspb.WriteRequest) (*writeHandler, error) {
 	if err := checkInitialPreconditions(req); err != nil {
 		return nil, err
 	}
@@ -398,7 +413,7 @@ func (w *writeHandler) Close() error {
 // `complete` or not.
 func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
 	ctx := stream.Context()
-	var streamState interfaces.ByteStreamWriteHandler
+	var streamState *writeHandler
 	for {
 		req, err := stream.Recv()
 		if err == io.EOF {


### PR DESCRIPTION
I did this to make it easier to optimize `byte_stream_server.Write` without having to also handle the `byte_stream_server.BeginWrite` path.

I think the new version is pretty clean, but a little bit harder to follow. In both the `Read` and `Write` paths, I'm creating an object that can be passed to `byte_stream_server.Write`, and each time `Recv()` is called on it, it also does some work on the side (forwarding to the client in Read, and writing to remote in Write).

Somehow, this the proxy faster. Benchmark results with new benchmarks from https://github.com/buildbuddy-io/buildbuddy/pull/9599:
```
                                             │     base      │               refactor               │
                                             │    sec/op     │    sec/op     vs base                │
ReadAlwaysPresent-24                            63.13µ ± 17%   65.96µ ±  9%        ~ (p=0.606 n=11)
ReadThroughCache/zstd=false/size=10000-24       143.6µ ±  2%   145.5µ ±  3%        ~ (p=0.949 n=11)
ReadThroughCache/zstd=false/size=3000000-24     4.241m ±  6%   3.112m ±  6%  -26.61% (p=0.000 n=11)
ReadThroughCache/zstd=false/size=20000000-24    23.17m ± 10%   20.62m ±  7%  -10.97% (p=0.016 n=11)
ReadThroughCache/zstd=true/size=10000-24        240.3µ ±  2%   246.3µ ±  2%   +2.49% (p=0.023 n=11)
ReadThroughCache/zstd=true/size=3000000-24      12.91m ±  2%   12.57m ±  2%   -2.63% (p=0.004 n=11)
ReadThroughCache/zstd=true/size=20000000-24     64.66m ±  3%   60.15m ±  4%   -6.98% (p=0.004 n=11)
WriteAlreadyExists-24                           118.2µ ±  4%   121.2µ ±  8%        ~ (p=0.401 n=11)
WriteUnique/zstd=false/size=10000-24            143.3µ ±  5%   141.6µ ±  7%        ~ (p=0.478 n=11)
WriteUnique/zstd=false/size=3000000-24          5.783m ± 20%   4.213m ±  3%  -27.15% (p=0.000 n=11)
WriteUnique/zstd=false/size=20000000-24         22.17m ± 11%   21.04m ±  7%   -5.09% (p=0.019 n=11)
WriteUnique/zstd=true/size=10000-24             178.2µ ±  1%   164.8µ ±  2%   -7.50% (p=0.000 n=11)
WriteUnique/zstd=true/size=3000000-24          10.010m ± 25%   4.536m ± 18%  -54.68% (p=0.000 n=11)
WriteUnique/zstd=true/size=20000000-24          55.98m ± 10%   38.79m ± 11%  -30.70% (p=0.000 n=11)
geomean                                         2.127m         1.839m        -13.53%

                                             │     base     │              refactor               │
                                             │     B/op     │     B/op      vs base               │
ReadAlwaysPresent-24                           111.1Ki ± 1%   111.0Ki ± 1%       ~ (p=0.898 n=11)
ReadThroughCache/zstd=false/size=10000-24      98.75Ki ± 0%   98.82Ki ± 0%       ~ (p=0.401 n=11)
ReadThroughCache/zstd=false/size=3000000-24    11.65Mi ± 0%   11.68Mi ± 0%       ~ (p=0.101 n=11)
ReadThroughCache/zstd=false/size=20000000-24   115.7Mi ± 0%   115.1Mi ± 0%       ~ (p=0.065 n=11)
ReadThroughCache/zstd=true/size=10000-24       78.88Ki ± 0%   79.08Ki ± 0%  +0.25% (p=0.000 n=11)
ReadThroughCache/zstd=true/size=3000000-24     10.95Mi ± 1%   10.82Mi ± 1%       ~ (p=0.151 n=11)
ReadThroughCache/zstd=true/size=20000000-24    91.64Mi ± 9%   90.76Mi ± 2%       ~ (p=0.193 n=11)
WriteAlreadyExists-24                          134.5Ki ± 0%   137.1Ki ± 0%  +1.91% (p=0.000 n=11)
WriteUnique/zstd=false/size=10000-24           96.20Ki ± 0%   96.29Ki ± 0%       ~ (p=0.133 n=11)
WriteUnique/zstd=false/size=3000000-24         11.60Mi ± 0%   11.62Mi ± 0%       ~ (p=0.606 n=11)
WriteUnique/zstd=false/size=20000000-24        110.5Mi ± 3%   110.1Mi ± 1%       ~ (p=0.699 n=11)
WriteUnique/zstd=true/size=10000-24            83.31Ki ± 0%   83.46Ki ± 0%  +0.18% (p=0.000 n=11)
WriteUnique/zstd=true/size=3000000-24          17.85Mi ± 1%   17.72Mi ± 0%       ~ (p=0.065 n=11)
WriteUnique/zstd=true/size=20000000-24         148.2Mi ± 3%   146.8Mi ± 3%       ~ (p=0.748 n=11)
geomean                                        2.946Mi        2.942Mi       -0.14%

                                             │    base     │              refactor              │
                                             │  allocs/op  │  allocs/op   vs base               │
ReadAlwaysPresent-24                            418.0 ± 0%    418.0 ± 0%       ~ (p=1.000 n=11)
ReadThroughCache/zstd=false/size=10000-24       867.0 ± 0%    868.0 ± 0%  +0.12% (p=0.000 n=11)
ReadThroughCache/zstd=false/size=3000000-24    1.053k ± 2%   1.061k ± 1%       ~ (p=0.076 n=11)
ReadThroughCache/zstd=false/size=20000000-24   2.271k ± 3%   2.294k ± 0%  +1.01% (p=0.000 n=11)
ReadThroughCache/zstd=true/size=10000-24        881.0 ± 0%    889.0 ± 0%  +0.91% (p=0.000 n=11)
ReadThroughCache/zstd=true/size=3000000-24      956.0 ± 0%    977.0 ± 0%  +2.20% (p=0.000 n=11)
ReadThroughCache/zstd=true/size=20000000-24    1.354k ± 1%   1.384k ± 1%  +2.22% (p=0.000 n=11)
WriteAlreadyExists-24                           838.0 ± 0%    861.0 ± 0%  +2.74% (p=0.000 n=11)
WriteUnique/zstd=false/size=10000-24            837.0 ± 0%    839.0 ± 0%  +0.24% (p=0.000 n=11)
WriteUnique/zstd=false/size=3000000-24         1.011k ± 0%   1.069k ± 0%  +5.74% (p=0.000 n=11)
WriteUnique/zstd=false/size=20000000-24        2.005k ± 2%   2.132k ± 1%  +6.33% (p=0.000 n=11)
WriteUnique/zstd=true/size=10000-24             846.0 ± 0%    850.0 ± 0%  +0.47% (p=0.000 n=11)
WriteUnique/zstd=true/size=3000000-24           925.0 ± 0%    942.0 ± 0%  +1.84% (p=0.000 n=11)
WriteUnique/zstd=true/size=20000000-24         1.325k ± 1%   1.348k ± 1%  +1.74% (p=0.001 n=11)
geomean                                        1.027k        1.046k       +1.86%
```