### PR TITLE
View media artifacts with browser instead of Code component

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1168,11 +1168,10 @@ code .comment {
 
 .artifact-view {
   font-weight: 600;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
+  gap: 2px;
   padding: 0 8px;
-  color: #888;
   white-space: nowrap;
 }
 

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -156,22 +156,26 @@ class RpcService {
     };
   }
 
-  getDownloadUrl(params: Record<string, string>): string {
+  getDownloadUrl(params: Record<string, string>, view = false): string {
     const encodedRequestContext = uint8ArrayToBase64(context.RequestContext.encode(this.requestContext).finish());
-    return `/file/download?${new URLSearchParams({
+    return `/file/${view ? "view" : "download"}?${new URLSearchParams({
       ...params,
       request_context: encodedRequestContext,
     })}`;
   }
 
-  getBytestreamUrl(bytestreamURL: string, invocationId: string, { filename = "", zip = "" } = {}): string {
+  getBytestreamUrl(
+    bytestreamURL: string,
+    invocationId: string,
+    { filename = "", zip = "", view = false } = {}
+  ): string {
     const params: Record<string, string> = {
       bytestream_url: bytestreamURL,
       invocation_id: invocationId,
     };
     if (filename) params.filename = filename;
     if (zip) params.z = zip;
-    return this.getDownloadUrl(params);
+    return this.getDownloadUrl(params, view);
   }
 
   downloadLog(invocationId: string, attempt: number) {

--- a/app/target/BUILD
+++ b/app/target/BUILD
@@ -70,6 +70,7 @@ ts_library(
         "//app/components/link",
         "//app/service:rpc_service",
         "//app/util:cache",
+        "//app/util:file_types",
         "//proto:build_event_stream_ts_proto",
         "//proto:zip_ts_proto",
     ],

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -211,3 +211,8 @@ ts_jasmine_node_test(
     srcs = ["shlex_test.ts"],
     deps = ["//app/util:shlex"],
 )
+
+ts_library(
+    name = "file_types",
+    srcs = ["file_types.ts"],
+)

--- a/app/util/file_types.ts
+++ b/app/util/file_types.ts
@@ -1,0 +1,43 @@
+/**
+ * Parses the file extension from the given file name. Returns the extension,
+ * including the `"."`. Returns `""` if no extension is detected.
+ */
+export function parseExtension(filename: string): string {
+  const index = filename.lastIndexOf(".");
+  if (index === -1) {
+    return "";
+  }
+  return filename.slice(index);
+}
+
+export function isImageExtension(extension: string): boolean {
+  switch (extension.toLowerCase()) {
+    case ".bmp":
+    case ".gif":
+    case ".ico":
+    case ".jpg":
+    case ".jpeg":
+    case ".png":
+    case ".svg":
+    case ".webp":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function isVideoExtension(extension: string): boolean {
+  switch (extension.toLowerCase()) {
+    case ".webm":
+    case ".mp4":
+    case ".mov":
+    case ".avi":
+    case ".mkv":
+    case ".wmv":
+    case ".flv":
+    case ".m4v":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//server/endpoint_urls/remote_exec_api_url",
         "//server/environment",
         "//server/eventlog",
+        "//server/http/interceptors",
         "//server/interfaces",
         "//server/real_environment",
         "//server/remote_cache/directory_size",

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -113,6 +113,57 @@ func SetSecurityHeaders(next http.Handler) http.Handler {
 	})
 }
 
+// BasicMIMETypeFromExtension returns a safe MIME type guessed from the given
+// extension. Only some basic media formats are supported. This function may be
+// useful in some cases where the user has requested to view their uploaded file
+// contents, but our default strict `X-Content-Type-Options: nosniff` header is
+// preventing the content from being displayed.
+//
+// The returned MIME types are all "inert" - executable contents such as JS, SVG
+// (which can contain embedded <script> tags), and PDF, are treated as generic
+// octet streams.
+func BasicMIMETypeFromExtension(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg", ".jfif":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".bmp":
+		return "image/bmp"
+	case ".webp":
+		return "image/webp"
+	case ".ico":
+		return "image/x-icon"
+	case ".tif", ".tiff":
+		return "image/tiff"
+	case ".mp4", ".m4v":
+		return "video/mp4"
+	case ".mov":
+		return "video/quicktime"
+	case ".avi":
+		return "video/x-msvideo"
+	case ".mkv":
+		return "video/x-matroska"
+	case ".webm":
+		return "video/webm"
+	case ".mp3":
+		return "audio/mpeg"
+	case ".wav":
+		return "audio/wav"
+	case ".ogg":
+		return "audio/ogg"
+	case ".flac":
+		return "audio/flac"
+	case ".m4a", ".m4b", ".m4p", ".m4r":
+		return "audio/mp4"
+	case ".aac":
+		return "audio/aac"
+	}
+	return "application/octet-stream"
+}
+
 func RedirectIfNotForwardedHTTPS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		protocol := r.Header.Get("X-Forwarded-Proto") // Set by load balancer
@@ -382,7 +433,7 @@ func routeLabel(r *http.Request) string {
 	if path == "" || path == "/" {
 		return "/"
 	}
-	if path == "/readyz" || path == "/healthz" || path == "/file/download" {
+	if path == "/readyz" || path == "/healthz" || path == "/file/download" || path == "/file/view" {
 		return path
 	}
 	if strings.HasPrefix(path, "/image/") {

--- a/server/http/interceptors/interceptors_test.go
+++ b/server/http/interceptors/interceptors_test.go
@@ -84,3 +84,20 @@ func TestRedirectIfNotForwardedHTTPS(t *testing.T) {
 		})
 	}
 }
+
+func TestBasicMIMETypeFromExtension(t *testing.T) {
+	for _, tc := range []struct {
+		ext      string
+		expected string
+	}{
+		{".png", "image/png"},
+		{".jpg", "image/jpeg"},
+		{".jpeg", "image/jpeg"},
+		{".webm", "video/webm"},
+		{".svg", "application/octet-stream"},
+		{".js", "application/octet-stream"},
+		{".pdf", "application/octet-stream"},
+	} {
+		assert.Equal(t, tc.expected, BasicMIMETypeFromExtension(tc.ext))
+	}
+}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -440,6 +440,7 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 	mux.Handle("/app/", interceptors.WrapExternalHandler(env, http.StripPrefix("/app", afs)))
 	mux.Handle("/rpc/BuildBuddyService/", interceptors.WrapAuthenticatedExternalProtoletHandler(env, "/rpc/BuildBuddyService/", protoletHandler))
 	mux.Handle("/file/download", interceptors.WrapAuthenticatedExternalHandler(env, env.GetBuildBuddyServer()))
+	mux.Handle("/file/view", interceptors.WrapAuthenticatedExternalHandler(env, env.GetBuildBuddyServer()))
 	mux.Handle("/healthz", env.GetHealthChecker().LivenessHandler())
 	mux.Handle("/readyz", env.GetHealthChecker().ReadinessHandler())
 


### PR DESCRIPTION
If a target artifact has a recognized media extension like `.png` or `.webm`, then when clicking the "View" link, open the file in the browser (in a new tab) instead of the Code component, which currently shows a bunch of binary data.

Working towards improving the UX a little bit for webdriver tests, which produce image and video artifacts: https://buildbuddy-corp.slack.com/archives/C04S4M5U3BK/p1763512291359519

Also tweak the icon styling of the "View" icon a bit. The current icon looks grayed out and not super clickable.

Before:

<img width="151" height="44" alt="image" src="https://github.com/user-attachments/assets/34d4c5e0-89f9-4980-9966-f18019f5d07d" />

After:

<img width="151" height="44" alt="image" src="https://github.com/user-attachments/assets/2bc002f0-821e-44e7-a21b-811ff3a3fd71" />
