### PR TITLE
Reduce errors from clickhouse replication lag when fetching executions

### DIFF
--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
@@ -276,10 +276,10 @@ func (c *collector) DeleteExecutions(ctx context.Context, iid string) error {
 	return c.rdb.Del(ctx, getExecutionKey(iid)).Err()
 }
 
-// SoftDeleteExecutions decreases the TTL of executions data so they're cleaned up soon,
-// but not immediately.
-func (c *collector) SoftDeleteExecutions(ctx context.Context, iid string) error {
-	return c.rdb.Expire(ctx, getExecutionKey(iid), 5*time.Minute).Err()
+// ExpireExecutions sets the TTL of executions data. This can be used to clean
+// up executions data after some delay.
+func (c *collector) ExpireExecutions(ctx context.Context, iid string, ttl time.Duration) error {
+	return c.rdb.Expire(ctx, getExecutionKey(iid), ttl).Err()
 }
 
 func (c *collector) DeleteExecutionInvocationLinks(ctx context.Context, executionID string) error {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -99,6 +99,11 @@ const (
 	// Max total pattern length to include in the Expanded event returned to the
 	// UI.
 	maxPatternLengthBytes = 10_000
+
+	// Rather than immediately deleting executions data from Redis after flushing
+	// finalized data to Clickhouse, expire it after this TTL so that even if Clickhouse
+	// has replication lag, clients will still be able to read the data from Redis.
+	expireRedisExecutionsTTL = 5 * time.Minute
 )
 
 var (
@@ -353,9 +358,11 @@ func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, ij *in
 	// Always clean up executions in Collector because we are not retrying
 	defer func() {
 		// Clickhouse ReplicatedMergeTree tables can have replication lag, which can cause
-		// reads of executions data to fail. Keep the data in Redis a little bit
+		// reads of executions data to fail.
+		// Rather than immediately deleting executions data from Redis after flushing
+		// finalized data to Clickhouse, keep the data in Redis a little bit
 		// longer, so clients can read executions data from Redis in these cases.
-		err := r.env.GetExecutionCollector().SoftDeleteExecutions(ctx, inv.InvocationID)
+		err := r.env.GetExecutionCollector().ExpireExecutions(ctx, inv.InvocationID, expireRedisExecutionsTTL)
 		if err != nil {
 			log.CtxErrorf(ctx, "failed to soft delete executions in collector: %s", err)
 		}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1469,7 +1469,7 @@ type ExecutionCollector interface {
 	// available starting from the start index.
 	GetExecutions(ctx context.Context, iid string, start, stop int64) ([]*repb.StoredExecution, error)
 	DeleteExecutions(ctx context.Context, iid string) error
-	SoftDeleteExecutions(ctx context.Context, iid string) error
+	ExpireExecutions(ctx context.Context, iid string, ttl time.Duration) error
 	AddInvocation(ctx context.Context, inv *sipb.StoredInvocation) error
 	GetInvocation(ctx context.Context, iid string) (*sipb.StoredInvocation, error)
 	AddExecutionInvocationLink(ctx context.Context, link *sipb.StoredInvocationLink, bidirectional bool) error


### PR DESCRIPTION
Executions data is stored in Redis before it's finalized, and eventually finalized and stored in Clickhouse. When written to Clickhouse, the Redis entries are deleted. Due to replication lag with clickhouse ReplicatedMergeTree tables, there can be a window when the data is unreadable - it's been deleted from Redis, and the Clickhouse read may go to a replica that doesn't have the data yet

This PR deletes the data from Redis with some buffer time instead, by setting a 5min TTL on the entries. In the last 2 weeks, [the max replication lag was ~2min](https://metrics.buildbuddy.io/d/clickhouse-operator/clickhouse-operator-dashboard?orgId=1&from=2025-06-19T05:12:30.621Z&to=2025-07-07T21:43:27.293Z&timezone=browser&var-exported_namespace=$__all&var-chi=$__all&var-hostname=$__all&refresh=1m&viewPanel=panel-7)

More context [here](https://buildbuddy-corp.slack.com/archives/C0495TM9UUE/p1751914394107319)