### PR TITLE
networking_test: Update ping target to google.com

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -1032,7 +1032,7 @@ func TestNetwork_Enabled(t *testing.T) {
 		Arguments: []string{"sh", "-ec", `
 			ping -c1 -W1 $(hostname)
 			ping -c1 -W2 8.8.8.8
-			ping -c1 -W2 example.com
+			ping -c1 -W2 google.com
 		`},
 	}
 	res := c.Run(ctx, cmd, wd, oci.Credentials{})

--- a/server/util/networking/networking_test.go
+++ b/server/util/networking/networking_test.go
@@ -144,7 +144,7 @@ func TestContainerNetworking(t *testing.T) {
 	netnsExec(t, c2.NamespacePath(), `ping -c 1 -W 3 8.8.8.8`)
 
 	// DNS should work from inside the netns.
-	netnsExec(t, c1.NamespacePath(), `ping -c 1 -W 3 example.com`)
+	netnsExec(t, c1.NamespacePath(), `ping -c 1 -W 3 google.com`)
 
 	// Containers should not be able to reach each other.
 	netnsExec(t, c1.NamespacePath(), `echo 'Pinging c1' && if ping -c 1 -W 1 `+c2.HostNetwork().NamespacedIP()+` ; then exit 1; fi`)


### PR DESCRIPTION
Currently example.com is resolved to these IPv4 addresses
```
> dig example.com 8.8.8.8 | grep 'example.com'
; <<>> DiG 9.10.6 <<>> example.com 8.8.8.8
;example.com.			IN	A
example.com.		277	IN	A	23.192.228.80
example.com.		277	IN	A	23.215.0.136
example.com.		277	IN	A	23.215.0.138
example.com.		277	IN	A	96.7.128.175
example.com.		277	IN	A	96.7.128.198
example.com.		277	IN	A	23.192.228.84
```

Out of which, the ones in `96.*.*.*` range are not pingable

```
> ping -c1 -W2 96.7.128.175
PING 96.7.128.175 (96.7.128.175): 56 data bytes
--- 96.7.128.175 ping statistics ---
1 packets transmitted, 0 packets received, 100.0% packet loss
exit 2

> ping -c1 -W2 96.7.128.198
PING 96.7.128.198 (96.7.128.198): 56 data bytes
--- 96.7.128.198 ping statistics ---
1 packets transmitted, 0 packets received, 100.0% packet loss
exit 2
```

Change our tests to use google.com instead.
