### PR TITLE
[FC] Increase balloon polling interval

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2924,7 +2924,7 @@ func (c *FirecrackerContainer) updateBalloon(ctx context.Context, targetSizeMib 
 	}()
 
 	// Wait for the balloon to reach its target size.
-	pollInterval := 300 * time.Millisecond
+	pollInterval := 1 * time.Second
 	slowCount := 0
 	for {
 		stats, err := c.machine.GetBalloonStats(ctx)


### PR DESCRIPTION
The guest only updates balloon stats roughly 1x/sec, so it may be a waste to poll more frequently. This will also give the balloon more time to expand before we exit early due to `slowCount == 5` (previously it would give up within 1.5s if there was minimal progress in the balloon.) This may be too quick, especially in GCP where it seems like the balloon is often much slower to inflate

Based on logs, the balloon usually takes several seconds to expand anyway