### PR TITLE
CLI: Give subparsers the aliases / shortcuts for commands to aid in parsing

### DIFF
--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//cli/plugin",
         "//cli/runscript",
         "//cli/setup",
-        "//cli/shortcuts",
         "//cli/watcher",
         "//server/util/rlimit",
         "//server/util/status",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -16,7 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/plugin"
 	"github.com/buildbuddy-io/buildbuddy/cli/runscript"
 	"github.com/buildbuddy-io/buildbuddy/cli/setup"
-	"github.com/buildbuddy-io/buildbuddy/cli/shortcuts"
 	"github.com/buildbuddy-io/buildbuddy/cli/watcher"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rlimit"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -77,9 +76,6 @@ func run() (exitCode int, err error) {
 
 	// Register all known cli commands so that we can query or iterate them later.
 	register_cli_commands.Register()
-
-	// Expand command shortcuts like b=>build, t=>test, etc.
-	args = shortcuts.HandleShortcuts(args)
 
 	// Make sure startup args are always in the format --foo=bar.
 	args, err = parser.CanonicalizeArgs(args)

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//cli/parser/bazelrc",
         "//cli/parser/options",
         "//cli/parser/parsed",
+        "//cli/shortcuts",
         "//cli/storage",
         "//cli/watcher/option_definitions",
         "//cli/workspace",

--- a/cli/shortcuts/BUILD
+++ b/cli/shortcuts/BUILD
@@ -5,7 +5,6 @@ go_library(
     srcs = ["shortcuts.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/shortcuts",
     visibility = ["//visibility:public"],
-    deps = ["//cli/arg"],
 )
 
 package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/shortcuts/shortcuts.go
+++ b/cli/shortcuts/shortcuts.go
@@ -1,9 +1,7 @@
 package shortcuts
 
-import "github.com/buildbuddy-io/buildbuddy/cli/arg"
-
 var (
-	shortcuts = map[string]string{
+	Shortcuts = map[string]string{
 		"b": "build",
 		"t": "test",
 		"q": "query",
@@ -11,12 +9,3 @@ var (
 		"f": "fix",
 	}
 )
-
-// HandleShorcuts finds the first non-flag command and tries to expand it
-func HandleShortcuts(args []string) []string {
-	command, idx := arg.GetCommandAndIndex(args)
-	if expanded, ok := shortcuts[command]; ok {
-		args[idx] = expanded
-	}
-	return args
-}


### PR DESCRIPTION
Since commands are associated with subparsers, and since subparsers need to know what commands they are looking at when parsing, we associate the aliases for commands with the related subparser.
