### PR TITLE
add gazelle to PATH using .envrc and `direnv`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if [ -d "$(pwd)/bin" ]; then
+  PATH_add bin
+fi

--- a/bin/gazelle
+++ b/bin/gazelle
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+QUIET_ARGS=(
+    --ui_event_filters=-info,-warning,-debug,-stdout,-stderr
+    --noshow_progress
+    --noshow_loading_progress
+)
+
+exec bazel run "${QUIET_ARGS[@]}" //:gazelle -- "$@"


### PR DESCRIPTION
If you have `direnv` installed, you can easily run commands within workspaces.

For example, if you `cd` into the buildbuddy directory, you can run `gazelle`, which will run `bazel run :gazelle --quiet`.

We can do other things such as:
- adding GOPATH and GOROOT to match that of rules_go
- using buildozer and buildifier prebuilt pinned versions (to avoid reading from system)

Example:
```
➜  ~ which gazelle
gazelle not found
➜  ~ cd buildbuddy 
direnv: loading ~/buildbuddy/.envrc
direnv: export ~PATH
➜  buildbuddy git:(tfrench/gazelle) which gazelle
/home/tyler/buildbuddy/bin/gazelle
➜  buildbuddy git:(tfrench/gazelle) gazelle
➜  buildbuddy git:(tfrench/gazelle) 
```