### PR TITLE
Log duplicate invocation/execution links and add tests

### DIFF
--- a/enterprise/server/backends/redis_execution_collector/BUILD
+++ b/enterprise/server/backends/redis_execution_collector/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//proto:stored_invocation_go_proto",
         "//server/real_environment",
+        "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",


### PR DESCRIPTION
We're seeing some duplicate invocation-execution links in logs: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5121

Add tests to make sure we ignore duplicates (to match the current MySQL behavior). Also add logging so that after switching to redis, we can keep investigating this issue.