### PR TITLE
running distributed -> meta cache locally

### DIFF
--- a/enterprise/config/buildbuddy-migration.local.yaml
+++ b/enterprise/config/buildbuddy-migration.local.yaml
@@ -33,6 +33,8 @@ cache:
         replication_factor: 3
         cluster_size: 4
         listen_addr: ${LISTEN_ADDR}
+        # The addresses of the peer nodes are defined in
+        # tools/goreman/procifles/Procfile.migration.
         nodes:
           - localhost:1337
           - localhost:1338

--- a/tools/goreman/procfiles/Procfile.migration
+++ b/tools/goreman/procfiles/Procfile.migration
@@ -1,3 +1,7 @@
+# If you change LISTEN_ADDR in app1 to app4, please also change
+# cache.migration.src.distributed.nodes in
+# enterprise/config/buildbuddy-metacache.local.yaml
+
 app1: ROOT_DIRECTORY=/tmp/dcache1 LISTEN_ADDR="localhost:1337" bazel run enterprise/server -- --config_file=enterprise/config/buildbuddy-migration.local.yaml --port=8080 --grpc_port=1985 --internal_grpc_port=1987 --telemetry_port=9099 --monitoring_port=9090 --config_secrets.provider=gcp --config_secrets.gcp.project_id=flame-build 
 
 app2: ROOT_DIRECTORY=/tmp/dcache2 LISTEN_ADDR="localhost:1338" bazel run enterprise/server -- --config_file=enterprise/config/buildbuddy-migration.local.yaml --port=8081 --grpc_port=2986 --internal_grpc_port=3986 --telemetry_port=9100 --monitoring_port=9191 --config_secrets.provider=gcp --config_secrets.gcp.project_id=flame-build 


### PR DESCRIPTION
Add a yaml and Procfile to run migration from distribtued -> meta cache locally

This depends on https://github.com/buildbuddy-io/buildbuddy/pull/10657
