### PR TITLE
Register vtprotocodec in the cache-proxy

### DIFF
--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/usageutil",
+        "//server/util/vtprotocodec",
         "//server/version",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -44,6 +44,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/buildbuddy-io/buildbuddy/server/util/usageutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"google.golang.org/grpc"
 
@@ -72,6 +73,11 @@ var (
 		authutil.ClientIdentityHeaderName,
 		bazel_request.RequestMetadataKey}
 )
+
+func init() {
+	// Register the codec for all RPC servers and clients.
+	vtprotocodec.Register()
+}
 
 func main() {
 	version.Print("BuildBuddy cache proxy")


### PR DESCRIPTION
This will make marshalling and unmarshalling faster