### PR TITLE
feat(enterprise/app): link executor pools to drilldown page

### DIFF
--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -1,10 +1,10 @@
-import { Cpu, Globe, Hash, Laptop, LucideIcon } from "lucide-react";
+import { BarChart2, Cpu, Globe, Hash, Laptop, LucideIcon } from "lucide-react";
 import React from "react";
 import { Subscription } from "rxjs";
 import { User } from "../../../app/auth/auth_service";
 import Banner from "../../../app/components/banner/banner";
 import LinkButton from "../../../app/components/button/link_button";
-import { TextLink } from "../../../app/components/link/link";
+import Link, { TextLink } from "../../../app/components/link/link";
 import Select, { Option } from "../../../app/components/select/select";
 import router from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
@@ -13,6 +13,8 @@ import { api_key } from "../../../proto/api_key_ts_proto";
 import { bazel_config } from "../../../proto/bazel_config_ts_proto";
 import { capability } from "../../../proto/capability_ts_proto";
 import { scheduler } from "../../../proto/scheduler_ts_proto";
+import { stat_filter } from "../../../proto/stat_filter_ts_proto";
+import { encodeEffectivePoolUrlParam, encodeMetricUrlParam } from "../trends/common";
 import ExecutorCardComponent from "./executor_card";
 
 enum FetchType {
@@ -167,9 +169,25 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
               if (!executors || executors.length == 0) {
                 return null;
               }
+              const poolName = executors[0].executor.node?.pool || "Default Pool";
+              const poolValue = executors[0].executor.node?.pool || "";
+              const poolUrlParam = encodeEffectivePoolUrlParam(poolValue);
+              const metricUrlParam = encodeMetricUrlParam(
+                stat_filter.Metric.create({
+                  execution: stat_filter.ExecutionMetricType.EXECUTION_WALL_TIME_EXECUTION_METRIC,
+                })
+              );
               return (
                 <>
-                  <h2>{executors[0].executor.node?.pool || "Default Pool"}</h2>
+                  <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+                    <h2>{poolName}</h2>
+                    <Link
+                      className="executor-history-button history-button"
+                      style={{ marginTop: "32px" }}
+                      href={`/trends/?d=${encodeURIComponent(poolUrlParam)}&ddMetric=${metricUrlParam}#drilldown`}>
+                      <BarChart2 /> View executions
+                    </Link>
+                  </div>
                   <div className="executor-details">
                     {executors[0].region && (
                       <ExecutorDetail Icon={Globe} label="">


### PR DESCRIPTION
## Summary

Added a button (looks like a bar graph), that when hovered, shows "View Executions".

This links the user over to the drilldown page by the pool.

No hover:
<img width="499" height="730" alt="2" src="https://github.com/user-attachments/assets/651f3abc-2730-40af-8ca9-cde11adab191" />

Hover:
<img width="483" height="578" alt="1" src="https://github.com/user-attachments/assets/2e45f44a-71ed-497c-9f83-c8cbf93f71fe" />

Ref https://github.com/buildbuddy-io/buildbuddy-internal/issues/5984