### PR TITLE
Better handle the case where destination.FindMissing fails

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -394,6 +394,10 @@ func (mc *MigrationCache) FindMissing(ctx context.Context, resources []*rspb.Res
 			dstMissing, dstErr := conf.dest.FindMissing(ctx, resources)
 			if dstErr != nil {
 				log.Warningf("Migration dest FindMissing %v failed: %s", resources, dstErr)
+				for _, r := range resources {
+					mc.sendNonBlockingCopy(ctx, r, true /*=onlyCopyMissing*/, conf)
+				}
+				return
 			}
 			missingOnlyInDest, _ := digest.Diff(srcMissing, dstMissing)
 			if len(missingOnlyInDest) == 0 {

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -1002,12 +1002,12 @@ func TestFindMissing_DestErr(t *testing.T) {
 	missing, err := mc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	for range 5 {
-		if destCache.calls.Load() > 1 {
+		if destCache.calls.Load() > 4 {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	require.Equal(t, int64(2), destCache.calls.Load(), "Expected dest cache to be called twice (Set and FindMissing)")
+	require.Equal(t, int64(5), destCache.calls.Load(), "Expected dest cache to be called twice (Set, FindMissing, 3x Contains)")
 	require.ElementsMatch(t, []*repb.Digest{notSetR1.GetDigest(), notSetR2.GetDigest()}, missing)
 }
 


### PR DESCRIPTION
Currently, we keep going if this errors, which means that dstMissing will be empty, so we assume that all the resources were found, and increment the `migration_double_read_hit_count` metric.

Instead, return early and enqueue all the resources for a potential copy.