### PR TITLE
Fix ActionCacheString missing slash

### DIFF
--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -229,9 +229,9 @@ func (r *ACResourceName) ActionCacheString() string {
 	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
 	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
 	if isOldStyleDigestFunction(r.rn.DigestFunction) {
-		return instanceName + "/" + blobTypeSegment(r.GetCompressor()) + "/ac/" + r.GetDigest().GetHash() + strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)
+		return instanceName + "/" + blobTypeSegment(r.GetCompressor()) + "/ac/" + r.GetDigest().GetHash() + "/" + strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)
 	}
-	return instanceName + "/" + blobTypeSegment(r.GetCompressor()) + "/ac/" + strings.ToLower(r.rn.DigestFunction.String()) + "/" + r.GetDigest().GetHash() + strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)
+	return instanceName + "/" + blobTypeSegment(r.GetCompressor()) + "/ac/" + strings.ToLower(r.rn.DigestFunction.String()) + "/" + r.GetDigest().GetHash() + "/" + strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)
 }
 
 func CacheTypeToPrefix(cacheType rspb.CacheType) string {

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -230,6 +230,55 @@ func TestParseUploadResourceName(t *testing.T) {
 	}
 }
 
+func TestActionCacheString(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		have string
+		want string
+	}{
+		{
+			name: "implicit sha256 hash",
+			have: "/blobs/ac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			want: "/blobs/ac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+		},
+		{
+			name: "explicit sha256 hash",
+			have: "/blobs/ac/sha256/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			want: "/blobs/ac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+		},
+		{
+			name: "implicit sha256 hash with instance name",
+			have: "instance_name/blobs/ac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			want: "instance_name/blobs/ac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+		},
+		{
+			name: "blake3 hash",
+			have: "/blobs/ac/blake3/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			want: "/blobs/ac/blake3/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+		},
+		{
+			name: "blake3 hash with instance name",
+			have: "instance_name/blobs/ac/blake3/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			want: "instance_name/blobs/ac/blake3/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+		},
+		{
+			name: "normalized instance name slashes",
+			have: "//foo//bar//blobs/ac/blake3/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			want: "/foo/bar/blobs/ac/blake3/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			have, err := digest.ParseActionCacheResourceName(tc.have)
+			if err != nil {
+				t.Fatalf("ParseActionCacheResourceName(%q) got err %v", tc.have, err)
+			}
+			if have.ActionCacheString() != tc.want {
+				t.Errorf("ActionCacheString(%q) got %q; want %q", tc.have, have.ActionCacheString(), tc.want)
+			}
+		})
+	}
+}
+
 func FuzzParseUploadResourceName(f *testing.F) {
 	f.Add("instance_name/uploads/2148e1f1-aacc-41eb-a31c-22b6da7c7ac1/blobs/da39a3ee5e6b4b0d3255bfef95601890afd80709/1234")
 	f.Add("instance/uploads/2148e1f1-aacc-41eb-a31c-22b6da7c7ac1/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234")

--- a/tools/cas/cas.go
+++ b/tools/cas/cas.go
@@ -28,9 +28,9 @@ import (
 var (
 	// Required flags:
 
-	target     = flag.String("target", "", "Cache grpc target, such as grpcs://remote.buildbuddy.io")
-	blobDigest = flag.String("digest", "", "Digest of the blob to fetch, in HASH/SIZE format.")
-	blobType   = flag.String("type", "", "Type of blob to inspect: Action, ActionResult, Command, Tree, file, stdout, stderr")
+	target   = flag.String("target", "", "Cache grpc target, such as grpcs://remote.buildbuddy.io")
+	resource = flag.String("resource", "", "Resource to fetch. May be a simple digest (HASH/SIZE) or a full resource name.")
+	blobType = flag.String("type", "", "Type of blob to inspect: Action, ActionResult, ExecuteResponse, Command, Tree, file, stdout, stderr")
 
 	// Optional flags:
 
@@ -59,26 +59,42 @@ func main() {
 	if *target == "" {
 		log.Fatalf("Missing --target")
 	}
-	if *blobDigest == "" {
-		log.Fatalf("Missing --digest")
+	if *resource == "" {
+		log.Fatalf("Missing --resource")
+	}
+
+	resourceNameString := *resource
+
+	// If fetching an ExecuteResponse then we're expecting an execution ID.
+	// Parse the execution ID, and use the hash function to get an AC resource
+	// name.
+	if *blobType == "ExecuteResponse" {
+		r, err := digest.ParseUploadResourceName(*resource)
+		if err != nil {
+			log.Fatalf("Parse --resource as upload resource name: %s", err)
+		}
+		executeResponseDigest, err := digest.Compute(strings.NewReader(*resource), r.GetDigestFunction())
+		if err != nil {
+			log.Fatalf("Failed to compute execute response digest: %s", err)
+		}
+		resourceNameString = digest.NewACResourceName(executeResponseDigest, r.GetInstanceName(), r.GetDigestFunction()).ActionCacheString()
 	}
 
 	// For backwards compatibility, attempt to fixup old style digest
 	// strings that don't start with a '/blobs/' prefix.
-	digestString := *blobDigest
-	if !strings.HasPrefix(digestString, "/blobs") {
-		digestString = "/blobs/" + digestString
+	if !strings.HasPrefix(resourceNameString, "/blobs") {
+		resourceNameString = "/blobs/" + resourceNameString
 	}
 
 	var ind *rspb.ResourceName
-	if *blobType == "ActionResult" {
-		indDownload, err := digest.ParseActionCacheResourceName(digestString)
+	if *blobType == "ActionResult" || *blobType == "ExecuteResponse" {
+		indDownload, err := digest.ParseActionCacheResourceName(resourceNameString)
 		if err != nil {
 			log.Fatal(status.Message(err))
 		}
 		ind = indDownload.ToProto()
 	} else {
-		indDownload, err := digest.ParseDownloadResourceName(digestString)
+		indDownload, err := digest.ParseDownloadResourceName(resourceNameString)
 		if err != nil {
 			log.Fatal(status.Message(err))
 		}
@@ -146,7 +162,7 @@ func main() {
 	}
 
 	// Handle ActionResults (these are stored in the action cache)
-	if *blobType == "ActionResult" {
+	if *blobType == "ActionResult" || *blobType == "ExecuteResponse" {
 		r, err := digest.ACResourceNameFromProto(ind)
 		if err != nil {
 			log.Fatalf("Failed to convert resource name to AC: %s", err)
@@ -154,6 +170,16 @@ func main() {
 		ar, err := cachetools.GetActionResult(ctx, acClient, r)
 		if err != nil {
 			log.Fatal(err.Error())
+		}
+		// When fetching an ExecuteResponse, the response is encoded in the
+		// action stdout.
+		if *blobType == "ExecuteResponse" {
+			executeResponse := &repb.ExecuteResponse{}
+			if err := proto.Unmarshal(ar.GetStdoutRaw(), executeResponse); err != nil {
+				log.Fatalf("Failed to unmarshal execute response: %s", err)
+			}
+			printMessage(executeResponse)
+			return
 		}
 		printMessage(ar)
 		return


### PR DESCRIPTION
ActionCacheString was missing a slash between the digest and the size. I don't think this was causing any problems in practice since it's only used for the lookaside cache ([here](https://github.com/buildbuddy-io/buildbuddy/blob/d4f341434dceada7184d359403c4b25aeeb195db/enterprise/server/backends/distributed/distributed.go#L389)) but I hit this bug while trying to call this function from `tools/cas`.