### PR TITLE
Use --force when checking out commits too

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1971,7 +1971,7 @@ func (ws *workspace) checkoutRef(ctx context.Context) error {
 			return err
 		}
 	} else {
-		if _, err := git(ctx, ws.log, "checkout", checkoutRef); err != nil {
+		if _, err := git(ctx, ws.log, "checkout", "--force", checkoutRef); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
We use `--force` when checking out branches, in order to discard any changes and avoid having to re-clone the repo to recover from this state. But we don't set `--force` when checking out a commit SHA. This seems unintentional?