### PR TITLE
Change remote_execution.redis_pubsub_pool_size from 10k to 5k

### DIFF
--- a/enterprise/server/remote_execution/redis_client/redis_client.go
+++ b/enterprise/server/remote_execution/redis_client/redis_client.go
@@ -16,7 +16,7 @@ import (
 	remote_execution_config "github.com/buildbuddy-io/buildbuddy/server/remote_execution/config"
 )
 
-var redisPubSubPoolSize = flag.Int("remote_execution.redis_pubsub_pool_size", 10_000, "Maximum number of connections used for waiting for execution updates.")
+var redisPubSubPoolSize = flag.Int("remote_execution.redis_pubsub_pool_size", 5_000, "Maximum number of connections used for waiting for execution updates.")
 
 func RegisterRemoteExecutionClient(env *real_environment.RealEnv) error {
 	if !remote_execution_config.RemoteExecutionEnabled() {


### PR DESCRIPTION
With 24 apps, we can currently have up to 240k connections. With 8 redis shards, that's 30k connections per redis shard, and redis seems to have a 20k limit.