### PR TITLE
Dedupe messages in error card

### DIFF
--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -138,7 +138,8 @@ export default class ErrorCardComponent extends React.Component<Props, State> {
         }
       }
     }
-    let text = lines.join("\n");
+
+    let text = deduplicateLines(lines).join("\n");
     text = deemphasizeSandboxDebug(text);
     text = underlineFileNames(text);
     return text;
@@ -213,6 +214,10 @@ function formatFailureDescription(failureDetail: failure_details.IFailureDetail)
 
 function joinNonEmpty(parts: string[], join: string) {
   return parts.filter((x) => x).join(join);
+}
+
+function deduplicateLines(lines: string[]): string[] {
+  return lines.filter((x, index, self) => self.indexOf(x) === index);
 }
 
 function modelsEqual(a: CardModel, b: CardModel): boolean {


### PR DESCRIPTION
In the error card we currently cobble together error descriptions from a bunch of different places.

Some of these errors can be duplicates, commonly `error.finished.failureDetail` and `error.action.failureDetail`.

This change dedupes those so if they match, only one will be printed.

Example:
<img width="1094" height="422" alt="Screenshot 2025-09-26 at 11 34 33 AM" src="https://github.com/user-attachments/assets/f1d05f6d-8c16-437d-adb1-77b88c8705aa" />
