### PR TITLE
don't double-count merged actions on targets page

### DIFF
--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -1308,6 +1308,10 @@ func (i *InvocationStatService) GetTargetTrends(ctx context.Context, req *stpb.G
 		return nil, err
 	}
 
+	// Merged actions appear in clickhouse as multiple rows with the same
+	// execution_id, but a different invocation_uuid.  This inner query dedupes
+	// by execution_id and takes the highest value (though all rows should have
+	// the same value).
 	innerQ := query_builder.NewQuery(fmt.Sprintf(`
 		SELECT target_label, execution_id, MAX(%s) as v
 		FROM "Executions"`, metric))


### PR DESCRIPTION
merged actions appear in clickhouse as multiple rows with the same `execution_id`, but a different `invocation_uuid`.  this change dedupes by `execution_id` and takes the highest value for the requested metric (all values for the metric should be identical, but taking `max` seems good)

I spot-checked against the last 7 days with:
```
SELECT target_label, SUM(cpu/ct) AS extras FROM (SELECT target_label, execution_id, count(*) AS ct, SUM(cpu_nanos) AS cpu FROM Executions WHERE updated_at_usec > 1757706462000000 AND group_id='***' GROUP BY (target_label, execution_id) ORDER BY ct DESC) WHERE ct > 1 GROUP BY target_label ORDER BY extras DESC;
```