### PR TITLE
Enable dynamic execution for GoLink actions

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -210,10 +210,6 @@ common:download-minimal --remote_download_minimal
 common:remote-shared --config=cache-shared
 common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
-common:remote-shared --internal_spawn_scheduler
-common:remote-shared --strategy=GoLink=dynamic
-common:remote-shared --dynamic_local_strategy=GoLink=worker,sandboxed
-common:remote-shared --dynamic_remote_strategy=GoLink=remote
 
 # Flags shared for prod RBE and cache
 common:remote-prod-shared --config=remote-shared

--- a/template-user.bazelrc
+++ b/template-user.bazelrc
@@ -43,3 +43,10 @@
 # Enable disk cache and garbage collection
 #common --disk_cache=~/.bazel/disk_cache/
 #common --experimental_disk_cache_gc_max_age=7d
+
+# Enable dynamic exeuction for GoLink actions. This significantly speeds up
+# incremental builds when using remote execution.
+#common:remote --internal_spawn_scheduler
+#common:remote --strategy=GoLink=dynamic
+#common:remote --dynamic_local_strategy=GoLink=worker,sandboxed
+#common:remote --dynamic_remote_strategy=GoLink=remote


### PR DESCRIPTION
This races a local execution against the remote one. In my experiments, the local GoLink is 3x faster.  In incremental builds, this often makes the whole build 3x faster. Compare [remote execution](https://app.buildbuddy.io/invocation/62e88fb1-330a-477e-ac85-9f850cea87a5?timingFilter=GoLink+enterprise%2Fserver%2Fcmd%2Fserver%2Fbuildbuddy_%2Fbuildbuddy#timing) vs [dynamic execution](https://app.buildbuddy.io/invocation/b4bd1db1-a6ed-4756-836f-30f3d411b317?timingFilter=GoLink+enterprise%2Fserver%2Fcmd%2Fserver%2Fbuildbuddy_%2Fbuildbuddy#timing).

See https://bazel.build/remote/dynamic