### PR TITLE
Add RPCs to AC and CAS services to fetch cache metadata

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -688,7 +688,7 @@ proto_library(
     name = "remote_execution_proto",
     srcs = ["remote_execution.proto"],
     deps = [
-        ":cache_proto",
+        ":context_proto",
         ":scheduler_proto",
         ":semver_proto",
         "@com_google_protobuf//:any_proto",
@@ -1850,6 +1850,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/remote_execution",
     proto = ":remote_execution_proto",
     deps = [
+        ":context_go_proto",
         ":scheduler_go_proto",
         ":semver_go_proto",
         "@com_google_cloud_go_longrunning//autogen/longrunningpb",

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 package build.bazel.remote.execution.v2;
 
-import "proto/cache.proto";
+import "proto/context.proto";
 import "proto/semver.proto";
 import "google/api/annotations.proto";
 import "google/longrunning/operations.proto";
@@ -213,7 +213,7 @@ service ActionCache {
 
   // BUILDBUDDY-SPECIFIC RPC.
   // Returns cache metadata for a given action result.
-  rpc GetCacheMetadata(cache.GetCacheMetadataRequest) returns (cache.GetCacheMetadataResponse);
+  rpc GetCacheMetadata(GetCacheMetadataRequest) returns (GetCacheMetadataResponse);
 }
 
 // The CAS (content-addressable storage) is used to store the inputs to and
@@ -567,7 +567,7 @@ service ContentAddressableStorage {
 
   // BUILDBUDDY-SPECIFIC RPC.
   // Returns cache metadata for a given blob.
-  rpc GetCacheMetadata(cache.GetCacheMetadataRequest) returns (cache.GetCacheMetadataResponse);
+  rpc GetCacheMetadata(GetCacheMetadataRequest) returns (GetCacheMetadataResponse);
 }
 
 // The Capabilities service may be used by remote execution clients to query
@@ -2906,4 +2906,27 @@ message StoredExecution {
   // The requested pool name from platform properties, before resolution to effective pool.
   string requested_pool = 77;
   string effective_pool = 78;
+}
+
+// Fetches metadata about a cache resource.
+message GetCacheMetadataRequest {
+  context.RequestContext request_context = 1;
+
+  // The digest of this resource.
+  Digest digest = 2;
+
+  // The namespace (remote instance name) this resource is stored in.
+  // Ex. "", "ios/1", "my_remote_instance"
+  string instance_name = 3;
+
+  // The digest function used to hash this resource and create the digest.
+  DigestFunction.Value digest_function = 4;
+}
+
+message GetCacheMetadataResponse {
+  context.ResponseContext response_context = 1;
+  int64 stored_size_bytes = 2;
+  int64 last_access_usec = 3;
+  int64 last_modify_usec = 4;
+  int64 digest_size_bytes = 5;
 }


### PR DESCRIPTION
We fetch cache metadata in 2 places: 

1. The cache requests card in the UI shows metadata about cache artifacts (both CAS and AC)
2. The fetch server needs to fetch cache metadata because the remote asset API only provides the digest hash and not the digest size. We need the digest size because our bytestream APIs to read and write blobs expect a fully formed digest including both hash + size. This is CAS-only

Currently the BuildbuddyService exposes a GetCacheMetadata RPC that we're using for these cases. When we move to a world where cache routing is enabled and there's not a single source of truth for the cache, each cache will need to expose a RPC for cache metadata

In the short-term this is needed to support the remote asset API in the cache proxies