### PR TITLE
Add an "extended cross references" operation to the kythe service

### DIFF
--- a/codesearch/server/BUILD
+++ b/codesearch/server/BUILD
@@ -62,5 +62,7 @@ go_test(
         "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_kythe//kythe/go/serving/graph",
+        "@io_kythe//kythe/go/services/xrefs",
     ],
 )

--- a/codesearch/server/BUILD
+++ b/codesearch/server/BUILD
@@ -62,7 +62,9 @@ go_test(
         "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@io_kythe//kythe/go/serving/graph",
         "@io_kythe//kythe/go/services/xrefs",
+        "@io_kythe//kythe/go/serving/graph",
+        "@io_kythe//kythe/proto:graph_go_proto",
+        "@io_kythe//kythe/proto:xref_go_proto",
     ],
 )

--- a/codesearch/server/BUILD
+++ b/codesearch/server/BUILD
@@ -38,6 +38,8 @@ go_library(
         "@io_kythe//kythe/go/serving/xrefs",
         "@io_kythe//kythe/go/storage/keyvalue",
         "@io_kythe//kythe/go/storage/table",
+        "@io_kythe//kythe/proto:graph_go_proto",
+        "@io_kythe//kythe/proto:xref_go_proto",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -794,27 +794,3 @@ func (css *codesearchServer) IngestAnnotations(ctx context.Context, req *inpb.In
 func (css *codesearchServer) Close(ctx context.Context) {
 	css.kdb.Close(ctx)
 }
-
-/*
-total:{references:4  ref_edge_to_count:{key:"/kythe/edge/ref/call"  value:4}}  filtered:{}
-cross_references:{
-	key:"kythe://buildbuddy?lang=go?path=codesearch/types/types?root=bazel-out/bin#method%20IndexWriter.UpdateDocument"
-	value:{ticket:"kythe://buildbuddy?lang=go?path=codesearch/types/types?root=bazel-out/bin#method%20IndexWriter.UpdateDocument"
-		reference:{
-			anchor:{
-				ticket:"kythe://buildbuddy?lang=go?path=codesearch/github/github.go#%232897%3A2945"  kind:"/kythe/edge/ref/call"  parent:"kythe://buildbuddy?path=codesearch/github/github.go"
-				span:{start:{byte_offset:2897  line_number:94  column_offset:11}  end:{byte_offset:2945  line_number:94  column_offset:59}}}}
-		reference:{
-			anchor:{
-				ticket:"kythe://buildbuddy?lang=go?path=codesearch/github/github.go#%232897%3A2945"  kind:"/kythe/edge/ref/call"  parent:"kythe://buildbuddy?path=codesearch/github/github.go"
-				span:{start:{byte_offset:2897  line_number:94  column_offset:11}  end:{byte_offset:2945  line_number:94  column_offset:59}}}}
-		reference:{
-			anchor:{
-				ticket:"kythe://buildbuddy?lang=go?path=codesearch/github/github.go#%234300%3A4348"  kind:"/kythe/edge/ref/call"  parent:"kythe://buildbuddy?path=codesearch/github/github.go"
-				span:{start:{byte_offset:4300  line_number:124  column_offset:11}  end:{byte_offset:4348  line_number:124  column_offset:59}}}}
-		reference:{
-			anchor:{
-				ticket:"kythe://buildbuddy?lang=go?path=codesearch/github/github.go#%234300%3A4348"  kind:"/kythe/edge/ref/call"  parent:"kythe://buildbuddy?path=codesearch/github/github.go"
-				span:{start:{byte_offset:4300  line_number:124  column_offset:11}  end:{byte_offset:4348  line_number:124  column_offset:59}}}}}}
-
-*/

--- a/codesearch/server/server_test.go
+++ b/codesearch/server/server_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/github"
@@ -334,7 +333,6 @@ type TestTable struct {
 }
 
 func (tt *TestTable) Edges(ctx context.Context, edgeReq *gpb.EdgesRequest) (*gpb.EdgesReply, error) {
-	fmt.Printf("TestTable Edges called with: %v\n", edgeReq)
 	tt.requestedTickets = edgeReq.GetTicket()
 	return tt.response, nil
 }
@@ -347,7 +345,6 @@ type TestXrefService struct {
 }
 
 func (xs *TestXrefService) CrossReferences(ctx context.Context, req *xrefpb.CrossReferencesRequest) (*xrefpb.CrossReferencesReply, error) {
-	fmt.Printf("TestXrefService CrossReferences called with: %v\n", req)
 	xs.requestedTickets = req.GetTicket()
 	return xs.response, nil
 }

--- a/codesearch/server/server_test.go
+++ b/codesearch/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/github"
@@ -18,6 +19,10 @@ import (
 	gitpb "github.com/buildbuddy-io/buildbuddy/proto/git"
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/index"
 	spb "github.com/buildbuddy-io/buildbuddy/proto/search"
+	xsrv "kythe.io/kythe/go/services/xrefs"
+	gsrv "kythe.io/kythe/go/serving/graph"
+	gpb "kythe.io/kythe/proto/graph_go_proto"
+	xrefpb "kythe.io/kythe/proto/xref_go_proto"
 )
 
 func mustMakeServer(t *testing.T) *codesearchServer {
@@ -319,4 +324,402 @@ func TestDropNamespace(t *testing.T) {
 	assert.Equal(t, &inpb.RepoStatusResponse{
 		LastIndexedCommitSha: "",
 	}, response)
+}
+
+type TestTable struct {
+	gsrv.Table
+
+	response         *gpb.EdgesReply
+	requestedTickets []string
+}
+
+func (tt *TestTable) Edges(ctx context.Context, edgeReq *gpb.EdgesRequest) (*gpb.EdgesReply, error) {
+	fmt.Printf("TestTable Edges called with: %v\n", edgeReq)
+	tt.requestedTickets = edgeReq.GetTicket()
+	return tt.response, nil
+}
+
+type TestXrefService struct {
+	xsrv.Service
+
+	response         *xrefpb.CrossReferencesReply
+	requestedTickets []string
+}
+
+func (xs *TestXrefService) CrossReferences(ctx context.Context, req *xrefpb.CrossReferencesRequest) (*xrefpb.CrossReferencesReply, error) {
+	fmt.Printf("TestXrefService CrossReferences called with: %v\n", req)
+	xs.requestedTickets = req.GetTicket()
+	return xs.response, nil
+}
+
+func TestUsage_Override(t *testing.T) {
+	// In this test, A overrides B. If A overrides B, we should see:
+	// 1. A's definition in Definitions
+	// 2. B's definition in Overrides
+	// 3. References to both A and B in CallHierarchy
+
+	ctx := context.Background()
+
+	ticketA := "kythe://test?path=a"
+	ticketB := "kythe://test?path=b"
+
+	// These canned responses don't have all fields filled in, but should have everything needed
+	// directly by the function under test.
+
+	edgeResp := &gpb.EdgesReply{
+		EdgeSets: map[string]*gpb.EdgeSet{
+			ticketA: {
+				Groups: map[string]*gpb.EdgeSet_Group{
+					"/kythe/edge/overrides": {
+						Edge: []*gpb.EdgeSet_Group_Edge{
+							{TargetTicket: ticketB},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	xrefResp := &xrefpb.CrossReferencesReply{
+		CrossReferences: map[string]*xrefpb.CrossReferencesReply_CrossReferenceSet{
+			ticketA: {
+				Ticket: ticketA,
+				Definition: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "a defn"}},
+				},
+				Reference: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "a ref"}},
+				},
+			},
+			ticketB: {
+				Ticket: ticketB,
+				Definition: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "b defn"}},
+				},
+				Reference: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "b ref"}},
+				},
+			},
+		},
+	}
+
+	testTable := &TestTable{
+		response: edgeResp,
+	}
+	testXrefService := &TestXrefService{
+		response: xrefResp,
+	}
+	css := &codesearchServer{
+		gs: testTable,
+		xs: testXrefService,
+	}
+
+	rsp, err := css.KytheProxy(ctx, &spb.KytheRequest{
+		Value: &spb.KytheRequest_UsageRequest{
+			UsageRequest: &spb.UsageRequest{
+				Tickets: []string{ticketA},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, rsp)
+
+	assert.Equal(t, []string{ticketA}, testTable.requestedTickets)
+	assert.Equal(t, []string{ticketA, ticketB}, testXrefService.requestedTickets)
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "a defn"}},
+	}, rsp.GetUsageReply().GetDefinitions())
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "b defn"}},
+	}, rsp.GetUsageReply().GetOverrides())
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "a ref"}},
+		{Anchor: &xrefpb.Anchor{Text: "b ref"}},
+	}, rsp.GetUsageReply().GetCallHierarchy())
+
+	assert.Empty(t, rsp.GetUsageReply().GetOverriddenBy())
+	assert.Empty(t, rsp.GetUsageReply().GetExtends())
+	assert.Empty(t, rsp.GetUsageReply().GetExtendedBy())
+}
+
+func TestUsage_OverridenBy(t *testing.T) {
+	// In this test, A is overriden by B. If A is overridden by B, we should see:
+	// 1. A's definition in Definitions
+	// 2. B's definition in Overrides
+	// 3. References to both A and B in CallHierarchy
+
+	ctx := context.Background()
+
+	ticketA := "kythe://test?path=a"
+	ticketB := "kythe://test?path=b"
+
+	// These canned responses don't have all fields filled in, but should have everything needed
+	// directly by the function under test.
+
+	edgeResp := &gpb.EdgesReply{
+		EdgeSets: map[string]*gpb.EdgeSet{
+			ticketA: {
+				Groups: map[string]*gpb.EdgeSet_Group{
+					"%/kythe/edge/overrides": {
+						Edge: []*gpb.EdgeSet_Group_Edge{
+							{TargetTicket: ticketB},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	xrefResp := &xrefpb.CrossReferencesReply{
+		CrossReferences: map[string]*xrefpb.CrossReferencesReply_CrossReferenceSet{
+			ticketA: {
+				Ticket: ticketA,
+				Definition: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "a defn"}},
+				},
+				Reference: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "a ref"}},
+				},
+			},
+			ticketB: {
+				Ticket: ticketB,
+				Definition: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "b defn"}},
+				},
+				Reference: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "b ref"}},
+				},
+			},
+		},
+	}
+
+	testTable := &TestTable{
+		response: edgeResp,
+	}
+	testXrefService := &TestXrefService{
+		response: xrefResp,
+	}
+	css := &codesearchServer{
+		gs: testTable,
+		xs: testXrefService,
+	}
+
+	rsp, err := css.KytheProxy(ctx, &spb.KytheRequest{
+		Value: &spb.KytheRequest_UsageRequest{
+			UsageRequest: &spb.UsageRequest{
+				Tickets: []string{ticketA},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, rsp)
+
+	assert.Equal(t, []string{ticketA}, testTable.requestedTickets)
+	assert.Equal(t, []string{ticketA, ticketB}, testXrefService.requestedTickets)
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "a defn"}},
+	}, rsp.GetUsageReply().GetDefinitions())
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "b defn"}},
+	}, rsp.GetUsageReply().GetOverriddenBy())
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "a ref"}},
+		{Anchor: &xrefpb.Anchor{Text: "b ref"}},
+	}, rsp.GetUsageReply().GetCallHierarchy())
+
+	assert.Empty(t, rsp.GetUsageReply().GetOverrides())
+	assert.Empty(t, rsp.GetUsageReply().GetExtends())
+	assert.Empty(t, rsp.GetUsageReply().GetExtendedBy())
+}
+
+func TestUsage_Extends(t *testing.T) {
+	// In this test, A extends B. If A extends B, we should see:
+	// 1. A's definition in Definitions
+	// 2. B's definition in Extends
+	// 3. References to A and B in CallHierarchy
+
+	ctx := context.Background()
+
+	ticketA := "kythe://test?path=a"
+	ticketB := "kythe://test?path=b"
+
+	// These canned responses don't have all fields filled in, but should have everything needed
+	// directly by the function under test.
+
+	edgeResp := &gpb.EdgesReply{
+		EdgeSets: map[string]*gpb.EdgeSet{
+			ticketA: {
+				Groups: map[string]*gpb.EdgeSet_Group{
+					"/kythe/edge/satisfies": {
+						Edge: []*gpb.EdgeSet_Group_Edge{
+							{TargetTicket: ticketB},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	xrefResp := &xrefpb.CrossReferencesReply{
+		CrossReferences: map[string]*xrefpb.CrossReferencesReply_CrossReferenceSet{
+			ticketA: {
+				Ticket: ticketA,
+				Definition: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "a defn"}},
+				},
+				Reference: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "a ref"}},
+				},
+			},
+			ticketB: {
+				Ticket: ticketB,
+				Definition: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "b defn"}},
+				},
+				Reference: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "b ref"}},
+				},
+			},
+		},
+	}
+
+	testTable := &TestTable{
+		response: edgeResp,
+	}
+	testXrefService := &TestXrefService{
+		response: xrefResp,
+	}
+	css := &codesearchServer{
+		gs: testTable,
+		xs: testXrefService,
+	}
+
+	rsp, err := css.KytheProxy(ctx, &spb.KytheRequest{
+		Value: &spb.KytheRequest_UsageRequest{
+			UsageRequest: &spb.UsageRequest{
+				Tickets: []string{ticketA},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, rsp)
+
+	assert.Equal(t, []string{ticketA}, testTable.requestedTickets)
+	assert.Equal(t, []string{ticketA, ticketB}, testXrefService.requestedTickets)
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "a defn"}},
+	}, rsp.GetUsageReply().GetDefinitions())
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "b defn"}},
+	}, rsp.GetUsageReply().GetExtends())
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "a ref"}},
+		{Anchor: &xrefpb.Anchor{Text: "b ref"}},
+	}, rsp.GetUsageReply().GetCallHierarchy())
+
+	assert.Empty(t, rsp.GetUsageReply().GetOverrides())
+	assert.Empty(t, rsp.GetUsageReply().GetOverriddenBy())
+	assert.Empty(t, rsp.GetUsageReply().GetExtendedBy())
+}
+
+func TestUsage_ExtendedBy(t *testing.T) {
+	// In this test, A is extended by B. If A is extended by B, we should see:
+	// 1. A's definition in Definitions
+	// 2. B's definition in ExtendedBy
+	// 3. References to A and B in CallHierarchy
+
+	ctx := context.Background()
+
+	ticketA := "kythe://test?path=a"
+	ticketB := "kythe://test?path=b"
+
+	// These canned responses don't have all fields filled in, but should have everything needed
+	// directly by the function under test.
+
+	edgeResp := &gpb.EdgesReply{
+		EdgeSets: map[string]*gpb.EdgeSet{
+			ticketA: {
+				Groups: map[string]*gpb.EdgeSet_Group{
+					"%/kythe/edge/extends": {
+						Edge: []*gpb.EdgeSet_Group_Edge{
+							{TargetTicket: ticketB},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	xrefResp := &xrefpb.CrossReferencesReply{
+		CrossReferences: map[string]*xrefpb.CrossReferencesReply_CrossReferenceSet{
+			ticketA: {
+				Ticket: ticketA,
+				Definition: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "a defn"}},
+				},
+				Reference: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "a ref"}},
+				},
+			},
+			ticketB: {
+				Ticket: ticketB,
+				Definition: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "b defn"}},
+				},
+				Reference: []*xrefpb.CrossReferencesReply_RelatedAnchor{
+					{Anchor: &xrefpb.Anchor{Text: "b ref"}},
+				},
+			},
+		},
+	}
+
+	testTable := &TestTable{
+		response: edgeResp,
+	}
+	testXrefService := &TestXrefService{
+		response: xrefResp,
+	}
+	css := &codesearchServer{
+		gs: testTable,
+		xs: testXrefService,
+	}
+
+	rsp, err := css.KytheProxy(ctx, &spb.KytheRequest{
+		Value: &spb.KytheRequest_UsageRequest{
+			UsageRequest: &spb.UsageRequest{
+				Tickets: []string{ticketA},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, rsp)
+
+	assert.Equal(t, []string{ticketA}, testTable.requestedTickets)
+	assert.Equal(t, []string{ticketA, ticketB}, testXrefService.requestedTickets)
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "a defn"}},
+	}, rsp.GetUsageReply().GetDefinitions())
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "b defn"}},
+	}, rsp.GetUsageReply().GetExtendedBy())
+
+	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
+		{Anchor: &xrefpb.Anchor{Text: "a ref"}},
+		{Anchor: &xrefpb.Anchor{Text: "b ref"}},
+	}, rsp.GetUsageReply().GetCallHierarchy())
+
+	assert.Empty(t, rsp.GetUsageReply().GetOverrides())
+	assert.Empty(t, rsp.GetUsageReply().GetOverriddenBy())
+	assert.Empty(t, rsp.GetUsageReply().GetExtends())
 }

