### PR TITLE
dirtools_test: add tests to verify down/uploads deduplication

### DIFF
--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -53,10 +53,10 @@ const (
 	// Should be big enough to feed the workers when they free up.
 	// Operations will block when the queue is full.
 	inputTreeOpsQueueSize = 4000
-	// batchReadLimitBytes controls how big an object or batch can be to use
+	// BatchReadLimitBytes controls how big an object or batch can be to use
 	// the BatchReadBlobs RPC. In experiments, 2MiB blobs are 5-10% faster to
 	// read using the bytestream.Read api.
-	batchReadLimitBytes = min(2*1024*1024, rpcutil.GRPCMaxSizeBytes)
+	BatchReadLimitBytes = min(2*1024*1024, rpcutil.GRPCMaxSizeBytes)
 )
 
 func groupIDStringFromContext(ctx context.Context) string {
@@ -941,7 +941,7 @@ func (ff *BatchFileFetcher) FetchFiles(opts *DownloadTreeOpts) (retErr error) {
 			// fit in the batch call, so we'll have to bytestream
 			// it.
 			size := f.key.SizeBytes
-			if size > batchReadLimitBytes || ff.env.GetContentAddressableStorageClient() == nil {
+			if size > BatchReadLimitBytes || ff.env.GetContentAddressableStorageClient() == nil {
 				eg.Go(func() error {
 					if len(f.fps) == 0 {
 						return status.FailedPreconditionError("empty file pointer list for key")
@@ -959,7 +959,7 @@ func (ff *BatchFileFetcher) FetchFiles(opts *DownloadTreeOpts) (retErr error) {
 			// If the digest would push our current batch request
 			// size over the gRPC max, dispatch the request and
 			// start a new one.
-			if currentBatchRequestSize+size > batchReadLimitBytes {
+			if currentBatchRequestSize+size > BatchReadLimitBytes {
 				reqCopy := req
 				eg.Go(func() error {
 					return ff.batchDownloadFiles(ctx, reqCopy, opts)

--- a/server/remote_cache/cachetools/BUILD
+++ b/server/remote_cache/cachetools/BUILD
@@ -42,6 +42,7 @@ go_test(
         "//server/testutil/testcache",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
+        "//server/util/prefix",
         "//server/util/rpcutil",
         "//server/util/status",
         "//server/util/testing/flags",


### PR DESCRIPTION
I recently have to review some of our logic related to cache consumption
for the user's Windows executor, it seems like we have the following
logic in place today:

Download inputs:
- If the input blob is larger than 2MB, we use bytestream.Read to download
  it from CAS. If there are multiple parallel actions using the same
  inputs blob, we deduplicate the downloads.

- If the input blob is 2MB or smaller, we use the BatchReadBlobs rpc to
  download multiple files at once. These downloads are NOT deduplicated.

Upload outputs:
- If an action create multiple identical outputs, we do deduplicate the
  upload effort.

- It's rare to see actions which create identical outputs to run in
  parallel. So there is no dedupe implemented for uploads cross actions.

Add tests to verify the deduplication behavior we have today.
