### PR TITLE
Revert "Update images"

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5,9 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 # When changing this version, a new release of podman-static may be needed.
 # See dockerfiles/executor_image/README.md for instructions.
 # The checksums below will also need to be updated.
-PODMAN_VERSION = "v5.7.0"
-PODMAN_STATIC_SHA256_AMD64 = "6a1c06b78d7dad15d8d7155a180874939a04bd39ce2f64726c7f11142ab7aa7d"
-PODMAN_STATIC_SHA256_ARM64 = "703ffad8972aa2db70a173c80804a88185e6c2dc8a88a247a8ebffeac424b0ba"
+PODMAN_VERSION = "v5.5.0"
+PODMAN_STATIC_SHA256_AMD64 = "8ce959cd2b0ea68ae8ac7ccbb181cad59504086d54d4c9521954ee49dae013eb"
+PODMAN_STATIC_SHA256_ARM64 = "ef1e84ab80ee5d78d4d2e59e128ff963038f39e1e4259a83e08d7c8f85faf90d"
 
 # Manually created
 def install_static_dependencies(workspace_name = "buildbuddy"):
@@ -404,8 +404,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             'filegroup(name = "containerd-shim-runc-v2.bin", srcs = ["containerd-shim-runc-v2"])',
             'filegroup(name = "ctr.bin", srcs = ["ctr"])',
         ]),
-        urls = ["https://github.com/containerd/containerd/releases/download/v2.2.0/containerd-2.2.0-linux-amd64.tar.gz"],
-        sha256 = "b9626a94ab93b00bcbcbf13d98deef972c6fb064690e57940632df54ad39ee71",
+        urls = ["https://github.com/containerd/containerd/releases/download/v2.1.1/containerd-2.1.1-linux-amd64.tar.gz"],
+        sha256 = "918e88fd393c28c89424e6535df0546ca36c1dfa7d8a5d685dee70b449380a9b",
     )
     http_archive(
         name = "com_github_containerd_containerd-linux-arm64",
@@ -416,8 +416,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             'filegroup(name = "containerd-shim-runc-v2.bin", srcs = ["containerd-shim-runc-v2"])',
             'filegroup(name = "ctr.bin", srcs = ["ctr"])',
         ]),
