### PR TITLE
invocation_execution: show Execution's primary output

### DIFF
--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -210,6 +210,7 @@ export default class SpawnCardComponent extends React.Component<Props, State> {
           execution.targetLabel?.toLowerCase()?.includes(filter) ||
           execution.actionMnemonic?.toLowerCase()?.includes(filter) ||
           execution.commandSnippet?.toLowerCase()?.includes(filter) ||
+          execution.primaryOutputPath?.toLowerCase()?.includes(filter) ||
           `${execution.actionDigest?.hash ?? ""}/${execution.actionDigest?.sizeBytes ?? ""}`
             .toLowerCase()
             .includes(filter)

--- a/app/invocation/invocation_execution_table.tsx
+++ b/app/invocation/invocation_execution_table.tsx
@@ -65,6 +65,14 @@ export default class InvocationExecutionTable extends React.Component<Props> {
                   mini={true}
                 />
                 <div className="invocation-execution-row-stats">
+                  {!!execution.primaryOutputPath && (
+                    <div>
+                      Primary output:{" "}
+                      <span className="primary-output" title={execution.primaryOutputPath}>
+                        {formatPrimaryOutput(execution.primaryOutputPath)}
+                      </span>
+                    </div>
+                  )}
                   <div>Executor Host ID: {execution.executedActionMetadata?.worker}</div>
                   <div>Total duration: {format.durationUsec(totalDuration(execution))}</div>
                   <div>Queued duration: {format.durationUsec(queuedDuration(execution))}</div>
@@ -102,4 +110,13 @@ function renderExecutionLabel(execution: execution_stats.Execution) {
       {joinReactNodes(nodes, <ChevronRight className="icon breadcrumb-separator" />)}
     </span>
   );
+}
+
+function formatPrimaryOutput(path: string) {
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length <= 2) {
+    return path;
+  }
+  const tail = segments.slice(-2).join("/");
+  return `…/${tail}`;
 }

--- a/enterprise/server/util/execution/execution.go
+++ b/enterprise/server/util/execution/execution.go
@@ -168,9 +168,10 @@ func OLAPExecToClientProto(in *olaptables.Execution) (*espb.Execution, error) {
 			},
 			DoNotCache: in.DoNotCache,
 		},
-		TargetLabel:    in.TargetLabel,
-		ActionMnemonic: in.ActionMnemonic,
-		CommandSnippet: in.CommandSnippet,
+		TargetLabel:       in.TargetLabel,
+		ActionMnemonic:    in.ActionMnemonic,
+		CommandSnippet:    in.CommandSnippet,
+		PrimaryOutputPath: in.OutputPath,
 	}
 
 	return out, nil
@@ -206,6 +207,7 @@ func ExecutionListingColumns() []string {
 		"cpu_nanos",
 		"peak_memory_bytes",
 		"do_not_cache",
+		"output_path",
 		"command_snippet",
 		"target_label",
 		"action_mnemonic",

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -136,6 +136,9 @@ message Execution {
   // describing the action being executed).
   string action_mnemonic = 17;
 
+  // The primary output path associated with the execution, if any.
+  string primary_output_path = 18;
+
   // The executor hostname that ran the execution. This is only populated if the
   // user has permission to view the executor metadata.
   string executor_hostname = 16;


### PR DESCRIPTION
Modify GetExecution RPC to start returning primary output path from
OLAP database.

If the path is available, show the last 2 segments of the path on the UI
while allowing the user to filter based on the output path.

The main motivation of this change is to help user differentiate between
multiple CcCompile executions, which can all share the same mnemonic and
target label, but different primary output.

Similarly, when a test target is sharded, all the sharded executions
will have the same target label - mnemonic(TestRunner) pair, but the
last 2 part of the primary output will be
`../shard_3_of_11/test.outputs` which can be a great way to
differentiate between them.
