### PR TITLE
Set compressor for remote hits

### DIFF
--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -307,8 +307,9 @@ func (t *TransferTimer) CloseWithBytesTransferred(bytesTransferredCache, bytesTr
 	hit := &hitpb.CacheHit{
 		RequestMetadata: t.requestMetadata,
 		Resource: &rspb.ResourceName{
-			Digest:    t.digest,
-			CacheType: t.cacheType,
+			Digest:     t.digest,
+			CacheType:  t.cacheType,
+			Compressor: compressor,
 		},
 		SizeBytes:        bytesTransferredClient,
 		Duration:         durationpb.New(time.Since(t.start)),


### PR DESCRIPTION
I'm not sure if this is necessary, but the server side does look at this field: https://github.com/buildbuddy-io/buildbuddy/blob/8a41964f24e0453ca17d2cc869957fad69ab7d3a/enterprise/server/hit_tracker_service/hit_tracker_service.go#L52