### PR TITLE
Fix tools/cas resource name parsing

### DIFF
--- a/tools/cas/cas.go
+++ b/tools/cas/cas.go
@@ -82,7 +82,7 @@ func main() {
 
 	// For backwards compatibility, attempt to fixup old style digest
 	// strings that don't start with a '/blobs/' prefix.
-	if !strings.HasPrefix(resourceNameString, "/blobs") {
+	if !strings.Contains(resourceNameString, "/blobs/") {
 		resourceNameString = "/blobs/" + resourceNameString
 	}
 


### PR DESCRIPTION
The current logic doesn't work if the resource name has an instance name prefix (hit this while trying to get logs from a self-hosted workflow execution)