### PR TITLE
[raft] refactor: add functionality to reserve multiple range ids

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -38,6 +38,7 @@ type IStore interface {
 	NodeHost() *dragonboat.NodeHost
 	Sender() *sender.Sender
 	TxnCoordinator() *txn.Coordinator
+	ReserveRangeID(ctx context.Context) (uint64, error)
 }
 
 type ClusterStarter struct {
@@ -538,7 +539,7 @@ func SendStartShardRequestsWithRanges(ctx context.Context, session *client.Sessi
 			return err
 		}
 
-		newRangeID, err := store.Sender().ReserveRangeID(ctx)
+		newRangeID, err := store.ReserveRangeID(ctx)
 		if err != nil {
 			return status.InternalErrorf("could not reserve RangeID for new range %d: %s", rangeID, err)
 		}

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -616,22 +616,3 @@ func (s *Sender) DirectRead(ctx context.Context, key []byte) ([]byte, error) {
 	}
 	return readResponse.GetKv().GetValue(), nil
 }
-
-func (s *Sender) ReserveRangeID(ctx context.Context) (uint64, error) {
-	metaRangeBatch, err := rbuilder.NewBatchBuilder().Add(&rfpb.IncrementRequest{
-		Key:   constants.LastRangeIDKey,
-		Delta: uint64(1),
-	}).ToProto()
-	if err != nil {
-		return 0, err
-	}
-	metaRangeRsp, err := s.SyncPropose(ctx, constants.MetaRangePrefix, metaRangeBatch)
-	if err != nil {
-		return 0, err
-	}
-	rangeIDIncrRsp, err := rbuilder.NewBatchResponseFromProto(metaRangeRsp).IncrementResponse(0)
-	if err != nil {
-		return 0, err
-	}
-	return rangeIDIncrRsp.GetValue(), nil
-}

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1773,7 +1773,7 @@ func TestSplitAcrossClusters(t *testing.T) {
 	sf.InitalizeShard(t, ctx, bootstrapInfo, initialRD, s2)
 
 	s := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
-	newRangeID, err := s.Sender().ReserveRangeID(ctx)
+	newRangeID, err := s.ReserveRangeID(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), newRangeID)
 


### PR DESCRIPTION
1. extract out a method reserveIDs in store
2. move ReserveRangeID to store, so it can reuse the reserveIDs method
