### PR TITLE
Optimize bytestream.Write by double buffering in distributed client

### DIFF
--- a/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
+++ b/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
@@ -1,4 +1,4 @@
-// Benchmarks for byte_stream_server.go. There are in /enterprise/ because they
+// Benchmarks for byte_stream_server.go. They live in enterprise because they
 // depend on the distributed cache, which is enterprise-only.
 package bytestream_server_benchmark_test
 

--- a/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
+++ b/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
@@ -1,4 +1,4 @@
-// Benchmarks for byte_stream_server.go. They live in enterprise because they
+// Benchmarks for byte_stream_server.go. There are in /enterprise/ because they
 // depend on the distributed cache, which is enterprise-only.
 package bytestream_server_benchmark_test
 
@@ -132,7 +132,7 @@ func BenchmarkWrite(b *testing.B) {
 
 	// Bazel uses 16KiB chunks. cachetools.UploadFromReader uses 1MB chunks, but
 	// maybe it should be changed to 256KiB.
-	chunkSizes := []int{16 * 1024, 256 * 1024, 1_000_000}
+	chunkSizes := []int{16 * 1024, 256 * 1024, 512 * 1024, 1_000_000}
 
 	for _, test := range []struct {
 		cacheType string

--- a/server/util/ioutil/BUILD
+++ b/server/util/ioutil/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/interfaces",
+        "//server/util/bytebufferpool",
         "//server/util/status",
     ],
 )
