### PR TITLE
[raft] fix transaction

### DIFF
--- a/enterprise/server/raft/bringup/BUILD
+++ b/enterprise/server/raft/bringup/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//enterprise/server/filestore",
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/header",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",

--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -396,9 +396,7 @@ func StartShard(ctx context.Context, store IStore, bootstrapInfo *ClusterBootstr
 		RangeId:  bootstrapInfo.rangeID,
 		Replicas: bootstrapInfo.Replicas,
 	}
-	syncRsp, err := store.Sender().SyncProposeWithRangeDescriptor(ctx, rd, batchProto, func(rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor) *rfpb.Header {
-		return header.NewWithoutRangeInfo(replica, rfpb.Header_LINEARIZABLE)
-	})
+	syncRsp, err := store.Sender().SyncProposeWithRangeDescriptor(ctx, rd, batchProto, header.MakeLinearizableWithoutRangeValidation)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/header"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
@@ -395,7 +396,9 @@ func StartShard(ctx context.Context, store IStore, bootstrapInfo *ClusterBootstr
 		RangeId:  bootstrapInfo.rangeID,
 		Replicas: bootstrapInfo.Replicas,
 	}
-	syncRsp, err := store.Sender().SyncProposeWithRangeDescriptor(ctx, rd, batchProto)
+	syncRsp, err := store.Sender().SyncProposeWithRangeDescriptor(ctx, rd, batchProto, func(rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor) *rfpb.Header {
+		return header.NewWithoutRangeInfo(replica, rfpb.Header_LINEARIZABLE)
+	})
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/raft/header/header.go
+++ b/enterprise/server/raft/header/header.go
@@ -4,6 +4,16 @@ import (
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 )
 
