### PR TITLE
[OCIFetcherServer] Add read-through caching for FetchBlob and FetchManifest

### DIFF
--- a/enterprise/server/oci/ocifetcher/BUILD
+++ b/enterprise/server/oci/ocifetcher/BUILD
@@ -7,11 +7,14 @@ go_library(
     srcs = ["ocifetcher.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ocifetcher",
     deps = [
+        "//enterprise/server/util/ocicache",
         "//proto:oci_fetcher_go_proto",
         "//proto:registry_go_proto",
+        "//proto:remote_execution_go_proto",
         "//server/http/httpclient",
         "//server/interfaces",
         "//server/real_environment",
+        "//server/util/bytebufferpool",
         "//server/util/claims",
         "//server/util/flag",
         "//server/util/hash",
@@ -23,6 +26,7 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],
 )
 
@@ -31,12 +35,16 @@ go_test(
     srcs = ["ocifetcher_test.go"],
     deps = [
         ":ocifetcher",
+        "//enterprise/server/testutil/enterprise_testenv",
         "//enterprise/server/testutil/testregistry",
         "//proto:capability_go_proto",
         "//proto:oci_fetcher_go_proto",
         "//proto:registry_go_proto",
+        "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/testutil/testauth",
+        "//server/testutil/testcache",
+        "//server/testutil/testenv",
         "//server/testutil/testhttp",
         "//server/util/claims",
         "//server/util/status",
@@ -44,6 +52,7 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -11,9 +11,11 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocicache"
 	"github.com/buildbuddy-io/buildbuddy/server/http/httpclient"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bytebufferpool"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
@@ -26,8 +28,10 @@ import (
 
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	gcrname "github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
 const (
@@ -38,15 +42,16 @@ const (
 var (
 	mirrors           = flag.Slice("executor.container_registry_mirrors", []interfaces.MirrorConfig{}, "")
 	allowedPrivateIPs = flag.Slice("executor.container_registry_allowed_private_ips", []string{}, "Allowed private IP ranges for container registries. Private IPs are disallowed by default.")
-)
 
-type pullerLRUEntry struct {
-	puller *remote.Puller
-}
+	blobBufPool = bytebufferpool.VariableSize(blobChunkSize)
+)
 
 type ociFetcherServer struct {
 	allowedPrivateIPs []*net.IPNet
 	mirrors           []interfaces.MirrorConfig
+
+	bsClient bspb.ByteStreamClient
+	acClient repb.ActionCacheClient
 
 	mu        sync.Mutex
 	pullerLRU *lru.LRU[*pullerLRUEntry]
@@ -55,9 +60,17 @@ type ociFetcherServer struct {
 // NewServer constructs an OCIFetcherServer that
 // fetches OCI blobs and manifests from remote registries.
 //
+// bsClient and acClient are required for blob caching.
+//
 // It is preferred to construct only one server, so that there is only
 // one Puller cache per process.
-func NewServer() (ofpb.OCIFetcherServer, error) {
+func NewServer(bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient) (ofpb.OCIFetcherServer, error) {
+	if bsClient == nil {
+		return nil, status.FailedPreconditionError("OCIFetcherServer requires a non-nil byte stream client")
+	}
+	if acClient == nil {
+		return nil, status.FailedPreconditionError("OCIFetcherServer requires a non-nil action cache client")
+	}
 	allowedPrivateIPs, err := ParseAllowedPrivateIPs()
 	if err != nil {
 		return nil, err
@@ -67,22 +80,474 @@ func NewServer() (ofpb.OCIFetcherServer, error) {
 		MaxSize: int64(pullerLRUMaxEntries),
 	})
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("error initializing puller cache: %s", err)
 	}
 	return &ociFetcherServer{
 		allowedPrivateIPs: allowedPrivateIPs,
 		mirrors:           Mirrors(),
+		bsClient:          bsClient,
+		acClient:          acClient,
 		pullerLRU:         pullerLRU,
 	}, nil
 }
 
 func RegisterServer(env *real_environment.RealEnv) error {
-	server, err := NewServer()
+	server, err := NewServer(env.GetByteStreamClient(), env.GetActionCacheClient())
 	if err != nil {
 		return err
 	}
 	env.SetOCIFetcherServer(server)
 	return nil
+}
+
+// FetchBlob streams an OCI blob from the byte stream server if present.
+// Otherwise it streams the blob from the upstream remote registry, writing
+// to the byte stream server at the same time.
+//
+// Requests may have a bypass_registry flag set.
+// Server admins can bypass the registry: the blob will be streamed from the byte stream
+// server if present, and FetchBlob will not fall back to the remote registry.
+func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	ctx := stream.Context()
+
+	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return err
+	}
+
+	blobRef, err := gcrname.ParseReference(req.GetRef())
+	if err != nil {
+		return status.InvalidArgumentErrorf("invalid blob reference %q: %s", req.GetRef(), err)
+	}
+
+	digestRef, ok := blobRef.(gcrname.Digest)
+	if !ok {
+		return status.InvalidArgumentErrorf("blob reference must be a digest reference, got %q", req.GetRef())
+	}
+
+	repo := digestRef.Context()
+	hash, err := gcr.NewHash(digestRef.DigestStr())
+	if err != nil {
+		return status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+	}
+
+	err = s.fetchBlobFromCache(ctx, stream, repo, hash)
+	if err == nil {
+		return nil
+	}
+	if !status.IsNotFoundError(err) {
+		// It is possible this error occurred while writing to the stream.
+		// Since we do not know the state of the stream, it is not safe
+		// to write bytes to the stream past this point.
+		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
+		return err
+	}
+
+	if req.GetBypassRegistry() {
+		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", blobRef)
+	}
+
+	layer, err := withPullerRetry(ctx, s, blobRef, req.GetCredentials(), func(puller *remote.Puller) (gcr.Layer, error) {
+		return puller.Layer(ctx, digestRef)
+	})
+	if err != nil {
+		return err
+	}
+
+	rc, err := layer.Compressed()
+	if err != nil {
+		return wrapError(err, "error getting compressed layer")
+	}
+	// Note: rc is closed by cachedRC.Close() in the happy path,
+	// or by defer rc.Close() in the early-return paths below.
+
+	mediaType, err := layer.MediaType()
+	if err != nil {
+		defer rc.Close()
+		log.CtxWarningf(ctx, "Could not get media type for layer, skipping cache: %s", err)
+		return s.streamBlob(rc, stream)
+	}
+
+	size, err := layer.Size()
+	if err != nil {
+		defer rc.Close()
+		log.CtxWarningf(ctx, "Could not get size for layer, skipping cache: %s", err)
+		return s.streamBlob(rc, stream)
+	}
+
+	cachedRC, err := ocicache.NewBlobReadThroughCacher(ctx, rc, s.bsClient, s.acClient, repo, hash, string(mediaType), size)
+	if err != nil {
+		defer rc.Close()
+		log.CtxWarningf(ctx, "Error creating read-through cacher, skipping cache: %s", err)
+		return s.streamBlob(rc, stream)
+	}
+	defer cachedRC.Close()
+
+	return s.streamBlob(cachedRC, stream)
+}
+
+// FetchBlobMetadata returns OCI blob metadata (size, media type).
+// It will first read this metadata from the action cache, falling back
+// to the upstream remote registry.
+//
+// Requests may have a bypass_registry flag set.
+// Server admins can bypass the registry: the metadata will be served from the action cache
+// if present. If not present, FetchBlobMetadata will not fall back to the remote registry.
+func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.FetchBlobMetadataRequest) (*ofpb.FetchBlobMetadataResponse, error) {
+	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
+	}
+
+	blobRef, err := gcrname.ParseReference(req.GetRef())
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid blob reference %q: %s", req.GetRef(), err)
+	}
+
+	digestRef, ok := blobRef.(gcrname.Digest)
+	if !ok {
+		return nil, status.InvalidArgumentErrorf("blob reference must be a digest reference (e.g., repo@sha256:...), got %q", req.GetRef())
+	}
+
+	repo := digestRef.Context()
+	hash, err := gcr.NewHash(digestRef.DigestStr())
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+	}
+
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
+	if err == nil {
+		return &ofpb.FetchBlobMetadataResponse{
+			Size:      metadata.GetContentLength(),
+			MediaType: metadata.GetContentType(),
+		}, nil
+	}
+	if !status.IsNotFoundError(err) {
+		log.CtxWarningf(ctx, "Error fetching blob metadata from cache: %s", err)
+	}
+
+	if req.GetBypassRegistry() {
+		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", blobRef)
+	}
+
+	layer, err := withPullerRetry(ctx, s, blobRef, req.GetCredentials(), func(puller *remote.Puller) (gcr.Layer, error) {
+		return puller.Layer(ctx, digestRef)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	size, sizeErr := layer.Size()
+	if sizeErr != nil {
+		return nil, wrapError(sizeErr, "error getting layer size")
+	}
+	mediaType, mtErr := layer.MediaType()
+	if mtErr != nil {
+		return nil, wrapError(mtErr, "error getting layer media type")
+	}
+	return &ofpb.FetchBlobMetadataResponse{
+		Size:      size,
+		MediaType: string(mediaType),
+	}, nil
+}
+
+// FetchManifest returns an OCI manifest from the action cache if present,
+// falling back to the remote registry if not present.
+// FetchManifest will write the manifest contents to the action cache
+// after reading from the remote registry.
+//
+// Requests may have a bypass_registry flag set.
+// Server admins can bypass the registry: the manifest will be served from the action cache
+// if present. If not present, FetchManifest will not fall back to the remote registry.
+func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchManifestRequest) (*ofpb.FetchManifestResponse, error) {
+	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
+	}
+
+	imageRef, err := gcrname.ParseReference(req.GetRef())
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", req.GetRef(), err)
+	}
+
+	var hash gcr.Hash
+	if digestRef, ok := imageRef.(gcrname.Digest); ok {
+		hash, err = gcr.NewHash(digestRef.DigestStr())
+		if err != nil {
+			return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+		}
+	} else {
+		if req.GetBypassRegistry() {
+			return nil, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", imageRef)
+		}
+
+		desc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*gcr.Descriptor, error) {
+			return puller.Head(ctx, imageRef)
+		})
+		if err != nil {
+			return nil, err
+		}
+		hash, err = gcr.NewHash(desc.Digest.String())
+		if err != nil {
+			return nil, status.InvalidArgumentErrorf("invalid resolved digest %q: %s", desc.Digest.String(), err)
+		}
+	}
+
+	repo := imageRef.Context()
+	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, repo, hash, imageRef)
+	if err == nil {
+		return &ofpb.FetchManifestResponse{
+			Digest:    hash.String(),
+			Size:      int64(len(cached.GetRaw())),
+			MediaType: cached.GetContentType(),
+			Manifest:  cached.GetRaw(),
+		}, nil
+	}
+	if !status.IsNotFoundError(err) {
+		log.CtxWarningf(ctx, "Error fetching manifest from cache: %s", err)
+	}
+
+	if req.GetBypassRegistry() {
+		return nil, status.NotFoundErrorf("bypassing registry, but manifest for %q not found in cache", imageRef)
+	}
+
+	remoteDesc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*remote.Descriptor, error) {
+		return puller.Get(ctx, imageRef)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, repo, hash, string(remoteDesc.MediaType), imageRef); err != nil {
+		log.CtxWarningf(ctx, "Error writing manifest to cache: %s", err)
+	}
+
+	return &ofpb.FetchManifestResponse{
+		Digest:    remoteDesc.Digest.String(),
+		Size:      remoteDesc.Size,
+		MediaType: string(remoteDesc.MediaType),
+		Manifest:  remoteDesc.Manifest,
+	}, nil
+}
+
+// FetchManifestMetadata fetches metadata (digest, size, media type) for an OCI manifest
+// from a remote registry.
+//
+// FetchManifestMetadata does not read from or write to the action cache or byte stream server.
+// Callers may rely on FetchManifestMetadata returning successfully as an indication
+// that the input credentials grant access to the OCI image in the remote registry.
+// Bypassing the registry is not possible. Requests that set the bypass_registry flag
+// will fail with an error.
+func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.FetchManifestMetadataRequest) (*ofpb.FetchManifestMetadataResponse, error) {
+	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
+	}
+	imageRef, err := gcrname.ParseReference(req.GetRef())
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", req.GetRef(), err)
+	}
+
+	desc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*gcr.Descriptor, error) {
+		return puller.Head(ctx, imageRef)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ofpb.FetchManifestMetadataResponse{
+		Digest:    desc.Digest.String(),
+		Size:      desc.Size,
+		MediaType: string(desc.MediaType),
+	}, nil
+}
+
+func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Credentials) []remote.Option {
+	opts := []remote.Option{remote.WithContext(ctx)}
+
+	if creds != nil && creds.GetUsername() != "" && creds.GetPassword() != "" {
+		opts = append(opts, remote.WithAuth(&authn.Basic{
+			Username: creds.GetUsername(),
+			Password: creds.GetPassword(),
+		}))
+	}
+
+	tr := httpclient.New(s.allowedPrivateIPs, "oci_fetcher").Transport
+
+	if len(s.mirrors) > 0 {
+		opts = append(opts, remote.WithTransport(NewMirrorTransport(tr, s.mirrors)))
+	} else {
+		opts = append(opts, remote.WithTransport(tr))
+	}
+
+	return opts
+}
+
+func (s *ociFetcherServer) getOrCreatePuller(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*remote.Puller, error) {
+	key := pullerKey(imageRef, creds)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.pullerLRU.Get(key)
+
+	if ok {
+		return entry.puller, nil
+	}
+
+	remoteOpts := s.getRemoteOpts(ctx, creds)
+	puller, err := remote.NewPuller(remoteOpts...)
+	if err != nil {
+		return nil, status.InternalErrorf("error creating puller: %s", err)
+	}
+	s.pullerLRU.Add(key, &pullerLRUEntry{puller: puller})
+
+	return puller, nil
+}
+
+func (s *ociFetcherServer) evictPuller(imageRef gcrname.Reference, creds *rgpb.Credentials) {
+	key := pullerKey(imageRef, creds)
+	s.mu.Lock()
+	s.pullerLRU.Remove(key)
+	s.mu.Unlock()
+}
+
+
+// fetchBlobFromCache attempts to fetch a blob from the cache and streams it directly to the gRPC response.
+// Returns nil if successful, NotFoundError if not in cache, or another error on failure.
+func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, repo gcrname.Repository, hash gcr.Hash) error {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
+	if err != nil {
+		return err
+	}
+	w := &grpcStreamWriter{stream: stream}
+	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, hash, metadata.GetContentLength())
+}
+
+// streamBlob reads from rc and streams the data to the gRPC stream in chunks.
+func (s *ociFetcherServer) streamBlob(rc io.Reader, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	buf := blobBufPool.Get(blobChunkSize)
+	defer blobBufPool.Put(buf)
+	for {
+		n, err := rc.Read(buf)
+		if n > 0 {
+			if sendErr := stream.Send(&ofpb.FetchBlobResponse{Data: buf[:n]}); sendErr != nil {
+				return status.WrapError(sendErr, "send")
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return status.InternalErrorf("error reading blob: %s", err)
+		}
+	}
+}
+
+func pullerKey(ref gcrname.Reference, creds *rgpb.Credentials) string {
+	if creds == nil {
+		return hash.Strings(
+			ref.Context().RegistryStr(),
+			ref.Context().RepositoryStr(),
+			"",
+			"",
+		)
+	}
+	return hash.Strings(
+		ref.Context().RegistryStr(),
+		ref.Context().RepositoryStr(),
+		creds.GetUsername(),
+		creds.GetPassword(),
+	)
+}
+
+// withPullerRetry handles the common pattern of executing an operation with a puller,
+// evicting and retrying on failure due to expired tokens.
+func withPullerRetry[T any](
+	ctx context.Context,
+	s *ociFetcherServer,
+	ref gcrname.Reference,
+	creds *rgpb.Credentials,
+	op func(puller *remote.Puller) (T, error),
+) (T, error) {
+	var zero T
+
+	puller, err := s.getOrCreatePuller(ctx, ref, creds)
+	if err != nil {
+		return zero, err
+	}
+
+	result, err := op(puller)
+	if err == nil {
+		return result, nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return zero, err
+	}
+
+	// Pullers from the LRU may have expired Bearer tokens, so we evict and retry on most errors.
+	s.evictPuller(ref, creds)
+	puller, err = s.getOrCreatePuller(ctx, ref, creds)
+	if err != nil {
+		return zero, err
+	}
+
+	result, err = op(puller)
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return zero, err
+	}
+	if err != nil {
+		s.evictPuller(ref, creds)
+		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
+			return zero, status.UnauthenticatedErrorf("not authorized to access resource: %s", err)
+		}
+		return zero, status.UnavailableErrorf("could not fetch from remote registry: %s", err)
+	}
+
+	return result, nil
+}
+
+// authorizeBypassRegistry checks if bypass_registry is enabled and if so,
+// verifies the caller has server admin permissions. Returns an error if
+// bypass_registry is true but the caller is not a server admin.
+func authorizeBypassRegistry(ctx context.Context, bypassRegistry bool) error {
+	if !bypassRegistry {
+		return nil
+	}
+	if err := claims.AuthorizeServerAdmin(ctx); err != nil {
+		return status.PermissionDeniedErrorf("not authorized to bypass registry: %s", err)
+	}
+	return nil
+}
+
+// checkBypassRegistry is used by FetchManifestMetadata which does not support
+// bypass_registry at all (it always needs registry access for credential validation).
+func checkBypassRegistry(ctx context.Context, bypassRegistry bool) error {
+	if !bypassRegistry {
+		return nil
+	}
+	if err := claims.AuthorizeServerAdmin(ctx); err != nil {
+		return status.PermissionDeniedErrorf("authorize bypass_registry: %s", err)
+	}
+	return status.NotFoundError("bypass_registry is not yet supported")
+}
+
+// wrapError wraps an error, converting 401 Unauthorized to Unauthenticated.
+func wrapError(err error, message string) error {
+	if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
+		return status.UnauthenticatedErrorf("not authorized to access resource: %s", err)
+	}
+	return status.InternalErrorf("%s: %s", message, err)
+}
+
+type grpcStreamWriter struct {
+	stream ofpb.OCIFetcher_FetchBlobServer
+}
+
+func (w *grpcStreamWriter) Write(p []byte) (int, error) {
+	if err := w.stream.Send(&ofpb.FetchBlobResponse{Data: p}); err != nil {
+		return 0, status.WrapError(err, "send")
+	}
+	return len(p), nil
+}
+
+type pullerLRUEntry struct {
+	puller *remote.Puller
 }
 
 func ParseAllowedPrivateIPs() ([]*net.IPNet, error) {
@@ -149,7 +614,7 @@ func (t *mirrorTransport) RoundTrip(in *http.Request) (out *http.Response, err e
 func matchesMirror(mc interfaces.MirrorConfig, u *url.URL) (bool, error) {
 	originalURL, err := url.Parse(mc.OriginalURL)
 	if err != nil {
-		return false, err
+		return false, status.InvalidArgumentErrorf("invalid mirror original URL %q: %s", mc.OriginalURL, err)
 	}
 	return originalURL.Host == u.Host, nil
 }
@@ -157,7 +622,7 @@ func matchesMirror(mc interfaces.MirrorConfig, u *url.URL) (bool, error) {
 func rewriteToMirror(mc interfaces.MirrorConfig, originalRequest *http.Request) (*http.Request, error) {
 	mirrorURL, err := url.Parse(mc.MirrorURL)
 	if err != nil {
-		return nil, err
+		return nil, status.InvalidArgumentErrorf("invalid mirror URL %q: %s", mc.MirrorURL, err)
 	}
 	originalURL := originalRequest.URL.String()
 	req := originalRequest.Clone(originalRequest.Context())
@@ -173,277 +638,11 @@ func rewriteToMirror(mc interfaces.MirrorConfig, originalRequest *http.Request) 
 func rewriteFallback(mc interfaces.MirrorConfig, originalRequest *http.Request) (*http.Request, error) {
 	originalURL, err := url.Parse(mc.OriginalURL)
 	if err != nil {
-		return nil, err
+		return nil, status.InvalidArgumentErrorf("invalid fallback URL %q: %s", mc.OriginalURL, err)
 	}
 	req := originalRequest.Clone(originalRequest.Context())
 	req.URL.Scheme = originalURL.Scheme
 	req.URL.Host = originalURL.Host
 	log.CtxDebugf(originalRequest.Context(), "(fallback) %q rewritten to %s", originalURL, req.URL.String())
 	return req, nil
-}
-
-func pullerKey(ref gcrname.Reference, creds *rgpb.Credentials) string {
-	if creds == nil {
-		return hash.Strings(
-			ref.Context().RegistryStr(),
-			ref.Context().RepositoryStr(),
-			"",
-			"",
-		)
-	}
-	return hash.Strings(
-		ref.Context().RegistryStr(),
-		ref.Context().RepositoryStr(),
-		creds.GetUsername(),
-		creds.GetPassword(),
-	)
-}
-
-// Server helper methods
-
-func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Credentials) []remote.Option {
-	opts := []remote.Option{remote.WithContext(ctx)}
-
-	if creds != nil && creds.GetUsername() != "" && creds.GetPassword() != "" {
-		opts = append(opts, remote.WithAuth(&authn.Basic{
-			Username: creds.GetUsername(),
-			Password: creds.GetPassword(),
-		}))
-	}
-
-	tr := httpclient.New(s.allowedPrivateIPs, "oci_fetcher").Transport
-
-	if len(s.mirrors) > 0 {
-		opts = append(opts, remote.WithTransport(NewMirrorTransport(tr, s.mirrors)))
-	} else {
-		opts = append(opts, remote.WithTransport(tr))
-	}
-
-	return opts
-}
-
-func (s *ociFetcherServer) getOrCreatePuller(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*remote.Puller, error) {
-	key := pullerKey(imageRef, creds)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	entry, ok := s.pullerLRU.Get(key)
-
-	if ok {
-		return entry.puller, nil
-	}
-
-	remoteOpts := s.getRemoteOpts(ctx, creds)
-	puller, err := remote.NewPuller(remoteOpts...)
-	if err != nil {
-		return nil, err
-	}
-	s.pullerLRU.Add(key, &pullerLRUEntry{puller: puller})
-
-	return puller, nil
-}
-
-func (s *ociFetcherServer) evictPuller(imageRef gcrname.Reference, creds *rgpb.Credentials) {
-	key := pullerKey(imageRef, creds)
-	s.mu.Lock()
-	s.pullerLRU.Remove(key)
-	s.mu.Unlock()
-}
-
-// withPullerRetry handles the common pattern of executing an operation with a puller,
-// evicting and retrying on failure due to expired tokens.
-func withPullerRetry[T any](
-	ctx context.Context,
-	s *ociFetcherServer,
-	ref gcrname.Reference,
-	creds *rgpb.Credentials,
-	op func(puller *remote.Puller) (T, error),
-) (T, error) {
-	var zero T
-
-	puller, err := s.getOrCreatePuller(ctx, ref, creds)
-	if err != nil {
-		return zero, status.InternalErrorf("error creating puller: %s", err)
-	}
-
-	result, err := op(puller)
-	if err == nil {
-		return result, nil
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return zero, err
-	}
-
-	// Pullers from the LRU may have expired Bearer tokens, so we evict and retry on most errors.
-	s.evictPuller(ref, creds)
-	puller, err = s.getOrCreatePuller(ctx, ref, creds)
-	if err != nil {
-		return zero, status.InternalErrorf("error creating puller: %s", err)
-	}
-
-	result, err = op(puller)
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return zero, err
-	}
-	if err != nil {
-		s.evictPuller(ref, creds)
-		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
-			return zero, status.PermissionDeniedErrorf("not authorized to access resource: %s", err)
-		}
-		return zero, status.UnavailableErrorf("could not fetch from remote registry: %s", err)
-	}
-
-	return result, nil
-}
-
-func checkBypassRegistry(ctx context.Context, bypassRegistry bool) error {
-	if !bypassRegistry {
-		return nil
-	}
-	if err := claims.AuthorizeServerAdmin(ctx); err != nil {
-		return status.PermissionDeniedErrorf("authorize bypass_registry: %s", err)
-	}
-	return status.NotFoundError("bypass_registry is not yet supported")
-}
-
-// wrapError wraps an error, converting 401 Unauthorized to PermissionDenied.
-func wrapError(err error, message string) error {
-	if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
-		return status.PermissionDeniedErrorf("not authorized to access resource: %s", err)
-	}
-	return status.InternalErrorf("%s: %s", message, err)
-}
-
-// Server RPC implementations
-
-func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.FetchManifestMetadataRequest) (*ofpb.FetchManifestMetadataResponse, error) {
-	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-	imageRef, err := gcrname.ParseReference(req.GetRef())
-	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", req.GetRef(), err)
-	}
-
-	desc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*gcr.Descriptor, error) {
-		return puller.Head(ctx, imageRef)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &ofpb.FetchManifestMetadataResponse{
-		Digest:    desc.Digest.String(),
-		Size:      desc.Size,
-		MediaType: string(desc.MediaType),
-	}, nil
-}
-
-func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchManifestRequest) (*ofpb.FetchManifestResponse, error) {
-	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-	imageRef, err := gcrname.ParseReference(req.GetRef())
-	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", req.GetRef(), err)
-	}
-
-	remoteDesc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*remote.Descriptor, error) {
-		return puller.Get(ctx, imageRef)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &ofpb.FetchManifestResponse{
-		Digest:    remoteDesc.Digest.String(),
-		Size:      remoteDesc.Size,
-		MediaType: string(remoteDesc.MediaType),
-		Manifest:  remoteDesc.Manifest,
-	}, nil
-}
-
-func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.FetchBlobMetadataRequest) (*ofpb.FetchBlobMetadataResponse, error) {
-	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-	blobRef, err := gcrname.ParseReference(req.GetRef())
-	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid blob reference %q: %s", req.GetRef(), err)
-	}
-
-	digestRef, ok := blobRef.(gcrname.Digest)
-	if !ok {
-		return nil, status.InvalidArgumentErrorf("blob reference must be a digest reference (e.g., repo@sha256:...), got %q", req.GetRef())
-	}
-
-	layer, err := withPullerRetry(ctx, s, blobRef, req.GetCredentials(), func(puller *remote.Puller) (gcr.Layer, error) {
-		return puller.Layer(ctx, digestRef)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	size, sizeErr := layer.Size()
-	if sizeErr != nil {
-		return nil, wrapError(sizeErr, "error getting layer size")
-	}
-	mediaType, mtErr := layer.MediaType()
-	if mtErr != nil {
-		return nil, wrapError(mtErr, "error getting layer media type")
-	}
-	return &ofpb.FetchBlobMetadataResponse{
-		Size:      size,
-		MediaType: string(mediaType),
-	}, nil
-}
-
-func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
-	ctx := stream.Context()
-	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return err
-	}
-
-	blobRef, err := gcrname.ParseReference(req.GetRef())
-	if err != nil {
-		return status.InvalidArgumentErrorf("invalid blob reference %q: %s", req.GetRef(), err)
-	}
-
-	digestRef, ok := blobRef.(gcrname.Digest)
-	if !ok {
-		return status.InvalidArgumentErrorf("blob reference must be a digest reference, got %q", req.GetRef())
-	}
-
-	layer, err := withPullerRetry(ctx, s, blobRef, req.GetCredentials(), func(puller *remote.Puller) (gcr.Layer, error) {
-		return puller.Layer(ctx, digestRef)
-	})
-	if err != nil {
-		return err
-	}
-
-	// Get compressed blob data
-	rc, err := layer.Compressed()
-	if err != nil {
-		return wrapError(err, "error getting compressed layer")
-	}
-	defer rc.Close()
-
-	// Stream in chunks
-	buf := make([]byte, blobChunkSize)
-	for {
-		n, err := rc.Read(buf)
-		if n > 0 {
-			if sendErr := stream.Send(&ofpb.FetchBlobResponse{
-				Data: buf[:n],
-			}); sendErr != nil {
-				return status.WrapError(sendErr, "send")
-			}
-		}
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return status.InternalErrorf("error reading blob: %s", err)
-		}
-	}
 }

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -11,9 +11,12 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ocifetcher"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testregistry"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testhttp"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -26,6 +29,8 @@ import (
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
 func imageMetadata(t *testing.T, img v1.Image) (digest string, size int64, mediaType string) {
@@ -64,10 +69,24 @@ func setupRegistry(t *testing.T, creds *testregistry.BasicAuthCreds, interceptor
 }
 
 func newTestServer(t *testing.T) ofpb.OCIFetcherServer {
+	_, bsClient, acClient := setupCacheEnv(t)
+	return newTestServerWithCache(t, bsClient, acClient)
+}
+
+func newTestServerWithCache(t *testing.T, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient) ofpb.OCIFetcherServer {
 	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.0/8", "::1/128"})
-	server, err := ocifetcher.NewServer()
+	server, err := ocifetcher.NewServer(bsClient, acClient)
 	require.NoError(t, err)
 	return server
+}
+
+func setupCacheEnv(t *testing.T) (*testenv.TestEnv, bspb.ByteStreamClient, repb.ActionCacheClient) {
+	te := testenv.GetTestEnv(t)
+	enterprise_testenv.AddClientIdentity(t, te, interfaces.ClientIdentityApp)
+	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
+	testcache.Setup(t, te, localGRPClis)
+	go runServer()
+	return te, te.GetByteStreamClient(), te.GetActionCacheClient()
 }
 
 // mockFetchBlobServer implements ofpb.OCIFetcher_FetchBlobServer for testing.
@@ -214,6 +233,50 @@ func TestServerHappyPath(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, expectedData, stream.collectData())
 		})
