### PR TITLE
Highlight matching symbols on hover in code browser

### DIFF
--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -12,6 +12,20 @@
   cursor: pointer;
 }
 
+.code-highlight-definition {
+  text-decoration: underline;
+  background-color: #f8f0ff;
+  cursor: pointer;
+  border: 1px solid #9334e6;
+}
+
+.code-highlight-reference {
+  text-decoration: underline;
+  background-color: #fef7e0;
+  cursor: pointer;
+  border: 1px solid #8f6b00;
+}
+
 .code-search-xrefs {
   height: 300px;
   overflow: hidden;

--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -12,7 +12,7 @@
   cursor: pointer;
 }
 
-.code-highlight-definition {
+.code-highlight-modification {
   text-decoration: underline;
   background-color: #f8f0ff;
   cursor: pointer;

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -576,12 +576,10 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
     // miss references.
     const decorInRange = this.editor?.getDecorationsInRange(range);
     if (!decorInRange) {
-      console.log("Warning: No decorations found in range", range);
       return [];
     }
 
     let refsInRange = decorInRange.map((decor) => this.decorToReference(decor)).filter((ref) => !!ref);
-    console.log("refsInRange", refsInRange);
 
     let minMatches: kythe.proto.DecorationsReply.Reference[] = [];
     let minMatchLength = Number.POSITIVE_INFINITY;


### PR DESCRIPTION
This mimics a nice feature from https://cs.opensource.google/ - highlighting symbols when you hover over them. Here's what it looks like. Purple highlights are definitions/modifications, yellow are references.

<img width="772" alt="Screenshot 2025-06-25 at 4 07 03 PM" src="https://github.com/user-attachments/assets/236baaed-9774-4e46-a8b0-9595221dae31" />
