### PR TITLE
Make LookupUserFromSubID slightly easier to understand.

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -500,10 +500,9 @@ func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables
 			LIMIT 1
 		) AS u
 			LEFT JOIN "UserGroups" AS ug
-				ON u.user_id = ug.user_user_id
+				ON u.user_id = ug.user_user_id AND ug.membership_status = ?
 			LEFT JOIN "Groups" AS g
 				ON ug.group_group_id = g.group_id
-		AND (ug.membership_status = ? OR ug.user_user_id IS NULL)
 		ORDER BY u.user_id, g.group_id ASC
 		`, subID, int32(grpb.GroupMembershipStatus_MEMBER),
 	)


### PR DESCRIPTION
 - Move the membership_status filter expression to the table join that contains that column.

 - Remove the `OR ug.user_user_id IS NULL` filter. I think the idea here was to make sure we always return the user fields even if the joins don't return any rows but that should already be the case as long as the filter is part of the JOIN ON clause and not part of the WHERE clause.