### PR TITLE
[grafana] separate panels for outgoing http reqs by host and overall

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -72,7 +72,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 1003
+            "y": 1067
           },
           "id": 21,
           "options": {
@@ -123,7 +123,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 5119
+            "y": 5183
           },
           "id": 6270,
           "options": {
@@ -214,7 +214,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5126
+            "y": 5190
           },
           "id": 932,
           "options": {
@@ -313,7 +313,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5126
+            "y": 5190
           },
           "id": 5492,
           "options": {
@@ -424,7 +424,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1004
+            "y": 2
           },
           "id": 348,
           "options": {
@@ -521,7 +521,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1004
+            "y": 2
           },
           "id": 804,
           "options": {
@@ -633,7 +633,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1005
+            "y": 1069
           },
           "id": 6840,
           "options": {
@@ -733,7 +733,7 @@
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 1005
+            "y": 1069
           },
           "id": 25,
           "options": {
@@ -831,7 +831,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 5090
+            "y": 5154
           },
           "id": 1232,
           "options": {
@@ -930,7 +930,7 @@
             "h": 8,
             "w": 12,
             "x": 9,
-            "y": 5090
+            "y": 5154
           },
           "id": 65,
           "options": {
@@ -1028,7 +1028,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 5098
+            "y": 5162
           },
           "id": 13,
           "options": {
@@ -1142,7 +1142,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1006
+            "y": 1070
           },
           "id": 1182,
           "options": {
@@ -1242,7 +1242,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1006
+            "y": 1070
           },
           "id": 1186,
           "options": {
@@ -1339,7 +1339,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5067
+            "y": 5131
           },
           "id": 1183,
           "options": {
@@ -1437,7 +1437,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5067
+            "y": 5131
           },
           "id": 1187,
           "options": {
@@ -1534,7 +1534,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5075
+            "y": 5139
           },
           "id": 1184,
           "options": {
@@ -1632,7 +1632,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 5075
+            "y": 5139
           },
           "id": 1188,
           "options": {
@@ -1743,7 +1743,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1007
+            "y": 1071
           },
           "id": 230,
           "options": {
@@ -1841,7 +1841,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1007
+            "y": 1071
           },
           "id": 310,
           "options": {
@@ -1949,7 +1949,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 5052
+            "y": 5116
           },
           "id": 312,
           "options": {
@@ -2061,7 +2061,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6
+            "y": 14
           },
           "id": 254,
           "options": {
@@ -2177,7 +2177,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6
+            "y": 14
           },
           "id": 251,
           "options": {
@@ -2322,7 +2322,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 78
           },
           "id": 250,
           "options": {
@@ -2468,7 +2468,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 78
           },
           "id": 252,
           "options": {
@@ -2614,7 +2614,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 86
           },
           "id": 253,
           "options": {
@@ -2760,7 +2760,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 86
           },
           "id": 10479,
           "options": {
@@ -2875,7 +2875,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 94
           },
           "id": 10604,
           "options": {
@@ -3013,7 +3013,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 94
           },
           "id": 10739,
           "options": {
@@ -3110,7 +3110,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 102
           },
           "id": 10740,
           "options": {
@@ -3263,7 +3263,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 724
+            "y": 788
           },
           "id": 17,
           "options": {
@@ -3363,7 +3363,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 724
+            "y": 788
           },
           "id": 19,
           "options": {
@@ -3479,7 +3479,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 732
+            "y": 796
           },
           "id": 10730,
           "options": {
@@ -3597,7 +3597,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 732
+            "y": 796
           },
           "id": 9,
           "options": {
@@ -3696,7 +3696,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 741
+            "y": 805
           },
           "id": 6656,
           "options": {
@@ -3793,7 +3793,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 741
+            "y": 805
           },
           "id": 6834,
           "options": {
@@ -3934,7 +3934,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 766
+            "y": 830
           },
           "id": 6732,
           "options": {
@@ -4059,7 +4059,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 775
+            "y": 839
           },
           "id": 646,
           "options": {
@@ -4121,7 +4121,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 783
+            "y": 847
           },
           "id": 1247,
           "maxDataPoints": 25,
