### PR TITLE
Simplify input file diffing view logic

### DIFF
--- a/app/compare/BUILD
+++ b/app/compare/BUILD
@@ -125,7 +125,6 @@ ts_library(
         "//:node_modules/react",
         "//app/compare:tree_utils",
         "//app/components/digest",
-        "//app/format",
         "//app/invocation:invocation_action_tree_node",
         "//app/invocation:invocation_model",
         "//proto:remote_execution_ts_proto",

--- a/app/compare/tree_utils.ts
+++ b/app/compare/tree_utils.ts
@@ -27,28 +27,3 @@ export function nodesEqual(nodeA?: TreeNode, nodeB?: TreeNode): boolean {
 
   return false;
 }
-
-export function hasChildDifferences(childrenA: TreeNode[], childrenB: TreeNode[]): boolean {
-  // Check if the number of children differs
-  if (childrenA.length !== childrenB.length) {
-    return true;
-  }
-
-  // Check each child
-  for (const childA of childrenA) {
-    const childB = findNodeByName(childrenB, childA.obj.name || "");
-    if (!nodesEqual(childA, childB)) {
-      return true;
-    }
-  }
-
-  // Check for children that exist only in B
-  for (const childB of childrenB) {
-    const childA = findNodeByName(childrenA, childB.obj.name || "");
-    if (!childA) {
-      return true;
-    }
-  }
-
-  return false;
-}


### PR DESCRIPTION
- Improve styling to make it clearer which files actually changed
- Rely on directory hashes to tell if directory changed rather than comparing children (leads to a lot of code deletion)
- Combine treeShaToExpanded and treeShaToChildren across left and right side
- Remove unused functions
- Stop expanding deleted directories