### PR TITLE
Adjust criteria for making new orgs

### DIFF
--- a/enterprise/server/test/integration/usage/usage_test.go
+++ b/enterprise/server/test/integration/usage/usage_test.go
@@ -39,6 +39,7 @@ func TestGetUsage_ParentAdminFetchesChildGroupUsage(t *testing.T) {
 	parent.IsParent = true
 	parent.SamlIdpMetadataUrl = "https://idp.example.test/metadata"
 	parent.URLIdentifier = "parent-org"
+	parent.Status = grpb.Group_ENTERPRISE_GROUP_STATUS
 	require.NoError(t, app.DB().Save(parent).Error)
 
 	// Create an ORG_ADMIN API key for the parent org using cookie-authenticated Web RPC.

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//server/util/canary",
         "//server/util/capabilities",
         "//server/util/claims",
+        "//server/util/flag",
         "//server/util/flagutil",
         "//server/util/git",
         "//server/util/log",


### PR DESCRIPTION
Only enterprise accounts should be able to make multiple groups that can be used under the same login.