-        urls = ["https://github.com/containerd/containerd/releases/download/v2.2.0/containerd-2.2.0-linux-arm64.tar.gz"],
-        sha256 = "8805c2123d3b7c7ee2030e9f8fc07a1167d8a3f871d6a7d7ec5d1deb0b51a4a7",
+        urls = ["https://github.com/containerd/containerd/releases/download/v2.1.1/containerd-2.1.1-linux-arm64.tar.gz"],
+        sha256 = "4e3c8c0c2e61438bb393a9ea6bb94f8f56b559ec3243d7b1a2943117bca4dcb4",
     )
 
     http_archive(
@@ -430,15 +430,15 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
 
     http_file(
         name = "com_github_opencontainers_runc_runc-linux-amd64",
-        urls = ["https://github.com/opencontainers/runc/releases/download/v1.3.3/runc.amd64"],
-        sha256 = "8781ab9f71c12f314d21c8e85f13ca1a82d90cf475aa5131a7b543fcc5487543",
+        urls = ["https://github.com/opencontainers/runc/releases/download/v1.3.0/runc.amd64"],
+        sha256 = "028986516ab5646370edce981df2d8e8a8d12188deaf837142a02097000ae2f2",
         downloaded_file_path = "runc",
         executable = True,
     )
     http_file(
         name = "com_github_opencontainers_runc_runc-linux-arm64",
-        urls = ["https://github.com/opencontainers/runc/releases/download/v1.3.3/runc.arm64"],
-        sha256 = "3c9a8e9e6dafd00db61f4611692447ebab4a56388bae4f82192aed67b66df712",
+        urls = ["https://github.com/opencontainers/runc/releases/download/v1.3.0/runc.arm64"],
+        sha256 = "85c5e4e4f72e442c8c17bac07527cd4f961ee48e4f2b71797f7533c94f4a52b9",
         downloaded_file_path = "runc",
         executable = True,
     )

--- a/deps/docker.MODULE.bazel
+++ b/deps/docker.MODULE.bazel
@@ -2,9 +2,9 @@ container_pull = use_repo_rule("@io_bazel_rules_docker//container:pull.bzl", "co
 
 container_pull(
     name = "buildbuddy_go_image_base",
-    digest = "sha256:54a30fb33d77e2d981f37fb34cfd2bcc124bf029ed2d73764b5b68951acabf85",
+    digest = "sha256:54b60abf4fff72d703e028d1c412a727776a6a191a00d7598214ef67b496ef95",
     registry = "gcr.io",
-    repository = "distroless/cc-debian13",
+    repository = "distroless/cc-debian12",
 )
 
 container_pull(

--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -2,22 +2,16 @@
 # See README for details.
 
 # debian 12
-FROM mirror.gcr.io/debian@sha256:01a723bf5bfb21b9dda0c9a33e0538106e4d02cce8f557e118dd61259553d598
+FROM mirror.gcr.io/debian@sha256:7ca9335a5953654f8feb8b846ad3dd78309a838d62b090c785d1f5908c2d59d2
 
 RUN \
     # /etc/apt/debian.sources doesn't pin the debian release by name, but by `stable`.
-    sed -i 's/^Suites: stable stable-updates$/Suites: trixie trixie-updates/' /etc/apt/sources.list.d/debian.sources && \
-    sed -i 's/^Suites: stable-security$/Suites: trixie-security/' /etc/apt/sources.list.d/debian.sources && \
+    # Now that debian 13 was upgraded to stable, the `apt-get upgrade` command below
+    # will attempt to upgrade the OS to debian 13. Manually pin it to debian 12 (bookworkm).
+    sed -i 's/^Suites: stable stable-updates$/Suites: bookworm bookworm-updates/' /etc/apt/sources.list.d/debian.sources && \
+    sed -i 's/^Suites: stable-security$/Suites: bookworm-security/' /etc/apt/sources.list.d/debian.sources && \
     apt-get update && \
     apt-get install -y \
-    # Necessary for rules_go
-    gcc \
-    # Necessary for rules_pkg
-    python3 \
-    # Necessary to build redis, for some reason???
-    libstdc++-14-dev \
-    # Necessary for firecracker
-    e2fsprogs \
     # FUSE support, used by vbd and vfs packages.
     # TODO: probably not needed since we use DirectMountStrict now?
     fuse \
@@ -28,17 +22,13 @@ RUN \
     amazon-ecr-credential-helper \
     # cgroup-aware proc mounts for OCI containers.
     lxcfs && \
-    apt-get remove -y docker.io docker-cli containerd runc docker-buildx && \
-    # Can't safely run autoremove, too many builds have non-hermetic implicit dependencies.
-    # TODO(zoey): investigate common implicit deps and install them explicitly
-    # so we can run autoremove
-    # apt-get autoremove -y && \
+    apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/* && apt-get clean
 
-RUN DOCKER_VERSION="5:29.0.1-1~debian.13~trixie" && \
-    CONTAINERD_DEB_VERSION="2.1.5-1~debian.13~trixie" && \
-    DOCKER_BUILDX_VERSION="0.30.0-1~debian.13~trixie" && \
-    DOCKER_COMPOSE_VERSION="2.40.3-1~debian.13~trixie" && \
+RUN DOCKER_VERSION="5:28.2.2-1~debian.12~bookworm" && \
+    CONTAINERD_DEB_VERSION="1.7.27-1" && \
+    DOCKER_BUILDX_VERSION="0.24.0-1~debian.12~bookworm" && \
+    DOCKER_COMPOSE_VERSION="2.36.2-1~debian.12~bookworm" && \
     apt-get update && \
     apt-get install -y \
     curl ca-certificates apt-transport-https && \
@@ -66,9 +56,10 @@ RUN DOCKER_VERSION="5:29.0.1-1~debian.13~trixie" && \
     #
     # containerd
     /usr/bin/containerd \
-    /usr/bin/containerd-shim-runc-v2 \
+    /usr/bin/containerd-shim \
+    /usr/bin/containerd-shim-runc-v1 \
     /usr/bin/ctr \
     # rootlesskit
-    # /usr/bin/rootlesskit \
+    /usr/bin/rootlesskit \
     # runc
     /usr/bin/runc

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -245,10 +245,10 @@ container_image(
         ":docker_credential_gcr_layer",
         ":docker_credential_gcr_docker_config_layer",
         ":containerd_layer",
-        ":runc_layer",
         # Updating these layers does not currently afford us any vulnerability
         # fixes; leave them out for now.
-        # ":rootlesskit_layer",
+        ":runc_layer",
+        ":rootlesskit_layer",
         ":executor_tools_layer",
         ":podman_static_layer",
     ],


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#10759

I think this change is probably fine and (I know we've tested it), but rather than merging directly to master I would like us to build and push these and mirror some traffic over and make sure it's 100% before we drop it for everyone. Sorry for not speaking up about this sooner.