### PR TITLE
[dev qa test] `test //...` in buildbuddy_dev_qa_test

### DIFF
--- a/tools/dev_qa_test/BUILD.bazel
+++ b/tools/dev_qa_test/BUILD.bazel
@@ -66,7 +66,7 @@ bazel_integration_test(
     env = {
         "QA_TARBALL_URL": "https://github.com/buildbuddy-io/buildbuddy/tarball/eb9115eafcdcd3c356fc470649c58a473910ae3c",
         "QA_STRIP_PREFIX": "buildbuddy-io-buildbuddy-eb9115e",
-        "QA_BAZEL_COMMAND": "test //cli/test/integration/compact:compact_test",
+        "QA_BAZEL_COMMAND": "test //...",
         "INJECT_TOOLCHAIN": "false",
         "UPDATE_LOCKFILE": "false",
     },

--- a/tools/dev_qa_test/dev_qa_test_runner.sh
+++ b/tools/dev_qa_test/dev_qa_test_runner.sh
@@ -112,7 +112,8 @@ build:dev_qa_test --jobs=100
 build:dev_qa_test --build_metadata=TAGS=qa-integration-test
 build:dev_qa_test --test_tag_filters=-performance,-webdriver,-docker,-bare
 build:dev_qa_test --nocache_test_results
-build:dev_qa_test --experimental_remote_cache_compression
+build:dev_qa_test --remote_cache_compression
+build:dev_qa_Test --remote_download_minimal
 EOF
 
 cat >> .bazelrc <<EOF


### PR DESCRIPTION
This change allows the `buildbuddy_dev_qa_test` target to run tests across the server, app, and enterprise directory trees. This brings the coverage of this test on par with the existing `dev_qa.py` test (and on a much more recent version of the codebase, to boot). Once we have cut a release that includes this change, I'll point the dev qa workflow at the //tools/dev_qa_test/... targets.