### PR TITLE
compare_invocations: diff canonical commands

### DIFF
--- a/app/compare/compare_invocations.tsx
+++ b/app/compare/compare_invocations.tsx
@@ -83,18 +83,22 @@ const FACETS = [
   { name: "Fetch count", facet: (i?: InvocationModel) => `${i?.getFetchURLs().length}` },
   {
     name: "Explicit command line",
-    facet: (i?: InvocationModel) => i?.optionsParsed?.explicitCmdLine.join("\n"),
+    facet: (i?: InvocationModel) => i?.getExplicitCommandLineOptions().join("\n"),
     type: "flag",
   },
-  { name: "Full command line", facet: (i?: InvocationModel) => i?.optionsParsed?.cmdLine.join("\n"), type: "flag" },
+  {
+    name: "Full command line",
+    facet: (i?: InvocationModel) => i?.getEffectiveCommandLineOptions().join("\n"),
+    type: "flag",
+  },
   {
     name: "Explicit startup options",
-    facet: (i?: InvocationModel) => i?.optionsParsed?.explicitStartupOptions.join("\n"),
+    facet: (i?: InvocationModel) => i?.getExplicitStartupOptions().join("\n"),
     type: "flag",
   },
   {
     name: "Full startup options",
-    facet: (i?: InvocationModel) => i?.optionsParsed?.startupOptions.join("\n"),
+    facet: (i?: InvocationModel) => i?.getEffectiveStartupOptions().join("\n"),
     type: "flag",
   },
   {


### PR DESCRIPTION
Some flags, such as user-defined starlark flags like
`--@@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig`, will not show
up in optionsParsed build event.  They will only show in
structuredCommandLine events, specifically the canonical one.

Use the structuredCommandLine as the source of truth when diff-ing 2
invocations. Fallback to the old optionsParsed comparision when we got
nothing from structuredCommandLine events.
