### PR TITLE
[WIP] Write diff snapshots directly on top of the memory snapshot

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -126,6 +126,7 @@ go_test(
         "--executor.enable_local_snapshot_sharing=true",
         "--executor.enable_remote_snapshot_sharing=true",
         "--executor.firecracker_enable_linux_6_1=true",
+        "--executor.firecracker_enable_native_snapshot_overwriting=true",
     ],
     exec_properties = {
         "test.Pool": "bare",

--- a/server/testutil/testnetworking/testnetworking.go
+++ b/server/testutil/testnetworking/testnetworking.go
@@ -20,7 +20,7 @@ import (
 
 // Setup sets up the test to be able to call networking functions.
 // It skips the test if the required net tools aren't available.
-func Setup(t *testing.T) {
+func Setup(t testing.TB) {
 	// Ensure ip tools are in PATH
 	os.Setenv("PATH", os.Getenv("PATH")+":/usr/sbin:/sbin")
 


### PR DESCRIPTION
```
cpu: Intel(R) Xeon(R) CPU @ 3.10GHz
                                         │ baseline_10.txt │             new_10.txt              │
                                         │     sec/op      │   sec/op     vs base                │
_PausePerformance/memory_size_500_mb-16        14.11 ±  1%   13.47 ±  3%   -4.50% (p=0.002 n=10)
_PausePerformance/memory_size_1000_mb-16       20.06 ±  6%   18.52 ±  1%   -7.64% (p=0.000 n=10)
_PausePerformance/memory_size_2000_mb-16       25.46 ± 14%   23.23 ± 19%   -8.75% (p=0.015 n=10)
_PausePerformance/memory_size_4000_mb-16       38.81 ±  1%   34.04 ±  9%  -12.29% (p=0.000 n=10)
geomean                                        22.99         21.08         -8.34% 
```

Generated with
```
 ./enterprise/server/remote_execution/containers/firecracker/test.sh  --  -executor.firecracker_enable_native_snapshot_overwriting=true -test.bench=Benchmark_PausePerformance -test.run=^$  -test.count=10 > new_10.txt
 ./enterprise/server/remote_execution/containers/firecracker/test.sh  --  -test.bench=Benchmark_PausePerformance -test.run=^$  -test.count=10 > baseline_10.txt
benchstat baseline_10.txt new_10.txt
```