### PR TITLE
Create new groups with inherited status

### DIFF
--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -593,6 +593,7 @@ func (s *BuildBuddyServer) CreateGroup(ctx context.Context, req *grpb.CreateGrou
 
 	group.URLIdentifier = strings.TrimSpace(req.GetUrlIdentifier())
 	group.SuggestionPreference = grpb.SuggestionPreference_ENABLED
+	group.Status = grpb.Group_UNKNOWN_GROUP_STATUS
 
 	groupID, err := userDB.CreateGroup(ctx, group)
 	if err != nil {

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -299,6 +299,7 @@ func userClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
 	groupMemberships := make([]*interfaces.GroupMembership, 0, len(u.Groups))
 	cacheEncryptionEnabled := false
 	enforceIPRules := false
+	groupStatus := grpb.Group_UNKNOWN_GROUP_STATUS
 	var capabilities []cappb.Capability
 	for _, g := range u.Groups {
 		allowedGroups = append(allowedGroups, g.Group.GroupID)
@@ -310,6 +311,7 @@ func userClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
 			// TODO: move these fields into u.GroupMemberships
 			cacheEncryptionEnabled = g.Group.CacheEncryptionEnabled
 			enforceIPRules = g.Group.EnforceIPRules
+			groupStatus = g.Group.Status
 			capabilities = g.Capabilities
 		}
 	}
@@ -321,6 +323,7 @@ func userClaims(u *tables.User, effectiveGroup string) (*Claims, error) {
 		Capabilities:           capabilities,
 		CacheEncryptionEnabled: cacheEncryptionEnabled,
 		EnforceIPRules:         enforceIPRules,
+		GroupStatus:            groupStatus,
 	}, nil
 }
 


### PR DESCRIPTION
If a user creates a new org from the settings, they should inherit from the creating user.

Group status needs to also properly propagate to the user when they're not using an API key.

In order to prevent any unexpected behavior or apply incorrect group statuses. Only free tier and blocked group statuses will inherit. This comes from the principle that we would much rather not apply restrictions than incorrectly apply restrictions.