### PR TITLE
Use hex.EncodeToString instead of fmt.Sprintf("%x")

### DIFF
--- a/enterprise/server/filestore/filestore.go
+++ b/enterprise/server/filestore/filestore.go
@@ -4,6 +4,7 @@ package filestore
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -276,7 +277,7 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 			if _, err := h.Write([]byte(hashExtra)); err != nil {
 				return nil, err
 			}
-			hashStr = fmt.Sprintf("%x", h.Sum(nil))
+			hashStr = hex.EncodeToString(h.Sum(nil))
 		}
 
 		filePath := filepath.Join(hashStr, strconv.Itoa(int(pmk.digestFunction)), pmk.isolation, pmk.encryptionKeyID)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -3,6 +3,7 @@ package firecracker
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -308,7 +309,7 @@ func putFileIntoDir(ctx context.Context, fsys fs.FS, fileName, destDir string, m
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err
 	}
-	fileHash := fmt.Sprintf("%x", h.Sum(nil))
+	fileHash := hex.EncodeToString(h.Sum(nil))
 	fileHome := filepath.Join(destDir, "executor", fileHash)
 	if err := disk.EnsureDirectoryExists(fileHome); err != nil {
 		return "", err

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -1410,7 +1410,7 @@ func newCID() (string, error) {
 	if _, err := rand.Read(b[:]); err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", b), nil
+	return hex.EncodeToString(b[:]), nil
 }
 
 // layerPath returns the path where the extracted image layer with the given

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -2,6 +2,7 @@ package filecache
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -495,7 +496,7 @@ func (v *verifiedWriter) Commit() error {
 	if v.file == nil {
 		return status.FailedPreconditionError("writer is closed")
 	}
-	hashStr := fmt.Sprintf("%x", v.csum.Sum(nil))
+	hashStr := hex.EncodeToString(v.csum.Sum(nil))
 	if v.node.GetDigest().GetHash() != hashStr {
 		return status.DataLossErrorf("data checksum %q does not match expected checksum %q", hashStr, v.node.GetDigest().GetHash())
 	}

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1435,7 +1435,8 @@ func platformHash(p *repb.Platform) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(sha256.Sum256(b)), nil
+	sha := sha256.Sum256(b)
+	return hex.EncodeToString(sha[:]), nil
 }
 
 type labeledError struct {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"math"
@@ -1434,7 +1435,7 @@ func platformHash(p *repb.Platform) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", sha256.Sum256(b)), nil
+	return hex.EncodeToString(sha256.Sum256(b)), nil
 }
 
 type labeledError struct {

--- a/enterprise/server/util/ociconv/ociconv.go
+++ b/enterprise/server/util/ociconv/ociconv.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -50,7 +51,7 @@ func hashFile(filename string) (string, error) {
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // getDiskImagesPath returns the parent directory where disk images are stored

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"io"
@@ -139,7 +140,8 @@ func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, workflowActio
 		workflowActionName,
 		wf.InstanceNameSuffix,
 	}, gitCleanExclude...)
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(keys, "|"))))
+	b := sha256.Sum256([]byte(strings.Join(keys, "|")))
+	return hex.EncodeToString(b[:])
 }
 
 // startWorkflowTask represents a workflow to be started in the background in

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -1064,6 +1064,10 @@ type mkdirAllRequest struct {
 }
 
 func (mar *mkdirAllRequest) Do() error {
+	err := os.Mkdir(mar.path, mar.perm)
+	if err == nil {
+		return nil
+	}
 	return os.MkdirAll(mar.path, mar.perm)
 }
 

