### PR TITLE
[cli] show help for `bb` and `bazel` commands

### DIFF
--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -16,8 +16,8 @@ go_library(
 go_test(
     name = "help_test",
     srcs = ["help_test.go"],
-    embed = [":help"],
     deps = [
+        ":help",
         "//cli/cli_command",
         "//cli/parser/arguments",
         "//cli/parser/parsed",

--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "help",
@@ -10,6 +10,19 @@ go_library(
         "//cli/parser/arguments",
         "//cli/parser/parsed",
         "//cli/version",
+    ],
+)
+
+go_test(
+    name = "help_test",
+    srcs = ["help_test.go"],
+    embed = [":help"],
+    deps = [
+        "//cli/cli_command",
+        "//cli/parser/arguments",
+        "//cli/parser/parsed",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -7,6 +7,7 @@ go_library(
     deps = [
         "//cli/bazelisk",
         "//cli/cli_command",
+        "//cli/parser/arguments",
         "//cli/parser/parsed",
         "//cli/version",
     ],

--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -19,6 +19,7 @@ go_test(
     deps = [
         ":help",
         "//cli/cli_command",
+        "//cli/cli_command/register",
         "//cli/parser/arguments",
         "//cli/parser/parsed",
         "@com_github_stretchr_testify//assert",

--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -18,7 +18,6 @@ go_test(
     srcs = ["help_test.go"],
     deps = [
         ":help",
-        "//cli/cli_command",
         "//cli/cli_command/register",
         "//cli/parser/arguments",
         "//cli/parser/parsed",

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -19,9 +19,9 @@ const (
 	cliName = "bb"
 )
 
-// findTargetCommandFromHelpArgs extracts the target command from "bb help <command>" arguments.
+// FindTargetCommandFromHelpArgs extracts the target command from "bb help <command>" arguments.
 // Returns the command name if found, empty string otherwise.
-func findTargetCommandFromHelpArgs(orderedArgs *parsed.OrderedArgs) string {
+func FindTargetCommandFromHelpArgs(orderedArgs *parsed.OrderedArgs) string {
 	_, command := parsed.Find[*parsed.Command](orderedArgs.Args)
 	if command == nil {
 		return ""
@@ -46,9 +46,9 @@ func findTargetCommandFromHelpArgs(orderedArgs *parsed.OrderedArgs) string {
 	return command.Value
 }
 
-// tryShowBBCommandHelp checks if the target command is a BB CLI command and shows its help.
+// TryShowBBCommandHelp checks if the target command is a BB CLI command and shows its help.
 // Returns true if help was shown, false if not a BB CLI command.
-func tryShowBBCommandHelp(targetCommand string) bool {
+func TryShowBBCommandHelp(targetCommand string) bool {
 	if targetCommand == "" {
 		return false
 	}
@@ -72,8 +72,8 @@ func tryShowBBCommandHelp(targetCommand string) bool {
 func HandleHelp(args parsed.Args) (exitCode int, err error) {
 	// Check if the help request is for a BB CLI command
 	if orderedArgs, ok := args.(*parsed.OrderedArgs); ok {
-		targetCommand := findTargetCommandFromHelpArgs(orderedArgs)
-		if tryShowBBCommandHelp(targetCommand) {
+		targetCommand := FindTargetCommandFromHelpArgs(orderedArgs)
+		if TryShowBBCommandHelp(targetCommand) {
 			return 0, nil
 		}
 	}

--- a/cli/help/help_test.go
+++ b/cli/help/help_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/buildbuddy-io/buildbuddy/cli/cli_command"
 	register_cli_commands "github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
 	"github.com/buildbuddy-io/buildbuddy/cli/help"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
@@ -14,283 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestFindTargetCommandFromHelpArgs(t *testing.T) {
-	tests := []struct {
-		name     string
-		args     []arguments.Argument
-		expected string
-	}{
-		{
-			name:     "no command found",
-			args:     []arguments.Argument{},
-			expected: "",
-		},
-		{
-			name: "direct command",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "build"},
-			},
-			expected: "build",
-		},
-		{
-			name: "help with target command",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "help"},
-				&arguments.PositionalArgument{Value: "add"},
-			},
-			expected: "add",
-		},
-		{
-			name: "help with bazel command",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "help"},
-				&arguments.PositionalArgument{Value: "query"},
-			},
-			expected: "query",
-		},
-		{
-			name: "help without target command",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "help"},
-			},
-			expected: "help",
-		},
-		{
-			name: "help with non-positional args mixed in",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "help"},
-				&arguments.PositionalArgument{Value: "login"},
-			},
-			expected: "login",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			orderedArgs := &parsed.OrderedArgs{Args: tt.args}
-			result := help.FindTargetCommandFromHelpArgs(orderedArgs)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestTryShowBBCommandHelp(t *testing.T) {
-	// Set up some mock commands for testing
-	originalCommands := cli_command.Commands
-	originalCommandsByName := cli_command.CommandsByName
-	defer func() {
-		cli_command.Commands = originalCommands
-		cli_command.CommandsByName = originalCommandsByName
-	}()
-
-	// Mock CLI commands
-	cli_command.Commands = []*cli_command.Command{
-		{Name: "add", Help: "Adds a dependency to your WORKSPACE file."},
-		{Name: "login", Help: "Configures bb commands to use your BuildBuddy API key."},
-	}
-	cli_command.CommandsByName = map[string]*cli_command.Command{
-		"add":   cli_command.Commands[0],
-		"login": cli_command.Commands[1],
-	}
-
-	tests := []struct {
-		name           string
-		targetCommand  string
-		expectedResult bool
-		expectedOutput string
-	}{
-		{
-			name:           "empty command",
-			targetCommand:  "",
-			expectedResult: false,
-			expectedOutput: "",
-		},
-		{
-			name:           "bb cli command",
-			targetCommand:  "add",
-			expectedResult: true,
-			expectedOutput: "Usage: bb add\n\nAdds a dependency to your WORKSPACE file.\n",
-		},
-		{
-			name:           "another bb cli command",
-			targetCommand:  "login",
-			expectedResult: true,
-			expectedOutput: "Usage: bb login\n\nConfigures bb commands to use your BuildBuddy API key.\n",
-		},
-		{
-			name:           "non-bb command",
-			targetCommand:  "query",
-			expectedResult: false,
-			expectedOutput: "",
-		},
-		{
-			name:           "unknown command",
-			targetCommand:  "unknown",
-			expectedResult: false,
-			expectedOutput: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Capture stdout
-			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
-			result := help.TryShowBBCommandHelp(tt.targetCommand)
-
-			// Restore stdout
-			w.Close()
-			os.Stdout = oldStdout
-
-			// Read captured output
-			var buf bytes.Buffer
-			io.Copy(&buf, r)
-			output := buf.String()
-
-			assert.Equal(t, tt.expectedResult, result)
-			assert.Equal(t, tt.expectedOutput, output)
-		})
-	}
-}
-
-func TestHandleHelp_BBCommands(t *testing.T) {
-	// Set up some mock commands for testing
-	originalCommands := cli_command.Commands
-	originalCommandsByName := cli_command.CommandsByName
-	defer func() {
-		cli_command.Commands = originalCommands
-		cli_command.CommandsByName = originalCommandsByName
-	}()
-
-	// Mock CLI commands
-	cli_command.Commands = []*cli_command.Command{
-		{Name: "add", Help: "Adds a dependency to your WORKSPACE file."},
-		{Name: "login", Help: "Configures bb commands to use your BuildBuddy API key."},
-	}
-	cli_command.CommandsByName = map[string]*cli_command.Command{
-		"add":   cli_command.Commands[0],
-		"login": cli_command.Commands[1],
-	}
-
-	tests := []struct {
-		name             string
-		args             []arguments.Argument
-		expectedExitCode int
-		expectedOutput   string
-		shouldCallBazel  bool
-	}{
-		{
-			name: "bb help add",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "help"},
-				&arguments.PositionalArgument{Value: "add"},
-			},
-			expectedExitCode: 0,
-			expectedOutput:   "Usage: bb add\n\nAdds a dependency to your WORKSPACE file.\n",
-			shouldCallBazel:  false,
-		},
-		{
-			name: "bb help login",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "help"},
-				&arguments.PositionalArgument{Value: "login"},
-			},
-			expectedExitCode: 0,
-			expectedOutput:   "Usage: bb login\n\nConfigures bb commands to use your BuildBuddy API key.\n",
-			shouldCallBazel:  false,
-		},
-		{
-			name: "bb add (direct command help)",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "add"},
-			},
-			expectedExitCode: 0,
-			expectedOutput:   "Usage: bb add\n\nAdds a dependency to your WORKSPACE file.\n",
-			shouldCallBazel:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Capture stdout
-			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
-			orderedArgs := &parsed.OrderedArgs{Args: tt.args}
-			exitCode, err := help.HandleHelp(orderedArgs)
-
-			// Restore stdout
-			w.Close()
-			os.Stdout = oldStdout
-
-			// Read captured output
-			var buf bytes.Buffer
-			io.Copy(&buf, r)
-			output := buf.String()
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedExitCode, exitCode)
-			assert.Equal(t, tt.expectedOutput, output)
-		})
-	}
-}
-
-func TestHandleHelp_NonBBCommands(t *testing.T) {
-	// Set up some mock commands for testing
-	originalCommands := cli_command.Commands
-	originalCommandsByName := cli_command.CommandsByName
-	defer func() {
-		cli_command.Commands = originalCommands
-		cli_command.CommandsByName = originalCommandsByName
-	}()
-
-	// Mock CLI commands (empty for this test)
-	cli_command.Commands = []*cli_command.Command{}
-	cli_command.CommandsByName = map[string]*cli_command.Command{}
-
-	tests := []struct {
-		name        string
-		args        []arguments.Argument
-		description string
-	}{
-		{
-			name: "bb help query",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "help"},
-				&arguments.PositionalArgument{Value: "query"},
-			},
-			description: "should forward to bazel for unknown commands",
-		},
-		{
-			name: "bb help build",
-			args: []arguments.Argument{
-				&arguments.PositionalArgument{Value: "help"},
-				&arguments.PositionalArgument{Value: "build"},
-			},
-			description: "should forward to bazel for bazel commands",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			orderedArgs := &parsed.OrderedArgs{Args: tt.args}
-
-			// We can't easily test the full bazelisk.Run call without mocking,
-			// but we can test that it doesn't return early (exitCode 0 from BB commands)
-			// This test will fail if the bazelisk.Run call fails, but that's expected
-			// in the test environment since we don't have bazel set up.
-			_, err := help.HandleHelp(orderedArgs)
-
-			// We expect an error here because bazelisk.Run will fail in test environment
-			// The important thing is that we reached this point (didn't return early)
-			assert.Error(t, err, tt.description)
-		})
-	}
-}
 
 // TestHelpForBBCommands exhaustively tests help for all BB CLI commands found under cli/
 func TestHelpForBBCommands(t *testing.T) {
@@ -349,6 +71,12 @@ func TestHelpForBBCommands(t *testing.T) {
 			assert.NotEmpty(t, output, "Output should not be empty for BB command: %s", cmdName)
 		})
 	}
+}
+
+// TestHelpAliases tests help for all known BB CLI command aliases
+func TestHelpAliases(t *testing.T) {
+	// Register all CLI commands
+	register_cli_commands.Register()
 
 	// Test known aliases
 	aliases := map[string]string{
@@ -384,6 +112,12 @@ func TestHelpForBBCommands(t *testing.T) {
 			assert.NotEmpty(t, output, "Output should not be empty for alias: %s", alias)
 		})
 	}
+}
+
+// TestHelpBazelCommands tests help for common Bazel commands (should forward to Bazel)
+func TestHelpBazelCommands(t *testing.T) {
+	// Register all CLI commands
+	register_cli_commands.Register()
 
 	// Test common Bazel commands (should forward to Bazel and fail in test environment)
 	bazelCommands := []string{

--- a/cli/help/help_test.go
+++ b/cli/help/help_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	register_cli_commands "github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
+	"github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
 	"github.com/buildbuddy-io/buildbuddy/cli/help"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
@@ -47,7 +47,7 @@ func testBBCommandHelp(t *testing.T, cmdName string, expectedCmdName string) {
 // TestHelpForBBCommands exhaustively tests help for all BB CLI commands found under cli/
 func TestHelpForBBCommands(t *testing.T) {
 	// Register all CLI commands
-	register_cli_commands.Register()
+	register.Register()
 
 	// All BB CLI command names found under cli/ directories
 	bbCommandNames := []string{
@@ -83,7 +83,7 @@ func TestHelpForBBCommands(t *testing.T) {
 // TestHelpAliases tests help for all known BB CLI command aliases
 func TestHelpAliases(t *testing.T) {
 	// Register all CLI commands
-	register_cli_commands.Register()
+	register.Register()
 
 	// Test known aliases
 	aliases := map[string]string{
@@ -101,7 +101,7 @@ func TestHelpAliases(t *testing.T) {
 // TestHelpBazelCommands tests that Bazel commands are not handled as BB commands
 func TestHelpBazelCommands(t *testing.T) {
 	// Register all CLI commands
-	register_cli_commands.Register()
+	register.Register()
 
 	// All Bazel commands from Bazel 8.4.0 - these should NOT be recognized as BB commands
 	bazelCommands := []string{

--- a/cli/help/help_test.go
+++ b/cli/help/help_test.go
@@ -103,10 +103,30 @@ func TestHelpBazelCommands(t *testing.T) {
 	// Register all CLI commands
 	register_cli_commands.Register()
 
-	// Test common Bazel commands - these should NOT be recognized as BB commands
+	// All Bazel commands from Bazel 8.4.0 - these should NOT be recognized as BB commands
 	bazelCommands := []string{
-		"build", "test", "run", "query", "cquery", "aquery", "clean", "info",
-		"coverage", "fetch", "sync", "dump", "shutdown",
+		"analyze-profile",
+		"aquery",
+		"build",
+		"canonicalize-flags",
+		"clean",
+		"coverage",
+		"cquery",
+		"dump",
+		"fetch",
+		"help",
+		"info",
+		"license",
+		"mobile-install",
+		"mod",
+		"print_action",
+		"query",
+		"run",
+		"shutdown",
+		"sync",
+		"test",
+		"vendor",
+		// Do not test "version", since this is a BB CLI command.
 	}
 
 	for _, cmdName := range bazelCommands {
@@ -123,17 +143,8 @@ func TestHelpBazelCommands(t *testing.T) {
 			assert.Equal(t, cmdName, targetCommand, "Should find target command: %s", cmdName)
 
 			// But TryShowBBCommandHelp should return false (not a BB command)
-			// Capture stdout to avoid polluting test output
-			oldStdout := os.Stdout
-			_, w, _ := os.Pipe()
-			os.Stdout = w
-
+			// No stdout redirection needed since TryShowBBCommandHelp won't print anything for non-BB commands
 			result := help.TryShowBBCommandHelp(targetCommand)
-
-			// Restore stdout
-			w.Close()
-			os.Stdout = oldStdout
-
 			assert.False(t, result, "Should not handle %s as BB command", cmdName)
 
 			// Note: We don't test the full HandleHelp because that would require

--- a/cli/help/help_test.go
+++ b/cli/help/help_test.go
@@ -1,0 +1,293 @@
+package help_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/cli_command"
+	"github.com/buildbuddy-io/buildbuddy/cli/help"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindTargetCommandFromHelpArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []arguments.Argument
+		expected string
+	}{
+		{
+			name:     "no command found",
+			args:     []arguments.Argument{},
+			expected: "",
+		},
+		{
+			name: "direct command",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "build"},
+			},
+			expected: "build",
+		},
+		{
+			name: "help with target command",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "help"},
+				&arguments.PositionalArgument{Value: "add"},
+			},
+			expected: "add",
+		},
+		{
+			name: "help with bazel command",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "help"},
+				&arguments.PositionalArgument{Value: "query"},
+			},
+			expected: "query",
+		},
+		{
+			name: "help without target command",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "help"},
+			},
+			expected: "help",
+		},
+		{
+			name: "help with non-positional args mixed in",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "help"},
+				&arguments.PositionalArgument{Value: "login"},
+			},
+			expected: "login",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orderedArgs := &parsed.OrderedArgs{Args: tt.args}
+			result := help.FindTargetCommandFromHelpArgs(orderedArgs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTryShowBBCommandHelp(t *testing.T) {
+	// Set up some mock commands for testing
+	originalCommands := cli_command.Commands
+	originalCommandsByName := cli_command.CommandsByName
+	defer func() {
+		cli_command.Commands = originalCommands
+		cli_command.CommandsByName = originalCommandsByName
+	}()
+
+	// Mock CLI commands
+	cli_command.Commands = []*cli_command.Command{
+		{Name: "add", Help: "Adds a dependency to your WORKSPACE file."},
+		{Name: "login", Help: "Configures bb commands to use your BuildBuddy API key."},
+	}
+	cli_command.CommandsByName = map[string]*cli_command.Command{
+		"add":   cli_command.Commands[0],
+		"login": cli_command.Commands[1],
+	}
+
+	tests := []struct {
+		name           string
+		targetCommand  string
+		expectedResult bool
+		expectedOutput string
+	}{
+		{
+			name:           "empty command",
+			targetCommand:  "",
+			expectedResult: false,
+			expectedOutput: "",
+		},
+		{
+			name:           "bb cli command",
+			targetCommand:  "add",
+			expectedResult: true,
+			expectedOutput: "Usage: bb add\n\nAdds a dependency to your WORKSPACE file.\n",
+		},
+		{
+			name:           "another bb cli command",
+			targetCommand:  "login",
+			expectedResult: true,
+			expectedOutput: "Usage: bb login\n\nConfigures bb commands to use your BuildBuddy API key.\n",
+		},
+		{
+			name:           "non-bb command",
+			targetCommand:  "query",
+			expectedResult: false,
+			expectedOutput: "",
+		},
+		{
+			name:           "unknown command",
+			targetCommand:  "unknown",
+			expectedResult: false,
+			expectedOutput: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			result := help.TryShowBBCommandHelp(tt.targetCommand)
+
+			// Restore stdout
+			w.Close()
+			os.Stdout = oldStdout
+
+			// Read captured output
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			output := buf.String()
+
+			assert.Equal(t, tt.expectedResult, result)
+			assert.Equal(t, tt.expectedOutput, output)
+		})
+	}
+}
+
+func TestHandleHelp_BBCommands(t *testing.T) {
+	// Set up some mock commands for testing
+	originalCommands := cli_command.Commands
+	originalCommandsByName := cli_command.CommandsByName
+	defer func() {
+		cli_command.Commands = originalCommands
+		cli_command.CommandsByName = originalCommandsByName
+	}()
+
+	// Mock CLI commands
+	cli_command.Commands = []*cli_command.Command{
+		{Name: "add", Help: "Adds a dependency to your WORKSPACE file."},
+		{Name: "login", Help: "Configures bb commands to use your BuildBuddy API key."},
+	}
+	cli_command.CommandsByName = map[string]*cli_command.Command{
+		"add":   cli_command.Commands[0],
+		"login": cli_command.Commands[1],
+	}
+
+	tests := []struct {
+		name             string
+		args             []arguments.Argument
+		expectedExitCode int
+		expectedOutput   string
+		shouldCallBazel  bool
+	}{
+		{
+			name: "bb help add",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "help"},
+				&arguments.PositionalArgument{Value: "add"},
+			},
+			expectedExitCode: 0,
+			expectedOutput:   "Usage: bb add\n\nAdds a dependency to your WORKSPACE file.\n",
+			shouldCallBazel:  false,
+		},
+		{
+			name: "bb help login",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "help"},
+				&arguments.PositionalArgument{Value: "login"},
+			},
+			expectedExitCode: 0,
+			expectedOutput:   "Usage: bb login\n\nConfigures bb commands to use your BuildBuddy API key.\n",
+			shouldCallBazel:  false,
+		},
+		{
+			name: "bb add (direct command help)",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "add"},
+			},
+			expectedExitCode: 0,
+			expectedOutput:   "Usage: bb add\n\nAdds a dependency to your WORKSPACE file.\n",
+			shouldCallBazel:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout
+			oldStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			orderedArgs := &parsed.OrderedArgs{Args: tt.args}
+			exitCode, err := help.HandleHelp(orderedArgs)
+
+			// Restore stdout
+			w.Close()
+			os.Stdout = oldStdout
+
+			// Read captured output
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			output := buf.String()
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedExitCode, exitCode)
+			assert.Equal(t, tt.expectedOutput, output)
+		})
+	}
+}
+
+func TestHandleHelp_NonBBCommands(t *testing.T) {
+	// Set up some mock commands for testing
+	originalCommands := cli_command.Commands
+	originalCommandsByName := cli_command.CommandsByName
+	defer func() {
+		cli_command.Commands = originalCommands
+		cli_command.CommandsByName = originalCommandsByName
+	}()
+
+	// Mock CLI commands (empty for this test)
+	cli_command.Commands = []*cli_command.Command{}
+	cli_command.CommandsByName = map[string]*cli_command.Command{}
+
+	tests := []struct {
+		name        string
+		args        []arguments.Argument
+		description string
+	}{
+		{
+			name: "bb help query",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "help"},
+				&arguments.PositionalArgument{Value: "query"},
+			},
+			description: "should forward to bazel for unknown commands",
+		},
+		{
+			name: "bb help build",
+			args: []arguments.Argument{
+				&arguments.PositionalArgument{Value: "help"},
+				&arguments.PositionalArgument{Value: "build"},
+			},
+			description: "should forward to bazel for bazel commands",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orderedArgs := &parsed.OrderedArgs{Args: tt.args}
+
+			// We can't easily test the full bazelisk.Run call without mocking,
+			// but we can test that it doesn't return early (exitCode 0 from BB commands)
+			// This test will fail if the bazelisk.Run call fails, but that's expected
+			// in the test environment since we don't have bazel set up.
+			_, err := help.HandleHelp(orderedArgs)
+
+			// We expect an error here because bazelisk.Run will fail in test environment
+			// The important thing is that we reached this point (didn't return early)
+			assert.Error(t, err, tt.description)
+		})
+	}
+}
+

