### PR TITLE
Clean up deprecated field in GetLinkedGitHubRepos

### DIFF
--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -271,9 +271,6 @@ func (s *GitHubAppService) GetLinkedGitHubRepos(ctx context.Context) (*ghpb.GetL
 	`, u.GetGroupID())
 	res := &ghpb.GetLinkedReposResponse{}
 	err = db.ScanEach(rq, func(ctx context.Context, row *tables.GitRepository) error {
-		// TODO(Maggie): Clean up after BE change is deployed
-		res.RepoUrls = append(res.RepoUrls, row.RepoURL)
-
 		res.Repos = append(res.Repos, &ghpb.GitRepository{
 			RepoUrl:                  row.RepoURL,
 			UseDefaultWorkflowConfig: row.UseDefaultWorkflowConfig,


### PR DESCRIPTION
Don't merge until https://github.com/buildbuddy-io/buildbuddy/pull/10457 is deployed