### PR TITLE
Add gRPC client/server request/response bytes graphs to dashboards

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -72,7 +72,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 269
+            "y": 286
           },
           "id": 21,
           "options": {
@@ -123,7 +123,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 4385
+            "y": 4402
           },
           "id": 6270,
           "options": {
@@ -214,7 +214,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4392
+            "y": 4409
           },
           "id": 932,
           "options": {
@@ -313,7 +313,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4392
+            "y": 4409
           },
           "id": 5492,
           "options": {
@@ -424,7 +424,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 270
+            "y": 287
           },
           "id": 348,
           "options": {
@@ -521,7 +521,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 270
+            "y": 287
           },
           "id": 804,
           "options": {
@@ -633,7 +633,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 271
+            "y": 288
           },
           "id": 6840,
           "options": {
@@ -733,7 +733,7 @@
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 271
+            "y": 288
           },
           "id": 25,
           "options": {
@@ -831,7 +831,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 4356
+            "y": 4373
           },
           "id": 1232,
           "options": {
@@ -930,7 +930,7 @@
             "h": 8,
             "w": 12,
             "x": 9,
-            "y": 4356
+            "y": 4373
           },
           "id": 65,
           "options": {
@@ -1028,7 +1028,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 4364
+            "y": 4381
           },
           "id": 13,
           "options": {
@@ -1142,7 +1142,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 272
+            "y": 289
           },
           "id": 1182,
           "options": {
@@ -1242,7 +1242,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 272
+            "y": 289
           },
           "id": 1186,
           "options": {
@@ -1339,7 +1339,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4333
+            "y": 4350
           },
           "id": 1183,
           "options": {
@@ -1437,7 +1437,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4333
+            "y": 4350
           },
           "id": 1187,
           "options": {
@@ -1534,7 +1534,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4341
+            "y": 4358
           },
           "id": 1184,
           "options": {
@@ -1632,7 +1632,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4341
+            "y": 4358
           },
           "id": 1188,
           "options": {
@@ -1743,7 +1743,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 273
+            "y": 290
           },
           "id": 230,
           "options": {
@@ -1841,7 +1841,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 273
+            "y": 290
           },
           "id": 310,
           "options": {
@@ -1949,7 +1949,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4318
+            "y": 4335
           },
           "id": 312,
           "options": {
@@ -2061,7 +2061,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 274
+            "y": 291
           },
           "id": 254,
           "options": {
@@ -2177,7 +2177,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 274
+            "y": 291
           },
           "id": 251,
           "options": {
@@ -2322,7 +2322,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 919
+            "y": 936
           },
           "id": 250,
           "options": {
@@ -2468,7 +2468,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 919
+            "y": 936
           },
           "id": 252,
           "options": {
@@ -2614,7 +2614,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 927
+            "y": 944
           },
           "id": 253,
           "options": {
@@ -2760,7 +2760,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 927
+            "y": 944
           },
           "id": 10479,
           "options": {
@@ -2875,7 +2875,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 935
+            "y": 952
           },
           "id": 10604,
           "options": {
@@ -3699,7 +3699,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 32
+            "y": 49
           },
           "id": 6732,
           "options": {
@@ -3824,7 +3824,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 41
+            "y": 58
           },
           "id": 646,
           "options": {
@@ -3886,7 +3886,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 66
           },
           "id": 1247,
           "maxDataPoints": 25,
@@ -4015,7 +4015,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 74
           },
           "id": 1338,
           "options": {
@@ -4118,7 +4118,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 65
+            "y": 82
           },
           "id": 2135,
           "options": {
@@ -4217,7 +4217,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 73
+            "y": 90
           },
           "id": 6422,
           "options": {
@@ -4316,7 +4316,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 98
           },
           "id": 10734,
           "options": {
@@ -4413,7 +4413,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 89
+            "y": 106
           },
           "id": 6428,
           "options": {
@@ -4510,7 +4510,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 97
+            "y": 114
           },
           "id": 2182,
           "options": {
@@ -4569,7 +4569,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 105
+            "y": 122
           },
           "id": 6382,
           "maxDataPoints": 25,
