### PR TITLE
Add status label to clickhouse query error metric

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2387,6 +2387,7 @@ var (
 		Help:      "Number of ClickHouse SQL queries that resulted in an error.",
 	}, []string{
 		SQLQueryTemplateLabel,
+		StatusHumanReadableLabel,
 	})
 	ClickhouseQueryCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -411,6 +411,7 @@ func recordMetricsAfterFn(db *gorm.DB) {
 	// Ignore "record not found" errors as they don't generally indicate a
 	// problem with the server.
 	if db.Error != nil && !errors.Is(db.Error, gorm.ErrRecordNotFound) {
+		labels[metrics.StatusHumanReadableLabel] = status.MetricsLabel(db.Error)
 		metrics.ClickhouseQueryErrorCount.With(labels).Inc()
 	}
 }


### PR DESCRIPTION
This will allow us to ignore some errors in alerts