### PR TITLE
Show average, min, and max duration on test target page

### DIFF
--- a/app/target/target_v2.tsx
+++ b/app/target/target_v2.tsx
@@ -189,7 +189,7 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
 
     for (const event of resultEvents) {
       const durationMillis = event.testResult?.testAttemptDurationMillis;
-      if (durationMillis && durationMillis > 0) {
+      if (durationMillis) {
         const duration = Number(durationMillis);
         totalDurationMillis += duration;
         minDurationMillis = Math.min(minDurationMillis, duration);

--- a/app/target/target_v2.tsx
+++ b/app/target/target_v2.tsx
@@ -1,4 +1,17 @@
-import { ArrowDownToLine, ArrowUpToLine, Box, CheckCircle, Clock, Copy, Hash, HelpCircle, History, SkipForward, Target, XCircle } from "lucide-react";
+import {
+  ArrowDownToLine,
+  ArrowUpToLine,
+  Box,
+  CheckCircle,
+  Clock,
+  Copy,
+  Hash,
+  HelpCircle,
+  History,
+  SkipForward,
+  Target,
+  XCircle,
+} from "lucide-react";
 import React from "react";
 import { api as api_common } from "../../proto/api/v1/common_ts_proto";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
@@ -189,7 +202,7 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
     return {
       avg: totalDurationMillis / validDurationCount,
       min: minDurationMillis,
-      max: maxDurationMillis
+      max: maxDurationMillis,
     };
   }
 
@@ -356,28 +369,29 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
                   {target.testSummary.totalRunCount ?? 0} total runs
                 </div>
               )}
-              {target?.testSummary && (() => {
-                const durationStats = this.getTestDurationStats();
-                if (durationStats !== null) {
-                  return (
-                    <>
-                      <div className="detail">
-                        <Clock className="icon" />
-                        {format.durationMillis(durationStats.avg)} avg duration
-                      </div>
-                      <div className="detail">
-                        <ArrowDownToLine className="icon" />
-                        {format.durationMillis(durationStats.min)} min duration
-                      </div>
-                      <div className="detail">
-                        <ArrowUpToLine className="icon" />
-                        {format.durationMillis(durationStats.max)} max duration
-                      </div>
-                    </>
-                  );
-                }
-                return null;
-              })()}
+              {target?.testSummary &&
+                (() => {
+                  const durationStats = this.getTestDurationStats();
+                  if (durationStats !== null) {
+                    return (
+                      <>
+                        <div className="detail">
+                          <Clock className="icon" />
+                          {format.durationMillis(durationStats.avg)} avg duration
+                        </div>
+                        <div className="detail">
+                          <ArrowDownToLine className="icon" />
+                          {format.durationMillis(durationStats.min)} min duration
+                        </div>
+                        <div className="detail">
+                          <ArrowUpToLine className="icon" />
+                          {format.durationMillis(durationStats.max)} max duration
+                        </div>
+                      </>
+                    );
+                  }
+                  return null;
+                })()}
               {Boolean(target?.metadata?.ruleType || target?.actionEvents.length) && (
                 <div className="detail">
                   <Target className="icon" />


### PR DESCRIPTION
Particularly useful / interesting on test pages where runs_per_test is set to > 1.

<img width="1122" height="299" alt="Screenshot 2025-08-07 at 1 27 36 PM" src="https://github.com/user-attachments/assets/1aa779ec-ee98-4f17-aaa7-98e1b11904b4" />

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5462