### PR TITLE
invocation_timing_card: name the timing profile json

### DIFF
--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -165,7 +165,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     }
 
     try {
-      rpcService.downloadBytestreamFile("timing_profile.gz", profileFile.uri, this.props.model.getInvocationId());
+      rpcService.downloadBytestreamFile("timing_profile.json.gz", profileFile.uri, this.props.model.getInvocationId());
     } catch {
       console.error("Error downloading bytestream timing profile");
     }


### PR DESCRIPTION
Add a json extension to the Bazel profile filename.
This will ultimately be added to the Content-Disposition response header
of the download request and let the browser saved the file with the same
name.

When user use `gzip -d` to decompress the `.gz` package, the file will
appear as json automatically instead of a generic blob file.
This automatically enables editor syntax highlight and auto formatter to
work on the file more easily.
