### PR TITLE
remove trends tabs, remove always-true trendsRangeSelection refs

### DIFF
--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -156,10 +156,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
       request.query.pattern = pattern;
     }
 
-    this.setState({ loading: true });
-    if (capabilities.config.trendsRangeSelectionEnabled) {
-      this.setState({ timeKeys: [] });
-    }
+    this.setState({ loading: true, timeKeys: [] });
     rpcService.service.getTrend(request).then((response) => {
       console.log(response);
       const timeToStatMap = new Map<number, stats.ITrendStat>();
@@ -281,31 +278,12 @@ export default class TrendsComponent extends React.Component<Props, State> {
             <div className="trends-title">Trends</div>
             <FilterComponent search={this.props.search} />
           </div>
-          {capabilities.config.trendsHeatmapEnabled && (
-            <div className="tabs">
-              <div
-                onClick={() => this.updateSelectedTab("charts")}
-                className={`tab ${this.getSelectedTab() == "charts" ? "selected" : ""}`}>
-                Charts
-              </div>
-              <div
-                onClick={() => this.updateSelectedTab("drilldown")}
-                className={`tab ${this.getSelectedTab() == "drilldown" ? "selected" : ""}`}>
-                Drilldown
-              </div>
-            </div>
-          )}
           {this.showingDrilldown(this.props.tab) && (
             <DrilldownPageComponent user={this.props.user} search={this.props.search}></DrilldownPageComponent>
           )}
-          {capabilities.config.trendsRangeSelectionEnabled && (
-            <div className="sticky-loading-overlay">
-              {!this.showingDrilldown(this.props.tab) && this.state.loading && <div className="loading"></div>}
-            </div>
-          )}
-          {!capabilities.config.trendsRangeSelectionEnabled &&
-            !this.showingDrilldown(this.props.tab) &&
-            this.state.loading && <div className="loading"></div>}
+          <div className="sticky-loading-overlay">
+            {!this.showingDrilldown(this.props.tab) && this.state.loading && <div className="loading"></div>}
+          </div>
           {!this.showingDrilldown(this.props.tab) && (
             <>
               {capabilities.config.trendsSummaryEnabled && this.state.currentSummary && (
@@ -320,7 +298,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 data={this.state.timeKeys}
                 dataSeries={[
                   {
-                    name: `failed builds (${format.count(getTotal(this.getStats(), (stat) => +(stat.failedBuilds ?? 0)))})`,
+                    name: `failed builds (${format.count(
+                      getTotal(this.getStats(), (stat) => +(stat.failedBuilds ?? 0))
+                    )})`,
                     extractValue: (tsMillis) => +(this.getStat(tsMillis).failedBuilds ?? 0),
                     formatHoverValue: (value) => (value || 0) + " failed builds",
                     onClick: this.onBarClicked.bind(this, "", ""),
@@ -328,7 +308,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
                     color: ChartColor.RED,
                   },
                   {
-                    name: `successful builds (${format.count(getTotal(this.getStats(), (stat) => +(stat.successfulBuilds ?? 0)))})`,
+                    name: `successful builds (${format.count(
+                      getTotal(this.getStats(), (stat) => +(stat.successfulBuilds ?? 0))
+                    )})`,
                     extractValue: (tsMillis) => +(this.getStat(tsMillis).successfulBuilds ?? 0),
                     formatHoverValue: (value) => (value || 0) + " successful builds",
                     onClick: this.onBarClicked.bind(this, "", ""),
@@ -365,9 +347,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 formatXAxisLabel={this.formatShortDate.bind(this)}
                 formatHoverXAxisLabel={this.formatLongDate.bind(this)}
                 ticks={this.state.ticks}
-                onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                }
+                onZoomSelection={this.onChartZoomed.bind(this, "")}
               />
               {this.state.enableInvocationPercentileCharts && (
                 <PercentilesChartComponent
@@ -383,11 +363,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   extractP95={(tsMillis) => +(this.getStat(tsMillis).buildTimeUsecP95 ?? 0) * SECONDS_PER_MICROSECOND}
                   extractP99={(tsMillis) => +(this.getStat(tsMillis).buildTimeUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
                   onColumnClicked={this.onBarClicked.bind(this, "", "duration")}
-                  onZoomSelection={
-                    capabilities.config.trendsRangeSelectionEnabled
-                      ? this.onChartZoomed.bind(this, "duration")
-                      : undefined
-                  }
+                  onZoomSelection={this.onChartZoomed.bind(this, "duration")}
                 />
               )}
               {!this.state.enableInvocationPercentileCharts && (
@@ -419,11 +395,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   formatXAxisLabel={this.formatShortDate.bind(this)}
                   formatHoverXAxisLabel={this.formatLongDate.bind(this)}
                   ticks={this.state.ticks}
-                  onZoomSelection={
-                    capabilities.config.trendsRangeSelectionEnabled
-                      ? this.onChartZoomed.bind(this, "duration")
-                      : undefined
-                  }
+                  onZoomSelection={this.onChartZoomed.bind(this, "duration")}
                 />
               )}
 
@@ -446,9 +418,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                       (stat) => +(stat.actionCacheHits ?? 0) + +(stat.actionCacheMisses ?? 0)
                     ) || 0
                 }
-                onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                }
+                onZoomSelection={this.onChartZoomed.bind(this, "")}
               />
               <CacheChartComponent
                 title="Content Addressable Store"
@@ -466,9 +436,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   getTotal(this.getStats(), (stat) => +(stat.casCacheHits ?? 0)) /
                     getTotal(this.getStats(), (stat) => +(stat.casCacheHits ?? 0) + +(stat.casCacheUploads ?? 0)) || 0
                 }
-                onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                }
+                onZoomSelection={this.onChartZoomed.bind(this, "")}
               />
 
               <TrendsChartComponent
@@ -476,7 +444,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 data={this.state.timeKeys}
                 dataSeries={[
                   {
-                    name: `total download size (${format.bytes(getTotal(this.getStats(), (stat) => +(stat.totalDownloadSizeBytes ?? 0)))})`,
+                    name: `total download size (${format.bytes(
+                      getTotal(this.getStats(), (stat) => +(stat.totalDownloadSizeBytes ?? 0))
+                    )})`,
                     extractValue: (tsMillis) => +(this.getStat(tsMillis).totalDownloadSizeBytes ?? 0),
                     formatHoverValue: (value) => `${format.bytes(value || 0)} downloaded`,
                   },
@@ -501,9 +471,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 formatXAxisLabel={this.formatShortDate.bind(this)}
                 formatHoverXAxisLabel={this.formatLongDate.bind(this)}
                 ticks={this.state.ticks}
-                onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                }
+                onZoomSelection={this.onChartZoomed.bind(this, "")}
               />
 
               <TrendsChartComponent
@@ -511,7 +479,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 data={this.state.timeKeys}
                 dataSeries={[
                   {
-                    name: `total upload size (${format.bytes(getTotal(this.getStats(), (stat) => +(stat.totalUploadSizeBytes ?? 0)))})`,
+                    name: `total upload size (${format.bytes(
+                      getTotal(this.getStats(), (stat) => +(stat.totalUploadSizeBytes ?? 0))
+                    )})`,
                     extractValue: (tsMillis) => +(this.getStat(tsMillis).totalUploadSizeBytes ?? 0),
                     formatHoverValue: (value) => `${format.bytes(value || 0)} uploaded`,
                   },
@@ -536,9 +506,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 formatXAxisLabel={this.formatShortDate.bind(this)}
                 formatHoverXAxisLabel={this.formatLongDate.bind(this)}
                 ticks={this.state.ticks}
-                onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                }
+                onZoomSelection={this.onChartZoomed.bind(this, "")}
               />
 
               {capabilities.config.trendsSummaryEnabled && (
@@ -561,9 +529,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   formatXAxisLabel={this.formatShortDate.bind(this)}
                   formatHoverXAxisLabel={this.formatLongDate.bind(this)}
                   ticks={this.state.ticks}
-                  onZoomSelection={
-                    capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                  }
+                  onZoomSelection={this.onChartZoomed.bind(this, "")}
                 />
               )}
               <TrendsChartComponent
@@ -669,7 +635,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
                     id="build_time"
                     dataSeries={[
                       {
-                        name: `build time, minutes (${format.durationUsec(getTotal(this.getExecutionStats(), (stat) => +(stat.totalBuildTimeUsec ?? 0)))})`,
+                        name: `build time, minutes (${format.durationUsec(
+                          getTotal(this.getExecutionStats(), (stat) => +(stat.totalBuildTimeUsec ?? 0))
+                        )})`,
                         extractValue: (tsMillis) =>
                           +(+(this.getExecutionStat(tsMillis).totalBuildTimeUsec ?? 0) / 60e6).toPrecision(3),
                         formatHoverValue: (value) => `${format.count(value || 0)} minutes of build time`,
@@ -682,9 +650,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                     formatXAxisLabel={this.formatShortDate.bind(this)}
                     formatHoverXAxisLabel={this.formatLongDate.bind(this)}
                     ticks={this.state.ticks}
-                    onZoomSelection={
-                      capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                    }
+                    onZoomSelection={this.onChartZoomed.bind(this, "")}
                   />
                   <PercentilesChartComponent
                     title="Remote Execution Queue Duration"
@@ -707,9 +673,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                     extractP99={(tsMillis) =>
                       +(this.getExecutionStat(tsMillis).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND
                     }
-                    onZoomSelection={
-                      capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                    }
+                    onZoomSelection={this.onChartZoomed.bind(this, "")}
                   />
                 </>
               )}


### PR DESCRIPTION
we show the drilldows link in the left-hand-side menu.

going to split out the drilldowns page in a separate PR--i'm cooking up something to make a few different tabs on the trends page (for cache, RBE, etc.) so in the end i'll still need the tab field.