### PR TITLE
fuse: when updating layout make failing to rm child non-fatal

### DIFF
--- a/enterprise/server/remote_execution/vfs/vfs_unix.go
+++ b/enterprise/server/remote_execution/vfs/vfs_unix.go
@@ -317,8 +317,7 @@ func (vfs *VFS) PrepareForTask(ctx context.Context, taskID string, invalidatedIn
 		}
 		success, _ := node.RmChild(invalidatedEntry.Name)
 		if !success {
-			log.CtxWarningf(ctx, "Failed to remove child %q from inode %d for path %q: %d", invalidatedEntry.Name, invalidatedEntry.InodeID, node.Path(nil), errno)
-			return status.InternalErrorf("could not remove child %q from inode %d for path %q: %s", invalidatedEntry.Name, invalidatedEntry.InodeID, node.Path(nil), errno)
+			log.CtxInfof(ctx, "Could not remove child %q from inode %d for path %q (may already have been removed async via kernel notification)", invalidatedEntry.Name, invalidatedEntry.InodeID, node.Path(nil))
 		}
 		numInvalidated++
 	}


### PR DESCRIPTION
The NotifyEntry call will eventually result in the kernel telling the fuse server to forget the node which will also remove the child so if it's already gone we don't need to treat it as an error.