### PR TITLE
[raft] make single op timeout configurable

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -786,6 +786,9 @@ func getReplica(t testing.TB, s *testutil.TestingStore, rangeID uint64) *replica
 
 func TestSplitNonMetaRange(t *testing.T) {
 	flags.Set(t, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
+	// store_test is sensitive to cpu pressure stall on remote executor. Increase
+	// the single op timeout to make it less sensitive.
+	flags.Set(t, "cache.raft.op_timeout", 3*time.Second)
 	sf := testutil.NewStoreFactory(t)
 	s1 := sf.NewStore(t)
 	s2 := sf.NewStore(t)


### PR DESCRIPTION
When running test remotely, sometimes the CPU can stall; and thus can cause dragonboat to timeout. 

[https://app.buildbuddy.io/invocation/c6c45016-c7b4-43f4-89ed-812ac6d8822c?executionId[…]cdbf6664ec534341f4b49058091d9d12e20b589512ca929a264119%2F127](https://app.buildbuddy.io/invocation/c6c45016-c7b4-43f4-89ed-812ac6d8822c?executionId=%2Fuploads%2F791ade06-ad7d-430b-a35a-834f0cf0e42b%2Fblobs%2Fblake3%2F23d26e362b167e33a723056fa795f958e48cd8a509cfdd26b36899db0a22b70e%2F352&actionDigest=23d26e362b167e33a723056fa795f958e48cd8a509cfdd26b36899db0a22b70e%2F352&executeResponseDigest=bff1aa7d27cdbf6664ec534341f4b49058091d9d12e20b589512ca929a264119%2F127#action) and [https://app.buildbuddy.io/invocation/c6c45016-c7b4-43f4-89ed-812ac6d8822c?executionId[…]17955f9c99f2367f38f97f2b6ad6df5e205760d0d8145b1de900c1%2F127](https://app.buildbuddy.io/invocation/c6c45016-c7b4-43f4-89ed-812ac6d8822c?executionId=%2Fuploads%2F3ee10b13-a915-43e5-97fd-877be4b70a92%2Fblobs%2Fblake3%2F8b1a83e7a84795dd7f70e3365d918f9dd431a654bda48fed33338ad42eb331dd%2F352&actionDigest=8b1a83e7a84795dd7f70e3365d918f9dd431a654bda48fed33338ad42eb331dd%2F352&executeResponseDigest=c4ee3fb4d617955f9c99f2367f38f97f2b6ad6df5e205760d0d8145b1de900c1%2F127#action)
Both has 4 - 5 seconds of CPU Partially stalled.