### PR TITLE
Allow setting API key expiration

### DIFF
--- a/enterprise/server/auditlog/auditlog_test.go
+++ b/enterprise/server/auditlog/auditlog_test.go
@@ -239,6 +239,7 @@ func TestChildGroupAuth(t *testing.T) {
 	grp1AuditKey, err := env.GetAuthDB().CreateAPIKey(
 		ctx1, us1Group.GroupID, "audit",
 		[]cappb.Capability{cappb.Capability_AUDIT_LOG_READ},
+		0, /*=expiresIn*/
 		false /*=visibleToDevelopers*/)
 	require.NoError(t, err)
 	group1AuditorCtx := env.GetAuthenticator().AuthContextFromAPIKey(ctx, grp1AuditKey.Value)
@@ -249,6 +250,7 @@ func TestChildGroupAuth(t *testing.T) {
 	grp2AuditKey, err := env.GetAuthDB().CreateAPIKey(
 		ctx2, us2Group.GroupID, "audit",
 		[]cappb.Capability{cappb.Capability_AUDIT_LOG_READ},
+		0, /*=expiresIn*/
 		false /*=visibleToDevelopers*/)
 	require.NoError(t, err)
 

--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -62,6 +62,7 @@ go_test(
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )
 
@@ -109,6 +110,7 @@ go_test(
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )
 
@@ -156,5 +158,6 @@ go_test(
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )

--- a/enterprise/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/enterprise/server/buildbuddy_server/buildbuddy_server_test.go
@@ -55,6 +55,7 @@ func TestCreateGroup(t *testing.T) {
 	adminKey, err := te.GetAuthDB().CreateAPIKey(
 		userCtx, parentGroup.GroupID, "admin",
 		[]cappb.Capability{cappb.Capability_ORG_ADMIN},
+		0, /*=expiresIn*/
 		false /*=visibleToDevelopers*/)
 	require.NoError(t, err)
 	adminKeyCtx := te.GetAuthenticator().AuthContextFromAPIKey(ctx, adminKey.Value)

--- a/enterprise/server/scim/scim_test.go
+++ b/enterprise/server/scim/scim_test.go
@@ -50,7 +50,7 @@ func prepareGroup(t *testing.T, ctx context.Context, env environment.Env) (strin
 	require.NoError(t, err)
 	g := u.Groups[0].Group
 
-	apiKey, err := env.GetAuthDB().CreateAPIKey(ctx, g.GroupID, "SCIM", []cappb.Capability{cappb.Capability_ORG_ADMIN}, false)
+	apiKey, err := env.GetAuthDB().CreateAPIKey(ctx, g.GroupID, "SCIM", []cappb.Capability{cappb.Capability_ORG_ADMIN}, 0, false)
 	require.NoError(t, err)
 
 	g.SamlIdpMetadataUrl = "foo"

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -44,6 +44,7 @@ proto_library(
     deps = [
         ":capability_proto",
         ":context_proto",
+        "@com_google_protobuf//:duration_proto",
     ],
 )
 
@@ -2061,6 +2062,7 @@ ts_proto_library(
     deps = [
         ":capability_ts_proto",
         ":context_ts_proto",
+        ":duration_ts_proto",
     ],
 )
 

--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "proto/capability.proto";
 import "proto/context.proto";
+import "google/protobuf/duration.proto";
 
 package api_key;
 
@@ -62,6 +63,9 @@ message CreateApiKeyRequest {
 
   // True if this API key should be visible to developers.
   bool visible_to_developers = 5;
+
+  // Optional. Duration after which the API key should no longer be valid.
+  google.protobuf.Duration expires_in = 7;
 }
 
 message CreateApiKeyResponse {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -748,7 +748,7 @@ func (s *BuildBuddyServer) CreateApiKey(ctx context.Context, req *akpb.CreateApi
 	}
 	k, err := authDB.CreateAPIKey(
 		ctx, req.GetRequestContext().GetGroupId(), req.GetLabel(), req.GetCapability(),
-		req.GetVisibleToDevelopers())
+		req.GetExpiresIn().AsDuration(), req.GetVisibleToDevelopers())
 	if err != nil {
 		return nil, err
 	}
@@ -957,7 +957,9 @@ func (s *BuildBuddyServer) CreateUserApiKey(ctx context.Context, req *akpb.Creat
 	if userID == "" {
 		userID = u.GetUserID()
 	}
-	k, err := authDB.CreateUserAPIKey(ctx, req.GetRequestContext().GetGroupId(), userID, req.GetLabel(), req.GetCapability())
+	k, err := authDB.CreateUserAPIKey(
+		ctx, req.GetRequestContext().GetGroupId(), userID, req.GetLabel(),
+		req.GetCapability(), req.GetExpiresIn().AsDuration())
 	if err != nil {
 		return nil, err
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -470,7 +470,7 @@ type AuthDB interface {
 	GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error)
 
 	// CreateAPIKey creates a group-level API key.
-	CreateAPIKey(ctx context.Context, groupID string, label string, capabilities []cappb.Capability, visibleToDevelopers bool) (*tables.APIKey, error)
+	CreateAPIKey(ctx context.Context, groupID string, label string, capabilities []cappb.Capability, expiresIn time.Duration, visibleToDevelopers bool) (*tables.APIKey, error)
 
 	// CreateAPIKeyWithoutAuthCheck creates a group-level API key without
 	// checking that the user has admin rights on the group. This should only
@@ -491,7 +491,7 @@ type AuthDB interface {
 	// user must be a member of the group. If the request is not authenticated
 	// as the given user, then the authenticated user or API key must have
 	// ORG_ADMIN capability.
-	CreateUserAPIKey(ctx context.Context, groupID, userID, label string, capabilities []cappb.Capability) (*tables.APIKey, error)
+	CreateUserAPIKey(ctx context.Context, groupID, userID, label string, capabilities []cappb.Capability, expiresIn time.Duration) (*tables.APIKey, error)
 
 	// GetAPIKey returns an API key by ID. The key may be user-owned or
 	// group-owned.


### PR DESCRIPTION
Allows `CreateApiKey` and `CreateUserApiKey` to accept an `expires_in` parameter that determines when the API key will expire.

The logic for API key expiration is mostly already implemented (for impersonation keys); this just adds the wiring to be able to set an expiration for normal API keys as well.