### PR TITLE
Add a util for copying outgoing RPC metadata to incoming RPC metadata

### DIFF
--- a/enterprise/server/auth_service/BUILD
+++ b/enterprise/server/auth_service/BUILD
@@ -24,6 +24,7 @@ go_test(
     deps = [
         "//proto:auth_go_proto",
         "//server/testutil/testauth",
+        "//server/testutil/testgrpc",
         "//server/util/authutil",
         "//server/util/status",
         "@com_github_stretchr_testify//assert",

--- a/enterprise/server/auth_service/auth_service_test.go
+++ b/enterprise/server/auth_service/auth_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgrpc"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
@@ -15,12 +16,7 @@ import (
 
 func contextWithApiKey(t *testing.T, key string) context.Context {
 	ctx := metadata.AppendToOutgoingContext(context.Background(), authutil.APIKeyHeader, key)
-	outgoingMD, ok := metadata.FromOutgoingContext(ctx)
-	assert.True(t, ok)
-	// Simulate an RPC by creating a new context with the incoming
-	// metadata set to the previously applied outgoing metadata.
-	ctx = context.Background()
-	return metadata.NewIncomingContext(ctx, outgoingMD)
+	return testgrpc.OutgoingToIncomingContext(t, ctx)
 }
 
 func TestAuthenticateNoCreds(t *testing.T) {

--- a/enterprise/server/auth_service/auth_service_test.go
+++ b/enterprise/server/auth_service/auth_service_test.go
@@ -15,13 +15,13 @@ import (
 )
 
 func contextWithApiKey(t *testing.T, key string) context.Context {
-	ctx := metadata.AppendToOutgoingContext(context.Background(), authutil.APIKeyHeader, key)
+	ctx := metadata.AppendToOutgoingContext(t.Context(), authutil.APIKeyHeader, key)
 	return testgrpc.OutgoingToIncomingContext(t, ctx)
 }
 
 func TestAuthenticateNoCreds(t *testing.T) {
 	service := AuthService{authenticator: testauth.NewTestAuthenticator(testauth.TestUsers("foo", "bar"))}
-	_, err := service.Authenticate(context.Background(), &authpb.AuthenticateRequest{})
+	_, err := service.Authenticate(t.Context(), &authpb.AuthenticateRequest{})
 	assert.True(t, status.IsUnauthenticatedError(err))
 }
 

--- a/enterprise/server/remoteauth/BUILD
+++ b/enterprise/server/remoteauth/BUILD
@@ -32,6 +32,7 @@ go_test(
         "//proto:auth_go_proto",
         "//server/interfaces",
         "//server/testutil/testenv",
+        "//server/testutil/testgrpc",
         "//server/util/authutil",
         "//server/util/claims",
         "//server/util/status",

--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -11,6 +11,7 @@ import (
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgrpc"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -91,12 +92,7 @@ func contextWithJwt(t *testing.T, jwt string) context.Context {
 
 func contextWith(t *testing.T, key string, value string) context.Context {
 	ctx := metadata.AppendToOutgoingContext(context.Background(), key, value)
-	outgoingMD, ok := metadata.FromOutgoingContext(ctx)
-	require.True(t, ok)
-	// Simulate an RPC by creating a new context with the incoming
-	// metadata set to the previously applied outgoing metadata.
-	ctx = context.Background()
-	return metadata.NewIncomingContext(ctx, outgoingMD)
+	return testgrpc.OutgoingToIncomingContext(t, ctx)
 }
 
 func validJwt(t *testing.T, uid string) string {

--- a/server/testutil/testgrpc/testgrpc.go
+++ b/server/testutil/testgrpc/testgrpc.go
@@ -118,3 +118,11 @@ func RandomDialer(targets []string) Director {
 		return ctx, cc, nil
 	}
 }
+
+// Simulates an outgoing RPC by copying outgoing metadatam from the provided
+// context into new incoming metadata in the provided context.
+func OutgoingToIncomingContext(t *testing.T, ctx context.Context) context.Context {
+	outgoingMD, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok)
+	return metadata.NewIncomingContext(ctx, outgoingMD)
+}

--- a/server/testutil/testgrpc/testgrpc.go
+++ b/server/testutil/testgrpc/testgrpc.go
@@ -120,7 +120,8 @@ func RandomDialer(targets []string) Director {
 }
 
 // Simulates an outgoing RPC by copying outgoing metadatam from the provided
-// context into new incoming metadata in the provided context.
+// context into new incoming metadata which is added to the provided context
+// and returned.
 func OutgoingToIncomingContext(t *testing.T, ctx context.Context) context.Context {
 	outgoingMD, ok := metadata.FromOutgoingContext(ctx)
 	require.True(t, ok)

--- a/server/util/usageutil/BUILD
+++ b/server/util/usageutil/BUILD
@@ -21,6 +21,7 @@ go_test(
         ":usageutil",
         "//proto:remote_execution_go_proto",
         "//server/tables",
+        "//server/testutil/testgrpc",
         "//server/util/bazel_request",
         "//server/util/proto",
         "//server/util/testing/flags",

--- a/server/util/usageutil/usageutil_test.go
+++ b/server/util/usageutil/usageutil_test.go
@@ -1,7 +1,6 @@
 package usageutil_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
@@ -75,7 +74,7 @@ func TestLabels(t *testing.T) {
 			if test.ClientHeader != "" {
 				md[usageutil.ClientHeaderName] = []string{test.ClientHeader}
 			}
-			ctx := metadata.NewIncomingContext(context.Background(), md)
+			ctx := metadata.NewIncomingContext(t.Context(), md)
 
 			labels, err := usageutil.LabelsForUsageRecording(ctx, "")
 
@@ -124,7 +123,7 @@ func TestLabelPropagation(t *testing.T) {
 			flags.Set(t, "grpc_client_origin_header", test.Origin)
 			usageutil.SetServerName(test.Client)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			// Set some pre-existing bazel request metadata on the incoming
 			// context; our propagated labels should always take precedence.
 			bazelMD := &repb.RequestMetadata{ToolDetails: &repb.ToolDetails{ToolName: "bazel"}}

--- a/server/util/usageutil/usageutil_test.go
+++ b/server/util/usageutil/usageutil_test.go
@@ -130,9 +130,6 @@ func TestLabelPropagation(t *testing.T) {
 			ctx, err := bazel_request.WithRequestMetadata(ctx, bazelMD)
 			ctx = usageutil.WithLocalServerLabels(ctx)
 			require.NoError(t, err)
-
-			// Simulate an RPC by creating a new context with the incoming
-			// metadata set to the previously applied outgoing metadata.
 			ctx = testgrpc.OutgoingToIncomingContext(t, ctx)
 
 			// Simulate that we've arrived at the receiving server by

--- a/server/util/usageutil/usageutil_test.go
+++ b/server/util/usageutil/usageutil_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgrpc"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
@@ -130,13 +131,10 @@ func TestLabelPropagation(t *testing.T) {
 			ctx, err := bazel_request.WithRequestMetadata(ctx, bazelMD)
 			ctx = usageutil.WithLocalServerLabels(ctx)
 			require.NoError(t, err)
-			outgoingMD, ok := metadata.FromOutgoingContext(ctx)
-			require.True(t, ok)
 
 			// Simulate an RPC by creating a new context with the incoming
 			// metadata set to the previously applied outgoing metadata.
-			ctx = context.Background()
-			ctx = metadata.NewIncomingContext(ctx, outgoingMD)
+			ctx = testgrpc.OutgoingToIncomingContext(t, ctx)
 
 			// Simulate that we've arrived at the receiving server by
 			// changing the server name on the fly.


### PR DESCRIPTION
We have a few places where we simulate RPCs in tests by creating a new context and copying the RPC metadata from a context that's passed in to the new context. This PR just pulls that few lines out of the few places we have it into a little utility function, mostly because I want to add another one soon and thought four of them was too many.