### PR TITLE
Fix context being overwritten

### DIFF
--- a/server/remote_cache/chunked_manifest/BUILD
+++ b/server/remote_cache/chunked_manifest/BUILD
@@ -22,6 +22,8 @@ go_test(
     deps = [
         ":chunked_manifest",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
+        "//server/interfaces",
         "//server/remote_cache/digest",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",


### PR DESCRIPTION
The `errgroup` context will end once the background tasks finish. This might cause `cache.Set` to fail.

Use a separate context