### PR TITLE
Upgrade local grafana version

### DIFF
--- a/tools/metrics/docker-compose.grafana.yml
+++ b/tools/metrics/docker-compose.grafana.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   grafana:
-    image: grafana/grafana:10.1.0
+    image: grafana/grafana:11.6.2
     environment:
       - GF_SERVER_HTTP_PORT=4500
       - GF_AUTH_ANONYMOUS_ENABLED=true
@@ -9,7 +9,7 @@ services:
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/buildbuddy.json
       - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
       - GF_DATASOURCE_URL=${GF_DATASOURCE_URL}
-      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - GF_PLUGINS_PREINSTALL=grafana-clickhouse-datasource@4.8.2
       - CLICKHOUSE_PORT=${CLICKHOUSE_PORT}
       - CLICKHOUSE_USERNAME=${CLICKHOUSE_USERNAME}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}

--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -72,7 +72,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 326
+            "y": 626
           },
           "id": 21,
           "options": {
@@ -123,7 +123,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 333
+            "y": 633
           },
           "id": 6270,
           "options": {
@@ -164,7 +164,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 340
+            "y": 640
           },
           "id": 932,
           "options": {
@@ -250,7 +250,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 340
+            "y": 640
           },
           "id": 5492,
           "options": {
@@ -308,7 +308,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 551
+            "y": 851
           },
           "id": 348,
           "options": {
@@ -343,7 +343,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 551
+            "y": 851
           },
           "id": 804,
           "options": {
@@ -393,7 +393,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 424
+            "y": 724
           },
           "id": 6840,
           "options": {
@@ -431,7 +431,7 @@
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 424
+            "y": 724
           },
           "id": 25,
           "options": {
@@ -467,7 +467,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 432
+            "y": 732
           },
           "id": 1232,
           "options": {
@@ -504,7 +504,7 @@
             "h": 8,
             "w": 12,
             "x": 9,
-            "y": 432
+            "y": 732
           },
           "id": 65,
           "options": {
@@ -540,7 +540,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 440
+            "y": 740
           },
           "id": 13,
           "options": {
@@ -640,7 +640,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 625
+            "y": 925
           },
           "id": 1182,
           "options": {
@@ -735,7 +735,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 625
+            "y": 925
           },
           "id": 1186,
           "options": {
@@ -827,7 +827,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 633
+            "y": 933
           },
           "id": 1183,
           "options": {
@@ -920,7 +920,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 633
+            "y": 933
           },
           "id": 1187,
           "options": {
@@ -1012,7 +1012,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 641
+            "y": 941
           },
           "id": 1184,
           "options": {
@@ -1105,7 +1105,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 641
+            "y": 941
           },
           "id": 1188,
           "options": {
@@ -1163,7 +1163,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 770
+            "y": 1070
           },
           "id": 230,
           "options": {
@@ -1199,7 +1199,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 770
+            "y": 1070
           },
           "id": 310,
           "options": {
@@ -1245,7 +1245,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 778
+            "y": 1078
           },
           "id": 312,
           "options": {
@@ -1399,7 +1399,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 323
+            "y": 623
           },
           "id": 250,
           "options": {
@@ -1466,7 +1466,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 323
+            "y": 623
           },
           "id": 252,
           "options": {
@@ -1533,7 +1533,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 331
+            "y": 631
           },
           "id": 253,
           "options": {
@@ -1600,7 +1600,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 331
+            "y": 631
           },
           "id": 10479,
           "options": {
@@ -1653,7 +1653,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 339
+            "y": 639
           },
           "id": 10604,
           "options": {
@@ -1936,36 +1936,231 @@
           },
           "description": "",
           "fieldConfig": {
-            "defaults": {},
-            "overrides": []
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Misses"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 9,
-            "w": 24,
+            "w": 12,
             "x": 0,
             "y": 15
           },
-          "id": 4,
+          "id": 10730,
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "10.1.0",
-          "repeat": "cache_type",
-          "repeatDirection": "h",
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "vm"
               },
-              "expr": "sum by (cache_event_type) (rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_type=\"action_cache\"}[${window}]))",
+              "editorMode": "code",
+              "expr": "sum by (cache_event_type) (rate(buildbuddy_remote_cache_events{region=\"us-west1\", job=\"buildbuddy-app\", cache_type=\"action_cache\"}[1m]))",
+              "interval": "",
+              "legendFormat": "{{cache_event_type}}",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Action cache",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Misses"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "id": 9,
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "expr": "sum by (cache_event_type) (rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_type=\"cas\"}[${window}]))",
               "interval": "",
               "legendFormat": "{{cache_event_type}}",
               "queryType": "randomWalk",
               "refId": "A"
             }
           ],
-          "title": "Action cache",
+          "title": "Content Addressable Store (CAS)",
           "type": "timeseries"
         },
         {
@@ -2072,122 +2267,6 @@
             "type": "prometheus",
             "uid": "vm"
           },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ops"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Misses"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "dark-red",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 24
-          },
-          "id": 9,
-          "options": {
-            "alertThreshold": true,
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "right",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.6.2",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum by (cache_event_type) (rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_type=\"cas\"}[${window}]))",
-              "interval": "",
-              "legendFormat": "{{cache_event_type}}",
-              "queryType": "randomWalk",
-              "refId": "A"
-            }
-          ],
-          "title": "Content Addressable Store (CAS)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2246,7 +2325,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 24
           },
           "id": 6834,
           "options": {
@@ -2284,6 +2363,167 @@
             }
           ],
           "title": "TreeCache by directory level",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "A"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "TreeCache"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "B"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "ActionCache"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "C"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "CAS"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
+          "id": 6732,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(buildbuddy_remote_cache_tree_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\", status=\"hit\"}[${window}]))/sum(rate(buildbuddy_remote_cache_tree_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\"}[${window}]))",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_event_type=\"hit\", cache_type=\"action_cache\"}[${window}]))/sum(rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_event_type=~\"hit|miss\", cache_type=\"action_cache\"}[${window}]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_event_type=\"hit\", cache_type=\"cas\"}[${window}]))/sum(rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_event_type=~\"hit|miss\", cache_type=\"cas\"}[${window}]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Cache Hit Rates",
           "type": "timeseries"
         },
         {
@@ -2667,163 +2907,6 @@
                   }
                 ]
               },
-              "unit": "percentunit"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "A"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "TreeCache"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "B"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "ActionCache"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byFrameRefID",
-                  "options": "C"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "CAS"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 73
-          },
-          "id": 6732,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "editorMode": "code",
-              "expr": "sum(rate(buildbuddy_remote_cache_tree_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\", status=\"hit\"}[${window}]))/sum(rate(buildbuddy_remote_cache_tree_cache_lookup_count{region=\"${region}\", job=\"buildbuddy-app\"}[${window}]))",
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "editorMode": "code",
-              "expr": "sum(rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_event_type=\"hit\", cache_type=\"action_cache\"}[${window}]))/sum(rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_event_type=~\"hit|miss\", cache_type=\"action_cache\"}[${window}]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "editorMode": "code",
-              "expr": "sum(rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_event_type=\"hit\", cache_type=\"cas\"}[${window}]))/sum(rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_event_type=~\"hit|miss\", cache_type=\"cas\"}[${window}]))",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "C"
-            }
-          ],
-          "title": "Cache Hit Rates",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
               "unit": "µs"
             },
             "overrides": []
@@ -2832,7 +2915,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 73
           },
           "id": 6422,
           "options": {
@@ -2927,7 +3010,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 89
+            "y": 81
           },
           "id": 6428,
           "options": {
@@ -3024,7 +3107,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 97
+            "y": 89
           },
           "id": 2182,
           "options": {
@@ -3083,7 +3166,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 105
+            "y": 97
           },
           "id": 6382,
           "maxDataPoints": 25,
