### PR TITLE
Cap the compress buffer size in bytestream.Write

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -363,7 +363,8 @@ func (s *ByteStreamServer) beginWrite(ctx context.Context, req *bspb.WriteReques
 		// If the cache supports compression but the request isn't compressed,
 		// wrap the cache writer in a compressor. This is faster than sending
 		// uncompressed data to the cache and letting it compress it.
-		compressor, err := compression.NewZstdCompressingWriter(committedWriteCloser, s.bufferPool, r.GetDigest().GetSizeBytes())
+		bufSize := int64(digest.SafeBufferSize(r.ToProto(), compressBufSize))
+		compressor, err := compression.NewZstdCompressingWriter(committedWriteCloser, s.bufferPool, bufSize)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This already works since by `bytebufferpool.VariableSizePool` won't return buffers larger than it's max size, but this makes it more explicit