### PR TITLE
Lower pool size for client connections that are direct

### DIFF
--- a/enterprise/server/backends/codesearch/codesearch.go
+++ b/enterprise/server/backends/codesearch/codesearch.go
@@ -40,7 +40,7 @@ func Register(realEnv *real_environment.RealEnv) error {
 }
 
 func New(env environment.Env) (*CodesearchService, error) {
-	conn, err := grpc_client.DialInternal(env, *codesearchBackend)
+	conn, err := grpc_client.DialInternalWithPoolSize(env, *codesearchBackend, 2)
 	if err != nil {
 		return nil, status.UnavailableErrorf("could not dial codesearch backend %q: %s", *codesearchBackend, err)
 	}

--- a/enterprise/server/remote_execution/redis_client/redis_client.go
+++ b/enterprise/server/remote_execution/redis_client/redis_client.go
@@ -28,7 +28,7 @@ func RegisterRemoteExecutionClient(env *real_environment.RealEnv) error {
 	if err != nil {
 		return status.InternalErrorf("Error initializing remote execution client: %s", err)
 	}
-	conn, err := grpc_client.DialInternal(env, fmt.Sprintf("grpc://localhost:%d", grpc_port))
+	conn, err := grpc_client.DialInternalWithoutPooling(env, fmt.Sprintf("grpc://localhost:%d", grpc_port))
 	if err != nil {
 		return status.InternalErrorf("Error initializing remote execution client: %s", err)
 	}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -986,7 +986,7 @@ func (c *schedulerClientCache) get(hostPort string) (schedulerClient, error) {
 			client = schedulerClient{localServer: c.localServer}
 		} else {
 			// This is non-blocking so it's OK to hold the lock.
-			conn, err := grpc_client.DialInternal(c.env, "grpc://"+hostPort)
+			conn, err := grpc_client.DialInternalWithPoolSize(c.env, "grpc://"+hostPort, 2)
 			if err != nil {
 				return schedulerClient{}, status.UnavailableErrorf("could not dial scheduler: %s", err)
 			}

--- a/enterprise/server/tasksize_model/tasksize_model.go
+++ b/enterprise/server/tasksize_model/tasksize_model.go
@@ -109,7 +109,7 @@ func New(env environment.Env) (*Model, error) {
 	}
 
 	// Connect to TF serving.
-	conn, err := grpc_client.DialSimple(*servingAddress)
+	conn, err := grpc_client.DialSimpleWithPoolSize(*servingAddress, 2)
 	if err != nil {
 		return nil, status.UnavailableErrorf("failed to dial TensorFlow serving at %s: %s", *servingAddress, err)
 	}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -331,7 +331,7 @@ func registerLocalGRPCClients(env *real_environment.RealEnv) error {
 	byte_stream_client.RegisterPooledBytestreamClient(env)
 
 	// TODO(jdhollen): Share this pool with the cache above.  Not a huge deal for now.
-	conn, err := grpc_client.DialInternal(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.GRPCPort()))
+	conn, err := grpc_client.DialInternalWithoutPooling(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.GRPCPort()))
 	if err != nil {
 		return status.InternalErrorf("Error initializing ByteStreamClient: %s", err)
 	}

--- a/server/remote_cache/byte_stream_client/byte_stream_client.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client.go
@@ -322,7 +322,7 @@ func (p *pooledByteStreamClient) getGrpcClientConnPoolForURL(target string) (con
 	}
 
 	// We didn't find a connection pool, so we'll make one.
-	connPool, err = grpc_client.DialInternal(p.env, target)
+	connPool, err = grpc_client.DialInternalWithPoolSize(p.env, target, 2)
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -75,7 +75,7 @@ func Register(env *real_environment.RealEnv) error {
 	}
 	env.SetCASServer(casServer)
 
-	conn, err := grpc_client.DialInternal(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.GRPCPort()))
+	conn, err := grpc_client.DialInternalWithoutPooling(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.GRPCPort()))
 	casClient := repb.NewContentAddressableStorageClient(conn)
 	if err != nil {
 		return status.InternalErrorf("Error initializing ContentAddressableStorageClient: %s", err)


### PR DESCRIPTION
When we don't go through a proxy or load balancer, we can handle unlimited streams per client connection, so there's no reason to create 15 connections.

When connecting to localhost, we don't need to worry about the health of the peer, so we can totally skip pooling.

Lowering the number of client connections lowers the number of goroutines used by the targeted servers, and this seems to lower heap size and GC duration.