### PR TITLE
[raft] stop replica when the partition descriptor is marked soft deleted

### DIFF
--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -715,7 +715,6 @@ func (bq *baseQueue) Stop() {
 }
 
 func (bq *baseQueue) processQueue() {
-	bq.log.Info("processQueue")
 	if bq.Len() == 0 {
 		return
 	}

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["store.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/store",
     deps = [
+        "//enterprise/server/filestore",
         "//enterprise/server/raft/bringup",
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/config",


### PR DESCRIPTION
Stop the replica in zombie janitor when the partition descriptor is marked soft
delete.

The data is not removed, so when the server is restarted, the shard will be
opened again; and stopped again by zombie janitor.

Also reads the partition from meta range in zombie janitor, and skip the range
IDs that are in the middle of partition set up.
