### PR TITLE
[RB] Deprecate duplicate os and arch fields on internal run API

### DIFF
--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -30,12 +30,6 @@ message RunRequest {
   // be routed to.
   string session_affinity_key = 6;
 
-  // OS on which to run. Defaults to "linux".
-  string os = 7;
-
-  // Arch on which to run. Defaults to "amd64".
-  string arch = 8;
-
   // Container image to run on. Defaults to the Ubuntu 20.04 Workflows image.
   // A `docker://` prefix is required.
   // Ex. `docker://gcr.io/flame-public/rbe-ubuntu20-04`
@@ -88,6 +82,13 @@ message RunRequest {
 
   // DEPRECATED: Use `steps` instead.
   string bazel_command = 4 [deprecated = true];
+
+  // DEPRECATED: Set OS and arch using the `exec_properties` named `os` and `arch`.
+  string os = 7 [deprecated = true];
+
+  // Arch on which to run. Defaults to "amd64".
+  string arch = 8 [deprecated = true];
+
 }
 
 message Step {


### PR DESCRIPTION
Also fixes a bug where we only look at the top-level request field and not the platform properties

Slack thread: https://buildbuddy-corp.slack.com/archives/C07SND71EDC/p1757692647960079