### PR TITLE
CLI: Improve `AccumulateValues`

### DIFF
--- a/cli/parser/options/BUILD
+++ b/cli/parser/options/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//cli/parser/arguments",
         "//cli/parser/bazelrc",
         "//proto:bazel_flags_go_proto",
+        "//server/util/lib/seq",
         "//server/util/lib/set",
     ],
 )

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -806,8 +806,7 @@ func AccumulateValues[T string | []string | bool | BoolOrEnum, O Option](acc T, 
 		case *BoolOrEnum:
 			b := opt.BoolLike()
 			if b == nil {
-				p.SetEnum(opt.GetValue())
-				continue
+				return *new(T), fmt.Errorf("Option '%s' is not a boolean (or boolean-or-enum) option.", opt.Name())
 			}
 			v, err := b.AsBool()
 			if err != nil {
@@ -815,6 +814,8 @@ func AccumulateValues[T string | []string | bool | BoolOrEnum, O Option](acc T, 
 				continue
 			}
 			p.SetBool(v)
+		default:
+			return *new(T), fmt.Errorf("Accumulator is of unsupported type %T.", acc)
 		}
 	}
 	return acc, nil

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lib/seq"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 
 	bfpb "github.com/buildbuddy-io/buildbuddy/proto/bazel_flags"
@@ -780,14 +781,14 @@ func NameFilter[O Option](name string) func(O) bool {
 	}
 }
 
-// AccumulateValues accepts an initial value, acc, and a variadic Option
+// AccumulateValues accepts an initial value, acc, and a Sequenceable Option
 // parameter, opts, and returns the resulting value of evaluating all of those
 // options in order. It should only be called with opts that all share the same
 // definition, and an inital value that matches the type of value that
 // definition implies. Otherwise, its output will be nonsensical.
-func AccumulateValues[T string | []string | bool | BoolOrEnum, O Option](acc T, opts ...O) (T, error) {
+func AccumulateValues[O Option, T string | []string | bool | BoolOrEnum, S seq.Sequenceable[O]](acc T, opts S) (T, error) {
 	p := any(&acc)
-	for _, opt := range opts {
+	for opt := range seq.Sequence[O](opts) {
 		switch p := p.(type) {
 		case *string:
 			*p = opt.GetValue()

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -585,7 +585,7 @@ func (a *OrderedArgs) appendOption(option options.Option, startupOptionInsertInd
 // args and appends an `ignore_all_rc_files` option to the startup options.
 // Returns a slice of all the rc files that should be parsed.
 func (a *OrderedArgs) ConsumeRCFileOptions(workspaceDir string) (rcFiles []string, err error) {
-	if ignore, err := options.AccumulateValues(false, a.RemoveStartupOptions("ignore_all_rc_files")...); err != nil {
+	if ignore, err := options.AccumulateValues[*IndexedOption](false, a.RemoveStartupOptions("ignore_all_rc_files")); err != nil {
 		return nil, fmt.Errorf("Failed to get value from 'ignore_all_rc_files' option: %s", err)
 	} else if ignore {
 		// Before we do anything, check whether --ignore_all_rc_files is already
@@ -598,7 +598,7 @@ func (a *OrderedArgs) ConsumeRCFileOptions(workspaceDir string) (rcFiles []strin
 	// Parse rc files in the order defined here:
 	// https://bazel.build/run/bazelrc#bazelrc-file-locations
 	for _, optName := range []string{"system_rc", "workspace_rc", " home_rc"} {
-		if v, err := options.AccumulateValues(true, a.RemoveStartupOptions(optName)...); err != nil {
+		if v, err := options.AccumulateValues[*IndexedOption](true, a.RemoveStartupOptions(optName)); err != nil {
 			return nil, fmt.Errorf("Failed to get value from '%s' option: %s", optName, err)
 		} else if !v {
 			// When these flags are false, they have no effect on the list of
@@ -658,7 +658,7 @@ func (a *OrderedArgs) ExpandConfigs(
 	// Replace the last occurrence of `--enable_platform_specific_config` with
 	// `--config=<bazelOS>`, so long as the last occurrence evaluates as true.
 	opts := expanded.RemoveCommandOptions(bazelrc.EnablePlatformSpecificConfigFlag)
-	if v, err := options.AccumulateValues(false, opts...); err != nil {
+	if v, err := options.AccumulateValues[*IndexedOption](false, opts); err != nil {
 		return nil, fmt.Errorf("Failed to get value from '%s' option: %s", bazelrc.EnablePlatformSpecificConfigFlag, err)
 	} else if v {
 		index := opts[len(opts)-1].Index


### PR DESCRIPTION
This PR:
- accounts for an unhandled type, which can't happen in this version of the code, but could if someone expanded the function's type constraint without adding types to the type switch
- Returns an error if a `BoolOrEnum` tries to accumulate a non-bool type.
- Takes a `seq.Sequenceable` so we can pass options we are filtering without allocating a slice for them.
