### PR TITLE
[FC] Don't save snapshots when the balloon is malfunctioning

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2796,7 +2796,7 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 
 	if shouldSaveSnapshot && c.isBalloonEnabled() && c.machineHasBalloon(ctx) {
 		if err := c.reclaimMemoryWithBalloon(ctx); err != nil {
-			return status.WrapError(err, "reclaiming memory with the balloon failed, not saving snapshot")
+			return status.WrapErrorf(err, "reclaiming memory with the balloon failed, not saving snapshot for key %v", c.SnapshotKeySet().GetWriteKey())
 		}
 	}
 


### PR DESCRIPTION
When investigating [corrupted snapshots](https://buildbuddy-corp.slack.com/archives/C0777L0C2UW/p1764898227430599) that have `Failed to update balloon stats, missing descriptor` in the guest kernel logs, I noticed a trend where:
1. A workload finishes running
2. We try to expand the balloon to reclaim 90% available memory in the VM
3. The balloon fails to fully inflate, and then deflate back down
4. We save the snapshot
5. The next time a workload tries to start from this snapshot, it fails to connect to the vmexec server

I think there's either a bug in our balloon handler implementation, or in the firecracker balloon code. I created a firecracker [issue](https://github.com/firecracker-microvm/firecracker/issues/5566) to help debug the issue further

In the meantime, we shouldn't save the snapshot in these cases. Hopefully this will help reduce snapshot corruption