### PR TITLE
[SS] Fix VM metadata parsing

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -585,7 +585,7 @@ func (l *FileCacheLoader) actionResultToManifest(ctx context.Context, remoteInst
 	}
 
 	var vmMetadata *fcpb.VMMetadata
-	if len(snapMetadata) == 2 {
+	if len(snapMetadata) >= 2 {
 		vmMetadata = &fcpb.VMMetadata{}
 		if err := snapMetadata[1].UnmarshalTo(vmMetadata); err != nil {
 			return nil, status.WrapErrorf(err, "unmarshall vm metadata")


### PR DESCRIPTION
The metadata wasn't being parsed correctly, because there are additional elements in AuxiliaryMetadata (Added here https://github.com/buildbuddy-io/buildbuddy/commit/146564cd98b76e9342da87f68cac8ef0d341a2b3) 