### PR TITLE
executor: remove containerd

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -394,32 +394,6 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/rootless-containers/rootlesskit/releases/download/v2.3.5/rootlesskit-aarch64.tar.gz"],
         sha256 = "478c14c3195bf989cd9a8e6bd129d227d5d88f1c11418967ffdc84a0072cc7a2",
     )
-
-    http_archive(
-        name = "com_github_containerd_containerd-linux-amd64",
-        strip_prefix = "bin",
-        build_file_content = "\n".join([
-            'package(default_visibility = ["//visibility:public"])',
-            'filegroup(name = "containerd.bin", srcs = ["containerd"])',
-            'filegroup(name = "containerd-shim-runc-v2.bin", srcs = ["containerd-shim-runc-v2"])',
-            'filegroup(name = "ctr.bin", srcs = ["ctr"])',
-        ]),
-        urls = ["https://github.com/containerd/containerd/releases/download/v2.1.1/containerd-2.1.1-linux-amd64.tar.gz"],
-        sha256 = "918e88fd393c28c89424e6535df0546ca36c1dfa7d8a5d685dee70b449380a9b",
-    )
-    http_archive(
-        name = "com_github_containerd_containerd-linux-arm64",
-        strip_prefix = "bin",
-        build_file_content = "\n".join([
-            'package(default_visibility = ["//visibility:public"])',
-            'filegroup(name = "containerd.bin", srcs = ["containerd"])',
-            'filegroup(name = "containerd-shim-runc-v2.bin", srcs = ["containerd-shim-runc-v2"])',
-            'filegroup(name = "ctr.bin", srcs = ["ctr"])',
-        ]),
-        urls = ["https://github.com/containerd/containerd/releases/download/v2.1.1/containerd-2.1.1-linux-arm64.tar.gz"],
-        sha256 = "4e3c8c0c2e61438bb393a9ea6bb94f8f56b559ec3243d7b1a2943117bca4dcb4",
-    )
-
     http_archive(
         name = "cloudprober",
         build_file_content = "exports_files([\"cloudprober\"])",

--- a/deps/static_deps.MODULE.bazel
+++ b/deps/static_deps.MODULE.bazel
@@ -9,8 +9,6 @@ use_repo(
     "com_github_buildbuddy_io_podman_static_podman-linux-amd64",
     "com_github_buildbuddy_io_podman_static_podman-linux-arm64",
     "com_github_buildbuddy_io_protoc_gen_protobufjs",
-    "com_github_containerd_containerd-linux-amd64",
-    "com_github_containerd_containerd-linux-arm64",
     "com_github_containers_crun_crun-linux-amd64",
     "com_github_containers_crun_crun-linux-arm64",
     "com_github_firecracker_microvm_firecracker",

--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -54,11 +54,6 @@ RUN DOCKER_VERSION="5:28.2.2-1~debian.12~bookworm" && \
     # keep these in sync with the binaries we are manually
     # adding in enterprise/server/cmd/executor/BUILD.
     #
-    # containerd
-    /usr/bin/containerd \
-    /usr/bin/containerd-shim \
-    /usr/bin/containerd-shim-runc-v1 \
-    /usr/bin/ctr \
     # rootlesskit
     /usr/bin/rootlesskit \
     # runc

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -132,25 +132,6 @@ container_layer(
 )
 
 container_layer(
-    name = "containerd_layer",
-    directory = "/usr/bin",
-    files = select({
-        "@platforms//cpu:x86_64": [
-            "@com_github_containerd_containerd-linux-amd64//:containerd.bin",
-            "@com_github_containerd_containerd-linux-amd64//:containerd-shim-runc-v2.bin",
-            "@com_github_containerd_containerd-linux-amd64//:ctr.bin",
-        ],
-        "@platforms//cpu:arm64": [
-            "@com_github_containerd_containerd-linux-arm64//:containerd.bin",
-            "@com_github_containerd_containerd-linux-arm64//:containerd-shim-runc-v2.bin",
-            "@com_github_containerd_containerd-linux-arm64//:ctr.bin",
-        ],
-        "//conditions:default": [],
-    }),
-    tags = ["manual"],
-)
-
-container_layer(
     name = "rootlesskit_layer",
     directory = "/usr/bin",
     files = select({
@@ -244,7 +225,6 @@ container_image(
         ":tini_layer",
         ":docker_credential_gcr_layer",
         ":docker_credential_gcr_docker_config_layer",
-        ":containerd_layer",
         # Updating these layers does not currently afford us any vulnerability
         # fixes; leave them out for now.
         ":runc_layer",


### PR DESCRIPTION
We no longer use containerd or ctr in any of the isolation options.
Remove the vendored binaries as well as the debian package installation
in the executor container image.
