### PR TITLE
[flakes ui] show flakes for default branch by default

### DIFF
--- a/enterprise/app/tap/flakes.tsx
+++ b/enterprise/app/tap/flakes.tsx
@@ -23,6 +23,7 @@ interface Props {
   search: URLSearchParams;
   repo: string;
   dark: boolean;
+  onDefaultBranchLoaded?: (defaultBranch: string) => void;
 }
 
 // Exactly one of these three fields will be set.
@@ -123,6 +124,10 @@ export default class FlakesComponent extends React.Component<Props, State> {
       .getGithubRepo(new github.GetGithubRepoRequest({ owner, repo: repo.replace(/\.git$/, "") }))
       .then((response) => {
         this.setState({ repoResponse: response }, () => {
+          // Notify parent component of the default branch
+          if (response.defaultBranch && this.props.onDefaultBranchLoaded) {
+            this.props.onDefaultBranchLoaded(response.defaultBranch);
+          }
           this.fetch();
         });
       })

--- a/enterprise/app/tap/flakes.tsx
+++ b/enterprise/app/tap/flakes.tsx
@@ -13,8 +13,8 @@ import { FlakyTargetSampleLogCardComponent } from "../../../app/target/target_te
 import { CancelablePromise } from "../../../app/util/async";
 import { copyToClipboard } from "../../../app/util/clipboard";
 import { timestampToDateWithFallback } from "../../../app/util/proto";
-import { target } from "../../../proto/target_ts_proto";
 import { github } from "../../../proto/github_ts_proto";
+import { target } from "../../../proto/target_ts_proto";
 import { getProtoFilterParams } from "../filter/filter_util";
 import TrendsChartComponent, { ChartColor } from "../trends/trends_chart";
 import TapEmptyStateComponent from "./tap_empty_state";
@@ -100,6 +100,12 @@ export default class FlakesComponent extends React.Component<Props, State> {
   }
 
   fetchRepoMetadata() {
+    // If there's an explicit branch in the URL, no need to fetch metadata
+    if (this.props.search.get("branch")) {
+      this.fetch();
+      return;
+    }
+
     if (!this.props.repo) {
       this.fetch();
       return;


### PR DESCRIPTION
I care way more about flakes on the default branch than on other branches. This change makes the Flakes page default to the default branch.

Some considerations:
* It is no longer possible to see flakes across all branches. If you leave the 'Branch' input blank, you will see flakes from the default branch.
* The page will not render until the call to GitHub returns. I can add a timeout, but do not see evidence that we do that anywhere else.

https://github.com/user-attachments/assets/8f732e10-8db1-4a3a-bac7-5c4e8f99e9da