### PR TITLE
remotebazel: don't retry PermissionDenied

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -953,6 +953,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 
 		if latestErr == nil ||
 			!rexec.Retryable(latestErr) ||
+			status.IsPermissionDeniedError(latestErr) ||
 			status.IsDeadlineExceededError(latestErr) ||
 			ctx.Err() != nil {
 			retry = false
@@ -962,7 +963,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 			break
 		}
 
-		log.Warnf("Remote run failed due to transient error. Retrying: %s", latestErr)
+		log.Warnf("Remote run failed due to a transient error. Retrying: %s", latestErr)
 		retryCount++
 	}
 	if *invocationIDFile != "" && len(inRsp.GetInvocation()) > 0 && inRsp.GetInvocation()[0].GetInvocationId() != "" {


### PR DESCRIPTION
Hit this locally (probably because I had an invalid API key configured). These seem unlikely to go away on their own.

```
$ bb remote --remote_runner=grpc://localhost:1985 --script='find .git/refs'

Waiting for available remote runner...
Warning: Remote run failed due to transient error. Retrying: rpc error: code = PermissionDenied desc = permission denied
Warning: Remote run failed due to transient error. Retrying: rpc error: code = PermissionDenied desc = permission denied
Warning: Remote run failed due to transient error. Retrying: rpc error: code = PermissionDenied desc = permission denied
Warning: Remote run failed due to transient error. Retrying: rpc error: code = PermissionDenied desc = permission denied
Warning: Remote run failed due to transient error. Retrying: rpc error: code = PermissionDenied desc = permission denied
permission denied
```