### PR TITLE
Don't call `RegisterRemoteExecutionClient` twice

### DIFF
--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -253,9 +253,6 @@ func main() {
 	if err := scheduler_server.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
-	if err := remote_execution_redis_client.RegisterRemoteExecutionClient(realEnv); err != nil {
-		log.Fatalf("%v", err)
-	}
 
 	if err := kms.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)


### PR DESCRIPTION
It's called ~20 lines above, on line 232, and nothing relevant seems to change between the 2 calls.