### PR TITLE
Implement AuthService.GetPublicKeys()

### DIFF
--- a/enterprise/server/auth_service/BUILD
+++ b/enterprise/server/auth_service/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/interfaces",
         "//server/real_environment",
         "//server/util/authutil",
+        "//server/util/claims",
         "//server/util/status",
         "//server/util/subdomain",
     ],
@@ -27,7 +28,9 @@ go_test(
         "//server/testutil/testgrpc",
         "//server/util/authutil",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//metadata",
     ],
 )

--- a/enterprise/server/auth_service/auth_service.go
+++ b/enterprise/server/auth_service/auth_service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 
@@ -36,5 +37,10 @@ func (a AuthService) Authenticate(ctx context.Context, req *authpb.AuthenticateR
 }
 
 func (a AuthService) GetPublicKeys(ctx context.Context, req *authpb.GetPublicKeysRequest) (*authpb.GetPublicKeysResponse, error) {
-	return &authpb.GetPublicKeysResponse{}, status.UnimplementedError("GetPublicKeys unimplemented")
+	keys := claims.GetRSAPublicKeys()
+	publicKeys := make([]*authpb.PublicKey, len(keys))
+	for i, key := range claims.GetRSAPublicKeys() {
+		publicKeys[i] = &authpb.PublicKey{Key: &key}
+	}
+	return &authpb.GetPublicKeysResponse{PublicKeys: publicKeys}, nil
 }

--- a/enterprise/server/auth_service/auth_service_test.go
+++ b/enterprise/server/auth_service/auth_service_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgrpc"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
@@ -36,4 +38,41 @@ func TestAuthenticateWrongCreds(t *testing.T) {
 	service := AuthService{authenticator: testauth.NewTestAuthenticator(testauth.TestUsers("foo", "bar"))}
 	_, err := service.Authenticate(contextWithApiKey(t, "baz"), &authpb.AuthenticateRequest{})
 	assert.True(t, status.IsUnauthenticatedError(err))
+}
+
+func TestGetPublicKeys_NoKeys(t *testing.T) {
+	service := AuthService{}
+	resp, err := service.GetPublicKeys(t.Context(), &authpb.GetPublicKeysRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.PublicKeys)
+}
+
+func TestGetPublicKeys_OnlyOldKey(t *testing.T) {
+	flags.Set(t, "auth.jwt_rsa_public_key", "old-public-key")
+	service := AuthService{}
+	resp, err := service.GetPublicKeys(t.Context(), &authpb.GetPublicKeysRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.PublicKeys, 1)
+	assert.Equal(t, "old-public-key", resp.PublicKeys[0].GetKey())
+}
+
+func TestGetPublicKeys_OnlyNewKey(t *testing.T) {
+	flags.Set(t, "auth.new_jwt_rsa_public_key", "new-public-key")
+	service := AuthService{}
+	resp, err := service.GetPublicKeys(t.Context(), &authpb.GetPublicKeysRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.PublicKeys, 1)
+	assert.Equal(t, "new-public-key", resp.PublicKeys[0].GetKey())
+}
+
+func TestGetPublicKeys_BothKeys(t *testing.T) {
+	flags.Set(t, "auth.jwt_rsa_public_key", "old-public-key")
+	flags.Set(t, "auth.new_jwt_rsa_public_key", "new-public-key")
+	service := AuthService{}
+	resp, err := service.GetPublicKeys(t.Context(), &authpb.GetPublicKeysRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.PublicKeys, 2)
+	// New key should come first
+	assert.Equal(t, "new-public-key", resp.PublicKeys[0].GetKey())
+	assert.Equal(t, "old-public-key", resp.PublicKeys[1].GetKey())
 }

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// Maximum number of entries in JWT -> Claims cache.
-	claimsCacheSize = 10_00
+	claimsCacheSize = 1_000
 
 	// The key the Claims are stored under in the context.
 	// If unset, the JWT can be used to reconstitute the claims.
@@ -41,6 +41,11 @@ var (
 	signUsingNewJwtKey = flag.Bool("auth.sign_using_new_jwt_key", false, "If true, new JWTs will be signed using the new JWT key.")
 	claimsCacheTTL     = flag.Duration("auth.jwt_claims_cache_ttl", 15*time.Second, "TTL for JWT string to parsed claims caching. Set to '0' to disable cache.")
 	jwtDuration        = flag.Duration("auth.jwt_duration", 6*time.Hour, "Maximum lifetime of the generated JWT.")
+
+	jwtRSAPublicKey     = flag.String("auth.jwt_rsa_public_key", "", "PEM-encoded RSA public key used to verify JWTs.", flag.Secret)
+	jwtRSAPrivateKey    = flag.String("auth.jwt_rsa_private_key", "", "PEM-encoded RSA private key used to sign JWTs.", flag.Secret)
+	newJWTRSAPublicKey  = flag.String("auth.new_jwt_rsa_public_key", "", "PEM-encoded RSA public key used to verify new JWTs during key rotation.", flag.Secret)
+	newJWTRSAPrivateKey = flag.String("auth.new_jwt_rsa_private_key", "", "PEM-encoded RSA private key used to sign new JWTs during key rotation.", flag.Secret)
 
 	serverAdminGroupID = flag.String("auth.admin_group_id", "", "ID of a group whose members can perform actions only accessible to server admins.")
 )
@@ -500,4 +505,15 @@ func (c *ClaimsCache) Get(token string) (*Claims, error) {
 	c.mu.Unlock()
 
 	return claims, nil
+}
+
+func GetRSAPublicKeys() []string {
+	var keys []string
+	if *newJWTRSAPublicKey != "" {
+		keys = append(keys, *newJWTRSAPublicKey)
+	}
+	if *jwtRSAPublicKey != "" {
+		keys = append(keys, *jwtRSAPublicKey)
+	}
+	return keys
 }


### PR DESCRIPTION
The JWT RSA keys are set as flags, which means rotating them requires restarting the apps, but that should be okay for now. We can move all of these into experiments in the future if we'd like to be able to rotate them without pushing new apps.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4539