### PR TITLE
Write compact exec log to workspace root

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -56,7 +56,7 @@ common --experimental_profile_include_primary_output
 common --noslim_profile
 # Include compact execution log
 # TODO(sluongng): make Bazel writes this to output_base automatically
-common --execution_log_compact_file=bazel_compact_exec_log.binpb.zst
+common --execution_log_compact_file=%workspace%/bazel_compact_exec_log.binpb.zst
 
 # Disable https://github.com/aspect-build/tools_telemetry.
 common --repo_env=DO_NOT_TRACK=1


### PR DESCRIPTION
Before this change, when invoking bazel from a subdir, the log would be written to the subdir, which is not desired.