### PR TITLE
Remove an unused leaser.DB call in pebble_cache.Write

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2254,11 +2254,6 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 			attribute.Int64("digest_size", r.GetDigest().GetSizeBytes()))
 	}
 	defer spn.End()
-	db, err := p.leaser.DB()
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close()
 
 	// If data is not already compressed, return a writer that will compress it before writing
 	// Only compress data over a given size for more optimal compression ratios


### PR DESCRIPTION
Benchmark results:
```
                              │   baseset    │             removelease             │
                              │    sec/op    │    sec/op     vs base               │
Set/LocalPebble10/AC-24         10.54µ ± 16%   10.03µ ± 19%        ~ (p=0.209 n=7)
Set/LocalPebble10/CAS-24        8.549µ ±  3%   7.718µ ±  4%   -9.72% (p=0.001 n=7)
Set/LocalPebble100/AC-24        15.00µ ± 24%   14.19µ ±  4%   -5.45% (p=0.011 n=7)
Set/LocalPebble100/CAS-24       12.91µ ± 19%   12.37µ ±  3%   -4.22% (p=0.001 n=7)
Set/LocalPebble1000/AC-24       22.93µ ±  5%   22.05µ ±  5%        ~ (p=0.053 n=7)
Set/LocalPebble1000/CAS-24      22.19µ ±  7%   19.96µ ±  5%  -10.04% (p=0.001 n=7)
Set/LocalPebble10000/AC-24      144.5µ ±  6%   136.2µ ±  4%   -5.77% (p=0.004 n=7)
Set/LocalPebble10000/CAS-24     138.2µ ±  1%   136.1µ ±  3%   -1.56% (p=0.017 n=7)
Set/LocalPebble1000000/AC-24    3.235m ± 25%   3.186m ±  1%   -1.52% (p=0.001 n=7)
Set/LocalPebble1000000/CAS-24   3.297m ± 22%   3.184m ±  1%   -3.42% (p=0.001 n=7)
geomean                         67.25µ         63.84µ         -5.08%

                              │    baseset    │             removelease              │
                              │      B/s      │      B/s       vs base               │
Set/LocalPebble10/AC-24         927.7Ki ± 14%   976.6Ki ± 17%        ~ (p=0.219 n=7)
Set/LocalPebble10/CAS-24        1.116Mi ±  3%   1.240Mi ±  4%  +11.11% (p=0.001 n=7)
Set/LocalPebble100/AC-24        6.361Mi ± 19%   6.723Mi ±  5%   +5.70% (p=0.010 n=7)
Set/LocalPebble100/CAS-24       7.381Mi ± 16%   7.715Mi ±  3%   +4.52% (p=0.001 n=7)
Set/LocalPebble1000/AC-24       41.60Mi ±  5%   43.25Mi ±  5%        ~ (p=0.053 n=7)
Set/LocalPebble1000/CAS-24      42.98Mi ±  7%   47.78Mi ±  4%  +11.16% (p=0.001 n=7)
Set/LocalPebble10000/AC-24      65.99Mi ±  6%   70.03Mi ±  3%   +6.11% (p=0.004 n=7)
Set/LocalPebble10000/CAS-24     68.98Mi ±  1%   70.08Mi ±  3%   +1.59% (p=0.017 n=7)
Set/LocalPebble1000000/AC-24    294.8Mi ± 20%   299.3Mi ±  1%   +1.54% (p=0.001 n=7)
Set/LocalPebble1000000/CAS-24   289.3Mi ± 18%   299.5Mi ±  1%   +3.54% (p=0.001 n=7)
geomean                         22.48Mi         23.69Mi         +5.40%

                              │     baseset      │              removelease              │
                              │       B/op       │      B/op        vs base              │
Set/LocalPebble10/AC-24          7.371Ki ±    5%   6.982Ki ±    5%  -5.27% (p=0.001 n=7)
Set/LocalPebble10/CAS-24         5.337Ki ±    0%   4.947Ki ±    0%  -7.30% (p=0.001 n=7)
Set/LocalPebble100/AC-24         7.498Ki ±    0%   7.108Ki ±    0%  -5.20% (p=0.001 n=7)
Set/LocalPebble100/CAS-24        5.463Ki ±    0%   5.075Ki ±    0%  -7.10% (p=0.001 n=7)
Set/LocalPebble1000/AC-24        9.024Ki ±    0%   8.643Ki ±    0%  -4.23% (p=0.001 n=7)
Set/LocalPebble1000/CAS-24       6.996Ki ±    0%   6.605Ki ±    0%  -5.58% (p=0.001 n=7)
Set/LocalPebble10000/AC-24      10.125Ki ±    0%   9.731Ki ±    0%  -3.89% (p=0.001 n=7)
Set/LocalPebble10000/CAS-24      8.096Ki ±    0%   7.703Ki ±    0%  -4.85% (p=0.001 n=7)
Set/LocalPebble1000000/AC-24     13.27Ki ± 8110%   15.67Ki ± 6796%       ~ (p=1.000 n=7)
Set/LocalPebble1000000/CAS-24    11.50Ki ±   24%   13.60Ki ±   40%       ~ (p=0.902 n=7)
geomean                          8.137Ki           8.046Ki          -1.12%

                              │   baseset   │            removelease            │
                              │  allocs/op  │ allocs/op   vs base               │
Set/LocalPebble10/AC-24         102.00 ± 0%   94.00 ± 0%   -7.84% (p=0.001 n=7)
Set/LocalPebble10/CAS-24         75.00 ± 0%   67.00 ± 0%  -10.67% (p=0.001 n=7)
Set/LocalPebble100/AC-24        100.00 ± 0%   92.00 ± 0%   -8.00% (p=0.001 n=7)
Set/LocalPebble100/CAS-24        73.00 ± 0%   65.00 ± 0%  -10.96% (p=0.001 n=7)
Set/LocalPebble1000/AC-24       100.00 ± 0%   92.00 ± 0%   -8.00% (p=0.001 n=7)
Set/LocalPebble1000/CAS-24       73.00 ± 0%   65.00 ± 0%  -10.96% (p=0.001 n=7)
Set/LocalPebble10000/AC-24       131.0 ± 0%   123.0 ± 0%   -6.11% (p=0.001 n=7)
Set/LocalPebble10000/CAS-24     104.00 ± 0%   96.00 ± 0%   -7.69% (p=0.001 n=7)
Set/LocalPebble1000000/AC-24     136.0 ± 2%   128.0 ± 2%   -5.88% (p=0.001 n=7)
Set/LocalPebble1000000/CAS-24    110.0 ± 3%   102.0 ± 2%   -7.27% (p=0.001 n=7)
geomean                          98.16        89.96        -8.36%
```