### PR TITLE
Don't asynchronously refresh remote_crypter encryption keys

### DIFF
--- a/enterprise/server/crypter_key_cache/crypter_key_cache.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache.go
@@ -202,6 +202,10 @@ func (c *KeyCache) cacheGet(ck CacheKey) (*cacheEntry, bool) {
 	e := v.(*cacheEntry)
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if c.clock.Now().After(e.expiresAfter) {
+		c.data.Delete(ck)
+		return nil, false
+	}
 	e.lastUse = c.clock.Now()
 	return e, true
 }

--- a/enterprise/server/remote_crypter/remote_crypter.go
+++ b/enterprise/server/remote_crypter/remote_crypter.go
@@ -77,14 +77,9 @@ func New(env environment.Env, authenticator interfaces.Authenticator, clientIden
 		return refreshKey(ctx, ck, client, clientIdentityService)
 	}
 
+	// Don't start the asynchronous key refresher. Instead, rely on refetching
+	// encryption keys synchronously when needed.
 	cache := crypter_key_cache.New(env, refreshFn, clock)
-	quitChan := make(chan struct{})
-	cache.StartRefresher(quitChan)
-
-	env.GetHealthChecker().RegisterShutdownFunction(func(ctx context.Context) error {
-		close(quitChan)
-		return nil
-	})
 
 	return &RemoteCrypter{
 		authenticator: authenticator,


### PR DESCRIPTION
The asynchronous refresh mechanism doesn't hang on to the user's credentials, so these requests fail today. We could fix this by hanging on to them or adding a bypass mechanism for system RPCs like this, but for now just synchronously refreshing the key should suffice.

This was definitely causing some unauthenticated errors in `GetEncryptionKey()` RPCs, but I'm not sure it was causing the "signature is invalid" errors.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4758