### PR TITLE
Reduce allocs when calling pebble key Bytes() method

### DIFF
--- a/enterprise/server/filestore/filestore.go
+++ b/enterprise/server/filestore/filestore.go
@@ -279,9 +279,7 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 			hashStr = fmt.Sprintf("%x", h.Sum(nil))
 		}
 
-		filePath := hashStr + "/" + strconv.Itoa(int(pmk.digestFunction)) + "/" + pmk.isolation + "/" + pmk.encryptionKeyID
-		partDir := PartitionDirectoryPrefix + pmk.partID
-		filePath = partDir + "/" + filePath + "v5"
+		filePath := PartitionDirectoryPrefix + pmk.partID + "/" + hashStr + "/" + strconv.Itoa(int(pmk.digestFunction)) + "/" + pmk.isolation + "/" + pmk.encryptionKeyID + "v5"
 		return []byte(filePath), nil
 	default:
 		return nil, status.FailedPreconditionErrorf("Unknown key version: %v", version)


### PR DESCRIPTION
Only bothering with V5 because that's what is out there.