### PR TITLE
Modify rbetest to allow starting separate executor processes.

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -80,6 +80,7 @@ var (
 	maximumDiskFullness       = flag.Float64("executor.maximum_disk_fullness", 1.01, "Fail health check if device containing executor.local_cache_directory is more than this full")
 	startupCommands           = flag.Slice("executor.startup_commands", []string{}, "Commands to run on startup. These are run sequentially and block executor startup.")
 	clientType                = flag.String("executor.grpc_client_type", "executor", "The client type label for requests from this executor, used to differentiate e.g. workflow executor traffic.")
+	testOnlyExecutorID        = flag.String("executor.test_only_executor_id", "", "(TEST ONLY) overrides the executor ID", flag.Internal)
 
 	listen            = flag.String("listen", "0.0.0.0", "The interface to listen on (default: 0.0.0.0)")
 	port              = flag.Int("port", 8080, "The port to listen for HTTP traffic on")
@@ -327,6 +328,9 @@ func main() {
 		log.Fatalf("Failed to generate executor instance ID: %s", err)
 	}
 	executorID := executorUUID.String()
+	if *testOnlyExecutorID != "" {
+		executorID = *testOnlyExecutorID
+	}
 
 	imageCacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	env.SetImageCacheAuthenticator(imageCacheAuth)

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -250,7 +250,7 @@ func runLocalServerAndExecutor(t *testing.T, mockPrivateGithubToken bool, envMod
 		},
 	})
 
