### PR TITLE
testenv: properly shutdown NewHealthChecker

### DIFF
--- a/enterprise/server/api/api_server_test.go
+++ b/enterprise/server/api/api_server_test.go
@@ -640,7 +640,6 @@ func getEnvAndCtx(t testing.TB, user string) (*testenv.TestEnv, context.Context)
 
 func streamBuildFromTestData(t testing.TB, te *testenv.TestEnv, testDataFile string) string {
 	handler := build_event_handler.NewBuildEventHandler(te)
-	defer handler.Stop()
 
 	f, err := os.Open(path.Join("testdata", testDataFile))
 	require.NoError(t, err)
@@ -690,7 +689,6 @@ func streamBuildFromTestData(t testing.TB, te *testenv.TestEnv, testDataFile str
 
 func streamBuild(t *testing.T, te *testenv.TestEnv, iid string) {
 	handler := build_event_handler.NewBuildEventHandler(te)
-	defer handler.Stop()
 	channel, err := handler.OpenChannel(context.Background(), iid)
 	require.NoError(t, err)
 	defer channel.Close()

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -285,6 +285,7 @@ func TestUnauthenticatedHandleEventWithStartedFirst(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send unauthenticated started event without an api key
 	request := streamRequest(startedEvent("--remote_upload_local_results"), testInvocationID, 1)
@@ -312,6 +313,7 @@ func TestAuthenticatedHandleEventWithStartedFirst(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send authenticated started event with api key
 	request := streamRequest(startedEvent("--remote_upload_local_results --remote_header='"+authutil.APIKeyHeader+"=APIKEY1' --remote_instance_name=foo --should_be_redacted=APIKEY1", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
@@ -353,6 +355,7 @@ func TestAuthenticatedHandleEventWithOptionlessStartedEvent(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	request := streamRequest(startedEvent("", &bspb.BuildEventId_WorkspaceStatus{}, &bspb.BuildEventId_OptionsParsed{}), testInvocationID, 1)
 	err = channel.HandleEvent(request)
@@ -396,6 +399,7 @@ func TestAuthenticatedHandleEventWithRedactedStartedEvent(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	request := streamRequest(startedEvent("", &bspb.BuildEventId_WorkspaceStatus{}, &bspb.BuildEventId_OptionsParsed{}), testInvocationID, 1)
 	err = channel.HandleEvent(request)
@@ -439,6 +443,7 @@ func TestAuthenticatedHandleEventWithProgressFirst(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send progress event
 	request := streamRequest(progressEvent(), testInvocationID, 1)
@@ -486,6 +491,7 @@ func TestUnAuthenticatedHandleEventWithProgressFirst(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send progress event
 	request := streamRequest(progressEvent(), testInvocationID, 1)
@@ -519,6 +525,7 @@ func TestHandleEventOver100ProgressEventsBeforeStarted(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send 104 progress events
 	for i := 1; i < 105; i++ {
@@ -554,6 +561,7 @@ func TestHandleEventWithWorkspaceStatusBeforeStarted(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send progress event
 	request := streamRequest(progressEvent(), testInvocationID, 1)
@@ -609,6 +617,7 @@ func TestHandleEventWithEnvAndMetadataRedaction(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send unauthenticated started event without an api key
 	request := streamRequest(startedEvent(
@@ -674,6 +683,7 @@ func TestHandleEventWithUsageTracking(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send started event with api key
 	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1' --should_be_redacted=USER1"), testInvocationID, 1)
@@ -703,6 +713,7 @@ func TestFinishedFinalizeWithCanceledContext(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send started event with api key
 	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
@@ -752,6 +763,7 @@ func TestFinishedFinalize(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send started event with api key
 	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
@@ -799,6 +811,7 @@ func TestUnfinishedFinalizeWithCanceledContext(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send started event with api key
 	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
@@ -843,6 +856,7 @@ func TestUnfinishedFinalize(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send started event with api key
 	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
@@ -887,6 +901,7 @@ func TestRetryOnComplete(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send started event with api key
 	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
@@ -935,6 +950,7 @@ func TestRetryOnComplete(t *testing.T) {
 	// Attempt to start a new invocation with the same id
 	channel, err = handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 	request = streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'"), testInvocationID, 1)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
@@ -963,6 +979,7 @@ func TestRetryOnDisconnect(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send started event with api key
 	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
@@ -1006,6 +1023,7 @@ func TestRetryOnDisconnect(t *testing.T) {
 	// Attempt to start a new invocation with the same id
 	channel, err = handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 	request = streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
@@ -1072,6 +1090,7 @@ func TestRetryTwiceOnDisconnect(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Send started event with api key
 	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
@@ -1115,6 +1134,7 @@ func TestRetryTwiceOnDisconnect(t *testing.T) {
 	// Attempt to start a new invocation with the same id
 	channel, err = handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 	request = streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
@@ -1166,6 +1186,7 @@ func TestRetryTwiceOnDisconnect(t *testing.T) {
 	// Attempt to start a new invocation with the same id
 	channel, err = handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 	request = streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
@@ -1253,6 +1274,7 @@ func TestRetryOnOldDisconnect(t *testing.T) {
 	handler := build_event_handler.NewBuildEventHandler(te)
 	channel, err := handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 
 	// Say that it occurred 5 hours ago
 	te.GetInvocationDB().SetNowFunc(func() time.Time {
@@ -1304,6 +1326,7 @@ func TestRetryOnOldDisconnect(t *testing.T) {
 	// Attempt to start a new invocation with the same id
 	channel, err = handler.OpenChannel(ctx, testInvocationID)
 	require.NoError(t, err)
+	defer channel.Close()
 	request = streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
@@ -1400,6 +1423,7 @@ func TestBuildStatusReporting(t *testing.T) {
 			seq := NewBESSequence(t)
 			channel, err := handler.OpenChannel(ctx, seq.InvocationID)
 			require.NoError(t, err)
+			defer channel.Close()
 
 			// Handle Started event referencing the metadata events as children.
 			var metadataEventIDs []*bspb.BuildEventId
@@ -1563,6 +1587,7 @@ func TestBuildStatusReportingDisabled(t *testing.T) {
 			seq := NewBESSequence(t)
 			channel, err := handler.OpenChannel(ctx, seq.InvocationID)
 			require.NoError(t, err)
+			defer channel.Close()
 
 			// Handle Started event referencing the metadata events as children.
 			var metadataEventIDs []*bspb.BuildEventId
@@ -1681,6 +1706,7 @@ func TestBuildStatusReporting_LegacyMethods(t *testing.T) {
 			seq := NewBESSequence(t)
 			channel, err := handler.OpenChannel(ctx, seq.InvocationID)
 			require.NoError(t, err)
+			defer channel.Close()
 
 			// Handle Started event referencing the metadata events as children.
 			var metadataEventIDs []*bspb.BuildEventId

--- a/server/buildbuddy_server/buildbuddy_server_test.go
+++ b/server/buildbuddy_server/buildbuddy_server_test.go
@@ -62,6 +62,7 @@ func createInvocationForTesting(te environment.Env, user string) (string, error)
 	if err != nil {
 		return "", err
 	}
+	defer channel.Close()
 
 	// Send started event with api key
 	options := ""
@@ -93,7 +94,7 @@ func createInvocationForTesting(te environment.Env, user string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	return testInvocationID, err
+	return testInvocationID, nil
 }
 
 func TestGetInvocation(t *testing.T) {

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -167,6 +167,7 @@ func GetTestEnv(t testing.TB) *real_environment.RealEnv {
 	}
 
 	healthChecker := healthcheck.NewHealthChecker("test")
+	t.Cleanup(healthChecker.Shutdown)
 	te := real_environment.NewRealEnv(healthChecker)
 	c, err := memory_cache.NewMemoryCache(1000 * 1000 * 1000 /* 1GB */)
 	if err != nil {


### PR DESCRIPTION
Make sure we shutdown NewHealthChecker after the test has finished
running to avoid goroutine leakages.

Since the NewHealthChecker shutdown logic includes the
build_event_handler stop call, remove the defer stop calls from
api_server_test.go.

Added missing cleanup to buildbuddy_server_test and build_event_handler_test.