+type MakeFunc func(rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor) *rfpb.Header
+
+func MakeLinearizableWithRangeValidation(rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor) *rfpb.Header {
+	return New(rd, replica, rfpb.Header_LINEARIZABLE)
+}
+
+func MakeLinearizableWithoutRangeValidation(rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor) *rfpb.Header {
+	return NewWithoutRangeInfo(replica, rfpb.Header_LINEARIZABLE)
+}
+
 func New(rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor, mode rfpb.Header_ConsistencyMode) *rfpb.Header {
 	return &rfpb.Header{
 		Replica:         replica,

--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -363,9 +363,10 @@ func NewTxn() *TxnBuilder {
 }
 
 type TxnStatementBuilder struct {
-	rangeDescriptor *rfpb.RangeDescriptor
-	rawBatch        *BatchBuilder
-	hooks           []*rfpb.TransactionHook
+	rangeDescriptor         *rfpb.RangeDescriptor
+	rawBatch                *BatchBuilder
+	hooks                   []*rfpb.TransactionHook
+	rangeValidationRequired bool
 }
 
 func (sb *TxnStatementBuilder) SetRangeDescriptor(rd *rfpb.RangeDescriptor) *TxnStatementBuilder {
@@ -375,6 +376,11 @@ func (sb *TxnStatementBuilder) SetRangeDescriptor(rd *rfpb.RangeDescriptor) *Txn
 
 func (sb *TxnStatementBuilder) SetBatch(batch *BatchBuilder) *TxnStatementBuilder {
 	sb.rawBatch = batch
+	return sb
+}
+
+func (sb *TxnStatementBuilder) SetRangeValidationRequired(required bool) *TxnStatementBuilder {
+	sb.rangeValidationRequired = required
 	return sb
 }
 
@@ -420,9 +426,10 @@ func (tb *TxnBuilder) ToProto() (*rfpb.TxnRequest, error) {
 			return nil, err
 		}
 		req.Statements = append(req.Statements, &rfpb.TxnRequest_Statement{
-			Range:    statement.rangeDescriptor,
-			RawBatch: batchProto,
-			Hooks:    statement.hooks,
+			Range:                   statement.rangeDescriptor,
+			RawBatch:                batchProto,
+			Hooks:                   statement.hooks,
+			RangeValidationRequired: statement.rangeValidationRequired,
 		})
 	}
 	return req, nil

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -263,7 +263,6 @@ func (s *Sender) UpdateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
 }
 
 type runFunc func(ctx context.Context, c rfspb.ApiClient, h *rfpb.Header) error
-type makeHeaderFunc func(rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor) *rfpb.Header
 
 func (s *Sender) tryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn runFunc, mode rfpb.Header_ConsistencyMode) (int, error) {
 	return s.TryReplicas(ctx, rd, fn, func(rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor) *rfpb.Header {
@@ -272,7 +271,7 @@ func (s *Sender) tryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 }
 
 // tryReplica tries the fn on the replica and returns whether to try a different replica
-func (s *Sender) tryReplica(ctx context.Context, rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor, fn runFunc, makeHeaderFn makeHeaderFunc) (bool, error) {
+func (s *Sender) tryReplica(ctx context.Context, rd *rfpb.RangeDescriptor, replica *rfpb.ReplicaDescriptor, fn runFunc, makeHeaderFn header.MakeFunc) (bool, error) {
 	select {
 	case <-ctx.Done():
 		return false, ctx.Err()
@@ -318,7 +317,7 @@ func (s *Sender) tryReplica(ctx context.Context, rd *rfpb.RangeDescriptor, repli
 	return false, err
 }
 
-func (s *Sender) TryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn runFunc, makeHeaderFn makeHeaderFunc) (replicaIdx int, returnedErr error) {
+func (s *Sender) TryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn runFunc, makeHeaderFn header.MakeFunc) (replicaIdx int, returnedErr error) {
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
 	attr := attribute.Int64("range_id", int64(rd.GetRangeId()))
 	spn.SetAttributes(attr)
@@ -561,7 +560,7 @@ func (s *Sender) SyncPropose(ctx context.Context, key []byte, batchCmd *rfpb.Bat
 
 // SyncProposeWithRangeDescriptor calls SyncPropose on different replicas
 // specified in the given range descriptor, until one of the replica succeeds.
-func (s *Sender) SyncProposeWithRangeDescriptor(ctx context.Context, rd *rfpb.RangeDescriptor, batchCmd *rfpb.BatchCmdRequest, makeHeaderFn makeHeaderFunc) (*rfpb.SyncProposeResponse, error) {
+func (s *Sender) SyncProposeWithRangeDescriptor(ctx context.Context, rd *rfpb.RangeDescriptor, batchCmd *rfpb.BatchCmdRequest, makeHeaderFn header.MakeFunc) (*rfpb.SyncProposeResponse, error) {
 	log.Infof("SyncProposeWithRD: %+v", rd)
 	var syncRsp *rfpb.SyncProposeResponse
 	runFn := func(ctx context.Context, c rfspb.ApiClient, h *rfpb.Header) error {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1370,6 +1370,7 @@ func (s *Store) SyncPropose(ctx context.Context, req *rfpb.SyncProposeRequest) (
 	session := s.session
 	if len(req.GetBatch().GetTransactionId()) > 0 {
 		session = s.txnSession
+		s.log.Infof("SyncPropose txn, finalize operation: ", req.GetBatch().GetFinalizeOperation())
 	} else {
 		// use eviction session for delete requests
 		unions := req.GetBatch().GetUnion()
@@ -3070,7 +3071,7 @@ func (s *Store) UpdateRangeDescriptor(ctx context.Context, rangeID uint64, old, 
 		metaRangeBatch.Add(metaRangeCasReq)
 
 		stmt := txn.AddStatement()
-		stmt.SetRangeDescriptor(new).SetBatch(localBatch)
+		stmt.SetRangeDescriptor(old).SetBatch(localBatch)
 
 		stmt = txn.AddStatement()
 		stmt.SetRangeDescriptor(mrd).SetBatch(metaRangeBatch)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2469,13 +2469,23 @@ func (s *Store) SplitRange(ctx context.Context, req *rfpb.SplitRangeRequest) (*r
 		RangeId:       newRangeID,
 		InitialMember: initialMembers,
 	})
+	// Range Validation is required on the existing range to make sure that the
+	// existing leader/range lease holder has the update-to-date range descriptor.
+	// This is achieved by running the leftStmt sync propose on the machine with
+	// the range lease holder.
+	leftStmt.SetRangeValidationRequired(true)
 
 	rightStmt := tb.AddStatement()
 	rightStmt.SetRangeDescriptor(newRightRange).SetBatch(rightBatch)
 	rightStmt.AddPostCommitHook(rfpb.TransactionHook_COMMIT, &rfpb.SnapshotClusterHook{})
+	// The range descriptor is a new one instead of existing one. Do not validate range on SyncPropose
+	rightStmt.SetRangeValidationRequired(false)
 
 	metaStmt := tb.AddStatement()
 	metaStmt.SetRangeDescriptor(mrd).SetBatch(metaBatch)
+	// The range descriptor is from range cache and can be not-up-to date; but since the
+	// meta range descriptor itself is not changed, we don't need range validation.
+	metaStmt.SetRangeValidationRequired(false)
 	if err := s.txnCoordinator.RunTxn(ctx, tb); err != nil {
 		return nil, err
 	}
@@ -3066,15 +3076,30 @@ func (s *Store) UpdateRangeDescriptor(ctx context.Context, rangeID uint64, old, 
 		localBatch.Add(metaRangeCasReq)
 		stmt := txn.AddStatement()
 		stmt.SetRangeDescriptor(mrd).SetBatch(localBatch)
+		// Range Validation is required on the existing range to make sure that the
+		// existing leader/range lease holder has the update-to-date range descriptor.
+		// This is achieved by running the stmt sync propose on the machine with
+		// the range lease holder. In this case, meta range itself is being
+		// modified.
+		stmt.SetRangeValidationRequired(true)
 	} else {
 		metaRangeBatch := rbuilder.NewBatchBuilder()
 		metaRangeBatch.Add(metaRangeCasReq)
 
 		stmt := txn.AddStatement()
 		stmt.SetRangeDescriptor(old).SetBatch(localBatch)
+		// Range Validation is required on the existing range to make sure that the
+		// existing leader/range lease holder has the update-to-date range descriptor.
+		// This is achieved by running the stmt sync propose on the machine with
+		// the range lease holder.
+		stmt.SetRangeValidationRequired(true)
 
 		stmt = txn.AddStatement()
 		stmt.SetRangeDescriptor(mrd).SetBatch(metaRangeBatch)
+		// Since meta range descriptor is not changed, we don't need range
+		// validation. Also, mrd can be out of date since we get it from range
+		// cache.
+		stmt.SetRangeValidationRequired(false)
 	}
 	err = s.txnCoordinator.RunTxn(ctx, txn)
 	if err != nil {

--- a/enterprise/server/raft/txn/BUILD
+++ b/enterprise/server/raft/txn/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/header",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -190,6 +190,11 @@ message TxnRequest {
     BatchCmdRequest raw_batch = 2;
     RangeDescriptor range = 3;
     repeated TransactionHook hooks = 4;
+	// Is range validation required for the statement? Generally, it's required
+	// for existing range, e.g. the left range in a split txn, or the txn to 
+	// update range descriptor; not required for new range: i.e. the right range
+	// in a split txn
+	bool range_validation_required = 5;
   }
   repeated Statement statements = 2;
 }


### PR DESCRIPTION
1. Add a boolean in txn statement to indicate whether the statement needs range
   validation
2. When a statement needs range validation, we will use the header.New to create
   header; otherwise use header.NewWithoutRangeInfo
3. Adds retry around TryReplicas in prepare and finalize txn

https://github.com/buildbuddy-io/buildbuddy-internal/issues/5196
