### PR TITLE
github: upgrade windows workflow to 2025

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -34,14 +34,14 @@ runs:
         echo "go-mod-cache-dir=/Users/runner/go-mod-cache" >> $GITHUB_OUTPUT
         echo "yarn-cache-dir=/Users/runner/.cache/yarn/v6" >> $GITHUB_OUTPUT
 
-    # Step to determine paths for Windows using D:\
+    # Step to determine paths for Windows using C:\
     - name: Determine Cache Paths (Windows)
       id: determine-paths-windows
       if: runner.os == 'Windows'
       shell: pwsh # PowerShell is default on Windows runners
       run: |
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "repo-cache-dir=D:/bazel/repo-cache"
-        Add-Content -Path $env:GITHUB_OUTPUT -Value "go-mod-cache-dir=D:/go-mod-cache"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "repo-cache-dir=C:/bazel/repo-cache"
+        Add-Content -Path $env:GITHUB_OUTPUT -Value "go-mod-cache-dir=C:/go-mod-cache"
         Add-Content -Path $env:GITHUB_OUTPUT -Value "yarn-cache-dir=~/AppData/Local/Yarn/Cache/v6"
 
     # Restore steps now use combined outputs from the determine steps

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build + Test Windows executor
-    runs-on: windows-2022
+    runs-on: windows-2025
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GO_REPOSITORY_USE_HOST_CACHE: 1
-          GOMODCACHE: "D:/go-mod-cache"
+          GOMODCACHE: "C:/go-mod-cache"
         # Because "startup" options could not be assigned to different configs in .bazelrc, we are adding them directly here.
         # These options follow the best practices in https://bazel.build/configure/windows. Specifically:
         #   - Set output_user_root to the shortest path possible to avoid Windows path length limitations.
@@ -54,14 +54,14 @@ jobs:
           if ($apiKey) {
             $authArgs = @("--remote_header=x-buildbuddy-api-key=$apiKey")
           }
-          bazelisk --output_user_root=D:/0 `
+          bazelisk --output_user_root=C:/0 `
                    --windows_enable_symlinks `
                    build `
                    --config=untrusted-ci-windows `
                    @authArgs `
                    -- `
                    //enterprise/server/cmd/executor:executor
-          bazelisk --output_user_root=D:/0 `
+          bazelisk --output_user_root=C:/0 `
                    --windows_enable_symlinks `
                    test `
                    --config=untrusted-ci-windows `

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,11 +43,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GO_REPOSITORY_USE_HOST_CACHE: 1
-          GOMODCACHE: "D:/go-mod-cache"
+          GOMODCACHE: "C:/go-mod-cache"
         run: |
-          bazelisk --output_user_root=D:/0 build --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
-          $execution_root = bazelisk --output_user_root=D:/0 info execution_root
-          $artifact_rel_path = bazelisk --output_user_root=D:/0 cquery --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --output=files //enterprise/server/cmd/executor:executor
+          bazelisk --output_user_root=C:/0 build --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
+          $execution_root = bazelisk --output_user_root=C:/0 info execution_root
+          $artifact_rel_path = bazelisk --output_user_root=C:/0 cquery --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --output=files //enterprise/server/cmd/executor:executor
           $artifact_abs_path = "${execution_root}\${artifact_rel_path}"
           Copy-Item -Path $artifact_abs_path -Destination executor-enterprise-windows-amd64-beta.exe
           gh release upload ${{ inputs.version_tag }} executor-enterprise-windows-amd64-beta.exe --clobber

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -212,16 +212,16 @@ buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbudd
 buildbuddy.platform(buildbuddy_container_image = "UBUNTU20_04_IMAGE")
 buildbuddy.msvc_toolchain(
     # This is the MSVC available on Github Action win22 image
-    # https://github.com/actions/runner-images/blob/win22/20250623.1/images/windows/Windows2022-Readme.md
+    # https://github.com/actions/runner-images/blob/win25/20250727.1/images/windows/Windows2025-Readme.md#visual-studio-enterprise-2022
     msvc_edition = "Enterprise",
     msvc_release = "2022",
     # From 'Microsoft Visual C++ 2022 Minimum Runtime' for x64 architecture
-    # https://github.com/actions/runner-images/blob/win22/20250623.1/images/windows/Windows2022-Readme.md#microsoft-visual-c
+    # https://github.com/actions/runner-images/blob/win25/20250727.1/images/windows/Windows2025-Readme.md#microsoft-visual-c
     msvc_version = "14.44.35207",
     # From 'Installed Windows SDKs'
-    # https://github.com/actions/runner-images/blob/win22/20250623.1/images/windows/Windows2022-Readme.md#installed-windows-sdks
+    # https://github.com/actions/runner-images/blob/win25/20250727.1/images/windows/Windows2025-Readme.md#installed-windows-sdks
     windows_kits_release = "10",
-    windows_kits_version = "10.0.22621.0",
+    windows_kits_version = "10.0.26100.0",
 )
 
 # Explicitly register the toolchains in the order which we want to use.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -612,12 +612,16 @@ buildbuddy(
     name = "buildbuddy_toolchain",
     container_image = UBUNTU20_04_IMAGE,
     # This is the MSVC available on Github Action win22 image
