### PR TITLE
Increase test size for  migration_cache_test

### DIFF
--- a/enterprise/server/backends/migration_cache/BUILD
+++ b/enterprise/server/backends/migration_cache/BUILD
@@ -37,7 +37,7 @@ go_library(
 
 go_test(
     name = "migration_cache_test",
-    size = "small",
+    size = "medium",
     srcs = ["migration_cache_test.go"],
     deps = [
         ":migration_cache",

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -448,7 +448,7 @@ func TestCopyDataInBackground(t *testing.T) {
 			destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 			require.NoError(t, err)
 
-			numTests := 1000
+			numTests := 100
 			config := &migration_cache.MigrationConfig{
 				CopyChanBufferSize: numTests + 1,
 				NumCopyWorkers:     2,


### PR DESCRIPTION
I guess when I ran it last, we weren't fully loaded so a 60s timeout was long enough, but when we're under load, we need a bit more time.

I also decreased the number of parallel requests in TestCopyDataInBackground. With only 2-8 CPUs for the test action, we're not getting anything out of running 1000 parallel requests.