### PR TITLE
action_card: fetch stderrout and profile on completion

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -162,18 +162,34 @@ export default class InvocationActionCardComponent extends React.Component<Props
         }
 
         this.setState({ lastOperation: operation });
-        if (operation.response && !this.state.executeResponse) {
-          this.setState({ executeResponse: operation.response });
-          console.log(operation.response);
-        }
-        if (operation.response?.result) {
-          this.setState({ actionResult: operation.response.result });
+        if (operation.response) {
+          if (!this.state.executeResponse) {
+            this.setState({ executeResponse: operation.response });
+            console.log(operation.response);
+          }
+          if (operation.response.result) {
+            const actionResult = operation.response.result;
+            this.setState({ actionResult });
+            this.fetchStdout(actionResult);
+            this.fetchStderr(actionResult);
+            if (operation.done) {
+              this.fetchServerLogs(operation.response);
+            }
+          }
         }
         // Fetch the full response from cache, since it contains some additional
         // metadata not sent on the stream. Disallow stream fallback since at
         // this point we're already in the stream.
         if (operation.done && !this.state.actionResult) {
           this.fetchExecuteResponseOrActionResult({ streamFallback: false });
+        }
+
+        if (operation.done) {
+          const executionId = this.getExecutionId();
+          if (executionId && !this.state.profile && !this.state.profileLoading) {
+            this.setState({ profileLoading: true });
+            this.fetchProfile(executionId);
+          }
         }
       },
       error: (error) => {
@@ -277,6 +293,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
       stderr: undefined,
       serverLogs: undefined,
       profile: undefined,
+      profileLoading: false,
     });
 
     const actionDigestParam = this.props.search.get("actionDigest");
@@ -475,6 +492,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
   }
 
   fetchProfile(executionId: string) {
+    this.setState({ profileLoading: true });
     this.profileRPC = rpcService
       .fetchFile(
         rpcService.getDownloadUrl({


### PR DESCRIPTION
Currently if we open the action page when the action was still in
progress, the client will wait until the action completed before
reloading the Action Result.

Make sure that when we fetch the Action Result, we also fetch the
stderr, stdout and the profile of the remote action. Otherwise user
will have to manually refresh the page to see these information.
