### PR TITLE
Allow setting visibility in workflow config

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -54,6 +54,7 @@ type Action struct {
 	GitFetchDepth      *int              `yaml:"git_fetch_depth"`
 	BazelWorkspaceDir  string            `yaml:"bazel_workspace_dir"`
 	Env                map[string]string `yaml:"env"`
+	Visibility         string            `yaml:"visibility"`
 	PlatformProperties map[string]string `yaml:"platform_properties"`
 	Steps              []*rnpb.Step      `yaml:"steps"`
 	Timeout            *time.Duration    `yaml:"timeout"`

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1059,6 +1059,9 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	if wd.IsTargetRepoPublic {
 		visibility = "PUBLIC"
 	}
+	if workflowAction.Visibility != "" {
+		visibility = workflowAction.Visibility
+	}
 	includeSecretsPropertyValue := "false"
 	if isTrusted && ws.env.GetSecretService() != nil {
 		includeSecretsPropertyValue = "true"


### PR DESCRIPTION
We already support `visibility` in the API - this PR adds support to the config YAML too.

Context: https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1763055814467329?thread_ts=1763055310.225499&cid=C01D5GHRJ59