### PR TITLE
[oci cache] log manifest hits and misses at info level

### DIFF
--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -292,7 +292,7 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 			http.Error(w, fmt.Sprintf("Error parsing resolved digest in %q: %s", resolvedRef.Context(), err), http.StatusInternalServerError)
 			return
 		}
-		err = fetchFromCacheWriteToResponse(ctx, w, bsClient, acClient, resolvedRef.Context(), hash, ociResourceType, writeBody)
+		err = fetchFromCacheWriteToResponse(ctx, w, bsClient, acClient, resolvedRef.Context(), hash, ociResourceType, writeBody, ref)
 		if err == nil {
 			return // Successfully served request from cache.
 		}
@@ -368,9 +368,9 @@ func writeBlobMetadataToResponse(ctx context.Context, w http.ResponseWriter, has
 	w.Header().Add(headerContentType, blobMetadata.GetContentType())
 }
 
-func fetchFromCacheWriteToResponse(ctx context.Context, w http.ResponseWriter, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, ociResourceType ocipb.OCIResourceType, writeBody bool) error {
+func fetchFromCacheWriteToResponse(ctx context.Context, w http.ResponseWriter, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, ociResourceType ocipb.OCIResourceType, writeBody bool, originalRef gcrname.Reference) error {
 	if ociResourceType == ocipb.OCIResourceType_MANIFEST {
-		mc, err := ocicache.FetchManifestFromAC(ctx, acClient, repo, hash)
+		mc, err := ocicache.FetchManifestFromAC(ctx, acClient, repo, hash, originalRef)
 		if err != nil {
 			return err
 		}

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -350,7 +350,7 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 		return
 	}
 
-	err = ocicache.WriteBlobOrManifestToCacheAndWriter(ctx, upresp.Body, w, bsClient, acClient, resolvedRef.Context(), ociResourceType, hash, contentType, contentLength)
+	err = ocicache.WriteBlobOrManifestToCacheAndWriter(ctx, upresp.Body, w, bsClient, acClient, resolvedRef.Context(), ociResourceType, hash, contentType, contentLength, ref)
 	if err != nil && err != context.Canceled {
 		log.CtxWarningf(ctx, "Error writing response body to cache for %q: %s", resolvedRef.Context(), err)
 	}

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -373,6 +373,7 @@ func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef gcrname.Ref
 			digestOrTagRef.Context(),
 			remoteDesc.Digest,
 			string(remoteDesc.MediaType),
+			digestOrTagRef,
 		)
 		if err != nil {
 			log.CtxWarningf(ctx, "Could not write manifest to cache: %s", err)

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -338,6 +338,7 @@ func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef gcrname.Ref
 			acClient,
 			digestOrTagRef.Context(),
 			desc.Digest,
+			digestOrTagRef,
 		)
 		if err != nil && !status.IsNotFoundError(err) {
 			log.CtxWarningf(ctx, "Error fetching manifest from cache: %s", err)

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -71,36 +71,40 @@ func updateCacheEventMetric(ociResourceTypeLabel, cacheEventType string) {
 	}).Inc()
 }
 