--- a/codesearch/server/server_test.go
+++ b/codesearch/server/server_test.go
@@ -356,7 +356,7 @@ func TestUsage_Override(t *testing.T) {
 	// In this test, A overrides B. If A overrides B, we should see:
 	// 1. A's definition in Definitions
 	// 2. B's definition in Overrides
-	// 3. References to both A and B in CallHierarchy
+	// 3. References to both A and B in References
 
 	ctx := context.Background()
 
@@ -415,8 +415,8 @@ func TestUsage_Override(t *testing.T) {
 	}
 
 	rsp, err := css.KytheProxy(ctx, &spb.KytheRequest{
-		Value: &spb.KytheRequest_UsageRequest{
-			UsageRequest: &spb.UsageRequest{
+		Value: &spb.KytheRequest_ExtendedXrefsRequest{
+			ExtendedXrefsRequest: &spb.ExtendedXrefsRequest{
 				Tickets: []string{ticketA},
 			},
 		},
@@ -429,27 +429,27 @@ func TestUsage_Override(t *testing.T) {
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "a defn"}},
-	}, rsp.GetUsageReply().GetDefinitions())
+	}, rsp.GetExtendedXrefsReply().GetDefinitions())
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "b defn"}},
-	}, rsp.GetUsageReply().GetOverrides())
+	}, rsp.GetExtendedXrefsReply().GetOverrides())
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "a ref"}},
 		{Anchor: &xrefpb.Anchor{Text: "b ref"}},
