### PR TITLE
[dev qa] get abseil cpp, rules_python, gazelle integration test targets working with bb toolchain 0.0.4

### DIFF
--- a/tools/dev_qa_test/BUILD.bazel
+++ b/tools/dev_qa_test/BUILD.bazel
@@ -68,6 +68,7 @@ bazel_integration_test(
         "QA_STRIP_PREFIX": "buildbuddy-2.224.1",
         "QA_BAZEL_COMMAND": "build //server/util/status",
         "INJECT_TOOLCHAIN": "false",
+        "UPDATE_LOCKFILE": "false",
     },
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
     test_runner = ":dev_qa_test_runner",

--- a/tools/dev_qa_test/dev_qa_test_runner.sh
+++ b/tools/dev_qa_test/dev_qa_test_runner.sh
@@ -129,10 +129,15 @@ fi
 echo "Remote execution configuration created"
 echo "=================================================="
 
-echo "Updating lockfile with injected BuildBuddy toolchain..."
-${bazel} mod deps --lockfile_mode=update
-echo "Lockfile updated successfully"
-echo "=================================================="
+if [[ "${UPDATE_LOCKFILE:-true}" == "true" ]]; then
+  echo "Updating lockfile with injected BuildBuddy toolchain..."
+  ${bazel} mod deps --lockfile_mode=update
+  echo "Lockfile updated successfully"
+  echo "=================================================="
+else
+  echo "Skipping lockfile update (UPDATE_LOCKFILE=false)"
+  echo "=================================================="
+fi
 
 echo "Running Bazel command: ${bazel_command}"
 echo "=================================================="


### PR DESCRIPTION
Also adds `BB_ENDPOINT` env var to the test runner, so we can configure different endpoints (necessary for internal workflows).