### PR TITLE
move compressionReader to util/compression.go

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -595,7 +595,7 @@ func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOf
 		if resourceSize > 0 && resourceSize < bufSize {
 			bufSize = resourceSize
 		}
-		return compression.NewBufferedCompressionReader(reader, c.bufferPool, bufSize)
+		return compression.NewBufferedZstdCompressingReader(reader, c.bufferPool, bufSize)
 	}
 
 	return reader, nil

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3387,7 +3387,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 			bufSize = resourceSize
 		}
 
-		return compression.NewBufferedCompressionReader(reader, p.bufferPool, bufSize)
+		return compression.NewBufferedZstdCompressingReader(reader, p.bufferPool, bufSize)
 	}
 
 	return reader, nil

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -156,7 +156,7 @@ func (s *ByteStreamServer) ReadCASResource(ctx context.Context, r *digest.CASRes
 		counter = &ioutil.Counter{}
 		rc := io.NopCloser(io.TeeReader(reader, counter))
 
-		reader, err = compression.NewBufferedCompressionReader(rc, s.bufferPool, bufSize)
+		reader, err = compression.NewBufferedZstdCompressingReader(rc, s.bufferPool, bufSize)
 		if err != nil {
 			return status.InternalErrorf("Failed to compress blob: %s", err)
 		}


### PR DESCRIPTION
Move the code from pebble_cache.go to util/compression.go, so that can be reused
in meta cache.
