### PR TITLE
[remote exec] log container image names after resolving to digest

### DIFF
--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -366,7 +366,7 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image %q", imageName)
 	}
-	log.CtxInfof(ctx, "Resolving image in registry %q", imageRef.Context().RegistryStr())
+	log.CtxInfof(ctx, "Resolving image %q", imageRef)
 
 	remoteOpts := r.getRemoteOpts(ctx, platform, credentials)
 	puller, err := remote.NewPuller(remoteOpts...)


### PR DESCRIPTION
Once `executor.resolve_image_digests` is set to true, we should no longer see image names with tags in the logs. Make sure to log after resolving image names to digests.