### PR TITLE
Deflake crypter_service_test

### DIFF
--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -653,7 +653,7 @@ func TestKeyCaching(t *testing.T) {
 	// Test error caching.
 	{
 		clock := clockwork.NewFakeClock()
-		keyRefreshScanFrequency := 10 * time.Second
+		keyRefreshScanFrequency := 10 * time.Hour
 		keyErrCacheTime := 10 * time.Second
 		opts := crypter_key_cache.Opts{KeyRefreshScanFrequency: keyRefreshScanFrequency, KeyErrCacheTime: keyErrCacheTime}
 		crypter, err := newWithOpts(env, clock, &opts)


### PR DESCRIPTION
The background key refresher was interfering with this test that expects a certain number of key refreshes due to error caching.

Before: https://app.buildbuddy.io/invocation/c5a64e2f-a558-4fef-8d36-35346ad1fe62
After: https://app.buildbuddy.io/invocation/6df750e4-50b6-4a34-8f34-62db63309bbe