### PR TITLE
Test add replicas from different intermediate states

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2835,7 +2835,6 @@ func (s *Store) AddReplica(ctx context.Context, req *rfpb.AddReplicaRequest) (*r
 		if replicaMembership.isNonVoting {
 			state = addReplicaStateNonVoter
 		} else {
-			log.Infof("this replica is a voter")
 			state = addReplicaStateVoter
 		}
 	} else {
@@ -3110,7 +3109,6 @@ func (s *Store) UpdateRangeDescriptor(ctx context.Context, rangeID uint64, old, 
 }
 
 func (s *Store) addStagingReplicaToRangeDescriptor(ctx context.Context, rangeID, replicaID uint64, nhid string, oldDescriptor *rfpb.RangeDescriptor) (*rfpb.RangeDescriptor, error) {
-	log.Infof("addStagingReplica")
 	newDescriptor := proto.Clone(oldDescriptor).(*rfpb.RangeDescriptor)
 	newDescriptor.Staging = append(newDescriptor.GetStaging(), &rfpb.ReplicaDescriptor{
 		RangeId:   rangeID,
@@ -3140,7 +3138,6 @@ func (s *Store) addReplicaToRangeDescriptor(ctx context.Context, rangeID, replic
 	if err := s.UpdateRangeDescriptor(ctx, rangeID, oldDescriptor, newDescriptor); err != nil {
 		return nil, err
 	}
-	log.Infof("addReplicaToRangeDescriptor finished. old: %+v, new: %+v", oldDescriptor, newDescriptor)
 	return newDescriptor, nil
 }
 

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2745,7 +2745,7 @@ func (s *Store) promoteToVoter(ctx context.Context, rd *rfpb.RangeDescriptor, ne
 			return status.InternalErrorf("failed to start shard c%dn%d: %s", rd.GetRangeId(), newReplicaID, err)
 		}
 	}
-	// StartShard ensures the node is up-to-date. We can promote non-voter to voter. (Note: there is an edge case where the first appempt of AddReplica failed at wait for catch up; and the second attempt
+	// StartShard ensures the node is up-to-date. We can promote non-voter to voter.
 	// Propose the config change (this adds the node as a non-voter to the raft cluster).
 	// Get the config change index for promoting a non-voter to a voter
 	configChangeID, err := s.getConfigChangeID(ctx, rd.GetRangeId())

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1162,19 +1162,22 @@ func (s *Store) StartShard(ctx context.Context, req *rfpb.StartShardRequest) (*r
 	s.log.Infof("Starting new raft node c%dn%d", req.GetRangeId(), req.GetReplicaId())
 	rc := raftConfig.GetRaftConfig(req.GetRangeId(), req.GetReplicaId())
 	rc.IsNonVoting = req.GetIsNonVoting()
-	err := s.nodeHost.StartOnDiskReplica(req.GetInitialMember(), req.GetJoin(), s.ReplicaFactoryFn, rc)
-	if err != nil {
-		if err == dragonboat.ErrShardAlreadyExist {
-			nu, nuErr := s.nodeHost.GetNodeUser(req.GetRangeId())
-			if nuErr != nil {
-				return nil, status.InternalErrorf("failed to get node user: %s", err)
-			}
-			if nu.ReplicaID() == req.GetReplicaId() {
-				return nil, status.AlreadyExistsError(err.Error())
-			}
+	startShardErr := s.nodeHost.StartOnDiskReplica(req.GetInitialMember(), req.GetJoin(), s.ReplicaFactoryFn, rc)
+	if startShardErr != nil {
+		if startShardErr != dragonboat.ErrShardAlreadyExist {
+			return nil, status.WrapErrorf(startShardErr, "failed to start node c%dn%d on dragonboat", req.GetRangeId(), req.GetReplicaId())
+		}
+		nu, nuErr := s.nodeHost.GetNodeUser(req.GetRangeId())
+		if nuErr != nil {
+			return nil, status.InternalErrorf("failed to get node user: %s", startShardErr)
+		}
+		if nu.ReplicaID() != req.GetReplicaId() {
 			return nil, status.InternalErrorf("cannot start c%dn%d because c%dn%d already exists", nu.ShardID(), nu.ReplicaID(), req.GetRangeId(), req.GetReplicaId())
 		}
-		return nil, status.WrapErrorf(err, "failed to start node c%dn%d on dragonboat", req.GetRangeId(), req.GetReplicaId())
+
+		// If the shard already exists, we want to wait for the replica to catch up
+		// if last_applied_index is set in the request
+		startShardErr = status.AlreadyExistsError(startShardErr.Error())
 	}
 
 	if req.GetLastAppliedIndex() > 0 {
@@ -1184,7 +1187,7 @@ func (s *Store) StartShard(ctx context.Context, req *rfpb.StartShardRequest) (*r
 	}
 
 	rsp := &rfpb.StartShardResponse{}
-	return rsp, nil
+	return rsp, startShardErr
 }
 
 func (s *Store) syncRequestDeleteReplica(ctx context.Context, rangeID, replicaID uint64) error {
@@ -2741,12 +2744,8 @@ func (s *Store) promoteToVoter(ctx context.Context, rd *rfpb.RangeDescriptor, ne
 		if !status.IsAlreadyExistsError(err) {
 			return status.InternalErrorf("failed to start shard c%dn%d: %s", rd.GetRangeId(), newReplicaID, err)
 		}
-		// The shard has been started in an previous attempt; but let's still wait for this replica to catch up.
-		if err := s.waitForReplicaToCatchUp(ctx, rd.GetRangeId(), lastAppliedIndex); err != nil {
-			return status.InternalErrorf("failed to wait for replica to catch up: %s", err)
-		}
 	}
-	// StartShard ensures the node is up-to-date. We can promote non-voter to voter.
+	// StartShard ensures the node is up-to-date. We can promote non-voter to voter. (Note: there is an edge case where the first appempt of AddReplica failed at wait for catch up; and the second attempt
 	// Propose the config change (this adds the node as a non-voter to the raft cluster).
 	// Get the config change index for promoting a non-voter to a voter
 	configChangeID, err := s.getConfigChangeID(ctx, rd.GetRangeId())
@@ -2836,6 +2835,7 @@ func (s *Store) AddReplica(ctx context.Context, req *rfpb.AddReplicaRequest) (*r
 		if replicaMembership.isNonVoting {
 			state = addReplicaStateNonVoter
 		} else {
+			log.Infof("this replica is a voter")
 			state = addReplicaStateVoter
 		}
 	} else {
@@ -3110,6 +3110,7 @@ func (s *Store) UpdateRangeDescriptor(ctx context.Context, rangeID uint64, old, 
 }
 
 func (s *Store) addStagingReplicaToRangeDescriptor(ctx context.Context, rangeID, replicaID uint64, nhid string, oldDescriptor *rfpb.RangeDescriptor) (*rfpb.RangeDescriptor, error) {
+	log.Infof("addStagingReplica")
 	newDescriptor := proto.Clone(oldDescriptor).(*rfpb.RangeDescriptor)
 	newDescriptor.Staging = append(newDescriptor.GetStaging(), &rfpb.ReplicaDescriptor{
 		RangeId:   rangeID,
@@ -3125,6 +3126,7 @@ func (s *Store) addStagingReplicaToRangeDescriptor(ctx context.Context, rangeID,
 
 func (s *Store) addReplicaToRangeDescriptor(ctx context.Context, rangeID, replicaID uint64, oldDescriptor *rfpb.RangeDescriptor) (*rfpb.RangeDescriptor, error) {
 	newDescriptor := proto.Clone(oldDescriptor).(*rfpb.RangeDescriptor)
+
 	for i, replica := range newDescriptor.GetStaging() {
 		if replica.GetReplicaId() == replicaID {
 			newDescriptor.Replicas = append(newDescriptor.GetReplicas(), newDescriptor.Staging[i])
@@ -3138,6 +3140,7 @@ func (s *Store) addReplicaToRangeDescriptor(ctx context.Context, rangeID, replic
 	if err := s.UpdateRangeDescriptor(ctx, rangeID, oldDescriptor, newDescriptor); err != nil {
 		return nil, err
 	}
+	log.Infof("addReplicaToRangeDescriptor finished. old: %+v, new: %+v", oldDescriptor, newDescriptor)
 	return newDescriptor, nil
 }
 

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -756,7 +756,7 @@ func TestAddReplica_Voter(t *testing.T) {
 	s = testutil.GetStoreWithRangeLease(t, ctx, storesAfter, 2)
 	rd = s.GetRange(2)
 	require.Equal(t, 3, len(rd.GetReplicas()))
-	require.Empty(t, rd.GetStaging(), "staging should be empty", "nhid: %s", s.NHID())
+	require.Empty(t, rd.GetStaging())
 	{
 		maxReplicaID := uint64(0)
 		for _, repl := range rd.GetReplicas() {


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/4913

Also, fix a bug I found around waiting for replica to catch up. This call can
only be called on the machine with the new shard and calling it at the
promoteToVoter doesn't have any effect on the new shard.

Instead, I make sure we wait for the new shard to catch up when the shard
already exists.
