### PR TITLE
execution_server_test: empty aux metadata before compare

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -729,6 +729,8 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 	cachedActionResult, err := cachetools.GetActionResult(ctx, env.GetActionCacheClient(), arnAC)
 	if !test.doNotCache && test.exitCode == 0 && test.status == nil && !test.cachedResult {
 		require.NoError(t, err)
+		// Trim the aux metadata before comparing
+		cachedActionResult.GetExecutionMetadata().AuxiliaryMetadata = nil
 		assert.Empty(t, cmp.Diff(trimmedExecuteResponse.GetResult(), cachedActionResult, protocmp.Transform()))
 	} else {
 		require.Equal(t, codes.NotFound, gstatus.Code(err), "Error should be NotFound, but is %v", err)


### PR DESCRIPTION
We started to make use of Aux Metadata more and more through out our
code base. That means there can be times where the server added
additional aux metadata to the Action Result, causing it to differ from
the originally uploaded message.

Empty the metadata before comparing.

Prep for #10993
