### PR TITLE
In distributed server `Write` only check find missing on the first request

### DIFF
--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -1951,7 +1951,7 @@ func TestAbandonedReadDoesntWriteToLookaside(t *testing.T) {
 	assert.Len(t, data, 100)
 	assert.Equal(t, buf, data)
 
-	assert.Equal(t, len(memoryCache.ops), 5, "Ops were %v", memoryCache.ops)
+	assert.Equal(t, 4, len(memoryCache.ops), "Ops were %v", memoryCache.ops)
 }
 
 func TestGetMultiLookaside(t *testing.T) {

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -352,13 +352,13 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 			return err
 		}
 		rn := getResource(req.GetResource(), req.GetIsolation(), req.GetKey())
-		if rn.GetCacheType() == rspb.CacheType_CAS && req.GetCheckAlreadyExists() {
-			missing, err := c.cache.FindMissing(ctx, []*rspb.ResourceName{rn})
-			if err == nil && len(missing) == 0 {
-				return status.AlreadyExistsError("CAS digest already exists")
-			}
-		}
 		if writeCloser == nil {
+			if rn.GetCacheType() == rspb.CacheType_CAS && req.GetCheckAlreadyExists() {
+				missing, err := c.cache.FindMissing(ctx, []*rspb.ResourceName{rn})
+				if err == nil && len(missing) == 0 {
+					return status.AlreadyExistsError("CAS digest already exists")
+				}
+			}
 			wc, err := c.cache.Writer(ctx, rn)
 			if err != nil {
 				c.log.Debugf("Write(%q) failed (user prefix: %s), err: %s", ResourceIsolationString(rn), up, err)


### PR DESCRIPTION
It seems unlikely that some other write will  complete between the first and last request.