### PR TITLE
Optimize buffer sizes for bytestream.Write

### DIFF
--- a/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
+++ b/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
@@ -130,9 +130,9 @@ func BenchmarkWrite(b *testing.B) {
 	*log.LogLevel = "error"
 	log.Configure()
 
-	// Bazel uses 16KiB chunks. cachetools.UploadFromReader uses 1MB chunks, but
-	// maybe it should be changed to 256KiB.
-	chunkSizes := []int{16 * 1024, 256 * 1024, 512 * 1024, 1_000_000}
+	// Bazel uses 16KiB chunks. cachetools.UploadFromReader uses 128KiB chunks,
+	// and this shows that's the sweetspot.
+	chunkSizes := []int{16 * 1024, 64 * 1024, 128 * 1024, 256 * 1024, 512 * 1024, 1_000_000}
 
 	for _, test := range []struct {
 		cacheType string

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -34,6 +34,12 @@ const (
 	// (Match the readBufSizeBytes in byte_stream_server.go)
 	readBufSizeBytes = (1024 * 1024 * 4) - (1024 * 256)
 
+	// writeBufSizeBytes controls the maximum size of buffers used for writing
+	// to a remote cache. This is also the maximum payload size for each
+	// WriteRequest, though with ioutil.DoubleBufferWriter, payloads will be
+	// smaller unless the remote cache is falling behind. Experiments and
+	// benchmarks show that values between 256KiB and 1MB are all about as fast.
+	// Values over 1MB cause more allocation in gRPC code.
 	writeBufSizeBytes = 512 * 1024 // 512 KiB
 )
 

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -33,6 +33,8 @@ const (
 	// Keep under the limit of ~4MB (save 256KB).
 	// (Match the readBufSizeBytes in byte_stream_server.go)
 	readBufSizeBytes = (1024 * 1024 * 4) - (1024 * 256)
+
+	writeBufSizeBytes = 512 * 1024 // 512 KiB
 )
 
 type Proxy struct {
@@ -688,8 +690,8 @@ func safeBufferSize(r *rspb.ResourceName) int {
 	if r.GetCacheType() == rspb.CacheType_CAS {
 		size = int(r.GetDigest().GetSizeBytes())
 	}
-	if size > readBufSizeBytes {
-		size = readBufSizeBytes
+	if size > writeBufSizeBytes {
+		size = writeBufSizeBytes
 	}
 	return size
 }
@@ -720,7 +722,7 @@ func (c *Proxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *r
 		stream:      stream,
 		r:           r,
 	}
-	return ioutil.NewDoubleBufferWriter(ctx, wc, c.readBufPool, safeBufferSize(r), readBufSizeBytes), nil
+	return ioutil.NewDoubleBufferWriter(ctx, wc, c.readBufPool, safeBufferSize(r), writeBufSizeBytes), nil
 }
 
 func (c *Proxy) SendHeartbeat(ctx context.Context, peer string) error {

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -39,7 +39,14 @@ import (
 )
 
 const (
-	uploadBufSizeBytes = 128 * 1024 // 128KiB
+	// uploadBufSizeBytes controls the size of the buffers used for uploading
+	// to bytestream.Write. This means it also controls the payload size for
+	// each WriteRequest. https://github.com/grpc/grpc.github.io/issues/371
+	// that 16KiB-64KiB payloads work best, but our experiments and benchmarks
+	// show that 128KiB works best. Values bigger and slower than that are both
+	// slower. Values bigger than that allocate more bytes, and values smaller
+	// than that allocate the same number of bytes but with more allocations.
+	uploadBufSizeBytes = 128 * 1024
 	// Matches https://github.com/bazelbuild/bazel/blob/9c22032c8dc0eb2ec20d8b5a5c73d1f5f075ae37/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java#L461-L464
 	minSizeBytesToCompress = 100
 )

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -39,8 +39,7 @@ import (
 )
 
 const (
-	uploadBufSizeBytes    = 1000000 // 1MB
-	maxCompressionBufSize = int64(4000000)
+	uploadBufSizeBytes = 128 * 1024 // 128KiB
 	// Matches https://github.com/bazelbuild/bazel/blob/9c22032c8dc0eb2ec20d8b5a5c73d1f5f075ae37/src/main/java/com/google/devtools/build/lib/remote/options/RemoteOptions.java#L461-L464
 	minSizeBytesToCompress = 100
 )


### PR DESCRIPTION
In benchmarks and dev experiments, these values seem to be the sweetspot. There's a few things at play:
- The smaller the chunk size, the earlier the server starts writing.
- gRPC flow control seems to be better with smaller payloads. According to https://github.com/grpc/grpc.github.io/issues/371, the ideal payload size is "16KiB - 64KiB, according to oral tradition". In my experiments, 128KiB worked just as well and seems safer. We can lower it even more later.
- The slower the underlying writer is, the better it is to send smaller chunks.
- gRPC has a variable buffer pool for receiving and sending payloads, but the [max size is 1MB](https://github.com/grpc/grpc-go/blob/e9e00cb28e350d6440145d883d1d6cf675f3c0f3/mem/buffer_pool.go#L43), so using payloads bigger than that allocates.

In the below benchmarks, the two columns represent different values for `distributed_client.writeBufSizeBytes`, and there is one row for each value of `cachetools.uploadBufSizeBytes`. Some key notes about the results:
- Smaller `distributed_client.writeBufSizeBytes` values are slightly faster and allocate up to 10% less memory.
- When the cache is slow, `cachetools.uploadBufSizeBytes` of 128KiB or 256KiB performs the best, but in dev experiments, 128KiB is better.

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                                                                                 │  double_4M   │           double_512Mi            │
                                                                                 │    sec/op    │   sec/op     vs base              │
cache_type=fast/object_size=1000/chunk_size=16384/compressor=ZSTD-24         247.6µ ±  5%   238.2µ ± 2%       ~ (p=0.073 n=7)
cache_type=fast/object_size=100000/chunk_size=16384/compressor=ZSTD-24       544.1µ ±  1%   524.8µ ± 2%  -3.55% (p=0.001 n=7)
cache_type=fast/object_size=100000/chunk_size=65536/compressor=ZSTD-24       514.9µ ±  4%   491.0µ ± 5%  -4.64% (p=0.038 n=7)
cache_type=fast/object_size=100000/chunk_size=131072/compressor=ZSTD-24      505.2µ ± 17%   498.2µ ± 4%       ~ (p=0.209 n=7)
cache_type=fast/object_size=5000001/chunk_size=16384/compressor=ZSTD-24      7.059m ±  1%   7.075m ± 1%       ~ (p=0.805 n=7)
cache_type=fast/object_size=5000001/chunk_size=65536/compressor=ZSTD-24      6.261m ±  1%   6.219m ± 1%       ~ (p=0.053 n=7)
cache_type=fast/object_size=5000001/chunk_size=131072/compressor=ZSTD-24     5.945m ±  1%   6.018m ± 2%       ~ (p=0.209 n=7)
cache_type=fast/object_size=5000001/chunk_size=262144/compressor=ZSTD-24     5.976m ±  2%   5.966m ± 2%       ~ (p=0.535 n=7)
cache_type=fast/object_size=5000001/chunk_size=524288/compressor=ZSTD-24     5.945m ±  2%   5.966m ± 2%       ~ (p=0.902 n=7)
cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24    5.949m ±  2%   5.998m ± 1%  +0.83% (p=0.026 n=7)
cache_type=fast/object_size=15000001/chunk_size=16384/compressor=ZSTD-24     22.15m ±  2%   22.20m ± 1%       ~ (p=0.620 n=7)
cache_type=fast/object_size=15000001/chunk_size=65536/compressor=ZSTD-24     19.20m ±  1%   19.06m ± 1%       ~ (p=0.073 n=7)
cache_type=fast/object_size=15000001/chunk_size=131072/compressor=ZSTD-24    18.58m ±  2%   18.32m ± 2%  -1.38% (p=0.017 n=7)
cache_type=fast/object_size=15000001/chunk_size=262144/compressor=ZSTD-24    18.19m ±  2%   18.18m ± 2%       ~ (p=0.902 n=7)
cache_type=fast/object_size=15000001/chunk_size=524288/compressor=ZSTD-24    18.11m ±  1%   18.16m ± 2%       ~ (p=0.535 n=7)
cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24   18.09m ±  2%   18.21m ± 2%       ~ (p=0.902 n=7)
cache_type=slow/object_size=1000/chunk_size=16384/compressor=ZSTD-24         251.6µ ±  1%   250.4µ ± 1%       ~ (p=0.535 n=7)
cache_type=slow/object_size=100000/chunk_size=16384/compressor=ZSTD-24       825.3µ ±  2%   832.8µ ± 1%       ~ (p=0.383 n=7)
cache_type=slow/object_size=100000/chunk_size=65536/compressor=ZSTD-24       836.2µ ±  3%   820.1µ ± 1%  -1.92% (p=0.026 n=7)
cache_type=slow/object_size=100000/chunk_size=131072/compressor=ZSTD-24      807.0µ ±  2%   809.3µ ± 2%       ~ (p=0.710 n=7)
cache_type=slow/object_size=5000001/chunk_size=16384/compressor=ZSTD-24      17.74m ±  1%   17.77m ± 1%       ~ (p=0.710 n=7)
cache_type=slow/object_size=5000001/chunk_size=65536/compressor=ZSTD-24      18.09m ±  1%   18.02m ± 1%       ~ (p=0.318 n=7)
cache_type=slow/object_size=5000001/chunk_size=131072/compressor=ZSTD-24     17.88m ±  1%   17.91m ± 1%       ~ (p=0.383 n=7)
cache_type=slow/object_size=5000001/chunk_size=262144/compressor=ZSTD-24     17.88m ±  0%   17.86m ± 0%       ~ (p=0.383 n=7)
cache_type=slow/object_size=5000001/chunk_size=524288/compressor=ZSTD-24     18.03m ±  1%   17.95m ± 1%       ~ (p=0.073 n=7)
cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24    18.45m ±  0%   18.28m ± 1%  -0.92% (p=0.004 n=7)
cache_type=slow/object_size=15000001/chunk_size=16384/compressor=ZSTD-24     52.33m ±  2%   51.87m ± 1%  -0.88% (p=0.026 n=7)
cache_type=slow/object_size=15000001/chunk_size=65536/compressor=ZSTD-24     52.36m ±  1%   52.07m ± 0%  -0.57% (p=0.004 n=7)
cache_type=slow/object_size=15000001/chunk_size=131072/compressor=ZSTD-24    52.23m ±  1%   51.88m ± 1%  -0.67% (p=0.007 n=7)
cache_type=slow/object_size=15000001/chunk_size=262144/compressor=ZSTD-24    51.83m ±  1%   51.57m ± 0%  -0.49% (p=0.026 n=7)
cache_type=slow/object_size=15000001/chunk_size=524288/compressor=ZSTD-24    51.68m ±  1%   51.76m ± 0%       ~ (p=0.259 n=7)
cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24   52.12m ±  1%   52.07m ± 1%       ~ (p=0.805 n=7)
geomean                                                                            7.468m         7.426m       -0.57%

                                                                                 │   double_4M   │            double_512Mi            │
                                                                                 │      B/s      │     B/s       vs base              │
cache_type=fast/object_size=1000/chunk_size=16384/compressor=ZSTD-24         3.853Mi ±  6%   4.005Mi ± 2%       ~ (p=0.068 n=7)
cache_type=fast/object_size=100000/chunk_size=16384/compressor=ZSTD-24       175.3Mi ±  1%   181.7Mi ± 2%  +3.68% (p=0.001 n=7)
cache_type=fast/object_size=100000/chunk_size=65536/compressor=ZSTD-24       185.2Mi ±  5%   194.2Mi ± 4%  +4.87% (p=0.038 n=7)
cache_type=fast/object_size=100000/chunk_size=131072/compressor=ZSTD-24      188.8Mi ± 14%   191.4Mi ± 4%       ~ (p=0.197 n=7)
cache_type=fast/object_size=5000001/chunk_size=16384/compressor=ZSTD-24      675.5Mi ±  1%   674.0Mi ± 1%       ~ (p=0.805 n=7)
cache_type=fast/object_size=5000001/chunk_size=65536/compressor=ZSTD-24      761.6Mi ±  1%   766.8Mi ± 1%       ~ (p=0.053 n=7)
cache_type=fast/object_size=5000001/chunk_size=131072/compressor=ZSTD-24     802.0Mi ±  1%   792.4Mi ± 2%       ~ (p=0.209 n=7)
cache_type=fast/object_size=5000001/chunk_size=262144/compressor=ZSTD-24     798.0Mi ±  2%   799.2Mi ± 2%       ~ (p=0.535 n=7)
cache_type=fast/object_size=5000001/chunk_size=524288/compressor=ZSTD-24     802.1Mi ±  2%   799.2Mi ± 2%       ~ (p=0.902 n=7)
cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24    801.5Mi ±  2%   795.0Mi ± 1%  -0.82% (p=0.026 n=7)
cache_type=fast/object_size=15000001/chunk_size=16384/compressor=ZSTD-24     645.9Mi ±  2%   644.5Mi ± 1%       ~ (p=0.620 n=7)
cache_type=fast/object_size=15000001/chunk_size=65536/compressor=ZSTD-24     744.9Mi ±  1%   750.4Mi ± 1%       ~ (p=0.073 n=7)
cache_type=fast/object_size=15000001/chunk_size=131072/compressor=ZSTD-24    769.9Mi ±  2%   780.6Mi ± 1%  +1.39% (p=0.017 n=7)
cache_type=fast/object_size=15000001/chunk_size=262144/compressor=ZSTD-24    786.2Mi ±  2%   786.8Mi ± 2%       ~ (p=0.902 n=7)
cache_type=fast/object_size=15000001/chunk_size=524288/compressor=ZSTD-24    789.8Mi ±  1%   787.7Mi ± 2%       ~ (p=0.535 n=7)
cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24   791.0Mi ±  2%   785.7Mi ± 2%       ~ (p=0.902 n=7)
cache_type=slow/object_size=1000/chunk_size=16384/compressor=ZSTD-24         3.796Mi ±  1%   3.805Mi ± 1%       ~ (p=0.561 n=7)
cache_type=slow/object_size=100000/chunk_size=16384/compressor=ZSTD-24       115.6Mi ±  2%   114.5Mi ± 1%       ~ (p=0.334 n=7)
cache_type=slow/object_size=100000/chunk_size=65536/compressor=ZSTD-24       114.0Mi ±  2%   116.3Mi ± 1%  +1.96% (p=0.026 n=7)
cache_type=slow/object_size=100000/chunk_size=131072/compressor=ZSTD-24      118.2Mi ±  2%   117.8Mi ± 2%       ~ (p=0.710 n=7)
cache_type=slow/object_size=5000001/chunk_size=16384/compressor=ZSTD-24      268.8Mi ±  1%   268.3Mi ± 1%       ~ (p=0.710 n=7)
cache_type=slow/object_size=5000001/chunk_size=65536/compressor=ZSTD-24      263.7Mi ±  1%   264.6Mi ± 1%       ~ (p=0.318 n=7)
cache_type=slow/object_size=5000001/chunk_size=131072/compressor=ZSTD-24     266.7Mi ±  1%   266.3Mi ± 1%       ~ (p=0.383 n=7)
cache_type=slow/object_size=5000001/chunk_size=262144/compressor=ZSTD-24     266.7Mi ±  0%   267.0Mi ± 0%       ~ (p=0.383 n=7)
cache_type=slow/object_size=5000001/chunk_size=524288/compressor=ZSTD-24     264.5Mi ±  1%   265.6Mi ± 1%       ~ (p=0.073 n=7)
cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24    258.5Mi ±  0%   260.8Mi ± 1%  +0.92% (p=0.004 n=7)
cache_type=slow/object_size=15000001/chunk_size=16384/compressor=ZSTD-24     273.4Mi ±  2%   275.8Mi ± 1%  +0.89% (p=0.026 n=7)
cache_type=slow/object_size=15000001/chunk_size=65536/compressor=ZSTD-24     273.2Mi ±  1%   274.8Mi ± 0%  +0.58% (p=0.003 n=7)
cache_type=slow/object_size=15000001/chunk_size=131072/compressor=ZSTD-24    273.9Mi ±  1%   275.8Mi ± 1%  +0.68% (p=0.007 n=7)
cache_type=slow/object_size=15000001/chunk_size=262144/compressor=ZSTD-24    276.0Mi ±  1%   277.4Mi ± 0%  +0.49% (p=0.024 n=7)
cache_type=slow/object_size=15000001/chunk_size=524288/compressor=ZSTD-24    276.8Mi ±  1%   276.4Mi ± 0%       ~ (p=0.259 n=7)
cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24   274.5Mi ±  1%   274.7Mi ± 1%       ~ (p=0.805 n=7)
geomean                                                                            271.9Mi         273.4Mi       +0.56%

                                                                                 │   double_4M   │             double_512Mi             │
                                                                                 │     B/op      │     B/op       vs base               │
cache_type=fast/object_size=1000/chunk_size=16384/compressor=ZSTD-24         66.53Ki ±  0%   66.53Ki ±  0%        ~ (p=0.642 n=7)
cache_type=fast/object_size=100000/chunk_size=16384/compressor=ZSTD-24       184.2Ki ±  1%   183.8Ki ±  1%        ~ (p=0.805 n=7)
cache_type=fast/object_size=100000/chunk_size=65536/compressor=ZSTD-24       193.2Ki ±  1%   192.5Ki ±  3%        ~ (p=0.710 n=7)
cache_type=fast/object_size=100000/chunk_size=131072/compressor=ZSTD-24      189.5Ki ±  2%   195.4Ki ±  2%   +3.09% (p=0.017 n=7)
cache_type=fast/object_size=5000001/chunk_size=16384/compressor=ZSTD-24      5.396Mi ±  4%   4.600Mi ±  5%  -14.76% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=65536/compressor=ZSTD-24      4.908Mi ±  6%   4.175Mi ±  6%  -14.93% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=131072/compressor=ZSTD-24     4.778Mi ±  5%   3.983Mi ± 11%  -16.64% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=262144/compressor=ZSTD-24     4.568Mi ±  6%   4.041Mi ±  4%  -11.54% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=524288/compressor=ZSTD-24     4.632Mi ±  5%   4.010Mi ±  8%  -13.43% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24    4.446Mi ±  6%   4.115Mi ±  4%   -7.44% (p=0.002 n=7)
cache_type=fast/object_size=15000001/chunk_size=16384/compressor=ZSTD-24     17.03Mi ±  6%   14.10Mi ±  7%  -17.25% (p=0.001 n=7)
cache_type=fast/object_size=15000001/chunk_size=65536/compressor=ZSTD-24     14.95Mi ±  1%   12.90Mi ±  5%  -13.67% (p=0.001 n=7)
cache_type=fast/object_size=15000001/chunk_size=131072/compressor=ZSTD-24    14.83Mi ±  4%   12.77Mi ±  7%  -13.88% (p=0.001 n=7)
cache_type=fast/object_size=15000001/chunk_size=262144/compressor=ZSTD-24    15.03Mi ±  6%   12.89Mi ±  6%  -14.23% (p=0.001 n=7)
cache_type=fast/object_size=15000001/chunk_size=524288/compressor=ZSTD-24    14.55Mi ±  8%   12.45Mi ±  8%  -14.38% (p=0.001 n=7)
cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24   14.24Mi ±  7%   12.57Mi ±  8%  -11.75% (p=0.001 n=7)
cache_type=slow/object_size=1000/chunk_size=16384/compressor=ZSTD-24         65.97Ki ±  0%   65.98Ki ±  0%        ~ (p=0.962 n=7)
cache_type=slow/object_size=100000/chunk_size=16384/compressor=ZSTD-24       165.9Ki ±  1%   166.3Ki ±  1%        ~ (p=0.383 n=7)
cache_type=slow/object_size=100000/chunk_size=65536/compressor=ZSTD-24       163.5Ki ±  2%   162.9Ki ±  1%        ~ (p=0.209 n=7)
cache_type=slow/object_size=100000/chunk_size=131072/compressor=ZSTD-24      163.1Ki ±  1%   161.8Ki ±  2%        ~ (p=0.805 n=7)
cache_type=slow/object_size=5000001/chunk_size=16384/compressor=ZSTD-24      6.111Mi ±  7%   5.031Mi ±  8%  -17.66% (p=0.001 n=7)
cache_type=slow/object_size=5000001/chunk_size=65536/compressor=ZSTD-24      5.485Mi ±  5%   4.561Mi ±  9%  -16.83% (p=0.001 n=7)
cache_type=slow/object_size=5000001/chunk_size=131072/compressor=ZSTD-24     5.562Mi ±  6%   4.330Mi ± 12%  -22.16% (p=0.001 n=7)
cache_type=slow/object_size=5000001/chunk_size=262144/compressor=ZSTD-24     5.132Mi ±  7%   4.224Mi ± 13%  -17.69% (p=0.001 n=7)
cache_type=slow/object_size=5000001/chunk_size=524288/compressor=ZSTD-24     4.966Mi ± 17%   4.163Mi ± 10%  -16.18% (p=0.001 n=7)
cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24    4.699Mi ± 11%   4.328Mi ±  8%        ~ (p=0.053 n=7)
cache_type=slow/object_size=15000001/chunk_size=16384/compressor=ZSTD-24     17.99Mi ± 11%   15.66Mi ± 13%  -12.96% (p=0.002 n=7)
cache_type=slow/object_size=15000001/chunk_size=65536/compressor=ZSTD-24     18.51Mi ± 15%   14.10Mi ±  4%  -23.86% (p=0.001 n=7)
cache_type=slow/object_size=15000001/chunk_size=131072/compressor=ZSTD-24    17.81Mi ±  5%   14.20Mi ±  4%  -20.23% (p=0.001 n=7)
cache_type=slow/object_size=15000001/chunk_size=262144/compressor=ZSTD-24    17.55Mi ± 15%   14.99Mi ±  9%  -14.59% (p=0.004 n=7)
cache_type=slow/object_size=15000001/chunk_size=524288/compressor=ZSTD-24    16.05Mi ± 10%   14.26Mi ± 11%  -11.15% (p=0.001 n=7)
cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24   14.93Mi ± 17%   14.14Mi ±  9%   -5.33% (p=0.007 n=7)
geomean                                                                            3.146Mi         2.793Mi        -11.20%

                                                                                 │  double_4M  │             double_512Mi             │
                                                                                 │  allocs/op  │  allocs/op   vs base                 │
cache_type=fast/object_size=1000/chunk_size=16384/compressor=ZSTD-24          904.0 ± 0%    904.0 ± 0%        ~ (p=0.462 n=7)
cache_type=fast/object_size=100000/chunk_size=16384/compressor=ZSTD-24       1.434k ± 0%   1.433k ± 0%   -0.07% (p=0.029 n=7)
cache_type=fast/object_size=100000/chunk_size=65536/compressor=ZSTD-24       1.363k ± 0%   1.363k ± 0%        ~ (p=0.755 n=7)
cache_type=fast/object_size=100000/chunk_size=131072/compressor=ZSTD-24      1.362k ± 0%   1.362k ± 0%        ~ (p=1.000 n=7)
cache_type=fast/object_size=5000001/chunk_size=16384/compressor=ZSTD-24      8.269k ± 0%   8.288k ± 0%   +0.23% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=65536/compressor=ZSTD-24      3.428k ± 0%   3.435k ± 0%   +0.20% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=131072/compressor=ZSTD-24     2.469k ± 0%   2.479k ± 0%   +0.41% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=262144/compressor=ZSTD-24     2.001k ± 0%   1.990k ± 0%   -0.55% (p=0.001 n=7)
cache_type=fast/object_size=5000001/chunk_size=524288/compressor=ZSTD-24     1.742k ± 0%   1.738k ± 0%   -0.23% (p=0.004 n=7)
cache_type=fast/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24    1.555k ± 0%   1.650k ± 0%   +6.11% (p=0.001 n=7)
cache_type=fast/object_size=15000001/chunk_size=16384/compressor=ZSTD-24     22.16k ± 0%   22.16k ± 0%        ~ (p=0.476 n=7)
cache_type=fast/object_size=15000001/chunk_size=65536/compressor=ZSTD-24     7.524k ± 0%   7.544k ± 0%   +0.27% (p=0.001 n=7)
cache_type=fast/object_size=15000001/chunk_size=131072/compressor=ZSTD-24    4.618k ± 0%   4.640k ± 0%   +0.48% (p=0.004 n=7)
cache_type=fast/object_size=15000001/chunk_size=262144/compressor=ZSTD-24    3.234k ± 1%   3.228k ± 0%        ~ (p=0.302 n=7)
cache_type=fast/object_size=15000001/chunk_size=524288/compressor=ZSTD-24    2.490k ± 0%   2.491k ± 1%        ~ (p=0.875 n=7)
cache_type=fast/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24   2.027k ± 0%   2.251k ± 1%  +11.05% (p=0.001 n=7)
cache_type=slow/object_size=1000/chunk_size=16384/compressor=ZSTD-24          905.0 ± 0%    905.0 ± 0%        ~ (p=1.000 n=7) ¹
cache_type=slow/object_size=100000/chunk_size=16384/compressor=ZSTD-24       1.433k ± 0%   1.433k ± 0%        ~ (p=1.000 n=7)
cache_type=slow/object_size=100000/chunk_size=65536/compressor=ZSTD-24       1.361k ± 0%   1.360k ± 0%        ~ (p=0.286 n=7)
cache_type=slow/object_size=100000/chunk_size=131072/compressor=ZSTD-24      1.363k ± 0%   1.362k ± 0%        ~ (p=0.592 n=7)
cache_type=slow/object_size=5000001/chunk_size=16384/compressor=ZSTD-24      8.257k ± 1%   7.623k ± 0%   -7.68% (p=0.001 n=7)
cache_type=slow/object_size=5000001/chunk_size=65536/compressor=ZSTD-24      3.385k ± 0%   3.277k ± 0%   -3.19% (p=0.001 n=7)
cache_type=slow/object_size=5000001/chunk_size=131072/compressor=ZSTD-24     2.465k ± 0%   2.419k ± 0%   -1.87% (p=0.001 n=7)
cache_type=slow/object_size=5000001/chunk_size=262144/compressor=ZSTD-24     1.980k ± 0%   1.987k ± 1%        ~ (p=0.086 n=7)
cache_type=slow/object_size=5000001/chunk_size=524288/compressor=ZSTD-24     1.729k ± 0%   1.746k ± 1%   +0.98% (p=0.002 n=7)
cache_type=slow/object_size=5000001/chunk_size=1000000/compressor=ZSTD-24    1.578k ± 1%   1.657k ± 0%   +5.01% (p=0.001 n=7)
cache_type=slow/object_size=15000001/chunk_size=16384/compressor=ZSTD-24     16.36k ± 1%   16.66k ± 1%   +1.83% (p=0.004 n=7)
cache_type=slow/object_size=15000001/chunk_size=65536/compressor=ZSTD-24     5.951k ± 1%   6.013k ± 1%   +1.04% (p=0.001 n=7)
cache_type=slow/object_size=15000001/chunk_size=131072/compressor=ZSTD-24    4.017k ± 1%   4.098k ± 1%   +2.02% (p=0.001 n=7)
cache_type=slow/object_size=15000001/chunk_size=262144/compressor=ZSTD-24    3.011k ± 1%   3.076k ± 1%   +2.16% (p=0.001 n=7)
cache_type=slow/object_size=15000001/chunk_size=524288/compressor=ZSTD-24    2.423k ± 2%   2.450k ± 1%   +1.11% (p=0.003 n=7)
cache_type=slow/object_size=15000001/chunk_size=1000000/compressor=ZSTD-24   2.038k ± 1%   2.218k ± 1%   +8.83% (p=0.001 n=7)
geomean                                                                            2.695k        2.717k        +0.83%
¹ all samples are equal
```