### PR TITLE
fix url escaping for dimension params in a few places

### DIFF
--- a/enterprise/app/targets/targets.tsx
+++ b/enterprise/app/targets/targets.tsx
@@ -268,7 +268,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
 
   navigateToTargetDrilldown = (target: string) => {
     const currentParams = Object.fromEntries(this.props.search.entries());
-    const dimensionParam = encodeTargetLabelUrlParam(target);
+    const dimensionParam = encodeURIComponent(encodeTargetLabelUrlParam(target));
     const dimensions = currentParams.d ? currentParams.d + "|" + dimensionParam : dimensionParam;
 
     // Set the metric to CPU nanos or execution time based on current selection

--- a/enterprise/app/trends/common.ts
+++ b/enterprise/app/trends/common.ts
@@ -156,15 +156,15 @@ export function decodeMetricUrlParam(param: string): stat_filter.Metric | undefi
 }
 
 export function encodeWorkerUrlParam(workerId: string): string {
-  return `e1|${workerId.length}|${encodeURIComponent(workerId)}`;
+  return `e1|${workerId.length}|${workerId}`;
 }
 
 export function encodeTargetLabelUrlParam(targetLabel: string): string {
-  return `e2|${targetLabel.length}|${encodeURIComponent(targetLabel)}`;
+  return `e2|${targetLabel.length}|${targetLabel}`;
 }
 
 export function encodeActionMnemonicUrlParam(actionMnemonic: string): string {
-  return `e3|${actionMnemonic.length}|${encodeURIComponent(actionMnemonic)}`;
+  return `e3|${actionMnemonic.length}|${actionMnemonic}`;
 }
 
 export function getTotal(stats: stats.ITrendStat[], fn: (stat: stats.ITrendStat) => number): number {


### PR DESCRIPTION
had one spot (targets) where the url was getting manually assembled + missing its own logic to escape -- otherwise, we rely on normal navigation / query param updating in `router.tsx` to escape params.