### PR TITLE
Fix panic in quota manager

### DIFF
--- a/enterprise/server/quota/BUILD
+++ b/enterprise/server/quota/BUILD
@@ -32,6 +32,7 @@ go_test(
         "//enterprise/server/backends/authdb",
         "//enterprise/server/backends/userdb",
         "//enterprise/server/experiments",
+        "//enterprise/server/testutil/testredis",
         "//proto:group_go_proto",
         "//server/environment",
         "//server/testutil/testauth",

--- a/enterprise/server/quota/quota_manager.go
+++ b/enterprise/server/quota/quota_manager.go
@@ -201,10 +201,10 @@ func createGCRABucket(env environment.Env, config *bucketConfig) (Bucket, error)
 	}
 
 	rateLimiter, err := throttled.NewGCRARateLimiterCtx(store, quota)
-	rateLimiter.SetMaxCASAttemptsLimit(maxRedisRetry)
 	if err != nil {
 		return nil, status.InternalErrorf("unable to create GCRARateLimiter: %s", err)
 	}
+	rateLimiter.SetMaxCASAttemptsLimit(maxRedisRetry)
 
 	return &rateLimitedBucket{
 		config:      config,


### PR DESCRIPTION
If the period overflows, or the rate is invalid, calling a method on the rate limiter would panic.