### PR TITLE
Show support isolation types on executors page

### DIFF
--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -38,6 +38,12 @@ export default class ExecutorCardComponent extends React.Component<Props> {
               <div className="executor-section-title">Assignable Milli CPU:</div>
               <div>{this.props.node.assignableMilliCpu}</div>
             </div>
+            {this.props.node.supportedIsolationTypes && this.props.node.supportedIsolationTypes.length > 0 && (
+              <div className="executor-section">
+                <div className="executor-section-title">Isolation Types:</div>
+                <div>{this.props.node.supportedIsolationTypes.join(", ")}</div>
+              </div>
+            )}
             {this.props.node.assignableCustomResources.map((r) => {
               return (
                 <div className="executor-section">

--- a/enterprise/server/scheduling/scheduler_client/BUILD
+++ b/enterprise/server/scheduling/scheduler_client/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_client",
     deps = [
         "//enterprise/server/remote_execution/executor_auth",
+        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/scheduling/priority_task_scheduler",
         "//proto:scheduler_go_proto",
         "//server/environment",

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor_auth"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_task_scheduler"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
@@ -60,6 +61,14 @@ func makeExecutionNode(pool, executorID, executorHostID string, options *Options
 		}
 		hostname = resHostname
 	}
+	
+	// Get supported isolation types from platform configuration
+	executorProps := platform.GetExecutorProperties()
+	supportedTypes := make([]string, 0, len(executorProps.SupportedIsolationTypes))
+	for _, t := range executorProps.SupportedIsolationTypes {
+		supportedTypes = append(supportedTypes, string(t))
+	}
+	
 	return &scpb.ExecutionNode{
 		Host: hostname,
 		// TODO: stop setting port once the scheduler no longer requires it.
@@ -73,6 +82,7 @@ func makeExecutionNode(pool, executorID, executorHostID string, options *Options
 		Version:                   version.Tag(),
 		ExecutorId:                executorID,
 		ExecutorHostId:            executorHostID,
+		SupportedIsolationTypes:   supportedTypes,
 	}, nil
 }
 

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -61,14 +61,14 @@ func makeExecutionNode(pool, executorID, executorHostID string, options *Options
 		}
 		hostname = resHostname
 	}
-	
+
 	// Get supported isolation types from platform configuration
 	executorProps := platform.GetExecutorProperties()
 	supportedTypes := make([]string, 0, len(executorProps.SupportedIsolationTypes))
 	for _, t := range executorProps.SupportedIsolationTypes {
 		supportedTypes = append(supportedTypes, string(t))
 	}
-	
+
 	return &scpb.ExecutionNode{
 		Host: hostname,
 		// TODO: stop setting port once the scheduler no longer requires it.

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -533,6 +533,10 @@ message ExecutionNode {
   //
   // Ex. "8BiY6U0F"
   string executor_host_id = 10;
+
+  // Supported isolation types for this executor.
+  // Ex. ["docker", "firecracker", "none"]
+  repeated string supported_isolation_types = 12;
 }
 
 message GetExecutionNodesRequest {


### PR DESCRIPTION
<img width="827" height="659" alt="Screenshot 2025-08-07 at 2 02 02 PM" src="https://github.com/user-attachments/assets/63387d81-b5b3-47e3-955f-6c06ce1e9145" />

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5143