-func manifestMiss(ctx context.Context) {
-	log.CtxDebug(ctx, "oci cache manifest miss")
+func manifestMiss(ctx context.Context, repo gcrname.Repository) {
+	log.CtxInfof(ctx, "OCI cache manifest miss in %q", repo)
 	updateCacheEventMetric(metrics.OCIManifestResourceTypeLabel, metrics.MissStatusLabel)
 }
 
-func manifestHit(ctx context.Context) {
-	log.CtxDebug(ctx, "oci cache manifest hit")
+func manifestHit(ctx context.Context, repo gcrname.Repository) {
+	log.CtxInfof(ctx, "OCI cache manifest hit in %q", repo)
 	updateCacheEventMetric(metrics.OCIManifestResourceTypeLabel, metrics.HitStatusLabel)
 }
 
 func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash) (*ocipb.OCIManifestContent, error) {
 	arRN, err := manifestACKey(repo, hash)
 	if err != nil {
-		manifestMiss(ctx)
+		manifestMiss(ctx, repo)
+		log.CtxWarningf(ctx, "Error creating key for manifest in %q: %s", repo, err)
 		return nil, err
 	}
 	ar, err := cachetools.GetActionResult(ctx, acClient, arRN)
 	if err != nil {
-		manifestMiss(ctx)
+		manifestMiss(ctx, repo)
+		if !status.IsNotFoundError(err) {
+			log.CtxWarningf(ctx, "Error getting action result for manifest in %q: %s", repo, err)
+		}
 		return nil, err
 	}
 	meta := ar.GetExecutionMetadata()
 	if meta == nil {
-		manifestMiss(ctx)
+		manifestMiss(ctx, repo)
 		log.CtxWarningf(ctx, "Missing execution metadata for manifest in %q", repo)
 		return nil, status.InternalErrorf("missing execution metadata for manifest in %q", repo)
 	}
 	aux := meta.GetAuxiliaryMetadata()
 	if aux == nil || len(aux) != 1 {
-		manifestMiss(ctx)
+		manifestMiss(ctx, repo)
 		log.CtxWarningf(ctx, "Missing auxiliary metadata for manifest in %q", repo)
 		return nil, status.InternalErrorf("missing auxiliary metadata for manifest in %q", repo)
 	}
@@ -108,10 +112,10 @@ func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, r
 	var mc ocipb.OCIManifestContent
 	err = any.UnmarshalTo(&mc)
 	if err != nil {
-		manifestMiss(ctx)
+		manifestMiss(ctx, repo)
 		return nil, status.InternalErrorf("could not unmarshal metadata for manifest in %q: %s", repo, err)
 	}
-	manifestHit(ctx)
+	manifestHit(ctx, repo)
 	return &mc, nil
 }
 

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -72,7 +72,7 @@ func updateCacheEventMetric(ociResourceTypeLabel, cacheEventType string) {
 }
 
 func manifestMiss(ctx context.Context, repo gcrname.Repository, hash gcr.Hash) {
-	log.CtxInfof(ctx, "OCI cache manifest miss in %s:%s", repo, hash)
+	log.CtxInfof(ctx, "OCI cache manifest miss %s:%s", repo, hash)
 	updateCacheEventMetric(metrics.OCIManifestResourceTypeLabel, metrics.MissStatusLabel)
 }
 

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -67,6 +67,7 @@ func WriteManifestToAC(ctx context.Context, raw []byte, acClient repb.ActionCach
 		log.CtxWarningf(ctx, "Error writing manifest %s:%s (original ref %q) to AC: %s", repo, hash, originalRef, err)
 		return err
 	}
+	log.CtxInfof(ctx, "Successfully wrote manifest %s:%s (original ref %q)", repo, hash, originalRef)
 	return nil
 }
 

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -113,6 +113,7 @@ func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, r
 	err = any.UnmarshalTo(&mc)
 	if err != nil {
 		manifestMiss(ctx, repo)
+		log.CtxWarningf(ctx, "Error unmarshalling manifest content in %q: %s", repo, err)
 		return nil, status.InternalErrorf("could not unmarshal metadata for manifest in %q: %s", repo, err)
 	}
 	manifestHit(ctx, repo)

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -68,7 +68,7 @@ func TestCacheSecret(t *testing.T) {
 			require.NoError(t, err)
 
 			flags.Set(t, "oci.cache.secret", tc.writeSecret)
-			err = ocicache.WriteManifestToAC(ctx, raw, acClient, ref.Context(), hash, contentType)
+			err = ocicache.WriteManifestToAC(ctx, raw, acClient, ref.Context(), hash, contentType, ref)
 			require.NoError(t, err)
 
 			flags.Set(t, "oci.cache.secret", tc.fetchSecret)
@@ -132,6 +132,7 @@ func TestManifestWrittenOnlyToAC(t *testing.T) {
 		hash,
 		contentType,
 		int64(len(raw)),
+		ref,
 	)
 	require.NoError(t, err)
 	require.Equal(t, len(raw), out.Len())

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -72,7 +72,7 @@ func TestCacheSecret(t *testing.T) {
 			require.NoError(t, err)
 
 			flags.Set(t, "oci.cache.secret", tc.fetchSecret)
-			mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref.Context(), hash)
+			mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref.Context(), hash, ref)
 			if !tc.canFetch {
 				require.Error(t, err)
 				require.Nil(t, mc)
@@ -137,7 +137,7 @@ func TestManifestWrittenOnlyToAC(t *testing.T) {
 	require.Equal(t, len(raw), out.Len())
 	require.Empty(t, cmp.Diff(raw, out.Bytes()))
 
-	mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref.Context(), hash)
+	mc, err := ocicache.FetchManifestFromAC(ctx, acClient, ref.Context(), hash, ref)
 	require.NoError(t, err)
 	require.NotNil(t, mc)
 


### PR DESCRIPTION
* Log OCI manifest cache hits and misses at info level (along with repository).
* Log warnings for any errors fetching manifests from the cache.