### PR TITLE
Improve rendering of custom resources on executor card

### DIFF
--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -40,20 +40,27 @@ export default class ExecutorCardComponent extends React.Component<Props> {
               <div className="executor-section-title">Assignable Milli CPU:</div>
               <div>{this.props.node.assignableMilliCpu}</div>
             </div>
+            {this.props.node.assignableCustomResources && this.props.node.assignableCustomResources.length > 0 && (
+              <div className="executor-section">
+                <div className="executor-section-title">Assignable Resources:</div>
+                <div className="executor-custom-resource">
+                  {this.props.node.assignableCustomResources.map((r) => {
+                    return (
+                      <div className="executor-custom-resource-wrapper">
+                        <div className="executor-custom-resource-key">{r.name}: </div>
+                        <div>{r.value}</div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
             {this.props.node.supportedIsolationTypes && this.props.node.supportedIsolationTypes.length > 0 && (
               <div className="executor-section">
                 <div className="executor-section-title">Isolation Types:</div>
                 <div>{this.props.node.supportedIsolationTypes.join(", ")}</div>
               </div>
             )}
-            {this.props.node.assignableCustomResources.map((r) => {
-              return (
-                <div className="executor-section">
-                  <div className="executor-section-title">Assignable {r.name}:</div>
-                  <div>{r.value}</div>
-                </div>
-              );
-            })}
             <div className="executor-section">
               <div className="executor-section-title">Version:</div>
               <div>{this.props.node.version}</div>

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -13,6 +13,10 @@
   flex-grow: 1;
 }
 
+.executors-page .executor-custom-resource div {
+  flex-grow: 0;
+}
+
 .executor-section div.executor-section-title {
   width: 200px;
   flex-grow: 0;
@@ -20,6 +24,23 @@
   text-align: left;
   margin-right: 16px;
   font-weight: 700;
+}
+
+.executor-custom-resource {
+  display: flex;
+  flex-direction: column;
+}
+
+.executor-custom-resource-wrapper {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: flex-start;
+}
+
+.executor-custom-resource-key {
+  width: 280px;
+  margin-right: 16px;
+  font-weight: 600;
 }
 
 .executor-section .executor-history-button {


### PR DESCRIPTION
Currently custom resources with long names are wrapped due to the `width` property on `div.executor-section-title`. This looks kind of bad and we have some customers with custom resources with long names, so this PR moves them under an "Assignable Resources" section with the property keys and values as values. IMO this looks better, but could still be improved. Open to feedback for how to do that!

Before:
<img width="1294" height="462" alt="before" src="https://github.com/user-attachments/assets/9c949e02-680e-43c6-a8fe-4c3837acfeb7" />

After:
<img width="1295" height="419" alt="after" src="https://github.com/user-attachments/assets/250d4356-9439-4d95-906f-fe60af1a868e" />
