### PR TITLE
CLI: Remove outdated sidecar comment

### DIFF
--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -228,8 +228,6 @@ func parseLogTimestamp(line string) (time.Time, bool) {
 func ConfigureSidecar(args []string) ([]string, *Instance) {
 	originalArgs := args
 
-	// Disable sidecar on CI for now since the async upload behavior can cause
-	// problems if the CI runner terminates before the uploads have completed.
 	if isCI(args) {
 		log.Debugf("CI build detected.")
 		syncFlag := arg.Get(args, "sync")


### PR DESCRIPTION
Since d9a6445cd8f4ece7713c1a9587f346c3d9ae158d this has been enabled on CI, just in the sync mode instead
