### PR TITLE
Merge newZstdCompressingReader and NewBufferedZstdCompressingReader

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -754,7 +754,7 @@ func (c *Cache) reader(ctx context.Context, md *sgpb.FileMetadata, r *rspb.Resou
 
 	if requestedCompression == repb.Compressor_ZSTD && cachedCompression == repb.Compressor_IDENTITY {
 		bufSize := digest.SafeBufferSize(r, CompressorBufSizeBytes)
-		return compression.NewBufferedZstdCompressingReader(reader, c.bufferPool, int64(bufSize))
+		return compression.NewZstdCompressingReader(reader, c.bufferPool, int64(bufSize))
 	}
 
 	return reader, nil

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3321,7 +3321,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 	if requestedCompression == repb.Compressor_ZSTD && cachedCompression == repb.Compressor_IDENTITY {
 		bufSize := digest.SafeBufferSize(r, CompressorBufSizeBytes)
 
-		return compression.NewBufferedZstdCompressingReader(reader, p.bufferPool, int64(bufSize))
+		return compression.NewZstdCompressingReader(reader, p.bufferPool, int64(bufSize))
 	}
 
 	return reader, nil

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -154,7 +154,7 @@ func (s *ByteStreamServer) ReadCASResource(ctx context.Context, r *digest.CASRes
 		counter = &ioutil.Counter{}
 		rc := io.NopCloser(io.TeeReader(reader, counter))
 
-		reader, err = compression.NewBufferedZstdCompressingReader(rc, s.bufferPool, bufSize)
+		reader, err = compression.NewZstdCompressingReader(rc, s.bufferPool, bufSize)
 		if err != nil {
 			return status.InternalErrorf("Failed to compress blob: %s", err)
 		}

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -270,7 +270,7 @@ func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 	bufSize := int64(digest.SafeBufferSize(r.ToProto(), uploadBufSizeBytes))
 	var rc io.ReadCloser = io.NopCloser(in)
 	if r.GetCompressor() == repb.Compressor_ZSTD {
-		reader, err := compression.NewBufferedZstdCompressingReader(rc, uploadBufPool, bufSize)
+		reader, err := compression.NewZstdCompressingReader(rc, uploadBufPool, bufSize)
 		if err != nil {
 			return nil, 0, status.InternalErrorf("Failed to compress blob: %s", err)
 		}

--- a/server/util/compression/compression_test.go
+++ b/server/util/compression/compression_test.go
@@ -47,18 +47,18 @@ func TestLossless(t *testing.T) {
 			decompress: decompressWithNewZstdDecompressingReader,
 		},
 		{
-			name:       "NewBufferedZstdCompressingReader -> DecompressZstd",
-			compress:   compressWithNewBufferedZstdCompressingReader,
+			name:       "NewZstdCompressingReader -> DecompressZstd",
+			compress:   compressWithNewZstdCompressingReader,
 			decompress: decompressWithDecompressZstd,
 		},
 		{
-			name:       "NewBufferedZstdCompressingReader -> NewZstdDecompressor",
-			compress:   compressWithNewBufferedZstdCompressingReader,
+			name:       "NewZstdCompressingReader -> NewZstdDecompressor",
+			compress:   compressWithNewZstdCompressingReader,
 			decompress: decompressWithNewZstdDecompressor,
 		},
 		{
-			name:       "NewBufferedZstdCompressingReader -> NewZstdDecompressingReader",
-			compress:   compressWithNewBufferedZstdCompressingReader,
+			name:       "NewZstdCompressingReader -> NewZstdDecompressingReader",
+			compress:   compressWithNewZstdCompressingReader,
 			decompress: decompressWithNewZstdDecompressingReader,
 		},
 		{
@@ -100,13 +100,13 @@ func compressWithCompressZstd(t *testing.T, src []byte) []byte {
 	return compressed
 }
 
-func compressWithNewBufferedZstdCompressingReader(t *testing.T, src []byte) []byte {
+func compressWithNewZstdCompressingReader(t *testing.T, src []byte) []byte {
 	bufSize := int64(readBufferSize)
 	if l := int64(len(src)); l < bufSize {
 		bufSize = l
 	}
 	rc := io.NopCloser(bytes.NewReader(src))
-	c, err := compression.NewBufferedZstdCompressingReader(rc, bufPool, bufSize)
+	c, err := compression.NewZstdCompressingReader(rc, bufPool, bufSize)
 	require.NoError(t, err)
 
 	compressed, err := io.ReadAll(c)
@@ -168,7 +168,7 @@ func TestCompressingReader_BufferSizes(t *testing.T) {
 				name := fmt.Sprintf("%d_total_bytes_%d_buf_size_%d_p", totalBytes, bufSize, pSize)
 				t.Run(name, func(t *testing.T) {
 					_, in := testdigest.RandomCASResourceBuf(t, int64(totalBytes))
-					zrc, err := compression.NewBufferedZstdCompressingReader(
+					zrc, err := compression.NewZstdCompressingReader(
 						io.NopCloser(bytes.NewReader(in)),
 						bufPool,
 						bufSize,
@@ -234,7 +234,7 @@ func TestCompressingReader_HoldErrors(t *testing.T) {
 		bytesToAllow:  bytesToAllow,
 		errorToReturn: errorToReturn,
 	}
-	zrc, err := compression.NewBufferedZstdCompressingReader(
+	zrc, err := compression.NewZstdCompressingReader(
 		io.NopCloser(er),
 		bufPool,
 		bufSize,


### PR DESCRIPTION
The former is never called directly, so we can shorten the name and simplify the code quite a bit.

I also fixed a potential bug, where calling Close multiple times would add the same buffers to the pool multiple times.