### PR TITLE
Link to Helm charts in self-hosted executor setup

### DIFF
--- a/enterprise/app/executors/BUILD
+++ b/enterprise/app/executors/BUILD
@@ -16,6 +16,7 @@ ts_library(
         "//app/auth:auth_service",
         "//app/components/banner",
         "//app/components/button:link_button",
+        "//app/components/link",
         "//app/components/select",
         "//app/router",
         "//app/service:rpc_service",

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -13,6 +13,7 @@ import router from "../../../app/router/router";
 import Select, { Option } from "../../../app/components/select/select";
 import LinkButton from "../../../app/components/button/link_button";
 import { Cpu, Globe, Hash, Laptop, LucideIcon } from "lucide-react";
+import { TextLink } from "../../../app/components/link/link";
 
 enum FetchType {
   Executors,
@@ -38,7 +39,13 @@ class ExecutorDeploy extends React.Component<ExecutorDeployProps, ExecutorDeploy
   render() {
     return (
       <>
-        <p>Self-hosted executors can be deployed by running a simple Docker image on any machine.</p>
+        <p>
+          Self-hosted executors can be deployed on Kubernetes using the{" "}
+          <TextLink href="https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-executor">
+            Helm charts
+          </TextLink>
+          , or by running the Docker image directly.
+        </p>
         <p>The example below shows how to run an executor manually using the Docker CLI.</p>
         API key:
         <Select


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3817e474-5d0a-48e6-b2c3-66bc233df9fb)
