### PR TITLE
Restore syncing for `deps.bzl`

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Update SHA
         run: |
           cd "$GITHUB_WORKSPACE"/buildbuddy-internal
-          sed -i "s/commit = \"[a-z0-9]*\",  # autoupdate buildbuddy-io\/buildbuddy/commit = \"$GITHUB_SHA\",  # autoupdate buildbuddy-io\/buildbuddy/g" WORKSPACE MODULE.bazel
+          sed -i "s/commit = \"[a-z0-9]*\",  # autoupdate buildbuddy-io\/buildbuddy/commit = \"$GITHUB_SHA\",  # autoupdate buildbuddy-io\/buildbuddy/g" MODULE.bazel
 
       - name: Commit
         env:
@@ -52,7 +52,6 @@ jobs:
           cd "$GITHUB_WORKSPACE"/buildbuddy-internal
           git config --local user.email "$AUTHOR_EMAIL"
           git config --local user.name "$AUTHOR_NAME"
-          git add WORKSPACE
           git add deps.bzl
           git add .bazelversion
           git add shared.bazelrc


### PR DESCRIPTION
We still have to sync `deps.bzl` as it contains the static deps.

Partially reverts buildbuddy-io/buildbuddy#10423