-	}, rsp.GetUsageReply().GetCallHierarchy())
+	}, rsp.GetExtendedXrefsReply().GetReferences())
 
-	assert.Empty(t, rsp.GetUsageReply().GetOverriddenBy())
-	assert.Empty(t, rsp.GetUsageReply().GetExtends())
-	assert.Empty(t, rsp.GetUsageReply().GetExtendedBy())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetOverriddenBy())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetExtends())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetExtendedBy())
 }
 
 func TestUsage_OverridenBy(t *testing.T) {
 	// In this test, A is overriden by B. If A is overridden by B, we should see:
 	// 1. A's definition in Definitions
 	// 2. B's definition in Overrides
-	// 3. References to both A and B in CallHierarchy
+	// 3. References to both A and B in References
 
 	ctx := context.Background()
 
@@ -508,8 +508,8 @@ func TestUsage_OverridenBy(t *testing.T) {
 	}
 
 	rsp, err := css.KytheProxy(ctx, &spb.KytheRequest{
-		Value: &spb.KytheRequest_UsageRequest{
-			UsageRequest: &spb.UsageRequest{
+		Value: &spb.KytheRequest_ExtendedXrefsRequest{
+			ExtendedXrefsRequest: &spb.ExtendedXrefsRequest{
 				Tickets: []string{ticketA},
 			},
 		},
@@ -522,27 +522,27 @@ func TestUsage_OverridenBy(t *testing.T) {
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "a defn"}},
-	}, rsp.GetUsageReply().GetDefinitions())
+	}, rsp.GetExtendedXrefsReply().GetDefinitions())
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "b defn"}},
-	}, rsp.GetUsageReply().GetOverriddenBy())
+	}, rsp.GetExtendedXrefsReply().GetOverriddenBy())
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "a ref"}},
 		{Anchor: &xrefpb.Anchor{Text: "b ref"}},
