### PR TITLE
Implement the RPC service for retrieving customer-managed encryption keys

### DIFF
--- a/enterprise/server/crypter_service/BUILD
+++ b/enterprise/server/crypter_service/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "crypter_service",
     srcs = ["crypter_service.go"],
@@ -15,6 +17,7 @@ go_library(
         "//server/real_environment",
         "//server/tables",
         "//server/util/db",
+        "//server/util/flag",
         "//server/util/log",
         "//server/util/retry",
         "//server/util/status",
@@ -33,6 +36,7 @@ go_test(
     embed = [":crypter_service"],
     deps = [
         "//enterprise/server/backends/pebble_cache",
+        "//enterprise/server/clientidentity",
         "//enterprise/server/testutil/enterprise_testauth",
         "//enterprise/server/testutil/enterprise_testenv",
         "//proto:capability_go_proto",
@@ -53,7 +57,6 @@ go_test(
         "//server/util/testing/flags",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//metadata",
     ],
 )
-
-package(default_visibility = ["//enterprise:__subpackages__"])

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1533,6 +1533,8 @@ type Crypter interface {
 
 	NewEncryptor(ctx context.Context, d *repb.Digest, w CommittedWriteCloser) (Encryptor, error)
 	NewDecryptor(ctx context.Context, d *repb.Digest, r io.ReadCloser, em *sgpb.EncryptionMetadata) (Decryptor, error)
+
+	enpb.EncryptionServiceServer
 }
 
 // Provides a duplicate function call suppression mechanism, just like the

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//proto:auth_go_proto",
         "//proto:buildbuddy_service_go_proto",
+        "//proto:encryption_go_proto",
         "//proto:hit_tracker_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_asset_go_proto",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -60,6 +60,7 @@ import (
 	apipb "github.com/buildbuddy-io/buildbuddy/proto/api/v1"
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
+	enpb "github.com/buildbuddy-io/buildbuddy/proto/encryption"
 	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
@@ -323,6 +324,9 @@ func registerServices(env *real_environment.RealEnv, grpcServer *grpc.Server) {
 	}
 	if ht := env.GetHitTrackerServiceServer(); ht != nil {
 		hitpb.RegisterHitTrackerServiceServer(grpcServer, ht)
+	}
+	if crypter := env.GetCrypter(); crypter != nil {
+		enpb.RegisterEncryptionServiceServer(grpcServer, crypter)
 	}
 }
 


### PR DESCRIPTION
This is the second part of the second step described in https://github.com/buildbuddy-io/buildbuddy-internal/issues/4758#issuecomment-3152798840.

Related Issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4758