### PR TITLE
Reduce contention in clientidentity.AddIdentityToContext

### DIFF
--- a/enterprise/server/clientidentity/clientidentity_test.go
+++ b/enterprise/server/clientidentity/clientidentity_test.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func newService(t *testing.T, clock clockwork.Clock) *clientidentity.Service {
+func newService(t testing.TB, clock clockwork.Clock) *clientidentity.Service {
 	key, err := random.RandomString(16)
 	require.NoError(t, err)
 	flags.Set(t, "app.client_identity.key", string(key))
@@ -134,4 +134,18 @@ func TestRequired(t *testing.T) {
 	ctx = metadata.NewIncomingContext(context.Background(), nil)
 	_, err = sis.ValidateIncomingIdentity(ctx)
 	require.Error(t, err)
+}
+
+func BenchmarkAddIdentityToContext(b *testing.B) {
+	sis := newService(b, clockwork.NewRealClock())
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := sis.AddIdentityToContext(ctx)
+			require.NoError(b, err)
+		}
+	})
 }


### PR DESCRIPTION
I saw this in blocking profiles for apps. It's particularly bad when there are many distributed.FindMissing calls, because each one sends multiple RPCs and each RPC goes through this code.

Benchmark results:

```
                        │    base     │                rw2                 │
                        │   sec/op    │   sec/op     vs base               │
AddIdentityToContext-24   253.8n ± 9%   202.0n ± 4%  -20.41% (p=0.001 n=7)

                        │    base    │              rw2              │
                        │    B/op    │    B/op     vs base           │
AddIdentityToContext-24   136.0 ± 0%   136.0 ± 0%  ~ (p=1.000 n=7) ¹
¹ all samples are equal

                        │    base    │              rw2              │
                        │ allocs/op  │ allocs/op   vs base           │
AddIdentityToContext-24   4.000 ± 0%   4.000 ± 0%  ~ (p=1.000 n=7) ¹
¹ all samples are equal
```