### PR TITLE
Revert "Prevent `tools/bazel` from breaking flags-as-proto parsing"

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -564,11 +564,7 @@ func runBazelHelpWithCache() (string, error) {
 	buf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
 	log.Debugf("\x1b[90mGathering metadata for bazel %s...\x1b[m", topic)
-	opts := &bazelisk.RunOpts{
-		Stdout:      io.MultiWriter(tmp, buf),
-		Stderr:      errBuf,
-		SkipWrapper: true,
-	}
+	opts := &bazelisk.RunOpts{Stdout: io.MultiWriter(tmp, buf), Stderr: errBuf}
 	exitCode, err := bazelisk.Run([]string{
 		"--ignore_all_rc_files",
 		// Run in a temp output base to avoid messing with any running bazel

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -385,21 +385,6 @@ startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 	require.NotContains(t, string(b), "Running Bazel server needs to be killed")
 }
 
-func TestHelpWithBazelWrapper(t *testing.T) {
-	ws := testcli.NewWorkspace(t)
-	testfs.WriteAllFileContents(t, ws, map[string]string{
-		"BUILD": "",
-		"tools/bazel": `#!/usr/bin/env bash
-echo "A message from ./tools/bazel that tries to break bb's parsing logic!"
-"$BAZEL_REAL" "$@"
-`,
-	})
-	testfs.MakeExecutable(t, ws, "tools/bazel")
-	cmd := testcli.BazelCommand(t, ws, "build", "//...")
-	b, err := testcli.CombinedOutput(cmd)
-	require.NoErrorf(t, err, "output: %s", string(b))
-}
-
 func retryUntilSuccess(t *testing.T, f func() error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#9350