### PR TITLE
refactor tracing.Configure() and allow the test to use a NoopExporter to test StartSpan performance

### DIFF
--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -30,6 +30,7 @@ go_test(
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/testing/flags",
+        "//server/util/tracing",
         "@com_github_open_feature_go_sdk//openfeature",
         "@com_github_open_feature_go_sdk//openfeature/memprovider",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -368,8 +368,8 @@ func BenchmarkFindMissing(b *testing.B) {
 	sizes := []int64{10, 100, 1000, 10000}
 	te := getTestEnv(b)
 	ctx := getUserContext(b, te)
-	flags.Set(b, "app.trace_fraction", "0.01")
-	err := tracing.Configure(te)
+	flags.Set(b, "app.trace_fraction", 0.01)
+	err := tracing.ConfigureWithNoopExporter(te)
 	require.NoError(b, err)
 
 	for _, cache := range getAllCaches(b, te) {


### PR DESCRIPTION
Also enable tracing in BenchmarkFindMissing test.
