### PR TITLE
Deprecate `async` in RunRequest in favor of `wait_mode` enum

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -640,6 +640,7 @@ func (s *APIServer) Run(ctx context.Context, req *apipb.RunRequest) (*apipb.RunR
 		},
 		Steps:          steps,
 		Async:          req.GetAsync(),
+		WaitMode:       fromApiWaitMode(req.GetWaitMode()),
 		Env:            req.GetEnv(),
 		Timeout:        req.GetTimeout(),
 		ExecProperties: execProps,
@@ -651,6 +652,19 @@ func (s *APIServer) Run(ctx context.Context, req *apipb.RunRequest) (*apipb.RunR
 		return nil, err
 	}
 	return &apipb.RunResponse{InvocationId: rsp.InvocationId}, nil
+}
+
+// Converts from internal wait mode to api wait mode.
+func fromApiWaitMode(waitMode apipb.WaitMode) rnpb.WaitMode {
+	switch waitMode {
+	case apipb.WaitMode_WAIT_MODE_CREATED:
+		return rnpb.WaitMode_WAIT_MODE_CREATED
+	case apipb.WaitMode_WAIT_MODE_COMPLETE:
+		return rnpb.WaitMode_WAIT_MODE_COMPLETE
+	case apipb.WaitMode_WAIT_MODE_IMMEDIATE:
+		return rnpb.WaitMode_WAIT_MODE_IMMEDIATE
+	}
+	return rnpb.WaitMode_WAIT_MODE_CREATED
 }
 
 func (s *APIServer) CreateUserApiKey(ctx context.Context, req *apipb.CreateUserApiKeyRequest) (*apipb.CreateUserApiKeyResponse, error) {

--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//enterprise/server/remote_execution/snaputil",
         "//enterprise/server/util/ci_runner_util",
         "//enterprise/server/workflow/config",
+        "//proto:invocation_status_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:runner_go_proto",
         "//server/endpoint_urls/build_buddy_url",

--- a/proto/api/v1/remote_runner.proto
+++ b/proto/api/v1/remote_runner.proto
@@ -45,9 +45,10 @@ message RunRequest {
   // Ex. "15s", "2h"
   string timeout = 7;
 
-  // If true, start the runner but do not wait for the action to be scheduled
-  // before returning a response.
-  bool async = 8;
+  // Specifies what to wait for before returning a RunResponse.
+  // Default is value is WAIT_MODE_CREATED which waits for the invocation to
+  // be created but not necessarily completed.
+  WaitMode wait_mode = 13;
 
   // Whether to use github credentials configured on the executor.
   //
@@ -61,10 +62,26 @@ message RunRequest {
 
   // Whether to skip the automatic GitHub setup steps on the remote runner.
   bool skip_auto_checkout = 12;
+
+  // DEPRECATED: Use wait_mode instead.
+  // If true, start the runner but do not wait for the action to be scheduled
+  // before returning a response.
+  bool async = 8 [deprecated = true];
 }
 
 message Step {
   string run = 1;
+}
+
+enum WaitMode {
+  // Wait until the invocation is created but not complete.
+  WAIT_MODE_CREATED = 0;
+
+  // Wait for the invocation to complete.
+  WAIT_MODE_COMPLETE = 1;
+  
+  // Return immediately without waiting.
+  WAIT_MODE_IMMEDIATE = 2;  
 }
 
 message RunResponse {

--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -36,13 +36,15 @@ message RunRequest {
   // Arch on which to run. Defaults to "amd64".
   string arch = 8;
 
-  // If true, start the runner but do not wait for the action to be scheduled.
-  bool async = 9;
-
   // Container image to run on. Defaults to the Ubuntu 20.04 Workflows image.
   // A `docker://` prefix is required.
   // Ex. `docker://gcr.io/flame-public/rbe-ubuntu20-04`
   string container_image = 10;
+
+  // Specifies what to wait for before returning a RunResponse.
+  // Default is value is WAIT_MODE_CREATED which waits for the invocation to
+  // be created but not necessarily completed.
+  WaitMode wait_mode = 20;
 
   // Environment variables to set in the runner env.
   map<string, string> env = 11;
@@ -80,12 +82,27 @@ message RunRequest {
   // For non-idempotent workloads, set to true to disable this behavior.
   bool disable_retry = 19;
 
+  // DEPRECATED: Use wait_mode instead.
+  // If true, start the runner but do not wait for the action to be scheduled.
+  bool async = 9 [deprecated = true];
+
   // DEPRECATED: Use `steps` instead.
   string bazel_command = 4 [deprecated = true];
 }
 
 message Step {
   string run = 1;
+}
+
+enum WaitMode {
+  // Wait until the invocation is created but not complete.
+  WAIT_MODE_CREATED = 0;
+
+  // Wait for the invocation to complete.
+  WAIT_MODE_COMPLETE = 1;
+  
+  // Return immediately without waiting.
+  WAIT_MODE_IMMEDIATE = 2;  
 }
 
 message RunResponse {


### PR DESCRIPTION
Currently with the `async` bool - we only have two options:
- Return immediately
- Return once the invocation has been created (but not necessarily finished)

With the `wait_mode` enum, we can add a third option which is:
- Wait for the invocation to be completed

This is useful if you're implementing something like a bazel query service where you're only interested in the final result.