### PR TITLE
[SS] Support snapshot sharing between machine models

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -3267,7 +3267,7 @@ func getCPUID() *fcpb.CPUID {
 	return &fcpb.CPUID{
 		VendorId: int64(cpuid.CPU.VendorID),
 		Family:   int64(cpuid.CPU.Family),
-		Model:    int64(cpuid.CPU.Model),
+		// Don't include the model number, so that different models can share snapshots.
 	}
 }
 


### PR DESCRIPTION
Now that we'll have different machine model types in the same pool in SJC, remove the model number from the snapshot key so that snapshots can be shared between them