### PR TITLE
Hardlink init binary instead of copying

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -326,7 +326,7 @@ func main() {
 	die(mkdirp("/mnt/dev", 0755))
 	die(mount("/dev", "/mnt/dev", "", syscall.MS_MOVE, ""))
 
-	die(copyFile("/init", "/mnt/init", 0555))
+	die(os.Link("/init", "/mnt/init"))
 
 	log.Debugf("switching root!")
 	die(chdir("/mnt"))


### PR DESCRIPTION
We copy `/init` to `/mnt/init` so that after changing root directories, we can re-invoke the init binary as a subprocess. This copying eats into the VM's memory, since this copy operation is happening in the initial ram FS. To save memory, we can hardlink instead of copying.