### PR TITLE
execution_server: record primary output path

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -777,6 +777,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		SelfHosted:                   test.expectedSelfHosted,
 		Region:                       "test-region",
 		CommandSnippet:               "test",
+		OutputPath:                   "bazel-out/k8-fastbuild/bin/some/test",
 		QueuedTimestampUsec:          queuedTime.UnixMicro(),
 		WorkerStartTimestampUsec:     workerStartTime.UnixMicro(),
 		WorkerCompletedTimestampUsec: workerEndTime.UnixMicro(),
@@ -898,7 +899,10 @@ func TestInvocationLink_EmptyInvocationID(t *testing.T) {
 }
 
 func uploadAction(ctx context.Context, t *testing.T, env *real_environment.RealEnv, instanceName string, df repb.DigestFunction_Value, action *repb.Action) *digest.CASResourceName {
-	cmd := &repb.Command{Arguments: []string{"test"}}
+	cmd := &repb.Command{
+		Arguments:   []string{"test"},
+		OutputFiles: []string{"bazel-out/k8-fastbuild/bin/some/test"},
+	}
 	cd, err := cachetools.UploadProto(ctx, env.GetByteStreamClient(), instanceName, df, cmd)
 	require.NoError(t, err)
 	action.CommandDigest = cd

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -325,6 +325,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) *s
 		OutputUploadCompletedTimestampUsec: in.GetOutputUploadCompletedTimestampUsec(),
 		StatusCode:                         in.GetStatusCode(),
 		StatusMessage:                      in.GetStatusMessage(),
+		OutputPath:                         in.GetOutputPath(),
 		ExitCode:                           in.GetExitCode(),
 		CachedResult:                       in.GetCachedResult(),
 		DoNotCache:                         in.GetDoNotCache(),


### PR DESCRIPTION
Record primary output path if we write the new execution through Redis
instead of MySQL.
Also make sure to propagate the output path to clickhouse for longer
term storage and analysis.
