### PR TITLE
Code browser: fetch kythe decorations once when loading files, rather than repeatedly

### DIFF
--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -63,6 +63,7 @@ interface State {
 
   fullPathToNodeMap: Map<string, workspace.Node>;
   fullPathToModelMap: Map<string, monaco.editor.ITextModel>;
+  fullPathToDecorationsMap: Map<string, string[]>;
   fullPathToDiffModelMap: Map<string, monaco.editor.IDiffEditorModel>;
 
   originalFileContents: Map<string, string>;
@@ -116,6 +117,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
     fullPathToChildrenMap: new Map<string, Array<workspace.Node>>(),
     fullPathToNodeMap: new Map<string, workspace.Node>(),
     fullPathToModelMap: new Map<string, monaco.editor.ITextModel>(),
+    fullPathToDecorationsMap: new Map<string, string[]>(),
     fullPathToDiffModelMap: new Map<string, monaco.editor.IDiffEditorModel>(),
     originalFileContents: new Map<string, string>(),
     tabs: new Map<string, string>(),
@@ -146,7 +148,6 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
   diffEditor: monaco.editor.IDiffEditor | undefined;
 
   // Note that these decoration collections are automatically cleared when the model is changed.
-  kytheDecorations: monaco.editor.IEditorDecorationsCollection | undefined;
   searchDecorations: monaco.editor.IEditorDecorationsCollection | undefined;
   lcovDecorations: monaco.editor.IEditorDecorationsCollection | undefined;
 
@@ -365,7 +366,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
           };
         })
         .filter((x) => x !== null) || [];
-    this.kytheDecorations?.set(newDecor);
+    return newDecor;
   }
 
   getChange(path: string) {
@@ -532,7 +533,6 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       readOnly: this.isSingleFile() || Boolean(this.getQuery()),
     });
     this.searchDecorations = this.editor.createDecorationsCollection();
-    this.kytheDecorations = this.editor.createDecorationsCollection();
     this.lcovDecorations = this.editor.createDecorationsCollection();
 
     this.editor.onMouseDown((e) => {
@@ -623,7 +623,6 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
     this.editor.onDidChangeModelContent(() => {
       this.handleContentChanged();
       this.highlightQuery();
-      this.fetchDecorations(this.currentPath());
     });
   }
 
@@ -659,7 +658,6 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       this.editor?.revealLinesInCenter(focusedLineNumber, focusedLineNumber);
       this.editor?.focus();
       this.highlightQuery();
-      this.fetchDecorations(this.currentPath());
     });
   }
 
@@ -1084,6 +1082,16 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       model = monaco.editor.createModel(fileContents, getLangHintFromFilePath(fullPath), monaco.Uri.file(fullPath));
       this.state.fullPathToModelMap.set(fullPath, model);
       this.state.fullPathToNodeMap.set(fullPath, node);
+
+      this.fetchDecorations(fullPath).then((newDecs) => {
+        if (!newDecs) {
+          return;
+        }
+        let oldDecs = this.state.fullPathToDecorationsMap.get(fullPath) || [];
+        let newDecIds = model!.deltaDecorations(oldDecs, newDecs);
+        this.state.fullPathToDecorationsMap.set(fullPath, newDecIds);
+      });
+
       this.updateState({ fullPathToModelMap: this.state.fullPathToModelMap });
     }
     return model;

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -390,7 +390,6 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
 
     return this.getModel(path).then((model) => {
       this.setModel(path, model);
-      this.focusLineNumberAndHighlightQuery();
       return true;
     });
   }


### PR DESCRIPTION
Previously, we fetched kythe decorations very often. We really only need to fetch them once when originally loading the file. The kythe decorations are stored on the model itself again, rather than on the ephemeral editor decoration collection.