--- a/cli/help/help_test.go
+++ b/cli/help/help_test.go
@@ -10,15 +10,12 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/help"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// Helper function to test BB CLI command help
 func testBBCommandHelp(t *testing.T, cmdName string, expectedCmdName string) {
 	t.Helper()
 
-	// Capture stdout
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
@@ -29,50 +26,44 @@ func testBBCommandHelp(t *testing.T, cmdName string, expectedCmdName string) {
 	}}
 	exitCode, err := help.HandleHelp(orderedArgs)
 
-	// Restore stdout
 	w.Close()
 	os.Stdout = oldStdout
 
-	// Read captured output
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	output := buf.String()
 
 	require.NoError(t, err, "Help should work for BB command: %s", cmdName)
-	assert.Equal(t, 0, exitCode, "Exit code should be 0 for BB command: %s", cmdName)
-	assert.Contains(t, output, "Usage: bb "+expectedCmdName, "Output should contain usage for: %s", expectedCmdName)
-	assert.NotEmpty(t, output, "Output should not be empty for BB command: %s", cmdName)
+	require.Equal(t, 0, exitCode, "Exit code should be 0 for BB command: %s", cmdName)
+	require.Contains(t, output, "Usage: bb "+expectedCmdName, "Output should contain usage for: %s", expectedCmdName)
+	require.NotEmpty(t, output, "Output should not be empty for BB command: %s", cmdName)
 }
 