@@ -18,6 +19,7 @@ go_test(
     deps = [
         ":ioutil",
         "//server/testutil/testdigest",
+        "//server/util/bytebufferpool",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/ioutil/ioutil.go
+++ b/server/util/ioutil/ioutil.go
@@ -258,7 +258,6 @@ func (w *DoubleBufferWriter) Write(data []byte) (int, error) {
 			case buffer = <-w.writes:
 			default:
 			}
-		} else {
 		}
 		buffer = w.resizeBuffer(buffer, initialDataSize)
 

--- a/server/util/ioutil/ioutil_test.go
+++ b/server/util/ioutil/ioutil_test.go
@@ -98,14 +98,6 @@ func mustWrite(t *testing.T, w io.Writer, p []byte) {
 	require.Equal(t, len(p), n)
 }
 
-// func mustRead(t *testing.T, r io.Reader, p []byte) {
-// 	buf := make([]byte, len(p))
-// 	n, err := r.Read(buf)
-// 	require.NoError(t, err)
-// 	require.Equal(t, p, buf[:n])
-// 	fmt.Println("\t\t\tREAD", n, "bytes")
-// }
-
 func mustRead(t *testing.T, r io.Reader, p []byte) int {
 	buf := make([]byte, len(p))
 	n, err := ioutil.ReadTryFillBuffer(r, buf)

--- a/server/util/ioutil/ioutil_test.go
+++ b/server/util/ioutil/ioutil_test.go
@@ -2,11 +2,15 @@ package ioutil_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"fmt"
 	"io"
+	"math/rand"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bytebufferpool"
 	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -86,4 +90,165 @@ func TestBestEffortWriter(t *testing.T) {
 	require.Zero(t, written)
 	require.Error(t, b.Err())
 	require.Empty(t, cmp.Diff(bytesToWrite[:22], w.Bytes()))
+}
+
+func mustWrite(t *testing.T, w io.Writer, p []byte) {
+	n, err := w.Write(p)
+	require.NoError(t, err)
+	require.Equal(t, len(p), n)
+}
+
+// func mustRead(t *testing.T, r io.Reader, p []byte) {
+// 	buf := make([]byte, len(p))
+// 	n, err := r.Read(buf)
+// 	require.NoError(t, err)
+// 	require.Equal(t, p, buf[:n])
+// 	fmt.Println("\t\t\tREAD", n, "bytes")
+// }
+
+func mustRead(t *testing.T, r io.Reader, p []byte) int {
+	buf := make([]byte, len(p))
+	n, err := ioutil.ReadTryFillBuffer(r, buf)
+	require.NoError(t, err)
+	require.Equal(t, p, buf[:n])
+	fmt.Println("\t\t\t\t\t\tREAD", n, "bytes")
+	return n
+}
+
+func TestDoubleBufferWriter(t *testing.T) {
+	pr, pw := io.Pipe()
+	cwc := ioutil.NewCustomCommitWriteCloser(pw)
+	var committed int64
+	cwc.CommitFn = func(n int64) error {
+		committed = n
+		return pw.Close()
+	}
+	dbw := ioutil.NewDoubleBufferWriter(context.Background(), cwc, bytebufferpool.VariableSize(8), 4, 8)
+
+	// Write 1 byte and immediately let it get written by pulling from the pipe.
+	mustWrite(t, dbw, []byte{1})
+	read := mustRead(t, pr, []byte{1})
+
+	// Should be able to write 4 bytes without blocking
+	mustWrite(t, dbw, []byte{1})
+	mustWrite(t, dbw, []byte{2, 3, 4})
+
+	// Should be able to write another 5 bytes without blocking
+	mustWrite(t, dbw, []byte{5, 6, 7, 8, 9})
+	read += mustRead(t, pr, []byte{1, 2, 3, 4})
+	read += mustRead(t, pr, []byte{5, 6, 7, 8, 9})
+
+	// The buffer increased to 8, so writing 12 more bytes shouldn't block.
+	// The first 4 bytes should be written immediately, and the next 8 bytes
+	// should be written once we read from the pipe.
+	for range 3 {
+		mustWrite(t, dbw, []byte{1, 2, 3, 4})
+	}
+	_ = committed
+	// The next write will block until we read from the pipe.
+	go mustWrite(t, dbw, []byte{5, 6, 7, 8, 9, 10, 11, 12})
+	read += mustRead(t, pr, []byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4})
+	read += mustRead(t, pr, []byte{5, 6, 7, 8, 9, 10, 11, 12})
+
+	require.NoError(t, dbw.Commit())
+	require.Equal(t, int64(read), committed)
+
+	require.NoError(t, dbw.Close())
+	// Pipe should be closed now.
+	_, err := pr.Read(nil)
+	require.Equal(t, io.EOF, err)
+}
+
+func TestDoubleBufferWriter_RandomWrites(t *testing.T) {
+	pr, pw := io.Pipe()
+	cwc := ioutil.NewCustomCommitWriteCloser(pw)
+	var committed int64
+	cwc.CommitFn = func(n int64) error {
+		committed = n
+		return pw.Close()
+	}
+	dbw := ioutil.NewDoubleBufferWriter(context.Background(), cwc, bytebufferpool.VariableSize(8), 4, 8)
+
+	writesDone, readsDone := make(chan struct{}), make(chan struct{})
+	_, buf := testdigest.RandomCASResourceBuf(t, 10_000)
+	go func() {
+		defer close(writesDone)
+		for left := buf; len(left) > 0; {
+			toWrite := rand.Intn((len(left)/2)+1) + 1
+			n, err := dbw.Write(left[:toWrite])
+			require.NoError(t, err)
+			require.Equal(t, toWrite, n)
+			left = left[toWrite:]
+		}
+	}()
+	go func() {
+		defer close(readsDone)
+		actual := make([]byte, len(buf))
+		n, err := io.ReadFull(pr, actual)
+		require.NoError(t, err)
+		require.Equal(t, len(buf), n)
+		require.Equal(t, buf, actual)
+	}()
+	<-writesDone
+	<-readsDone
+
+	require.NoError(t, dbw.Commit())
+	require.Equal(t, int64(len(buf)), committed)
+
+	require.NoError(t, dbw.Close())
+	// Pipe should be closed now.
+	_, err := pr.Read(nil)
+	require.Equal(t, io.EOF, err)
+}
+
+func TestDoubleBufferWriter_Errors(t *testing.T) {
+	pr, pw := io.Pipe()
+	cwc := ioutil.NewCustomCommitWriteCloser(pw)
+	cwc.CommitFn = func(n int64) error {
+		return pw.Close()
+	}
+	dbw := ioutil.NewDoubleBufferWriter(context.Background(), cwc, bytebufferpool.VariableSize(8), 4, 8)
+
+	require.NoError(t, pw.Close())
+
+	// The first write will buffer but then fail to write. The second one
+	// might buffer before the first fails. The third will definitely return an
+	// error.
+	_, err := dbw.Write([]byte{1, 2, 3, 4})
+	require.NoError(t, err)
+	_, err = dbw.Write([]byte{1, 2, 3, 4})
+	if err != nil {
+		require.Equal(t, io.ErrClosedPipe, err)
+	}
+	_, err = dbw.Write([]byte{1, 2, 3, 4})
+	require.Equal(t, io.ErrClosedPipe, err)
+
+	require.NoError(t, pr.Close())
+}
+
+func TestDoubleBufferWriter_WriteAfterClose(t *testing.T) {
+	cwc := ioutil.NewCustomCommitWriteCloser(io.Discard)
+	dbw := ioutil.NewDoubleBufferWriter(context.Background(), cwc, bytebufferpool.VariableSize(8), 4, 8)
+	require.NoError(t, dbw.Close())
+	_, err := dbw.Write(nil)
+	require.Error(t, err)
+
+	cwc = ioutil.NewCustomCommitWriteCloser(io.Discard)
+	dbw = ioutil.NewDoubleBufferWriter(context.Background(), cwc, bytebufferpool.VariableSize(8), 4, 8)
+	require.NoError(t, dbw.Commit())
+	_, err = dbw.Write(nil)
+	require.Error(t, err)
+}
+
+func TestDoubleBufferWriter_WriteAfterCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	_, pw := io.Pipe()
+	cwc := ioutil.NewCustomCommitWriteCloser(pw)
+	dbw := ioutil.NewDoubleBufferWriter(ctx, cwc, bytebufferpool.VariableSize(8), 4, 8)
+
+	_, err := dbw.Write([]byte{1, 2, 3, 4})
+	require.NoError(t, err)
+	cancel()
+	_, err = dbw.Write([]byte{1, 2, 3, 4})
+	require.Equal(t, ctx.Err(), err)
 }

