### PR TITLE
Rename `seq.Truncate` to `seq.Take`

### DIFF
--- a/server/util/lib/seq/seq.go
+++ b/server/util/lib/seq/seq.go
@@ -115,9 +115,9 @@ func Drop[E any, S Sequenceable[E]](s S, n int) iter.Seq[E] {
 	}
 }
 
-// Truncate truncates the passed sequence after N elements. If the sequence is
-// fewer than N elements in length, it will be returned unchanged. If N is less
-// than one, the empty sequence is returned
+// Take returns a sequence consisting only of the first N elements of the passed
+// sequence. If the sequence is fewer than N elements in length, it will be
+// returned unchanged. If N is less than one, the empty sequence is returned.
 //
 // As with all sequences returned by this library, so long as the parameters are
 // stateless, the returned sequence will be stateless.
@@ -125,7 +125,7 @@ func Drop[E any, S Sequenceable[E]](s S, n int) iter.Seq[E] {
 // the element type must be specified as a type parameter. However, if
 // https://github.com/golang/go/issues/73527 is ever accepted/addressed, the
 // explicit type specification will no longer be needed.
-func Truncate[E any, S Sequenceable[E]](s S, n int) iter.Seq[E] {
+func Take[E any, S Sequenceable[E]](s S, n int) iter.Seq[E] {
 	if n < 1 {
 		return EmptySeq[E]
 	}

--- a/server/util/lib/seq/seq_test.go
+++ b/server/util/lib/seq/seq_test.go
@@ -256,7 +256,7 @@ func TestDrop(t *testing.T) {
 	}
 }
 
-func TestTruncate(t *testing.T) {
+func TestTake(t *testing.T) {
 	for name, tc := range map[string]struct {
 		input    []string
 		n        int
@@ -338,23 +338,23 @@ func TestTruncate(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			originalInput := slices.Clone(tc.input)
-			truncated := seq.Truncate[string](tc.input, tc.n)
-			assert.ElementsMatch(t, tc.expected, slices.Collect(truncated))
+			taken := seq.Take[string](tc.input, tc.n)
+			assert.ElementsMatch(t, tc.expected, slices.Collect(taken))
 			assert.ElementsMatch(t, originalInput, tc.input)
 			// test statelessness
-			assert.ElementsMatch(t, tc.expected, slices.Collect(truncated))
+			assert.ElementsMatch(t, tc.expected, slices.Collect(taken))
 
-			truncated = seq.Truncate[string](slices.Values(tc.input), tc.n)
-			assert.ElementsMatch(t, tc.expected, slices.Collect(truncated))
+			taken = seq.Take[string](slices.Values(tc.input), tc.n)
+			assert.ElementsMatch(t, tc.expected, slices.Collect(taken))
 			// test statelessness
-			assert.ElementsMatch(t, tc.expected, slices.Collect(truncated))
+			assert.ElementsMatch(t, tc.expected, slices.Collect(taken))
 		})
 	}
 	t.Run("stateful truncate", func(t *testing.T) {
 		input := "hello\nthere\ncool\nworld\n"
 		// string.Lines is a stateful sequence.
 		lines := strings.Lines(input)
-		truncated := seq.Truncate[string](lines, 2)
+		truncated := seq.Take[string](lines, 2)
 		assert.ElementsMatch(
 			t,
 			[]string{"hello\n", "there\n"},

--- a/server/util/lib/seq/seq_test.go
+++ b/server/util/lib/seq/seq_test.go
@@ -354,11 +354,11 @@ func TestTake(t *testing.T) {
 		input := "hello\nthere\ncool\nworld\n"
 		// string.Lines is a stateful sequence.
 		lines := strings.Lines(input)
-		truncated := seq.Take[string](lines, 2)
+		taken := seq.Take[string](lines, 2)
 		assert.ElementsMatch(
 			t,
 			[]string{"hello\n", "there\n"},
-			slices.Collect(truncated),
+			slices.Collect(taken),
 		)
 
 		assert.ElementsMatch(


### PR DESCRIPTION
This is to pair better with `Drop` and to open the door to implementing a `TakeWhile` and `DropWhile`.
