### PR TITLE
[SS] Update local snapshot saving behavior

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -1236,86 +1236,93 @@ export default class InvocationActionCardComponent extends React.Component<Props
                                 {vmMetadata.snapshotId && (
                                   <div className="snapshot-id-container">
                                     <div className="snapshot-id-details">
-                                      <div className="metadata-title">Saved to snapshot ID</div>
-                                      <div className="metadata-detail">{vmMetadata.snapshotId}</div>
+                                      {vmMetadata.savedLocalSnapshot || vmMetadata.savedRemoteSnapshot ? (
+                                        <>
+                                          <div className="metadata-title">Saved to snapshot ID</div>
+                                          <div className="metadata-detail">{vmMetadata.snapshotId}</div>
+                                        </>
+                                      ) : (
+                                        <div className="metadata-title">No snapshot saved for this run</div>
+                                      )}
                                     </div>
                                     <div>
-                                      {vmMetadata.snapshotKey && (
-                                        <div className="invocation-menu-container">
-                                          <a
-                                            className="invalidate-button"
-                                            onClick={() => this.setState({ showInvalidateSnapshotModal: true })}>
-                                            Invalidate VM snapshot
-                                          </a>
-                                          <OutlinedButton
-                                            title="Snapshot options"
-                                            className="snapshot-more-button"
-                                            onClick={() => this.setState({ showSnapshotMenu: true })}>
-                                            <MoreVertical />
-                                          </OutlinedButton>
-                                          <Popup
-                                            isOpen={this.state.showSnapshotMenu}
-                                            onRequestClose={() => this.setState({ showSnapshotMenu: false })}>
-                                            <Menu className="workflow-dropdown-menu">
-                                              <MenuItem onClick={this.onClickCopySnapshotKey.bind(this, vmMetadata)}>
-                                                Copy snapshot key
-                                              </MenuItem>
-                                              <MenuItem
-                                                onClick={this.onClickCopyRemoteBazelCommand.bind(
-                                                  this,
-                                                  vmMetadata,
-                                                  this.state.actionResult.executionMetadata
-                                                )}>
-                                                Copy Remote Bazel command to run commands in snapshot
-                                              </MenuItem>
-                                            </Menu>
-                                          </Popup>
-                                          <Modal
-                                            isOpen={this.state.showInvalidateSnapshotModal}
-                                            onRequestClose={() =>
-                                              this.setState({
-                                                showInvalidateSnapshotModal: false,
-                                                isMenuOpen: false,
-                                              })
-                                            }>
-                                            <Dialog>
-                                              <DialogHeader>
-                                                <DialogTitle>Confirm invalidate VM snapshot</DialogTitle>
-                                              </DialogHeader>
-                                              <DialogBody>
-                                                <p>
-                                                  Are you sure you want to invalidate the VM snapshot used for this
-                                                  action?
-                                                </p>
-                                                <p>
-                                                  A new VM, instead of a recycled VM, will be used for the next run of
-                                                  this action, which may result in longer execution time.
-                                                </p>
-                                              </DialogBody>
-                                              <DialogFooter>
-                                                <DialogFooterButtons>
-                                                  <OutlinedButton
-                                                    onClick={() =>
-                                                      this.setState({
-                                                        showInvalidateSnapshotModal: false,
-                                                        isMenuOpen: false,
-                                                      })
-                                                    }>
-                                                    Cancel
-                                                  </OutlinedButton>
-                                                  <Button
-                                                    onClick={this.onClickInvalidateSnapshot.bind(
-                                                      this,
-                                                      vmMetadata.snapshotKey
-                                                    )}>
-                                                    Invalidate
-                                                  </Button>
-                                                </DialogFooterButtons>
-                                              </DialogFooter>
-                                            </Dialog>
-                                          </Modal>
-                                        </div>
-                                      )}
+                                      {vmMetadata.snapshotKey &&
+                                        (vmMetadata.savedLocalSnapshot || vmMetadata.savedRemoteSnapshot) && (
+                                          <div className="invocation-menu-container">
+                                            <a
+                                              className="invalidate-button"
+                                              onClick={() => this.setState({ showInvalidateSnapshotModal: true })}>
+                                              Invalidate VM snapshot
+                                            </a>
+                                            <OutlinedButton
+                                              title="Snapshot options"
+                                              className="snapshot-more-button"
+                                              onClick={() => this.setState({ showSnapshotMenu: true })}>
+                                              <MoreVertical />
+                                            </OutlinedButton>
+                                            <Popup
+                                              isOpen={this.state.showSnapshotMenu}
+                                              onRequestClose={() => this.setState({ showSnapshotMenu: false })}>
+                                              <Menu className="workflow-dropdown-menu">
+                                                <MenuItem onClick={this.onClickCopySnapshotKey.bind(this, vmMetadata)}>
+                                                  Copy snapshot key
+                                                </MenuItem>
+                                                <MenuItem
+                                                  onClick={this.onClickCopyRemoteBazelCommand.bind(
+                                                    this,
+                                                    vmMetadata,
+                                                    this.state.actionResult.executionMetadata
+                                                  )}>
+                                                  Copy Remote Bazel command to run commands in snapshot
+                                                </MenuItem>
+                                              </Menu>
+                                            </Popup>
+                                            <Modal
+                                              isOpen={this.state.showInvalidateSnapshotModal}
+                                              onRequestClose={() =>
+                                                this.setState({
+                                                  showInvalidateSnapshotModal: false,
+                                                  isMenuOpen: false,
+                                                })
+                                              }>
+                                              <Dialog>
+                                                <DialogHeader>
+                                                  <DialogTitle>Confirm invalidate VM snapshot</DialogTitle>
+                                                </DialogHeader>
+                                                <DialogBody>
+                                                  <p>
+                                                    Are you sure you want to invalidate the VM snapshot used for this
+                                                    action?
+                                                  </p>
+                                                  <p>
+                                                    A new VM, instead of a recycled VM, will be used for the next run of
+                                                    this action, which may result in longer execution time.
+                                                  </p>
+                                                </DialogBody>
+                                                <DialogFooter>
+                                                  <DialogFooterButtons>
+                                                    <OutlinedButton
+                                                      onClick={() =>
+                                                        this.setState({
+                                                          showInvalidateSnapshotModal: false,
+                                                          isMenuOpen: false,
+                                                        })
+                                                      }>
+                                                      Cancel
+                                                    </OutlinedButton>
+                                                    <Button
+                                                      onClick={this.onClickInvalidateSnapshot.bind(
+                                                        this,
+                                                        vmMetadata.snapshotKey
+                                                      )}>
+                                                      Invalidate
+                                                    </Button>
+                                                  </DialogFooterButtons>
+                                                </DialogFooter>
+                                              </Dialog>
+                                            </Modal>
+                                          </div>
+                                        )}
                                     </div>
                                   </div>
                                 )}

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -90,36 +90,36 @@ const (
 	// dockerReuse is treated as an alias for recycle-runner.
 	dockerReusePropertyName = "dockerReuse"
 
-	RunnerRecyclingKey                      = "runner-recycling-key"
-	RunnerRecyclingMaxWaitPropertyName      = "runner-recycling-max-wait"
-	runnerCrashedExitCodesPropertyName      = "runner-crashed-exit-codes"
-	transientErrorExitCodes                 = "transient-error-exit-codes"
-	RemoteSnapshotSavePolicyPropertyName    = "remote-snapshot-save-policy"
-	SnapshotReadPolicyPropertyName          = "snapshot-read-policy"
-	PreserveWorkspacePropertyName           = "preserve-workspace"
-	overlayfsWorkspacePropertyName          = "overlayfs-workspace"
-	cleanWorkspaceInputsPropertyName        = "clean-workspace-inputs"
-	persistentWorkerPropertyName            = "persistent-workers"
-	PersistentWorkerKeyPropertyName         = "persistentWorkerKey"
-	persistentWorkerProtocolPropertyName    = "persistentWorkerProtocol"
-	WorkflowIDPropertyName                  = "workflow-id"
-	WorkloadIsolationPropertyName           = "workload-isolation-type"
-	initDockerdPropertyName                 = "init-dockerd"
-	enableDockerdTCPPropertyName            = "enable-dockerd-tcp"
-	enableVFSPropertyName                   = "enable-vfs"
-	HostedBazelAffinityKeyPropertyName      = "hosted-bazel-affinity-key"
-	useSelfHostedExecutorsPropertyName      = "use-self-hosted-executors"
-	disableMeasuredTaskSizePropertyName     = "debug-disable-measured-task-size"
-	disablePredictedTaskSizePropertyName    = "debug-disable-predicted-task-size"
-	extraArgsPropertyName                   = "extra-args"
-	EnvOverridesPropertyName                = "env-overrides"
-	EnvOverridesBase64PropertyName          = "env-overrides-base64"
-	IncludeSecretsPropertyName              = "include-secrets"
-	DefaultTimeoutPropertyName              = "default-timeout"
-	TerminationGracePeriodPropertyName      = "termination-grace-period"
-	SnapshotKeyOverridePropertyName         = "snapshot-key-override"
-	RetryPropertyName                       = "retry"
-	PersistentVolumesPropertyName           = "persistent-volumes"
+	RunnerRecyclingKey                   = "runner-recycling-key"
+	RunnerRecyclingMaxWaitPropertyName   = "runner-recycling-max-wait"
+	runnerCrashedExitCodesPropertyName   = "runner-crashed-exit-codes"
+	transientErrorExitCodes              = "transient-error-exit-codes"
+	SnapshotSavePolicyPropertyName       = "remote-snapshot-save-policy"
+	SnapshotReadPolicyPropertyName       = "snapshot-read-policy"
+	PreserveWorkspacePropertyName        = "preserve-workspace"
+	overlayfsWorkspacePropertyName       = "overlayfs-workspace"
+	cleanWorkspaceInputsPropertyName     = "clean-workspace-inputs"
+	persistentWorkerPropertyName         = "persistent-workers"
+	PersistentWorkerKeyPropertyName      = "persistentWorkerKey"
+	persistentWorkerProtocolPropertyName = "persistentWorkerProtocol"
+	WorkflowIDPropertyName               = "workflow-id"
+	WorkloadIsolationPropertyName        = "workload-isolation-type"
+	initDockerdPropertyName              = "init-dockerd"
+	enableDockerdTCPPropertyName         = "enable-dockerd-tcp"
+	enableVFSPropertyName                = "enable-vfs"
+	HostedBazelAffinityKeyPropertyName   = "hosted-bazel-affinity-key"
+	useSelfHostedExecutorsPropertyName   = "use-self-hosted-executors"
+	disableMeasuredTaskSizePropertyName  = "debug-disable-measured-task-size"
+	disablePredictedTaskSizePropertyName = "debug-disable-predicted-task-size"
+	extraArgsPropertyName                = "extra-args"
+	EnvOverridesPropertyName             = "env-overrides"
+	EnvOverridesBase64PropertyName       = "env-overrides-base64"
+	IncludeSecretsPropertyName           = "include-secrets"
+	DefaultTimeoutPropertyName           = "default-timeout"
+	TerminationGracePeriodPropertyName   = "termination-grace-period"
+	SnapshotKeyOverridePropertyName      = "snapshot-key-override"
+	RetryPropertyName                    = "retry"
+	PersistentVolumesPropertyName        = "persistent-volumes"
 
 	OperatingSystemPropertyName = "OSFamily"
 	LinuxOperatingSystemName    = "linux"
@@ -438,9 +438,9 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		return nil, err
 	}
 
