### PR TITLE
raft: return gcs metadata in find

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1061,6 +1061,7 @@ func (sm *Replica) find(db ReplicaReader, req *rfpb.FindRequest) (*rfpb.FindResp
 	return &rfpb.FindResponse{
 		Present:        present,
 		LastAccessUsec: fileMetadata.GetLastAccessUsec(),
+		GcsMetadata:    fileMetadata.GetStorageMetadata().GetGcsMetadata(),
 	}, nil
 }
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -651,6 +651,8 @@ message FindResponse {
   bool present = 1;
   // The last time this file record was accessed.
   int64 last_access_usec = 2;
+  // The gcs_metadata of this file record, if exist.
+  storage.StorageMetadata.GCSMetadata gcs_metadata = 3;
 }
 
 message GetRequest {


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/6072

In order to update a time for gcs, we need to know the gcs metadata in find
response, similar to last_access_time_usec to avoid an additional lookup.

Added a test to make sure both fields are set.
