### PR TITLE
Add a query template name for clickhouse inserts

### DIFF
--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -219,8 +219,9 @@ func isTimeout(err error) bool {
 func (h *DBHandle) insertWithRetrier(ctx context.Context, tableName string, numEntries int, value interface{}) error {
 	retrier := retry.DefaultWithContext(ctx)
 	var lastError error
+	queryName := fmt.Sprintf("INSERT INTO '%v'", tableName)
 	for retrier.Next() {
-		res := h.DB(ctx).Create(value)
+		res := h.GORM(ctx, queryName).Create(value)
 		lastError = res.Error
 		if errors.Is(res.Error, syscall.ECONNRESET) || errors.Is(res.Error, syscall.ECONNREFUSED) || isTimeout(res.Error) || errors.Is(res.Error, driver.ErrBadConn) {
 			// Retry since it's an transient error.


### PR DESCRIPTION
Currently, we're just using the query SQL in metrics, which results in many very similar but distinct labels.
<img width="2535" height="494" alt="image" src="https://github.com/user-attachments/assets/e714ae63-d1fd-456f-ad88-a09931109d9e" />

Use a short name instead.