+
+		t.Run("FetchBlob/WithCaching/"+ac.name, func(t *testing.T) {
+			reg, counter := setupRegistry(t, ac.registryCreds, nil)
+			imageName, img := reg.PushNamedImage(t, "test-image", ac.registryCreds)
+
+			layers, err := img.Layers()
+			require.NoError(t, err)
+			require.NotEmpty(t, layers)
+
+			layer := layers[0]
+			digest, err := layer.Digest()
+			require.NoError(t, err)
+			expectedData := layerData(t, layer)
+
+			_, bsClient, acClient := setupCacheEnv(t)
+			server := newTestServerWithCache(t, bsClient, acClient)
+
+			// First fetch - cache miss, should hit registry
+			counter.Reset()
+			stream := &mockFetchBlobServer{ctx: context.Background()}
+			err = server.FetchBlob(&ofpb.FetchBlobRequest{
+				Ref:         imageName + "@" + digest.String(),
+				Credentials: ac.requestCreds,
+			}, stream)
+			require.NoError(t, err)
+			require.Equal(t, expectedData, stream.collectData())
+
+			// Verify registry was hit (blob request)
+			blobRequests := counter.Snapshot()[http.MethodGet+" /v2/test-image/blobs/"+digest.String()]
+			require.Greater(t, blobRequests, 0, "expected at least one blob request to registry on cache miss")
+
+			// Second fetch - cache hit, should NOT hit registry
+			counter.Reset()
+			stream = &mockFetchBlobServer{ctx: context.Background()}
+			err = server.FetchBlob(&ofpb.FetchBlobRequest{
+				Ref:         imageName + "@" + digest.String(),
+				Credentials: ac.requestCreds,
+			}, stream)
+			require.NoError(t, err)
+			require.Equal(t, expectedData, stream.collectData())
+
+			// Verify registry was NOT hit (served from cache)
+			assertRequests(t, counter, map[string]int{})
+		})
 	}
 }
 
