### PR TITLE
Make role field in GroupRole optional.

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -533,7 +533,7 @@ func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables
 		if err != nil {
 			return nil, status.WrapError(err, "could not convert role to capabilities")
 		}
-		user.Groups = append(user.Groups, &tables.GroupRole{Group: *v.Group, Role: v.UserGroup.Role, Capabilities: caps})
+		user.Groups = append(user.Groups, &tables.GroupRole{Group: *v.Group, Role: &v.UserGroup.Role, Capabilities: caps})
 	}
 	return user, nil
 }

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -528,7 +528,8 @@ func TestLookupUserFromSubID(t *testing.T) {
 
 		// The new user is an admin in the new group but the user we added as a member should
 		// only be added as a developer.
-		u.Groups[0].Role = uint32(role.Developer)
+		r := uint32(role.Developer)
+		u.Groups[0].Role = &r
 		u.Groups[0].Capabilities = role.DeveloperCapabilities
 		user.Groups = append(user.Groups, u.Groups[0])
 	}

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -869,7 +869,7 @@ func usersFromUserGroupJoin(ugj []*userGroupJoin) ([]*tables.User, error) {
 		if err != nil {
 			return nil, status.WrapError(err, "could not convert role to capabilities")
 		}
-		user.Groups = append(user.Groups, &tables.GroupRole{Group: *v.Group, Role: v.UserGroup.Role, Capabilities: caps})
+		user.Groups = append(user.Groups, &tables.GroupRole{Group: *v.Group, Role: &v.UserGroup.Role, Capabilities: caps})
 	}
 	return users, nil
 }
@@ -943,7 +943,8 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 	}
 	// Grant admin role within the impersonated group.
 	gr.Capabilities = role.AdminCapabilities
-	gr.Role = uint32(role.Admin)
+	r := uint32(role.Admin)
+	gr.Role = &r
 	user.Groups = []*tables.GroupRole{gr}
 	return user, nil
 }

--- a/enterprise/server/scim/BUILD
+++ b/enterprise/server/scim/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/interfaces",
         "//server/real_environment",
         "//server/tables",
+        "//server/util/alert",
         "//server/util/log",
         "//server/util/role",
         "//server/util/status",

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -283,7 +283,7 @@ func (ug *UserGroup) TableName() string {
 type GroupRole struct {
 	Group
 	// Deprecated. Don't reference this in any new code!
-	Role         uint32
+	Role         *uint32
 	Capabilities []cappb.Capability
 }
 


### PR DESCRIPTION
With the introduction of indirect memberships, a user could have more than one role assigned. In those cases, we'll not populate the role at all.

SCIM is the last remaining user of the role field and will only look at direct memberships for user attributes in which case it can continue to use the role field until everyone has been migrated to use uesr lists.