### PR TITLE
[executor] pass executor API key to image warmup

### DIFF
--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/auth",
         "//enterprise/server/remote_execution/commandutil",
+        "//enterprise/server/remote_execution/executor_auth",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
         "//proto:execution_stats_go_proto",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor_auth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -96,7 +97,12 @@ func (s *Executor) HostID() string {
 }
 
 func (s *Executor) Warmup() {
-	s.runnerPool.Warmup(context.Background())
+	ctx := context.Background()
+	auth := s.env.GetAuthenticator()
+	if auth != nil && executor_auth.APIKey() != "" {
+		ctx = auth.AuthContextFromAPIKey(ctx, executor_auth.APIKey())
+	}
+	s.runnerPool.Warmup(ctx)
 }
 
 func timevalDuration(tv syscall.Timeval) time.Duration {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -99,6 +99,12 @@ func (s *Executor) HostID() string {
 func (s *Executor) Warmup() {
 	ctx := context.Background()
 	auth := s.env.GetAuthenticator()
+	if auth == nil {
+		log.CtxWarning(ctx, "No authenticator for executor warmup, cannot auth with executor API key")
+	}
+	if executor_auth.APIKey() == "" {
+		log.CtxWarning(ctx, "Empty executor API key, cannot auth during executor warmup")
+	}
 	if auth != nil && executor_auth.APIKey() != "" {
 		ctx = auth.AuthContextFromAPIKey(ctx, executor_auth.APIKey())
 	}


### PR DESCRIPTION
Firecracker container image warmup currently logs errors because it's making anonymous AC requests to the cache_proxy. Attaching the executor API key to the warmup context _should_ make both snapshot loading and image caching Just Work™️.