@@ -253,23 +316,23 @@ func TestServerMissingAndInvalidCredentials(t *testing.T) {
 				Credentials: cc.requestCreds,
 			})
 			require.Error(t, err)
-			require.True(t, status.IsPermissionDeniedError(err), "FetchManifestMetadata: expected PermissionDenied, got: %v", err)
+			require.True(t, status.IsUnauthenticatedError(err), "FetchManifestMetadata: expected Unauthenticated, got: %v", err)
 			assertRequests(t, counter, map[string]int{
 				http.MethodGet + " /v2/":                             2,
 				http.MethodHead + " /v2/test-image/manifests/latest": 2,
 			})
 
-			// FetchManifest
+			// FetchManifest (uses HEAD to resolve tag to digest first, then fails on auth)
 			counter.Reset()
 			_, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
 				Ref:         imageName,
 				Credentials: cc.requestCreds,
 			})
 			require.Error(t, err)
-			require.True(t, status.IsPermissionDeniedError(err), "FetchManifest: expected PermissionDenied, got: %v", err)
+			require.True(t, status.IsUnauthenticatedError(err), "FetchManifest: expected Unauthenticated, got: %v", err)
 			assertRequests(t, counter, map[string]int{
-				http.MethodGet + " /v2/":                            2,
-				http.MethodGet + " /v2/test-image/manifests/latest": 2,
+				http.MethodGet + " /v2/":                             2,
+				http.MethodHead + " /v2/test-image/manifests/latest": 2,
 			})
 
 			// FetchBlobMetadata
