### PR TITLE
cli: fix plugin arg file handling

### DIFF
--- a/cli/parser/parsed/BUILD
+++ b/cli/parser/parsed/BUILD
@@ -13,5 +13,6 @@ go_library(
         "//cli/parser/bazelrc",
         "//cli/parser/options",
         "//server/util/lib/set",
+        "//server/util/shlex",
     ],
 )

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -21,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/bazelrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
+	"github.com/buildbuddy-io/buildbuddy/server/util/shlex"
 )
 
 type Args interface {
@@ -731,7 +732,7 @@ func (a *OrderedArgs) expandConfigs(
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("Fully expanded args: %+v", arguments.FormatAll(expanded))
+	log.Debugf("Fully expanded args: %s", shlex.Quote(arguments.FormatAll(expanded)...))
 
 	// Append to new OrderedArgs to make sure `--` is handled correctly.
 	expandedArgs := &OrderedArgs{}

--- a/cli/plugin/BUILD
+++ b/cli/plugin/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//cli/workspace",
         "//server/util/disk",
         "//server/util/git",
+        "//server/util/shlex",
         "//server/util/status",
         "@com_github_creack_pty//:pty",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -385,6 +385,15 @@ startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 	require.NotContains(t, string(b), "Running Bazel server needs to be killed")
 }
 
+func TestBazelModDumpRepoMappingEmptyString(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	cmd := testcli.Command(t, ws, "mod", "dump_repo_mapping", "")
+	b, err := testcli.Output(cmd)
+	require.NoErrorf(t, err, "output: %s", string(b))
+	// stdout should look like a JSON object
+	require.Regexp(t, `^\{.*\}$`, strings.TrimSpace(string(b)))
+}
+
 func retryUntilSuccess(t *testing.T, f func() error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
When we pass bazel args through the CLI plugin pipeline, we're currently dropping args that are empty.

This PR fixes that by preserving blank lines in the args file. This does mean that plugins now have to be more careful about whitespace handling, which might be annoying, but I'm not sure if there's a better solution :thinking: 