### PR TITLE
Display servers' connection sockets in channelz

### DIFF
--- a/buildpatches/go-grpc-channelz.patch
+++ b/buildpatches/go-grpc-channelz.patch
@@ -1,0 +1,94 @@
+diff --git a/servers-page.go b/servers-page.go
+index cf56ba9..18326ec 100644
+--- a/servers-page.go
++++ b/servers-page.go
+@@ -8,11 +8,24 @@ import (
+ 	log "google.golang.org/grpc/grpclog"
+ )
+ 
++type Server struct {
++	Server  *channelzgrpc.Server
++	Sockets *channelzgrpc.GetServerSocketsResponse
++}
++
+ // writeServers writes HTML to w containing RPC servers stats.
+ //
+ // It includes neither a header nor footer, so you can embed this data in other pages.
+ func (h *grpcChannelzHandler) writeServers(w io.Writer) {
+-	if err := serversTemplate.Execute(w, h.getServers()); err != nil {
++	serversRsp := h.getServers()
++	servers := make(map[int64]Server, len(serversRsp.Server))
++	for _, s := range serversRsp.Server {
++		servers[s.Ref.ServerId] = Server{
++			Server:  s,
++			Sockets: h.getServerSockets(s.Ref.ServerId),
++		}
++	}
++	if err := serversTemplate.Execute(w, servers); err != nil {
+ 		log.Errorf("channelz: executing template: %v", err)
+ 	}
+ }
+@@ -32,6 +45,21 @@ func (h *grpcChannelzHandler) getServers() *channelzgrpc.GetServersResponse {
+ 	return servers
+ }
+ 
++func (h *grpcChannelzHandler) getServerSockets(serverID int64) *channelzgrpc.GetServerSocketsResponse {
++	client, err := h.connect()
++	if err != nil {
++		log.Errorf("Error creating channelz client %+v", err)
++		return nil
++	}
++	ctx := context.Background()
++	sockets, err := client.GetServerSockets(ctx, &channelzgrpc.GetServerSocketsRequest{ServerId: serverID})
++	if err != nil {
++		log.Errorf("Error querying GetServerSockets for server %d: %+v", serverID, err)
++		return nil
++	}
++	return sockets
++}
++
+ const serversTemplateHTML = `
+ {{define "server-header"}}
+     <tr classs="header">
+@@ -47,19 +75,19 @@ const serversTemplateHTML = `
+ 
+ {{define "server-body"}}
+     <tr>
+-        <td><a href="{{link "server" .Ref.ServerId}}"><b>{{.Ref.ServerId}}</b> {{.Ref.Name}}</a></td>
+-        <td>{{with .Data.Trace}} {{.CreationTimestamp | timestamp}} {{end}}</td>
+-        <td>{{.Data.CallsStarted}}</td>
+-        <td>{{.Data.CallsSucceeded}}</td>
+-        <td>{{.Data.CallsFailed}}</td>
+-        <td>{{.Data.LastCallStartedTimestamp | timestamp}}</td>
++        <td><a href="{{link "server" .Server.Ref.ServerId}}"><b>{{.Server.Ref.ServerId}}</b> {{.Server.Ref.Name}}</a></td>
++        <td>{{with .Server.Data.Trace}} {{.CreationTimestamp | timestamp}} {{end}}</td>
++        <td>{{.Server.Data.CallsStarted}}</td>
++        <td>{{.Server.Data.CallsSucceeded}}</td>
++        <td>{{.Server.Data.CallsFailed}}</td>
++        <td>{{.Server.Data.LastCallStartedTimestamp | timestamp}}</td>
+ 		<td>
+-			{{range .ListenSocket}}
++			{{range .Sockets.SocketRef }}
+ 				<a href="{{link "socket" .SocketId}}"><b>{{.SocketId}}</b> {{.Name}}</a> <br/>
+ 			{{end}}
+ 		</td>
+ 	</tr>
+-	{{with .Data.Trace}}
++	{{with .Server.Data.Trace}}
+ 		<tr classs="header">
+ 			<th colspan=100>Events</th>
+ 		</tr>
+@@ -79,11 +107,11 @@ const serversTemplateHTML = `
+ <p><table class="section-header" width=100%><tr align=center><td>Servers</td></tr></table></p>
+ <table frame=box cellspacing=0 cellpadding=2>
+     <tr class="header">
+-		<th colspan=100 style="text-align:left">Servers: {{.Server | len}}</th>
++		<th colspan=100 style="text-align:left">Servers: {{. | len}}</th>
+     </tr>
+ 
+ 	{{template "server-header"}}
+-	{{range .Server}}
++	{{range . }}
+ 		{{template "server-body" .}}
+ 	{{end}}
+ </table>

--- a/buildpatches/go-grpc-channelz.patch
+++ b/buildpatches/go-grpc-channelz.patch
@@ -1,8 +1,8 @@
-diff --git a/servers-page.go b/servers-page.go
-index cf56ba9..18326ec 100644
---- a/servers-page.go
-+++ b/servers-page.go
-@@ -8,11 +8,24 @@ import (
+diff --git a/server-page.go b/server-page.go
+index 4948aa0..bb00052 100644
+--- a/server-page.go
++++ b/server-page.go
+@@ -9,6 +9,11 @@ import (
  	log "google.golang.org/grpc/grpclog"
  )
  
@@ -11,25 +11,28 @@ index cf56ba9..18326ec 100644
 +	Sockets *channelzgrpc.GetServerSocketsResponse
 +}
 +
- // writeServers writes HTML to w containing RPC servers stats.
+ func (h *grpcChannelzHandler) WriteServerPage(w io.Writer, server int64) {
+ 	writeHeader(w, fmt.Sprintf("ChannelZ server %d", server))
+ 	h.writeServer(w, server)
+@@ -18,8 +23,14 @@ func (h *grpcChannelzHandler) WriteServerPage(w io.Writer, server int64) {
+ // writeServer writes HTML to w containing RPC single server stats.
  //
  // It includes neither a header nor footer, so you can embed this data in other pages.
- func (h *grpcChannelzHandler) writeServers(w io.Writer) {
--	if err := serversTemplate.Execute(w, h.getServers()); err != nil {
-+	serversRsp := h.getServers()
-+	servers := make(map[int64]Server, len(serversRsp.Server))
-+	for _, s := range serversRsp.Server {
-+		servers[s.Ref.ServerId] = Server{
-+			Server:  s,
-+			Sockets: h.getServerSockets(s.Ref.ServerId),
-+		}
+-func (h *grpcChannelzHandler) writeServer(w io.Writer, server int64) {
+-	if err := serverTemplate.Execute(w, h.getServer(server)); err != nil {
++func (h *grpcChannelzHandler) writeServer(w io.Writer, serverID int64) {
++	serverRsp := h.getServer(serverID)
++	sockets := h.getServerSockets(serverID)
++	data := Server{
++		Server:  serverRsp.GetServer(),
++		Sockets: sockets,
 +	}
-+	if err := serversTemplate.Execute(w, servers); err != nil {
++	if err := serverTemplate.Execute(w, data); err != nil {
  		log.Errorf("channelz: executing template: %v", err)
  	}
  }
-@@ -32,6 +45,21 @@ func (h *grpcChannelzHandler) getServers() *channelzgrpc.GetServersResponse {
- 	return servers
+@@ -39,6 +50,21 @@ func (h *grpcChannelzHandler) getServer(serverID int64) *channelzgrpc.GetServerR
+ 	return server
  }
  
 +func (h *grpcChannelzHandler) getServerSockets(serverID int64) *channelzgrpc.GetServerSocketsResponse {
@@ -47,48 +50,30 @@ index cf56ba9..18326ec 100644
 +	return sockets
 +}
 +
- const serversTemplateHTML = `
- {{define "server-header"}}
-     <tr classs="header">
-@@ -47,19 +75,19 @@ const serversTemplateHTML = `
- 
- {{define "server-body"}}
+ const serverTemplateHTML = `
+ <table frame=box cellspacing=0 cellpadding=2 class="vertical">
      <tr>
--        <td><a href="{{link "server" .Ref.ServerId}}"><b>{{.Ref.ServerId}}</b> {{.Ref.Name}}</a></td>
--        <td>{{with .Data.Trace}} {{.CreationTimestamp | timestamp}} {{end}}</td>
--        <td>{{.Data.CallsStarted}}</td>
--        <td>{{.Data.CallsSucceeded}}</td>
--        <td>{{.Data.CallsFailed}}</td>
--        <td>{{.Data.LastCallStartedTimestamp | timestamp}}</td>
-+        <td><a href="{{link "server" .Server.Ref.ServerId}}"><b>{{.Server.Ref.ServerId}}</b> {{.Server.Ref.Name}}</a></td>
-+        <td>{{with .Server.Data.Trace}} {{.CreationTimestamp | timestamp}} {{end}}</td>
-+        <td>{{.Server.Data.CallsStarted}}</td>
-+        <td>{{.Server.Data.CallsSucceeded}}</td>
-+        <td>{{.Server.Data.CallsFailed}}</td>
-+        <td>{{.Server.Data.LastCallStartedTimestamp | timestamp}}</td>
- 		<td>
--			{{range .ListenSocket}}
-+			{{range .Sockets.SocketRef }}
- 				<a href="{{link "socket" .SocketId}}"><b>{{.SocketId}}</b> {{.Name}}</a> <br/>
- 			{{end}}
- 		</td>
+@@ -70,7 +96,7 @@ const serverTemplateHTML = `
+         <td>{{.Server.Data.LastCallStartedTimestamp | timestamp}}</td>
  	</tr>
--	{{with .Data.Trace}}
-+	{{with .Server.Data.Trace}}
- 		<tr classs="header">
- 			<th colspan=100>Events</th>
+ 	<tr>
+-		<th>Sockets</th>
++		<th>Listen Sockets</th>
+ 		<td>
+ 			{{range .Server.ListenSocket}}
+ 				<a href="{{link "socket" .SocketId}}"><b>{{.SocketId}}</b> {{.Name}}</a> <br/>
+@@ -90,4 +116,14 @@ const serverTemplateHTML = `
  		</tr>
-@@ -79,11 +107,11 @@ const serversTemplateHTML = `
- <p><table class="section-header" width=100%><tr align=center><td>Servers</td></tr></table></p>
- <table frame=box cellspacing=0 cellpadding=2>
-     <tr class="header">
--		<th colspan=100 style="text-align:left">Servers: {{.Server | len}}</th>
-+		<th colspan=100 style="text-align:left">Servers: {{. | len}}</th>
-     </tr>
- 
- 	{{template "server-header"}}
--	{{range .Server}}
-+	{{range . }}
- 		{{template "server-body" .}}
  	{{end}}
  </table>
++<table frame=box cellspacing=0 cellpadding=2 class="vertical">
++	<tr>
++		<th>Connection Sockets</th>
++		<td>
++			{{range .Sockets.SocketRef }}
++				<a href="{{link "socket" .SocketId}}"><b>{{.SocketId}}</b> {{.Name}}</a> <br/>
++			{{end}}
++		</td>
++    </tr>
++</table>
+ `

--- a/buildpatches/go-grpc-channelz.patch
+++ b/buildpatches/go-grpc-channelz.patch
@@ -77,3 +77,68 @@ index 4948aa0..bb00052 100644
 +    </tr>
 +</table>
  `
+diff --git a/socket-page.go b/socket-page.go
+index 0bd36ff..5786788 100644
+--- a/socket-page.go
++++ b/socket-page.go
+@@ -56,7 +56,7 @@ const socketTemplateHTML = `
+ 	<tr>
+ 		<th>Socket Local -> Remote</th>
+         <td>
+-			<pre>{{.Socket.Local}} -> {{.Socket.Remote}} {{with .Socket.RemoteName}}({{.}}){{end}}</pre>
++			<pre>{{.Socket.Local | address}} -> {{.Socket.Remote | address}} {{with .Socket.RemoteName}}({{.}}){{end}}</pre>
+ 		</td>
+ 	</tr>
+ 	<tr>
+diff --git a/templates.go b/templates.go
+index 2caac51..9635ec2 100644
+--- a/templates.go
++++ b/templates.go
+@@ -1,10 +1,13 @@
+ package channelz
+ 
+ import (
++	"fmt"
+ 	"io"
++	"net"
+ 	"text/template"
+ 	"time"
+ 
++	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1"
+ 	log "google.golang.org/grpc/grpclog"
+ 	"google.golang.org/protobuf/types/known/timestamppb"
+ )
+@@ -33,6 +36,7 @@ func parseTemplate(name, html string) *template.Template {
+ func getFuncs() template.FuncMap {
+ 	return template.FuncMap{
+ 		"timestamp": formatTimestamp,
++		"address":   formatAddress,
+ 		"link":      createHyperlink,
+ 	}
+ }
+@@ -41,6 +45,25 @@ func formatTimestamp(ts *timestamppb.Timestamp) string {
+ 	return ts.AsTime().Format(time.RFC3339)
+ }
+ 
++func formatAddress(addr *channelzgrpc.Address) string {
++	if addr == nil {
++		return ""
++	}
++	
++	switch a := addr.GetAddress().(type) {
++	case *channelzgrpc.Address_TcpipAddress:
++		tcpAddr := a.TcpipAddress
++		ip := net.IP(tcpAddr.GetIpAddress())
++		return fmt.Sprintf("%s:%d", ip.String(), tcpAddr.GetPort())
++	case *channelzgrpc.Address_UdsAddress_:
++		return fmt.Sprintf("unix:%s", a.UdsAddress.GetFilename())
++	case *channelzgrpc.Address_OtherAddress_:
++		return fmt.Sprintf("%s:%s", a.OtherAddress.GetName(), a.OtherAddress.GetValue())
++	default:
++		return addr.String()
++	}
++}
++
+ func writeHeader(w io.Writer, title string) {
+ 	if err := headerTemplate.Execute(w, headerData{Title: title}); err != nil {
+ 		log.Errorf("channelz: executing template: %v", err)

--- a/deps.bzl
+++ b/deps.bzl
@@ -4268,6 +4268,9 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_rantav_go_grpc_channelz",
         importpath = "github.com/rantav/go-grpc-channelz",
+        patch_args = ["-p1"],
+        patch_tool = "patch",
+        patches = ["@{}//buildpatches:go-grpc-channelz.patch".format(workspace_name)],
         sum = "h1:svoYt8ZD0uO6B/EZVWGNIDRJY/JXfak2y5Ks+1xwaVo=",
         version = "v0.0.3",
     )


### PR DESCRIPTION
[Pull request to the original repo ](https://github.com/rantav/go-grpc-channelz/pull/16)

Now the server page looks something like: 
<img width="690" height="914" alt="image" src="https://github.com/user-attachments/assets/2efd69c8-2da9-4acf-b9c2-8c008708e32e" />

Also fixed a bug around printing the socket address. Before it was printing the address pointer. Now it looks something like:
<img width="521" height="58" alt="image" src="https://github.com/user-attachments/assets/c04a3cd0-9ebb-4cf9-98e6-e6b6a4a56e27" />

