### PR TITLE
Use RWLock in pebble leaser

### DIFF
--- a/enterprise/server/util/pebble/pebble.go
+++ b/enterprise/server/util/pebble/pebble.go
@@ -479,7 +479,7 @@ type Leaser interface {
 type leaser struct {
 	db       IPebbleDB
 	waiters  sync.WaitGroup
-	closedMu sync.Mutex // PROTECTS(closed)
+	closedMu sync.RWMutex // PROTECTS(closed)
 	closed   bool
 }
 
@@ -496,7 +496,7 @@ func NewDBLeaser(db IPebbleDB) Leaser {
 	return &leaser{
 		db:       db,
 		waiters:  sync.WaitGroup{},
-		closedMu: sync.Mutex{},
+		closedMu: sync.RWMutex{},
 		closed:   false,
 	}
 }
@@ -514,8 +514,8 @@ func (l *leaser) Close() {
 }
 
 func (l *leaser) DB() (IPebbleDB, error) {
-	l.closedMu.Lock()
-	defer l.closedMu.Unlock()
+	l.closedMu.RLock()
+	defer l.closedMu.RUnlock()
 	if l.closed {
 		return nil, status.FailedPreconditionError("db is closed")
 	}


### PR DESCRIPTION
I created a benchmark which shows that this is faster:
```
                                 │ baseparallel │           rwlockparallel            │
                                 │    sec/op    │    sec/op     vs base               │
Parallel/LocalPebble20000/AC-24    40.86µ ± 20%   30.23µ ±  4%  -26.02% (p=0.001 n=7)
Parallel/LocalPebble20000/CAS-24   44.40µ ± 23%   33.14µ ± 28%  -25.37% (p=0.011 n=7)
geomean                            42.60µ         31.65µ        -25.70%

                                 │ baseparallel │           rwlockparallel           │
                                 │     B/op     │     B/op      vs base              │
Parallel/LocalPebble20000/AC-24    49.93Ki ± 1%   48.79Ki ± 1%  -2.27% (p=0.001 n=7)
Parallel/LocalPebble20000/CAS-24   40.34Ki ± 2%   39.11Ki ± 2%  -3.04% (p=0.002 n=7)
geomean                            44.88Ki        43.69Ki       -2.66%

                                 │ baseparallel │           rwlockparallel           │
                                 │  allocs/op   │ allocs/op   vs base                │
Parallel/LocalPebble20000/AC-24      334.0 ± 0%   334.0 ± 0%       ~ (p=1.000 n=7) ¹
Parallel/LocalPebble20000/CAS-24     261.0 ± 0%   261.0 ± 0%       ~ (p=1.000 n=7) ¹
geomean                              295.3        295.3       +0.00%
¹ all samples are equal
```