### PR TITLE
Fix pebble_cache.Delete

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1840,7 +1840,6 @@ func (p *PebbleCache) deleteFileAndMetadata(ctx context.Context, key filestore.P
 	if err != nil {
 		return err
 	}
-
 	// N.B. This deletes the file metadata. Because inlined files are stored
 	// with their metadata, this means we don't need to delete the metadata
 	// again below in the switch statement.
@@ -1920,13 +1919,12 @@ func (p *PebbleCache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 
 	md := sgpb.FileMetadataFromVTPool()
 	defer md.ReturnToVTPool()
-	err = p.lookupFileMetadata(ctx, db, key, md)
+	version, err := p.lookupFileMetadataAndVersion(ctx, db, key, md)
 	if err != nil {
 		return err
 	}
 
-	// TODO(tylerw): Make version aware.
-	if err := p.deleteFileAndMetadata(ctx, key, filestore.UndefinedKeyVersion, md); err != nil {
+	if err := p.deleteFileAndMetadata(ctx, key, version, md); err != nil {
 		log.Errorf("[%s] Error deleting old record %q: %s", p.name, key.String(), err)
 		return err
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -807,6 +807,19 @@ func TestReadWrite(t *testing.T) {
 				require.NoError(t, err, "Error getting %q reader", rn.GetDigest().GetHash())
 				d2 := testdigest.ReadDigestAndClose(t, reader)
 				require.Equal(t, rn.GetDigest().GetHash(), d2.GetHash())
+
+				contains, err := pc.Contains(ctx, rn)
+				require.NoError(t, err)
+				require.True(t, contains)
+
+				require.NoError(t, pc.Delete(ctx, rn))
+
+				_, err = pc.Reader(ctx, rn, 0, 0)
+				require.True(t, status.IsNotFoundError(err), "error should be NotFound but is %v", err)
+
+				contains, err = pc.Contains(ctx, rn)
+				require.NoError(t, err)
+				require.False(t, contains)
 			})
 		}
 	}


### PR DESCRIPTION
The previous version would delete the file (if there was one) but keep the metadata because it was using the wrong key version.