### PR TITLE
Don't log warnings on undefined experiments

### DIFF
--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -147,7 +147,7 @@ func WithContext(key string, value interface{}) Option {
 func (fp *FlagProvider) Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool {
 	v, err := fp.client.BooleanValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
-		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
 		return defaultValue
 	}
 	return v
@@ -159,7 +159,7 @@ func (fp *FlagProvider) Boolean(ctx context.Context, flagName string, defaultVal
 func (fp *FlagProvider) String(ctx context.Context, flagName string, defaultValue string, opts ...any) string {
 	v, err := fp.client.StringValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
-		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
 		return defaultValue
 	}
 	return v
@@ -171,7 +171,7 @@ func (fp *FlagProvider) String(ctx context.Context, flagName string, defaultValu
 func (fp *FlagProvider) Float64(ctx context.Context, flagName string, defaultValue float64, opts ...any) float64 {
 	v, err := fp.client.FloatValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
-		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
 		return defaultValue
 	}
 	return v
@@ -183,7 +183,7 @@ func (fp *FlagProvider) Float64(ctx context.Context, flagName string, defaultVal
 func (fp *FlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
 	v, err := fp.client.IntValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
-		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
 		return defaultValue
 	}
 	return v
@@ -195,7 +195,7 @@ func (fp *FlagProvider) Int64(ctx context.Context, flagName string, defaultValue
 func (fp *FlagProvider) Object(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) map[string]any {
 	v, err := fp.client.ObjectValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
-		log.CtxWarningf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
+		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
 		return defaultValue
 	}
 	if v == nil {


### PR DESCRIPTION
This is causing the app canary to be rolled back.

I think it should be fine to reference flags that aren't yet defined in the flagd config, similar to how it's fine to reference go flags that we haven't yet set up in the app config YAML.

If the goal here was to catch typos in the flagd config, another solution might be to have a centralized definition of allowed experiment flags, and in the deployment workflow, validate the internal flagd configs against those definitions.