### PR TITLE
janitor: bulk-delete expired invocations

### DIFF
--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -258,7 +258,7 @@ func (d *InvocationDB) FillCounts(ctx context.Context, stat *telpb.TelemetryStat
 }
 
 func (d *InvocationDB) DeleteInvocation(ctx context.Context, invocationID string) error {
-	return d.deleteInvocation(ctx, d.h, invocationID)
+	return d.DeleteInvocations(ctx, []string{invocationID})
 }
 
 func (d *InvocationDB) DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *interfaces.UserInfo, invocationID string) error {
@@ -294,20 +294,27 @@ func (d *InvocationDB) DeleteInvocationWithPermsCheck(ctx context.Context, authe
 	})
 }
 
-func (d *InvocationDB) deleteInvocation(ctx context.Context, tx interfaces.DB, invocationID string) error {
-	if err := tx.NewQuery(ctx, "invocationdb_delete_invocation").Raw(
-		`DELETE FROM "Invocations" WHERE invocation_id = ?`, invocationID).Exec().Error; err != nil {
-		return err
+func (d *InvocationDB) DeleteInvocations(ctx context.Context, invocationIDs []string) error {
+	if len(invocationIDs) == 0 {
+		return nil
 	}
-	if err := tx.NewQuery(ctx, "invocationdb_delete_executions").Raw(
-		`DELETE FROM "Executions" WHERE invocation_id = ?`, invocationID).Exec().Error; err != nil {
-		return err
+	args := make([]any, len(invocationIDs))
+	for i, id := range invocationIDs {
+		args[i] = id
 	}
-	if err := tx.NewQuery(ctx, "invocationdb_delete_execution_links").Raw(
-		`DELETE FROM "InvocationExecutions" WHERE invocation_id = ?`, invocationID).Exec().Error; err != nil {
-		return err
-	}
-	return nil
+	where := ` WHERE invocation_id IN (?` + strings.Repeat(",?", len(args)-1) + `)`
+	return d.h.Transaction(ctx, func(tx interfaces.DB) error {
+		if err := tx.NewQuery(ctx, "invocationdb_delete_invocations").Raw(
+			`DELETE FROM "Invocations"`+where, args...).Exec().Error; err != nil {
+			return err
+		}
+		if err := tx.NewQuery(ctx, "invocationdb_delete_executions").Raw(
+			`DELETE FROM "Executions"`+where, args...).Exec().Error; err != nil {
+			return err
+		}
+		return tx.NewQuery(ctx, "invocationdb_delete_execution_links").Raw(
+			`DELETE FROM "InvocationExecutions"`+where, args...).Exec().Error
+	})
 }
 
 func (d *InvocationDB) SetNowFunc(now func() time.Time) {

--- a/server/backends/invocationdb/invocationdb_test.go
+++ b/server/backends/invocationdb/invocationdb_test.go
@@ -93,6 +93,71 @@ func TestCreateReadUpdateDelete(t *testing.T) {
 	require.Equal(t, "invocation-2-execution", ie.ExecutionID)
 }
 
+func TestDeleteInvocations(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	dbh := env.GetDBHandle()
+	idb := invocationdb.NewInvocationDB(env, dbh)
+
+	for _, invocationID := range []string{"delete-1", "delete-2", "keep"} {
+		executionID := invocationID + "-execution"
+		require.NoError(t, dbh.NewQuery(ctx, "insert_invocation").Raw(
+			`INSERT INTO "Invocations" (invocation_id) VALUES (?)`, invocationID).Exec().Error)
+		require.NoError(t, dbh.NewQuery(ctx, "insert_execution").Raw(
+			`INSERT INTO "Executions" (execution_id, invocation_id) VALUES (?, ?)`, executionID, invocationID).Exec().Error)
+		require.NoError(t, dbh.NewQuery(ctx, "insert_invocation_execution").Raw(
+			`INSERT INTO "InvocationExecutions" (invocation_id, execution_id) VALUES (?, ?)`, invocationID, executionID).Exec().Error)
+	}
+
+	// Duplicate IDs must not affect the rows that are not selected for deletion.
+	require.NoError(t, idb.DeleteInvocations(ctx, []string{"delete-1", "delete-2", "delete-1"}))
+	for _, table := range []string{"Invocations", "Executions", "InvocationExecutions"} {
+		var count int
+		require.NoError(t, dbh.NewQuery(ctx, "count_remaining_rows").Raw(
+			fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE invocation_id = ?`, table), "keep").Take(&count))
+		require.Equal(t, 1, count, "table %s", table)
+		require.NoError(t, dbh.NewQuery(ctx, "count_deleted_rows").Raw(
+			fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE invocation_id IN (?, ?)`, table), "delete-1", "delete-2").Take(&count))
+		require.Zero(t, count, "table %s", table)
+	}
+
+	// An empty batch is deliberately a no-op.
+	require.NoError(t, idb.DeleteInvocations(ctx, nil))
+	var count int
+	require.NoError(t, dbh.NewQuery(ctx, "count_remaining_invocations").Raw(
+		`SELECT COUNT(*) FROM "Invocations" WHERE invocation_id = ?`, "keep").Take(&count))
+	require.Equal(t, 1, count)
+
+	// Overlapping cleanup batches may race across app pods. Already-deleted and
+	// missing IDs must be harmless and must not affect unrelated rows.
+	require.NoError(t, idb.DeleteInvocations(ctx, []string{"delete-1", "missing"}))
+	require.NoError(t, dbh.NewQuery(ctx, "count_remaining_after_overlapping_batch").Raw(
+		`SELECT COUNT(*) FROM "Invocations" WHERE invocation_id = ?`, "keep").Take(&count))
+	require.Equal(t, 1, count)
+}
+
+func TestDeleteInvocationsRollsBackOnFailure(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	dbh := env.GetDBHandle()
+	idb := invocationdb.NewInvocationDB(env, dbh)
+
+	require.NoError(t, dbh.NewQuery(ctx, "insert_invocation").Raw(
+		`INSERT INTO "Invocations" (invocation_id) VALUES (?)`, "rollback").Exec().Error)
+	require.NoError(t, dbh.NewQuery(ctx, "insert_execution").Raw(
+		`INSERT INTO "Executions" (execution_id, invocation_id) VALUES (?, ?)`, "rollback-execution", "rollback").Exec().Error)
+	require.NoError(t, dbh.NewQuery(ctx, "drop_invocation_executions").Raw(
+		`DROP TABLE "InvocationExecutions"`).Exec().Error)
+
+	require.Error(t, idb.DeleteInvocations(ctx, []string{"rollback"}))
+	for _, table := range []string{"Invocations", "Executions"} {
+		var count int
+		require.NoError(t, dbh.NewQuery(ctx, "count_rows_after_rollback").Raw(
+			fmt.Sprintf(`SELECT COUNT(*) FROM "%s" WHERE invocation_id = ?`, table), "rollback").Take(&count))
+		require.Equal(t, 1, count, "table %s", table)
+	}
+}
+
 func TestAttemptLogic(t *testing.T) {
 	ctx := context.Background()
 	env := testenv.GetTestEnv(t)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -501,6 +501,9 @@ type InvocationDB interface {
 	LookupExpiredInvocations(ctx context.Context, cutoffTime time.Time, limit int) ([]*tables.Invocation, error)
 	LookupChildInvocations(ctx context.Context, parentRunID string) ([]string, error)
 	DeleteInvocation(ctx context.Context, invocationID string) error
+	// DeleteInvocations deletes the invocations and their execution rows and links
+	// in a single transaction. Missing IDs are ignored.
+	DeleteInvocations(ctx context.Context, invocationIDs []string) error
 	DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *UserInfo, invocationID string) error
 	FillCounts(ctx context.Context, log *telpb.TelemetryStat) error
 	SetNowFunc(now func() time.Time)

--- a/server/janitor/BUILD
+++ b/server/janitor/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "janitor",
@@ -8,7 +8,19 @@ go_library(
     deps = [
         "//server/environment",
         "//server/interfaces",
-        "//server/tables",
         "//server/util/log",
+    ],
+)
+
+go_test(
+    name = "janitor_test",
+    size = "small",
+    srcs = ["janitor_test.go"],
+    embed = [":janitor"],
+    deps = [
+        "//server/interfaces",
+        "//server/tables",
+        "//server/testutil/testenv",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/janitor/janitor.go
+++ b/server/janitor/janitor.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
-	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
@@ -48,18 +47,6 @@ type Janitor struct {
 	deleteFn func(c *JanitorConfig)
 }
 
-func deleteInvocation(c *JanitorConfig, invocation *tables.Invocation) {
-	ctx := c.env.GetServerContext()
-	if err := c.env.GetBlobstore().DeleteBlob(ctx, invocation.BlobID); err != nil {
-		log.Warningf("Error deleting blob (%s): %s", invocation.BlobID, err)
-	}
-
-	// Try to delete the row too, even if blob deletion failed.
-	if err := c.env.GetInvocationDB().DeleteInvocation(ctx, invocation.InvocationID); err != nil {
-		log.Warningf("Error deleting invocation (%s): %s", invocation.InvocationID, err)
-	}
-}
-
 func deleteExpiredInvocations(c *JanitorConfig) {
 	ctx := c.env.GetServerContext()
 	cutoff := time.Now().Add(-1 * c.ttl)
@@ -69,8 +56,21 @@ func deleteExpiredInvocations(c *JanitorConfig) {
 		return
 	}
 
+	if len(expired) == 0 {
+		return
+	}
+	invocationIDs := make([]string, 0, len(expired))
 	for _, exp := range expired {
-		deleteInvocation(c, exp)
+		if err := c.env.GetBlobstore().DeleteBlob(ctx, exp.BlobID); err != nil {
+			log.Warningf("Error deleting blob (%s): %s", exp.BlobID, err)
+		}
+		invocationIDs = append(invocationIDs, exp.InvocationID)
+	}
+
+	// Try to delete the rows too, even if blob deletion failed. Other janitors
+	// may select the same batch; deleting already-removed SQL rows is a no-op.
+	if err := c.env.GetInvocationDB().DeleteInvocations(ctx, invocationIDs); err != nil {
+		log.Warningf("Error deleting expired invocations: %s", err)
 	}
 }
 

--- a/server/janitor/janitor_test.go
+++ b/server/janitor/janitor_test.go
@@ -1,0 +1,87 @@
+package janitor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/stretchr/testify/require"
+)
+
+type invocationDBStub struct {
+	interfaces.InvocationDB
+	expired        []*tables.Invocation
+	lookupErr      error
+	deletedBatches [][]string
+	events         *[]string
+}
+
+func (s *invocationDBStub) LookupExpiredInvocations(ctx context.Context, cutoff time.Time, limit int) ([]*tables.Invocation, error) {
+	return s.expired, s.lookupErr
+}
+
+func (s *invocationDBStub) DeleteInvocations(ctx context.Context, invocationIDs []string) error {
+	s.deletedBatches = append(s.deletedBatches, append([]string(nil), invocationIDs...))
+	*s.events = append(*s.events, "delete invocations")
+	return nil
+}
+
+type blobstoreStub struct {
+	interfaces.Blobstore
+	deletedBlobs []string
+	errs         map[string]error
+	events       *[]string
+}
+
+func (s *blobstoreStub) DeleteBlob(ctx context.Context, blobName string) error {
+	s.deletedBlobs = append(s.deletedBlobs, blobName)
+	*s.events = append(*s.events, "delete "+blobName)
+	return s.errs[blobName]
+}
+
+func TestDeleteExpiredInvocationsDeletesBatchAfterAllBlobs(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+	var events []string
+	idb := &invocationDBStub{expired: []*tables.Invocation{
+		{InvocationID: "invocation-1", BlobID: "blob-1"},
+		{InvocationID: "invocation-2", BlobID: "blob-2"},
+	}, events: &events}
+	bs := &blobstoreStub{errs: map[string]error{"blob-1": errors.New("blob deletion failed")}, events: &events}
+	env.SetInvocationDB(idb)
+	env.SetBlobstore(bs)
+
+	deleteExpiredInvocations(&JanitorConfig{env: env, ttl: time.Hour, batchSize: 10})
+
+	require.Equal(t, []string{"blob-1", "blob-2"}, bs.deletedBlobs)
+	require.Equal(t, [][]string{{"invocation-1", "invocation-2"}}, idb.deletedBatches)
+	require.Equal(t, []string{"delete blob-1", "delete blob-2", "delete invocations"}, events)
+}
+
+func TestDeleteExpiredInvocationsDoesNotDeleteAnEmptyOrFailedLookup(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		expired   []*tables.Invocation
+		lookupErr error
+	}{
+		{name: "empty"},
+		{name: "lookup error", lookupErr: errors.New("lookup failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testenv.GetTestEnv(t)
+			var events []string
+			idb := &invocationDBStub{expired: tc.expired, lookupErr: tc.lookupErr, events: &events}
+			bs := &blobstoreStub{events: &events}
+			env.SetInvocationDB(idb)
+			env.SetBlobstore(bs)
+
+			deleteExpiredInvocations(&JanitorConfig{env: env, ttl: time.Hour, batchSize: 10})
+
+			require.Empty(t, bs.deletedBlobs)
+			require.Empty(t, idb.deletedBatches)
+		})
+	}
+}

--- a/server/testutil/mockinvocationdb/mockinvocationdb.go
+++ b/server/testutil/mockinvocationdb/mockinvocationdb.go
@@ -47,6 +47,9 @@ func (m *MockInvocationDB) LookupChildInvocations(ctx context.Context, parentRun
 func (m *MockInvocationDB) DeleteInvocation(ctx context.Context, invocationID string) error {
 	return nil
 }
+func (m *MockInvocationDB) DeleteInvocations(ctx context.Context, invocationIDs []string) error {
+	return nil
+}
 func (m *MockInvocationDB) DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *interfaces.UserInfo, invocationID string) error {
 	return nil
 }


### PR DESCRIPTION
Invocation cleanup issues three SQL deletes per expired invocation,
adding database round trips for every item in a batch. Delete each
batch's invocation rows, executions, and execution links with three
IN queries in one transaction, so a later SQL failure rolls back the
entire batch. Reuse this path for single-invocation deletion.

Keep blob deletion outside the transaction and preserve the existing
policy of attempting SQL cleanup even when a blob deletion fails.
Execution cleanup already uses bulk SQL deletion.

Keep the existing expiration lookup and worker scheduling. Multiple
app pods may select overlapping batches; deleting missing SQL rows
is a no-op, but this change does not claim work or coordinate blob
deletion across pods.

Cover related-row cleanup, unrelated-row preservation, empty and
repeated batches, rollback on a later SQL failure, and blob cleanup
ordering and errors.

