### PR TITLE
Remove timeutil.StopAndDrain*Timer since it's not necessary since go1.23

### DIFF
--- a/server/backends/chunkstore/chunkstore.go
+++ b/server/backends/chunkstore/chunkstore.go
@@ -12,7 +12,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 )
 
 const (
@@ -404,8 +403,7 @@ type ChunkstoreWriter struct {
 
 func (w *ChunkstoreWriter) readFromWriteResultChannel() (int, error) {
 	delay := time.NewTimer(w.writeTimeoutDuration)
-	// don't leak the timer
-	defer timeutil.StopAndDrainTimer(delay)
+	defer delay.Stop()
 	select {
 	case result, open := <-w.writeResultChannel:
 		if !open || result.Close {
@@ -502,8 +500,7 @@ func (l *writeLoop) run(ctx context.Context) {
 		var req *WriteRequest
 
 		delay := time.NewTimer(time.Until(flushTime))
-		// don't leak the timer
-		defer timeutil.StopAndDrainTimer(delay)
+		defer delay.Stop()
 		// Get the write request for this iteration.
 		select {
 		case req, open = <-l.writeChannel:

--- a/server/util/timeutil/timeutil.go
+++ b/server/util/timeutil/timeutil.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -46,23 +45,4 @@ func ShortFormatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dms", d/time.Millisecond)
 	}
 	return "< 1ms"
-}
-
-func StopAndDrainTimer(t *time.Timer) {
-	if !t.Stop() {
-		select {
-		case <-t.C:
-		default:
-		}
-	}
-}
-
-// TODO: combine StopAndDrainClockworkTimer and StopAndDrainTimer.
-func StopAndDrainClockworkTimer(t clockwork.Timer) {
-	if !t.Stop() {
-		select {
-		case <-t.Chan():
-		default:
-		}
-	}
 }


### PR DESCRIPTION
From the go docs:
> Before Go 1.23, the garbage collector did not recover timers that had not yet expired or been stopped, so code often immediately deferred t.Stop after calling NewTimer, to make the timer recoverable when it was no longer needed. As of Go 1.23, the garbage collector can recover unreferenced timers, even if they haven't expired or been stopped. The Stop method is no longer necessary to help the garbage collector. (Code may of course still want to call Stop to stop the timer for other reasons.)

> Before Go 1.23, the channel associated with a Timer was asynchronous (buffered, capacity 1), which meant that stale time values could be received even after Timer.Stop or Timer.Reset returned. As of Go 1.23, the channel is synchronous (unbuffered, capacity 0), eliminating the possibility of those stale values.

> For a chan-based timer created with NewTimer(d), as of Go 1.23, any receive from t.C after Stop has returned is guaranteed to block rather than receive a stale time value from before the Stop; if the program has not received from t.C already and the timer is running, Stop is guaranteed to return true. Before Go 1.23, the only safe way to use Stop was insert an extra <-t.C if Stop returned false to drain a potential stale value.

In short, StopAndDrain would always take the default case in the select, which makes it unnecessary.