### PR TITLE
POC: Add built in steps to workflows

### DIFF
--- a/enterprise/server/workflow/config/BUILD
+++ b/enterprise/server/workflow/config/BUILD
@@ -10,6 +10,8 @@ go_library(
         "//enterprise/server/webhooks/webhook_data",
         "//proto:runner_go_proto",
         "//server/build_event_protocol/accumulator",
+        "//server/endpoint_urls/cache_api_url",
+        "//server/tables",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )
@@ -22,6 +24,8 @@ go_test(
         ":config",
         "//enterprise/server/workflow/config/test_data",
         "//proto:runner_go_proto",
+        "//server/endpoint_urls/cache_api_url",
+        "//server/tables",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -11,6 +10,8 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/webhook_data"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/accumulator"
+	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/cache_api_url"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"gopkg.in/yaml.v2"
 
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
@@ -255,33 +256,17 @@ fi
 	return buf
 }
 
-func KytheIndexingAction(targetRepoDefaultBranch string) *Action {
-	var pushTriggerBranches []string
-	if targetRepoDefaultBranch != "" {
-		pushTriggerBranches = append(pushTriggerBranches, targetRepoDefaultBranch)
-	}
+func KytheIndexingAction(_ *tables.Workflow) []*rnpb.Step {
 	kytheDirName := filepath.Base(strings.TrimSuffix(kytheDownloadURL, ".tar.gz"))
-	return &Action{
-		Name: KytheActionName,
-		Triggers: &Triggers{
-			Push: &PushTrigger{Branches: pushTriggerBranches},
+	return []*rnpb.Step{
+		{
+			Run: checkoutKythe(kytheDirName, kytheDownloadURL),
 		},
-		ContainerImage: `ubuntu-20.04`,
-		ResourceRequests: ResourceRequests{
-			CPU:    "24",   // 24 BCU
-			Memory: "60GB", // 24 BCU
-			Disk:   "100GB",
+		{
+			Run: buildWithKythe(kytheDirName),
 		},
-		Steps: []*rnpb.Step{
-			{
-				Run: checkoutKythe(kytheDirName, kytheDownloadURL),
-			},
-			{
-				Run: buildWithKythe(kytheDirName),
-			},
-			{
-				Run: prepareKytheOutputs(kytheDirName),
-			},
+		{
+			Run: prepareKytheOutputs(kytheDirName),
 		},
 	}
 }
@@ -295,26 +280,10 @@ bb index --target %s --repo-url %s`, apiTarget, repoURL)
 	return buf
 }
 
-func CodesearchIncrementalUpdateAction(apiTarget *url.URL, repoURL, targetRepoDefaultBranch string) *Action {
-	var pushTriggerBranches []string
-	if targetRepoDefaultBranch != "" {
-		pushTriggerBranches = append(pushTriggerBranches, targetRepoDefaultBranch)
-	}
-	return &Action{
-		Name: CSIncrementalUpdateName,
-		Triggers: &Triggers{
-			Push: &PushTrigger{Branches: pushTriggerBranches},
-		},
-		ContainerImage: `ubuntu-22.04`,
-		ResourceRequests: ResourceRequests{
-			CPU:    "2",
-			Memory: "4GB",
-			Disk:   "10GB",
-		},
-		Steps: []*rnpb.Step{
-			{
-				Run: sendIncrementalUpdate(apiTarget.String(), repoURL),
-			},
+func CodesearchIncrementalUpdateAction(workflow *tables.Workflow) []*rnpb.Step {
+	return []*rnpb.Step{
+		{
+			Run: sendIncrementalUpdate(cache_api_url.WithPath("").String(), workflow.RepoURL),
 		},
 	}
 }

--- a/enterprise/server/workflow/config/config_test.go
+++ b/enterprise/server/workflow/config/config_test.go
@@ -2,12 +2,13 @@ package config_test
 
 import (
 	"bytes"
-	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config/test_data"
+	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/cache_api_url"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -153,19 +154,14 @@ func TestGetGitFetchFilters(t *testing.T) {
 }
 
 func TestCodeSearchAction(t *testing.T) {
-	apiURL, err := url.Parse("grpcs://example.com")
-	require.NoError(t, err)
 	ghURL := "https://github.com/buildbuddy-io/buildbuddy"
 
-	action := config.CodesearchIncrementalUpdateAction(apiURL, ghURL, "master")
+	fakeWorkflow := &tables.Workflow{
+		RepoURL: "github.com/buildbuddy-io/buildbuddy",
+	}
+	steps := config.CodesearchIncrementalUpdateAction(fakeWorkflow)
 
-	require.NotNil(t, action)
-	assert.Equal(t, config.CSIncrementalUpdateName, action.Name)
-	require.NotNil(t, action.Triggers)
-	require.NotNil(t, action.Triggers.Push)
-	assert.Equal(t, []string{"master"}, action.Triggers.Push.Branches)
-	require.NotNil(t, action.Steps)
-	assert.Len(t, action.Steps, 1)
-	assert.Contains(t, action.Steps[0].Run, apiURL.String())
-	assert.Contains(t, action.Steps[0].Run, ghURL)
+	assert.Equal(t, 1, len(steps))
+	assert.Contains(t, steps[0].Run, ghURL)
+	assert.Contains(t, steps[0].Run, cache_api_url.WithPath("").String())
 }

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//proto:context_go_proto",
         "//proto:invocation_status_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:runner_go_proto",
         "//proto:user_id_go_proto",
         "//proto:workflow_go_proto",
         "//server/backends/github",

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -56,6 +56,7 @@ import (
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	inspb "github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 	wfpb "github.com/buildbuddy-io/buildbuddy/proto/workflow"
 	remote_execution_config "github.com/buildbuddy-io/buildbuddy/server/remote_execution/config"
@@ -153,12 +154,15 @@ type startWorkflowTask struct {
 	workflow    *tables.Workflow
 }
 
+type StepMaker func(workflow *tables.Workflow) []*rnpb.Step
+
 type workflowService struct {
 	env environment.Env
 
-	wg    sync.WaitGroup
-	tasks chan *startWorkflowTask
-	bbUrl *url.URL
+	wg           sync.WaitGroup
+	tasks        chan *startWorkflowTask
+	bbUrl        *url.URL
+	builtInSteps map[string]StepMaker // Actions that are built-in to the workflow service.
 }
 
 func NewWorkflowService(env environment.Env) *workflowService {
@@ -166,6 +170,10 @@ func NewWorkflowService(env environment.Env) *workflowService {
 		env:   env,
 		tasks: make(chan *startWorkflowTask, webhookWorkerTaskQueueSize),
 		bbUrl: build_buddy_url.WithPath(""),
+		builtInSteps: map[string]StepMaker{
+			"@kythe":            config.KytheIndexingAction,
+			"@codesearch_index": config.CodesearchIncrementalUpdateAction,
+		},
 	}
 	ws.startBackgroundWorkers()
 	return ws
@@ -600,20 +608,6 @@ func (ws *workflowService) InvalidateAllSnapshotsForRepo(ctx context.Context, re
 	).Exec().Error
 
 	return err
-}
-
-func (ws *workflowService) addCodesearchActionsIfEnabled(ctx context.Context, c *config.BuildBuddyConfig, workflow *tables.Workflow, wd *interfaces.WebhookData) error {
-
-	enableCS, err := ws.isCodesearchIndexingEnabled(ctx, workflow.GroupID)
-	if err != nil {
-		return err
-	}
-	if enableCS {
-		// TODO(jdelfino): Using the cache API URL here is hacky, long term we might want a codesearch_api_url
-		c.Actions = append(c.Actions, config.CodesearchIncrementalUpdateAction(cache_api_url.WithPath(""), workflow.RepoURL, wd.TargetRepoDefaultBranch))
-		c.Actions = append(c.Actions, config.KytheIndexingAction(wd.TargetRepoDefaultBranch))
-	}
-	return nil
 }
 
 func (ws *workflowService) isCodesearchIndexingEnabled(ctx context.Context, groupID string) (bool, error) {
@@ -1314,9 +1308,20 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider 
 		}
 	}
 
-	if err := ws.addCodesearchActionsIfEnabled(ctx, c, workflow, webhookData); err != nil {
-		return nil, err
+	for _, action := range c.Actions {
+		newSteps := make([]*rnpb.Step, 0, len(action.Steps))
+		for _, step := range action.Steps {
+			if len(step.Uses) > 0 {
+				if builtIn, ok := ws.builtInSteps[step.Uses]; ok {
+					newSteps = append(newSteps, builtIn(workflow)...)
+				} else {
+					newSteps = append(newSteps, step)
+				}
+			}
+		}
+		action.Steps = newSteps
 	}
+
 	return c, nil
 }
 

--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -86,6 +86,7 @@ message RunRequest {
 
 message Step {
   string run = 1;
+  string uses = 2;
 }
 
 message RunResponse {


### PR DESCRIPTION
I imagine this interface change would require some more discussion and documentation, so I'm not looking to submit this, but wanted to send for discussion.

This change would support custom setup for kythe/codesearch indexing. It would unfortunately remove "automatic" injection of these steps, and require anyone using codesearch to inject boilerplate steps into their workflow config. 

The main alternative that I can think of to this approach would be a separate "codesearch" top-level section in the workflow config that allowed specification of setup steps required for a kythe build, or maybe even just packages to install or a docker container to use. The adoption curve for that would be gentler - if no custom setup steps were required, kythe & CS indexing would continue to "just work" when codesearch was enabled.

This is based on GH Actions `uses`: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses