### PR TITLE
update docs to reference buildbuddy-toolchain@0.0.3

### DIFF
--- a/docs/rbe-github-actions.md
+++ b/docs/rbe-github-actions.md
@@ -107,9 +107,8 @@ And the following lines to your `WORKSPACE` file:
 ```python title="WORKSPACE"
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    integrity = "sha256-VtJjefgP2Vq5S6DiGYczsupNkosybmSBGWwcLUAYz8c=",
-    strip_prefix = "buildbuddy-toolchain-66146a3015faa348391fcceea2120caa390abe03",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/66146a3015faa348391fcceea2120caa390abe03.tar.gz"],
+    integrity = "sha256-5zVDos35dx9w9zmrcenyTg8tKwSg1/nUAZPLK8mo5KI=",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/download/v0.0.3/buildbuddy-toolchain-v0.0.3.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/docs/rbe-setup.md
+++ b/docs/rbe-setup.md
@@ -25,13 +25,7 @@ Projects that build native libraries or binaries or depend on platform-specific 
 If your project uses [Bazel modules](https://bazel.build/external/module), you can add the BuildBuddy Toolchain as a dependency for your module:
 
 ```python title="MODULE.bazel"
-bazel_dep(name = "toolchains_buildbuddy")
-archive_override(
-    module_name = "toolchains_buildbuddy",
-    integrity = "sha256-VtJjefgP2Vq5S6DiGYczsupNkosybmSBGWwcLUAYz8c=",
-    strip_prefix = "buildbuddy-toolchain-66146a3015faa348391fcceea2120caa390abe03",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/66146a3015faa348391fcceea2120caa390abe03.tar.gz"],
-)
+bazel_dep(name = "toolchains_buildbuddy", version = "0.0.3")
 buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbuddy")
 
 register_toolchains(
@@ -57,9 +51,8 @@ If your project still uses a [`WORKSPACE`](https://bazel.build/concepts/build-re
 ```python title="WORKSPACE"
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    integrity = "sha256-VtJjefgP2Vq5S6DiGYczsupNkosybmSBGWwcLUAYz8c=",
-    strip_prefix = "buildbuddy-toolchain-66146a3015faa348391fcceea2120caa390abe03",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/66146a3015faa348391fcceea2120caa390abe03.tar.gz"],
+    integrity = "sha256-5zVDos35dx9w9zmrcenyTg8tKwSg1/nUAZPLK8mo5KI=",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/download/v0.0.3/buildbuddy-toolchain-v0.0.3.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/template-user.bazelrc
+++ b/template-user.bazelrc
@@ -24,7 +24,7 @@
 #################################
 ## Use when developing the toolchain repo
 ## Uncomment the line below and update the path to point to your local toolchain directory
-#common --override_repository=io_buildbuddy_buildbuddy_toolchain=/ABSOLUTE_PATH_TO_YOUR_TOOLCHAIN_DIRECTORY/buildbuddy-toolchain/
+#common --override_module=toolchains_buildbuddy=/ABSOLUTE_PATH_TO_YOUR_TOOLCHAIN_DIRECTORY/buildbuddy-toolchain/
 
 ##########
 ## Misc ##


### PR DESCRIPTION
update docs to reference released 0.0.3 toolchain versions

we can update the actual toolchain separately