### PR TITLE
Get rid of "advanced filters" distinction

### DIFF
--- a/app/components/popup/popup.css
+++ b/app/components/popup/popup.css
@@ -29,6 +29,16 @@
   left: 0;
 }
 
+.popup.anchor-center {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.popup.anchor-center-right {
+  right: 0;
+  transform: translateX(25%);
+}
+
 .popup-container {
   position: relative;
 }

--- a/app/components/popup/popup.tsx
+++ b/app/components/popup/popup.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export type PopupProps = JSX.IntrinsicElements["div"] & {
   isOpen: boolean;
   onRequestClose: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-  anchor?: "left" | "right";
+  anchor?: "left" | "right" | "center" | "center-right";
 };
 
 /**

--- a/enterprise/app/filter/filter.css
+++ b/enterprise/app/filter/filter.css
@@ -41,6 +41,14 @@
   padding: 4px 16px;
 }
 
+.global-filter .option-group-section-title {
+  font-weight: 600;
+  font-size: 15px;
+  background: white;
+  padding: 4px 16px;
+  margin-top: 16px;
+}
+
 .global-filter .option-group {
   padding: 4px 0;
   padding-right: 16px;

--- a/enterprise/app/filter/filter.tsx
+++ b/enterprise/app/filter/filter.tsx
@@ -78,8 +78,6 @@ interface State {
   isFilterMenuOpen: boolean;
   isSortMenuOpen: boolean;
 
-  isAdvancedFilterOpen: boolean;
-
   user?: string;
   repo?: string;
   branch?: string;
@@ -107,30 +105,11 @@ export default class FilterComponent extends React.Component<FilterProps, State>
     }
   }
 
-  isAdvancedFilterOpen(search: URLSearchParams): boolean {
-    return Boolean(
-      search.get(USER_PARAM_NAME) ||
-        search.get(REPO_PARAM_NAME) ||
-        search.get(BRANCH_PARAM_NAME) ||
-        search.get(COMMIT_PARAM_NAME) ||
-        search.get(HOST_PARAM_NAME) ||
-        search.get(COMMAND_PARAM_NAME) ||
-        (capabilities.config.patternFilterEnabled && search.get(PATTERN_PARAM_NAME)) ||
-        search.get(GENERIC_FILTER_PARAM_NAME) ||
-        (capabilities.config.tagsUiEnabled && search.get(TAG_PARAM_NAME)) ||
-        search.get(MINIMUM_DURATION_PARAM_NAME) ||
-        search.get(MAXIMUM_DURATION_PARAM_NAME) ||
-        search.get(DIMENSION_PARAM_NAME) ||
-        search.get(GENERIC_FILTER_PARAM_NAME)
-    );
-  }
-
   newFilterState(search: URLSearchParams): State {
     return {
       isDatePickerOpen: false,
       isFilterMenuOpen: false,
       isSortMenuOpen: false,
-      isAdvancedFilterOpen: this.isAdvancedFilterOpen(search),
       user: search.get(USER_PARAM_NAME) || undefined,
       repo: search.get(REPO_PARAM_NAME) || undefined,
       branch: search.get(BRANCH_PARAM_NAME) || undefined,
@@ -150,7 +129,6 @@ export default class FilterComponent extends React.Component<FilterProps, State>
 
   updateFilterState(search: URLSearchParams) {
     return {
-      isAdvancedFilterOpen: this.isAdvancedFilterOpen(search),
       user: search.get(USER_PARAM_NAME) || undefined,
       repo: search.get(REPO_PARAM_NAME) || undefined,
       branch: search.get(BRANCH_PARAM_NAME) || undefined,
@@ -454,10 +432,102 @@ export default class FilterComponent extends React.Component<FilterProps, State>
             )}
           </OutlinedButton>
           <Popup
+            anchor="center-right"
             isOpen={this.state.isFilterMenuOpen}
             onRequestClose={this.onCloseFilterMenu.bind(this)}
             className="filter-menu-popup">
-            <div className="option-groups-row">
+            <form className="option-groups-row">
+              <div className="option-group">
+                <div className="option-group-title">User</div>
+                <div className="option-group-input">
+                  <TextInput
+                    placeholder={"e.g. tylerw"}
+                    value={this.state.user}
+                    onChange={(e) => this.setState({ user: e.target.value })}
+                  />
+                </div>
+                <div className="option-group-title">Repo</div>
+                <div className="option-group-input">
+                  <TextInput
+                    placeholder={"e.g. github.com/buildbuddy-io/buildbuddy"}
+                    value={this.state.repo}
+                    onChange={(e) => this.setState({ repo: e.target.value })}
+                  />
+                </div>
+                <div className="option-group-title">Branch</div>
+                <div className="option-group-input">
+                  <TextInput
+                    placeholder={"e.g. main"}
+                    value={this.state.branch}
+                    onChange={(e) => this.setState({ branch: e.target.value })}
+                  />
+                </div>
+                <div className="option-group-title">Commit</div>
+                <div className="option-group-input">
+                  <TextInput
+                    placeholder={"e.g. 115a0cdbe816b8cb80089dd200247752fef723fe"}
+                    value={this.state.commit}
+                    onChange={(e) => this.setState({ commit: e.target.value })}
+                  />
+                </div>
+                <div className="option-group-title">Host</div>
+                <div className="option-group-input">
+                  <TextInput
+                    placeholder={"e.g. lunchbox"}
+                    value={this.state.host}
+                    onChange={(e) => this.setState({ host: e.target.value })}
+                  />
+                </div>
+                <div className="option-group-title">Command</div>
+                <div className="option-group-input">
+                  <TextInput
+                    placeholder={"e.g. test"}
+                    value={this.state.command}
+                    onChange={(e) => this.setState({ command: e.target.value })}
+                  />
+                </div>
+
+                {capabilities.config.patternFilterEnabled && (
+                  <>
+                    <div className="option-group-title">Pattern</div>
+                    <div className="option-group-input">
+                      <TextInput
+                        placeholder={"e.g. //foo/..."}
+                        value={this.state.pattern}
+                        onChange={(e) => this.setState({ pattern: e.target.value })}
+                      />
+                    </div>
+                  </>
+                )}
+                {capabilities.config.tagsUiEnabled && (
+                  <>
+                    <div className="option-group-title">Tag</div>
+                    <div className="option-group-input">
+                      <TextInput
+                        placeholder={"e.g. coverage-build"}
+                        value={this.state.tag}
+                        onChange={(e) => this.setState({ tag: e.target.value })}
+                      />
+                    </div>
+                  </>
+                )}
+                {this.maybeRenderDimensionFilterInputs()}
+                {genericFilterString && (
+                  <>
+                    <div className="option-group-title">Advanced</div>
+                    <div className="option-group-input">
+                      <TextInput
+                        placeholder={"e.g., branch:main -command:test"}
+                        value={this.state.genericFilterString}
+                        onChange={(e) => this.setState({ genericFilterString: e.target.value })}
+                      />
+                    </div>
+                  </>
+                )}
+                <div className="option-group-input">
+                  <FilledButton onClick={this.handleFilterApplyClicked.bind(this)}>Apply</FilledButton>
+                </div>
+              </div>
               <div className="option-group">
                 <div className="option-group-title">Role</div>
                 <div className="option-group-options">
@@ -466,9 +536,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
                   {this.renderRoleCheckbox("Workflow", "CI_RUNNER", selectedRoles)}
                   {this.renderRoleCheckbox("Remote Bazel", "HOSTED_BAZEL", selectedRoles)}
                 </div>
-              </div>
-              <div className="option-group">
-                <div className="option-group-title">Status</div>
+                <div className="option-group-section-title">Status</div>
                 <div className="option-group-options">
                   {this.renderStatusCheckbox("Succeeded", invocation_status.OverallStatus.SUCCESS, selectedStatuses)}
                   {this.renderStatusCheckbox("Failed", invocation_status.OverallStatus.FAILURE, selectedStatuses)}
@@ -483,135 +551,35 @@ export default class FilterComponent extends React.Component<FilterProps, State>
                     selectedStatuses
                   )}
                 </div>
-              </div>
-            </div>
-            <div
-              className="filter-menu-advanced-filter-toggle"
-              onClick={() => this.setState({ isAdvancedFilterOpen: !this.state.isAdvancedFilterOpen })}>
-              {this.state.isAdvancedFilterOpen ? "Hide advanced filters" : "Show advanced filters"}
-            </div>
-            {this.state.isAdvancedFilterOpen && (
-              <form className="option-groups-row">
-                <div className="option-group">
-                  <div className="option-group-title">User</div>
-                  <div className="option-group-input">
-                    <TextInput
-                      placeholder={"e.g. tylerw"}
-                      value={this.state.user}
-                      onChange={(e) => this.setState({ user: e.target.value })}
-                    />
-                  </div>
-                  <div className="option-group-title">Repo</div>
-                  <div className="option-group-input">
-                    <TextInput
-                      placeholder={"e.g. github.com/buildbuddy-io/buildbuddy"}
-                      value={this.state.repo}
-                      onChange={(e) => this.setState({ repo: e.target.value })}
-                    />
-                  </div>
-                  <div className="option-group-title">Branch</div>
-                  <div className="option-group-input">
-                    <TextInput
-                      placeholder={"e.g. main"}
-                      value={this.state.branch}
-                      onChange={(e) => this.setState({ branch: e.target.value })}
-                    />
-                  </div>
-                  <div className="option-group-title">Commit</div>
-                  <div className="option-group-input">
-                    <TextInput
-                      placeholder={"e.g. 115a0cdbe816b8cb80089dd200247752fef723fe"}
-                      value={this.state.commit}
-                      onChange={(e) => this.setState({ commit: e.target.value })}
-                    />
-                  </div>
-                  <div className="option-group-title">Host</div>
-                  <div className="option-group-input">
-                    <TextInput
-                      placeholder={"e.g. lunchbox"}
-                      value={this.state.host}
-                      onChange={(e) => this.setState({ host: e.target.value })}
-                    />
-                  </div>
-                  <div className="option-group-title">Command</div>
-                  <div className="option-group-input">
-                    <TextInput
-                      placeholder={"e.g. test"}
-                      value={this.state.command}
-                      onChange={(e) => this.setState({ command: e.target.value })}
-                    />
-                  </div>
-
-                  {capabilities.config.patternFilterEnabled && (
-                    <>
-                      <div className="option-group-title">Pattern</div>
-                      <div className="option-group-input">
-                        <TextInput
-                          placeholder={"e.g. //foo/..."}
-                          value={this.state.pattern}
-                          onChange={(e) => this.setState({ pattern: e.target.value })}
-                        />
-                      </div>
-                    </>
-                  )}
-                  {capabilities.config.tagsUiEnabled && (
-                    <>
-                      <div className="option-group-title">Tag</div>
-                      <div className="option-group-input">
-                        <TextInput
-                          placeholder={"e.g. coverage-build"}
-                          value={this.state.tag}
-                          onChange={(e) => this.setState({ tag: e.target.value })}
-                        />
-                      </div>
-                    </>
-                  )}
-                  {this.maybeRenderDimensionFilterInputs()}
-                  <div className="option-group-title">Duration</div>
-                  <div className="option-group-input">
-                    <Slider
-                      value={[
-                        DURATION_SLIDER_VALUES.indexOf(this.state.minimumDuration || DURATION_SLIDER_MIN_VALUE),
-                        DURATION_SLIDER_VALUES.indexOf(this.state.maximumDuration || DURATION_SLIDER_MAX_VALUE),
-                      ]}
-                      renderThumb={(props, state) => (
-                        <div {...props}>
-                          <div className="slider-thumb-circle"></div>
-                          <div className="slider-thumb-value">
-                            {compactDurationSec(DURATION_SLIDER_VALUES[state.valueNow])}
-                          </div>
+                <div className="option-group-section-title">Duration</div>
+                <div className="option-group-input">
+                  <Slider
+                    value={[
+                      DURATION_SLIDER_VALUES.indexOf(this.state.minimumDuration || DURATION_SLIDER_MIN_VALUE),
+                      DURATION_SLIDER_VALUES.indexOf(this.state.maximumDuration || DURATION_SLIDER_MAX_VALUE),
+                    ]}
+                    renderThumb={(props, state) => (
+                      <div {...props}>
+                        <div className="slider-thumb-circle"></div>
+                        <div className="slider-thumb-value">
+                          {compactDurationSec(DURATION_SLIDER_VALUES[state.valueNow])}
                         </div>
-                      )}
-                      min={DURATION_SLIDER_MIN_INDEX}
-                      max={DURATION_SLIDER_MAX_INDEX}
-                      pearling
-                      minDistance={1}
-                      onChange={(e) =>
-                        this.setState({
-                          minimumDuration: DURATION_SLIDER_VALUES[e[0]],
-                          maximumDuration: DURATION_SLIDER_VALUES[e[1]],
-                        })
-                      }
-                    />
-                  </div>
-                  {genericFilterString && (
-                    <>
-                      <div className="option-group-title">Advanced</div>
-                      <div className="option-group-input">
-                        <TextInput
-                          placeholder={"e.g., branch:main -command:test"}
-                          value={this.state.genericFilterString}
-                          onChange={(e) => this.setState({ genericFilterString: e.target.value })}
-                        />
                       </div>
-                    </>
-                  )}
-                  <div className="option-group-input">
-                    <FilledButton onClick={this.handleFilterApplyClicked.bind(this)}>Apply</FilledButton>
-                  </div>
+                    )}
+                    min={DURATION_SLIDER_MIN_INDEX}
+                    max={DURATION_SLIDER_MAX_INDEX}
+                    pearling
+                    minDistance={1}
+                    onChange={(e) =>
+                      this.setState({
+                        minimumDuration: DURATION_SLIDER_VALUES[e[0]],
+                        maximumDuration: DURATION_SLIDER_VALUES[e[1]],
+                      })
+                    }
+                  />
                 </div>
-              </form>
-            )}
+              </div>
+            </form>
           </Popup>
         </div>
         <div className="popup-wrapper">


### PR DESCRIPTION
The reason why I initially hid filters under "Advanced filters" is because we were doing the filtering in MySQL and many of them were slow.

Now that we're using clickhouse - I don't think we need to hide them under an expando anymore.

Before:
<img width="451" height="340" alt="Screenshot 2025-09-18 at 3 22 48 PM" src="https://github.com/user-attachments/assets/b59e3c65-2680-40d4-9aa9-fb25d02f2e2c" />

Before expanded:
<img width="475" height="716" alt="Screenshot 2025-09-18 at 3 22 52 PM" src="https://github.com/user-attachments/assets/5eb61c2a-de15-4c40-99fe-b82c3e6b05a2" />

After:
<img width="660" height="631" alt="Screenshot 2025-09-18 at 3 22 40 PM" src="https://github.com/user-attachments/assets/7302ed1b-94f5-40b3-84cc-471e829aeabe" />

