### PR TITLE
Fix flake due to healthchecker not shutting down

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -50,6 +50,7 @@ go_test(
         "//server/util/testing/flags",
         "//server/util/uuid",
         "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",
     ],

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -167,7 +167,10 @@ func GetTestEnv(t testing.TB) *real_environment.RealEnv {
 	}
 
 	healthChecker := healthcheck.NewHealthChecker("test")
-	t.Cleanup(healthChecker.Shutdown)
+	t.Cleanup(func() {
+		healthChecker.Shutdown()
+		healthChecker.WaitForGracefulShutdown()
+	})
 	te := real_environment.NewRealEnv(healthChecker)
 	c, err := memory_cache.NewMemoryCache(1000 * 1000 * 1000 /* 1GB */)
 	if err != nil {


### PR DESCRIPTION
Add `WaitForGracefulShutdown` to test env cleanup because not doing it was causing flakes.

[Example](https://buildbuddy.buildbuddy.dev/invocation/82e4d37a-6801-43f8-b2c7-31425d4c27fa?target=%2F%2Fenterprise%2Fserver%2Fapi%3Aapi_test&targetStatus=6)

Basically, there is a race condition around setting flags because they can be used during the healthchecker shutdown. If we wait for shutdown, this race condition disappears.

However, this means we have to shut down the `priority_task_scheduler` in cleanup for the `priority_task_scheduler` tests. Which also means we have to complete all the scheduler's tasks. Initially, this caused the task scheduler to hang, so this PR also switches the way we track how many cancel tasks are active and how to wait for them to finish.
