### PR TITLE
Fix cache service name

### DIFF
--- a/proto/cache_service.proto
+++ b/proto/cache_service.proto
@@ -6,7 +6,7 @@ package cache.service;
 
 option go_package = "cache_service";
 
-service CacheService {
+service Cache {
   rpc GetMetadata(cache.GetCacheMetadataRequest)
       returns (cache.GetCacheMetadataResponse);
 }


### PR DESCRIPTION
I realized that in the generated code, it automatically appends `Server` to the service name. So with the previous name, it was named `CacheServiceServer`