### PR TITLE
Add java and cpp indexing to kythe workflow

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -256,7 +256,7 @@ find -L ../bazel-out/*/extra_actions -name "*.cxx.kzip" \
 	--experimental_dynamic_claim_cache="--SERVER=localhost:11211" \
 	-cache="--SERVER=localhost:11211" \
 	-cache_stats \
-  | $KYTHE_DIR/tools/dedup_stream >> kythe_entries_all
+  | $KYTHE_DIR/tools/dedup_stream >> kythe_entries
 kill $memcached_pid
 
 "$KYTHE_DIR"/tools/write_tables --entries kythe_entries --out leveldb:kythe_tables


### PR DESCRIPTION
- Add Java indexing to kythe workflow - this is straightforward (assuming jre is installed on the workflow machines)
- Add cpp indexing to kythe workflow - this requires a local memcached instance
- Modify go and proto indexers to use `parallel` and the kythe `dedup_stream` utility, to match java/cpp.`parallel` use speeds up indexing a bit for java/go/proto, but is basically required for cpp indexing to complete in a reasonable amount of time.