### PR TITLE
Fetch_server: some improvements

### DIFF
--- a/proto/remote_asset.proto
+++ b/proto/remote_asset.proto
@@ -497,3 +497,23 @@ message PushDirectoryRequest {
 // A response message for
 // [Push.PushDirectory][build.bazel.remote.asset.v1.Push.PushDirectory].
 message PushDirectoryResponse { /* empty */ }
+
+/******************************************************************************/
+/*                                                                            */
+/*                BEGIN BUILDBUDDY-SPECIFIC PROTO DECLARATIONS                */
+/*                                                                            */
+/******************************************************************************/
+
+// Key used for ActionCache entries representing remote-asset downloads
+// keyed by Bazel's canonical_id qualifier.
+message RemoteAssetActionKey {
+  // The canonical identifier supplied by Bazel via qualifier "bazel.canonical_id".
+  string canonical_id = 1;
+
+  // Optional checksum information provided via the "checksum.sri" qualifier.
+  build.bazel.remote.execution.v2.DigestFunction.Value checksum_digest_function = 2;
+  string checksum = 3;
+
+  // Reserved for future cache invalidation / partitioning.
+  string salt = 4;
+}

--- a/server/remote_asset/fetch_server/BUILD
+++ b/server/remote_asset/fetch_server/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/util/prefix",
         "//server/util/scratchspace",
         "//server/util/status",
+        "//third_party/singleflight",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",
         "@org_golang_google_genproto_googleapis_rpc//status",

--- a/server/remote_asset/fetch_server/BUILD
+++ b/server/remote_asset/fetch_server/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/buildbuddy_server",
+        "//server/remote_cache/action_cache_server",
         "//server/remote_cache/byte_stream_server",
         "//server/remote_cache/content_addressable_storage_server",
         "//server/remote_cache/digest",

--- a/server/remote_asset/fetch_server/fetch_server_test.go
+++ b/server/remote_asset/fetch_server/fetch_server_test.go
@@ -9,11 +9,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/buildbuddy_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_asset/fetch_server"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/action_cache_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -42,6 +44,8 @@ func runFetchServer(ctx context.Context, t *testing.T, env *testenv.TestEnv) *gr
 	require.NoError(t, err)
 	err = content_addressable_storage_server.Register(env)
 	require.NoError(t, err)
+	err = action_cache_server.Register(env)
+	require.NoError(t, err)
 
 	// Allow 127.0.0.1 so we can dial the server in the test.
 	flags.Set(t, "remote_asset.allowed_private_ips", []string{"127.0.0.0/8"})
@@ -52,6 +56,7 @@ func runFetchServer(ctx context.Context, t *testing.T, env *testenv.TestEnv) *gr
 
 	env.SetByteStreamClient(bspb.NewByteStreamClient(clientConn))
 	env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(clientConn))
+	env.SetActionCacheClient(repb.NewActionCacheClient(clientConn))
 	env.SetBuildBuddyServiceClient(bbspb.NewBuildBuddyServiceClient(clientConn))
 
 	fetchServer, err := fetch_server.NewFetchServer(env)
@@ -61,6 +66,7 @@ func runFetchServer(ctx context.Context, t *testing.T, env *testenv.TestEnv) *gr
 	bspb.RegisterByteStreamServer(grpcServer, byteStreamServer)
 	bbspb.RegisterBuildBuddyServiceServer(grpcServer, env.GetBuildBuddyServer())
 	repb.RegisterContentAddressableStorageServer(grpcServer, env.GetCASServer())
+	repb.RegisterActionCacheServer(grpcServer, env.GetActionCacheServer())
 
 	go runFunc()
 
@@ -422,6 +428,55 @@ func TestSubsequentRequestCacheHit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCanonicalIDUsesActionCache(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	require.NoError(t, scratchspace.Init())
+	clientConn := runFetchServer(ctx, t, te)
+	fetchClient := rapb.NewFetchClient(clientConn)
+
+	var upstreamHits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		fmt.Fprint(w, content)
+	}))
+	defer ts.Close()
+
+	checksumDigest, err := digest.Compute(bytes.NewReader([]byte(content)), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	qualifiers := []*rapb.Qualifier{
+		{
+			Name:  fetch_server.ChecksumQualifier,
+			Value: checksumQualifierFromContent(t, checksumDigest.GetHash(), repb.DigestFunction_SHA256),
+		},
+		{
+			Name:  fetch_server.BazelCanonicalIDQualifier,
+			Value: ts.URL, // Bazel concat all the urls and use it as the canonical id
+		},
+	}
+
+	req := &rapb.FetchBlobRequest{
+		Uris:           []string{ts.URL},
+		DigestFunction: repb.DigestFunction_SHA256,
+		Qualifiers:     qualifiers,
+	}
+
+	resp, err := fetchClient.FetchBlob(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(0), resp.GetStatus().Code)
+	assert.Equal(t, int32(1), upstreamHits.Load())
+
+	req.Uris = []string{ts.URL + "/should-not-be-hit"}
+
+	resp, err = fetchClient.FetchBlob(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(0), resp.GetStatus().Code)
+	assert.Equal(t, int32(1), upstreamHits.Load(), "canonical ID should allow serving from AC without refetching")
+	assert.Equal(t, checksumDigest.GetHash(), resp.GetBlobDigest().GetHash())
 }
 
 func TestFetchBlobWithBazelQualifiers(t *testing.T) {


### PR DESCRIPTION
This PR include a stack of changes:
- **fetch_server: use CutPrefix**
- **fetch_server: start using AC**
- **fetch_server: dedupe fetch requests with singleflight**

I just push them here for CI to run.
Probably should split them out to get reviewed separately.
