### PR TITLE
Only set cache headers for static resources if hash matches

### DIFF
--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -369,7 +369,7 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 		log.Fatalf("Error initializing static file server: %s", err)
 	}
 
-	afs, err := static.NewStaticFileServer(env, env.GetAppFilesystem(), []string{}, "")
+	afs, err := static.NewStaticFileServer(env, env.GetAppFilesystem(), []string{}, appBundleHash)
 	if err != nil {
 		log.Fatalf("Error initializing app server: %s", err)
 	}


### PR DESCRIPTION
We set the hash query parameter (which isn't actually used) to make sure the browser makes a new request when a new version of style.css or app.js is pushed.

Currently we only check whether or not a hash query is present on static resource requests when deciding whether or not to set a cache header marking the resource as immutable.

This can lead to issues where during a rollout, if the index.html request and style.css?hash=foo request hit different servers - the old style.css file can be immutably cached under the new hash.

This change fixes that by only setting the immutable cache header if the hashes match, and setting a no-cache flag when the caches don't match so the new css file can be picked up on the next refresh.

There are other approaches here like:
- Actually serving the css file from a path containing the hash - but then you run into an issue where if you look up the new hash but hit an old server it won't be found.
- Serving css from GCS like we do for for the js bundle - we should probably switch to this long term, but we probably want to fix this anyway for local development or on-prem deployments.