### PR TITLE
Move user/group-specific experiments to GetUser

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -191,6 +191,7 @@ export class AuthService {
       ),
       isImpersonating: response.isImpersonating,
       subdomainGroupID: response.subdomainGroupId,
+      codesearchAllowed: response.experiments?.codesearchAllowed ?? false,
     });
   }
 

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -210,7 +210,9 @@ export class AuthService {
     let match = document.cookie.match("(^|[^;]+)\\s*" + cookieName + "\\s*=\\s*([^;]+)");
     let userIdFromCookie = match ? match.pop() : "";
     rpcService.requestContext.userId = new user_id.UserId({ id: userIdFromCookie });
-    rpcService.requestContext.groupId = this.user?.selectedGroup?.id || "";
+    let groupId = this.user?.selectedGroup?.id || "";
+    rpcService.requestContext.groupId = groupId;
+    this.setCookie(SELECTED_GROUP_ID_COOKIE, groupId);
   }
 
   async setSelectedGroupId(groupId: string, groupURL: string, { reload = false }: { reload?: boolean } = {}) {

--- a/app/auth/user.ts
+++ b/app/auth/user.ts
@@ -19,6 +19,7 @@ export class User {
   /** Whether the user is temporarily acting as a member of the selected group. */
   isImpersonating: boolean;
   subdomainGroupID: string;
+  codesearchAllowed: boolean;
 
   constructor(init: Partial<User>) {
     this.displayUser = init.displayUser!;
@@ -33,6 +34,7 @@ export class User {
     this.githubLinked = init.githubLinked!;
     this.isImpersonating = init.isImpersonating!;
     this.subdomainGroupID = init.subdomainGroupID!;
+    this.codesearchAllowed = init.codesearchAllowed!;
 
     // All props are required, but it's a pain in TS to get a type representing
     // "only the fields of User, not the methods". So do a runtime check here.

--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -238,7 +238,7 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
             <span>Enable "Ask Buddy" button</span>
           </label>
         )}
-        {capabilities.config.codeSearchEnabled && (
+        {capabilities.config.codeSearchEnabled && this.props.user.codesearchAllowed (
           <label className="form-row input-label">
             <input
               autoComplete="off"

--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -238,7 +238,7 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
             <span>Enable "Ask Buddy" button</span>
           </label>
         )}
-        {capabilities.config.codeSearchEnabled && this.props.user.codesearchAllowed (
+        {capabilities.config.codeSearchEnabled && this.props.user.codesearchAllowed && (
           <label className="form-row input-label">
             <input
               autoComplete="off"

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -24,6 +24,10 @@ message SelectedGroup {
   Access access = 2;
 }
 
+message Experiments {
+  bool codesearch_allowed = 1;
+}
+
 message GetUserResponse {
   reserved 5;
 
@@ -62,6 +66,8 @@ message GetUserResponse {
 
   // True if the user is using impersonation to access a group.
   bool is_impersonating = 10;
+
+  Experiments experiments = 11;
 }
 
 message CreateUserRequest {

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//server/util/authutil",
         "//server/util/canary",
         "//server/util/capabilities",
+        "//server/util/claims",
         "//server/util/flagutil",
         "//server/util/git",
         "//server/util/log",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -418,6 +418,12 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 	if err != nil {
 		return nil, err
 	}
+
+	cs := false
+	if efp := s.env.GetExperimentFlagProvider(); efp != nil {
+		cs = efp.Boolean(ctx, "codesearch_allowed", false /*=default*/)
+	}
+
 	return &uspb.GetUserResponse{
 		DisplayUser:     tu.ToProto(),
 		UserGroup:       groups,
@@ -430,6 +436,9 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 		GithubLinked:     tu.GithubToken != "",
 		SubdomainGroupId: subdomainGroupID,
 		IsImpersonating:  u.IsImpersonating(),
+		Experiments: &uspb.Experiments{
+			CodesearchAllowed: cs,
+		},
 	}, nil
 }
 

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -422,7 +422,7 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 
 	cs := false
 	if efp := s.env.GetExperimentFlagProvider(); efp != nil {
-		// On an initial page load, the group id may not be set in the claims yet.
+		// HACK: On an initial page load, the group id may not be set in the claims yet.
 		// Add it in here so the experiment flags are resolved correctly.
 		clm, err := claims.ClaimsFromContext(ctx)
 		if err == nil {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -421,7 +421,7 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 
 	cs := false
 	if efp := s.env.GetExperimentFlagProvider(); efp != nil {
-		cs = efp.Boolean(ctx, "codesearch_allowed", false /*=default*/)
+		cs = efp.Boolean(ctx, "codesearch-allowed", false /*=default*/)
 	}
 
 	return &uspb.GetUserResponse{

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -423,10 +423,10 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 
 	mux := env.GetMux()
 	// Register all of our HTTP handlers on the default mux.
-	mux.Handle("/", interceptors.WrapAuthenticatedExternalHandler(env, staticFileServer))
+	mux.Handle("/", interceptors.WrapExternalHandler(env, staticFileServer))
 	for _, appRoute := range appRoutes {
 		// this causes the muxer to handle redirects from e. g. /path -> /path/
-		mux.Handle(appRoute, interceptors.WrapAuthenticatedExternalHandler(env, staticFileServer))
+		mux.Handle(appRoute, interceptors.WrapExternalHandler(env, staticFileServer))
 	}
 	mux.Handle("/app/", interceptors.WrapExternalHandler(env, http.StripPrefix("/app", afs)))
 	mux.Handle("/rpc/BuildBuddyService/", interceptors.WrapAuthenticatedExternalProtoletHandler(env, "/rpc/BuildBuddyService/", protoletHandler))

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -221,10 +221,8 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 
 	if efp := env.GetExperimentFlagProvider(); efp != nil {
 		config.FlipLogoOnHover = efp.Boolean(ctx, "flip-logo-on-hover", false /*=default*/)
-		// These variables are only updated when the app is reloaded.
-		// This means that global experiments can be handled here, but experiments that
-		// are user or group specific should be included in the experiments field of
-		// GetUserResponse. This is because these variables are only refreshed on a page reload.
+		// Global experiments can be handled here, but experiments that are user or group specific
+		// should be included in the experiments field of GetUserResponse instead.
 	}
 
 	configJSON, err := protojson.Marshal(&config)

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -221,9 +221,10 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 
 	if efp := env.GetExperimentFlagProvider(); efp != nil {
 		config.FlipLogoOnHover = efp.Boolean(ctx, "flip-logo-on-hover", false /*=default*/)
-		if *codeSearchEnabled {
-			config.CodeSearchEnabled = efp.Boolean(ctx, "codesearch-allowed", false /*=default*/)
-		}
+		// These variables are only updated when the app is reloaded.
+		// This means that global experiments can be handled here, but experiments that
+		// are user or group specific should be included in the experiments field of
+		// GetUserResponse. This is because these variables are only refreshed on a page reload.
 	}
 
 	configJSON, err := protojson.Marshal(&config)


### PR DESCRIPTION
We shouldn't send user- or group- specific data or experiment flags in the `FrontendConfig` - it requires a full page refresh to update these. Instead, this PR moves user-specific experiment data to `GetUser`.

- Add a new message to hold experiment data to `GetUserResponse`, and populate it in the `GetUser` call
- Plumb that to the frontend `User` struct
- Update the frontend to check the new codesearch experiment flag when deciding whether to render the "Enable Codesearch" checkbox on the settings page. 
- Set the selected group id cookie whenever group id changes.
- Undo the auth wrapping for root app requests from #9529, it is no longer needed.