### PR TITLE
More replay_action tweaks

### DIFF
--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -27,6 +27,7 @@ var (
 	signingKey = flag.String("app.client_identity.key", "", "The key used to sign and verify identity JWTs.", flag.Secret)
 	client     = flag.String("app.client_identity.client", "", "The client identifier to place in the identity header.")
 	origin     = flag.String("app.client_identity.origin", "", "The origin identifier to place in the identity header.")
+	expiration = flag.Duration("app.client_identity.expiration", DefaultExpiration, "The expiration time for the identity header.")
 	required   = flag.Bool("app.client_identity.required", false, "If set, a client identity is required.")
 )
 
@@ -82,7 +83,7 @@ func (s *Service) AddIdentityToContext(ctx context.Context) (context.Context, er
 	header, err := s.IdentityHeader(&interfaces.ClientIdentity{
 		Origin: *origin,
 		Client: *client,
-	}, DefaultExpiration)
+	}, *expiration)
 	if err != nil {
 		return ctx, err
 	}


### PR DESCRIPTION
- Fix clientidentity JWT expiration (5 minutes is too short for long-running replay attempts, so add a flag for it and set it to 6h for replay_action)
- Add comment about setting `--oci.cache.secret` (necessary in order for cached image AC keys to match prod)
- Dedupe container-image copying (speeds up replays significantly)
- When replaying all executions from an invocation, replay in order of queued timestamp (makes replays match the original invocation more closely and probably increases the likelihood of reproducing issues from the invocation)
- Reduce noisiness of some log messages (change level from info => debug)