### PR TITLE
gosdk: upgrade to 1.25.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -250,7 +250,7 @@ register_toolchains(
 )
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.24.5")
+go_sdk.download(version = "1.25.0")
 go_sdk.nogo(nogo = "@//:vet")
 use_repo(
     go_sdk,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -190,7 +190,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_nogo", "
 
 go_rules_dependencies()
 
-GO_SDK_VERSION = "1.24.5"
+GO_SDK_VERSION = "1.25.0"
 
 # Register multiple Go SDKs so that we can perform cross-compilation remotely.
 # i.e. We might want to trigger a Linux AMD64 Go build remotely from a MacOS ARM64 laptop.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbuddy-io/buildbuddy
 
-go 1.24.5
+go 1.25.0
 
 replace (
 	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.9.0-buildbuddy // keep in sync with buildpatches/com_github_awslabs_soci_snapshotter.patch


### PR DESCRIPTION
Now that we have upgraded rules_go and gazelle, we can upgrade GoSDK to
the latest version.
