### PR TITLE
bazel: Migrate copy genrule to copy_file rule

### DIFF
--- a/rules/typescript/index.bzl
+++ b/rules/typescript/index.bzl
@@ -2,6 +2,7 @@ load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_jasmine//jasmine:defs.bzl", "jasmine_test")
 load("@aspect_rules_swc//swc:defs.bzl", "swc_compile")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 def _swc(**kwargs):
     swc_compile(
@@ -60,11 +61,11 @@ def ts_jasmine_node_test(name, srcs, deps = [], size = "small", **kwargs):
     # Copy the commonjs module to trick jasmine_node_test into thinking this is
     # a plain JS source. The test fails with "no specs found" if we try to pass
     # the commonjs module output as srcs directly.
-    native.genrule(
+    copy_file(
         name = "%s_entrypoint" % name,
-        srcs = [":%s_commonjs.js" % name],
-        outs = [":%s_commonjs.test.js" % name],
-        cmd_bash = "cp $(SRCS) $@",
+        src = ":%s_commonjs.js" % name,
+        out = ":%s_commonjs.test.js" % name,
+        allow_symlink = True,
     )
 
     jasmine_test(

--- a/server/util/bazel/defs.bzl
+++ b/server/util/bazel/defs.bzl
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 def _extract_bazel_installation_impl(ctx):
@@ -74,17 +75,17 @@ extract_bazel_installation = rule(
 def bazel_pkg_tar(name, versions = [], **kwargs):
     """Create a tar file containing Bazel executable for each version in versions."""
     for version in versions:
-        native.genrule(
+        copy_file(
             name = "bazel-{}_crossplatform".format(version),
-            srcs = select({
-                "//platforms/configs:linux_x86_64": ["@io_bazel_bazel-{}-linux-x86_64//file:downloaded".format(version)],
-                "//platforms/configs:linux_arm64": ["@io_bazel_bazel-{}-linux-arm64//file:downloaded".format(version)],
-                "//platforms/configs:macos_x86_64": ["@io_bazel_bazel-{}-darwin-x86_64//file:downloaded".format(version)],
-                "//platforms/configs:macos_arm64": ["@io_bazel_bazel-{}-darwin-arm64//file:downloaded".format(version)],
+            src = select({
+                "//platforms/configs:linux_x86_64": "@io_bazel_bazel-{}-linux-x86_64//file:downloaded".format(version),
+                "//platforms/configs:linux_arm64": "@io_bazel_bazel-{}-linux-arm64//file:downloaded".format(version),
+                "//platforms/configs:macos_x86_64": "@io_bazel_bazel-{}-darwin-x86_64//file:downloaded".format(version),
+                "//platforms/configs:macos_arm64": "@io_bazel_bazel-{}-darwin-arm64//file:downloaded".format(version),
             }),
-            outs = ["bazel-{}".format(version)],
-            cmd_bash = "cp $(SRCS) $@",
-            executable = True,
+            out = "bazel-{}".format(version),
+            allow_symlink = True,
+            is_executable = True,
             **kwargs
         )
 


### PR DESCRIPTION
Stop using genrule to rename file, instead favor using skylib's
copy_file with symlink enabled to replace the remote action with a
Bazel internal action.
