### PR TITLE
Simplify filestore.InlineReader

### DIFF
--- a/enterprise/server/filestore/filestore.go
+++ b/enterprise/server/filestore/filestore.go
@@ -655,11 +655,8 @@ func (fs *fileStorer) NewReader(ctx context.Context, fileDir string, md *sgpb.St
 }
 
 func (fs *fileStorer) InlineReader(f *sgpb.StorageMetadata_InlineMetadata, offset, limit int64) (io.ReadCloser, error) {
-	data := f.GetData()
-	if offset > 0 {
-		data = data[offset:]
-	}
-	if limit != 0 && limit < int64(len(data)) {
+	data := f.GetData()[offset:]
+	if limit > 0 && limit < int64(len(data)) {
 		data = data[:limit]
 	}
 	return io.NopCloser(bytes.NewReader(data)), nil

--- a/enterprise/server/filestore/filestore.go
+++ b/enterprise/server/filestore/filestore.go
@@ -655,16 +655,14 @@ func (fs *fileStorer) NewReader(ctx context.Context, fileDir string, md *sgpb.St
 }
 
 func (fs *fileStorer) InlineReader(f *sgpb.StorageMetadata_InlineMetadata, offset, limit int64) (io.ReadCloser, error) {
-	r := bytes.NewReader(f.GetData())
-	r.Seek(offset, 0)
-	length := int64(len(f.GetData()))
-	if limit != 0 && limit < length {
-		length = limit
+	data := f.GetData()
+	if offset > 0 {
+		data = data[offset:]
 	}
-	if length > 0 {
-		return io.NopCloser(io.LimitReader(r, length)), nil
+	if limit != 0 && limit < int64(len(data)) {
+		data = data[:limit]
 	}
-	return io.NopCloser(r), nil
+	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
 type inlineWriter struct {


### PR DESCRIPTION
I think this is simpler. It also avoids an allocation for LimitReader, and it returns a reader which implements a WriterTo.

Previously, we used a LimitReader even when limit was 0.

Benchmark results:
```
                                  │    base     │               simple               │
                                  │   sec/op    │   sec/op     vs base               │
GetSingle/LocalPebble10/AC-24       5.868µ ± 2%   5.775µ ± 3%  -1.58% (p=0.047 n=11)
GetSingle/LocalPebble10/CAS-24      4.372µ ± 2%   4.335µ ± 2%       ~ (p=0.217 n=11)
GetSingle/LocalPebble100/AC-24      6.161µ ± 1%   6.085µ ± 2%  -1.23% (p=0.040 n=11)
GetSingle/LocalPebble100/CAS-24     4.712µ ± 1%   4.697µ ± 1%       ~ (p=0.699 n=11)
GetSingle/LocalPebble1000/AC-24     6.932µ ± 3%   6.915µ ± 2%       ~ (p=0.156 n=11)
GetSingle/LocalPebble1000/CAS-24    5.666µ ± 2%   5.677µ ± 2%       ~ (p=0.898 n=11)
GetSingle/LocalPebble10000/AC-24    22.44µ ± 2%   22.25µ ± 1%       ~ (p=0.562 n=11)
GetSingle/LocalPebble10000/CAS-24   20.84µ ± 1%   20.81µ ± 1%       ~ (p=0.606 n=11)
GetMulti/LocalPebble10-24           243.0µ ± 1%   237.4µ ± 1%  -2.32% (p=0.000 n=11)
GetMulti/LocalPebble100-24          269.6µ ± 3%   259.7µ ± 2%  -3.67% (p=0.000 n=11)
GetMulti/LocalPebble1000-24         351.7µ ± 2%   342.9µ ± 2%  -2.52% (p=0.000 n=11)
GetMulti/LocalPebble10000-24        1.846m ± 1%   1.834m ± 1%  -0.66% (p=0.034 n=11)
geomean                             30.23µ        29.87µ       -1.19%

                                  │     base     │               simple                │
                                  │     B/s      │     B/s       vs base               │
GetSingle/LocalPebble10/AC-24       1.621Mi ± 4%   1.650Mi ± 2%  +1.76% (p=0.029 n=11)
GetSingle/LocalPebble10/CAS-24      2.184Mi ± 2%   2.203Mi ± 2%       ~ (p=0.209 n=11)
GetSingle/LocalPebble100/AC-24      15.48Mi ± 1%   15.67Mi ± 2%  +1.23% (p=0.042 n=11)
GetSingle/LocalPebble100/CAS-24     20.24Mi ± 1%   20.30Mi ± 1%       ~ (p=0.687 n=11)
GetSingle/LocalPebble1000/AC-24     137.6Mi ± 4%   137.9Mi ± 2%       ~ (p=0.156 n=11)
GetSingle/LocalPebble1000/CAS-24    168.3Mi ± 2%   168.0Mi ± 2%       ~ (p=0.898 n=11)
GetSingle/LocalPebble10000/AC-24    425.0Mi ± 1%   428.7Mi ± 1%       ~ (p=0.562 n=11)
GetSingle/LocalPebble10000/CAS-24   457.7Mi ± 1%   458.2Mi ± 1%       ~ (p=0.606 n=11)
GetMulti/LocalPebble10-24           3.920Mi ± 1%   4.015Mi ± 1%  +2.43% (p=0.000 n=11)
GetMulti/LocalPebble100-24          35.38Mi ± 2%   36.73Mi ± 1%  +3.80% (p=0.000 n=11)
GetMulti/LocalPebble1000-24         271.2Mi ± 1%   278.2Mi ± 2%  +2.58% (p=0.000 n=11)
GetMulti/LocalPebble10000-24        516.6Mi ± 1%   520.0Mi ± 1%  +0.66% (p=0.034 n=11)
geomean                             46.30Mi        46.86Mi       +1.22%

                                  │     base     │               simple                │
                                  │     B/op     │     B/op      vs base               │
GetSingle/LocalPebble10/AC-24       8.141Ki ± 0%   8.116Ki ± 0%  -0.30% (p=0.000 n=11)
GetSingle/LocalPebble10/CAS-24      2.996Ki ± 0%   2.972Ki ± 0%  -0.81% (p=0.000 n=11)
GetSingle/LocalPebble100/AC-24      8.187Ki ± 0%   8.163Ki ± 0%  -0.29% (p=0.000 n=11)
GetSingle/LocalPebble100/CAS-24     3.133Ki ± 0%   3.108Ki ± 0%  -0.78% (p=0.000 n=11)
GetSingle/LocalPebble1000/AC-24     8.499Ki ± 0%   8.475Ki ± 0%  -0.29% (p=0.000 n=11)
GetSingle/LocalPebble1000/CAS-24    4.337Ki ± 0%   4.312Ki ± 0%  -0.56% (p=0.000 n=11)
GetSingle/LocalPebble10000/AC-24    18.50Ki ± 0%   18.49Ki ± 0%  -0.03% (p=0.029 n=11)
GetSingle/LocalPebble10000/CAS-24   13.33Ki ± 0%   13.33Ki ± 0%       ~ (p=0.752 n=11)
GetMulti/LocalPebble10-24           217.2Ki ± 0%   214.8Ki ± 0%  -1.10% (p=0.000 n=11)
GetMulti/LocalPebble100-24          230.9Ki ± 0%   228.5Ki ± 0%  -1.04% (p=0.000 n=11)
GetMulti/LocalPebble1000-24         351.4Ki ± 0%   349.0Ki ± 0%  -0.68% (p=0.000 n=11)
GetMulti/LocalPebble10000-24        1.221Mi ± 0%   1.221Mi ± 0%       ~ (p=0.401 n=11)
geomean                             26.60Ki        26.47Ki       -0.49%

                                  │    base     │                simple                │
                                  │  allocs/op  │  allocs/op   vs base                 │
GetSingle/LocalPebble10/AC-24        68.00 ± 0%    67.00 ± 0%  -1.47% (p=0.000 n=11)
GetSingle/LocalPebble10/CAS-24       53.00 ± 0%    52.00 ± 0%  -1.89% (p=0.000 n=11)
GetSingle/LocalPebble100/AC-24       68.00 ± 0%    67.00 ± 0%  -1.47% (p=0.000 n=11)
GetSingle/LocalPebble100/CAS-24      53.00 ± 0%    52.00 ± 0%  -1.89% (p=0.000 n=11)
GetSingle/LocalPebble1000/AC-24      68.00 ± 0%    67.00 ± 0%  -1.47% (p=0.000 n=11)
GetSingle/LocalPebble1000/CAS-24     53.00 ± 0%    52.00 ± 0%  -1.89% (p=0.000 n=11)
GetSingle/LocalPebble10000/AC-24     70.00 ± 0%    70.00 ± 0%       ~ (p=1.000 n=11) ¹
GetSingle/LocalPebble10000/CAS-24    54.00 ± 0%    54.00 ± 0%       ~ (p=1.000 n=11) ¹
GetMulti/LocalPebble10-24           3.412k ± 0%   3.312k ± 0%  -2.93% (p=0.000 n=11)
GetMulti/LocalPebble100-24          3.413k ± 0%   3.313k ± 0%  -2.93% (p=0.000 n=11)
GetMulti/LocalPebble1000-24         3.413k ± 0%   3.313k ± 0%  -2.93% (p=0.000 n=11)
GetMulti/LocalPebble10000-24        3.518k ± 0%   3.518k ± 0%       ~ (p=0.909 n=11)
geomean                              232.3         228.7       -1.58%
```