### PR TITLE
Add comments to StartSpan that it's not supporting overriding trace fraction

### DIFF
--- a/server/util/tracing/tracing.go
+++ b/server/util/tracing/tracing.go
@@ -375,6 +375,12 @@ func (m *HttpServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // StartSpan starts a new span named after the calling function.
+// Note:
+// (1) StartSpan doesn't support --app.trace_fraction_overrides, if you would
+// like to override the trace fraction with a specified function, please use
+// StartNamedSpan instead.
+// (2) If you want to record a trace inside a loop, or in a performance-critical
+// path, please use StartNamedSpan instead.
 func StartSpan(ctx context.Context, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	ctx, span := tracer.Start(ctx, "unknown_go_function", opts...)
 	if !span.IsRecording() {


### PR DESCRIPTION
Right now, when we start a span, we started with a "unknown_go_function". When
the span is started, the sampling decision is made based on this generic name.
See https://github.com/open-telemetry/opentelemetry-go/blob/19a5a6815c7ea4444f72bab5035cf13ae4611c89/sdk/trace/tracer.go#L109
Later, when the name is set, the sampling decision is not re-made.

Add a comment to StartSpan that it is not compatible with overriding trace fraction. 
