### PR TITLE
Add Subscribe function to ExperimentFlagProvider

### DIFF
--- a/enterprise/server/experiments/BUILD
+++ b/enterprise/server/experiments/BUILD
@@ -28,6 +28,7 @@ go_test(
         "//server/tables",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
+        "//server/testutil/testfs",
         "//server/util/authutil",
         "//server/util/claims",
         "//server/util/random",

--- a/enterprise/server/experiments/experiments_test.go
+++ b/enterprise/server/experiments/experiments_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
@@ -362,4 +365,56 @@ func TestTargetingGroupID(t *testing.T) {
 		s := fp.String(ctx, "test_flag", "")
 		require.Equal(t, "default", s)
 	})
+}
+
+func TestSubscribe(t *testing.T) {
+	ctx := context.Background()
+
+	const testFlags = `{
+	  "$schema": "https://flagd.dev/schema/v0/flags.json",
+	  "flags": {
+	    "test_flag": {
+	      "state": "ENABLED",
+	      "variants": {
+	        "default": "FOO"
+	      },
+	      "defaultVariant": "default"
+	    }
+	  }
+	}
+	`
+
+	offlineFlagPath := writeFlagConfig(t, testFlags)
+	provider := flagd.NewProvider(flagd.WithInProcessResolver(), flagd.WithOfflineFilePath(offlineFlagPath))
+	openfeature.SetProviderAndWait(provider)
+
+	fp, err := experiments.NewFlagProvider("test-name")
+	require.NoError(t, err)
+
+	ch := make(chan struct{}, 4)
+	unsubscribe := fp.Subscribe(ch)
+	defer unsubscribe()
+
+	// Drain any initial updates on the channel (the implementation may or may
+	// not choose to send initial updates)
+	for {
+		select {
+		case <-ch:
+			continue
+		case <-time.After(100 * time.Millisecond):
+		}
+		break
+	}
+
+	// Write a change to the config.
+	updatedFlags := strings.Replace(testFlags, "FOO", "BAR", 1)
+	testfs.WriteFile(t, "", offlineFlagPath, updatedFlags)
+
+	// An update should be sent on the channel now that the config has changed.
+	<-ch
+
+	// The flag should evaluate to the new value after we're notified of the
+	// change.
+	flagVal := fp.String(ctx, "test_flag", "")
+	require.Equal(t, "BAR", flagVal)
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1839,6 +1839,17 @@ type ExperimentFlagProvider interface {
 	Float64Details(ctx context.Context, flagName string, defaultValue float64, opts ...any) (float64, ExperimentFlagDetails)
 	Int64Details(ctx context.Context, flagName string, defaultValue int64, opts ...any) (int64, ExperimentFlagDetails)
 	ObjectDetails(ctx context.Context, flagName string, defaultValue map[string]any, opts ...any) (map[string]any, ExperimentFlagDetails)
+
+	// Subscribe registers a channel that will receive a value whenever the
+	// experiment config might have changed. The given function should be called
+	// to unsubscribe from changes. Config changes are published in a
+	// non-blocking fashion, so the channel should be buffered. If the channel
+	// buffer is full, then updates will be dropped.
+	//
+	// NOTE: This is a best-effort mechanism to reduce latency between the
+	// experiment flags changing and the app re-reading the changes. To avoid
+	// missing changes, the caller should also poll at an appropriate interval.
+	Subscribe(ch chan<- struct{}) (stop func())
 }
 
 // ExperimentFlagDetails contains details about the flag evaluation.


### PR DESCRIPTION
This allows syncing experiment configuration as soon as the app is notified of the config change. It's intended to help reduce service disruption when we change the redis shard configuration (see #10597)