### PR TITLE
Clean up unreachable code in runner pool eviction loop

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -744,11 +744,7 @@ func (p *pool) add(ctx context.Context, r *taskRunner) *labeledError {
 		}
 
 		r := p.runners[evictIndex]
-		if p.pausedRunnerCount() >= p.maxRunnerCount {
-			log.Infof("Evicting runner %s (pool max count %d exceeded).", r, p.maxRunnerCount)
-		} else if p.pausedRunnerMemoryUsageBytes()+stats.MemoryBytes > p.maxRunnerMemoryUsageBytes {
-			log.Infof("Evicting runner %s (max memory %d exceeded).", r, p.maxRunnerMemoryUsageBytes)
-		}
+		log.Infof("Evicting runner %s (pool max count %d exceeded).", r, p.maxRunnerCount)
 		p.runners = append(p.runners[:evictIndex], p.runners[evictIndex+1:]...)
 
 		metrics.RunnerPoolEvictions.Inc()


### PR DESCRIPTION
Every time I come across the `else` branch in this code (which I probably wrote originally), I always think "this looks wrong" - we're checking whether the pool's total memory usage (across all runners) is less than the max limit for a _single_ runner. But it has been somewhat mystifying, because even though it looks clearly wrong, and seems like it would be triggering lots of unnecessary evictions, we never actually see the log message from that branch in practice.

Turns out, this code is unreachable. The first branch of the `if` is always true, because the outer loop is already checking the same condition `p.pausedRunnerCount() >= p.maxRunnerCount`, so because we're in the loop body, and because neither of those expressions can change between the `for` check and the `if` check, it must still be true:

- `p.pausedRunnerCount()` can't change because the pool mutex is held while doing this loop (`pausedRunnerCount()` is based on the number of runners in `p.runners` which have `state == paused`, but we never update `p.runners` or mutate runner states without holding the pool mutex).
- `p.maxRunnerCount` can't change because it's set once in the constructor and then never modified anywhere else.