### PR TITLE
Show execution target and mnemonic on the execution page

### DIFF
--- a/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
+++ b/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
@@ -157,10 +157,15 @@ common --incompatible_strict_action_env=true
 	require.Contains(t, execution.Text(), "Succeeded", "should show stage")
 	require.Contains(t, execution.Text(), "genrule-setup.sh", "should show command_snippet")
 
-	// Click the execution and make sure the execution ID matches the original.
+	// Click the execution and make sure the execution ID matches the original,
+	// and that we can see basic execution metadata.
 	execution.Click()
 	executionID2 := wt.Find(`[debug-id="execution-id"]`).Text()
 	require.Equal(t, originalExecutionID, executionID2)
+	if tc.expectTargetLabelVisible {
+		targetLabel := wt.Find(`[debug-id="target-label"]`).Text()
+		require.Equal(t, "//:target1", targetLabel)
+	}
 
 	// Now go to Drilldowns, drilldown by execution wall time, and click the
 	// rectangle shown in the heatmap. This should select the invocations

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -202,12 +202,16 @@ message RunnerMetadata {
 }
 
 message ExecutionLookup {
-  // The invocation_id: a fully qualified execution ID
+  // The invocation_id associated with the execution.
   string invocation_id = 1;
 
   // Optional action digest filter. Only the executions for this action digest
   // will be returned.
   string action_digest_hash = 2;
+
+  // Optional execution ID. Only the specific execution with this ID will be
+  // returned.
+  string execution_id = 3;
 }
 
 message GetExecutionRequest {


### PR DESCRIPTION
We currently show the target label and action mnemonic in the execution listing, but not when clicking the execution. This makes it so that we show it when clicking the execution as well.

<img width="1106" height="429" alt="image" src="https://github.com/user-attachments/assets/56df1300-ecc2-4df9-afcc-72f412777b3a" />
