### PR TITLE
Sync changes to BES proto

### DIFF
--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -440,6 +440,12 @@ message BuildStarted {
 
   // The process ID of the Bazel server.
   int64 server_pid = 8;
+
+  // The short hostname of the machine where the build is running.
+  string host = 10;
+
+  // The username of the user who started the build.
+  string user = 11;
 }
 
 // Configuration related to the blaze workspace and output tree.
@@ -627,6 +633,8 @@ message ActionExecuted {
   // The command-line of the action, if the action is a command.
   repeated string command_line = 9;
 
+  // TODO: This has been removed at HEAD, but may still be used by older
+  // versions of Bazel.
   // List of paths to log files
   repeated File action_metadata_logs = 10 [deprecated = true];
 
@@ -1105,6 +1113,9 @@ message BuildMetrics {
     // The elapsed wall time in milliseconds until the first action execution
     // started (excluding workspace status actions).
     int64 actions_execution_start_in_ms = 5;
+
+    // The elapsed wall time in milliseconds that the critical path took.
+    google.protobuf.Duration critical_path_time = 6;
   }
   TimingMetrics timing_metrics = 5;
 
@@ -1418,6 +1429,11 @@ message BuildMetrics {
     int64 analysis_cache_key_bytes_sent = 13;
     int64 analysis_cache_ops = 14;
     int64 analysis_cache_batches = 15;
+
+    // TODO: Add the required analysis_cache_service_metadata_status.proto when
+    // we have to use this field.
+    // The result of the Skycache metadata lookup.
+    // devtools_blaze_proto.TopLevelTargetsMatchStatus metadata_lookup_result = 16;
   }
   RemoteAnalysisCacheStatistics remote_analysis_cache_statistics = 13;
 }


### PR DESCRIPTION
Skip the new Skycache-related field as it requires a new proto file using editions, which our version of vtproto doesn't support yet.