### PR TITLE
Bump GitHub MacOS runner version from 13 --> 15

### DIFF
--- a/.github/workflows/build-mac-intel-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-intel-github-release-artifacts.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-mac-m1-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-m1-github-release-artifacts.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13-xlarge
+    runs-on: macos-15-xlarge
     defaults:
       run:
         shell: "/usr/bin/arch -arch arm64e /bin/bash --noprofile --norc -eo pipefail {0}"

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -141,9 +141,9 @@ jobs:
             flags: --config=static
           - os: ubuntu-22.04-16cpu-arm64-arm-limited # linux arm64
             flags: --config=static-arm64
-          - os: macos-13 # macOS amd64
+          - os: macos-15-intel # macOS amd64
             flags: ""
-          - os: macos-13-xlarge # macOS arm64
+          - os: macos-15-xlarge # macOS arm64
             flags: ""
     runs-on: ${{ matrix.os }}
     needs: [push-tag, create-release]


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/