### PR TITLE
Filter admin from audit logs

### DIFF
--- a/enterprise/server/auditlog/BUILD
+++ b/enterprise/server/auditlog/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/interfaces",
         "//server/real_environment",
         "//server/util/capabilities",
+        "//server/util/claims",
         "//server/util/clickhouse/schema",
         "//server/util/clientip",
         "//server/util/db",


### PR DESCRIPTION
Users can see the audit logs for their organization. But to emphasize principle of least privilege, admin's credentials are not shown in the audit log.

The real identity and values will still be kept in the Database and can always be queried