### PR TITLE
ci_runner: disable interactive git credential prompts

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1986,7 +1986,7 @@ func (ws *workspace) config(ctx context.Context) error {
 		{"user.email", "ci-runner@buildbuddy.io"},
 		{"user.name", "BuildBuddy"},
 		{"advice.detachedHead", "false"},
-		[]string{"credential.interactive", "false"},
+		{"credential.interactive", "false"},
 		// With the version of git that we have installed in the CI runner
 		// image, --filter=blob:none requires the partialClone extension to be
 		// enabled.


### PR DESCRIPTION
In a CI runner environment, Git operations must be non-interactive.
Setting `credential.interactive` to `false` ensures that Git will
not attempt to prompt for credentials, which would otherwise hang
the runner process if credentials were not available through other
means (e.g., credential helpers).
