### PR TITLE
cli: fix diff mode

### DIFF
--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -84,7 +84,11 @@ func runGazelle(repoRoot, baseFile string) error {
 
 func runRepoGazelle() error {
 	log.Debugf("Running %s", gazelleTarget)
-	_, err := bazelisk.Run([]string{"run", gazelleTarget}, &bazelisk.RunOpts{})
+	args := []string{"run", "--", gazelleTarget}
+	if *diff {
+		args = append(args, "-mode=diff")
+	}
+	_, err := bazelisk.Run(args, &bazelisk.RunOpts{})
 	return err
 }
 


### PR DESCRIPTION
The new `runRepoGazelle` func doesn't respect the `--diff` flag; this PR fixes that.