### PR TITLE
Upgrade node to 20

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -302,7 +302,7 @@ rules_js_dependencies()
 
 load("@aspect_rules_js//js:toolchains.bzl", "rules_js_register_toolchains")
 
-rules_js_register_toolchains(node_version = "18.20.3")
+rules_js_register_toolchains(node_version = "20.11.1")
 
 load("@aspect_rules_js//npm:repositories.bzl", "npm_translate_lock")
 

--- a/deps/toolchains.MODULE.bazel
+++ b/deps/toolchains.MODULE.bazel
@@ -45,7 +45,7 @@ use_repo(
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 node.toolchain(
     name = "nodejs",
-    node_version = "18.20.3",
+    node_version = "20.11.1",
 )
 
 toolchains_musl = use_extension("@toolchains_musl//:toolchains_musl.bzl", "toolchains_musl", dev_dependency = True)


### PR DESCRIPTION
Update to the latest LTS version of `node`.

This lets us upgrade docusaurus, which allows us to stop depending on a vulnerable version of tar-fs:

https://github.com/buildbuddy-io/buildbuddy/security/dependabot/223
