### PR TITLE
[oci] do not fetch layer metadata in MediaType()

### DIFF
--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -925,14 +925,7 @@ func (l *layerFromDigest) Size() (int64, error) {
 }
 
 func (l *layerFromDigest) MediaType() (types.MediaType, error) {
-	if l.desc != nil {
-		return l.desc.MediaType, nil
-	}
-	remoteLayer, err := l.createRemoteLayer()
-	if err != nil {
-		return "", err
-	}
-	return remoteLayer.MediaType()
+	return types.DockerLayer, nil
 }
 
 func (l *layerFromDigest) fetchLayerFromCache() (io.ReadCloser, error) {


### PR DESCRIPTION
Under the hood, `go-containerregistry` just returns a constant for layer's media type. We may as well, too!

https://github.com/google/go-containerregistry/blob/v0.20.3/pkg/v1/remote/layer.go#L59