### PR TITLE
Add a helper func to convert experiment objects to go structs

### DIFF
--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -2,6 +2,7 @@ package experiments
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"strconv"
@@ -146,6 +147,24 @@ func (fp *FlagProvider) getEvaluationContext(ctx context.Context, opts ...any) o
 
 	evalContext := openfeature.NewEvaluationContext(options.targetingKey, options.attributes)
 	return evalContext
+}
+
+// ObjectToStruct is a utility function to get a Go struct from an object
+// returned by [interfaces.ExperimentFlagProvider.Object] or
+// [interfaces.ExperimentFlagProvider.ObjectDetails].
+//
+// It uses an intermediate JSON conversion, so any `json` tags on struct fields
+// can be used to control how the object fields are unmarshaled into struct
+// fields.
+func ObjectToStruct(object map[string]any, dest any) error {
+	b, err := json.Marshal(object)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := json.Unmarshal(b, dest); err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+	return nil
 }
 
 // WithContext adds the provided key and value into the experiment context when

--- a/enterprise/server/experiments/experiments_test.go
+++ b/enterprise/server/experiments/experiments_test.go
@@ -96,6 +96,13 @@ func TestPrimitiveFlags(t *testing.T) {
 	require.Equal(t, int64(1), fp.Int64(ctx, "int_flag", 0))
 	require.Equal(t, 99.9999999, fp.Float64(ctx, "float_flag", 1.0))
 	require.Equal(t, map[string]any{"foo": "foo value"}, fp.Object(ctx, "object_flag", nil))
+	type ObjStruct struct {
+		Foo string `json:"foo"`
+	}
+	var obj ObjStruct
+	err = experiments.ObjectToStruct(fp.Object(ctx, "object_flag", nil), &obj)
+	require.NoError(t, err)
+	require.Equal(t, ObjStruct{Foo: "foo value"}, obj)
 
 	b, d := fp.BooleanDetails(ctx, "bool_flag", false)
 	require.True(t, b)


### PR DESCRIPTION
Example usage: https://github.com/buildbuddy-io/buildbuddy/pull/10601

Also will be used in https://github.com/buildbuddy-io/buildbuddy/pull/10597