### PR TITLE
integration/podman: shard to 4 shards

### DIFF
--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -31,6 +31,7 @@ go_test(
         "no-sandbox",
     ],
     target_compatible_with = ["@platforms//os:linux"],
+    shard_count = 4,
     x_defs = {
         "crunRlocationpath": "$(rlocationpath //enterprise/server/remote_execution/containers/ociruntime:crun)",
         "podmanArchiveRlocationpath": "$(rlocationpath //enterprise/server/remote_execution/containers/podman:podman-static.tar.gz)",


### PR DESCRIPTION
Currently this test takes roughly 3m20 seconds to run.
Sharding this to 4 bring it down to 1m40s.
