### PR TITLE
bzlmod: remove rules_go overrid

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -76,12 +76,6 @@ archive_override(
     urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/badf8034b2952ec613970a27f24fb140be7eaf73.tar.gz"],
 )
 
-bazel_dep(name = "rules_go", version = "0.55.1", repo_name = "io_bazel_rules_go")
-single_version_override(
-    module_name = "rules_go",
-    version = "0.55.1",
-)
-
 bazel_dep(name = "rules_docker", repo_name = "io_bazel_rules_docker")
 archive_override(
     module_name = "rules_docker",
@@ -114,6 +108,7 @@ bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_go", version = "0.55.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_oci", version = "2.0.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")


### PR DESCRIPTION
The patch has already been removed when we last upgrade rules_go
version. Remove the entire override to cleanup.
