### PR TITLE
[CLI]: Include bazel exit code as environment variable to post_bazel plugin

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -366,7 +366,7 @@ func handleBazelCommand(start time.Time, args []string, originalArgs []string) (
 	watcher.Pause()
 	defer watcher.Unpause()
 	for _, p := range plugins {
-		if err := p.PostBazel(outputPath); err != nil {
+		if err := p.PostBazel(outputPath, exitCode); err != nil {
 			return 1, err
 		}
 	}

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -713,7 +713,7 @@ func (p *Plugin) PreBazel(args, execArgs []string) ([]string, []string, error) {
 // is passed as the first argument.
 //
 // See cli/example_plugins/go-deps/post_bazel.sh for an example.
-func (p *Plugin) PostBazel(bazelOutputPath string) error {
+func (p *Plugin) PostBazel(bazelOutputPath string, exitCode int) error {
 	path, err := p.Path()
 	if err != nil {
 		return err
@@ -734,6 +734,7 @@ func (p *Plugin) PostBazel(bazelOutputPath string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Env = p.commandEnv()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("BAZEL_EXIT_CODE=%d", exitCode))
 	if err := cmd.Run(); err != nil {
 		return status.InternalErrorf("Post-bazel hook for %s/%s failed: %s", p.config.Repo, p.config.Path, err)
 	}


### PR DESCRIPTION
This allows post-bazel plugins to perform actions on only failing builds. 