### PR TITLE
Add support for TAG_ prefixed tags

### DIFF
--- a/docs/guide-metadata.md
+++ b/docs/guide-metadata.md
@@ -236,6 +236,28 @@ Example:
 --build_metadata=TAGS="foo,bar,baz"
 ```
 
+### Using TAG_ prefix for automatic tag creation
+
+As an alternative to using the `TAGS` field with comma-separated values, you can use build metadata flags piecemeal with a `TAG_` prefix. These will automatically be converted to tags by removing the prefix.
+
+Examples:
+
+```bash
+# Creates a tag "ENV=production"
+--build_metadata=TAG_ENV=production
+
+# Creates a tag "VERSION=v1.2.3"
+--build_metadata=TAG_VERSION=v1.2.3
+
+# Creates a tag "FEATURE" (no value)
+--build_metadata=TAG_FEATURE=
+
+# Multiple TAG_ prefixed flags can be used together
+--build_metadata=TAG_ENV=staging --build_metadata=TAG_REGION=us-west-1
+```
+
+The TAG_ prefix method can be combined with the regular TAGS field - all tags will be merged together.
+
 You can filter by these tags on build history pages and the trends page. Note that when filtering by tags, you will not see in-progress and disconnected builds.
 
 ## Environment variable redacting

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -428,17 +428,36 @@ func (sep *StreamingEventParser) fillInvocationFromBuildMetadata(metadata map[st
 	if visibility, ok := metadata["VISIBILITY"]; ok && visibility == "PUBLIC" {
 		sep.setReadPermission(inpb.InvocationPermission_PUBLIC, priority)
 	}
-	if tags, ok := metadata["TAGS"]; ok && tags != "" {
-		if err := sep.setTags(tags, priority); err != nil {
-			return err
-		}
-	}
 	if parentRunId, ok := metadata["PARENT_RUN_ID"]; ok && parentRunId != "" {
 		sep.setParentRunId(parentRunId, priority)
 	}
 	if runId, ok := metadata["RUN_ID"]; ok && runId != "" {
 		sep.setRunId(runId, priority)
 	}
+	
+	var tagValues []string
+	if existingTags, ok := metadata["TAGS"]; ok && existingTags != "" {
+		tagValues = append(tagValues, existingTags)
+	}
+	
+	// Support TAG_ prefixed metadata
+	for key, value := range metadata {
+		if strings.HasPrefix(key, "TAG_") {
+			tagKey := strings.TrimPrefix(key, "TAG_")
+			if value != "" {
+				tagValues = append(tagValues, tagKey+"="+value)
+			} else {
+				tagValues = append(tagValues, tagKey)
+			}
+		}
+	}
+	
+	if len(tagValues) > 0 {
+		if err := sep.setTags(strings.Join(tagValues, ","), priority); err != nil {
+			return err
+		}
+	}
+	
 	return nil
 }
 

--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -266,6 +266,75 @@ func TestFillInvocation(t *testing.T) {
 	assert.Equal(t, inpb.DownloadOutputsOption_MINIMAL, invocation.GetDownloadOutputsOption())
 }
 
+func TestBuildMetadataWithTagPrefix(t *testing.T) {
+	flags.Set(t, "app.tags_enabled", true)
+	
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		wantTags []string
+	}{
+		{
+			name: "TAG_ prefix creates tags",
+			metadata: map[string]string{
+				"TAG_FOO": "BAR",
+				"TAG_ENV": "production",
+			},
+			wantTags: []string{"ENV=production", "FOO=BAR"},
+		},
+		{
+			name: "TAG_ prefix combined with TAGS",
+			metadata: map[string]string{
+				"TAGS":      "existing,tags",
+				"TAG_BUILD": "v1.2.3",
+				"TAG_TYPE":  "release",
+			},
+			wantTags: []string{"BUILD=v1.2.3", "TYPE=release", "existing", "tags"},
+		},
+		{
+			name: "Empty TAG_ values create tags without equals",
+			metadata: map[string]string{
+				"TAG_EMPTY": "",
+				"TAG_VALID": "value",
+			},
+			wantTags: []string{"EMPTY", "VALID=value"},
+		},
+		{
+			name: "Non-TAG_ prefixed keys are ignored for tags",
+			metadata: map[string]string{
+				"ROLE":      "CI",
+				"TAG_STAGE": "beta",
+			},
+			wantTags: []string{"STAGE=beta"},
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			invocation := &inpb.Invocation{
+				InvocationId: "test-invocation",
+			}
+			parser := event_parser.NewStreamingEventParser(invocation)
+			
+			buildMetadata := &build_event_stream.BuildMetadata{
+				Metadata: tt.metadata,
+			}
+			event := &build_event_stream.BuildEvent{
+				Payload: &build_event_stream.BuildEvent_BuildMetadata{BuildMetadata: buildMetadata},
+			}
+			
+			parser.ParseEvent(event)
+			
+			outputTags := make([]string, 0)
+			for _, tag := range invocation.Tags {
+				outputTags = append(outputTags, tag.Name)
+			}
+			
+			assert.ElementsMatch(t, tt.wantTags, outputTags)
+		})
+	}
+}
+
 func TestRemoteCacheOptions(t *testing.T) {
 	tests := []struct {
 		desc                              string


### PR DESCRIPTION
This allows for setting tags piecemeal (Bazel overwrites build metadata with the same key instead of accumulating).