### PR TITLE
treat empty timestamps as invalid for rendering durations

### DIFF
--- a/app/invocation/invocation_execution_util.tsx
+++ b/app/invocation/invocation_execution_util.tsx
@@ -48,11 +48,15 @@ export function getExecutionStatus(execution: execution_stats.Execution): Execut
   return STATUSES_BY_STAGE[execution.stage];
 }
 
+function isZeroTimestamp(ts: google_ts.protobuf.ITimestamp) {
+  return !ts.seconds && !ts.nanos;
+}
+
 export function subtractTimestamp(
   timestampA?: google_ts.protobuf.ITimestamp | null,
   timestampB?: google_ts.protobuf.ITimestamp | null
 ) {
-  if (!timestampA || !timestampB) return NaN;
+  if (!timestampA || !timestampB || isZeroTimestamp(timestampA) || isZeroTimestamp(timestampB)) return NaN;
   let microsA = +(timestampA.seconds ?? 0) * 1000000 + +(timestampA.nanos ?? 0) / 1000;
   let microsB = +(timestampB.seconds ?? 0) * 1000000 + +(timestampB.nanos ?? 0) / 1000;
   return microsA - microsB;


### PR DESCRIPTION
this fixes very long durations in cases where one timestamp is not defined.  i don't really think there's a legitimate case where we genuinely want to subtract a zero timestamp to get a duration.