### PR TITLE
Upgrade bundled docker-credential-gcr to v2.1.30

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -7040,8 +7040,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             'package(default_visibility = ["//visibility:public"])',
             'filegroup(name = "docker-credential-gcr.bin", srcs = ["docker-credential-gcr"])',
         ]),
-        urls = ["https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_amd64-2.1.22.tar.gz"],
-        sha256 = "443e897dc383d69e55e6dbcb13802f4ec88444848612e83f0381df2ddd721694",
+        urls = ["https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.30/docker-credential-gcr_linux_amd64-2.1.30.tar.gz"],
+        sha256 = "d5c90c03d90271873a8619b1f73023a0266ae3fc91965ce9c81d7903e4b54eb6",
     )
     http_archive(
         name = "com_github_googlecloudplatform_docker-credential-gcr-linux-arm64",
@@ -7049,8 +7049,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             'package(default_visibility = ["//visibility:public"])',
             'filegroup(name = "docker-credential-gcr.bin", srcs = ["docker-credential-gcr"])',
         ]),
-        urls = ["https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.22/docker-credential-gcr_linux_arm64-2.1.22.tar.gz"],
-        sha256 = "b607dfb7516dc1ca6a2a05322d938cea58cc5975e2063efc3695ee6ddb2dccc7",
+        urls = ["https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.30/docker-credential-gcr_linux_arm64-2.1.30.tar.gz"],
+        sha256 = "ac9c0237e40505f09796c2bf8a90377246a6fd3cb65e6eada77009ae0f2d3b00",
     )
 
     http_archive(


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/tag/v2.1.30

Contains a fix that avoids rare credentials errors when using GCE/GKE
metadata server: https://github.com/GoogleCloudPlatform/docker-credential-gcr/pull/183
