### PR TITLE
Double the size of the pebble table cache

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -514,6 +514,7 @@ func defaultPebbleOptions(mc *pebble.MetricsCollector, pcOpts *Options) *pebble.
 		L0CompactionThreshold:    2,
 		MaxConcurrentCompactions: func() int { return 18 },
 		MemTableSize:             64 << 20, // 64 MB
+		MaxOpenFiles:             2000,     // double the default
 		EventListener: &pebble.EventListener{
 			BackgroundError: mc.BackgroundError,
 			WriteStallBegin: mc.WriteStallBegin,


### PR DESCRIPTION
Since the size of the pebble cache is doubling with GCS, the table cache hit rate went from 99.9% to 93.7%. I hope that doubling the table cache size will recover the cache hit rate. This only takes an extra 1MB per pebble cache (so 2MB during the migration).

The table cache size is controlled by the MaxOpenFiles option.