### PR TITLE
Fix fix_go_deps.sh diffing logic

### DIFF
--- a/tools/fix_go_deps.sh
+++ b/tools/fix_go_deps.sh
@@ -97,5 +97,9 @@ if ! "$BAZEL_COMMAND" mod tidy --enable_bzlmod &>"$tmp_log_file"; then
 fi
 
 if ((DIFF_MODE)); then
-  git diff
+  DIFF=$(git diff -- "${AFFECTED_FILES[@]}")
+  if [[ "$DIFF" ]]; then
+    echo >&2 "$DIFF"
+    exit 1
+  fi
 fi


### PR DESCRIPTION
Make sure to exit with a non-zero code if there's a diff, otherwise `tools/lint` will not treat the non-empty diff as a lint error.

Also, only diff the files that might be modified by `fix_go_deps.sh`, otherwise it can report unrelated diffs which aren't relevant to go deps.