### PR TITLE
Upgrade the local clickhouse grafana plugin

### DIFF
--- a/tools/metrics/docker-compose.grafana.yml
+++ b/tools/metrics/docker-compose.grafana.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   grafana:
     image: grafana/grafana:11.6.2
@@ -9,7 +8,7 @@ services:
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/buildbuddy.json
       - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
       - GF_DATASOURCE_URL=${GF_DATASOURCE_URL}
-      - GF_PLUGINS_PREINSTALL=grafana-clickhouse-datasource@4.8.2
+      - GF_PLUGINS_PREINSTALL=grafana-clickhouse-datasource@4.11.2
       - CLICKHOUSE_PORT=${CLICKHOUSE_PORT}
       - CLICKHOUSE_USERNAME=${CLICKHOUSE_USERNAME}
       - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}


### PR DESCRIPTION
Here is the [full diff](https://github.com/grafana/clickhouse-datasource/compare/v4.8.2...v4.11.2), but the 2 features I want are a [basic autocomplete](https://github.com/grafana/clickhouse-datasource/pull/1204) and [working ctrl+enter](https://github.com/grafana/clickhouse-datasource/pull/1205) to run the query. The latter also adds a format button, though I'm not a fan of the format it chooses.

<img width="713" height="478" alt="image" src="https://github.com/user-attachments/assets/12cf0603-808c-4feb-87a7-37c29ab16c70" />
