### PR TITLE
Skip image registry requests in a few more cases

### DIFF
--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -707,14 +707,20 @@ func TestResolve_WithCache(t *testing.T) {
 			})
 			registry.PushIndex(t, index, tc.imageName+"_index")
 
+			// Test with normal image manifest
 			{
 				imageAddress := registry.ImageAddress(tc.args.imageName + "_image")
+				imageDigest, err := pushedImage.Digest()
+				require.NoError(t, err)
 				pushedLayers, err := pushedImage.Layers()
 				require.NoError(t, err)
 				require.Len(t, pushedLayers, 1)
 				layerDigest, err := pushedLayers[0].Digest()
 				require.NoError(t, err)
 
+				// Initially, nothing is cached, and we expect to make requests
+				// to resolve the manifest, as well as to fetch the manifest and
+				// layer contents.
 				expected := map[string]int{
 					http.MethodGet + " /v2/": 1,
 					http.MethodHead + " /v2/" + tc.args.imageName + "_image/manifests/latest":             1,
@@ -723,13 +729,25 @@ func TestResolve_WithCache(t *testing.T) {
 				}
 				resolveAndCheck(t, tc, te, imageAddress, expected, counter)
 
+				// Try resolving again - the image should now be cached and we
+				// should be able to avoid GET requests for manifests and blobs,
+				// but we still expect some requests to resolve the tag to a
+				// digest.
 				expected = map[string]int{
 					http.MethodGet + " /v2/": 1,
 					http.MethodHead + " /v2/" + tc.args.imageName + "_image/manifests/latest": 1,
 				}
 				resolveAndCheck(t, tc, te, imageAddress, expected, counter)
+
+				// Try resolving again but fetch using a digest ref - should be
+				// able to avoid contacting the registry entirely, since we
+				// don't need to resolve the tag to a digest.
+				imageAddressWithDigest := imageAddress + "@" + imageDigest.String()
+				expected = map[string]int{}
+				resolveAndCheck(t, tc, te, imageAddressWithDigest, expected, counter)
 			}
 
+			// Test with index manifest
 			{
 				indexAddress := registry.ImageAddress(tc.args.imageName + "_index")
 				imageDigest, err := pushedImage.Digest()
@@ -740,22 +758,36 @@ func TestResolve_WithCache(t *testing.T) {
 				layerDigest, err := pushedLayers[0].Digest()
 				require.NoError(t, err)
 
+				// Initially, nothing is cached, and we expect to make requests
+				// to resolve the manifest, as well as to fetch the manifest and
+				// layer contents. Note that we have one more GET request here
+				// compared to the non-index manifest case, since the index
+				// manifest points to the platform-specific image manifest.
 				expected := map[string]int{
 					http.MethodGet + " /v2/": 1,
-					http.MethodHead + " /v2/" + tc.args.imageName + "_index/manifests/latest":                  1,
-					http.MethodGet + " /v2/" + tc.args.imageName + "_index/manifests/latest":                   1,
-					http.MethodHead + " /v2/" + tc.args.imageName + "_index/manifests/" + imageDigest.String(): 1,
-					http.MethodGet + " /v2/" + tc.args.imageName + "_index/manifests/" + imageDigest.String():  1,
-					http.MethodGet + " /v2/" + tc.args.imageName + "_index/blobs/" + layerDigest.String():      1,
+					http.MethodHead + " /v2/" + tc.args.imageName + "_index/manifests/latest":                 1,
+					http.MethodGet + " /v2/" + tc.args.imageName + "_index/manifests/latest":                  1,
+					http.MethodGet + " /v2/" + tc.args.imageName + "_index/manifests/" + imageDigest.String(): 1,
+					http.MethodGet + " /v2/" + tc.args.imageName + "_index/blobs/" + layerDigest.String():     1,
 				}
 				resolveAndCheck(t, tc, te, indexAddress, expected, counter)
 
+				// Try resolving again - the image should now be cached and we
+				// should be able to avoid GET requests for manifests and blobs,
+				// but we still expect some requests to resolve the tag to a
+				// digest.
 				expected = map[string]int{
 					http.MethodGet + " /v2/": 1,
-					http.MethodHead + " /v2/" + tc.args.imageName + "_index/manifests/latest":                  1,
-					http.MethodHead + " /v2/" + tc.args.imageName + "_index/manifests/" + imageDigest.String(): 1,
+					http.MethodHead + " /v2/" + tc.args.imageName + "_index/manifests/latest": 1,
 				}
 				resolveAndCheck(t, tc, te, indexAddress, expected, counter)
+
+				// Try resolving again but fetch using a digest ref - should be
+				// able to avoid contacting the registry entirely, since we
+				// don't need to resolve the tag to a digest.
+				imageAddressWithDigest := indexAddress + "@" + imageDigest.String()
+				expected = map[string]int{}
+				resolveAndCheck(t, tc, te, imageAddressWithDigest, expected, counter)
 			}
 		})
 	}


### PR DESCRIPTION
- Skip registry ping (`/v2/`) if the image is cached. The fix is to just move `createRemoteLayer()` to later in the `Compressed()` function (after the cache check), since this seems to be what causes the ping request.
- Skip HEAD request to resolve the image to a digest if we already know the digest (i.e. the container-image string already contains a digest). The HEAD request just gives us an image descriptor (digest, length, content-type), but if we have a digest ref and we have the manifest cached, then we have everything we need already and can build the descriptor directly, without hitting the registry.

Work towards https://github.com/buildbuddy-io/buildbuddy/pull/10199