### PR TITLE
Decrease filecache subdir prefix length to 2

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -48,7 +48,8 @@ const (
 
 var (
 	enableAlwaysClone   = flag.Bool("executor.local_cache_always_clone", false, "If true, files from the filecache will always be cloned instead of hardlinked")
-	includeSubdirPrefix = flag.Bool("executor.include_subdir_prefix", false, "If true, store files under subdirs named by the first 4 chars of file digest")
+	includeSubdirPrefix = flag.Bool("executor.include_subdir_prefix", false, "If true, store files under subdirs named by a short prefix of the file digest. This can help improve throughput on systems with high core counts. The prefix length is controlled by subdir_prefix_length.")
+	subdirPrefixLength  = flag.Int("executor.subdir_prefix_length", 2, "The length of the subdir prefix to use if include_subdir_prefix is true.")
 )
 
 // fileCache implements a fixed-size, filesystem backed, LRU cache.
@@ -167,7 +168,7 @@ func filecachePath(rootDir, key string) string {
 	// Don't use filepath.Join since it's relatively slow and allocates more.
 	if *includeSubdirPrefix {
 		groupDir, file := filepath.Split(key)
-		return rootDir + "/" + groupDir + file[:4] + "/" + file
+		return rootDir + "/" + groupDir + file[:*subdirPrefixLength] + "/" + file
 	}
 	return rootDir + "/" + key
 }


### PR DESCRIPTION
Decrease subdir prefix length from 4 -> 2 and add tests to make sure we can evict properly in this case (since I'm a bit paranoid about breaking people that might've found this flag and enabled it)

Benefits:
* Subdir prefix length 2 seems to perform better than prefix length 4 in a benchmark that adds 10M small files to the filecache with 100 concurrent goroutines - 2m29s for 256 shards (subdir prefix length 2) vs 2m55s for 65536 shards (subdir prefix length 4). I haven't looked too deeply at this; one possible explanation is that the larger amount of inodes with prefix length 4 results in more inode cache misses.
* Subdir prefix length 2 requires significantly less metadata storage for the directory inodes. Benchmarks show that using prefix length 4 would consume something like 220MiB for the required extra metadata for each group, assuming each group has at least one file per shard.

Benchmark results for various subdir / "shard" counts (1 corresponds to setting `include_subdir_prefix=false`, 256 corresponds to setting `subdir_prefix_length=2`, and 65536 corresponds to setting `subdir_prefix_length=4` like we have today). 

```
Shards  Wall             p25        p50        p75         p90         p95          p99           p99.9         p99.99        Max           DiskUsage  
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
     1  4m8.213015833s   556.517µs  665.12µs   818.866µs   7.540398ms  12.790941ms  27.764749ms   46.32595ms    62.010832ms   657.500935ms  47119650816
     2  2m32.649624124s  56.395µs   216.644µs  2.528711ms  4.672856ms  5.137942ms   8.895352ms    27.607895ms   204.917163ms  346.746249ms  47122124800
     4  2m23.013585032s  42.118µs   91.17µs    594.357µs   2.942211ms  4.362758ms   7.228197ms    186.340669ms  207.66666ms   303.724861ms  47144296448
     8  2m32.51651392s   26.99µs    34.995µs   56.977µs    104.415µs   158.174µs    100.995106ms  154.537437ms  207.542386ms  2.011929742s  47142707200
    16  2m42.1966526s    26.61µs    32.64µs    46.076µs    73.367µs    107.51µs     103.948597ms  158.005004ms  207.289403ms  704.145631ms  47150493696
   256  2m29.536702861s  27.982µs   34.554µs   47.819µs    80.44µs     119.272µs    5.398397ms    197.581183ms  207.572288ms  358.000174ms  47116034048
  4096  2m48.813561775s  31.92µs    39.073µs   54.502µs    89.698µs    128.089µs    9.186895ms    204.988803ms  212.7002ms    851.403802ms  47156539392
 65536  2m55.914622357s  26.99µs    33.332µs   47.558µs    85.419µs    140.151µs    21.840198ms   206.043106ms  444.101546ms  1.638051933s  47351341056
```

Benchmark code is here: https://github.com/buildbuddy-io/buildbuddy/compare/master...xfsbench