### PR TITLE
Fix warning logged by GetImpersonatedUser group scan

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -937,7 +937,7 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 			WHERE group_id = ?
 		`,
 		u.GetGroupID(),
-	).Take(gr)
+	).Take(&gr.Group)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GORM logs an "unsupported data type" warning because `tables.GroupRole` contains a `[]cappb.Capability` field which is not scannable. To fix the warning, scan into the `Group` field instead, which is a DB-mapped struct.