### PR TITLE
retry.go: fix logging non-retryable error

### DIFF
--- a/server/util/retry/retry.go
+++ b/server/util/retry/retry.go
@@ -236,7 +236,7 @@ func Do[T any](ctx context.Context, opts *Options, fn func(ctx context.Context) 
 			return rsp, nil
 		}
 		if _, ok := err.(*nonRetryableError); ok {
-			logFailedAttempt(lastError, " and could not be retried due to a non-retryable error")
+			logFailedAttempt(err, " and could not be retried due to a non-retryable error")
 			return rsp, err
 		}
 		lastError = err


### PR DESCRIPTION
Right now we are logging the last error (which can be retryable) when we log the
line "attempt failed and could not be retried due to a non-retryable error: "

https://github.com/buildbuddy-io/buildbuddy-internal/issues/5752