-	}, rsp.GetUsageReply().GetCallHierarchy())
+	}, rsp.GetExtendedXrefsReply().GetReferences())
 
-	assert.Empty(t, rsp.GetUsageReply().GetOverrides())
-	assert.Empty(t, rsp.GetUsageReply().GetExtends())
-	assert.Empty(t, rsp.GetUsageReply().GetExtendedBy())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetOverrides())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetExtends())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetExtendedBy())
 }
 
 func TestUsage_Extends(t *testing.T) {
 	// In this test, A extends B. If A extends B, we should see:
 	// 1. A's definition in Definitions
 	// 2. B's definition in Extends
-	// 3. References to A and B in CallHierarchy
+	// 3. References to A and B in References
 
 	ctx := context.Background()
 
@@ -601,8 +601,8 @@ func TestUsage_Extends(t *testing.T) {
 	}
 
 	rsp, err := css.KytheProxy(ctx, &spb.KytheRequest{
-		Value: &spb.KytheRequest_UsageRequest{
-			UsageRequest: &spb.UsageRequest{
+		Value: &spb.KytheRequest_ExtendedXrefsRequest{
+			ExtendedXrefsRequest: &spb.ExtendedXrefsRequest{
 				Tickets: []string{ticketA},
 			},
 		},
@@ -615,27 +615,27 @@ func TestUsage_Extends(t *testing.T) {
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "a defn"}},
-	}, rsp.GetUsageReply().GetDefinitions())
+	}, rsp.GetExtendedXrefsReply().GetDefinitions())
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "b defn"}},
-	}, rsp.GetUsageReply().GetExtends())
+	}, rsp.GetExtendedXrefsReply().GetExtends())
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "a ref"}},
 		{Anchor: &xrefpb.Anchor{Text: "b ref"}},
