### PR TITLE
Fix text cutoff at the bottom of the "References" panel in the code browser

### DIFF
--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -37,7 +37,7 @@
 
 .xrefs-container {
   overflow-y: auto;
-  height: 100%;
+  height: 85%;
 }
 
 .xrefs-file {


### PR DESCRIPTION
Before (scrolled all the way down):
<img width="841" alt="Screenshot 2025-06-23 at 1 26 56 PM" src="https://github.com/user-attachments/assets/75506bbc-52c1-4a6c-b514-5f679ac9e875" />

After (also scrolled all the way down):
<img width="843" alt="Screenshot 2025-06-23 at 1 27 04 PM" src="https://github.com/user-attachments/assets/55dda9c5-7cef-48d8-a8f2-83d581941195" />
