### PR TITLE
Changing group status should refresh buckets

### DIFF
--- a/enterprise/server/quota/BUILD
+++ b/enterprise/server/quota/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/quota",
     deps = [
         "//proto:group_go_proto",
+        "//proto:server_notification_go_proto",
         "//server/environment",
         "//server/metrics",
         "//server/real_environment",

--- a/proto/server_notification.proto
+++ b/proto/server_notification.proto
@@ -7,8 +7,13 @@ message InvalidateIPRulesCache {
   string group_id = 1;
 }
 
+// Reloads the quota buckets, but does not reset their state. This would 
+// remove a bucket that longer applies to a group.
+message ReloadQuotaBuckets {}
+
 message Notification {
   // Only one of the fields should be set.
 
   InvalidateIPRulesCache invalidate_ip_rules_cache = 1;
+  ReloadQuotaBuckets reload_quota_buckets = 2;
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -663,6 +663,12 @@ func (s *BuildBuddyServer) SetGroupStatus(ctx context.Context, req *grpb.SetGrou
 		return nil, err
 	}
 
+	if gsm := s.env.GetQuotaManager(); gsm != nil {
+		if err := gsm.ReloadBucketsAndNotify(ctx); err != nil {
+			log.Warningf("Error reloading quota buckets: %s", err)
+		}
+	}
+
 	return &grpb.SetGroupStatusResponse{}, nil
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1383,6 +1383,11 @@ type QuotaManager interface {
 	// If the rate limit has not been exceeded, the underlying storage is updated
 	// by the supplied quantity.
 	Allow(ctx context.Context, namespace string, quantity int64) error
+
+	// Reloads the quota buckets, but does not reset their state. This would
+	// remove a bucket that longer applies to a group. It will send a notification
+	// so that other servers also reload.
+	ReloadBucketsAndNotify(ctx context.Context) error
 }
 
 // A Metadater implements the Metadata() method and returns a StorageMetadata


### PR DESCRIPTION
PR will tell quota to reload the buckets (this won't reset them, but will remove any deleted/changed buckets) any time the status of a group is set.