### PR TITLE
Return NotFound on WaitExecution failure so bazel will retry the execution

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -994,13 +994,13 @@ func (s *ExecutionServer) waitExecution(ctx context.Context, req *repb.WaitExecu
 			return status.UnavailableErrorf("Stream PubSub channel closed for %q", req.GetName())
 		}
 		var data string
-		// If there's an error maintaining the subscription (e.g. because a Redis node went away) send a failed
-		// operation message to Bazel so that it retries the execution.
+		// If there's an error maintaining the subscription (e.g. because a Redis node went away) send a
+		// NOT FOUND error to Bazel so that it retries the execution.
 		if msg.Err != nil {
 			op, err := operation.Assemble(
 				req.GetName(),
 				operation.Metadata(repb.ExecutionStage_COMPLETED, actionResource.GetDigest()),
-				operation.ErrorResponse(status.UnavailableErrorf("receive execution update: %s", msg.Err)),
+				operation.ErrorResponse(status.NotFoundErrorf("receive execution update: %s", msg.Err)),
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
[Bazel will retry an execution if it receives a not found error on the wait execution stream](https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/remote/ExperimentalGrpcRemoteExecutor.java;l=208;drc=cf0332782f0d92b55890e49deaf4548cf445fe1a). Return a not found error so builds are more resilient to failures around maintaining the stream, like if a Redis node goes away