### PR TITLE
Add version to docker-compose.grafana.yml

### DIFF
--- a/tools/metrics/docker-compose.grafana.yml
+++ b/tools/metrics/docker-compose.grafana.yml
@@ -1,3 +1,4 @@
+version: "3.3"
 services:
   grafana:
     image: grafana/grafana:11.6.2


### PR DESCRIPTION
I think I upgraded docker recently and `bazel run //tools/metrics/grafana` stopped working. This fixes it and all of the other docker compose files in this directory have it.