### PR TITLE
Fill in group ID based on cookie if not set in request context

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -209,7 +209,10 @@ export class AuthService {
     let match = document.cookie.match("(^|[^;]+)\\s*" + cookieName + "\\s*=\\s*([^;]+)");
     let userIdFromCookie = match ? match.pop() : "";
     rpcService.requestContext.userId = new user_id.UserId({ id: userIdFromCookie });
-    rpcService.requestContext.groupId = this.user?.selectedGroup?.id || "";
+    let groupId = this.user?.selectedGroup?.id || "";
+    rpcService.requestContext.groupId = groupId;
+    this.setCookie(SELECTED_GROUP_ID_COOKIE, groupId);
+
   }
 
   async setSelectedGroupId(groupId: string, groupURL: string, { reload = false }: { reload?: boolean } = {}) {

--- a/server/http/interceptors/BUILD
+++ b/server/http/interceptors/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/util/alert",
         "//server/util/clientip",
         "//server/util/compression",
+        "//server/util/cookie",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/region",

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -27,6 +27,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
+	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/region"
@@ -306,6 +307,11 @@ func RequestContextFromURL(next http.Handler) http.Handler {
 		if err != nil {
 			log.Warningf("Failed to parse request_context param: %s", err)
 		} else if reqCtx != nil {
+			// On initial page loads, the request context hasn't been set by the frontend
+			// yet, but the group ID may be available from this cookie.
+			if reqCtx.GetGroupId() == "" {
+				reqCtx.GroupId = cookie.GetCookie(r, cookie.SelectedGroupID)
+			}
 			ctx := requestcontext.ContextWithProtoRequestContext(r.Context(), reqCtx)
 			r = r.WithContext(ctx)
 		}

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -263,6 +263,12 @@ func userClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
 	groupMemberships := make([]*interfaces.GroupMembership, 0, len(u.Groups))
 	cacheEncryptionEnabled := false
 	enforceIPRules := false
+
+	if effectiveGroup == "" && len(u.Groups) > 0 {
+		// If no effective group is specified, use the first group in the list.
+		effectiveGroup = u.Groups[0].Group.GroupID
+	}
+
 	var capabilities []cappb.Capability
 	for _, g := range u.Groups {
 		allowedGroups = append(allowedGroups, g.Group.GroupID)

--- a/server/util/cookie/cookie.go
+++ b/server/util/cookie/cookie.go
@@ -17,6 +17,7 @@ const (
 	sessionDurationCookie = "Session-Duration-Seconds"
 	AuthIssuerCookie      = "Authorization-Issuer"
 	RedirCookie           = "Redirect-Url"
+	SelectedGroupID       = "Selected-Group-ID"
 
 	loginCookieDuration = 365 * 24 * time.Hour
 )


### PR DESCRIPTION
Typically, the user's group id is set into the request context by the frontend auth flow. However, on initial page loads, the client-side auth flow hasn't run yet.

If the user has logged in before, they likely have a cookie set with their selected group id. This change modifies the `RequestContextFromURL` middleware to use that group id if no group id is set in the request context.