### PR TITLE
Add back the channelz patch

### DIFF
--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -78,6 +78,11 @@ go_deps.module_override(
     ],
     path = "kythe.io",
 )
+go_deps.module_override(
+    patch_strip = 1,
+    patches = ["@com_github_buildbuddy_io_buildbuddy//buildpatches:go-grpc-channelz.patch"],
+    path = "github.com/rantav/go-grpc-channelz",
+)
 
 # Go repos with custom directives
 go_deps.gazelle_override(


### PR DESCRIPTION
This seems trivially safe to do since we haven't updated the patched library in 2 years.