### PR TITLE
CLI: Reduce logging when getting flag proto from bazel

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -687,15 +687,12 @@ func runBazelHelpWithCache() (string, error) {
 	}
 	// try with `--quiet` to avoid problems caused by log messages.
 	exitCode, err := bazelisk.Run(append([]string{"--quiet"}, args...), opts)
-	if err != nil {
-		if exitCode != 2 {
-			return "", fmt.Errorf("failed to run bazel: %s", err)
-		}
+	if exitCode == 2 {
 		// try again without `--quiet`, which is only supported by bazel 8+
 		exitCode, err = bazelisk.Run(args, opts)
-		if err != nil {
-			return "", fmt.Errorf("failed to run bazel: %s", err)
-		}
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to run bazel: %s", err)
 	}
 	if exitCode != 0 {
 		return "", fmt.Errorf("unknown error from `bazel help %s`: exit code %d", topic, exitCode)

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -683,6 +683,8 @@ func runBazelHelpWithCache() (string, error) {
 		// Make sure this server doesn't stick around for long.
 		"--max_idle_secs=10",
 		"help",
+		// Don't print any debug information
+		"--logging=6",
 		topic,
 	}, opts)
 	if err != nil {


### PR DESCRIPTION
This PR should remove any problematic logging lines like the "Starting bazel server and connecting to it..." line from the base64 string we're trying to ingest programmatically.
