### PR TITLE
Delete from lookaside cache in distributed.Delete

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1521,6 +1521,14 @@ func (c *Cache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 			return err
 		}
 	}
+	if c.lookasideCacheEnabled() {
+		key, ok := c.lookasideKey(ctx, r)
+		if ok {
+			c.lookasideMu.Lock()
+			defer c.lookasideMu.Unlock()
+			c.lookaside.Remove(key)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Delete is only called in tests and benchmarks, so this isn't affecting prod, but it is nice to fix for tests and benchmarks.