### PR TITLE
Fix loading state for queued invocations

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -83,7 +83,7 @@ const smallPageSize = 10;
 
 export default class InvocationComponent extends React.Component<Props, State> {
   state: State = {
-    loading: false,
+    loading: true,
     error: null,
     keyboardShortcutHandle: "",
     childInvocations: [],
@@ -104,7 +104,11 @@ export default class InvocationComponent extends React.Component<Props, State> {
     // TODO(siggisim): Move moment configuration elsewhere
     moment.relativeTimeThreshold("ss", 0);
 
-    if (!this.failedToStart()) {
+    if (this.failedToStart()) {
+      // If the invocation failed to start then there will be nothing to load -
+      // just disable the loading state so we can show the error.
+      this.setState({ loading: false });
+    } else {
       this.fetchInvocation();
 
       this.logsModel = new InvocationLogsModel(this.props.invocationId);
@@ -238,8 +242,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
   }
 
   async fetchInvocation() {
-    this.setState({ loading: true });
-
     // If applicable, fetch the CI runner execution in parallel. The CI runner
     // execution is what creates the invocation, so it can give us some
     // diagnostic info in the case where the invocation is never created, and
@@ -473,9 +475,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
   }
 
   render() {
-    // When fetching the invocation and we have nothing to show, display a
-    // loading spinner.
-    if (this.state.loading && !this.state.model) {
+    if (this.state.loading) {
       return <div className="loading" debug-id="invocation-loading"></div>;
     }
 


### PR DESCRIPTION
This PR reverts some of the loading state logic changes from the previous few PRs, and takes a new, less risky approach - instead of trying to set `loading: true` whenever we're actively doing an invocation fetch (which toggles the `loading` bit back and forth and causes flashing in a few cases), go back to the old approach of only setting `loading: true` initially and then permanently setting it to `false` after we've done our initial RPC.

This compare view, looking at only invocation.tsx, might be helpful for seeing the changes in this PR compared to before I started messing with the loading state: https://github.com/buildbuddy-io/buildbuddy/compare/5015b0f2bbfeec7ce5b7ed44ac344eb585a73af5..3a08de90939e3c91f8fb2c526711952f5f1261eb#diff-c7b8a8a9006ec90cb0b657e33c54bf6f896e90810b93fc14b0fae2617f3c7111