### PR TITLE
[SS] Change default remote snapshot write policy

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1116,15 +1116,12 @@ func (c *FirecrackerContainer) shouldSaveRemoteSnapshot(ctx context.Context) boo
 		// We want to always save the default snapshot, because it is used as a fallback for
 		// runs on other branches, so we want it to stay up-to-date.
 		return true
-	} else if remoteSavePolicy == platform.OnlySaveNonDefaultSnapshotIfNoneAvailable {
-		return !c.hasRemoteSnapshot(ctx, c.loader)
+	} else if remoteSavePolicy == platform.OnlySaveFirstNonDefaultSnapshot {
+		return !c.hasRemoteSnapshotForKey(ctx, c.loader, c.SnapshotKeySet().GetBranchKey())
 	}
 
-	// By default (applies if save policy is unset or invalid) or if
-	// savePolicy=OnlySaveFirstNonDefaultRemoteSnapshot,
-	// only save a remote snapshot if a remote snapshot for the primary git branch key
-	// doesn't already exist.
-	return !c.hasRemoteSnapshotForKey(ctx, c.loader, c.SnapshotKeySet().GetBranchKey())
+	// By default, savePolicy=OnlySaveNonDefaultSnapshotIfNoneAvailable,
+	return !c.hasRemoteSnapshot(ctx, c.loader)
 }
 
 func (c *FirecrackerContainer) shouldSaveLocalSnapshot(ctx context.Context) bool {

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -170,10 +170,10 @@ const (
 const (
 	// Every run will save a snapshot.
 	AlwaysSaveSnapshot = "always"
-	// Default. Only the first run on a non-default ref will save a snapshot.
+	// Only the first run on a non-default ref will save a snapshot.
 	// All runs on default refs will save a snapshot.
 	OnlySaveFirstNonDefaultSnapshot = "first-non-default-ref"
-	// Will only save a snapshot on a non-default ref if there are no
+	// Default. Will only save a snapshot on a non-default ref if there are no
 	// snapshots available. If there is a fallback default snapshot, still will not save
 	// a snapshot.
 	// All runs on default refs will save a snapshot.


### PR DESCRIPTION
Now that the new Workflows cluster doesn't have auto-scaling, we are able to reuse a higher number of local snapshots. This means we don't need to write as many remote snapshots