### PR TITLE
bb print: init remote_execution proto

### DIFF
--- a/cli/printlog/BUILD
+++ b/cli/printlog/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//cli/printlog/compact",
+        "//proto:remote_execution_go_proto",
         "//proto:remote_execution_log_go_proto",
         "//server/util/proto",
         "@org_golang_google_protobuf//encoding/protodelim",

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/protobuf/encoding/protodelim"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	// Need to init this so that we can marshal messages type Any such as OriginMetadata
+	_ "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rlpb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution_log"
 )
 


### PR DESCRIPTION
We got this error when trying to inspect an grpc log:

  failed to marshal remote gRPC log entry:
    proto: google.protobuf.Any:
      unable to resolve "type.googleapis.com/build.bazel.remote.execution.v2.OriginMetadata": not found

This is caused by our new OriginMetadata added to
ActionResult.execution_metadata.auxiliary_metadata.

In order to marshal the Any message, we need to include the go package
so that init() func is run and register the type.
