### PR TITLE
move readCloser from pebble_cache to ioutil.go

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -132,12 +132,6 @@ func (r *compressionReader) Close() error {
 	return err
 }
 
-// TODO(tylerw): move to ioutil
-type readCloser struct {
-	io.Reader
-	io.Closer
-}
-
 func (c *Cache) encryptionEnabled(ctx context.Context) (bool, error) {
 	if !authutil.EncryptionEnabled(ctx, c.env.GetAuthenticator()) {
 		return false, nil
@@ -607,7 +601,7 @@ func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOf
 			}
 		}
 		if uncompressedLimit != 0 {
-			reader = &readCloser{io.LimitReader(reader, uncompressedLimit), reader}
+			reader = ioutil.LimitReadCloser(reader, uncompressedLimit)
 		}
 	}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3249,11 +3249,6 @@ func (r *compressionReader) Close() error {
 	return err
 }
 
-type readCloser struct {
-	io.Reader
-	io.Closer
-}
-
 // newChunkedReader returns a reader to read chunked content.
 // When shouldDecompress is true, the content read is decompressed.
 func (p *PebbleCache) newChunkedReader(ctx context.Context, chunkedMD *sgpb.StorageMetadata_ChunkedMetadata, shouldDecompress bool) (io.ReadCloser, error) {
@@ -3396,7 +3391,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 			}
 		}
 		if uncompressedLimit != 0 {
-			reader = &readCloser{io.LimitReader(reader, uncompressedLimit), reader}
+			reader = ioutil.LimitReadCloser(reader, uncompressedLimit)
 		}
 	}
 

--- a/server/util/ioutil/ioutil.go
+++ b/server/util/ioutil/ioutil.go
@@ -32,6 +32,19 @@ func (discardWriteCloser) Close() error {
 	return nil
 }
 
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// LimitReadCloser returns a readCloser with a LimitReader.
+func LimitReadCloser(reader io.ReadCloser, limit int64) io.ReadCloser {
+	return &readCloser{
+		io.LimitReader(reader, limit),
+		reader,
+	}
+}
+
 type CloseFunc func() error
 type CommitFunc func(int64) error
 


### PR DESCRIPTION
Create a ioutil.LimitReadCloser to be re-used by both pebble cache and meta
cache.
