### PR TITLE
feat(enterprise/server): record execution pool information in clickhouse

### DIFF
--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2886,4 +2886,8 @@ message StoredExecution {
 
   // Experiments used by this execution.
   repeated string experiments = 61;
+
+  // The requested pool name from platform properties, before resolution to effective pool.
+  string requested_pool = 77;
+  string effective_pool = 78;
 }

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -360,6 +360,8 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) *s
 		RunnerID:                           in.GetRunnerId(),
 		PlatformHash:                       in.GetPlatformHash(),
 		PersistentWorkerKey:                in.GetPersistentWorkerKey(),
+		RequestedPool:                      in.GetRequestedPool(),
+		EffectivePool:                      in.GetEffectivePool(),
 	}
 }
 

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -228,6 +228,8 @@ type Execution struct {
 	ExecutionPriority      int32
 	RequestedIsolationType string
 	EffectiveIsolationType string `gorm:"type:LowCardinality(String)"` // This values comes from the executor
+	RequestedPool          string
+	EffectivePool          string
 
 	// Runner metadata
 	RunnerID            string
@@ -323,6 +325,8 @@ func (e *Execution) AdditionalFields() []string {
 		"ExecutionPriority",
 		"RequestedIsolationType",
 		"EffectiveIsolationType",
+		"RequestedPool",
+		"EffectivePool",
 		"RunnerID",
 		"RunnerTaskNumber",
 		"PlatformHash",


### PR DESCRIPTION
## Summary

Users may want to see stats about their builds that apply only to certain pools of executors. This PR adds both the user's requested pool, and the actual (resolved) pool to the data emit.

The UI will still need to be updated to filter by this information.

The only change in logic is that if either `s.insertInvocationLink` or `platform.ParseProperties(executionTask)` fail, then we wont `insertExecution`. But this is arguably alright since the execution won't dispatch if either of these fail.

Ref: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5984
## Test

Create executor with pool:
```
➜  MY_POOL=tfrench-pool bazel run //enterprise/server/cmd/executor
```

Deploy `enterprise/server` using config from: https://github.com/buildbuddy-io/buildbuddy/pull/10630
```
Scheduler: registered executor "ee67048b-ae0d-4da8-8ca1-60c354270ce6" (host ID "a80d7ebd-95fc-41cc-8ab3-26bd96a7bbe4", host "Tylers-MacBook-Pro.local", version "unknown") for pool {groupID: os:darwin arch:arm64 pool:tfrench-pool} request_id=746278f0-b29f-4071-b437-8ee3c8ee0d88
```

Run a test
```
INFO: Found 1 target and 1 test target...
INFO: Elapsed time: 11.620s, Critical Path: 10.46s
INFO: 2328 processes: 1630 action cache hit, 1597 disk cache hit, 706 remote cache hit, 15 internal, 10 remote.
INFO: Build completed successfully, 2328 total actions

Executed 1 out of 1 test: 1 test passes.
INFO: Streaming build results to: http://localhost:8080/invocation/5c43b406-1fd3-4d2c-9b82-41d069a0d934
```
<img width="1235" height="854" alt="Screenshot 2025-11-04 at 3 00 10 PM" src="https://github.com/user-attachments/assets/3b93fb39-7c8f-4980-91f1-5f043b6bc057" />
<img width="505" height="165" alt="Screenshot 2025-11-04 at 2 59 49 PM" src="https://github.com/user-attachments/assets/a192bd80-ca7e-45bb-b782-cbd2e58fa714" />

Check the metrics:
```
➜  buildbuddy git:(tfrench-poolmetrics) docker run --rm --entrypoint=clickhouse-client --net=host mirror.gcr.io/clickhouse/clickhouse-server:25.3 --query "USE buildbuddy_local; SELECT *  FROM Executions WHERE requested_pool != '' AND invocation_uuid = '5c43b4061fd34d2c9b8241d069a0d934' AND action_mnemonic = 'TestRunner' LIMIT 1" --format=PrettyCompact
Row 1:
──────
invocation_uuid:                        5c43b4061fd34d2c9b8241d069a0d934
execution_id:                           /uploads/149e9a20-6770-4a79-b42b-3118aba47eed/blobs/blake3/3e57e673b7da40e32a881ab880ffdffce7d2f46a4d67d705923094e93f6edf4f/256
invocation_link_type:                   1
created_at_usec:                        0
user_id:                                
worker:                                 a80d7ebd-95fc-41cc-8ab3-26bd96a7bbe4
executor_hostname:                      Tylers-MacBook-Pro.local
self_hosted:                            0
region:                                 
stage:                                  4
target_label:                           //enterprise/server/content_addressable_storage_server_proxy:content_addressable_storage_server_proxy_test
action_mnemonic:                        TestRunner
...
requested_pool:                         tfrench-pool
effective_pool:                         tfrench-pool
```

Verified in Dev with https://shared-executors.buildbuddy.dev/invocation/594567e1-cfc9-43d0-ad26-6c958f45bb7f