### PR TITLE
Clean up ociruntime_test OCI image setup

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(
     name = "buildbuddy",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Load core rulesets before invoking any dependency macros to ensure that the
 # versions listed below are actually honored - the last repo from the first
@@ -592,6 +592,15 @@ oci_pull(
     name = "busybox",
     digest = "sha256:c230832bd3b0be59a6c47ed64294f9ce71e91b327957920b6929a0caa8353140",
     image = "mirror.gcr.io/library/busybox:1.36.1",
+    platforms = ["linux/amd64"],
+)
+
+load("//dockerfiles/test_images:defs.bzl", "NET_TOOLS_IMAGE_DIGEST", "NET_TOOLS_IMAGE_REPO")
+
+oci_pull(
+    name = "net_tools",
+    digest = NET_TOOLS_IMAGE_DIGEST,
+    image = NET_TOOLS_IMAGE_REPO,
     platforms = ["linux/amd64"],
 )
 

--- a/dockerfiles/test_images/defs.bzl
+++ b/dockerfiles/test_images/defs.bzl
@@ -1,1 +1,6 @@
-NET_TOOLS_IMAGE = "gcr.io/flame-public/net-tools@sha256:fdd8b0a391871eaf47664b2f6620b64d2bc4bdf8c86b57c1e0d013935cac1215"
+# Keep in sync with oci.MODULE.bazel
+
+NET_TOOLS_IMAGE_REPO = "gcr.io/flame-public/net-tools"
+NET_TOOLS_IMAGE_DIGEST = "sha256:fdd8b0a391871eaf47664b2f6620b64d2bc4bdf8c86b57c1e0d013935cac1215"
+
+NET_TOOLS_IMAGE = NET_TOOLS_IMAGE_REPO + "@" + NET_TOOLS_IMAGE_DIGEST

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -62,11 +62,11 @@ go_test(
     name = "ociruntime_test",
     srcs = ["ociruntime_test.go"],
     data = [
-        ":busybox",
         ":crun",
         "//enterprise/server/cmd/executor:tini",
         "//enterprise/server/remote_execution/runner/testworker",
         "@busybox",
+        "@net_tools",
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
@@ -89,10 +89,9 @@ go_test(
     ],
     x_defs = {
         "crunRlocationpath": "$(rlocationpath :crun)",
-        "busyboxRlocationpath": "$(rlocationpath :busybox)",
-        "ociBusyboxRlocationpath": "$(rlocationpath @busybox)",
+        "busyboxImageRlocationpath": "$(rlocationpath @busybox)",
+        "netToolsImageRlocationpath": "$(rlocationpath @net_tools)",
         "testworkerRlocationpath": "$(rlocationpath //enterprise/server/remote_execution/runner/testworker)",
-        "netToolsImageRef": NET_TOOLS_IMAGE,
     },
     deps = [
         ":ociruntime",

--- a/oci.MODULE.bazel
+++ b/oci.MODULE.bazel
@@ -17,6 +17,12 @@ oci.pull(
     image = "mirror.gcr.io/library/busybox:1.36.1",
     platforms = ["linux/amd64"],
 )
+oci.pull(
+    name = "net_tools",
+    digest = "sha256:fdd8b0a391871eaf47664b2f6620b64d2bc4bdf8c86b57c1e0d013935cac1215",
+    image = "gcr.io/flame-public/net-tools",
+    platforms = ["linux/amd64"],
+)
 use_repo(
     oci,
     "bazel_oci_image_base",
@@ -25,4 +31,6 @@ use_repo(
     "buildbuddy_go_oci_image_base_linux_amd64",
     "busybox",
     "busybox_linux_amd64",
+    "net_tools",
+    "net_tools_linux_amd64",
 )


### PR DESCRIPTION
- Remove support for the hard-coded, readonly busybox rootfs that has a separate codepath from the overlayfs codepath. This was helpful while initially writing the oci isolation type (before we could pull and mount images) but isn't very useful now and complicates the code.
- Use a real busybox image everywhere that we were using the hard-coded busybox image.
- Don't pull any images (either busybox or net-tools) from the external internet - get all images from runfiles instead.