### PR TITLE
Fix a potential bug in compression.ZstdCompressingWriter

### DIFF
--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -85,7 +85,7 @@ func (c *ZstdCompressingWriter) writeCompressed(p []byte) error {
 	n, err := c.writer.Write(c.compressBuffer)
 	c.CompressedBytesWritten += n
 	if err == nil && n < len(c.compressBuffer) {
-		c.err = io.ErrShortWrite
+		err = io.ErrShortWrite
 	}
 	c.err = err
 	return c.err


### PR DESCRIPTION
If the underlying writer returned a nil error but didn't write all the bytes, we want to return io.ErrShortWrite, but we were returning nil.