@@ -279,7 +342,7 @@ func TestServerMissingAndInvalidCredentials(t *testing.T) {
 				Credentials: cc.requestCreds,
 			})
 			require.Error(t, err)
-			require.True(t, status.IsPermissionDeniedError(err), "FetchBlobMetadata: expected PermissionDenied, got: %v", err)
+			require.True(t, status.IsUnauthenticatedError(err), "FetchBlobMetadata: expected Unauthenticated, got: %v", err)
 
 			// FetchBlob
 			counter.Reset()
@@ -289,7 +352,7 @@ func TestServerMissingAndInvalidCredentials(t *testing.T) {
 				Credentials: cc.requestCreds,
 			}, stream)
 			require.Error(t, err)
-			require.True(t, status.IsPermissionDeniedError(err), "FetchBlob: expected PermissionDenied, got: %v", err)
+			require.True(t, status.IsUnauthenticatedError(err), "FetchBlob: expected Unauthenticated, got: %v", err)
 		})
 	}
 }
@@ -366,12 +429,13 @@ func TestServerRetryOnHTTPErrors(t *testing.T) {
 	require.Equal(t, int32(2), blobAttempts.Load(), "expected 2 blob attempts")
 
 	// FetchBlob - reset counter, first blob request fails, retry succeeds
+	// Note: with caching enabled, layer.Size() also makes a HEAD request after the retry succeeds
 	blobAttempts.Store(0)
 	stream := &mockFetchBlobServer{ctx: context.Background()}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
 	require.NoError(t, err)
 	require.Equal(t, expectedLayerData, stream.collectData())
-	require.Equal(t, int32(2), blobAttempts.Load(), "expected 2 blob attempts")
+	require.GreaterOrEqual(t, blobAttempts.Load(), int32(2), "expected at least 2 blob attempts")
 }
 
 func TestServerNoRetryOnContextErrors(t *testing.T) {
@@ -447,7 +511,7 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected DeadlineExceeded, got: %v", err)
 	require.Equal(t, int32(1), getAttempts.Load(), "should not retry on context error")
 
-	// FetchManifest: Puller should still be cached
+	// FetchManifest: Puller should still be cached (but HEAD and GET both happen for tag refs)
 	blockGet.Store(false)
 	counter.Reset()
 	manifestResp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: imageName})
