### PR TITLE
Add env file to ci_runner for carrying env vars across steps

### DIFF
--- a/enterprise/server/ci_runner/envfile/BUILD
+++ b/enterprise/server/ci_runner/envfile/BUILD
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "envfile",
+    srcs = ["envfile.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/ci_runner/envfile",
+)
+
+go_test(
+    name = "envfile_test",
+    srcs = ["envfile_test.go"],
+    deps = [
+        ":envfile",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/ci_runner/envfile/envfile.go
+++ b/enterprise/server/ci_runner/envfile/envfile.go
@@ -1,0 +1,120 @@
+// Package envfile manages the env file, which lets workflow steps persist
+// environment variables to subsequent steps by appending to the file that
+// $BUILDBUDDY_ENV points to.
+package envfile
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	// FileName is the name of the env file.
+	FileName = "buildbuddy.env"
+	// EnvVarName is the name of the environment variable holding the env
+	// file path.
+	EnvVarName = "BUILDBUDDY_ENV"
+)
+
+// Provision creates an empty env file at the given path and sets the
+// BUILDBUDDY_ENV environment variable to point to it. This should be called
+// once at the start of an action, before any steps run.
+func Provision(path string) error {
+	// N.B. os.WriteFile overwrites path by default if it already exists.
+	if err := os.WriteFile(path, nil, 0644); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return os.Setenv(EnvVarName, path)
+}
+
+// ParseAndReset parses the env file at the given path and returns a map of
+// environment variables. After parsing, the file is truncated to prepare for
+// the next step.
+func ParseAndReset(path string) (map[string]string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	envVars, err := Parse(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("parse $%s: %w", EnvVarName, err)
+	}
+	// Truncate the file for the next step
+	if err := os.Truncate(path, 0); err != nil {
+		return nil, err
+	}
+	return envVars, nil
+}
+
+// Parse parses env file content and returns a map of environment variables.
+// It follows the same syntax and semantics as GitHub's GITHUB_ENV file:
+// - Single-line values: NAME=value
+// - Multiline values (heredoc syntax):
+//
+//	NAME<<DELIMITER
+//	line1
+//	line2
+//	DELIMITER
+//
+// If a line contains both "=" and "<<", whichever appears first determines
+// the format. Names and delimiters are not trimmed, and the closing delimiter
+// line must match the delimiter exactly.
+func Parse(content string) (map[string]string, error) {
+	envVars := make(map[string]string)
+	lines := strings.Split(content, "\n")
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		// Skip empty lines
+		if line == "" {
+			continue
+		}
+
+		equalsIndex := strings.Index(line, "=")
+		heredocIndex := strings.Index(line, "<<")
+
+		// Single-line format: NAME=value
+		if equalsIndex >= 0 && (heredocIndex < 0 || equalsIndex < heredocIndex) {
+			name := line[:equalsIndex]
+			value := line[equalsIndex+1:]
+			if name == "" {
+				return nil, fmt.Errorf("line %d: invalid format %q: variable name must not be empty", i+1, line)
+			}
+			envVars[name] = value
+			continue
+		}
+
+		// Multiline format: NAME<<DELIMITER
+		if heredocIndex >= 0 {
+			name := line[:heredocIndex]
+			delimiter := line[heredocIndex+2:]
+			if name == "" || delimiter == "" {
+				return nil, fmt.Errorf("line %d: invalid format %q: variable name and delimiter must not be empty", i+1, line)
+			}
+
+			// Collect lines verbatim until a line exactly matching the
+			// delimiter is found.
+			var valueLines []string
+			startLine := i + 1 // 1-indexed
+			i++
+			found := false
+			for ; i < len(lines); i++ {
+				if lines[i] == delimiter {
+					found = true
+					break
+				}
+				valueLines = append(valueLines, lines[i])
+			}
+			if !found {
+				return nil, fmt.Errorf("line %d: matching delimiter %q not found for variable %q", startLine, delimiter, name)
+			}
+			envVars[name] = strings.Join(valueLines, "\n")
+			continue
+		}
+
+		return nil, fmt.Errorf("line %d: invalid format %q: expected NAME=value or NAME<<DELIMITER", i+1, line)
+	}
+
+	return envVars, nil
+}