-    # https://github.com/actions/runner-images/blob/win22/20250623.1/images/windows/Windows2022-Readme.md
+    # https://github.com/actions/runner-images/blob/win25/20250727.1/images/windows/Windows2025-Readme.md#visual-studio-enterprise-2022
     msvc_edition = "Enterprise",
     msvc_release = "2022",
     # From 'Microsoft Visual C++ 2022 Minimum Runtime' for x64 architecture
-    # https://github.com/actions/runner-images/blob/win22/20250623.1/images/windows/Windows2022-Readme.md#microsoft-visual-c
+    # https://github.com/actions/runner-images/blob/win25/20250727.1/images/windows/Windows2025-Readme.md#microsoft-visual-c
     msvc_version = "14.44.35207",
+    # From 'Installed Windows SDKs'
+    # https://github.com/actions/runner-images/blob/win25/20250727.1/images/windows/Windows2025-Readme.md#installed-windows-sdks
+    windows_kits_release = "10",
+    windows_kits_version = "10.0.26100.0",
 )
 
 http_archive(

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -67,7 +67,7 @@ common --test_env=GO_TEST_WRAP_TESTV=1
 
 # In rules_go v0.50.0, nogo static analysis was moved from GoCompilePkg to a couple of
 # actions: RunNogo and ValidateNogo. Among these, ValidateNogo is a validation action*.
-# When the validation runs on top of the go_test binary, it will prevent the test 
+# When the validation runs on top of the go_test binary, it will prevent the test
 # execution (TestRunner) until the validation is success.
 #
 # This flag will run the validation action as an aspect, which will not block the test
@@ -311,8 +311,8 @@ common:release-m1 --config=release-shared
 # Configuration used for release-windows workflow
 common:release-windows --config=cache
 common:release-windows --config=release-shared
-common:release-windows --repository_cache=D:/bazel/repo-cache/
-common:release-windows --remote_instance_name=buildbuddy-io/buildbuddy/release-windows
+common:release-windows --repository_cache=C:/bazel/repo-cache/
+common:release-windows --remote_instance_name=buildbuddy-io/buildbuddy/release-windows-25
 
 # Common flags for Github Actions and BuildBuddy Workflows setup
 # Note that the actual Remote endpoint is not included here.
@@ -336,8 +336,8 @@ common:untrusted-ci --remote_header=x-buildbuddy-platform.enable-vfs=true
 
 # Disabled RBE for Windows
 common:untrusted-ci-windows --config=ci-shared
-common:untrusted-ci-windows --remote_instance_name=buildbuddy-io/buildbuddy/untrusted-ci-windows
-common:untrusted-ci-windows --repository_cache=D:/bazel/repo-cache/
+common:untrusted-ci-windows --remote_instance_name=buildbuddy-io/buildbuddy/untrusted-ci-windows-25
+common:untrusted-ci-windows --repository_cache=C:/bazel/repo-cache/
 common:untrusted-ci-windows --bes_results_url=https://app.buildbuddy.io/invocation/
 common:untrusted-ci-windows --bes_backend=grpcs://remote.buildbuddy.io
 common:untrusted-ci-windows --remote_cache=grpcs://remote.buildbuddy.io


### PR DESCRIPTION
Upgrade the workflows to Windows 2025 instances so that we get access to
newer tools such as `fsutil devdrv` for manipulating Dev Drive.

https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-devdrv

Upgrade our Toolchain Paths as a result.
Update the remote_instance_name to properly invalidate the remote_cache.

There is no `D:` drive starting from 2025, so migrate all cache paths to point to `C:` instead.

https://github.com/actions/runner-images/issues/12416
