### PR TITLE
Add a `tools/fix` target using rules_multirun

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -114,6 +114,7 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "toolchains_musl", version = "0.1.15")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
+bazel_dep(name = "rules_multirun", version = "0.13.0")
 
 ## Included extensions
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -682,3 +682,9 @@ load_musl_toolchains(
 load("@musl_toolchains//:toolchains.bzl", "register_musl_toolchains")
 
 register_musl_toolchains()
+
+http_archive(
+    name = "rules_multirun",
+    sha256 = "a203b9f098297b8e5b38e8e746d3f9e55ce2687a76a18599ae0b3fbf8359a7eb",
+    url = "https://github.com/keith/rules_multirun/releases/download/0.13.0/rules_multirun.0.13.0.tar.gz",
+)

--- a/tools/fix/BUILD
+++ b/tools/fix/BUILD
@@ -1,0 +1,9 @@
+load("@rules_multirun//:defs.bzl", "command")
+
+package(default_visibility = ["//visibility:public"])
+
+command(
+    name = "fix",
+    arguments = ["-fix"],
+    command = "//tools/lint",
+)


### PR DESCRIPTION
This just calls tools/lint with the `-fix` flag set.

A convenience alias so you can run `bb run tools/fix` instead of `bb run tools/lint -- -fix`