### PR TITLE
Correctly populate `FAILED_TO_BUILD` status in api

### DIFF
--- a/server/api/common/common.go
+++ b/server/api/common/common.go
@@ -185,7 +185,11 @@ func (tm *TargetMap) ProcessEvent(iid string, event *bespb.BuildEvent) {
 	case *bespb.BuildEvent_Completed:
 		{
 			if target := tm.Targets[event.GetId().GetTargetCompleted().GetLabel()]; target != nil {
-				target.Status = cmnpb.Status_BUILT
+				if p.Completed.GetSuccess() {
+					target.Status = cmnpb.Status_BUILT
+				} else {
+					target.Status = cmnpb.Status_FAILED_TO_BUILD
+				}
 			}
 		}
 	case *bespb.BuildEvent_TestSummary:


### PR DESCRIPTION
Currently we handle test statuses correctly, but assume that if we receive a `BuildEvent_Completed` that the target built correctly.

This is not accurate, because the Completed event contains a `success` field that we're currently ignoring.

This PR fixes the API to correctly report the `FAILED_TO_BUILD` status and adds a test for this.