### PR TITLE
cli: another fix for plugin whitespace handling

### DIFF
--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -791,7 +791,7 @@ func appendExpansion(
 	removeDoubleDash bool,
 ) ([]arguments.Argument, error) {
 	for _, a := range toExpand {
-		log.Debugf("Expanding '%+v'", a.Format())
+		log.Debugf("Expanding %s", shlex.Quote(a.Format()...))
 		switch a := a.(type) {
 		case *arguments.DoubleDash:
 			if removeDoubleDash {

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -387,6 +387,15 @@ startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 
 func TestBazelModDumpRepoMappingEmptyString(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		// Add a nop plugin to make sure we properly handle args when there is
+		// at least one plugin in the pre-bazel plugin pipeline.
+		"testplugin/pre_bazel.sh": `#!/usr/bin/env bash`,
+		"buildbuddy.yaml": `
+plugins:
+- path: testplugin
+`,
+	})
 	cmd := testcli.Command(t, ws, "mod", "dump_repo_mapping", "")
 	b, err := testcli.Output(cmd)
 	require.NoErrorf(t, err, "output: %s", string(b))

--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -30,7 +30,7 @@ var (
 	bbRunfilePath string
 
 	streamOutputs = flag.Bool("test_stream_cli_output", false, "Show live CLI output during test execution.")
-	verbose       = flag.Bool("test_cli_verbose", false, "Whether to add --verbose=1 to the CLI.")
+	verbose       = flag.Bool("test_cli_verbose", false, "Whether to add --verbose to the CLI.")
 
 	initEnvOnce sync.Once
 )
@@ -56,7 +56,7 @@ func Command(t *testing.T, workspacePath string, args ...string) *exec.Cmd {
 		require.NoError(t, err)
 	})
 	if *verbose {
-		args = append(args, "--verbose=1")
+		args = append([]string{"--verbose"}, args...)
 	}
 	cmd := exec.Command(BinaryPath(t), args...)
 	cmd.Dir = workspacePath


### PR DESCRIPTION
Instead of writing `\n` to the file when there are no args, make sure we write an empty string. This ensures that we correctly read back an empty arg list.