### PR TITLE
remove partition metadata in replica

### DIFF
--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -1064,18 +1064,6 @@ func TestUsage(t *testing.T) {
 		ru, err := repl.Usage()
 		require.NoError(t, err)
 		require.InDelta(t, 2100, ru.GetEstimatedDiskBytesUsed(), 600.0)
-		require.Len(t, ru.GetPartitions(), 2)
-
-		for _, usage := range ru.GetPartitions() {
-			switch usage.GetPartitionId() {
-			case defaultPartition:
-				require.EqualValues(t, 1500, usage.GetSizeBytes())
-				require.EqualValues(t, 2, usage.GetTotalCount())
-			case anotherPartition:
-				require.EqualValues(t, 600, usage.GetSizeBytes())
-				require.EqualValues(t, 3, usage.GetTotalCount())
-			}
-		}
 	}
 
 	// Delete a single record and verify updated usage.
@@ -1087,17 +1075,6 @@ func TestUsage(t *testing.T) {
 		ru, err := repl.Usage()
 		require.NoError(t, err)
 		require.InDelta(t, 1100, ru.GetEstimatedDiskBytesUsed(), 500.0)
-
-		for _, usage := range ru.GetPartitions() {
-			switch usage.GetPartitionId() {
-			case defaultPartition:
-				require.EqualValues(t, 500, usage.GetSizeBytes())
-				require.EqualValues(t, 1, usage.GetTotalCount())
-			case anotherPartition:
-				require.EqualValues(t, 600, usage.GetSizeBytes())
-				require.EqualValues(t, 3, usage.GetTotalCount())
-			}
-		}
 	}
 }
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -398,7 +398,7 @@ message ReplicaUsage {
   int64 read_qps = 5;
   int64 raft_propose_qps = 6;
 
-  repeated storage.PartitionMetadata partitions = 7;
+  reserved 7;
 }
 
 message StoreUsage {


### PR DESCRIPTION
we are not using partition metadata to track usage anymore. And it costs ~5%
cpus to update and flush the partition metadata.
