### PR TITLE
Remove noisy warning from retry package

### DIFF
--- a/server/util/retry/retry.go
+++ b/server/util/retry/retry.go
@@ -224,7 +224,6 @@ func Do[T any](ctx context.Context, opts *Options, fn func(ctx context.Context) 
 	for {
 		makeAttempt, err := r.next()
 		if err != nil {
-			logFailedAttempt(lastError, " and could not be retried as the context is done")
 			return *new(T), err
 		}
 		if !makeAttempt {


### PR DESCRIPTION
In replay_action, this warning can wind up getting printed thousands of times when pressing Ctrl+C, which makes it harder to go back and look at log output.

I think this warning is not needed because an error is already being returned to the caller, who can decide how best to handle the error.