### PR TITLE
[SS] Cache snapshot manifest locally immediately after fetching it

### DIFF
--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -39,6 +39,7 @@ go_test(
         ":snaploader",
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/filecache",
+        "//enterprise/server/remote_execution/snaputil",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",

--- a/enterprise/tools/upload_local_snapshot/BUILD
+++ b/enterprise/tools/upload_local_snapshot/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/snaploader",
+        "//enterprise/server/remote_execution/snaputil",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",

--- a/enterprise/tools/upload_local_snapshot/upload_local_snapshot.go
+++ b/enterprise/tools/upload_local_snapshot/upload_local_snapshot.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/nullauth"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
@@ -146,6 +147,7 @@ func main() {
 	flagutil.SetValueForFlagName("executor.enable_remote_snapshot_sharing", true, nil, false)
 	_, err = loader.GetSnapshot(ctx, &fcpb.SnapshotKeySet{BranchKey: key}, &snaploader.GetSnapshotOptions{
 		RemoteReadEnabled: true,
+		ReadPolicy:        snaputil.AlwaysReadNewestSnapshot,
 	})
 	if err != nil {
 		log.Fatalf("Snapshot upload failed. Snapshot is not in the remote cache after it should've been uploaded.")


### PR DESCRIPTION
Currently this situation can happen: 

1. `pr-1` runs on Executor A. It fetches the remote fallback snapshot on `main`. When it finishes running, it saves a local snapshot for `pr-1`. Even though some of the `main` snapshot chunks exist locally, it does not save a local manifest for `main`
2. The remote `main` snapshot is updated
3. `pr-2` runs on Executor A. It fetches the remote fallback snapshot on `main`. Unfortunately it's unable to use all the local snapshot chunks that were fetched during # 1, because the `main` snapshot was changed

With this PR, the following can happen instead: 

1. `pr-1` runs on Executor A. It fetches the remote fallback snapshot on `main`. It saves that `main` manifest locally
2. The remote `main` snapshot is updated
3. `pr-2` runs on Executor A. Because # 1 saved the `main` manifest locally, it will use that instead of fetching the remote snapshot. It will reuse more local snapshot chunks

Should be used with this change: https://github.com/buildbuddy-io/buildbuddy/pull/10244