### PR TITLE
Don't parse auth headers twice between atime_updater and hit_tracker_client

### DIFF
--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -156,7 +156,7 @@ func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests
 	}
 
 	groupID := u.groupID(ctx)
-	authHeaders := authutil.GetAuthHeaders(ctx, u.authenticator)
+	authHeaders := authutil.GetAuthHeaders(ctx)
 	if len(authHeaders) == 0 {
 		log.Infof("Dropping remote atime update due to missing auth headers in context")
 		return

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -96,7 +96,7 @@ func (s *ByteStreamServerProxy) read(ctx context.Context, req *bspb.ReadRequest,
 
 	// Store auth headers in context so they can be reused between the
 	// atime_updater and the hit_tracker_client.
-	ctx = authutil.ContextWithAuthHeaders(ctx, s.authenticator)
+	ctx = authutil.ContextWithCachedAuthHeaders(ctx, s.authenticator)
 
 	if proxy_util.SkipRemote(ctx) {
 		if err := s.readLocalOnly(req, stream); err != nil {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -93,6 +93,11 @@ func (s *ByteStreamServerProxy) read(ctx context.Context, req *bspb.ReadRequest,
 	if authutil.EncryptionEnabled(ctx, s.authenticator) {
 		return metrics.UncacheableStatusLabel, s.readRemoteOnly(ctx, req, stream)
 	}
+
+	// Store auth headers in context so they can be reused between the
+	// atime_updater and the hit_tracker_client.
+	ctx = authutil.ContextWithAuthHeaders(ctx, s.authenticator)
+
 	if proxy_util.SkipRemote(ctx) {
 		if err := s.readLocalOnly(req, stream); err != nil {
 			log.CtxInfof(ctx, "Error reading local: %v", err)

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -163,6 +163,10 @@ func (s *CASServerProxy) BatchReadBlobs(ctx context.Context, req *repb.BatchRead
 	defer spn.End()
 	tracing.AddStringAttributeToCurrentSpan(ctx, "requested-blobs", strconv.Itoa(len(req.Digests)))
 
+	// Store auth headers in context so they can be reused between the
+	// atime_updater and the hit_tracker_client.
+	ctx = authutil.ContextWithAuthHeaders(ctx, s.authenticator)
+
 	mergedResp := repb.BatchReadBlobsResponse{}
 	mergedDigests := []*repb.Digest{}
 	localResp := &repb.BatchReadBlobsResponse{}

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -165,7 +165,7 @@ func (s *CASServerProxy) BatchReadBlobs(ctx context.Context, req *repb.BatchRead
 
 	// Store auth headers in context so they can be reused between the
 	// atime_updater and the hit_tracker_client.
-	ctx = authutil.ContextWithAuthHeaders(ctx, s.authenticator)
+	ctx = authutil.ContextWithCachedAuthHeaders(ctx, s.authenticator)
 
 	mergedResp := repb.BatchReadBlobsResponse{}
 	mergedDigests := []*repb.Digest{}

--- a/enterprise/server/hit_tracker_client/BUILD
+++ b/enterprise/server/hit_tracker_client/BUILD
@@ -40,6 +40,7 @@ go_test(
         "//server/interfaces",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
+        "//server/util/authutil",
         "//server/util/log",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -227,7 +227,7 @@ func (h *HitTrackerFactory) enqueue(ctx context.Context, hit *hitpb.CacheHit) {
 
 	groupHits := h.hitsByGroup[groupID]
 	h.mu.Unlock()
-	authHeaders := authutil.GetAuthHeaders(ctx, h.authenticator)
+	authHeaders := authutil.GetAuthHeaders(ctx)
 	if groupHits.enqueue(hit, authHeaders) {
 		metrics.RemoteHitTrackerUpdates.WithLabelValues(
 			string(groupID),

--- a/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
@@ -146,6 +147,14 @@ func setup(t testing.TB) (interfaces.Authenticator, *HitTrackerFactory, *testHit
 	return authenticator, newHitTrackerClient(ctx, te, conn), hitTrackerService
 }
 
+func authenticatedContext(user string, authenticator interfaces.Authenticator) context.Context {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(authutil.ClientIdentityHeaderName, "fakeheader"))
+	if user != "" {
+		ctx = authenticator.AuthContextFromAPIKey(ctx, user)
+	}
+	return authutil.ContextWithCachedAuthHeaders(ctx, authenticator)
+}
+
 func TestACHitTracker(t *testing.T) {
 	_, hitTrackerFactory, hitTrackerService := setup(t)
 	ctx := context.Background()
@@ -229,7 +238,7 @@ func TestCASHitTracker_SplitsUpdates(t *testing.T) {
 	// Pause the hit-tracker RPC service and send an RPC that'll block the
 	// hit-tracker-client worker so updates are queued.
 	hitTrackerService.wg.Add(1)
-	group1Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user1)
+	group1Ctx := authenticatedContext(user1, authenticator)
 	hitTracker := hitTrackerFactory.NewCASHitTracker(group1Ctx, &repb.RequestMetadata{})
 	hitTracker.TrackDownload(fDigest).CloseWithBytesTransferred(1_000_000, 2_000_000, repb.Compressor_IDENTITY, "test")
 
@@ -267,7 +276,7 @@ func TestCASHitTracker_DropsUpdates(t *testing.T) {
 	// Pause the hit-tracker RPC service and send an RPC that'll block the
 	// hit-tracker-client worker so updates are queued.
 	hitTrackerService.wg.Add(1)
-	group1Ctx := authenticator.AuthContextFromAPIKey(context.Background(), user1)
+	group1Ctx := authenticatedContext(user1, authenticator)
 	hitTracker := hitTrackerFactory.NewCASHitTracker(group1Ctx, &repb.RequestMetadata{})
 	hitTracker.TrackDownload(fDigest).CloseWithBytesTransferred(1_000_000, 2_000_000, repb.Compressor_IDENTITY, "test")
 

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -175,7 +175,7 @@ func EncryptionEnabled(ctx context.Context, authenticator interfaces.Authenticat
 
 // Returns a context derived from the provided context that has the
 // client-supplied parsed and cached for retrieval using GetAuthHeaders.
-func ContextWithAuthHeaders(ctx context.Context, authenticator interfaces.Authenticator) context.Context {
+func ContextWithCachedAuthHeaders(ctx context.Context, authenticator interfaces.Authenticator) context.Context {
 	headers := map[string][]string{}
 
 	keys := metadata.ValueFromIncomingContext(ctx, ClientIdentityHeaderName)
@@ -210,7 +210,7 @@ func GetAuthHeaders(ctx context.Context) map[string][]string {
 }
 
 // Adds the provided auth headers into the provided context and returns a new
-// context containng them. This function is intended for use along with
+// context containing them. This function is intended for use along with
 // GetAuthHeaders when auth headers must be copied between contexts.
 func AddAuthHeadersToContext(ctx context.Context, headers map[string][]string, authenticator interfaces.Authenticator) context.Context {
 	for key, values := range headers {


### PR DESCRIPTION
This is a little bit trickier than throwing it in an interceptor and calling it a day because these headers are only used in the atime_updater and the hit_tracker_client, and those are only called for requests that are served locally, so it's most efficient to do this work only when we know that's how the request will be processed. This is my attempt at that. 😛 

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5094