### PR TITLE
refactor: move server admin flag / auth logic to claims package, and simplify

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"flag"
 	"net/http"
 	"strings"
 
@@ -22,15 +21,11 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-var (
-	adminGroupID = flag.String("auth.admin_group_id", "", "ID of a group whose members can perform actions only accessible to server admins.")
-)
-
 func Register(ctx context.Context, env *real_environment.RealEnv) error {
 	httpAuthenticators := []interfaces.HTTPAuthenticator{}
 	userAuthenticators := []interfaces.UserAuthenticator{}
 
-	oidc, err := oidc.NewOpenIDAuthenticator(ctx, env, *adminGroupID)
+	oidc, err := oidc.NewOpenIDAuthenticator(ctx, env)
 	if err != nil {
 		return status.InternalErrorf("OIDC authenticator failed to configure: %v", err)
 	}
@@ -70,12 +65,8 @@ func Register(ctx context.Context, env *real_environment.RealEnv) error {
 }
 
 func RegisterNullAuth(env *real_environment.RealEnv) error {
-	env.SetAuthenticator(
-		nullauth.NewNullAuthenticator(
-			oidc.AnonymousUsageEnabled(),
-			*adminGroupID,
-		),
-	)
+	na := nullauth.NewNullAuthenticator(oidc.AnonymousUsageEnabled())
+	env.SetAuthenticator(na)
 	return nil
 }
 

--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/tables",
         "//server/util/authutil",
         "//server/util/capabilities",
+        "//server/util/claims",
         "//server/util/db",
         "//server/util/flag",
         "//server/util/log",

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -696,11 +697,7 @@ func (d *AuthDB) CreateImpersonationAPIKey(ctx context.Context, groupID string) 
 	// Can't check group membership because impersonation modifies
 	// group information.
 	if !u.IsImpersonating() {
-		adminGroupID := d.env.GetAuthenticator().AdminGroupID()
-		if adminGroupID == "" {
-			return nil, status.PermissionDeniedError("You do not have access to the requested organization")
-		}
-		if err := authutil.AuthorizeOrgAdmin(u, adminGroupID); err != nil {
+		if err := claims.AuthorizeServerAdmin(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -139,7 +139,7 @@ func TestImpersonationKeys(t *testing.T) {
 	// Now treat the random group we picked as the server admin group.
 	// Same user should now be able to create an impersonation key for any
 	// group.
-	auth.ServerAdminGroupID = admin.Groups[0].Group.GroupID
+	flags.Set(t, "auth.admin_group_id", admin.Groups[0].Group.GroupID)
 	u := users[0]
 	targetGroupID := u.Groups[0].Group.GroupID
 	targetGroupAdminCtx, err := auth.WithAuthenticatedUser(ctx, u.UserID)
@@ -824,7 +824,7 @@ func TestImpersonationAPIKeys(t *testing.T) {
 	// Now treat the random group we picked as the server admin group.
 	// Same user should now be able to create an impersonation key for any
 	// group.
-	auth.ServerAdminGroupID = admin.Groups[0].Group.GroupID
+	flags.Set(t, "auth.admin_group_id", admin.Groups[0].Group.GroupID)
 	for _, u := range users {
 		al.Reset()
 		targetGroupID := u.Groups[0].Group.GroupID

--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//server/util/authutil",
         "//server/util/background",
         "//server/util/bazel_request",
+        "//server/util/claims",
         "//server/util/db",
         "//server/util/flag",
         "//server/util/log",

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -724,7 +725,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 
 	// Check permissions for server admin-only properties.
 	if props.ContainerRegistryBypass {
-		if err := authutil.AuthorizeServerAdmin(ctx, s.env); err != nil {
+		if err := claims.AuthorizeServerAdmin(ctx); err != nil {
 			return nil, status.WrapError(err, "authorize container-registry-bypass property")
 		}
 	}

--- a/enterprise/tools/replay_action/replay_action.go
+++ b/enterprise/tools/replay_action/replay_action.go
@@ -1066,7 +1066,7 @@ func startCacheServerForBundle(bundleDir string) (*localCache, error) {
 	if err := clientidentity.Register(env); err != nil {
 		return nil, fmt.Errorf("register client identity: %w", err)
 	}
-	na := nullauth.NewNullAuthenticator(true /*=anonEnabled*/, "" /*=adminGroupID*/)
+	na := nullauth.NewNullAuthenticator(true /*=anonEnabled*/)
 	env.SetAuthenticator(na)
 	hit_tracker.Register(env)
 

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -100,7 +100,7 @@ func getToolEnv() *real_environment.RealEnv {
 	re.SetByteStreamClient(bspb.NewByteStreamClient(conn))
 	re.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
 	re.SetActionCacheClient(repb.NewActionCacheClient(conn))
-	re.SetAuthenticator(nullauth.NewNullAuthenticator(true /*anonymousEnabled*/, ""))
+	re.SetAuthenticator(nullauth.NewNullAuthenticator(true /*anonymousEnabled*/))
 	re.SetImageCacheAuthenticator(container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{}))
 	return re
 }

--- a/server/capabilities_filter/BUILD
+++ b/server/capabilities_filter/BUILD
@@ -8,8 +8,8 @@ go_library(
     deps = [
         "//proto:capability_go_proto",
         "//server/environment",
-        "//server/util/authutil",
         "//server/util/capabilities",
+        "//server/util/claims",
         "//server/util/status",
     ],
 )
@@ -26,6 +26,7 @@ go_test(
         "//proto/api/v1:api_v1_go_proto",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -7,8 +7,8 @@ import (
 	"slices"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
@@ -215,7 +215,7 @@ func AllowedRPCs(ctx context.Context, env environment.Env, groupID string) []str
 	var out []string
 	out = append(out, getUnfilteredRPCs()...)
 
-	if err := authutil.AuthorizeServerAdmin(ctx, env); err == nil {
+	if err := claims.AuthorizeServerAdmin(ctx); err == nil {
 		out = append(out, serverAdminOnlyRPCs...)
 	}
 

--- a/server/capabilities_filter/capabilities_filter_test.go
+++ b/server/capabilities_filter/capabilities_filter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/capabilities_filter"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -148,7 +149,7 @@ func TestAllowedRPCs(t *testing.T) {
 			env := testenv.GetTestEnv(t)
 			users := testauth.TestUsers("US1", "GR1")
 			ta := testauth.NewTestAuthenticator(users)
-			ta.ServerAdminGroupID = test.ServerAdminGroupID
+			flags.Set(t, "auth.admin_group_id", test.ServerAdminGroupID)
 			env.SetAuthenticator(ta)
 			u := users["US1"].(*testauth.TestUser)
 			u.Capabilities = test.Capabilities

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -136,8 +136,6 @@ const (
 )
 
 type InstallationAuthenticator interface {
-	// The ID of the admin group
-	AdminGroupID() string
 	// Whether or not anonymous usage is enabled
 	AnonymousUsageEnabled(ctx context.Context) bool
 	// Return a slice containing the providers

--- a/server/nullauth/nullauth.go
+++ b/server/nullauth/nullauth.go
@@ -16,20 +16,14 @@ var (
 	unimplementedError  = status.UnimplementedError("Auth not implemented")
 )
 
-func NewNullAuthenticator(anonymousUsageEnabled bool, adminGroupID string) *NullAuthenticator {
+func NewNullAuthenticator(anonymousUsageEnabled bool) *NullAuthenticator {
 	return &NullAuthenticator{
-		adminGroupID:           adminGroupID,
 		anonymousUsageDisabled: !anonymousUsageEnabled,
 	}
 }
 
 type NullAuthenticator struct {
-	adminGroupID           string
 	anonymousUsageDisabled bool
-}
-
-func (a *NullAuthenticator) AdminGroupID() string {
-	return a.adminGroupID
 }
 
 func (a *NullAuthenticator) AnonymousUsageEnabled(ctx context.Context) bool {

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -72,9 +72,8 @@ type apiKeyUserProvider func(ctx context.Context, apiKey string) (interfaces.Use
 
 type TestAuthenticator struct {
 	*nullauth.NullAuthenticator
-	UserProvider       userProvider
-	APIKeyProvider     apiKeyUserProvider
-	ServerAdminGroupID string
+	UserProvider   userProvider
+	APIKeyProvider apiKeyUserProvider
 }
 
 func NewTestAuthenticator(testUsers map[string]interfaces.UserInfo) *TestAuthenticator {
@@ -83,10 +82,6 @@ func NewTestAuthenticator(testUsers map[string]interfaces.UserInfo) *TestAuthent
 		UserProvider:      func(ctx context.Context, userID string) (interfaces.UserInfo, error) { return testUsers[userID], nil },
 		APIKeyProvider:    func(ctx context.Context, apiKey string) (interfaces.UserInfo, error) { return testUsers[apiKey], nil },
 	}
-}
-
-func (a *TestAuthenticator) AdminGroupID() string {
-	return a.ServerAdminGroupID
 }
 
 func (a *TestAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *http.Request) context.Context {

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -70,33 +70,6 @@ func AuthorizeOrgAdmin(u interfaces.UserInfo, groupID string) error {
 	return status.PermissionDeniedError("you are not a member of the requested organization")
 }
 
-// AuthorizeServerAdmin checks whether the authenticated user is a server admin
-// (a member of the server admin group, with ORG_ADMIN capability).
-func AuthorizeServerAdmin(ctx context.Context, env environment.Env) error {
-	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
-	if err != nil {
-		return err
-	}
-
-	// If impersonation is in effect, it implies the user is an admin.
-	// Can't check group membership because impersonation modifies
-	// group information.
-	if u.IsImpersonating() {
-		return nil
-	}
-
-	serverAdminGID := env.GetAuthenticator().AdminGroupID()
-	if serverAdminGID == "" {
-		return status.PermissionDeniedError("permission denied")
-	}
-	for _, m := range u.GetGroupMemberships() {
-		if m.GroupID == serverAdminGID && slices.Contains(m.Capabilities, cappb.Capability_ORG_ADMIN) {
-			return nil
-		}
-	}
-	return status.PermissionDeniedError("permission denied")
-}
-
 // AuthorizeGroupAccess checks whether the user is a member of the given group.
 // Where applicable, make sure to check the user's capabilities within the group
 // as well.

--- a/server/util/capabilities/capabilities_test.go
+++ b/server/util/capabilities/capabilities_test.go
@@ -81,7 +81,7 @@ func TestIsGranted_NullAuthenticator(t *testing.T) {
 
 func TestNotGranted_NullAuthenticator_AnonymousUsage_Disabled(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
-	te.SetAuthenticator(nullauth.NewNullAuthenticator(false, ""))
+	te.SetAuthenticator(nullauth.NewNullAuthenticator(false))
 
 	anonCtx := context.Background()
 


### PR DESCRIPTION
Context: I'd like to add a new field `ExperimentTargetingGroupID` to `Claims`, which will be based on a gRPC header that only server admins should be able to set. The current code structure makes this difficult to implement - `ClaimsFromContext` does not currently get passed an `env` or an `Authenticator`, but the authenticator is needed to know the server admin group ID (using the `AdminGroupID()` method).

So, this PR shuffles things around so that `claims.go` has more direct access to the server admin group ID. In particular, it makes the server admin group ID a plain old flag, which makes things simpler overall.