### PR TITLE
add an info log when qm reloads the config

### DIFF
--- a/enterprise/server/quota/quota_manager.go
+++ b/enterprise/server/quota/quota_manager.go
@@ -578,6 +578,7 @@ func (qm *QuotaManager) reloadNamespaces() error {
 		}
 		return true
 	})
+	log.Info("quota manager reloaded namespaces")
 	return nil
 }
 


### PR DESCRIPTION
This can help us in debugging to know when the config become effective. Quota
manager uses pub sub; so there is a delay between when the ModifyNamespace and
ApplyBucket returns and when the the config is live.
