### PR TITLE
nogo: simplify config

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,70 +22,10 @@ write_file(
         json.encode_indent(
             {
                 "exhaustive": {
-                    "exclude_files": {
-                        "external[\\\\,\\/]": "third_party",
-                    },
                     "analyzer_flags": {
                         "default-signifies-exhaustive": "true",
                     },
                 },
-            } | {
-                analyzer: {
-                    "exclude_files": {
-                        "external[\\\\,\\/]": "third_party",
-                        ".*\\.pb\\.go": "Auto-generated proto files",
-                        # TODO(sluongng): this should be fixed on rules_go side
-                        # https://github.com/bazelbuild/rules_go/issues/3619
-                        "cgo[\\\\,\\/]github.com[\\\\,\\/]shirou[\\\\,\\/]gopsutil[\\\\,\\/]": "third_party cgo",
-                    },
-                }
-                for analyzer in ANALYZERS + [
-                    "appends",
-                    "asmdecl",
-                    "assign",
-                    "atomicalign",
-                    "bools",
-                    "buildtag",
-                    # "cgocall",
-                    "composites",
-                    "copylocks",
-                    "deepequalerrors",
-                    "defers",
-                    "directive",
-                    "errorsas",
-                    # Noisy and is not part of 'go vet'
-                    # "fieldalignment",
-                    "framepointer",
-                    "hostport",
-                    "httpmux",
-                    "httpresponse",
-                    "ifaceassert",
-                    "loopclosure",
-                    "lostcancel",
-                    "nilfunc",
-                    "nilness",
-                    "printf",
-                    "reflectvaluecompare",
-                    # Everyone shadows `err`
-                    # "shadow",
-                    "shift",
-                    "sigchanyzer",
-                    "slog",
-                    "sortslice",
-                    "stdmethods",
-                    "stdversion",
-                    "stringintconv",
-                    "structtag",
-                    "testinggoroutine",
-                    "tests",
-                    "timeformat",
-                    "unmarshal",
-                    "unreachable",
-                    "unsafeptr",
-                    "unusedresult",
-                    "unusedwrite",
-                    "waitgroup",
-                ]
             },
         ),
     ],


### PR DESCRIPTION
Now that we have switched to bzlmod, most of the external deps and code
gen are excluded by nogo by default.

Remove redundant nogo configs.