@@ -3223,7 +3306,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 598
+            "y": 898
           },
           "id": 6580,
           "options": {
@@ -3342,7 +3425,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 606
+            "y": 906
           },
           "id": 3763,
           "options": {
@@ -3470,7 +3553,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 614
+            "y": 914
           },
           "id": 5574,
           "options": {
@@ -3623,7 +3706,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 622
+            "y": 922
           },
           "id": 3846,
           "options": {
@@ -3718,7 +3801,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 630
+            "y": 930
           },
           "id": 5160,
           "options": {
@@ -3813,7 +3896,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 638
+            "y": 938
           },
           "id": 5242,
           "options": {
@@ -3907,7 +3990,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 646
+            "y": 946
           },
           "id": 5324,
           "options": {
@@ -4001,7 +4084,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 654
+            "y": 954
           },
           "id": 5406,
           "options": {
@@ -4108,7 +4191,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 634
+            "y": 934
           },
           "id": 3929,
           "options": {
@@ -4200,7 +4283,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 634
+            "y": 934
           },
           "id": 4011,
           "options": {
@@ -4292,7 +4375,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 642
+            "y": 942
           },
           "id": 4093,
           "options": {
@@ -4384,7 +4467,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 642
+            "y": 942
           },
           "id": 4175,
           "options": {
@@ -4476,7 +4559,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 650
+            "y": 950
           },
           "id": 4257,
           "options": {
@@ -4568,7 +4651,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 650
+            "y": 950
           },
           "id": 4339,
           "options": {
@@ -4660,7 +4743,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 658
+            "y": 958
           },
           "id": 4421,
           "options": {
@@ -4752,7 +4835,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 658
+            "y": 958
           },
           "id": 4503,
           "options": {
@@ -4844,7 +4927,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 666
+            "y": 966
           },
           "id": 4585,
           "options": {
@@ -4936,7 +5019,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 666
+            "y": 966
           },
           "id": 4667,
           "options": {
@@ -5028,7 +5111,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 674
+            "y": 974
           },
           "id": 4749,
           "options": {
@@ -5120,7 +5203,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 674
+            "y": 974
           },
           "id": 4831,
           "options": {
@@ -5212,7 +5295,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 682
+            "y": 982
           },
           "id": 4913,
           "options": {
@@ -5254,7 +5337,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 10
       },
       "id": 264,
       "panels": [
@@ -5272,7 +5355,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2027
+            "y": 4850
           },
           "id": 274,
           "options": {
@@ -5328,7 +5411,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2027
+            "y": 4850
           },
           "id": 276,
           "options": {
@@ -5364,7 +5447,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2035
+            "y": 4858
           },
           "id": 290,
           "options": {
@@ -5400,7 +5483,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2035
+            "y": 4858
           },
           "id": 292,
           "options": {
@@ -5438,7 +5521,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2043
+            "y": 4866
           },
           "id": 278,
           "options": {
@@ -5476,7 +5559,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2043
+            "y": 4866
           },
           "id": 280,
           "options": {
@@ -5510,7 +5593,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 38,
       "panels": [
@@ -5577,7 +5660,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 4475
+            "y": 17043
           },
           "id": 40,
           "options": {
@@ -5718,7 +5801,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 4488
+            "y": 17056
           },
           "id": 76,
           "options": {
@@ -5771,7 +5854,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4502
+            "y": 17070
           },
           "id": 42,
           "options": {
@@ -5807,7 +5890,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4502
+            "y": 17070
           },
           "id": 46,
           "options": {
@@ -5843,7 +5926,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4510
+            "y": 17078
           },
           "id": 44,
           "options": {
@@ -5876,7 +5959,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 458,
       "panels": [
@@ -5897,7 +5980,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 4494
+            "y": 17062
           },
           "id": 498,
           "options": {
@@ -5938,7 +6021,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 4494
+            "y": 17062
           },
           "id": 542,
           "options": {
@@ -6025,7 +6108,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 4503
+            "y": 17071
           },
           "id": 506,
           "options": {
@@ -6079,7 +6162,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 4512
+            "y": 17080
           },
           "id": 496,
           "options": {
@@ -6120,7 +6203,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 4522
+            "y": 17090
           },
           "id": 500,
           "options": {
@@ -6161,7 +6244,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 4522
+            "y": 17090
           },
           "id": 504,
           "options": {
@@ -6197,7 +6280,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 48,
       "panels": [
@@ -6214,7 +6297,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4309
+            "y": 16877
           },
           "id": 50,
           "options": {
@@ -6250,7 +6333,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4309
+            "y": 16877
           },
           "id": 53,
           "options": {
@@ -6286,7 +6369,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4317
+            "y": 16885
           },
           "id": 51,
           "options": {
@@ -6322,7 +6405,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4317
+            "y": 16885
           },
           "id": 55,
           "options": {
@@ -6355,7 +6438,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "id": 384,
       "panels": [
@@ -6421,7 +6504,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4406
+            "y": 16974
           },
           "id": 742,
           "options": {
@@ -6523,7 +6606,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4406
+            "y": 16974
           },
           "id": 422,
           "options": {
@@ -6622,7 +6705,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4414
+            "y": 16982
           },
           "id": 420,
           "options": {
@@ -6721,7 +6804,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4414
+            "y": 16982
           },
           "id": 6504,
           "options": {
@@ -6869,7 +6952,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4422
+            "y": 16990
           },
           "id": 1223,
           "options": {
@@ -7039,7 +7122,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4422
+            "y": 16990
           },
           "id": 1224,
           "options": {
@@ -7094,7 +7177,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4430
+            "y": 16998
           },
           "id": 6943,
           "options": {
@@ -7185,7 +7268,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4430
+            "y": 16998
           },
           "id": 6944,
           "options": {
@@ -7304,7 +7387,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4438
+            "y": 17006
           },
           "id": 7133,
           "options": {
@@ -7492,7 +7575,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4438
+            "y": 17006
           },
           "id": 7039,
           "options": {
@@ -7606,7 +7689,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 107,
       "panels": [
@@ -7623,7 +7706,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4190
+            "y": 16758
           },
           "id": 122,
           "options": {
@@ -7659,7 +7742,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4190
+            "y": 16758
           },
           "id": 116,
           "options": {
@@ -7695,7 +7778,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4198
+            "y": 16766
           },
           "id": 112,
           "options": {
@@ -7731,7 +7814,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4198
+            "y": 16766
           },
           "id": 120,
           "options": {
@@ -7768,7 +7851,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4206
+            "y": 16774
           },
           "id": 118,
           "options": {
@@ -7804,7 +7887,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4206
+            "y": 16774
           },
           "id": 124,
           "options": {
@@ -7840,7 +7923,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4214
+            "y": 16782
           },
           "id": 9138,
           "options": {
@@ -7878,7 +7961,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4214
+            "y": 16782
           },
           "id": 9139,
           "options": {
@@ -7916,7 +7999,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4222
+            "y": 16790
           },
           "id": 9266,
           "options": {
@@ -7951,7 +8034,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
       "id": 28,
       "panels": [
@@ -7969,7 +8052,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4191
+            "y": 16759
           },
           "id": 190,
           "options": {
@@ -8184,7 +8267,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4191
+            "y": 16759
           },
           "id": 159,
           "options": {
@@ -8307,7 +8390,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4199
+            "y": 16767
           },
           "id": 210,
           "options": {
@@ -8394,7 +8477,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4199
+            "y": 16767
           },
           "id": 1209,
           "options": {
@@ -8488,7 +8571,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4207
+            "y": 16775
           },
           "id": 31,
           "options": {
@@ -8535,7 +8618,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4207
+            "y": 16775
           },
           "id": 178,
           "options": {
@@ -8632,7 +8715,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4215
+            "y": 16783
           },
           "id": 8505,
           "options": {
@@ -8748,7 +8831,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4215
+            "y": 16783
           },
           "id": 8606,
           "options": {
@@ -8886,7 +8969,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4223
+            "y": 16791
           },
           "id": 1216,
           "options": {
@@ -9015,7 +9098,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4223
+            "y": 16791
           },
           "id": 1231,
           "options": {
@@ -9098,7 +9181,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4231
+            "y": 16799
           },
           "id": 33,
           "options": {
@@ -9134,7 +9217,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4231
+            "y": 16799
           },
           "id": 35,
           "options": {
@@ -9171,7 +9254,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4239
+            "y": 16807
           },
           "id": 102,
           "options": {
@@ -9207,7 +9290,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4239
+            "y": 16807
           },
           "id": 180,
           "options": {
@@ -9359,7 +9442,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4247
+            "y": 16815
           },
           "id": 1195,
           "options": {
@@ -9520,7 +9603,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4247
+            "y": 16815
           },
           "id": 1196,
           "options": {
@@ -9617,7 +9700,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4255
+            "y": 16823
           },
           "id": 1202,
           "options": {
@@ -9710,7 +9793,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4255
+            "y": 16823
           },
           "id": 7145,
           "options": {
@@ -9790,7 +9873,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4263
+            "y": 16831
           },
           "id": 7139,
           "options": {
@@ -9870,7 +9953,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4263
+            "y": 16831
           },
           "id": 7157,
           "options": {
@@ -9950,7 +10033,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4271
+            "y": 16839
           },
           "id": 7151,
           "options": {
@@ -10030,7 +10113,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4271
+            "y": 16839
           },
           "id": 7169,
           "options": {
@@ -10110,7 +10193,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4279
+            "y": 16847
           },
           "id": 7163,
           "options": {
@@ -10177,7 +10260,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 21
       },
       "id": 83,
       "panels": [
@@ -10195,7 +10278,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 7824
+            "y": 45219
           },
           "id": 85,
           "options": {
@@ -10243,7 +10326,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 7824
+            "y": 45219
           },
           "id": 93,
           "options": {
@@ -10281,7 +10364,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 7833
+            "y": 45228
           },
           "id": 87,
           "options": {
@@ -10319,7 +10402,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 7833
+            "y": 45228
           },
           "id": 10729,
           "options": {
@@ -10355,7 +10438,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 25
       },
       "id": 71,
       "panels": [
@@ -10372,7 +10455,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 12496
+            "y": 102142
           },
           "id": 73,
           "options": {
@@ -10409,7 +10492,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 12496
+            "y": 102142
           },
           "id": 79,
           "options": {
@@ -10494,7 +10577,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12505
+            "y": 102151
           },
           "id": 2087,
           "options": {
@@ -10596,7 +10679,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12505
+            "y": 102151
           },
           "id": 2039,
           "options": {
@@ -10654,7 +10737,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 29
       },
       "id": 9283,
       "panels": [
@@ -10721,7 +10804,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18501
+            "y": 206288
           },
           "id": 9300,
           "options": {
@@ -10818,7 +10901,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18501
+            "y": 206288
           },
           "id": 9301,
           "options": {
@@ -10928,7 +11011,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18509
+            "y": 206296
           },
           "id": 9303,
           "options": {
@@ -10985,7 +11068,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 30
       },
       "id": 9320,
       "panels": [
@@ -11052,7 +11135,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18502
+            "y": 206289
           },
           "id": 9337,
           "options": {
@@ -11149,7 +11232,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18502
+            "y": 206289
           },
           "id": 9462,
           "options": {
@@ -11259,7 +11342,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18510
+            "y": 206297
           },
           "id": 9587,
           "options": {
@@ -11316,7 +11399,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 31
       },
       "id": 1088,
       "panels": [
@@ -11383,7 +11466,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18526
+            "y": 206313
           },
           "id": 1127,
           "options": {
@@ -11480,7 +11563,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18526
+            "y": 206313
           },
           "id": 1166,
           "options": {
@@ -11590,7 +11673,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18534
+            "y": 206321
           },
           "id": 1168,
           "options": {
@@ -11648,7 +11731,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 37
       },
       "id": 8,
       "panels": [
@@ -11666,7 +11749,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 27530
+            "y": 559258
           },
           "id": 2,
           "options": {
@@ -11723,7 +11806,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 27530
+            "y": 559258
           },
           "id": 578,
           "options": {
@@ -11756,7 +11839,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 38
       },
       "id": 1346,
       "panels": [
@@ -11773,7 +11856,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 27575
+            "y": 559303
           },
           "id": 2556,
           "options": {
@@ -11812,7 +11895,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 27588
+            "y": 559316
           },
           "id": 2840,
           "options": {
@@ -11850,7 +11933,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27602
+            "y": 559330
           },
           "id": 2890,
           "options": {
@@ -11888,7 +11971,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27602
+            "y": 559330
           },
           "id": 2940,
           "options": {
@@ -11974,7 +12057,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27610
+            "y": 559338
           },
           "id": 1353,
           "links": [
@@ -12021,7 +12104,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 39
       },
       "id": 5641,
       "panels": [
@@ -12086,7 +12169,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27359
+            "y": 559087
           },
           "id": 5595,
           "options": {
@@ -12178,7 +12261,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27359
+            "y": 559087
           },
           "id": 5608,
           "options": {
@@ -12271,7 +12354,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27367
+            "y": 559095
           },
           "id": 5622,
           "options": {
@@ -12364,7 +12447,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27367
+            "y": 559095
           },
           "id": 5629,
           "options": {
@@ -12456,7 +12539,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27375
+            "y": 559103
           },
           "id": 5615,
           "options": {
@@ -12497,7 +12580,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 40
       },
       "id": 7275,
       "panels": [
@@ -12564,7 +12647,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27275
+            "y": 559003
           },
           "id": 7381,
           "options": {
@@ -12684,7 +12767,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27275
+            "y": 559003
           },
           "id": 7382,
           "options": {
@@ -12782,7 +12865,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27283
+            "y": 559011
           },
           "id": 7489,
           "options": {
@@ -12880,7 +12963,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27283
+            "y": 559011
           },
           "id": 7488,
           "options": {
@@ -12975,7 +13058,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27291
+            "y": 559019
           },
           "id": 7595,
           "options": {
@@ -13070,7 +13153,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27291
+            "y": 559019
           },
           "id": 8743,
           "options": {
@@ -13165,7 +13248,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27299
+            "y": 559027
           },
           "id": 8880,
           "options": {
@@ -13260,7 +13343,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27299
+            "y": 559027
           },
           "id": 9017,
           "options": {
@@ -13302,7 +13385,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 41
       },
       "id": 9846,
       "panels": [
@@ -13367,7 +13450,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27154
+            "y": 558882
           },
           "id": 10100,
           "options": {
@@ -13460,7 +13543,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27154
+            "y": 558882
           },
           "id": 10227,
           "options": {
@@ -13506,7 +13589,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27162
+            "y": 558890
           },
           "id": 10354,
           "options": {

--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -48,14 +48,9 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -65,52 +60,27 @@
       "id": 23,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 7,
-            "w": 6,
+            "w": 24,
             "x": 0,
-            "y": 17
+            "y": 326
           },
-          "hiddenSeries": false,
           "id": 21,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
           "repeat": "job",
           "repeatDirection": "h",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -136,88 +106,32 @@
               "refId": "B"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "${job} instances",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:365",
-              "decimals": 0,
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:366",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 7,
-            "w": 6,
+            "w": 24,
             "x": 0,
-            "y": 24
+            "y": 333
           },
-          "hiddenSeries": false,
           "id": 6270,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
           "repeat": "job",
           "repeatDirection": "h",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -234,84 +148,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "${job} versions",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:365",
-              "decimals": 0,
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:366",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 340
           },
-          "hiddenSeries": false,
           "id": 932,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -326,40 +185,10 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Unexpected Restarts",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:137",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:138",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -421,7 +250,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 340
           },
           "id": 5492,
           "options": {
@@ -453,24 +282,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "System status",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -480,48 +296,25 @@
       "id": 330,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 242
+            "y": 551
           },
-          "hiddenSeries": false,
           "id": 348,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -534,82 +327,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Success Rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:518",
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:519",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 242
+            "y": 551
           },
-          "hiddenSeries": false,
           "id": 804,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -623,46 +363,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "RBE Prober Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:62",
-              "format": "µs",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:63",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "Probers",
@@ -670,10 +372,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -683,54 +381,25 @@
       "id": 11,
       "panels": [
         {
-          "aliasColors": {
-            "Failure": "dark-red",
-            "failure": "red",
-            "success": "green"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 115
+            "y": 424
           },
-          "hiddenSeries": false,
           "id": 6840,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -746,83 +415,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Invocations per second (by status)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:608",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:609",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 115
+            "y": 424
           },
-          "hiddenSeries": false,
           "id": 25,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -836,110 +451,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Median invocation duration",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:763",
-              "format": "µs",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:764",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Failure": "dark-red",
-            "failure": "red",
-            "success": "green"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 123
+            "y": 432
           },
-          "hiddenSeries": false,
           "id": 1232,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:201",
-              "alias": "SUCCESS",
-              "color": "#37872D"
-            },
-            {
-              "$$hashKey": "object:206",
-              "alias": "OK",
-              "color": "#1F60C4"
-            },
-            {
-              "$$hashKey": "object:211",
-              "alias": "REMOTE_ERROR",
-              "color": "#C4162A"
-            },
-            {
-              "$$hashKey": "object:231",
-              "alias": "Failed",
-              "color": "#FFB357"
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -954,83 +488,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Invocations per second (by bazel exit code)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:608",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:609",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 9,
-            "y": 123
+            "y": 432
           },
-          "hiddenSeries": false,
           "id": 65,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -1044,88 +524,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Build events uploaded per second",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:841",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:842",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Failure": "dark-red",
-            "failure": "red",
-            "success": "green"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 131
+            "y": 440
           },
