### PR TITLE
Migrate `pkg_tar` call from `bazel_tools` to `rules_pkg`

### DIFF
--- a/server/util/bazel/defs.bzl
+++ b/server/util/bazel/defs.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 def _extract_bazel_installation_impl(ctx):
     out_dir = ctx.actions.declare_directory(ctx.attr.out_dir)


### PR DESCRIPTION
This silences a verbose information message during build and also matches all our other `pkg_tar` calls.
