### PR TITLE
Make migration_cache.config more lenient with missing or invalid configs

### DIFF
--- a/enterprise/server/backends/migration_cache/BUILD
+++ b/enterprise/server/backends/migration_cache/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//server/metrics",
         "//server/real_environment",
         "//server/remote_cache/digest",
+        "//server/util/alert",
         "//server/util/background",
         "//server/util/claims",
         "//server/util/compression",

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -211,8 +211,6 @@ type config struct {
 	doubleReadPercentage, decompressPercentage float64
 }
 
-var configInvalidAlertOnce sync.Once
-
 // TODO(vanja) either return errors, or remove the error return value.
 func (mc *MigrationCache) config(ctx context.Context) (*config, error) {
 	c := &config{

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -245,9 +245,11 @@ func (mc *MigrationCache) config(ctx context.Context) (*config, error) {
 				c.dest = nil
 			default:
 				alert.CtxUnexpectedEvent(ctx, "migration_cache_invalid_config", "Unknown migration cache state: %s", state)
+				return c, nil
 			}
 		} else {
 			alert.CtxUnexpectedEvent(ctx, "migration_cache_invalid_config", "MigrationStateField is not a string: %T(%v)", v, v)
+			return c, nil
 		}
 	}
 	if v, ok := m[AsyncDestWriteField]; ok {
@@ -255,6 +257,7 @@ func (mc *MigrationCache) config(ctx context.Context) (*config, error) {
 			c.asyncDestWrites = asyncDestWrites
 		} else {
 			alert.CtxUnexpectedEvent(ctx, "migration_cache_invalid_config", "AsyncDestWriteField is not a bool: %T(%v)", v, v)
+			return c, nil
 		}
 	}
 	if v, ok := m[DoubleReadPercentageField]; ok {
@@ -262,6 +265,7 @@ func (mc *MigrationCache) config(ctx context.Context) (*config, error) {
 			c.doubleReadPercentage = doubleReadPercentage
 		} else {
 			alert.CtxUnexpectedEvent(ctx, "migration_cache_invalid_config", "DoubleReadPercentageField is not a float64: %T(%v)", v, v)
+			return c, nil
 		}
 	}
 	if v, ok := m[DecompressReadPercentageField]; ok {
@@ -269,6 +273,7 @@ func (mc *MigrationCache) config(ctx context.Context) (*config, error) {
 			c.decompressPercentage = decompressPercentage
 		} else {
 			alert.CtxUnexpectedEvent(ctx, "migration_cache_invalid_config", "DecompressReadPercentageField is not a float64: %T(%v)", v, v)
+			return c, nil
 		}
 	}
 	return c, nil

--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -145,35 +145,59 @@ func WithContext(key string, value interface{}) Option {
 // overrides, and returns the Boolean value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool {
-	return fp.client.Boolean(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, err := fp.client.BooleanValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	if err != nil {
+		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		return defaultValue
+	}
+	return v
 }
 
 // String extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the String value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) String(ctx context.Context, flagName string, defaultValue string, opts ...any) string {
-	return fp.client.String(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, err := fp.client.StringValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	if err != nil {
+		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		return defaultValue
+	}
+	return v
 }
 
 // Float64 extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the Float64 value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Float64(ctx context.Context, flagName string, defaultValue float64, opts ...any) float64 {
-	return fp.client.Float(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, err := fp.client.FloatValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	if err != nil {
+		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		return defaultValue
+	}
+	return v
 }
 
 // Int64 extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the Int64 value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
-	return fp.client.Int(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, err := fp.client.IntValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	if err != nil {
+		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		return defaultValue
+	}
+	return v
 }
 
 // Object extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the map[string]any value for flagName, or defaultValue
 // if no experiment provider is configured.
 func (fp *FlagProvider) Object(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) map[string]any {
-	v := fp.client.Object(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, err := fp.client.ObjectValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	if err != nil {
+		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		return defaultValue
+	}
 	if v == nil {
 		return defaultValue
 	}

--- a/server/util/alert/alert.go
+++ b/server/util/alert/alert.go
@@ -1,6 +1,7 @@
 package alert
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
@@ -20,6 +21,12 @@ import (
 //	alert.UnexpectedEvent("cannot_unmarshal_proto")
 //	alert.UnexpectedEvent("cannot_unmarshal_proto", "invocation_id %s err: %s", invocation_id, err)
 func UnexpectedEvent(name string, msgAndArgs ...interface{}) {
+	CtxUnexpectedEvent(context.Background(), name, msgAndArgs...)
+}
+
+// CtxUnexpectedEvent is the same as UnexpectedEvent, but takes a context
+// which is used when logging the event.
+func CtxUnexpectedEvent(ctx context.Context, name string, msgAndArgs ...interface{}) {
 	metrics.UnexpectedEvent.With(prometheus.Labels{metrics.EventName: name}).Inc()
 	logMsg := fmt.Sprintf("Unexpected event %q", name)
 	if len(msgAndArgs) == 1 {
@@ -33,5 +40,5 @@ func UnexpectedEvent(name string, msgAndArgs ...interface{}) {
 			logMsg += "<invalid args to UnexpectedEvent>"
 		}
 	}
-	log.Warning(logMsg)
+	log.CtxWarning(ctx, logMsg)
 }


### PR DESCRIPTION
Currently when flagd is not configured, we use `openfeature.NoopProvider`, which always returns the default value. Since this is nil, `config` always returns an error.

When flagd is configured, but the configuration is invalid, it also returns the default, so again `config` always returns an error.

Instead log errors when the config is invalid or when flagd returns an error. Don't log error when the config is missing, because this could be just because flagd isn't configured.