### PR TITLE
Fix missing blank lines in terminal

### DIFF
--- a/app/terminal/text.tsx
+++ b/app/terminal/text.tsx
@@ -140,7 +140,7 @@ export function getContent(text: string, search: string, lineLengthLimit: number
     const [plaintext, tags] = parseAnsi(line, currentStyle);
     const matchRanges = getMatchedRanges(plaintext, search);
     let matchIndex = 0;
-    const numRowsForLine = lineLengthLimit ? Math.ceil(plaintext.length / lineLengthLimit) : 1;
+    const numRowsForLine = lineLengthLimit ? Math.max(1, Math.ceil(plaintext.length / lineLengthLimit)) : 1;
     for (let i = 0; i < numRowsForLine; i++) {
       const rowEndIndex = (i + 1) * lineLengthLimit;
       while (matchRanges[matchIndex] && matchRanges[matchIndex].start < rowEndIndex) {

--- a/app/terminal/text_test.ts
+++ b/app/terminal/text_test.ts
@@ -25,8 +25,48 @@ describe("normalizeSpace", () => {
 });
 
 describe("getContent", () => {
+  it("should preserve blank lines", () => {
+    expect(getContent("Hello\n\nWorld", "", Number.MAX_SAFE_INTEGER).rows).toEqual([
+      {
+        plaintext: "Hello",
+        matchStartIndex: null,
+        wrapOffset: 0,
+        tags: [{ length: 5, style: {} }],
+      },
+      {
+        plaintext: "",
+        matchStartIndex: null,
+        wrapOffset: 0,
+        tags: [],
+      },
+      {
+        plaintext: "World",
+        matchStartIndex: null,
+        wrapOffset: 0,
+        tags: [{ length: 5, style: {} }],
+      },
+    ]);
+  });
+
+  it("should preserve trailing blank lines", () => {
+    expect(getContent("Hello\n", "", 0).rows).toEqual([
+      {
+        plaintext: "Hello",
+        matchStartIndex: null,
+        wrapOffset: 0,
+        tags: [{ length: 5, style: {} }],
+      },
+      {
+        plaintext: "",
+        matchStartIndex: null,
+        wrapOffset: 0,
+        tags: [],
+      },
+    ]);
+  });
+
   it("should handle ANSI SGR state that persists across lines", () => {
-    expect(getContent("\x1b[32mMulti-line\nColor\x1b[m\nReset", "", 0).rows).toEqual([
+    expect(getContent("\x1b[32mMulti-line\nColor\x1b[m\nReset", "", Number.MAX_SAFE_INTEGER).rows).toEqual([
       {
         plaintext: "Multi-line",
         matchStartIndex: null,
@@ -62,7 +102,7 @@ describe("getContent", () => {
       },
     ]);
 
-    expect(getContent("\x1b[32mMulti-line\nColor\x1b[mReset", "", 0).rows).toEqual([
+    expect(getContent("\x1b[32mMulti-line\nColor\x1b[mReset", "", Number.MAX_SAFE_INTEGER).rows).toEqual([
       {
         plaintext: "Multi-line",
         matchStartIndex: null,
@@ -91,7 +131,7 @@ describe("getContent", () => {
       },
     ]);
 
-    expect(getContent("\x1b[32mMulti-line\n\x1b[32mColor\x1b[m\nReset", "", 0).rows).toEqual([
+    expect(getContent("\x1b[32mMulti-line\n\x1b[32mColor\x1b[m\nReset", "", Number.MAX_SAFE_INTEGER).rows).toEqual([
       {
         plaintext: "Multi-line",
         matchStartIndex: null,

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1180,7 +1180,6 @@ func (e *EventChannel) authenticateEvent(bazelBuildEvent *build_event_stream.Bui
 
 func (e *EventChannel) InitializeLogWriter(iid string) error {
 	var err error
-	log.Infof("Initializing log writer with %dw x %dh", e.requestedTerminalColumns, e.requestedTerminalLines)
 	e.logWriter, err = eventlog.NewEventLogWriter(
 		e.ctx,
 		e.env.GetBlobstore(),


### PR DESCRIPTION
`plaintext.length` will be 0 if the line is blank, so we wind up computing 0 rows for blank lines.