### PR TITLE
In remote-download CLI, automatically fetch and apply the checksum for Google Artifact Registry urls

### DIFF
--- a/cli/remote_download/BUILD
+++ b/cli/remote_download/BUILD
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/arg",
+        "//cli/log",
         "//cli/login",
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",


### PR DESCRIPTION
`bb remote-download` can be used to cache artifacts from the Google Artifact Registry to reduce egress costs

`remote-download` hits the remote asset API, which takes a checksum for the requested URL. If no checksum is provided, the URL is always fetched from source, in case the contents have changed since the last fetch. This nullifies the benefits of caching the data

This PR fetches the checksum if not provided, to guarantee that cached artifacts are actually used