### PR TITLE
deps: Update smarter-device-manager hash

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5078,7 +5078,7 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
             "gazelle:resolve go google.golang.org/grpc @org_golang_google_grpc//:grpc",
         ],
         importpath = "gitlab.com/arm-research/smarter/smarter-device-manager",
-        sha256 = "4926695678627f4f316cf6ec107d0b2847f5051a12cb05862a257703336d83ce",
+        sha256 = "f4c2a3654e52b8af0676c6619cd2055b832620067b0cdfbf1a0ed9f8f2c921f8",
         strip_prefix = "smarter-device-manager-v1.20.11",
         urls = ["https://gitlab.com/arm-research/smarter/smarter-device-manager/-/archive/v1.20.11/smarter-device-manager-v1.20.11.zip"],
     )


### PR DESCRIPTION
It seems like gitlab.com changed their git-archive implementation
