### PR TITLE
Don't log a warning for unauthenticated users

### DIFF
--- a/enterprise/server/quota/quota_manager.go
+++ b/enterprise/server/quota/quota_manager.go
@@ -75,7 +75,6 @@ func (qm *QuotaManager) checkGroupBlocked(ctx context.Context) error {
 
 	c, err := claims.ClaimsFromContext(ctx)
 	if err != nil {
-		log.CtxWarningf(ctx, "Failed to get claims from context: %s", err)
 		return nil
 	}
 


### PR DESCRIPTION
If no claims are available, it's likely the user is just not authenticated. 

In this case, we always `Allow`, but we create noisy logging.

This PR disables the unnecessary logs.