### PR TITLE
Support HTTP format for OTEL traces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,7 @@ require (
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.33.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.56.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -1782,7 +1782,6 @@ go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=
 go.opentelemetry.io/otel v1.36.0/go.mod h1:/TcFMXYjyRNh8khOAO9ybYkqaDBb/70aVwkNML4pP8E=
 go.opentelemetry.io/otel/exporters/jaeger v1.17.0 h1:D7UpUy2Xc2wsi1Ras6V40q806WM07rqoCWzXu7Sqy+4=
 go.opentelemetry.io/otel/exporters/jaeger v1.17.0/go.mod h1:nPCqOnEH9rNLKqH/+rrUjiMzHJdV1BlpKcTwRTyKkKI=
-go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0/go.mod h1:YIieizyaN77rtLJra0buKiNBOm9XQfkPEKBeuhoMwAM=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0/go.mod h1:VpP4/RMn8bv8gNo9uK7/IMY4mtWLELsS+JIP0inH0h4=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0/go.mod h1:hO1KLR7jcKaDDKDkvI9dP/FIhpmna5lkqPUQdEjFAM8=

--- a/go_deps.MODULE.bazel
+++ b/go_deps.MODULE.bazel
@@ -303,6 +303,7 @@ use_repo(
     "io_opentelemetry_go_otel",
     "io_opentelemetry_go_otel_exporters_jaeger",
     "io_opentelemetry_go_otel_exporters_otlp_otlptrace_otlptracegrpc",
+    "io_opentelemetry_go_otel_exporters_otlp_otlptrace_otlptracehttp",
     "io_opentelemetry_go_otel_exporters_prometheus",
     "io_opentelemetry_go_otel_metric",
     "io_opentelemetry_go_otel_sdk",

--- a/server/util/tracing/BUILD
+++ b/server/util/tracing/BUILD
@@ -20,6 +20,7 @@ go_library(
         "@io_opentelemetry_go_otel//semconv/v1.4.0:v1_4_0",
         "@io_opentelemetry_go_otel_exporters_jaeger//:jaeger",
         "@io_opentelemetry_go_otel_exporters_otlp_otlptrace_otlptracegrpc//:otlptracegrpc",
+        "@io_opentelemetry_go_otel_exporters_otlp_otlptrace_otlptracehttp//:otlptracehttp",
         "@io_opentelemetry_go_otel_sdk//resource",
         "@io_opentelemetry_go_otel_sdk//trace",
         "@io_opentelemetry_go_otel_trace//:trace",

--- a/server/util/tracing/tracing.go
+++ b/server/util/tracing/tracing.go
@@ -2,10 +2,12 @@ package tracing
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -24,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
@@ -39,6 +42,7 @@ var (
 	traceProjectID            = flag.String("app.trace_project_id", "", "Optional GCP project ID to export traces to. If not specified, determined from default credentials or metadata server if running on GCP.")
 	traceJaegerCollector      = flag.String("app.trace_jaeger_collector", "", "Address of the Jaeger collector HTTP endpoint where traces will be sent, e.g. http://jaeger.svc.cluster.local:14268")
 	traceOTLPCollector        = flag.String("app.trace_otlp_grpc_collector", "", "Address of the OTLP gRPC collector endpoint where traces will be sent, e.g. otel-collector.svc.cluster.local:4317")
+	traceOTLPHTTPCollector    = flag.String("app.trace_otlp_http_collector", "", "Address of the OTLP HTTP collector endpoint where traces will be sent, e.g. http://otel-collector.svc.cluster.local:4318")
 	traceServiceName          = flag.String("app.trace_service_name", "", "Name of the service to associate with traces.")
 	traceFraction             = flag.Float64("app.trace_fraction", 0, "Fraction of requests to sample for tracing.")
 	traceFractionOverrides    = flag.Slice("app.trace_fraction_overrides", []string{}, "Tracing fraction override based on name in format name=fraction.")
@@ -129,13 +133,6 @@ func Configure(env environment.Env) error {
 		return nil
 	}
 
-	if *traceJaegerCollector == "" && *traceOTLPCollector == "" {
-		return status.InvalidArgumentErrorf("Tracing enabled but no collector endpoint is set. Set either app.trace_jaeger_collector or app.trace_otlp_grpc_collector.")
-	}
-	if *traceJaegerCollector != "" && *traceOTLPCollector != "" {
-		return status.InvalidArgumentErrorf("Only one collector can be configured at a time. Set either app.trace_jaeger_collector or app.trace_otlp_grpc_collector, not both.")
-	}
-
 	var traceExporter sdktrace.SpanExporter
 	var err error
 
@@ -145,12 +142,34 @@ func Configure(env environment.Env) error {
 			log.Warningf("Could not initialize Jaeger exporter: %s", err)
 			return nil
 		}
-	} else if *traceOTLPCollector != "" {
+	}
+	if *traceOTLPCollector != "" {
+		if traceExporter != nil {
+			return status.InvalidArgumentErrorf("only one trace collector ('app.trace_*_collector') can be configured at a time.")
+		}
 		traceExporter, err = otlptracegrpc.New(env.GetServerContext(), otlptracegrpc.WithEndpoint(*traceOTLPCollector), otlptracegrpc.WithInsecure())
 		if err != nil {
 			log.Warningf("Could not initialize OTEL exporter: %s", err)
 			return nil
 		}
+	}
+	if *traceOTLPHTTPCollector != "" {
+		if traceExporter != nil {
+			return status.InvalidArgumentErrorf("only one trace collector ('app.trace_*_collector') can be configured at a time.")
+		}
+		opts, err := parseHTTPOptions(*traceOTLPHTTPCollector)
+		if err != nil {
+			return status.InvalidArgumentErrorf("parse OTEL HTTP collector endpoint: %s", err)
+		}
+		traceExporter, err = otlptracehttp.New(env.GetServerContext(), opts...)
+		if err != nil {
+			log.Warningf("Could not initialize OTEL exporter: %s", err)
+			return nil
+		}
+	}
+
+	if traceExporter == nil {
+		return status.InvalidArgumentErrorf("no trace collector ('app.trace_{jaeger,otlp_grpc,otlp_http}_collector') configured")
 	}
 
 	fractionOverrides := make(map[string]float64)
@@ -203,6 +222,24 @@ func Configure(env environment.Env) error {
 	otel.SetTextMapPropagator(propagator)
 	log.Infof("Tracing enabled with sampler: %s", sampler.Description())
 	return nil
+}
+
+func parseHTTPOptions(s string) ([]otlptracehttp.Option, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("parse URL: %w", err)
+	}
+	var opts []otlptracehttp.Option
+	opts = append(opts, otlptracehttp.WithEndpoint(u.Host))
+	if u.Scheme == "http" {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+	if user := u.User.String(); user != "" {
+		opts = append(opts, otlptracehttp.WithHeaders(map[string]string{
+			"Authorization": fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(user))),
+		}))
+	}
+	return opts, nil
 }
 
 type SetMetadata func(m *tpb.Metadata)


### PR DESCRIPTION
For basic auth support, support OTLP http endpoints too. This will be used to send traces across clusters so that we can aggregate all traces in a single clickhouse DB.

Example: `--app.trace_otlp_http_collector=https://user:pass@host:port`.

Tested in dev.