### PR TITLE
Make distributed.Cache.Contains use the lookaside cache

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -975,6 +975,9 @@ func (c *Cache) getBackfillOrders(r *rspb.ResourceName, ps *peerset.PeerSet) []*
 //
 // Values found on a non-primary replica will be backfilled to the primary.
 func (c *Cache) Contains(ctx context.Context, r *rspb.ResourceName) (bool, error) {
+	if _, found := c.getLookasideEntry(ctx, r); found {
+		return true, nil
+	}
 	ps := c.readPeers(r.GetDigest())
 	backfill := func() {
 		if err := c.backfillPeers(ctx, c.getBackfillOrders(r, ps)); err != nil {


### PR DESCRIPTION
I don't expect this to have any large performance benefits, since Contains is only used when starting a bytestream write and when caching a TreeNode, but it's an easy change and makes things more consistent.