### PR TITLE
refactor: improve task sizer interface

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -923,7 +923,7 @@ func (p *pool) warmupImage(ctx context.Context, cfg *WarmupConfig) error {
 		SchedulingMetadata: &scpb.SchedulingMetadata{
 			// Note: this will use the default task size estimates and not
 			// measurement-based task sizing, which requires the app.
-			TaskSize: tasksize.ApplyLimits(ctx, p.env.GetExperimentFlagProvider(), task, tasksize.Default(task)),
+			TaskSize: tasksize.ApplyLimits(ctx, p.env.GetExperimentFlagProvider(), task.GetCommand(), platProps, tasksize.Default(task)),
 		},
 		ExecutionTask: task,
 	}

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -44,6 +44,7 @@ go_test(
         "//server/util/bazel",
         "//server/util/grpc_client",
         "//server/util/log",
+        "//server/util/platform",
         "//server/util/rexec",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -62,6 +62,7 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/grpc_server",
         "//server/util/log",
+        "//server/util/platform",
         "//server/util/prefix",
         "//server/util/retry",
         "//server/util/status",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -61,6 +61,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -1356,23 +1357,23 @@ func (r *testRunner) Run(ctx context.Context, ioStats *repb.IOStats) *interfaces
 }
 
 type FakeTaskSizer struct {
-	GetImpl func(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize
+	GetImpl func(ctx context.Context, cmd *repb.Command, props *platform.Properties) *scpb.TaskSize
 }
 
 var _ interfaces.TaskSizer = (*FakeTaskSizer)(nil)
 
-func (f *FakeTaskSizer) Get(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize {
+func (f *FakeTaskSizer) Get(ctx context.Context, cmd *repb.Command, props *platform.Properties) *scpb.TaskSize {
 	if f.GetImpl == nil {
 		return nil
 	}
-	return f.GetImpl(ctx, task)
+	return f.GetImpl(ctx, cmd, props)
 }
 
-func (f *FakeTaskSizer) Update(ctx context.Context, action *repb.Action, cmd *repb.Command, md *repb.ExecutedActionMetadata) error {
+func (f *FakeTaskSizer) Update(ctx context.Context, cmd *repb.Command, props *platform.Properties, md *repb.ExecutedActionMetadata) error {
 	return nil
 }
 
-func (f *FakeTaskSizer) Predict(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize {
+func (f *FakeTaskSizer) Predict(ctx context.Context, action *repb.Action, cmd *repb.Command, props *platform.Properties) *scpb.TaskSize {
 	return nil
 }
 

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rexec"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
@@ -2439,7 +2440,7 @@ func testCustomResources(t *testing.T, test customResourcesTest) {
 		EnvModifier: func(env *real_environment.RealEnv) {
 			env.SetTaskRouter(taskRouter)
 			env.SetTaskSizer(&rbetest.FakeTaskSizer{
-				GetImpl: func(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize {
+				GetImpl: func(ctx context.Context, cmd *repb.Command, props *platform.Properties) *scpb.TaskSize {
 					return test.MeasuredTaskSize
 				},
 			})

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1008,14 +1008,14 @@ type TaskRouter interface {
 type TaskSizer interface {
 	// Get returns the previously measured size for a task, or nil if this data
 	// is not available.
-	Get(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize
+	Get(ctx context.Context, cmd *repb.Command, props *platform.Properties) *scpb.TaskSize
 
 	// Predict returns a predicted task size using a model, or nil if no model
 	// is configured.
-	Predict(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize
+	Predict(ctx context.Context, action *repb.Action, cmd *repb.Command, props *platform.Properties) *scpb.TaskSize
 
 	// Update records a measured task size.
-	Update(ctx context.Context, action *repb.Action, cmd *repb.Command, md *repb.ExecutedActionMetadata) error
+	Update(ctx context.Context, cmd *repb.Command, props *platform.Properties, md *repb.ExecutedActionMetadata) error
 }
 
 // ScheduledTask represents an execution task along with its scheduling metadata


### PR DESCRIPTION
Instead of having `TaskSizer` take an `ExecutionTask` in its interface methods, have it take the action, command, and parsed platform props explicitly (as needed).

This has a few benefits:
- It allows `Update` to call `Get`, which should allow us to experiment with task sizing logic that updates the current task size based on the previous size in various ways - e.g. not changing the size too drastically relative to the previous size
- It lets us avoid re-parsing platform props, and simplifies the error handling associated with that.
- It reduces dependencies, since ExecutionTask is a big proto with lots of other fields that aren't needed for task sizing.