### PR TITLE
Flag-guard cluster-local reads/writes of workflow VM snapshots

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1252,6 +1252,9 @@ func TestFirecracker_RemoteSnapshotSharing_CacheProxy(t *testing.T) {
 	// Disable local snapshot sharing with filecache to simplify the setup.
 	flags.Set(t, "executor.enable_local_snapshot_sharing", false)
 
+	// Enable cache proxy cluster-local snapshot storage
+	flags.Set(t, "executor.store_snapshots_in_local_cluster_only", true)
+
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{runProxy: true})
 	rootDir := testfs.MakeTempDir(t)

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/snaputil",
-        "//enterprise/server/util/proxy_util",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",


### PR DESCRIPTION
When I moved the dev GCP cache proxy to a deployment model instead of a statefulset model, I broke snapshot sharing in dev. This is because there's now no guarantee that an entire snapshot will be present in the cache proxy that serves the snapshot read request. This PR adds a flag that control whether or not to read/write snapshots from/to the backing cache as well, so that we can do this in dev GCP, but not do it in SJC where we anticipate continuing to run a distributed cache ring in the Cache Proxies.