-// TestHelpForBBCommands exhaustively tests help for all BB CLI commands found under cli/
 func TestHelpForBBCommands(t *testing.T) {
-	// Register all CLI commands
 	register.Register()
 
-	// All BB CLI command names found under cli/ directories
 	bbCommandNames := []string{
-		"add",             // cli/add
-		"analyze",         // cli/analyze
-		"ask",             // cli/ask (with aliases wtf, huh)
-		"download",        // cli/download
-		"execute",         // cli/execute
-		"explain",         // cli/explain
-		"fix",             // cli/fix
-		"index",           // cli/index
-		"login",           // cli/login (includes logout functionality)
-		"print",           // cli/printlog
-		"remote",          // cli/remotebazel
-		"remote-download", // cli/remote_download
-		"search",          // cli/search
-		"update",          // cli/update
-		"upload",          // cli/upload
-		"version",         // cli/versioncmd
-		"view",            // cli/view
-		"install",         // cli/plugin (install command)
-		"logout",          // cli/login (logout command)
+		"add",
+		"analyze",
+		"ask",
+		"download",
+		"execute",
+		"explain",
+		"fix",
+		"index",
+		"login",
+		"print",
+		"remote",
+		"remote-download",
+		"search",
+		"update",
+		"upload",
+		"version",
+		"view",
+		"install",
+		"logout",
 	}
 
-	// Test "bb help <command>" for each BB command
 	for _, cmdName := range bbCommandNames {
 		t.Run("bb help "+cmdName, func(t *testing.T) {
 			testBBCommandHelp(t, cmdName, cmdName)
@@ -80,12 +71,9 @@ func TestHelpForBBCommands(t *testing.T) {
 	}
 }
 
-// TestHelpAliases tests help for all known BB CLI command aliases
 func TestHelpAliases(t *testing.T) {
-	// Register all CLI commands
 	register.Register()
 
-	// Test known aliases
 	aliases := map[string]string{
 		"wtf": "ask",
 		"huh": "ask",
@@ -98,12 +86,9 @@ func TestHelpAliases(t *testing.T) {
 	}
 }
 
-// TestHelpBazelCommands tests that Bazel commands are not handled as BB commands
 func TestHelpBazelCommands(t *testing.T) {
-	// Register all CLI commands
 	register.Register()
 
-	// All Bazel commands from Bazel 8.4.0 - these should NOT be recognized as BB commands
 	bazelCommands := []string{
 		"analyze-profile",
 		"aquery",
@@ -131,26 +116,16 @@ func TestHelpBazelCommands(t *testing.T) {
 
 	for _, cmdName := range bazelCommands {
 		t.Run("bb help "+cmdName+" (not a BB command)", func(t *testing.T) {
-			// Test that this command is not recognized as a BB CLI command
-			// by checking our helper functions directly
 			orderedArgs := &parsed.OrderedArgs{Args: []arguments.Argument{
 				&arguments.PositionalArgument{Value: "help"},
 				&arguments.PositionalArgument{Value: cmdName},
 			}}
 
-			// This should find the target command
 			targetCommand := help.FindTargetCommandFromHelpArgs(orderedArgs)
-			assert.Equal(t, cmdName, targetCommand, "Should find target command: %s", cmdName)
+			require.Equal(t, cmdName, targetCommand, "Should find target command: %s", cmdName)
 
-			// But TryShowBBCommandHelp should return false (not a BB command)
-			// No stdout redirection needed since TryShowBBCommandHelp won't print anything for non-BB commands
 			result := help.TryShowBBCommandHelp(targetCommand)
-			assert.False(t, result, "Should not handle %s as BB command", cmdName)
-
-			// Note: We don't test the full HandleHelp because that would require
-			// mocking bazelisk.Run or having Bazel installed. The important thing
-			// is that these commands are correctly identified as non-BB commands
-			// and would be forwarded to Bazel.
+			require.False(t, result, "Should not handle %s as BB command", cmdName)
 		})
 	}
 }


### PR DESCRIPTION
Prior to this change, `bb help remote` (or any other BB CLI command) would print an error message saying the `remote` command could not be found. This is because we were always routing to `bb help <command>` to `bazelisk`.

This change has `bb help <command>` determine whether `<command>` is a BB CLI command. If so, it will print the help for that command and exit. Otherwise, it will invoke `bazelisk help <command>`.

This change adds tests for all BB CLI commands currently in the source tree and all Bazel commands present in `8.4.0`.

This change does not test `bb <command> -h` or `bb <command> --help`. Cooking that right now.