### PR TITLE
Fix target history button spacing

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1935,3 +1935,8 @@ code .comment {
 .coverage-total-label {
   font-weight: 600;
 }
+
+.target-history-button {
+  margin-left: 16px;
+  gap: 8px;
+}


### PR DESCRIPTION
Went with a targeted fix here rather than something more principled (like adding gap to the parent) because I'm pretty positive that would break something (since the parent layout is used ~everywhere).

Before: 
<img width="2666" height="1420" alt="image" src="https://github.com/user-attachments/assets/b2bfbece-6b7b-4fad-8466-3c28df157ab4" />

After:
<img width="1414" height="710" alt="Screenshot 2025-11-21 at 11 45 41 AM" src="https://github.com/user-attachments/assets/140430bd-d3b3-421f-81c2-f30fa9150eea" />
