### PR TITLE
[oci cache] record high-level manifest, blob cache events

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -311,6 +311,10 @@ const (
 	// only use its local cache to fulfil the request. If "default", the proxy
 	// should fall back to the remote cache as the source of truth.
 	CacheProxyRequestType = "proxy_request_type"
+
+	OCIResourceTypeLabel = "oci_resource_type"
+	OCIManifest          = "manifest"
+	OCIBlob              = "blob"
 )
 
 // Label value constants
@@ -3322,9 +3326,9 @@ var (
 		Subsystem: "ociregistry",
 		Name:      "cache_download_size_bytes",
 		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
-		Help:      "Number of bytes downloaded from the cache by the OCI registry mirror (only tracking CAS currently)",
+		Help:      "Number of bytes downloaded from the cache by the OCI registry mirror",
 	}, []string{
-		CacheTypeLabel,
+		OCIResourceTypeLabel,
 	})
 
 	OCIRegistryCacheEvents = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -3333,7 +3337,7 @@ var (
 		Name:      "cache_events",
 		Help:      "Number of cache events handled.",
 	}, []string{
-		CacheTypeLabel,
+		OCIResourceTypeLabel,
 		CacheEventTypeLabel,
 	})
 )


### PR DESCRIPTION
OCI image manifests are stored in a single action result in the AC.
OCI image blobs have two entries in the CAS (a metadata proto and the blob payload) plus an action result in the AC.

This change records hits and misses for manifests and blobs instead of individual AC and CAS entries.
@bduffany suggested this accounting earlier! It's now time.