### PR TITLE
invocation_exec_log_card: avoid calling GetExecution twice

### DIFF
--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -52,7 +52,13 @@ export default class SpawnCardComponent extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (this.props.model !== prevProps.model) {
+    const invocationIdChanged = this.props.model.getInvocationId() !== prevProps.model.getInvocationId();
+    const invocationStatusChanged =
+      this.props.model.invocation.invocationStatus !== prevProps.model.invocation.invocationStatus;
+
+    if (invocationIdChanged || invocationStatusChanged) {
+      clearTimeout(this.timeoutRef);
+      this.timeoutRef = undefined;
       this.fetchExecution();
     }
   }


### PR DESCRIPTION
Currently we are calling GetExecution twice in an interval when the
invocation is still in progress. One is triggered by
fetchUpdatedProgress, which updates the invocation model and trigger
componentDidUpdate to call GetExecution again.

Tighten the componentDidUpdate trigger by making sure that we would only
fetchExecution when the invocation id or status changed.
This leaves the timer-driven polling the only remaining source of
periodic GetExecution requests.