@@ -4250,7 +4250,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 791
+            "y": 855
           },
           "id": 1338,
           "options": {
@@ -4353,7 +4353,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 799
+            "y": 863
           },
           "id": 2135,
           "options": {
@@ -4452,7 +4452,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 807
+            "y": 871
           },
           "id": 6422,
           "options": {
@@ -4551,7 +4551,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 815
+            "y": 879
           },
           "id": 10734,
           "options": {
@@ -4648,7 +4648,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 823
+            "y": 887
           },
           "id": 6428,
           "options": {
@@ -4745,7 +4745,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 831
+            "y": 895
           },
           "id": 2182,
           "options": {
@@ -4804,7 +4804,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 839
+            "y": 903
           },
           "id": 6382,
           "maxDataPoints": 25,
@@ -4946,7 +4946,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 938
+            "y": 1002
           },
           "id": 6580,
           "options": {
@@ -5067,7 +5067,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 946
+            "y": 1010
           },
           "id": 3763,
           "options": {
@@ -5195,7 +5195,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 954
+            "y": 1018
           },
           "id": 5574,
           "options": {
@@ -5348,7 +5348,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 962
+            "y": 1026
           },
           "id": 3846,
           "options": {
@@ -5443,7 +5443,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 970
+            "y": 1034
           },
           "id": 5160,
           "options": {
@@ -5538,7 +5538,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 978
+            "y": 1042
           },
           "id": 5242,
           "options": {
@@ -5632,7 +5632,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 986
+            "y": 1050
           },
           "id": 5324,
           "options": {
@@ -5726,7 +5726,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 994
+            "y": 1058
           },
           "id": 5406,
           "options": {
@@ -5836,7 +5836,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4550
+            "y": 4614
           },
           "id": 3929,
           "options": {
@@ -5933,7 +5933,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4550
+            "y": 4614
           },
           "id": 4011,
           "options": {
@@ -6030,7 +6030,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4558
+            "y": 4622
           },
           "id": 4093,
           "options": {
@@ -6127,7 +6127,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4558
+            "y": 4622
           },
           "id": 4175,
           "options": {
@@ -6224,7 +6224,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4566
+            "y": 4630
           },
           "id": 4257,
           "options": {
@@ -6321,7 +6321,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4566
+            "y": 4630
           },
           "id": 4339,
           "options": {
@@ -6418,7 +6418,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4574
+            "y": 4638
           },
           "id": 4421,
           "options": {
@@ -6515,7 +6515,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4574
+            "y": 4638
           },
           "id": 4503,
           "options": {
@@ -6612,7 +6612,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4582
+            "y": 4646
           },
           "id": 4585,
           "options": {
@@ -6709,7 +6709,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4582
+            "y": 4646
           },
           "id": 4667,
           "options": {
@@ -6806,7 +6806,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4590
+            "y": 4654
           },
           "id": 4749,
           "options": {
@@ -6903,7 +6903,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4590
+            "y": 4654
           },
           "id": 4831,
           "options": {
@@ -7000,7 +7000,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4598
+            "y": 4662
           },
           "id": 4913,
           "options": {
@@ -7112,7 +7112,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50030
+            "y": 54748
           },
           "id": 274,
           "options": {
@@ -7230,7 +7230,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50030
+            "y": 54748
           },
           "id": 276,
           "options": {
@@ -7328,7 +7328,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50038
+            "y": 54756
           },
           "id": 290,
           "options": {
@@ -7426,7 +7426,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50038
+            "y": 54756
           },
           "id": 292,
           "options": {
@@ -7524,7 +7524,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50046
+            "y": 54764
           },
           "id": 278,
           "options": {
@@ -7622,7 +7622,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50046
+            "y": 54764
           },
           "id": 280,
           "options": {
@@ -7736,7 +7736,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 329925
+            "y": 389390
           },
           "id": 40,
           "options": {
@@ -7880,7 +7880,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 330031
+            "y": 389496
           },
           "id": 76,
           "options": {
@@ -7985,7 +7985,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 330045
+            "y": 389510
           },
           "id": 42,
           "options": {
@@ -8083,7 +8083,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 330045
+            "y": 389510
           },
           "id": 46,
           "options": {
@@ -8181,7 +8181,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 330053
+            "y": 389518
           },
           "id": 44,
           "options": {
@@ -8295,7 +8295,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 329926
+            "y": 389391
           },
           "id": 498,
           "options": {
@@ -8397,7 +8397,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 329926
+            "y": 389391
           },
           "id": 542,
           "options": {
@@ -8497,7 +8497,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 329991
+            "y": 389456
           },
           "id": 506,
           "options": {
@@ -8601,7 +8601,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 330000
+            "y": 389465
           },
           "id": 496,
           "options": {
@@ -8703,7 +8703,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 330010
+            "y": 389475
           },
           "id": 500,
           "options": {
@@ -8805,7 +8805,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 330010
+            "y": 389475
           },
           "id": 504,
           "options": {
@@ -8920,7 +8920,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329927
+            "y": 389392
           },
           "id": 50,
           "options": {
@@ -9018,7 +9018,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 329927
+            "y": 389392
           },
           "id": 53,
           "options": {
@@ -9116,7 +9116,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329975
+            "y": 389440
           },
           "id": 51,
           "options": {
@@ -9214,7 +9214,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 329975
+            "y": 389440
           },
           "id": 55,
           "options": {
@@ -9326,7 +9326,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329928
+            "y": 389393
           },
           "id": 742,
           "options": {
@@ -9431,7 +9431,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 329928
+            "y": 389393
           },
           "id": 422,
           "options": {
@@ -9533,7 +9533,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329936
+            "y": 389401
           },
           "id": 420,
           "options": {
@@ -9635,7 +9635,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 329936
+            "y": 389401
           },
           "id": 6504,
           "options": {
@@ -9787,7 +9787,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329944
+            "y": 389409
           },
           "id": 1223,
           "options": {
@@ -9961,7 +9961,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 329944
+            "y": 389409
           },
           "id": 1224,
           "options": {
@@ -10018,7 +10018,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329952
+            "y": 389417
           },
           "id": 6943,
           "options": {
@@ -10110,7 +10110,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 329952
+            "y": 389417
           },
           "id": 6944,
           "options": {
@@ -10232,7 +10232,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 329960
+            "y": 389425
           },
           "id": 7133,
           "options": {
@@ -10423,7 +10423,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 329960
+            "y": 389425
           },
           "id": 7039,
           "options": {
@@ -10548,20 +10548,81 @@
             "uid": "vm"
           },
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 399847
+            "y": 18
           },
           "id": 122,
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "10.1.0",
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -10584,20 +10645,81 @@
             "uid": "vm"
           },
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 399847
+            "y": 18
           },
           "id": 116,
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "10.1.0",
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -10620,20 +10742,81 @@
             "uid": "vm"
           },
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 399855
+            "y": 26
           },
           "id": 112,
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "10.1.0",
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -10656,20 +10839,81 @@
             "uid": "vm"
           },
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 399855
+            "y": 26
           },
           "id": 120,
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "10.1.0",
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -10693,20 +10937,81 @@
           },
           "description": "",
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 399863
+            "y": 34
           },
           "id": 118,
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "10.1.0",
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -10729,20 +11034,81 @@
             "uid": "vm"
           },
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 399863
+            "y": 34
           },
           "id": 124,
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "10.1.0",
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -10765,20 +11131,284 @@
             "uid": "vm"
           },
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 399871
+            "y": 42
           },
           "id": 9138,
           "options": {
-            "alertThreshold": true
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
-          "pluginVersion": "10.1.0",
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate(buildbuddy_http_client_request_count{region=\"${region}\"}[${window}]))",
+              "interval": "",
+              "legendFormat": "{{method}}",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP client outgoing requests per second",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 9266,
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "editorMode": "code",
+              "expr": "sum (rate(buildbuddy_http_client_response_size_bytes_sum{region=\"${region}\"}[${window}]))",
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP client bytes read",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 66
+          },
+          "id": 10741,
+          "options": {
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -10803,58 +11433,86 @@
             "uid": "vm"
           },
           "fieldConfig": {
-            "defaults": {},
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 399871
+            "y": 66
           },
-          "id": 9139,
+          "id": 10742,
           "options": {
-            "alertThreshold": true
-          },
-          "pluginVersion": "10.1.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "vm"
-              },
-              "editorMode": "code",
-              "expr": "sum by (method) (rate(buildbuddy_http_client_request_count{region=\"${region}\"}[${window}]))",
-              "interval": "",
-              "legendFormat": "{{method}}",
-              "queryType": "randomWalk",
-              "range": true,
-              "refId": "A"
+            "alertThreshold": true,
+            "legend": {
+              "calcs": [
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
             }
-          ],
-          "title": "HTTP client outgoing requests per second by method",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "vm"
           },
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 399879
-          },
-          "id": 9266,
-          "options": {
-            "alertThreshold": true
-          },
-          "pluginVersion": "10.1.0",
+          "pluginVersion": "11.6.2",
           "targets": [
             {
               "datasource": {
@@ -10951,7 +11609,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300178
+            "y": 359643
           },
           "id": 190,
           "options": {
@@ -11179,7 +11837,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300178
+            "y": 359643
           },
           "id": 159,
           "options": {
@@ -11354,7 +12012,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300186
+            "y": 359651
           },
           "id": 210,
           "options": {
@@ -11454,7 +12112,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300186
+            "y": 359651
           },
           "id": 1209,
           "options": {
@@ -11552,7 +12210,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300194
+            "y": 359659
           },
           "id": 31,
           "options": {
@@ -11650,7 +12308,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300194
+            "y": 359659
           },
           "id": 178,
           "options": {
@@ -11760,7 +12418,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300202
+            "y": 359667
           },
           "id": 8505,
           "options": {
@@ -11879,7 +12537,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300202
+            "y": 359667
           },
           "id": 8606,
           "options": {
@@ -12020,7 +12678,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300210
+            "y": 359675
           },
           "id": 1216,
           "options": {
@@ -12153,7 +12811,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300210
+            "y": 359675
           },
           "id": 1231,
           "options": {
@@ -12277,7 +12935,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300218
+            "y": 359683
           },
           "id": 33,
           "options": {
@@ -12375,7 +13033,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300218
+            "y": 359683
           },
           "id": 35,
           "options": {
@@ -12473,7 +13131,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300226
+            "y": 359691
           },
           "id": 102,
           "options": {
@@ -12570,7 +13228,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300226
+            "y": 359691
           },
           "id": 180,
           "options": {
@@ -12735,7 +13393,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300234
+            "y": 359699
           },
           "id": 1195,
           "options": {
@@ -12900,7 +13558,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300234
+            "y": 359699
           },
           "id": 1196,
           "options": {
@@ -13001,7 +13659,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300242
+            "y": 359707
           },
           "id": 1202,
           "options": {
@@ -13096,7 +13754,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300242
+            "y": 359707
           },
           "id": 7145,
           "options": {
@@ -13177,7 +13835,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300250
+            "y": 359715
           },
           "id": 7139,
           "options": {
@@ -13258,7 +13916,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300250
+            "y": 359715
           },
           "id": 7157,
           "options": {
@@ -13339,7 +13997,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300258
+            "y": 359723
           },
           "id": 7151,
           "options": {
@@ -13420,7 +14078,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 300258
+            "y": 359723
           },
           "id": 7169,
           "options": {
@@ -13501,7 +14159,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 300266
+            "y": 359731
           },
           "id": 7163,
           "options": {
@@ -13638,7 +14296,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1359174
+            "y": 1723744
           },
           "id": 85,
           "options": {
@@ -13748,7 +14406,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1359174
+            "y": 1723744
           },
           "id": 93,
           "options": {
@@ -13847,7 +14505,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1359200
+            "y": 1723770
           },
           "id": 87,
           "options": {
@@ -13946,7 +14604,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1359200
+            "y": 1723770
           },
           "id": 10729,
           "options": {
@@ -14061,7 +14719,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 3176573
+            "y": 4905096
           },
           "id": 73,
           "options": {
@@ -14160,7 +14818,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 3176573
+            "y": 4905096
           },
           "id": 79,
           "options": {
@@ -14258,7 +14916,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3176582
+            "y": 4905105
           },
           "id": 2087,
           "options": {
@@ -14364,7 +15022,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3176582
+            "y": 4905105
           },
           "id": 2039,
           "options": {
@@ -14477,7 +15135,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3176590
+            "y": 4905113
           },
           "id": 10735,
           "options": {
@@ -14580,7 +15238,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3176590
+            "y": 4905113
           },
           "id": 10736,
           "options": {
@@ -14683,7 +15341,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3176598
+            "y": 4905121
           },
           "id": 10737,
           "options": {
@@ -14786,7 +15444,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3176598
+            "y": 4905121
           },
           "id": 10738,
           "options": {
@@ -14903,7 +15561,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16283086
+            "y": 21192952
           },
           "id": 9300,
           "options": {
@@ -15000,7 +15658,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16283086
+            "y": 21192952
           },
           "id": 9301,
           "options": {
@@ -15110,7 +15768,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16283094
+            "y": 21192960
           },
           "id": 9303,
           "options": {
@@ -15236,7 +15894,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10969504
+            "y": 15879370
           },
           "id": 9337,
           "options": {
@@ -15337,7 +15995,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10969504
+            "y": 15879370
           },
           "id": 9462,
           "options": {
@@ -15451,7 +16109,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10969512
+            "y": 15879378
           },
           "id": 9587,
           "options": {
@@ -15577,7 +16235,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16283111
+            "y": 21192977
           },
           "id": 1127,
           "options": {
@@ -15674,7 +16332,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16283111
+            "y": 21192977
           },
           "id": 1166,
           "options": {
@@ -15784,7 +16442,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16283119
+            "y": 21192985
           },
           "id": 1168,
           "options": {
@@ -15911,7 +16569,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 88577164
+            "y": 109774891
           },
           "id": 2,
           "options": {
@@ -16030,7 +16688,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 88577164
+            "y": 109774891
           },
           "id": 578,
           "options": {
@@ -16142,7 +16800,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 88577165
+            "y": 109774892
           },
           "id": 2556,
           "options": {
@@ -16243,7 +16901,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 88577250
+            "y": 109774977
           },
           "id": 2840,
           "options": {
@@ -16343,7 +17001,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577264
+            "y": 109774991
           },
           "id": 2890,
           "options": {
@@ -16443,7 +17101,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88577264
+            "y": 109774991
           },
           "id": 2940,
           "options": {
@@ -16544,7 +17202,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577272
+            "y": 109774999
           },
           "id": 1353,
           "links": [
@@ -16660,7 +17318,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577166
+            "y": 109774893
           },
           "id": 5595,
           "options": {
@@ -16756,7 +17414,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88577166
+            "y": 109774893
           },
           "id": 5608,
           "options": {
@@ -16853,7 +17511,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577222
+            "y": 109774949
           },
           "id": 5622,
           "options": {
@@ -16950,7 +17608,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88577222
+            "y": 109774949
           },
           "id": 5629,
           "options": {
@@ -17046,7 +17704,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577230
+            "y": 109774957
           },
           "id": 5615,
           "options": {
@@ -17158,7 +17816,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577167
+            "y": 109774894
           },
           "id": 7381,
           "options": {
@@ -17282,7 +17940,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88577167
+            "y": 109774894
           },
           "id": 7382,
           "options": {
@@ -17384,7 +18042,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577191
+            "y": 109774918
           },
           "id": 7489,
           "options": {
@@ -17486,7 +18144,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88577191
+            "y": 109774918
           },
           "id": 7488,
           "options": {
@@ -17585,7 +18243,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577199
+            "y": 109774926
           },
           "id": 7595,
           "options": {
@@ -17684,7 +18342,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88577199
+            "y": 109774926
           },
           "id": 8743,
           "options": {
@@ -17783,7 +18441,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577207
+            "y": 109774934
           },
           "id": 8880,
           "options": {
@@ -17882,7 +18540,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88577207
+            "y": 109774934
           },
           "id": 9017,
           "options": {
@@ -17994,7 +18652,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577168
+            "y": 43
           },
           "id": 10100,
           "options": {
@@ -18092,7 +18750,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88577168
+            "y": 43
           },
           "id": 10227,
           "options": {
@@ -18116,7 +18774,7 @@
                 "uid": "vm"
               },
               "editorMode": "code",
-              "expr": "sum by (cache_event_type) (rate(buildbuddy_ociregistry_cache_events{region=\"${region}\", oci_resource_type=\"blob\"}[${window}]))",
+              "expr": "sum by (cache_event_type) (rate(buildbuddy_ociregistry_cache_events{region=\"${region}\", oci_resource_type=~\"blob.*\"}[${window}]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
@@ -18183,7 +18841,7 @@
                   }
                 ]
               },
-              "unit": "decbytes"
+              "unit": "Bps"
             },
             "overrides": []
           },
@@ -18191,7 +18849,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88577176
+            "y": 51
           },
           "id": 10354,
           "options": {
@@ -18200,7 +18858,7 @@
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "tooltip": {
               "hideZeros": false,
@@ -18329,7 +18987,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 60519961
+            "y": 81717688
           },
           "id": 10731,
           "options": {
@@ -18421,7 +19079,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 60519961
+            "y": 81717688
           },
           "id": 10733,
           "options": {


### PR DESCRIPTION
<img width="1487" height="613" alt="Screenshot 2025-08-08 at 9 19 38 AM" src="https://github.com/user-attachments/assets/27a013f7-0fd9-4ae9-88af-45becbe48551" />

Also, a small change to pick up both blob and blob_metadata hits/misses in the OCI mirror panel.