### PR TITLE
gazelle: remove extra deps in task_router

### DIFF
--- a/enterprise/server/scheduling/task_router/BUILD
+++ b/enterprise/server/scheduling/task_router/BUILD
@@ -7,7 +7,6 @@ go_library(
     srcs = ["task_router.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router",
     deps = [
-        "//enterprise/server/experiments",
         "//enterprise/server/remote_execution/platform",
         "//proto:remote_execution_go_proto",
         "//server/environment",


### PR DESCRIPTION
The dep was added from #10524, most likely as an accident.