@@ -457,7 +521,8 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	require.Equal(t, expectedMediaType, manifestResp.GetMediaType())
 	require.Equal(t, expectedManifest, manifestResp.GetManifest())
 	assertRequests(t, counter, map[string]int{
-		http.MethodGet + " /v2/test-image/manifests/latest": 1,
+		http.MethodHead + " /v2/test-image/manifests/latest": 1,
+		http.MethodGet + " /v2/test-image/manifests/latest":  1,
 	})
 
 	// FetchBlobMetadata: establish cached layer access
@@ -483,30 +548,23 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	require.Equal(t, expectedLayerSize, blobMetaResp.GetSize())
 	require.Equal(t, expectedLayerMediaType, blobMetaResp.GetMediaType())
 
-	// FetchBlob: establish cached layer access
+	// FetchBlob: first fetch caches the blob
 	stream := &mockFetchBlobServer{ctx: context.Background()}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
 	require.NoError(t, err)
 	require.Equal(t, expectedLayerData, stream.collectData())
 
-	// FetchBlob: times out, should NOT retry
-	blockBlob.Store(true)
-	blobAttempts.Store(0)
+	// FetchBlob: second fetch serves from cache (no network calls), even with short timeout
+	// Since blob is cached, there's no network call to timeout, so this succeeds instantly
+	counter.Reset()
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
 	stream = &mockFetchBlobServer{ctx: ctx}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
 	cancel()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "deadline exceeded", "expected deadline exceeded error, got: %v", err)
