### PR TITLE
byte_stream_client: improve error handling

### DIFF
--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -105,6 +105,7 @@ go_test(
         "//server/util/grpc_server",
         "//server/util/prefix",
         "//server/util/proto",
+        "//server/util/testing/flags",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//types/known/anypb",

--- a/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/server/buildbuddy_server/buildbuddy_server_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -292,76 +293,129 @@ func TestFileDownloadEndpoint(t *testing.T) {
 	te.SetAuthenticator(auth)
 	err := buildbuddy_server.Register(te)
 	require.NoError(t, err)
-	// Start gRPC server (for cache API)
-	grpcPort := testport.FindFree(t)
-	gs, err := grpc_server.New(te, grpcPort, false /*=ssl*/, grpc_server.GRPCServerConfig{})
-	require.NoError(t, err)
-	te.SetGRPCServer(gs.GetServer())
-	testcache.RegisterServers(t, te)
-	err = gs.Start()
-	require.NoError(t, err)
-	// Register gRPC clients
-	conn, err := grpc_client.DialSimpleWithoutPooling(fmt.Sprintf("grpc://localhost:%d", grpcPort))
-	require.NoError(t, err)
-	t.Cleanup(func() { conn.Close() })
-	testcache.RegisterClients(te, conn)
-	// Start HTTP server (for /file/download endpoint)
-	mux := http.NewServeMux()
-	mux.Handle("/file/download", interceptors.WrapAuthenticatedExternalHandler(te, te.GetBuildBuddyServer()))
-	baseURL := testhttp.StartServer(t, mux)
+	for _, tc := range []struct {
+		Name                      string
+		ClientUseLocalPort        bool
+		RestrictBytestreamDialing bool
+		ExpectError               bool
+	}{
+		{
+			Name:                      "localhost_norestrict",
+			ClientUseLocalPort:        true,
+			RestrictBytestreamDialing: false,
+		},
+		{
+			Name:                      "localhost_restrict",
+			ClientUseLocalPort:        true,
+			RestrictBytestreamDialing: true,
+		},
+		{
+			Name:                      "remote_norestrict",
+			ClientUseLocalPort:        false,
+			RestrictBytestreamDialing: false,
+		},
+		{
+			Name:                      "remote_restrict",
+			ClientUseLocalPort:        false,
+			RestrictBytestreamDialing: true,
+			ExpectError:               true,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			// Start gRPC server (for cache API)
+			grpcPort := testport.FindFree(t)
+			if tc.ClientUseLocalPort {
+				flags.Set(t, "grpc_port", grpcPort)
+			} else {
+				// Tell client to use the wrong port
+				flags.Set(t, "grpc_port", grpcPort+1)
+			}
+			if tc.RestrictBytestreamDialing {
+				flags.Set(t, "app.restrict_bytestream_dialing", true)
+			} else {
+				flags.Set(t, "app.restrict_bytestream_dialing", false)
+			}
+			gs, err := grpc_server.New(te, grpcPort, false /*=ssl*/, grpc_server.GRPCServerConfig{})
+			require.NoError(t, err)
+			te.SetGRPCServer(gs.GetServer())
+			testcache.RegisterServers(t, te)
+			err = gs.Start()
+			require.NoError(t, err)
+			// Register gRPC clients
+			conn, err := grpc_client.DialSimpleWithoutPooling(fmt.Sprintf("grpc://localhost:%d", grpcPort))
+			require.NoError(t, err)
+			t.Cleanup(func() { conn.Close() })
+			testcache.RegisterClients(te, conn)
+			// Start HTTP server (for /file/download endpoint)
+			mux := http.NewServeMux()
+			mux.Handle("/file/download", interceptors.WrapAuthenticatedExternalHandler(te, te.GetBuildBuddyServer()))
+			baseURL := testhttp.StartServer(t, mux)
 
-	iid, err := createInvocationForTesting(te, "" /*=user*/)
-	require.NoError(t, err)
+			iid, err := createInvocationForTesting(te, "" /*=user*/)
+			require.NoError(t, err)
 
-	{
-		// Upload CAS resource
-		rn, b := testdigest.RandomCASResourceBuf(t, 100)
-		casrn, err := digest.CASResourceNameFromProto(rn)
-		require.NoError(t, err)
-		_, _, err = cachetools.UploadFromReader(ctx, te.GetByteStreamClient(), casrn, bytes.NewReader(b))
-		require.NoError(t, err)
+			t.Run("CAS_resource", func(t *testing.T) {
+				rn, b := testdigest.RandomCASResourceBuf(t, 100)
+				casrn, err := digest.CASResourceNameFromProto(rn)
+				require.NoError(t, err)
+				_, _, err = cachetools.UploadFromReader(ctx, te.GetByteStreamClient(), casrn, bytes.NewReader(b))
+				require.NoError(t, err)
 
-		// Fetch it from /file/download endpoint
-		bsURL := fmt.Sprintf("bytestream://localhost:%d/blobs/%s", grpcPort, digest.String(rn.GetDigest()))
-		rsp, err := http.Get(fmt.Sprintf(
-			"%s/file/download?invocation_id=%s&bytestream_url=%s",
-			baseURL, iid, url.QueryEscape(bsURL)))
-		require.NoError(t, err)
-		defer rsp.Body.Close()
-		body, err := io.ReadAll(rsp.Body)
-		require.NoError(t, err)
-		require.Equal(t, b, body)
-	}
+				// Fetch it from /file/download endpoint
+				bsURL := fmt.Sprintf("bytestream://localhost:%d/blobs/%s", grpcPort, digest.String(rn.GetDigest()))
+				rsp, err := http.Get(fmt.Sprintf(
+					"%s/file/download?invocation_id=%s&bytestream_url=%s",
+					baseURL, iid, url.QueryEscape(bsURL)))
+				require.NoError(t, err)
+				defer rsp.Body.Close()
+				body, err := io.ReadAll(rsp.Body)
+				require.NoError(t, err)
 
-	{
-		// Upload AC resource
-		key := &repb.Digest{
-			// Note: hash here can be arbitrary.
-			Hash:      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
-			SizeBytes: 111,
-		}
-		rn := digest.NewACResourceName(key, "", repb.DigestFunction_SHA256)
-		ar := &repb.ActionResult{
-			StdoutRaw: []byte("test-stdout"),
-			ExecutionMetadata: &repb.ExecutedActionMetadata{
-				// Set worker explicitly, otherwise AC server sets it to a uuid.
-				Worker: "test-worker",
-			},
-		}
-		err = cachetools.UploadActionResult(ctx, te.GetActionCacheClient(), rn, ar)
-		require.NoError(t, err)
+				if tc.ExpectError {
+					require.Equal(t, http.StatusInternalServerError, rsp.StatusCode)
+					require.Equal(t, "rpc error: code = Internal desc = Internal server error\n", string(body))
+				} else {
+					require.Equal(t, http.StatusOK, rsp.StatusCode)
+					require.Equal(t, b, body)
+				}
+			})
 
-		// Fetch it with /file/download endpoint
-		acURL := fmt.Sprintf("actioncache://localhost:%d/blobs/ac/%s", grpcPort, digest.String(key))
-		rsp, err := http.Get(fmt.Sprintf(
-			"%s/file/download?invocation_id=%s&bytestream_url=%s",
-			baseURL, iid, url.QueryEscape(acURL)))
-		require.NoError(t, err)
-		defer rsp.Body.Close()
-		body, err := io.ReadAll(rsp.Body)
-		require.NoError(t, err)
-		arb, err := proto.Marshal(ar)
-		require.NoError(t, err)
-		require.Equal(t, arb, body)
+			t.Run("AC_resource", func(t *testing.T) {
+				key := &repb.Digest{
+					// Note: hash here can be arbitrary.
+					Hash:      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+					SizeBytes: 111,
+				}
+				rn := digest.NewACResourceName(key, "", repb.DigestFunction_SHA256)
+				ar := &repb.ActionResult{
+					StdoutRaw: []byte("test-stdout"),
+					ExecutionMetadata: &repb.ExecutedActionMetadata{
+						// Set worker explicitly, otherwise AC server sets it to a uuid.
+						Worker: "test-worker",
+					},
+				}
+				err = cachetools.UploadActionResult(ctx, te.GetActionCacheClient(), rn, ar)
+				require.NoError(t, err)
+				arb, err := proto.Marshal(ar)
+				require.NoError(t, err)
+
+				// Fetch it with /file/download endpoint
+				acURL := fmt.Sprintf("actioncache://localhost:%d/blobs/ac/%s", grpcPort, digest.String(key))
+				rsp, err := http.Get(fmt.Sprintf(
+					"%s/file/download?invocation_id=%s&bytestream_url=%s",
+					baseURL, iid, url.QueryEscape(acURL)))
+				require.NoError(t, err)
+				defer rsp.Body.Close()
+				body, err := io.ReadAll(rsp.Body)
+				require.NoError(t, err)
+				if tc.ExpectError {
+					require.Equal(t, http.StatusNotFound, rsp.StatusCode)
+					require.Equal(t, "rpc error: code = NotFound desc = File not found.\n", string(body))
+				} else {
+					require.Equal(t, http.StatusOK, rsp.StatusCode)
+					require.Equal(t, arb, body)
+				}
+			})
+		})
 	}
 }

--- a/server/remote_cache/byte_stream_client/byte_stream_client.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client.go
@@ -3,6 +3,7 @@ package byte_stream_client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/url"
 	"strconv"
@@ -159,7 +160,7 @@ func (p *pooledByteStreamClient) StreamBytestreamFileChunk(ctx context.Context, 
 		return status.InvalidArgumentErrorf("Only bytestream:// uris are supported")
 	}
 
-	var err error
+	var allErrs error
 
 	// If we have a cache enabled, try connecting to that first
 	if p.env.GetCache() != nil {
@@ -169,29 +170,38 @@ func (p *pooledByteStreamClient) StreamBytestreamFileChunk(ctx context.Context, 
 			grpcPort = strconv.Itoa(p)
 		}
 		localURL.Host = "localhost:" + grpcPort
-		err = p.streamFromUrl(ctx, localURL, false, offset, limit, writer)
+		err := p.streamFromUrl(ctx, localURL, false, offset, limit, writer)
+		if err == nil {
+			return nil
+		}
+		allErrs = status.WrapErrorf(err, "failed to read from local cache %q", localURL.Host)
 	}
 
 	// If the local cache did not work, maybe a remote cache is being used.
 	// Try to connect to that, first over grpcs.
-	if err != nil || p.env.GetCache() == nil {
-		err = p.streamFromUrl(ctx, url, true, offset, limit, writer)
+	if allErrs != nil || p.env.GetCache() == nil {
+		err := p.streamFromUrl(ctx, url, true, offset, limit, writer)
+		if err == nil {
+			return nil
+		}
+		allErrs = errors.Join(allErrs, status.WrapErrorf(err, "failed to read from grpcs cache %q", url.Host))
 	}
 
 	// If that didn't work, try plain old grpc.
-	if !*restrictBytestreamDialing && err != nil {
-		err = p.streamFromUrl(ctx, url, false, offset, limit, writer)
+	if !*restrictBytestreamDialing {
+		err := p.streamFromUrl(ctx, url, false, offset, limit, writer)
+		if err == nil {
+			return nil
+		}
+		allErrs = errors.Join(allErrs, status.WrapErrorf(err, "failed to read from grpc cache %q", url.Host))
 	}
 
 	// Sanitize the error so as to not expose internal services via the
 	// error message.
-	if err != nil {
-		if !status.IsNotFoundError(err) {
-			log.Warningf("Error byte-streaming from %q: %s", stripUser(url), err)
-		}
-		return status.UnavailableErrorf("failed to read byte stream resource %q", stripUser(url))
+	if !status.IsNotFoundError(allErrs) {
+		log.Warningf("Error byte-streaming from %q: %s", stripUser(url), allErrs.Error())
 	}
-	return nil
+	return status.UnavailableErrorf("failed to read byte stream resource %q", stripUser(url))
 }
 
 func stripUser(u *url.URL) *url.URL {

--- a/server/remote_cache/byte_stream_client/byte_stream_client.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client.go
@@ -199,7 +199,7 @@ func (p *pooledByteStreamClient) StreamBytestreamFileChunk(ctx context.Context, 
 	// Sanitize the error so as to not expose internal services via the
 	// error message.
 	if !status.IsNotFoundError(allErrs) {
-		log.Warningf("Error byte-streaming from %q: %s", stripUser(url), allErrs.Error())
+		log.Warningf("Error byte-streaming from %q: %s", stripUser(url), allErrs)
 	}
 	return status.UnavailableErrorf("failed to read byte stream resource %q", stripUser(url))
 }


### PR DESCRIPTION
Aggregate errors from all streaming attempts using `errors.Join`.