--- a/server/util/ioutil/ioutil_test.go
+++ b/server/util/ioutil/ioutil_test.go
@@ -242,5 +242,11 @@ func TestDoubleBufferWriter_WriteAfterCancel(t *testing.T) {
 	require.NoError(t, err)
 	cancel()
 	_, err = dbw.Write([]byte{1, 2, 3, 4})
+	if err == nil {
+		// The first write might succeed since `select` can pick any case if
+		// multiple are ready. The next write will be blocked though so it
+		// should definitely fail.
+		_, err = dbw.Write([]byte{1, 2, 3, 4})
+	}
 	require.Equal(t, ctx.Err(), err)
 }


### PR DESCRIPTION
In order to get the full benefits of this, I also had to write to the cache first in the `io.MultiWriter` created in `byte_stream_server.beginWrite`.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                                                                                     │    base_4M    │           double_4M_flip           │
                                                                                     │    sec/op     │   sec/op     vs base               │
Write/cache_type=fast/object_size=1000/chunk_size=16384/compressor=IDENTITY-24          236.6µ ±  2%   244.6µ ± 2%   +3.37% (p=0.002 n=7)
Write/cache_type=fast/object_size=1000/chunk_size=16384/compressor=ZSTD-24              233.8µ ±  1%   234.4µ ± 1%        ~ (p=0.620 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=16384/compressor=IDENTITY-24        1.098m ±  1%   1.121m ± 2%   +2.09% (p=0.007 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=16384/compressor=ZSTD-24            577.1µ ±  1%   512.1µ ± 3%  -11.25% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=262144/compressor=IDENTITY-24       1.076m ±  3%   1.036m ± 2%   -3.78% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=262144/compressor=ZSTD-24           559.2µ ±  1%   489.4µ ± 1%  -12.47% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=16384/compressor=IDENTITY-24       17.30m ± 10%   16.48m ± 8%   -4.70% (p=0.017 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=16384/compressor=ZSTD-24           7.661m ±  2%   7.069m ± 2%   -7.73% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=262144/compressor=IDENTITY-24      17.09m ±  6%   16.13m ± 4%   -5.62% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=262144/compressor=ZSTD-24          7.178m ±  1%   5.891m ± 1%  -17.93% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=524288/compressor=IDENTITY-24      16.96m ±  5%   16.01m ± 5%   -5.60% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=524288/compressor=ZSTD-24          7.164m ±  1%   5.891m ± 2%  -17.76% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=IDENTITY-24     17.16m ±  4%   16.05m ± 5%   -6.49% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24         7.162m ±  1%   5.890m ± 1%  -17.75% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=16384/compressor=IDENTITY-24      51.83m ±  2%   47.85m ± 1%   -7.69% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=16384/compressor=ZSTD-24          21.28m ±  3%   22.31m ± 1%   +4.86% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=262144/compressor=IDENTITY-24     47.08m ±  5%   46.26m ± 5%   -1.74% (p=0.017 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=262144/compressor=ZSTD-24         20.67m ±  2%   18.03m ± 3%  -12.75% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=524288/compressor=IDENTITY-24     49.52m ±  6%   44.35m ± 6%  -10.44% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=524288/compressor=ZSTD-24         21.70m ±  2%   17.99m ± 2%  -17.12% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=IDENTITY-24    46.39m ±  7%   44.73m ± 3%   -3.57% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24        21.76m ±  2%   18.19m ± 2%  -16.40% (p=0.001 n=7)
Write/cache_type=slow/object_size=1000/chunk_size=16384/compressor=IDENTITY-24          251.1µ ±  2%   261.9µ ± 2%   +4.30% (p=0.001 n=7)
Write/cache_type=slow/object_size=1000/chunk_size=16384/compressor=ZSTD-24              251.4µ ±  2%   251.0µ ± 2%        ~ (p=0.710 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=16384/compressor=IDENTITY-24        1.392m ±  7%   1.420m ± 4%   +2.02% (p=0.026 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=16384/compressor=ZSTD-24            924.8µ ±  2%   824.7µ ± 2%  -10.82% (p=0.001 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=262144/compressor=IDENTITY-24       1.379m ±  5%   1.342m ± 5%   -2.67% (p=0.017 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=262144/compressor=ZSTD-24           923.1µ ±  2%   814.9µ ± 1%  -11.73% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=16384/compressor=IDENTITY-24       35.33m ±  1%   31.84m ± 2%   -9.88% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=16384/compressor=ZSTD-24           23.56m ±  4%   17.69m ± 1%  -24.90% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=262144/compressor=IDENTITY-24      33.14m ±  5%   29.94m ± 6%   -9.67% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=262144/compressor=ZSTD-24          23.09m ±  0%   17.82m ± 1%  -22.81% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=524288/compressor=IDENTITY-24      33.05m ±  6%   31.21m ± 2%   -5.57% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=524288/compressor=ZSTD-24          23.14m ±  1%   17.97m ± 1%  -22.32% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=IDENTITY-24     34.89m ±  1%   31.17m ± 4%  -10.67% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24         23.19m ±  3%   18.29m ± 1%  -21.12% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=16384/compressor=IDENTITY-24     101.47m ±  1%   64.48m ± 2%  -36.46% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=16384/compressor=ZSTD-24          69.83m ±  3%   52.24m ± 1%  -25.18% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=262144/compressor=IDENTITY-24    100.05m ±  1%   64.17m ± 2%  -35.86% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=262144/compressor=ZSTD-24         68.83m ±  2%   51.81m ± 0%  -24.72% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=524288/compressor=IDENTITY-24     99.83m ±  1%   64.29m ± 1%  -35.60% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=524288/compressor=ZSTD-24         69.83m ±  1%   51.97m ± 1%  -25.57% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=IDENTITY-24    99.63m ±  1%   64.56m ± 2%  -35.21% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24        70.22m ±  2%   52.16m ± 1%  -25.72% (p=0.001 n=7)
geomean                                                                                 10.41m         9.000m       -13.52%

                                                                                     │   base_4M    │           double_4M_flip            │
                                                                                     │     B/s      │     B/s       vs base               │
Write/cache_type=fast/object_size=1000/chunk_size=16384/compressor=IDENTITY-24         4.034Mi ± 2%   3.901Mi ± 2%   -3.31% (p=0.002 n=7)
Write/cache_type=fast/object_size=1000/chunk_size=16384/compressor=ZSTD-24             4.082Mi ± 1%   4.072Mi ± 1%        ~ (p=0.520 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=16384/compressor=IDENTITY-24       86.89Mi ± 1%   85.11Mi ± 2%   -2.05% (p=0.005 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=16384/compressor=ZSTD-24           165.3Mi ± 1%   186.2Mi ± 3%  +12.68% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=262144/compressor=IDENTITY-24      88.60Mi ± 3%   92.08Mi ± 2%   +3.93% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=262144/compressor=ZSTD-24          170.5Mi ± 1%   194.9Mi ± 1%  +14.25% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=16384/compressor=IDENTITY-24      275.7Mi ± 9%   289.3Mi ± 8%   +4.93% (p=0.017 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=16384/compressor=ZSTD-24          622.4Mi ± 2%   674.5Mi ± 2%   +8.38% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=262144/compressor=IDENTITY-24     279.1Mi ± 6%   295.7Mi ± 4%   +5.96% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=262144/compressor=ZSTD-24         664.3Mi ± 1%   809.5Mi ± 1%  +21.85% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=524288/compressor=IDENTITY-24     281.2Mi ± 5%   297.9Mi ± 5%   +5.93% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=524288/compressor=ZSTD-24         665.6Mi ± 1%   809.4Mi ± 2%  +21.60% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=IDENTITY-24    277.8Mi ± 4%   297.1Mi ± 5%   +6.94% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24        665.8Mi ± 1%   809.5Mi ± 1%  +21.58% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=16384/compressor=IDENTITY-24     276.0Mi ± 2%   299.0Mi ± 1%   +8.33% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=16384/compressor=ZSTD-24         672.4Mi ± 3%   641.2Mi ± 1%   -4.64% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=262144/compressor=IDENTITY-24    303.8Mi ± 5%   309.2Mi ± 5%   +1.77% (p=0.017 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=262144/compressor=ZSTD-24        692.2Mi ± 3%   793.4Mi ± 3%  +14.61% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=524288/compressor=IDENTITY-24    288.9Mi ± 7%   322.6Mi ± 5%  +11.66% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=524288/compressor=ZSTD-24        659.1Mi ± 2%   795.3Mi ± 2%  +20.66% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=IDENTITY-24   308.4Mi ± 6%   319.8Mi ± 4%   +3.70% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24       657.4Mi ± 2%   786.4Mi ± 2%  +19.62% (p=0.001 n=7)
Write/cache_type=slow/object_size=1000/chunk_size=16384/compressor=IDENTITY-24         3.796Mi ± 2%   3.643Mi ± 2%   -4.02% (p=0.001 n=7)
Write/cache_type=slow/object_size=1000/chunk_size=16384/compressor=ZSTD-24             3.796Mi ± 2%   3.796Mi ± 2%        ~ (p=0.685 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=16384/compressor=IDENTITY-24       68.50Mi ± 6%   67.15Mi ± 4%   -1.98% (p=0.026 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=16384/compressor=ZSTD-24           103.1Mi ± 2%   115.6Mi ± 2%  +12.13% (p=0.001 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=262144/compressor=IDENTITY-24      69.15Mi ± 5%   71.05Mi ± 5%   +2.74% (p=0.017 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=262144/compressor=ZSTD-24          103.3Mi ± 2%   117.0Mi ± 1%  +13.28% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=16384/compressor=IDENTITY-24      135.0Mi ± 1%   149.8Mi ± 2%  +10.96% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=16384/compressor=ZSTD-24          202.4Mi ± 3%   269.5Mi ± 1%  +33.16% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=262144/compressor=IDENTITY-24     143.9Mi ± 5%   159.3Mi ± 5%  +10.70% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=262144/compressor=ZSTD-24         206.5Mi ± 0%   267.5Mi ± 1%  +29.55% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=524288/compressor=IDENTITY-24     144.3Mi ± 6%   152.8Mi ± 2%   +5.90% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=524288/compressor=ZSTD-24         206.1Mi ± 1%   265.3Mi ± 1%  +28.73% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=IDENTITY-24    136.7Mi ± 1%   153.0Mi ± 4%  +11.94% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24        205.7Mi ± 3%   260.7Mi ± 1%  +26.78% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=16384/compressor=IDENTITY-24     141.0Mi ± 1%   221.9Mi ± 2%  +57.38% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=16384/compressor=ZSTD-24         204.9Mi ± 3%   273.8Mi ± 1%  +33.66% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=262144/compressor=IDENTITY-24    143.0Mi ± 1%   222.9Mi ± 2%  +55.92% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=262144/compressor=ZSTD-24        207.8Mi ± 2%   276.1Mi ± 0%  +32.84% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=524288/compressor=IDENTITY-24    143.3Mi ± 1%   222.5Mi ± 1%  +55.28% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=524288/compressor=ZSTD-24        204.9Mi ± 1%   275.2Mi ± 1%  +34.36% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=IDENTITY-24   143.6Mi ± 1%   221.6Mi ± 2%  +54.33% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24       203.7Mi ± 2%   274.3Mi ± 1%  +34.63% (p=0.001 n=7)
geomean                                                                                154.7Mi        178.8Mi       +15.63%

                                                                                     │    base_4M     │            double_4M_flip             │
                                                                                     │      B/op      │      B/op       vs base               │
Write/cache_type=fast/object_size=1000/chunk_size=16384/compressor=IDENTITY-24         66.19Ki ±  12%   66.54Ki ±  13%   +0.54% (p=0.017 n=7)
Write/cache_type=fast/object_size=1000/chunk_size=16384/compressor=ZSTD-24             67.04Ki ±   0%   67.47Ki ±   0%   +0.65% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=16384/compressor=IDENTITY-24       261.2Ki ±   3%   261.2Ki ±   3%        ~ (p=0.456 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=16384/compressor=ZSTD-24           192.4Ki ±   1%   184.9Ki ±   1%   -3.91% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=262144/compressor=IDENTITY-24      254.5Ki ±   5%   256.2Ki ±   3%        ~ (p=0.805 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=262144/compressor=ZSTD-24          188.7Ki ±   2%   193.3Ki ±   1%   +2.47% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=16384/compressor=IDENTITY-24      8.095Mi ± 113%   8.680Mi ± 103%        ~ (p=0.073 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=16384/compressor=ZSTD-24          4.709Mi ±  17%   5.450Mi ±   6%  +15.74% (p=0.007 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=262144/compressor=IDENTITY-24     7.473Mi ±  19%   7.757Mi ±  14%        ~ (p=0.318 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=262144/compressor=ZSTD-24         4.365Mi ±   6%   4.678Mi ±   5%   +7.17% (p=0.038 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=524288/compressor=IDENTITY-24     7.279Mi ±  19%   8.248Mi ±  18%  +13.31% (p=0.017 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=524288/compressor=ZSTD-24         4.612Mi ±   9%   4.591Mi ±   3%        ~ (p=0.805 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=IDENTITY-24    7.391Mi ±  19%   7.666Mi ±  11%        ~ (p=0.902 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24        4.222Mi ±  18%   4.491Mi ±   4%        ~ (p=0.456 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=16384/compressor=IDENTITY-24     26.63Mi ±   6%   27.94Mi ±   6%        ~ (p=0.053 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=16384/compressor=ZSTD-24         15.02Mi ±   9%   16.78Mi ±   6%  +11.71% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=262144/compressor=IDENTITY-24    22.00Mi ±  14%   24.54Mi ±   9%  +11.55% (p=0.026 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=262144/compressor=ZSTD-24        14.37Mi ±   6%   14.49Mi ±   5%        ~ (p=0.165 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=524288/compressor=IDENTITY-24    23.59Mi ±   6%   23.66Mi ±  16%        ~ (p=0.710 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=524288/compressor=ZSTD-24        14.92Mi ±   8%   14.46Mi ±   5%   -3.09% (p=0.038 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=IDENTITY-24   23.09Mi ±   9%   23.34Mi ±  15%        ~ (p=0.383 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24       13.24Mi ±   5%   13.97Mi ±   7%   +5.54% (p=0.038 n=7)
Write/cache_type=slow/object_size=1000/chunk_size=16384/compressor=IDENTITY-24         65.69Ki ±   0%   66.12Ki ±   0%   +0.65% (p=0.001 n=7)
Write/cache_type=slow/object_size=1000/chunk_size=16384/compressor=ZSTD-24             66.52Ki ±   0%   66.92Ki ±   0%   +0.59% (p=0.001 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=16384/compressor=IDENTITY-24       242.8Ki ±   2%   243.3Ki ±   2%        ~ (p=0.805 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=16384/compressor=ZSTD-24           167.1Ki ±   2%   168.6Ki ±   1%        ~ (p=0.073 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=262144/compressor=IDENTITY-24      232.7Ki ±   4%   234.1Ki ±   2%        ~ (p=0.710 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=262144/compressor=ZSTD-24          164.7Ki ±   2%   163.8Ki ±   1%        ~ (p=0.383 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=16384/compressor=IDENTITY-24      8.989Mi ±  21%   9.500Mi ±  15%        ~ (p=0.383 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=16384/compressor=ZSTD-24          5.152Mi ±  10%   6.074Mi ±  11%  +17.89% (p=0.004 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=262144/compressor=IDENTITY-24     7.944Mi ±  34%   7.591Mi ±  27%        ~ (p=0.535 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=262144/compressor=ZSTD-24         4.578Mi ±  16%   5.116Mi ±  11%  +11.75% (p=0.017 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=524288/compressor=IDENTITY-24     8.070Mi ±  27%   8.857Mi ±  13%        ~ (p=0.097 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=524288/compressor=ZSTD-24         4.793Mi ±   9%   4.961Mi ±   7%        ~ (p=0.456 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=IDENTITY-24    8.792Mi ±  10%   8.055Mi ±  27%        ~ (p=0.620 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24        4.539Mi ±  23%   4.788Mi ±   8%        ~ (p=0.620 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=16384/compressor=IDENTITY-24     28.36Mi ±   9%   27.00Mi ±   4%        ~ (p=0.053 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=16384/compressor=ZSTD-24         16.44Mi ±  23%   18.79Mi ±   9%  +14.27% (p=0.017 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=262144/compressor=IDENTITY-24    26.73Mi ±  11%   26.21Mi ±  11%        ~ (p=1.000 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=262144/compressor=ZSTD-24        16.26Mi ±  12%   18.27Mi ±  14%        ~ (p=0.097 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=524288/compressor=IDENTITY-24    27.67Mi ±   8%   24.90Mi ±   7%  -10.02% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=524288/compressor=ZSTD-24        16.00Mi ±  18%   17.56Mi ±   6%   +9.71% (p=0.017 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=IDENTITY-24   27.68Mi ±   5%   24.96Mi ±  12%   -9.82% (p=0.007 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24       15.08Mi ±  18%   15.92Mi ±  10%        ~ (p=0.535 n=7)
geomean                                                                                3.328Mi          3.434Mi          +3.19%

                                                                                     │   base_4M   │           double_4M_flip            │
                                                                                     │  allocs/op  │  allocs/op   vs base                │
Write/cache_type=fast/object_size=1000/chunk_size=16384/compressor=IDENTITY-24          900.0 ± 0%    906.0 ± 0%    +0.67% (p=0.001 n=7)
Write/cache_type=fast/object_size=1000/chunk_size=16384/compressor=ZSTD-24              909.0 ± 0%    916.0 ± 0%    +0.77% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=16384/compressor=IDENTITY-24       1.566k ± 0%   1.571k ± 0%    +0.32% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=16384/compressor=ZSTD-24           1.405k ± 0%   1.460k ± 0%    +3.91% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=262144/compressor=IDENTITY-24      1.374k ± 0%   1.379k ± 0%    +0.36% (p=0.001 n=7)
Write/cache_type=fast/object_size=100000/chunk_size=262144/compressor=ZSTD-24          1.370k ± 0%   1.381k ± 0%    +0.80% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=16384/compressor=IDENTITY-24      11.37k ± 2%   11.42k ± 3%    +0.49% (p=0.016 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=16384/compressor=ZSTD-24          4.885k ± 0%   9.155k ± 0%   +87.41% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=262144/compressor=IDENTITY-24     2.349k ± 0%   2.410k ± 0%    +2.60% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=262144/compressor=ZSTD-24         1.745k ± 0%   2.058k ± 0%   +17.94% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=524288/compressor=IDENTITY-24     1.936k ± 2%   1.984k ± 4%    +2.48% (p=0.002 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=524288/compressor=ZSTD-24         1.621k ± 0%   1.776k ± 0%    +9.56% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=IDENTITY-24    1.730k ± 2%   1.796k ± 2%    +3.82% (p=0.001 n=7)
Write/cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24        1.523k ± 0%   1.581k ± 0%    +3.81% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=16384/compressor=IDENTITY-24     31.12k ± 0%   31.27k ± 0%    +0.46% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=16384/compressor=ZSTD-24         11.87k ± 0%   24.75k ± 0%  +108.52% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=262144/compressor=IDENTITY-24    4.050k ± 1%   4.197k ± 1%    +3.63% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=262144/compressor=ZSTD-24        2.475k ± 1%   3.355k ± 0%   +35.56% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=524288/compressor=IDENTITY-24    3.035k ± 2%   3.169k ± 1%    +4.42% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=524288/compressor=ZSTD-24        2.139k ± 1%   2.554k ± 0%   +19.40% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=IDENTITY-24   2.505k ± 2%   2.665k ± 2%    +6.39% (p=0.001 n=7)
Write/cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24       1.909k ± 0%   2.067k ± 1%    +8.28% (p=0.001 n=7)
Write/cache_type=slow/object_size=1000/chunk_size=16384/compressor=IDENTITY-24          902.0 ± 0%    908.0 ± 0%    +0.67% (p=0.001 n=7)
Write/cache_type=slow/object_size=1000/chunk_size=16384/compressor=ZSTD-24              911.0 ± 0%    917.0 ± 0%    +0.66% (p=0.001 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=16384/compressor=IDENTITY-24       1.566k ± 0%   1.570k ± 0%    +0.26% (p=0.001 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=16384/compressor=ZSTD-24           1.404k ± 0%   1.461k ± 0%    +4.06% (p=0.001 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=262144/compressor=IDENTITY-24      1.374k ± 0%   1.379k ± 0%    +0.36% (p=0.001 n=7)
Write/cache_type=slow/object_size=100000/chunk_size=262144/compressor=ZSTD-24          1.368k ± 0%   1.378k ± 0%    +0.73% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=16384/compressor=IDENTITY-24      11.35k ± 2%   11.45k ± 3%    +0.89% (p=0.049 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=16384/compressor=ZSTD-24          4.866k ± 0%   8.482k ± 0%   +74.31% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=262144/compressor=IDENTITY-24     2.291k ± 1%   2.415k ± 1%    +5.41% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=262144/compressor=ZSTD-24         1.734k ± 1%   2.064k ± 0%   +19.03% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=524288/compressor=IDENTITY-24     1.922k ± 1%   2.013k ± 3%    +4.73% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=524288/compressor=ZSTD-24         1.623k ± 0%   1.784k ± 1%    +9.92% (p=0.001 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=IDENTITY-24    1.737k ± 4%   1.802k ± 2%    +3.74% (p=0.002 n=7)
Write/cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24        1.528k ± 0%   1.586k ± 0%    +3.80% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=16384/compressor=IDENTITY-24     31.18k ± 0%   31.24k ± 0%    +0.21% (p=0.026 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=16384/compressor=ZSTD-24         11.92k ± 0%   16.55k ± 0%   +38.81% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=262144/compressor=IDENTITY-24    4.086k ± 3%   4.188k ± 1%    +2.50% (p=0.017 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=262144/compressor=ZSTD-24        2.519k ± 2%   3.026k ± 1%   +20.13% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=524288/compressor=IDENTITY-24    3.063k ± 3%   3.140k ± 2%    +2.51% (p=0.016 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=524288/compressor=ZSTD-24        2.148k ± 2%   2.437k ± 1%   +13.45% (p=0.001 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=IDENTITY-24   2.527k ± 6%   2.619k ± 2%    +3.64% (p=0.017 n=7)
Write/cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24       1.946k ± 2%   2.048k ± 1%    +5.24% (p=0.001 n=7)
geomean                                                                                2.531k        2.796k        +10.45%
```