### PR TITLE
[oci resolver] use Puller to avoid re-authing to fetch layers

### DIFF
--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -743,13 +743,15 @@ func TestResolve_WithCache(t *testing.T) {
 
 			{
 				imageAddress := registry.ImageAddress(tc.args.imageName + "_image")
-				resolveCount := int32(1)
+				// initial GET /v2/, then GET on manifest
+				resolveCount := int32(2)
 				filesCount := int32(1)
 				resolveAndCheck(t, tc, te, imageAddress, &counter, resolveCount, filesCount)
 
-				resolveCount = int32(1)
+				resolveCount = int32(2)
 				if tc.writeManifests && tc.readManifests {
-					resolveCount = int32(0)
+					// initial GET /v2/ request
+					resolveCount = int32(1)
 				}
 				filesCount = int32(1)
 				if tc.writeLayers && tc.readLayers {
@@ -760,13 +762,13 @@ func TestResolve_WithCache(t *testing.T) {
 
 			{
 				indexAddress := registry.ImageAddress(tc.args.imageName + "_index")
-				resolveCount := int32(2)
+				resolveCount := int32(3)
 				filesCount := int32(1)
 				resolveAndCheck(t, tc, te, indexAddress, &counter, resolveCount, filesCount)
 
-				resolveCount = int32(2)
+				resolveCount = int32(3)
 				if tc.writeManifests && tc.readManifests {
-					resolveCount = int32(0)
+					resolveCount = int32(1)
 				}
 				filesCount = int32(1)
 				if tc.writeLayers && tc.readLayers {

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -443,7 +443,7 @@ func TestResolve_Layers_DiffIDs(t *testing.T) {
 				upstreamCounter := atomic.Int32{}
 				registry := testregistry.Run(t, testregistry.Opts{
 					HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
-						if r.Method == http.MethodGet && r.URL.Path != "/v2/" {
+						if r.Method == http.MethodGet {
 							upstreamCounter.Add(1)
 						}
 						return true
@@ -725,7 +725,7 @@ func TestResolve_WithCache(t *testing.T) {
 			counter := atomic.Int32{}
 			registry := testregistry.Run(t, testregistry.Opts{
 				HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
-					if r.Method == http.MethodGet && r.URL.Path != "/v2/" {
+					if r.Method == http.MethodGet {
 						counter.Add(1)
 					}
 					return true


### PR DESCRIPTION
Calls to `remote.Head(...)`, `remote.Get(...)`, and `remote.Layer(...)` will cause the OCI client to re-authenticate to the remote registry. This change creates a single `Puller` and uses it to fetch manifests and layers, reducing the `GET /v2/` (and subsequent authentication) requests. Each call to `Resolve(...)` still has to authenticate once.