### PR TITLE
CLI: Use `set.Set` for `Definition.supportedCommands`

### DIFF
--- a/cli/parser/options/BUILD
+++ b/cli/parser/options/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//cli/parser/arguments",
         "//cli/parser/bazelrc",
         "//proto:bazel_flags_go_proto",
+        "//server/util/lib/set",
     ],
 )
 


### PR DESCRIPTION
This change makes use of the `set.Set` type to amke the code a little more concise and readable.