-          "hiddenSeries": false,
           "id": 13,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -1141,47 +562,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Invocations per second (by Bazel version)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:608",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:609",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "Invocations",
@@ -1189,10 +571,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1202,7 +580,6 @@
       "id": 1175,
       "panels": [
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -1263,7 +640,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 316
+            "y": 625
           },
           "id": 1182,
           "options": {
@@ -1297,7 +674,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -1359,7 +735,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 316
+            "y": 625
           },
           "id": 1186,
           "options": {
@@ -1391,7 +767,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -1452,7 +827,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 324
+            "y": 633
           },
           "id": 1183,
           "options": {
@@ -1484,7 +859,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -1546,7 +920,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 324
+            "y": 633
           },
           "id": 1187,
           "options": {
@@ -1578,7 +952,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -1639,7 +1012,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 332
+            "y": 641
           },
           "id": 1184,
           "options": {
@@ -1671,7 +1044,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -1733,7 +1105,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 332
+            "y": 641
           },
           "id": 1188,
           "options": {
@@ -1765,24 +1137,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Invocation finalizers",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1792,48 +1151,25 @@
       "id": 220,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 461
+            "y": 770
           },
-          "hiddenSeries": false,
           "id": 230,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "8.3.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -1847,82 +1183,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Workflows started",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:931",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:932",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 461
