### PR TITLE
Fix preserve-workspace on case-insensitive filesystems

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -280,7 +280,9 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, layout *container.FileS
 		return &dirtools.TransferInfo{}, nil
 	}
 
-	opts := &dirtools.DownloadTreeOpts{}
+	opts := &dirtools.DownloadTreeOpts{
+		CaseInsensitive: ws.Opts.CaseInsensitive,
+	}
 	if ws.Opts.Preserve {
 		opts.Skip = ws.Inputs
 		opts.TrackTransfers = true


### PR DESCRIPTION
Propagate the `CaseInsensitive` option to the `DownloadTree` utility.

This ensures that the workspace preservation logic correctly handles file paths
on filesystems that do not distinguish between upper and lower case, preventing
potential issues with path resolution and input preservation.
