### PR TITLE
Make util.RecordReadMetrics accept a size instead of slice

### DIFF
--- a/server/backends/blobstore/aws/aws.go
+++ b/server/backends/blobstore/aws/aws.go
@@ -189,7 +189,7 @@ func (a *AwsS3BlobStore) createBucketIfNotExists(ctx context.Context, bucketName
 func (a *AwsS3BlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, error) {
 	start := time.Now()
 	b, err := a.download(ctx, blobName)
-	util.RecordReadMetrics(awsS3Label, start, b, err)
+	util.RecordReadMetrics(awsS3Label, start, len(b), err)
 	return util.Decompress(b, err)
 }
 

--- a/server/backends/blobstore/azure/azure.go
+++ b/server/backends/blobstore/azure/azure.go
@@ -118,7 +118,7 @@ func (z *AzureBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte,
 	if err != nil {
 		return nil, err
 	}
-	util.RecordReadMetrics(azureLabel, start, b, err)
+	util.RecordReadMetrics(azureLabel, start, len(b), err)
 	return util.Decompress(b, err)
 }
 

--- a/server/backends/blobstore/disk/disk.go
+++ b/server/backends/blobstore/disk/disk.go
@@ -83,7 +83,7 @@ func (d *DiskBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, 
 	ctx, spn := tracing.StartSpan(ctx)
 	b, err := disk.ReadFile(ctx, fullPath)
 	spn.End()
-	util.RecordReadMetrics(diskLabel, start, b, err)
+	util.RecordReadMetrics(diskLabel, start, len(b), err)
 	return util.Decompress(b, err)
 }
 

--- a/server/backends/blobstore/gcs/gcs.go
+++ b/server/backends/blobstore/gcs/gcs.go
@@ -120,7 +120,7 @@ func (g *GCSBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, e
 	if err := reader.Close(); err != nil {
 		log.Errorf("Error closing blobreader: %s", err)
 	}
-	util.RecordReadMetrics(gcsLabel, start, b, err)
+	util.RecordReadMetrics(gcsLabel, start, len(b), err)
 	if g.compress {
 		return util.Decompress(b, err)
 	} else {

--- a/server/backends/blobstore/util/util.go
+++ b/server/backends/blobstore/util/util.go
@@ -133,9 +133,8 @@ func RecordWriteMetrics(typeLabel string, startTime time.Time, size int, err err
 	}).Observe(float64(size))
 }
 
-func RecordReadMetrics(typeLabel string, startTime time.Time, b []byte, err error) {
+func RecordReadMetrics(typeLabel string, startTime time.Time, size int, err error) {
 	duration := time.Since(startTime)
-	size := len(b)
 	metrics.BlobstoreReadCount.With(prometheus.Labels{
 		metrics.StatusLabel:        fmt.Sprintf("%d", gstatus.Code(err)),
 		metrics.BlobstoreTypeLabel: typeLabel,


### PR DESCRIPTION
It just takes the length of this slice anyway. This makes it possible to call this method without keeping the whole slice.