### PR TITLE
raft fix a rangelease bug

### DIFF
--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -59,7 +59,6 @@ type Lease struct {
 }
 
 func New(nodeHost client.NodeHost, session *client.Session, log log.Logger, liveness *nodeliveness.Liveness, rangeID uint64, r *replica.Replica) *Lease {
-	ctx, cancelFunc := context.WithCancel(context.Background())
 	return &Lease{
 		nodeHost:              nodeHost,
 		log:                   log,
@@ -72,8 +71,6 @@ func New(nodeHost client.NodeHost, session *client.Session, log log.Logger, live
 		mu:                    sync.RWMutex{},
 		leaseRecord:           &rfpb.RangeLeaseRecord{},
 		timeUntilLeaseRenewal: time.Duration(math.MaxInt64),
-		ctx:                   ctx,
-		cancel:                cancelFunc,
 	}
 }
 
@@ -98,6 +95,9 @@ func (l *Lease) Release(ctx context.Context) error {
 }
 
 func (l *Lease) isStopped() bool {
+	if l.ctx == nil {
+		return true
+	}
 	select {
 	case <-l.ctx.Done():
 		return true


### PR DESCRIPTION
The bug is introduced in https://github.com/buildbuddy-io/buildbuddy/pull/9356

Originally, the stopped var is initialized to true. When we remove the var and
use ctx instead, the l.isStopped() always return false so the keepLeaseAlive
loop is not run.
