### PR TITLE
Add history-based routing strategy for persistent worker actions

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -100,7 +100,7 @@ const (
 	overlayfsWorkspacePropertyName          = "overlayfs-workspace"
 	cleanWorkspaceInputsPropertyName        = "clean-workspace-inputs"
 	persistentWorkerPropertyName            = "persistent-workers"
-	persistentWorkerKeyPropertyName         = "persistentWorkerKey"
+	PersistentWorkerKeyPropertyName         = "persistentWorkerKey"
 	persistentWorkerProtocolPropertyName    = "persistentWorkerProtocol"
 	WorkflowIDPropertyName                  = "workflow-id"
 	WorkloadIsolationPropertyName           = "workload-isolation-type"
@@ -367,7 +367,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 	//   runner recycling)
 	recycleRunner := boolProp(m, recycleRunnerPropertyName, false) ||
 		boolProp(m, dockerReusePropertyName, false) ||
-		stringProp(m, persistentWorkerKeyPropertyName, "") != ""
+		stringProp(m, PersistentWorkerKeyPropertyName, "") != ""
 	isolationType := stringProp(m, WorkloadIsolationPropertyName, "")
 
 	// Only Enable VFS if it is also enabled via flags.
@@ -484,7 +484,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		OverlayfsWorkspace:        boolProp(m, overlayfsWorkspacePropertyName, false),
 		CleanWorkspaceInputs:      stringProp(m, cleanWorkspaceInputsPropertyName, ""),
 		PersistentWorker:          boolProp(m, persistentWorkerPropertyName, false),
-		PersistentWorkerKey:       stringProp(m, persistentWorkerKeyPropertyName, ""),
+		PersistentWorkerKey:       stringProp(m, PersistentWorkerKeyPropertyName, ""),
 		PersistentWorkerProtocol:  stringProp(m, persistentWorkerProtocolPropertyName, ""),
 		WorkflowID:                stringProp(m, WorkflowIDPropertyName, ""),
 		HostedBazelAffinityKey:    stringProp(m, HostedBazelAffinityKeyPropertyName, ""),

--- a/enterprise/server/scheduling/task_router/BUILD
+++ b/enterprise/server/scheduling/task_router/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["task_router.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router",
     deps = [
+        "//enterprise/server/experiments",
         "//enterprise/server/remote_execution/platform",
         "//proto:remote_execution_go_proto",
         "//server/environment",
@@ -25,6 +26,7 @@ go_test(
     srcs = ["task_router_test.go"],
     deps = [
         ":task_router",
+        "//enterprise/server/experiments",
         "//enterprise/server/testutil/enterprise_testenv",
         "//enterprise/server/testutil/testredis",
         "//proto:remote_execution_go_proto",
@@ -33,6 +35,9 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/testing/flags",
+        "@com_github_open_feature_go_sdk//openfeature",
+        "@com_github_open_feature_go_sdk//openfeature/memprovider",
+        "@com_github_open_feature_go_sdk//openfeature/testing",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//slices",
     ],

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -43,6 +43,9 @@ const (
 	// set less than the number of probes so that we can autoscale the workflow
 	// executor pool effectively.
 	ciRunnerPreferredNodeLimit = 1
+
+	// Preferred node limit for tasks using [persistentWorkerRouter].
+	persistentWorkerRouterPreferredNodeLimit = 128
 )
 
 type taskRouter struct {
@@ -73,7 +76,13 @@ func New(env environment.Env) (interfaces.TaskRouter, error) {
 	if rdb == nil {
 		return nil, status.FailedPreconditionError("Redis is required for task router")
 	}
-	strategies := []Router{ciRunnerRouter{}, affinityRouter{}}
+	// Define the available routing strategies (note: strategies earlier in the
+	// list have higher precedence)
+	strategies := []Router{
+		ciRunnerRouter{},
+		&persistentWorkerRouter{env: env, rdb: rdb},
+		affinityRouter{},
+	}
 	return &taskRouter{
 		env:        env,
 		rdb:        rdb,
@@ -212,10 +221,21 @@ func (tr *taskRouter) RankNodes(ctx context.Context, action *repb.Action, cmd *r
 			break
 		}
 
-		preferredHostIDs, err := tr.rdb.LRange(ctx, routingKey, 0, -1).Result()
-		if err != nil {
-			log.Errorf("Failed to rank nodes: redis LRANGE failed: %s", err)
-			return nodesAsRanked(nodes)
+		var preferredHostIDs []string
+		if strategy, ok := strategy.(PreferredHostIDGetter); ok {
+			h, err := strategy.GetPreferredHostIDs(ctx, routingKey)
+			if err != nil {
+				log.Errorf("Failed to rank nodes: failed to get preferred host IDs: %s", err)
+				return nodesAsRanked(nodes)
+			}
+			preferredHostIDs = h
+		} else {
+			h, err := tr.rdb.LRange(ctx, routingKey, 0, -1).Result()
+			if err != nil {
+				log.Errorf("Failed to rank nodes: redis LRANGE failed: %s", err)
+				return nodesAsRanked(nodes)
+			}
+			preferredHostIDs = h
 		}
 
 		log.Debugf("Preferred executor host IDs for %q: %v", routingKey, preferredHostIDs)
@@ -369,6 +389,12 @@ type Router interface {
 	RoutingInfo(params routingParams) (int, []string, error)
 }
 
+// Hook that allows overriding the redis read for getting the preferred host
+// IDs.
+type PreferredHostIDGetter interface {
+	GetPreferredHostIDs(ctx context.Context, key string) ([]string, error)
+}
+
 // The ciRunnerRouter routes ci_runner tasks according to git branch
 // information.
 type ciRunnerRouter struct{}
@@ -494,4 +520,87 @@ func getFirstOutput(cmd *repb.Command) string {
 		return cmd.OutputDirectories[0]
 	}
 	return ""
+}
+
+// persistentWorkerRouter routes tasks in a way that attempts to maximize
+// persistent worker hit rate.
+//
+// It generates routing keys based on:
+//
+//   - remoteInstanceName
+//   - groupID
+//   - platform properties (including the persistent worker key)
+//
+// Compared to the affinity router (which attempts to maximize filecache hit
+// rate):
+//   - It uses a larger preferred node limit, storing a longer "history" of
+//     which nodes have executed tasks with a given persistent worker key. This
+//     lets us roughly approximate the state of the runner pools on each
+//     executor without actually having to communicate this state explicitly
+//     (which would be fairly complex and introduce its own problems).
+//   - When the routing keys are queried, the first preferred node is popped
+//     from the head of the list, which roughly models the fact that this node
+//     is most likely to receive the task (compared to the nodes behind it) and
+//     that it no longer makes sense for this node to be preferred, since
+//     the pooled runner will be in use while the task is executing. Without
+//     this change, we'd wind up creating hotspots when there are bursts of
+//     tasks with the same persistent worker keys (workloads can be very bursty
+//     so this situation is pretty common).
+type persistentWorkerRouter struct {
+	env environment.Env
+	rdb redis.UniversalClient
+}
+
+func (h *persistentWorkerRouter) Applies(ctx context.Context, params routingParams) bool {
+	fp := h.env.GetExperimentFlagProvider()
+	if fp == nil {
+		return false
+	}
+	persistentWorkerKey := platform.FindValue(params.platform, platform.PersistentWorkerKeyPropertyName)
+	if persistentWorkerKey == "" {
+		return false
+	}
+	val := fp.Boolean(ctx, "remote_execution.persistent_worker_router_enabled", false)
+	return val
+}
+
+func (h *persistentWorkerRouter) RoutingInfo(params routingParams) (int, []string, error) {
+	keys, err := h.routingKeys(params)
+	return persistentWorkerRouterPreferredNodeLimit, keys, err
+}
+
+func (h *persistentWorkerRouter) routingKeys(params routingParams) ([]string, error) {
+	parts := []string{"task_route", params.groupID}
+	if params.remoteInstanceName != "" {
+		parts = append(parts, params.remoteInstanceName)
+	}
+	b, err := proto.Marshal(params.platform)
+	if err != nil {
+		return nil, status.InternalErrorf("failed to marshal Command: %s", err)
+	}
+	parts = append(parts, hash.Bytes(b))
+	key := strings.Join(parts, "/")
+	return []string{key}, nil
+}
+
+// Compile-time assertion that [*persistentWorkerRouter] implements [PreferredHostIDGetter]
+var _ PreferredHostIDGetter = (*persistentWorkerRouter)(nil)
+
+// GetPreferredHostIDs overrides the routing key query to also pop from the list
+// in addition to just reading from it. This models the fact that the first
+// returned node is most likely to be the one that receives the task, and that
+// the persistent worker on that node will be "in use" once the task gets
+// scheduled.
+//
+// Note that the node will later be added back to the list once the node
+// completes the task.
+func (h *persistentWorkerRouter) GetPreferredHostIDs(ctx context.Context, key string) ([]string, error) {
+	pipe := h.rdb.TxPipeline()
+	lrangeCmd := pipe.LRange(ctx, key, 0, -1)
+	pipe.LPop(ctx, key)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, status.InternalErrorf("exec pipeline: %s", err)
+	}
+	preferredHostIDs := lrangeCmd.Val()
+	return preferredHostIDs, nil
 }

--- a/enterprise/server/scheduling/task_router/task_router_test.go
+++ b/enterprise/server/scheduling/task_router/task_router_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
@@ -14,10 +15,13 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	openfeatureTesting "github.com/open-feature/go-sdk/openfeature/testing"
 )
 
 // Executor host IDs for use in test cases.
@@ -449,6 +453,113 @@ func TestTaskRouter_WorkflowGitRefRouting_DefaultRef(t *testing.T) {
 	// executor that last ran the pr branch, not the one that last ran the default branch.
 	ranked = router.RankNodes(ctx, nil, prBranchCmd, instanceName, nodes)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+}
+
+func TestTaskRouter_PersistentWorkerRouterDisabled(t *testing.T) {
+	env := newTestEnv(t)
+
+	testProvider := openfeatureTesting.NewTestProvider()
+	testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+		"remote_execution.persistent_worker_router_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "disabled",
+			Variants: map[string]any{
+				"enabled":  true,
+				"disabled": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetProviderAndWait(testProvider))
+	defer testProvider.Cleanup()
+	fp, err := experiments.NewFlagProvider("test" /*=client*/)
+	require.NoError(t, err)
+	env.SetExperimentFlagProvider(fp)
+
+	nodes := sequentiallyNumberedNodes(100)
+
+	router := newTaskRouter(t, env)
+	ctx := withAuthUser(t, context.Background(), env, "US1")
+	instanceName := "test-instance"
+	cmd := &repb.Command{
+		Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+			{Name: "persistentWorkerKey", Value: "PW123"},
+		}},
+	}
+	// Initially, node 0 should not always be ranked first.
+	requireNotAlwaysRanked(0, nodes[0].GetExecutorHostId(), t, router, ctx, cmd, instanceName)
+
+	// Mark node 0 as having executed a task with the persistent worker key.
+	router.MarkSucceeded(ctx, nil, cmd, instanceName, nodes[0].GetExecutorHostId())
+
+	// Node 0 should not always be ranked first since the persistent worker
+	// router is disabled, and no other routers should be applicable either. In
+	// particular, the affinity router should not be active since there are no
+	// declared output paths.
+	requireNotAlwaysRanked(0, nodes[0].GetExecutorHostId(), t, router, ctx, cmd, instanceName)
+}
+
+func TestTaskRouter_PersistentWorkerRouterEnabled(t *testing.T) {
+	env := newTestEnv(t)
+
+	testProvider := openfeatureTesting.NewTestProvider()
+	testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+		"remote_execution.persistent_worker_router_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "enabled",
+			Variants: map[string]any{
+				"enabled":  true,
+				"disabled": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetProviderAndWait(testProvider))
+	defer testProvider.Cleanup()
+	fp, err := experiments.NewFlagProvider("test" /*=client*/)
+	require.NoError(t, err)
+	env.SetExperimentFlagProvider(fp)
+
+	nodes := sequentiallyNumberedNodes(100)
+
+	router := newTaskRouter(t, env)
+	ctx := withAuthUser(t, context.Background(), env, "US1")
+	instanceName := "test-instance"
+	cmd := &repb.Command{
+		Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+			{Name: "persistentWorkerKey", Value: "PW123"},
+		}},
+		OutputPaths: []string{"/bazel-out/foo.a"},
+	}
+	// Initially, node 0 should not always be ranked first.
+	requireNotAlwaysRanked(0, nodes[0].GetExecutorHostId(), t, router, ctx, cmd, instanceName)
+
+	// Mark node 0 as having executed a task with the persistent worker key.
+	router.MarkSucceeded(ctx, nil, cmd, instanceName, nodes[0].GetExecutorHostId())
+
+	// Node 0 should now be ranked first.
+	ranked := router.RankNodes(ctx, nil, cmd, instanceName, nodes)
+	require.Equal(t, nodes[0].GetExecutorHostId(), ranked[0].GetExecutionNode().GetExecutorHostId())
+
+	// Since node 0 is now presumed to be executing the task, it no longer
+	// should be ranked first.
+	requireNotAlwaysRanked(0, nodes[0].GetExecutorHostId(), t, router, ctx, cmd, instanceName)
+
+	// Mark the task executed by the first 10 nodes.
+	for i := 0; i < 10; i++ {
+		router.MarkSucceeded(ctx, nil, cmd, instanceName, nodes[i].GetExecutorHostId())
+	}
+
+	// The first 10 nodes should now be preferred (but in reverse order, since
+	// the most recent should be preferred first).
+	var expectedPreferredNodes []string
+	for i := 0; i < 10; i++ {
+		expectedPreferredNodes = append(expectedPreferredNodes, nodes[i].GetExecutorHostId())
+	}
+	slices.Reverse(expectedPreferredNodes)
+	ranked = router.RankNodes(ctx, nil, cmd, instanceName, nodes)
+	for i := 0; i < 10; i++ {
+		require.Equal(t, expectedPreferredNodes[i], ranked[i].GetExecutionNode().GetExecutorHostId())
+	}
+	requireNonSequential(t, ranked[10:])
 }
 
 func requireNonePreferred(t *testing.T, rankedNodes []interfaces.RankedExecutionNode) {


### PR DESCRIPTION
Context: https://buildbuddy-corp.slack.com/archives/C0495TM9UUE/p1760814121846319?thread_ts=1760538558.555559&cid=C0495TM9UUE