### PR TITLE
Track /file/download in HTTP metrics

### DIFF
--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -382,7 +382,7 @@ func routeLabel(r *http.Request) string {
 	if path == "" || path == "/" {
 		return "/"
 	}
-	if path == "/readyz" || path == "/healthz" {
+	if path == "/readyz" || path == "/healthz" || path == "/file/download" {
 		return path
 	}
 	if strings.HasPrefix(path, "/image/") {


### PR DESCRIPTION
This is the bytestream download path that is heavily used by the UI (guessing this accounts for the majority of `[OTHER]` traffic, except for misc bot queries)