@@ -4711,7 +4711,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 204
+            "y": 221
           },
           "id": 6580,
           "options": {
@@ -4832,7 +4832,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 212
+            "y": 229
           },
           "id": 3763,
           "options": {
@@ -4960,7 +4960,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 220
+            "y": 237
           },
           "id": 5574,
           "options": {
@@ -5113,7 +5113,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 228
+            "y": 245
           },
           "id": 3846,
           "options": {
@@ -5208,7 +5208,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 236
+            "y": 253
           },
           "id": 5160,
           "options": {
@@ -5303,7 +5303,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 244
+            "y": 261
           },
           "id": 5242,
           "options": {
@@ -5397,7 +5397,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 252
+            "y": 269
           },
           "id": 5324,
           "options": {
@@ -5491,7 +5491,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 260
+            "y": 277
           },
           "id": 5406,
           "options": {
@@ -5601,7 +5601,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3816
+            "y": 3833
           },
           "id": 3929,
           "options": {
@@ -5698,7 +5698,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3816
+            "y": 3833
           },
           "id": 4011,
           "options": {
@@ -5795,7 +5795,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3824
+            "y": 3841
           },
           "id": 4093,
           "options": {
@@ -5892,7 +5892,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3824
+            "y": 3841
           },
           "id": 4175,
           "options": {
@@ -5989,7 +5989,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3832
+            "y": 3849
           },
           "id": 4257,
           "options": {
@@ -6086,7 +6086,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3832
+            "y": 3849
           },
           "id": 4339,
           "options": {
@@ -6183,7 +6183,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3840
+            "y": 3857
           },
           "id": 4421,
           "options": {
@@ -6280,7 +6280,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3840
+            "y": 3857
           },
           "id": 4503,
           "options": {
@@ -6377,7 +6377,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3848
+            "y": 3865
           },
           "id": 4585,
           "options": {
@@ -6474,7 +6474,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3848
+            "y": 3865
           },
           "id": 4667,
           "options": {
@@ -6571,7 +6571,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3856
+            "y": 3873
           },
           "id": 4749,
           "options": {
@@ -6668,7 +6668,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3856
+            "y": 3873
           },
           "id": 4831,
           "options": {
@@ -6765,7 +6765,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3864
+            "y": 3881
           },
           "id": 4913,
           "options": {
@@ -6877,7 +6877,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32219
+            "y": 36156
           },
           "id": 274,
           "options": {
@@ -6995,7 +6995,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32219
+            "y": 36156
           },
           "id": 276,
           "options": {
@@ -7093,7 +7093,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32227
+            "y": 36164
           },
           "id": 290,
           "options": {
@@ -7191,7 +7191,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32227
+            "y": 36164
           },
           "id": 292,
           "options": {
@@ -7289,7 +7289,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32235
+            "y": 36172
           },
           "id": 278,
           "options": {
@@ -7387,7 +7387,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32235
+            "y": 36172
           },
           "id": 280,
           "options": {
@@ -7501,7 +7501,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 152732
+            "y": 188952
           },
           "id": 40,
           "options": {
@@ -7645,7 +7645,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 152838
+            "y": 189058
           },
           "id": 76,
           "options": {
@@ -7750,7 +7750,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152852
+            "y": 189072
           },
           "id": 42,
           "options": {
@@ -7848,7 +7848,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152852
+            "y": 189072
           },
           "id": 46,
           "options": {
@@ -7946,7 +7946,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152860
+            "y": 189080
           },
           "id": 44,
           "options": {
@@ -8060,7 +8060,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 152733
+            "y": 188953
           },
           "id": 498,
           "options": {
@@ -8162,7 +8162,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 152733
+            "y": 188953
           },
           "id": 542,
           "options": {
@@ -8262,7 +8262,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 152798
+            "y": 189018
           },
           "id": 506,
           "options": {
@@ -8366,7 +8366,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 152807
+            "y": 189027
           },
           "id": 496,
           "options": {
@@ -8468,7 +8468,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 152817
+            "y": 189037
           },
           "id": 500,
           "options": {
@@ -8570,7 +8570,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 152817
+            "y": 189037
           },
           "id": 504,
           "options": {
@@ -8685,7 +8685,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152734
+            "y": 188954
           },
           "id": 50,
           "options": {
@@ -8783,7 +8783,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152734
+            "y": 188954
           },
           "id": 53,
           "options": {
@@ -8881,7 +8881,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152782
+            "y": 189002
           },
           "id": 51,
           "options": {
@@ -8979,7 +8979,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152782
+            "y": 189002
           },
           "id": 55,
           "options": {
@@ -9091,7 +9091,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152735
+            "y": 188955
           },
           "id": 742,
           "options": {
@@ -9196,7 +9196,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152735
+            "y": 188955
           },
           "id": 422,
           "options": {
@@ -9298,7 +9298,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152743
+            "y": 188963
           },
           "id": 420,
           "options": {
@@ -9400,7 +9400,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152743
+            "y": 188963
           },
           "id": 6504,
           "options": {
@@ -9552,7 +9552,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152751
+            "y": 188971
           },
           "id": 1223,
           "options": {
@@ -9726,7 +9726,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152751
+            "y": 188971
           },
           "id": 1224,
           "options": {
@@ -9783,7 +9783,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152759
+            "y": 188979
           },
           "id": 6943,
           "options": {
@@ -9875,7 +9875,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152759
+            "y": 188979
           },
           "id": 6944,
           "options": {
@@ -9997,7 +9997,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 152767
+            "y": 188987
           },
           "id": 7133,
           "options": {
@@ -10188,7 +10188,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 152767
+            "y": 188987
           },
           "id": 7039,
           "options": {
@@ -10320,7 +10320,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 222654
+            "y": 258874
           },
           "id": 122,
           "options": {
@@ -10356,7 +10356,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 222654
+            "y": 258874
           },
           "id": 116,
           "options": {
@@ -10392,7 +10392,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 222662
+            "y": 258882
           },
           "id": 112,
           "options": {
@@ -10428,7 +10428,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 222662
+            "y": 258882
           },
           "id": 120,
           "options": {
@@ -10465,7 +10465,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 222670
+            "y": 258890
           },
           "id": 118,
           "options": {
@@ -10501,7 +10501,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 222670
+            "y": 258890
           },
           "id": 124,
           "options": {
@@ -10537,7 +10537,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 222678
+            "y": 258898
           },
           "id": 9138,
           "options": {
@@ -10575,7 +10575,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 222678
+            "y": 258898
           },
           "id": 9139,
           "options": {
@@ -10613,7 +10613,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 222686
+            "y": 258906
           },
           "id": 9266,
           "options": {
@@ -10716,7 +10716,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 122985
+            "y": 159205
           },
           "id": 190,
           "options": {
@@ -10944,7 +10944,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 122985
+            "y": 159205
           },
           "id": 159,
           "options": {
@@ -11119,7 +11119,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 122993
+            "y": 159213
           },
           "id": 210,
           "options": {
@@ -11219,7 +11219,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 122993
+            "y": 159213
           },
           "id": 1209,
           "options": {
@@ -11317,7 +11317,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123001
+            "y": 159221
           },
           "id": 31,
           "options": {
@@ -11415,7 +11415,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123001
+            "y": 159221
           },
           "id": 178,
           "options": {
@@ -11525,7 +11525,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123009
+            "y": 159229
           },
           "id": 8505,
           "options": {
@@ -11644,7 +11644,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123009
+            "y": 159229
           },
           "id": 8606,
           "options": {
@@ -11785,7 +11785,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123017
+            "y": 159237
           },
           "id": 1216,
           "options": {
@@ -11918,7 +11918,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123017
+            "y": 159237
           },
           "id": 1231,
           "options": {
@@ -12042,7 +12042,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123025
+            "y": 159245
           },
           "id": 33,
           "options": {
@@ -12140,7 +12140,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123025
+            "y": 159245
           },
           "id": 35,
           "options": {
@@ -12238,7 +12238,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123033
+            "y": 159253
           },
           "id": 102,
           "options": {
@@ -12335,7 +12335,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123033
+            "y": 159253
           },
           "id": 180,
           "options": {
@@ -12500,7 +12500,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123041
+            "y": 159261
           },
           "id": 1195,
           "options": {
@@ -12665,7 +12665,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123041
+            "y": 159261
           },
           "id": 1196,
           "options": {
@@ -12766,7 +12766,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123049
+            "y": 159269
           },
           "id": 1202,
           "options": {
@@ -12861,7 +12861,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123049
+            "y": 159269
           },
           "id": 7145,
           "options": {
@@ -12942,7 +12942,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123057
+            "y": 159277
           },
           "id": 7139,
           "options": {
@@ -13023,7 +13023,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123057
+            "y": 159277
           },
           "id": 7157,
           "options": {
@@ -13104,7 +13104,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123065
+            "y": 159285
           },
           "id": 7151,
           "options": {
@@ -13185,7 +13185,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 123065
+            "y": 159285
           },
           "id": 7169,
           "options": {
@@ -13266,7 +13266,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 123073
+            "y": 159293
           },
           "id": 7163,
           "options": {
@@ -13334,7 +13334,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 123275
+        "y": 21
       },
       "id": 83,
       "panels": [
@@ -13403,7 +13403,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 398489
+            "y": 557968
           },
           "id": 85,
           "options": {
@@ -13513,7 +13513,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 398489
+            "y": 557968
           },
           "id": 93,
           "options": {
@@ -13612,7 +13612,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 398515
+            "y": 557994
           },
           "id": 87,
           "options": {
@@ -13711,7 +13711,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 398515
+            "y": 557994
           },
           "id": 10729,
           "options": {
@@ -13758,7 +13758,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 398632
+        "y": 25
       },
       "id": 71,
       "panels": [
@@ -13826,7 +13826,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1011454
+            "y": 26
           },
           "id": 73,
           "options": {
@@ -13925,7 +13925,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1011454
+            "y": 26
           },
           "id": 79,
           "options": {
@@ -14023,7 +14023,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1011463
+            "y": 35
           },
           "id": 2087,
           "options": {
@@ -14129,7 +14129,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1011463
+            "y": 35
           },
           "id": 2039,
           "options": {
@@ -14177,6 +14177,418 @@
           ],
           "title": "gRPC client messages sent by method",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 10735,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (rpc_service, rpc_method) (rate(rpc_client_request_size_bytes_sum{region=\"${region}\", job=\"${job}\"})[$window])",
+              "interval": "",
+              "legendFormat": "/{{rpc_service}}/{{rpc_method}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Client Request Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 10736,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (rpc_service, rpc_method) (rate(rpc_client_response_size_bytes_sum{region=\"${region}\", job=\"${job}\"})[$window])",
+              "interval": "",
+              "legendFormat": "/{{rpc_service}}/{{rpc_method}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Client Response Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 10737,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (rpc_service, rpc_method) (rate(rpc_server_request_size_bytes_sum{region=\"${region}\", job=\"${job}\"})[$window])",
+              "interval": "",
+              "legendFormat": "/{{rpc_service}}/{{rpc_method}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Server Request Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 10738,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (rpc_service, rpc_method) (rate(rpc_server_response_size_bytes_sum{region=\"${region}\", job=\"${job}\"})[$window])",
+              "interval": "",
+              "legendFormat": "/{{rpc_service}}/{{rpc_method}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Server Request Bytes",
+          "type": "timeseries"
         }
       ],
       "repeat": "job",
@@ -14189,7 +14601,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011525
+        "y": 29
       },
       "id": 9283,
       "panels": [
@@ -14256,7 +14668,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7601472
+            "y": 9171172
           },
           "id": 9300,
           "options": {
@@ -14353,7 +14765,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7601472
+            "y": 9171172
           },
           "id": 9301,
           "options": {
@@ -14463,7 +14875,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7601480
+            "y": 9171180
           },
           "id": 9303,
           "options": {
@@ -14520,7 +14932,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011526
+        "y": 30
       },
       "id": 9320,
       "panels": [
@@ -14589,7 +15001,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2287890
+            "y": 3857590
           },
           "id": 9337,
           "options": {
@@ -14690,7 +15102,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2287890
+            "y": 3857590
           },
           "id": 9462,
           "options": {
@@ -14804,7 +15216,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2287898
+            "y": 3857598
           },
           "id": 9587,
           "options": {
@@ -14863,7 +15275,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011527
+        "y": 31
       },
       "id": 1088,
       "panels": [
@@ -14930,7 +15342,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7601497
+            "y": 9171197
           },
           "id": 1127,
           "options": {
@@ -15027,7 +15439,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7601497
+            "y": 9171197
           },
           "id": 1166,
           "options": {
@@ -15137,7 +15549,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7601505
+            "y": 9171205
           },
           "id": 1168,
           "options": {
@@ -15195,7 +15607,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011535
+        "y": 39
       },
       "id": 8,
       "panels": [
@@ -15264,7 +15676,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 35996189
+            "y": 46737073
           },
           "id": 2,
           "options": {
@@ -15383,7 +15795,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 35996189
+            "y": 46737073
           },
           "id": 578,
           "options": {
@@ -15427,7 +15839,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011536
+        "y": 40
       },
       "id": 1346,
       "panels": [
@@ -15495,7 +15907,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 35996190
+            "y": 46737074
           },
           "id": 2556,
           "options": {
@@ -15596,7 +16008,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 35996275
+            "y": 46737159
           },
           "id": 2840,
           "options": {
@@ -15696,7 +16108,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996289
+            "y": 46737173
           },
           "id": 2890,
           "options": {
@@ -15796,7 +16208,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35996289
+            "y": 46737173
           },
           "id": 2940,
           "options": {
@@ -15897,7 +16309,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996297
+            "y": 46737181
           },
           "id": 1353,
           "links": [
@@ -15946,7 +16358,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011537
+        "y": 41
       },
       "id": 5641,
       "panels": [
@@ -16013,7 +16425,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996191
+            "y": 46737075
           },
           "id": 5595,
           "options": {
@@ -16109,7 +16521,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35996191
+            "y": 46737075
           },
           "id": 5608,
           "options": {
@@ -16206,7 +16618,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996247
+            "y": 46737131
           },
           "id": 5622,
           "options": {
@@ -16303,7 +16715,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35996247
+            "y": 46737131
           },
           "id": 5629,
           "options": {
@@ -16399,7 +16811,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996255
+            "y": 46737139
           },
           "id": 5615,
           "options": {
@@ -16442,7 +16854,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011538
+        "y": 42
       },
       "id": 7275,
       "panels": [
@@ -16511,7 +16923,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996192
+            "y": 46737076
           },
           "id": 7381,
           "options": {
@@ -16635,7 +17047,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35996192
+            "y": 46737076
           },
           "id": 7382,
           "options": {
@@ -16737,7 +17149,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996216
+            "y": 46737100
           },
           "id": 7489,
           "options": {
@@ -16839,7 +17251,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35996216
+            "y": 46737100
           },
           "id": 7488,
           "options": {
@@ -16938,7 +17350,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996224
+            "y": 46737108
           },
           "id": 7595,
           "options": {
@@ -17037,7 +17449,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35996224
+            "y": 46737108
           },
           "id": 8743,
           "options": {
@@ -17136,7 +17548,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996232
+            "y": 46737116
           },
           "id": 8880,
           "options": {
@@ -17235,7 +17647,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35996232
+            "y": 46737116
           },
           "id": 9017,
           "options": {
@@ -17279,7 +17691,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011539
+        "y": 43
       },
       "id": 9846,
       "panels": [
@@ -17347,7 +17759,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996193
+            "y": 46737077
           },
           "id": 10100,
           "options": {
@@ -17445,7 +17857,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35996193
+            "y": 46737077
           },
           "id": 10227,
           "options": {
@@ -17544,7 +17956,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35996201
+            "y": 46737085
           },
           "id": 10354,
           "options": {
@@ -17590,7 +18002,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1011540
+        "y": 44
       },
       "id": 10732,
       "panels": [
@@ -17682,7 +18094,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7938986
+            "y": 18679870
           },
           "id": 10731,
           "options": {
@@ -17774,7 +18186,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7938986
+            "y": 18679870
           },
           "id": 10733,
           "options": {
@@ -18077,9 +18489,7 @@
       },
       {
         "current": {
-          "text": [
-            "All"
-          ],
+          "text": "All",
           "value": [
             "$__all"
           ]
@@ -18104,9 +18514,7 @@
       },
       {
         "current": {
-          "text": [
-            "All"
-          ],
+          "text": "All",
           "value": [
             "$__all"
           ]

--- a/tools/metrics/grafana/dashboards/cache-proxy.json
+++ b/tools/metrics/grafana/dashboards/cache-proxy.json
@@ -200,7 +200,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 1181
+            "y": 1223
           },
           "id": 6270,
           "options": {
@@ -292,7 +292,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1188
+            "y": 1230
           },
           "id": 5492,
           "options": {
@@ -389,7 +389,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1188
+            "y": 1230
           },
           "id": 932,
           "options": {
@@ -702,7 +702,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1135
+            "y": 1177
           },
           "id": 8756,
           "options": {
@@ -815,7 +815,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1135
+            "y": 1177
           },
           "id": 8757,
           "options": {
@@ -928,7 +928,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1143
+            "y": 1185
           },
           "id": 8022,
           "options": {
@@ -1041,7 +1041,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1143
+            "y": 1185
           },
           "id": 8751,
           "options": {
@@ -1154,7 +1154,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 1151
+            "y": 1193
           },
           "id": 8128,
           "options": {
@@ -1268,7 +1268,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 1151
+            "y": 1193
           },
           "id": 8752,
           "options": {
@@ -1382,7 +1382,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 1151
+            "y": 1193
           },
           "id": 8753,
           "options": {
@@ -1496,7 +1496,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 1159
+            "y": 1201
           },
           "id": 8758,
           "options": {
@@ -1597,7 +1597,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 1159
+            "y": 1201
           },
           "id": 8759,
           "options": {
@@ -1698,7 +1698,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 1159
+            "y": 1201
           },
           "id": 8760,
           "options": {
@@ -1799,7 +1799,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 1167
+            "y": 1209
           },
           "id": 8761,
           "options": {
@@ -1900,7 +1900,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 1167
+            "y": 1209
           },
           "id": 8762,
           "options": {
@@ -2001,7 +2001,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 1167
+            "y": 1209
           },
           "id": 8763,
           "options": {
@@ -2965,7 +2965,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 593
+            "y": 635
           },
           "id": 250,
           "options": {
@@ -3111,7 +3111,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 593
+            "y": 635
           },
           "id": 252,
           "options": {
@@ -3257,7 +3257,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 601
+            "y": 643
           },
           "id": 253,
           "options": {
@@ -3403,7 +3403,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 601
+            "y": 643
           },
           "id": 8780,
           "options": {
@@ -3518,7 +3518,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 609
+            "y": 651
           },
           "id": 8781,
           "options": {
@@ -3815,7 +3815,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 14
+            "y": 56
           },
           "id": 4,
           "options": {
@@ -3905,7 +3905,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 65
           },
           "id": 6656,
           "options": {
@@ -4003,7 +4003,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 65
           },
           "id": 9,
           "options": {
@@ -4100,7 +4100,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 74
           },
           "id": 6834,
           "options": {
@@ -4205,7 +4205,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 82
           },
           "id": 646,
           "options": {
@@ -4267,7 +4267,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 48
+            "y": 90
           },
           "id": 1247,
           "maxDataPoints": 25,
@@ -4396,7 +4396,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 56
+            "y": 98
           },
           "id": 1338,
           "options": {
@@ -4496,7 +4496,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 64
+            "y": 106
           },
           "id": 2135,
           "options": {
@@ -4591,7 +4591,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 72
+            "y": 114
           },
           "id": 6422,
           "options": {
@@ -4686,7 +4686,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 80
+            "y": 122
           },
           "id": 6428,
           "options": {
@@ -4818,7 +4818,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 88
+            "y": 130
           },
           "id": 6732,
           "options": {
@@ -4940,7 +4940,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 96
+            "y": 138
           },
           "id": 2182,
           "options": {
@@ -4999,7 +4999,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 104
+            "y": 146
           },
           "id": 6382,
           "maxDataPoints": 25,
@@ -5141,7 +5141,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 350
+            "y": 392
           },
           "id": 6580,
           "options": {
@@ -5262,7 +5262,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 358
+            "y": 400
           },
           "id": 3763,
           "options": {
@@ -5390,7 +5390,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 366
+            "y": 408
           },
           "id": 5574,
           "options": {
@@ -5543,7 +5543,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 374
+            "y": 416
           },
           "id": 3846,
           "options": {
@@ -5638,7 +5638,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 382
+            "y": 424
           },
           "id": 5160,
           "options": {
@@ -5733,7 +5733,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 390
+            "y": 432
           },
           "id": 5242,
           "options": {
@@ -5827,7 +5827,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 398
+            "y": 440
           },
           "id": 5324,
           "options": {
@@ -5921,7 +5921,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 406
+            "y": 448
           },
           "id": 5406,
           "options": {
@@ -6029,7 +6029,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1503
+            "y": 1545
           },
           "id": 3929,
           "options": {
@@ -6122,7 +6122,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1503
+            "y": 1545
           },
           "id": 4011,
           "options": {
@@ -6215,7 +6215,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1511
+            "y": 1553
           },
           "id": 4093,
           "options": {
@@ -6308,7 +6308,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1511
+            "y": 1553
           },
           "id": 4175,
           "options": {
@@ -6401,7 +6401,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1519
+            "y": 1561
           },
           "id": 4257,
           "options": {
@@ -6494,7 +6494,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1519
+            "y": 1561
           },
           "id": 4339,
           "options": {
@@ -6587,7 +6587,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1527
+            "y": 1569
           },
           "id": 4421,
           "options": {
@@ -6680,7 +6680,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1527
+            "y": 1569
           },
           "id": 4503,
           "options": {
@@ -6773,7 +6773,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1535
+            "y": 1577
           },
           "id": 4585,
           "options": {
@@ -6866,7 +6866,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1535
+            "y": 1577
           },
           "id": 4667,
           "options": {
@@ -6959,7 +6959,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1543
+            "y": 1585
           },
           "id": 4749,
           "options": {
@@ -7052,7 +7052,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1543
+            "y": 1585
           },
           "id": 4831,
           "options": {
@@ -7145,7 +7145,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1551
+            "y": 1593
           },
           "id": 4913,
           "options": {
@@ -7255,7 +7255,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 4409
+            "y": 9
           },
           "id": 73,
           "options": {
@@ -7354,7 +7354,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 4409
+            "y": 9
           },
           "id": 79,
           "options": {
@@ -7452,7 +7452,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4443
+            "y": 18
           },
           "id": 2087,
           "options": {
@@ -7558,7 +7558,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4443
+            "y": 18
           },
           "id": 2039,
           "options": {
@@ -7605,6 +7605,418 @@
             }
           ],
           "title": "gRPC client messages sent by method",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 8783,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (rpc_service, rpc_method) (rate(rpc_client_request_size_bytes_sum{region=\"${region}\", job=\"${job}\"})[$window])",
+              "interval": "",
+              "legendFormat": "/{{rpc_service}}/{{rpc_method}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Client Request Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 8784,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (rpc_service, rpc_method) (rate(rpc_client_response_size_bytes_sum{region=\"${region}\", job=\"${job}\"})[$window])",
+              "interval": "",
+              "legendFormat": "/{{rpc_service}}/{{rpc_method}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Client Response Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 8785,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (rpc_service, rpc_method) (rate(rpc_server_request_size_bytes_sum{region=\"${region}\", job=\"${job}\"})[$window])",
+              "interval": "",
+              "legendFormat": "/{{rpc_service}}/{{rpc_method}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Server Request Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 8786,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (rpc_service, rpc_method) (rate(rpc_server_response_size_bytes_sum{region=\"${region}\", job=\"${job}\"})[$window])",
+              "interval": "",
+              "legendFormat": "/{{rpc_service}}/{{rpc_method}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Server Request Bytes",
           "type": "timeseries"
         }
       ],
@@ -7687,7 +8099,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3006
+            "y": 3048
           },
           "id": 85,
           "options": {
@@ -7797,7 +8209,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3006
+            "y": 3048
           },
           "id": 93,
           "options": {
@@ -7896,7 +8308,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3015
+            "y": 3057
           },
           "id": 87,
           "options": {
@@ -7995,7 +8407,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3015
+            "y": 3057
           },
           "id": 8782,
           "options": {
@@ -8109,7 +8521,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6082
+            "y": 6124
           },
           "id": 1127,
           "options": {
@@ -8206,7 +8618,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6082
+            "y": 6124
           },
           "id": 1166,
           "options": {
@@ -8316,7 +8728,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6090
+            "y": 6132
           },
           "id": 1168,
           "options": {
@@ -8441,7 +8853,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 4412
+            "y": 4454
           },
           "id": 578,
           "options": {


### PR DESCRIPTION
<img width="1718" height="1299" alt="Screenshot 2025-07-17 at 3 11 37 PM" src="https://github.com/user-attachments/assets/60f1aef8-dd46-4c8e-8bd1-0f7182a133f5" />

I still don't know why these are backwards from what I expect!