### PR TITLE
Fix relative paths in Kythe indexing scripts

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -244,8 +244,8 @@ func prepareKytheOutputs(dirName string) string {
 export KYTHE_DIR="$BUILDBUDDY_CI_RUNNER_ROOT_DIR"/%s
 ulimit -n 10240
 
-find -L ../bazel-out/ -name "*.go.kzip" | xargs -P $(nproc) -n 1 $KYTHE_DIR/indexers/go_indexer -continue | $KYTHE_DIR/tools/dedup_stream >> kythe_entries
-find -L ../bazel-out/ -name "*.proto.kzip" | xargs -P $(nproc) -n 1 $KYTHE_DIR/indexers/proto_indexer -index_file {} | $KYTHE_DIR/tools/dedup_stream >> kythe_entries
+find -L bazel-out/ -name "*.go.kzip" | xargs -P $(nproc) -n 1 $KYTHE_DIR/indexers/go_indexer -continue | $KYTHE_DIR/tools/dedup_stream >> kythe_entries
+find -L bazel-out/ -name "*.proto.kzip" | xargs -P $(nproc) -n 1 $KYTHE_DIR/indexers/proto_indexer -index_file {} | $KYTHE_DIR/tools/dedup_stream >> kythe_entries
 find -L bazel-out -name '*.java.kzip' | xargs -P $(nproc) -n 1 java -jar $KYTHE_DIR/indexers/java_indexer.jar | $KYTHE_DIR/tools/dedup_stream >> kythe_entries
 
 # cxx indexing needs a cache to complete in a "reasonable" amount of time. It still takes a long time
@@ -254,7 +254,7 @@ find -L bazel-out -name '*.java.kzip' | xargs -P $(nproc) -n 1 java -jar $KYTHE_
 # TODO(jdelfino): apt update / install are slow - consider either creating a statically linked
 # memcached binary, or installing it in the container image.
 
-cxx_kzips=$(find -L ../bazel-out/*/extra_actions -name "*.cxx.kzip")
+cxx_kzips=$(find -L bazel-out/*/extra_actions -name "*.cxx.kzip")
 if [ ! -z "$cxx_kzips" ]; then
   sudo apt update && sudo apt install -y memcached
   memcached -p 11211 --listen localhost -m 512 & memcached_pid=$!


### PR DESCRIPTION
The **Generate Kythe Annotations** workflows have failed consistently for some time. There's a chance this change fixes them.