### PR TITLE
[raft] clean up mappedRangeLockTxnID

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -501,6 +501,7 @@ func (sm *Replica) releaseLocks(wb pebble.Batch, txid []byte) {
 			delete(sm.lockedKeys, keyString)
 		}
 	}
+	sm.mappedRangeLockingTXID = nil
 }
 
 func (sm *Replica) loadTxnIntoMemory(txid []byte, batchReq *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {


### PR DESCRIPTION
also add unit test to make sure that after committing txn, it is unlocked. 