### PR TITLE
cli: Add --api_key flag to download

### DIFF
--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -37,6 +37,7 @@ var (
 	outputDirectory = flags.String("output_directory", "", "A directory where Directory contents will be recursively extracted. Implies --type=Directory.")
 	outputFile      = flags.String("output_file", "", "A destination file where the output should be written; stdout will be used if not set")
 	remoteHeader    = flag.New(flags, "remote_header", []string{}, "Arbitrary remote headers to set on the request, in `KEY=VALUE` format. Can be specified multiple times.")
+	apiKey          = flags.String("api_key", "", "Optionally override the API key with this value")
 
 	usage = `
 usage: bb ` + flags.Name() + ` {digest}/{size}
@@ -142,7 +143,9 @@ func HandleDownload(args []string) (int, error) {
 	}
 
 	ctx := context.Background()
-	if apiKey, err := login.GetAPIKey(); err == nil && apiKey != "" {
+	if *apiKey != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", *apiKey)
+	} else if apiKey, err := login.GetAPIKey(); err == nil && apiKey != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey)
 	}
 	if len(*remoteHeader) > 0 {

--- a/cli/upload/BUILD
+++ b/cli/upload/BUILD
@@ -8,7 +8,6 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//cli/login",
-        "//cli/storage",
         "//proto:remote_execution_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -11,7 +11,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/login"
-	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -91,7 +90,7 @@ func uploadFile(args []string) error {
 	ctx := context.Background()
 	if *apiKey != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", *apiKey)
-	} else if apiKey, err := storage.ReadRepoConfig("api-key"); err == nil && apiKey != "" {
+	} else if apiKey, err := login.GetAPIKey(); err == nil && apiKey != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey)
 	}
 	if *forceTracing {


### PR DESCRIPTION
Implement the same flag as the upload command.
Force both to use the new login.GetAPIKey api when the flag is not set
explicitly by the user.
