### PR TITLE
Move grafana dashboards to Buildbuddy Standard Time (BST)

### DIFF
--- a/tools/metrics/grafana/dashboards/baremetal-networking.json
+++ b/tools/metrics/grafana/dashboards/baremetal-networking.json
@@ -755,7 +755,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "America/Los_Angeles",
   "title": "Baremetal Networking",
   "uid": "df22a5nr1yio0e"
 }

--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -20107,7 +20107,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "BuildBuddy Metrics",
   "uid": "1rsE5yoGz"
 }

--- a/tools/metrics/grafana/dashboards/cache-proxy.json
+++ b/tools/metrics/grafana/dashboards/cache-proxy.json
@@ -8665,7 +8665,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "Cache Proxy Metrics",
   "uid": "lVC084qx5"
 }

--- a/tools/metrics/grafana/dashboards/cache.json
+++ b/tools/metrics/grafana/dashboards/cache.json
@@ -1606,7 +1606,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "Remote Cache",
   "uid": "9Zuc5O7Iz"
 }

--- a/tools/metrics/grafana/dashboards/globalstatus.json
+++ b/tools/metrics/grafana/dashboards/globalstatus.json
@@ -1427,7 +1427,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "globalstatus",
   "uid": "a42a59ae-6753-4b18-baad-34dd8183d9d4"
 }

--- a/tools/metrics/grafana/dashboards/mac.json
+++ b/tools/metrics/grafana/dashboards/mac.json
@@ -5163,7 +5163,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "BuildBuddy Mac Metrics",
   "uid": "U-ICDemSz"
 }

--- a/tools/metrics/grafana/dashboards/nodes.json
+++ b/tools/metrics/grafana/dashboards/nodes.json
@@ -954,7 +954,7 @@
       "1d"
     ]
   },
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "Kubernetes Nodes",
   "uid": "QfTfJH7Iz",
   "weekStart": ""

--- a/tools/metrics/grafana/dashboards/raft.json
+++ b/tools/metrics/grafana/dashboards/raft.json
@@ -8829,7 +8829,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "Raft",
   "uid": "dbbffdbe-e2d2-4297-bd36-2544b51850ef"
 }

--- a/tools/metrics/grafana/dashboards/rbeperf.json
+++ b/tools/metrics/grafana/dashboards/rbeperf.json
@@ -462,7 +462,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "BuildBuddy Remote Execution Performance",
   "uid": "bKW9Rr_Mk"
 }

--- a/tools/metrics/grafana/dashboards/workflow.json
+++ b/tools/metrics/grafana/dashboards/workflow.json
@@ -1366,7 +1366,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "America/Los_Angeles",
   "title": "Workflow Snapshotting",
   "uid": "KI6NxDWSk"
 }


### PR DESCRIPTION
We don't have to do this, but I thought it might make our oncall discussions when triaging issues a little easier.


Why not UTC? Well, then we'd all be doing the conversion wrong.