### PR TITLE
Revert "Don't parse auth headers twice between atime_updater and hit_tracker_client"

### DIFF
--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -156,7 +156,7 @@ func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests
 	}
 
 	groupID := u.groupID(ctx)
-	authHeaders := authutil.GetAuthHeaders(ctx)
+	authHeaders := authutil.GetAuthHeaders(ctx, u.authenticator)
 	if len(authHeaders) == 0 {
 		log.Infof("Dropping remote atime update due to missing auth headers in context")
 		return

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -93,11 +93,6 @@ func (s *ByteStreamServerProxy) read(ctx context.Context, req *bspb.ReadRequest,
 	if authutil.EncryptionEnabled(ctx, s.authenticator) {
 		return metrics.UncacheableStatusLabel, s.readRemoteOnly(ctx, req, stream)
 	}
-
-	// Store auth headers in context so they can be reused between the
-	// atime_updater and the hit_tracker_client.
-	ctx = authutil.ContextWithCachedAuthHeaders(ctx, s.authenticator)
-
 	if proxy_util.SkipRemote(ctx) {
 		if err := s.readLocalOnly(req, stream); err != nil {
 			log.CtxInfof(ctx, "Error reading local: %v", err)

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -163,10 +163,6 @@ func (s *CASServerProxy) BatchReadBlobs(ctx context.Context, req *repb.BatchRead
 	defer spn.End()
 	tracing.AddStringAttributeToCurrentSpan(ctx, "requested-blobs", strconv.Itoa(len(req.Digests)))
 
-	// Store auth headers in context so they can be reused between the
-	// atime_updater and the hit_tracker_client.
-	ctx = authutil.ContextWithCachedAuthHeaders(ctx, s.authenticator)
-
 	mergedResp := repb.BatchReadBlobsResponse{}
 	mergedDigests := []*repb.Digest{}
 	localResp := &repb.BatchReadBlobsResponse{}

--- a/enterprise/server/hit_tracker_client/BUILD
+++ b/enterprise/server/hit_tracker_client/BUILD
@@ -40,7 +40,6 @@ go_test(
         "//server/interfaces",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
-        "//server/util/authutil",
         "//server/util/log",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -227,7 +227,7 @@ func (h *HitTrackerFactory) enqueue(ctx context.Context, hit *hitpb.CacheHit) {
 
 	groupHits := h.hitsByGroup[groupID]
 	h.mu.Unlock()
-	authHeaders := authutil.GetAuthHeaders(ctx)
+	authHeaders := authutil.GetAuthHeaders(ctx, h.authenticator)
 	if groupHits.enqueue(hit, authHeaders) {
 		metrics.RemoteHitTrackerUpdates.WithLabelValues(
 			string(groupID),

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -40,9 +40,6 @@ const (
 	// The context key under which client-identity information is stored.
 	ClientIdentityHeaderName = "x-buildbuddy-client-identity"
 
-	// The context key under which auth headers are stored.
-	authHeadersKey = "auth-headers"
-
 	// WARNING: app/auth/auth_service.ts depends on these messages matching.
 	UserNotFoundMsg   = "User not found"
 	LoggedOutMsg      = "User logged out"
@@ -173,9 +170,10 @@ func EncryptionEnabled(ctx context.Context, authenticator interfaces.Authenticat
 	return u.GetCacheEncryptionEnabled()
 }
 
-// Returns a context derived from the provided context that has the
-// client-supplied parsed and cached for retrieval using GetAuthHeaders.
-func ContextWithCachedAuthHeaders(ctx context.Context, authenticator interfaces.Authenticator) context.Context {
+// Extracts auth headers from the provided context and returns them as a map.
+// This function is intended for use along with AddAuthHeadersToContext when
+// auth headers must be copied between contexts.
+func GetAuthHeaders(ctx context.Context, authenticator interfaces.Authenticator) map[string][]string {
 	headers := map[string][]string{}
 
 	keys := metadata.ValueFromIncomingContext(ctx, ClientIdentityHeaderName)
@@ -189,28 +187,11 @@ func ContextWithCachedAuthHeaders(ctx context.Context, authenticator interfaces.
 	if jwt := authenticator.TrustedJWTFromAuthContext(ctx); jwt != "" {
 		headers[ContextTokenStringKey] = []string{jwt}
 	}
-
-	return context.WithValue(ctx, authHeadersKey, headers)
-}
-
-// Retrieves a multi-map of the auth headers cached in the provided context.
-func GetAuthHeaders(ctx context.Context) map[string][]string {
-	rawHeaders := ctx.Value(authHeadersKey)
-	if rawHeaders == nil {
-		alert.UnexpectedEvent("No auth headers found in context, did you remember to call authutil.StoreAuthHeadersInContext?")
-		return map[string][]string{}
-	}
-
-	headers, ok := rawHeaders.(map[string][]string)
-	if !ok {
-		alert.UnexpectedEvent("Auth headers in context have the wrong type")
-		return map[string][]string{}
-	}
 	return headers
 }
 
 // Adds the provided auth headers into the provided context and returns a new
-// context containing them. This function is intended for use along with
+// context containng them. This function is intended for use along with
 // GetAuthHeaders when auth headers must be copied between contexts.
 func AddAuthHeadersToContext(ctx context.Context, headers map[string][]string, authenticator interfaces.Authenticator) context.Context {
 	for key, values := range headers {


### PR DESCRIPTION
Missed a path :-/

Reverts buildbuddy-io/buildbuddy#9740