### PR TITLE
Add more filecache latency buckets

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1657,7 +1657,7 @@ var (
 		Subsystem: "remote_execution",
 		Name:      "file_cache_op_latency_usec",
 		Help:      "Latency of individual file cache operations.",
-		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*time.Second, 10),
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*time.Hour, 2),
 	}, []string{
 		OpLabel,
 	})


### PR DESCRIPTION
These metrics are very low cardinality (only 4 distinct ops) so we can probably afford to add higher resolution and increase the max bucket.