### PR TITLE
Generalize platform experiments

### DIFF
--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -45,6 +45,7 @@ func Register(env *real_environment.RealEnv) error {
 	if err := openfeature.SetProviderAndWait(provider); err != nil {
 		return err
 	}
+	// TODO: register shutdown function to close the provider?
 	fp, err := NewFlagProvider(*appName)
 	if err != nil {
 		return err
@@ -60,6 +61,22 @@ func NewFlagProvider(clientName string) (*FlagProvider, error) {
 	return &FlagProvider{
 		client: openfeature.NewClient(clientName),
 	}, nil
+}
+
+// details implements the interfaces.ExperimentFlagDetails interface,
+// providing details about flag evaluation.
+type details struct {
+	variant string
+}
+
+// noDetails are returned when flag evaluation fails.
+var noDetails = (*details)(nil)
+
+func (d *details) Variant() string {
+	if d == nil {
+		return ""
+	}
+	return d.variant
 }
 
 // FlagProvider implements the interface.ExperimentFlagProvider interface.
@@ -145,66 +162,109 @@ func WithContext(key string, value interface{}) Option {
 // overrides, and returns the Boolean value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool {
-	v, err := fp.client.BooleanValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, _ := fp.BooleanDetails(ctx, flagName, defaultValue, opts...)
+	return v
+}
+
+// BooleanDetails extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the Boolean value for flagName, or defaultValue if no
+// experiment provider is configured. It also returns the details about the flag
+// evaluation.
+func (fp *FlagProvider) BooleanDetails(ctx context.Context, flagName string, defaultValue bool, opts ...any) (bool, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.BooleanValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	return v
+	return d.Value, &details{d.Variant}
 }
 
 // String extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the String value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) String(ctx context.Context, flagName string, defaultValue string, opts ...any) string {
-	v, err := fp.client.StringValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, _ := fp.StringDetails(ctx, flagName, defaultValue, opts...)
+	return v
+}
+
+// StringDetails extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the String value for flagName, or defaultValue if no
+// experiment provider is configured. It also returns the details about the flag
+// evaluation.
+func (fp *FlagProvider) StringDetails(ctx context.Context, flagName string, defaultValue string, opts ...any) (string, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.StringValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	return v
+	return d.Value, &details{d.Variant}
 }
 
 // Float64 extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the Float64 value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Float64(ctx context.Context, flagName string, defaultValue float64, opts ...any) float64 {
-	v, err := fp.client.FloatValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, _ := fp.Float64Details(ctx, flagName, defaultValue, opts...)
+	return v
+}
+
+// Float64Details extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the Float64 value for flagName, or defaultValue if no
+// experiment provider is configured. It also returns the details about the flag
+// evaluation.
+func (fp *FlagProvider) Float64Details(ctx context.Context, flagName string, defaultValue float64, opts ...any) (float64, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.FloatValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	return v
+	return d.Value, &details{d.Variant}
 }
 
 // Int64 extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the Int64 value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
