### PR TITLE
Kythe: add flag that makes vnames agree across compilation units

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -244,7 +244,7 @@ find -L bazel-out/ -name *.go.kzip -print0 | xargs -r0 zipmerge output.go.kzip
 find -L bazel-out/ -name *.protobuf.kzip -print0 | xargs -r0 zipmerge output.protobuf.kzip
 
 if [ -f output.go.kzip ]; then
-  "$KYTHE_DIR"/indexers/go_indexer -continue output.go.kzip >> kythe_entries
+  "$KYTHE_DIR"/indexers/go_indexer -continue -use_compilation_corpus_for_all output.go.kzip >> kythe_entries
 fi
 if [ -f output.protobuf.kzip ]; then
   "$KYTHE_DIR"/indexers/proto_indexer -index_file output.protobuf.kzip >> kythe_entries


### PR DESCRIPTION
Leaving a long description for posterity / future investigations: 

I was digging into why `IndexWriter` did not have a reverse `/kythe/edge/satisfies` edge that showed that `Writer` satisfied the `IndexWriter` interface... and found that the nodes for `IndexWriter` were getting split across 2 VNames:

`kythe:?lang=go?path=codesearch/types/types?root=bazel-out/bin#type%20IndexWriter`
and
`kythe://kythe?lang=go?path=codesearch/types/types?root=bazel-out/bin#type%20IndexWriter`

i.e. one had a "corpus" set, and one didn't ([kythe docs](https://kythe.io/docs/kythe-storage.html#TermVName)). 

Setting this flag fixes the problem, although I admit I am not confident about whether there are wider negative implications for this... it seems to cause the corpus to be omitted from all of the entries. 

I tried various incantations to avoid needing this flag, including mimicking the use of `kzip create_metadata` [here](https://github.com/buildbuddy-io/kythe/blob/master/kythe/extractors/bazel/extract.sh#L93), in the hopes that that would set the corpus correctly for everything... but it didn't seem to make a difference. So, for now we'll use this, and revisit if necessary.