### PR TITLE
Optimize the limits for using `Batch{Read|Upload}Blobs` RPCs

### DIFF
--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -53,6 +53,10 @@ const (
 	// Should be big enough to feed the workers when they free up.
 	// Operations will block when the queue is full.
 	inputTreeOpsQueueSize = 4000
+	// batchReadLimitBytes controls how big an object or batch can be to use
+	// the BatchReadBlobs RPC. In experiments, 2MiB blobs are 5-10% faster to
+	// read using the bytestream.Read api.
+	batchReadLimitBytes = min(2*1024*1024, rpcutil.GRPCMaxSizeBytes)
 )
 
 func groupIDStringFromContext(ctx context.Context) string {
@@ -964,7 +968,7 @@ func (ff *BatchFileFetcher) FetchFiles(opts *DownloadTreeOpts) (retErr error) {
 			// fit in the batch call, so we'll have to bytestream
 			// it.
 			size := f.key.SizeBytes
-			if size > rpcutil.GRPCMaxSizeBytes || ff.env.GetContentAddressableStorageClient() == nil {
+			if size > batchReadLimitBytes || ff.env.GetContentAddressableStorageClient() == nil {
 				eg.Go(func() error {
 					if len(f.fps) == 0 {
 						return status.FailedPreconditionError("empty file pointer list for key")
@@ -982,7 +986,7 @@ func (ff *BatchFileFetcher) FetchFiles(opts *DownloadTreeOpts) (retErr error) {
 			// If the digest would push our current batch request
 			// size over the gRPC max, dispatch the request and
 			// start a new one.
-			if currentBatchRequestSize+size > rpcutil.GRPCMaxSizeBytes {
+			if currentBatchRequestSize+size > batchReadLimitBytes {
 				reqCopy := req
 				eg.Go(func() error {
 					return ff.batchDownloadFiles(ctx, reqCopy, opts)


### PR DESCRIPTION
In dev experiments, reducing these limits so that more blobs use the bytestream API reduces latency for those blobs by 5-10%. Reducing the limit further didn't have any additional benefits in my experiments, and it does create more RPCs. It might be that with more realistic experiments, an even lower limit would be better, but I'm being somewhat cautious.

The mechanism here is very similar to https://github.com/buildbuddy-io/buildbuddy/pull/10392 and https://github.com/buildbuddy-io/buildbuddy/pull/10354.

For example, in the write path, uploading a 4MB blob using the batch api follows these sequential steps:
- compress the blob on the client side
- send the whole blob as single payload
- receive the blob on the server, which can take 10-100ms
- decompress the whole blob on the server before writing anything (to check the digest).
- write the blob.

Using the streaming API allows these steps to be overlapping. Additionally, it reduces the chances that small blobs are in the same batch as a single large blob which slows them all down.