### PR TITLE
resources: fix finding 'ver'

### DIFF
--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -230,13 +230,18 @@ func GetOSDisplayName() string {
 	case "linux":
 		command = []string{"sh", "-c", "grep '^PRETTY_NAME=' /etc/os-release | cut -d= -f2- | tr -d '\"'"}
 	case "windows":
-		command = []string{"ver"}
+		// Calling PowerShell 7 (or newer) which include OS information.
+		command = []string{"pwsh", "-Command", "$PSVersionTable.OS"}
+	}
+	if len(command) == 0 {
+		return runtime.GOOS
 	}
 	b, err := exec.Command(command[0], command[1:]...).Output()
 	if err != nil {
 		log.Warningf("Error getting operating system display name: %v", err)
+		return runtime.GOOS
 	}
-	return string(b)
+	return strings.TrimSpace(string(b))
 }
 
 func GetMyHostname() (string, error) {


### PR DESCRIPTION
Our Windows user reported this warning

```bash
Error getting operating system display name: exec: "ver": executable file not found in %PATH%
```

Change to use PowerShell version table instead

```
son@BEELINK-MINI-S D:\>pwsh -Command $PSVersionTable

Name                           Value
----                           -----
PSVersion                      7.5.4
PSEdition                      Core
GitCommitId                    7.5.4
OS                             Microsoft Windows 10.0.26200
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```

In case we fail to run these, or are testing out a new OS, fallback to
runtime.GOOS as the OS display name.
