### PR TITLE
Fix failing podman_test on arm64

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -17,6 +17,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # podman_test installs its own version of podman under / in order to test
+      # the same version that we use in the executor while not having to
+      # configure various podman directory paths. For now just uninstall the
+      # podman installation that already comes with the GH actions runner.
+      - name: Uninstall podman
+        run: |
+          sudo apt-get remove -y podman
+          # Hack to work around https://github.com/containers/podman/issues/9164
+          find /dev/shm -name 'libpod*' | xargs -r sudo rm -rf
+
       - name: Restore caches
         id: cache-restore
         uses: ./.github/actions/cache-restore


### PR DESCRIPTION
This broke with https://github.com/buildbuddy-io/buildbuddy/pull/9986. The breakage didn't show up in that PR because the tests were cached, and the cache was not invalidated because the PR only changed system deps.