### PR TITLE
Remove copies from metadata calls in migration cache

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -350,9 +350,6 @@ func (mc *MigrationCache) Metadata(ctx context.Context, r *rspb.ResourceName) (*
 						metrics.CacheRequestType: "metadata",
 						metrics.GroupID:          groupID(ctx),
 					}).Inc()
-					mc.sendNonBlockingCopy(ctx, r, false /*=onlyCopyMissing*/, conf)
-				} else {
-					mc.sendNonBlockingCopy(ctx, r, true /*=onlyCopyMissing*/, conf)
 				}
 				if mc.logNotFoundErrors || !status.IsNotFoundError(dstErr) {
 					log.CtxWarningf(ctx, "Migration dest %v metadata failed: %s", r.GetDigest(), dstErr)

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -882,8 +882,6 @@ func TestMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(100), md.StoredSizeBytes)
 
-	waitForCopy(t, ctx, destCache, r)
-
 	notWrittenResource, _ := testdigest.RandomCASResourceBuf(t, 100)
 	md, err = mc.Metadata(ctx, notWrittenResource)
 	require.True(t, status.IsNotFoundError(err))


### PR DESCRIPTION
This causes a bug with the remote downloader ([code](https://github.com/buildbuddy-io/buildbuddy/blob/52f1dccb5fad2e294766de1996bd981834c42128/server/remote_asset/fetch_server/fetch_server.go#L352)), which makes a Metadata() call with an incorrect digest size