### PR TITLE
Add a mini compare button to the invocation list view

### DIFF
--- a/app/components/popup/popup.tsx
+++ b/app/components/popup/popup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export type PopupProps = JSX.IntrinsicElements["div"] & {
   isOpen: boolean;
-  onRequestClose: ((event: React.MouseEvent<HTMLElement, MouseEvent>) => void);
+  onRequestClose: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   anchor?: "left" | "right";
 };
 

--- a/app/components/popup/popup.tsx
+++ b/app/components/popup/popup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export type PopupProps = JSX.IntrinsicElements["div"] & {
   isOpen: boolean;
-  onRequestClose: () => void;
+  onRequestClose: ((event: React.MouseEvent<HTMLElement, MouseEvent>) => void);
   anchor?: "left" | "right";
 };
 

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -277,6 +277,7 @@ ts_library(
     srcs = ["invocation_compare_button.tsx"],
     deps = [
         "//:node_modules/@types/react",
+        "//:node_modules/lucide-react",
         "//:node_modules/react",
         "//:node_modules/rxjs",
         "//:node_modules/tslib",
@@ -783,6 +784,7 @@ ts_library(
         "//:node_modules/tslib",
         "//app/components/link",
         "//app/format",
+        "//app/invocation:invocation_compare_button",
         "//app/router",
         "//app/util:exit_codes",
         "//proto:invocation_status_ts_proto",

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -1482,7 +1482,7 @@ svg.invocation-query-graph .nodes rect {
 
   .comparison-buffer-illustration {
     position: absolute;
-    top: 0;
+    bottom: 0;
     right: 0;
     padding: 16px;
     margin-right: 0;
@@ -1502,4 +1502,18 @@ svg.invocation-query-graph .nodes rect {
 .target-more-buttons svg {
   height: 16px;
   color: rgba(0, 0, 0, 0.5);
+}
+
+.invocation-compare-button-container-mini {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.invocation-compare-button-container-mini .invocation-menu-button {
+  width: 40px;
+  height: 40px;
+  border: none;
+  padding: 0;
+  justify-content: center;
 }

--- a/app/invocation/invocation_card.tsx
+++ b/app/invocation/invocation_card.tsx
@@ -219,7 +219,7 @@ export default class InvocationCardComponent extends React.Component<Props, Stat
             <div className="title">{this.getTitle()}</div>
             {roleLabel && <div className={`role-badge ${this.props.invocation.role}`}>{roleLabel}</div>}
             <div className="subtitle">{format.formatTimestampUsec(this.props.invocation.createdAtUsec)}</div>
-            <InvocationCompareButton mini={true} invocationId={this.props.invocation.invocationId} />
+            {!this.props.hover && <InvocationCompareButton mini={true} invocationId={this.props.invocation.invocationId} />}
           </div>
           <div className="details">
             {!this.props.hover && (

--- a/app/invocation/invocation_card.tsx
+++ b/app/invocation/invocation_card.tsx
@@ -21,6 +21,7 @@ import Link from "../components/link/link";
 import format from "../format/format";
 import router from "../router/router";
 import { exitCode } from "../util/exit_codes";
+import InvocationCompareButton from "./invocation_compare_button";
 
 const durationRefreshIntervalMillis = 3000;
 
@@ -218,6 +219,7 @@ export default class InvocationCardComponent extends React.Component<Props, Stat
             <div className="title">{this.getTitle()}</div>
             {roleLabel && <div className={`role-badge ${this.props.invocation.role}`}>{roleLabel}</div>}
             <div className="subtitle">{format.formatTimestampUsec(this.props.invocation.createdAtUsec)}</div>
+            <InvocationCompareButton mini={true} invocationId={this.props.invocation.invocationId} />
           </div>
           <div className="details">
             {!this.props.hover && (

--- a/app/invocation/invocation_card.tsx
+++ b/app/invocation/invocation_card.tsx
@@ -219,7 +219,9 @@ export default class InvocationCardComponent extends React.Component<Props, Stat
             <div className="title">{this.getTitle()}</div>
             {roleLabel && <div className={`role-badge ${this.props.invocation.role}`}>{roleLabel}</div>}
             <div className="subtitle">{format.formatTimestampUsec(this.props.invocation.createdAtUsec)}</div>
-            {!this.props.hover && <InvocationCompareButton mini={true} invocationId={this.props.invocation.invocationId} />}
+            {!this.props.hover && (
+              <InvocationCompareButton mini={true} invocationId={this.props.invocation.invocationId} />
+            )}
           </div>
           <div className="details">
             {!this.props.hover && (

--- a/app/invocation/invocation_compare_button.tsx
+++ b/app/invocation/invocation_compare_button.tsx
@@ -1,3 +1,4 @@
+import { MoreVertical } from "lucide-react";
 import React from "react";
 import { Subscription } from "rxjs";
 import capabilities from "../capabilities/capabilities";
@@ -6,8 +7,6 @@ import Menu, { MenuItem } from "../components/menu/menu";
 import Popup from "../components/popup/popup";
 import router from "../router/router";
 import service, { IdAndModel } from "./invocation_comparison_service";
-import { OutlinedButtonGroup } from "../components/button/button_group";
-import { MoreVertical } from "lucide-react";
 
 export interface InvocationCompareButtonComponentProps {
   invocationId: string;
@@ -75,13 +74,23 @@ export default class InvocationCompareButtonComponent extends React.Component<
     }
 
     return (
-      <div className={this.props.mini ? "invocation-compare-button-container-mini" : "invocation-compare-button-container"}>
-        {!this.props.mini && <><OutlinedButton onClick={this.onClick.bind(this)}>
-          <ComparisonBufferIllustration isBuffered={Boolean(this.state.invocationIdToCompare)} />
-          <div>Compare</div>
-        </OutlinedButton></>}
-        {this.props.mini && <OutlinedButton className="invocation-menu-button"
- onClick={this.onClick.bind(this)}><MoreVertical /></OutlinedButton>}
+      <div
+        className={
+          this.props.mini ? "invocation-compare-button-container-mini" : "invocation-compare-button-container"
+        }>
+        {!this.props.mini && (
+          <>
+            <OutlinedButton onClick={this.onClick.bind(this)}>
+              <ComparisonBufferIllustration isBuffered={Boolean(this.state.invocationIdToCompare)} />
+              <div>Compare</div>
+            </OutlinedButton>
+          </>
+        )}
+        {this.props.mini && (
+          <OutlinedButton className="invocation-menu-button" onClick={this.onClick.bind(this)}>
+            <MoreVertical />
+          </OutlinedButton>
+        )}
         <Popup isOpen={this.state.isDropdownOpen} onRequestClose={this.onRequestCloseDropdown.bind(this)}>
           <Menu>
             <MenuItem onClick={this.onClickSelectForComparison.bind(this)}>Select for comparison</MenuItem>

--- a/app/invocation/invocation_compare_button.tsx
+++ b/app/invocation/invocation_compare_button.tsx
@@ -41,20 +41,20 @@ export default class InvocationCompareButtonComponent extends React.Component<
     this.setState({ invocationIdToCompare: data.id });
   }
 
-  private onClick(event: React.MouseEvent<HTMLButtonElement>) {
+  private onClick(event: React.MouseEvent<HTMLElement>) {
     this.setState({ isDropdownOpen: true });
     event.preventDefault();
     event.stopPropagation();
   }
 
-  private onClickSelectForComparison(event: React.MouseEvent<HTMLButtonElement>) {
+  private onClickSelectForComparison(event: React.MouseEvent<HTMLElement>) {
     service.setComparisonInvocation(this.props.invocationId);
     this.setState({ isDropdownOpen: false, invocationIdToCompare: this.props.invocationId });
     event.preventDefault();
     event.stopPropagation();
   }
 
-  private onClickCompareWithSelected(event: React.MouseEvent<HTMLButtonElement>) {
+  private onClickCompareWithSelected(event: React.MouseEvent<HTMLElement>) {
     const invocationIdToCompare = this.state.invocationIdToCompare;
     this.setState({ isDropdownOpen: false, invocationIdToCompare: "" });
     router.navigateTo(`/compare/${invocationIdToCompare}...${this.props.invocationId}`);
@@ -62,7 +62,7 @@ export default class InvocationCompareButtonComponent extends React.Component<
     event.stopPropagation();
   }
 
-  private onRequestCloseDropdown(event: React.MouseEvent<HTMLButtonElement>) {
+  private onRequestCloseDropdown(event: React.MouseEvent<HTMLElement>) {
     this.setState({ isDropdownOpen: false });
     event.preventDefault();
     event.stopPropagation();

--- a/app/invocation/invocation_compare_button.tsx
+++ b/app/invocation/invocation_compare_button.tsx
@@ -6,9 +6,12 @@ import Menu, { MenuItem } from "../components/menu/menu";
 import Popup from "../components/popup/popup";
 import router from "../router/router";
 import service, { IdAndModel } from "./invocation_comparison_service";
+import { OutlinedButtonGroup } from "../components/button/button_group";
+import { MoreVertical } from "lucide-react";
 
 export interface InvocationCompareButtonComponentProps {
   invocationId: string;
+  mini?: boolean;
 }
 
 interface State {
@@ -39,23 +42,31 @@ export default class InvocationCompareButtonComponent extends React.Component<
     this.setState({ invocationIdToCompare: data.id });
   }
 
-  private onClick() {
+  private onClick(event: React.MouseEvent<HTMLButtonElement>) {
     this.setState({ isDropdownOpen: true });
+    event.preventDefault();
+    event.stopPropagation();
   }
 
-  private onClickSelectForComparison() {
+  private onClickSelectForComparison(event: React.MouseEvent<HTMLButtonElement>) {
     service.setComparisonInvocation(this.props.invocationId);
     this.setState({ isDropdownOpen: false, invocationIdToCompare: this.props.invocationId });
+    event.preventDefault();
+    event.stopPropagation();
   }
 
-  private onClickCompareWithSelected() {
+  private onClickCompareWithSelected(event: React.MouseEvent<HTMLButtonElement>) {
     const invocationIdToCompare = this.state.invocationIdToCompare;
     this.setState({ isDropdownOpen: false, invocationIdToCompare: "" });
     router.navigateTo(`/compare/${invocationIdToCompare}...${this.props.invocationId}`);
+    event.preventDefault();
+    event.stopPropagation();
   }
 
-  private onRequestCloseDropdown() {
+  private onRequestCloseDropdown(event: React.MouseEvent<HTMLButtonElement>) {
     this.setState({ isDropdownOpen: false });
+    event.preventDefault();
+    event.stopPropagation();
   }
 
   render() {
@@ -64,11 +75,13 @@ export default class InvocationCompareButtonComponent extends React.Component<
     }
 
     return (
-      <div className="invocation-compare-button-container">
-        <OutlinedButton onClick={this.onClick.bind(this)}>
+      <div className={this.props.mini ? "invocation-compare-button-container-mini" : "invocation-compare-button-container"}>
+        {!this.props.mini && <><OutlinedButton onClick={this.onClick.bind(this)}>
           <ComparisonBufferIllustration isBuffered={Boolean(this.state.invocationIdToCompare)} />
           <div>Compare</div>
-        </OutlinedButton>
+        </OutlinedButton></>}
+        {this.props.mini && <OutlinedButton className="invocation-menu-button"
+ onClick={this.onClick.bind(this)}><MoreVertical /></OutlinedButton>}
         <Popup isOpen={this.state.isDropdownOpen} onRequestClose={this.onRequestCloseDropdown.bind(this)}>
           <Menu>
             <MenuItem onClick={this.onClickSelectForComparison.bind(this)}>Select for comparison</MenuItem>

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -451,7 +451,6 @@ body {
   font-size: 14px;
   display: flex;
   align-items: flex-start;
-  overflow: hidden;
   background-color: #fff;
 }
 


### PR DESCRIPTION
Currently comparing two invocations takes a lot of clicks (you have to actually click into the invocation) - this should reduce them:
<img width="1370" height="721" alt="Screenshot 2025-09-04 at 4 22 02 PM" src="https://github.com/user-attachments/assets/8c1d8578-635c-41ca-b14f-3dbed2e8896c" />