+            "y": 770
           },
-          "hiddenSeries": false,
           "id": 310,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "8.3.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -1946,82 +1229,29 @@
               "refId": "B"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Workflows started by trigger event",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1009",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1010",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 469
+            "y": 778
           },
-          "hiddenSeries": false,
           "id": 312,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "8.3.2",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -2035,47 +1265,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Webhook events by response code",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1163",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1164",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "Workflows",
@@ -2083,10 +1274,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2096,57 +1283,26 @@
       "id": 240,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
             "y": 6
           },
-          "hiddenSeries": false,
           "id": 254,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1261",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -2160,90 +1316,30 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Request Mix",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1268",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1269",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
             "y": 6
           },
-          "hiddenSeries": false,
           "id": 251,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1348",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -2287,89 +1383,29 @@
               "refId": "D"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "/GetMulti",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1355",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1356",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 323
           },
-          "hiddenSeries": false,
           "id": 250,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:74",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -2413,90 +1449,30 @@
               "refId": "D"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "/FindMissing",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:81",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:82",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 323
           },
-          "hiddenSeries": false,
           "id": 252,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1687",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -2540,90 +1516,30 @@
               "refId": "D"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "/Write",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1694",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1695",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 331
           },
-          "hiddenSeries": false,
           "id": 253,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1858",
-              "alias": "QPS",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -2667,90 +1583,30 @@
               "refId": "D"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "/Read",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1865",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1866",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 331
           },
-          "hiddenSeries": false,
           "id": 10479,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": false
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:1261",
-              "alias": "hit_ratio",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -2780,84 +1636,30 @@
               "refId": "B"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Lookaside cache hits and misses",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1268",
-              "format": "reqps",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1269",
-              "format": "none",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 339
           },
-          "hiddenSeries": false,
           "id": 10604,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": false
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -2910,46 +1712,8 @@
               "refId": "D"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Lookaside cache eviction age by reason",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1865",
-              "format": "ms",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1866",
-              "format": "reqps",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "Distributed Cache",
@@ -2957,10 +1721,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2970,50 +1730,89 @@
       "id": 15,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "Total number of bytes downloaded by consumers of the cache, per second. This does _not_ represent the average download speed across cache requests.",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 7
           },
-          "hiddenSeries": false,
           "id": 17,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -3027,84 +1826,93 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Download throughput",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:2049",
-              "format": "binBps",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:2050",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "Total number of bytes uploaded by consumers of the cache, per second. This does _not_ represent the average upload speed across cache requests.",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 7
           },
-          "hiddenSeries": false,
           "id": 19,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
           },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -3118,103 +1926,32 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Upload throughput",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:2127",
-              "format": "binBps",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:2128",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Misses": "red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 9,
-            "w": 12,
+            "w": 24,
             "x": 0,
-            "y": 40
+            "y": 15
           },
-          "hiddenSeries": false,
           "id": 4,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
           "repeat": "cache_type",
           "repeatDirection": "h",
-          "seriesOverrides": [
-            {
-              "$$hashKey": "object:2205"
-            },
-            {
-              "$$hashKey": "object:2206",
-              "alias": "Misses",
-              "yaxis": 2
-            },
-            {
-              "$$hashKey": "object:2207",
-              "alias": "Hits",
-              "yaxis": 1
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -3228,133 +1965,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Action cache",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:2224",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:2225",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {
-            "Misses": "dark-red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "description": "",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 40
-          },
-          "hiddenSeries": false,
-          "id": 9,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "repeatDirection": "h",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "expr": "sum by (cache_event_type) (rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_type=\"cas\"}[${window}]))",
-              "interval": "",
-              "legendFormat": "{{cache_event_type}}",
-              "queryType": "randomWalk",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Content Addressable Store (CAS)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:2300",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:2301",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -3368,11 +1980,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3419,7 +2033,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 24
           },
           "id": 6656,
           "options": {
@@ -3430,10 +2044,12 @@
               "showLegend": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -3456,17 +2072,135 @@
             "type": "prometheus",
             "uid": "vm"
           },
+          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Misses"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 9,
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "expr": "sum by (cache_event_type) (rate(buildbuddy_remote_cache_events{region=\"${region}\", job=\"buildbuddy-app\", cache_type=\"cas\"}[${window}]))",
+              "interval": "",
+              "legendFormat": "{{cache_event_type}}",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "title": "Content Addressable Store (CAS)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -3512,7 +2246,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 33
           },
           "id": 6834,
           "options": {
@@ -3529,10 +2263,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -3551,52 +2287,28 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "Avg age of last item evicted by the disk cache",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 41
           },
-          "hiddenSeries": false,
           "id": 646,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
           "repeat": "cache_name",
           "repeatDirection": "h",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -3612,52 +2324,10 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Disk Cache Avg Last Evicted Age (${cache_name})",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:108",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:109",
