### PR TITLE
Include execution error in firecracker log

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2355,8 +2355,8 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 		logTail = strings.ReplaceAll(logTail, "\r\n", "\n")
 
 		if result.Error != nil {
-			if !status.IsDeadlineExceededError(result.Error) {
-				log.CtxWarningf(ctx, "Execution error occurred. VM logs: %s", string(c.vmLog.Tail()))
+			if !status.IsDeadlineExceededError(result.Error) && !status.IsCanceledError(result.Error) {
+				log.CtxWarningf(ctx, "Execution error occurred: %s. VM logs: %s", result.Error, string(c.vmLog.Tail()))
 			}
 		} else if err := c.parseOOMError(logTail); err != nil {
 			// TODO(bduffany): maybe fail the whole command if we see an OOM


### PR DESCRIPTION
This will make it easier to filter out logs for expected errors

Based on this conversation: https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1760723288909169?thread_ts=1760650643.627739&cid=C01D5GHRJ59