### PR TITLE
WebUI: Ignore unset experimental_remote_cache_compression_threshold for Bazel 8

### DIFF
--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -363,7 +363,9 @@ ${yamlSuggestions.map((s) => `      ${s}`).join("\n")}`}
 
     const version = getBazelVersion(model);
     // threshold flag is available from Bazel 7.1 forward
-    if (version === null || version.major < 7 || version.minor < 1) return null;
+    if (version === null || version.major < 7 || (version.major == 7 && version.minor < 1)) return null;
+    // experimental_remote_cache_compression_threshold defaults to 100 from Bazel 8.0 forward
+    if (version === null || version.major >= 8) return null;
 
     return {
       level: SuggestionLevel.INFO,


### PR DESCRIPTION
Starting in Bazel 8, `--experimental_remote_cache_compression_threshold`'s default value changes from 0 to 100. The existing warning recommendation is a false positive for Bazel 8 workspaces. Check for Bazel 8 to not show the recommendation. If a Bazel 8 workspace explicitly sets `--experimental_remote_cache_compression_threshold` as well in Bazel 8 (even to 0), then the recommendation is not required anyways.
