### PR TITLE
[FC] Enable TUN in 6.1 kernel

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6949,8 +6949,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
     )
     http_file(
         name = "org_kernel_git_linux_kernel-vmlinux-6.1",
-        sha256 = "4f7af51e2147b5e65c80ae277374944d63919672c7987ee86c74cbd07b7eb864",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/linux/vmlinux-x86_64-v6.1-4f7af51e2147b5e65c80ae277374944d63919672c7987ee86c74cbd07b7eb864"],
+        sha256 = "221765c1c163d7f4687c0fba573c47a17ada6cbe4063c16e6205fabc7066fd15",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/linux/vmlinux-x86_64-v6.1-221765c1c163d7f4687c0fba573c47a17ada6cbe4063c16e6205fabc7066fd15"],
         executable = True,
     )
     http_file(

--- a/enterprise/vmsupport/kernel/microvm-kernel-x86_64-v6.1.config
+++ b/enterprise/vmsupport/kernel/microvm-kernel-x86_64-v6.1.config
@@ -2,6 +2,7 @@
 # BuildBuddy-specific modifications:
 # - Set CONFIG_PCI=y (see https://github.com/firecracker-microvm/firecracker/issues/4881)
 # - Set CONFIG_FUSE_FS=y for FUSE support
+# - Set CONFIG_TUN=y for networking
 
 #
 # Automatically generated file; DO NOT EDIT.
@@ -1616,7 +1617,7 @@ CONFIG_NET_CORE=y
 # CONFIG_AMT is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
-# CONFIG_TUN is not set
+CONFIG_TUN=y
 # CONFIG_TUN_VNET_CROSS_LE is not set
 CONFIG_VETH=y
 CONFIG_VIRTIO_NET=y


### PR DESCRIPTION
The last time we tried to upgrade the firecracker guest kernel to v6.1, we saw [some networking errors](https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1747062596622109). This config change should resolve them (I tested with the problematic test target to ensure it now passes)