### PR TITLE
Test that flagd percentage experiments are stable

### DIFF
--- a/enterprise/server/experiments/BUILD
+++ b/enterprise/server/experiments/BUILD
@@ -29,6 +29,7 @@ go_test(
         "//server/testutil/testenv",
         "//server/util/authutil",
         "//server/util/claims",
+        "//server/util/random",
         "@com_github_open_feature_go_sdk//openfeature",
         "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_open_feature_go_sdk//openfeature/testing",


### PR DESCRIPTION
Ensure that once a context is in an experiment, it continues to be when we increase the percentage.