### PR TITLE
Fix bug in cachetools.UploadWriter

### DIFF
--- a/server/remote_cache/cachetools/BUILD
+++ b/server/remote_cache/cachetools/BUILD
@@ -50,7 +50,9 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -1275,11 +1275,11 @@ func (uw *UploadWriter) Commit() error {
 		if status.IsAlreadyExistsError(err) {
 			// If we know the resource already exists, flush already called
 			// CloseAndRecv and populated uw.committedSize. Don't return an
-			// error because from the clients point of view. Also, sends
-			// are not guaranteed to return an EOF, so it's possible the server
-			// didn't let us know that the object exists. For consistency,
-			// it's better to always return nil instead of sometimes returning
-			// AlreadyExists here.
+			// error because from the clients point of view, the write
+			// succeeded. Also, sends are not guaranteed to return an EOF, so
+			// it's possible the server didn't let us know that the object
+			// exists. For consistency, it's better to always return nil instead
+			// of sometimes returning AlreadyExists here.
 			return nil
 		}
 		return err

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -1188,7 +1188,7 @@ type UploadWriter struct {
 
 // Write copies the input bytes to an internal buffer and may send some or all of the bytes to the CAS.
 // Bytes are not guaranteed to be uploaded to the CAS until a call to Commit() succeeds.
-// Returning EOF indicates that the blob already exists in the CAS and no further writes are necessary.
+// Returning status.AlreadyExists indicates that the blob already exists in the CAS and no further writes are necessary.
 func (uw *UploadWriter) Write(p []byte) (int, error) {
 	if uw.closed {
 		return 0, status.FailedPreconditionError("Cannot write to UploadWriter after it is closed")
@@ -1205,9 +1205,6 @@ func (uw *UploadWriter) Write(p []byte) (int, error) {
 		uw.bytesBuffered += n
 		written += n
 		if err := uw.flush(false /* finish */); err != nil {
-			if err == io.EOF {
-				return written, io.ErrShortWrite
-			}
 			return written, err
 		}
 		p = p[n:]
@@ -1236,6 +1233,19 @@ func (uw *UploadWriter) flush(finish bool) error {
 	}
 	uw.sendErr = uw.sender.SendWithTimeoutCause(req, *casRPCTimeout, status.DeadlineExceededError("Timed out sending Write request"))
 	if uw.sendErr != nil {
+		if uw.sendErr == io.EOF {
+			// The server closed the stream, so we need to call CloseAndRecv
+			// to find the error.
+			rsp, err := uw.stream.CloseAndRecv()
+			if err == nil {
+				uw.committedSize = rsp.GetCommittedSize()
+				// byte_stream_server.go doesn't return an error when the
+				// resource already exists, but this is the only case where
+				// send returns EOF and recv returns nil.
+				err = status.AlreadyExistsError(req.GetResourceName())
+			}
+			uw.sendErr = err
+		}
 		return uw.sendErr
 	}
 	uw.bytesUploaded += int64(len(data))
@@ -1252,15 +1262,26 @@ func (uw *UploadWriter) Commit() error {
 	if uw.committed {
 		return nil
 	}
-	if uw.sendErr != nil && uw.sendErr != io.EOF {
+	if uw.sendErr != nil {
+		if status.IsAlreadyExistsError(uw.sendErr) {
+			return nil
+		}
 		return status.WrapError(uw.sendErr, "UploadWriter already encountered send error, cannot commit")
 	}
 
 	uw.committed = true
 	err := uw.flush(true /* finish */)
-	// If the blob already exists in the CAS, the server can respond with an EOF.
-	// The blob exists, it is safe to finish committing.
-	if err != nil && err != io.EOF {
+	if err != nil {
+		if status.IsAlreadyExistsError(err) {
+			// If we know the resource already exists, flush already called
+			// CloseAndRecv and populated uw.committedSize. Don't return an
+			// error because from the clients point of view. Also, sends
+			// are not guaranteed to return an EOF, so it's possible the server
+			// didn't let us know that the object exists. For consistency,
+			// it's better to always return nil instead of sometimes returning
+			// AlreadyExists here.
+			return nil
+		}
 		return err
 	}
 	rsp, err := uw.stream.CloseAndRecv()

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
@@ -902,7 +904,7 @@ func TestUploadWriterAndGetBlob(t *testing.T) {
 
 func TestUploadWriter_BlobExists(t *testing.T) {
 	for _, useZstd := range []bool{false, true} {
-		t.Run(fmt.Sprintf("/use_zstd_%t", useZstd), func(t *testing.T) {
+		t.Run(fmt.Sprintf("zstd=%t", useZstd), func(t *testing.T) {
 			te := testenv.GetTestEnv(t)
 			_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
 			testcache.Setup(t, te, localGRPClis)
@@ -946,17 +948,22 @@ func TestUploadWriter_BlobExists(t *testing.T) {
 				uw, err := cachetools.NewUploadWriter(ctx, te.GetByteStreamClient(), casRN)
 				require.NoError(t, err)
 
+				// This will return an error iff it flushed.
 				n, err := uw.Write(buf)
-				if useZstd {
-					require.Error(t, err)
-					require.Greater(t, n, 0)
+				if err != nil {
+					require.Equalf(t, gstatus.Code(err).String(), codes.AlreadyExists.String(), "Error wasn't AlreadyExists: %v", err)
 				} else {
-					require.NoError(t, err)
 					require.Equal(t, uploadSize, int64(n))
 				}
 
 				err = uw.Commit()
 				require.NoError(t, err)
+				// require.Equalf(t, gstatus.Code(err).String(), codes.AlreadyExists.String(), "Error wasn't AlreadyExists: %v", err)
+				if useZstd {
+					require.Equal(t, int64(-1), uw.GetCommittedSize())
+				} else {
+					require.Equal(t, uploadSize, uw.GetCommittedSize())
+				}
 
 				err = uw.Close()
 				require.NoError(t, err)

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -948,7 +948,8 @@ func TestUploadWriter_BlobExists(t *testing.T) {
 				uw, err := cachetools.NewUploadWriter(ctx, te.GetByteStreamClient(), casRN)
 				require.NoError(t, err)
 
-				// This will return an error iff it flushed.
+				// This will return an error iff it flushed and the server
+				// closed the stream before the last client send started.
 				n, err := uw.Write(buf)
 				if err != nil {
 					require.Equalf(t, gstatus.Code(err).String(), codes.AlreadyExists.String(), "Error wasn't AlreadyExists: %v", err)
@@ -958,7 +959,6 @@ func TestUploadWriter_BlobExists(t *testing.T) {
 
 				err = uw.Commit()
 				require.NoError(t, err)
-				// require.Equalf(t, gstatus.Code(err).String(), codes.AlreadyExists.String(), "Error wasn't AlreadyExists: %v", err)
 				if useZstd {
 					require.Equal(t, int64(-1), uw.GetCommittedSize())
 				} else {


### PR DESCRIPTION
We would return io.ErrShortWrite instead of status.AlreadyExists when the resource already exists.

This is a bit clunky since byte_stream_server.go doesn't guarantee that it will notify the client if the object already exists. So in UploadWriter.Write, we do a best effort check so the caller can short-circuit, but in Commit, we treat that as success for consistency.