### PR TITLE
Simplify and optimize migration_cache.Reader

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -1202,27 +1202,28 @@ func TestReadsCopyData(t *testing.T) {
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
-	// Read
-	r, buf := testdigest.RandomCASResourceBuf(t, 10)
-	require.NoError(t, srcCache.Set(ctx, r, buf))
-	reader, err := mc.Reader(ctx, r, 0, 0)
-	require.NoError(t, err)
-	reader.Close()
-	waitForCopy(t, ctx, destCache, r)
-
-	// Get
-	r, buf = testdigest.RandomCASResourceBuf(t, 10)
-	require.NoError(t, srcCache.Set(ctx, r, buf))
-	_, err = mc.Get(ctx, r)
-	require.NoError(t, err)
-	waitForCopy(t, ctx, destCache, r)
-
-	// GetMulti
-	r, buf = testdigest.RandomCASResourceBuf(t, 10)
-	require.NoError(t, srcCache.Set(ctx, r, buf))
-	_, err = mc.GetMulti(ctx, []*rspb.ResourceName{r})
-	require.NoError(t, err)
-	waitForCopy(t, ctx, destCache, r)
+	t.Run("Reader", func(t *testing.T) {
+		r, buf := testdigest.RandomCASResourceBuf(t, 10)
+		require.NoError(t, srcCache.Set(ctx, r, buf))
+		reader, err := mc.Reader(ctx, r, 0, 0)
+		require.NoError(t, err)
+		reader.Close()
+		waitForCopy(t, ctx, destCache, r)
+	})
+	t.Run("Get", func(t *testing.T) {
+		r, buf := testdigest.RandomCASResourceBuf(t, 10)
+		require.NoError(t, srcCache.Set(ctx, r, buf))
+		_, err = mc.Get(ctx, r)
+		require.NoError(t, err)
+		waitForCopy(t, ctx, destCache, r)
+	})
+	t.Run("GetMulti", func(t *testing.T) {
+		r, buf := testdigest.RandomCASResourceBuf(t, 10)
+		require.NoError(t, srcCache.Set(ctx, r, buf))
+		_, err = mc.GetMulti(ctx, []*rspb.ResourceName{r})
+		require.NoError(t, err)
+		waitForCopy(t, ctx, destCache, r)
+	})
 }
 
 func TestReadWrite(t *testing.T) {


### PR DESCRIPTION
This started as a change to improve migration cache logging and metrics, but I had to rework the Reader method to do that. Once I did, I realized it's now faster. They key changes:

- Instead of allocating a buffer for destination reads, use io.Discard
- If the source reader fails, don't create a double reader. There's no point since we won't do anything useful when the src read fails.
- Create both readers in the main goroutine. The overhead of errgroup isn't worth it.
- If the destination read succeeds, don't send a non-blocking copy.

Benchmark results:
```
                            │    base2    │               after3                │
                            │   sec/op    │   sec/op     vs base                │
Read/LocalMigration10-24      23.84µ ± 2%   16.79µ ± 3%  -29.58% (p=0.000 n=11)
Read/LocalMigration100-24     25.27µ ± 2%   18.01µ ± 1%  -28.73% (p=0.000 n=11)
Read/LocalMigration1000-24    28.40µ ± 2%   20.09µ ± 1%  -29.27% (p=0.000 n=11)
Read/LocalMigration10000-24   71.74µ ± 7%   63.60µ ± 5%  -11.34% (p=0.000 n=11)
Read/DistMigration10-24       145.7µ ± 1%   142.5µ ± 1%   -2.14% (p=0.001 n=11)
Read/DistMigration100-24      146.6µ ± 1%   146.6µ ± 3%        ~ (p=0.898 n=11)
Read/DistMigration1000-24     153.5µ ± 1%   151.3µ ± 3%        ~ (p=0.133 n=11)
Read/DistMigration10000-24    215.4µ ± 1%   207.0µ ± 2%   -3.89% (p=0.000 n=11)
geomean                       73.65µ        63.14µ       -14.27%

                            │    base2     │                 after3                 │
                            │     B/s      │     B/s       vs base                  │
Read/LocalMigration10-24      410.2Ki ± 2%   585.9Ki ± 2%  +42.86% (p=0.000 n=11)
Read/LocalMigration100-24     3.777Mi ± 1%   5.293Mi ± 1%  +40.15% (p=0.000 n=11)
Read/LocalMigration1000-24    33.59Mi ± 2%   47.48Mi ± 2%  +41.37% (p=0.000 n=11)
Read/LocalMigration10000-24   132.9Mi ± 7%   149.9Mi ± 6%  +12.79% (p=0.000 n=11)
Read/DistMigration10-24       68.36Ki ± 0%   68.36Ki ± 0%        ~ (p=1.000 n=11) ¹
Read/DistMigration100-24      664.1Ki ± 4%   664.1Ki ± 6%        ~ (p=0.903 n=11)
Read/DistMigration1000-24     6.218Mi ± 3%   6.304Mi ± 3%        ~ (p=0.128 n=11)
Read/DistMigration10000-24    44.28Mi ± 1%   46.07Mi ± 2%   +4.05% (p=0.000 n=11)
geomean                       4.104Mi        4.777Mi       +16.39%
¹ all samples are equal

                            │     base2      │                after3                │
                            │      B/op      │     B/op      vs base                │
Read/LocalMigration10-24      12.241Ki ±  0%   9.497Ki ± 0%  -22.42% (p=0.000 n=11)
Read/LocalMigration100-24     12.571Ki ±  0%   9.856Ki ± 0%  -21.60% (p=0.000 n=11)
Read/LocalMigration1000-24     15.29Ki ± 12%   12.90Ki ± 1%  -15.62% (p=0.000 n=11)
Read/LocalMigration10000-24    51.31Ki ± 37%   45.03Ki ± 4%        ~ (p=0.748 n=11)
Read/DistMigration10-24        45.43Ki ±  0%   42.69Ki ± 0%   -6.02% (p=0.000 n=11)
Read/DistMigration100-24       46.17Ki ±  0%   43.35Ki ± 0%   -6.11% (p=0.000 n=11)
Read/DistMigration1000-24      52.09Ki ±  0%   49.03Ki ± 0%   -5.87% (p=0.000 n=11)
Read/DistMigration10000-24     85.61Ki ±  1%   81.75Ki ± 1%   -4.50% (p=0.000 n=11)
geomean                        32.10Ki         28.23Ki       -12.07%

                            │   base2    │               after3               │
                            │ allocs/op  │ allocs/op   vs base                │
Read/LocalMigration10-24      187.0 ± 0%   144.0 ± 0%  -22.99% (p=0.000 n=11)
Read/LocalMigration100-24     187.0 ± 0%   144.0 ± 0%  -22.99% (p=0.000 n=11)
Read/LocalMigration1000-24    187.0 ± 0%   144.0 ± 0%  -22.99% (p=0.000 n=11)
Read/LocalMigration10000-24   189.0 ± 0%   146.0 ± 0%  -22.75% (p=0.000 n=11)
Read/DistMigration10-24       673.0 ± 0%   630.0 ± 0%   -6.39% (p=0.000 n=11)
Read/DistMigration100-24      673.0 ± 0%   630.0 ± 0%   -6.39% (p=0.000 n=11)
Read/DistMigration1000-24     673.0 ± 0%   630.0 ± 0%   -6.39% (p=0.000 n=11)
Read/DistMigration10000-24    671.0 ± 0%   628.0 ± 0%   -6.41% (p=0.000 n=11)
geomean                       355.1        301.6       -15.07%
```