### PR TITLE
ci: Bump `checkout` action to `v5`

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -12,7 +12,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Restore caches
         id: cache-restore

--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04-16cpu
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04-16cpu-arm64-arm-limited
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/build-mac-intel-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-intel-github-release-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/build-mac-m1-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-m1-github-release-artifacts.yaml
@@ -39,7 +39,7 @@ jobs:
           ls -la ./
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/buildbuddy-foss.yaml
+++ b/.github/workflows/buildbuddy-foss.yaml
@@ -19,7 +19,7 @@ jobs:
           destination_repo: "https://${{ secrets.BUILDBUDDY_GITHUB_USER_TOKEN }}@github.com/buildbuddy-io/buildbuddy-foss.git"
           destination_branch: "master"
       - name: Checkout buildbuddy-foss
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: "buildbuddy-io/buildbuddy-foss"
           ref: master

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Mount Bazel cache
         uses: actions/cache@v4

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: buildbuddy
 
       - name: Checkout internal
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: "buildbuddy-io/buildbuddy-internal"
           ref: "master"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: "buildbuddy-io/buildbuddy-helm"
           ref: "master"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Restore caches
         id: cache-restore

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Restore caches
         id: cache-restore

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -16,7 +16,7 @@ jobs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout /buildbuddy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           # We need to fetch git tags to obtain the latest cli version tag.
           fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
     needs: push-tag
     steps:
       - name: Checkout buildbuddy-io/bazel
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: buildbuddy-io/bazel
           path: bazel-fork
@@ -78,12 +78,12 @@ jobs:
     needs: [push-tag, create-release]
     steps:
       - name: Checkout buildbuddy-io/buildbuddy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: buildbuddy
 
       - name: Checkout buildbuddy-io/plugins
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: buildbuddy-io/plugins
           path: plugins
@@ -153,7 +153,7 @@ jobs:
           ls -la ./
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: buildbuddy
 

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # podman_test installs its own version of podman under / in order to test
       # the same version that we use in the executor while not having to

--- a/.github/workflows/website-pr.yaml
+++ b/.github/workflows/website-pr.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Restore caches
         id: cache-restore

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Restore caches
         id: cache-restore


### PR DESCRIPTION
* Bump `checkout` action to `v5`
https://github.com/actions/checkout/releases