### PR TITLE
[ocicache] track blob metadata hits, misses

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -327,8 +327,9 @@ const (
 	LocalOnlyCacheProxyRequestLabel = "local_only"
 	DefaultCacheProxyRequestLabel   = "default"
 
-	OCIManifestResourceTypeLabel = "manifest"
-	OCIBlobResourceTypeLabel     = "blob"
+	OCIManifestResourceTypeLabel     = "manifest"
+	OCIBlobResourceTypeLabel         = "blob"
+	OCIBlobMetadataResourceTypeLabel = "blob_metadata"
 )
 
 // Other constants


### PR DESCRIPTION
The image returned from `oci.Resolver.Resolve(...)` ultimately looks to see if blob metadata exists before attempting to fetch the blob itself; worth tracking hits and misses here as well.