### PR TITLE
Revert "Add parallel to workflows image"

### DIFF
--- a/dockerfiles/rbe-ubuntu20-04/Dockerfile
+++ b/dockerfiles/rbe-ubuntu20-04/Dockerfile
@@ -43,7 +43,6 @@ RUN apt-get update && \
       git \
       less \
       openssh-client \
-      parallel \
       unzip \
       netcat-traditional \
       wget \


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#10002

turns out we don't need parallel.