### PR TITLE
Revert "populate server field in usages table (#9756)"

### DIFF
--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -104,7 +104,6 @@ func main() {
 	if err := distributed.Register(env); err != nil {
 		log.Fatal(err.Error())
 	}
-	usageutil.SetServerName("cache-proxy")
 
 	env.SetListenAddr(*listen)
 	if err := ssl.Register(env); err != nil {

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -228,7 +228,7 @@ func GetConfiguredEnvironmentOrDie(cacheRoot string, healthChecker *healthcheck.
 	}
 
 	// Identify ourselves in gRPC requests to the app.
-	usageutil.SetServerName(*clientType)
+	usageutil.SetClientType(*clientType)
 
 	initializeCacheClientsOrDie(*appTarget, *cacheTarget, *cacheTargetTrafficPercent, realEnv)
 

--- a/enterprise/server/hit_tracker_service/hit_tracker_service.go
+++ b/enterprise/server/hit_tracker_service/hit_tracker_service.go
@@ -28,6 +28,7 @@ func Register(env *real_environment.RealEnv) error {
 	return nil
 }
 
+// TODO(iain): record a source (e.g. Cache Proxy).
 func (h HitTrackerService) Track(ctx context.Context, req *hitpb.TrackRequest) (*hitpb.TrackResponse, error) {
 	for _, hit := range req.GetHits() {
 		var hitTracker interfaces.HitTracker

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1391,7 +1391,7 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb
 	if !pool.IsSelfHosted && usg.GetCpuNanos() > 0 {
 		counts.CPUNanos = usg.GetCpuNanos()
 	}
-	labels, err := usageutil.LabelsForUsageRecording(ctx)
+	labels, err := usageutil.Labels(ctx)
 	if err != nil {
 		return status.WrapError(err, "compute usage labels")
 	}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1663,7 +1663,7 @@ func toStoredInvocation(inv *tables.Invocation) *sipb.StoredInvocation {
 }
 
 func incrementInvocationUsage(ctx context.Context, ut interfaces.UsageTracker) {
-	labels, err := usageutil.LabelsForUsageRecording(ctx)
+	labels, err := usageutil.Labels(ctx)
 	if err != nil {
 		log.CtxWarningf(ctx, "Failed to compute invocation usage labels: %s", err)
 		return

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -326,7 +326,7 @@ func registerServices(env *real_environment.RealEnv, grpcServer *grpc.Server) {
 
 func registerLocalGRPCClients(env *real_environment.RealEnv) error {
 	// Identify ourselves as an app client in gRPC requests to other apps.
-	usageutil.SetServerName("app")
+	usageutil.SetClientType("app")
 	byte_stream_client.RegisterPooledBytestreamClient(env)
 
 	// TODO(jdhollen): Share this pool with the cache above.  Not a huge deal for now.

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -532,7 +532,7 @@ func (h *HitTracker) recordCacheUsage(ctx context.Context, d *repb.Digest, actio
 	} else {
 		return nil
 	}
-	labels, err := usageutil.LabelsForUsageRecording(ctx)
+	labels, err := usageutil.Labels(ctx)
 	if err != nil {
 		return status.WrapError(err, "get usage labels")
 	}

--- a/server/util/usageutil/usageutil_test.go
+++ b/server/util/usageutil/usageutil_test.go
@@ -76,7 +76,7 @@ func TestLabels(t *testing.T) {
 			}
 			ctx := metadata.NewIncomingContext(context.Background(), md)
 
-			labels, err := usageutil.LabelsForUsageRecording(ctx)
+			labels, err := usageutil.Labels(ctx)
 
 			require.NoError(t, err)
 			require.Equal(t, test.Expected, labels)
@@ -88,7 +88,6 @@ func TestLabelPropagation(t *testing.T) {
 	for _, test := range []struct {
 		Name     string
 		Client   string
-		Server   string
 		Origin   string
 		Expected *tables.UsageLabels
 	}{
@@ -102,26 +101,20 @@ func TestLabelPropagation(t *testing.T) {
 			Expected: &tables.UsageLabels{Client: "executor"},
 		},
 		{
-			Name:     "Server",
-			Server:   "app",
-			Expected: &tables.UsageLabels{Server: "app"},
-		},
-		{
 			Name:     "Origin",
 			Origin:   "external",
 			Expected: &tables.UsageLabels{Origin: "external"},
 		},
 		{
 			Name:     "All",
-			Client:   "executor",
-			Server:   "cache-proxy",
+			Client:   "app",
 			Origin:   "internal",
-			Expected: &tables.UsageLabels{Client: "executor", Server: "cache-proxy", Origin: "internal"},
+			Expected: &tables.UsageLabels{Client: "app", Origin: "internal"},
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			flags.Set(t, "grpc_client_origin_header", test.Origin)
-			usageutil.SetServerName(test.Client)
+			usageutil.SetClientType(test.Client)
 
 			ctx := context.Background()
 			// Set some pre-existing bazel request metadata on the incoming
@@ -138,10 +131,7 @@ func TestLabelPropagation(t *testing.T) {
 			ctx = context.Background()
 			ctx = metadata.NewIncomingContext(ctx, outgoingMD)
 
-			// Simulate that we've arrived at the receiving server by
-			// changing the server name on the fly.
-			usageutil.SetServerName(test.Server)
-			labels, err := usageutil.LabelsForUsageRecording(ctx)
+			labels, err := usageutil.Labels(ctx)
 
 			require.NoError(t, err)
 			require.Equal(t, test.Expected, labels)


### PR DESCRIPTION
turns out it's easy to write a test that passes when it doesn't test the right flow.