### PR TITLE
Fix a couple of bugs in action-merging logic

### DIFF
--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -128,7 +128,8 @@ func RecordClaimedExecution(ctx context.Context, rdb redis.UniversalClient, exec
 	}
 
 	pipe := rdb.TxPipeline()
-	pipe.HSet(ctx, forwardKey, executionIDKey, executionID, ttl)
+	pipe.HSet(ctx, forwardKey, executionIDKey, executionID)
+	pipe.Expire(ctx, forwardKey, ttl)
 	pipe.Set(ctx, reverseKey, forwardKey, ttl)
 	_, err = pipe.Exec(ctx)
 	return err

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1864,8 +1864,7 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 
 		// If the task was successfully claimed, record action-merging state.
 		if claimed {
-			action_merger.RecordClaimedExecution(ctx, s.rdb, taskID, s.actionMergingLeaseTTL)
-			if err != nil {
+			if err := action_merger.RecordClaimedExecution(ctx, s.rdb, taskID, s.actionMergingLeaseTTL); err != nil {
 				log.CtxWarningf(ctx, "could not record claimed pending execution %q: %s", taskID, err)
 			}
 		}


### PR DESCRIPTION
1. Correctly set TTL on hash keys used for claimed executions. This bug was preventing hedging from working.
2. Check the correct `err` returned from claiming executions. This was just making us log a warning in the wrong case.