### PR TITLE
Revert Don't save snapshots when the balloon is malfunctioning

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2805,7 +2805,7 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 
 	if shouldSaveSnapshot && c.isBalloonEnabled() && c.machineHasBalloon(ctx) {
 		if err := c.reclaimMemoryWithBalloon(ctx); err != nil {
-			return status.WrapErrorf(err, "reclaiming memory with the balloon failed, not saving snapshot for key %v", c.SnapshotKeySet().GetWriteKey())
+			log.CtxWarningf(ctx, "Reclaiming memory with the balloon failed, not saving snapshot for key %v: %s", c.SnapshotKeySet().GetWriteKey(), err)
 		}
 	}
 


### PR DESCRIPTION
Looking at the dev logs, this error is being returned more than I expected

After a workload completes, we try to (A) inflate the balloon to reclaim 90% of available memory, and then (B) shrink the balloon back down so the guest has full memory available for future workloads.

When I was investigating snapshot failures, balloon failures in (B) seemed problematic. In addition to potentially indicating the guest has been corrupted, if the balloon fails to shrink down, future workloads won't have enough memory to run

In dev, it seems like (A) is triggering frequently. This might not actually be a problem. Reset the error back to a log so we can do more investigation before this goes to prod