-              "format": "m",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "cards": {
-            "cardPadding": 0.25,
-            "cardRound": 2
-          },
-          "collapsed": true,
-          "color": {
-            "cardColor": "#3274D9",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
-            "exponent": 0.5,
-            "mode": "opacity"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -3681,15 +2351,9 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 65
+            "y": 49
           },
-          "heatmap": {},
-          "hideZeroBuckets": false,
-          "highlightCards": true,
           "id": 1247,
-          "legend": {
-            "show": false
-          },
           "maxDataPoints": 25,
           "options": {
             "calculate": false,
@@ -3733,7 +2397,6 @@
           "pluginVersion": "10.1.0",
           "repeat": "cache_name",
           "repeatDirection": "h",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -3751,24 +2414,9 @@
             }
           ],
           "title": "Files Added to Disk Cache by Size (${cache_name})",
-          "tooltip": {
-            "show": true,
-            "showHistogram": true
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "decimals": 0,
-            "format": "bytes",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -3832,7 +2480,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 73
+            "y": 57
           },
           "id": 1338,
           "options": {
@@ -3872,7 +2520,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -3933,7 +2580,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 65
           },
           "id": 2135,
           "options": {
@@ -4065,7 +2712,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 89
+            "y": 73
           },
           "id": 6732,
           "options": {
@@ -4124,7 +2771,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -4186,7 +2832,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 97
+            "y": 81
           },
           "id": 6422,
           "options": {
@@ -4220,7 +2866,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -4282,7 +2927,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 105
+            "y": 89
           },
           "id": 6428,
           "options": {
@@ -4316,7 +2961,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -4380,7 +3024,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 113
+            "y": 97
           },
           "id": 2182,
           "options": {
@@ -4416,19 +3060,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {
-            "cardPadding": 0.25,
-            "cardRound": 2
-          },
-          "collapsed": true,
-          "color": {
-            "cardColor": "#3274D9",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
-            "exponent": 0.5,
-            "mode": "opacity"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -4452,15 +3083,9 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 121
+            "y": 105
           },
-          "heatmap": {},
-          "hideZeroBuckets": false,
-          "highlightCards": true,
           "id": 6382,
-          "legend": {
-            "show": false
-          },
           "maxDataPoints": 25,
           "options": {
             "calculate": false,
@@ -4504,7 +3129,6 @@
           "pluginVersion": "10.1.0",
           "repeat": "cache_name",
           "repeatDirection": "h",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -4522,30 +3146,7 @@
             }
           ],
           "title": "Number of Chunks Per File (${cache_name})",
-          "tooltip": {
-            "show": true,
-            "showHistogram": true
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "decimals": 0,
-            "format": "bytes",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "heatmap"
         }
       ],
       "title": "Remote cache",
@@ -4622,7 +3223,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 289
+            "y": 598
           },
           "id": 6580,
           "options": {
@@ -4681,7 +3282,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -4742,7 +3342,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 297
+            "y": 606
           },
           "id": 3763,
           "options": {
@@ -4776,7 +3376,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -4871,7 +3470,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 305
+            "y": 614
           },
           "id": 5574,
           "options": {
@@ -4930,7 +3529,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -5025,7 +3623,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 313
+            "y": 622
           },
           "id": 3846,
           "options": {
@@ -5059,7 +3657,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -5121,7 +3718,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 321
+            "y": 630
           },
           "id": 5160,
           "options": {
@@ -5155,7 +3752,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -5217,7 +3813,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 329
+            "y": 638
           },
           "id": 5242,
           "options": {
@@ -5251,7 +3847,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -5312,7 +3907,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 337
+            "y": 646
           },
           "id": 5324,
           "options": {
@@ -5346,7 +3941,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -5407,7 +4001,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 345
+            "y": 654
           },
           "id": 5406,
           "options": {
@@ -5514,7 +4108,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 325
+            "y": 634
           },
           "id": 3929,
           "options": {
@@ -5606,7 +4200,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 325
+            "y": 634
           },
           "id": 4011,
           "options": {
@@ -5698,7 +4292,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 333
+            "y": 642
           },
           "id": 4093,
           "options": {
@@ -5790,7 +4384,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 333
+            "y": 642
           },
           "id": 4175,
           "options": {
@@ -5882,7 +4476,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 341
+            "y": 650
           },
           "id": 4257,
           "options": {
@@ -5974,7 +4568,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 341
+            "y": 650
           },
           "id": 4339,
           "options": {
@@ -6066,7 +4660,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 349
+            "y": 658
           },
           "id": 4421,
           "options": {
@@ -6158,7 +4752,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 349
+            "y": 658
           },
           "id": 4503,
           "options": {
@@ -6250,7 +4844,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 357
+            "y": 666
           },
           "id": 4585,
           "options": {
@@ -6342,7 +4936,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 357
+            "y": 666
           },
           "id": 4667,
           "options": {
@@ -6434,7 +5028,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 365
+            "y": 674
           },
           "id": 4749,
           "options": {
@@ -6526,7 +5120,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 365
+            "y": 674
           },
           "id": 4831,
           "options": {
@@ -6618,7 +5212,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 373
+            "y": 682
           },
           "id": 4913,
           "options": {
@@ -6651,16 +5245,11 @@
         }
       ],
       "repeat": "cache_name",
-      "repeatDirection": "h",
       "title": "Remote cache pebble levels (${cache_name})",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6670,52 +5259,26 @@
       "id": 264,
       "panels": [
         {
-          "aliasColors": {
-            "Executor count (for comparison)": "semi-dark-blue"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 2027
           },
-          "hiddenSeries": false,
           "id": 274,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -6749,85 +5312,29 @@
               "refId": "C"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Pooled runner count",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1190",
-              "decimals": 0,
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1191",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-red"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 2027
           },
-          "hiddenSeries": false,
           "id": 276,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -6841,84 +5348,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Runner pool evictions",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1268",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1269",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "max_memory_exceeded": "dark-orange"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 2035
           },
-          "hiddenSeries": false,
           "id": 290,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -6932,84 +5384,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Recycling failures by reason",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1346",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1347",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "miss": "dark-red"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 2035
           },
-          "hiddenSeries": false,
           "id": 292,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -7023,46 +5420,10 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Pool requests by status",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1424",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1425",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-yellow"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -7073,40 +5434,17 @@
             },
             "overrides": []
           },
-          "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 2043
           },
-          "hiddenSeries": false,
           "id": 278,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -7120,46 +5458,10 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Total memory usage",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1502",
-              "format": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1503",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-purple"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -7170,40 +5472,17 @@
             },
             "overrides": []
           },
-          "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 2043
           },
-          "hiddenSeries": false,
           "id": 280,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "7.3.5",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -7217,59 +5496,16 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Total workspace size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1580",
-              "format": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1581",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "repeat": "pool",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Runner recycling (${pool})",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -7279,7 +5515,6 @@
       "id": 38,
       "panels": [
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -7342,7 +5577,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 302
+            "y": 4475
           },
           "id": 40,
           "options": {
@@ -7379,7 +5614,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -7484,7 +5718,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 315
+            "y": 4488
           },
           "id": 76,
           "options": {
@@ -7525,49 +5759,25 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329
+            "y": 4502
           },
-          "hiddenSeries": false,
           "id": 42,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -7581,85 +5791,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "SQL queries per second",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4152",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4153",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 329
+            "y": 4502
           },
-          "hiddenSeries": false,
           "id": 46,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -7673,85 +5827,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "SQL error rate (errors per second / queries per second)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4229",
-              "format": "percent",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4230",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 337
+            "y": 4510
           },
-          "hiddenSeries": false,
           "id": 44,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -7765,47 +5863,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "SQL errors per second",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4307",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4308",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "SQL",
