### PR TITLE
flaky_target_chip: set repo when available

### DIFF
--- a/app/target/flaky_target_chip.tsx
+++ b/app/target/flaky_target_chip.tsx
@@ -57,7 +57,7 @@ export default class FlakyTargetChipComponent extends React.Component<Props, Sta
         this.props.labels.length === 1
           ? "This target was recently flaky--click to see samples."
           : "Some failed targets were recently flaky--click to see samples.";
-      const href = `${Path.tapPath}?${params.toString()}#flakes`;
+      const href = `${Path.tapPath}?${params}#flakes`;
       return (
         <OutlinedLinkButton href={href} title={title} className="flaky-target-chip">
           <HelpCircle className="icon orange" /> Recently flaky


### PR DESCRIPTION
For users with a lot of repos, clicking on 'Recently flaky' button will
take them to the Flakes page without a repo pre-selected, thus they will
always get the default repo view.

Set the 'repo' url param when it's available on the Invocation page.
