### PR TITLE
Express action-merging claimed execution TTL in terms of executor lease periods

### DIFF
--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -21,10 +21,12 @@ const (
 	// approximately equal to the longest execution queue times.
 	queuedExecutionTTL = 10 * time.Minute
 
-	// Default TTL for action-merging data about claimed executions. This is
-	// set to twice the length of `remote_execution.lease_duration` to give a
-	// short grace period in the event of missed leases.
-	DefaultClaimedExecutionTTL = 20 * time.Second
+	// The default TTL for action-merging data about claimed execution. This
+	// is expressed in the number of "lease periods," which is defined in
+	// `remote_execution.lease_duration` and should be thought of in terms of
+	// how many missed execution-leases are needed to stop merging against a
+	// given execution.
+	DefaultClaimedExecutionLeasePeriods = 4
 
 	// Redis Hash keys for storing information about action-merging.
 	//

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1086,7 +1086,7 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 		clock = options.Clock
 	}
 
-	actionMergingLeaseTTL := action_merger.DefaultClaimedExecutionTTL
+	actionMergingLeaseTTL := action_merger.DefaultClaimedExecutionLeasePeriods * *leaseDuration
 	if options.ActionMergingLeaseTTLOverride > 0*time.Second {
 		actionMergingLeaseTTL = options.ActionMergingLeaseTTLOverride
 	}


### PR DESCRIPTION
Instead of as a raw time. Also increase it to 4x `remote_execution.lease_duration` instead of 2x, which feels a little bit aggressive.