### PR TITLE
Remove Role from GroupMembership.

### DIFF
--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -318,9 +318,6 @@ func TestGetAPIKeyGroupFromAPIKey(t *testing.T) {
 				{
 					GroupID:      randKey.GroupID,
 					Capabilities: capabilities.FromInt(randKey.Capabilities),
-					// TODO(bduffany): API keys should not have roles - just
-					// capabilities.
-					Role: role.Developer,
 				},
 			}, c.GetGroupMemberships())
 

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -43,7 +43,6 @@ go_library(
         "//server/tables",
         "//server/util/clickhouse/schema",
         "//server/util/proto",
-        "//server/util/role",
         "@com_github_golang_jwt_jwt_v4//:jwt",
         "@com_github_google_go_github_v59//github",
         "@com_github_hashicorp_serf//serf",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
-	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-github/v59/github"
 	"github.com/hashicorp/serf/serf"
@@ -88,8 +87,6 @@ type BasicAuthToken interface {
 type GroupMembership struct {
 	GroupID      string             `json:"group_id"`
 	Capabilities []cappb.Capability `json:"capabilities"`
-	// DEPRECATED. Check Capabilities instead.
-	Role role.Role `json:"role"`
 }
 
 type APIKeyInfo struct {

--- a/server/testutil/testauth/BUILD
+++ b/server/testutil/testauth/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//server/util/capabilities",
         "//server/util/claims",
         "//server/util/log",
-        "//server/util/role",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",
     ],

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -11,7 +11,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"google.golang.org/grpc/metadata"
 
@@ -41,7 +40,6 @@ func User(userID, groupID string) *TestUser {
 			{
 				GroupID:      groupID,
 				Capabilities: capabilities.DefaultAuthenticatedUserCapabilities,
-				Role:         role.Admin,
 			},
 		},
 		Capabilities: capabilities.DefaultAuthenticatedUserCapabilities,

--- a/server/util/claims/BUILD
+++ b/server/util/claims/BUILD
@@ -33,7 +33,6 @@ go_test(
         "//server/util/authutil",
         "//server/util/capabilities",
         "//server/util/request_context",
-        "//server/util/role",
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",

--- a/server/util/claims/claims_test.go
+++ b/server/util/claims/claims_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
-	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
@@ -117,7 +116,6 @@ func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {
 	expectedBaseMembership := &interfaces.GroupMembership{
 		GroupID:      baseGroupID,
 		Capabilities: caps,
-		Role:         role.Default,
 	}
 	require.Equal(t, baseGroupID, c.GetGroupID())
 	require.Equal(t, []string{baseGroupID}, c.GetAllowedGroups())
@@ -153,7 +151,6 @@ func TestAPIKeyGroupClaimsWithRequestContext(t *testing.T) {
 	expectedChildMembership := &interfaces.GroupMembership{
 		GroupID:      childGroupID,
 		Capabilities: caps,
-		Role:         role.Default,
 	}
 	require.Equal(t, baseGroupID, c.GetGroupID())
 	require.Equal(t, baseGroupID, c.GetAPIKeyInfo().OwnerGroupID)


### PR DESCRIPTION
Most call sites were already updated to use capabilities, this cleans up a straggler.