### PR TITLE
Optimize buffer sizes for bytestream reads

### DIFF
--- a/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
+++ b/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
@@ -86,7 +86,7 @@ type slowWriter struct {
 }
 
 func (w *slowWriter) Write(p []byte) (int, error) {
-	proportinalSleep(len(p))
+	proportionalSleep(len(p))
 	return w.CommittedWriteCloser.Write(p)
 }
 
@@ -97,7 +97,7 @@ type slowWriterReaderFrom struct {
 
 func (w *slowWriterReaderFrom) ReadFrom(r io.Reader) (int64, error) {
 	n, err := w.ReaderFrom.ReadFrom(r)
-	proportinalSleep(int(n))
+	proportionalSleep(int(n))
 	return n, err
 }
 
@@ -107,7 +107,7 @@ type slowReader struct {
 
 func (r *slowReader) Read(buf []byte) (int, error) {
 	n, err := r.ReadCloser.Read(buf)
-	proportinalSleep(n)
+	proportionalSleep(n)
 	return n, err
 }
 
@@ -118,11 +118,11 @@ type slowReaderWriterTo struct {
 
 func (r *slowReaderWriterTo) WriteTo(w io.Writer) (int64, error) {
 	n, err := r.WriterTo.WriteTo(w)
-	proportinalSleep(int(n))
+	proportionalSleep(int(n))
 	return n, err
 }
 
-func proportinalSleep(n int) {
+func proportionalSleep(n int) {
 	busyLoop(time.Duration(n/100) * time.Microsecond)
 }
 

--- a/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
+++ b/enterprise/server/test/performance/bytestream/bytestream_server_benchmark_test.go
@@ -45,13 +45,13 @@ func runByteStreamServer(ctx context.Context, t testing.TB, env *testenv.TestEnv
 	return clientConn
 }
 
-// slowWriteCache wraps a Cache, but makes each write operation sleep for 1us per
-// 100 bytes (or 10ms per 1MB).
-type slowWriteCache struct {
+// slowCache wraps a Cache, but makes each write and read operation sleep for
+// 1us per 100 bytes (or 10ms per 1MB).
+type slowCache struct {
 	interfaces.Cache
 }
 
-func (c *slowWriteCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {
+func (c *slowCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {
 	w, err := c.Cache.Writer(ctx, r)
 	if err != nil {
 		return nil, err
@@ -67,21 +67,27 @@ func (c *slowWriteCache) Writer(ctx context.Context, r *rspb.ResourceName) (inte
 	}, nil
 }
 
+func (c *slowCache) Reader(ctx context.Context, rn *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+	r, err := c.Cache.Reader(ctx, rn, uncompressedOffset, limit)
+	if err != nil {
+		return nil, err
+	}
+	if writerTo, ok := r.(io.WriterTo); ok {
+		return &slowReaderWriterTo{
+			slowReader: slowReader{r},
+			WriterTo:   writerTo,
+		}, nil
+	}
+	return &slowReader{r}, nil
+}
+
 type slowWriter struct {
 	interfaces.CommittedWriteCloser
 }
 
 func (w *slowWriter) Write(p []byte) (int, error) {
-	busyLoop(time.Duration(len(p)/100) * time.Microsecond)
+	proportinalSleep(len(p))
 	return w.CommittedWriteCloser.Write(p)
-}
-
-// time.Sleep can't reliably sleep for less than 1ms, so use a busy loop
-// instead.
-func busyLoop(dur time.Duration) {
-	start := time.Now()
-	for time.Since(start) < dur {
-	}
 }
 
 type slowWriterReaderFrom struct {
@@ -91,8 +97,41 @@ type slowWriterReaderFrom struct {
 
 func (w *slowWriterReaderFrom) ReadFrom(r io.Reader) (int64, error) {
 	n, err := w.ReaderFrom.ReadFrom(r)
-	busyLoop(time.Duration(n/100) * time.Microsecond)
+	proportinalSleep(int(n))
 	return n, err
+}
+
+type slowReader struct {
+	io.ReadCloser
+}
+
+func (r *slowReader) Read(buf []byte) (int, error) {
+	n, err := r.ReadCloser.Read(buf)
+	proportinalSleep(n)
+	return n, err
+}
+
+type slowReaderWriterTo struct {
+	slowReader
+	io.WriterTo
+}
+
+func (r *slowReaderWriterTo) WriteTo(w io.Writer) (int64, error) {
+	n, err := r.WriterTo.WriteTo(w)
+	proportinalSleep(int(n))
+	return n, err
+}
+
+func proportinalSleep(n int) {
+	busyLoop(time.Duration(n/100) * time.Microsecond)
+}
+
+// time.Sleep can't reliably sleep for less than 1ms, so use a busy loop
+// instead.
+func busyLoop(dur time.Duration) {
+	start := time.Now()
+	for time.Since(start) < dur {
+	}
 }
 
 func getDistributedCache(t testing.TB, te environment.Env, c interfaces.Cache, lookasideCacheSizeBytes int64) interfaces.Cache {
@@ -147,7 +186,7 @@ func BenchmarkWrite(b *testing.B) {
 		{
 			"slow",
 			func(b *testing.B, env environment.Env) interfaces.Cache {
-				return getDistributedCache(b, env, &slowWriteCache{getPebbleCache(b, env)}, 0)
+				return getDistributedCache(b, env, &slowCache{getPebbleCache(b, env)}, 0)
 			},
 		},
 	} {
@@ -245,5 +284,102 @@ func benchmarkWrite(b *testing.B, ctx context.Context, objectSize int64, chunkSi
 			require.False(b, cont)
 		}
 		b.StartTimer()
+	}
+}
+
+func BenchmarkRead(b *testing.B) {
+	*log.LogLevel = "error"
+	log.Configure()
+
+	for _, test := range []struct {
+		cacheType string
+		cacheFunc func(b *testing.B, env environment.Env) interfaces.Cache
+	}{
+		{
+			"fast",
+			func(b *testing.B, env environment.Env) interfaces.Cache {
+				return getDistributedCache(b, env, getPebbleCache(b, env), 0)
+			},
+		},
+		{
+			"slow",
+			func(b *testing.B, env environment.Env) interfaces.Cache {
+				return getDistributedCache(b, env, &slowCache{getPebbleCache(b, env)}, 0)
+			},
+		},
+		{
+			"non-distributed", // benchmark reads which land on the correct app
+			func(b *testing.B, env environment.Env) interfaces.Cache {
+				return getPebbleCache(b, env)
+			},
+		},
+	} {
+		b.Run(fmt.Sprintf("cache_type=%v", test.cacheType), func(b *testing.B) {
+			env := testenv.GetTestEnv(b)
+			ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env.GetAuthenticator())
+			require.NoError(b, err)
+			cache := test.cacheFunc(b, env)
+			env.SetCache(cache)
+			conn := runByteStreamServer(ctx, b, env)
+			client := bspb.NewByteStreamClient(conn)
+			for _, objectSize := range []int64{1000, 100_000, 5_000_001, 15_000_001} {
+				b.Run(fmt.Sprintf("object_size=%d", objectSize), func(b *testing.B) {
+					for _, compressor := range []repb.Compressor_Value{repb.Compressor_IDENTITY, repb.Compressor_ZSTD} {
+						b.Run(fmt.Sprintf("compressor=%s", compressor), func(b *testing.B) {
+							benchmarkRead(b, ctx, objectSize, compressor, cache, client)
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func benchmarkRead(b *testing.B, ctx context.Context, objectSize int64, compressor repb.Compressor_Value, cache interfaces.Cache, client bspb.ByteStreamClient) {
+	r, buf := testdigest.RandomCASResourceBuf(b, objectSize)
+	r.Compressor = compressor
+	rn, err := digest.CASResourceNameFromProto(r)
+	require.NoError(b, err)
+	compressedBuf := buf
+	if compressor == repb.Compressor_ZSTD {
+		compressedBuf = compression.CompressZstd(nil, buf)
+	}
+	writeClient, err := client.Write(ctx)
+	require.NoError(b, err)
+	err = writeClient.Send(&bspb.WriteRequest{Data: compressedBuf, ResourceName: rn.NewUploadString(), FinishWrite: true})
+	require.NoError(b, err)
+	resp, err := writeClient.CloseAndRecv()
+	require.NoError(b, err)
+	require.Less(b, int64(0), resp.GetCommittedSize())
+
+	b.ReportAllocs()
+	b.SetBytes(objectSize)
+	i := 0
+	for b.Loop() {
+		i++
+		stream, err := client.Read(ctx, &bspb.ReadRequest{ResourceName: rn.DownloadString()})
+		require.NoError(b, err)
+		var readBytes []byte
+		if i == 1 {
+			readBytes = make([]byte, 0, len(compressedBuf))
+		}
+		for {
+			reply, err := stream.Recv()
+			if i == 1 {
+				// Only test data validity once
+				b.StopTimer()
+				readBytes = append(readBytes, reply.GetData()...)
+				b.StartTimer()
+			}
+			if err == io.EOF {
+				break
+			}
+			require.NoError(b, err)
+		}
+		if i == 1 {
+			b.StopTimer()
+			require.Equal(b, compressedBuf, readBytes)
+			b.StartTimer()
+		}
 	}
 }

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -30,9 +30,11 @@ import (
 )
 
 const (
-	// Keep under the limit of ~4MB (save 256KB).
-	// (Match the readBufSizeBytes in byte_stream_server.go)
-	readBufSizeBytes = (1024 * 1024 * 4) - (1024 * 256)
+	// readBufSizeBytes controls the buffer size used for reading from the
+	// remote cache. This should match the readBufSizeBytes in
+	// byte_stream_server.go, or it can be up to 2 times larger and still have
+	// similar performance.
+	readBufSizeBytes = 256 * 1024 // 256 KiB
 
 	// writeBufSizeBytes controls the maximum size of buffers used for writing
 	// to a remote cache. This is also the maximum payload size for each
@@ -47,8 +49,7 @@ type Proxy struct {
 	env                   environment.Env
 	cache                 interfaces.Cache
 	log                   log.Logger
-	readBufPool           *bytebufferpool.VariableSizePool
-	writeBufPool          *bytebufferpool.VariableWriteBufPool
+	bufPool               *bytebufferpool.VariableSizePool
 	mu                    *sync.Mutex
 	server                *grpc.Server
 	clients               map[string]*grpc_client.ClientConnPool
@@ -60,13 +61,12 @@ type Proxy struct {
 
 func New(env environment.Env, c interfaces.Cache, listenAddr string) *Proxy {
 	proxy := &Proxy{
-		env:          env,
-		cache:        c,
-		log:          log.NamedSubLogger(fmt.Sprintf("Proxy(%s)", listenAddr)),
-		readBufPool:  bytebufferpool.VariableSize(readBufSizeBytes),
-		writeBufPool: bytebufferpool.NewVariableWriteBufPool(readBufSizeBytes),
-		listenAddr:   listenAddr,
-		mu:           &sync.Mutex{},
+		env:        env,
+		cache:      c,
+		log:        log.NamedSubLogger(fmt.Sprintf("Proxy(%s)", listenAddr)),
+		bufPool:    bytebufferpool.VariableSize(max(readBufSizeBytes, writeBufSizeBytes)),
+		listenAddr: listenAddr,
+		mu:         &sync.Mutex{},
 		// server goes here
 		clients: make(map[string]*grpc_client.ClientConnPool),
 	}
@@ -313,18 +313,17 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 	}
 	defer reader.Close()
 
-	bufSize := int64(readBufSizeBytes)
-	resourceSize := rn.GetDigest().GetSizeBytes()
-	if resourceSize > 0 && resourceSize < bufSize {
-		bufSize = resourceSize
-	}
-	copyBuf := c.readBufPool.Get(bufSize)
-	defer c.readBufPool.Put(copyBuf)
+	bufSize := int64(safeBufferSize(rn, readBufSizeBytes))
+	copyBuf := c.bufPool.Get(bufSize)
+	defer c.bufPool.Put(copyBuf)
 
 	for {
 		n, err := ioutil.ReadTryFillBuffer(reader, copyBuf)
 		if err == io.EOF {
 			break
+		}
+		if err != nil {
+			return err
 		}
 		if err := stream.Send(&dcpb.ReadResponse{Data: copyBuf[:n]}); err != nil {
 			return err
@@ -332,7 +331,7 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 	}
 
 	c.log.Debugf("Read(%q) succeeded (user prefix: %s)", ResourceIsolationString(rn), up)
-	return err
+	return nil
 }
 
 func (c *Proxy) callHintedHandoffCB(ctx context.Context, peer string, r *rspb.ResourceName) {
@@ -691,15 +690,11 @@ func (wc *streamWriteCloser) Close() error {
 	return nil
 }
 
-func safeBufferSize(r *rspb.ResourceName) int {
-	size := int(4096 * 4) // low / safe / default
-	if r.GetCacheType() == rspb.CacheType_CAS {
-		size = int(r.GetDigest().GetSizeBytes())
+func safeBufferSize(r *rspb.ResourceName, maxSize int) int {
+	if r.GetCacheType() != rspb.CacheType_CAS || r.GetDigest().GetSizeBytes() <= 0 {
+		return 4096 * 4 // low / safe / default
 	}
-	if size > writeBufSizeBytes {
-		size = writeBufSizeBytes
-	}
-	return size
+	return min(int(r.GetDigest().GetSizeBytes()), maxSize)
 }
 
 func (c *Proxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {
@@ -728,7 +723,7 @@ func (c *Proxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *r
 		stream:      stream,
 		r:           r,
 	}
-	return ioutil.NewDoubleBufferWriter(ctx, wc, c.readBufPool, safeBufferSize(r), writeBufSizeBytes), nil
+	return ioutil.NewDoubleBufferWriter(ctx, wc, c.bufPool, safeBufferSize(r, writeBufSizeBytes), writeBufSizeBytes), nil
 }
 
 func (c *Proxy) SendHeartbeat(ctx context.Context, peer string) error {

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -29,8 +29,11 @@ import (
 )
 
 const (
-	// Keep under the limit of ~4MB (save 256KB).
-	readBufSizeBytes = (1024 * 1024 * 4) - (1024 * 256)
+	// readBufSizeBytes controls the buffer size used for reading from the
+	// cache. Benchmarks show that 256KiB or 512KiB perform similarly,
+	// but experiments in dev show that 256KiB is better. Values smaller than
+	// 256KiB or larger than 1MiB are both slower and allocate more bytes.
+	readBufSizeBytes = 256 * 1024
 )
 
 var (


### PR DESCRIPTION
This is similar to https://github.com/buildbuddy-io/buildbuddy/pull/10354, but for reads.

The smaller buffer size is faster and allocates less, in benchmarks and dev experiments. In dev experiments, this removes 33% of the RPC duration for reads of more than 5MB.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                                                                            │ base_4M_4M_b  │          base_256K_256K_c           │
                                                                            │    sec/op     │    sec/op     vs base               │
Read/cache_type=fast/object_size=1000/compressor=IDENTITY-24                   182.3µ ± 19%   178.0µ ±  3%   -2.39% (p=0.038 n=7)
Read/cache_type=fast/object_size=1000/compressor=ZSTD-24                       175.3µ ±  3%   175.0µ ±  3%        ~ (p=0.620 n=7)
Read/cache_type=fast/object_size=100000/compressor=IDENTITY-24                 410.5µ ±  7%   390.2µ ±  3%   -4.94% (p=0.038 n=7)
Read/cache_type=fast/object_size=100000/compressor=ZSTD-24                     210.7µ ±  4%   209.0µ ±  3%        ~ (p=0.805 n=7)
Read/cache_type=fast/object_size=5000001/compressor=IDENTITY-24                6.914m ± 13%   4.236m ± 10%  -38.73% (p=0.001 n=7)
Read/cache_type=fast/object_size=5000001/compressor=ZSTD-24                    1.650m ± 20%   1.033m ±  7%  -37.39% (p=0.001 n=7)
Read/cache_type=fast/object_size=15000001/compressor=IDENTITY-24               14.89m ± 11%   11.48m ±  2%  -22.89% (p=0.001 n=7)
Read/cache_type=fast/object_size=15000001/compressor=ZSTD-24                   4.659m ±  6%   2.348m ±  3%  -49.61% (p=0.001 n=7)
Read/cache_type=slow/object_size=1000/compressor=IDENTITY-24                   185.8µ ± 12%   183.4µ ± 10%        ~ (p=0.383 n=7)
Read/cache_type=slow/object_size=1000/compressor=ZSTD-24                       173.1µ ±  1%   171.8µ ±  1%        ~ (p=0.364 n=7)
Read/cache_type=slow/object_size=100000/compressor=IDENTITY-24                 1.422m ±  6%   1.422m ±  6%        ~ (p=0.902 n=7)
Read/cache_type=slow/object_size=100000/compressor=ZSTD-24                     549.8µ ±  2%   553.7µ ±  3%        ~ (p=0.259 n=7)
Read/cache_type=slow/object_size=5000001/compressor=IDENTITY-24                55.89m ±  7%   53.85m ±  2%   -3.65% (p=0.001 n=7)
Read/cache_type=slow/object_size=5000001/compressor=ZSTD-24                    17.85m ±  4%   16.64m ±  1%   -6.75% (p=0.001 n=7)
Read/cache_type=slow/object_size=15000001/compressor=IDENTITY-24               164.9m ±  3%   159.9m ±  1%   -3.03% (p=0.001 n=7)
Read/cache_type=slow/object_size=15000001/compressor=ZSTD-24                   50.73m ±  0%   49.08m ±  0%   -3.25% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=1000/compressor=IDENTITY-24        77.29µ ±  4%   75.76µ ±  9%        ~ (p=0.805 n=7)
Read/cache_type=non-distributed/object_size=1000/compressor=ZSTD-24            70.90µ ±  6%   71.15µ ±  6%        ~ (p=0.620 n=7)
Read/cache_type=non-distributed/object_size=100000/compressor=IDENTITY-24      188.3µ ±  7%   185.5µ ± 13%        ~ (p=0.902 n=7)
Read/cache_type=non-distributed/object_size=100000/compressor=ZSTD-24          92.75µ ±  2%   92.36µ ± 11%        ~ (p=0.535 n=7)
Read/cache_type=non-distributed/object_size=5000001/compressor=IDENTITY-24     4.143m ± 30%   3.386m ±  2%  -18.27% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=5000001/compressor=ZSTD-24         684.5µ ± 25%   492.0µ ±  7%  -28.13% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=15000001/compressor=IDENTITY-24   11.260m ±  5%   9.771m ±  6%  -13.22% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=15000001/compressor=ZSTD-24        1.943m ± 11%   1.168m ±  9%  -39.89% (p=0.001 n=7)
geomean                                                                        1.390m         1.207m        -13.18%

                                                                            │ base_4M_4M_b  │           base_256K_256K_c            │
                                                                            │      B/s      │      B/s        vs base               │
Read/cache_type=fast/object_size=1000/compressor=IDENTITY-24                  5.226Mi ± 16%    5.360Mi ±  3%   +2.55% (p=0.027 n=7)
Read/cache_type=fast/object_size=1000/compressor=ZSTD-24                      5.436Mi ±  3%    5.445Mi ±  2%        ~ (p=0.607 n=7)
Read/cache_type=fast/object_size=100000/compressor=IDENTITY-24                232.3Mi ±  7%    244.4Mi ±  3%   +5.20% (p=0.038 n=7)
Read/cache_type=fast/object_size=100000/compressor=ZSTD-24                    452.5Mi ±  4%    456.3Mi ±  3%        ~ (p=0.805 n=7)
Read/cache_type=fast/object_size=5000001/compressor=IDENTITY-24               689.7Mi ± 11%   1125.6Mi ±  9%  +63.20% (p=0.001 n=7)
Read/cache_type=fast/object_size=5000001/compressor=ZSTD-24                   2.822Gi ± 17%    4.507Gi ±  6%  +59.71% (p=0.001 n=7)
Read/cache_type=fast/object_size=15000001/compressor=IDENTITY-24              960.7Mi ± 10%   1245.8Mi ±  2%  +29.68% (p=0.001 n=7)
Read/cache_type=fast/object_size=15000001/compressor=ZSTD-24                  2.999Gi ±  6%    5.951Gi ±  3%  +98.44% (p=0.001 n=7)
Read/cache_type=slow/object_size=1000/compressor=IDENTITY-24                  5.131Mi ± 10%    5.198Mi ±  9%        ~ (p=0.368 n=7)
Read/cache_type=slow/object_size=1000/compressor=ZSTD-24                      5.512Mi ±  1%    5.550Mi ±  1%        ~ (p=0.561 n=7)
Read/cache_type=slow/object_size=100000/compressor=IDENTITY-24                67.05Mi ±  6%    67.05Mi ±  5%        ~ (p=0.831 n=7)
Read/cache_type=slow/object_size=100000/compressor=ZSTD-24                    173.4Mi ±  2%    172.2Mi ±  3%        ~ (p=0.259 n=7)
Read/cache_type=slow/object_size=5000001/compressor=IDENTITY-24               85.32Mi ±  7%    88.55Mi ±  2%   +3.79% (p=0.001 n=7)
Read/cache_type=slow/object_size=5000001/compressor=ZSTD-24                   267.2Mi ±  4%    286.5Mi ±  1%   +7.24% (p=0.001 n=7)
Read/cache_type=slow/object_size=15000001/compressor=IDENTITY-24              86.75Mi ±  3%    89.45Mi ±  1%   +3.12% (p=0.001 n=7)
Read/cache_type=slow/object_size=15000001/compressor=ZSTD-24                  282.0Mi ±  0%    291.5Mi ±  0%   +3.36% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=1000/compressor=IDENTITY-24       12.34Mi ±  4%    12.59Mi ±  8%        ~ (p=0.805 n=7)
Read/cache_type=non-distributed/object_size=1000/compressor=ZSTD-24           13.45Mi ±  5%    13.41Mi ±  5%        ~ (p=0.620 n=7)
Read/cache_type=non-distributed/object_size=100000/compressor=IDENTITY-24     506.4Mi ±  6%    514.0Mi ± 12%        ~ (p=0.902 n=7)
Read/cache_type=non-distributed/object_size=100000/compressor=ZSTD-24         1.004Gi ±  2%    1.008Gi ± 10%        ~ (p=0.535 n=7)
Read/cache_type=non-distributed/object_size=5000001/compressor=IDENTITY-24    1.124Gi ± 23%    1.375Gi ±  2%  +22.35% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=5000001/compressor=ZSTD-24        6.803Gi ± 20%    9.465Gi ±  7%  +39.14% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=15000001/compressor=IDENTITY-24   1.241Gi ±  5%    1.430Gi ±  5%  +15.24% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=15000001/compressor=ZSTD-24       7.189Gi ± 10%   11.958Gi ± 10%  +66.35% (p=0.001 n=7)
geomean                                                                       201.8Mi          232.5Mi        +15.18%

                                                                            │  base_4M_4M_b  │           base_256K_256K_c           │
                                                                            │      B/op      │     B/op       vs base               │
Read/cache_type=fast/object_size=1000/compressor=IDENTITY-24                   62.30Ki ±  0%   62.26Ki ±  0%        ~ (p=0.598 n=7)
Read/cache_type=fast/object_size=1000/compressor=ZSTD-24                       58.17Ki ±  0%   58.15Ki ±  1%        ~ (p=0.902 n=7)
Read/cache_type=fast/object_size=100000/compressor=IDENTITY-24                 300.6Ki ±  2%   299.0Ki ±  3%        ~ (p=0.383 n=7)
Read/cache_type=fast/object_size=100000/compressor=ZSTD-24                     123.5Ki ±  1%   123.3Ki ±  0%        ~ (p=0.383 n=7)
Read/cache_type=fast/object_size=5000001/compressor=IDENTITY-24                12.21Mi ± 17%   11.00Mi ± 10%   -9.95% (p=0.002 n=7)
Read/cache_type=fast/object_size=5000001/compressor=ZSTD-24                    3.407Mi ± 36%   3.198Mi ±  1%   -6.14% (p=0.001 n=7)
Read/cache_type=fast/object_size=15000001/compressor=IDENTITY-24               35.89Mi ±  5%   30.88Mi ±  1%  -13.95% (p=0.001 n=7)
Read/cache_type=fast/object_size=15000001/compressor=ZSTD-24                   9.944Mi ±  1%   9.449Mi ±  0%   -4.97% (p=0.001 n=7)
Read/cache_type=slow/object_size=1000/compressor=IDENTITY-24                   61.70Ki ±  0%   61.69Ki ±  0%        ~ (p=1.000 n=7)
Read/cache_type=slow/object_size=1000/compressor=ZSTD-24                       57.68Ki ±  1%   57.69Ki ±  1%        ~ (p=0.928 n=7)
Read/cache_type=slow/object_size=100000/compressor=IDENTITY-24                 270.8Ki ±  2%   269.1Ki ±  2%        ~ (p=0.318 n=7)
Read/cache_type=slow/object_size=100000/compressor=ZSTD-24                     119.6Ki ±  0%   119.6Ki ±  1%        ~ (p=0.902 n=7)
Read/cache_type=slow/object_size=5000001/compressor=IDENTITY-24                13.74Mi ± 24%   11.23Mi ±  7%  -18.24% (p=0.002 n=7)
Read/cache_type=slow/object_size=5000001/compressor=ZSTD-24                    3.188Mi ± 44%   3.205Mi ±  1%        ~ (p=0.710 n=7)
Read/cache_type=slow/object_size=15000001/compressor=IDENTITY-24               40.01Mi ± 20%   33.65Mi ±  3%  -15.89% (p=0.001 n=7)
Read/cache_type=slow/object_size=15000001/compressor=ZSTD-24                  10.822Mi ± 25%   9.624Mi ±  1%  -11.07% (p=0.007 n=7)
Read/cache_type=non-distributed/object_size=1000/compressor=IDENTITY-24        33.29Ki ±  0%   33.28Ki ±  0%        ~ (p=0.402 n=7)
Read/cache_type=non-distributed/object_size=1000/compressor=ZSTD-24            30.91Ki ±  1%   30.92Ki ±  1%        ~ (p=0.300 n=7)
Read/cache_type=non-distributed/object_size=100000/compressor=IDENTITY-24      136.4Ki ±  0%   136.5Ki ±  0%        ~ (p=0.456 n=7)
Read/cache_type=non-distributed/object_size=100000/compressor=ZSTD-24          62.05Ki ±  0%   62.05Ki ±  0%        ~ (p=0.778 n=7)
Read/cache_type=non-distributed/object_size=5000001/compressor=IDENTITY-24     5.417Mi ±  7%   5.126Mi ±  2%   -5.37% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=5000001/compressor=ZSTD-24         1.629Mi ± 19%   1.590Mi ±  0%   -2.38% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=15000001/compressor=IDENTITY-24    17.52Mi ±  8%   15.50Mi ±  1%  -11.51% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=15000001/compressor=ZSTD-24        4.794Mi ±  1%   4.713Mi ±  0%   -1.68% (p=0.001 n=7)
geomean                                                                        872.1Ki         833.4Ki         -4.43%

                                                                            │ base_4M_4M_b │           base_256K_256K_c            │
                                                                            │  allocs/op   │  allocs/op   vs base                  │
Read/cache_type=fast/object_size=1000/compressor=IDENTITY-24                   822.0 ±  0%    822.0 ± 0%         ~ (p=1.000 n=7)
Read/cache_type=fast/object_size=1000/compressor=ZSTD-24                       819.0 ±  0%    819.0 ± 0%         ~ (p=1.000 n=7) ¹
Read/cache_type=fast/object_size=100000/compressor=IDENTITY-24                 842.0 ±  0%    842.0 ± 0%         ~ (p=1.000 n=7)
Read/cache_type=fast/object_size=100000/compressor=ZSTD-24                     817.0 ±  0%    817.0 ± 0%         ~ (p=1.000 n=7) ¹
Read/cache_type=fast/object_size=5000001/compressor=IDENTITY-24               1.351k ± 20%   2.884k ± 6%  +113.47% (p=0.001 n=7)
Read/cache_type=fast/object_size=5000001/compressor=ZSTD-24                    951.0 ±  0%   1332.0 ± 3%   +40.06% (p=0.001 n=7)
Read/cache_type=fast/object_size=15000001/compressor=IDENTITY-24              2.198k ±  3%   5.810k ± 0%  +164.33% (p=0.001 n=7)
Read/cache_type=fast/object_size=15000001/compressor=ZSTD-24                  1.225k ±  0%   2.289k ± 0%   +86.86% (p=0.001 n=7)
Read/cache_type=slow/object_size=1000/compressor=IDENTITY-24                   823.0 ±  0%    823.0 ± 0%         ~ (p=1.000 n=7) ¹
Read/cache_type=slow/object_size=1000/compressor=ZSTD-24                       820.0 ±  0%    820.0 ± 0%         ~ (p=1.000 n=7) ¹
Read/cache_type=slow/object_size=100000/compressor=IDENTITY-24                 842.0 ±  0%    842.0 ± 0%         ~ (p=1.000 n=7)
Read/cache_type=slow/object_size=100000/compressor=ZSTD-24                     818.0 ±  0%    818.0 ± 0%         ~ (p=1.000 n=7)
Read/cache_type=slow/object_size=5000001/compressor=IDENTITY-24               1.598k ± 12%   3.171k ± 0%   +98.44% (p=0.001 n=7)
Read/cache_type=slow/object_size=5000001/compressor=ZSTD-24                    996.0 ±  4%   1513.0 ± 3%   +51.91% (p=0.001 n=7)
Read/cache_type=slow/object_size=15000001/compressor=IDENTITY-24              2.462k ±  3%   7.415k ± 1%  +201.18% (p=0.001 n=7)
Read/cache_type=slow/object_size=15000001/compressor=ZSTD-24                  1.339k ±  1%   2.900k ± 0%  +116.58% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=1000/compressor=IDENTITY-24        436.0 ±  0%    436.0 ± 0%         ~ (p=1.000 n=7)
Read/cache_type=non-distributed/object_size=1000/compressor=ZSTD-24            433.0 ±  0%    433.0 ± 0%         ~ (p=1.000 n=7) ¹
Read/cache_type=non-distributed/object_size=100000/compressor=IDENTITY-24      447.0 ±  0%    447.0 ± 0%         ~ (p=1.000 n=7) ¹
Read/cache_type=non-distributed/object_size=100000/compressor=ZSTD-24          434.0 ±  0%    434.0 ± 0%         ~ (p=0.462 n=7)
Read/cache_type=non-distributed/object_size=5000001/compressor=IDENTITY-24     608.0 ± 51%   1361.0 ± 2%  +123.85% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=5000001/compressor=ZSTD-24         477.0 ±  0%    686.0 ± 5%   +43.82% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=15000001/compressor=IDENTITY-24    924.0 ±  1%   2859.0 ± 0%  +209.42% (p=0.001 n=7)
Read/cache_type=non-distributed/object_size=15000001/compressor=ZSTD-24        591.0 ±  0%   1149.0 ± 0%   +94.42% (p=0.001 n=7)
geomean                                                                        854.0         1.224k        +43.30%
```