### PR TITLE
Fix comparison indicator updating

### DIFF
--- a/app/invocation/action_comparison_service.ts
+++ b/app/invocation/action_comparison_service.ts
@@ -68,6 +68,7 @@ export class ActionComparisonService {
 
   private publishState() {
     this.subject.next(this.comparisonData || {});
+    window.dispatchEvent(new Event("storage"));
   }
 
   subscribe(observer: (value: ActionComparisonData) => void): Subscription {

--- a/app/invocation/invocation_comparison_service.ts
+++ b/app/invocation/invocation_comparison_service.ts
@@ -108,6 +108,7 @@ export class InvocationComparisonService {
 
   private publishState() {
     this.subject.next({ id: this.invocationId, model: this.invocationModel });
+    window.dispatchEvent(new Event("storage"));
   }
 
   isLoading(): boolean {


### PR DESCRIPTION
When selecting invocations for comparison - we show a little dot indicator on the selected invocation's row that identifies which invocation is currently selected.

To update this when the user makes a selection in a different tab / window - we listen for "storage" window events which are triggered any time local storage is updated. Confusingly these [only trigger](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) when local storage is updated in a *different* tab.

Previously this wasn't an issue because you couldn't update comparison state from the invocation list view.

In https://github.com/buildbuddy-io/buildbuddy/pull/10209 I added a way to change the compared invocation from the list view - so now the fact that "storage" doesn't trigger in the same window becomes an issue.

This PR fixes this by manually triggering the "storage" event when comparison data is updated.

