### PR TITLE
Log dropped-digest messages at Debug instead of Warning

### DIFF
--- a/enterprise/server/batch_operator/batch_operator.go
+++ b/enterprise/server/batch_operator/batch_operator.go
@@ -439,7 +439,7 @@ func (u *batchOperator) batch(eqd *enqueuedDigests) {
 		if batchesForGroup.numDigests+1 > u.maxDigestsPerGroup {
 			batchesForGroup.mu.Unlock()
 			dropped = len(eqd.digests) - enqueued - duplicate
-			log.Warningf("[%s] maxDigestsPerGroup exceeded for group %s, dropping %d digests", u.name, groupID, dropped)
+			log.Debugf("[%s] maxDigestsPerGroup exceeded for group %s, dropping %d digests", u.name, groupID, dropped)
 			break
 		}
 		batchesForGroup.numDigests++


### PR DESCRIPTION
These messages make up most of the logs from AWS, and are already captured in metrics, so they're really just noise.