### PR TITLE
github: remove fieldgetter usage

### DIFF
--- a/enterprise/server/webhooks/github/BUILD
+++ b/enterprise/server/webhooks/github/BUILD
@@ -7,7 +7,6 @@ go_library(
     srcs = ["github.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/github",
     deps = [
-        "//enterprise/server/util/fieldgetter",
         "//enterprise/server/webhooks/webhook_data",
         "//server/backends/github",
         "//server/environment",


### PR DESCRIPTION
The `fieldgetter` utility was used to extract values from GitHub webhook
event structs using reflection. This commit removes its usage and
replaces it with direct method calls on the event objects. This
simplifies the code by removing an unnecessary dependency and allows for
direct, type-safe access to event fields.
