### PR TITLE
Task router: small cleanup

### DIFF
--- a/enterprise/server/scheduling/task_router/BUILD
+++ b/enterprise/server/scheduling/task_router/BUILD
@@ -25,7 +25,6 @@ go_test(
     srcs = ["task_router_test.go"],
     deps = [
         ":task_router",
-        "//enterprise/server/experiments",
         "//enterprise/server/testutil/enterprise_testenv",
         "//enterprise/server/testutil/testredis",
         "//proto:remote_execution_go_proto",
@@ -34,9 +33,6 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/testing/flags",
-        "@com_github_open_feature_go_sdk//openfeature",
-        "@com_github_open_feature_go_sdk//openfeature/memprovider",
-        "@com_github_open_feature_go_sdk//openfeature/testing",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//slices",
     ],


### PR DESCRIPTION
- Remove unused persistentWorkerRouter (I think we do need some sort of persistent worker routing but the current code results in load imbalance, so it's disabled. We'll probably want to replace it with something written from scratch)
- Remove RankNodes method which is now returning the same value for all routers