### PR TITLE
Add a library to handle sequence / slice operations seamlessly

### DIFF
--- a/server/util/lib/seq/BUILD
+++ b/server/util/lib/seq/BUILD
@@ -9,10 +9,10 @@ go_library(
 
 go_test(
     name = "seq_test",
+    size = "small",
     srcs = ["seq_test.go"],
     deps = [
         ":seq",
         "@com_github_stretchr_testify//assert",
     ],
-    size = "small",
 )

--- a/server/util/lib/seq/BUILD
+++ b/server/util/lib/seq/BUILD
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "seq",
+    srcs = ["seq.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/lib/seq",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "seq_test",
+    srcs = ["seq_test.go"],
+    deps = [
+        ":seq",
+        "@com_github_stretchr_testify//assert",
+    ],
+    size = "small",
+)

--- a/server/util/lib/seq/seq.go
+++ b/server/util/lib/seq/seq.go
@@ -1,0 +1,266 @@
+// seq exists to save allocations when iterating over intermediary versions of a
+// sequence that is being processed, as well as to save cpu time in the case
+// that it turns out that not all of a list was needed, as these functions
+// evaluate the sequences they are passed lazily and do not allocate slices for
+// intermediary values.
+package seq
+
+import (
+	"fmt"
+	"iter"
+	"slices"
+)
+
+// Sequenceable is a constraint which requires the type it constrains to either
+// be a slice or an iter.Seq.
+type Sequenceable[E any] interface {
+	[]E | iter.Seq[E]
+}
+
+// Sequence turns a Sequenceable into an iter.Seq.
+func Sequence[E any, S Sequenceable[E]](s S) iter.Seq[E] {
+	if s == nil {
+		return EmptySeq[E]
+	}
+	switch v := any(s).(type) {
+	case []E:
+		return slices.Values(v)
+	case iter.Seq[E]:
+		return v
+	default:
+		// This should be impossible
+		panic(fmt.Errorf("seq.Sequence called with invalid type %T. This code should never be reached.", s))
+	}
+}
+
+// EmptySeq is the empty sequence.
+func EmptySeq[E any](func(E) bool) {}
+
+// Chain chains two Sequenceable types together into one sequence and returns
+// the result.
+// NOTE: as of writing, go's type inference does not work on this function, so
+// the element type must be specified as a type parameter. However, if
+// https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
+// explicit type specification will no longer be needed.
+func Chain[E any, S1 Sequenceable[E], S2 Sequenceable[E]](s1 S1, s2 S2) iter.Seq[E] {
+	return func(yield func(E) bool) {
+		for e := range Sequence[E](s1) {
+			if !yield(e) {
+				return
+			}
+		}
+		for e := range Sequence[E](s2) {
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}
+
+// Fmap maps a function over the passed sequence, which is to say it returns the
+// result of calling the passed function on each of the elements in the passed
+// sequence as a sequence.
+func Fmap[I any, O any, S Sequenceable[I]](s S, f func(I) O) iter.Seq[O] {
+	return func(yield func(O) bool) {
+		for e := range Sequence[I](s) {
+			if !yield(f(e)) {
+				return
+			}
+		}
+	}
+}
+
+// Truncate truncates the passed sequence after N elements. If the sequence is
+// fewer than N elements in length, it will be returned unchanged.
+// NOTE: as of writing, go's type inference does not work on this function, so
+// the element type must be specified as a type parameter. However, if
+// https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
+// explicit type specification will no longer be needed.
+func Truncate[E any, S Sequenceable[E]](s S, n uint) iter.Seq[E] {
+	return func(yield func(E) bool) {
+		i := uint(0)
+		for e := range Sequence[E](s) {
+			if i == n {
+				return
+			}
+			if !yield(e) {
+				return
+			}
+			i++
+		}
+	}
+}
+
+func setupRepeat[E any, S Sequenceable[E]](s S) (*[]E, iter.Seq[E]) {
+	elements := new([]E)
+	var sequence iter.Seq[E]
+	switch v := any(s).(type) {
+	case []E:
+		elements = &v
+		sequence = slices.Values(v)
+	case iter.Seq[E]:
+		sequence = Fmap(v, func(e E) E {
+			// populates elements while iterating the sequence, if necessary.
+			*elements = append(*elements, e)
+			return e
+		})
+	}
+	return elements, sequence
+}
+
+// Repeat repeats the passed sequence forever. Since sequences can not be
+// iterated multiple times, it will allocate a slice (if it is not passed one)
+// to store the elements on the first pass so that they can be repeated on
+// subsequent passes. If the passed sequence is zero-length, the returned
+// sequence will also be zero-length.
+// NOTE: as of writing, go's type inference does not work on this function, so
+// the element type must be specified as a type parameter. However, if
+// https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
+// explicit type specification will no longer be needed.
+func Repeat[E any, S Sequenceable[E]](s S) iter.Seq[E] {
+	return func(yield func(E) bool) {
+		elements, sequence := setupRepeat[E](s)
+		for e := range sequence {
+			if !yield(e) {
+				return
+			}
+		}
+		if len(*elements) == 0 {
+			return
+		}
+		for {
+			for _, e := range *elements {
+				if !yield(e) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// RepeatN repeats the passed sequence the specified number of times. Since
+// sequences can not be iterated multiple times, it will allocate a slice (if it
+// is not passed one) to store the elements on the first pass so that it can
+// repeat them on subsequent passes if N is greater than one.
+// NOTE: as of writing, go's type inference does not work on this function, so
+// the element type must be specified as a type parameter. However, if
+// https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
+// explicit type specification will no longer be needed.
+func RepeatN[E any, S Sequenceable[E]](s S, n uint) iter.Seq[E] {
+	switch n {
+	case 0:
+		return EmptySeq[E]
+	case 1:
+		return Sequence[E](s)
+	default:
+		return func(yield func(E) bool) {
+			elements, sequence := setupRepeat[E](s)
+			for e := range sequence {
+				if !yield(e) {
+					return
+				}
+			}
+			if len(*elements) == 0 {
+				return
+			}
+			for i := uint(1); i < n; i++ {
+				for _, e := range *elements {
+					if !yield(e) {
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+// Sum returns the result of joining all of the elements with the passed
+// function acting as a left-associative infix binary operator. It is very
+// similar to Accumulate, except that it uses the first value of the sequence as
+// the initial value, and thus the return value must be the same type as the
+// elements of the sequence. If the sequence is length one, the lone element is
+// returned unmodified. If the sequence is empty, the zero-value of the element
+// type is returned.
+func Sum[E any, S Sequenceable[E]](s S, f func(E, E) E) E {
+	var sum *E
+	for e := range Sequence[E](s) {
+		if sum == nil {
+			sum = &e
+			continue
+		}
+		*sum = f(*sum, e)
+	}
+	if sum == nil {
+		return *new(E)
+	}
+	return *sum
+}
+
+// Accumulate accumulates all of the elements in the passed sequence into a
+// single value using the passed function and initial value.
+func Accumulate[E any, V any, S Sequenceable[E]](init V, s S, f func(V, E) V) V {
+	v := init
+	for e := range Sequence[E](s) {
+		v = f(v, e)
+	}
+	return v
+}
+
+// Any is a special-case of Accumulate that returns true if the passed function
+// returns true for any of the elements in the passed sequence. It will
+// short-circuit, skipping processing the rest of the list, as soon as it finds 
+// an element for which the passed function returns true.
+func Any[E any, S Sequenceable[E]](s S, f func(E) bool) bool {
+	for e := range Sequence[E](s) {
+		if f(e) {
+			return true
+		}
+	}
+	return false
+}
+
+// None is a special-case of Accumulate that returns true if the passed function
+// returns false for all of the elements in the passed sequence. It will
+// short-circuit, skipping processing the rest of the list, as soon as it finds 
+// an element for which the passed function returns true.
+func None[E any, S Sequenceable[E]](s S, f func(E) bool) bool {
+	return !Any(s, f)
+}
+
+// All is a special-case of Accumulate that returns true if the passed function
+// returns true for all of the elements in the passed sequence. It will
+// short-circuit, skipping processing the rest of the list, as soon as it finds 
+// an element for which the passed function returns false.
+func All[E any, S Sequenceable[E]](s S, f func(E) bool) bool {
+	return !Any(s, func(e E) bool { return !f(e) })
+}
+
+// ComposeFilters takes a list of functions and returns a function that only
+// returns true if all of the passed functions return true.
+func ComposeFilters[E any](filters ...func(E) bool) func(E) bool {
+	return func(e E) bool {
+		for _, filter := range filters {
+			if !filter(e) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// Filter filters out all elements from the passed sequence for which any of the
+// passed functions return false.
+func Filter[E any, S Sequenceable[E]](s S, filter func(E) bool) iter.Seq[E] {
+	if filter == nil {
+		return Sequence[E](s)
+	}
+	return func(yield func(E) bool) {
+		for e := range Sequence[E](s) {
+			if filter(e) {
+				if !yield(e) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/server/util/lib/seq/seq.go
+++ b/server/util/lib/seq/seq.go
@@ -3,7 +3,7 @@
 // that it turns out that not all of a list was needed, as these functions
 // evaluate the sequences they are passed lazily and do not allocate slices for
 // intermediary values.
-// 
+//
 // Guarantees:
 // - All sequences returned by functions in this library are stateless as long
 // as the parameters passed to the functions are stateless.
@@ -49,7 +49,7 @@ func EmptySeq[E any](func(E) bool) {}
 
 // Chain chains two Sequenceable types together into one sequence and returns
 // the result.
-// 
+//
 // As with all sequences returned by this library, so long as the parameters are
 // stateless, the returned sequence will be stateless.
 // NOTE: as of writing, go's type inference does not work on this function, so
@@ -74,7 +74,7 @@ func Chain[E any, S1 Sequenceable[E], S2 Sequenceable[E]](s1 S1, s2 S2) iter.Seq
 // Fmap maps a function over the passed sequence, which is to say it returns the
 // result of calling the passed function on each of the elements in the passed
 // sequence as a sequence.
-// 
+//
 // As with all sequences returned by this library, so long as the parameters are
 // stateless, the returned sequence will be stateless.
 func Fmap[I any, O any, S Sequenceable[I]](s S, f func(I) O) iter.Seq[O] {
@@ -90,7 +90,7 @@ func Fmap[I any, O any, S Sequenceable[I]](s S, f func(I) O) iter.Seq[O] {
 // Truncate truncates the passed sequence after N elements. If the sequence is
 // fewer than N elements in length, it will be returned unchanged. If N is less
 // than one, the empty sequence is returned
-// 
+//
 // As with all sequences returned by this library, so long as the parameters are
 // stateless, the returned sequence will be stateless.
 // NOTE: as of writing, go's type inference does not work on this function, so
@@ -137,7 +137,7 @@ func setupRepeat[E any, S Sequenceable[E]](s S) (*[]E, iter.Seq[E]) {
 // to store the elements on the first pass so that they can be repeated on
 // subsequent passes. If the passed sequence is zero-length, the returned
 // sequence will also be zero-length.
-// 
+//
 // As with all sequences returned by this library, so long as the parameters are
 // stateless, the returned sequence will be stateless.
 // NOTE: as of writing, go's type inference does not work on this function, so
@@ -170,7 +170,7 @@ func Repeat[E any, S Sequenceable[E]](s S) iter.Seq[E] {
 // is not passed one) to store the elements on the first pass so that it can
 // repeat them on subsequent passes if N is greater than one. If N is less than
 // one, the empty sequence is returned.
-// 
+//
 // As with all sequences returned by this library, so long as the parameters are
 // stateless, the returned sequence will be stateless.
 // NOTE: as of writing, go's type inference does not work on this function, so

--- a/server/util/lib/seq/seq.go
+++ b/server/util/lib/seq/seq.go
@@ -208,7 +208,7 @@ func Accumulate[E any, V any, S Sequenceable[E]](init V, s S, f func(V, E) V) V 
 
 // Any is a special-case of Accumulate that returns true if the passed function
 // returns true for any of the elements in the passed sequence. It will
-// short-circuit, skipping processing the rest of the list, as soon as it finds 
+// short-circuit, skipping processing the rest of the list, as soon as it finds
 // an element for which the passed function returns true.
 func Any[E any, S Sequenceable[E]](s S, f func(E) bool) bool {
 	for e := range Sequence[E](s) {
@@ -221,7 +221,7 @@ func Any[E any, S Sequenceable[E]](s S, f func(E) bool) bool {
 
 // None is a special-case of Accumulate that returns true if the passed function
 // returns false for all of the elements in the passed sequence. It will
-// short-circuit, skipping processing the rest of the list, as soon as it finds 
+// short-circuit, skipping processing the rest of the list, as soon as it finds
 // an element for which the passed function returns true.
 func None[E any, S Sequenceable[E]](s S, f func(E) bool) bool {
 	return !Any(s, f)
@@ -229,7 +229,7 @@ func None[E any, S Sequenceable[E]](s S, f func(E) bool) bool {
 
 // All is a special-case of Accumulate that returns true if the passed function
 // returns true for all of the elements in the passed sequence. It will
-// short-circuit, skipping processing the rest of the list, as soon as it finds 
+// short-circuit, skipping processing the rest of the list, as soon as it finds
 // an element for which the passed function returns false.
 func All[E any, S Sequenceable[E]](s S, f func(E) bool) bool {
 	return !Any(s, func(e E) bool { return !f(e) })

--- a/server/util/lib/seq/seq.go
+++ b/server/util/lib/seq/seq.go
@@ -3,6 +3,12 @@
 // that it turns out that not all of a list was needed, as these functions
 // evaluate the sequences they are passed lazily and do not allocate slices for
 // intermediary values.
+// 
+// Guarantees:
+// - All sequences returned by functions in this library are stateless as long
+// as the parameters passed to the functions are stateless.
+// - No function in this library will iterate over a passed sequence more than
+// once.
 package seq
 
 import (

--- a/server/util/lib/seq/seq.go
+++ b/server/util/lib/seq/seq.go
@@ -224,7 +224,7 @@ func Sum[E any, S Sequenceable[E]](s S, f func(E, E) E) E {
 
 // Accumulate accumulates all of the elements in the passed sequence into a
 // single value using the passed function and initial value.
-func Accumulate[E any, V any, S Sequenceable[E]](init V, s S, f func(V, E) V) V {
+func Accumulate[E any, V any, S Sequenceable[E]](s S, init V, f func(V, E) V) V {
 	v := init
 	for e := range Sequence[E](s) {
 		v = f(v, e)

--- a/server/util/lib/seq/seq.go
+++ b/server/util/lib/seq/seq.go
@@ -18,6 +18,11 @@ type Sequenceable[E any] interface {
 }
 
 // Sequence turns a Sequenceable into an iter.Seq.
+//
+// As with all sequences returned by this library, so long as the parameters are
+// stateless, the returned sequence will be stateless. If the parameter is a
+// slice, it is not cloned, so changing the underlying slice will change the
+// elements of the returned sequence.
 func Sequence[E any, S Sequenceable[E]](s S) iter.Seq[E] {
 	if s == nil {
 		return EmptySeq[E]
@@ -33,11 +38,14 @@ func Sequence[E any, S Sequenceable[E]](s S) iter.Seq[E] {
 	}
 }
 
-// EmptySeq is the empty sequence.
+// EmptySeq is the (stateless) empty sequence.
 func EmptySeq[E any](func(E) bool) {}
 
 // Chain chains two Sequenceable types together into one sequence and returns
 // the result.
+// 
+// As with all sequences returned by this library, so long as the parameters are
+// stateless, the returned sequence will be stateless.
 // NOTE: as of writing, go's type inference does not work on this function, so
 // the element type must be specified as a type parameter. However, if
 // https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
@@ -60,6 +68,9 @@ func Chain[E any, S1 Sequenceable[E], S2 Sequenceable[E]](s1 S1, s2 S2) iter.Seq
 // Fmap maps a function over the passed sequence, which is to say it returns the
 // result of calling the passed function on each of the elements in the passed
 // sequence as a sequence.
+// 
+// As with all sequences returned by this library, so long as the parameters are
+// stateless, the returned sequence will be stateless.
 func Fmap[I any, O any, S Sequenceable[I]](s S, f func(I) O) iter.Seq[O] {
 	return func(yield func(O) bool) {
 		for e := range Sequence[I](s) {
@@ -76,6 +87,9 @@ func Fmap[I any, O any, S Sequenceable[I]](s S, f func(I) O) iter.Seq[O] {
 // the element type must be specified as a type parameter. However, if
 // https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
 // explicit type specification will no longer be needed.
+// 
+// As with all sequences returned by this library, so long as the parameters are
+// stateless, the returned sequence will be stateless.
 func Truncate[E any, S Sequenceable[E]](s S, n uint) iter.Seq[E] {
 	return func(yield func(E) bool) {
 		i := uint(0)
@@ -113,6 +127,9 @@ func setupRepeat[E any, S Sequenceable[E]](s S) (*[]E, iter.Seq[E]) {
 // to store the elements on the first pass so that they can be repeated on
 // subsequent passes. If the passed sequence is zero-length, the returned
 // sequence will also be zero-length.
+// 
+// As with all sequences returned by this library, so long as the parameters are
+// stateless, the returned sequence will be stateless.
 // NOTE: as of writing, go's type inference does not work on this function, so
 // the element type must be specified as a type parameter. However, if
 // https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
@@ -142,6 +159,9 @@ func Repeat[E any, S Sequenceable[E]](s S) iter.Seq[E] {
 // sequences can not be iterated multiple times, it will allocate a slice (if it
 // is not passed one) to store the elements on the first pass so that it can
 // repeat them on subsequent passes if N is greater than one.
+// 
+// As with all sequences returned by this library, so long as the parameters are
+// stateless, the returned sequence will be stateless.
 // NOTE: as of writing, go's type inference does not work on this function, so
 // the element type must be specified as a type parameter. However, if
 // https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
@@ -250,6 +270,9 @@ func ComposeFilters[E any](filters ...func(E) bool) func(E) bool {
 
 // Filter filters out all elements from the passed sequence for which any of the
 // passed functions return false.
+//
+// As with all sequences returned by this library, so long as the parameters are
+// stateless, the returned sequence will be stateless.
 func Filter[E any, S Sequenceable[E]](s S, filter func(E) bool) iter.Seq[E] {
 	if filter == nil {
 		return Sequence[E](s)

--- a/server/util/lib/seq/seq_test.go
+++ b/server/util/lib/seq/seq_test.go
@@ -1,0 +1,928 @@
+package seq_test
+
+import (
+	"iter"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/lib/seq"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSequence(t *testing.T) {
+	input := []int{0, 3, 5, 2, 7}
+	originalInput := slices.Clone(input)
+	expected := slices.Clone(input)
+
+	s := seq.Sequence[int](input)
+	assert.ElementsMatch(t, expected, slices.Collect(s))
+	assert.ElementsMatch(t, originalInput, input)
+
+	s = seq.Sequence[int](slices.Values(input))
+	assert.ElementsMatch(t, input, slices.Collect(s))
+
+	s = seq.Sequence[int](((iter.Seq[int])(nil)))
+	assert.ElementsMatch(t, make([]int, 0), slices.Collect(s))
+
+	s = seq.Sequence[int]((([]int)(nil)))
+	assert.ElementsMatch(t, make([]int, 0), slices.Collect(s))
+}
+
+func TestChain(t *testing.T) {
+	for name, tc := range map[string]struct{
+		s1 []string
+		s2 []string
+	} {
+		"chain empty to empty": {
+			s1: make([]string, 0),
+			s2: make([]string, 0),
+		},
+		"chain empty to nil": {
+			s1: make([]string, 0),
+			s2: nil,
+		},
+		"chain nil to empty": {
+			s1: nil,
+			s2: make([]string, 0),
+		},
+		"chain nil to nil": {
+			s1: nil,
+			s2: nil,
+		},
+		"chain empty to non-empty": {
+			s1: make([]string, 0),
+			s2: []string{"foo", "bar", "foobar"},
+		},
+		"chain nil to non-empty": {
+			s1: nil,
+			s2: []string{"foo", "bar", "foobar"},
+		},
+		"chain non-empty to empty": {
+			s1: []string{"barfoo", "barbar", "foofoo"},
+			s2: make([]string, 0),
+		},
+		"chain non-empty to nil": {
+			s1: []string{"barfoo", "barbar", "foofoo"},
+			s2: nil,
+		},
+		"chain non-empty to non-empty": {
+			s1: []string{"barfoo", "barbar", "foofoo"},
+			s2: []string{"foo", "bar", "foobar"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalS1 := slices.Clone(tc.s1)
+			originalS2 := slices.Clone(tc.s2)
+			
+			chained := seq.Chain[string](tc.s1, tc.s2)
+			assert.ElementsMatch(t, append(tc.s1, tc.s2...), slices.Collect(chained))
+			assert.ElementsMatch(t, originalS1, tc.s1)
+			assert.ElementsMatch(t, originalS2, tc.s2)
+
+			chained = seq.Chain[string](tc.s1, slices.Values(tc.s2))
+			assert.ElementsMatch(t, append(tc.s1, tc.s2...), slices.Collect(chained))
+			assert.ElementsMatch(t, originalS1, tc.s1)
+			assert.ElementsMatch(t, originalS2, tc.s2)
+
+			chained = seq.Chain[string](slices.Values(tc.s1), tc.s2)
+			assert.ElementsMatch(t, append(tc.s1, tc.s2...), slices.Collect(chained))
+			assert.ElementsMatch(t, originalS1, tc.s1)
+			assert.ElementsMatch(t, originalS2, tc.s2)
+
+			chained = seq.Chain[string](slices.Values(tc.s1), slices.Values(tc.s2))
+			assert.ElementsMatch(t, append(tc.s1, tc.s2...), slices.Collect(chained))
+			assert.ElementsMatch(t, originalS1, tc.s1)
+			assert.ElementsMatch(t, originalS2, tc.s2)
+		})
+	}
+}
+
+func TestFmap(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []string
+		f func(string) string
+		expected []string
+	} {
+		"empty": {
+			input: make([]string, 0),
+			f: func(string) string { t.FailNow(); return "" },
+			expected: []string{},
+		},
+		"nil": {
+			input: make([]string, 0),
+			f: func(string) string { t.FailNow(); return "" },
+			expected: []string{},
+		},
+		"string to string": {
+			input: []string{"foo", "bar", "foofoo"},
+			f: func(s string) string { return s + "foo" },
+			expected: []string{"foofoo", "barfoo", "foofoofoo"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mapped := seq.Fmap(tc.input, tc.f)
+			assert.ElementsMatch(t, slices.Collect(mapped), tc.expected)
+		})
+	}
+	t.Run("int to string", func(t *testing.T) {
+		input := []int{2, 7, 1, 8, 2, 8}
+		originalInput := slices.Clone(input)
+		expected := []string{"2", "7", "1", "8", "2", "8"}
+
+		mapped := seq.Fmap(input, strconv.Itoa)
+		assert.ElementsMatch(t, expected, slices.Collect(mapped))
+		assert.ElementsMatch(t, originalInput, input)
+
+		mapped = seq.Fmap(slices.Values(input), strconv.Itoa)
+		assert.ElementsMatch(t, expected, slices.Collect(mapped))
+		assert.ElementsMatch(t, originalInput, input)
+	})
+}
+
+func TestTruncate(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []string
+		n uint
+		expected []string
+	} {
+		"empty with zero": {
+			input: make([]string, 0),
+			n: 0,
+			expected: make([]string, 0),
+		},
+		"nil with zero": {
+			input: nil,
+			n: 0,
+			expected: make([]string, 0),
+		},
+		"empty with non-zero": {
+			input: make([]string, 0),
+			n: 10,
+			expected: make([]string, 0),
+		},
+		"nil with non-zero": {
+			input: nil,
+			n: 10,
+			expected: make([]string, 0),
+		},
+		"non-empty with zero": {
+			input: []string{
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+			},
+			n: 0,
+			expected: make([]string, 0),
+		},
+		"non-empty with n less than length": {
+			input: []string{
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+			},
+			n: 2,
+			expected: []string{
+				"foo",
+				"bar",
+			},
+		},
+		"non-empty with n equal to length": {
+			input: []string{
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+			},
+			n: 4,
+			expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+			},
+		},
+		"non-empty with n greater than length": {
+			n: 100,
+			input: []string{
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+			},
+			expected: []string{
+				"foo",
+				"bar",
+				"foobar",
+				"barfoo",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+			truncated := seq.Truncate[string](tc.input, tc.n)
+			assert.ElementsMatch(t, tc.expected, slices.Collect(truncated))
+			assert.ElementsMatch(t, originalInput, tc.input)
+
+			truncated = seq.Truncate[string](slices.Values(tc.input), tc.n)
+			assert.ElementsMatch(t, tc.expected, slices.Collect(truncated))
+		})
+	}
+}
+
+func TestRepeat(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []string
+		expected []string
+	} {
+		"one element": {
+			input: []string{"foo"},
+			expected: []string{
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+			},
+		},
+		"two elements": {
+			input: []string{"foo", "bar"},
+			expected: []string{
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+				"foo", "bar",
+			},
+		},
+		"three elements": {
+			input: []string{"foo", "bar", "foo"},
+			expected: []string{
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo", "bar", "foo",
+				"foo",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+			repeated := seq.Repeat[string](tc.input)
+			i := 0
+			for e := range repeated {
+				if i == len(tc.expected) {
+					break
+				}
+				assert.Equalf(t, tc.expected[i], e, "at element %d, '%s' was expected, but '%s' was provided.", i, tc.expected[i], e )
+				i++
+			}
+			assert.Equalf(t, len(tc.expected), i, "Sequence should repeat forever, but was instead %d elements in length", i)
+			assert.ElementsMatch(t, originalInput, tc.input)
+
+			repeated = seq.Repeat[string](slices.Values(tc.input))
+			i = 0
+			for e := range repeated {
+				if i == len(tc.expected) {
+					break
+				}
+				assert.Equalf(t, tc.expected[i], e, "at element %d, '%s' was expected, but '%s' was provided.", i, tc.expected[i], e )
+				i++
+			}
+			assert.Equalf(t, len(tc.expected), i, "Sequence should repeat forever, but was instead %d elements in length", i)
+		})
+	}
+	t.Run("zero-length", func(t *testing.T) {
+		input := make([]string, 0)
+		originalInput := slices.Clone(input)
+		repeated := seq.Repeat[string](input)
+		for e := range repeated {
+			assert.FailNowf(t, "sequence should be zero-length, but instead contained element '%s'.", e)
+		}
+		assert.ElementsMatch(t, originalInput, input)
+
+		repeated = seq.Repeat[string](slices.Values(input))
+		for e := range repeated {
+			assert.FailNowf(t, "sequence should be zero-length, but instead contained element '%s'.", e)
+		}
+
+		input = []string(nil)
+		originalInput = slices.Clone(input)
+		repeated = seq.Repeat[string](input)
+		for e := range repeated {
+			assert.FailNowf(t, "sequence should be zero-length, but instead contained element '%s'.", e)
+		}
+		assert.ElementsMatch(t, originalInput, input)
+
+		repeated = seq.Repeat[string](slices.Values(input))
+		for e := range repeated {
+			assert.FailNowf(t, "sequence should be zero-length, but instead contained element '%s'.", e)
+		}
+	})
+}
+
+func TestRepeatN(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []string
+		n uint
+		expected []string
+	} {
+		"empty 0 times": {
+			input: make([]string, 0),
+			n: 0,
+			expected: make([]string, 0),
+		},
+		"empty 1 time": {
+			input: make([]string, 0),
+			n: 1,
+			expected: make([]string, 0),
+		},
+		"empty 2 times": {
+			input: make([]string, 0),
+			n: 2,
+			expected: make([]string, 0),
+		},
+		"empty 10 times": {
+			input: make([]string, 0),
+			n: 10,
+			expected: make([]string, 0),
+		},
+		"nil 0 times": {
+			input: nil,
+			n: 0,
+			expected: make([]string, 0),
+		},
+		"nil 1 time": {
+			input: nil,
+			n: 1,
+			expected: make([]string, 0),
+		},
+		"nil 2 times": {
+			input: nil,
+			n: 2,
+			expected: make([]string, 0),
+		},
+		"nil 10 times": {
+			input: nil,
+			n: 10,
+			expected: make([]string, 0),
+		},
+		"one element 0 times": {
+			input: []string{"foo"},
+			n: 0,
+			expected: make([]string, 0),
+		},
+		"one element 1 time": {
+			input: []string{"foo"},
+			n: 1,
+			expected: []string{
+				"foo",
+			},
+		},
+		"one element 2 times": {
+			input: []string{"foo"},
+			n: 2,
+			expected: []string{
+				"foo",
+				"foo",
+			},
+		},
+		"one element 10 times": {
+			input: []string{"foo"},
+			n: 10,
+			expected: []string{
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+				"foo",
+			},
+		},
+		"five elements 0 times": {
+			input: []string{"foo", "bar", "foo", "barfoo", "foofoo"},
+			n: 0,
+			expected: make([]string, 0),
+		},
+		"five elements 1 time": {
+			input: []string{"foo", "bar", "foo", "barfoo", "foofoo"},
+			n: 1,
+			expected: []string{
+				"foo", "bar", "foo", "barfoo", "foofoo",
+			},
+		},
+		"five elements 2 times": {
+			input: []string{"foo", "bar", "foo", "barfoo", "foofoo"},
+			n: 2,
+			expected: []string{
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+			},
+		},
+		"five elements 10 times": {
+			input: []string{"foo", "bar", "foo", "barfoo", "foofoo"},
+			n: 10,
+			expected: []string{
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+				"foo", "bar", "foo", "barfoo", "foofoo",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+			repeated := seq.RepeatN[string](tc.input, tc.n)
+			assert.ElementsMatch(t, tc.expected, slices.Collect(repeated))
+			assert.ElementsMatch(t, originalInput, tc.input)
+
+			repeated = seq.RepeatN[string](slices.Values(tc.input), tc.n)
+			assert.ElementsMatch(t, tc.expected, slices.Collect(repeated))
+		})
+	}
+}
+
+func TestAccumulate(t *testing.T) {
+	for name, tc := range map[string]struct{
+		init string
+		input []string
+		f func(string, string) string
+		expected string
+	} {
+		"empty": {
+			input: make([]string, 0),
+			f: func(string, string) string { panic("Shouldn't run") },
+			expected: "",
+		},
+		"nil": {
+			input: make([]string, 0),
+			f: func(string, string) string { panic("Shouldn't run") },
+			expected: "",
+		},
+		"empty with initial value": {
+			init: "foo",
+			input: make([]string, 0),
+			f: func(string, string) string { panic("Shouldn't run") },
+			expected: "foo",
+		},
+		"nil with initial value": {
+			init: "foo",
+			input: make([]string, 0),
+			f: func(string, string) string { panic("Shouldn't run") },
+			expected: "foo",
+		},
+		"string to string": {
+			input: []string{"foo", "bar", "foofoo"},
+			f: func(s1 string, s2 string) string { return s1 + "hi" + s2 },
+			expected: "hifoohibarhifoofoo",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+
+			accumulated := seq.Accumulate(tc.init, tc.input, tc.f)
+			assert.Equal(t, tc.expected, accumulated)
+			assert.Equal(t, tc.input, originalInput)
+
+			accumulated = seq.Accumulate(tc.init, slices.Values(tc.input), tc.f)
+			assert.Equal(t, tc.expected, accumulated)
+			assert.Equal(t, tc.input, originalInput)
+		})
+	}
+	t.Run("int to string", func(t *testing.T) {
+		input := []int{2, 7, 1, 8, 2, 8}
+		originalInput := slices.Clone(input)
+		expected := "foo 271828"
+
+		accumulated := seq.Accumulate(
+			"foo ",
+			input,
+			func(s string, i int) string {
+				return s + strconv.Itoa(i)
+			},
+		)
+		assert.Equal(t, expected, accumulated)
+		assert.Equal(t, input, originalInput)
+
+		input = []int{2, 7, 1, 8, 2, 8}
+		accumulated = seq.Accumulate(
+			"foo ",
+			slices.Values(input),
+			func(s string, i int) string {
+				return s + strconv.Itoa(i)
+			},
+		)
+		assert.Equal(t, expected, accumulated)
+	})
+}
+
+func TestSum(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []string
+		f func(string, string) string
+		expected string
+	} {
+		"empty": {
+			input: make([]string, 0),
+			f: func(string, string) string { panic("Shouldn't run") },
+			expected: "",
+		},
+		"nil": {
+			input: make([]string, 0),
+			f: func(string, string) string { panic("Shouldn't run") },
+			expected: "",
+		},
+		"one value": {
+			input: []string{"foo"},
+			f: func(string, string) string { panic("Shouldn't run") },
+			expected: "foo",
+		},
+		"several string values": {
+			input: []string{"foo", "bar", "foofoo"},
+			f: func(s1 string, s2 string) string { return s1 + "+" + s2 },
+			expected: "foo+bar+foofoo",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+
+			sum := seq.Sum(tc.input, tc.f)
+			assert.Equal(t, tc.expected, sum)
+			assert.Equal(t, tc.input, originalInput)
+
+			sum = seq.Sum(slices.Values(tc.input), tc.f)
+			assert.Equal(t, tc.expected, sum)
+			assert.Equal(t, tc.input, originalInput)
+		})
+	}
+	t.Run("several int values", func(t *testing.T) {
+		input := []int{2, 7, 1, 8, 2, 8}
+		originalInput := slices.Clone(input)
+		expected := 28
+
+		accumulated := seq.Sum(
+			input,
+			func(i1, i2 int) int {
+				return i1 + i2
+			},
+		)
+		assert.Equal(t, expected, accumulated)
+		assert.Equal(t, input, originalInput)
+
+		accumulated = seq.Sum(
+			slices.Values(input),
+			func(i1, i2 int) int {
+				return i1 + i2
+			},
+		)
+		assert.Equal(t, expected, accumulated)
+	})
+}
+
+func TestAny(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []int
+		expected bool
+	} {
+		"empty": {
+			input: make([]int, 0),
+			expected: false,
+		},
+		"nil": {
+			input: nil,
+			expected: false,
+		},
+		"none": {
+			input: []int{0, 0, 0},
+			expected: false,
+		},
+		"all": {
+			input: []int{1, 1, 1},
+			expected: true,
+		},
+		"first": {
+			input: []int{1, 0, 0},
+			expected: true,
+		},
+		"middle": {
+			input: []int{0, 1, 0},
+			expected: true,
+		},
+		"last": {
+			input: []int{0, 0, 1},
+			expected: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+			result := seq.Any(tc.input, func(e int) bool {return e == 1})
+			assert.Equal(t, tc.expected, result)
+			assert.Equal(t, originalInput, tc.input)
+
+			result = seq.Any(slices.Values(tc.input), func(e int) bool {return e == 1})
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+	t.Run("infinite", func(t *testing.T) {
+		input := seq.Repeat[int]([]int{0, 0, 1})
+		expected := true
+		result := seq.Any(input, func(e int) bool {return e == 1})
+		assert.Equal(t, expected, result)
+	})
+}
+
+func TestAll(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []int
+		expected bool
+	} {
+		"empty": {
+			input: make([]int, 0),
+			expected: true,
+		},
+		"nil": {
+			input: nil,
+			expected: true,
+		},
+		"none": {
+			input: []int{0, 0, 0},
+			expected: false,
+		},
+		"all": {
+			input: []int{1, 1, 1},
+			expected: true,
+		},
+		"first": {
+			input: []int{1, 0, 0},
+			expected: false,
+		},
+		"middle": {
+			input: []int{0, 1, 0},
+			expected: false,
+		},
+		"last": {
+			input: []int{0, 0, 1},
+			expected: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+			result := seq.All(tc.input, func(e int) bool {return e == 1})
+			assert.Equal(t, tc.expected, result)
+			assert.Equal(t, originalInput, tc.input)
+
+			result = seq.All(slices.Values(tc.input), func(e int) bool {return e == 1})
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+	t.Run("infinite", func(t *testing.T) {
+		input := seq.Repeat[int]([]int{1, 1, 0})
+		expected := false
+		result := seq.All(input, func(e int) bool {return e == 1})
+		assert.Equal(t, expected, result)
+	})
+}
+
+func TestNone(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []int
+		expected bool
+	} {
+		"empty": {
+			input: make([]int, 0),
+			expected: true,
+		},
+		"nil": {
+			input: nil,
+			expected: true,
+		},
+		"none": {
+			input: []int{0, 0, 0},
+			expected: true,
+		},
+		"all": {
+			input: []int{1, 1, 1},
+			expected: false,
+		},
+		"first": {
+			input: []int{1, 0, 0},
+			expected: false,
+		},
+		"middle": {
+			input: []int{0, 1, 0},
+			expected: false,
+		},
+		"last": {
+			input: []int{0, 0, 1},
+			expected: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+			result := seq.None(tc.input, func(e int) bool {return e == 1})
+			assert.Equal(t, tc.expected, result)
+			assert.Equal(t, originalInput, tc.input)
+
+			result = seq.None(slices.Values(tc.input), func(e int) bool {return e == 1})
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+	t.Run("infinite", func(t *testing.T) {
+		input := seq.Repeat[int]([]int{0, 0, 1})
+		expected := false
+		result := seq.None(input, func(e int) bool {return e == 1})
+		assert.Equal(t, expected, result)
+	})
+}
+
+func TestComposeFilters(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []int
+		filters []func(int) bool
+		expected []bool
+	} {
+		"empty filters": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{},
+			expected: []bool{ true, true, true, true, true, true, true, true, true, true },
+		},
+		"nil filters": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: nil,
+			expected: []bool{ true, true, true, true, true, true, true, true, true, true },
+		},
+		"even filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{
+				func(i int) bool { return i % 2 == 0 },
+			},
+			expected: []bool{ true, false, true, false, true, false, true, false, true, false },
+		},
+		"odd filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{
+				func(i int) bool { return i % 2 != 0 },
+			},
+			expected: []bool{ false, true, false, true, false, true, false, true, false, true },
+		},
+		"even and odd filters": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{
+				func(i int) bool { return i % 2 == 0 },
+				func(i int) bool { return i % 2 != 0 },
+			},
+			expected: []bool{ false, false, false, false, false, false, false, false, false, false },
+		},
+		"multiple of 3 filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{
+				func(i int) bool { return i % 3 == 0 },
+			},
+			expected: []bool{ true, false, false, true, false, false, true, false, false, true },
+		},
+		"greater than 5 filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{
+				func(i int) bool { return i > 5 },
+			},
+			expected: []bool{ false, false, false, false, false, false, true, true, true, true },
+		},
+		"odd and multiple of 3 filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{
+				func(i int) bool { return i % 3 == 0 },
+				func(i int) bool { return i % 2 != 0 },
+			},
+			expected: []bool{ false, false, false, true, false, false, false, false, false, true },
+		},
+		"even and multiple of 3 filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{
+				func(i int) bool { return i % 3 == 0 },
+				func(i int) bool { return i % 2 == 0 },
+			},
+			expected: []bool{ true, false, false, false, false, false, true, false, false, false },
+		},
+		"even, multiple of 3, and greater than 5 filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filters: []func(int) bool{
+				func(i int) bool { return i % 3 == 0 },
+				func(i int) bool { return i % 2 == 0 },
+				func(i int) bool { return i > 5 },
+			},
+			expected: []bool{ false, false, false, false, false, false, true, false, false, false },
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			filter := seq.ComposeFilters(tc.filters...)
+			for i := range len(tc.input) {
+				assert.Equal(t, tc.expected[i], filter(tc.input[i]))
+			}
+		})
+	}
+}
+
+func TestFilter(t *testing.T) {
+	for name, tc := range map[string]struct{
+		input []int
+		filter func(int) bool
+		expected []int
+	} {
+		"empty": {
+			input: make([]int, 0),
+			filter: func(int) bool {t.FailNow(); return false},
+			expected: make([]int, 0),
+		},
+		"nil": {
+			input: nil,
+			filter: func(int) bool {t.FailNow(); return false},
+			expected: make([]int, 0),
+		},
+		"sequential values nil filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filter: nil,
+			expected: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+		},
+		"sequential values even filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filter: func(e int) bool { return e % 2 == 0 },
+			expected: []int{ 0, 2, 4, 6, 8 },
+		},
+		"sequential values odd filter": {
+			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			filter: func(e int) bool { return e % 2 != 0 },
+			expected: []int{ 1, 3, 5, 7, 9 },
+		},
+		"arbitrary values nil filter": {
+			input: []int{ 5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256 },
+			filter: nil,
+			expected: []int{ 5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256 },
+		},
+		"arbitrary values even filter": {
+			input: []int{ 5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256 },
+			filter: func(e int) bool { return e % 2 == 0 },
+			expected: []int{ 5000, 444, 90, 812734, 812734, 0, 256 },
+		},
+		"arbitrary values odd filter": {
+			input: []int{ 5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256 },
+			filter: func(e int) bool { return e % 2 != 0 },
+			expected: []int{ 75, 909, -5 },
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			originalInput := slices.Clone(tc.input)
+			filtered := seq.Filter(tc.input, tc.filter)
+			assert.ElementsMatch(t, tc.expected, slices.Collect(filtered))
+			assert.ElementsMatch(t, originalInput, tc.input)
+
+			filtered = seq.Filter(slices.Values(tc.input), tc.filter)
+			assert.ElementsMatch(t, tc.expected, slices.Collect(filtered))
+		})
+	}
+}

--- a/server/util/lib/seq/seq_test.go
+++ b/server/util/lib/seq/seq_test.go
@@ -30,10 +30,10 @@ func TestSequence(t *testing.T) {
 }
 
 func TestChain(t *testing.T) {
-	for name, tc := range map[string]struct{
+	for name, tc := range map[string]struct {
 		s1 []string
 		s2 []string
-	} {
+	}{
 		"chain empty to empty": {
 			s1: make([]string, 0),
 			s2: make([]string, 0),
@@ -74,7 +74,7 @@ func TestChain(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			originalS1 := slices.Clone(tc.s1)
 			originalS2 := slices.Clone(tc.s2)
-			
+
 			chained := seq.Chain[string](tc.s1, tc.s2)
 			assert.ElementsMatch(t, append(tc.s1, tc.s2...), slices.Collect(chained))
 			assert.ElementsMatch(t, originalS1, tc.s1)
@@ -99,24 +99,24 @@ func TestChain(t *testing.T) {
 }
 
 func TestFmap(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []string
-		f func(string) string
+	for name, tc := range map[string]struct {
+		input    []string
+		f        func(string) string
 		expected []string
-	} {
+	}{
 		"empty": {
-			input: make([]string, 0),
-			f: func(string) string { t.FailNow(); return "" },
+			input:    make([]string, 0),
+			f:        func(string) string { t.FailNow(); return "" },
 			expected: []string{},
 		},
 		"nil": {
-			input: make([]string, 0),
-			f: func(string) string { t.FailNow(); return "" },
+			input:    make([]string, 0),
+			f:        func(string) string { t.FailNow(); return "" },
 			expected: []string{},
 		},
 		"string to string": {
-			input: []string{"foo", "bar", "foofoo"},
-			f: func(s string) string { return s + "foo" },
+			input:    []string{"foo", "bar", "foofoo"},
+			f:        func(s string) string { return s + "foo" },
 			expected: []string{"foofoo", "barfoo", "foofoofoo"},
 		},
 	} {
@@ -141,29 +141,29 @@ func TestFmap(t *testing.T) {
 }
 
 func TestTruncate(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []string
-		n uint
+	for name, tc := range map[string]struct {
+		input    []string
+		n        uint
 		expected []string
-	} {
+	}{
 		"empty with zero": {
-			input: make([]string, 0),
-			n: 0,
+			input:    make([]string, 0),
+			n:        0,
 			expected: make([]string, 0),
 		},
 		"nil with zero": {
-			input: nil,
-			n: 0,
+			input:    nil,
+			n:        0,
 			expected: make([]string, 0),
 		},
 		"empty with non-zero": {
-			input: make([]string, 0),
-			n: 10,
+			input:    make([]string, 0),
+			n:        10,
 			expected: make([]string, 0),
 		},
 		"nil with non-zero": {
-			input: nil,
-			n: 10,
+			input:    nil,
+			n:        10,
 			expected: make([]string, 0),
 		},
 		"non-empty with zero": {
@@ -173,7 +173,7 @@ func TestTruncate(t *testing.T) {
 				"foobar",
 				"barfoo",
 			},
-			n: 0,
+			n:        0,
 			expected: make([]string, 0),
 		},
 		"non-empty with n less than length": {
@@ -233,10 +233,10 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestRepeat(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []string
+	for name, tc := range map[string]struct {
+		input    []string
 		expected []string
-	} {
+	}{
 		"one element": {
 			input: []string{"foo"},
 			expected: []string{
@@ -310,7 +310,7 @@ func TestRepeat(t *testing.T) {
 				if i == len(tc.expected) {
 					break
 				}
-				assert.Equalf(t, tc.expected[i], e, "at element %d, '%s' was expected, but '%s' was provided.", i, tc.expected[i], e )
+				assert.Equalf(t, tc.expected[i], e, "at element %d, '%s' was expected, but '%s' was provided.", i, tc.expected[i], e)
 				i++
 			}
 			assert.Equalf(t, len(tc.expected), i, "Sequence should repeat forever, but was instead %d elements in length", i)
@@ -322,7 +322,7 @@ func TestRepeat(t *testing.T) {
 				if i == len(tc.expected) {
 					break
 				}
-				assert.Equalf(t, tc.expected[i], e, "at element %d, '%s' was expected, but '%s' was provided.", i, tc.expected[i], e )
+				assert.Equalf(t, tc.expected[i], e, "at element %d, '%s' was expected, but '%s' was provided.", i, tc.expected[i], e)
 				i++
 			}
 			assert.Equalf(t, len(tc.expected), i, "Sequence should repeat forever, but was instead %d elements in length", i)
@@ -358,66 +358,66 @@ func TestRepeat(t *testing.T) {
 }
 
 func TestRepeatN(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []string
-		n uint
+	for name, tc := range map[string]struct {
+		input    []string
+		n        uint
 		expected []string
-	} {
+	}{
 		"empty 0 times": {
-			input: make([]string, 0),
-			n: 0,
+			input:    make([]string, 0),
+			n:        0,
 			expected: make([]string, 0),
 		},
 		"empty 1 time": {
-			input: make([]string, 0),
-			n: 1,
+			input:    make([]string, 0),
+			n:        1,
 			expected: make([]string, 0),
 		},
 		"empty 2 times": {
-			input: make([]string, 0),
-			n: 2,
+			input:    make([]string, 0),
+			n:        2,
 			expected: make([]string, 0),
 		},
 		"empty 10 times": {
-			input: make([]string, 0),
-			n: 10,
+			input:    make([]string, 0),
+			n:        10,
 			expected: make([]string, 0),
 		},
 		"nil 0 times": {
-			input: nil,
-			n: 0,
+			input:    nil,
+			n:        0,
 			expected: make([]string, 0),
 		},
 		"nil 1 time": {
-			input: nil,
-			n: 1,
+			input:    nil,
+			n:        1,
 			expected: make([]string, 0),
 		},
 		"nil 2 times": {
-			input: nil,
-			n: 2,
+			input:    nil,
+			n:        2,
 			expected: make([]string, 0),
 		},
 		"nil 10 times": {
-			input: nil,
-			n: 10,
+			input:    nil,
+			n:        10,
 			expected: make([]string, 0),
 		},
 		"one element 0 times": {
-			input: []string{"foo"},
-			n: 0,
+			input:    []string{"foo"},
+			n:        0,
 			expected: make([]string, 0),
 		},
 		"one element 1 time": {
 			input: []string{"foo"},
-			n: 1,
+			n:     1,
 			expected: []string{
 				"foo",
 			},
 		},
 		"one element 2 times": {
 			input: []string{"foo"},
-			n: 2,
+			n:     2,
 			expected: []string{
 				"foo",
 				"foo",
@@ -425,7 +425,7 @@ func TestRepeatN(t *testing.T) {
 		},
 		"one element 10 times": {
 			input: []string{"foo"},
-			n: 10,
+			n:     10,
 			expected: []string{
 				"foo",
 				"foo",
@@ -440,20 +440,20 @@ func TestRepeatN(t *testing.T) {
 			},
 		},
 		"five elements 0 times": {
-			input: []string{"foo", "bar", "foo", "barfoo", "foofoo"},
-			n: 0,
+			input:    []string{"foo", "bar", "foo", "barfoo", "foofoo"},
+			n:        0,
 			expected: make([]string, 0),
 		},
 		"five elements 1 time": {
 			input: []string{"foo", "bar", "foo", "barfoo", "foofoo"},
-			n: 1,
+			n:     1,
 			expected: []string{
 				"foo", "bar", "foo", "barfoo", "foofoo",
 			},
 		},
 		"five elements 2 times": {
 			input: []string{"foo", "bar", "foo", "barfoo", "foofoo"},
-			n: 2,
+			n:     2,
 			expected: []string{
 				"foo", "bar", "foo", "barfoo", "foofoo",
 				"foo", "bar", "foo", "barfoo", "foofoo",
@@ -461,7 +461,7 @@ func TestRepeatN(t *testing.T) {
 		},
 		"five elements 10 times": {
 			input: []string{"foo", "bar", "foo", "barfoo", "foofoo"},
-			n: 10,
+			n:     10,
 			expected: []string{
 				"foo", "bar", "foo", "barfoo", "foofoo",
 				"foo", "bar", "foo", "barfoo", "foofoo",
@@ -489,37 +489,37 @@ func TestRepeatN(t *testing.T) {
 }
 
 func TestAccumulate(t *testing.T) {
-	for name, tc := range map[string]struct{
-		init string
-		input []string
-		f func(string, string) string
+	for name, tc := range map[string]struct {
+		init     string
+		input    []string
+		f        func(string, string) string
 		expected string
-	} {
+	}{
 		"empty": {
-			input: make([]string, 0),
-			f: func(string, string) string { panic("Shouldn't run") },
+			input:    make([]string, 0),
+			f:        func(string, string) string { panic("Shouldn't run") },
 			expected: "",
 		},
 		"nil": {
-			input: make([]string, 0),
-			f: func(string, string) string { panic("Shouldn't run") },
+			input:    make([]string, 0),
+			f:        func(string, string) string { panic("Shouldn't run") },
 			expected: "",
 		},
 		"empty with initial value": {
-			init: "foo",
-			input: make([]string, 0),
-			f: func(string, string) string { panic("Shouldn't run") },
+			init:     "foo",
+			input:    make([]string, 0),
+			f:        func(string, string) string { panic("Shouldn't run") },
 			expected: "foo",
 		},
 		"nil with initial value": {
-			init: "foo",
-			input: make([]string, 0),
-			f: func(string, string) string { panic("Shouldn't run") },
+			init:     "foo",
+			input:    make([]string, 0),
+			f:        func(string, string) string { panic("Shouldn't run") },
 			expected: "foo",
 		},
 		"string to string": {
-			input: []string{"foo", "bar", "foofoo"},
-			f: func(s1 string, s2 string) string { return s1 + "hi" + s2 },
+			input:    []string{"foo", "bar", "foofoo"},
+			f:        func(s1 string, s2 string) string { return s1 + "hi" + s2 },
 			expected: "hifoohibarhifoofoo",
 		},
 	} {
@@ -563,29 +563,29 @@ func TestAccumulate(t *testing.T) {
 }
 
 func TestSum(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []string
-		f func(string, string) string
+	for name, tc := range map[string]struct {
+		input    []string
+		f        func(string, string) string
 		expected string
-	} {
+	}{
 		"empty": {
-			input: make([]string, 0),
-			f: func(string, string) string { panic("Shouldn't run") },
+			input:    make([]string, 0),
+			f:        func(string, string) string { panic("Shouldn't run") },
 			expected: "",
 		},
 		"nil": {
-			input: make([]string, 0),
-			f: func(string, string) string { panic("Shouldn't run") },
+			input:    make([]string, 0),
+			f:        func(string, string) string { panic("Shouldn't run") },
 			expected: "",
 		},
 		"one value": {
-			input: []string{"foo"},
-			f: func(string, string) string { panic("Shouldn't run") },
+			input:    []string{"foo"},
+			f:        func(string, string) string { panic("Shouldn't run") },
 			expected: "foo",
 		},
 		"several string values": {
-			input: []string{"foo", "bar", "foofoo"},
-			f: func(s1 string, s2 string) string { return s1 + "+" + s2 },
+			input:    []string{"foo", "bar", "foofoo"},
+			f:        func(s1 string, s2 string) string { return s1 + "+" + s2 },
 			expected: "foo+bar+foofoo",
 		},
 	} {
@@ -626,237 +626,237 @@ func TestSum(t *testing.T) {
 }
 
 func TestAny(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []int
+	for name, tc := range map[string]struct {
+		input    []int
 		expected bool
-	} {
+	}{
 		"empty": {
-			input: make([]int, 0),
+			input:    make([]int, 0),
 			expected: false,
 		},
 		"nil": {
-			input: nil,
+			input:    nil,
 			expected: false,
 		},
 		"none": {
-			input: []int{0, 0, 0},
+			input:    []int{0, 0, 0},
 			expected: false,
 		},
 		"all": {
-			input: []int{1, 1, 1},
+			input:    []int{1, 1, 1},
 			expected: true,
 		},
 		"first": {
-			input: []int{1, 0, 0},
+			input:    []int{1, 0, 0},
 			expected: true,
 		},
 		"middle": {
-			input: []int{0, 1, 0},
+			input:    []int{0, 1, 0},
 			expected: true,
 		},
 		"last": {
-			input: []int{0, 0, 1},
+			input:    []int{0, 0, 1},
 			expected: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			originalInput := slices.Clone(tc.input)
-			result := seq.Any(tc.input, func(e int) bool {return e == 1})
+			result := seq.Any(tc.input, func(e int) bool { return e == 1 })
 			assert.Equal(t, tc.expected, result)
 			assert.Equal(t, originalInput, tc.input)
 
-			result = seq.Any(slices.Values(tc.input), func(e int) bool {return e == 1})
+			result = seq.Any(slices.Values(tc.input), func(e int) bool { return e == 1 })
 			assert.Equal(t, tc.expected, result)
 		})
 	}
 	t.Run("infinite", func(t *testing.T) {
 		input := seq.Repeat[int]([]int{0, 0, 1})
 		expected := true
-		result := seq.Any(input, func(e int) bool {return e == 1})
+		result := seq.Any(input, func(e int) bool { return e == 1 })
 		assert.Equal(t, expected, result)
 	})
 }
 
 func TestAll(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []int
+	for name, tc := range map[string]struct {
+		input    []int
 		expected bool
-	} {
+	}{
 		"empty": {
-			input: make([]int, 0),
+			input:    make([]int, 0),
 			expected: true,
 		},
 		"nil": {
-			input: nil,
+			input:    nil,
 			expected: true,
 		},
 		"none": {
-			input: []int{0, 0, 0},
+			input:    []int{0, 0, 0},
 			expected: false,
 		},
 		"all": {
-			input: []int{1, 1, 1},
+			input:    []int{1, 1, 1},
 			expected: true,
 		},
 		"first": {
-			input: []int{1, 0, 0},
+			input:    []int{1, 0, 0},
 			expected: false,
 		},
 		"middle": {
-			input: []int{0, 1, 0},
+			input:    []int{0, 1, 0},
 			expected: false,
 		},
 		"last": {
-			input: []int{0, 0, 1},
+			input:    []int{0, 0, 1},
 			expected: false,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			originalInput := slices.Clone(tc.input)
-			result := seq.All(tc.input, func(e int) bool {return e == 1})
+			result := seq.All(tc.input, func(e int) bool { return e == 1 })
 			assert.Equal(t, tc.expected, result)
 			assert.Equal(t, originalInput, tc.input)
 
-			result = seq.All(slices.Values(tc.input), func(e int) bool {return e == 1})
+			result = seq.All(slices.Values(tc.input), func(e int) bool { return e == 1 })
 			assert.Equal(t, tc.expected, result)
 		})
 	}
 	t.Run("infinite", func(t *testing.T) {
 		input := seq.Repeat[int]([]int{1, 1, 0})
 		expected := false
-		result := seq.All(input, func(e int) bool {return e == 1})
+		result := seq.All(input, func(e int) bool { return e == 1 })
 		assert.Equal(t, expected, result)
 	})
 }
 
 func TestNone(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []int
+	for name, tc := range map[string]struct {
+		input    []int
 		expected bool
-	} {
+	}{
 		"empty": {
-			input: make([]int, 0),
+			input:    make([]int, 0),
 			expected: true,
 		},
 		"nil": {
-			input: nil,
+			input:    nil,
 			expected: true,
 		},
 		"none": {
-			input: []int{0, 0, 0},
+			input:    []int{0, 0, 0},
 			expected: true,
 		},
 		"all": {
-			input: []int{1, 1, 1},
+			input:    []int{1, 1, 1},
 			expected: false,
 		},
 		"first": {
-			input: []int{1, 0, 0},
+			input:    []int{1, 0, 0},
 			expected: false,
 		},
 		"middle": {
-			input: []int{0, 1, 0},
+			input:    []int{0, 1, 0},
 			expected: false,
 		},
 		"last": {
-			input: []int{0, 0, 1},
+			input:    []int{0, 0, 1},
 			expected: false,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			originalInput := slices.Clone(tc.input)
-			result := seq.None(tc.input, func(e int) bool {return e == 1})
+			result := seq.None(tc.input, func(e int) bool { return e == 1 })
 			assert.Equal(t, tc.expected, result)
 			assert.Equal(t, originalInput, tc.input)
 
-			result = seq.None(slices.Values(tc.input), func(e int) bool {return e == 1})
+			result = seq.None(slices.Values(tc.input), func(e int) bool { return e == 1 })
 			assert.Equal(t, tc.expected, result)
 		})
 	}
 	t.Run("infinite", func(t *testing.T) {
 		input := seq.Repeat[int]([]int{0, 0, 1})
 		expected := false
-		result := seq.None(input, func(e int) bool {return e == 1})
+		result := seq.None(input, func(e int) bool { return e == 1 })
 		assert.Equal(t, expected, result)
 	})
 }
 
 func TestComposeFilters(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []int
-		filters []func(int) bool
+	for name, tc := range map[string]struct {
+		input    []int
+		filters  []func(int) bool
 		expected []bool
-	} {
+	}{
 		"empty filters": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
-			filters: []func(int) bool{},
-			expected: []bool{ true, true, true, true, true, true, true, true, true, true },
+			input:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			filters:  []func(int) bool{},
+			expected: []bool{true, true, true, true, true, true, true, true, true, true},
 		},
 		"nil filters": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
-			filters: nil,
-			expected: []bool{ true, true, true, true, true, true, true, true, true, true },
+			input:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			filters:  nil,
+			expected: []bool{true, true, true, true, true, true, true, true, true, true},
 		},
 		"even filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			filters: []func(int) bool{
-				func(i int) bool { return i % 2 == 0 },
+				func(i int) bool { return i%2 == 0 },
 			},
-			expected: []bool{ true, false, true, false, true, false, true, false, true, false },
+			expected: []bool{true, false, true, false, true, false, true, false, true, false},
 		},
 		"odd filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			filters: []func(int) bool{
-				func(i int) bool { return i % 2 != 0 },
+				func(i int) bool { return i%2 != 0 },
 			},
-			expected: []bool{ false, true, false, true, false, true, false, true, false, true },
+			expected: []bool{false, true, false, true, false, true, false, true, false, true},
 		},
 		"even and odd filters": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			filters: []func(int) bool{
-				func(i int) bool { return i % 2 == 0 },
-				func(i int) bool { return i % 2 != 0 },
+				func(i int) bool { return i%2 == 0 },
+				func(i int) bool { return i%2 != 0 },
 			},
-			expected: []bool{ false, false, false, false, false, false, false, false, false, false },
+			expected: []bool{false, false, false, false, false, false, false, false, false, false},
 		},
 		"multiple of 3 filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			filters: []func(int) bool{
-				func(i int) bool { return i % 3 == 0 },
+				func(i int) bool { return i%3 == 0 },
 			},
-			expected: []bool{ true, false, false, true, false, false, true, false, false, true },
+			expected: []bool{true, false, false, true, false, false, true, false, false, true},
 		},
 		"greater than 5 filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			filters: []func(int) bool{
 				func(i int) bool { return i > 5 },
 			},
-			expected: []bool{ false, false, false, false, false, false, true, true, true, true },
+			expected: []bool{false, false, false, false, false, false, true, true, true, true},
 		},
 		"odd and multiple of 3 filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			filters: []func(int) bool{
-				func(i int) bool { return i % 3 == 0 },
-				func(i int) bool { return i % 2 != 0 },
+				func(i int) bool { return i%3 == 0 },
+				func(i int) bool { return i%2 != 0 },
 			},
-			expected: []bool{ false, false, false, true, false, false, false, false, false, true },
+			expected: []bool{false, false, false, true, false, false, false, false, false, true},
 		},
 		"even and multiple of 3 filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			filters: []func(int) bool{
-				func(i int) bool { return i % 3 == 0 },
-				func(i int) bool { return i % 2 == 0 },
+				func(i int) bool { return i%3 == 0 },
+				func(i int) bool { return i%2 == 0 },
 			},
-			expected: []bool{ true, false, false, false, false, false, true, false, false, false },
+			expected: []bool{true, false, false, false, false, false, true, false, false, false},
 		},
 		"even, multiple of 3, and greater than 5 filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			filters: []func(int) bool{
-				func(i int) bool { return i % 3 == 0 },
-				func(i int) bool { return i % 2 == 0 },
+				func(i int) bool { return i%3 == 0 },
+				func(i int) bool { return i%2 == 0 },
 				func(i int) bool { return i > 5 },
 			},
-			expected: []bool{ false, false, false, false, false, false, true, false, false, false },
+			expected: []bool{false, false, false, false, false, false, true, false, false, false},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -869,50 +869,50 @@ func TestComposeFilters(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	for name, tc := range map[string]struct{
-		input []int
-		filter func(int) bool
+	for name, tc := range map[string]struct {
+		input    []int
+		filter   func(int) bool
 		expected []int
-	} {
+	}{
 		"empty": {
-			input: make([]int, 0),
-			filter: func(int) bool {t.FailNow(); return false},
+			input:    make([]int, 0),
+			filter:   func(int) bool { t.FailNow(); return false },
 			expected: make([]int, 0),
 		},
 		"nil": {
-			input: nil,
-			filter: func(int) bool {t.FailNow(); return false},
+			input:    nil,
+			filter:   func(int) bool { t.FailNow(); return false },
 			expected: make([]int, 0),
 		},
 		"sequential values nil filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
-			filter: nil,
-			expected: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+			input:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			filter:   nil,
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 		},
 		"sequential values even filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
-			filter: func(e int) bool { return e % 2 == 0 },
-			expected: []int{ 0, 2, 4, 6, 8 },
+			input:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			filter:   func(e int) bool { return e%2 == 0 },
+			expected: []int{0, 2, 4, 6, 8},
 		},
 		"sequential values odd filter": {
-			input: []int{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
-			filter: func(e int) bool { return e % 2 != 0 },
-			expected: []int{ 1, 3, 5, 7, 9 },
+			input:    []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			filter:   func(e int) bool { return e%2 != 0 },
+			expected: []int{1, 3, 5, 7, 9},
 		},
 		"arbitrary values nil filter": {
-			input: []int{ 5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256 },
-			filter: nil,
-			expected: []int{ 5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256 },
+			input:    []int{5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256},
+			filter:   nil,
+			expected: []int{5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256},
 		},
 		"arbitrary values even filter": {
-			input: []int{ 5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256 },
-			filter: func(e int) bool { return e % 2 == 0 },
-			expected: []int{ 5000, 444, 90, 812734, 812734, 0, 256 },
+			input:    []int{5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256},
+			filter:   func(e int) bool { return e%2 == 0 },
+			expected: []int{5000, 444, 90, 812734, 812734, 0, 256},
 		},
 		"arbitrary values odd filter": {
-			input: []int{ 5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256 },
-			filter: func(e int) bool { return e % 2 != 0 },
-			expected: []int{ 75, 909, -5 },
+			input:    []int{5000, 75, 909, 444, 90, -5, 812734, 812734, 0, 256},
+			filter:   func(e int) bool { return e%2 != 0 },
+			expected: []int{75, 909, -5},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/server/util/lib/seq/seq_test.go
+++ b/server/util/lib/seq/seq_test.go
@@ -167,7 +167,7 @@ func TestFmap(t *testing.T) {
 func TestTruncate(t *testing.T) {
 	for name, tc := range map[string]struct {
 		input    []string
-		n        uint
+		n        int
 		expected []string
 	}{
 		"empty with zero": {
@@ -424,7 +424,7 @@ func TestRepeat(t *testing.T) {
 func TestRepeatN(t *testing.T) {
 	for name, tc := range map[string]struct {
 		input    []string
-		n        uint
+		n        int
 		expected []string
 	}{
 		"empty 0 times": {

--- a/server/util/lib/seq/seq_test.go
+++ b/server/util/lib/seq/seq_test.go
@@ -594,11 +594,11 @@ func TestAccumulate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			originalInput := slices.Clone(tc.input)
 
-			accumulated := seq.Accumulate(tc.init, tc.input, tc.f)
+			accumulated := seq.Accumulate(tc.input, tc.init, tc.f)
 			assert.Equal(t, tc.expected, accumulated)
 			assert.Equal(t, tc.input, originalInput)
 
-			accumulated = seq.Accumulate(tc.init, slices.Values(tc.input), tc.f)
+			accumulated = seq.Accumulate(slices.Values(tc.input), tc.init, tc.f)
 			assert.Equal(t, tc.expected, accumulated)
 			assert.Equal(t, tc.input, originalInput)
 		})
@@ -609,8 +609,8 @@ func TestAccumulate(t *testing.T) {
 		expected := "foo 271828"
 
 		accumulated := seq.Accumulate(
-			"foo ",
 			input,
+			"foo ",
 			func(s string, i int) string {
 				return s + strconv.Itoa(i)
 			},
@@ -619,8 +619,8 @@ func TestAccumulate(t *testing.T) {
 		assert.Equal(t, input, originalInput)
 
 		accumulated = seq.Accumulate(
-			"foo ",
 			slices.Values(input),
+			"foo ",
 			func(s string, i int) string {
 				return s + strconv.Itoa(i)
 			},


### PR DESCRIPTION
The `seq` library has three main motivations:

- Frequently, when doing complex processing on a slice, intermediary slice allocations are made to store intermediary values, or filtered versions of the slice. These allocations can be quite significant, depending on the size of the original slice. Using sequences prevents these allocations, as the sequence is necessarily only looped over once and does not store prior values, nor does it need to make copies in order to remove filtered elements, as those are just skipped when iterating.

- Similarly, lazy evaluation when processing a slice could lead to saving cpu time if it turns out that we only needed to process part of the slice. The sequence functions here are lazy, only processing a given element at time of access, so early returns or breaks short-circuit the rest of the processing,

- Sequences (`iter.Seq[E]`) in go are cumbersome to use, and traditionally require separate functions for handling slices as opposed to sequences or additional verbosity that affects readability (like `slices.Values`). The functions in the `seq` library do not have this problem, as they make use of the `Sequenceable[E any]` type constraint and the `Sequence[E]` function, allowing them to accept either slices or sequences without issue.
