### PR TITLE
Enforce IP rules against parent group ACLs.

### DIFF
--- a/enterprise/server/auditlog/auditlog.go
+++ b/enterprise/server/auditlog/auditlog.go
@@ -132,12 +132,12 @@ func (l *Logger) insertLog(ctx context.Context, resource *alpb.ResourceID, actio
 		entry.AuthUserEmail = ui.Email
 	}
 
-	if u.GetAPIKeyID() != "" {
-		ak, err := l.env.GetAuthDB().GetAPIKey(ctx, u.GetAPIKeyID())
+	if id := u.GetAPIKeyInfo().ID; id != "" {
+		ak, err := l.env.GetAuthDB().GetAPIKey(ctx, id)
 		if err != nil {
 			return status.WrapError(err, "could not lookup API key")
 		}
-		entry.AuthAPIKeyID = u.GetAPIKeyID()
+		entry.AuthAPIKeyID = id
 		entry.AuthAPIKeyLabel = ak.Label
 	}
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -91,12 +91,18 @@ type GroupMembership struct {
 	Role role.Role `json:"role"`
 }
 
+type APIKeyInfo struct {
+	ID           string
+	OwnerGroupID string
+}
+
 type UserInfo interface {
 	jwt.Claims
 
-	// ID of the API Key used to authenticate the request or empty if an API
-	// key was not used.
-	GetAPIKeyID() string
+	// GetAPIKeyInfo returns the metadata for the API key used for
+	// authentication. An empty struct will be returned if an API key
+	// was not used.
+	GetAPIKeyInfo() APIKeyInfo
 	// ID of the authenticated user. Empty if authenticated using an Org API
 	// key.
 	GetUserID() string

--- a/server/util/claims/claims_test.go
+++ b/server/util/claims/claims_test.go
@@ -129,6 +129,7 @@ func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {
 	c, err = claims.APIKeyGroupClaims(rctx, akg)
 	require.NoError(t, err)
 	require.Equal(t, baseGroupID, c.GetGroupID())
+	require.Equal(t, baseGroupID, c.GetAPIKeyInfo().OwnerGroupID)
 	require.Equal(t, []string{baseGroupID}, c.GetAllowedGroups())
 	require.Equal(t, []*interfaces.GroupMembership{expectedBaseMembership}, c.GetGroupMemberships())
 
@@ -155,6 +156,7 @@ func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {
 		Role:         role.Default,
 	}
 	require.Equal(t, baseGroupID, c.GetGroupID())
+	require.Equal(t, baseGroupID, c.GetAPIKeyInfo().OwnerGroupID)
 	require.Equal(t, []string{baseGroupID, childGroupID}, c.GetAllowedGroups())
 	require.Equal(t, []*interfaces.GroupMembership{expectedBaseMembership, expectedChildMembership}, c.GetGroupMemberships())
 
@@ -163,6 +165,7 @@ func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {
 	c, err = claims.APIKeyGroupClaims(rctx, akg)
 	require.NoError(t, err)
 	require.Equal(t, childGroupID, c.GetGroupID())
+	require.Equal(t, baseGroupID, c.GetAPIKeyInfo().OwnerGroupID) // onwer group should still be parent
 	require.Equal(t, []string{baseGroupID, childGroupID}, c.GetAllowedGroups())
 	require.Equal(t, []*interfaces.GroupMembership{expectedBaseMembership, expectedChildMembership}, c.GetGroupMemberships())
 


### PR DESCRIPTION
This only affects to users that have parent/child groups.

Prior to this change, enforcement was done using the ACL list of the target child group rather than of the group that owns the API key.