### PR TITLE
docs: document PostgreSQL support

### DIFF
--- a/docs/config-database.md
+++ b/docs/config-database.md
@@ -12,7 +12,7 @@ sidebar_label: Database
 
 **Required**
 
-- `data_source` This is a connection string used by the database driver to connect to the database. MySQL and SQLite databases are supported.
+- `data_source` This is a connection string used by the database driver to connect to the database. MySQL, PostgreSQL, and SQLite databases are supported.
 
 ## Example sections
 
@@ -28,4 +28,11 @@ database:
 ```yaml title="config.yaml"
 database:
   data_source: "mysql://buildbuddy_user:pAsSwOrD@tcp(12.34.56.78)/buildbuddy_db"
+```
+
+### PostgreSQL
+
+```yaml title="config.yaml"
+database:
+  data_source: "postgresql://buildbuddy_user:pAsSwOrD@12.34.56.78:5433/buildbuddy_db"
 ```


### PR DESCRIPTION
A quick, small addition to the `database` configuration documentation, adding a note and example about PostgreSQL support.

Looks like this has been supported for 2 years but isn't in the documentation.