### PR TITLE
[FC] Decrease memory threshold for corrupted balloon state

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2904,8 +2904,9 @@ func (c *FirecrackerContainer) reclaimMemoryWithBalloon(ctx context.Context) err
 	balloonSizeMB, err := c.updateBalloon(ctx, 0)
 	if err != nil {
 		return status.WrapError(err, "deflate balloon")
-	} else if balloonSizeMB > int64(float64(availableMemMB)*0.7) {
-		// If the balloon was unable to deflate to less than 70% of available memory, something is likely broken in the VM.
+	} else if balloonSizeMB > int64(float64(availableMemMB)*0.2) {
+		// If the balloon was unable to deflate, something is likely broken in the VM and the runner shouldn't
+		// be reused, or workloads will have less memory than expected.
 		return fmt.Errorf("failed to deflate balloon, stalled at %d MB. vmlog: %s", balloonSizeMB, c.vmLog.Tail())
 	}
 	return nil


### PR DESCRIPTION
I realized the memory threshold of 70% is too high for whether to consider a balloon faulty.

Let's say availableMem = 1000. The balloon target is 80% of that, so balloonTarget = 800. Then lets say the balloon stalls at 80% of the balloon Target: 800 * .8 = 640

At this point the runner is in an unhealthy state, with 64% of its memory unusable by future workloads because it's being occupied by the balloon. But we won't trigger the if statement that returns the error, because balloon size 640 is only 64% of the available memory, and doesn't hit the 70% threshold