### PR TITLE
buildbuddy-toolchain: upgrade to v0.0.4

### DIFF
--- a/deps/bazel_dep.MODULE.bazel
+++ b/deps/bazel_dep.MODULE.bazel
@@ -107,7 +107,7 @@ bazel_dep(name = "rules_bazel_integration_test", version = "0.34.0")
 # - docs/rbe-setup.md
 # - docs/rbe-github-actions.md
 # - tools/dev_qa.py
-bazel_dep(name = "toolchains_buildbuddy", version = "0.0.2")
+bazel_dep(name = "toolchains_buildbuddy", version = "0.0.4")
 bazel_dep(name = "toolchains_musl", version = "0.1.27")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 bazel_dep(name = "rules_multirun", version = "0.13.0")

--- a/docs/rbe-setup.md
+++ b/docs/rbe-setup.md
@@ -25,7 +25,7 @@ Projects that build native libraries or binaries or depend on platform-specific 
 If your project uses [Bazel modules](https://bazel.build/external/module), you can add the BuildBuddy Toolchain as a dependency for your module:
 
 ```python title="MODULE.bazel"
-bazel_dep(name = "toolchains_buildbuddy", version = "0.0.3")
+bazel_dep(name = "toolchains_buildbuddy", version = "0.0.4")
 buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbuddy")
 
 register_toolchains(
@@ -51,8 +51,9 @@ If your project still uses a [`WORKSPACE`](https://bazel.build/concepts/build-re
 ```python title="WORKSPACE"
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    integrity = "sha256-5zVDos35dx9w9zmrcenyTg8tKwSg1/nUAZPLK8mo5KI=",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/download/v0.0.3/buildbuddy-toolchain-v0.0.3.tar.gz"],
+    integrity = "sha256-4rtmioGI2dzQey1h0fw7z2exUCCelNv0Uff7uwrQihc=",
+    strip_prefix = "buildbuddy-toolchain-v0.0.4",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/download/v0.0.4/buildbuddy-toolchain-v0.0.4.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/tools/dev_qa.py
+++ b/tools/dev_qa.py
@@ -119,9 +119,9 @@ REPO_CONFIGS = [
 BUILDBUDDY_TOOLCHAIN_SNIPPET = """
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    integrity = "sha256-VtJjefgP2Vq5S6DiGYczsupNkosybmSBGWwcLUAYz8c=",
-    strip_prefix = "buildbuddy-toolchain-66146a3015faa348391fcceea2120caa390abe03",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/66146a3015faa348391fcceea2120caa390abe03.tar.gz"],
+    integrity = "sha256-4rtmioGI2dzQey1h0fw7z2exUCCelNv0Uff7uwrQihc=",
+    strip_prefix = "buildbuddy-toolchain-v0.0.4",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/download/v0.0.4/buildbuddy-toolchain-v0.0.4.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")


### PR DESCRIPTION
This should help fix our coverage pipeline
