### PR TITLE
[raft] return errors when partition.NumRanges is set to > 10

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -454,11 +454,13 @@ func InitializeShardsForMetaRange(ctx context.Context, session *client.Session, 
 // have performance issues when we try to initialize tons of range descriptors at
 // once.
 func InitializeShardsForPartition(ctx context.Context, store IStore, nodeGrpcAddrs map[string]string, partition disk.Partition) error {
+	if partition.NumRanges > 10 {
+		return status.FailedPreconditionErrorf("NumRanges is set to %d (>10) for partition %s", partition.NumRanges, partition.ID)
+	}
 	ranges, err := evenlyDividePartitionIntoRanges(partition)
 	if err != nil {
 		return err
 	}
-
 	log.Info("The following partitions will be configured:")
 	for i, rd := range ranges {
 		log.Infof("%d [%q, %q)", i, rd.GetStart(), rd.GetEnd())

--- a/enterprise/server/raft/metadata/metadata.go
+++ b/enterprise/server/raft/metadata/metadata.go
@@ -151,6 +151,9 @@ func NewFromFlags(env *real_environment.RealEnv) (*Server, error) {
 		if p.NumRanges == 0 {
 			ps[i].NumRanges = 1
 		}
+		if p.NumRanges > 10 {
+			return nil, status.FailedPreconditionErrorf("NumRanges is set to %d (>10) for partition %s", p.NumRanges, p.ID)
+		}
 		partitionSet.Add(p.ID)
 		if p.ID == constants.DefaultPartitionID {
 			haveDefault = true


### PR DESCRIPTION
In order to support a large p.NumRanges, we want to batch the number of ranges we initialize and also have partition descriptor where we can store the state of the initialization so that we can recover from failures. Before this happens, I don't want us accidentally put very large number of statements in a transaction. 
