### PR TITLE
ociruntime: no-op cleanup

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -832,11 +832,13 @@ func (c *ociContainer) doWithStatsTracking(ctx context.Context, invokeRuntimeFn 
 		log.CtxWarning(ctx, status.Message(err))
 	}
 
-	networkStats, err := c.network.Stats(ctx)
-	if err != nil {
-		log.CtxWarningf(ctx, "Failed to get network stats: %s", err)
-	} else {
-		res.UsageStats.NetworkStats = networkStats
+	if c.network != nil {
+		networkStats, err := c.network.Stats(ctx)
+		if err != nil {
+			log.CtxWarningf(ctx, "Failed to get network stats: %s", err)
+		} else {
+			res.UsageStats.NetworkStats = networkStats
+		}
 	}
 
 	return res

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -1556,7 +1556,7 @@ func TestPersistentWorker(t *testing.T) {
 
 	// Start worker (Exec)
 	worker := persistentworker.Start(ctx, ws, c, "proto" /*=protocol*/, &repb.Command{
-		Arguments: []string{"./testworker", "--persistent_worker", "--response_base64", responseBase64},
+		Arguments: []string{"./testworker", "--response_base64", responseBase64},
 	})
 
 	// Send work request.


### PR DESCRIPTION
This is a preparation patch for #9978.

First, change to only collect network statistics when c.network is non-nil.
In some test cases, network can be nil and cause a panic with the existing
code.

Second, remove the redundant `--persistent_worker` flag from TestPersistentWorker
as persistentworker.Start should be adding that flag automatically.
