### PR TITLE
Add missing mnemonic to extract_bazel_installation

### DIFF
--- a/server/util/bazel/defs.bzl
+++ b/server/util/bazel/defs.bzl
@@ -6,6 +6,7 @@ def _extract_bazel_installation_impl(ctx):
     ctx.actions.run_shell(
         outputs = [out_dir],
         inputs = [ctx.executable.bazel],
+        mnemonic = "ExtractBazelInstall",
         command = """
             set -e
 


### PR DESCRIPTION
It's helpful to identify each action with a mnemonic so they can be filtered appropriately