### PR TITLE
Patch gRPC to have more tiers in the default buffer pool

### DIFF
--- a/buildpatches/org_golang_google_grpc_more_buffer_sizes.patch
+++ b/buildpatches/org_golang_google_grpc_more_buffer_sizes.patch
@@ -1,0 +1,23 @@
+diff --git a/mem/buffer_pool.go b/mem/buffer_pool.go
+index f211e727..3880f83f 100644
+--- a/mem/buffer_pool.go
++++ b/mem/buffer_pool.go
+@@ -40,10 +40,14 @@ type BufferPool interface {
+ 
+ var defaultBufferPoolSizes = []int{
+ 	256,
+-	4 << 10,  // 4KB (go page size)
+-	16 << 10, // 16KB (max HTTP/2 frame size used by gRPC)
+-	32 << 10, // 32KB (default buffer size for io.Copy)
+-	1 << 20,  // 1MB
++	4 << 10,   // 4KB (go page size)
++	16 << 10,  // 16KB (max HTTP/2 frame size used by gRPC)
++	32 << 10,  // 32KB (default buffer size for io.Copy)
++	64 << 10,  // 64KB
++	128 << 10, // 128KB
++	256 << 10, // 256KB
++	512 << 10, // 512KB
++	1 << 20,   // 1MB
+ }
+ 
+ var defaultBufferPool BufferPool

--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -65,6 +65,9 @@ go_deps.module_override(
         # server gracefully, it's safe for us to allow gRPC to wait for all
         # ongoing requests to finish.
         "@com_github_buildbuddy_io_buildbuddy//buildpatches:org_golang_google_grpc_remove_drain_panic.patch",
+        # Add more buffer sizes to grpc mem buffer pool to reduce allocations.
+        # This speeds up large reads/writes.
+        "@com_github_buildbuddy_io_buildbuddy//buildpatches:org_golang_google_grpc_more_buffer_sizes.patch",
     ],
     path = "google.golang.org/grpc",
 )


### PR DESCRIPTION
This improves bytestream reads and writes by 10-20% in benchmarks, while allocating 10% less.

With the previous tiers, payloads of 32KiB+1byte would fall in the 1MiB tier, so they would allocate a lot more memory, plus every time we would get a 1MiB from the pool, we would clear the whole thing, even though we only use a part of it.

I'll send a PR or issue in the grpc-go repo.