### PR TITLE
Remove FE reference to deprecated field

### DIFF
--- a/enterprise/app/code/code_empty.tsx
+++ b/enterprise/app/code/code_empty.tsx
@@ -39,7 +39,7 @@ export default class CodeEmptyStateComponent extends React.Component<{}, State> 
 
     rpcService.service.getLinkedGitHubRepos({}).then((response) => {
       console.log(response);
-      this.setState({ linkedRepos: response.repoUrls });
+      this.setState({ linkedRepos: response.repos.map((repo) => repo.repoUrl) });
     });
 
     return;


### PR DESCRIPTION
Before I can merge [this](https://github.com/buildbuddy-io/buildbuddy/pull/10458), I realized I had missed one FE cleanup 