### PR TITLE
Register vtprotocodec in rpcutil

### DIFF
--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -47,7 +47,6 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/usageutil",
-        "//server/util/vtprotocodec",
         "//server/version",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -44,7 +44,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/buildbuddy-io/buildbuddy/server/util/usageutil"
-	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"google.golang.org/grpc"
 
@@ -73,11 +72,6 @@ var (
 		authutil.ClientIdentityHeaderName,
 		bazel_request.RequestMetadataKey}
 )
-
-func init() {
-	// Register the codec for all RPC servers and clients.
-	vtprotocodec.Register()
-}
 
 func main() {
 	version.Print("BuildBuddy cache proxy")

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -59,7 +59,6 @@ go_library(
         "//server/util/statusz",
         "//server/util/tracing",
         "//server/util/usageutil",
-        "//server/util/vtprotocodec",
         "//server/version",
         "//server/xcode",
         "@com_github_google_uuid//:uuid",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -51,7 +51,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/buildbuddy-io/buildbuddy/server/util/usageutil"
-	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"github.com/buildbuddy-io/buildbuddy/server/xcode"
 	"github.com/google/uuid"
@@ -87,11 +86,6 @@ var (
 	serverType        = flag.String("server_type", "prod-buildbuddy-executor", "The server type to match on health checks")
 	maxThreads        = flag.Int("executor.max_threads", 0, "The maximum number of threads to allow before panicking. If unset, the golang default will be used (currently 10,000).")
 )
-
-func init() {
-	// Register the codec for all RPC servers and clients.
-	vtprotocodec.Register()
-}
 
 func isOldEndpoint(endpoint string) bool {
 	u, err := url.Parse(endpoint)

--- a/enterprise/server/cmd/metadata_server/BUILD
+++ b/enterprise/server/cmd/metadata_server/BUILD
@@ -27,7 +27,6 @@ go_library(
         "//server/util/monitoring",
         "//server/util/statusz",
         "//server/util/tracing",
-        "//server/util/vtprotocodec",
         "//server/version",
     ],
 )

--- a/enterprise/server/cmd/metadata_server/main.go
+++ b/enterprise/server/cmd/metadata_server/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
-	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 
 	mdspb "github.com/buildbuddy-io/buildbuddy/proto/metadata_service"
@@ -35,11 +34,6 @@ var (
 	monitoringPort = flag.Int("monitoring_port", 9090, "The port to listen for monitoring traffic on")
 	serverType     = flag.String("server_type", "metadata-server", "The server type to match on health checks")
 )
-
-func init() {
-	// Register the codec for all RPC servers and clients.
-	vtprotocodec.Register()
-}
 
 func main() {
 	version.Print("BuildBuddy Metadata Server")

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -60,7 +60,6 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "//server/util/usageutil",
-        "//server/util/vtprotocodec",
         "//static:bundle",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -53,7 +53,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/buildbuddy-io/buildbuddy/server/util/usageutil"
-	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
 
 	"google.golang.org/grpc"
 
@@ -112,8 +111,6 @@ var (
 
 func init() {
 	grpc.EnableTracing = false
-	// Register the codec for all RPC servers and clients.
-	vtprotocodec.Register()
 }
 
 func configureFilesystemsOrDie(realEnv *real_environment.RealEnv, appBundleFS fs.FS) {

--- a/server/testutil/testenv/BUILD
+++ b/server/testutil/testenv/BUILD
@@ -29,7 +29,6 @@ go_library(
         "//server/util/healthcheck",
         "//server/util/log",
         "//server/util/testing/flags",
-        "//server/util/vtprotocodec",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//test/bufconn",

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -29,7 +29,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
-	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
@@ -81,10 +80,6 @@ http:
    client:
       allow_localhost: true
 `
-
-func init() {
-	vtprotocodec.Register()
-}
 
 // RegisterLocalGRPCServer registers a local gRPC server to the environment and
 // returns the server.

--- a/server/util/rpcutil/BUILD
+++ b/server/util/rpcutil/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/util/alert",
         "//server/util/proto",
+        "//server/util/vtprotocodec",
         "@io_opentelemetry_go_otel_exporters_prometheus//:prometheus",
         "@io_opentelemetry_go_otel_metric//:metric",
         "@io_opentelemetry_go_otel_metric//noop",

--- a/server/util/rpcutil/rpcutil.go
+++ b/server/util/rpcutil/rpcutil.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -15,6 +16,10 @@ import (
 )
 
 const GRPCMaxSizeBytes = int64(4 * 1000 * 1000)
+
+func init() {
+	vtprotocodec.Register()
+}
 
 type StreamMsg[T proto.Message] struct {
 	Data  T


### PR DESCRIPTION
rpcutil is used by both grpc_client and grpc_server, which means that all of our jobs import rpcutil. This way, we don't have to remember to register the vtprotocodec in every new app.