### PR TITLE
Fix NotFound error returned when inputs are missing

### DIFF
--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -63,5 +63,8 @@ go_test(
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto//googleapis/longrunning",
+        "@org_golang_google_genproto_googleapis_rpc//errdetails",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -26,9 +26,12 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/longrunning"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
+	gstatus "google.golang.org/grpc/status"
 )
 
 type mockExecutionServer struct {
@@ -337,4 +340,99 @@ func TestExecuteTaskAndStreamResults_InternalInputDownloadTimeout(t *testing.T) 
 	require.GreaterOrEqual(t, len(mockServer.operations), 1)
 	completedOp := mockServer.operations[len(mockServer.operations)-1]
 	require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
+}
+
+func TestExecuteTaskAndStreamResults_MissingInput(t *testing.T) {
+	missingInputRoot := &repb.Directory{
+		// Set some arbitrary properties to ensure the Directory proto is not
+		// empty, since empty digests do not require consulting the cache.
+		NodeProperties: &repb.NodeProperties{Mtime: timestamppb.New(time.Now())},
+	}
+	uploadedInputRootWithMissingSmallFile := &repb.Directory{
+		Files: []*repb.FileNode{
+			{
+				Name: "small_file.txt",
+				Digest: &repb.Digest{
+					Hash:      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+					SizeBytes: 3,
+				},
+			},
+		},
+	}
+	uploadedInputRootWithMissingLargeFile := &repb.Directory{
+		Files: []*repb.FileNode{
+			{
+				Name: "large_file.txt",
+				Digest: &repb.Digest{
+					Hash:      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+					SizeBytes: 128 * 1024 * 1024,
+				},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		inputRoot *repb.Directory
+	}{
+		{
+			name:      "missing input root",
+			inputRoot: missingInputRoot,
+		},
+		{
+			name:      "missing small file",
+			inputRoot: uploadedInputRootWithMissingSmallFile,
+		},
+		{
+			name:      "missing large file",
+			inputRoot: uploadedInputRootWithMissingLargeFile,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			exec, env, execClient, mockServer, mockCounter := getExecutor(t, nil)
+			task := getTask()
+
+			// Upload the two "uploadedInputRoot" protos to the CAS, but not
+			// their referenced files.
+			_, err := cachetools.UploadProto(ctx, env.GetByteStreamClient(), "", repb.DigestFunction_SHA256, uploadedInputRootWithMissingLargeFile)
+			require.NoError(t, err)
+			_, err = cachetools.UploadProto(ctx, env.GetByteStreamClient(), "", repb.DigestFunction_SHA256, uploadedInputRootWithMissingSmallFile)
+			require.NoError(t, err)
+
+			// Set the input root digest to a missing digest.
+			ird, err := digest.ComputeForMessage(tc.inputRoot, repb.DigestFunction_SHA256)
+			require.NoError(t, err)
+			task.ExecutionTask.Action.InputRootDigest = ird
+			publisher, err := operation.Publish(ctx, execClient, task.ExecutionTask.ExecutionId)
+			require.NoError(t, err)
+			retry, err := exec.ExecuteTaskAndStreamResults(ctx, task, publisher)
+			require.True(t, status.IsFailedPreconditionError(err), "expected FailedPrecondition error, got: %v", err)
+			s, ok := gstatus.FromError(err)
+			require.True(t, ok, "expected a status error, got: %v", err)
+			// Expecting a "MISSING" violation.
+			details := s.Details()
+			require.Equal(t, 1, len(details))
+			pf, ok := details[0].(*errdetails.PreconditionFailure)
+			require.True(t, ok, "expected a PreconditionFailure, got: %v", details[0])
+			require.NotEmpty(t, pf.Violations)
+			for _, v := range pf.Violations {
+				require.Equal(t, "MISSING", v.Type)
+				require.Regexp(t, "blobs/(blake3/)?[0-9a-f]+/[0-9]+", v.Subject)
+			}
+			require.False(t, retry, "bazel will retry MissingDigest errors, so we should not retry internally")
+
+			<-mockServer.finished
+			// We should still recycle the runner if inputs are missing.
+			require.Equal(t, 1, mockCounter.countRecycled)
+			operationStageCount := make(map[repb.ExecutionStage_Value]int, len(mockServer.operations))
+			for _, op := range mockServer.operations {
+				stage := operation.ExtractStage(op)
+				operationStageCount[stage]++
+			}
+			require.GreaterOrEqual(t, len(mockServer.operations), 1)
+			completedOp := mockServer.operations[len(mockServer.operations)-1]
+			require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
+		})
+	}
 }


### PR DESCRIPTION
We need to return a digest.MissingDigestError to ensure that bazel reuploads action inputs, otherwise it will just retry the execution without attempting a reupload.