### PR TITLE
Fix target filtering in dense mode

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -572,7 +572,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
             activeTab == "spawns" ||
             activeTab == "files") && (
             <InvocationFilterComponent
-              tab={this.props.tab}
+              tab={`#${activeTab}`}
               search={this.props.search}
               placeholder={activeTab === "execution" ? "Filter by target, action mnemonic, command, or digest..." : ""}
               // When serving a paginated invocation, debounce since searching


### PR DESCRIPTION
In dense mode, the targets tab is the default tab when no hash is set - which breaks InvocationFilterComponent (which expects the hash to be targets).

This PR fixes that by passing down the active tab to the filter component (which is correct regardless of whether or not we're in dense mode).

Fixes: https://github.com/buildbuddy-io/buildbuddy/issues/8829