### PR TITLE
fix dev_qa

### DIFF
--- a/tools/dev_qa.py
+++ b/tools/dev_qa.py
@@ -117,11 +117,14 @@ REPO_CONFIGS = [
 ]
 
 BUILDBUDDY_TOOLCHAIN_SNIPPET = """
+
+// Keep this at an older version until we fix WORKSPACE deps
+// resolution in Buildbuddy Toolchain.
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    integrity = "sha256-4rtmioGI2dzQey1h0fw7z2exUCCelNv0Uff7uwrQihc=",
-    strip_prefix = "buildbuddy-toolchain-v0.0.4",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/download/v0.0.4/buildbuddy-toolchain-v0.0.4.tar.gz"],
+    integrity = "sha256-VtJjefgP2Vq5S6DiGYczsupNkosybmSBGWwcLUAYz8c=",
+    strip_prefix = "buildbuddy-toolchain-66146a3015faa348391fcceea2120caa390abe03",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/66146a3015faa348391fcceea2120caa390abe03.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")


### PR DESCRIPTION
New buildbuddy_toolchain breaks dev QA due to WORKSPACE dependency resolution.

For now, lets test QA with old toolchain while we fix the dependency nightmare.

Example success: https://github.com/buildbuddy-io/buildbuddy-internal/actions/runs/19639550678/job/56239052784