### PR TITLE
Add `bb view` command that prints invocation logs

### DIFF
--- a/cli/cli_command/register/BUILD
+++ b/cli/cli_command/register/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//cli/update",
         "//cli/upload",
         "//cli/versioncmd",
+        "//cli/view",
     ],
 )
 

--- a/cli/cli_command/register/register.go
+++ b/cli/cli_command/register/register.go
@@ -21,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/update"
 	"github.com/buildbuddy-io/buildbuddy/cli/upload"
 	"github.com/buildbuddy-io/buildbuddy/cli/versioncmd"
+	"github.com/buildbuddy-io/buildbuddy/cli/view"
 )
 
 // Register registers all known cli commands in the structures laid out in
@@ -121,6 +122,11 @@ func register() {
 			Name:    "version",
 			Help:    "Prints bb cli version info.",
 			Handler: versioncmd.HandleVersion,
+		},
+		{
+			Name:    "view",
+			Help:    "Views build logs from BuildBuddy.",
+			Handler: view.HandleView,
 		},
 		{
 			Name:    "explain",

--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -398,8 +398,11 @@ func GetAPIKey() (string, error) {
 		return apiKey, nil
 	}
 	apiKey, err = storage.ReadRepoConfig("api-key")
+	apiKey = strings.TrimSpace(apiKey)
 	if err != nil {
 		log.Debugf("Could not read api key from bb config: %s", err)
+	} else if apiKey == "" {
+		log.Debugf("API key is empty")
 	} else {
 		log.Debugf("API key read from `buildbuddy.api-key` in .git/config.")
 		return apiKey, nil

--- a/cli/view/BUILD
+++ b/cli/view/BUILD
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_library(
+    name = "view",
+    srcs = ["view.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/view",
+    deps = [
+        "//cli/arg",
+        "//cli/log",
+        "//cli/login",
+        "//proto:buildbuddy_service_go_proto",
+        "//proto:eventlog_go_proto",
+        "//server/util/grpc_client",
+        "@org_golang_google_grpc//metadata",
+    ],
+)

--- a/cli/view/view.go
+++ b/cli/view/view.go
@@ -1,0 +1,105 @@
+package view
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/login"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"google.golang.org/grpc/metadata"
+
+	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
+	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
+)
+
+var (
+	flags = flag.NewFlagSet("view", flag.ContinueOnError)
+
+	apiTarget = flags.String("target", "remote.buildbuddy.io", "BuildBuddy gRPC target")
+	lines     = flags.Int("lines", 100_000, "Minimum number of lines to fetch")
+
+	usage = `
+bb ` + flags.Name() + ` <invocation-id-or-url> [--lines=100000] [--target=remote.buildbuddy.io]
+
+Views build logs from BuildBuddy using the GetEventLogChunk API.
+
+Examples:
+  bb view 12345678-1234-1234-1234-123456789012
+  bb view https://app.buildbuddy.io/invocation/12345678-1234-1234-1234-123456789012
+`
+)
+
+func extractInvocationID(input string) (string, error) {
+	uuidPattern := regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	if uuidPattern.MatchString(input) {
+		return input, nil
+	}
+
+	parsedURL, err := url.Parse(input)
+	if err == nil {
+		pathPattern := regexp.MustCompile(`/invocation/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})`)
+		if matches := pathPattern.FindStringSubmatch(parsedURL.Path); len(matches) > 1 {
+			return matches[1], nil
+		}
+	}
+
+	return "", fmt.Errorf("could not extract invocation ID from: %s", input)
+}
+
+func HandleView(args []string) (exitCode int, err error) {
+	if err := arg.ParseFlagSet(flags, args); err != nil {
+		if err == flag.ErrHelp {
+			log.Print(usage)
+			return 1, nil
+		}
+		return -1, err
+	}
+
+	if flags.NArg() < 1 {
+		log.Print("Error: invocation ID or URL required")
+		log.Print(usage)
+		return 1, nil
+	}
+
+	invocationID, err := extractInvocationID(flags.Arg(0))
+	if err != nil {
+		return -1, err
+	}
+
+	apiKey, err := login.GetAPIKey()
+	if err != nil || apiKey == "" {
+		return -1, fmt.Errorf("not logged in: %w", err)
+	}
+
+	conn, err := grpc_client.DialSimple(*apiTarget)
+	if err != nil {
+		return -1, fmt.Errorf("failed to connect to BuildBuddy: %w", err)
+	}
+	defer conn.Close()
+	bbClient := bbspb.NewBuildBuddyServiceClient(conn)
+
+	ctx := context.Background()
+	if apiKey != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey)
+	}
+
+	resp, err := bbClient.GetEventLogChunk(ctx, &elpb.GetEventLogChunkRequest{
+		InvocationId: invocationID,
+		MinLines:     int32(*lines),
+	})
+	if err != nil {
+		return -1, fmt.Errorf("failed to get log chunk: %w", err)
+	}
+
+	// Print the log chunk
+	if len(resp.Buffer) > 0 {
+		fmt.Print(string(resp.Buffer))
+	}
+
+	return 0, nil
+}

--- a/cli/view/view.go
+++ b/cli/view/view.go
@@ -23,6 +23,9 @@ var (
 	apiTarget = flags.String("target", "remote.buildbuddy.io", "BuildBuddy gRPC target")
 	lines     = flags.Int("lines", 100_000, "Minimum number of lines to fetch")
 
+	pathPattern = regexp.MustCompile(`/invocation/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})`)
+	uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
 	usage = `
 bb ` + flags.Name() + ` <invocation-id-or-url> [--lines=100000] [--target=remote.buildbuddy.io]
 
@@ -35,14 +38,12 @@ Examples:
 )
 
 func extractInvocationID(input string) (string, error) {
-	uuidPattern := regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 	if uuidPattern.MatchString(input) {
 		return input, nil
 	}
 
 	parsedURL, err := url.Parse(input)
 	if err == nil {
-		pathPattern := regexp.MustCompile(`/invocation/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})`)
 		if matches := pathPattern.FindStringSubmatch(parsedURL.Path); len(matches) > 1 {
 			return matches[1], nil
 		}


### PR DESCRIPTION
Supports invocation ids and urls.

Examples:
  bb view 12345678-1234-1234-1234-123456789012
  bb view https://app.buildbuddy.io/invocation/12345678-1234-1234-1234-123456789012