### PR TITLE
Don't refresh the model / highlight if we don't need to

### DIFF
--- a/enterprise/app/code/code_v2.tsx
+++ b/enterprise/app/code/code_v2.tsx
@@ -1052,6 +1052,11 @@ export default class CodeComponentV2 extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Props, prevState: State) {
     this.fetchInitialContent();
 
+    // If path or line number hasn't change, we don't need to do anything.
+    if (prevProps.tab == this.props.tab && prevProps.path == this.props.path) {
+      return;
+    }    
+
     const path = this.currentPath();
     this.getModel(path).then((model) => {
       this.setModel(path, model);


### PR DESCRIPTION
This PR https://github.com/buildbuddy-io/buildbuddy/commit/1481f5b0d6a0255a575e57abfc869407230e86c5 made us reload the model and highlight on every `componentDidUpdate`.

There are changes other than path / line number that can cause `componentDidUpdate` to be called, so this change scopes the previous change down to only fetch / highlight when those change.