-	}, rsp.GetUsageReply().GetCallHierarchy())
+	}, rsp.GetExtendedXrefsReply().GetReferences())
 
-	assert.Empty(t, rsp.GetUsageReply().GetOverrides())
-	assert.Empty(t, rsp.GetUsageReply().GetOverriddenBy())
-	assert.Empty(t, rsp.GetUsageReply().GetExtendedBy())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetOverrides())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetOverriddenBy())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetExtendedBy())
 }
 
 func TestUsage_ExtendedBy(t *testing.T) {
 	// In this test, A is extended by B. If A is extended by B, we should see:
 	// 1. A's definition in Definitions
 	// 2. B's definition in ExtendedBy
-	// 3. References to A and B in CallHierarchy
+	// 3. References to A and B in References
 
 	ctx := context.Background()
 
@@ -694,8 +694,8 @@ func TestUsage_ExtendedBy(t *testing.T) {
 	}
 
 	rsp, err := css.KytheProxy(ctx, &spb.KytheRequest{
-		Value: &spb.KytheRequest_UsageRequest{
-			UsageRequest: &spb.UsageRequest{
+		Value: &spb.KytheRequest_ExtendedXrefsRequest{
+			ExtendedXrefsRequest: &spb.ExtendedXrefsRequest{
 				Tickets: []string{ticketA},
 			},
 		},
@@ -708,18 +708,18 @@ func TestUsage_ExtendedBy(t *testing.T) {
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "a defn"}},
-	}, rsp.GetUsageReply().GetDefinitions())
+	}, rsp.GetExtendedXrefsReply().GetDefinitions())
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "b defn"}},
-	}, rsp.GetUsageReply().GetExtendedBy())
+	}, rsp.GetExtendedXrefsReply().GetExtendedBy())
 
 	assert.ElementsMatch(t, []*xrefpb.CrossReferencesReply_RelatedAnchor{
 		{Anchor: &xrefpb.Anchor{Text: "a ref"}},
 		{Anchor: &xrefpb.Anchor{Text: "b ref"}},
-	}, rsp.GetUsageReply().GetCallHierarchy())
+	}, rsp.GetExtendedXrefsReply().GetReferences())
 
