### PR TITLE
User list role assignment.

### DIFF
--- a/enterprise/app/org/BUILD
+++ b/enterprise/app/org/BUILD
@@ -96,7 +96,6 @@ ts_library(
         "//:node_modules/tslib",
         "//app/alert:alert_service",
         "//app/auth:auth_service",
-        "//app/auth:user",
         "//app/capabilities",
         "//app/components/button",
         "//app/components/dialog",
@@ -105,9 +104,10 @@ ts_library(
         "//app/components/spinner",
         "//app/errors:error_service",
         "//app/service:rpc_service",
-        "//enterprise/app/org:user_list",
+        "//enterprise/app/org:member_list",
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",
+        "//proto:user_list_ts_proto",
     ],
 )
 
@@ -140,8 +140,8 @@ ts_library(
         "//app/errors:error_service",
         "//app/router",
         "//app/service:rpc_service",
+        "//enterprise/app/org:member_list",
         "//enterprise/app/org:org_user_list",
-        "//enterprise/app/org:user_list",
         "//proto:user_list_ts_proto",
     ],
 )
@@ -163,7 +163,7 @@ ts_library(
         "//app/errors:error_service",
         "//app/router",
         "//app/service:rpc_service",
-        "//enterprise/app/org:user_list",
+        "//enterprise/app/org:member_list",
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",
         "//proto:user_list_ts_proto",
@@ -171,8 +171,8 @@ ts_library(
 )
 
 ts_library(
-    name = "user_list",
-    srcs = ["user_list.tsx"],
+    name = "member_list",
+    srcs = ["member_list.tsx"],
     deps = [
         "//:node_modules/@types/react",
         "//:node_modules/lucide-react",
@@ -186,5 +186,6 @@ ts_library(
         "//app/icons:google",
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",
+        "//proto:user_list_ts_proto",
     ],
 )

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -318,6 +318,10 @@
   border: 1px solid transparent;
 }
 
+.org-members .org-member-role-unassigned {
+  color: #616161;
+}
+
 .org-members .org-member-more-rows-link {
   cursor: pointer;
 }

--- a/enterprise/app/org/org_user_list.tsx
+++ b/enterprise/app/org/org_user_list.tsx
@@ -19,7 +19,7 @@ import rpcService from "../../../app/service/rpc_service";
 import { grp } from "../../../proto/group_ts_proto";
 import { user_id } from "../../../proto/user_id_ts_proto";
 import { user_list } from "../../../proto/user_list_ts_proto";
-import UserListComponent, { UserListUser } from "./user_list";
+import MemberListComponent, { MemberListMember } from "./member_list";
 import MembershipAction = user_list.UpdateUserListMembershipRequest.MembershipAction;
 
 export type OrgUserListProps = {
@@ -183,10 +183,10 @@ export default class OrgUserListComponent extends React.Component<OrgUserListPro
 
     const memberIDs = new Set<string>(this.state.userList.user.map((m) => m.userId!.id));
 
-    const members = this.state.userList.user.map((m) => new UserListUser(m));
+    const members = this.state.userList.user.map((m) => new MemberListMember(m));
     const nonMembers = this.state.allUsers
       ?.filter((gu) => gu.user && !memberIDs.has(gu.user.userId!.id))
-      .map((gu) => new UserListUser(gu.user!, gu.role));
+      .map((gu) => new MemberListMember(gu.user!, gu.role));
 
     return (
       <>
@@ -208,9 +208,9 @@ export default class OrgUserListComponent extends React.Component<OrgUserListPro
         <div className="settings-option-title">Members</div>
         {members.length == 0 && <div>There are no users in the IAM group.</div>}
         {members.length > 0 && (
-          <UserListComponent
+          <MemberListComponent
             user={this.props.user}
-            users={members}
+            members={members}
             buttons={[removeButton]}
             showRole={false}
             onButtonClick={this.onClickRemoveUsers.bind(this)}
@@ -220,9 +220,9 @@ export default class OrgUserListComponent extends React.Component<OrgUserListPro
         <div className="settings-option-title">Add users</div>
         {nonMembers?.length == 0 && <div>There are no users that can be added.</div>}
         {nonMembers?.length > 0 && (
-          <UserListComponent
+          <MemberListComponent
             user={this.props.user}
-            users={nonMembers}
+            members={nonMembers}
             buttons={[addButton]}
             showRole={false}
             onButtonClick={this.onClickAddUsers.bind(this)}

--- a/enterprise/app/org/org_user_lists.tsx
+++ b/enterprise/app/org/org_user_lists.tsx
@@ -17,8 +17,8 @@ import errorService from "../../../app/errors/error_service";
 import router from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
 import { user_list } from "../../../proto/user_list_ts_proto";
+import MemberListComponent, { MemberListMember } from "./member_list";
 import OrgUserListComponent from "./org_user_list";
-import UserListComponent, { UserListUser } from "./user_list";
 
 type ChildProps = {
   user: User;
@@ -173,9 +173,9 @@ class OrgUserListsChildComponent extends React.Component<ChildProps, ChildState>
                 <div className="org-user-list-name">{userList.name}</div>
                 <div className="org-user-list-members">
                   {userList.user.length > 0 && (
-                    <UserListComponent
+                    <MemberListComponent
                       user={this.props.user}
-                      users={userList.user.map((u) => new UserListUser(u))}
+                      members={userList.user.map((u) => new MemberListMember(u))}
                       showRole={false}
                       readOnly={true}
                       maxRows={10}


### PR DESCRIPTION
Groups are shown at the top of the member list (both assigned and unassigned). 
I expect the number of groups per organization to be small so having them accessible directly in the member list is convenient.
<img width="1297" height="767" alt="image" src="https://github.com/user-attachments/assets/514f94ae-b028-4305-926d-f28eb4a82d3b" />

Role assignment and removal works the same as it does for users (except that removing role from a user list does not remove it from the UI)
