### PR TITLE
Support all ExecutionMetricType enums with GenericFilter

### DIFF
--- a/proto/stat_filter.proto
+++ b/proto/stat_filter.proto
@@ -267,24 +267,24 @@ enum FilterType {
     supported_objects:
       [INVOCATION_OBJECTS];
   }];
-  INVOCATION_CAS_CACHE_DOWNLOAD_SIZE_FILTER_TYPE = 20 [(filter_type_options) = {
-    category:
-      INT_FILTER_CATEGORY;
-    database_column_name:
-      "total_download_size_bytes";
-    supported_objects:
-      [INVOCATION_OBJECTS];
-  }];
-  INVOCATION_CAS_CACHE_DOWNLOAD_SPEED_FILTER_TYPE = 21
+  INVOCATION_CAS_CACHE_DOWNLOAD_BYTES_FILTER_TYPE = 20
       [(filter_type_options) = {
         category:
           INT_FILTER_CATEGORY;
         database_column_name:
-          "download_throughput_bytes_per_second";
+          "total_download_size_bytes";
         supported_objects:
           [INVOCATION_OBJECTS];
       }];
-  INVOCATION_CAS_CACHE_UPLOAD_SIZE_FILTER_TYPE = 22 [(filter_type_options) = {
+  INVOCATION_CAS_CACHE_DOWNLOAD_BPS_FILTER_TYPE = 21 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "download_throughput_bytes_per_second";
+    supported_objects:
+      [INVOCATION_OBJECTS];
+  }];
+  INVOCATION_CAS_CACHE_UPLOAD_BYTES_FILTER_TYPE = 22 [(filter_type_options) = {
     category:
       INT_FILTER_CATEGORY;
     database_column_name:
@@ -292,7 +292,7 @@ enum FilterType {
     supported_objects:
       [INVOCATION_OBJECTS];
   }];
-  INVOCATION_CAS_CACHE_UPLOAD_SPEED_FILTER_TYPE = 23 [(filter_type_options) = {
+  INVOCATION_CAS_CACHE_UPLOAD_BPS_FILTER_TYPE = 23 [(filter_type_options) = {
     category:
       INT_FILTER_CATEGORY;
     database_column_name:
@@ -307,6 +307,86 @@ enum FilterType {
       "total_cached_action_exec_usec";
     supported_objects:
       [INVOCATION_OBJECTS];
+  }];
+  EXECUTION_QUEUE_TIME_USEC_FILTER_TYPE = 25 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "IF(worker_start_timestamp_usec < queued_timestamp_usec, 0, (worker_start_timestamp_usec - queued_timestamp_usec))";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  EXECUTION_INPUT_DOWNLOAD_TIME_USEC_FILTER_TYPE = 26 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "(input_fetch_completed_timestamp_usec - input_fetch_start_timestamp_usec)";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  EXECUTION_REAL_TIME_USEC_FILTER_TYPE = 27 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "(execution_completed_timestamp_usec - execution_start_timestamp_usec)";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  OUTPUT_UPLOAD_TIME_USEC_FILTER_TYPE = 28 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "(output_upload_completed_timestamp_usec - output_upload_start_timestamp_usec)";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  PEAK_MEMORY_BYTES_FILTER_TYPE = 29 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "peak_memory_bytes";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  INPUT_DOWNLOAD_SIZE_BYTES_FILTER_TYPE = 30 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "file_download_size_bytes";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  OUTPUT_UPLOAD_SIZE_BYTES_FILTER_TYPE = 31 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "file_upload_size_bytes";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  EXECUTION_WALL_TIME_USEC_FILTER_TYPE = 32 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "IF(worker_completed_timestamp_usec < queued_timestamp_usec, 0, (worker_completed_timestamp_usec - queued_timestamp_usec))";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  EXECUTION_CPU_NANOS_FILTER_TYPE = 33 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "cpu_nanos";
+    supported_objects:
+      [EXECUTION_OBJECTS];
+  }];
+  EXECUTION_AVERAGE_MILLICORES_FILTER_TYPE = 34 [(filter_type_options) = {
+    category:
+      INT_FILTER_CATEGORY;
+    database_column_name:
+      "IF(cpu_nanos <= 0 OR (execution_completed_timestamp_usec - execution_start_timestamp_usec) <= 0, 0, intDivOrZero(cpu_nanos*1000, (execution_completed_timestamp_usec - execution_start_timestamp_usec) * 1000))";
+    supported_objects:
+      [EXECUTION_OBJECTS];
   }];
 }
 

--- a/server/util/filter/filter_test.go
+++ b/server/util/filter/filter_test.go
@@ -130,7 +130,7 @@ func TestValidGenericFilters(t *testing.T) {
 		},
 		{
 			filter: &stat_filter.GenericFilter{
-				Type:    stat_filter.FilterType_INVOCATION_CAS_CACHE_DOWNLOAD_SIZE_FILTER_TYPE,
+				Type:    stat_filter.FilterType_INVOCATION_CAS_CACHE_DOWNLOAD_BYTES_FILTER_TYPE,
 				Operand: stat_filter.FilterOperand_LESS_THAN_OPERAND,
 				Value: &stat_filter.FilterValue{
 					IntValue: []int64{2001},
@@ -142,7 +142,7 @@ func TestValidGenericFilters(t *testing.T) {
 		},
 		{
 			filter: &stat_filter.GenericFilter{
-				Type:    stat_filter.FilterType_INVOCATION_CAS_CACHE_DOWNLOAD_SPEED_FILTER_TYPE,
+				Type:    stat_filter.FilterType_INVOCATION_CAS_CACHE_DOWNLOAD_BPS_FILTER_TYPE,
 				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
 				Value: &stat_filter.FilterValue{
 					IntValue: []int64{10_000},
@@ -154,7 +154,7 @@ func TestValidGenericFilters(t *testing.T) {
 		},
 		{
 			filter: &stat_filter.GenericFilter{
-				Type:    stat_filter.FilterType_INVOCATION_CAS_CACHE_UPLOAD_SIZE_FILTER_TYPE,
+				Type:    stat_filter.FilterType_INVOCATION_CAS_CACHE_UPLOAD_BYTES_FILTER_TYPE,
 				Operand: stat_filter.FilterOperand_LESS_THAN_OPERAND,
 				Value: &stat_filter.FilterValue{
 					IntValue: []int64{2001},
@@ -166,7 +166,7 @@ func TestValidGenericFilters(t *testing.T) {
 		},
 		{
 			filter: &stat_filter.GenericFilter{
-				Type:    stat_filter.FilterType_INVOCATION_CAS_CACHE_UPLOAD_SPEED_FILTER_TYPE,
+				Type:    stat_filter.FilterType_INVOCATION_CAS_CACHE_UPLOAD_BPS_FILTER_TYPE,
 				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
 				Value: &stat_filter.FilterValue{
 					IntValue: []int64{10_000},
@@ -187,6 +187,126 @@ func TestValidGenericFilters(t *testing.T) {
 			filterType:    stat_filter.ObjectTypes_INVOCATION_OBJECTS,
 			expectedQStr:  "total_cached_action_exec_usec > ?",
 			expectedQArgs: []interface{}{int64(456)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_EXECUTION_QUEUE_TIME_USEC_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_LESS_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{500},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "IF(worker_start_timestamp_usec < queued_timestamp_usec, 0, (worker_start_timestamp_usec - queued_timestamp_usec)) < ?",
+			expectedQArgs: []interface{}{int64(500)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_EXECUTION_INPUT_DOWNLOAD_TIME_USEC_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_LESS_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{1000},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "(input_fetch_completed_timestamp_usec - input_fetch_start_timestamp_usec) < ?",
+			expectedQArgs: []interface{}{int64(1000)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_EXECUTION_REAL_TIME_USEC_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_LESS_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{9090},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "(execution_completed_timestamp_usec - execution_start_timestamp_usec) < ?",
+			expectedQArgs: []interface{}{int64(9090)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_OUTPUT_UPLOAD_TIME_USEC_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{100},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "(output_upload_completed_timestamp_usec - output_upload_start_timestamp_usec) > ?",
+			expectedQArgs: []interface{}{int64(100)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_PEAK_MEMORY_BYTES_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{250},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "peak_memory_bytes > ?",
+			expectedQArgs: []interface{}{int64(250)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_INPUT_DOWNLOAD_SIZE_BYTES_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{400},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "file_download_size_bytes > ?",
+			expectedQArgs: []interface{}{int64(400)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_OUTPUT_UPLOAD_SIZE_BYTES_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{500},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "file_upload_size_bytes > ?",
+			expectedQArgs: []interface{}{int64(500)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_EXECUTION_WALL_TIME_USEC_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{7500},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "IF(worker_completed_timestamp_usec < queued_timestamp_usec, 0, (worker_completed_timestamp_usec - queued_timestamp_usec)) > ?",
+			expectedQArgs: []interface{}{int64(7500)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_EXECUTION_CPU_NANOS_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{10_000},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "cpu_nanos > ?",
+			expectedQArgs: []interface{}{int64(10_000)},
+		},
+		{
+			filter: &stat_filter.GenericFilter{
+				Type:    stat_filter.FilterType_EXECUTION_AVERAGE_MILLICORES_FILTER_TYPE,
+				Operand: stat_filter.FilterOperand_GREATER_THAN_OPERAND,
+				Value: &stat_filter.FilterValue{
+					IntValue: []int64{4000},
+				},
+			},
+			filterType:    stat_filter.ObjectTypes_EXECUTION_OBJECTS,
+			expectedQStr:  "IF(cpu_nanos <= 0 OR (execution_completed_timestamp_usec - execution_start_timestamp_usec) <= 0, 0, intDivOrZero(cpu_nanos*1000, (execution_completed_timestamp_usec - execution_start_timestamp_usec) * 1000)) > ?",
+			expectedQArgs: []interface{}{int64(4000)},
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Also rename a couple of the enums added in https://github.com/buildbuddy-io/buildbuddy/pull/9834/files to be less ambiguous.