### PR TITLE
Mark executions that fail to dispatch as failed

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -903,6 +903,9 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 		log.CtxInfof(ctx, "Scheduling new execution %s for %q for invocation %q", executionID, downloadString, invocationID)
 		if err := s.Dispatch(ctx, req, action, executionID); err != nil {
 			log.CtxWarningf(ctx, "Error dispatching execution for %q: %s", downloadString, err)
+			if err := s.MarkExecutionFailed(ctx, executionID, err); err != nil {
+				log.CtxWarningf(ctx, "Error marking execution failed: %s", err)
+			}
 			return err
 		}
 		ctx = log.EnrichContext(ctx, log.ExecutionIDKey, executionID)


### PR DESCRIPTION
Currently, if an action fails to dispatch (say because there are no executors available in its pool) - the actions remain in Starting state for ever and never get any failure details attached to them.

With this change, this actions are marked as failed - and they show up in the UI as failed with the appropriate error details.

Before:
<img width="1134" height="697" alt="Screenshot 2025-09-26 at 11 40 22 AM" src="https://github.com/user-attachments/assets/ddc6a165-877c-4f7e-b914-b0ab602a9d21" />

After:
<img width="1147" height="712" alt="Screenshot 2025-09-26 at 11 41 56 AM" src="https://github.com/user-attachments/assets/1a192f5a-ff9e-45f7-bc31-f1539082a067" />
