### PR TITLE
Revert "Add a flag to use async clickhouse inserts"

### DIFF
--- a/enterprise/server/invocation_search_service/invocation_search_service_test.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service_test.go
@@ -115,7 +115,6 @@ func setUpFakeData(ctx context.Context, env *real_environment.RealEnv, t *testin
 func setUpDB(ctx context.Context, env *real_environment.RealEnv, t *testing.T) *testauth.TestAuthenticator {
 	// Disable async invocation batch inserts.
 	flags.Set(t, "olap_database.invocation_batch_insert_interval", 0)
-	flags.Set(t, "olap_database.async_insert", true)
 
 	ta := testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1", "US2", "GR2"))
 	env.SetAuthenticator(ta)

--- a/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
+++ b/enterprise/server/test/webdriver/executions_clickhouse/executions_clickhouse_test.go
@@ -59,7 +59,6 @@ func testInvocationWithRemoteExecutionWithClickHouse(t *testing.T, tc executions
 	clickhouseDSN := testclickhouse.Start(t, true /*=reuseServer*/)
 	bbFlags := append([]string{
 		"--olap_database.data_source=" + clickhouseDSN,
-		"--olap_database.async_insert=true",
 		"--remote_execution.enable_remote_exec=true",
 		"--remote_execution.olap_reads_enabled=true",
 	}, tc.flags...)


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#10754. Maybe this was causing dev to queue?