### PR TITLE
set a default value in pebble cache for min_bytes_auto_zstd_compression

### DIFF
--- a/enterprise/server/backends/migration_cache/config.go
+++ b/enterprise/server/backends/migration_cache/config.go
@@ -58,7 +58,7 @@ type PebbleCacheConfig struct {
 	AtimeUpdateThreshold        *time.Duration          `yaml:"atime_update_threshold"`
 	AtimeBufferSize             *int                    `yaml:"atime_buffer_size"`
 	MinEvictionAge              *time.Duration          `yaml:"min_eviction_age"`
-	MinBytesAutoZstdCompression int64                   `yaml:"min_bytes_auto_zstd_compression"`
+	MinBytesAutoZstdCompression *int64                  `yaml:"min_bytes_auto_zstd_compression"`
 	AverageChunkSizeBytes       int                     `yaml:"average_chunk_size_bytes"`
 	ClearCacheOnStartup         bool                    `yaml:"clear_cache_on_startup"`
 	ActiveKeyVersion            *int64                  `yaml:"active_key_version"`

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -97,7 +97,7 @@ var (
 	migrationQPSLimit = flag.Int("cache.pebble.migration_qps_limit", 50, "QPS limit for data version migration")
 
 	// Compression related flags
-	minBytesAutoZstdCompression = flag.Int64("cache.pebble.min_bytes_auto_zstd_compression", 100, "Blobs larger than this will be zstd compressed before written to disk.")
+	minBytesAutoZstdCompression = flag.Int64("cache.pebble.min_bytes_auto_zstd_compression", DefaultMinBytesAutoZstdCompression, "Blobs larger than this will be zstd compressed before written to disk.")
 
 	// Chunking related flags
 	averageChunkSizeBytes = flag.Int("cache.pebble.average_chunk_size_bytes", 0, "Average size of chunks that's stored in the cache. Disabled if 0.")
@@ -114,15 +114,16 @@ var (
 	// Default values for Options
 	// (It is valid for these options to be 0, so we use ptrs to indicate whether they're set.
 	// Their defaults must be vars so we can take their addresses)
-	DefaultAtimeUpdateThreshold     = 10 * time.Minute
-	DefaultAtimeBufferSize          = 100000
-	DefaultNumAtimeUpdateWorkers    = 16
-	DefaultSampleBufferSize         = 8000
-	DefaultSamplesPerBatch          = 10000
-	DefaultSamplerIterRefreshPeriod = 5 * time.Minute
-	DefaultDeleteBufferSize         = 20
-	DefaultNumDeleteWorkers         = 16
-	DefaultMinEvictionAge           = 6 * time.Hour
+	DefaultAtimeUpdateThreshold        = 10 * time.Minute
+	DefaultAtimeBufferSize             = 100000
+	DefaultNumAtimeUpdateWorkers       = 16
+	DefaultSampleBufferSize            = 8000
+	DefaultSamplesPerBatch             = 10000
+	DefaultSamplerIterRefreshPeriod    = 5 * time.Minute
+	DefaultDeleteBufferSize            = 20
+	DefaultNumDeleteWorkers            = 16
+	DefaultMinEvictionAge              = 6 * time.Hour
+	DefaultMinBytesAutoZstdCompression = int64(100)
 
 	DefaultName         = "pebble_cache"
 	DefaultMaxSizeBytes = cache_config.MaxSizeBytes()
@@ -178,7 +179,7 @@ type Options struct {
 	Partitions        []disk.Partition
 	PartitionMappings []disk.PartitionMapping
 
-	MinBytesAutoZstdCompression int64
+	MinBytesAutoZstdCompression *int64
 
 	MaxSizeBytes           int64
 	BlockCacheSizeBytes    int64
@@ -346,7 +347,7 @@ func Register(env *real_environment.RealEnv) error {
 		BlockCacheSizeBytes:         *blockCacheSizeBytesFlag,
 		MaxSizeBytes:                cache_config.MaxSizeBytes(),
 		MaxInlineFileSizeBytes:      *maxInlineFileSizeBytesFlag,
-		MinBytesAutoZstdCompression: *minBytesAutoZstdCompression,
+		MinBytesAutoZstdCompression: minBytesAutoZstdCompression,
 		AtimeUpdateThreshold:        atimeUpdateThresholdFlag,
 		AtimeBufferSize:             atimeBufferSizeFlag,
 		NumAtimeUpdateWorkers:       numAtimeUpdateWorkers,
@@ -470,6 +471,9 @@ func SetOptionDefaults(opts *Options) {
 	if opts.GCSTTLDays == nil || *opts.GCSTTLDays == 0 {
 		var ttlInDays int64 = 0
 		opts.GCSTTLDays = &ttlInDays
+	}
+	if opts.MinBytesAutoZstdCompression == nil {
+		opts.MinBytesAutoZstdCompression = &DefaultMinBytesAutoZstdCompression
 	}
 }
 
@@ -667,7 +671,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		accesses:                    make(chan *accessTimeUpdate, *opts.AtimeBufferSize),
 		evictors:                    make([]*partitionEvictor, len(opts.Partitions)),
 		bufferPool:                  bytebufferpool.VariableSize(CompressorBufSizeBytes),
-		minBytesAutoZstdCompression: opts.MinBytesAutoZstdCompression,
+		minBytesAutoZstdCompression: *opts.MinBytesAutoZstdCompression,
 		metricsCollector:            mc,
 		includeMetadataSize:         opts.IncludeMetadataSize,
 		minGCSFileSizeBytes:         *opts.MinGCSFileSizeBytes,

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -563,6 +563,9 @@ func TestMetadata(t *testing.T) {
 
 	averageChunkSizeBytesParam := []int{0, 64 * 4}
 
+	// Turn off automatic compression
+	minBytesAutoZstdCompression := int64(math.MaxInt64)
+
 	testCases := []struct {
 		name       string
 		cacheType  rspb.CacheType
@@ -598,7 +601,7 @@ func TestMetadata(t *testing.T) {
 			RootDirectory:               testfs.MakeTempDir(t),
 			MaxSizeBytes:                maxSizeBytes,
 			MaxInlineFileSizeBytes:      100,
-			MinBytesAutoZstdCompression: math.MaxInt64, // Turn off automatic compression
+			MinBytesAutoZstdCompression: &minBytesAutoZstdCompression,
 			AverageChunkSizeBytes:       averageChunkSizeBytes,
 		}
 		pc, err := pebble_cache.NewPebbleCache(te, options)
@@ -1607,7 +1610,7 @@ func TestLRU(t *testing.T) {
 				AtimeUpdateThreshold:        pointer(time.Duration(0)), // update atime on every access
 				AtimeBufferSize:             pointer(0),                // blocking channel of atime updates
 				MinEvictionAge:              pointer(time.Duration(0)), // no min eviction age
-				MinBytesAutoZstdCompression: maxSizeBytes,
+				MinBytesAutoZstdCompression: &maxSizeBytes,
 				MaxInlineFileSizeBytes:      tc.maxInlineFileSizeBytes,
 				AverageChunkSizeBytes:       tc.averageChunkSizeBytes,
 				ActiveKeyVersion:            pointer(int64(5)),
@@ -3196,6 +3199,9 @@ func dirSizeFiles(path string) (int64, error) {
 }
 
 func TestCacheStaysBelowConfiguredSize(t *testing.T) {
+	// minBytesAutoZstdCompression setting so that we don't compress anything.
+	minBytesAutoZstdCompression := int64(math.MaxInt64)
+
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(t, te)
@@ -3217,7 +3223,7 @@ func TestCacheStaysBelowConfiguredSize(t *testing.T) {
 				MinEvictionAge:              pointer(time.Duration(0)),
 				AtimeUpdateThreshold:        pointer(time.Duration(0)),
 				AtimeBufferSize:             pointer(0),
-				MinBytesAutoZstdCompression: math.MaxInt64, // don't compress anything.
+				MinBytesAutoZstdCompression: &minBytesAutoZstdCompression,
 			},
 		},
 		{
@@ -3228,8 +3234,8 @@ func TestCacheStaysBelowConfiguredSize(t *testing.T) {
 				MinEvictionAge:              pointer(time.Duration(0)),
 				AtimeUpdateThreshold:        pointer(time.Duration(0)),
 				AtimeBufferSize:             pointer(0),
-				MinBytesAutoZstdCompression: math.MaxInt64, // don't compress anything.
-				MaxInlineFileSizeBytes:      -1,            // don't inline anything.
+				MinBytesAutoZstdCompression: &minBytesAutoZstdCompression,
+				MaxInlineFileSizeBytes:      -1, // don't inline anything.
 			},
 		},
 		{
@@ -3240,7 +3246,7 @@ func TestCacheStaysBelowConfiguredSize(t *testing.T) {
 				MinEvictionAge:              pointer(time.Duration(0)),
 				AtimeUpdateThreshold:        pointer(time.Duration(0)),
 				AtimeBufferSize:             pointer(0),
-				MinBytesAutoZstdCompression: math.MaxInt64, // don't compress anything.
+				MinBytesAutoZstdCompression: &minBytesAutoZstdCompression,
 				IncludeMetadataSize:         true,
 			},
 		},
@@ -3252,7 +3258,7 @@ func TestCacheStaysBelowConfiguredSize(t *testing.T) {
 				MinEvictionAge:              pointer(time.Duration(0)),
 				AtimeUpdateThreshold:        pointer(time.Duration(0)),
 				AtimeBufferSize:             pointer(0),
-				MinBytesAutoZstdCompression: math.MaxInt64, // don't compress anything.
+				MinBytesAutoZstdCompression: &minBytesAutoZstdCompression,
 				IncludeMetadataSize:         true,
 
 				Clock:                  clock,


### PR DESCRIPTION
Right now, the default value is inconsistent between pebble cache and the pebble
cache inside the migration cache. Make sure they share the same default.

Since 0 is a valid value, I change it to a pointer similar to other fields.
