### PR TITLE
Further reduce the number of buckets for executed_action_metadata_durations_usec

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -970,7 +970,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
 		Name:      "executed_action_metadata_durations_usec",
-		Buckets:   durationUsecBuckets(1*time.Millisecond, 1*day, 1.4),
+		Buckets:   durationUsecBuckets(1*time.Millisecond, 1*day, 2.0),
 		Help:      "Time spent in each stage of action execution, in **microseconds**. Queries should filter or group by the `stage` label, taking care not to aggregate different stages.",
 	}, []string{
 		ExecutedActionStageLabel,


### PR DESCRIPTION
The "Action stage durations" graph still can't load for 2 days. This halves the number of buckets, from 56 to 28.

Old bucket:
```
Bucket count: 56
0 = 1ms
1 = 1.4ms
2 = 1.959ms
3 = 2.743ms
4 = 3.841ms
5 = 5.378ms
6 = 7.529ms
7 = 10.541ms
8 = 14.757ms
9 = 20.661ms
10 = 28.925ms
11 = 40.495ms
12 = 56.693ms
13 = 79.371ms
14 = 111.12ms
15 = 155.568ms
16 = 217.795ms
17 = 304.913ms
18 = 426.878ms
19 = 597.63ms
20 = 836.682ms
21 = 1.171355s
22 = 1.639897s
23 = 2.295856s
24 = 3.214199s
25 = 4.499879s
26 = 6.299831s
27 = 8.819763s
28 = 12.347669s
29 = 17.286737s
30 = 24.201432s
31 = 33.882005s
32 = 47.434807s
33 = 1m6.40873s
34 = 1m32.972222s
35 = 2m10.161111s
36 = 3m2.225556s
37 = 4m15.115778s
38 = 5m57.16209s
39 = 8m20.026926s
40 = 11m40.037696s
41 = 16m20.052775s
42 = 22m52.073885s
43 = 32m0.903439s
44 = 44m49.264815s
45 = 1h2m44.970741s
46 = 1h27m50.959037s
47 = 2h2m59.342652s
48 = 2h52m11.079714s
49 = 4h1m3.511599s
50 = 5h37m28.916239s
51 = 7h52m28.482735s
52 = 11h1m27.875829s
53 = 15h26m3.026161s
54 = 21h36m28.236626s
55 = inf
```

New buckets:
```
Bucket count: 28
0 = 1ms
1 = 2ms
2 = 4ms
3 = 8ms
4 = 16ms
5 = 32ms
6 = 64ms
7 = 128ms
8 = 256ms
9 = 512ms
10 = 1.024s
11 = 2.048s
12 = 4.096s
13 = 8.192s
14 = 16.384s
15 = 32.768s
16 = 1m5.536s
17 = 2m11.072s
18 = 4m22.144s
19 = 8m44.288s
20 = 17m28.576s
21 = 34m57.152s
22 = 1h9m54.304s
23 = 2h19m48.608s
24 = 4h39m37.216s
25 = 9h19m14.432s
26 = 18h38m28.864s
27 = inf
```