### PR TITLE
Tweak tracing in raft/sender

### DIFF
--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -181,7 +181,7 @@ func (s *Sender) LookupRangeDescriptorsForPartition(ctx context.Context, partiti
 func (s *Sender) LookupRangeDescriptor(ctx context.Context, key []byte, skipCache bool) (returnedRD *rfpb.RangeDescriptor, returnedErr error) {
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
 	defer func() {
-		replica_ids := []int64{}
+		replica_ids := make([]int64, 0, len(returnedRD.GetReplicas()))
 		for _, repl := range returnedRD.GetReplicas() {
 			replica_ids = append(replica_ids, int64(repl.GetReplicaId()))
 		}
@@ -292,10 +292,12 @@ func (s *Sender) tryReplica(ctx context.Context, rd *rfpb.RangeDescriptor, repli
 	header := makeHeaderFn(rd, replica)
 
 	fnCtx, spn := tracing.StartSpan(ctx)
-	spn.SetName("TryReplicas: fn")
-	rangeIDAttr := attribute.Int64("range_id", int64(replica.GetRangeId()))
-	replicaIDAttr := attribute.Int64("replica_id", int64(replica.GetReplicaId()))
-	spn.SetAttributes(rangeIDAttr, replicaIDAttr)
+	spn.SetName("tryReplica: fn")
+	spn.SetAttributes(
+		attribute.Int64("range_id", int64(replica.GetRangeId())),
+		attribute.Int64("replica_id", int64(replica.GetReplicaId())),
+		attribute.String("consistency_mode", header.GetConsistencyMode().String()),
+	)
 
 	err = fn(fnCtx, client, header)
 	tracing.RecordErrorToSpan(spn, err)
@@ -329,13 +331,18 @@ func (s *Sender) TryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 
 	logs := []string{}
 	defer func() {
+		// TODO(vanja) figure out why errors aren't recorded properly in the, so
+		// we can remove this.
+		if returnedErr != nil {
+			spn.SetAttributes(attribute.String("error_string", returnedErr.Error()))
+		}
 		tracing.RecordErrorToSpan(spn, returnedErr)
 		if returnedErr != nil {
 			if len(logs) > 0 {
 				log.CtxDebugf(ctx, "failed to TryReplicas: %s. Detailed logs: %s", returnedErr, strings.Join(logs, "\n"))
 			}
 		}
-		replicaIdxAttr := attribute.Int64("replica_idx", int64(replicaIdx))
+		replicaIdxAttr := attribute.Int("replica_idx", replicaIdx)
 		spn.SetAttributes(replicaIdxAttr)
 	}()
 
@@ -452,6 +459,8 @@ type rangeKeys struct {
 }
 
 func (s *Sender) partitionKeysByRange(ctx context.Context, keys []*KeyMeta, skipRangeCache bool) (map[uint64]*rangeKeys, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
 	keysByRange := make(map[uint64]*rangeKeys)
 	for _, keyMeta := range keys {
 		rd, err := s.LookupRangeDescriptor(ctx, keyMeta.Key, skipRangeCache)


### PR DESCRIPTION
I'm trying to better understand situation where we end up in exponential backoff.

A few notable changes:
- add a span for partitionKeysByRange
- report errors in TryReplicas as attributes until I figure out why the errors aren't visible
- add a consistency_mode attribute to tryReplica