@@ -7813,10 +5872,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -7826,19 +5881,11 @@
       "id": 458,
       "panels": [
         {
-          "aliasColors": {
-            "max": "#BF1B00"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "editable": true,
-          "error": false,
           "fieldConfig": {
             "defaults": {
               "links": [],
@@ -7846,44 +5893,17 @@
             },
             "overrides": []
           },
-          "fill": 0,
-          "fillGradient": 0,
-          "grid": {},
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 321
+            "y": 4494
           },
-          "hiddenSeries": false,
           "id": 498,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null as zero",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -7902,84 +5922,29 @@
               "target": ""
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Memory usage",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4408",
-              "format": "percentunit",
-              "logBase": 1,
-              "max": "1",
-              "min": 0,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4409",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 321
+            "y": 4494
           },
-          "hiddenSeries": false,
           "id": 542,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -7993,38 +5958,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Total items per DB",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:203",
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:204",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -8090,11 +6025,9 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 330
+            "y": 4503
           },
-          "hideTimeOverride": true,
           "id": 506,
-          "links": [],
           "options": {
             "legend": {
               "calcs": [],
@@ -8131,61 +6064,28 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "editable": true,
-          "error": false,
           "fieldConfig": {
             "defaults": {
               "links": []
             },
             "overrides": []
           },
-          "fill": 10,
-          "fillGradient": 0,
-          "grid": {},
           "gridPos": {
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 339
+            "y": 4512
           },
-          "hiddenSeries": false,
           "id": 496,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -8202,94 +6102,31 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Total commands per second",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:487",
-              "format": "ops",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:488",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "editable": true,
-          "error": false,
           "fieldConfig": {
             "defaults": {
               "links": []
             },
             "overrides": []
           },
-          "fill": 10,
-          "fillGradient": 0,
-          "grid": {},
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 349
+            "y": 4522
           },
-          "hiddenSeries": false,
           "id": 500,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -8306,94 +6143,31 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Average time spent by command per second",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4712",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4713",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "editable": true,
-          "error": false,
           "fieldConfig": {
             "defaults": {
               "links": []
             },
             "overrides": []
           },
-          "fill": 10,
-          "fillGradient": 0,
-          "grid": {},
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 349
+            "y": 4522
           },
-          "hiddenSeries": false,
           "id": 504,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -8410,47 +6184,8 @@
               "step": 240
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Total Time Spent by Command / sec",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:516",
-              "format": "s",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:517",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "Redis",
@@ -8458,10 +6193,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -8471,48 +6202,25 @@
       "id": 48,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 136
+            "y": 4309
           },
-          "hiddenSeries": false,
           "id": 50,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -8526,84 +6234,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Downloaded bytes per second",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4882",
-              "format": "binBps",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4883",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-green"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 136
+            "y": 4309
           },
-          "hiddenSeries": false,
           "id": 53,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -8617,83 +6270,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Median download duration",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4959",
-              "format": "µs",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4960",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-yellow"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 144
+            "y": 4317
           },
-          "hiddenSeries": false,
           "id": 51,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -8707,84 +6306,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Uploaded bytes per second",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5037",
-              "format": "binBps",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5038",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-yellow"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 144
+            "y": 4317
           },
-          "hiddenSeries": false,
           "id": 55,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -8798,47 +6342,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Median upload duration",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5114",
-              "format": "µs",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5115",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "Blobstore",
@@ -8846,10 +6351,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -8859,7 +6360,6 @@
       "id": 384,
       "panels": [
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -8921,7 +6421,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 233
+            "y": 4406
           },
           "id": 742,
           "options": {
@@ -8962,7 +6462,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -9024,7 +6523,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 233
+            "y": 4406
           },
           "id": 422,
           "options": {
@@ -9062,7 +6561,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -9124,7 +6622,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 241
+            "y": 4414
           },
           "id": 420,
           "options": {
@@ -9162,7 +6660,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -9224,7 +6721,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 241
+            "y": 4414
           },
           "id": 6504,
           "options": {
@@ -9264,7 +6761,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -9373,7 +6869,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 249
+            "y": 4422
           },
           "id": 1223,
           "options": {
@@ -9405,7 +6901,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -9544,7 +7039,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 249
+            "y": 4422
           },
           "id": 1224,
           "options": {
@@ -9576,7 +7071,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -9600,7 +7094,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 257
+            "y": 4430
           },
           "id": 6943,
           "options": {
@@ -9668,7 +7162,6 @@
           "type": "heatmap"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -9692,7 +7185,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 257
+            "y": 4430
           },
           "id": 6944,
           "options": {
@@ -9750,7 +7243,6 @@
           "type": "heatmap"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -9812,7 +7304,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 265
+            "y": 4438
           },
           "id": 7133,
           "options": {
@@ -9866,7 +7358,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -10001,7 +7492,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 265
+            "y": 4438
           },
           "id": 7039,
           "options": {
@@ -10106,24 +7597,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Remote execution",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -10133,51 +7611,25 @@
       "id": 107,
       "panels": [
         {
-          "aliasColors": {
-            "Error ratio": "dark-red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 4190
           },
-          "hiddenSeries": false,
           "id": 122,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10191,87 +7643,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "HTTP 5xx error ratio",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5215",
-              "format": "percentunit",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5216",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 4190
           },
-          "hiddenSeries": false,
           "id": 116,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10285,87 +7679,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "HTTP requests per second by route",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5293",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5294",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 4198
           },
-          "hiddenSeries": false,
           "id": 112,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10379,90 +7715,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "HTTP requests per second by method",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5373",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5374",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "404": "dark-orange",
-            "500": "dark-red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 4198
           },
-          "hiddenSeries": false,
           "id": 120,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10476,84 +7751,30 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "HTTP responses per second by status",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5453",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5454",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 4206
           },
-          "hiddenSeries": false,
           "id": 118,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10567,83 +7788,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Median HTTP request handler duration (2xx responses only)",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5532",
-              "format": "µs",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5533",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 4206
           },
-          "hiddenSeries": false,
           "id": 124,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10657,89 +7824,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Median HTTP response size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5609",
-              "format": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5610",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 4214
           },
-          "hiddenSeries": false,
           "id": 9138,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sort": "avg",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10755,87 +7862,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "HTTP client outgoing requests per second by host",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5373",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5374",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 4214
           },
-          "hiddenSeries": false,
           "id": 9139,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10851,88 +7900,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "HTTP client outgoing requests per second by method",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5373",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5374",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 4222
           },
-          "hiddenSeries": false,
           "id": 9266,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "sort": "avg",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -10948,47 +7938,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "HTTP client bytes read by host",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5609",
-              "format": "bytes",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5610",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "HTTP",
@@ -10996,10 +7947,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -11009,52 +7956,26 @@
       "id": 28,
       "panels": [
         {
-          "aliasColors": {
-            "Idle": "dark-purple"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "Chart is stacked, so values always add up to 100%.",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 4191
           },
-          "hiddenSeries": false,
           "id": 190,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -11079,42 +8000,10 @@
               "refId": "B"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Fraction of working executors",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:126",
-              "format": "percentunit",
-              "logBase": 1,
-              "max": "1",
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:127",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -11295,7 +8184,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 4191
           },
           "id": 159,
           "options": {
@@ -11406,54 +8295,25 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "output_upload": "dark-orange",
-            "output_upload stage": "dark-orange",
-            "queued": "dark-red",
-            "queued stage": "dark-red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 4199
           },
-          "hiddenSeries": false,
           "id": 210,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -11469,41 +8329,10 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Action stage durations (quantile=${quantile})",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:505",
-              "format": "µs",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:506",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -11565,7 +8394,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 4199
           },
           "id": 1209,
           "options": {
@@ -11597,7 +8426,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -11660,7 +8488,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 4207
           },
           "id": 31,
           "options": {
@@ -11694,51 +8522,26 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 4207
           },
-          "hiddenSeries": false,
           "id": 178,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -11762,41 +8565,10 @@
               "refId": "B"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Avg resources allocated to tasks",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:582",
