### PR TITLE
[executor] simply append executor api key to context during warmup

### DIFF
--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/rpc/interceptors",
         "//server/util/alert",
+        "//server/util/authutil",
         "//server/util/background",
         "//server/util/bazel_request",
         "//server/util/canary",

--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -36,6 +36,7 @@ go_library(
         "@com_github_docker_go_units//:go-units",
         "@com_github_prometheus_client_golang//prometheus",
         "@io_opentelemetry_go_otel//attribute",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_google_protobuf//types/known/timestamppb",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -99,13 +100,9 @@ func (s *Executor) HostID() string {
 
 func (s *Executor) Warmup() {
 	ctx := context.Background()
-	auth := s.env.GetAuthenticator()
-	if auth != nil && executor_auth.APIKey() != "" {
+	if executor_auth.APIKey() != "" {
 		log.CtxInfo(ctx, "Using executor API key during warmup")
-		ctx = auth.AuthContextFromAPIKey(ctx, executor_auth.APIKey())
-		if err, ok := authutil.AuthErrorFromContext(ctx); ok {
-			log.CtxWarningf(ctx, "Error creating auth context from API key: %s", err)
-		}
+		ctx = metadata.AppendToOutgoingContext(ctx, authutil.APIKeyHeader, executor_auth.APIKey())
 	}
 	s.runnerPool.Warmup(ctx)
 }

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/rpc/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/canary"
@@ -102,6 +103,9 @@ func (s *Executor) Warmup() {
 	if auth != nil && executor_auth.APIKey() != "" {
 		log.CtxInfo(ctx, "Using executor API key during warmup")
 		ctx = auth.AuthContextFromAPIKey(ctx, executor_auth.APIKey())
+		if err, ok := authutil.AuthErrorFromContext(ctx); ok {
+			log.CtxWarningf(ctx, "Error creating auth context from API key: %s", err)
+		}
 	}
 	s.runnerPool.Warmup(ctx)
 }


### PR DESCRIPTION
`auth.AuthContextFromAPIKey(...)` relies on having an AuthDB in the environment, which is not the case on executors.
Simply append the executor API key to the context used for image warmups.

Tested in dev: no more warnings about `Missing API Key`.