### PR TITLE
go.mod: replace tools/deps with tool directive in go.mod

### DIFF
--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -254,6 +254,7 @@ use_repo(
     "com_github_xiam_s_expr",
     "com_github_zeebo_blake3",
     "com_gitlab_arm_research_smarter_smarter_device_manager",
+    "com_google_cloud_go",
     "com_google_cloud_go_compute",
     "com_google_cloud_go_compute_metadata",
     "com_google_cloud_go_logging",

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,28 @@ module github.com/buildbuddy-io/buildbuddy
 
 go 1.25.3
 
+// Device Manager
+tool gitlab.com/arm-research/smarter/smarter-device-manager
+
+// Gazelle deps for 'bb fix'
+tool github.com/pmezard/go-difflib/difflib
+
+// rules_webtesting deps
+tool github.com/gorilla/mux
+
+tool (
+	// static analyzers
+	github.com/nishanths/exhaustive
+	golang.org/x/tools/go/analysis
+	honnef.co/go/tools/staticcheck
+)
+
+// Used by cli/explain/compactgraph/testdata/generate
+tool github.com/otiai10/copy
+
+// Used indirectly through a data dependency by //tools/lint on gomimports
+tool golang.org/x/telemetry/counter
+
 replace (
 	github.com/buildkite/terminal-to-html/v3 => github.com/buildbuddy-io/terminal-to-html/v3 v3.16.8-18
 	github.com/jotfs/fastcdc-go v0.2.0 => github.com/buildbuddy-io/fastcdc-go v0.2.0-rc2
@@ -74,7 +96,6 @@ require (
 	github.com/google/go-github/v59 v59.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/mux v1.8.1
 	github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/hanwen/go-fuse/v2 v2.7.2
@@ -102,14 +123,11 @@ require (
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9
 	github.com/ncruces/go-sqlite3 v0.25.2
-	github.com/nishanths/exhaustive v0.7.11
 	github.com/open-feature/go-sdk v1.14.1
 	github.com/open-feature/go-sdk-contrib/providers/flagd v0.2.6
 	github.com/opencontainers/runtime-spec v1.2.1
-	github.com/otiai10/copy v1.14.0
 	github.com/pkg/errors v0.9.1
 	github.com/planetscale/vtprotobuf v0.6.1-0.20241121165744-79df5c4772f2
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.2
@@ -129,7 +147,6 @@ require (
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/xiam/s-expr v0.0.0-20240311144413-9d7e25c9d7d1
 	github.com/zeebo/blake3 v0.2.3
-	gitlab.com/arm-research/smarter/smarter-device-manager v1.20.11
 	go.opentelemetry.io/contrib/detectors/gcp v1.36.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
@@ -150,10 +167,8 @@ require (
 	golang.org/x/oauth2 v0.32.0
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.37.0
-	golang.org/x/telemetry v0.0.0-20251028164327-d7a2859f34e8
 	golang.org/x/text v0.30.0
 	golang.org/x/time v0.12.0
-	golang.org/x/tools v0.38.0
 	google.golang.org/api v0.247.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c
 	google.golang.org/genproto/googleapis/bytestream v0.0.0-20250804133106-a7a43d27e69b
@@ -167,7 +182,6 @@ require (
 	gorm.io/driver/postgres v1.5.2
 	gorm.io/driver/sqlite v1.5.2
 	gorm.io/gorm v1.25.2
-	honnef.co/go/tools v0.5.1
 	kythe.io v0.0.72
 )
 
@@ -293,6 +307,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -346,15 +361,18 @@ require (
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
+	github.com/nishanths/exhaustive v0.7.11 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/open-feature/flagd-schemas v0.2.9-0.20250127221449-bb763438abc5 // indirect
 	github.com/open-feature/flagd/core v0.11.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/otiai10/copy v1.14.0 // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
 	github.com/prometheus/procfs v0.19.1 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
@@ -383,6 +401,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
+	gitlab.com/arm-research/smarter/smarter-device-manager v1.20.11 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
@@ -391,12 +410,15 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
+	golang.org/x/telemetry v0.0.0-20251028164327-d7a2859f34e8 // indirect
 	golang.org/x/term v0.36.0 // indirect
+	golang.org/x/tools v0.38.0 // indirect
 	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
 	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	honnef.co/go/tools v0.5.1 // indirect
 	k8s.io/apimachinery v0.31.4 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kubelet v0.29.1 // indirect

--- a/tools/deps/deps.go
+++ b/tools/deps/deps.go
@@ -11,30 +11,14 @@
 // The package is shielded with a "go:build tools" directive.
 // Without a specific flag, gazelle should NOT generate go targets for this
 // package.
+//
+// Deprecated: use "go get tool <tool_name>" to add the tool directly into go.mod file instead.
 package deps
 
 import (
-	// Device manager
-	_ "gitlab.com/arm-research/smarter/smarter-device-manager"
-
-	// Gazelle deps for 'bb fix'
-	_ "github.com/pmezard/go-difflib/difflib"
-
-	// rules_webtesting deps
-	_ "github.com/gorilla/mux"
-
-	// static analyzers
-	_ "github.com/nishanths/exhaustive"
-	_ "golang.org/x/tools/go/analysis"
-	_ "honnef.co/go/tools/staticcheck"
-
 	// Protobuf and grpc deps
+	// We still keep these here so that they remain in the direct require portion of the go.mod file.
+	// This prevents "go mod tidy -e" inconsistent formatting for "pbsync" users.
 	_ "github.com/planetscale/vtprotobuf/vtproto"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
-
-	// Used by cli/explain/compactgraph/testdata/generate to generate test data.
-	_ "github.com/otiai10/copy"
-
-	// Used indirectly through a data dependency by //tools/lint on gomimports
-	_ "golang.org/x/telemetry/counter"
 )


### PR DESCRIPTION
Also run `bazel mod tidy` after, which formatted some MODULE.bazel files
