### PR TITLE
cli/explain: Use default API target as fallback

### DIFF
--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -207,6 +207,8 @@ func openLog(pathOrId string) (io.ReadCloser, error) {
 		backend, err = flaghistory.GetLastBackend()
 		if err != nil {
 			log.Debugf("Failed to get last backend: %v", err)
+		}
+		if backend == "" {
 			backend = login.DefaultApiTarget
 		}
 	}

--- a/cli/flaghistory/flaghistory.go
+++ b/cli/flaghistory/flaghistory.go
@@ -55,7 +55,6 @@ func GetNthPreviousFlag(flag string, n int) (string, error) {
 func GetLastBackend() (string, error) {
 	lastBackend, err := GetPreviousFlag(besBackendFlagName)
 	if lastBackend == "" || err != nil {
-		log.Printf("The previous invocation didn't have the --bes_backend= set.")
 		return "", err
 	}
 


### PR DESCRIPTION
Previously, the command tried to connect to `grpcs://` if it couldn't retrieve the BES backend from the last Bazel command.

Also drop the log message mentioning `--bes_backend`, which is a Bazel flag, not a bb flag, and is thus more confusing than helpful.