### PR TITLE
Simplify and optimize digest.RandomDigestBuf

### DIFF
--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -704,11 +704,11 @@ func (g *Generator) fill(p []byte) {
 			val = g.src.Int63()
 		}
 		for range 8 {
-			p[offset] = byte(val)
-			todo--
 			if todo == 0 {
 				return
 			}
+			p[offset] = byte(val)
+			todo--
 			offset++
 			val >>= 8
 		}

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -689,11 +689,11 @@ func Diff(s1 []*repb.Digest, s2 []*repb.Digest) (missingFromS1 []*repb.Digest, m
 }
 
 func (g *Generator) fill(p []byte) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
 	todo := len(p)
 	offset := 0
 	compressionPercent := int64(g.compressionRatio * 100)
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	for {
 		// Generate a new random int64 (8 bytes) with a percent chance given by
 		// the compression ratio. This is a *very* rough way to generate blobs

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -695,14 +695,13 @@ func (g *Generator) fill(p []byte) {
 	offset := 0
 	compressionPercent := int64(g.compressionRatio * 100)
 	for {
-		// Generate a new random int64 (8 bytes) if we haven't generated one
-		// yet, or with a percent chance given by the compression ratio. This is
-		// a *very* rough way to generate blobs with the average compression
-		// ratios that we see in practice.
-		var val int64
-		if g.src.Int63()%100 >= compressionPercent {
-			val = g.src.Int63()
+		// Generate a new random int64 (8 bytes) with a percent chance given by
+		// the compression ratio. This is a *very* rough way to generate blobs
+		// with the average compression ratios that we see in practice.
+		if g.val == 0 || g.src.Int63()%100 >= compressionPercent {
+			g.val = g.src.Int63()
 		}
+		val := g.val
 		for range 8 {
 			if todo == 0 {
 				return
@@ -716,9 +715,11 @@ func (g *Generator) fill(p []byte) {
 }
 
 type Generator struct {
-	src              rand.Source
 	compressionRatio float64
-	mu               sync.Mutex
+
+	mu  sync.Mutex // mu protects src and val.
+	src rand.Source
+	val int64
 }
 
 // RandomGenerator returns a digest sample generator for use in testing tools.

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -555,7 +555,7 @@ func TestRandomGenerator(t *testing.T) {
 	const expectedCompression = 0.3
 	gen := digest.RandomGenerator(0)
 
-	for _, size := range []int64{1_000, 10_000, 100_000} {
+	for _, size := range []int64{0, 1_000, 10_000, 100_000} {
 		d, b, err := gen.RandomDigestBuf(size)
 		cb := compression.CompressZstd(nil, b)
 

--- a/server/util/compression/compression_test.go
+++ b/server/util/compression/compression_test.go
@@ -196,7 +196,10 @@ func TestCompressingReader_HoldErrors(t *testing.T) {
 	readBufSize := 64
 	compressBufSize := 64
 
-	_, in := testdigest.RandomCASResourceBuf(t, int64(totalBytes))
+	in := make([]byte, totalBytes)
+	for i := range totalBytes {
+		in[i] = byte(i % 256)
+	}
 	er := &erroringReader{
 		inputReader:   bytes.NewReader(in),
 		bytesToAllow:  bytesToAllow,
@@ -216,7 +219,7 @@ func TestCompressingReader_HoldErrors(t *testing.T) {
 		require.Equal(t, len(p), n)
 	}
 
-	p = make([]byte, 32)
+	p = make([]byte, 64)
 	_, err = zrc.Read(p)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errorToReturn)


### PR DESCRIPTION
- Reduced the locked region
- Stopped using io.Copy which resulted in more allocations and copying every byte twice. Instead, just fill random bytes directly into a buffer.

This helps cacheload.go send more QPS without locking up my machine.