### PR TITLE
Add default line length for emulated terminal for build logs

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -105,6 +105,8 @@ const (
 	// finalized data to Clickhouse, expire it after this TTL so that even if Clickhouse
 	// has replication lag, clients will still be able to read the data from Redis.
 	expireRedisExecutionsTTL = 5 * time.Minute
+
+	defaultTerminalLineLength = 300
 )
 
 var (
@@ -197,6 +199,7 @@ func (b *BuildEventHandler) OpenChannel(ctx context.Context, iid string) (interf
 		hasReceivedEventWithOptions: false,
 		hasReceivedStartedEvent:     false,
 		bufferedEvents:              make([]*inpb.InvocationEvent, 0),
+		requestedTerminalColumns:    defaultTerminalLineLength,
 		logWriter:                   nil,
 		onClose:                     onClose,
 		attempt:                     1,


### PR DESCRIPTION
Sometimes we do not receive the build event containing the terminal line length before we are forced to begin logging, and we should have a sane default for that. We were falling back to the max length before this PR, which is 2000, but that resulted in too few max line lines, since that is governed by max window size / max line length, so we were getting the "leaving behind lines" behavior in this case.
