### PR TITLE
[terminal ui] re-render terminal upon entering full-screen

### DIFF
--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -102,9 +102,9 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
 
   componentDidMount() {
     this.initialScrollToEnd();
-    window.addEventListener("keydown", (this.windowKeyDownListener = this.onWindowKeyDown.bind(this)));
+    window.addEventListener("keydown", (this.windowKeyDownListener = (e) => this.onWindowKeyDown(e)));
     window.addEventListener("fullscreenchange", (this.fullScreenListener = () => this.forceUpdate()));
-    window.addEventListener("resize", (this.resizeListener = this.updateLineLengthLimit.bind(this)));
+    window.addEventListener("resize", (this.resizeListener = () => this.updateLineLengthLimit()));
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Currently, if you press the full-screen button on a terminal in the UI, it will enter full-screen but not re-render the text to take advantage of all the space. Clicking inside the terminal causes a re-render.

<img width="1512" height="982" alt="Screenshot 2025-10-03 at 1 04 15 PM" src="https://github.com/user-attachments/assets/a1f9eeb2-80a5-45ff-a3b1-d7070f07c895" />

With this change, the text re-renders the moment the terminal enters full screen.
<img width="1512" height="982" alt="Screenshot 2025-10-03 at 1 04 58 PM" src="https://github.com/user-attachments/assets/cda4f6c7-422b-40e5-be44-639a5c53d67e" />
