### PR TITLE
org_members: refactor remaining spots to use accountName

### DIFF
--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -299,14 +299,14 @@
   background-color: #bbdefb;
 }
 
-.org-members .org-member-email {
+.org-members .org-member-name {
   font-weight: 600;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.org-members .org-member-email svg {
+.org-members .org-member-name svg {
   width: 16px;
   height: 16px;
 }

--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -365,14 +365,14 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
               {!this.props.user.selectedGroup.externalUserManagement && (
                 <div>
                   <Checkbox
-                    title={`Select ${member?.user?.email || member?.user?.name?.full}`}
+                    title={`Select ${accountName(member.user)}`}
                     className="org-member-checkbox"
                     checked={this.state.selectedUserIds.has(member?.user?.userId?.id || "")}
                   />
                 </div>
               )}
-              <div className="org-member-email">
-                {member?.user?.email || member?.user?.name?.full} {iconFromAccountType(member.user?.accountType)}
+              <div className="org-member-name">
+                {accountName(member.user)} {iconFromAccountType(member.user?.accountType)}
               </div>
               <div className="org-member-role">
                 {getRoleLabel(member?.role || 0)} {this.isLoggedInUser(member) && <>(You)</>}


### PR DESCRIPTION
In a9aa1fa663629cbec6484652f15d40bc658dc482, we introduced accountName
function which output the standardized account name based on the
provided UserGroup.

Update the remaining places in the org_members page to use the new
function.