--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -3,6 +3,7 @@ package fetch_server
 import (
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -142,7 +143,7 @@ func parseChecksumQualifier(qualifier *rapb.Qualifier) (repb.DigestFunction_Valu
 			if err != nil {
 				return repb.DigestFunction_UNKNOWN, "", status.FailedPreconditionErrorf("Error decoding qualifier %q: %s", qualifier.GetName(), err.Error())
 			}
-			expectedChecksum := fmt.Sprintf("%x", decodedHash)
+			expectedChecksum := hex.EncodeToString(decodedHash)
 			return digestFunc, expectedChecksum, nil
 		}
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -2,7 +2,7 @@ package byte_stream_server
 
 import (
 	"context"
-	"fmt"
+	"encoding/hex"
 	"hash"
 	"io"
 
@@ -572,7 +572,7 @@ func (s *Checksum) Write(p []byte) (int, error) {
 
 func (s *Checksum) Check(r *digest.CASResourceName) error {
 	d := r.GetDigest()
-	computedDigest := fmt.Sprintf("%x", s.hash.Sum(nil))
+	computedDigest := hex.EncodeToString(s.hash.Sum(nil))
 	if computedDigest != d.GetHash() {
 		return status.DataLossErrorf("Hash of uploaded bytes %q [%s] did not match provided digest: %q [%s].", computedDigest, s.digestFunction, d.GetHash(), r.GetDigestFunction())
 	}

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -3,6 +3,7 @@ package cachetools
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"io"
@@ -122,7 +123,7 @@ func getBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASR
 			return err
 		}
 	}
-	computedDigest := fmt.Sprintf("%x", checksum.Sum(nil))
+	computedDigest := hex.EncodeToString(checksum.Sum(nil))
 	if computedDigest != r.GetDigest().GetHash() {
 		return status.DataLossErrorf("Downloaded content (hash %q) did not match expected (hash %q)", computedDigest, r.GetDigest().GetHash())
 	}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -3,6 +3,7 @@ package content_addressable_storage_server
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -222,7 +223,7 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 			}
 		}
 		checksum.Write(decompressedData)
-		computedDigest := fmt.Sprintf("%x", checksum.Sum(nil))
+		computedDigest := hex.EncodeToString(checksum.Sum(nil))
 		if computedDigest != rn.GetDigest().GetHash() {
 			err := status.DataLossErrorf("Uploaded bytes checksum (%q) did not match digest (%q).", computedDigest, rn.GetDigest().GetHash())
 			rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/hex"
 	"fmt"
 	"hash"
 	"io"
@@ -398,7 +399,7 @@ func Compute(in io.Reader, digestType repb.DigestFunction_Value) (*repb.Digest, 
 		return nil, err
 	}
 	return &repb.Digest{
-		Hash:      fmt.Sprintf("%x", h.Sum(nil)),
+		Hash:      hex.EncodeToString(h.Sum(nil)),
 		SizeBytes: n,
 	}, nil
 }

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -545,8 +545,7 @@ func BenchmarkDigestCompute(b *testing.B) {
 				buf := make([]byte, size)
 				_, err := rand.Read(buf)
 				require.NoError(b, err)
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					digest.Compute(bytes.NewReader(buf), df)
 				}
 			})

