### PR TITLE
Revert "sample partition size per group while evicting instead of trying to fully count size"

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -11,7 +11,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -89,6 +89,7 @@ var (
 	includeMetadataSize       = flag.Bool("cache.pebble.include_metadata_size", false, "If true, include metadata size")
 	enableTableBloomFilter    = flag.Bool("cache.pebble.enable_table_bloom_filter", true, "If true, write bloom filter data with pebble SSTables.")
 	enableAutoRatchet         = flag.Bool("cache.pebble.enable_auto_ratchet", false, "If true, automatically upgrade on-disk format to latest version.")
+	groupTrackingMinTimeUsec  = flag.Int64("cache.pebble.min_time_for_group_tracking_usec", math.MaxInt64, "If a file was created after this timestamp, we will count it when tracking cache space usage by group.")
 
 	activeKeyVersion  = flag.Int64("cache.pebble.active_key_version", int64(filestore.UnspecifiedKeyVersion), "The key version new data will be written with. If negative, will write to the highest existing version in the database, or the highest known version if a new database is created.")
 	migrationQPSLimit = flag.Int("cache.pebble.migration_qps_limit", 50, "QPS limit for data version migration")
@@ -1357,20 +1358,6 @@ func (p *PebbleCache) backgroundRepairIteration(quitChan chan struct{}, opts *re
 	return nil
 }
 
-func computeEstimatedSizeByGroup(sizeByGroup map[string]int64, totalSizeBytes int64) map[string]int64 {
-	out := make(map[string]int64, len(sizeByGroup))
-	totalSampledSize := int64(0)
-	for _, s := range sizeByGroup {
-		totalSampledSize += s
-	}
-	totalSampledSize = max(1, totalSampledSize)
-	sampleScalingFactor := float64(totalSizeBytes) / float64(totalSampledSize)
-	for k, v := range sizeByGroup {
-		out[k] = int64(float64(v) * sampleScalingFactor)
-	}
-	return out
-}
-
 func (p *PebbleCache) Statusz(ctx context.Context) string {
 	db, err := p.leaser.DB()
 	if err != nil {
@@ -1394,29 +1381,35 @@ func (p *PebbleCache) Statusz(ctx context.Context) string {
 		buf += fmt.Sprintf("Estimated pebble DB disk usage: %d bytes\n", diskEstimateBytes)
 	}
 	var totalSizeBytes, totalCASCount, totalACCount int64
-	sampledSizeByGroup := make(map[string]int64)
+	sizeByGroup := make(map[string]int64)
 	for _, e := range evictors {
 		sizeBytes, sbg, casCount, acCount := e.Counts()
 		for g, s := range sbg {
-			sampledSizeByGroup[g] += s
+			sizeByGroup[g] += s
 		}
 		totalSizeBytes += sizeBytes
 		totalCASCount += casCount
 		totalACCount += acCount
 	}
-	estimatedSizeByGroup := computeEstimatedSizeByGroup(sampledSizeByGroup, totalSizeBytes)
 	buf += fmt.Sprintf("Min DB version: %d, Max DB version: %d, Active version: %d\n", p.minDatabaseVersion(), p.maxDatabaseVersion(), p.activeDatabaseVersion())
 	buf += fmt.Sprintf("[All Partitions] Total Size: %d bytes\n", totalSizeBytes)
 	buf += fmt.Sprintf("[All Partitions] CAS total: %d items\n", totalCASCount)
 	buf += fmt.Sprintf("[All Partitions] AC total: %d items\n", totalACCount)
-	if len(estimatedSizeByGroup) > 0 {
-		sortedKeys := slices.Sorted(maps.Keys(estimatedSizeByGroup))
-		buf += "\n[All partitions] Approximate size by group:\n"
+	if len(sizeByGroup) > 0 {
+		extra := totalSizeBytes
+		sortedKeys := make([]string, 0, len(sizeByGroup))
+		for k, _ := range sizeByGroup {
+			sortedKeys = append(sortedKeys, k)
+		}
+		sort.Strings(sortedKeys)
+		buf += "\n[All partitions] Size by group:\n"
 		for _, g := range sortedKeys {
-			if s, ok := estimatedSizeByGroup[g]; ok {
+			if s, ok := sizeByGroup[g]; ok {
 				buf += fmt.Sprintf("  %s: %d bytes\n", g, s)
+				extra -= s
 			}
 		}
+		buf += fmt.Sprintf("Extra space (from before counting began): %d bytes\n", extra)
 	}
 
 	buf += "</pre>"
@@ -2595,13 +2588,14 @@ func newPartitionEvictor(ctx context.Context, part disk.Partition, fileStorer fi
 
 	start := time.Now()
 	log.Infof("Pebble Cache [%s]: Initializing cache partition %q...", pe.cacheName, part.ID)
-	sizeBytes, casCount, acCount, err := pe.computeSize()
+	sizeBytes, sizeByGroup, casCount, acCount, err := pe.computeSize()
 	if err != nil {
 		return nil, err
 	}
 	pe.sizeBytes = sizeBytes
 	pe.casCount = casCount
 	pe.acCount = acCount
+	pe.sizeByGroup = sizeByGroup
 	pe.lru.UpdateSizeBytes(sizeBytes)
 
 	log.Infof("Pebble Cache [%s]: Initialized cache partition %q AC: %d, CAS: %d, Size: %d [bytes] in %s", pe.cacheName, part.ID, pe.acCount, pe.casCount, pe.sizeBytes, time.Since(start))
@@ -2717,13 +2711,6 @@ func (e *partitionEvictor) generateSamplesForEviction(quitChan chan struct{}) er
 			}
 			iter.Close()
 			iter = newIter
-			// Decay away sampled partition sizes over time.  This value is kinda arbitrary,
-			// but was chosen based on the default sampler refresh period of 5 minutes to
-			// ensure that samples mostly decay within an hour (normally it's faster than this,
-			// assuming eviction is firing on all cylinders).
-			for k, v := range e.sizeByGroup {
-				e.sizeByGroup[k] = int64(float64(v) * 0.8)
-			}
 		}
 		totalCount += 1
 		if !iter.Valid() {
@@ -2746,8 +2733,6 @@ func (e *partitionEvictor) generateSamplesForEviction(quitChan chan struct{}) er
 			log.Warningf("[%s] cannot generate sample for eviction, skipping: failed to read proto: %s", e.cacheName, err)
 			continue
 		}
-
-		e.sizeByGroup[fileMetadata.GetFileRecord().GetIsolation().GetGroupId()] += fileMetadata.GetStoredSizeBytes()
 
 		e.maybeAddToSampleChan(iter, fileMetadata, quitChan, timer)
 
@@ -2802,10 +2787,8 @@ func (e *partitionEvictor) updateMetrics() {
 		metrics.PartitionID:    e.part.ID,
 		metrics.CacheNameLabel: e.cacheName,
 		metrics.CacheTypeLabel: "cas"}).Set(float64(e.casCount))
-
-	estimatedSizeByGroup := computeEstimatedSizeByGroup(e.sizeByGroup, e.sizeBytes)
-	for g, sizeBytes := range estimatedSizeByGroup {
-		metrics.DiskCacheSampledPartitionGroupSizeBytes.With(prometheus.Labels{
+	for g, sizeBytes := range e.sizeByGroup {
+		metrics.DiskCachePartitionGroupSizeBytes.With(prometheus.Labels{
 			metrics.PartitionID:    e.part.ID,
 			metrics.CacheNameLabel: e.cacheName,
 			metrics.GroupID:        g}).Set(float64(sizeBytes))
@@ -2821,6 +2804,10 @@ func (e *partitionEvictor) updateSize(cacheType rspb.CacheType, lastModifyUsec i
 		deltaCount = -1
 	}
 
+	if lastModifyUsec > *groupTrackingMinTimeUsec {
+		e.sizeByGroup[groupID] += deltaSize
+	}
+
 	switch cacheType {
 	case rspb.CacheType_CAS:
 		e.casCount += deltaCount
@@ -2833,10 +2820,10 @@ func (e *partitionEvictor) updateSize(cacheType rspb.CacheType, lastModifyUsec i
 	e.lru.UpdateSizeBytes(e.sizeBytes)
 }
 
-func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, int64, int64, error) {
+func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, map[string]int64, int64, int64, error) {
 	db, err := e.dbGetter.DB()
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, nil, 0, 0, err
 	}
 	defer db.Close()
 	iter, err := db.NewIter(&pebble.IterOptions{
@@ -2844,7 +2831,7 @@ func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, int64, 
 		UpperBound: end,
 	})
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, nil, 0, 0, err
 	}
 	defer iter.Close()
 	iter.SeekLT(start)
@@ -2852,16 +2839,20 @@ func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, int64, 
 	casCount := int64(0)
 	acCount := int64(0)
 	totalSizeBytes := int64(0)
+	totalSizeByGroup := make(map[string]int64)
 	fileMetadata := sgpb.FileMetadataFromVTPool()
 	defer fileMetadata.ReturnToVTPool()
 
 	for iter.Next() {
 		if err := proto.Unmarshal(iter.Value(), fileMetadata); err != nil {
-			return 0, 0, 0, err
+			return 0, nil, 0, 0, err
 		}
 
 		sizeBytes := getSizeOnLocalDisk(iter.Key(), fileMetadata, true)
 		totalSizeBytes += sizeBytes
+		if fileMetadata.GetLastModifyUsec() > *groupTrackingMinTimeUsec {
+			totalSizeByGroup[fileMetadata.GetFileRecord().GetIsolation().GetGroupId()] += sizeBytes
+		}
 
 		// identify and count CAS vs AC files.
 		if bytes.Contains(iter.Key(), casDir) {
@@ -2874,7 +2865,7 @@ func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, int64, 
 		fileMetadata.ResetVT()
 	}
 
-	return totalSizeBytes, casCount, acCount, nil
+	return totalSizeBytes, totalSizeByGroup, casCount, acCount, nil
 }
 
 func partitionMetadataKey(partID string) []byte {
@@ -2898,6 +2889,15 @@ func (e *partitionEvictor) lookupPartitionMetadata() (*sgpb.PartitionMetadata, e
 		return nil, err
 	}
 
+	// Because we enabled group ID-based tracking in the cache without
+	// performing a migration, we had to set an arbitrary timestamp after
+	// which we started tracking.  If we have to reset that to a new time
+	// in the future for whatever reason, we need to clear past tracking
+	// data (or else it may never get removed from the "total size").
+	if partitionMD.GetSizeByGroup() == nil || *groupTrackingMinTimeUsec > e.clock.Now().UnixMicro() {
+		partitionMD.SizeByGroup = make(map[string]int64)
+	}
+
 	return partitionMD, nil
 }
 
@@ -2912,30 +2912,31 @@ func (e *partitionEvictor) writePartitionMetadata(db pebble.IPebbleDB, md *sgpb.
 }
 
 func (e *partitionEvictor) flushPartitionMetadata(db pebble.IPebbleDB) error {
-	sizeBytes, _, casCount, acCount := e.Counts()
+	sizeBytes, sizeByGroup, casCount, acCount := e.Counts()
 	return e.writePartitionMetadata(db, &sgpb.PartitionMetadata{
-		SizeBytes: sizeBytes,
-		CasCount:  casCount,
-		AcCount:   acCount,
+		SizeBytes:   sizeBytes,
+		SizeByGroup: sizeByGroup,
+		CasCount:    casCount,
+		AcCount:     acCount,
 	})
 }
 
-func (e *partitionEvictor) computeSize() (int64, int64, int64, error) {
+func (e *partitionEvictor) computeSize() (int64, map[string]int64, int64, int64, error) {
 	if !*forceCalculateMetadata {
 		partitionMD, err := e.lookupPartitionMetadata()
 		if err == nil {
 			log.Infof("[%s] Loaded partition %q metadata from cache: %+v", e.cacheName, e.part.ID, partitionMD)
-			return partitionMD.GetSizeBytes(), partitionMD.GetCasCount(), partitionMD.GetAcCount(), nil
+			return partitionMD.GetSizeBytes(), partitionMD.GetSizeByGroup(), partitionMD.GetCasCount(), partitionMD.GetAcCount(), nil
 		} else if !status.IsNotFoundError(err) {
-			return 0, 0, 0, err
+			return 0, nil, 0, 0, err
 		}
 	}
 
 	start := append([]byte(e.partitionKeyPrefix()+"/"), keys.MinByte...)
 	end := append([]byte(e.partitionKeyPrefix()+"/"), keys.MaxByte...)
-	totalSizeBytes, totalCasCount, totalAcCount, err := e.computeSizeInRange(start, end)
+	totalSizeBytes, totalSizeByGroup, totalCasCount, totalAcCount, err := e.computeSizeInRange(start, end)
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, nil, 0, 0, err
 	}
 
 	partitionMD := &sgpb.PartitionMetadata{
@@ -2948,14 +2949,14 @@ func (e *partitionEvictor) computeSize() (int64, int64, int64, error) {
 
 	db, err := e.dbGetter.DB()
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, nil, 0, 0, err
 	}
 	defer db.Close()
 	if err := e.writePartitionMetadata(db, partitionMD); err != nil {
-		return 0, 0, 0, err
+		return 0, nil, 0, 0, err
 	}
 
-	return totalSizeBytes, totalCasCount, totalAcCount, nil
+	return totalSizeBytes, totalSizeByGroup, totalCasCount, totalAcCount, nil
 }
 
 func (e *partitionEvictor) Counts() (int64, map[string]int64, int64, int64) {

--- a/proto/storage.proto
+++ b/proto/storage.proto
@@ -108,8 +108,7 @@ message PartitionMetadata {
   int64 ac_count = 3;
   int64 total_count = 4;
   string partition_id = 5;
-
-  reserved 6;
+  map<string, int64> size_by_group = 6;
 }
 
 message PartitionMetadatas {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -685,11 +685,11 @@ var (
 		CacheNameLabel,
 	})
 
-	DiskCacheSampledPartitionGroupSizeBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	DiskCachePartitionGroupSizeBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
-		Name:      "disk_cache_sampled_partition_group_size_bytes",
-		Help:      "Number of bytes seen while sampling the partition for eviction, by group ID.",
+		Name:      "disk_cache_partition_group_size_bytes",
+		Help:      "Number of bytes in the partition, by group ID.",
 	}, []string{
 		PartitionID,
 		CacheNameLabel,


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#9595