### PR TITLE
use toolchains_buildbuddy 0.0.1 from BCR

### DIFF
--- a/deps/bazel_dep.MODULE.bazel
+++ b/deps/bazel_dep.MODULE.bazel
@@ -103,7 +103,6 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 # - docs/rbe-setup.md
 # - docs/rbe-github-actions.md
 # - tools/dev_qa.py
-# - WORKSPACE
 bazel_dep(name = "toolchains_buildbuddy", version = "0.0.1")
 bazel_dep(name = "toolchains_musl", version = "0.1.27")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")


### PR DESCRIPTION
Once BuildBuddy itself has been running successfully on `toolchains_buildbuddy` `0.0.1`, I'll update the docs to tell other people to use that.