### PR TITLE
remove gazelle:ignore directives

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -93,7 +93,6 @@ genrule(
     cmd_bash = "touch $@",
 )
 
-# gazelle:ignore
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],

--- a/aws_rds_certs/BUILD
+++ b/aws_rds_certs/BUILD
@@ -9,11 +9,10 @@ filegroup(
     srcs = [":rds-combined-ca-bundle.pem"],
 )
 
-# gazelle:ignore
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],
-    embedsrcs = [":embedded_certs"],
+    embedsrcs = [":embedded_certs"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/aws_rds_certs",
     deps = [
         "//server/util/fileresolver",

--- a/cli/fix/langs/BUILD
+++ b/cli/fix/langs/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
-# gazelle:ignore
+# gazelle:exclude langs.go
 
 go_library(
     name = "gazelle",

--- a/config/BUILD
+++ b/config/BUILD
@@ -11,11 +11,10 @@ filegroup(
     }),
 )
 
-# gazelle:ignore
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],
-    embedsrcs = [":config_files"],
+    embedsrcs = [":config_files"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/config",
     deps = [
         "//server/util/fileresolver",

--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -11,7 +11,6 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-# gazelle:ignore
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],

--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -103,7 +103,6 @@ genrule(
     cmd_bash = "touch $@",
 )
 
-# gazelle:ignore
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],

--- a/enterprise/config/BUILD
+++ b/enterprise/config/BUILD
@@ -14,11 +14,10 @@ filegroup(
     }),
 )
 
-# gazelle:ignore
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],
-    embedsrcs = [":config_files"],
+    embedsrcs = [":config_files"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/config",
     deps = [
         "//server/util/fileresolver",

--- a/enterprise/vmsupport/BUILD
+++ b/enterprise/vmsupport/BUILD
@@ -9,7 +9,6 @@ genrule(
     cmd_bash = "touch $@",
 )
 
-# gazelle:ignore
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],
@@ -26,7 +25,7 @@ go_library(
         "//conditions:default": [
             ":empty",  # embed fails with no embedsrcs
         ],
-    }),
+    }),  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/vmsupport",
     visibility = ["//visibility:public"],
     deps = [

--- a/static/BUILD
+++ b/static/BUILD
@@ -12,7 +12,6 @@ filegroup(
     ]),
 )
 
-# gazelle:ignore
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],


### PR DESCRIPTION
`# gazelle:ignore` makes gazelle completely ignore the contents of the BUILD file, including formatting and additional rules.

Instead, we should replace these directives with more explicit statements, such as `# keep`, which prevents gazelle from modifying individual attributes, or `# gazelle:exclude <file>`, which prevents gazelle from generating rules from specific files.