### PR TITLE
Fix workflow history query for sqlite

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -833,7 +833,7 @@ func (ws *workflowService) GetWorkflowHistory(ctx context.Context) (*wfpb.GetWor
 		actionQStr, actionQArgs := q.Build()
 		actionHistoryQArgs = append(actionHistoryQArgs, actionQArgs...)
 		// Wrap as a subquery to support ORDER BY and LIMIT in SQLite UNION queries.
-		actionHistoryQStrs = append(actionHistoryQStrs, "SELECT * FROM ("+actionQStr+")")
+		actionHistoryQStrs = append(actionHistoryQStrs, "(SELECT * FROM ("+actionQStr+"))")
 		summary := &wfpb.ActionHistory_Summary{
 			TotalRuns:       row.TotalRuns,
 			SuccessfulRuns:  row.SuccessfulRuns,


### PR DESCRIPTION
When testing the workflows UI locally, I noticed the query is broken for sqlite

Sqlite does not allow applying an ORDER BY and LIMIT to each part of a UNION. Wrapping each part of the UNION with a `Select * FROM` turns each segment into a subquery, and the ORDER BY/LIMIT are allowed.