-	assert.Empty(t, rsp.GetUsageReply().GetOverrides())
-	assert.Empty(t, rsp.GetUsageReply().GetOverriddenBy())
-	assert.Empty(t, rsp.GetUsageReply().GetExtends())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetOverrides())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetOverriddenBy())
+	assert.Empty(t, rsp.GetExtendedXrefsReply().GetExtends())
 }

--- a/proto/search.proto
+++ b/proto/search.proto
@@ -99,6 +99,19 @@ message SearchResponse {
   PerformanceMetrics performance_metrics = 4;
 }
 
+message UsageRequest {
+  repeated string tickets = 1;
+}
+
+message UsageReply {
+  repeated kythe.proto.CrossReferencesReply.RelatedAnchor definitions = 1;
+  repeated kythe.proto.CrossReferencesReply.RelatedAnchor overrides = 2;
+  repeated kythe.proto.CrossReferencesReply.RelatedAnchor overridden_by = 3;
+  repeated kythe.proto.CrossReferencesReply.RelatedAnchor extends = 4;
+  repeated kythe.proto.CrossReferencesReply.RelatedAnchor extended_by = 5;
+  repeated kythe.proto.CrossReferencesReply.RelatedAnchor call_hierarchy = 6;
+}
+
 message KytheRequest {
   context.RequestContext request_context = 1;
 
@@ -108,6 +121,7 @@ message KytheRequest {
     kythe.proto.CrossReferencesRequest cross_references_request = 4;
     kythe.proto.CorpusRootsRequest corpus_roots_request = 5;
     kythe.proto.DirectoryRequest directory_request = 6;
+    UsageRequest usage_request = 7;
   }
 }
 
