### PR TITLE
Add group_status to experimental flag targeting

### DIFF
--- a/enterprise/server/experiments/BUILD
+++ b/enterprise/server/experiments/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:group_go_proto",
         "//server/interfaces",
         "//server/real_environment",
         "//server/util/bazel_request",
@@ -27,6 +28,7 @@ go_test(
     srcs = ["experiments_test.go"],
     deps = [
         ":experiments",
+        "//proto:group_go_proto",
         "//server/tables",
         "//server/testutil/testauth",
         "//server/testutil/testenv",

--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-feature/go-sdk/openfeature"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
 )
 
@@ -111,6 +112,8 @@ type Option func(*Options)
 //   - group_id: this as used as the target key (default ID) and also provided
 //     as an attribute. Parsed from claims.
 //   - user_id: Parsed from claims.
+//   - group_status: The group's status as a string (e.g., "FREE_TIER_GROUP_STATUS",
+//     "ENTERPRISE_GROUP_STATUS"). Parsed from claims.
 //   - invocation_id: Parsed from the bazel request metadata, if set.
 //   - action_id: Parsed from the bazel request metadata, if set.
 //
@@ -127,6 +130,9 @@ func (fp *FlagProvider) getEvaluationContext(ctx context.Context, opts ...any) o
 		options.targetingKey = claims.GetExperimentTargetingGroupID()
 		options.attributes["group_id"] = claims.GetExperimentTargetingGroupID()
 		options.attributes["user_id"] = claims.GetUserID()
+		if status := claims.GetGroupStatus(); status != grpb.Group_UNKNOWN_GROUP_STATUS {
+			options.attributes["group_status"] = grpb.Group_GroupStatus_name[int32(status)]
+		}
 	}
 	rmd := bazel_request.GetRequestMetadata(ctx)
 	if iid := rmd.GetToolInvocationId(); len(iid) > 0 {


### PR DESCRIPTION
This also allows us to use targeting for any specific features to a group's status.

We could use this, for example, to attach quotas to a specific `FREE_TIER_GROUP_STATUS`.