### PR TITLE
make `workspace_status.sh` robust to running outside git checkout

### DIFF
--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -12,6 +12,18 @@
 
 set -eo pipefail # exit immediately if any command fails.
 
+# Check if we're in a git repository
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  # Not in a git repo - output defaults
+  echo "REPO_URL"
+  echo "COMMIT_SHA dev"
+  echo "GIT_BRANCH unknown"
+  echo "GIT_TREE_STATUS Unknown"
+  echo "STABLE_VERSION_TAG dev"
+  echo "STABLE_COMMIT_SHA dev"
+  exit 0
+fi
+
 function remove_url_credentials() {
   which perl >/dev/null && perl -pe 's#//.*?:.*?@#//#' || cat
 }


### PR DESCRIPTION
#10811 failed even after pointing the buildbuddy test to a commit that offers fallbacks in the `populate_version` and `populate_commit` targets in the `//server/version` package. This change makes sure stamping succeeds even when building outside of a git checkout.