### PR TITLE
Fail on startup if http port is busy

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -405,9 +406,14 @@ func main() {
 		reg.Start(rootContext)
 	}()
 
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", *listen, *port))
+	if err != nil {
+		log.Fatalf("Failed to listen on port %d: %s", *port, err)
+	}
 	go func() {
-		http.ListenAndServe(fmt.Sprintf("%s:%d", *listen, *port), nil)
+		_ = http.Serve(lis, nil)
 	}()
+
 	env.GetHealthChecker().WaitForGracefulShutdown()
 }
 


### PR DESCRIPTION
This caused me some confusion during local development - the executor will happily start up if something is listening on port 8888 already, but it should probably fail. In my case I forgot I was running some pprof web stuff listening on port 8888, and I was confused when I tried to check /readyz on port 8888 (for the executor) and it gave me a 404.