### PR TITLE
Add Details methods to FlagProvider

### DIFF
--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -45,6 +45,7 @@ func Register(env *real_environment.RealEnv) error {
 	if err := openfeature.SetProviderAndWait(provider); err != nil {
 		return err
 	}
+	// TODO: register shutdown function to close the provider?
 	fp, err := NewFlagProvider(*appName)
 	if err != nil {
 		return err
@@ -60,6 +61,22 @@ func NewFlagProvider(clientName string) (*FlagProvider, error) {
 	return &FlagProvider{
 		client: openfeature.NewClient(clientName),
 	}, nil
+}
+
+// details implements the interfaces.ExperimentFlagDetails interface,
+// providing details about flag evaluation.
+type details struct {
+	variant string
+}
+
+// noDetails are returned when flag evaluation fails.
+var noDetails = (*details)(nil)
+
+func (d *details) Variant() string {
+	if d == nil {
+		return ""
+	}
+	return d.variant
 }
 
 // FlagProvider implements the interface.ExperimentFlagProvider interface.
@@ -145,66 +162,109 @@ func WithContext(key string, value interface{}) Option {
 // overrides, and returns the Boolean value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool {
-	v, err := fp.client.BooleanValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, _ := fp.BooleanDetails(ctx, flagName, defaultValue, opts...)
+	return v
+}
+
+// BooleanDetails extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the Boolean value for flagName, or defaultValue if no
+// experiment provider is configured. It also returns the details about the flag
+// evaluation.
+func (fp *FlagProvider) BooleanDetails(ctx context.Context, flagName string, defaultValue bool, opts ...any) (bool, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.BooleanValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	return v
+	return d.Value, &details{d.Variant}
 }
 
 // String extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the String value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) String(ctx context.Context, flagName string, defaultValue string, opts ...any) string {
-	v, err := fp.client.StringValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, _ := fp.StringDetails(ctx, flagName, defaultValue, opts...)
+	return v
+}
+
+// StringDetails extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the String value for flagName, or defaultValue if no
+// experiment provider is configured. It also returns the details about the flag
+// evaluation.
+func (fp *FlagProvider) StringDetails(ctx context.Context, flagName string, defaultValue string, opts ...any) (string, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.StringValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	return v
+	return d.Value, &details{d.Variant}
 }
 
 // Float64 extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the Float64 value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Float64(ctx context.Context, flagName string, defaultValue float64, opts ...any) float64 {
-	v, err := fp.client.FloatValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, _ := fp.Float64Details(ctx, flagName, defaultValue, opts...)
+	return v
+}
+
+// Float64Details extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the Float64 value for flagName, or defaultValue if no
+// experiment provider is configured. It also returns the details about the flag
+// evaluation.
+func (fp *FlagProvider) Float64Details(ctx context.Context, flagName string, defaultValue float64, opts ...any) (float64, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.FloatValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	return v
+	return d.Value, &details{d.Variant}
 }
 
 // Int64 extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the Int64 value for flagName, or defaultValue if no
 // experiment provider is configured.
 func (fp *FlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
-	v, err := fp.client.IntValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	v, _ := fp.Int64Details(ctx, flagName, defaultValue, opts...)
+	return v
+}
+
+// Int64Details extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the Int64 value for flagName, or defaultValue if no
+// experiment provider is configured. It also returns the details about the flag
+// evaluation.
+func (fp *FlagProvider) Int64Details(ctx context.Context, flagName string, defaultValue int64, opts ...any) (int64, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.IntValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	return v
+	return d.Value, &details{d.Variant}
 }
 
 // Object extracts the evaluationContext from ctx, applies any option
 // overrides, and returns the map[string]any value for flagName, or defaultValue
 // if no experiment provider is configured.
 func (fp *FlagProvider) Object(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) map[string]any {
-	v, err := fp.client.ObjectValue(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
+	m, _ := fp.ObjectDetails(ctx, flagName, defaultValue, opts...)
+	return m
+}
+
+// ObjectDetails extracts the evaluationContext from ctx, applies any option
+// overrides, and returns the map[string]any value for flagName, or defaultValue
+// if no experiment provider is configured. It also returns the details about
+// the flag evaluation.
+func (fp *FlagProvider) ObjectDetails(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) (map[string]any, interfaces.ExperimentFlagDetails) {
+	d, err := fp.client.ObjectValueDetails(ctx, flagName, defaultValue, fp.getEvaluationContext(ctx, opts...))
 	if err != nil {
 		log.CtxDebugf(ctx, "Experiment flag %q could not be evaluated: %v", flagName, err)
-		return defaultValue
+		return defaultValue, noDetails
 	}
-	if v == nil {
-		return defaultValue
-	}
-	if m, ok := v.(map[string]any); ok {
-		return m
+	v := d.Value
+	if m, ok := d.Value.(map[string]any); ok {
+		return m, &details{d.Variant}
 	} else {
-		log.CtxWarningf(ctx, "Experiment flag %q expected a map[string]any value, but the value is %T (%v)", flagName, v, v)
+		log.CtxWarningf(ctx, "Experiment flag %q expected value of type map[string]any, but the value is %T (%v)", flagName, v, v)
 	}
-	return defaultValue
+	return defaultValue, noDetails
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1761,12 +1761,30 @@ type HitTrackerFactory interface {
 // ExperimentFlagProvider can be use for getting a flag value for a request to
 // enable or disable some experimental functionality. The experiment config is
 // managed outside of the app.
+//
+// Two different sets of methods are provided:
+//   - Boolean, String, Float64, Int64, Object: returns the flag value directly.
+//   - BooleanDetails, StringDetails, Float64Details, Int64Details, ObjectDetails:
+//     returns the flag value and details, including variant name.
 type ExperimentFlagProvider interface {
 	Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool
 	String(ctx context.Context, flagName string, defaultValue string, opts ...any) string
 	Float64(ctx context.Context, flagName string, defaultValue float64, opts ...any) float64
 	Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64
 	Object(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) map[string]any
+
+	BooleanDetails(ctx context.Context, flagName string, defaultValue bool, opts ...any) (bool, ExperimentFlagDetails)
+	StringDetails(ctx context.Context, flagName string, defaultValue string, opts ...any) (string, ExperimentFlagDetails)
+	Float64Details(ctx context.Context, flagName string, defaultValue float64, opts ...any) (float64, ExperimentFlagDetails)
+	Int64Details(ctx context.Context, flagName string, defaultValue int64, opts ...any) (int64, ExperimentFlagDetails)
+	ObjectDetails(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) (map[string]any, ExperimentFlagDetails)
+}
+
+// ExperimentFlagDetails contains details about the flag evaluation.
+type ExperimentFlagDetails interface {
+	// Variant returns the variant name. If the flag is either not configured or
+	// could not be evaluated, it returns an empty string.
+	Variant() string
 }
 
 // Wrapper around a bspb.ByteStream_ReadServer that supports directly providing


### PR DESCRIPTION
It's sometimes necessary to know which `variant` was selected, e.g. https://github.com/buildbuddy-io/buildbuddy/pull/9799

This PR adds "Details" versions of each FlagProvider method so that this info can be retrieved. There are some other things in the flagd Details which might be interesting (such as Error) so I went with an interface exposing a `Variant()` method which we can extend later, rather than just exposing a `variant` string.