### PR TITLE
[raft] make txn_test/testutil_test run on firecracker

### DIFF
--- a/enterprise/server/raft/testutil/BUILD
+++ b/enterprise/server/raft/testutil/BUILD
@@ -41,6 +41,10 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 go_test(
     name = "testutil_test",
     srcs = ["testutil_test.go"],
+    exec_properties = {
+        "test.EstimatedComputeUnits": "8",
+        "test.workload-isolation-type": "firecracker",
+    },
     deps = [
         ":testutil",
         "@com_github_jonboulle_clockwork//:clockwork",

--- a/enterprise/server/raft/txn/BUILD
+++ b/enterprise/server/raft/txn/BUILD
@@ -24,6 +24,10 @@ go_test(
     name = "txn_test",
     srcs = ["txn_test.go"],
     tags = ["block-network"],
+    exec_properties = {
+        "test.EstimatedComputeUnits": "8",
+        "test.workload-isolation-type": "firecracker",
+    },
     deps = [
         ":txn",
         "//enterprise/server/raft/constants",


### PR DESCRIPTION
txn_test has 5 flakes and testutil_test has 1 flake last 7 days.

The errors are mostly timeout; so moving them to firecracker first.
