### PR TITLE
disk_windows: fix windows file size estimation

### DIFF
--- a/server/util/disk/disk_windows.go
+++ b/server/util/disk/disk_windows.go
@@ -10,7 +10,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// 4KiB block size
+// 4KiB cluster size is the default for both NTFS and ReFS(DevDrive)
+// References:
+//
+//	https://techcommunity.microsoft.com/blog/filecab/cluster-size-recommendations-for-refs-and-ntfs/425960
+//	https://learn.microsoft.com/en-us/windows-server/storage/file-server/ntfs-overview#support-for-large-volumes
 const clusterSize = int64(4096)
 
 func GetDirUsage(path string) (*DirUsage, error) {


### PR DESCRIPTION
On Linux, we use this

  ```
  os.FileInfo.Sys().(*syscall.Stat_t).Blocks * 512
  ```

To estimate the impact storing the file would have on the current disk.
It counts the block allocated by the file system and multiply it by the
block size (assume to be 512 bytes).

Add similar estimation for Windows based on cluster allocation.
We picked 4KiB based on the default NTFS and ReFS(DevDrive) block size.

References:
- https://techcommunity.microsoft.com/blog/filecab/cluster-size-recommendations-for-refs-and-ntfs/425960
- https://learn.microsoft.com/en-us/windows-server/storage/file-server/ntfs-overview#support-for-large-volumes
