### PR TITLE
Validate default_isolation_type flag

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -583,6 +583,20 @@ func GetExecutorProperties() *ExecutorProperties {
 	return p
 }
 
+func ValidateIsolationTypes() error {
+	if *defaultIsolationType == "" {
+		return nil
+	}
+	if !slices.Contains(KnownContainerTypes, ContainerType(*defaultIsolationType)) {
+		return status.InvalidArgumentErrorf("the configured 'default_isolation_type' %q is invalid. Valid values: %v", *defaultIsolationType, KnownContainerTypes)
+	}
+	executorProps := GetExecutorProperties()
+	if !executorProps.SupportsIsolation(ContainerType(*defaultIsolationType)) {
+		return status.InvalidArgumentErrorf("the configured 'default_isolation_type' %q is not enabled for this executor. Enabled isolation types: %v", *defaultIsolationType, executorProps.SupportedIsolationTypes)
+	}
+	return nil
+}
+
 // ApplyOverrides modifies the platformProps and command as needed to match the
 // locally configured executor properties.
 func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, platformProps *Properties, command *repb.Command) error {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -574,6 +574,11 @@ type pool struct {
 }
 
 func NewPool(env environment.Env, cacheRoot string, opts *PoolOptions) (*pool, error) {
+	// Validate configured isolation types.
+	if err := platform.ValidateIsolationTypes(); err != nil {
+		return nil, status.WrapError(err, "invalid configuration")
+	}
+
 	hc := env.GetHealthChecker()
 	if hc == nil {
 		return nil, status.FailedPreconditionError("Missing health checker")


### PR DESCRIPTION
Context: https://buildbuddy-corp.slack.com/archives/C091JA2J1RU/p1757519819422909?thread_ts=1757469653.024489&cid=C091JA2J1RU

Based on the error message and the provided invocation link (specifically the platform props shown for the failing executions), it looks like the customer has `default_isolation_type: oci` configured, but not `enable_oci: true`. This is a configuration error that we can surface in a more obvious way.