### PR TITLE
Add an RPC service for retrieving customer-managed encryption keys

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1942,6 +1942,7 @@ go_proto_library(
     name = "encryption_go_proto",
     compilers = [
         "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/encryption",

--- a/proto/encryption.proto
+++ b/proto/encryption.proto
@@ -58,3 +58,40 @@ message GetEncryptionConfigResponse {
 
   repeated KMS supported_kms = 3;
 }
+
+// Auth info (client, group) is passed via headers.
+message GetEncryptionKeyRequest {
+  // Metadata about the encryption key to retrieve. If absent, the most recent
+  // encryption key for the desired group is returned.
+  EncryptionKeyMetadata metadata = 1;
+}
+
+message EncryptionKeyMetadata {
+  // A unique identifier for this encryption key. Supplied by the server.
+  string id = 1;
+
+  // Encryption keys are versioned to support key rotation. Cache contents are
+  // encrypted using the latest available version of a key and the key version
+  // used is stored in the record's metadata so the correct version can be used
+  // for decryption.
+  //
+  // More about customer-managed encryption can be found in
+  // http://go/customer-managed-encryption
+  int64 version = 2;
+}
+
+message EncryptionKey {
+  EncryptionKeyMetadata metadata = 1;
+
+  // The encryption key.
+  bytes key = 3;
+}
+
+message GetEncryptionKeyResponse {
+  EncryptionKey key = 1;
+}
+
+service EncryptionService {
+  rpc GetEncryptionKey(GetEncryptionKeyRequest)
+      returns (GetEncryptionKeyResponse);
+}

--- a/proto/encryption.proto
+++ b/proto/encryption.proto
@@ -67,7 +67,8 @@ message GetEncryptionKeyRequest {
 }
 
 message EncryptionKeyMetadata {
-  // A unique identifier for this encryption key. Supplied by the server.
+  // A unique identifier for this encryption key. Supplied by the server. This
+  // will be something like "EK123456789012345678".
   string id = 1;
 
   // Encryption keys are versioned to support key rotation. Cache contents are


### PR DESCRIPTION
This is the second step described in https://github.com/buildbuddy-io/buildbuddy-internal/issues/4758#issuecomment-3152798840.

Related Issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4758