-	v, err := fp.client.IntValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, _ := fp.Int64Details(ctx, flagName, defaultValue, opts...)
+	return v
+}
+
+// Int64Details extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the Int64 value for flagName, or defaultValue if no
+// experiment provider is configured. It also returns the details about the flag
+// evaluation.
+func (fp *FlagProvider) Int64Details(ctx context.Context, flagName string, defaultValue int64, opts ...any) (int64, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.IntValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	return v
+	return d.Value, &details{d.Variant}
 }
 
 // Object extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the map[string]any value for flagName, or defaultValue
 // if no experiment provider is configured.
 func (fp *FlagProvider) Object(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) map[string]any {
-	v, err := fp.client.ObjectValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	m, _ := fp.ObjectDetails(ctx, flagName, defaultValue, opts...)
+	return m
+}
+
+// ObjectDetails extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the map[string]any value for flagName, or defaultValue
+// if no experiment provider is configured. It also returns the details about
+// the flag evaluation.
+func (fp *FlagProvider) ObjectDetails(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) (map[string]any, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.ObjectValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	if v == nil {
-		return defaultValue
-	}
-	if m, ok := v.(map[string]any); ok {
-		return m
+	v := d.Value
+	if m, ok := d.Value.(map[string]any); ok {
+		return m, &details{d.Variant}
 	} else {
-		log.CtxWarningf(ctx, "Experiment flag %q expected a map[string]any value, but the value is %T (%v)", flagName, v, v)
+		log.CtxWarningf(ctx, "Experiment flag %q expected value of type map[string]any, but the value is %T (%v)", flagName, v, v)
 	}
-	return defaultValue
+	return defaultValue, noDetails
 }

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -72,11 +72,13 @@ go_test(
         "//server/util/proto",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_google_uuid//:uuid",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_open_feature_go_sdk//openfeature",
         "@com_github_open_feature_go_sdk_contrib_providers_flagd//pkg",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//testing/protocmp",
         "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1895,11 +1895,6 @@ func (s *SchedulerServer) modifyTaskForExperiments(ctx context.Context, executor
 		return task
 	}
 	isolationType := platform.FindEffectiveValue(taskProto, platform.WorkloadIsolationPropertyName)
-	if isolationType != string(platform.FirecrackerContainerType) {
-		return task
-	}
-	expOptions := make([]any, 0, 2)
-	expOptions = append(expOptions, experiments.WithContext("executor_hostname", executorHostname))
 
 	selfHosted := false
 	if is := s.env.GetClientIdentityService(); is != nil {
@@ -1907,7 +1902,12 @@ func (s *SchedulerServer) modifyTaskForExperiments(ctx context.Context, executor
 		// Client identity is only set on managed executors.
 		selfHosted = err != nil || identity.Client != interfaces.ClientIdentityExecutor
 	}
-	expOptions = append(expOptions, experiments.WithContext("self_hosted_executor", selfHosted))
+
+	expOptions := []any{
+		experiments.WithContext("executor_hostname", executorHostname),
+		experiments.WithContext("self_hosted", selfHosted),
+		experiments.WithContext("requested_isolation_type", isolationType),
+	}
 
 	// We need the bazel RequestMetadata to make experiment decisions. The Lease
 	// RPC doesn't get this metadata, because the executor doesn't get it until
@@ -1915,21 +1915,77 @@ func (s *SchedulerServer) modifyTaskForExperiments(ctx context.Context, executor
 	// with the value in the task.
 	ctx = bazel_request.OverrideRequestMetadata(ctx, taskProto.GetRequestMetadata())
 
-	skipResavingGroup := fp.String(ctx, "skip-resaving-action-snapshots", "", expOptions...)
-	if skipResavingGroup == "" {
-		return task
-	}
-	taskProto.Experiments = append(taskProto.Experiments, "skip-resaving-action-snapshots:"+skipResavingGroup)
 	if taskProto.GetPlatformOverrides() == nil {
-		taskProto.PlatformOverrides = new(repb.Platform)
+		taskProto.PlatformOverrides = &repb.Platform{}
 	}
+
+	// TODO: clean up skip-resaving-snapshots experiment (it's 100% rolled out
+	// in prod).
 	plat := taskProto.GetPlatformOverrides()
-	if strings.EqualFold(skipResavingGroup, "treatment") { // No point in setting the property when it's false.
+	if isolationType == string(platform.FirecrackerContainerType) {
 		plat.Properties = append(plat.Properties, &repb.Platform_Property{
 			Name:  platform.SkipResavingActionSnapshotsPropertyName,
 			Value: "true",
 		})
 	}
+
+	// The "remote_execution.platform_experiments" flag evaluates to a list of
+	// experiment names. For each experiment name in the list, we then evaluate
+	// each experiment separately. This allows running multiple platform
+	// experiments at once, which is desired so that experiments can be ramped
+	// up independently.
+	const platformExperimentsFlagName = "remote_execution.platform_experiments"
+	var platformExperiments []any
+	// platform experiments is a map[string]any because openfeature doesn't
+	// support arrays as top-level values. So we model it as a map[string]any
+	// with an array-valued "experiments" field.
+	platformExperimentsObj := fp.Object(ctx, platformExperimentsFlagName, nil, expOptions...)
+	if experiments, ok := platformExperimentsObj["experiments"]; ok {
+		if arr, ok := experiments.([]any); ok {
+			platformExperiments = arr
+		} else {
+			log.CtxInfof(ctx, "%s: experiments field is not an array: %T", platformExperimentsFlagName, experiments)
+		}
+	}
+	for _, experiment := range platformExperiments {
+		experimentName, ok := experiment.(string)
+		if !ok {
+			log.CtxInfof(ctx, "%s: skipping non-string experiment %T", platformExperimentsFlagName, experiment)
+			continue
+		}
+		// Get the object value for the experiment as well as the details.
+		m, details := fp.ObjectDetails(ctx, experimentName, map[string]any{}, expOptions...)
+		if details.Variant() == "" {
+			// Experiment not enabled; skip.
+			continue
+		}
+		// Validate platform properties. Buffer properties and only append them
+		// if all properties are valid.
+		// TODO: check for conflicting experiments.
+		props := make([]*repb.Platform_Property, 0, len(m))
+		var invalid bool
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				props = append(props, &repb.Platform_Property{
+					Name:  k,
+					Value: s,
+				})
+			} else {
+				log.CtxInfof(ctx, "%s: experiment %s: type must be map[string]string, but map contains value of type %T", platformExperimentsFlagName, experimentName, v)
+				invalid = true
+				break
+			}
+		}
+		if invalid {
+			continue
+		}
+		slices.SortFunc(props, func(a, b *repb.Platform_Property) int {
+			return strings.Compare(a.GetName(), b.GetName())
+		})
+		plat.Properties = append(plat.Properties, props...)
+		taskProto.Experiments = append(taskProto.Experiments, experimentName+":"+details.Variant())
+	}
+
 	if newTask, err := proto.Marshal(taskProto); err != nil {
 		log.CtxWarningf(ctx, "Failed to marshal ExecutionTask: %s", err)
 		return task

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -25,10 +25,12 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
@@ -305,7 +307,7 @@ func TestSchedulerServerGetPoolInfoWithPoolOverride(t *testing.T) {
 }`)
 	provider := flagd.NewProvider(flagd.WithInProcessResolver(), flagd.WithOfflineFilePath(configFile))
 	openfeature.SetProviderAndWait(provider)
-	defer provider.Shutdown()
+	defer openfeature.Shutdown()
 	fp, err := experiments.NewFlagProvider("test")
 	require.NoError(t, err)
 
@@ -338,6 +340,63 @@ func TestSchedulerServerGetPoolInfoWithPoolOverride(t *testing.T) {
 	}, p)
 }
 
+func TestSchedulerServerPlatformExperiments(t *testing.T) {
+	tmp := testfs.MakeTempDir(t)
+	configFile := testfs.WriteFile(t, tmp, "config.flagd.json", `{
+	"$schema": "https://flagd.dev/schema/v0/flags.json",
+	"flags": {
+		"remote_execution.platform_experiments": {
+			"state": "ENABLED",
+			"defaultVariant": "default",
+			"variants": {
+				"default": {
+					"experiments": ["remote_execution.enable_cool_new_isolation_type"]
+				}
+			}
+		},
+		"remote_execution.enable_cool_new_isolation_type": {
+			"state": "ENABLED",
+			"defaultVariant": "default",
+			"variants": {
+				"treatment": {
+					"workload-isolation-type": "turbo-encabulator"
+				},
+				"control": {},
+				"default": {}
+			},
+			"targeting": {
+				"fractional": [
+					["treatment", 50],
+					["control", 50],
+					["default", 0]
+				]
+			}
+		}
+	}
+}`)
+	provider := flagd.NewProvider(flagd.WithInProcessResolver(), flagd.WithOfflineFilePath(configFile))
+	openfeature.SetProviderAndWait(provider)
+	defer openfeature.Shutdown()
+	fp, err := experiments.NewFlagProvider("test")
+	require.NoError(t, err)
+
+	env, ctx := getEnv(t, &schedulerOpts{}, "")
+	env.SetExperimentFlagProvider(fp)
+	fe := newFakeExecutor(ctx, t, env.GetSchedulerClient())
+	fe.Register()
+
+	taskID := scheduleTask(ctx, t, env, map[string]string{})
+
+	fe.WaitForTask(taskID)
+	lease := fe.Claim(taskID)
+	defer lease.Finalize()
+
+	require.Equal(t, []string{"remote_execution.enable_cool_new_isolation_type:treatment"}, lease.task.GetExperiments())
+	require.Empty(t, cmp.Diff([]*repb.Platform_Property{
+		{Name: "workload-isolation-type", Value: "turbo-encabulator"},
+	}, lease.task.GetPlatformOverrides().GetProperties(), protocmp.Transform()), nil)
+}
+
 type task struct {
 	delay time.Duration
 }
@@ -359,9 +418,10 @@ type fakeExecutor struct {
 	id   string
 	node *scpb.ExecutionNode
 
-	ctx context.Context
-
+	ctx       context.Context
+	stop      context.CancelFunc
 	unhealthy atomic.Bool
+	wg        sync.WaitGroup
 
 	mu    sync.Mutex
 	tasks map[string]task
@@ -390,7 +450,8 @@ func newFakeExecutorWithId(ctx context.Context, t *testing.T, id string, schedul
 		AssignableMilliCpu:    32_000,
 	}
 	ctx = log.EnrichContext(ctx, "executor_id", id)
-	return &fakeExecutor{
+	ctx, cancel := context.WithCancel(ctx)
+	fe := &fakeExecutor{
 		t:                 t,
 		schedulerClient:   schedulerClient,
 		id:                id,
@@ -399,7 +460,13 @@ func newFakeExecutorWithId(ctx context.Context, t *testing.T, id string, schedul
 		node:              node,
 		send:              make(chan *scpb.RegisterAndStreamWorkRequest),
 		schedulerMessages: make(chan *scpb.RegisterAndStreamWorkResponse, 128),
+		stop:              cancel,
 	}
+	t.Cleanup(func() {
+		fe.stop()
+		fe.wait()
+	})
+	return fe
 }
 
 func (e *fakeExecutor) markUnhealthy() {
@@ -424,16 +491,25 @@ func (e *fakeExecutor) Register() {
 	})
 	require.NoError(e.t, err)
 
-	recvChan := make(chan Result[*scpb.RegisterAndStreamWorkResponse])
+	recvChan := make(chan Result[*scpb.RegisterAndStreamWorkResponse], 1)
+	e.wg.Add(1)
 	go func() {
+		defer e.wg.Done()
 		for {
 			msg, err := stream.Recv()
 			recvChan <- Result[*scpb.RegisterAndStreamWorkResponse]{Value: msg, Err: err}
+			if err != nil {
+				return
+			}
 		}
 	}()
+	e.wg.Add(1)
 	go func() {
+		defer e.wg.Done()
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case msg := <-recvChan:
 				rsp, err := msg.Value, msg.Err
 				if status.IsUnavailableError(err) {
@@ -467,9 +543,10 @@ func (e *fakeExecutor) Register() {
 			}
 		}
 	}()
+}
 
-	// Give the executor a moment to register with the scheduler.
-	time.Sleep(100 * time.Millisecond)
+func (e *fakeExecutor) wait() {
+	e.wg.Wait()
 }
 
 func (e *fakeExecutor) WaitForTask(taskID string) {
@@ -514,8 +591,9 @@ func (e *fakeExecutor) ResetTasks() {
 type taskLease struct {
 	t       *testing.T
 	stream  scpb.Scheduler_LeaseTaskClient
-	taskID  string
 	leaseID string
+	taskID  string
+	task    *repb.ExecutionTask
 }
 
 func (tl *taskLease) Renew() error {
@@ -558,10 +636,18 @@ func (e *fakeExecutor) Claim(taskID string) *taskLease {
 	require.NoError(e.t, err)
 	require.NotZero(e.t, rsp.GetLeaseDurationSeconds())
 
+	var task *repb.ExecutionTask
+	if len(rsp.GetSerializedTask()) > 0 {
+		task = &repb.ExecutionTask{}
+		err = proto.Unmarshal(rsp.GetSerializedTask(), task)
+		require.NoError(e.t, err)
+	}
+
 	lease := &taskLease{
 		t:       e.t,
 		stream:  stream,
 		taskID:  taskID,
+		task:    task,
 		leaseID: rsp.GetLeaseId(),
 	}
 	return lease

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1761,12 +1761,30 @@ type HitTrackerFactory interface {
 // ExperimentFlagProvider can be use for getting a flag value for a request to
 // enable or disable some experimental functionality. The experiment config is
 // managed outside of the app.
+//
+// Two different sets of methods are provided:
+//   - Boolean, String, Float64, Int64, Object: returns the flag value directly.
+//   - BooleanDetails, StringDetails, Float64Details, Int64Details, ObjectDetails:
+//     returns the flag value and details, including variant name.
 type ExperimentFlagProvider interface {
 	Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool
 	String(ctx context.Context, flagName string, defaultValue string, opts ...any) string
 	Float64(ctx context.Context, flagName string, defaultValue float64, opts ...any) float64
 	Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64
 	Object(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) map[string]any
+
+	BooleanDetails(ctx context.Context, flagName string, defaultValue bool, opts ...any) (bool, ExperimentFlagDetails)
+	StringDetails(ctx context.Context, flagName string, defaultValue string, opts ...any) (string, ExperimentFlagDetails)
+	Float64Details(ctx context.Context, flagName string, defaultValue float64, opts ...any) (float64, ExperimentFlagDetails)
+	Int64Details(ctx context.Context, flagName string, defaultValue int64, opts ...any) (int64, ExperimentFlagDetails)
+	ObjectDetails(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) (map[string]any, ExperimentFlagDetails)
+}
+
+// ExperimentFlagDetails contains details about the flag evaluation.
+type ExperimentFlagDetails interface {
+	// Variant returns the variant name. If the flag is either not configured or
+	// could not be evaluated, it returns an empty string.
+	Variant() string
 }
 
 // Wrapper around a bspb.ByteStream_ReadServer that supports directly providing


### PR DESCRIPTION
Add support for a `remote_execution.platform_experiments` experiment, which defines a list of other experiments that are enabled. Each experiment is evaluated independently to allow for different targeting.