### PR TITLE
Specify a `--target` for bb explain

### DIFF
--- a/app/compare/compare_invocations.tsx
+++ b/app/compare/compare_invocations.tsx
@@ -206,7 +206,7 @@ export default class CompareInvocationsComponent extends React.Component<Compare
 
       const command = `
 curl -fsSL https://install.buildbuddy.io | bash
-output=$(bb explain --old ${modelB.getInvocationId()} --new ${modelA.getInvocationId()} --verbose)
+output=$(bb explain --old ${modelB.getInvocationId()} --new ${modelA.getInvocationId()} --target ${modelA.getCacheAddress()} --verbose)
 if [ -z "$output" ]; then
     echo "There are no differences between the compact execution logs of the two invocations."
 else

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -396,7 +396,7 @@ export default class InvocationModel {
    * Returns the hostname or hostname:port of the cache address used as the
    * remote cache target for this invocation.
    */
-  private getCacheAddress(): string | undefined {
+  getCacheAddress(): string | undefined {
     const prefix = this.parseBytestreamURIPrefix();
     if (prefix) {
       return prefix.host;


### PR DESCRIPTION
This will help bb explain work in dev (otherwise it just defaults to looking up the invocations in prod).