### PR TITLE
Revert "Fix `runfiles` access via file resolver and static fs"

### DIFF
--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -5,9 +5,6 @@ go_library(
     srcs = ["static.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/static",
     visibility = ["//visibility:public"],
-    x_defs = {
-        "staticGoRlocation": "$(rlocationpath static.go)",
-    },
     deps = [
         "//proto:config_go_proto",
         "//server/backends/github",
@@ -25,7 +22,7 @@ go_library(
         "//server/util/status",
         "//server/util/subdomain",
         "//server/version",
-        "@io_bazel_rules_go//go/runfiles",
+        "@io_bazel_rules_go//go/tools/bazel",
         "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -5,9 +5,11 @@ import (
 	"html/template"
 	"io/fs"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
-	"github.com/bazelbuild/rules_go/go/runfiles"
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/github"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/target_tracker"
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
@@ -27,8 +29,6 @@ import (
 	remote_execution_config "github.com/buildbuddy-io/buildbuddy/server/remote_execution/config"
 	scheduler_server_config "github.com/buildbuddy-io/buildbuddy/server/scheduling/scheduler_server/config"
 )
-
-var staticGoRlocation string
 
 const (
 	indexTemplateFilename = "index.html"
@@ -76,16 +76,13 @@ var (
 )
 
 func FSFromRelPath(relPath string) (fs.FS, error) {
-	// Get a filesystem containing the runfiles (static content bundled with the binary).
-	runfilesFS, err := runfiles.New()
+	// Figure out where our runfiles (static content bundled with the binary) live.
+	rfp, err := bazel.RunfilesPath()
 	if err != nil {
 		return nil, err
 	}
-	moduleName, _, _ := strings.Cut(staticGoRlocation, "/")
-	if relPath != "" && !strings.HasPrefix(relPath, "/") {
-		moduleName = moduleName + "/"
-	}
-	return fs.Sub(runfilesFS, moduleName+relPath)
+	dirFS := os.DirFS(filepath.Join(rfp, relPath))
+	return dirFS, nil
 }
 
 // StaticFileServer implements a static file http server that serves static

--- a/server/util/fileresolver/BUILD
+++ b/server/util/fileresolver/BUILD
@@ -5,9 +5,6 @@ go_library(
     srcs = ["fileresolver.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/fileresolver",
     visibility = ["//visibility:public"],
-    x_defs = {
-        "fileresolverGoRlocation": "$(rlocationpath fileresolver.go)",
-    },
     deps = ["@io_bazel_rules_go//go/runfiles"],
 )
 
@@ -15,9 +12,6 @@ go_test(
     name = "fileresolver_test",
     size = "small",
     srcs = ["fileresolver_test.go"],
-    data = [
-        "//server/util/fileresolver/test_data:runfiles",
-    ],
     deps = [
         ":fileresolver",
         "//server/util/fileresolver/test_data:bundle",

--- a/server/util/fileresolver/fileresolver.go
+++ b/server/util/fileresolver/fileresolver.go
@@ -1,7 +1,6 @@
 package fileresolver
 
 import (
-	"fmt"
 	"io/fs"
 	"os"
 	"strings"
@@ -9,12 +8,9 @@ import (
 	"github.com/bazelbuild/rules_go/go/runfiles"
 )
 
-var fileresolverGoRlocation string
-
 type fileResolver struct {
 	bundleFS     fs.FS
 	bundlePrefix string
-	moduleName   string
 }
 
 // Open resolves a logical path to a local file, where the path is relative to
@@ -23,30 +19,8 @@ type fileResolver struct {
 // `os.NotExists` can be used to check whether the file does not exist, if an
 // error is returned. The caller is responsible for closing the returned file.
 func (r *fileResolver) Open(name string) (fs.File, error) {
-	rlocation := strings.Builder{}
-	rlocation.WriteString(r.moduleName)
-	if name != "" && !strings.HasPrefix(name, "/") {
-		rlocation.WriteString("/")
-	}
-	rlocation.WriteString(name)
-	return r.OpenFromRlocation(rlocation.String())
-}
-
-// Open resolves a logical path to a local file, where the path is relative to
-// the Bazel workspace root. It first consults the bundle, then Bazel runfiles.
-//
-// `os.NotExists` can be used to check whether the file does not exist, if an
-// error is returned. The caller is responsible for closing the returned file.
-func (r *fileResolver) OpenFromRlocation(rlocation string) (fs.File, error) {
-	if moduleName, _, _ := strings.Cut(rlocation, "/"); r.moduleName != moduleName {
-		return nil, &fs.PathError{
-			Op:   "open",
-			Path: rlocation,
-			Err:  fmt.Errorf("invalid rlocation for file resolver with module name %s", r.moduleName),
-		}
-	}
-	if strings.HasPrefix(rlocation, r.moduleName+"/"+r.bundlePrefix) {
-		f, err := r.bundleFS.Open(strings.TrimPrefix(rlocation, r.moduleName+"/"+r.bundlePrefix))
+	if strings.HasPrefix(name, r.bundlePrefix) {
+		f, err := r.bundleFS.Open(strings.TrimPrefix(name, r.bundlePrefix))
 		if err == nil {
 			return f, nil
 		}
@@ -55,7 +29,7 @@ func (r *fileResolver) OpenFromRlocation(rlocation string) (fs.File, error) {
 		}
 	}
 
-	runfilePath, err := runfiles.Rlocation(rlocation)
+	runfilePath, err := runfiles.Rlocation(name)
 	if err != nil {
 		return nil, err
 	}
@@ -77,10 +51,8 @@ func New(bundleFS fs.FS, bundleRoot string) fs.FS {
 	if bundleRoot != "" && !strings.HasSuffix(bundleRoot, "/") {
 		bundlePrefix = bundleRoot + "/"
 	}
-	moduleName, _, _ := strings.Cut(fileresolverGoRlocation, "/")
 	return &fileResolver{
 		bundleFS:     bundleFS,
 		bundlePrefix: bundlePrefix,
-		moduleName:   moduleName,
 	}
 }

--- a/server/util/fileresolver/test_data/BUILD
+++ b/server/util/fileresolver/test_data/BUILD
@@ -21,12 +21,14 @@ filegroup(
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],
+    data = [":runfiles"],
     embedsrcs = [
         "BUILD",
         "bundle.go",
         "embedded_dir/embedded_child.txt",
         "embedded_file.txt",
-    ],  # keep
+        "runfile.txt",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/fileresolver/test_data",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#10663

This makes the dev push fail because of
```
Error getting static FS from relPath: "../+_repo_rules+com_github_buildbuddy_io_buildbuddy/static/": sub +_repo_rules+com_github_buildbuddy_io_buildbuddy/../+_repo_rules+com_github_buildbuddy_io_buildbuddy/static/: invalid argument
```