### PR TITLE
[raft] add monitoring to process txn records

### DIFF
--- a/enterprise/server/raft/txn/BUILD
+++ b/enterprise/server/raft/txn/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
+        "//server/metrics",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/retry",

--- a/enterprise/server/raft/txn/txn.go
+++ b/enterprise/server/raft/txn/txn.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
@@ -240,32 +241,36 @@ func (tj *Coordinator) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-tj.clock.After(txnCleanupPeriod):
-			err := tj.processTxnRecords(ctx)
-			if err != nil {
-				log.Warningf("Failed to processTxnRecords: %s", err)
-			}
+			tj.processTxnRecords(ctx)
 		}
 	}
 }
 
-func (tc *Coordinator) processTxnRecords(ctx context.Context) error {
+func (tc *Coordinator) processTxnRecords(ctx context.Context) {
 	if !tc.store.HasReplicaAndIsLeader(constants.MetaRangeID) {
-		return nil
+		return
 	}
 	txnRecords, err := tc.FetchTxnRecords(ctx)
-	if err != nil {
-		return status.InternalErrorf("failed to fetch txn records: %s", err)
-	}
+	log.Warningf("Failed to fetch txn records: %s", err)
 
-	log.Infof("fetched %d TxnRecords to process", len(txnRecords))
+	errCount := 0
 	for _, txnRecord := range txnRecords {
 		txnID := txnRecord.GetTxnRequest().GetTransactionId()
 		if err := tc.ProcessTxnRecord(ctx, txnRecord); err != nil {
-			return status.InternalErrorf("failed to process txn record %q: %s", txnID, err)
+			log.Warningf("Failed to processTxnRecords: %s", err)
+			errCount++
 		}
 		log.Debugf("Successfully processed txn record %q", txnID)
 	}
-	return nil
+	successCount := len(txnRecords) - errCount
+
+	if successCount > 0 {
+		metrics.RaftTxnRecordProcessCount.WithLabelValues("success").Add(float64(successCount))
+	}
+
+	if errCount > 0 {
+		metrics.RaftTxnRecordProcessCount.WithLabelValues("failure").Add(float64(errCount))
+	}
 }
 
 func (tc *Coordinator) FetchTxnRecords(ctx context.Context) ([]*rfpb.TxnRecord, error) {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -219,6 +219,9 @@ const (
 	// Raft Replica State: staging, removing
 	RaftReplicaState = "replica_state"
 
+	// The status of processing txn record: "success" or "failure"
+	RaftTxnRecordProcessStatus = "txn_record_process_status"
+
 	// Binary version. Example: `v2.0.0`.
 	VersionLabel = "version"
 
@@ -2698,6 +2701,15 @@ var (
 	}, []string{
 		RaftReplicaState,
 		RaftRangeIDLabel,
+	})
+
+	RaftTxnRecordProcessCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "txn_record_process_count",
+		Help:      "The total number of driver action",
+	}, []string{
+		RaftTxnRecordProcessStatus,
 	})
 
 	APIKeyLookupCount = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
If there is an error in processing one record, don't return immediately so that we can process other records too. 