--- a/server/testutil/testregistry/testregistry.go
+++ b/server/testutil/testregistry/testregistry.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -194,11 +195,12 @@ type bytesLayer struct {
 //
 // testtar.EntryBytes may be useful for constructing tarball contents.
 func NewBytesLayer(t *testing.T, b []byte) gcr.Layer {
+	sha := sha256.Sum256(b)
 	layer, err := partial.UncompressedToLayer(&bytesLayer{
 		mediaType: types.OCILayer,
 		diffID: gcr.Hash{
 			Algorithm: "sha256",
-			Hex:       fmt.Sprintf("%x", sha256.Sum256(b)),
+			Hex:       hex.EncodeToString(sha[:]),
 		},
 		content: b,
 	})

--- a/server/util/blocklist/blocklist.go
+++ b/server/util/blocklist/blocklist.go
@@ -1,16 +1,5 @@
 package blocklist
 
-import (
-	"crypto/sha256"
-	"fmt"
-)
-
-func hashGroupID(groupID string) string {
-	h := sha256.New()
-	h.Write([]byte(groupID))
-	return fmt.Sprintf("%x", h.Sum(nil))
-}
-
 func IsBlockedForStatsQuery(groupID string) bool {
 	return false
 }

--- a/server/util/hash/hash.go
+++ b/server/util/hash/hash.go
@@ -2,13 +2,14 @@ package hash
 
 import (
 	"crypto/sha256"
-	"fmt"
+	"encoding/hex"
 	"reflect"
 	"unsafe"
 )
 
 func Bytes(input []byte) string {
-	return fmt.Sprintf("%x", sha256.Sum256(input))
+	sha := sha256.Sum256(input)
+	return hex.EncodeToString(sha[:])
 }
 
 func String(input string) string {


### PR DESCRIPTION
EncodeToString is faster and more clear.

Benchmark results for digest.Compute:
```
                               │    base3     │                hex3                 │
                               │    sec/op    │    sec/op     vs base               │
DigestCompute/SHA256/1-24        272.2n ± 12%   194.4n ± 13%  -28.58% (p=0.001 n=7)
DigestCompute/BLAKE3/1-24        1.665µ ± 15%   1.293µ ± 10%  -22.34% (p=0.001 n=7)
DigestCompute/SHA256/10-24       235.3n ± 17%   185.9n ± 10%  -20.99% (p=0.001 n=7)
DigestCompute/BLAKE3/10-24       1.605µ ± 19%   1.300µ ±  8%  -19.00% (p=0.001 n=7)
DigestCompute/SHA256/100-24      259.2n ±  9%   241.6n ± 19%   -6.79% (p=0.026 n=7)
DigestCompute/BLAKE3/100-24      1.749µ ± 43%   1.328µ ±  9%  -24.07% (p=0.001 n=7)
DigestCompute/SHA256/1000-24     608.3n ±  9%   559.1n ±  3%   -8.09% (p=0.001 n=7)
DigestCompute/BLAKE3/1000-24     2.375µ ± 43%   1.985µ ± 32%        ~ (p=0.165 n=7)
DigestCompute/SHA256/10000-24    3.983µ ±  2%   3.969µ ± 15%        ~ (p=0.535 n=7)
DigestCompute/BLAKE3/10000-24    4.924µ ±  7%   4.441µ ± 15%        ~ (p=0.209 n=7)
DigestCompute/SHA256/100000-24   39.46µ ± 15%   37.55µ ±  0%   -4.84% (p=0.001 n=7)
DigestCompute/BLAKE3/100000-24   19.68µ ±  3%   19.46µ ±  3%        ~ (p=0.165 n=7)
geomean                          1.859µ         1.599µ        -14.02%

                               │    base3     │                hex3                 │
                               │     B/op     │     B/op      vs base               │
DigestCompute/SHA256/1-24          360.0 ± 0%     400.0 ± 0%  +11.11% (p=0.001 n=7)
DigestCompute/BLAKE3/1-24        10.90Ki ± 0%   10.92Ki ± 0%   +0.19% (p=0.001 n=7)
DigestCompute/SHA256/10-24         360.0 ± 0%     400.0 ± 0%  +11.11% (p=0.001 n=7)
DigestCompute/BLAKE3/10-24       10.90Ki ± 0%   10.92Ki ± 0%   +0.20% (p=0.001 n=7)
DigestCompute/SHA256/100-24        360.0 ± 0%     400.0 ± 0%  +11.11% (p=0.001 n=7)
DigestCompute/BLAKE3/100-24      10.90Ki ± 0%   10.92Ki ± 0%   +0.19% (p=0.001 n=7)
DigestCompute/SHA256/1000-24       360.0 ± 0%     400.0 ± 0%  +11.11% (p=0.001 n=7)
DigestCompute/BLAKE3/1000-24     10.90Ki ± 0%   10.92Ki ± 0%   +0.19% (p=0.001 n=7)
DigestCompute/SHA256/10000-24      360.0 ± 0%     400.0 ± 0%  +11.11% (p=0.001 n=7)
DigestCompute/BLAKE3/10000-24    10.90Ki ± 0%   10.92Ki ± 0%   +0.21% (p=0.001 n=7)
DigestCompute/SHA256/100000-24     360.0 ± 0%     400.0 ± 0%  +11.11% (p=0.001 n=7)
DigestCompute/BLAKE3/100000-24   10.90Ki ± 0%   10.92Ki ± 0%   +0.22% (p=0.001 n=7)
geomean                          1.958Ki        2.066Ki        +5.51%

                               │   base3    │                hex3                │
                               │ allocs/op  │ allocs/op   vs base                │
DigestCompute/SHA256/1-24        6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/BLAKE3/1-24        7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/SHA256/10-24       6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/BLAKE3/10-24       7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/SHA256/100-24      6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/BLAKE3/100-24      7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/SHA256/1000-24     6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/BLAKE3/1000-24     7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/SHA256/10000-24    6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/BLAKE3/10000-24    7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/SHA256/100000-24   6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=7) ¹
DigestCompute/BLAKE3/100000-24   7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=7) ¹
geomean                          6.481        6.481       +0.00%
¹ all samples are equal
```