### PR TITLE
Add a platform property to mark exit codes as runner crashes and prevent recycling

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -325,6 +326,10 @@ func (r *taskRunner) Run(ctx context.Context, ioStats *repb.IOStats) (res *inter
 		if ioStallDuration := time.Duration(stats.GetIoPressure().GetFull().GetTotal()) * time.Microsecond; ioStallDuration > runDuration {
 			log.CtxWarningf(ctx, "Discarding IO PSI stats: full-stall duration %s exceeds execution duration %s", ioStallDuration, runDuration)
 			stats.IoPressure = nil
+			res.DoNotRecycle = true
+		}
+		if slices.Contains(r.PlatformProperties.RunnerCrashedExitCodes, res.ExitCode) {
+			log.CtxInfof(ctx, "Exit code is in runner-crashed-exit-codes list %v - not recycling", r.PlatformProperties.RunnerCrashedExitCodes)
 			res.DoNotRecycle = true
 		}
 


### PR DESCRIPTION
Context: https://buildbuddy-corp.slack.com/archives/C03JL0YT6G5/p1760106252479379