### PR TITLE
Various fixes for `tools/lint` and `bb fix`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,15 +4,9 @@ module(
 )
 
 include("//deps:bazel_dep.MODULE.bazel")
-
 include("//deps:docker.MODULE.bazel")
-
 include("//deps:go_deps.MODULE.bazel")
-
 include("//deps:oci.MODULE.bazel")
-
 include("//deps:static_deps.MODULE.bazel")
-
 include("//deps:toolchains.MODULE.bazel")
-
 include("//deps:web.MODULE.bazel")

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -125,7 +125,7 @@ func walk(moduleOrWorkspaceFile string) error {
 			if d.IsDir() {
 				// Don't recurse into hidden directories such as .git or .ijwb
 				// (IntelliJ).
-				if strings.HasPrefix(d.Name(), ".") {
+				if d.Name() != "." && strings.HasPrefix(d.Name(), ".") {
 					return filepath.SkipDir
 				} else {
 					return nil

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -361,13 +361,16 @@ func TestQueryFile(t *testing.T) {
 	require.NoErrorf(t, err, "output: %s", string(b))
 }
 
-func TestFix(t *testing.T) {
+func TestFixDiff(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
-
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"MODULE.bazel": `module(  name = "cli_test"    )`,
+	})
 	cmd := testcli.Command(t, ws, "fix", "--diff")
-	b, err := testcli.CombinedOutput(cmd)
-
-	require.NoError(t, err, "output:\n%s", string(b))
+	stdout, stderr, err := testcli.SplitOutput(cmd)
+	// TODO: a non-empty diff probably *should* return an error (exit code 1)
+	require.NoError(t, err, "stdout: %q\nstderr: %q", string(stdout), string(stderr))
+	require.NotEmpty(t, string(stdout))
 }
 
 func TestCLIDoesNotRestartBazelServer(t *testing.T) {

--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -97,6 +97,25 @@ func Output(cmd *exec.Cmd) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// SplitOutput runs the command and returns stdout and stderr in separate
+// buffers. It allows streaming CLI outputs for debugging purposes.
+func SplitOutput(cmd *exec.Cmd) (stdout, stderr []byte, _ error) {
+	stdoutBuf := bytes.NewBuffer(nil)
+	var stdoutW io.Writer = stdoutBuf
+	if *streamOutputs {
+		stdoutW = io.MultiWriter(stdoutW, os.Stderr)
+	}
+	stderrBuf := bytes.NewBuffer(nil)
+	var stderrW io.Writer = stderrBuf
+	if *streamOutputs {
+		stderrW = io.MultiWriter(stderrW, os.Stderr)
+	}
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
+	err := cmd.Run()
+	return stdoutBuf.Bytes(), stderrBuf.Bytes(), err
+}
+
 // CombinedOutput is like cmd.CombinedOutput() except that it allows streaming
 // CLI outputs for debugging purposes.
 func CombinedOutput(cmd *exec.Cmd) ([]byte, error) {

--- a/cli/translate/BUILD
+++ b/cli/translate/BUILD
@@ -7,8 +7,5 @@ go_library(
     srcs = ["translate.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/translate",
     visibility = ["//visibility:public"],
-    deps = [
-        "//cli/translate/js",
-        "//cli/translate/yaml",
-    ],
+    deps = ["//cli/translate/js"],
 )

--- a/cli/translate/translate.go
+++ b/cli/translate/translate.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/translate/js"
-	"github.com/buildbuddy-io/buildbuddy/cli/translate/yaml"
 )
 
 type Translator interface {
@@ -15,8 +14,10 @@ type Translator interface {
 
 var (
 	translators = map[string]Translator{
-		".js":    js.New(),
-		".yaml":  yaml.New(),
+		".js": js.New(),
+		// TODO: this produces an undesired diff in our WORKSPACE file.
+		// Fix and re-enable.
+		// ".yaml":  yaml.New(),
 		".bazel": nil,
 		"":       nil,
 	}

--- a/cli/workspace/workspace.go
+++ b/cli/workspace/workspace.go
@@ -25,7 +25,12 @@ var (
 	pathErr  error
 	basename string
 
-	WorkspaceIndicatorFiles = []string{WorkspaceFileName, WorkspaceAltFileName, ModuleFileName}
+	WorkspaceIndicatorFiles = []string{
+		// Prioritize MODULE if both MODULE and WORKSPACE exist, since MODULE is
+		// newer.
+		ModuleFileName,
+		WorkspaceFileName, WorkspaceAltFileName,
+	}
 )
 
 // Path returns the current Bazel workspace path by traversing upwards until

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -118,9 +118,7 @@ genrule(
 go_test(
     name = "firecracker_test",
     timeout = "long",
-    srcs = [
-        "firecracker_test.go",
-    ],
+    srcs = ["firecracker_test.go"],
     args = [
         "--executor.enable_local_snapshot_sharing=true",
         "--executor.enable_remote_snapshot_sharing=true",
@@ -153,7 +151,6 @@ go_test(
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/platform",
-        "//enterprise/server/remote_execution/snaploader",
         "//enterprise/server/remote_execution/snaputil",
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/testutil/testcontainer",
@@ -168,7 +165,6 @@ go_test(
         "//server/remote_cache/action_cache_server",
         "//server/remote_cache/byte_stream_server",
         "//server/remote_cache/content_addressable_storage_server",
-        "//server/remote_cache/digest",
         "//server/resources",
         "//server/rpc/interceptors",
         "//server/testutil/testauth",
@@ -184,7 +180,6 @@ go_test(
         "//server/util/random",
         "//server/util/status",
         "//server/util/testing/flags",
-        "//server/util/tracing",
         "@com_github_google_go_cmp//cmp",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_stretchr_testify//assert",

--- a/tools/lint/BUILD
+++ b/tools/lint/BUILD
@@ -24,6 +24,7 @@ go_library(
     },
     deps = [
         "//server/util/flag",
+        "//server/util/ioutil",
         "//server/util/lockingbuffer",
         "//server/util/log",
         "@io_bazel_rules_go//go/runfiles",


### PR DESCRIPTION
- The "skip hidden dirs" check wasn't accounting for `"."` being the root dir in the traversal (`strings.HasPrefix(".", ".")` returns true), which made it so that we short circuit immediately and never actually traverse anything - this PR fixes that
- `tools/lint` had a separate bug where even if there is a diff produced on stdout, we don't fail (fix that too)
- Some undesired diffs were being produced in `deps.bzl` - I think this is because we were prioritizing the WORKSPACE file over the MODULE.bazel file, and so [here](https://github.com/buildbuddy-io/buildbuddy/blob/170e6d3da26369e14dccbf575a25b6b40769b71e/cli/fix/fix.go#L105) we would run the wrong gazelle command. After switching the priority so that we prefer MODULE.bazel if it exists, `bb fix` no longer produces the undesired diffs to deps.bzl
- Disable `yaml` stuff - it was causing undesired stuff to get generated in the WORKSPACE file