### PR TITLE
Fix metadata request in cache requests card

### DIFF
--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -585,6 +585,8 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
             digest: digest,
             cacheType: scorecardResult.cacheType,
             instanceName: remoteInstanceName,
+            compressor: scorecardResult.compressor,
+            digestFunction: this.props.model.getDigestFunction(),
           }),
         })
       )


### PR DESCRIPTION
We fetch cache metadata to populate this card:

<img width="1143" height="359" alt="image" src="https://github.com/user-attachments/assets/5ba7cb44-ffa6-483e-947a-f86dc0663733" />
