### PR TITLE
Remove an extra goroutine in distributed.StartListening

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -608,15 +608,13 @@ func (c *Cache) StartListening() {
 	}
 	c.shutDownChan = make(chan struct{})
 	go c.heartbeatPeers(c.shutDownChan)
-	go func() {
-		log.Infof("Distributed cache listening on %q", c.config.ListenAddr)
-		if c.heartbeatChannel != nil {
-			c.heartbeatChannel.StartAdvertising()
-		}
-		if err := c.distributedProxy.StartListening(); err != nil {
-			log.Warningf("Unable to start cacheproxy: %s", err)
-		}
-	}()
+	log.Infof("Distributed cache listening on %q", c.config.ListenAddr)
+	if c.heartbeatChannel != nil {
+		c.heartbeatChannel.StartAdvertising()
+	}
+	if err := c.distributedProxy.StartListening(); err != nil {
+		log.Warningf("Unable to start cacheproxy: %s", err)
+	}
 	c.finishedShutdown = false
 }
 


### PR DESCRIPTION
Both of the calls in this goroutine start their own goroutine, so the parent one isn't necessary. It also sometimes causes race conditions in tests because it makes the distributed cache startup less predictable.