### PR TITLE
Decrease the default `--storage.gcs.grpc_pool_size`

### DIFF
--- a/server/backends/blobstore/gcs/gcs.go
+++ b/server/backends/blobstore/gcs/gcs.go
@@ -31,7 +31,7 @@ var (
 	gcsCredentials     = flag.String("storage.gcs.credentials", "", "Credentials in JSON format that will be used to authenticate to GCS.", flag.Secret)
 	gcsProjectID       = flag.String("storage.gcs.project_id", "", "The Google Cloud project ID of the project owning the above credentials and GCS bucket.")
 	useGRPC            = flag.Bool("storage.gcs.use_grpc", false, "Whether to use the gRPC client for GCS", flag.Internal)
-	grpcPoolSize       = flag.Int("storage.gcs.grpc_pool_size", 15, "The number of gRPC connections to open to GCS. Only used when `use_grpc=true`", flag.Internal)
+	grpcPoolSize       = flag.Int("storage.gcs.grpc_pool_size", 1, "The number of gRPC connections to open to GCS. Only used when `use_grpc=true`", flag.Internal)
 )
 
 // GCSBlobStore implements the blobstore API on top of the google cloud storage API.


### PR DESCRIPTION
When using directpath, every connection in the pool actually results in many connections (because we're connecting directly to GCS jobs, and not a load balancer). Each of these connections creates multiple goroutines. All together, each increment of `storage.gcs.grpc_pool_size` seems to create ~5800 goroutines.