### PR TITLE
Make the back button work in the code browser

### DIFF
--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -822,7 +822,7 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Props, prevState: State) {
     this.fetchInitialContent();
     this.editor?.setModel(this.state.fullPathToModelMap.get(this.currentPath()) || null);
-    this.focusLineNumberAndHighlightQuery()
+    this.focusLineNumberAndHighlightQuery();
   }
 
   parsePath() {

--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -821,6 +821,8 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props, prevState: State) {
     this.fetchInitialContent();
+    this.editor?.setModel(this.state.fullPathToModelMap.get(this.currentPath()) || null);
+    this.focusLineNumberAndHighlightQuery()
   }
 
   parsePath() {


### PR DESCRIPTION
This is kind of hacky, but it does make the back button work when navigating through code. The overall fetching / rendering logic in this file deserves some untangling, but I'll leave that as an exercise to the reader for now.