### PR TITLE
Don't store contents for encrypted groups in the lookaside cache

### DIFF
--- a/enterprise/server/backends/distributed/BUILD
+++ b/enterprise/server/backends/distributed/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/remote_cache/content_addressable_storage_server",
         "//server/remote_cache/digest",
         "//server/resources",
+        "//server/util/authutil",
         "//server/util/background",
         "//server/util/consistent_hash",
         "//server/util/flag",

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -373,9 +373,14 @@ func isTreeCacheResource(r *rspb.ResourceName) bool {
 // lookasideKey returns the resource's key in the lookaside cache and true,
 // or "" and false if the resource shouldn't be stored in the lookaside cache.
 func (c *Cache) lookasideKey(ctx context.Context, r *rspb.ResourceName) (key string, ok bool) {
+	// Don't store contents for encrypted users/groups in the lookaside cache
+	// to avoid cache inconsistencies between the group's cache and the
+	// lookaside cache.
+	// TODO(go/b/5175): treat non-default-partition contents this way too.
 	if authutil.EncryptionEnabled(ctx, c.authenticator) {
 		return "", false
 	}
+
 	if isTreeCacheResource(r) {
 		// These are OK to put in the lookaside cache because even
 		// though they are technically AC entries, they are based on CAS


### PR DESCRIPTION
Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5175