### PR TITLE
Catch v2 code editor up to v1 changes

### DIFF
--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -1111,6 +1111,10 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
       .catch((e) => error_service.handleError(e));
     console.log(repoResponse);
 
+    if (!repoResponse) {
+      return;
+    }
+
     let repo = this.getRepo();
     repo.branch = repo.branch || repoResponse.defaultBranch;
 


### PR DESCRIPTION
My ultimate goal here is to launch v2 in prod and delete v1.

It looks like a few changes have been made to v1 since v2 was created. This PR ports these changes to v2:
- https://github.com/buildbuddy-io/buildbuddy/commit/5371c5e85bdc45114328a5d95ee35618844f2670
- https://github.com/buildbuddy-io/buildbuddy/commit/46aec2f9dea5deac236fab2b2051f224812028bc
- https://github.com/buildbuddy-io/buildbuddy/commit/5a024ef0790ba2da1da9c229870fcf966f06feb9