### PR TITLE
Don't block on mutexes when calling atime_updater.Enqueue functions

### DIFF
--- a/enterprise/server/atime_updater/atime_updater.go
+++ b/enterprise/server/atime_updater/atime_updater.go
@@ -19,6 +19,8 @@ import (
 )
 
 var (
+	atimeUpdaterEnqueueChanSize = flag.Int("cache_proxy.remote_atime_queue_size", 1000*1000, "The size of the channel to use for buffering enqueued atime updates.")
+
 	// The maximum gRPC message size is 4MB. Each digest proto is
 	// 64 bytes (hash) + 8 bytes (size) + 2 bytes (tags) = 74 bytes. The
 	// remaining fields in FindMissingBlobsRequest should be small (1kb?), so
@@ -100,8 +102,18 @@ func (u *atimeUpdates) findOrCreatePendingUpdate(instanceName string, digestFunc
 	return pendingUpdate
 }
 
+// An enqueued atime update
+type enqueuedAtimeUpdates struct {
+	groupID        string
+	authHeaders    map[string][]string
+	instanceName   string
+	digests        []*repb.Digest
+	digestFunction repb.DigestFunction_Value
+}
 type atimeUpdater struct {
 	authenticator interfaces.Authenticator
+
+	enqueueChan chan *enqueuedAtimeUpdates
 
 	ticker <-chan time.Time
 	quit   chan struct{}
@@ -117,16 +129,30 @@ type atimeUpdater struct {
 }
 
 func Register(env *real_environment.RealEnv) error {
+	updater, err := new(env)
+	if err != nil {
+		return err
+	}
+	// TODO(iain): make an effort to drain queue on server shutdown.
+	go updater.startBatcher()
+	go updater.startSender()
+	env.SetAtimeUpdater(updater)
+	env.GetHealthChecker().RegisterShutdownFunction(updater.shutdown)
+	return nil
+}
+
+func new(env *real_environment.RealEnv) (*atimeUpdater, error) {
 	authenticator := env.GetAuthenticator()
 	if authenticator == nil {
-		return fmt.Errorf("An Authenticator is required to enable the AtimeUpdater.")
+		return nil, fmt.Errorf("An Authenticator is required to enable the AtimeUpdater.")
 	}
 	remote := env.GetContentAddressableStorageClient()
 	if remote == nil {
-		return fmt.Errorf("A remote CAS client is required to enable the AtimeUpdater.")
+		return nil, fmt.Errorf("A remote CAS client is required to enable the AtimeUpdater.")
 	}
 	updater := atimeUpdater{
 		authenticator:       authenticator,
+		enqueueChan:         make(chan *enqueuedAtimeUpdates, *atimeUpdaterEnqueueChanSize),
 		ticker:              env.GetClock().NewTicker(*atimeUpdaterBatchUpdateInterval).Chan(),
 		quit:                make(chan struct{}, 1),
 		updates:             make(map[string]*atimeUpdates),
@@ -135,11 +161,7 @@ func Register(env *real_environment.RealEnv) error {
 		maxDigestsPerGroup:  *atimeUpdaterMaxDigestsPerGroup,
 		remote:              remote,
 	}
-	// TODO(iain): make an effort to drain queue on server shutdown.
-	go updater.start()
-	env.SetAtimeUpdater(&updater)
-	env.GetHealthChecker().RegisterShutdownFunction(updater.shutdown)
-	return nil
+	return &updater, nil
 }
 
 func (u *atimeUpdater) groupID(ctx context.Context) string {
@@ -150,18 +172,58 @@ func (u *atimeUpdater) groupID(ctx context.Context) string {
 	return user.GetGroupID()
 }
 
-func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests []*repb.Digest, digestFunction repb.DigestFunction_Value) {
+func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests []*repb.Digest, digestFunction repb.DigestFunction_Value) bool {
 	if len(digests) == 0 {
-		return
+		return false
 	}
 
 	groupID := u.groupID(ctx)
 	authHeaders := authutil.GetAuthHeaders(ctx)
 	if len(authHeaders) == 0 {
 		log.Infof("Dropping remote atime update due to missing auth headers in context")
-		return
+		return false
+	}
+	update := enqueuedAtimeUpdates{
+		groupID:        groupID,
+		authHeaders:    authHeaders,
+		instanceName:   instanceName,
+		digests:        digests,
+		digestFunction: digestFunction,
 	}
 
+	// Try to send the update to the enqueueChan, where it will be processed by
+	// the batcher, but only if this will not block.
+	select {
+	case u.enqueueChan <- &update:
+		return true
+	default:
+		metrics.RemoteAtimeUpdates.WithLabelValues(
+			groupID,
+			"dropped_channel_full",
+		).Add(float64(len(digests)))
+		return false
+	}
+}
+
+func (u *atimeUpdater) EnqueueByResourceName(ctx context.Context, rn *digest.CASResourceName) bool {
+	return u.Enqueue(ctx, rn.GetInstanceName(), []*repb.Digest{rn.GetDigest()}, rn.GetDigestFunction())
+}
+
+// Runs a loop that consumes updates from enqueueChan and adds them to the
+// batches of pending atime updates to be sent to the backend.
+func (u *atimeUpdater) startBatcher() {
+	for {
+		select {
+		case <-u.quit:
+			return
+		case update := <-u.enqueueChan:
+			u.batch(update)
+		}
+	}
+}
+
+func (u *atimeUpdater) batch(update *enqueuedAtimeUpdates) {
+	groupID := update.groupID
 	u.mu.Lock()
 	updates, ok := u.updates[groupID]
 	if !ok {
@@ -173,24 +235,24 @@ func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests
 	// Uniqueify the incoming digests. Note this wrecks the order of the
 	// requested updates. Too bad. Keep track of the counts for metrics below.
 	keys := map[digest.Key]int{}
-	for _, digestProto := range digests {
+	for _, digestProto := range update.digests {
 		keys[digest.NewKey(digestProto)]++
 	}
 
 	// Always use the most recent auth headers for a group for remote atime updates.
 	updates.mu.Lock()
-	updates.authHeaders = authHeaders
+	updates.authHeaders = update.authHeaders
 
 	// First, find the update that the new digests can be merged into, or create
 	// a new one if one doesn't exist.
-	pendingUpdate := updates.findOrCreatePendingUpdate(instanceName, digestFunction)
+	pendingUpdate := updates.findOrCreatePendingUpdate(update.instanceName, update.digestFunction)
 	updates.mu.Unlock()
 	if pendingUpdate == nil {
-		log.CtxInfof(ctx, "Too many pending FindMissingBlobsRequests for updating remote atime for group %s, dropping %d pending atime updates", groupID, len(keys))
+		log.Infof("Too many pending FindMissingBlobsRequests for updating remote atime for group %s, dropping %d pending atime updates", groupID, len(keys))
 		metrics.RemoteAtimeUpdates.WithLabelValues(
 			groupID,
 			"dropped_too_many_batches",
-		).Add(float64(len(digests)))
+		).Add(float64(len(update.digests)))
 		return
 	}
 
@@ -206,8 +268,8 @@ func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests
 		updates.mu.Lock()
 		if updates.numDigests+1 > u.maxDigestsPerGroup {
 			updates.mu.Unlock()
-			dropped = len(digests) - enqueued - duplicate
-			log.CtxWarningf(ctx, "maxDigestsPerGroup exceeded for group %s, dropping %d digests", groupID, dropped)
+			dropped = len(update.digests) - enqueued - duplicate
+			log.Warningf("maxDigestsPerGroup exceeded for group %s, dropping %d digests", groupID, dropped)
 			break
 		}
 		updates.numDigests++
@@ -217,8 +279,8 @@ func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests
 		duplicate += count - 1
 	}
 
-	if enqueued+duplicate+dropped != len(digests) {
-		log.Debugf("atime-updater metrics don't add up. incoming digests: %d, added: %d, duplicates: %d, dropped: %d", len(digests), enqueued, duplicate, dropped)
+	if enqueued+duplicate+dropped != len(update.digests) {
+		log.Debugf("atime-updater metrics don't add up. incoming digests: %d, added: %d, duplicates: %d, dropped: %d", len(update.digests), enqueued, duplicate, dropped)
 	}
 
 	metrics.RemoteAtimeUpdates.WithLabelValues(
@@ -235,11 +297,8 @@ func (u *atimeUpdater) Enqueue(ctx context.Context, instanceName string, digests
 	).Add(float64(dropped))
 }
 
-func (u *atimeUpdater) EnqueueByResourceName(ctx context.Context, rn *digest.CASResourceName) {
-	u.Enqueue(ctx, rn.GetInstanceName(), []*repb.Digest{rn.GetDigest()}, rn.GetDigestFunction())
-}
-
-func (u *atimeUpdater) start() {
+// Starts the loop that sends atime updates to the backend.
+func (u *atimeUpdater) startSender() {
 	for {
 		select {
 		case <-u.quit:

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -137,38 +137,12 @@ func runFakeCAS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (*fakeC
 	return &cas, repb.NewContentAddressableStorageClient(conn)
 }
 
-func waitExpectingNUpdates(t *testing.T, n int, cas *fakeCAS) {
-	wait := time.Millisecond
-	for i := 0; i < 6; i++ {
-		time.Sleep(wait)
-		wait = wait * 2
-		actual := cas.getUpdates()
-		if len(actual) == n {
-			return
-		}
-	}
-	t.Fatalf("Timed out waiting for expected number of digests. Expected %d, found %d", n, len(cas.getUpdates()))
+func batchUpdate(updater *atimeUpdater) {
+	update := <-updater.enqueueChan
+	updater.batch(update)
 }
 
-func waitExpectingUpdates(t *testing.T, expected []update, cas *fakeCAS) {
-	waitExpectingNUpdates(t, len(expected), cas)
-	require.ElementsMatch(t, expected, cas.getUpdates())
-}
-
-func tickAlot(clock clockwork.FakeClock, interval time.Duration) {
-	for i := 0; i < 25; i++ {
-		clock.Advance(interval)
-		time.Sleep(5 * time.Millisecond)
-	}
-}
-
-func expectNoMoreUpdates(t *testing.T, clock clockwork.FakeClock, cas *fakeCAS) {
-	cas.clearUpdates()
-	tickAlot(clock, time.Second)
-	require.Equal(t, 0, len(cas.updates))
-}
-
-func setup(t testing.TB) (interfaces.Authenticator, interfaces.AtimeUpdater, *fakeCAS, clockwork.FakeClock) {
+func setup(t testing.TB) (interfaces.Authenticator, *atimeUpdater, *fakeCAS, clockwork.FakeClock) {
 	env := testenv.GetTestEnv(t)
 	authenticator := testauth.NewTestAuthenticator(testauth.TestUsers(user1, group1, user2, group2))
 	env.SetAuthenticator(authenticator)
@@ -176,14 +150,13 @@ func setup(t testing.TB) (interfaces.Authenticator, interfaces.AtimeUpdater, *fa
 	env.SetContentAddressableStorageClient(casClient)
 	fakeClock := clockwork.NewFakeClock()
 	env.SetClock(fakeClock)
-	require.NoError(t, Register(env))
-	updater := env.GetAtimeUpdater()
-	require.NotNil(t, updater)
+	updater, err := new(env)
+	require.NoError(t, err)
 	return authenticator, updater, cas, fakeClock
 }
 
-func authenticatedContext(user string, authenticator interfaces.Authenticator) context.Context {
-	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(authutil.ClientIdentityHeaderName, "fakeheader"))
+func authenticatedContext(ctx context.Context, user string, authenticator interfaces.Authenticator) context.Context {
+	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(authutil.ClientIdentityHeaderName, "fakeheader"))
 	if user != "" {
 		ctx = authenticator.AuthContextFromAPIKey(ctx, user)
 	}
@@ -191,21 +164,20 @@ func authenticatedContext(user string, authenticator interfaces.Authenticator) c
 }
 
 func TestAuth(t *testing.T) {
-	authenticator, updater, cas, clock := setup(t)
+	authenticator, updater, cas, _ := setup(t)
 
 	// No auth, no updates
-	ctx := context.Background()
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	clock.Advance(time.Minute)
-	expectNoMoreUpdates(t, clock, cas)
+	ctx := t.Context()
+	require.False(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
 
 	// Anon updates with client-identity header
-	ctx = authenticatedContext("", authenticator)
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	clock.Advance(time.Minute)
-	waitExpectingUpdates(t,
+	ctx = authenticatedContext(t.Context(), "", authenticator)
+	require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
 		[]update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256)},
-		cas)
+		cas.getUpdates())
 
 	cas.mu.Lock()
 	clientIdentity := metadata.ValueFromIncomingContext(cas.lastCtx, authutil.ClientIdentityHeaderName)
@@ -215,12 +187,13 @@ func TestAuth(t *testing.T) {
 	cas.clearUpdates()
 
 	// Group updates with JWT and client-identity header
-	group1Ctx := authenticatedContext(user1, authenticator)
-	updater.Enqueue(group1Ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	clock.Advance(time.Minute)
-	waitExpectingUpdates(t,
+	group1Ctx := authenticatedContext(t.Context(), user1, authenticator)
+	require.True(t, updater.Enqueue(group1Ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
 		[]update{updateOf(group1, "instance-1", digest0, repb.DigestFunction_SHA256)},
-		cas)
+		cas.getUpdates())
 
 	cas.mu.Lock()
 	clientIdentity = metadata.ValueFromIncomingContext(cas.lastCtx, authutil.ClientIdentityHeaderName)
@@ -229,180 +202,210 @@ func TestAuth(t *testing.T) {
 }
 
 func TestEnqueue_SimpleBatching(t *testing.T) {
-	authenticator, updater, cas, clock := setup(t)
-	ctx := authenticatedContext("", authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	ctx := authenticatedContext(t.Context(), "", authenticator)
 
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0, digest1}, repb.DigestFunction_SHA256)
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest2}, repb.DigestFunction_SHA256)
-	require.Equal(t, 0, len(cas.getUpdates()))
-	clock.Advance(time.Minute)
-	waitExpectingUpdates(t,
+	require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0, digest1}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest2}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
 		[]update{
 			updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256),
 			updateOf(anon, "instance-1", digest1, repb.DigestFunction_SHA256),
 			updateOf(anon, "instance-1", digest2, repb.DigestFunction_SHA256)},
-		cas)
-	expectNoMoreUpdates(t, clock, cas)
+		cas.getUpdates())
 }
 
 func TestEnqueue_Deduping(t *testing.T) {
-	flags.Set(t, "cache_proxy.remote_atime_update_interval", time.Millisecond)
-	authenticator, updater, cas, clock := setup(t)
-	ctx := authenticatedContext("", authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	ctx := authenticatedContext(t.Context(), "", authenticator)
 
 	for i := 0; i < 10; i++ {
-		updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
+		require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+		batchUpdate(updater)
 	}
-	require.Equal(t, 0, len(cas.getUpdates()))
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t, []update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256)}, cas)
-	expectNoMoreUpdates(t, clock, cas)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
+		[]update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256)},
+		cas.getUpdates())
 }
 
 func TestEnqueue_InstanceNamesIsolated(t *testing.T) {
-	flags.Set(t, "cache_proxy.remote_atime_update_interval", 999*time.Millisecond)
-	authenticator, updater, cas, clock := setup(t)
-	ctx := authenticatedContext("", authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	ctx := authenticatedContext(t.Context(), "", authenticator)
 
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	updater.Enqueue(ctx, "instance-2", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	updater.Enqueue(ctx, "instance-3", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	require.Equal(t, 0, len(cas.getUpdates()))
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t, []update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256)}, cas)
+	require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	require.True(t, updater.Enqueue(ctx, "instance-2", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	require.True(t, updater.Enqueue(ctx, "instance-3", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
+		[]update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256)},
+		cas.getUpdates())
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t, []update{updateOf(anon, "instance-2", digest0, repb.DigestFunction_SHA256)}, cas)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
+		[]update{updateOf(anon, "instance-2", digest0, repb.DigestFunction_SHA256)},
+		cas.getUpdates())
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t, []update{updateOf(anon, "instance-3", digest0, repb.DigestFunction_SHA256)}, cas)
-	expectNoMoreUpdates(t, clock, cas)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
+		[]update{updateOf(anon, "instance-3", digest0, repb.DigestFunction_SHA256)},
+		cas.getUpdates())
 }
 
 func TestEnqueue_DigestFunctionsIsolated(t *testing.T) {
-	flags.Set(t, "cache_proxy.remote_atime_update_interval", 999*time.Millisecond)
-	authenticator, updater, cas, clock := setup(t)
-	ctx := authenticatedContext("", authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	ctx := authenticatedContext(t.Context(), "", authenticator)
 
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_BLAKE3)
-	require.Equal(t, 0, len(cas.getUpdates()))
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t, []update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256)}, cas)
+	require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_BLAKE3))
+	batchUpdate(updater)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
+		[]update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256)},
+		cas.getUpdates())
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t, []update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_BLAKE3)}, cas)
-	expectNoMoreUpdates(t, clock, cas)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
+		[]update{updateOf(anon, "instance-1", digest0, repb.DigestFunction_BLAKE3)},
+		cas.getUpdates())
 }
 
 func TestEnqueue_GroupsIsolated(t *testing.T) {
-	flags.Set(t, "cache_proxy.remote_atime_update_interval", time.Millisecond)
-	authenticator, updater, cas, clock := setup(t)
-	anonCtx := authenticatedContext("", authenticator)
-	group1Ctx := authenticatedContext(user1, authenticator)
-	group2Ctx := authenticatedContext(user2, authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	anonCtx := authenticatedContext(t.Context(), "", authenticator)
+	group1Ctx := authenticatedContext(t.Context(), user1, authenticator)
+	group2Ctx := authenticatedContext(t.Context(), user2, authenticator)
 
-	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	updater.Enqueue(group1Ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	updater.Enqueue(group2Ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t,
+	require.True(t, updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	require.True(t, updater.Enqueue(group1Ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	require.True(t, updater.Enqueue(group2Ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
 		[]update{
 			updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256),
 			updateOf(group1, "instance-1", digest0, repb.DigestFunction_SHA256),
 			updateOf(group2, "instance-1", digest0, repb.DigestFunction_SHA256)},
-		cas)
-	expectNoMoreUpdates(t, clock, cas)
+		cas.getUpdates())
 }
 
 func TestEnqueue_DedupesToFrontOfLine(t *testing.T) {
-	flags.Set(t, "cache_proxy.remote_atime_update_interval", 999*time.Millisecond)
-	authenticator, updater, cas, clock := setup(t)
-	ctx := authenticatedContext("", authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	ctx := authenticatedContext(t.Context(), "", authenticator)
 
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
-	updater.Enqueue(ctx, "instance-2", []*repb.Digest{digest1}, repb.DigestFunction_SHA256)
-	updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest2}, repb.DigestFunction_SHA256)
-	require.Equal(t, 0, len(cas.getUpdates()))
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t,
+	require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	require.True(t, updater.Enqueue(ctx, "instance-2", []*repb.Digest{digest1}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest2}, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
 		[]update{
 			updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256),
 			updateOf(anon, "instance-1", digest2, repb.DigestFunction_SHA256)},
-		cas)
+		cas.getUpdates())
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingUpdates(t, []update{updateOf(anon, "instance-2", digest1, repb.DigestFunction_SHA256)}, cas)
-	expectNoMoreUpdates(t, clock, cas)
+	updater.sendUpdates(t.Context())
+	require.ElementsMatch(t,
+		[]update{updateOf(anon, "instance-2", digest1, repb.DigestFunction_SHA256)},
+		cas.getUpdates())
+}
+
+func TestEnqueue_EnqueuesDropped(t *testing.T) {
+	flags.Set(t, "cache_proxy.remote_atime_queue_size", 2)
+	authenticator, updater, _, _ := setup(t)
+	anonCtx := authenticatedContext(t.Context(), "", authenticator)
+	group1Ctx := authenticatedContext(t.Context(), user1, authenticator)
+	group2Ctx := authenticatedContext(t.Context(), user2, authenticator)
+
+	require.True(t, updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	require.True(t, updater.Enqueue(anonCtx, "instance-2", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	require.False(t, updater.Enqueue(anonCtx, "instance-3", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+
+	batchUpdate(updater)
+	batchUpdate(updater)
+
+	require.True(t, updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+	require.True(t, updater.Enqueue(group1Ctx, "instance-2", []*repb.Digest{digest1}, repb.DigestFunction_SHA256))
+	require.False(t, updater.Enqueue(group2Ctx, "instance-3", []*repb.Digest{digest2}, repb.DigestFunction_SHA256))
 }
 
 func TestEnqueue_DigestsDropped(t *testing.T) {
 	flags.Set(t, "cache_proxy.remote_atime_max_digests_per_group", 7)
-	authenticator, updater, cas, clock := setup(t)
-	ctx := authenticatedContext("", authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	ctx := authenticatedContext(t.Context(), "", authenticator)
 	digests := []*repb.Digest{digest0, digest1, digest2, digest3, digest4, digest5, digest6, digest7, digest8, digest9, digestA}
 
 	// If the updater accumulates too many digests in a group, it drops them.
 	// This threshold is set to 7 above, so expect that many to be sent, though
 	// order is not guaranteed so we don't know which 7 will be sent.
-	updater.Enqueue(ctx, "instance-1", digests, repb.DigestFunction_SHA256)
-	tickAlot(clock, time.Second)
-	waitExpectingNUpdates(t, 7, cas)
-	expectNoMoreUpdates(t, clock, cas)
-
-	// Make sure there are no more updates sent.
+	require.True(t, updater.Enqueue(ctx, "instance-1", digests, repb.DigestFunction_SHA256))
+	batchUpdate(updater)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 7, len(cas.getUpdates()))
 	cas.clearUpdates()
-	expectNoMoreUpdates(t, clock, cas)
 
 	// Expect the same behavior if they're sent one-by-one.
 	for _, digest := range digests {
-		updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest}, repb.DigestFunction_SHA256)
+		require.True(t, updater.Enqueue(ctx, "instance-1", []*repb.Digest{digest}, repb.DigestFunction_SHA256))
+		batchUpdate(updater)
 	}
-	tickAlot(clock, time.Second)
-	waitExpectingNUpdates(t, 7, cas)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 7, len(cas.getUpdates()))
 	cas.clearUpdates()
-	expectNoMoreUpdates(t, clock, cas)
 
 	// It shouldn't matter what instance name / digest function they're using.
 	for i, digest := range digests {
-		updater.Enqueue(ctx, fmt.Sprintf("instance-%d", i%3), []*repb.Digest{digest}, repb.DigestFunction_SHA256)
+		require.True(t, updater.Enqueue(ctx, fmt.Sprintf("instance-%d", i%3), []*repb.Digest{digest}, repb.DigestFunction_SHA256))
+		batchUpdate(updater)
 	}
-	tickAlot(clock, time.Second)
-	waitExpectingNUpdates(t, 7, cas)
-	expectNoMoreUpdates(t, clock, cas)
+	updater.sendUpdates(t.Context())
+	updater.sendUpdates(t.Context())
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 7, len(cas.getUpdates()))
 }
 
 func TestEnqueue_UpdatesDropped(t *testing.T) {
 	flags.Set(t, "cache_proxy.remote_atime_max_digests_per_update", 5)
 	flags.Set(t, "cache_proxy.remote_atime_max_updates_per_group", 3)
-	flags.Set(t, "cache_proxy.remote_atime_update_interval", 999*time.Millisecond)
-	authenticator, updater, cas, clock := setup(t)
-	ctx := authenticatedContext("", authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	ctx := authenticatedContext(t.Context(), "", authenticator)
 
 	// If the updater accumulates too many updates, it should start to drop
 	// them. setupTest() sets the value of remote_atime_max_updates_per_group to
 	// 3, so expect the first 3 to be sent and the others to be dropped.
 	for i := 1; i <= 10; i++ {
-		updater.Enqueue(ctx, fmt.Sprintf("instance-%d", i), []*repb.Digest{digest0}, repb.DigestFunction_SHA256)
+		require.True(t, updater.Enqueue(ctx, fmt.Sprintf("instance-%d", i), []*repb.Digest{digest0}, repb.DigestFunction_SHA256))
+		batchUpdate(updater)
 	}
-	tickAlot(clock, time.Second)
-	waitExpectingUpdates(t,
+	for i := 1; i <= 10; i++ {
+		updater.sendUpdates(t.Context())
+	}
+	require.ElementsMatch(t,
 		[]update{
 			updateOf(anon, "instance-1", digest0, repb.DigestFunction_SHA256),
 			updateOf(anon, "instance-2", digest0, repb.DigestFunction_SHA256),
 			updateOf(anon, "instance-3", digest0, repb.DigestFunction_SHA256)},
-		cas)
-	expectNoMoreUpdates(t, clock, cas)
+		cas.getUpdates())
 }
 
 func TestEnqueue_Fairness(t *testing.T) {
 	flags.Set(t, "cache_proxy.remote_atime_max_digests_per_update", 5)
 	flags.Set(t, "cache_proxy.remote_atime_max_updates_per_group", 3)
-	flags.Set(t, "cache_proxy.remote_atime_update_interval", 999*time.Millisecond)
-	authenticator, updater, cas, clock := setup(t)
-	anonCtx := authenticatedContext("", authenticator)
-	group1Ctx := authenticatedContext(user1, authenticator)
-	group2Ctx := authenticatedContext(user2, authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	anonCtx := authenticatedContext(t.Context(), "", authenticator)
+	group1Ctx := authenticatedContext(t.Context(), user1, authenticator)
+	group2Ctx := authenticatedContext(t.Context(), user2, authenticator)
 
 	// Updates (in order of first update in the shard):
 	//   Anon/1/SHA: 0, 1, 2, 3, 4
@@ -413,18 +416,22 @@ func TestEnqueue_Fairness(t *testing.T) {
 	//   Grp2/1/SHA: 0, 6, 1, 6
 	//   Anon/1/SHA: 0, 1, 9, 6, 9, 0, 1, 9, 2
 	//   Anon/1/SHA: 0, 0, 0, 6, 1, 0, 1, 2, 2
-	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0, digest1, digest2, digest3, digest4}, repb.DigestFunction_SHA256)
-	updater.Enqueue(group1Ctx, "instance-1", []*repb.Digest{digest0, digest5, digest2, digest6, digest7, digest8}, repb.DigestFunction_SHA256)
-	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0, digest1, digest2, digest3, digest4}, repb.DigestFunction_MD5)
-	updater.Enqueue(anonCtx, "instance-2", []*repb.Digest{digest5, digest6, digest8, digest9, digestA}, repb.DigestFunction_SHA256)
-	updater.Enqueue(group1Ctx, "instance-2", []*repb.Digest{digest0, digest5}, repb.DigestFunction_SHA256)
-	updater.Enqueue(group2Ctx, "instance-1", []*repb.Digest{digest0, digest6, digest1, digest6}, repb.DigestFunction_SHA256)
-	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0, digest1, digest9, digest6, digest9, digest0, digest1, digest9, digest2}, repb.DigestFunction_SHA256)
-	updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0, digest0, digest0, digest6, digest1, digest0, digest1, digest2, digest2}, repb.DigestFunction_SHA256)
-	clock.Advance(time.Second)
+	require.True(t, updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0, digest1, digest2, digest3, digest4}, repb.DigestFunction_SHA256))
+	require.True(t, updater.Enqueue(group1Ctx, "instance-1", []*repb.Digest{digest0, digest5, digest2, digest6, digest7, digest8}, repb.DigestFunction_SHA256))
+	require.True(t, updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0, digest1, digest2, digest3, digest4}, repb.DigestFunction_MD5))
+	require.True(t, updater.Enqueue(anonCtx, "instance-2", []*repb.Digest{digest5, digest6, digest8, digest9, digestA}, repb.DigestFunction_SHA256))
+	require.True(t, updater.Enqueue(group1Ctx, "instance-2", []*repb.Digest{digest0, digest5}, repb.DigestFunction_SHA256))
+	require.True(t, updater.Enqueue(group2Ctx, "instance-1", []*repb.Digest{digest0, digest6, digest1, digest6}, repb.DigestFunction_SHA256))
+	require.True(t, updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0, digest1, digest9, digest6, digest9, digest0, digest1, digest9, digest2}, repb.DigestFunction_SHA256))
+	require.True(t, updater.Enqueue(anonCtx, "instance-1", []*repb.Digest{digest0, digest0, digest0, digest6, digest1, digest0, digest1, digest2, digest2}, repb.DigestFunction_SHA256))
+
+	for i := 0; i < 8; i++ {
+		batchUpdate(updater)
+	}
 
 	// Expect 5 updates from anon, 5 from group1, and 3 from group2.
