### PR TITLE
[FC] store creation and update timestamps in VMMetadata

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -83,6 +83,7 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//health/grpc_health_v1",
+        "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sys//unix",
     ],

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -75,6 +75,7 @@ import (
 	fcclient "github.com/firecracker-microvm/firecracker-go-sdk"
 	fcmodels "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 	hlpb "google.golang.org/grpc/health/grpc_health_v1"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
@@ -1037,9 +1038,10 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 func (c *FirecrackerContainer) getVMMetadata() *fcpb.VMMetadata {
 	if c.snapshot == nil || c.snapshot.GetVMMetadata() == nil {
 		return &fcpb.VMMetadata{
-			VmId:        c.id,
-			SnapshotId:  c.snapshotID,
-			SnapshotKey: c.SnapshotKeySet().GetBranchKey(),
+			VmId:         c.id,
+			SnapshotId:   c.snapshotID,
+			SnapshotKey:  c.SnapshotKeySet().GetBranchKey(),
+			CreationTime: tspb.New(c.currentTaskInitTime),
 		}
 	}
 	return c.snapshot.GetVMMetadata()
@@ -1053,6 +1055,7 @@ func (c *FirecrackerContainer) getVMTask() *fcpb.VMMetadata_VMTask {
 		ActionDigest:          c.task.GetExecuteRequest().GetActionDigest(),
 		ExecuteResponseDigest: d,
 		SnapshotId:            c.snapshotID, // Unique ID pertaining to this execution run
+		FinishTime:            tspb.Now(),
 	}
 }
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1038,10 +1038,10 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 func (c *FirecrackerContainer) getVMMetadata() *fcpb.VMMetadata {
 	if c.snapshot == nil || c.snapshot.GetVMMetadata() == nil {
 		return &fcpb.VMMetadata{
-			VmId:         c.id,
-			SnapshotId:   c.snapshotID,
-			SnapshotKey:  c.SnapshotKeySet().GetBranchKey(),
-			CreationTime: tspb.New(c.currentTaskInitTime),
+			VmId:             c.id,
+			SnapshotId:       c.snapshotID,
+			SnapshotKey:      c.SnapshotKeySet().GetBranchKey(),
+			CreatedTimestamp: tspb.New(c.currentTaskInitTime),
 		}
 	}
 	return c.snapshot.GetVMMetadata()
@@ -1055,7 +1055,7 @@ func (c *FirecrackerContainer) getVMTask() *fcpb.VMMetadata_VMTask {
 		ActionDigest:          c.task.GetExecuteRequest().GetActionDigest(),
 		ExecuteResponseDigest: d,
 		SnapshotId:            c.snapshotID, // Unique ID pertaining to this execution run
-		FinishTime:            tspb.Now(),
+		CompletedTimestamp:    tspb.Now(),
 	}
 }
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -211,6 +211,7 @@ proto_library(
     srcs = ["firecracker.proto"],
     deps = [
         ":remote_execution_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -2617,6 +2617,7 @@ ts_proto_library(
     proto = ":firecracker_proto",
     deps = [
         ":remote_execution_ts_proto",
+        ":timestamp_ts_proto",
     ],
 )
 

--- a/proto/firecracker.proto
+++ b/proto/firecracker.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package firecracker;
 
+import "google/protobuf/timestamp.proto";
 import "proto/remote_execution.proto";
 
 // VM properties which cannot be changed across snapshot/resume cycles.
@@ -187,6 +188,9 @@ message VMMetadata {
     // For example, even if the same execution is retried multiple times using
     // the same snapshot key, each run will have a unqiue snapshot_id.
     string snapshot_id = 5;
+
+    // The approximate finish time of the task.
+    google.protobuf.Timestamp finish_time = 6;
   }
 
   // The last task to execute on this VM. When resuming from snapshot, this
@@ -198,6 +202,9 @@ message VMMetadata {
 
   // The snapshot key the currently executing task saved to after execution.
   SnapshotKey snapshot_key = 4;
+
+  // The time at which the VM was created.
+  google.protobuf.Timestamp creation_time = 5;
 }
 
 // SnapshotVersionMetadata contains the version ID to be used for snapshots.


### PR DESCRIPTION
This will allow us to expire snapshots that were created or updated a long time ago.

I'm still not sure if this is necessary, but storing the timestamps makes it easier to do this in the future. Also, it's cheap and it allows us to see how long snapshots survive.