### PR TITLE
Use arm-limited runners for test workflow

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -10,27 +10,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04-16cpu-arm64
+    runs-on: ubuntu-22.04-16cpu-arm64-arm-limited
     if: "!contains(github.event.head_commit.message, 'ci skip')"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      # GitHub's arm64 runners do not have the same pre-installed software as
-      # the amd64 runners so we have to install a few things here.
-
-      - name: Install bazelisk
-        run: |
-          curl -L --output /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64
-          chmod +x /tmp/bazelisk
-          sudo mv /tmp/bazelisk /usr/bin/bazelisk
-          sudo ln -s /usr/bin/bazelisk /usr/bin/bazel
-
-      - name: Install apt packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc g++
 
       - name: Restore caches
         id: cache-restore


### PR DESCRIPTION
The current pool was created during the arm runner beta and we never migrated to the newer runners which use the image provided by ARM Limited, which has more software pre-installed. This PR fixes that.