### PR TITLE
Improve error messaging when persistent worker crashes

### DIFF
--- a/enterprise/server/remote_execution/persistentworker/BUILD
+++ b/enterprise/server/remote_execution/persistentworker/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//proto:worker_go_proto",
         "//server/interfaces",
+        "//server/util/alert",
         "//server/util/background",
         "//server/util/lockingbuffer",
         "//server/util/log",


### PR DESCRIPTION
Before, we'd see

```
UNAVAILABLE: failed to read persistent work response: EOF
```

After, we should see something like

```
UNAVAILABLE: failed to read persistent work response: worker exited with code 137
```

In this example, exit code 137 usually means SIGKILL which usually means OOM, so this error is more helpful.