### PR TITLE
[raft] start the zombie janitor after the cluster is configured

### DIFF
--- a/enterprise/server/raft/metadata/metadata.go
+++ b/enterprise/server/raft/metadata/metadata.go
@@ -225,6 +225,7 @@ func New(env environment.Env, conf *Config) (*Server, error) {
 		for !rc.clusterStarter.Done() {
 			time.Sleep(100 * time.Millisecond)
 		}
+		rc.store.StartReplicaJanitor()
 	}()
 
 	env.GetHealthChecker().RegisterShutdownFunction(func(ctx context.Context) error {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -667,10 +667,6 @@ func (s *Store) Start() error {
 		s.acquireNodeLiveness(s.egCtx)
 		return nil
 	})
-	s.eg.Go(func() error {
-		s.replicaJanitor.Start(s.egCtx)
-		return nil
-	})
 
 	if maxRangeSizeBytes := raftConfig.MaxRangeSizeBytes(); maxRangeSizeBytes != 0 {
 		s.eg.Go(func() error {
@@ -703,6 +699,14 @@ func (s *Store) Start() error {
 		return nil
 	})
 	return nil
+}
+
+// StartReplicaJanitor starts the replica janitor.
+func (s *Store) StartReplicaJanitor() {
+	s.eg.Go(func() error {
+		s.replicaJanitor.Start(s.egCtx)
+		return nil
+	})
 }
 
 func (s *Store) Stop(ctx context.Context) error {

--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -122,6 +122,7 @@ func (sf *StoreFactory) RecreateStore(t *testing.T, ts *TestingStore) {
 	require.NoError(t, err)
 	require.NotNil(t, store)
 	store.Start()
+	store.StartReplicaJanitor()
 	ts.Store = store
 
 	t.Cleanup(func() {


### PR DESCRIPTION
I plan to remove zombieMinDuration as a heuristic to detect zombies. Instead,
I want to check against ranges in txnRecords in meta range. However, when we
start the clusters, we didn't use transactions to update the range descriptors
and also we don't need txn to update the meta range. By starting the janitor
after the cluster is configured, we can prevent the zombie janitor from deleting
shards that are being created during this phase.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/5402
