### PR TITLE
Revert "Add a log for stuck BSS reads"

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -400,7 +400,7 @@ func main() {
 
 func deleteBuildRoot(ctx context.Context, rootDir string) {
 	log.Infof("Cleaning build root dir at %q", rootDir)
-	stop := canary.StartWithRepeatedLateFn(1*time.Minute, func(timeTaken time.Duration) {
+	stop := canary.StartWithLateFn(1*time.Minute, func(timeTaken time.Duration) {
 		log.Infof("Still cleaning build root dir (%s elapsed)", timeTaken)
 	}, func(timeTaken time.Duration) {})
 	defer stop()

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -207,7 +207,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	}()
 
 	if *slowTaskThreshold > 0 {
-		stop := canary.StartWithRepeatedLateFn(*slowTaskThreshold, func(duration time.Duration) {
+		stop := canary.StartWithLateFn(*slowTaskThreshold, func(duration time.Duration) {
 			log.CtxInfof(ctx, "Task still running after %s", duration)
 		}, func(time.Duration) {})
 		defer stop()

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1347,7 +1347,7 @@ func (s *BuildBuddyServer) GetEventLog(req *elpb.GetEventLogChunkRequest, stream
 	ctx := stream.Context()
 
 	var bytesSent atomic.Int64
-	stop := canary.StartWithRepeatedLateFn(5*time.Minute, func(d time.Duration) {
+	stop := canary.StartWithLateFn(5*time.Minute, func(d time.Duration) {
 		log.CtxInfof(ctx, "Long-running GetEventLog stream: invocation_id=%s, duration=%s, bytes_sent=%d", req.GetInvocationId(), d, bytesSent.Load())
 	}, func(time.Duration) {})
 	defer stop()

--- a/server/remote_cache/byte_stream_server/BUILD
+++ b/server/remote_cache/byte_stream_server/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//server/util/bazel_deprecation",
         "//server/util/bazel_request",
         "//server/util/bytebufferpool",
-        "//server/util/canary",
         "//server/util/capabilities",
         "//server/util/compression",
         "//server/util/flag",

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"hash"
 	"io"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -14,7 +13,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_deprecation"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bytebufferpool"
-	"github.com/buildbuddy-io/buildbuddy/server/util/canary"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
@@ -110,13 +108,6 @@ func (s *ByteStreamServer) ReadCASResource(ctx context.Context, r *digest.CASRes
 		return err
 	}
 
-	cancel := canary.StartWithLateFn(5*time.Minute, func() {
-		log.CtxWarningf(ctx, "BSS read possibly stuck: %s", r.ToProto())
-	}, func(d time.Duration) {
-		log.CtxWarningf(ctx, "Slow BSS read completed after %s: %s", d, r.ToProto())
-	})
-	defer cancel()
-
 	ht := s.env.GetHitTrackerFactory().NewCASHitTracker(ctx, bazel_request.GetRequestMetadata(ctx))
 	if r.IsEmpty() {
 		dt := ht.TrackDownload(r.GetDigest())
@@ -177,7 +168,7 @@ func (s *ByteStreamServer) ReadCASResource(ctx context.Context, r *digest.CASRes
 		if err != nil {
 			return err
 		}
-		if err := send(ctx, stream, r, &bspb.ReadResponse{Data: copyBuf[:n]}); err != nil {
+		if err := stream.Send(&bspb.ReadResponse{Data: copyBuf[:n]}); err != nil {
 			return err
 		}
 	}
@@ -192,16 +183,6 @@ func (s *ByteStreamServer) ReadCASResource(ctx context.Context, r *digest.CASRes
 		log.Debugf("ByteStream Read: downloadTracker.CloseWithBytesTransferred error: %s", err)
 	}
 	return err
-}
-
-func send(ctx context.Context, stream bspb.ByteStream_ReadServer, rn *digest.CASResourceName, rsp *bspb.ReadResponse) error {
-	cancel := canary.StartWithLateFn(30*time.Second, func() {
-		log.CtxWarningf(ctx, "BSS send read response possibly stuck: %s", rn.ToProto())
-	}, func(d time.Duration) {
-		log.CtxWarningf(ctx, "Slow BSS send read response completed after %s: %s", d, rn.ToProto())
-	})
-	defer cancel()
-	return stream.Send(rsp)
 }
 
 // writeHandler enapsulates an on-going ByteStream write to a cache,

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -133,7 +133,7 @@ func (p *ClientConnPool) Invoke(ctx context.Context, method string, args any, re
 }
 
 func (p *ClientConnPool) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-	cancel := canary.StartWithRepeatedLateFn(
+	cancel := canary.StartWithLateFn(
 		stuckStreamWarningPeriod,
 		func(timeTaken time.Duration) {
 			log.CtxWarningf(ctx, "Streaming RPC %q has not been established after %q.", method, timeTaken)


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#10045

Realizing that unfortunately this will probably create too many goroutines. Going to revert and work on a different approach