-	snapshotSavePolicy := stringProp(m, RemoteSnapshotSavePolicyPropertyName, "")
+	snapshotSavePolicy := stringProp(m, SnapshotSavePolicyPropertyName, "")
 	switch snapshotSavePolicy {
-	case snaputil.AlwaysSaveRemoteSnapshot, snaputil.OnlySaveFirstNonDefaultRemoteSnapshot, snaputil.OnlySaveNonDefaultRemoteSnapshotIfNoneAvailable, "":
+	case snaputil.AlwaysSaveSnapshot, snaputil.OnlySaveFirstNonDefaultSnapshot, snaputil.OnlySaveNonDefaultSnapshotIfNoneAvailable, "":
 	default:
 		return nil, status.InvalidArgumentErrorf("%s is not a valid value for the `remote-snapshot-save-policy` platform property", snapshotSavePolicy)
 	}

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -64,17 +64,18 @@ const (
 	ChunkSourceRemoteCache
 )
 
+// Values for platform.SnapshotSavePolicyPropertyName
 const (
-	// Every run will save a remote snapshot.
-	AlwaysSaveRemoteSnapshot = "always"
-	// Default. Only the first run on a non-default ref will save a remote snapshot.
-	// All runs on default refs will save a remote snapshot.
-	OnlySaveFirstNonDefaultRemoteSnapshot = "first-non-default-ref"
-	// Will only save a remote snapshot on a non-default ref if there are no remote
+	// Every run will save a snapshot.
+	AlwaysSaveSnapshot = "always"
+	// Default. Only the first run on a non-default ref will save a snapshot.
+	// All runs on default refs will save a snapshot.
+	OnlySaveFirstNonDefaultSnapshot = "first-non-default-ref"
+	// Will only save a snapshot on a non-default ref if there are no
 	// snapshots available. If there is a fallback default snapshot, still will not save
-	// a remote snapshot.
-	// All runs on default refs will save a remote snapshot.
-	OnlySaveNonDefaultRemoteSnapshotIfNoneAvailable = "none-available"
+	// a snapshot.
+	// All runs on default refs will save a snapshot.
+	OnlySaveNonDefaultSnapshotIfNoneAvailable = "none-available"
 )
 
 // Values for platform.SnapshotReadPolicyPropertyName:


### PR DESCRIPTION
Use the platform property that determines remote snapshot save behavior for local snapshot save behavior as well. Previously we always saved a local snapshot. In most cases, unless the platform property SnapshotSavePolicyPropertyName=always, now we will only save one local snapshot per branch.