### PR TITLE
action-card: make target label clickable

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -82,7 +82,6 @@
 .invocation-action-card .text-link {
   font-weight: 600;
   text-decoration: underline;
-  color: #212121;
 }
 
 .invocation-targets-card .targets-table {

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -1077,7 +1077,15 @@ export default class InvocationActionCardComponent extends React.Component<Props
                     {this.state.execution?.targetLabel && (
                       <div className="action-section">
                         <div className="action-property-title">Target label</div>
-                        <div debug-id="target-label">{this.state.execution?.targetLabel}</div>
+                        <div debug-id="target-label">
+                          <TextLink
+                            className="target-label-link"
+                            href={`/invocation/${this.props.model.getInvocationId()}?${new URLSearchParams({
+                              target: this.state.execution.targetLabel,
+                            })}`}>
+                            {this.state.execution.targetLabel}
+                          </TextLink>
+                        </div>
                       </div>
                     )}
                     {this.state.execution?.actionMnemonic && (


### PR DESCRIPTION
Also update the .text-link css under action card to stop using black
color. This better signal to our users that the link is clickable.

This affects the new target label as well as the old "No result details
found." message which links people back to our /doc/setup page.
