### PR TITLE
Allow testauth.AuthenticatedUser to use the cached claims 

### DIFF
--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -147,10 +147,15 @@ func (a *TestAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.U
 	if err, ok := authutil.AuthErrorFromContext(ctx); ok {
 		return nil, err
 	}
-	if jwt, ok := ctx.Value(authutil.ContextTokenStringKey).(string); ok {
-		return claims.ParseClaims(jwt)
-	}
-	return nil, authutil.AnonymousUserError("User not found")
+	return claims.ClaimsFromContext(ctx)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// return c, nil
+	// if jwt, ok := ctx.Value(authutil.ContextTokenStringKey).(string); ok {
+	// 	return claims.ParseClaims(jwt)
+	// }
+	// return nil, authutil.AnonymousUserError("User not found")
 }
 
 func (a *TestAuthenticator) FillUser(ctx context.Context, user *tables.User) error {

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -148,14 +148,6 @@ func (a *TestAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.U
 		return nil, err
 	}
 	return claims.ClaimsFromContext(ctx)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// return c, nil
-	// if jwt, ok := ctx.Value(authutil.ContextTokenStringKey).(string); ok {
-	// 	return claims.ParseClaims(jwt)
-	// }
-	// return nil, authutil.AnonymousUserError("User not found")
 }
 
 func (a *TestAuthenticator) FillUser(ctx context.Context, user *tables.User) error {


### PR DESCRIPTION
This prevents the jwt from getting parsed over and over, which makes benchmarks non-representative.