### PR TITLE
WIP create ephemeral cache experiment

### DIFF
--- a/server/cache_proxy/BUILD
+++ b/server/cache_proxy/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/cache_proxy",
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//proto:semver_go_proto",
         "//server/environment",
         "//server/interfaces",
@@ -19,6 +20,7 @@ go_library(
         "//server/remote_cache/hit_tracker",
         "//server/util/bazel_request",
         "//server/util/log",
+        "//server/util/prefix",
         "//server/util/proto",
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",


### PR DESCRIPTION
To reduce costs for certain traffic patterns, this enables an experiment which creates a "soft" blocker for certain traffic.

CAS write for files over a threshold from specified groups will cache on the proxy, but not propagate to the backend