### PR TITLE
Remove print statement from bb remote-download

### DIFF
--- a/cli/remote_download/remote_download.go
+++ b/cli/remote_download/remote_download.go
@@ -103,7 +103,6 @@ func HandleRemoteDownload(args []string) (int, error) {
 			Name:  name,
 			Value: value,
 		})
-		fmt.Printf("Qualifier name: %q value: %q\n", name, value)
 	}
 	client := rapb.NewFetchClient(conn)
 


### PR DESCRIPTION
`bb remote-download` returns a digest that you can pass to `bb download` to download the artifact from the cache.

Theoretically you could do something like `bb remote-download <URI> | xargs bb download` but because remote-download prints debug logs, they interfere with the output. Also the qualifiers may contain things like tokens to fetch the URI that we don't want to log