### PR TITLE
Add property to allow pulling images only from cache

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -689,6 +689,13 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		return nil, err
 	}
 
+	// Check permissions for server admin-only properties.
+	if props.ContainerRegistryBypass {
+		if err := authutil.AuthorizeServerAdmin(ctx, s.env); err != nil {
+			return nil, status.WrapError(err, "authorize container-registry-bypass property")
+		}
+	}
+
 	if fp := s.env.GetExperimentFlagProvider(); fp != nil {
 		expOverrides := fp.Object(
 			ctx, "remote_execution.task_size_overrides", nil,

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -77,6 +77,7 @@ const (
 
 	containerRegistryUsernamePropertyName = "container-registry-username"
 	containerRegistryPasswordPropertyName = "container-registry-password"
+	containerRegistryBypassPropertyName   = "container-registry-bypass"
 
 	// container-image prop value which behaves the same way as if the prop were
 	// empty or unset.
@@ -276,6 +277,14 @@ type Properties struct {
 	// Persistent volumes shared across all actions within a group. Requires
 	// `executor.enable_persistent_volumes` to be enabled.
 	PersistentVolumes []PersistentVolume
+
+	// ContainerRegistryBypass skips pulling images from the container registry
+	// and pulls images only from the cache instead. Note that this does not
+	// skip cache authentication.
+	//
+	// This property can only be used by server admins, otherwise the execution
+	// request will be rejected.
+	ContainerRegistryBypass bool
 }
 
 type PersistentVolume struct {
@@ -467,6 +476,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		PersistentVolumes:         persistentVolumes,
 		SnapshotReadPolicy:        snapshotReadPolicy,
 		RemoteSnapshotSavePolicy:  snapshotSavePolicy,
+		ContainerRegistryBypass:   boolProp(m, containerRegistryBypassPropertyName, false),
 	}, nil
 }
 

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -215,7 +215,8 @@ func (c *Command) processUpdatesAsync(ctx context.Context, stream repb.Execution
 			if err != nil {
 				sendStatus(&CommandResult{
 					Stage: repb.ExecutionStage_COMPLETED,
-					Err:   status.AbortedErrorf("stream to server broken: %v", err)})
+					Err:   err,
+				})
 			}
 			continue // retry recv using new stream
 		}
@@ -223,7 +224,8 @@ func (c *Command) processUpdatesAsync(ctx context.Context, stream repb.Execution
 		if err != nil {
 			sendStatus(&CommandResult{
 				Stage: repb.ExecutionStage_COMPLETED,
-				Err:   status.AbortedErrorf("stream to server broken: %v", err)})
+				Err:   err,
+			})
 			return
 		}
 

--- a/server/capabilities_filter/BUILD
+++ b/server/capabilities_filter/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto:capability_go_proto",
         "//server/environment",
+        "//server/util/authutil",
         "//server/util/capabilities",
         "//server/util/status",
     ],


### PR DESCRIPTION
This will allow replaying actions using only the cached image contents, bypassing requests to the registry but still requiring image cache auth. This also will require some updates to replay_action - will send those out separately.