@@ -120,5 +134,6 @@ message KytheResponse {
     kythe.proto.CrossReferencesReply cross_references_reply = 4;
     kythe.proto.CorpusRootsReply corpus_roots_reply = 5;
     kythe.proto.DirectoryReply directory_reply = 6;
+    UsageReply usage_reply = 7;
   }
 }

--- a/proto/search.proto
+++ b/proto/search.proto
@@ -99,16 +99,38 @@ message SearchResponse {
   PerformanceMetrics performance_metrics = 4;
 }
 
+// "Extended" xrefs are cross-references that are needed by the code browser UI, but that are not
+// available via a single kythe CrossReferences request. The returned data requires navigating
+// the annotation graph to find additional nodes and fetch their cross-references.
+// This request/reply are intended to provide the data needed to populate the "References" panel
+// in the UI.
 message ExtendedXrefsRequest {
   repeated string tickets = 1;
 }
 
+// See https://kythe.io/docs/schema/ for Kythe schema details.
 message ExtendedXrefsReply {
+  // Definitions of the requested ticket
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor definitions = 1;
+
+  // Overrides of the requested ticket.
+  // See /kythe/edge/overrides[/transitive]
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor overrides = 2;
+
+  // Places where the requested ticket is overridden. The inverse of `overrides`.
+  // See /kythe/edge/overrides[/transitive]
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor overridden_by = 3;
+
+  // References to entities which the requested ticket extends.
+  // See /kythe/edge/extends and /kythe/edge/satisfies.
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor extends = 4;
+
+  // References to entities which extend the requested ticket. The inverse of `extends`.
+  // See /kythe/edge/extends and /kythe/edge/satisfies.
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor extended_by = 5;
+
+  // Extended references to the requested ticket. This will include references to super/sub-classes
+  // and overridden/overriding methods.
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor references = 6;
 }
 

--- a/proto/search.proto
+++ b/proto/search.proto
@@ -103,6 +103,7 @@ message UsageRequest {
   repeated string tickets = 1;
 }
 
