### PR TITLE
Remove unused CancelTaskReservationResponse

### DIFF
--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -446,10 +446,6 @@ message CancelTaskReservationRequest {
   string task_id = 1;
 }
 
-// CancelTaskReservationResponse is sent from the executor to the scheduler to
-// acknowledge receipt of a CancelTaskReservationRequest.
-message CancelTaskReservationResponse {}
-
 message RegisterExecutorRequest {
   ExecutionNode node = 1;
 }


### PR DESCRIPTION
This message is unused. We don't need an explicit acknowledgement from the executor about the cancelled task reservation for now, since it's best-effort.