### PR TITLE
delete EnableLocalCompressionLookup from DistributedCacheConfig

### DIFF
--- a/enterprise/server/backends/cache_config/cache_config.go
+++ b/enterprise/server/backends/cache_config/cache_config.go
@@ -80,16 +80,15 @@ type MetaCacheConfig struct {
 }
 
 type DistributedCacheConfig struct {
-	ListenAddr                   string   `yaml:"listen_addr"`
-	GroupName                    string   `yaml:"group_name"`
-	Nodes                        []string `yaml:"nodes"`
-	NewNodes                     []string `yaml:"new_nodes"`
-	ReplicationFactor            int      `yaml:"replication_factor"`
-	ClusterSize                  int      `yaml:"cluster_size"`
-	LookasideCacheSizeBytes      int64    `yaml:"lookaside_cache_size_bytes"`
-	EnableLocalWrites            bool     `yaml:"enable_local_writes"`
-	EnableLocalCompressionLookup bool     `yaml:"enable_local_compression_lookup"`
-	ReadThroughLocalCache        bool     `yaml:"read_through_local_cache"`
+	ListenAddr              string   `yaml:"listen_addr"`
+	GroupName               string   `yaml:"group_name"`
+	Nodes                   []string `yaml:"nodes"`
+	NewNodes                []string `yaml:"new_nodes"`
+	ReplicationFactor       int      `yaml:"replication_factor"`
+	ClusterSize             int      `yaml:"cluster_size"`
+	LookasideCacheSizeBytes int64    `yaml:"lookaside_cache_size_bytes"`
+	EnableLocalWrites       bool     `yaml:"enable_local_writes"`
+	ReadThroughLocalCache   bool     `yaml:"read_through_local_cache"`
 }
 
 func (cfg *MigrationConfig) SetConfigDefaults() {

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -231,7 +231,7 @@ func distributedCacheFromConfig(env environment.Env, baseCache interfaces.Cache,
 		ClusterSize:                  cfg.ClusterSize,
 		LookasideCacheSizeBytes:      cfg.LookasideCacheSizeBytes,
 		EnableLocalWrites:            cfg.EnableLocalWrites,
-		EnableLocalCompressionLookup: cfg.EnableLocalCompressionLookup,
+		EnableLocalCompressionLookup: true,
 		ReadThroughLocalCache:        cfg.ReadThroughLocalCache,
 	}
 


### PR DESCRIPTION
This is defaulted to true in distributed. Currently, we will set to false by default in DistributedCacheConfig

Instead of creating a bool ptr and set to true when it's new, I just removed the
field from the config and always set to true.
