### PR TITLE
go_deps: fix redundant use_repo

### DIFF
--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -254,7 +254,6 @@ use_repo(
     "com_github_xiam_s_expr",
     "com_github_zeebo_blake3",
     "com_gitlab_arm_research_smarter_smarter_device_manager",
-    "com_google_cloud_go",
     "com_google_cloud_go_compute",
     "com_google_cloud_go_compute_metadata",
     "com_google_cloud_go_logging",


### PR DESCRIPTION
We should no longer need this after 380b044924b5b32749afc9450619d87a26f78c33
but 16072afa7bfa7681ec6e3c7b6e3efe9a0e54bea0 accidentally added it back
in after a rebase.
