### PR TITLE
Replace headerFromRangeDescriptor with header.MakeLinearizableWithRangeValidation

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1373,9 +1373,6 @@ func TestSplitMetaRange(t *testing.T) {
 	require.Error(t, err)
 }
 
-func headerFromRangeDescriptor(rd *rfpb.RangeDescriptor) *rfpb.Header {
-	return &rfpb.Header{RangeId: rd.GetRangeId(), Generation: rd.GetGeneration()}
-}
 
 func waitForReplicaToCatchUp(t testing.TB, ctx context.Context, r *replica.Replica, desiredLastAppliedIndex uint64) {
 	// Wait for raft replication to finish bringing the new node up to date.
@@ -1439,7 +1436,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 		require.NotNil(t, replStore)
 		require.Equal(t, replStore.RaftAddress, raftAddr)
 	}
-	header := headerFromRangeDescriptor(rd)
+	header := header.MakeLinearizableWithRangeValidation(rd)
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.
@@ -1460,7 +1457,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 		require.NotNil(t, replStore)
 		require.Equal(t, replStore.RaftAddress, raftAddr)
 	}
-	header = headerFromRangeDescriptor(rd)
+	header = header.MakeLinearizableWithRangeValidation(rd)
 	require.Equal(t, 3, len(rd.GetReplicas()))
 
 	// Expect that a new cluster was added with rangeID = 3
@@ -1507,7 +1504,7 @@ func TestPostFactoSplit(t *testing.T) {
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	rd := s.GetRange(2)
-	header := headerFromRangeDescriptor(rd)
+	header := header.MakeLinearizableWithRangeValidation(rd)
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.
@@ -1598,7 +1595,7 @@ func TestManySplits(t *testing.T) {
 				continue
 			}
 			rd := s.GetRange(rangeID)
-			header := headerFromRangeDescriptor(rd)
+			header := header.MakeLinearizableWithRangeValidation(rd)
 			rsp, err := s.SplitRange(ctx, &rfpb.SplitRangeRequest{
 				Header: header,
 				Range:  rd,
@@ -1775,7 +1772,7 @@ func TestSplitAcrossClusters(t *testing.T) {
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	rd := s.GetRange(2)
-	header := headerFromRangeDescriptor(rd)
+	header := header.MakeLinearizableWithRangeValidation(rd)
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1373,7 +1373,6 @@ func TestSplitMetaRange(t *testing.T) {
 	require.Error(t, err)
 }
 
-
 func waitForReplicaToCatchUp(t testing.TB, ctx context.Context, r *replica.Replica, desiredLastAppliedIndex uint64) {
 	// Wait for raft replication to finish bringing the new node up to date.
 	waitStart := time.Now()
@@ -1436,7 +1435,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 		require.NotNil(t, replStore)
 		require.Equal(t, replStore.RaftAddress, raftAddr)
 	}
-	header := header.MakeLinearizableWithRangeValidation(rd)
+	header := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.
@@ -1457,7 +1456,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 		require.NotNil(t, replStore)
 		require.Equal(t, replStore.RaftAddress, raftAddr)
 	}
-	header = header.MakeLinearizableWithRangeValidation(rd)
+	header = header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 	require.Equal(t, 3, len(rd.GetReplicas()))
 
 	// Expect that a new cluster was added with rangeID = 3
@@ -1504,7 +1503,7 @@ func TestPostFactoSplit(t *testing.T) {
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	rd := s.GetRange(2)
-	header := header.MakeLinearizableWithRangeValidation(rd)
+	header := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.
@@ -1595,7 +1594,7 @@ func TestManySplits(t *testing.T) {
 				continue
 			}
 			rd := s.GetRange(rangeID)
-			header := header.MakeLinearizableWithRangeValidation(rd)
+			header := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 			rsp, err := s.SplitRange(ctx, &rfpb.SplitRangeRequest{
 				Header: header,
 				Range:  rd,
@@ -1772,7 +1771,7 @@ func TestSplitAcrossClusters(t *testing.T) {
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	rd := s.GetRange(2)
-	header := header.MakeLinearizableWithRangeValidation(rd)
+	header := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1435,13 +1435,13 @@ func TestSplitNonMetaRange(t *testing.T) {
 		require.NotNil(t, replStore)
 		require.Equal(t, replStore.RaftAddress, raftAddr)
 	}
-	header := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
+	hd := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.
 	written := writeNRecords(ctx, t, s, 50)
 	_, err := s.SplitRange(ctx, &rfpb.SplitRangeRequest{
-		Header: header,
+		Header: hd,
 		Range:  rd,
 	})
 	require.NoError(t, err)
@@ -1456,7 +1456,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 		require.NotNil(t, replStore)
 		require.Equal(t, replStore.RaftAddress, raftAddr)
 	}
-	header = header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
+	hd = header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 	require.Equal(t, 3, len(rd.GetReplicas()))
 
 	// Expect that a new cluster was added with rangeID = 3
@@ -1472,7 +1472,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 	// Write some more records to the new end range.
 	written = append(written, writeNRecords(ctx, t, s1, 50)...)
 	_, err = s.SplitRange(ctx, &rfpb.SplitRangeRequest{
-		Header: header,
+		Header: hd,
 		Range:  rd,
 	})
 	require.NoError(t, err)
@@ -1503,14 +1503,14 @@ func TestPostFactoSplit(t *testing.T) {
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	rd := s.GetRange(2)
-	header := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
+	hd := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.
 	written := writeNRecords(ctx, t, s1, 50)
 
 	splitResponse, err := s.SplitRange(ctx, &rfpb.SplitRangeRequest{
-		Header: header,
+		Header: hd,
 		Range:  rd,
 	})
 	require.NoError(t, err)
@@ -1594,9 +1594,9 @@ func TestManySplits(t *testing.T) {
 				continue
 			}
 			rd := s.GetRange(rangeID)
-			header := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
+			hd := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 			rsp, err := s.SplitRange(ctx, &rfpb.SplitRangeRequest{
-				Header: header,
+				Header: hd,
 				Range:  rd,
 			})
 			require.NoError(t, err)
@@ -1771,13 +1771,13 @@ func TestSplitAcrossClusters(t *testing.T) {
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
 	rd := s.GetRange(2)
-	header := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
+	hd := header.MakeLinearizableWithRangeValidation(rd, rd.GetReplicas()[0])
 
 	// Attempting to Split an empty range will always fail. So write a
 	// a small number of records before trying to Split.
 	written := writeNRecords(ctx, t, s1, 50)
 	_, err = s.SplitRange(ctx, &rfpb.SplitRangeRequest{
-		Header: header,
+		Header: hd,
 		Range:  rd,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Remove helper function and use standard header creation method in raft store tests.
