### PR TITLE
[executor image] use debian 13 trixie as base image

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -1,5 +1,5 @@
 # Debian 13 (trixie) — multi-arch
-FROM mirror.gcr.io/debian:trixie-slim
+FROM mirror.gcr.io/debian@sha256:cc92da07b99dd5c078cb5583fdb4ba639c7c9c14eb78508a2be285ca67cc738a
 
 # Base utilities
 RUN apt-get update && \

--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -1,59 +1,47 @@
-# NOTE: this is a multi-platform image, so each step needs to work on both amd64 and arm64.
-# See README for details.
+# Debian 13 (trixie) — multi-arch
+FROM mirror.gcr.io/debian:trixie-slim
 
-# debian 12
-FROM mirror.gcr.io/debian@sha256:7ca9335a5953654f8feb8b846ad3dd78309a838d62b090c785d1f5908c2d59d2
-
+# Base utilities
 RUN apt-get update && \
-    apt-get install -y \
-    # FUSE support, used by vbd and vfs packages.
-    # TODO: probably not needed since we use DirectMountStrict now?
-    fuse \
-    # Networking tools used by networking package.
-    # iproute2 provides the "ip" command.
-    iproute2 conntrack \
-    # Credential helper for custom execution images hosted on ECR.
-    amazon-ecr-credential-helper \
-    # cgroup-aware proc mounts for OCI containers.
-    lxcfs && \
+    apt-get install -y --no-install-recommends \
+      # FUSE support (Debian 13 uses fuse3; 'fuse' is transitional)
+      fuse3 \
+      # Networking tools
+      iproute2 conntrack \
+      # ECR credential helper (in Debian repos)
+      amazon-ecr-credential-helper \
+      # cgroup-aware /proc for containers
+      lxcfs && \
     apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/* && apt-get clean
 
-RUN DOCKER_VERSION="5:28.2.2-1~debian.12~bookworm" && \
+# Docker Engine + containerd/buildx/compose from Docker's APT repo for trixie
+RUN DOCKER_VERSION="5:28.3.3-1~debian.13~trixie" && \
     CONTAINERD_DEB_VERSION="1.7.27-1" && \
-    DOCKER_BUILDX_VERSION="0.24.0-1~debian.12~bookworm" && \
-    DOCKER_COMPOSE_VERSION="2.36.2-1~debian.12~bookworm" && \
+    DOCKER_BUILDX_VERSION="0.26.1-1~debian.13~trixie" && \
+    DOCKER_COMPOSE_VERSION="2.39.1-1~debian.13~trixie" && \
     apt-get update && \
-    apt-get install -y \
-    curl ca-certificates apt-transport-https && \
+    apt-get install -y --no-install-recommends \
+      curl ca-certificates && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
-    echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
-      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-    tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt-get update && apt-get install -y \
-    docker-ce=${DOCKER_VERSION} \
-    docker-ce-cli=${DOCKER_VERSION} \
-    docker-ce-rootless-extras=${DOCKER_VERSION} \
-    containerd.io=${CONTAINERD_DEB_VERSION} \
-    docker-buildx-plugin=${DOCKER_BUILDX_VERSION} \
-    docker-compose-plugin=${DOCKER_COMPOSE_VERSION} && \
-    apt-mark auto \
-    curl ca-certificates apt-transport-https && \
+    sh -lc 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list' && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      docker-ce=${DOCKER_VERSION} \
+      docker-ce-cli=${DOCKER_VERSION} \
+      docker-ce-rootless-extras=${DOCKER_VERSION} \
+      containerd.io=${CONTAINERD_DEB_VERSION} \
+      docker-buildx-plugin=${DOCKER_BUILDX_VERSION} \
+      docker-compose-plugin=${DOCKER_COMPOSE_VERSION} && \
+    apt-mark auto curl ca-certificates && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && apt-get clean && \
     rm \
-    # keep these in sync with the binaries we are manually
-    # adding in enterprise/server/cmd/executor/BUILD.
-    #
-    # containerd
-    /usr/bin/containerd \
-    /usr/bin/containerd-shim \
-    /usr/bin/containerd-shim-runc-v1 \
-    /usr/bin/ctr \
-    # rootlesskit
-    /usr/bin/rootlesskit \
-    # runc
-    /usr/bin/runc
+      /usr/bin/containerd \
+      /usr/bin/containerd-shim \
+      /usr/bin/containerd-shim-runc-v1 \
+      /usr/bin/ctr \
+      /usr/bin/rootlesskit \
+      /usr/bin/runc


### PR DESCRIPTION
Draft, just in case.
We're still working on getting the image to build with Debian 12.