-	executors := env.AddExecutors(t, 1)
+	executors := env.AddInProcessExecutors(t, 1)
 	require.Equal(t, 1, len(executors))
 	flags.Set(t, "executor.enable_bare_runner", true)
 	flags.Set(t, "github.app.enabled", true)

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
@@ -104,7 +104,7 @@ func TestPersistentUnavailableError_Retried(t *testing.T) {
 	env.AddBuildBuddyServer()
 	const errMsg = "error injected by test"
 	errResult := commandutil.ErrorResult(status.UnavailableError(errMsg))
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.AlwaysReturn(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -128,7 +128,7 @@ func TestTransientUnavailableError_Retried(t *testing.T) {
 	env.AddBuildBuddyServer()
 	const errMsg = "error injected by test"
 	errResult := commandutil.ErrorResult(status.UnavailableError(errMsg))
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.ReturnForFirstAttempt(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -152,7 +152,7 @@ func TestTransientInternalError_Retried(t *testing.T) {
 	env.AddBuildBuddyServer()
 	const errMsg = "error injected by test"
 	errResult := commandutil.ErrorResult(status.InternalError(errMsg))
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddSingleTaskInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.ReturnForFirstAttempt(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -176,7 +176,7 @@ func TestTransientAbortedError_Retried(t *testing.T) {
 	env.AddBuildBuddyServer()
 	const errMsg = "error injected by test"
 	errResult := commandutil.ErrorResult(status.AbortedError(errMsg))
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.ReturnForFirstAttempt(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -200,7 +200,7 @@ func TestDeadlineExceededError_NotRetried(t *testing.T) {
 	env.AddBuildBuddyServer()
 	const errMsg = "error injected by test"
 	errResult := commandutil.ErrorResult(status.DeadlineExceededError(errMsg))
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.AlwaysReturn(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -223,7 +223,7 @@ func TestUnauthenticatedError_RetriedOnce(t *testing.T) {
 	env.AddBuildBuddyServer()
 	const errMsg = "error injected by test"
 	errResult := commandutil.ErrorResult(status.UnauthenticatedError(errMsg))
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.AlwaysReturn(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -250,7 +250,7 @@ func TestTransientExecutorShutdown_Retried(t *testing.T) {
 	// TODO(bduffany): Simplify executor shutdown logic across runner types and
 	// remove reliance on ErrSIGKILL here
 	errResult := commandutil.ErrorResult(commandutil.ErrSIGKILL)
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.ReturnForFirstAttempt(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -282,7 +282,7 @@ func TestPersistentExecutorShutdown_Retried(t *testing.T) {
 	// remove reliance on ErrSIGKILL here
 	errResult := commandutil.ErrorResult(commandutil.ErrSIGKILL)
 	errResult.Stderr = []byte("THIS_MSG_SHOULD_APPEAR_IN_BAZEL_STDERR")
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.AlwaysReturn(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -307,7 +307,7 @@ func TestTransientCacheNotFoundError_Retried(t *testing.T) {
 	env := rbetest.NewRBETestEnv(t)
 	env.AddBuildBuddyServer()
 	errResult := commandutil.ErrorResult(status.NotFoundError("not found"))
-	env.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	env.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.ReturnForFirstAttempt(errResult),
 	})
 	// observe initial count so that we can get the diff at the end of the test
@@ -370,7 +370,7 @@ func setup(t *testing.T) *rbetest.Env {
 	// Run the executor with an API key to more closely match a production
 	// setup.
 	flags.Set(t, "executor.api_key", env.APIKey1)
-	env.AddExecutor(t)
+	env.AddInProcessExecutor(t)
 	// observe initial count so that we can get the diff at the end of the test
 	_ = tasksStarted(t)
 	return env

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//enterprise/server/testutil/enterprise_testauth",
         "//enterprise/server/testutil/enterprise_testenv",
         "//enterprise/server/testutil/testcontext",
+        "//enterprise/server/testutil/testexecutor",
         "//enterprise/server/testutil/testredis",
         "//proto:buildbuddy_service_go_proto",
         "//proto:capability_go_proto",
@@ -76,5 +77,6 @@ go_library(
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//encoding/prototext",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -35,6 +35,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testcontext"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testexecutor"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_handler"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_server"
@@ -70,6 +71,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -292,6 +294,9 @@ func NewRBETestEnv(t *testing.T) *Env {
 		log.Warningf("Shutting down executors...")
 		var wg sync.WaitGroup
 		for id, e := range rbe.executors {
+			if e.separateProcess {
+				continue
+			}
 			id, e := id, e
 			e.env.GetHealthChecker().Shutdown()
 			wg.Add(1)
@@ -643,7 +648,7 @@ func newTestCommandController(t *testing.T, env environment.Env) *testCommandCon
 	return controller
 }
 
-type ExecutorOptions struct {
+type InProcessExecutorOptions struct {
 	// Optional name that will appear in executor logs.
 	// To ease debugging, you should specify an explicit name if it's important to the test on which executor an action
 	// is executed.
@@ -657,6 +662,19 @@ type ExecutorOptions struct {
 	priorityTaskSchedulerOptions priority_task_scheduler.Options
 }
 
+type ExecutorOptions struct {
+	// Optional name that will appear in executor logs.
+	// To ease debugging, you should specify an explicit name if it's important to the test on which executor an action
+	// is executed.
+	Name string
+	// Optional API key to be sent by executor
+	APIKey string
+	// Optional Pool name for the executor
+	Pool string
+	// Additional args to pass to the executor binary.
+	Args []string
+}
+
 // Executor is a handle for a running executor instance.
 type Executor struct {
 	env                *testenv.TestEnv
@@ -664,6 +682,7 @@ type Executor struct {
 	grpcServer         *grpc.Server
 	cancelRegistration context.CancelFunc
 	taskScheduler      *priority_task_scheduler.PriorityTaskScheduler
+	separateProcess    bool
 }
 
 // Stop unregisters the executor from the BuildBuddy server.
@@ -673,10 +692,14 @@ func (e *Executor) stop() {
 }
 
 // ShutdownTaskScheduler stops the task scheduler from de-queueing any more work.
-func (e *Executor) ShutdownTaskScheduler() {
+func (e *Executor) ShutdownTaskScheduler() error {
+	if e.separateProcess {
+		return status.UnimplementedErrorf("cannot shut down scheduler in executor running in a separate process")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), defaultWaitTimeout)
 	defer cancel()
 	e.taskScheduler.Shutdown(ctx)
+	return nil
 }
 
 func (r *Env) AddBuildBuddyServer() *BuildBuddyServer {
@@ -725,25 +748,86 @@ func (r *Env) updateAppProxy() {
 
 // AddExecutorWithOptions brings up an executor with custom options.
 // Blocks until executor registers with the scheduler.
-func (r *Env) AddExecutorWithOptions(t testing.TB, opts *ExecutorOptions) *Executor {
+func (r *Env) AddInProcessExecutorWithOptions(t testing.TB, opts *InProcessExecutorOptions) *Executor {
 	executor := r.addExecutor(t, opts)
 	r.waitForExecutorRegistration()
 	return executor
+}
+
+func (r *Env) AddExecutorWithOptions(t *testing.T, opts *ExecutorOptions) *testexecutor.Executor {
+	name := opts.Name
+	if name == "" {
+		name = fmt.Sprintf("unnamedExecutor%d", atomic.AddUint64(&r.executorNameCounter, 1))
+	}
+
+	teOpts := &testexecutor.Opts{
+		DebugName: name,
+		Args: []string{
+			"--executor.app_target=" + r.AppProxy.GRPCTarget(),
+			"--executor.test_only_executor_id=" + name,
+		},
+	}
+	if opts.Pool != "" {
+		teOpts.Args = append(teOpts.Args, "--executor.pool="+opts.Pool)
+	}
+	if opts.APIKey != "" {
+		teOpts.Args = append(teOpts.Args, "--executor.api_key="+opts.APIKey)
+	}
+	teOpts.Args = append(teOpts.Args, opts.Args...)
+	e := testexecutor.RunWithOpts(t, teOpts)
+	r.executors[name] = &Executor{id: name, separateProcess: true}
+	r.waitForExecutorRegistration()
+	return e
+}
+
+// AddInProcessExecutor brings up an executor with an auto generated name with default settings.
+// Use this function in tests where it's not important on which executor tasks are executed,
+// otherwise use AddExecutorWithOptions and specify a custom Name.
+// Blocks until executor registers with the scheduler.
+// Deprecated. Use AddExecutor when possible.
+func (r *Env) AddInProcessExecutor(t testing.TB) *Executor {
+	name := fmt.Sprintf("unnamedExecutor%d", atomic.AddUint64(&r.executorNameCounter, 1))
+	return r.AddInProcessExecutorWithOptions(t, &InProcessExecutorOptions{Name: name})
 }
 
 // AddExecutor brings up an executor with an auto generated name with default settings.
 // Use this function in tests where it's not important on which executor tasks are executed,
 // otherwise use AddExecutorWithOptions and specify a custom Name.
 // Blocks until executor registers with the scheduler.
-func (r *Env) AddExecutor(t testing.TB) *Executor {
+func (r *Env) AddExecutor(t *testing.T) *testexecutor.Executor {
 	name := fmt.Sprintf("unnamedExecutor%d", atomic.AddUint64(&r.executorNameCounter, 1))
-	return r.AddExecutorWithOptions(t, &ExecutorOptions{Name: name})
+	opts := &testexecutor.Opts{
+		DebugName: name,
+		Args: []string{
+			"--executor.app_target=" + r.AppProxy.GRPCTarget(),
+			"--executor.test_only_executor_id=" + name,
+		},
+	}
+	e := testexecutor.RunWithOpts(t, opts)
+	r.executors[name] = &Executor{id: name, separateProcess: true}
+	r.waitForExecutorRegistration()
+	return e
 }
 
 // AddSingleTaskExecutorWithOptions brings up an executor with custom options that is configured with capacity to
 // accept only a single "default" sized task.
 // Blocks until executor registers with the scheduler.
-func (r *Env) AddSingleTaskExecutorWithOptions(t testing.TB, options *ExecutorOptions) *Executor {
+func (r *Env) AddSingleTaskExecutorWithOptions(t *testing.T, options *ExecutorOptions) *testexecutor.Executor {
+	optionsCopy := *options
+	if optionsCopy.Name == "" {
+		optionsCopy.Name = fmt.Sprintf("unnamedExecutor%d_singleTask", atomic.AddUint64(&r.executorNameCounter, 1))
+	}
+	optionsCopy.Args = append(optionsCopy.Args, fmt.Sprintf("--executor.memory_bytes=%d", tasksize.DefaultMemEstimate))
+	optionsCopy.Args = append(optionsCopy.Args, fmt.Sprintf("--executor.millicpu=%d", tasksize.DefaultCPUEstimate))
+	return r.AddExecutorWithOptions(t, &optionsCopy)
+}
+
+// AddSingleTaskInProcessExecutorWithOptions brings up an executor with
+// custom options that is configured with capacity to
+// accept only a single "default" sized task.
+// Blocks until executor registers with the scheduler.
+// Deprecated. Use AddSingleTaskExecutorWithOptions when possible.
+func (r *Env) AddSingleTaskInProcessExecutorWithOptions(t testing.TB, options *InProcessExecutorOptions) *Executor {
 	optionsCopy := *options
 	optionsCopy.priorityTaskSchedulerOptions = priority_task_scheduler.Options{
 		RAMBytesCapacityOverride:  tasksize.DefaultMemEstimate,
@@ -759,19 +843,50 @@ func (r *Env) AddSingleTaskExecutorWithOptions(t testing.TB, options *ExecutorOp
 // Use this function in tests where it's not important on which executor tasks are executed,
 // otherwise use AddSingleTaskExecutorWithOptions and specify a custom Name.
 // Blocks until executor registers with the scheduler.
-func (r *Env) AddSingleTaskExecutor(t testing.TB) *Executor {
-	name := fmt.Sprintf("unnamedExecutor%d_singleTask", atomic.AddUint64(&r.executorNameCounter, 1))
-	return r.AddSingleTaskExecutorWithOptions(t, &ExecutorOptions{Name: name})
+func (r *Env) AddSingleTaskExecutor(t *testing.T) *testexecutor.Executor {
+	return r.AddSingleTaskExecutorWithOptions(t, &ExecutorOptions{})
 }
 
 // AddNamedExecutors brings up N named executors with default settings.
 // Use this function if it matters for the test on which executor tasks are executed, otherwise
 // use AddExecutors.
 // Blocks until all executors register with the scheduler.
-func (r *Env) AddNamedExecutors(t testing.TB, names []string) []*Executor {
+func (r *Env) AddNamedExecutors(t *testing.T, names []string) []*testexecutor.Executor {
+	var eg errgroup.Group
+
+	var executors []*testexecutor.Executor
+	for _, name := range names {
+		opts := &testexecutor.Opts{
+			DebugName: name,
+			Args: []string{
+				"--executor.app_target=" + r.AppProxy.GRPCTarget(),
+				"--executor.test_only_executor_id=" + name,
+			},
+			SkipWaitToBeReady: true,
+		}
+		e := testexecutor.RunWithOpts(t, opts)
+		eg.Go(func() error {
+			return e.WaitForReady()
+		})
+		r.executors[name] = &Executor{id: name, separateProcess: true}
+		executors = append(executors, e)
+	}
+	if err := eg.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	r.waitForExecutorRegistration()
+	return executors
+}
+
+// AddNamedExecutors brings up N named executors with default settings.
+// Use this function if it matters for the test on which executor tasks are executed, otherwise
+// use AddExecutors.
+// Blocks until all executors register with the scheduler.
+// Deprecated. Use AddNamedExecutors instead when possible.
+func (r *Env) AddNamedInProcessExecutors(t testing.TB, names []string) []*Executor {
 	var executors []*Executor
 	for _, name := range names {
-		executors = append(executors, r.addExecutor(t, &ExecutorOptions{Name: name}))
+		executors = append(executors, r.addExecutor(t, &InProcessExecutorOptions{Name: name}))
 	}
 	r.waitForExecutorRegistration()
 	return executors
@@ -781,7 +896,7 @@ func (r *Env) AddNamedExecutors(t testing.TB, names []string) []*Executor {
 // Use this function in tests where it's not important on which executor tasks are exected,
 // otherwise use AddNamedExecutors.
 // Blocks until all executors register with the scheduler.
-func (r *Env) AddExecutors(t testing.TB, n int) []*Executor {
+func (r *Env) AddExecutors(t *testing.T, n int) []*testexecutor.Executor {
 	var names []string
 	for i := 0; i < n; i++ {
 		name := fmt.Sprintf("unnamedExecutor%d", atomic.AddUint64(&r.executorNameCounter, 1))
@@ -790,7 +905,21 @@ func (r *Env) AddExecutors(t testing.TB, n int) []*Executor {
 	return r.AddNamedExecutors(t, names)
 }
 
-func (r *Env) addExecutor(t testing.TB, options *ExecutorOptions) *Executor {
+// AddExecutors brings up N executors with auto generated names with default settings.
+// Use this function in tests where it's not important on which executor tasks are exected,
+// otherwise use AddNamedExecutors.
+// Blocks until all executors register with the scheduler.
+// Deprecated. Use AddExecutors when possible.
+func (r *Env) AddInProcessExecutors(t testing.TB, n int) []*Executor {
+	var names []string
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("unnamedExecutor%d", atomic.AddUint64(&r.executorNameCounter, 1))
+		names = append(names, name)
+	}
+	return r.AddNamedInProcessExecutors(t, names)
+}
+
+func (r *Env) addExecutor(t testing.TB, options *InProcessExecutorOptions) *Executor {
 	env := enterprise_testenv.GetCustomTestEnv(r.t, r.envOpts)
 
 	clientConn := r.appProxyConn
@@ -862,6 +991,9 @@ func (r *Env) addExecutor(t testing.TB, options *ExecutorOptions) *Executor {
 }
 
 func (r *Env) RemoveExecutor(executor *Executor) {
+	if executor.separateProcess {
+		assert.FailNow(r.t, "removing executors started as separate processes is not yet supported")
+	}
 	if _, ok := r.executors[executor.id]; !ok {
 		assert.FailNow(r.t, fmt.Sprintf("Executor %q not in executor map", executor.id))
 	}

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -219,7 +219,7 @@ func TestSimpleCommand_Timeout_StdoutStderrStillVisible(t *testing.T) {
 func TestSimpleCommand_Abort_ReturnsExecutionError(t *testing.T) {
 	rbe := rbetest.NewRBETestEnv(t)
 	rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
+	rbe.AddInProcessExecutor(t)
 	initialTaskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
 
 	cmd := rbe.ExecuteCustomCommand("sh", "-c", `
@@ -242,7 +242,7 @@ func TestWorkflowCommand_InternalError_RetriedByScheduler(t *testing.T) {
 	rbe := rbetest.NewRBETestEnv(t)
 	rbe.AddBuildBuddyServer()
 	errResult := commandutil.ErrorResult(status.InternalError("test error message"))
-	rbe.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	rbe.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.AlwaysReturn(errResult),
 	})
 	initialTaskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
@@ -262,7 +262,7 @@ func TestWorkflowCommand_ExecutorShutdown_RetriedByScheduler(t *testing.T) {
 	rbe := rbetest.NewRBETestEnv(t)
 	rbe.AddBuildBuddyServer()
 	errResult := commandutil.ErrorResult(commandutil.ErrSIGKILL)
-	rbe.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	rbe.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: rbetest.AlwaysReturn(errResult),
 	})
 	initialTaskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
@@ -280,7 +280,7 @@ func TestWorkflowCommand_ExecutorShutdown_RetriedByScheduler(t *testing.T) {
 func TestTimeoutAlwaysReturnsDeadlineExceeded(t *testing.T) {
 	rbe := rbetest.NewRBETestEnv(t)
 	rbe.AddBuildBuddyServer()
-	rbe.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{
+	rbe.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{
 		RunInterceptor: func(ctx context.Context, original rbetest.RunFunc) *interfaces.CommandResult {
 			// Wait for the action timeout to pass
 			<-ctx.Done()
@@ -480,7 +480,7 @@ func TestSimpleCommand_RunnerReuse_MultipleExecutors_RoutesCommandToSameExecutor
 	rbe := rbetest.NewRBETestEnv(t)
 
 	rbe.AddBuildBuddyServers(3)
-	rbe.AddExecutors(t, 10)
+	rbe.AddInProcessExecutors(t, 10)
 
 	platform := &repb.Platform{
 		Properties: []*repb.Platform_Property{
@@ -535,7 +535,7 @@ func TestSimpleCommand_RunnerReuse_PoolSelectionViaHeader_RoutesCommandToSameExe
 
 	rbe.AddBuildBuddyServers(3)
 	for i := 0; i < 5; i++ {
-		rbe.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{Pool: "foo"})
+		rbe.AddInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{Pool: "foo"})
 	}
 
 	platform := &repb.Platform{
@@ -1407,7 +1407,7 @@ func TestUnregisterExecutor(t *testing.T) {
 
 	// Start with two executors.
 	// AddExecutors will block until both are registered.
-	executors := rbe.AddExecutors(t, 2)
+	executors := rbe.AddInProcessExecutors(t, 2)
 
 	// Remove one of the executors.
 	// RemoveExecutor will block until the executor is unregistered.
@@ -1586,8 +1586,9 @@ func TestTaskReservationsNotLostOnExecutorShutdown(t *testing.T) {
 
 	var busyExecutors []*rbetest.Executor
 	for _, id := range busyExecutorIDs {
-		e := rbe.AddSingleTaskExecutorWithOptions(t, &rbetest.ExecutorOptions{Name: id})
-		e.ShutdownTaskScheduler()
+		e := rbe.AddSingleTaskInProcessExecutorWithOptions(t, &rbetest.InProcessExecutorOptions{Name: id})
+		err := e.ShutdownTaskScheduler()
+		require.NoError(t, err)
 		busyExecutors = append(busyExecutors, e)
 	}
 
@@ -1623,7 +1624,7 @@ func TestTaskReservationsNotLostOnExecutorShutdown(t *testing.T) {
 func TestCommandWithMissingInputRootDigest(t *testing.T) {
 	rbe := rbetest.NewRBETestEnv(t)
 	rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
+	rbe.AddInProcessExecutor(t)
 	initialTaskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
 
 	platform := &repb.Platform{
@@ -1752,7 +1753,7 @@ func testInvocationCancellation(t *testing.T, tc cancelInvocationTestCase) {
 	rbe := rbetest.NewRBETestEnv(t)
 
 	bbServer := rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
+	rbe.AddInProcessExecutor(t)
 	initialTaskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
 
 	iid := uuid.NewString()
@@ -2052,7 +2053,7 @@ func TestAppShutdownDuringExecution_PublishOperationRetried(t *testing.T) {
 
 	app1 := rbe.AddBuildBuddyServer()
 	app2 := rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
+	rbe.AddInProcessExecutor(t)
 
 	// Set up a custom proxy director that makes sure we choose app1 for the
 	// initial PublishOperation request, so that we can test stopping app1 while
@@ -2178,7 +2179,7 @@ func TestAppShutdownDuringExecution_LeaseTaskRetried(t *testing.T) {
 	rbe.AppProxy.SetDirector(director)
 
 	// Add the executor after the proxy so the executor registers with app 1.
-	rbe.AddExecutor(t)
+	rbe.AddInProcessExecutor(t)
 
 	var cmds []*rbetest.ControlledCommand
 	for i := 0; i < 10; i++ {
@@ -2303,8 +2304,9 @@ func testCustomResources(t *testing.T, test customResourcesTest) {
 			})
 		},
 	})
-	rbe.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{Name: ex1ID})
-	rbe.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{Name: ex2ID})
+	resourceArg := `--executor.custom_resources={"name": "foo", "value": 1.0}`
+	rbe.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{Name: ex1ID, Args: []string{resourceArg}})
+	rbe.AddExecutorWithOptions(t, &rbetest.ExecutorOptions{Name: ex2ID, Args: []string{resourceArg}})
 
 	// First try scheduling a task that requires 2 "foo" resources. This should
 	// not be assigned to any executor because the executors each only have 1

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -143,7 +143,7 @@ func setup(t *testing.T, gp interfaces.GitProvider) (*rbetest.Env, interfaces.Wo
 	// workflow will not be printed
 	//flags.Set(t, "debug_stream_command_outputs", true)
 
-	env.AddExecutors(t, 10)
+	env.AddInProcessExecutors(t, 10)
 	return env, workflowService
 }
 

--- a/enterprise/server/testutil/testexecutor/testexecutor.go
+++ b/enterprise/server/testutil/testexecutor/testexecutor.go
@@ -12,28 +12,47 @@ import (
 type Executor struct {
 	httpPort       int
 	monitoringPort int
+
+	server *testserver.Server
+}
+
+func (e *Executor) WaitForReady() error {
+	return e.server.WaitForReady()
 }
 
 // set by x_defs in BUILD file
 var executorRlocationpath string
 
+type Opts struct {
+	Args              []string
+	DebugName         string
+	SkipWaitToBeReady bool
+}
+
 // Run a local BuildBuddy executor binary for the scope of the given test case.
-func Run(t *testing.T, args ...string) *Executor {
+func RunWithOpts(t *testing.T, opts *Opts) *Executor {
 	e := &Executor{
 		httpPort:       testport.FindFree(t),
 		monitoringPort: testport.FindFree(t),
 	}
-	testserver.Run(t, &testserver.Opts{
+	s := testserver.Run(t, &testserver.Opts{
+		DebugName:         opts.DebugName,
 		BinaryRunfilePath: executorRlocationpath,
 		Args: append(
-			args,
+			opts.Args,
+			"--health_check_period=1s",
 			"--app.log_level=debug",
 			fmt.Sprintf("--port=%d", e.httpPort),
 			fmt.Sprintf("--monitoring_port=%d", e.monitoringPort),
 		),
 		HTTPPort:              e.httpPort,
 		HealthCheckServerType: "prod-buildbuddy-executor",
+		SkipWaitForReady:      opts.SkipWaitToBeReady,
 	})
-
+	e.server = s
 	return e
+}
+
+func Run(t *testing.T, args ...string) *Executor {
+	return RunWithOpts(t, &Opts{Args: args})
 }

--- a/server/util/healthcheck/BUILD
+++ b/server/util/healthcheck/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/interfaces",
         "//server/metrics",
+        "//server/util/flag",
         "//server/util/log",
         "//server/util/status",
         "//server/util/statusz",


### PR DESCRIPTION
Moves first batch of rbe tests to use the new method.

I ran into an issue with some state (incorrectly) being shared across executors in a test which was causing weird errors so I figure I'd fix the underlying issue rather than trying to add another hack.

Helps towards https://github.com/buildbuddy-io/buildbuddy-internal/issues/338