### PR TITLE
fix promise cancellation on drilldowns page

### DIFF
--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -389,7 +389,11 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     this.roundEndDateAndAddZoomFiltersToQuery(request.query!);
 
     this.pendingEventsRequest?.cancel();
-    const promise = rpcService.service.searchInvocation(request);
+    const promise = rpcService.service
+      .searchInvocation(request)
+      .then((response) => this.setState({ eventData: { invocations: response.invocation } }))
+      .catch(() => this.setState({ eventsFailed: true, eventData: undefined }))
+      .finally(() => this.setState({ loadingEvents: false }));
     this.pendingEventsRequest = promise;
 
     this.setState({
@@ -397,10 +401,6 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       eventsFailed: false,
       eventData: undefined,
     });
-    promise
-      .then((response) => this.setState({ eventData: { invocations: response.invocation } }))
-      .catch(() => this.setState({ eventsFailed: true, eventData: undefined }))
-      .finally(() => this.setState({ loadingEvents: false }));
   }
 
   fetchEventList() {


### PR DESCRIPTION
need to cancel the last call (`finally`) in order to prevent the loading state from getting updated even though an rpc was cancelled.