-              "format": "percentunit",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:583",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -11860,7 +8632,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 4215
           },
           "id": 8505,
           "options": {
@@ -11900,7 +8672,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -11977,7 +8748,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 4215
           },
           "id": 8606,
           "options": {
@@ -12053,7 +8824,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -12116,7 +8886,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 4223
           },
           "id": 1216,
           "options": {
@@ -12184,7 +8954,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -12246,7 +9015,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 4223
           },
           "id": 1231,
           "options": {
@@ -12316,50 +9085,26 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 4231
           },
-          "hiddenSeries": false,
           "id": 33,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -12373,85 +9118,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Total downloaded bytes per second",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:816",
-              "format": "binBps",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:817",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "yellow"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 4231
           },
-          "hiddenSeries": false,
           "id": 35,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -12465,85 +9154,30 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Total uploaded bytes per second",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:738",
-              "format": "binBps",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:739",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "Number of actions waiting to be executed",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 66
+            "y": 4239
           },
-          "hiddenSeries": false,
           "id": 102,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -12557,87 +9191,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Executor queue length by pod",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:893",
-              "decimals": 0,
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:894",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 66
+            "y": 4239
           },
-          "hiddenSeries": false,
           "id": 180,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": false,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -12651,41 +9227,10 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Total CPU usage (CPU seconds)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:1049",
-              "format": "s",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:1050",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -12814,7 +9359,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 74
+            "y": 4247
           },
           "id": 1195,
           "options": {
@@ -12887,7 +9432,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -12976,7 +9520,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 74
+            "y": 4247
           },
           "id": 1196,
           "options": {
@@ -13010,7 +9554,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -13074,7 +9617,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 4255
           },
           "id": 1202,
           "options": {
@@ -13144,7 +9687,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -13168,7 +9710,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 4255
           },
           "id": 7145,
           "options": {
@@ -13225,7 +9767,6 @@
           "type": "heatmap"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -13249,7 +9790,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 4263
           },
           "id": 7139,
           "options": {
@@ -13306,7 +9847,6 @@
           "type": "heatmap"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -13330,7 +9870,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 4263
           },
           "id": 7157,
           "options": {
@@ -13387,7 +9927,6 @@
           "type": "heatmap"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -13411,7 +9950,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 4271
           },
           "id": 7151,
           "options": {
@@ -13468,7 +10007,6 @@
           "type": "heatmap"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -13492,7 +10030,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 4271
           },
           "id": 7169,
           "options": {
@@ -13549,7 +10087,6 @@
           "type": "heatmap"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -13573,7 +10110,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 106
+            "y": 4279
           },
           "id": 7163,
           "options": {
@@ -13631,24 +10168,11 @@
         }
       ],
       "repeat": "pool",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Executor pool (${pool})",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -13658,52 +10182,26 @@
       "id": 83,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "Number of heap bytes allocated and still in use.",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 7824
           },
-          "hiddenSeries": false,
           "id": 85,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -13729,84 +10227,29 @@
               "refId": "B"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Heap size",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5702",
-              "format": "bytes",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5703",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 7824
           },
-          "hiddenSeries": false,
           "id": 93,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -13822,85 +10265,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Median GC duration",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5933",
-              "format": "s",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5934",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 7833
           },
-          "hiddenSeries": false,
           "id": 87,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -13916,84 +10303,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "goroutines",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5779",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5780",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 7833
           },
-          "hiddenSeries": false,
           "id": 10729,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -14009,58 +10341,16 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "OS threads",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:5779",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "$$hashKey": "object:5780",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "repeat": "job",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "golang (${job})",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -14070,68 +10360,25 @@
       "id": 71,
       "panels": [
         {
-          "aliasColors": {
-            "Aborted": "dark-orange",
-            "AlreadyExists": "dark-blue",
-            "Canceled": "dark-yellow",
-            "DataLoss": "dark-red",
-            "DeadlineExceeded": "dark-red",
-            "FailedPrecondition": "dark-red",
-            "Internal": "dark-red",
-            "NotFound": "semi-dark-yellow",
-            "OK": "dark-green",
-            "OutOfRange": "rgb(188, 68, 176)",
-            "PermissionDenied": "dark-purple",
-            "ResourceExhausted": "dark-yellow",
-            "Unauthenticated": "dark-purple",
-            "Unavailable": "dark-red",
-            "Unimplemented": "dark-purple",
-            "Unknown": "rgb(168, 168, 168)"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 154
+            "y": 12496
           },
-          "hiddenSeries": false,
           "id": 73,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -14146,85 +10393,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Handled gRPC requests per second by status",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6051",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6052",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 154
+            "y": 12496
           },
-          "hiddenSeries": false,
           "id": 79,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -14238,38 +10429,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Handled gRPC requests per second by method",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6129",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6130",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -14333,7 +10494,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 163
+            "y": 12505
           },
           "id": 2087,
           "options": {
@@ -14435,7 +10596,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 163
+            "y": 12505
           },
           "id": 2039,
           "options": {
@@ -14484,15 +10645,6 @@
         }
       ],
       "repeat": "job",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "gRPC (${job})",
       "type": "row"
     },
@@ -14569,7 +10721,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 18501
           },
           "id": 9300,
           "options": {
@@ -14666,7 +10818,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 18501
           },
           "id": 9301,
           "options": {
@@ -14776,7 +10928,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 18509
           },
           "id": 9303,
           "options": {
@@ -14900,7 +11052,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 18502
           },
           "id": 9337,
           "options": {
@@ -14997,7 +11149,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 18502
           },
           "id": 9462,
           "options": {
@@ -15107,7 +11259,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 18510
           },
           "id": 9587,
           "options": {
@@ -15160,10 +11312,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -15235,7 +11383,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 18526
           },
           "id": 1127,
           "options": {
@@ -15332,7 +11480,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 18526
           },
           "id": 1166,
           "options": {
@@ -15442,7 +11590,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 18534
           },
           "id": 1168,
           "options": {
@@ -15491,81 +11639,40 @@
         }
       ],
       "repeat": "gkepool",
-      "repeatDirection": "h",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "GKE Nodepool Overview (${gkepool})",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 31
       },
       "id": 8,
       "panels": [
         {
-          "aliasColors": {
-            "95th %": "dark-purple"
-          },
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "Measures the time spent handling build events. In a healthy state, this should be very small (on the order of microseconds) in most cases, since the build event handler needs to be very high throughput.",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 420
+            "y": 27530
           },
-          "hiddenSeries": false,
           "id": 2,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "9.3.1",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -15600,83 +11707,29 @@
               "refId": "C"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Build event handler duration",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:6214",
-              "format": "µs",
-              "label": "",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:6215",
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 420
+            "y": 27530
           },
-          "hiddenSeries": false,
           "id": 578,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "9.3.1",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -15690,47 +11743,8 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Unexpected events",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:99",
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:100",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
+          "type": "timeseries"
         }
       ],
       "title": "Internal",
@@ -15738,67 +11752,34 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "vm"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 32
       },
       "id": 1346,
       "panels": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 465
+            "y": 27575
           },
-          "hiddenSeries": false,
           "id": 2556,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "9.3.1",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -15814,98 +11795,30 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [
-            {
-              "colorMode": "background6",
-              "fill": true,
-              "fillColor": "rgba(234, 112, 112, 0.12)",
-              "line": false,
-              "lineColor": "rgba(237, 46, 24, 0.60)",
-              "op": "time"
-            }
-          ],
           "title": "ClickHouse SQL queries per second (by query template)",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:3993",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:3994",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "",
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 478
+            "y": 27588
           },
-          "hiddenSeries": false,
           "id": 2840,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "9.3.1",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -15921,85 +11834,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "Median ClickHouse SQL query duration by query template",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4070",
-              "format": "µs",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4071",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 492
+            "y": 27602
           },
