### PR TITLE
gosdk: upgrade to 1.25.3

### DIFF
--- a/deps/toolchains.MODULE.bazel
+++ b/deps/toolchains.MODULE.bazel
@@ -34,7 +34,7 @@ register_toolchains(
 )
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.25.2")
+go_sdk.from_file(go_mod = "@com_github_buildbuddy_io_buildbuddy//:go.mod")
 go_sdk.nogo(nogo = "@com_github_buildbuddy_io_buildbuddy//:vet")
 use_repo(
     go_sdk,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbuddy-io/buildbuddy
 
-go 1.25.2
+go 1.25.3
 
 replace (
 	github.com/buildkite/terminal-to-html/v3 => github.com/buildbuddy-io/terminal-to-html/v3 v3.16.8-18


### PR DESCRIPTION
https://github.com/golang/go/issues?q=milestone%3AGo1.25.3+label%3ACherryPickApproved