--- a/enterprise/server/ci_runner/envfile/envfile_test.go
+++ b/enterprise/server/ci_runner/envfile/envfile_test.go
@@ -1,0 +1,174 @@
+package envfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/ci_runner/envfile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	// Parse follows GitHub's GITHUB_ENV syntax, so these cases pin down
+	// GitHub's semantics: no trimming of names or delimiters, exact delimiter
+	// matching, and "=" vs "<<" precedence based on whichever appears first
+	// in the line.
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    map[string]string
+		wantErr string
+	}{
+		{
+			name:    "empty file",
+			content: "",
+			want:    map[string]string{},
+		},
+		{
+			name:    "single-line var",
+			content: "FOO=bar\n",
+			want:    map[string]string{"FOO": "bar"},
+		},
+		{
+			name:    "multiple vars with empty lines between",
+			content: "FOO=bar\n\nBAZ=qux\n",
+			want:    map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name:    "value containing '='",
+			content: "FOO=a=b\n",
+			want:    map[string]string{"FOO": "a=b"},
+		},
+		{
+			// "=" appears before "<<", so this is a single-line var,
+			// not a heredoc.
+			name:    "value containing '<<' after '='",
+			content: "URL=https://example.com<<path\n",
+			want:    map[string]string{"URL": "https://example.com<<path"},
+		},
+		{
+			// Quotes are not interpreted; they are part of the value.
+			name:    "quotes are preserved literally",
+			content: "FOO=\"double quoted\"\nBAR='single quoted'\n",
+			want:    map[string]string{"FOO": `"double quoted"`, "BAR": `'single quoted'`},
+		},
+		{
+			// Like GITHUB_ENV, names are not trimmed.
+			name:    "name is not trimmed",
+			content: " FOO=bar\n",
+			want:    map[string]string{" FOO": "bar"},
+		},
+		{
+			name:    "last assignment wins for duplicate names",
+			content: "FOO=a\nFOO=b\n",
+			want:    map[string]string{"FOO": "b"},
+		},
+		{
+			name:    "multiline var",
+			content: "FOO<<EOF\nline1\nline2\nEOF\n",
+			want:    map[string]string{"FOO": "line1\nline2"},
+		},
+		{
+			name:    "multiline var with empty value",
+			content: "FOO<<EOF\nEOF\n",
+			want:    map[string]string{"FOO": ""},
+		},
+		{
+			// Empty and whitespace-only lines within a multiline value are
+			// preserved verbatim.
+			name:    "multiline var preserves whitespace",
+			content: "FOO<<EOF\nline1\n\n  indented\n \nEOF\n",
+			want:    map[string]string{"FOO": "line1\n\n  indented\n "},
+		},
+		{
+			// A line containing "=" within a multiline value is part of the
+			// value, not a new assignment.
+			name:    "multiline var containing '='",
+			content: "FOO<<EOF\nBAR=baz\nEOF\n",
+			want:    map[string]string{"FOO": "BAR=baz"},
+		},
+		{
+			// A line that contains the delimiter plus trailing whitespace
+			// does not close the heredoc; only an exact match does.
+			name:    "closing delimiter must match exactly",
+			content: "FOO<<EOF\nEOF \nEOF\n",
+			want:    map[string]string{"FOO": "EOF "},
+		},
+		{
+			name:    "line without '=' or '<<'",
+			content: "FOO\n",
+			wantErr: `line 1: invalid format "FOO": expected NAME=value or NAME<<DELIMITER`,
+		},
+		{
+			// Whitespace-only lines are not skipped; like GITHUB_ENV, only
+			// exactly empty lines are.
+			name:    "whitespace-only line",
+			content: "   \n",
+			wantErr: "line 1: invalid format",
+		},
+		{
+			name:    "empty name",
+			content: "=bar\n",
+			wantErr: `line 1: invalid format "=bar": variable name must not be empty`,
+		},
+		{
+			name:    "empty delimiter",
+			content: "FOO<<\n",
+			wantErr: `line 1: invalid format "FOO<<": variable name and delimiter must not be empty`,
+		},
+		{
+			name:    "missing closing delimiter",
+			content: "FOO<<EOF\nline1\nline2\n",
+			wantErr: `line 1: matching delimiter "EOF" not found for variable "FOO"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			envVars, err := envfile.Parse(tc.content)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, envVars)
+		})
+	}
+}
+
+func TestProvision(t *testing.T) {
+	// Write stale content to the env file path, simulating a leftover file
+	// from a previous run.
+	path := filepath.Join(t.TempDir(), envfile.FileName)
+	err := os.WriteFile(path, []byte("STALE_VAR=1\n"), 0644)
+	require.NoError(t, err)
+	// Use t.Setenv to restore the BUILDBUDDY_ENV var after the test;
+	// Provision overwrites it below.
+	t.Setenv(envfile.EnvVarName, "")
+
+	err = envfile.Provision(path)
+	require.NoError(t, err)
+
+	// The env file should be empty (stale content discarded), and
+	// BUILDBUDDY_ENV should point to it.
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Empty(t, string(content))
+	assert.Equal(t, path, os.Getenv(envfile.EnvVarName))
+}
+
+func TestParseAndReset(t *testing.T) {
+	// Write an env var to the env file, as a step would.
+	path := filepath.Join(t.TempDir(), envfile.FileName)
+	err := os.WriteFile(path, []byte("FOO=bar\n"), 0644)
+	require.NoError(t, err)
+
+	// Parsing should return the env var and truncate the file so that the
+	// var is not applied again after the next step.
+	envVars, err := envfile.ParseAndReset(path)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"FOO": "bar"}, envVars)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Empty(t, string(content))
+}

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/ci_runner",
     deps = [
         "//enterprise/server/bes_artifacts",
+        "//enterprise/server/ci_runner/envfile",
         "//enterprise/server/workflow/config",
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -97,6 +97,17 @@ const (
 	// stream.
 	artifactsDirEnvVarName = "BUILDBUDDY_ARTIFACTS_DIRECTORY"
 
+	// Name of the file where env vars can be written to have them applied to
+	// subsequent steps. The format is:
+	// - Simple values: NAME=value
+	// - Multiline values:
+	//   NAME<<DELIMITER
+	//   line1
+	//   line2
+	//   DELIMITER
+	envFileName       = "buildbuddy.env"
+	envFileEnvVarName = "BUILDBUDDY_ENV"
+
 	defaultGitRemoteName = "origin"
 	forkGitRemoteName    = "fork"
 
@@ -291,6 +302,105 @@ func provisionArtifactsDir(ws *workspace, bazelCommandIndex int) error {
 		return err
 	}
 	return nil
+}
+
+func envFilePath(ws *workspace) string {
+	return filepath.Join(ws.rootDir, envFileName)
+}
+
+// provisionEnvFile creates an empty env file and sets the BUILDBUDDY_ENV
+// environment variable to point to it. This should be called once at the
+// start of an action, before any steps run.
+func provisionEnvFile(ws *workspace) error {
+	path := envFilePath(ws)
+	if err := os.WriteFile(path, nil, 0644); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	return os.Setenv(envFileEnvVarName, path)
+}
+
+// parseEnvFile parses the env file and returns a map of environment variables.
+// The format supports:
+// - Simple values: NAME=value
+// - Multiline values:
+//
+//	NAME<<DELIMITER
+//	line1
+//	line2
+//	DELIMITER
+//
+// After parsing, the file is truncated to prepare for the next step.
+func parseEnvFile(ws *workspace) (map[string]string, error) {
+	path := envFilePath(ws)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	envVars, err := parseEnvFileContent(string(content))
+	if err != nil {
+		return nil, fmt.Errorf("parse $BUILDBUDDY_ENV: %w", err)
+	}
+	// Truncate the file for the next step
+	if err := os.Truncate(path, 0); err != nil {
+		return nil, err
+	}
+	return envVars, nil
+}
+
+// parseEnvFileContent parses the content of an env file and returns a map of
+// environment variables.
+func parseEnvFileContent(content string) (map[string]string, error) {
+	envVars := make(map[string]string)
+	lines := strings.Split(content, "\n")
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		// Skip empty lines
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Check for multiline format: NAME<<DELIMITER
+		if idx := strings.Index(line, "<<"); idx != -1 {
+			name := strings.TrimSpace(line[:idx])
+			delimiter := strings.TrimSpace(line[idx+2:])
+			if name == "" || delimiter == "" {
+				return nil, fmt.Errorf("line %d: invalid multiline format", i+1)
+			}
+
+			// Collect lines until we find the delimiter
+			var valueLines []string
+			startLine := i + 1 // 1-indexed
+			i++
+			found := false
+			for ; i < len(lines); i++ {
+				if lines[i] == delimiter {
+					found = true
+					break
+				}
+				valueLines = append(valueLines, lines[i])
+			}
+			if !found {
+				return nil, fmt.Errorf("line %d: missing closing delimiter for %q", startLine, name)
+			}
+			envVars[name] = strings.Join(valueLines, "\n")
+			continue
+		}
+
+		// Simple format: NAME=value
+		idx := strings.Index(line, "=")
+		if idx == -1 {
+			return nil, fmt.Errorf("line %d: missing '='", i+1)
+		}
+		name := line[:idx]
+		value := line[idx+1:]
+		if name == "" {
+			return nil, fmt.Errorf("line %d: empty name", i+1)
+		}
+		envVars[name] = value
+	}
+
+	return envVars, nil
 }
 
 type buildEventReporter struct {
@@ -1112,6 +1222,12 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		})
 	}
 
+	// Provision the env file before any steps run. This file allows steps to
+	// set environment variables that persist to subsequent steps.
+	if err := provisionEnvFile(ws); err != nil {
+		return err
+	}
+
 	for i, step := range action.Steps {
 		cmdStartTime := time.Now()
 
@@ -1266,6 +1382,17 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 
 		if exitCode != 0 {
 			return runErr
+		}
+
+		// Parse env file and apply env vars to subsequent steps.
+		envVars, err := parseEnvFile(ws)
+		if err != nil {
+			return status.WrapError(err, "parse env file")
+		}
+		for k, v := range envVars {
+			if err := os.Setenv(k, v); err != nil {
+				return status.WrapErrorf(err, "set env var %q", k)
+			}
 		}
 
 		// Flush progress after every command.

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/bes_artifacts"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/ci_runner/envfile"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_publisher"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
@@ -96,17 +97,6 @@ const (
 	// files can be written to have them associated with the workflow BES
 	// stream.
 	artifactsDirEnvVarName = "BUILDBUDDY_ARTIFACTS_DIRECTORY"
-
-	// Name of the file where env vars can be written to have them applied to
-	// subsequent steps. The format is:
-	// - Simple values: NAME=value
-	// - Multiline values:
-	//   NAME<<DELIMITER
-	//   line1
-	//   line2
-	//   DELIMITER
-	envFileName       = "buildbuddy.env"
-	envFileEnvVarName = "BUILDBUDDY_ENV"
 
 	defaultGitRemoteName = "origin"
 	forkGitRemoteName    = "fork"
@@ -305,102 +295,7 @@ func provisionArtifactsDir(ws *workspace, bazelCommandIndex int) error {
 }
 
 func envFilePath(ws *workspace) string {
-	return filepath.Join(ws.rootDir, envFileName)
-}
-
-// provisionEnvFile creates an empty env file and sets the BUILDBUDDY_ENV
-// environment variable to point to it. This should be called once at the
-// start of an action, before any steps run.
-func provisionEnvFile(ws *workspace) error {
-	path := envFilePath(ws)
-	if err := os.WriteFile(path, nil, 0644); err != nil {
-		return fmt.Errorf("write %q: %w", path, err)
-	}
-	return os.Setenv(envFileEnvVarName, path)
-}
-
-// parseEnvFile parses the env file and returns a map of environment variables.
-// The format supports:
-// - Simple values: NAME=value
-// - Multiline values:
-//
-//	NAME<<DELIMITER
-//	line1
-//	line2
-//	DELIMITER
-//
-// After parsing, the file is truncated to prepare for the next step.
-func parseEnvFile(ws *workspace) (map[string]string, error) {
-	path := envFilePath(ws)
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	envVars, err := parseEnvFileContent(string(content))
-	if err != nil {
-		return nil, fmt.Errorf("parse $BUILDBUDDY_ENV: %w", err)
-	}
-	// Truncate the file for the next step
-	if err := os.Truncate(path, 0); err != nil {
-		return nil, err
-	}
-	return envVars, nil
-}
-
-// parseEnvFileContent parses the content of an env file and returns a map of
-// environment variables.
-func parseEnvFileContent(content string) (map[string]string, error) {
-	envVars := make(map[string]string)
-	lines := strings.Split(content, "\n")
-
-	for i := 0; i < len(lines); i++ {
-		line := lines[i]
-		// Skip empty lines
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-
-		// Check for multiline format: NAME<<DELIMITER
-		if idx := strings.Index(line, "<<"); idx != -1 {
-			name := strings.TrimSpace(line[:idx])
-			delimiter := strings.TrimSpace(line[idx+2:])
-			if name == "" || delimiter == "" {
-				return nil, fmt.Errorf("line %d: invalid multiline format", i+1)
-			}
-
-			// Collect lines until we find the delimiter
-			var valueLines []string
-			startLine := i + 1 // 1-indexed
-			i++
-			found := false
-			for ; i < len(lines); i++ {
-				if lines[i] == delimiter {
-					found = true
-					break
-				}
-				valueLines = append(valueLines, lines[i])
-			}
-			if !found {
-				return nil, fmt.Errorf("line %d: missing closing delimiter for %q", startLine, name)
-			}
-			envVars[name] = strings.Join(valueLines, "\n")
-			continue
-		}
-
-		// Simple format: NAME=value
-		idx := strings.Index(line, "=")
-		if idx == -1 {
-			return nil, fmt.Errorf("line %d: missing '='", i+1)
-		}
-		name := line[:idx]
-		value := line[idx+1:]
-		if name == "" {
-			return nil, fmt.Errorf("line %d: empty name", i+1)
-		}
-		envVars[name] = value
-	}
-
-	return envVars, nil
+	return filepath.Join(ws.rootDir, envfile.FileName)
 }
 
 type buildEventReporter struct {
@@ -1224,7 +1119,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 
 	// Provision the env file before any steps run. This file allows steps to
 	// set environment variables that persist to subsequent steps.
-	if err := provisionEnvFile(ws); err != nil {
+	if err := envfile.Provision(envFilePath(ws)); err != nil {
 		return err
 	}
 
@@ -1385,7 +1280,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		}
 
 		// Parse env file and apply env vars to subsequent steps.
-		envVars, err := parseEnvFile(ws)
+		envVars, err := envfile.ParseAndReset(envFilePath(ws))
 		if err != nil {
 			return status.WrapError(err, "parse env file")
 		}

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -1950,7 +1950,7 @@ actions:
 	require.Contains(t, result.Output, "fake-cli-command: OK")
 }
 
-func TestBuildBuddyEnv_SingleLineEnvVars(t *testing.T) {
+func TestBuildBuddyEnv(t *testing.T) {
 	wsPath := testfs.MakeTempDir(t)
 
 	workspaceContents := map[string]string{
@@ -1962,52 +1962,16 @@ actions:
     steps:
       - run: |
           echo "MY_VAR=hello_world" >> "$BUILDBUDDY_ENV"
-          echo "ANOTHER_VAR=foo_bar" >> "$BUILDBUDDY_ENV"
-      - run: |
-          echo "MY_VAR=$MY_VAR"
-          echo "ANOTHER_VAR=$ANOTHER_VAR"
-`,
-	}
-
-	repoPath, headCommitSHA := testgit.MakeTempRepo(t, workspaceContents)
-	runnerFlags := []string{
-		"--workflow_id=test-workflow",
-		"--action_name=Test",
-		"--trigger_event=push",
-		"--pushed_repo_url=file://" + repoPath,
-		"--pushed_branch=master",
-		"--commit_sha=" + headCommitSHA,
-		"--target_repo_url=file://" + repoPath,
-		"--target_branch=master",
-	}
-	app := buildbuddy.Run(t)
-	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
-
-	result := invokeRunner(t, runnerFlags, []string{}, wsPath)
-
-	checkRunnerResult(t, result)
-	runnerInvocation := getRunnerInvocation(t, app, result)
-	assert.Contains(t, runnerInvocation.ConsoleBuffer, "MY_VAR=hello_world")
-	assert.Contains(t, runnerInvocation.ConsoleBuffer, "ANOTHER_VAR=foo_bar")
-}
-
-func TestBuildBuddyEnv_MultiLineEnvVars(t *testing.T) {
-	wsPath := testfs.MakeTempDir(t)
-
-	workspaceContents := map[string]string{
-		"buildbuddy.yaml": `
-actions:
-  - name: "Test"
-    triggers:
-      push: { branches: [ master ] }
-    steps:
+          export NOT_PERSISTED=exported_but_not_written
       - run: |
           echo 'MULTILINE_VAR<<ENDOFVAR' >> "$BUILDBUDDY_ENV"
           echo 'line one' >> "$BUILDBUDDY_ENV"
           echo 'line two' >> "$BUILDBUDDY_ENV"
-          echo 'line three' >> "$BUILDBUDDY_ENV"
           echo 'ENDOFVAR' >> "$BUILDBUDDY_ENV"
-      - run: echo "MULTILINE_VAR=$MULTILINE_VAR"
+      - run: |
+          echo "step 3 MY_VAR: [$MY_VAR]"
+          echo "step 3 MULTILINE_VAR: [$MULTILINE_VAR]"
+          echo "step 3 NOT_PERSISTED: [$NOT_PERSISTED]"
 `,
 	}
 
@@ -2029,89 +1993,11 @@ actions:
 
 	checkRunnerResult(t, result)
 	runnerInvocation := getRunnerInvocation(t, app, result)
-	assert.Contains(t, runnerInvocation.ConsoleBuffer, "MULTILINE_VAR=line one\nline two\nline three")
-}
-
-func TestBuildBuddyEnv_ResetBetweenWorkflowRuns(t *testing.T) {
-	wsPath := testfs.MakeTempDir(t)
-
-	workspaceContents := map[string]string{
-		"buildbuddy.yaml": `
-actions:
-  - name: "Test"
-    triggers:
-      push: { branches: [ master ] }
-    steps:
-      - run: |
-          echo "PREVIOUS_RUN_VAR=$PREVIOUS_RUN_VAR"
-          echo "PREVIOUS_RUN_VAR=from_previous_run" >> "$BUILDBUDDY_ENV"
-`,
-	}
-
-	repoPath, headCommitSHA := testgit.MakeTempRepo(t, workspaceContents)
-	runnerFlags := []string{
-		"--workflow_id=test-workflow",
-		"--action_name=Test",
-		"--trigger_event=push",
-		"--pushed_repo_url=file://" + repoPath,
-		"--pushed_branch=master",
-		"--commit_sha=" + headCommitSHA,
-		"--target_repo_url=file://" + repoPath,
-		"--target_branch=master",
-		// Disable clean checkout fallback for this test since we expect to sync
-		// without errors.
-		"--fallback_to_clean_checkout=false",
-	}
-	app := buildbuddy.Run(t)
-	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
-
-	// First run - sets PREVIOUS_RUN_VAR
-	result := invokeRunner(t, runnerFlags, []string{}, wsPath)
-	checkRunnerResult(t, result)
-	runnerInvocation := getRunnerInvocation(t, app, result)
-	// Var should be empty on first run
-	assert.Contains(t, runnerInvocation.ConsoleBuffer, "PREVIOUS_RUN_VAR=\n")
-
-	// Second run - PREVIOUS_RUN_VAR should NOT be set (env file is reset)
-	result = invokeRunner(t, runnerFlags, []string{}, wsPath)
-	checkRunnerResult(t, result)
-	runnerInvocation = getRunnerInvocation(t, app, result)
-	// Var should still be empty on second run (not carried over)
-	assert.Contains(t, runnerInvocation.ConsoleBuffer, "PREVIOUS_RUN_VAR=\n")
-}
-
-func TestBuildBuddyEnv_InvalidLine(t *testing.T) {
-	wsPath := testfs.MakeTempDir(t)
-
-	workspaceContents := map[string]string{
-		"buildbuddy.yaml": `
-actions:
-  - name: "Test"
-    triggers:
-      push: { branches: [ master ] }
-    steps:
-      - run: |
-          echo "INVALID_LINE_WITHOUT_EQUALS" >> "$BUILDBUDDY_ENV"
-      - run: echo "This should not run"
-`,
-	}
-
-	repoPath, headCommitSHA := testgit.MakeTempRepo(t, workspaceContents)
-	runnerFlags := []string{
-		"--workflow_id=test-workflow",
-		"--action_name=Test",
-		"--trigger_event=push",
-		"--pushed_repo_url=file://" + repoPath,
-		"--pushed_branch=master",
-		"--commit_sha=" + headCommitSHA,
-		"--target_repo_url=file://" + repoPath,
-		"--target_branch=master",
-	}
-	app := buildbuddy.Run(t)
-	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
-
-	result := invokeRunner(t, runnerFlags, []string{}, wsPath)
-
-	require.NotEqual(t, 0, result.ExitCode, "runner should fail when env file contains invalid line")
-	assert.Contains(t, result.Output, `parse $BUILDBUDDY_ENV: line 1: missing '='`)
+	// Env vars written to $BUILDBUDDY_ENV in steps 1 and 2 should both be
+	// visible in step 3.
+	assert.Contains(t, runnerInvocation.ConsoleBuffer, "step 3 MY_VAR: [hello_world]")
+	assert.Contains(t, runnerInvocation.ConsoleBuffer, "step 3 MULTILINE_VAR: [line one\nline two]")
+	// An env var that was exported but not written to $BUILDBUDDY_ENV should
+	// not propagate to later steps.
+	assert.Contains(t, runnerInvocation.ConsoleBuffer, "step 3 NOT_PERSISTED: []")
 }


### PR DESCRIPTION
Adds support for `$BUILDBUDDY_ENV`, which points to a file where workflows can write environment variables that persist across steps. The initial use case is `reninja` where the Golang setup involves a `$PATH` modification that needs to be persisted across steps (prepending `/usr/local/go/bin` to the `$PATH`).

The file is wiped at the beginning of each workflow run. In the future, we could potentially add something like `$BUILDBUDDY_PERSISTENT_ENV` if people want something that they can just write once and have it persist across snapshots.

The syntax of this env file is:

```
# Single-line env vars
FOO1=bar
FOO2=baz

# Multi-line env var
FOO<<EOF
bar
baz
EOF

```