-	require.Equal(t, int32(1), blobAttempts.Load(), "should not retry on context error")
-
-	// FetchBlob: Puller should still be cached
-	blockBlob.Store(false)
-	counter.Reset()
-	stream = &mockFetchBlobServer{ctx: context.Background()}
-	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
-	require.NoError(t, err)
+	require.NoError(t, err, "cached blob should serve without network calls")
 	require.Equal(t, expectedLayerData, stream.collectData())
+	// Verify no registry requests were made (served from cache)
+	assertRequests(t, counter, map[string]int{})
 }
 
 func TestServerBypassRegistry(t *testing.T) {
@@ -570,7 +628,7 @@ func TestServerBypassRegistry(t *testing.T) {
 			require.True(t, tc.checkError(err), "unexpected error type: %v", err)
 		})
 
-		t.Run("FetchBlobMetadata/"+tc.name, func(t *testing.T) {
+		t.Run("FetchBlobMetadata/CacheMiss/"+tc.name, func(t *testing.T) {
 			flags.Set(t, "auth.admin_group_id", adminGroupID)
 			server := newTestServer(t)
 			ctx := context.Background()
@@ -578,14 +636,14 @@ func TestServerBypassRegistry(t *testing.T) {
 				ctx = testauth.WithAuthenticatedUserInfo(ctx, tc.user)
 			}
 			_, err := server.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{
-				Ref:            "gcr.io/test/image@sha256:abc123",
+				Ref:            "gcr.io/test/image@sha256:abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1",
 				BypassRegistry: true,
 			})
 			require.Error(t, err)
 			require.True(t, tc.checkError(err), "unexpected error type: %v", err)
 		})
 
-		t.Run("FetchBlob/"+tc.name, func(t *testing.T) {
+		t.Run("FetchBlob/CacheMiss/"+tc.name, func(t *testing.T) {
 			flags.Set(t, "auth.admin_group_id", adminGroupID)
 			server := newTestServer(t)
 			ctx := context.Background()
@@ -594,11 +652,359 @@ func TestServerBypassRegistry(t *testing.T) {
 			}
 			stream := &mockFetchBlobServer{ctx: ctx}
 			err := server.FetchBlob(&ofpb.FetchBlobRequest{
-				Ref:            "gcr.io/test/image@sha256:abc123",
+				Ref:            "gcr.io/test/image@sha256:abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1",
 				BypassRegistry: true,
 			}, stream)
 			require.Error(t, err)
 			require.True(t, tc.checkError(err), "unexpected error type: %v", err)
 		})
 	}
+
+	// Test that FetchBlob with bypass_registry serves from cache when blob is cached
+	t.Run("FetchBlob/CacheHit/ServesFromCache", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+
+		layers, err := img.Layers()
+		require.NoError(t, err)
+		require.NotEmpty(t, layers)
+
+		layer := layers[0]
+		digest, err := layer.Digest()
+		require.NoError(t, err)
+		expectedData := layerData(t, layer)
+
+		_, bsClient, acClient := setupCacheEnv(t)
+		server := newTestServerWithCache(t, bsClient, acClient)
+
+		// First fetch - populate cache
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref: imageName + "@" + digest.String(),
+		}, stream)
+		require.NoError(t, err)
+		require.Equal(t, expectedData, stream.collectData())
+
+		// Second fetch with bypass_registry (admin required) - should serve from cache without registry contact
+		counter.Reset()
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+		stream = &mockFetchBlobServer{ctx: ctx}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref:            imageName + "@" + digest.String(),
+			BypassRegistry: true,
+		}, stream)
+		require.NoError(t, err)
+		require.Equal(t, expectedData, stream.collectData())
+
+		// Verify no registry requests were made
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchBlob with bypass_registry for admin returns NotFound and doesn't fallback to registry
+	t.Run("FetchBlob/CacheMiss/Admin_NoRegistryFallback", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		// Set up a real registry with a real blob
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		layers, err := img.Layers()
+		require.NoError(t, err)
+		require.NotEmpty(t, layers)
+		layer := layers[0]
+		digest, err := layer.Digest()
+		require.NoError(t, err)
+
+		// Create server (cache is empty - blob not cached)
+		server := newTestServer(t)
+
+		// Admin user context
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+
+		// Reset counter before the bypass_registry request
+		counter.Reset()
+
+		stream := &mockFetchBlobServer{ctx: ctx}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref:            imageName + "@" + digest.String(),
+			BypassRegistry: true,
+		}, stream)
+
+		// Should return NotFoundError (blob not in cache)
+		require.Error(t, err)
+		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got: %v", err)
+
+		// Verify NO registry requests were made (no fallback to remote)
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchBlobMetadata returns cached metadata when available
+	t.Run("FetchBlobMetadata/WithCaching", func(t *testing.T) {
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+
+		layers, err := img.Layers()
+		require.NoError(t, err)
+		require.NotEmpty(t, layers)
+
+		layer := layers[0]
+		digest, err := layer.Digest()
+		require.NoError(t, err)
+		expectedSize, expectedMediaType := layerMetadata(t, layer)
+
+		_, bsClient, acClient := setupCacheEnv(t)
+		server := newTestServerWithCache(t, bsClient, acClient)
+
+		// First, fetch the blob to populate the cache (FetchBlob writes metadata to AC)
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref: imageName + "@" + digest.String(),
+		}, stream)
+		require.NoError(t, err)
+
+		// Now fetch metadata - should be served from cache
+		counter.Reset()
+		resp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{
+			Ref: imageName + "@" + digest.String(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedSize, resp.GetSize())
+		require.Equal(t, expectedMediaType, resp.GetMediaType())
+
+		// Verify no registry requests were made (served from cache)
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchBlobMetadata with bypass_registry serves from cache when metadata is cached
+	t.Run("FetchBlobMetadata/CacheHit/ServesFromCache", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+
+		layers, err := img.Layers()
+		require.NoError(t, err)
+		require.NotEmpty(t, layers)
+
+		layer := layers[0]
+		digest, err := layer.Digest()
+		require.NoError(t, err)
+		expectedSize, expectedMediaType := layerMetadata(t, layer)
+
+		_, bsClient, acClient := setupCacheEnv(t)
+		server := newTestServerWithCache(t, bsClient, acClient)
+
+		// First fetch - populate cache via FetchBlob
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref: imageName + "@" + digest.String(),
+		}, stream)
+		require.NoError(t, err)
+
+		// Second fetch with bypass_registry (admin required) - should serve from cache without registry contact
+		counter.Reset()
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+		resp, err := server.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{
+			Ref:            imageName + "@" + digest.String(),
+			BypassRegistry: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedSize, resp.GetSize())
+		require.Equal(t, expectedMediaType, resp.GetMediaType())
+
+		// Verify no registry requests were made
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchBlobMetadata with bypass_registry for admin returns NotFound and doesn't fallback to registry
+	t.Run("FetchBlobMetadata/CacheMiss/Admin_NoRegistryFallback", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		// Set up a real registry with a real blob
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		layers, err := img.Layers()
+		require.NoError(t, err)
+		require.NotEmpty(t, layers)
+		layer := layers[0]
+		digest, err := layer.Digest()
+		require.NoError(t, err)
+
+		// Create server (cache is empty - blob metadata not cached)
+		server := newTestServer(t)
+
+		// Admin user context
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+
+		// Reset counter before the bypass_registry request
+		counter.Reset()
+
+		_, err = server.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{
+			Ref:            imageName + "@" + digest.String(),
+			BypassRegistry: true,
+		})
+
+		// Should return NotFoundError (metadata not in cache)
+		require.Error(t, err)
+		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got: %v", err)
+
+		// Verify NO registry requests were made (no fallback to remote)
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchManifest returns cached manifest when available (digest ref)
+	t.Run("FetchManifest/WithCaching/DigestRef", func(t *testing.T) {
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		digest, _, _ := imageMetadata(t, img)
+		expectedManifest, err := img.RawManifest()
+		require.NoError(t, err)
+
+		_, bsClient, acClient := setupCacheEnv(t)
+		server := newTestServerWithCache(t, bsClient, acClient)
+
+		// First fetch by digest - cache miss, should fetch from registry and cache
+		counter.Reset()
+		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+			Ref: imageName + "@" + digest,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedManifest, resp.GetManifest())
+
+		// Verify registry was hit
+		require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/manifests/"+digest], 0)
+
+		// Second fetch by digest - should serve from cache
+		counter.Reset()
+		resp, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+			Ref: imageName + "@" + digest,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedManifest, resp.GetManifest())
+
+		// Verify no registry requests were made (served from cache)
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchManifest caching works for tag refs (HEAD to resolve, then cache lookup)
+	t.Run("FetchManifest/WithCaching/TagRef", func(t *testing.T) {
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		digest, _, _ := imageMetadata(t, img)
+		expectedManifest, err := img.RawManifest()
+		require.NoError(t, err)
+
+		_, bsClient, acClient := setupCacheEnv(t)
+		server := newTestServerWithCache(t, bsClient, acClient)
+
+		// First fetch by tag - cache miss, should HEAD then GET from registry
+		counter.Reset()
+		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+			Ref: imageName,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedManifest, resp.GetManifest())
+		require.Equal(t, digest, resp.GetDigest())
+
+		// Verify registry was hit (HEAD + GET)
+		require.Greater(t, counter.Snapshot()[http.MethodHead+" /v2/test-image/manifests/latest"], 0)
+		require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/manifests/latest"], 0)
+
+		// Second fetch by tag - should only HEAD (cache hit avoids GET)
+		counter.Reset()
+		resp, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+			Ref: imageName,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedManifest, resp.GetManifest())
+
+		// Verify only HEAD was made (cache hit), no GET
+		require.Greater(t, counter.Snapshot()[http.MethodHead+" /v2/test-image/manifests/latest"], 0)
+		require.Equal(t, 0, counter.Snapshot()[http.MethodGet+" /v2/test-image/manifests/latest"])
+	})
+
+	// Test that FetchManifest with bypass_registry serves from cache when manifest is cached (digest ref)
+	t.Run("FetchManifest/CacheHit/DigestRef/ServesFromCache", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		digest, _, _ := imageMetadata(t, img)
+		expectedManifest, err := img.RawManifest()
+		require.NoError(t, err)
+
+		_, bsClient, acClient := setupCacheEnv(t)
+		server := newTestServerWithCache(t, bsClient, acClient)
+
+		// First fetch - populate cache
+		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+			Ref: imageName + "@" + digest,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedManifest, resp.GetManifest())
+
+		// Second fetch with bypass_registry (admin required) - should serve from cache
+		counter.Reset()
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+		resp, err = server.FetchManifest(ctx, &ofpb.FetchManifestRequest{
+			Ref:            imageName + "@" + digest,
+			BypassRegistry: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedManifest, resp.GetManifest())
+
+		// Verify no registry requests were made
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchManifest with bypass_registry for admin returns NotFound for uncached digest ref
+	t.Run("FetchManifest/CacheMiss/DigestRef/Admin_NoRegistryFallback", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		digest, _, _ := imageMetadata(t, img)
+
+		// Create server (cache is empty)
+		server := newTestServer(t)
+
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+		counter.Reset()
+
+		_, err := server.FetchManifest(ctx, &ofpb.FetchManifestRequest{
+			Ref:            imageName + "@" + digest,
+			BypassRegistry: true,
+		})
+
+		require.Error(t, err)
+		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got: %v", err)
+
+		// Verify NO registry requests were made
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchManifest with bypass_registry for admin returns NotFound for tag ref
+	t.Run("FetchManifest/TagRef/Admin_NoRegistryFallback", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, _ := reg.PushNamedImage(t, "test-image", nil)
+
+		server := newTestServer(t)
+
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+		counter.Reset()
+
+		_, err := server.FetchManifest(ctx, &ofpb.FetchManifestRequest{
+			Ref:            imageName,
+			BypassRegistry: true,
+		})
+
+		require.Error(t, err)
+		require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got: %v", err)
+
+		// Verify NO registry requests were made (can't resolve tag without registry)
+		assertRequests(t, counter, map[string]int{})
+	})
 }


### PR DESCRIPTION
This change also modifies FetchBlobMetadata to read from the byte stream server first before making an upstream registry request.

It may be best to look at [`ocifetcher.go` on this branch](https://github.com/buildbuddy-io/buildbuddy/blob/dan-fetcher-server-caching/enterprise/server/oci/ocifetcher/ocifetcher.go) without diffing, since I moved some public methods to the top of the file.