### PR TITLE
action_cache_server: record origin of of ActionResult

### DIFF
--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2499,6 +2499,13 @@ message RequestMetadata {
 /*                                                                            */
 /******************************************************************************/
 
+// A metadata to attach to each ActionResult message through
+// [ExecutedActionMetadata][build.bazel.remote.execution.v2.ExecutedActionMetadata]'s
+// `auxiliary_metadata`. This should help us audit when/where/how the ActionResult was created.
+message OriginMetadata {
+  string invocation_id = 1;
+}
+
 // Next tag: 9
 message ExecutionTask {
   ExecuteRequest execute_request = 1;

--- a/server/remote_cache/action_cache_server/BUILD
+++ b/server/remote_cache/action_cache_server/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//server/util/proto",
         "//server/util/status",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_x_sync//errgroup",
     ],
 )


### PR DESCRIPTION
When user get an AC hit, it might be useful for them to know where did
the cache entry came from.

Today, we already have the worker id recorded within the
ExecutedActionMetadata, but the user don't often care about the worker
alone, they care about the invocation and data attached to that
invocation (i.e. PR number, Commit hash, User, etc...).

So let's start record the origin of the ActionResult based on the
incoming RequestMetadata when it's available. This will be kept within
the ActionResult's auxiliary_metadata for easy keeping.

NOTE: This should not be treated as a security feature since
RequestMetadata can be dupe and modified by custom clients.
