### PR TITLE
Set a default value cache.client.input_tree_setup_parallelism.

### DIFF
--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -42,7 +42,7 @@ import (
 var (
 	enableDownloadCompresssion = flag.Bool("cache.client.enable_download_compression", true, "If true, enable compression of downloads from remote caches")
 	linkParallelism            = flag.Int("cache.client.filecache_link_parallelism", 0, "Number of goroutines to use when linking inputs from filecache. If 0 uses the value of GOMAXPROCS.")
-	inputTreeSetupParallelism  = flag.Int("cache.client.input_tree_setup_parallelism", -1, "Maximum number of concurrent filesystem operations to perform across all tasks when setting up the input tree structure. -1 means no limit.")
+	inputTreeSetupParallelism  = flag.Int("cache.client.input_tree_setup_parallelism", 1000, "Maximum number of concurrent filesystem operations to perform across all tasks when setting up the input tree structure. -1 means no limit.")
 
 	initInputTreeWrangler     sync.Once
 	inputTreeWranglerInstance *inputTreeWrangler


### PR DESCRIPTION
An optimal value is not easy to figure out but we can set a conservatively high upper bound to prevent the executors from blowing up.

At 1000 concurrent ops, an executor can perform 20 million fs ops per second assuming 50 micros per op. Don't think anyone is going to be hitting this any time soon.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/5050