### PR TITLE
Allow overriding experiment targeting group ID

### DIFF
--- a/enterprise/server/experiments/BUILD
+++ b/enterprise/server/experiments/BUILD
@@ -26,6 +26,7 @@ go_test(
     deps = [
         ":experiments",
         "//server/tables",
+        "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/authutil",
         "//server/util/claims",

--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -121,8 +121,8 @@ func (fp *FlagProvider) getEvaluationContext(ctx context.Context, opts ...any) o
 	}
 
 	if claims, err := claims.ClaimsFromContext(ctx); err == nil {
-		options.targetingKey = claims.GetGroupID()
-		options.attributes["group_id"] = claims.GetGroupID()
+		options.targetingKey = claims.GetExperimentTargetingGroupID()
+		options.attributes["group_id"] = claims.GetExperimentTargetingGroupID()
 		options.attributes["user_id"] = claims.GetUserID()
 	}
 	rmd := bazel_request.GetRequestMetadata(ctx)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -106,6 +106,11 @@ type UserInfo interface {
 	// key.
 	GetUserID() string
 	GetGroupID() string
+	// GetExperimentTargetingGroupID returns the group ID used for experiment
+	// targeting purposes. This should return the same value as GetGroupID()
+	// except when a server admin is setting a special header to target a
+	// different group for debugging purposes.
+	GetExperimentTargetingGroupID() string
 	// IsImpersonating returns whether the group ID is being impersonated by the
 	// user. This means that the user is not actually a member of the group, but
 	// is temporarily acting as a group member. Only server admins have this

--- a/server/util/claims/BUILD
+++ b/server/util/claims/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//server/util/status",
         "//server/util/subdomain",
         "@com_github_golang_jwt_jwt_v4//:jwt",
+        "@org_golang_google_grpc//metadata",
     ],
 )
 
@@ -28,13 +29,18 @@ go_test(
     srcs = ["claims_test.go"],
     deps = [
         ":claims",
+        "//proto:capability_go_proto",
         "//proto:context_go_proto",
         "//server/interfaces",
+        "//server/testutil/testauth",
+        "//server/testutil/testenv",
         "//server/util/authutil",
         "//server/util/capabilities",
         "//server/util/request_context",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//metadata",
     ],
 )


### PR DESCRIPTION
Allow server admins to override the experiment targeting group ID. Named the header `x-buildbuddy-experiment.group_id` since it seems likely that we'll want to allow overriding other vars too (for debugging purposes), and we could use the same naming convention (`x-buildbuddy-experiment.<var> = <value>`)