### PR TITLE
Add platform property alias for recycle-runner

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -721,7 +721,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		// If recycling is enabled and a snapshot exists, then when calling
 		// Create(), load the snapshot instead of creating a new VM.
 
-		recyclingEnabled := platform.IsTrue(platform.FindValue(platform.GetProto(task.GetAction(), task.GetCommand()), platform.RecycleRunnerPropertyName))
+		recyclingEnabled := platform.IsRecyclingEnabled(task)
 		c.recyclingEnabled = recyclingEnabled
 		if recyclingEnabled && snaputil.IsChunkedSnapshotSharingEnabled() {
 			snap, err := loader.GetSnapshot(ctx, c.snapshotKeySet, c.supportsRemoteSnapshots)

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -80,7 +80,10 @@ const (
 	// empty or unset.
 	unsetContainerImageVal = "none"
 
-	RecycleRunnerPropertyName               = "recycle-runner"
+	recycleRunnerPropertyName = "recycle-runner"
+	// dockerReuse is treated as an alias for recycle-runner.
+	dockerReusePropertyName = "dockerReuse"
+
 	RunnerRecyclingKey                      = "runner-recycling-key"
 	RemoteSnapshotSavePolicyPropertyName    = "remote-snapshot-save-policy"
 	RunnerRecyclingMaxWaitPropertyName      = "runner-recycling-max-wait"
@@ -305,7 +308,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 	if pool == DefaultPoolValue {
 		pool = ""
 	}
-	recycleRunner := boolProp(m, RecycleRunnerPropertyName, false)
+	recycleRunner := boolProp(m, recycleRunnerPropertyName, false) || boolProp(m, dockerReusePropertyName, false)
 	isolationType := stringProp(m, WorkloadIsolationPropertyName, "")
 
 	// Only Enable VFS if it is also enabled via flags.
@@ -795,6 +798,16 @@ func FindEffectiveValue(task *repb.ExecutionTask, name string) string {
 // IsTrue returns whether the given platform property value is truthy.
 func IsTrue(value string) bool {
 	return strings.EqualFold(value, "true")
+}
+
+// IsRecyclingEnabled returns whether runner recycling is enabled for the given
+// task.
+func IsRecyclingEnabled(task *repb.ExecutionTask) bool {
+	parsed, err := ParseProperties(task)
+	if err != nil {
+		return false
+	}
+	return parsed.RecycleRunner
 }
 
 func DockerSocket() string {

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -401,7 +401,7 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, cmd *repb.Command, execu
 			// runner should be removed and cannot affect any files in the
 			// workspace anymore, so it is safe to rename the outputs files in
 			// upperdir here rather than copying.
-			recyclingEnabled := platform.IsTrue(platform.FindValue(platform.GetProto(ws.task.GetAction(), ws.task.GetCommand()), platform.RecycleRunnerPropertyName))
+			recyclingEnabled := platform.IsRecyclingEnabled(ws.task)
 			opts := overlayfs.ApplyOpts{AllowRename: !recyclingEnabled}
 			if err := ws.overlay.Apply(egCtx, opts); err != nil {
 				return status.WrapError(err, "apply overlay upperdir changes")

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -367,7 +367,9 @@ type Router interface {
 type ciRunnerRouter struct{}
 
 func (ciRunnerRouter) Applies(params routingParams) bool {
-	return platform.IsCICommand(params.cmd, params.platform) && platform.IsTrue(platform.FindValue(params.platform, platform.RecycleRunnerPropertyName))
+	// TODO: pass parsed platform into routingParams and avoid manual parsing
+	// here.
+	return platform.IsCICommand(params.cmd, params.platform) && platform.IsTrue(platform.FindValue(params.platform, "recycle-runner"))
 }
 
 func (ciRunnerRouter) preferredNodeLimit(_ routingParams) int {


### PR DESCRIPTION
Tested locally:

```shell
$ bb execute --remote_executor=grpc://localhost:1985 \
      --exec_properties=dockerReuse=True -- sh -c 'date >> /tmp/log; cat /tmp/log'
Wed Jun 25 18:02:10 UTC 2025

$ bb execute --remote_executor=grpc://localhost:1985 \
      --exec_properties=dockerReuse=True -- sh -c 'date >> /tmp/log; cat /tmp/log'
Wed Jun 25 18:02:10 UTC 2025
Wed Jun 25 18:02:13 UTC 2025

```