### PR TITLE
fix(enterprise/app): show "(empty)" values explicitly for drilldown

### DIFF
--- a/enterprise/app/filter/filter_util.tsx
+++ b/enterprise/app/filter/filter_util.tsx
@@ -106,7 +106,7 @@ function parseDimensionType(stringValue: string): stat_filter.Dimension | undefi
 export function getDimensionParamFromFilters(filters: stat_filter.DimensionFilter[]): string {
   const filterStrings = filters
     .map((f) => {
-      if (!(f.dimension?.execution || f.dimension?.invocation) || !f.value) {
+      if (!(f.dimension?.execution || f.dimension?.invocation) || f.value === undefined || f.value === null) {
         return undefined;
       }
       let dimensionName = "";
@@ -146,7 +146,7 @@ export function getFiltersFromDimensionParam(dimensionParamValue: string): stat_
     }
     dimensionParamValue = dimensionParamValue.substring(separatorIndex + 1);
     separatorIndex = dimensionParamValue.indexOf("|");
-    if (separatorIndex == -1 || separatorIndex + 1 === dimensionParamValue.length) {
+    if (separatorIndex == -1) {
       break;
     }
 


### PR DESCRIPTION
Previously, empty values just show up as nothing, and drilldown by them doesn't work. If users want to explicitly drill down by the Default pool, they need to be able to filter where `pool = ""`. 

Before:
<img width="706" height="345" alt="Screenshot 2025-11-06 at 12 19 06 PM" src="https://github.com/user-attachments/assets/d7cef07b-b5a0-496c-bc17-34fb15dfdedb" />

After:
<img width="670" height="224" alt="Screenshot 2025-11-06 at 1 00 39 PM" src="https://github.com/user-attachments/assets/29055960-3209-4d5b-b803-0bb26a6ba145" />

Ref: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5984