-          "hiddenSeries": false,
           "id": 2890,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "9.3.1",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -16015,85 +11872,29 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "ClickHouse SQL errors per second",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4307",
-              "format": "ops",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4308",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "aliasColors": {
-            "Value": "dark-red"
-          },
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
-          "fill": 0,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 492
+            "y": 27602
           },
-          "hiddenSeries": false,
           "id": 2940,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "9.3.1",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -16109,41 +11910,10 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "ClickHouse SQL error rate (errors per second / queries per second)",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:4229",
-              "format": "percent",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:4230",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -16204,7 +11974,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 500
+            "y": 27610
           },
           "id": 1353,
           "links": [
@@ -16242,15 +12012,6 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "ClickHouse",
       "type": "row"
     },
@@ -16260,12 +12021,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 33
       },
       "id": 5641,
       "panels": [
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -16326,7 +12086,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 249
+            "y": 27359
           },
           "id": 5595,
           "options": {
@@ -16358,7 +12118,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -16419,7 +12178,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 249
+            "y": 27359
           },
           "id": 5608,
           "options": {
@@ -16451,7 +12210,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -16513,7 +12271,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 257
+            "y": 27367
           },
           "id": 5622,
           "options": {
@@ -16545,7 +12303,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -16607,7 +12364,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 257
+            "y": 27367
           },
           "id": 5629,
           "options": {
@@ -16639,7 +12396,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -16700,7 +12456,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 265
+            "y": 27375
           },
           "id": 5615,
           "options": {
@@ -16741,12 +12497,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 34
       },
       "id": 7275,
       "panels": [
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -16809,7 +12564,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 165
+            "y": 27275
           },
           "id": 7381,
           "options": {
@@ -16842,7 +12597,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -16930,7 +12684,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 165
+            "y": 27275
           },
           "id": 7382,
           "options": {
@@ -16963,7 +12717,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -17029,7 +12782,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 173
+            "y": 27283
           },
           "id": 7489,
           "options": {
@@ -17062,7 +12815,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -17128,7 +12880,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 173
+            "y": 27283
           },
           "id": 7488,
           "options": {
@@ -17161,7 +12913,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -17224,7 +12975,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 181
+            "y": 27291
           },
           "id": 7595,
           "options": {
@@ -17257,7 +13008,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -17320,7 +13070,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 181
+            "y": 27291
           },
           "id": 8743,
           "options": {
@@ -17353,7 +13103,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -17416,7 +13165,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 189
+            "y": 27299
           },
           "id": 8880,
           "options": {
@@ -17449,7 +13198,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -17512,7 +13260,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 189
+            "y": 27299
           },
           "id": 9017,
           "options": {
@@ -17554,12 +13302,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 35
       },
       "id": 9846,
       "panels": [
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -17620,7 +13367,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 27154
           },
           "id": 10100,
           "options": {
@@ -17653,7 +13400,6 @@
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
@@ -17714,7 +13460,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 27154
           },
           "id": 10227,
           "options": {
@@ -17747,50 +13493,26 @@
           "type": "timeseries"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "collapsed": true,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "vm"
           },
           "description": "Total number of bytes downloaded by consumers of the cache, per second. This does _not_ represent the average download speed across cache requests.",
-          "fill": 1,
-          "fillGradient": 0,
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 27162
           },
-          "hiddenSeries": false,
           "id": 10354,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
           "options": {
             "alertThreshold": true
           },
-          "percentage": false,
           "pluginVersion": "10.1.0",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
               "datasource": {
@@ -17806,47 +13528,17 @@
               "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
           "title": "OCI registry mirror cache download throughput",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "$$hashKey": "object:2049",
-              "format": "binBps",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "$$hashKey": "object:2050",
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
+          "type": "timeseries"
         }
       ],
       "title": "OCI registry mirror",
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "1m",
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 41,
   "tags": [
     "file:buildbuddy.json"
   ],
@@ -17854,7 +13546,6 @@
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "us-west1",
           "value": "us-west1"
         },
@@ -17863,9 +13554,7 @@
           "uid": "vm"
         },
         "definition": "label_values(up, region)",
-        "hide": 0,
         "includeAll": false,
-        "multi": false,
         "name": "region",
         "options": [],
         "query": {
@@ -17874,23 +13563,16 @@
         },
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "1m",
           "value": "1m"
         },
-        "hide": 0,
         "includeAll": false,
         "label": "Averaging Window",
-        "multi": false,
         "name": "window",
         "options": [
           {
@@ -17980,13 +13662,10 @@
           }
         ],
         "query": "30s, 1m, 5m, 10m, 15m, 30m, 1h, 2h, 4h, 8h, 16h, 1d, 2d, 5d, 7d, 14d, 30d",
-        "queryValue": "",
-        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -17995,10 +13674,8 @@
           "uid": "vm"
         },
         "definition": "label_values(up{region=\"$region\"}, job)",
-        "hide": 0,
         "includeAll": true,
         "label": "Jobs",
-        "multi": false,
         "name": "job",
         "options": [],
         "query": {
@@ -18007,16 +13684,10 @@
         },
         "refresh": 1,
         "regex": "buildbuddy-app|executor.*",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -18025,10 +13696,8 @@
           "uid": "vm"
         },
         "definition": "label_values(up{region=\"$region\"}, job)",
-        "hide": 0,
         "includeAll": true,
         "label": "Executor pool",
-        "multi": false,
         "name": "pool",
         "options": [],
         "query": {
@@ -18037,22 +13706,14 @@
         },
         "refresh": 1,
         "regex": "executor.*",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "0.5",
           "value": "0.5"
         },
-        "hide": 0,
         "includeAll": false,
-        "multi": false,
         "name": "quantile",
         "options": [
           {
@@ -18097,13 +13758,10 @@
           }
         ],
         "query": "0.25,0.5,0.75,0.9,0.95,0.99,0.999,0.9999",
-        "queryValue": "",
-        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -18112,9 +13770,7 @@
           "uid": "vm"
         },
         "definition": "label_values(buildbuddy_remote_cache_disk_cache_partition_capacity_bytes{region=\"$region\", job=\"buildbuddy-app\", namespace!=\"raft-dev\"},cache_name)",
-        "hide": 0,
         "includeAll": true,
-        "multi": false,
         "name": "cache_name",
         "options": [],
         "query": {
@@ -18123,13 +13779,10 @@
         },
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -18138,9 +13791,7 @@
           "uid": "vm"
         },
         "definition": "label_values(node_uname_info{region=\"$region\"}, nodename)",
-        "hide": 0,
         "includeAll": true,
-        "multi": false,
         "name": "gkepool",
         "options": [],
         "query": {
@@ -18149,13 +13800,11 @@
         },
         "refresh": 2,
         "regex": "^(gke-.*)-([0-9a-f]{8})-(grp-)?([0-9a-z]{4})$",
-        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -18168,7 +13817,6 @@
           "uid": "vm"
         },
         "definition": "label_values(kube_pod_info{pod=~\"buildbuddy-app-.*\", region=\"$region\"}, node)",
-        "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "appnode",
@@ -18179,13 +13827,11 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -18198,7 +13844,6 @@
           "uid": "vm"
         },
         "definition": "label_values(kube_pod_info{pod=~\"executor-.*\", region=\"$region\"}, node)",
-        "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "executornode",
@@ -18209,7 +13854,6 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
         "type": "query"
       }
@@ -18237,6 +13881,5 @@
   },
   "timezone": "",
   "title": "BuildBuddy Metrics",
-  "uid": "1rsE5yoGz",
-  "weekStart": ""
+  "uid": "1rsE5yoGz"
 }


### PR DESCRIPTION
This allows us to easily pin to a specific version of the grafana clickhouse plugin, so we can work around https://github.com/grafana/clickhouse-datasource/issues/1256.

I checked all the graphs, and they seem to work the same as the deployed version. Unfortunately, the diff is huge because grafana ran some migration when upgrading the version.