### PR TITLE
Imrovements to navigation and references in code browser

### DIFF
--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -17,10 +17,14 @@
   overflow-y: auto;
   overflow-x: hidden;
 <<<<<<< HEAD
+<<<<<<< HEAD
   border: 2px solid #fafafa;
 =======
   border: 2px solid #fafafa
 >>>>>>> 355144be80 (ui stuff)
+=======
+  border: 2px solid #fafafa;
+>>>>>>> d33e1ea939 (prettier)
 }
 
 .xrefs-header {

--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -16,7 +16,11 @@
   height: 300px;
   overflow-y: auto;
   overflow-x: hidden;
+<<<<<<< HEAD
   border: 2px solid #fafafa;
+=======
+  border: 2px solid #fafafa
+>>>>>>> 355144be80 (ui stuff)
 }
 
 .xrefs-header {

--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -16,15 +16,7 @@
   height: 300px;
   overflow-y: auto;
   overflow-x: hidden;
-<<<<<<< HEAD
-<<<<<<< HEAD
   border: 2px solid #fafafa;
-=======
-  border: 2px solid #fafafa
->>>>>>> 355144be80 (ui stuff)
-=======
-  border: 2px solid #fafafa;
->>>>>>> d33e1ea939 (prettier)
 }
 
 .xrefs-header {

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -478,15 +478,6 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
     return decor?.options?.after?.attachedData as kythe.proto.DecorationsReply.Reference | undefined;
   }
 
-  getKytheRefsInRange(range: monaco.Range): kythe.proto.DecorationsReply.Reference[] | undefined {
-    const decorInRange = this.editor?.getDecorationsInRange(range);
-    if (!decorInRange) {
-      return undefined;
-    }
-
-    return decorInRange.map((decor) => this.decorToReference(decor)).filter((ref) => !!ref);
-  }
-
   getKytheRefsForRange(range: monaco.Range): kythe.proto.DecorationsReply.Reference[] | undefined {
     // This finds the smallest decorations in a given range.
     // All decorations that share the same smallest span will be returned.

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -144,6 +144,17 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
 
   editor: monaco.editor.IStandaloneCodeEditor | undefined;
   diffEditor: monaco.editor.IDiffEditor | undefined;
+  decorIdToData: Map<string, kythe.proto.DecorationsReply.Reference> = new Map();
+
+  // Note that these decoration collections are automatically cleared when the model is changed.
+  kytheDecorations: monaco.editor.IEditorDecorationsCollection | undefined;
+  searchDecorations: monaco.editor.IEditorDecorationsCollection | undefined;
+  lcovDecorations: monaco.editor.IEditorDecorationsCollection | undefined;
+
+  findRefsKey?: monaco.editor.IContextKey<boolean>;
+  goToDefKey?: monaco.editor.IContextKey<boolean>;
+  pendingXrefsRequest?: CancelablePromise<search.KytheResponse>;
+  mousedownTarget?: monaco.Position;
 
   // Note that these decoration collections are automatically cleared when the model is changed.
   kytheDecorations: monaco.editor.IEditorDecorationsCollection | undefined;
@@ -1836,7 +1847,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 height="56"
                 viewBox="0 0 68 56"
                 fill="none"
-                xmlns="http://www.w3.org/2000/svg">
+                xmlns="http://www.w3.org/2000/svg"
+              >
                 <path
                   d="M62.8577 29.2897C61.8246 27.7485 60.4825 26.5113 58.8722 25.5604C59.7424 24.8245 60.493 23.998 61.1109 23.0756C62.5071 21.0593 63.1404 18.6248 63.1404 15.8992C63.1404 13.4509 62.7265 11.2489 61.7955 9.37839C60.9327 7.5562 59.6745 6.07124 58.0282 4.96992C56.4328 3.85851 54.5665 3.09733 52.4736 2.64934C50.4289 2.21166 48.1997 2 45.7961 2H4H2V4V52V54H4H46.4691C48.7893 54 51.0473 53.7102 53.2377 53.1272C55.5055 52.5357 57.5444 51.6134 59.3289 50.3425C61.2008 49.0417 62.6877 47.3709 63.7758 45.3524L63.7808 45.3431L63.7857 45.3338C64.9054 43.2032 65.4286 40.7655 65.4286 38.084C65.4286 34.7488 64.6031 31.7823 62.8577 29.2897Z"
                   stroke-width="4"
@@ -1906,7 +1918,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                   } else {
                     rpcService.downloadBytestreamFile(this.props.search.get("filename") || "", bsUrl, invocationId);
                   }
-                }}>
+                }}
+              >
                 <Download /> Download File
               </OutlinedButton>
             </div>
@@ -1924,7 +1937,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 <OutlinedButton
                   disabled={this.state.requestingReview}
                   className="request-review-button"
