### PR TITLE
Count disk write ops from mke2fs and debugfs

### DIFF
--- a/enterprise/server/util/ext4/BUILD
+++ b/enterprise/server/util/ext4/BUILD
@@ -9,9 +9,11 @@ go_library(
     target_compatible_with = ["@platforms//os:linux"],
     deps = select({
         "@io_bazel_rules_go//go/platform:linux": [
+            "//server/metrics",
             "//server/util/log",
             "//server/util/status",
             "//server/util/tracing",
+            "@com_github_prometheus_client_golang//prometheus",
             "@io_opentelemetry_go_otel//attribute",
         ],
         "//conditions:default": [],

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1529,6 +1529,15 @@ var (
 		FileName,
 	})
 
+	FirecrackerWorkspaceDiskWriteOps = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "workspace_conversion_disk_write_ops",
+		Help:      "Total number of disk write operations performed converting Firecracker action workspaces to/from ext4 images.",
+	}, []string{
+		CommandName,
+	})
+
 	MaxRecyclableResourceUsageEvent = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",


### PR DESCRIPTION
Tested this locally with

```
for SIZE in 1 10 100 1000 10000 100000; do
  mkdir -p /tmp/firecracker_root
  cat /dev/random | head -c $(( SIZE * 512 )) > /tmp/firecracker_root/input.txt
  bb execute \
    --remote_executor=grpc://localhost:1985 \
    --input_root=/tmp/firecracker_root \
    --exec_properties=workload-isolation-type=firecracker \
    -- \
    stat input.txt
done
```

and verified w/ debug logs that `rusage.Oublock` roughly matches SIZE (it's slightly bigger because of the ext4 FS metadata blocks)