### PR TITLE
remote_bazel_test: deflake TestCancel

### DIFF
--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -249,6 +249,7 @@ func runLocalServerAndExecutor(t *testing.T, mockPrivateGithubToken bool, envMod
 			}
 		},
 	})
+	t.Cleanup(bbServer.Shutdown)
 
 	executors := env.AddExecutors(t, 1)
 	require.Equal(t, 1, len(executors))


### PR DESCRIPTION
Given a test run like this
```
> bazel test \
    --config=remote-minimal \
    --test_tag_filters=docker \
    --test_sharding_strategy=disabled \
    --runs_per_test=20 \
    --test_filter=TestCancel \
    //enterprise/server/test/integration/remote_bazel:remote_bazel_test
```

We have flakes like this
```
...
2025/07/24 08:26:35.224 WRN               build_event_handler.go:1495 > Failed to read scorecard for invocation e4128763-9892-4777-ad4b-356b06bcf901: rpc error: code = NotFound desc = open /workspace/_tmp/ab35a989054042c28d12cc5826a84d1a/buildbuddy-test-895015488/storage/e4128763-9892-4777-ad4b-356b06bcf901/e4128763-9892-4777-ad4b-356b06bcf901-scorecard.pb: no such file or directory
2025/07/24 08:26:35.233 WRN                 build_event_server.go:132 > Disconnecting invocation "e4128763-9892-4777-ad4b-356b06bcf901": rpc error: code = Canceled desc = context canceled group_id=GR5845667763898603259 invocation_id=e4128763-9892-4777-ad4b-356b06bcf901 request_id=ca7fa15c-648e-4d17-ae31-6864296be694
2025/07/24 08:26:35.234 WRN                build_event_handler.go:898 > Reporting disconnected status for invocation group_id=GR5845667763898603259 invocation_attempt=1 invocation_id=e4128763-9892-4777-ad4b-356b06bcf901 request_id=ca7fa15c-648e-4d17-ae31-6864296be694
    testfs.go:61:
        	Error Trace:	server/testutil/testfs/testfs.go:61
        	            				GOROOT/src/testing/testing.go:1211
        	            				GOROOT/src/testing/testing.go:1445
        	            				GOROOT/src/testing/testing.go:1786
        	Error:      	failed to clean up temp dir
        	Test:       	TestCancel
        	Messages:   	unlinkat /workspace/_tmp/ab35a989054042c28d12cc5826a84d1a/buildbuddy-test-895015488/storage/e4128763-9892-4777-ad4b-356b06bcf901/1/chunks: directory not empty
2025/07/24 08:26:33.082 WRN                        healthcheck.go:255 > Checker err: rpc error: code = Unavailable desc = Service sql_primary is unhealthy: sql: database is closed
...
```

Ensure that the server is shutdown at the end of the test.