+// TODO(jdelfino): Ugh, rename this to something better
 message UsageReply {
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor definitions = 1;
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor overrides = 2;

--- a/proto/search.proto
+++ b/proto/search.proto
@@ -99,11 +99,11 @@ message SearchResponse {
   PerformanceMetrics performance_metrics = 4;
 }
 
-// "Extended" xrefs are cross-references that are needed by the code browser UI, but that are not
-// available via a single kythe CrossReferences request. The returned data requires navigating
-// the annotation graph to find additional nodes and fetch their cross-references.
-// This request/reply are intended to provide the data needed to populate the "References" panel
-// in the UI.
+// "Extended" xrefs are cross-references that are needed by the code browser UI,
+// but that are not available via a single kythe CrossReferences request. The
+// returned data requires navigating the annotation graph to find additional
+// nodes and fetch their cross-references. This request/reply are intended to
+// provide the data needed to populate the "References" panel in the UI.
 message ExtendedXrefsRequest {
   repeated string tickets = 1;
 }
@@ -117,20 +117,20 @@ message ExtendedXrefsReply {
   // See /kythe/edge/overrides[/transitive]
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor overrides = 2;
 
-  // Places where the requested ticket is overridden. The inverse of `overrides`.
-  // See /kythe/edge/overrides[/transitive]
+  // Places where the requested ticket is overridden. The inverse of
+  // `overrides`. See /kythe/edge/overrides[/transitive]
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor overridden_by = 3;
 
   // References to entities which the requested ticket extends.
   // See /kythe/edge/extends and /kythe/edge/satisfies.
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor extends = 4;
 
-  // References to entities which extend the requested ticket. The inverse of `extends`.
-  // See /kythe/edge/extends and /kythe/edge/satisfies.
+  // References to entities which extend the requested ticket. The inverse of
+  // `extends`. See /kythe/edge/extends and /kythe/edge/satisfies.
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor extended_by = 5;
 
-  // Extended references to the requested ticket. This will include references to super/sub-classes
-  // and overridden/overriding methods.
+  // Extended references to the requested ticket. This will include references
+  // to super/sub-classes and overridden/overriding methods.
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor references = 6;
 }
 

--- a/proto/search.proto
+++ b/proto/search.proto
@@ -99,18 +99,17 @@ message SearchResponse {
   PerformanceMetrics performance_metrics = 4;
 }
 
-message UsageRequest {
+message ExtendedXrefsRequest {
   repeated string tickets = 1;
 }
 
-// TODO(jdelfino): Ugh, rename this to something better
-message UsageReply {
+message ExtendedXrefsReply {
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor definitions = 1;
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor overrides = 2;
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor overridden_by = 3;
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor extends = 4;
   repeated kythe.proto.CrossReferencesReply.RelatedAnchor extended_by = 5;
-  repeated kythe.proto.CrossReferencesReply.RelatedAnchor call_hierarchy = 6;
+  repeated kythe.proto.CrossReferencesReply.RelatedAnchor references = 6;
 }
 
 message KytheRequest {
@@ -122,7 +121,7 @@ message KytheRequest {
     kythe.proto.CrossReferencesRequest cross_references_request = 4;
     kythe.proto.CorpusRootsRequest corpus_roots_request = 5;
     kythe.proto.DirectoryRequest directory_request = 6;
-    UsageRequest usage_request = 7;
+    ExtendedXrefsRequest extended_xrefs_request = 7;
   }
 }
 
@@ -135,6 +134,6 @@ message KytheResponse {
     kythe.proto.CrossReferencesReply cross_references_reply = 4;
     kythe.proto.CorpusRootsReply corpus_roots_reply = 5;
     kythe.proto.DirectoryReply directory_reply = 6;
-    UsageReply usage_reply = 7;
+    ExtendedXrefsReply extended_xrefs_reply = 7;
   }
 }


### PR DESCRIPTION
This operation will populate data about overrides, inheritance, and (in the future) generated code. This will be used by the UI to display more complete reference for symbols.