### PR TITLE
Add separate redis buffering for clickhouse usage

### DIFF
--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -26,6 +26,7 @@ go_library(
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/server/util/usageutil/BUILD
+++ b/server/util/usageutil/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/interfaces",
         "//server/tables",
+        "//server/usage/sku",
         "//server/util/alert",
         "//server/util/bazel_request",
         "//server/util/claims",


### PR DESCRIPTION
Working towards using the OLAP interface directly: instead of flushing the same buffered data to both MySQL and ClickHouse (and converting the MySQL-oriented buffer format to the OLAP format), add separate buffering tailored to the ClickHouse format. This gets us a step closer to being able to use the OLAP format directly, with arbitrary SKUs and labels, since the new redis format supports arbitrary `label=key=value` pairs (rather than fixed known labels), as well as arbitrary SKUs.

The current redis layout for buffered MySQL usage is

```
Key: "usage/collections/<period>"
Value (SET):
  - "group_id=<gid>&origin=<origin>&client=<client>&server=<server>" # encoded `Collection` struct
  - ...

Key: "usage/counts/<period>/<encoded_collection>"
Value (HASH):
  "invocation_count": <invocation_count>
  ...
  "cache_downloaded_bytes": <cache_downloaded_bytes>

...
```

The new redis layout specifically for ClickHouse is

```
Key: "usage/v2/collections/<period>"
Value (SET):
  - "group_id=<gid>&label=key1=val1&...&label=keyN=valueN" # encoded `OLAPCollection` struct
  - ...

Key: "usage/v2/counts/<period>/<encoded_collection>"
Value (HASH):
  <sku>: <count>
  ...

...
```

The new format is almost identical except for the "/v2/" part of the keys, and also the labels and SKUs can be arbitrary instead of just a fixed list of supported values.

