### PR TITLE
fix failing coverage by disabling gcc_coverage_map

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -48,6 +48,10 @@ common --@io_bazel_rules_docker//transitions:enable=false
 #   $ open cover/index.html
 common --combined_report=lcov
 
+# Disable gcc_coverage_map_format to avoid feature conflicts with custom toolchains.
+# This might mean we're not collecting coverage for some targets.
+coverage --features=-gcc_coverage_map_format
+
 # Include target names in timing profile so it's clickable.
 common --experimental_profile_include_target_label
 # Include primary output name in timing profile.


### PR DESCRIPTION
Reproduce locally with:
```
➜  buildbuddy git:(master) ✗ bazel coverage //...  --extra_execution_platforms=@toolchains_buildbuddy//platforms:linux_x86_64 

ERROR: /home/tyler/.cache/bazel/_bazel_tyler/84318bd592db7a1eca61439de061d188/external/rules_go+/BUILD.bazel:88:17: in cgo_context_data rule @@rules_go+//:cgo_context_data: 
Traceback (most recent call last):
        File "/home/tyler/.cache/bazel/_bazel_tyler/84318bd592db7a1eca61439de061d188/external/rules_go+/go/private/context.bzl", line 740, column 57, in cgo_context_data_impl
                feature_configuration = cc_common.configure_features(
        File "/virtual_builtins_bzl/common/cc/cc_common.bzl", line 184, column 49, in _configure_features
Error in configure_features: Symbol profile is provided by all of the following features: coverage gcc_coverage_map_format
```

This might reduce our coverage information from c++ files.

Test https://github.com/buildbuddy-io/buildbuddy/actions/runs/19526057585/job/55899065223