-	waitExpectingNUpdates(t, 13, cas)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 13, len(cas.getUpdates()))
 	updateCount := map[string]int{anon: 0, group1: 0, group2: 0}
 	for _, update := range cas.getUpdates() {
 		updateCount[update.groupID]++
@@ -433,8 +440,8 @@ func TestEnqueue_Fairness(t *testing.T) {
 
 	// Expect 5 more updates from anon, 2 from group1, and 0 from group2.
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingNUpdates(t, 7, cas)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 7, len(cas.getUpdates()))
 	updateCount = map[string]int{anon: 0, group1: 0, group2: 0}
 	for _, update := range cas.getUpdates() {
 		updateCount[update.groupID]++
@@ -443,8 +450,8 @@ func TestEnqueue_Fairness(t *testing.T) {
 
 	// Expect 5 more for anon and 1 more for group1.
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingNUpdates(t, 6, cas)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 6, len(cas.getUpdates()))
 	updateCount = map[string]int{anon: 0, group1: 0, group2: 0}
 	for _, update := range cas.getUpdates() {
 		updateCount[update.groupID]++
@@ -453,8 +460,8 @@ func TestEnqueue_Fairness(t *testing.T) {
 
 	// Finally, expect 2 more for anon.
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingNUpdates(t, 2, cas)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 2, len(cas.getUpdates()))
 	updateCount = map[string]int{anon: 0, group1: 0, group2: 0}
 	for _, update := range cas.getUpdates() {
 		updateCount[update.groupID]++
@@ -469,9 +476,11 @@ func TestEnqueue_Raciness(t *testing.T) {
 	flags.Set(t, "cache_proxy.remote_atime_max_updates_per_group", 1_000)
 	flags.Set(t, "cache_proxy.remote_atime_update_interval", time.Millisecond)
 	authenticator, updater, _, clock := setup(t)
-	anonCtx := authenticatedContext("", authenticator)
-	group1Ctx := authenticatedContext(user1, authenticator)
-	group2Ctx := authenticatedContext(user2, authenticator)
+	go updater.startBatcher()
+	go updater.startSender()
+	anonCtx := authenticatedContext(t.Context(), "", authenticator)
+	group1Ctx := authenticatedContext(t.Context(), user1, authenticator)
+	group2Ctx := authenticatedContext(t.Context(), user2, authenticator)
 
 	contexts := []context.Context{anonCtx, group1Ctx, group2Ctx}
 	instances := []string{"instance-1", "instance-2", "instance-3"}
@@ -505,11 +514,10 @@ func casResourceName(t *testing.T, d *repb.Digest, instanceName string) *digest.
 func TestEnqueueByResourceName_CAS(t *testing.T) {
 	flags.Set(t, "cache_proxy.remote_atime_max_digests_per_update", 5)
 	flags.Set(t, "cache_proxy.remote_atime_max_updates_per_group", 3)
-	flags.Set(t, "cache_proxy.remote_atime_update_interval", 999*time.Millisecond)
-	authenticator, updater, cas, clock := setup(t)
-	anonCtx := authenticatedContext("", authenticator)
-	group1Ctx := authenticatedContext(user1, authenticator)
-	group2Ctx := authenticatedContext(user2, authenticator)
+	authenticator, updater, cas, _ := setup(t)
+	anonCtx := authenticatedContext(t.Context(), "", authenticator)
+	group1Ctx := authenticatedContext(t.Context(), user1, authenticator)
+	group2Ctx := authenticatedContext(t.Context(), user2, authenticator)
 
 	rn01 := casResourceName(t, digest0, "instance-1")
 	rn02 := casResourceName(t, digest0, "instance-2")
@@ -543,9 +551,13 @@ func TestEnqueueByResourceName_CAS(t *testing.T) {
 	updater.EnqueueByResourceName(group2Ctx, rn21)
 	updater.EnqueueByResourceName(anonCtx, rn51)
 
+	for i := 0; i < 15; i++ {
+		batchUpdate(updater)
+	}
+
 	// First update should be 3 for Anon/2, 1 for Grp1/1, and 1 for Grp2/1
-	clock.Advance(time.Second)
-	waitExpectingNUpdates(t, 6, cas)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 6, len(cas.getUpdates()))
 	updateCount := map[string]int{anon: 0, group1: 0, group2: 0}
 	for _, update := range cas.getUpdates() {
 		updateCount[update.groupID]++
@@ -554,8 +566,8 @@ func TestEnqueueByResourceName_CAS(t *testing.T) {
 
 	// Second update should be 5 for Anon/1
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingNUpdates(t, 5, cas)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 5, len(cas.getUpdates()))
 	updateCount = map[string]int{anon: 0, group1: 0, group2: 0}
 	for _, update := range cas.getUpdates() {
 		updateCount[update.groupID]++
@@ -564,8 +576,8 @@ func TestEnqueueByResourceName_CAS(t *testing.T) {
 
 	// Expect that final Anon/1 update to come through.
 	cas.clearUpdates()
-	clock.Advance(time.Second)
-	waitExpectingNUpdates(t, 1, cas)
+	updater.sendUpdates(t.Context())
+	require.Equal(t, 1, len(cas.getUpdates()))
 	updateCount = map[string]int{anon: 0, group1: 0, group2: 0}
 	for _, update := range cas.getUpdates() {
 		updateCount[update.groupID]++
@@ -597,7 +609,7 @@ func BenchmarkEnqueue(b *testing.B) {
 				for _, digest := range digests {
 					wg.Add(1)
 					go func() {
-						updater.Enqueue(authenticatedContext("", authenticator), instance, []*repb.Digest{digest}, repb.DigestFunction_SHA256)
+						updater.Enqueue(authenticatedContext(b.Context(), "", authenticator), instance, []*repb.Digest{digest}, repb.DigestFunction_SHA256)
 						wg.Done()
 					}()
 				}

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -476,8 +476,8 @@ func TestEnqueue_Raciness(t *testing.T) {
 	flags.Set(t, "cache_proxy.remote_atime_max_updates_per_group", 1_000)
 	flags.Set(t, "cache_proxy.remote_atime_update_interval", time.Millisecond)
 	authenticator, updater, _, clock := setup(t)
-	go updater.startBatcher()
-	go updater.startSender()
+	go updater.batcher()
+	go updater.sender()
 	anonCtx := authenticatedContext(t.Context(), "", authenticator)
 	group1Ctx := authenticatedContext(t.Context(), user1, authenticator)
 	group2Ctx := authenticatedContext(t.Context(), user2, authenticator)
@@ -505,6 +505,8 @@ func TestEnqueue_Raciness(t *testing.T) {
 			clock.Advance(time.Second)
 		}
 	}
+
+	updater.quit <- struct{}{}
 }
 
 func casResourceName(t *testing.T, d *repb.Digest, instanceName string) *digest.CASResourceName {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1681,8 +1681,8 @@ type RegistryService interface {
 }
 
 type AtimeUpdater interface {
-	Enqueue(ctx context.Context, instanceName string, digests []*repb.Digest, digestFunction repb.DigestFunction_Value)
-	EnqueueByResourceName(ctx context.Context, rn *digest.CASResourceName)
+	Enqueue(ctx context.Context, instanceName string, digests []*repb.Digest, digestFunction repb.DigestFunction_Value) bool
+	EnqueueByResourceName(ctx context.Context, rn *digest.CASResourceName) bool
 }
 
 type CPULeaser interface {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1681,7 +1681,13 @@ type RegistryService interface {
 }
 
 type AtimeUpdater interface {
+	// Enqueues atime updates for the provided instanceName, digestFunction,
+	// and set of digests provided. Returns true if the updates were
+	// successfully enqueued, false if not.
 	Enqueue(ctx context.Context, instanceName string, digests []*repb.Digest, digestFunction repb.DigestFunction_Value) bool
+
+	// Enqueues atime updates for the provided resource name. Returns true if
+	// the update was successfully enqueued, false if not.
 	EnqueueByResourceName(ctx context.Context, rn *digest.CASResourceName) bool
 }
 

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -217,6 +217,9 @@ func GetTestEnv(t testing.TB) *real_environment.RealEnv {
 
 type NoOpAtimeUpdater struct{}
 
-func (a *NoOpAtimeUpdater) Enqueue(_ context.Context, _ string, _ []*repb.Digest, _ repb.DigestFunction_Value) {
+func (a *NoOpAtimeUpdater) Enqueue(_ context.Context, _ string, _ []*repb.Digest, _ repb.DigestFunction_Value) bool {
+	return true
 }
-func (a *NoOpAtimeUpdater) EnqueueByResourceName(_ context.Context, _ *digest.CASResourceName) {}
+func (a *NoOpAtimeUpdater) EnqueueByResourceName(_ context.Context, _ *digest.CASResourceName) bool {
+	return true
+}


### PR DESCRIPTION
This PR restructures the atime_updater to use a channel for enqueuing updates, instead of doing it synchronously. Updates are formed and sent to the channel only if sending to the channel will not block. Then, there is a goroutine that consumes updates from this channel and batches them into the per-group, and per-instance-name-and-digest-function maps. There is still another goroutine that consumes these batches and sends them to the backend, as before. This means that calls to atime_updater Enqueue functions should now never block, which should help cache proxy throughput under load a bit. This makes the code a little bit more complicated, but I think it's a reasonable tradeoff to make.

I also changed the tests to call the lifecycle functions on atime_updater directly, instead of relying on a fake clock and sleeps, which should make it a bit faster and less flaky.

Related Issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4944