### PR TITLE
Add a flag to enable a /rpcz like endpoint

### DIFF
--- a/server/util/monitoring/BUILD
+++ b/server/util/monitoring/BUILD
@@ -18,5 +18,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_rantav_go_grpc_channelz//:go-grpc-channelz",
         "@com_github_victoriametrics_metrics//:metrics",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_x_net//trace",
     ],
 )

--- a/server/util/monitoring/monitoring.go
+++ b/server/util/monitoring/monitoring.go
@@ -17,6 +17,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/net/trace"
+	"google.golang.org/grpc"
 
 	channelz "github.com/rantav/go-grpc-channelz"
 )
@@ -24,6 +26,8 @@ import (
 var (
 	mutexProfileFraction = flag.Int("mutex_profile_fraction", 0, "The fraction of mutex contention events reported. (1/rate, 0 disables)")
 	blockProfileRate     = flag.Int("block_profile_rate", 0, "The fraction of goroutine blocking events reported. (1/rate, 0 disables)")
+
+	enableRpcz = flag.Bool("enable_rpcz", false, "Enables a /rpcz endpoint for viewing gRPC requests")
 
 	basicAuthUser = flag.String("monitoring.basic_auth.username", "", "Optional username for basic auth on the monitoring port.")
 	basicAuthPass = flag.String("monitoring.basic_auth.password", "", "Optional password for basic auth on the monitoring port.", flag.Secret)
@@ -53,6 +57,13 @@ func RegisterMonitoringHandlers(env environment.Env, mux *http.ServeMux) {
 	handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
 	handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
 	handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+
+	if *enableRpcz {
+		grpc.EnableTracing = true
+		handle("/debug/requests", http.HandlerFunc(trace.Traces))
+		handle("/debug/events", http.HandlerFunc(trace.Events))
+		handle("/rpcz", http.RedirectHandler("/debug/requests", http.StatusFound))
+	}
 
 	// Statusz page
 	handle(statusz.Route, statusz.Server())


### PR DESCRIPTION
As far as I can tell, this doesn't impact performance at all, but I'll only enable it in dev at first.

Example:
<img width="1281" height="362" alt="image" src="https://github.com/user-attachments/assets/b1cf32d3-4bbf-42ee-99cc-829c78c9136f" />
