### PR TITLE
Add a concurrency limit on FileWriter ops.

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -3343,6 +3343,13 @@ var (
 	}, []string{
 		OpLabel,
 	})
+
+	DiskFileWriterInProgressOps = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "disk",
+		Name:      "file_writer_in_progress_ops",
+		Help:      "Number of in-progress FileWriter operations.",
+	})
 )
 
 // exponentialBucketRange returns prometheus.ExponentialBuckets specified in

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -3348,7 +3348,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "disk",
 		Name:      "file_writer_in_progress_ops",
-		Help:      "Number of in-progress FileWriter operations.",
+		Help:      "Number of started, but not yet finished, FileWriter operations. This number includes operations that are blocked on the concurrency limiter.",
 	})
 )
 

--- a/server/util/disk/BUILD
+++ b/server/util/disk/BUILD
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/interfaces",
+        "//server/metrics",
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -267,7 +267,7 @@ func reserveFileWriterQuota(ctx context.Context) (func(), error) {
 			<-fileWriterQuotaReservations()
 		}, nil
 	case <-ctx.Done():
-		metrics.DiskFileWriterInProgressOps.Inc()
+		metrics.DiskFileWriterInProgressOps.Dec()
 		return nil, ctx.Err()
 	}
 }

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -258,6 +258,9 @@ var fileWriterQuotaReservations = sync.OnceValue(func() chan struct{} {
 	return make(chan struct{}, *fileWriterConcurrencyLimit)
 })
 
+// reserveFileWriterQuota blocks until quota is available.
+// If a reservation is obtained, the returned function must be called
+// to release the quota.
 func reserveFileWriterQuota(ctx context.Context) (func(), error) {
 	metrics.DiskFileWriterInProgressOps.Inc()
 	select {


### PR DESCRIPTION
FileWriters are used to write artifacts to disk by the cache implementations. When there are bursts of file writer operations, it can cause the Go runtime to create an unbounded number of system threads as file writer ops end up blocked on syscalls.

The concurrency limit places an upper bound on the system threads created via this code path.

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5325