### PR TITLE
[cli] pull out `bb` package in order to test `InterpretAsBBCliCommand`

### DIFF
--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "bb_lib",
@@ -35,16 +35,29 @@ go_library(
     ],
 )
 
+go_test(
+    name = "bb_test",
+    srcs = ["bb_test.go"],
+    embed = [":bb_lib"],
+    deps = [
+        "//cli/cli_command/register",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
 go_binary(
     name = "bb",
-    embed = [":bb_lib"],
+    srcs = ["main.go"],
+    deps = [":bb_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_binary(
     name = "bb-darwin-amd64",
     out = "bb-darwin-amd64",
-    embed = [":bb_lib"],
+    srcs = ["main.go"],
+    deps = [":bb_lib"],
     gc_linkopts = [
         "-s",
         "-w",
@@ -59,7 +72,8 @@ go_binary(
 go_binary(
     name = "bb-darwin-arm64",
     out = "bb-darwin-arm64",
-    embed = [":bb_lib"],
+    srcs = ["main.go"],
+    deps = [":bb_lib"],
     gc_linkopts = [
         "-s",
         "-w",
@@ -74,7 +88,8 @@ go_binary(
 go_binary(
     name = "bb-linux-amd64",
     out = "bb-linux-amd64",
-    embed = [":bb_lib"],
+    srcs = ["main.go"],
+    deps = [":bb_lib"],
     gc_linkopts = [
         "-s",
         "-w",
@@ -89,7 +104,8 @@ go_binary(
 go_binary(
     name = "bb-linux-arm64",
     out = "bb-linux-arm64",
-    embed = [":bb_lib"],
+    srcs = ["main.go"],
+    deps = [":bb_lib"],
     gc_linkopts = [
         "-s",
         "-w",
@@ -104,7 +120,8 @@ go_binary(
 go_binary(
     name = "bb-windows-amd64",
     out = "bb-windows-amd64.exe",
-    embed = [":bb_lib"],
+    srcs = ["main.go"],
+    deps = [":bb_lib"],
     goarch = "amd64",
     goos = "windows",
     pure = "on",

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -41,6 +41,7 @@ go_test(
     embed = [":bb_lib"],
     deps = [
         "//cli/cli_command/register",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -1,4 +1,4 @@
-package main
+package bb
 
 import (
 	"maps"
@@ -39,7 +39,7 @@ const (
 	bazelExitCodeInterrupted          = 8
 )
 
-func main() {
+func Main() {
 	// If we're the sidecar (CLI server) process, run the sidecar instead of the
 	// CLI.
 	sidecarmain.Handle()
@@ -132,7 +132,7 @@ func run() (exitCode int, err error) {
 	// the command.
 	// This is to shortcut the startup-time of the bazel client / server if they
 	// do not need to be run.
-	if opts, command, args := interpretAsBBCliCommand(os.Args[1:]); command != nil && command.Name != "help" {
+	if opts, command, args := InterpretAsBBCliCommand(os.Args[1:]); command != nil && command.Name != "help" {
 		// Let the help parser handle a help command; otherwise, let's handle the
 		// CLI command.
 		Configure(opts)
@@ -145,7 +145,7 @@ func run() (exitCode int, err error) {
 	// Since we do overly-permissive parsing for help commands to try to reduce
 	// frustration when learning how to use the CLI, we should attempt to parse
 	// this as a help command.
-	if helpArgs, err := interpretAsHelpCommand(os.Args[1:]); err != nil {
+	if helpArgs, err := InterpretAsHelpCommand(os.Args[1:]); err != nil {
 		return -1, err
 	} else if helpArgs.GetCommand() == "help" {
 		// Handle help command if applicable.
@@ -177,13 +177,13 @@ func run() (exitCode int, err error) {
 	return handleBazelCommand(start, canonicalizedArgs.Format(), originalArgs)
 }
 
-// interpretAsBBCliCommand strips the bb options from the beginning of a bb
+// InterpretAsBBCliCommand strips the bb options from the beginning of a bb
 // command and returns the options, the command, and the truncated args. If any
 // unrecognized option is encountered before the first positional argument or if
 // the first positional argument is not a bb command (like it might be if it
 // were a bazel command, for example), the args are returned untouched, the
 // options will be nil, and the command will be nil.
-func interpretAsBBCliCommand(args []string) ([]options.Option, *cli_command.Command, []string) {
+func InterpretAsBBCliCommand(args []string) ([]options.Option, *cli_command.Command, []string) {
 	p := parser.GetNativeParser().StartupOptionParser
 	p.Permissive = true
 	opts, argIndex, err := p.ParseOptions(args, "startup")
@@ -205,7 +205,7 @@ func interpretAsBBCliCommand(args []string) ([]options.Option, *cli_command.Comm
 	return nil, nil, args
 }
 
-func interpretAsHelpCommand(args []string) (*parsed.OrderedArgs, error) {
+func InterpretAsHelpCommand(args []string) (*parsed.OrderedArgs, error) {
 	helpParser, err := parser.GetHelpParser()
 	if err != nil {
 		return nil, err

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -242,6 +242,151 @@ func TestInterpretAsBBCliCommand(t *testing.T) {
 				TruncatedArgs: []string{"version"},
 			},
 		},
+		// bb commands from bb-help.txt
+		{
+			name: "bb command: add",
+			args: []string{"add"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "add",
+				TruncatedArgs: []string{"add"},
+			},
+		},
+		{
+			name: "bb command: analyze",
+			args: []string{"analyze"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "analyze",
+				TruncatedArgs: []string{"analyze"},
+			},
+		},
+		{
+			name: "bb command: ask",
+			args: []string{"ask"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "ask",
+				TruncatedArgs: []string{"ask"},
+			},
+		},
+		{
+			name: "bb command: download",
+			args: []string{"download"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "download",
+				TruncatedArgs: []string{"download"},
+			},
+		},
+		{
+			name: "bb command: execute",
+			args: []string{"execute"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "execute",
+				TruncatedArgs: []string{"execute"},
+			},
+		},
+		{
+			name: "bb command: fix",
+			args: []string{"fix"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "fix",
+				TruncatedArgs: []string{"fix"},
+			},
+		},
+		{
+			name: "bb command: install",
+			args: []string{"install"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "install",
+				TruncatedArgs: []string{"install"},
+			},
+		},
+		{
+			name: "bb command: logout",
+			args: []string{"logout"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "logout",
+				TruncatedArgs: []string{"logout"},
+			},
+		},
+		{
+			name: "bb command: print",
+			args: []string{"print"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "print",
+				TruncatedArgs: []string{"print"},
+			},
+		},
+		{
+			name: "bb command: remote",
+			args: []string{"remote"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "remote",
+				TruncatedArgs: []string{"remote"},
+			},
+		},
+		{
+			name: "bb command: remote-download",
+			args: []string{"remote-download"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "remote-download",
+				TruncatedArgs: []string{"remote-download"},
+			},
+		},
+		{
+			name: "bb command: search",
+			args: []string{"search"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "search",
+				TruncatedArgs: []string{"search"},
+			},
+		},
+		{
+			name: "bb command: index",
+			args: []string{"index"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "index",
+				TruncatedArgs: []string{"index"},
+			},
+		},
+		{
+			name: "bb command: update",
+			args: []string{"update"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "update",
+				TruncatedArgs: []string{"update"},
+			},
+		},
+		{
+			name: "bb command: upload",
+			args: []string{"upload"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "upload",
+				TruncatedArgs: []string{"upload"},
+			},
+		},
+		{
+			name: "bb command: explain",
+			args: []string{"explain"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "explain",
+				TruncatedArgs: []string{"explain"},
+			},
+		},
 		{
 			name: "unknown command",
 			args: []string{"unknown_command"},

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	register_cli_commands "github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -13,191 +13,84 @@ func init() {
 	register_cli_commands.Register()
 }
 
+type TestResult struct {
+	OptionNames   []string
+	CommandName   string
+	TruncatedArgs []string
+}
+
 func TestInterpretAsBBCliCommand(t *testing.T) {
-	tests := []struct {
-		name            string
-		args            []string
-		expectOpts      bool // whether we expect non-nil options
-		expectCommand   *string // expected command name, nil if no command expected
-		expectTruncated []string // expected truncated args
+	tcs := []struct {
+		name     string
+		args     []string
+		expected TestResult
 	}{
 		{
-			name:            "valid bb command without options",
-			args:            []string{"login"},
-			expectOpts:      true,
-			expectCommand:   stringPtr("login"),
-			expectTruncated: []string{"login"},
+			name: "valid bb command without options",
+			args: []string{"login"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "login",
+				TruncatedArgs: []string{"login"},
+			},
 		},
 		{
-			name:            "valid bb command with options",
-			args:            []string{"--verbose", "login"},
-			expectOpts:      true,
-			expectCommand:   stringPtr("login"),
-			expectTruncated: []string{"login"},
+			name: "valid bb command with options",
+			args: []string{"--verbose", "login"},
+			expected: TestResult{
+				OptionNames:   []string{"verbose"},
+				CommandName:   "login",
+				TruncatedArgs: []string{"login"},
+			},
 		},
 		{
-			name:            "valid bb command with multiple options",
-			args:            []string{"--verbose", "--watch", "build", "//..."},
-			expectOpts:      true,
-			expectCommand:   stringPtr("build"),
-			expectTruncated: []string{"build", "//..."},
+			name: "bazel command (not bb command)",
+			args: []string{"build", "//..."},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"build", "//..."},
+			},
 		},
 		{
-			name:            "valid bb command alias",
-			args:            []string{"ask"},
-			expectOpts:      true,
-			expectCommand:   stringPtr("ask"),
-			expectTruncated: []string{"ask"},
+			name: "unknown command",
+			args: []string{"unknown_command"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"unknown_command"},
+			},
 		},
 		{
-			name:            "valid bb command alias wtf",
-			args:            []string{"wtf"},
-			expectOpts:      true,
-			expectCommand:   stringPtr("ask"), // wtf is an alias for ask
-			expectTruncated: []string{"wtf"},
-		},
-		{
-			name:            "bazel command (not bb command)",
-			args:            []string{"build", "//..."},
-			expectOpts:      false,
-			expectCommand:   nil,
-			expectTruncated: []string{"build", "//..."},
-		},
-		{
-			name:            "bazel command with options",
-			args:            []string{"--compilation_mode=opt", "build", "//..."},
-			expectOpts:      false,
-			expectCommand:   nil,
-			expectTruncated: []string{"--compilation_mode=opt", "build", "//..."},
-		},
-		{
-			name:            "unknown command",
-			args:            []string{"unknown_command"},
-			expectOpts:      false,
-			expectCommand:   nil,
-			expectTruncated: []string{"unknown_command"},
-		},
-		{
-			name:            "empty args",
-			args:            []string{},
-			expectOpts:      false,
-			expectCommand:   nil,
-			expectTruncated: []string{},
-		},
-		{
-			name:            "only options without command",
-			args:            []string{"--verbose"},
-			expectOpts:      false,
-			expectCommand:   nil,
-			expectTruncated: []string{"--verbose"},
-		},
-		{
-			name:            "help command with options",
-			args:            []string{"--verbose", "help", "build"},
-			expectOpts:      true,
-			expectCommand:   stringPtr("help"),
-			expectTruncated: []string{"help", "build"},
-		},
-		{
-			name:            "bb command with additional args",
-			args:            []string{"search", "pattern", "--path", "src/"},
-			expectOpts:      true,
-			expectCommand:   stringPtr("search"),
-			expectTruncated: []string{"search", "pattern", "--path", "src/"},
-		},
-		{
-			name:            "remote command",
-			args:            []string{"remote", "build", "//..."},
-			expectOpts:      true,
-			expectCommand:   stringPtr("remote"),
-			expectTruncated: []string{"remote", "build", "//..."},
-		},
-		{
-			name:            "version command",
-			args:            []string{"version"},
-			expectOpts:      true,
-			expectCommand:   stringPtr("version"),
-			expectTruncated: []string{"version"},
+			name: "empty args",
+			args: []string{},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{},
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts, command, truncatedArgs := InterpretAsBBCliCommand(tt.args)
-
-			// Check options
-			if tt.expectOpts {
-				assert.NotNil(t, opts, "Expected non-nil options")
-			} else {
-				assert.Nil(t, opts, "Expected nil options")
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, command, truncatedArgs := InterpretAsBBCliCommand(tc.args)
+			optionNames := []string{}
+			for _, opt := range opts {
+				optionNames = append(optionNames, opt.Name())
+			}
+			commandName := ""
+			if command != nil {
+				commandName = command.Name
 			}
 
-			// Check command
-			if tt.expectCommand != nil {
-				require.NotNil(t, command, "Expected non-nil command")
-				assert.Equal(t, *tt.expectCommand, command.Name, "Command name mismatch")
-			} else {
-				assert.Nil(t, command, "Expected nil command")
+			actual := TestResult{
+				OptionNames:   optionNames,
+				CommandName:   commandName,
+				TruncatedArgs: truncatedArgs,
 			}
 
-			// Check truncated args
-			assert.Equal(t, tt.expectTruncated, truncatedArgs, "Truncated args mismatch")
+			assert.Empty(t, cmp.Diff(tc.expected, actual))
 		})
 	}
-}
-
-func TestInterpretAsBBCliCommand_WithUnknownOption(t *testing.T) {
-	// Test case where unknown option causes function to return original args
-	args := []string{"--unknown-startup-option", "login"}
-	opts, command, truncatedArgs := InterpretAsBBCliCommand(args)
-
-	assert.Nil(t, opts, "Expected nil options due to unknown option")
-	assert.Nil(t, command, "Expected nil command due to unknown option")
-	assert.Equal(t, args, truncatedArgs, "Expected original args returned")
-}
-
-func TestInterpretAsBBCliCommand_AllRegisteredCommands(t *testing.T) {
-	// Test that all registered commands are recognized
-	expectedCommands := []string{
-		"add", "analyze", "ask", "download", "execute", "fix", "install",
-		"login", "logout", "print", "remote", "remote-download", "search",
-		"index", "update", "upload", "version", "explain",
-	}
-
-	for _, cmdName := range expectedCommands {
-		t.Run("command_"+cmdName, func(t *testing.T) {
-			args := []string{cmdName}
-			opts, command, truncatedArgs := InterpretAsBBCliCommand(args)
-
-			assert.NotNil(t, opts, "Expected non-nil options for command %s", cmdName)
-			require.NotNil(t, command, "Expected non-nil command for %s", cmdName)
-			assert.Equal(t, cmdName, command.Name, "Command name mismatch for %s", cmdName)
-			assert.Equal(t, []string{cmdName}, truncatedArgs, "Truncated args mismatch for %s", cmdName)
-		})
-	}
-}
-
-func TestInterpretAsBBCliCommand_Aliases(t *testing.T) {
-	// Test command aliases
-	aliases := map[string]string{
-		"wtf": "ask",
-		"huh": "ask",
-	}
-
-	for alias, expectedCmd := range aliases {
-		t.Run("alias_"+alias, func(t *testing.T) {
-			args := []string{alias}
-			opts, command, truncatedArgs := InterpretAsBBCliCommand(args)
-
-			assert.NotNil(t, opts, "Expected non-nil options for alias %s", alias)
-			require.NotNil(t, command, "Expected non-nil command for alias %s", alias)
-			assert.Equal(t, expectedCmd, command.Name, "Command name mismatch for alias %s", alias)
-			assert.Equal(t, []string{alias}, truncatedArgs, "Truncated args mismatch for alias %s", alias)
-		})
-	}
-}
-
-// Helper function to create string pointers for test cases
-func stringPtr(s string) *string {
-	return &s
 }

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -52,6 +52,196 @@ func TestInterpretAsBBCliCommand(t *testing.T) {
 				TruncatedArgs: []string{"build", "//..."},
 			},
 		},
+		// Bazel commands from bb-help.txt
+		{
+			name: "bazel command: analyze-profile",
+			args: []string{"analyze-profile"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"analyze-profile"},
+			},
+		},
+		{
+			name: "bazel command: aquery",
+			args: []string{"aquery"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"aquery"},
+			},
+		},
+		{
+			name: "bazel command: canonicalize-flags",
+			args: []string{"canonicalize-flags"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"canonicalize-flags"},
+			},
+		},
+		{
+			name: "bazel command: clean",
+			args: []string{"clean"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"clean"},
+			},
+		},
+		{
+			name: "bazel command: coverage",
+			args: []string{"coverage"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"coverage"},
+			},
+		},
+		{
+			name: "bazel command: cquery",
+			args: []string{"cquery"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"cquery"},
+			},
+		},
+		{
+			name: "bazel command: dump",
+			args: []string{"dump"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"dump"},
+			},
+		},
+		{
+			name: "bazel command: fetch",
+			args: []string{"fetch"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"fetch"},
+			},
+		},
+		{
+			name: "bazel command: help (recognized as bb help)",
+			args: []string{"help"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "help",
+				TruncatedArgs: []string{"help"},
+			},
+		},
+		{
+			name: "bazel command: info",
+			args: []string{"info"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"info"},
+			},
+		},
+		{
+			name: "bazel command: license",
+			args: []string{"license"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"license"},
+			},
+		},
+		{
+			name: "bazel command: mobile-install",
+			args: []string{"mobile-install"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"mobile-install"},
+			},
+		},
+		{
+			name: "bazel command: mod",
+			args: []string{"mod"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"mod"},
+			},
+		},
+		{
+			name: "bazel command: print_action",
+			args: []string{"print_action"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"print_action"},
+			},
+		},
+		{
+			name: "bazel command: query",
+			args: []string{"query"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"query"},
+			},
+		},
+		{
+			name: "bazel command: run",
+			args: []string{"run"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"run"},
+			},
+		},
+		{
+			name: "bazel command: shutdown",
+			args: []string{"shutdown"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"shutdown"},
+			},
+		},
+		{
+			name: "bazel command: sync",
+			args: []string{"sync"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"sync"},
+			},
+		},
+		{
+			name: "bazel command: test",
+			args: []string{"test"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"test"},
+			},
+		},
+		{
+			name: "bazel command: vendor",
+			args: []string{"vendor"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"vendor"},
+			},
+		},
+		{
+			name: "bazel command: version (recognized as bb version)",
+			args: []string{"version"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "version",
+				TruncatedArgs: []string{"version"},
+			},
+		},
 		{
 			name: "unknown command",
 			args: []string{"unknown_command"},

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -1,0 +1,203 @@
+package bb
+
+import (
+	"testing"
+
+	register_cli_commands "github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	// Ensure CLI commands are registered for testing
+	register_cli_commands.Register()
+}
+
+func TestInterpretAsBBCliCommand(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		expectOpts      bool // whether we expect non-nil options
+		expectCommand   *string // expected command name, nil if no command expected
+		expectTruncated []string // expected truncated args
+	}{
+		{
+			name:            "valid bb command without options",
+			args:            []string{"login"},
+			expectOpts:      true,
+			expectCommand:   stringPtr("login"),
+			expectTruncated: []string{"login"},
+		},
+		{
+			name:            "valid bb command with options",
+			args:            []string{"--verbose", "login"},
+			expectOpts:      true,
+			expectCommand:   stringPtr("login"),
+			expectTruncated: []string{"login"},
+		},
+		{
+			name:            "valid bb command with multiple options",
+			args:            []string{"--verbose", "--watch", "build", "//..."},
+			expectOpts:      true,
+			expectCommand:   stringPtr("build"),
+			expectTruncated: []string{"build", "//..."},
+		},
+		{
+			name:            "valid bb command alias",
+			args:            []string{"ask"},
+			expectOpts:      true,
+			expectCommand:   stringPtr("ask"),
+			expectTruncated: []string{"ask"},
+		},
+		{
+			name:            "valid bb command alias wtf",
+			args:            []string{"wtf"},
+			expectOpts:      true,
+			expectCommand:   stringPtr("ask"), // wtf is an alias for ask
+			expectTruncated: []string{"wtf"},
+		},
+		{
+			name:            "bazel command (not bb command)",
+			args:            []string{"build", "//..."},
+			expectOpts:      false,
+			expectCommand:   nil,
+			expectTruncated: []string{"build", "//..."},
+		},
+		{
+			name:            "bazel command with options",
+			args:            []string{"--compilation_mode=opt", "build", "//..."},
+			expectOpts:      false,
+			expectCommand:   nil,
+			expectTruncated: []string{"--compilation_mode=opt", "build", "//..."},
+		},
+		{
+			name:            "unknown command",
+			args:            []string{"unknown_command"},
+			expectOpts:      false,
+			expectCommand:   nil,
+			expectTruncated: []string{"unknown_command"},
+		},
+		{
+			name:            "empty args",
+			args:            []string{},
+			expectOpts:      false,
+			expectCommand:   nil,
+			expectTruncated: []string{},
+		},
+		{
+			name:            "only options without command",
+			args:            []string{"--verbose"},
+			expectOpts:      false,
+			expectCommand:   nil,
+			expectTruncated: []string{"--verbose"},
+		},
+		{
+			name:            "help command with options",
+			args:            []string{"--verbose", "help", "build"},
+			expectOpts:      true,
+			expectCommand:   stringPtr("help"),
+			expectTruncated: []string{"help", "build"},
+		},
+		{
+			name:            "bb command with additional args",
+			args:            []string{"search", "pattern", "--path", "src/"},
+			expectOpts:      true,
+			expectCommand:   stringPtr("search"),
+			expectTruncated: []string{"search", "pattern", "--path", "src/"},
+		},
+		{
+			name:            "remote command",
+			args:            []string{"remote", "build", "//..."},
+			expectOpts:      true,
+			expectCommand:   stringPtr("remote"),
+			expectTruncated: []string{"remote", "build", "//..."},
+		},
+		{
+			name:            "version command",
+			args:            []string{"version"},
+			expectOpts:      true,
+			expectCommand:   stringPtr("version"),
+			expectTruncated: []string{"version"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, command, truncatedArgs := InterpretAsBBCliCommand(tt.args)
+
+			// Check options
+			if tt.expectOpts {
+				assert.NotNil(t, opts, "Expected non-nil options")
+			} else {
+				assert.Nil(t, opts, "Expected nil options")
+			}
+
+			// Check command
+			if tt.expectCommand != nil {
+				require.NotNil(t, command, "Expected non-nil command")
+				assert.Equal(t, *tt.expectCommand, command.Name, "Command name mismatch")
+			} else {
+				assert.Nil(t, command, "Expected nil command")
+			}
+
+			// Check truncated args
+			assert.Equal(t, tt.expectTruncated, truncatedArgs, "Truncated args mismatch")
+		})
+	}
+}
+
+func TestInterpretAsBBCliCommand_WithUnknownOption(t *testing.T) {
+	// Test case where unknown option causes function to return original args
+	args := []string{"--unknown-startup-option", "login"}
+	opts, command, truncatedArgs := InterpretAsBBCliCommand(args)
+
+	assert.Nil(t, opts, "Expected nil options due to unknown option")
+	assert.Nil(t, command, "Expected nil command due to unknown option")
+	assert.Equal(t, args, truncatedArgs, "Expected original args returned")
+}
+
+func TestInterpretAsBBCliCommand_AllRegisteredCommands(t *testing.T) {
+	// Test that all registered commands are recognized
+	expectedCommands := []string{
+		"add", "analyze", "ask", "download", "execute", "fix", "install",
+		"login", "logout", "print", "remote", "remote-download", "search",
+		"index", "update", "upload", "version", "explain",
+	}
+
+	for _, cmdName := range expectedCommands {
+		t.Run("command_"+cmdName, func(t *testing.T) {
+			args := []string{cmdName}
+			opts, command, truncatedArgs := InterpretAsBBCliCommand(args)
+
+			assert.NotNil(t, opts, "Expected non-nil options for command %s", cmdName)
+			require.NotNil(t, command, "Expected non-nil command for %s", cmdName)
+			assert.Equal(t, cmdName, command.Name, "Command name mismatch for %s", cmdName)
+			assert.Equal(t, []string{cmdName}, truncatedArgs, "Truncated args mismatch for %s", cmdName)
+		})
+	}
+}
+
+func TestInterpretAsBBCliCommand_Aliases(t *testing.T) {
+	// Test command aliases
+	aliases := map[string]string{
+		"wtf": "ask",
+		"huh": "ask",
+	}
+
+	for alias, expectedCmd := range aliases {
+		t.Run("alias_"+alias, func(t *testing.T) {
+			args := []string{alias}
+			opts, command, truncatedArgs := InterpretAsBBCliCommand(args)
+
+			assert.NotNil(t, opts, "Expected non-nil options for alias %s", alias)
+			require.NotNil(t, command, "Expected non-nil command for alias %s", alias)
+			assert.Equal(t, expectedCmd, command.Name, "Command name mismatch for alias %s", alias)
+			assert.Equal(t, []string{alias}, truncatedArgs, "Truncated args mismatch for alias %s", alias)
+		})
+	}
+}
+
+// Helper function to create string pointers for test cases
+func stringPtr(s string) *string {
+	return &s
+}

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -126,11 +126,11 @@ func TestInterpretAsBBCliCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "bazel command: help (recognized as bb help)",
+			name: "bazel command: help",
 			args: []string{"help"},
 			expected: TestResult{
 				OptionNames:   []string{},
-				CommandName:   "help",
+				CommandName:   "",
 				TruncatedArgs: []string{"help"},
 			},
 		},

--- a/cli/cmd/bb/bb_test.go
+++ b/cli/cmd/bb/bb_test.go
@@ -1,16 +1,17 @@
-package bb
+package bb_test
 
 import (
 	"testing"
 
-	register_cli_commands "github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
+	"github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
+	"github.com/buildbuddy-io/buildbuddy/cli/cmd/bb"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
 func init() {
 	// Ensure CLI commands are registered for testing
-	register_cli_commands.Register()
+	register.Register()
 }
 
 type TestResult struct {
@@ -25,34 +26,6 @@ func TestInterpretAsBBCliCommand(t *testing.T) {
 		args     []string
 		expected TestResult
 	}{
-		{
-			name: "valid bb command without options",
-			args: []string{"login"},
-			expected: TestResult{
-				OptionNames:   []string{},
-				CommandName:   "login",
-				TruncatedArgs: []string{"login"},
-			},
-		},
-		{
-			name: "valid bb command with options",
-			args: []string{"--verbose", "login"},
-			expected: TestResult{
-				OptionNames:   []string{"verbose"},
-				CommandName:   "login",
-				TruncatedArgs: []string{"login"},
-			},
-		},
-		{
-			name: "bazel command (not bb command)",
-			args: []string{"build", "//..."},
-			expected: TestResult{
-				OptionNames:   []string{},
-				CommandName:   "",
-				TruncatedArgs: []string{"build", "//..."},
-			},
-		},
-		// Bazel commands from bb-help.txt
 		{
 			name: "bazel command: analyze-profile",
 			args: []string{"analyze-profile"},
@@ -69,6 +42,15 @@ func TestInterpretAsBBCliCommand(t *testing.T) {
 				OptionNames:   []string{},
 				CommandName:   "",
 				TruncatedArgs: []string{"aquery"},
+			},
+		},
+		{
+			name: "bazel command: build",
+			args: []string{"build"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "",
+				TruncatedArgs: []string{"build"},
 			},
 		},
 		{
@@ -307,6 +289,15 @@ func TestInterpretAsBBCliCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "bb command: login",
+			args: []string{"login"},
+			expected: TestResult{
+				OptionNames:   []string{},
+				CommandName:   "login",
+				TruncatedArgs: []string{"login"},
+			},
+		},
+		{
 			name: "bb command: logout",
 			args: []string{"logout"},
 			expected: TestResult{
@@ -409,7 +400,7 @@ func TestInterpretAsBBCliCommand(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			opts, command, truncatedArgs := InterpretAsBBCliCommand(tc.args)
+			opts, command, truncatedArgs := bb.InterpretAsBBCliCommand(tc.args)
 			optionNames := []string{}
 			for _, opt := range opts {
 				optionNames = append(optionNames, opt.Name())

--- a/cli/cmd/bb/main.go
+++ b/cli/cmd/bb/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/buildbuddy-io/buildbuddy/cli/cmd/bb"
+
+func main() {
+	bb.Main()
+}


### PR DESCRIPTION
I wanted straightforward unit tests for "will `bb` or `bazelisk` handle this command?"
So I wrote those tests!
Need to create a `bb` package in the process.