### PR TITLE
fastcopy: Make Clone and FastCopy platform-specific

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -65,10 +65,12 @@ jobs:
                    --windows_enable_symlinks `
                    test `
                    --config=untrusted-ci-windows `
+                   --test_tag_filters=-performance `
                    @authArgs `
                    -- `
                    //enterprise/server/remote_execution/workspace:workspace_test `
-                   //enterprise/server/util/procstats:procstats_test
+                   //enterprise/server/util/procstats:procstats_test `
+                   //server/util/fastcopy:fastcopy_test
 
       - name: Save caches
         uses: ./.github/actions/cache-save

--- a/server/util/fastcopy/BUILD
+++ b/server/util/fastcopy/BUILD
@@ -17,9 +17,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "@org_golang_x_sys//unix",
         ],
-        "@io_bazel_rules_go//go/platform:windows": [
-            "//server/util/status",
-        ],
         "//conditions:default": [],
     }),
 )

--- a/server/util/fastcopy/fastcopy.go
+++ b/server/util/fastcopy/fastcopy.go
@@ -1,26 +1,5 @@
-//go:build !darwin
-// +build !darwin
-
 package fastcopy
 
-import (
-	"flag"
-	"os"
-)
+import "flag"
 
 var enableFastcopyReflinking = flag.Bool("executor.enable_fastcopy_reflinking", false, "If true, attempt to use `cp --reflink=auto` to link files")
-
-func Clone(source, destination string) error {
-	if *enableFastcopyReflinking {
-		return reflink(source, destination)
-	}
-	return FastCopy(source, destination)
-}
-
-func FastCopy(source, destination string) error {
-	err := os.Link(source, destination)
-	if !os.IsExist(err) {
-		return err
-	}
-	return nil
-}

--- a/server/util/fastcopy/fastcopy_linux.go
+++ b/server/util/fastcopy/fastcopy_linux.go
@@ -8,6 +8,21 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func Clone(source, destination string) error {
+	if *enableFastcopyReflinking {
+		return reflink(source, destination)
+	}
+	return FastCopy(source, destination)
+}
+
+func FastCopy(source, destination string) error {
+	err := os.Link(source, destination)
+	if !os.IsExist(err) {
+		return err
+	}
+	return nil
+}
+
 func reflink(source, destination string) error {
 	sourceFile, err := os.Open(source)
 	if err != nil {

--- a/server/util/fastcopy/fastcopy_windows.go
+++ b/server/util/fastcopy/fastcopy_windows.go
@@ -2,10 +2,16 @@
 
 package fastcopy
 
-import (
-	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-)
+import "os"
 
-func reflink(source, destination string) error {
-	return status.UnimplementedError("reflink not supported")
+func Clone(source, destination string) error {
+	return FastCopy(source, destination)
+}
+
+func FastCopy(source, destination string) error {
+	err := os.Link(source, destination)
+	if !os.IsExist(err) {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Moved `Clone` and `FastCopy` functions from `fastcopy.go` to
platform-specific files (`fastcopy_linux.go` and `fastcopy_windows.go`).

Enable running fastcopy_test on Windows Github Action.

This is a prepatory no-op patch for future implementation of
fastcopy.Clone on Windows.
