### PR TITLE
Make sure we don't drop out of the `scheduleRefetch` loop

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -300,6 +300,9 @@ export default class InvocationComponent extends React.Component<Props, State> {
 
       await this.fetchInvocation();
       this.timeoutRef = undefined;
+      if (this.state.model?.isInProgress() || this.isQueued()) {
+        this.scheduleRefetch();
+      }
     }, 3000);
   }
 
@@ -344,6 +347,8 @@ export default class InvocationComponent extends React.Component<Props, State> {
       .then((response) => {
         const runnerExecution = response.execution?.[response.execution.length - 1] ?? undefined;
         this.setState({ runnerExecution });
+      }).catch((e) => {
+        console.error("Failed to fetch runner execution", e);
       });
     return this.runnerExecutionRPC;
   }

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -350,6 +350,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
       })
       .catch((e) => {
         console.error("Failed to fetch runner execution", e);
+        this.setState({ runnerExecution: undefined });
       });
     return this.runnerExecutionRPC;
   }

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -347,7 +347,8 @@ export default class InvocationComponent extends React.Component<Props, State> {
       .then((response) => {
         const runnerExecution = response.execution?.[response.execution.length - 1] ?? undefined;
         this.setState({ runnerExecution });
-      }).catch((e) => {
+      })
+      .catch((e) => {
         console.error("Failed to fetch runner execution", e);
       });
     return this.runnerExecutionRPC;


### PR DESCRIPTION
Currently depending on ordering of componentDidUpdate calls, we have a chance of dropping out of this loop and stopping our periodic UI refreshes.