### PR TITLE
Merge build metadata and workspace status tags

### DIFF
--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -527,13 +527,19 @@ func (sep *StreamingEventParser) setPattern(value []string, priority int) {
 	}
 }
 func (sep *StreamingEventParser) setTags(value string, priority int) error {
-	if *tagsEnabled && sep.priority.Tags <= priority {
+	if *tagsEnabled {
 		tags, err := invocation_format.SplitAndTrimAndDedupeTags(value, true)
 		if err != nil {
 			return err
 		}
+
+		if sep.priority.Tags <= priority {
+			sep.invocation.Tags = append(sep.invocation.Tags, tags...)
+		} else {
+			sep.invocation.Tags = append(tags, sep.invocation.Tags...)
+		}
+
 		sep.priority.Tags = priority
-		sep.invocation.Tags = tags
 	}
 	return nil
 }

--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -334,6 +334,84 @@ func TestBuildMetadataWithTagPrefix(t *testing.T) {
 		})
 	}
 }
+func TestTagMerging(t *testing.T) {
+	flags.Set(t, "app.tags_enabled", true)
+
+	tests := []struct {
+		name            string
+		metadata        map[string]string
+		workspaceStatus string
+		wantTags        []string
+	}{
+		{
+			name: "Just metadata tags",
+			metadata: map[string]string{
+				"TAG_metadata_tag_a": "",
+				"TAG_metadata_tag_b": "test",
+				"TAGS":               "metadata_tag_c,metadata_tag_d",
+			},
+			workspaceStatus: "",
+			wantTags:        []string{"metadata_tag_a", "metadata_tag_b=test", "metadata_tag_c", "metadata_tag_d"},
+		},
+		{
+			name:            "Just workspace status tags",
+			metadata:        map[string]string{},
+			workspaceStatus: "workspace_tag_a,workspace_tag_b",
+			wantTags:        []string{"workspace_tag_a", "workspace_tag_b"},
+		},
+		{
+			name: "Tags merge",
+			metadata: map[string]string{
+				"TAGS": "metadata_tag_a,metadata_tag_b",
+			},
+			workspaceStatus: "workspace_tag_a,workspace_tag_b",
+			wantTags:        []string{"metadata_tag_a", "metadata_tag_b", "workspace_tag_a", "workspace_tag_b"},
+		},
+
+		{
+			name: "Tag prefix merge",
+			metadata: map[string]string{
+				"TAG_metadata_tag_a": "",
+				"TAG_metadata_tag_b": "test",
+				"TAGS":               "metadata_tag_c,metadata_tag_d",
+			},
+			workspaceStatus: "workspace_tag_a,workspace_tag_b",
+			wantTags:        []string{"metadata_tag_a", "metadata_tag_b=test", "metadata_tag_c", "metadata_tag_d", "workspace_tag_a", "workspace_tag_b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			invocation := &inpb.Invocation{
+				InvocationId: "test-invocation",
+			}
+			parser := event_parser.NewStreamingEventParser(invocation)
+
+			metadataEvent := &build_event_stream.BuildEvent{
+				Payload: &build_event_stream.BuildEvent_BuildMetadata{BuildMetadata: &build_event_stream.BuildMetadata{
+					Metadata: tt.metadata,
+				}},
+			}
+			parser.ParseEvent(metadataEvent)
+
+			workspaceStatusEvent := &build_event_stream.BuildEvent{
+				Payload: &build_event_stream.BuildEvent_WorkspaceStatus{WorkspaceStatus: &build_event_stream.WorkspaceStatus{
+					Item: []*build_event_stream.WorkspaceStatus_Item{
+						{Key: "TAGS", Value: tt.workspaceStatus},
+					},
+				}},
+			}
+			parser.ParseEvent(workspaceStatusEvent)
+
+			outputTags := make([]string, 0)
+			for _, tag := range invocation.Tags {
+				outputTags = append(outputTags, tag.Name)
+			}
+
+			assert.ElementsMatch(t, tt.wantTags, outputTags)
+		})
+	}
+}
 
 func TestRemoteCacheOptions(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Currently they clobber each other. With this change we merge tags from both build metadata and workspace status.