### PR TITLE
separate minimum size to chunk and chunk size

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -52,6 +52,7 @@ go_test(
     name = "pebble_cache_test",
     size = "medium",
     srcs = ["pebble_cache_test.go"],
+    data = ["//website:static_test_image"],
     shard_count = 2,
     deps = [
         ":pebble_cache",

--- a/website/BUILD.bazel
+++ b/website/BUILD.bazel
@@ -44,3 +44,9 @@ yarn(
         ":website",
     ],
 )
+
+filegroup(
+    name = "static_test_image",
+    srcs = ["static/img/bazel_6_0.png"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Because CDC adds CPU overhead, we probably only want to chunk larger files.

This PR allows us to adjust the minimum size to enable chunking separately from the average chunk size.

We can use this to test the performance of chunking on larger blobs in certain situations.