### PR TITLE
Don't always set ChunkSize=0

### DIFF
--- a/server/testutil/mockgcs/mockgcs.go
+++ b/server/testutil/mockgcs/mockgcs.go
@@ -67,7 +67,7 @@ func (m *mockGCS) Reader(ctx context.Context, blobName string) (io.ReadCloser, e
 	return io.NopCloser(bytes.NewReader(blob.data)), nil
 }
 
-func (m *mockGCS) ConditionalWriter(ctx context.Context, blobName string, overwriteExisting bool, customTime time.Time) (interfaces.CommittedWriteCloser, error) {
+func (m *mockGCS) ConditionalWriter(ctx context.Context, blobName string, overwriteExisting bool, customTime time.Time, estimatedSize int64) (interfaces.CommittedWriteCloser, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	_, exists := m.items[blobName]


### PR DESCRIPTION
For large writes, keep it set to the default 16MiB, so we don't try to send a single HTTP POST with hundreds or thousands of MiB. This also allows the GCS client library to retry a failed chunk, so we don't lose the whole upload with a temporary error, which might help with tail latency.