### PR TITLE
Fix CombinedForm field in ci_runner

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2433,12 +2433,11 @@ func getStructuredCommandLine() *clpb.CommandLine {
 		if !strings.HasPrefix(arg, "--") || !strings.Contains(arg, "=") {
 			continue
 		}
-		arg = strings.TrimPrefix(arg, "--")
-		parts := strings.SplitN(arg, "=", 2)
+		nameValue := strings.SplitN(strings.TrimPrefix(arg, "--"), "=", 2)
 		options = append(options, &clpb.Option{
 			CombinedForm: arg,
-			OptionName:   parts[0],
-			OptionValue:  parts[1],
+			OptionName:   nameValue[0],
+			OptionValue:  nameValue[1],
 		})
 	}
 	return &clpb.CommandLine{


### PR DESCRIPTION
To match Bazel's behavior, the `combined_form` field should be `--name=value` rather than `name=value` (we were missing the leading `--`)