-                  onClick={this.handleShowReviewModalClicked.bind(this)}>
+                  onClick={this.handleShowReviewModalClicked.bind(this)}
+                >
                   {this.state.requestingReview ? (
                     <>
                       <Spinner className="icon" /> Requesting...
@@ -1940,7 +1954,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 <OutlinedButton
                   disabled={this.state.updatingPR}
                   className="request-review-button"
-                  onClick={this.handleUpdatePR.bind(this)}>
+                  onClick={this.handleUpdatePR.bind(this)}
+                >
                   {this.state.updatingPR ? (
                     <>
                       <Spinner className="icon" /> Updating...
@@ -2004,7 +2019,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 {[...this.state.tabs.keys()].reverse().map((t) => (
                   <div
                     className={`code-viewer-tab ${t == this.currentPath() ? "selected" : ""}`}
-                    onClick={this.handleTabClicked.bind(this, t)}>
+                    onClick={this.handleTabClicked.bind(this, t)}
+                  >
                     <span>{t.split("/").pop() || "Untitled"}</span>
                     <XCircle
                       onClick={(e) => {
@@ -2079,7 +2095,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                     <div
                       className={`code-diff-viewer-item-path${
                         this.state.changes.get(fullPath)?.changeType == workspace.ChangeType.DELETED ? " deleted" : ""
-                      }${this.state.changes.get(fullPath)?.changeType == workspace.ChangeType.ADDED ? " added" : ""}`}>
+                      }${this.state.changes.get(fullPath)?.changeType == workspace.ChangeType.ADDED ? " added" : ""}`}
+                    >
                       {fullPath}
                     </div>
                     {this.state.mergeConflicts.has(fullPath) && fullPath != this.currentPath() && (
@@ -2089,7 +2106,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                           this,
                           fullPath,
                           this.state.mergeConflicts.get(fullPath)!
-                        )}>
+                        )}
+                      >
                         View Conflict
                       </span>
                     )}
@@ -2138,20 +2156,24 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
             <div
               className="context-menu"
               onClick={this.clearContextMenu.bind(this)}
-              style={{ top: this.state.contextMenuY, left: this.state.contextMenuX }}>
+              style={{ top: this.state.contextMenuY, left: this.state.contextMenuX }}
+            >
               <div
-                onClick={() => this.handleNewFileClicked(this.state.contextMenuFile!, this.state.contextMenuFullPath!)}>
+                onClick={() => this.handleNewFileClicked(this.state.contextMenuFile!, this.state.contextMenuFullPath!)}
+              >
                 New file
               </div>
               <div
                 onClick={() =>
                   this.handleNewFolderClicked(this.state.contextMenuFile!, this.state.contextMenuFullPath!)
-                }>
+                }
+              >
                 New folder
               </div>
               <div onClick={() => this.handleRenameClicked(this.state.contextMenuFullPath!)}>Rename</div>
               <div
-                onClick={() => this.handleDeleteClicked(this.state.contextMenuFullPath!, this.state.contextMenuFile!)}>
+                onClick={() => this.handleDeleteClicked(this.state.contextMenuFullPath!, this.state.contextMenuFile!)}
+              >
                 Delete
               </div>
             </div>
@@ -2176,14 +2198,16 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                     onClick={() =>
                       window.open(applicableInstallation?.url + `/permissions/update`, "_blank") &&
                       this.updateState({ installationsResponse: undefined })
-                    }>
+                    }
+                  >
                     <Key className="icon white" /> Permissions
                   </FilledButton>
                 )}
                 <FilledButton
                   disabled={this.state.requestingReview || applicableInstallation?.permissions?.pullRequests == "read"}
                   className="code-request-review-button"
-                  onClick={this.handleReviewClicked.bind(this)}>
+                  onClick={this.handleReviewClicked.bind(this)}
+                >
                   {this.state.requestingReview ? (
                     <>
                       <Spinner className="icon white" /> Sending...

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -1792,6 +1792,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       fileToRefsMap.get(parentTicket)!.push(a);
     });
 
+    // Unique all the anchors (duplicates are common).
+    // Also, sort them by position in the file.
     for (const [key, refs] of fileToRefsMap.entries()) {
       const uniques = new Map<number, kythe.proto.CrossReferencesReply.RelatedAnchor>();
       const uniqueLineRefs = refs.filter((ra) => {
@@ -1811,6 +1813,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       fileToRefsMap.set(key, uniqueLineRefs);
     }
 
+    // Now sort the files, putting non-tests before tests.
     let sortedFiles = new Map(
       [...fileToRefsMap.entries()].sort((a, b) => {
         const aTest = a[0].toLowerCase().includes("test");

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -296,16 +296,19 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
     this.fetchXrefs(tickets, (xrefReply) => {
       const defs = Object.values(xrefReply.crossReferences).filter((item) => item.definition.length > 0);
 
-      if (defs.length === 0) {
+      let anchor: kythe.proto.Anchor | undefined = undefined;
+      if (defs.length > 0 && defs[0].definition && defs[0].definition.length > 0 && defs[0].definition[0].anchor) {
+        anchor = defs[0].definition[0].anchor;
+      }
+
+      if (!anchor) {
         if (fallbackToPanel) {
           this.populateXrefsPanel(tickets);
         } else {
           console.log("Warning: No definitions found for tickets", tickets);
         }
       } else {
-        if (defs.length > 0 && defs[0].definition?.length > 0 && defs[0].definition[0].anchor) {
-          this.navigateToAnchor(defs[0].definition[0].anchor);
-        }
+        this.navigateToAnchor(anchor);
       }
     });
   }

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -1916,8 +1916,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                   } else {
                     rpcService.downloadBytestreamFile(this.props.search.get("filename") || "", bsUrl, invocationId);
                   }
-                }}
-              >
+                }}>
                 <Download /> Download File
               </OutlinedButton>
             </div>
@@ -2187,8 +2186,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                     onClick={() =>
                       window.open(applicableInstallation?.url + `/permissions/update`, "_blank") &&
                       this.updateState({ installationsResponse: undefined })
-                    }
-                  >
+                    }>
                     <Key className="icon white" /> Permissions
                   </FilledButton>
                 )}

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -144,7 +144,6 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
 
   editor: monaco.editor.IStandaloneCodeEditor | undefined;
   diffEditor: monaco.editor.IDiffEditor | undefined;
-  decorIdToData: Map<string, kythe.proto.DecorationsReply.Reference> = new Map();
 
   // Note that these decoration collections are automatically cleared when the model is changed.
   kytheDecorations: monaco.editor.IEditorDecorationsCollection | undefined;
@@ -1847,8 +1846,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 height="56"
                 viewBox="0 0 68 56"
                 fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
+                xmlns="http://www.w3.org/2000/svg">
                 <path
                   d="M62.8577 29.2897C61.8246 27.7485 60.4825 26.5113 58.8722 25.5604C59.7424 24.8245 60.493 23.998 61.1109 23.0756C62.5071 21.0593 63.1404 18.6248 63.1404 15.8992C63.1404 13.4509 62.7265 11.2489 61.7955 9.37839C60.9327 7.5562 59.6745 6.07124 58.0282 4.96992C56.4328 3.85851 54.5665 3.09733 52.4736 2.64934C50.4289 2.21166 48.1997 2 45.7961 2H4H2V4V52V54H4H46.4691C48.7893 54 51.0473 53.7102 53.2377 53.1272C55.5055 52.5357 57.5444 51.6134 59.3289 50.3425C61.2008 49.0417 62.6877 47.3709 63.7758 45.3524L63.7808 45.3431L63.7857 45.3338C64.9054 43.2032 65.4286 40.7655 65.4286 38.084C65.4286 34.7488 64.6031 31.7823 62.8577 29.2897Z"
                   stroke-width="4"
@@ -1937,8 +1935,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 <OutlinedButton
                   disabled={this.state.requestingReview}
                   className="request-review-button"
-                  onClick={this.handleShowReviewModalClicked.bind(this)}
-                >
+                  onClick={this.handleShowReviewModalClicked.bind(this)}>
                   {this.state.requestingReview ? (
                     <>
                       <Spinner className="icon" /> Requesting...
@@ -1954,8 +1951,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 <OutlinedButton
                   disabled={this.state.updatingPR}
                   className="request-review-button"
-                  onClick={this.handleUpdatePR.bind(this)}
-                >
+                  onClick={this.handleUpdatePR.bind(this)}>
                   {this.state.updatingPR ? (
                     <>
                       <Spinner className="icon" /> Updating...
@@ -2019,8 +2015,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 {[...this.state.tabs.keys()].reverse().map((t) => (
                   <div
                     className={`code-viewer-tab ${t == this.currentPath() ? "selected" : ""}`}
-                    onClick={this.handleTabClicked.bind(this, t)}
-                  >
+                    onClick={this.handleTabClicked.bind(this, t)}>
                     <span>{t.split("/").pop() || "Untitled"}</span>
                     <XCircle
                       onClick={(e) => {
@@ -2095,8 +2090,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                     <div
                       className={`code-diff-viewer-item-path${
                         this.state.changes.get(fullPath)?.changeType == workspace.ChangeType.DELETED ? " deleted" : ""
-                      }${this.state.changes.get(fullPath)?.changeType == workspace.ChangeType.ADDED ? " added" : ""}`}
-                    >
+                      }${this.state.changes.get(fullPath)?.changeType == workspace.ChangeType.ADDED ? " added" : ""}`}>
                       {fullPath}
                     </div>
                     {this.state.mergeConflicts.has(fullPath) && fullPath != this.currentPath() && (
@@ -2106,8 +2100,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                           this,
                           fullPath,
                           this.state.mergeConflicts.get(fullPath)!
-                        )}
-                      >
+                        )}>
                         View Conflict
                       </span>
                     )}
@@ -2156,24 +2149,20 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
             <div
               className="context-menu"
               onClick={this.clearContextMenu.bind(this)}
-              style={{ top: this.state.contextMenuY, left: this.state.contextMenuX }}
-            >
+              style={{ top: this.state.contextMenuY, left: this.state.contextMenuX }}>
               <div
-                onClick={() => this.handleNewFileClicked(this.state.contextMenuFile!, this.state.contextMenuFullPath!)}
-              >
+                onClick={() => this.handleNewFileClicked(this.state.contextMenuFile!, this.state.contextMenuFullPath!)}>
                 New file
               </div>
               <div
                 onClick={() =>
                   this.handleNewFolderClicked(this.state.contextMenuFile!, this.state.contextMenuFullPath!)
-                }
-              >
+                }>
                 New folder
               </div>
               <div onClick={() => this.handleRenameClicked(this.state.contextMenuFullPath!)}>Rename</div>
               <div
-                onClick={() => this.handleDeleteClicked(this.state.contextMenuFullPath!, this.state.contextMenuFile!)}
-              >
+                onClick={() => this.handleDeleteClicked(this.state.contextMenuFullPath!, this.state.contextMenuFile!)}>
                 Delete
               </div>
             </div>
@@ -2206,8 +2195,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
                 <FilledButton
                   disabled={this.state.requestingReview || applicableInstallation?.permissions?.pullRequests == "read"}
                   className="code-request-review-button"
-                  onClick={this.handleReviewClicked.bind(this)}
-                >
+                  onClick={this.handleReviewClicked.bind(this)}>
                   {this.state.requestingReview ? (
                     <>
                       <Spinner className="icon white" /> Sending...

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -265,9 +265,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
   }
 
   ticketsForPosition(pos: monaco.Position): string[] {
-    const refs = this.getKytheRefsForRange(
-      new monaco.Range(pos.lineNumber, pos.column, pos.lineNumber, pos.column)
-    );
+    const refs = this.getKytheRefsForRange(new monaco.Range(pos.lineNumber, pos.column, pos.lineNumber, pos.column));
     if (!refs) {
       return [];
     }
@@ -275,9 +273,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
   }
 
   navigateToDefinitionOrPopulatePanel(pos: monaco.Position) {
-    const refs = this.getKytheRefsForRange(
-      new monaco.Range(pos.lineNumber, pos.column, pos.lineNumber, pos.column)
-    );
+    const refs = this.getKytheRefsForRange(new monaco.Range(pos.lineNumber, pos.column, pos.lineNumber, pos.column));
     if (!refs) {
       return;
     }
@@ -485,9 +481,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       return undefined;
     }
 
-    return decorInRange
-      .map((decor) => this.decorToReference(decor))
-      .filter((ref) => !!ref);
+    return decorInRange.map((decor) => this.decorToReference(decor)).filter((ref) => !!ref);
   }
 
   getKytheRefsForRange(range: monaco.Range): kythe.proto.DecorationsReply.Reference[] | undefined {
@@ -501,9 +495,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       return undefined;
     }
 
-    let refsInRange = decorInRange
-      .map((decor) => this.decorToReference(decor))
-      .filter((ref) => !!ref);
+    let refsInRange = decorInRange.map((decor) => this.decorToReference(decor)).filter((ref) => !!ref);
 
     let minMatches: kythe.proto.DecorationsReply.Reference[] = [];
     let minMatchLength = Number.POSITIVE_INFINITY;
@@ -525,7 +517,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       }
     }
 
-    return minMatches
+    return minMatches;
   }
 
   fetchInitialContent() {
@@ -1807,7 +1799,10 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
         return true;
       });
       uniqueLineRefs.sort((a, b) => {
-        return (a.anchor?.span?.start?.byteOffset || Number.POSITIVE_INFINITY) - (b.anchor?.span?.start?.byteOffset || Number.POSITIVE_INFINITY);
+        return (
+          (a.anchor?.span?.start?.byteOffset || Number.POSITIVE_INFINITY) -
+          (b.anchor?.span?.start?.byteOffset || Number.POSITIVE_INFINITY)
+        );
       });
 
       fileToRefsMap.set(key, uniqueLineRefs);


### PR DESCRIPTION
This PR has a few tangentially related changes (sorry for not breaking it up more):

- Sort test files after non-test files in references panel
- Fetch and display references for multiple matching decorations if the decorations share the same span
- When clicking on a usage/call, navigate immediately to the definition.
   - Fall back to displaying references if the definition isn't found (e.g. if you click on a method from an external lib). We could detect and do better with external references in the future...