### PR TITLE
enable proto toolchain resolution and prebuilt protoc

### DIFF
--- a/buildpatches/protoc_gen_protobufjs_use_toolchain.patch
+++ b/buildpatches/protoc_gen_protobufjs_use_toolchain.patch
@@ -1,0 +1,62 @@
+diff --git a/rules.bzl b/rules.bzl
+index b4a6843..cbb0315 100644
+--- a/rules.bzl
++++ b/rules.bzl
+@@ -1,4 +1,6 @@
+ load("@rules_proto//proto:defs.bzl", "ProtoInfo")
++load("@rules_proto//proto:proto_common.bzl", proto_toolchains = "toolchains")
++load("@com_google_protobuf//bazel/common:proto_common.bzl", "proto_common")
+ 
+ def _trim_prefix(text, prefix):
+     if text.startswith(prefix):
+@@ -18,6 +20,13 @@ ProtobufjsInfo = provider(
+ )
+ 
+ def _protoc_gen_protobufjs_impl(ctx):
++    if getattr(proto_common, "INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION", False):
++        proto_toolchain = ctx.toolchains["@rules_proto//proto:toolchain_type"]
++        if not proto_toolchain:
++            fail("No proto toolchain found.")
++        protoc_executable = proto_toolchain.proto.proto_compiler
++    else:
++        protoc_executable = ctx.executable._protoc
+     gen_import_path = _package_path(ctx) + "/" + ctx.attr.out
+ 
+     # Use strict_imports since we expect all direct proto imports to
+@@ -71,7 +80,7 @@ def _protoc_gen_protobufjs_impl(ctx):
+         outputs = outputs,
+         inputs = inputs,
+         tools = [ctx.executable._protoc_gen_protobufjs],
+-        executable = ctx.executable._protoc,
++        executable = protoc_executable,
+         arguments = args,
+ 
+         # Debug:
+@@ -131,12 +140,6 @@ protoc_gen_protobufjs = rule(
+             """,
+             default = [],
+         ),
+-        "_protoc": attr.label(
+-            default = "@com_google_protobuf//:protoc",
+-            executable = True,
+-            cfg = "exec",
+-            allow_single_file = True,
+-        ),
+         "_protoc_gen_protobufjs": attr.label(
+             default = "@com_github_buildbuddy_io_protoc_gen_protobufjs//:protoc-gen-protobufjs",
+             executable = True,
+@@ -159,5 +162,13 @@ protoc_gen_protobufjs = rule(
+                 "@com_google_protobuf//:wrappers_proto",
+             ],
+         ),
+-    },
++    } | proto_toolchains.if_legacy_toolchain({
++        "_protoc": attr.label(
++            default = "@com_google_protobuf//:protoc",
++            executable = True,
++            cfg = "exec",
++            allow_single_file = True,
++        ),
++    }),
++    toolchains = proto_toolchains.use_toolchain("@rules_proto//proto:toolchain_type"),
+ )

--- a/deps.bzl
+++ b/deps.bzl
@@ -15,6 +15,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         name = "com_github_buildbuddy_io_protoc_gen_protobufjs",
         integrity = "sha256-VL3iXrCZj9OiYrads5Ve6uHjppfc5i8mHexOrVvpOI4=",
         urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.13/protoc-gen-protobufjs-v0.0.13.tar.gz"],
+        patches = ["//buildpatches:protoc_gen_protobufjs_use_toolchain.patch"],
+        patch_strip = 1,
     )
     http_archive(
         name = "com_github_sluongng_nogo_analyzer",

--- a/deps/bazel_dep.MODULE.bazel
+++ b/deps/bazel_dep.MODULE.bazel
@@ -70,6 +70,16 @@ archive_override(
     urls = ["https://github.com/buildbuddy-io/rules_k8s/archive/a40e8ad10fe00afd8bd149e558e5572793ca5873.tar.gz"],
 )
 
+bazel_dep(name = "toolchains_protoc", version = "0.6.0") # must come BEFORE protobuf so the toolchain registration wins
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf")
+# TODO(tyler-french): remove once https://github.com/protocolbuffers/protobuf/pull/19679 is included in a protobuf release.
+archive_override(
+    module_name = "protobuf",
+    integrity = "sha256-escvR0NBkLeowzVsjSbTzVsopPtU3f5+gESVq5puD2Y=",
+    strip_prefix = "protobuf-4986a7722460e3163f37c98da1cb47f52c6406e1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/4986a7722460e3163f37c98da1cb47f52c6406e1.tar.gz"],
+)
+
 ## Regular bazel_deps
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
@@ -80,7 +90,6 @@ bazel_dep(name = "aspect_rules_swc", version = "2.5.0")
 bazel_dep(name = "aspect_rules_ts", version = "3.6.3")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "protobuf", version = "32.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "redis", version = "5.0.4")
 bazel_dep(name = "rules_cc", version = "0.2.9")
 bazel_dep(name = "rules_go", version = "0.58.3", repo_name = "io_bazel_rules_go")

--- a/deps/toolchains.MODULE.bazel
+++ b/deps/toolchains.MODULE.bazel
@@ -54,6 +54,9 @@ toolchains_musl.config(
 )
 use_repo(toolchains_musl, "musl_toolchains_hub")
 
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+protoc.toolchain(version = "v32.1")
+
 # Bazel binaries for integration testing
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -20,6 +20,9 @@ common --module_mirrors=https://bcr.cloudflaremirrors.com
 # Avoid being broken by version requirement changes in transitive deps.
 common --check_direct_dependencies=error
 
+# Enable proto toolchain resolution to use pre-built protoc.
+common --incompatible_enable_proto_toolchain_resolution
+
 # Sanitize environment variables to avoid cache misses.
 common --incompatible_strict_action_env
 


### PR DESCRIPTION
## Summary

Since we're just using standard protobuf `v32.1`, we can use the prebuilt protoc toolchain, rather than building the protoc binary from source.

Certain protobuf things, like well known protos, will still need to be built using the protobuf library; however, this should still speed up builds, and also prevent any non-determinism or non-hermeticity from building protoc from leaking into action digests.

One additional patch needed is to tell the `ts_proto_library` to use the toolchain.

## Test
Disable: `--incompatible_enable_proto_toolchain_resolution`
```
➜  buildbuddy git:(tfrench/protoc) ✗ bazel query "somepath(//enterprise/server/cmd/server:buildbuddy, @com_google_protobuf//:protoc)" --output=graph
INFO: Invocation ID: fc930973-8e98-4951-81ff-146020f7454a
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/fc930973-8e98-4951-81ff-146020f7454a
digraph mygraph {
  node [shape=box];
  "//enterprise/server/cmd/server:buildbuddy"
  "//enterprise/server/cmd/server:buildbuddy" -> "//enterprise/app:app_bundle"
  "//enterprise/server/cmd/server:buildbuddy" -> "@com_google_protobuf//:protoc"
  "//enterprise/app:app_bundle"
  "//enterprise/app:app_bundle" -> "//enterprise/app:app"
  "//enterprise/app:app"
  "//enterprise/app:app" -> "//enterprise/app/root:root"
  "//enterprise/app/root:root"
  "//enterprise/app/root:root" -> "@com_google_protobuf//:protoc"
  "//enterprise/app/root:root" -> "//proto:api_key_ts_proto"
  "//enterprise/app/root:root" -> "//proto:api_key_ts_proto__gen_protobufjs"
  "//proto:api_key_ts_proto"
  "//proto:api_key_ts_proto" -> "//proto:api_key_ts_proto__gen_protobufjs"
  "//proto:api_key_ts_proto" -> "@com_google_protobuf//:protoc"
  "//proto:api_key_ts_proto__gen_protobufjs"
  "//proto:api_key_ts_proto__gen_protobufjs" -> "@com_google_protobuf//:protoc"
  "@com_google_protobuf//:protoc"
}
Loading: 2217 packages loaded
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/fc930973-8e98-4951-81ff-146020f7454a
```
Enable `--incompatible_enable_proto_toolchain_resolution`
```
➜  buildbuddy git:(tfrench/protoc) ✗ bazel query "somepath(//enterprise/server/cmd/server:buildbuddy, @com_google_protobuf//:protoc)" --output=graph
INFO: Invocation ID: 41144741-793e-4e9f-9fba-663e1ce78b7a
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/41144741-793e-4e9f-9fba-663e1ce78b7a
digraph mygraph {
  node [shape=box];
}
INFO: Empty results
Loading: 2155 packages loaded
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/41144741-793e-4e9f-9fba-663e1ce78b7a
```