### PR TITLE
Remove corrupted metadata cleanup code in the fetch server

### DIFF
--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -363,16 +363,6 @@ func (p *FetchServer) findBlobInCache(ctx context.Context, instanceName string, 
 		return nil
 	}
 
-	// TODO(Maggie): Remove after corrupted data has been evicted from cache.
-	// If the size is 1, that indicates metadata corruption. Delete the entry from the cache.
-	if md.DigestSizeBytes == 1 {
-		log.CtxInfof(ctx, "FetchServer found corrupted metadata for %v. Deleting from cache.", cacheRN.ToProto())
-		if err := cache.Delete(ctx, cacheRN.ToProto()); err != nil {
-			log.CtxErrorf(ctx, "Failed to delete artifact with corrupted metadata %v from cache: %s", cacheRN.ToProto(), err)
-		}
-		return nil
-	}
-
 	blobDigest.SizeBytes = md.DigestSizeBytes
 
 	// Even though we successfully fetched metadata, we need to renew


### PR DESCRIPTION
Follow up to https://github.com/buildbuddy-io/buildbuddy/pull/10509

The last log was from 10/22, so all the corrupted data appears to be gone