### PR TITLE
[oci] keep thread-safe LRU cache for ResolveImageDigest(...)

### DIFF
--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//server/util/claims",
         "//server/util/flag",
         "//server/util/log",
+        "//server/util/lru",
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_distribution_reference//:reference",
@@ -28,6 +29,7 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
         "@com_github_google_go_containerregistry//pkg/v1/types",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -60,6 +60,7 @@ go_test(
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/empty",
         "@com_github_google_go_containerregistry//pkg/v1/mutate",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocicache"
@@ -21,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/distribution/reference"
@@ -29,12 +31,19 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/jonboulle/clockwork"
 
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	gcrname "github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+const (
+	// resolveImageDigestLRUMaxEntries limits the number of entries in the image-tag-to-digest cache.
+	resolveImageDigestLRUMaxEntries = 1000
+	resolveImageDigestLRUDuration   = time.Minute * 15
 )
 
 var (
@@ -237,10 +246,18 @@ func (c Credentials) Equals(o Credentials) bool {
 	return c.Username == o.Username && c.Password == o.Password
 }
 
+type tagToDigestEntry struct {
+	nameWithDigest string
+	expiration     time.Time
+}
+
 type Resolver struct {
 	env environment.Env
 
 	allowedPrivateIPs []*net.IPNet
+
+	imageTagToDigestLRU *lru.LRU[tagToDigestEntry]
+	clock               clockwork.Clock
 }
 
 func NewResolver(env environment.Env) (*Resolver, error) {
@@ -252,7 +269,19 @@ func NewResolver(env environment.Env) (*Resolver, error) {
 		}
 		allowedPrivateIPNets = append(allowedPrivateIPNets, ipNet)
 	}
-	return &Resolver{env: env, allowedPrivateIPs: allowedPrivateIPNets}, nil
+	imageTagToDigestLRU, err := lru.NewLRU[tagToDigestEntry](&lru.Config[tagToDigestEntry]{
+		SizeFn:  func(_ tagToDigestEntry) int64 { return 1 },
+		MaxSize: int64(resolveImageDigestLRUMaxEntries),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Resolver{
+		env:                 env,
+		imageTagToDigestLRU: imageTagToDigestLRU,
+		allowedPrivateIPs:   allowedPrivateIPNets,
+		clock:               env.GetClock(),
+	}, nil
 }
 
 // AuthenticateWithRegistry makes a HEAD request to a remote registry with the input credentials.
@@ -285,6 +314,8 @@ func (r *Resolver) AuthenticateWithRegistry(ctx context.Context, imageName strin
 // If the input image name includes a digest, a canonicalized version of the name is returned.
 // If the input image name refers to a tag (either explictly or implicity), ResolveImageDigest
 // will make a HEAD request to the remote registry.
+// ResolveImageDigest keeps an LRU cache that maps between canonical image names with tags
+// to image names with digests, to reduce the number of HEAD requests.
 func (r *Resolver) ResolveImageDigest(ctx context.Context, imageName string, platform *rgpb.Platform, credentials Credentials) (string, error) {
 	if imageRefWithDigest, err := gcrname.NewDigest(imageName); err == nil {
 		return imageRefWithDigest.String(), nil
@@ -292,6 +323,14 @@ func (r *Resolver) ResolveImageDigest(ctx context.Context, imageName string, pla
 	tagRef, err := gcrname.ParseReference(imageName)
 	if err != nil {
 		return "", status.InvalidArgumentErrorf("invalid image name %q", imageName)
+	}
+
+	if entry, ok := r.imageTagToDigestLRU.Get(tagRef.String()); ok {
+		if entry.expiration.After(r.clock.Now()) {
+			return entry.nameWithDigest, nil
+		}
+		// Expired; evict and refresh via remote.Head below.
+		r.imageTagToDigestLRU.Remove(tagRef.String())
 	}
 
 	remoteOpts := r.getRemoteOpts(ctx, platform, credentials)
@@ -303,6 +342,11 @@ func (r *Resolver) ResolveImageDigest(ctx context.Context, imageName string, pla
 		return "", status.UnavailableErrorf("could not authorize to remote registry: %s", err)
 	}
 	imageNameWithDigest := tagRef.Context().Digest(desc.Digest.String()).String()
+	entry := tagToDigestEntry{
+		nameWithDigest: imageNameWithDigest,
+		expiration:     r.clock.Now().Add(resolveImageDigestLRUDuration),
+	}
+	r.imageTagToDigestLRU.Add(tagRef.String(), entry)
 	return imageNameWithDigest, nil
 }
 

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
@@ -34,6 +35,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1062,4 +1064,172 @@ func TestResolveImageDigest_AlreadyDigest_NoHTTPRequests(t *testing.T) {
 	require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
 
 	require.Empty(t, counter.snapshot())
+}
+
+func TestResolveImageDigest_CacheHit_NoHTTPRequests(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
+
+	counter := newRequestCounter()
+	registry := testregistry.Run(t, testregistry.Opts{
+		HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+			counter.Inc(r)
+			return true
+		},
+	})
+
+	imageName := "cache_hit"
+	_, img := registry.PushNamedImage(t, imageName)
+	pushedDigest, err := img.Digest()
+	require.NoError(t, err)
+	nameToResolve := registry.ImageAddress(imageName)
+
+	resolver := newResolver(t, te)
+
+	{
+		counter.reset()
+		nameWithDigest, err := resolver.ResolveImageDigest(
+			context.Background(),
+			nameToResolve,
+			oci.RuntimePlatform(),
+			oci.Credentials{},
+		)
+		require.NoError(t, err)
+		resolvedDigest, err := name.NewDigest(nameWithDigest)
+		require.NoError(t, err)
+		require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
+
+		expectedRequests := map[string]int{
+			http.MethodGet + " /v2/":                                    1,
+			http.MethodHead + " /v2/" + imageName + "/manifests/latest": 1,
+		}
+		require.Empty(t, cmp.Diff(expectedRequests, counter.snapshot()))
+	}
+
+	{
+		counter.reset()
+		nameWithDigest, err := resolver.ResolveImageDigest(
+			context.Background(),
+			nameToResolve,
+			oci.RuntimePlatform(),
+			oci.Credentials{},
+		)
+		require.NoError(t, err)
+
+		resolvedDigest, err := name.NewDigest(nameWithDigest)
+		require.NoError(t, err)
+		require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
+
+		require.Empty(t, counter.snapshot())
+	}
+
+	{
+		ref, err := name.ParseReference(nameToResolve)
+		require.NoError(t, err)
+		registryAndRepoNoTag := ref.Context().String()
+		counter.reset()
+		nameWithDigest, err := resolver.ResolveImageDigest(
+			context.Background(),
+			registryAndRepoNoTag,
+			oci.RuntimePlatform(),
+			oci.Credentials{},
+		)
+		require.NoError(t, err)
+
+		resolvedDigest, err := name.NewDigest(nameWithDigest)
+		require.NoError(t, err)
+		require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
+
+		require.Empty(t, counter.snapshot())
+	}
+}
+
+func TestResolveImageDigest_CacheExpiration(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
+
+	counter := newRequestCounter()
+	registry := testregistry.Run(t, testregistry.Opts{
+		HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+			counter.Inc(r)
+			return true
+		},
+	})
+
+	imageName := "cache_expiration"
+	_, img := registry.PushNamedImage(t, imageName)
+	pushedDigest, err := img.Digest()
+	require.NoError(t, err)
+	nameToResolve := registry.ImageAddress(imageName)
+
+	fakeClock := clockwork.NewFakeClock()
+	te.SetClock(fakeClock)
+	resolver := newResolver(t, te)
+
+	counter.reset()
+	nameWithDigest, err := resolver.ResolveImageDigest(
+		context.Background(),
+		nameToResolve,
+		oci.RuntimePlatform(),
+		oci.Credentials{},
+	)
+	require.NoError(t, err)
+	resolvedDigest, err := name.NewDigest(nameWithDigest)
+	require.NoError(t, err)
+	require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
+
+	expectedFirst := map[string]int{
+		http.MethodGet + " /v2/":                                    1,
+		http.MethodHead + " /v2/" + imageName + "/manifests/latest": 1,
+	}
+	require.Empty(t, cmp.Diff(expectedFirst, counter.snapshot()))
+
+	// 2) Immediate resolve should be a cache hit; no HTTP requests.
+	counter.reset()
+	nameWithDigest, err = resolver.ResolveImageDigest(
+		context.Background(),
+		nameToResolve,
+		oci.RuntimePlatform(),
+		oci.Credentials{},
+	)
+	require.NoError(t, err)
+	resolvedDigest, err = name.NewDigest(nameWithDigest)
+	require.NoError(t, err)
+	require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
+	require.Empty(t, counter.snapshot())
+
+	// 3) Advance time to just before TTL expiry; still a cache hit.
+	fakeClock.Advance(15*time.Minute - time.Second)
+	counter.reset()
+	nameWithDigest, err = resolver.ResolveImageDigest(
+		context.Background(),
+		nameToResolve,
+		oci.RuntimePlatform(),
+		oci.Credentials{},
+	)
+	require.NoError(t, err)
+	resolvedDigest, err = name.NewDigest(nameWithDigest)
+	require.NoError(t, err)
+	require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
+	require.Empty(t, counter.snapshot())
+
+	// 4) Advance past TTL; expect cache refresh (GET /v2/ and HEAD manifest).
+	fakeClock.Advance(2 * time.Second)
+	counter.reset()
+	nameWithDigest, err = resolver.ResolveImageDigest(
+		context.Background(),
+		nameToResolve,
+		oci.RuntimePlatform(),
+		oci.Credentials{},
+	)
+	require.NoError(t, err)
+	resolvedDigest, err = name.NewDigest(nameWithDigest)
+	require.NoError(t, err)
+	require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
+
+	expectedRefresh := map[string]int{
+		http.MethodGet + " /v2/":                                    1,
+		http.MethodHead + " /v2/" + imageName + "/manifests/latest": 1,
+	}
+	require.Empty(t, cmp.Diff(expectedRefresh, counter.snapshot()))
 }


### PR DESCRIPTION
This change re-adds an LRU cache to `oci.Resolver.ResolveImageDigest(...)`, this time with a mutex protecting LRU calls (the `lru` package is not thread-safe).

There are still no callers for `ResolveImageDigest`.