### PR TITLE
Add groupID as a dimension to most of the migration cache metrics

### DIFF
--- a/enterprise/server/backends/migration_cache/BUILD
+++ b/enterprise/server/backends/migration_cache/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/digest",
         "//server/util/background",
+        "//server/util/claims",
         "//server/util/compression",
         "//server/util/disk",
         "//server/util/flag",

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -211,7 +211,6 @@ func (mc *MigrationCache) Contains(ctx context.Context, r *rspb.ResourceName) (b
 				if mc.logNotFoundErrors {
 					log.Warningf("Migration digest %v src contains, dest does not", r.GetDigest())
 				}
-				mc.sendNonBlockingCopy(ctx, r, true /*=onlyCopyMissing*/)
 			} else if srcContains && dstContains {
 				metrics.MigrationDoubleReadHitCount.With(prometheus.Labels{
 					metrics.CacheRequestType: "contains",

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -793,6 +793,7 @@ var (
 		Help:      "Number of not found errors from the destination cache during a cache migration.",
 	}, []string{
 		CacheRequestType,
+		GroupID,
 	})
 
 	MigrationDoubleReadHitCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -802,6 +803,7 @@ var (
 		Help:      "Number of double reads where the source and destination caches hold the same digests during a cache migration.",
 	}, []string{
 		CacheRequestType,
+		GroupID,
 	})
 
 	MigrationCopyChanSize = promauto.NewGauge(prometheus.GaugeOpts{
@@ -818,6 +820,7 @@ var (
 		Help:      "Number of bytes copied from the source to destination cache during a cache migration.",
 	}, []string{
 		CacheTypeLabel,
+		GroupID,
 	})
 
 	MigrationBlobsCopied = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -827,6 +830,7 @@ var (
 		Help:      "Number of blobs copied from the source to destination cache during a cache migration.",
 	}, []string{
 		CacheTypeLabel,
+		GroupID,
 	})
 
 	TreeCacheLookupCount = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
This allows us to track migration progress per group, since we might migrate one group at a time.