### PR TITLE
Fix more labels for Bzlmod and update internal module file git ref

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Update SHA
         run: |
           cd "$GITHUB_WORKSPACE"/buildbuddy-internal
-          sed -i "s/commit = \"[a-z0-9]*\",  # autoupdate buildbuddy-io\/buildbuddy/commit = \"$GITHUB_SHA\",  # autoupdate buildbuddy-io\/buildbuddy/g" WORKSPACE
+          sed -i "s/commit = \"[a-z0-9]*\",  # autoupdate buildbuddy-io\/buildbuddy/commit = \"$GITHUB_SHA\",  # autoupdate buildbuddy-io\/buildbuddy/g" WORKSPACE MODULE.bazel
 
       - name: Commit
         env:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -239,7 +239,7 @@ go_download_sdk(
 )
 
 go_register_nogo(
-    nogo = "@//:vet",
+    nogo = "@com_github_buildbuddy_io_buildbuddy//:vet",
 )
 
 go_register_toolchains()

--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -5,6 +5,7 @@ go_deps.from_file(go_mod = "@com_github_buildbuddy_io_buildbuddy//:go.mod")
 # Non-Go repos referenced by Go repos
 inject_repo(
     go_deps,
+    "com_github_buildbuddy_io_buildbuddy",
     "googleapis",
     "zlib",
 )
@@ -78,7 +79,7 @@ go_deps.module_override(
 # Go repos with custom directives
 go_deps.gazelle_override(
     directives = [
-        "gazelle:go_proto_compilers @io_bazel_rules_go//proto:go_proto,@@//proto:vtprotobuf_compiler",
+        "gazelle:go_proto_compilers @io_bazel_rules_go//proto:go_proto,@com_github_buildbuddy_io_buildbuddy//proto:vtprotobuf_compiler",
     ],
     path = "github.com/prometheus/client_model",
 )

--- a/deps/toolchains.MODULE.bazel
+++ b/deps/toolchains.MODULE.bazel
@@ -35,7 +35,7 @@ register_toolchains(
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.25.0")
-go_sdk.nogo(nogo = "@//:vet")
+go_sdk.nogo(nogo = "@com_github_buildbuddy_io_buildbuddy//:vet")
 use_repo(
     go_sdk,
     "go_toolchains",


### PR DESCRIPTION
With this change, the following build passes in the internal repo:

```
bazel build @com_github_buildbuddy_io_buildbuddy//cli --enable_bzlmod --noenable_workspace
```

Requires https://github.com/buildbuddy-io/buildbuddy-internal/pull/5736