### PR TITLE
Add more benchmarks for byte_stream_proxy_server

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -590,7 +590,8 @@ func BenchmarkReadThroughCache(b *testing.B) {
 	}
 
 	for _, zstd := range []bool{false, true} {
-		// The largest size is such after compression, it's bigger than 5MiB.
+		// The largest size is such after compression, it's bigger than 5MiB,
+		// just to be bigger than 4MiB, which we often use as max buffer size.
 		for _, size := range []int64{10_000, 3_000_000, 20_000_000} {
 			b.Run(fmt.Sprintf("zstd=%v/size=%v", zstd, size), func(b *testing.B) {
 				b.ReportAllocs()


### PR DESCRIPTION
For read and write, add dimensions for size and using zstd compression.

Also, write unique digests, so we don't just get cache hits.