### PR TITLE
Install the remote_crypter in the Cache Proxy

### DIFF
--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//enterprise/server/capabilities_server_proxy",
         "//enterprise/server/content_addressable_storage_server_proxy",
         "//enterprise/server/hit_tracker_client",
+        "//enterprise/server/remote_crypter",
         "//enterprise/server/remoteauth",
         "//enterprise/server/routing/routing_action_cache_client",
         "//enterprise/server/routing/routing_byte_stream_client",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/capabilities_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/content_addressable_storage_server_proxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hit_tracker_client"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_crypter"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remoteauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/routing/routing_action_cache_client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/routing/routing_byte_stream_client"
@@ -101,6 +102,9 @@ func main() {
 	env.SetAuthenticator(authenticator)
 
 	hit_tracker_client.Register(env)
+	if err := remote_crypter.Register(env); err != nil {
+		log.Fatalf("%v", err)
+	}
 
 	// Configure a local cache.
 	if err := pebble_cache.Register(env); err != nil {


### PR DESCRIPTION
This is currently a no-op because the remote_crypter doesn't actually install itself if `crypter.remote_target` is empty: https://github.com/buildbuddy-io/buildbuddy/blob/0e68263d9623b89499ff8ab7ec10e5a9f9dc02b4/enterprise/server/remote_crypter/remote_crypter.go#L34-L36