### PR TITLE
[raft] split out the methods to initialize shards for meta range and for partition

### DIFF
--- a/enterprise/server/raft/metadata/metadata.go
+++ b/enterprise/server/raft/metadata/metadata.go
@@ -232,7 +232,11 @@ func New(env environment.Env, conf *Config) (*Server, error) {
 
 	// bring up any clusters that were previously configured, or
 	// bootstrap a new one based on the join params in the config.
-	rc.clusterStarter = bringup.New(rc.grpcAddr, rc.gossipManager, rc.store, rc.conf.Partitions)
+	clusterStarter, err := bringup.New(rc.grpcAddr, rc.gossipManager, rc.store, rc.conf.Partitions)
+	if err != nil {
+		return nil, err
+	}
+	rc.clusterStarter = clusterStarter
 	if err := rc.clusterStarter.InitializeClusters(); err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/sender/BUILD
+++ b/enterprise/server/raft/sender/BUILD
@@ -36,10 +36,8 @@ go_test(
     },
     tags = ["block-network"],
     deps = [
-        "//enterprise/server/raft/constants",
-        "//enterprise/server/raft/keys",
         "//enterprise/server/raft/testutil",
-        "//proto:raft_go_proto",
+        "//server/util/disk",
         "//server/util/proto",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/raft/sender/sender_test.go
+++ b/enterprise/server/raft/sender/sender_test.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/testutil"
-	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
 )
+
+func requireProtoEqual(t *testing.T, expected, actual proto.Message) {
+	require.True(t, proto.Equal(expected, actual), "expected proto: %+v, actual: %+v", expected, actual)
+}
 
 func TestLookupRangeDescriptor(t *testing.T) {
 	flags.Set(t, "cache.raft.enable_driver", false)
@@ -35,15 +37,15 @@ func TestLookupRangeDescriptor(t *testing.T) {
 
 	gotRD, err := sender.LookupRangeDescriptor(ctx, []byte("PTdefault/"), true)
 	require.NoError(t, err)
-	require.True(t, proto.Equal(rd, gotRD))
+	requireProtoEqual(t, rd, gotRD)
 
 	gotRD, err = sender.LookupRangeDescriptor(ctx, []byte("PTdefault/aaaa"), true)
 	require.NoError(t, err)
-	require.True(t, proto.Equal(rd, gotRD))
+	requireProtoEqual(t, rd, gotRD)
 
 	gotRD, err = sender.LookupRangeDescriptor(ctx, []byte("PTdefault/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff/cas/v5"), true)
 	require.NoError(t, err)
-	require.True(t, proto.Equal(rd, gotRD))
+	requireProtoEqual(t, rd, gotRD)
 }
 
 func TestLookupRangeDescriptorsForPartition(t *testing.T) {
@@ -57,41 +59,23 @@ func TestLookupRangeDescriptorsForPartition(t *testing.T) {
 
 	// Start shard to set up meta range
 	stores := []*testutil.TestingStore{s1}
-	startingRanges := []*rfpb.RangeDescriptor{
-		&rfpb.RangeDescriptor{
-			Start:      constants.MetaRangePrefix,
-			End:        keys.Key{constants.UnsplittableMaxByte},
-			Generation: 1,
+	sf.InitializeShardsForMetaRange(t, ctx, stores...)
+	partitions := []disk.Partition{
+		{
+			ID:        "default",
+			NumRanges: 3,
 		},
-		&rfpb.RangeDescriptor{
-			Start:      []byte("PTdefault/"),
-			End:        []byte("PTdefault/d"),
-			Generation: 1,
-		},
-		&rfpb.RangeDescriptor{
-			Start:      []byte("PTdefault/d"),
-			End:        []byte("PTdefault/h"),
-			Generation: 1,
-		},
-		&rfpb.RangeDescriptor{
-			Start:      []byte("PTdefault/d"),
-			End:        keys.MakeKey([]byte("PTdefault/z"), keys.MaxByte),
-			Generation: 1,
-		},
-		&rfpb.RangeDescriptor{
-			Start:      []byte("PTfoo/"),
-			End:        []byte("PTfoo/h"),
-			Generation: 1,
-		},
-		&rfpb.RangeDescriptor{
-			Start:      []byte("PTfoo/d"),
-			End:        keys.MakeKey([]byte("PTfoo/z"), keys.MaxByte),
-			Generation: 1,
+		{
+			ID:        "foo",
+			NumRanges: 2,
 		},
 	}
-	sf.StartShardWithRanges(t, ctx, startingRanges, stores...)
 
-	for i := 1; i <= len(startingRanges); i++ {
+	for _, p := range partitions {
+		sf.InitializeShardsForPartition(t, ctx, p, s1)
+	}
+
+	for i := 1; i <= 6; i++ {
 		testutil.WaitForRangeLease(t, ctx, stores, uint64(i))
 	}
 
@@ -100,14 +84,14 @@ func TestLookupRangeDescriptorsForPartition(t *testing.T) {
 	res, err := sender.LookupRangeDescriptorsForPartition(ctx, "default", 2)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(res))
-	require.True(t, proto.Equal(startingRanges[1], res[0]))
-	require.True(t, proto.Equal(startingRanges[2], res[1]))
+	requireProtoEqual(t, s1.GetRange(2), res[0])
+	requireProtoEqual(t, s1.GetRange(3), res[1])
 
 	res, err = sender.LookupRangeDescriptorsForPartition(ctx, "foo", 3)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(res))
-	require.True(t, proto.Equal(startingRanges[4], res[0]))
-	require.True(t, proto.Equal(startingRanges[5], res[1]))
+	requireProtoEqual(t, s1.GetRange(5), res[0])
+	requireProtoEqual(t, s1.GetRange(6), res[1])
 
 	res, err = sender.LookupRangeDescriptorsForPartition(ctx, "bar", 1)
 	require.NoError(t, err)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2876,6 +2876,7 @@ func (s *Store) AddReplica(ctx context.Context, req *rfpb.AddReplicaRequest) (*r
 			return nil, status.InternalErrorf("AddReplica failed to add range(%d) to node %q: failed to reserve replica IDs: %s", rangeID, node.GetNhid(), err)
 		}
 		newReplicaID = replicaIDs[0]
+		log.Infof("=====newReplicaID: %d", newReplicaID)
 		rd, err = s.addStagingReplicaToRangeDescriptor(ctx, rangeID, newReplicaID, node.GetNhid(), rd)
 		if err != nil {
 			return nil, status.WrapErrorf(err, "AddReplica failed to add staging replica c%dn%d on %q: %s", rangeID, newReplicaID, node.GetNhid(), err)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2985,8 +2985,8 @@ func (s *Store) reserveIDs(ctx context.Context, key []byte, n int) ([]uint64, er
 		return nil, err
 	}
 	ids := make([]uint64, 0, n)
-	for i := 0; i < n; i++ {
-		ids = append(ids, newVal-uint64(i))
+	for i := 1; i <= n; i++ {
+		ids = append(ids, newVal-uint64(n-i))
 	}
 	return ids, nil
 }

--- a/enterprise/server/raft/testutil/BUILD
+++ b/enterprise/server/raft/testutil/BUILD
@@ -34,7 +34,6 @@ go_library(
         "@com_github_lni_dragonboat_v4//statemachine",
         "@com_github_lni_goutils//random",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_sync//errgroup",
     ],
 )
 


### PR DESCRIPTION
make one transaction to update range descriptors for all ranges

Also update testutil to use the new methods.
