### PR TITLE
When linking to action history, drill down to execution metric

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -1556,7 +1556,7 @@ function getDrilldownUrl(targetLabel?: string, actionMnemonic?: string): string 
     return "";
   }
   const dimensionParam = `${encodeTargetLabelUrlParam(targetLabel)}|${encodeActionMnemonicUrlParam(actionMnemonic)}`;
-  return `/trends/?d=${encodeURIComponent(dimensionParam)}#drilldown`;
+  return `/trends/?d=${encodeURIComponent(dimensionParam)}&ddMetric=e4#drilldown`;
 }
 
 export function encodeTargetLabelUrlParam(targetLabel: string): string {


### PR DESCRIPTION
Without this, you'll drill-down to invocations here the target / mnemonic filters have no effect. Going with `Execution action execution time`.