### PR TITLE
CLI: Add option definitions for native options

### DIFF
--- a/cli/help/option_definitions/BUILD
+++ b/cli/help/option_definitions/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "option_definitions",
+    srcs = ["option_definitions.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/help/option_definitions",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/parser/bazelrc",
+        "//cli/parser/options",
+    ],
+)
+
+package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/help/option_definitions/option_definitions.go
+++ b/cli/help/option_definitions/option_definitions.go
@@ -1,0 +1,21 @@
+package option_definitions
+
+import (
+	"slices"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
+)
+
+var (
+	// Help defines the option `--help` and the abbreviation `-h` to support
+	// command-line invocations like `bb --help build`
+	Help = options.NewDefinition(
+		"help",
+		options.WithShortName("h"),
+		options.WithNegative(),
+		options.WithPluginID(options.NativeBuiltinPluginID),
+		options.WithSupportFor("startup"),
+		options.WithSupportFor(slices.Collect(bazelrc.BazelCommands().All())...),
+	)
+)

--- a/cli/log/option_definitions/BUILD
+++ b/cli/log/option_definitions/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "option_definitions",
+    srcs = ["option_definitions.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/log/option_definitions",
+    visibility = ["//visibility:public"],
+    deps = ["//cli/parser/options"],
+)
+
+package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/log/option_definitions/option_definitions.go
+++ b/cli/log/option_definitions/option_definitions.go
@@ -1,0 +1,13 @@
+package option_definitions
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
+)
+
+var Verbose = options.NewDefinition(
+	"verbose",
+	options.WithShortName("v"),
+	options.WithNegative(),
+	options.WithPluginID(options.NativeBuiltinPluginID),
+	options.WithSupportFor("startup"),
+)

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -7,11 +7,13 @@ go_library(
     deps = [
         "//cli/bazelisk",
         "//cli/log",
+        "//cli/log/option_definitions",
         "//cli/parser/arguments",
         "//cli/parser/bazelrc",
         "//cli/parser/options",
         "//cli/parser/parsed",
         "//cli/storage",
+        "//cli/watcher/option_definitions",
         "//cli/workspace",
         "//proto:bazel_flags_go_proto",
         "//proto:remote_execution_go_proto",

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	NativeBuiltinPluginID   = "//builtin/native"
 	StarlarkBuiltinPluginID = "//builtin/starlark"
 	UnknownBuiltinPluginID  = "//builtin/unknown"
 )

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -27,11 +27,25 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 
+	helpoptdef "github.com/buildbuddy-io/buildbuddy/cli/help/option_definitions"
+	logoptdef "github.com/buildbuddy-io/buildbuddy/cli/log/option_definitions"
+	watchoptdef "github.com/buildbuddy-io/buildbuddy/cli/watcher/option_definitions"
+
 	bfpb "github.com/buildbuddy-io/buildbuddy/proto/bazel_flags"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 var (
+	nativeDefinitions = map[string]*options.Definition {
+			// Set to print debug output for the bb CLI.
+			logoptdef.Verbose.Name(): logoptdef.Verbose,
+			// Reinvokes the CLI as a subprocess on changes to source files.
+			watchoptdef.Watch.Name(): watchoptdef.Watch,
+			// Allow specifying --watcher_flags to forward args to the watcher.
+			// Mostly useful for debugging, e.g. --watcher_flags='--verbose'
+			watchoptdef.WatcherFlags.Name(): watchoptdef.WatcherFlags,
+	}
+
 	flagShortNamePattern = regexp.MustCompile(`^[a-z]$`)
 
 	// make this a var so the test can replace it.

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -27,7 +27,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 
-	helpoptdef "github.com/buildbuddy-io/buildbuddy/cli/help/option_definitions"
 	logoptdef "github.com/buildbuddy-io/buildbuddy/cli/log/option_definitions"
 	watchoptdef "github.com/buildbuddy-io/buildbuddy/cli/watcher/option_definitions"
 
@@ -36,14 +35,14 @@ import (
 )
 
 var (
-	nativeDefinitions = map[string]*options.Definition {
-			// Set to print debug output for the bb CLI.
-			logoptdef.Verbose.Name(): logoptdef.Verbose,
-			// Reinvokes the CLI as a subprocess on changes to source files.
-			watchoptdef.Watch.Name(): watchoptdef.Watch,
-			// Allow specifying --watcher_flags to forward args to the watcher.
-			// Mostly useful for debugging, e.g. --watcher_flags='--verbose'
-			watchoptdef.WatcherFlags.Name(): watchoptdef.WatcherFlags,
+	nativeDefinitions = map[string]*options.Definition{
+		// Set to print debug output for the bb CLI.
+		logoptdef.Verbose.Name(): logoptdef.Verbose,
+		// Reinvokes the CLI as a subprocess on changes to source files.
+		watchoptdef.Watch.Name(): watchoptdef.Watch,
+		// Allow specifying --watcher_flags to forward args to the watcher.
+		// Mostly useful for debugging, e.g. --watcher_flags='--verbose'
+		watchoptdef.WatcherFlags.Name(): watchoptdef.WatcherFlags,
 	}
 
 	flagShortNamePattern = regexp.MustCompile(`^[a-z]$`)

--- a/cli/watcher/option_definitions/BUILD
+++ b/cli/watcher/option_definitions/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "option_definitions",
+    srcs = ["option_definitions.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/watcher/option_definitions",
+    visibility = ["//visibility:public"],
+    deps = ["//cli/parser/options"],
+)
+
+package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/watcher/option_definitions/option_definitions.go
+++ b/cli/watcher/option_definitions/option_definitions.go
@@ -1,0 +1,23 @@
+package option_definitions
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
+)
+
+var (
+	Watch = options.NewDefinition(
+		"watch",
+		options.WithShortName("w"),
+		options.WithNegative(),
+		options.WithPluginID(options.NativeBuiltinPluginID),
+		options.WithSupportFor("startup"),
+	)
+
+	WatcherFlags = options.NewDefinition(
+		"watcher_flags",
+		options.WithRequiresValue(),
+		options.WithMulti(),
+		options.WithPluginID(options.NativeBuiltinPluginID),
+		options.WithSupportFor("startup"),
+	)
+)


### PR DESCRIPTION
This PR adds native option definitions, which will be utilized by the parser in a later PR
