### PR TITLE
Remove unnecessary errgroup in startSampleGenerator

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2609,12 +2609,7 @@ func newPartitionEvictor(ctx context.Context, part disk.Partition, fileStorer fi
 }
 
 func (e *partitionEvictor) startSampleGenerator(quitChan chan struct{}) {
-	eg := &errgroup.Group{}
-	eg.Go(func() error {
-		return e.generateSamplesForEviction(quitChan)
-	})
-	eg.Wait()
-
+	e.generateSamplesForEviction(quitChan)
 	// Drain samples chan before exiting
 	for len(e.samples) > 0 {
 		<-e.samples

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -283,11 +283,7 @@ func (pu *partitionUsage) processEviction(ctx context.Context) {
 }
 
 func (pu *partitionUsage) startSampleGenerator(ctx context.Context) {
-	eg := &errgroup.Group{}
-	eg.Go(func() error {
-		return pu.generateSamplesForEviction(ctx)
-	})
-	eg.Wait()
+	pu.generateSamplesForEviction(ctx)
 	// Drain samples chan before exiting
 	for len(pu.samples) > 0 {
 		<-pu.samples


### PR DESCRIPTION
If we're just starting one goroutine and waiting for its result right away, we might as well call the function directly.