### PR TITLE
[FC] Use /proc/meminfo to determine available memory for the balloon

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2882,14 +2882,10 @@ func (c *FirecrackerContainer) reclaimMemoryWithBalloon(ctx context.Context) err
 	}
 	// TODO(Maggie): Don't depend on sh existing within the container image
 	client := vmxpb.NewExecClient(conn)
+	// Read available memory in the guest to determine the target balloon size.
+	// /proc/meminfo reports amounts in KiB, and we're converting to MiB.
 	cmd := &repb.Command{
-		Arguments: []string{"sh", "-c", `awk '
-/MemAvailable/ {avail=$2}
-/Buffers/      {buf=$2}
-/^Cached:/     {cache=$2}
-END {print (avail + buf + cache) / 1024}
-' /proc/meminfo
-`},
+		Arguments: []string{"sh", "-c", "awk '/MemAvailable/ {print $2 / 1024}' /proc/meminfo"},
 	}
 	res := vmexec_client.Execute(ctx, client, cmd, "/workspace/", "0:0", nil /* statsListener*/, &interfaces.Stdio{})
 	if res.Error != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1689,7 +1689,8 @@ func TestFirecrackerBalloon(t *testing.T) {
 
 	cmd := &repb.Command{
 		// Mount a RAM-based filesystem to /tmp/randomdata to simulate memory usage.
-		Arguments: []string{"sh", "-c", `
+		Arguments: []string{"bash", "-c", `
+set -eo pipefail
 mkdir /tmp/randomdata && mount -t tmpfs -o size=1700M tmpfs /tmp/randomdata
 dd if=/dev/urandom of=/tmp/randomdata/data bs=1M count=1600
 free -h
@@ -1698,7 +1699,8 @@ free -h
 
 	res := c.Exec(ctx, cmd, nil /*=stdio*/)
 	require.NoError(t, res.Error)
-	assert.Equal(t, int64(0), res.VMMetadata.GetSavedSnapshotVersionNumber())
+	require.Equal(t, 0, res.ExitCode)
+	require.Equal(t, int64(0), res.VMMetadata.GetSavedSnapshotVersionNumber())
 
 	// Try pause, unpause, exec several times.
 	for i := 1; i <= 4; i++ {


### PR DESCRIPTION
Previously we explicitly dropped the page cache in the guest and used the balloon statistics to determine how much memory to reclaim. This approach could be increasing memory thrash, increasing the likelihood of a stall and guest corruption.

When the cache is dropped, the kernel must synchronously reclaim the page cache, which incurs some CPU and memory overhead. Then immediately afterwards, we are inflating the balloon, which allocates a lot of memory. This is also a CPU intensive process and requires a lot of memory accounting. These two processes happening simultaneously could compete and cause pressure on the guest

The balloon is able to naturally reclaim the page cache, so it doesn't have to be explicitly freed. This way, the memory accounting overhead only happens once, and because we're only reclaiming ~80% of the cache, the kernel can preserve what it perceives to be the most valuable cached data