### PR TITLE
[bazelrbe prober] use MODULE.bazel instead of WORKSPACE in probes

### DIFF
--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -62,7 +62,7 @@ genrule(
 }
 
 func createWorkspace(dir string, numTargets, numInputsPerTarget, inputSizeBytes int) error {
-	err := os.WriteFile(filepath.Join(dir, "WORKSPACE"), []byte(""), 0644)
+	err := os.WriteFile(filepath.Join(dir, "MODULE.bazel"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We no longer use Bazel versions earlier than 6.x, meaning it is safe to use `MODULE.bazel` in our probes.