### PR TITLE
use a separate output_base for gopackagesdriver

### DIFF
--- a/tools/gopackagesdriver
+++ b/tools/gopackagesdriver
@@ -3,4 +3,8 @@
 # cannot be run, so cd back to the workspace root.
 SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 cd $SCRIPT_DIR/..
-exec bazel run -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"
+
+# Use a separate output base for the Go packages driver to allow parallel execution
+# with command-line bazel. The repo cache and disk cache are shared via user.bazelrc.
+OUTPUT_BASE="${HOME}/.bazel/output_base_gopackagesdriver"
+exec -a bazel-gopackagesdriver bazel --output_base="${OUTPUT_BASE}" run -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"


### PR DESCRIPTION
When running bazel commands, I will sometimes see:
```
Another command (pid=60928) is running. Waiting for it to complete on the server (server_pid=19217)..
```
We can avoid this by running go packages driver under a separate outputbase.

This PR additionally:
- Adds the [--preemptible](https://bazel.build/reference/command-line-reference#startup_options-flag--preemptible) flag
- Changes the process name to `bazel-gopackagesdriver`, to distinguish from bazel