### PR TITLE
Add target and mnemonic to initial execution metadata

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -247,6 +247,11 @@ func (s *ExecutionServer) insertExecution(ctx context.Context, executionID, invo
 		execution.Model.CreatedAtUsec = now.UnixMicro()
 		execution.Model.UpdatedAtUsec = now.UnixMicro()
 		executionProto := executil.TableExecToProto(execution, nil /*=invocationLink*/)
+		// Store some basic metadata in the initial proto so we can show a nicer
+		// UI while the execution is in progress.
+		rmd := bazel_request.GetRequestMetadata(ctx)
+		executionProto.TargetLabel = rmd.GetTargetId()
+		executionProto.ActionMnemonic = rmd.GetActionMnemonic()
 		executionProto.OutputPath = primaryOutputPath(command)
 		if err := s.env.GetExecutionCollector().UpdateInProgressExecution(ctx, executionProto); err != nil {
 			log.CtxErrorf(ctx, "Failed to write execution update to redis: %s", err)

--- a/enterprise/server/test/webdriver/executions_clickhouse/BUILD
+++ b/enterprise/server/test/webdriver/executions_clickhouse/BUILD
@@ -12,7 +12,7 @@ go_web_test_suite(
         "test.runner-recycling-key": "clickhouse",
         "test.EstimatedComputeUnits": "8",
     },
-    shard_count = 1,
+    shard_count = 2,
     tags = ["docker"],
     deps = [
         "//enterprise/server/testutil/buildbuddy_enterprise",

--- a/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
+++ b/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
@@ -23,7 +23,8 @@ import (
 )
 
 type executionsClickhouseTest struct {
-	flags []string
+	flags                    []string
+	expectTargetLabelVisible bool
 }
 
 func TestInvocationWithRemoteExecutionWithClickHouse_StoreMetadataInRedisAndClickHouse(t *testing.T) {
@@ -34,6 +35,7 @@ func TestInvocationWithRemoteExecutionWithClickHouse_StoreMetadataInRedisAndClic
 			"--remote_execution.primary_db_reads_enabled=false",
 			"--remote_execution.olap_reads_enabled=true",
 		},
+		expectTargetLabelVisible: true,
 	})
 }
 
@@ -124,9 +126,13 @@ common --incompatible_strict_action_env=true
 	wt.Find(`[href="#execution"]`).Click()
 	waitForExecutionsToAppear(t, wt)
 
-	// There should be one execution in in-progress state.
+	// There should be one execution in in-progress state, and it should show
+	// the target label (if the new redis implementation is enabled).
 	execution := wt.Find(".invocation-execution-row")
 	require.Regexp(t, "(Executing|Starting)", execution.Text())
+	if tc.expectTargetLabelVisible {
+		require.Contains(t, execution.Text(), "//:target1")
+	}
 	execution.Click()
 	originalExecutionID := wt.Find(`[debug-id="execution-id"]`).Text()
 


### PR DESCRIPTION
This makes it so that we have the target and mnemonic available in the UI, even if the execution is in-progress. It also makes it so that if the execution hits certain errors (e.g. canceled) we will still store this metadata in ClickHouse.