### PR TITLE
[attempt 2] enable proto toolchain resolution and prebuilt protoc

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -13,8 +13,8 @@ PODMAN_STATIC_SHA256_ARM64 = "ef1e84ab80ee5d78d4d2e59e128ff963038f39e1e4259a83e0
 def install_static_dependencies(workspace_name = "buildbuddy"):
     http_archive(
         name = "com_github_buildbuddy_io_protoc_gen_protobufjs",
-        integrity = "sha256-VL3iXrCZj9OiYrads5Ve6uHjppfc5i8mHexOrVvpOI4=",
-        urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.13/protoc-gen-protobufjs-v0.0.13.tar.gz"],
+        integrity = "sha256-0Glb6xE/18H8cVTsfolRVmAOX1Rgrm3XAkJMT1W1dkI=",
+        urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.14/protoc-gen-protobufjs-v0.0.14.tar.gz"],
     )
     http_archive(
         name = "com_github_sluongng_nogo_analyzer",

--- a/deps/bazel_dep.MODULE.bazel
+++ b/deps/bazel_dep.MODULE.bazel
@@ -70,6 +70,16 @@ archive_override(
     urls = ["https://github.com/buildbuddy-io/rules_k8s/archive/a40e8ad10fe00afd8bd149e558e5572793ca5873.tar.gz"],
 )
 
+bazel_dep(name = "toolchains_protoc", version = "0.6.0") # must come BEFORE protobuf so the toolchain registration wins
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf")
+# TODO(tyler-french): remove once https://github.com/protocolbuffers/protobuf/pull/19679 is included in a protobuf release.
+archive_override(
+    module_name = "protobuf",
+    integrity = "sha256-escvR0NBkLeowzVsjSbTzVsopPtU3f5+gESVq5puD2Y=",
+    strip_prefix = "protobuf-4986a7722460e3163f37c98da1cb47f52c6406e1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/4986a7722460e3163f37c98da1cb47f52c6406e1.tar.gz"],
+)
+
 ## Regular bazel_deps
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
@@ -80,7 +90,6 @@ bazel_dep(name = "aspect_rules_swc", version = "2.5.0")
 bazel_dep(name = "aspect_rules_ts", version = "3.6.3")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "protobuf", version = "32.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "redis", version = "5.0.4")
 bazel_dep(name = "rules_cc", version = "0.2.9")
 bazel_dep(name = "rules_go", version = "0.58.3", repo_name = "io_bazel_rules_go")

--- a/deps/toolchains.MODULE.bazel
+++ b/deps/toolchains.MODULE.bazel
@@ -54,6 +54,9 @@ toolchains_musl.config(
 )
 use_repo(toolchains_musl, "musl_toolchains_hub")
 
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+protoc.toolchain(version = "v32.1")
+
 # Bazel binaries for integration testing
 bazel_binaries = use_extension(
     "@rules_bazel_integration_test//:extensions.bzl",

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -20,6 +20,9 @@ common --module_mirrors=https://bcr.cloudflaremirrors.com
 # Avoid being broken by version requirement changes in transitive deps.
 common --check_direct_dependencies=error
 
+# Enable proto toolchain resolution to use pre-built protoc.
+common --incompatible_enable_proto_toolchain_resolution
+
 # Sanitize environment variables to avoid cache misses.
 common --incompatible_strict_action_env
 


### PR DESCRIPTION
Previous attempt couldn't properly resolve the patch file on deploy.

To avoid this issue, we simply upstreamed the patch: https://github.com/buildbuddy-io/protoc-gen-protobufjs/pull/4