### PR TITLE
Don't set the inode64 mount option for /dev/shm

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -1078,7 +1078,7 @@ func (c *ociContainer) createSpec(ctx context.Context, cmd *repb.Command) (*spec
 				Destination: "/dev/shm",
 				Type:        "tmpfs",
 				Source:      "shm",
-				Options:     []string{"rw", "nosuid", "nodev", "noexec", "relatime", "size=64000k", "inode64"},
+				Options:     []string{"rw", "nosuid", "nodev", "noexec", "relatime", "size=64000k"},
 			},
 			// TODO: .containerenv
 			// {


### PR DESCRIPTION
Context: https://buildbuddy-corp.slack.com/archives/C091JA2J1RU/p1756840184665559?thread_ts=1756507672.036899&cid=C091JA2J1RU

This mount option is not supported everywhere, and the kernel will set this option automatically if `CONFIG_TMPFS_INODE64` is set.

I could not find any references to "inode64" in the podman codebase, so it seems podman does not set this option either.