### PR TITLE
Fix chained incremental backups not working

### DIFF
--- a/enterprise/tools/clickhouse_backup/clickhouse_backup.go
+++ b/enterprise/tools/clickhouse_backup/clickhouse_backup.go
@@ -237,9 +237,9 @@ func runRestore(ctx context.Context, env environment.Env) error {
 }
 
 func backupExists(ctx context.Context, env environment.Env, backupName, databaseName string) (bool, error) {
-	blobName := backupName + "/metadata/" + databaseName + ".sql"
-	log.Infof("Checking if backup %q exists", blobName)
-	return env.GetBlobstore().BlobExists(ctx, blobName)
+	backupMarkerBlobName := backupName + "/.backup"
+	log.Infof("Checking if backup %q exists", backupMarkerBlobName)
+	return env.GetBlobstore().BlobExists(ctx, backupMarkerBlobName)
 }
 
 func backtickQuote(s string) string {


### PR DESCRIPTION
We're checking whether the previous day's backup exists by looking for the DB metadata file, but this file doesn't seem to get created for incremental backups. As a result, we're taking a full backup every other day, instead of creating a longer chain of incremental backups where each one is based on the previous day.

Check for `.backup` instead, which gets created for both full and incremental backups.