### PR TITLE
Store original_pool in ClickHouse

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -375,6 +375,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 				executionProto.RequestedMemoryBytes = properties.EstimatedMemoryBytes
 				executionProto.RequestedMilliCpu = properties.EstimatedMilliCPU
 				executionProto.RequestedFreeDiskBytes = properties.EstimatedFreeDiskBytes
+				executionProto.OriginalPool = properties.OriginalPool
 			}
 
 			schedulingMeta := auxMeta.GetSchedulingMetadata()

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2797,6 +2797,7 @@ message StoredExecution {
   // Executor metadata
   bool self_hosted = 58;
   string region = 59;
+  string original_pool = 73;
 
   // IO Stats
   int64 file_download_count = 9;

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -212,6 +212,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) *s
 		ExecutorHostname:                   in.GetExecutorHostname(),
 		SelfHosted:                         in.GetSelfHosted(),
 		Region:                             in.GetRegion(),
+		OriginalPool:                       in.GetOriginalPool(),
 		Stage:                              in.GetStage(),
 		FileDownloadCount:                  in.GetFileDownloadCount(),
 		FileDownloadSizeBytes:              in.GetFileDownloadSizeBytes(),

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -159,8 +159,10 @@ type Execution struct {
 	ExecutorHostname   string
 
 	// Executor metadata
-	SelfHosted bool
-	Region     string `gorm:"type:LowCardinality(String)"`
+	SelfHosted   bool
+	Region       string `gorm:"type:LowCardinality(String)"`
+	OriginalPool string // non-BB pool (for routing/analysis purposes)
+	// TODO: Pool
 
 	Stage int64
 
@@ -325,6 +327,7 @@ func (e *Execution) AdditionalFields() []string {
 		"EffectiveTimeoutUsec",
 		"Region",
 		"SelfHosted",
+		"OriginalPool",
 		"ExecutorHostname",
 		"Experiments",
 	}


### PR DESCRIPTION
Store original pool so that we can break down execution performance (using ad-hoc clickhouse queries) according to the original RE pool name from non-BB platforms.

This is a pretty niche property so it kind of sucks to add an explicit column for it, but right now it seems preferable to something more generic (like storing the entire platform proto in the Executions table or something like that). If we don't get much use out of this beyond the immediate use case, it's easy enough to just delete this column later.