### PR TITLE
[streaming redactor] rm unused env

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -190,7 +190,7 @@ func (b *BuildEventHandler) OpenChannel(ctx context.Context, iid string) (interf
 		ctx:            ctx,
 		pw:             nil,
 		beValues:       buildEventAccumulator,
-		redactor:       redact.NewStreamingRedactor(b.env),
+		redactor:       redact.NewStreamingRedactor(),
 		statusReporter: build_status_reporter.NewBuildStatusReporter(b.env, buildEventAccumulator),
 		targetTracker:  target_tracker.NewTargetTracker(b.env, buildEventAccumulator),
 		collector:      b.env.GetMetricsCollector(),
@@ -1570,7 +1570,7 @@ func FetchAllInvocationEventsWithCallback(ctx context.Context, env environment.E
 	var redactor *redact.StreamingRedactor
 	if invRedactionFlags&redact.RedactionFlagStandardRedactions != redact.RedactionFlagStandardRedactions {
 		// only redact if we hadn't redacted enough, only parse again if we redact
-		redactor = redact.NewStreamingRedactor(env)
+		redactor = redact.NewStreamingRedactor()
 	}
 	beValues := accumulator.NewBEValues(inv)
 	structuredCommandLines := []*command_line.CommandLine{}

--- a/server/util/redact/BUILD
+++ b/server/util/redact/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
-        "//server/environment",
         "//server/util/flag",
         "//server/util/git",
         "//server/util/status",
@@ -25,7 +24,6 @@ go_test(
         ":redact",
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
-        "//server/testutil/testenv",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/shlex"
@@ -568,13 +567,11 @@ func parseAllowedEnv(optionsDescription string) []string {
 // StreamingRedactor processes a stream of build events and redacts them as they are
 // received by the event handler.
 type StreamingRedactor struct {
-	env            environment.Env
 	allowedEnvVars []string
 }
 
-func NewStreamingRedactor(env environment.Env) *StreamingRedactor {
+func NewStreamingRedactor() *StreamingRedactor {
 	return &StreamingRedactor{
-		env:            env,
 		allowedEnvVars: defaultAllowedEnvVars,
 	}
 }


### PR DESCRIPTION
Cleans up the code, should also clean up the redact_test logs.