### PR TITLE
[raft] tune a few flags to make tests less flaky

### DIFF
--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["client.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client",
     deps = [
+        "//enterprise/server/raft/config",
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/rbuilder",
         "//proto:raft_go_proto",

--- a/enterprise/server/raft/config/config.go
+++ b/enterprise/server/raft/config/config.go
@@ -2,16 +2,25 @@ package config
 
 import (
 	"flag"
+	"time"
 
 	dbConfig "github.com/lni/dragonboat/v4/config"
 )
 
 var (
 	maxRangeSizeBytes = flag.Int64("cache.raft.max_range_size_bytes", 1e8, "If set to a value greater than 0, ranges will be split until smaller than this size")
+	// This value should be approximately 10x the config.RTTMilliseconds,
+	// but we want to include a little more time for the operation itself to
+	// complete.
+	singleRaftOpTimeout = flag.Duration("cache.raft.op_timeout", 1*time.Second, "The duration of timeout for a single raft operation")
 )
 
 func MaxRangeSizeBytes() int64 {
 	return *maxRangeSizeBytes
+}
+
+func SingleRaftOpTimeout() time.Duration {
+	return *singleRaftOpTimeout
 }
 
 func GetRaftConfig(rangeID, replicaID uint64) dbConfig.Config {

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -59,7 +59,7 @@ go_test(
     name = "store_test",
     srcs = ["store_test.go"],
     exec_properties = {
-        "test.EstimatedComputeUnits": "8",
+        "test.EstimatedComputeUnits": "10",
         "test.workload-isolation-type": "firecracker",
     },
     shard_count = 8,

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -365,6 +365,9 @@ func TestAddNodeToCluster(t *testing.T) {
 	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
 	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
 	flags.Set(t, "cache.raft.enable_driver", false)
+	// store_test is sensitive to cpu pressure stall on remote executor. Increase
+	// the single op timeout to make it less sensitive.
+	flags.Set(t, "cache.raft.op_timeout", 3*time.Second)
 	sf := testutil.NewStoreFactory(t)
 	s1 := sf.NewStore(t)
 	s2 := sf.NewStore(t)
@@ -1182,6 +1185,10 @@ func TestUpReplicate(t *testing.T) {
 	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
 	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
 	flags.Set(t, "cache.raft.min_meta_range_replicas", 3)
+	// store_test is sensitive to cpu pressure stall on remote executor. Increase
+	// the single op timeout to make it less sensitive.
+	flags.Set(t, "cache.raft.op_timeout", 3*time.Second)
+	flags.Set(t, "gossip.retransmit_mult", 10)
 
 	clock := clockwork.NewFakeClock()
 	sf := testutil.NewStoreFactoryWithClock(t, clock)
@@ -1257,6 +1264,7 @@ func TestDownReplicate(t *testing.T) {
 	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
 	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
 	flags.Set(t, "cache.raft.min_meta_range_replicas", 3)
+	flags.Set(t, "gossip.retransmit_mult", 10)
 
 	clock := clockwork.NewFakeClock()
 	sf := testutil.NewStoreFactoryWithClock(t, clock)
@@ -1395,6 +1403,7 @@ func TestReplaceDeadReplica(t *testing.T) {
 	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
 	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
 	flags.Set(t, "cache.raft.min_meta_range_replicas", 3)
+	flags.Set(t, "gossip.retransmit_mult", 10)
 
 	clock := clockwork.NewFakeClock()
 	sf := testutil.NewStoreFactoryWithClock(t, clock)
@@ -1465,6 +1474,7 @@ func TestRemoveDeadReplica(t *testing.T) {
 	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
 	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
 	flags.Set(t, "cache.raft.min_meta_range_replicas", 3)
+	flags.Set(t, "gossip.retransmit_mult", 10)
 
 	clock := clockwork.NewFakeClock()
 	sf := testutil.NewStoreFactoryWithClock(t, clock)
@@ -1517,6 +1527,7 @@ func TestRebalance(t *testing.T) {
 	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
 	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
 	flags.Set(t, "cache.raft.min_meta_range_replicas", 3)
+	flags.Set(t, "gossip.retransmit_mult", 10)
 
 	startingRanges := []*rfpb.RangeDescriptor{
 		&rfpb.RangeDescriptor{

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -57,7 +57,8 @@ func addNonVoting(t *testing.T, ts *testutil.TestingStore, ctx context.Context, 
 	membership, err := ts.GetMembership(ctx, rangeID)
 	require.NoError(t, err)
 	ccid := membership.ConfigChangeID
-	err = client.RunNodehostFn(ctx, func(ctx context.Context) error {
+	maxSingleOpTimeout := 3 * time.Second
+	err = client.RunNodehostFn(ctx, maxSingleOpTimeout, func(ctx context.Context) error {
 		return ts.NodeHost().SyncRequestAddNonVoting(ctx, rangeID, replicaID, nhid, ccid)
 	})
 	require.NoError(t, err)
@@ -539,7 +540,7 @@ func TestAddRangeBack(t *testing.T) {
 			ReplicaId: replicaToRemove.GetReplicaId(),
 			Range:     rd,
 		})
-		if rsp != nil {
+		if removeDataRsp.GetRange() != nil {
 			rd = removeDataRsp.GetRange()
 		}
 		if err != nil {
@@ -1012,7 +1013,8 @@ func readSessionIDs(t *testing.T, ctx context.Context, rangeID uint64, store *te
 	}).ToProto()
 	require.NoError(t, err)
 
-	rsp, err := client.SyncReadLocal(ctx, store.NodeHost(), rangeID, req)
+	maxSingleOpTimeout := 3 * time.Second
+	rsp, err := client.SyncReadLocal(ctx, store.NodeHost(), rangeID, req, maxSingleOpTimeout)
 	require.NoError(t, err)
 	readBatch := rbuilder.NewBatchResponseFromProto(rsp)
 	scanRsp, err := readBatch.ScanResponse(0)


### PR DESCRIPTION
Increase the timeout, and also retries in gossip in driver tests to make tests
less flaky.

Also refactor the code to prevent from race conditions on setting the flag in
the test.
