### PR TITLE
a (hopefully readable) way to stream BS writes to two servers

### DIFF
--- a/enterprise/server/routing/routing_byte_stream_client/BUILD
+++ b/enterprise/server/routing/routing_byte_stream_client/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/metrics",
         "//server/remote_cache/digest",
         "//server/util/background",
         "//server/util/flag",
@@ -21,5 +22,6 @@ go_library(
         "//server/util/usageutil",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//status",
     ],
 )


### PR DESCRIPTION
this literally just queues up the different function calls from the incoming stream to be sent to a secondary stream while continuing to do the primary stream synchronously.  since a secondary stream failure should ideally not hold up the primary stream, we use a channel as a queue to allow it to lag a bit (this uses ExtendContentForFinalization to let the secondary write run a little longer)