### PR TITLE
Add specific operating system, Xcode version(s), and Xcode SDKs to executor card

### DIFF
--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -32,6 +32,12 @@ export default class ExecutorCardComponent extends React.Component<Props> {
               <div className="executor-section-title">Executor Host ID:</div>
               <div>{this.props.node.executorHostId}</div>
             </div>
+            {this.props.node.osDisplayName && (
+              <div className="executor-section">
+                <div className="executor-section-title">Operating System:</div>
+                <div>{this.props.node.osDisplayName}</div>
+              </div>
+            )}
             <div className="executor-section">
               <div className="executor-section-title">Assignable Memory:</div>
               <div>{format.bytes(+this.props.node.assignableMemoryBytes)}</div>
@@ -53,6 +59,23 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                     );
                   })}
                 </div>
+              </div>
+            )}
+            {this.props.node.xcodeVersions && this.props.node.xcodeVersions.length > 0 && (
+              <div className="executor-section">
+                {this.props.node.xcodeVersions.length == 1 && (
+                  <div className="executor-section-title">Xcode Version:</div>
+                )}
+                {this.props.node.xcodeVersions.length > 1 && (
+                  <div className="executor-section-title">Xcode Versions:</div>
+                )}
+                <div>{this.props.node.xcodeVersions.join(", ")}</div>
+              </div>
+            )}
+            {this.props.node.xcodeSdks && this.props.node.xcodeSdks.length > 0 && (
+              <div className="executor-section">
+                <div className="executor-section-title">Xcode SDKs:</div>
+                <div>{this.props.node.xcodeSdks.join(", ")}</div>
               </div>
             )}
             {this.props.node.supportedIsolationTypes && this.props.node.supportedIsolationTypes.length > 0 && (

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -149,7 +149,7 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
     >();
     for (const r of this.props.regions) {
       for (const e of r.response.executor) {
-        const key = r.name + "-" + (e.node?.os || "") + "-" + (e.node?.arch || "") + "-" + (e.node?.pool || "");
+        const key = r.name + "-" + (e.node?.osFamily || "") + "-" + (e.node?.arch || "") + "-" + (e.node?.pool || "");
         if (!executorsByPool.has(key)) {
           executorsByPool.set(key, []);
         }
@@ -180,7 +180,7 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
                       {executors.length} {executors.length === 1 ? "executor" : "executors"}
                     </ExecutorDetail>
                     <ExecutorDetail Icon={Laptop} label="OS">
-                      {executors[0].executor.node?.os || "unknown"}
+                      {executors[0].executor.node?.osFamily || "unknown"}
                     </ExecutorDetail>
                     <ExecutorDetail Icon={Cpu} label="Arch">
                       {executors[0].executor.node?.arch || "unknown"}

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -757,3 +757,11 @@ func (x *xcodeLocator) PathsForVersionAndSDK(xcodeVersion string, sdk string) (s
 	sdkRoot := fmt.Sprintf("%s/%s", developerDir, sdkPath)
 	return developerDir, sdkRoot, nil
 }
+
+func (x *xcodeLocator) Versions() []string {
+	return []string{}
+}
+
+func (x *xcodeLocator) SDKs() []string {
+	return []string{}
+}

--- a/enterprise/server/scheduling/scheduler_client/BUILD
+++ b/enterprise/server/scheduling/scheduler_client/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//enterprise/server/scheduling/priority_task_scheduler",
         "//proto:scheduler_go_proto",
         "//server/environment",
+        "//server/interfaces",
         "//server/resources",
         "//server/util/authutil",
         "//server/util/log",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -292,7 +292,7 @@ func (h *executorHandle) setRegistration(r *scpb.ExecutionNode) {
 }
 
 func (h *executorHandle) nodePoolKey(node *scpb.ExecutionNode) nodePoolKey {
-	key := nodePoolKey{os: node.GetOs(), arch: node.GetArch(), pool: node.GetPool()}
+	key := nodePoolKey{os: node.GetOsFamily(), arch: node.GetArch(), pool: node.GetPool()}
 	if h.scheduler.enableUserOwnedExecutors {
 		key.groupID = h.groupID
 	}
@@ -2412,8 +2412,8 @@ func (s *SchedulerServer) GetExecutionNodes(ctx context.Context, req *scpb.GetEx
 	executors := make([]*scpb.GetExecutionNodesResponse_Executor, len(registeredNodes))
 	for i, regNode := range registeredNodes {
 		node := regNode.GetRegistration()
-		isDarwinExecutor := strings.EqualFold(node.Os, platform.DarwinOperatingSystemName)
-		isWindowsExecutor := strings.EqualFold(node.Os, platform.WindowsOperatingSystemName)
+		isDarwinExecutor := strings.EqualFold(node.OsFamily, platform.DarwinOperatingSystemName)
+		isWindowsExecutor := strings.EqualFold(node.OsFamily, platform.WindowsOperatingSystemName)
 		executors[i] = &scpb.GetExecutionNodesResponse_Executor{
 			Node: node,
 			IsDefault: !s.requireExecutorAuthorization ||

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -428,7 +428,7 @@ func newFakeExecutor(ctx context.Context, t *testing.T, schedulerClient scpb.Sch
 func newFakeExecutorWithId(ctx context.Context, t *testing.T, id string, schedulerClient scpb.SchedulerClient) *fakeExecutor {
 	node := &scpb.ExecutionNode{
 		ExecutorId:            id,
-		Os:                    defaultOS,
+		OsFamily:              defaultOS,
 		Arch:                  defaultArch,
 		Host:                  "foo",
 		AssignableMemoryBytes: 64_000_000_000,

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -507,9 +507,12 @@ message ExecutionNode {
   // Assignable custom resources.
   repeated CustomResource assignable_custom_resources = 11;
 
-  // Remote execution node operating system.
-  // Ex. "linux".
-  string os = 5;
+  // Node's operating system family. One of: "darwin", "linux", or "windows".
+  string os_family = 5;
+
+  // Node's operating system with version info, suitable for display. This will
+  // be something like "macOS 10.17 Sierra".
+  string os_display_name = 15;
 
   // Architecture of the remote execution node.
   // Ex. "amd64"
@@ -543,6 +546,12 @@ message ExecutionNode {
 
   // The number of in-flight actions the executor is currently executing.
   int32 active_action_count = 14;
+
+  // The Xcode versions installed on this executor.
+  repeated string xcode_versions = 16;
+
+  // The Xcode SDKs installed on this executor.
+  repeated string xcode_sdks = 17;
 }
 
 message GetExecutionNodesRequest {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1290,8 +1290,17 @@ type HealthChecker interface {
 
 // Locates all Xcode versions installed on the host system.
 type XcodeLocator interface {
-	// Finds the Xcode that matches the given Xcode version.
-	// Returns the developer directory for that Xcode and the SDK root for the given SDK.
+	// Returns a slice containing the most specific version specifier for each
+	// Xcode installed on this host. E.g.: ["16.2.0.16C503", "16.0.0.16A242"]
+	Versions() []string
+
+	// Returns a slice containing the most specific version specifier for each
+	// Xcode SDK installed on this host. E.g.:
+	// ["iPhoneOS18.2", "iPhoneSimulator18.2"]
+	SDKs() []string
+
+	// Finds the Xcode matching the given Xcode version selector. Returns the
+	// developer directory for that Xcode and the SDK root for the given SDK.
 	PathsForVersionAndSDK(xcodeVersion string, sdk string) (string, string, error)
 }
 

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -217,8 +218,25 @@ func GetArch() string {
 	return runtime.GOARCH
 }
 
-func GetOS() string {
+func GetOSFamily() string {
 	return runtime.GOOS
+}
+
+func GetOSDisplayName() string {
+	var command []string
+	switch runtime.GOOS {
+	case "darwin":
+		command = []string{"sh", "-c", "echo \"$(sw_vers -productName) $(sw_vers -productVersion)\""}
+	case "linux":
+		command = []string{"sh", "-c", "grep '^PRETTY_NAME=' /etc/os-release | cut -d= -f2- | tr -d '\"'"}
+	case "windows":
+		command = []string{"ver"}
+	}
+	b, err := exec.Command(command[0], command[1:]...).Output()
+	if err != nil {
+		log.Warningf("Error getting operating system display name: %v", err)
+	}
+	return string(b)
 }
 
 func GetMyHostname() (string, error) {

--- a/server/xcode/BUILD
+++ b/server/xcode/BUILD
@@ -34,7 +34,7 @@ go_test(
     target_compatible_with = ["@platforms//os:macos"],
     deps = select({
         "@io_bazel_rules_go//go/platform:darwin": [
-            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
         ],
         "//conditions:default": [],
     }),

--- a/server/xcode/xcode.go
+++ b/server/xcode/xcode.go
@@ -10,6 +10,14 @@ func NewXcodeLocator() *xcodeLocator {
 	return &xcodeLocator{}
 }
 
+func (x *xcodeLocator) Versions() []string {
+	return []string{}
+}
+
+func (x *xcodeLocator) SDKs() []string {
+	return []string{}
+}
+
 func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
 	return "", nil
 }

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -12,9 +12,11 @@ import "C"
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"unsafe"
@@ -35,13 +37,30 @@ const defaultXcodeVersion = "default-xcode-version"
 var desiredXcodeVersions = flag.Slice("executor.desired_xcode_versions", []string{}, "List of Xcode versions desired on the host system. If any of the provided Xcode versions cannot be found on the host, the executor will log a warning message.")
 
 type xcodeLocator struct {
+	// Map from Xcode version string (e.g. "16" or "16.0.0.16A242") to an
+	// xcodeVersion containing information about that Xcode installation. Note
+	// that a single xcodeVersion will appear multiple times in this map, once
+	// for each degree of version specificity. For example, Xcode version
+	// "16.0.0" will appear under the following keys: "16", "16.0", "16.0.0",
+	// and "16.0.0.16A242" (16A242 is the build number). This is done so that
+	// the client may target it via just the major version number, or a more
+	// specific version if desired.
 	versions map[string]*xcodeVersion
 }
 
 type xcodeVersion struct {
+	// The specific version of Xcode (e.g. "16.0.0.16A242")
 	version          string
 	developerDirPath string
-	sdks             map[string]string
+
+	// This map contains all of the Xcode SDKs that are installed and available
+	// for this version of Xcode. The keys are the SDK versions, and the values
+	// are the filesystem path of this SDKs developer directory. Like the
+	// xcodeLocator.versions map above, SDKs can appear in this map multiple
+	// times under different levels of version specifity, for example this map
+	// can contain keys: "iPhoneSimulator" and "iPhoneSimulator18.2" pointing
+	// to the same underlying SDK.
+	sdks map[string]string
 }
 
 // The interesting bits to pull from Xcode's version plist.
@@ -65,6 +84,51 @@ func (x *xcodeLocator) verify() {
 			alert.UnexpectedEvent("xcode version missing", "Failed to locate desired Xcode version %s", version)
 		}
 	}
+}
+
+func (x *xcodeLocator) Versions() []string {
+	xcodes := map[string]struct{}{}
+	for _, xcode := range x.versions {
+		if xcode.version == defaultXcodeVersion {
+			continue
+		}
+		xcodes[xcode.version] = struct{}{}
+	}
+	return slices.Sorted(maps.Keys(xcodes))
+}
+
+func (x *xcodeLocator) SDKs() []string {
+	allSDKs := map[string]struct{}{}
+	for _, xcode := range x.versions {
+		if xcode.version == defaultXcodeVersion {
+			continue
+		}
+		for sdk := range xcode.sdks {
+			allSDKs[sdk] = struct{}{}
+		}
+	}
+
+	// Determine the most specific version of each SDK and return that one.
+	sdks := []string{}
+	for sdk := range allSDKs {
+		add := true
+		for otherSDK := range allSDKs {
+			if sdk == otherSDK {
+				continue
+			}
+			if strings.HasPrefix(otherSDK, sdk) {
+				add = false
+				break
+			}
+		}
+
+		if add {
+			sdks = append(sdks, sdk)
+		}
+	}
+
+	slices.Sort(sdks)
+	return sdks
 }
 
 // Finds the Xcode that matches the given Xcode version.

--- a/server/xcode/xcode_darwin_test.go
+++ b/server/xcode/xcode_darwin_test.go
@@ -7,19 +7,87 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestXcodeLocator(t *testing.T) {
 	xl := NewXcodeLocator()
 	for k, v := range xl.versions {
 		t.Run(k, func(t *testing.T) {
-			assert.False(
+			require.False(
 				t,
 				strings.HasPrefix(v.developerDirPath, "//"),
 				fmt.Sprintf("developerDirPath of Xcode version %q should not has '//' prefix: %q", k, v.developerDirPath),
 			)
-			assert.DirExists(t, v.developerDirPath)
+			require.DirExists(t, v.developerDirPath)
 		})
 	}
+}
+
+func TestVersions(t *testing.T) {
+	xl := xcodeLocator{}
+	require.Empty(t, xl.Versions())
+
+	xcode154Version := "15.4.0.92A424"
+	xcode160Version := "16.0.0.16A242"
+	xcode164Version := "16.4.0.55A224"
+	xcode154 := &xcodeVersion{version: xcode154Version}
+	xcode160 := &xcodeVersion{version: xcode160Version}
+	xcode164 := &xcodeVersion{version: xcode164Version}
+	xl = xcodeLocator{
+		versions: map[string]*xcodeVersion{
+			"15":            xcode154,
+			"15.4":          xcode154,
+			"15.4.0":        xcode154,
+			xcode154Version: xcode154,
+			"16":            xcode164,
+			"16.0":          xcode160,
+			"16.0.0":        xcode160,
+			xcode160Version: xcode160,
+			"16.4":          xcode164,
+			"16.4.0":        xcode164,
+			xcode164Version: xcode164,
+		},
+	}
+	require.Equal(t,
+		[]string{xcode154Version, xcode160Version, xcode164Version},
+		xl.Versions())
+}
+
+func TestSDKs(t *testing.T) {
+	xl := xcodeLocator{}
+	require.Empty(t, xl.SDKs())
+
+	xcode160Version := "16.0.0.16A242"
+	xcode164Version := "16.4.0.55A224"
+	sdks := map[string]string{
+		"AppleTVOS":            "/Users/administrator/AppleTVOS18.0",
+		"AppleTVOS18.0":        "/Users/administrator/AppleTVOS18.0",
+		"AppleTVSimulator":     "/Users/administrator/AppleTVSimulator18.0",
+		"AppleTVSimulator18.0": "/Users/administrator/AppleTVSimulator18.0",
+		"iPhoneOS":             "/Users/administrator/iPhoneOS18.0",
+		"iPhoneOS18.0":         "/Users/administrator/iPhoneOS18.0",
+		"iPhoneSimulator":      "/Users/administrator/iPhoneSimulator18.0",
+		"iPhoneSimulator18.0":  "/Users/administrator/iPhoneSimulator18.0",
+	}
+	xcode160 := &xcodeVersion{version: xcode160Version, sdks: sdks}
+	xcode164 := &xcodeVersion{version: xcode164Version, sdks: sdks}
+	xl = xcodeLocator{
+		versions: map[string]*xcodeVersion{
+			"16":            xcode164,
+			"16.0":          xcode160,
+			"16.0.0":        xcode160,
+			xcode160Version: xcode160,
+			"16.4":          xcode164,
+			"16.4.0":        xcode164,
+			xcode164Version: xcode164,
+		},
+	}
+	require.Equal(t,
+		[]string{
+			"AppleTVOS18.0",
+			"AppleTVSimulator18.0",
+			"iPhoneOS18.0",
+			"iPhoneSimulator18.0"},
+		xl.SDKs())
 }


### PR DESCRIPTION
Looks like this (IP address redacted):
<img width="1329" height="403" alt="Screenshot 2025-08-20 at 9 07 13 PM" src="https://github.com/user-attachments/assets/31b9b73f-7091-43fb-ba02-b21167b74666" />

We could add some logic to improve the display names of the SDKs as opposed to what we get from Xcode, but I figured this was probably good enough for now. Also not sure if there are cases where we'd want to not show the full operating system with version, let me know if you can think of any.