### PR TITLE
[raft] fix a bug in add replica

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2880,7 +2880,7 @@ func (s *Store) AddReplica(ctx context.Context, req *rfpb.AddReplicaRequest) (*r
 		newReplicaID = existingStaging.GetReplicaId()
 		if replicaMembership != nil {
 			if newReplicaID != replicaMembership.replicaID {
-				alert.UnexpectedEvent("staging-replica-id-not-match", "c%dn%d is on nhid %q in staging replicas, but raft membership finds replica id %d", rangeID, newReplicaID, node.GetNhid(), replicaMembership.replicaID)
+				alert.UnexpectedEvent("staging-replica-id-mismatch", "c%dn%d is on nhid %q in staging replicas, but raft membership holds replica id %d", rangeID, newReplicaID, node.GetNhid(), replicaMembership.replicaID)
 			}
 			if replicaMembership.isNonVoting {
 				state = addReplicaStateNonVoter


### PR DESCRIPTION
If in AddReplica, after the replica descriptor is added to the staging replica, we failed to add it as a non-voter in raft. When AddReplica tries to run again, it tries to reserve a new replica ID and add it to staging replicas of the range descriptor. Even if the second time it succeeded, we will have a stale staging replica in the descriptor. The driver will try to resolve it by calling AddReplica again. But this time, verifyRequest fails since there is a replica descriptor with the requested NHID in the replica descriptor. 