### PR TITLE
[raft] in InitializeClusters log the error returned from matchesListenAddress

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -184,7 +184,7 @@ func (cs *ClusterStarter) InitializeClusters() error {
 		// have info about other nodes that started simultaneously. Don't return
 		// the error as this will restart the server. Instead, we assumes that
 		// this is not the bringup coordinator.
-		cs.log.Infof("failed to match listen address %q: %s", err)
+		cs.log.Infof("failed to match listen address %q: %s", cs.join[0], err)
 	}
 	isBringupCoordinator := (isMatch && err == nil)
 	if cs.bootstrapped || !isBringupCoordinator {


### PR DESCRIPTION
When we start raft clusters from scratch, sometimes the machines restarted
because matchesListenAddresses return no such host error. It can happen when the
machine doesn't have info about other machines yet. When it returns no-such-host
error, it indicates that it's not the bringup coordinator. This also matches the
other callsite of this function.
