### PR TITLE
[firecracker] ensure ext4 dependencies are present during pool creation

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -495,6 +495,10 @@ func NewProvider(env environment.Env, buildRoot, cacheRoot string) (*Provider, e
 		return nil, err
 	}
 
+	if err := ext4.EnsureDependencies(); err != nil {
+		return nil, status.WrapError(err, "verify ext4 tooling")
+	}
+
 	if _, err := os.Stat("/dev/kvm"); err != nil {
 		return nil, status.WrapError(err, "Firecracker isolation requires kvm")
 	}

--- a/enterprise/server/util/ext4/ext4.go
+++ b/enterprise/server/util/ext4/ext4.go
@@ -36,10 +36,7 @@ const (
 	// FS block size that we always use when creating ext4 images.
 	blockSize = 4096
 
-	// mke2fsPath is the path to the binary used for creating ext4 images.
-	mke2fsPath = "/sbin/mke2fs"
-
-	// debugfsPath is the path to the binary used for extracting from ext4 images.
+	mke2fsPath  = "/sbin/mke2fs"
 	debugfsPath = "/sbin/debugfs"
 )
 


### PR DESCRIPTION
If either `/sbin/mke2fs` or `/sbin/debugfs` are not present, the Firecracker pool will not be able to run any tasks. So ensure those binaries are present and executable at pool creation time, and error if not.