### PR TITLE
[SS] Support falling back to snapshots from any git ref

### DIFF
--- a/docs/remote-runner-introduction.md
+++ b/docs/remote-runner-introduction.md
@@ -170,20 +170,23 @@ PR base branch `users-api`:
    The `users-api` and `main` branch snapshots will not be
    affected.
 
+For more technical details on our VM implementation, see our BazelCon
+talk [Reusing Bazel's Analysis Cache by Cloning Micro-VMs](https://www.youtube.com/watch?v=YycEXBlv7ZA).
+
 ##### The universal snapshot
 
 The universal snapshot exists so that repos which never run on their default
 branch still have something to resume from. Without it, every new PR branch
 boots a VM from scratch.
 
-**NOTE:** We strongly recommend triggering a remote run on every push to the default branch to improve performance. See [Optimal usage of remote runners](#optimal-usage-of-remote-runners). The universal snapshot can be helpful as a fallback,
-but performance will not be as good.
-
 Resuming from the universal snapshot is enabled by default. To opt out, set the
 `allow-universal-snapshot=false` platform property.
 
-For more technical details on our VM implementation, see our BazelCon
-talk [Reusing Bazel's Analysis Cache by Cloning Micro-VMs](https://www.youtube.com/watch?v=YycEXBlv7ZA).
+**NOTE:** We strongly recommend triggering a remote run on every push to the default branch to improve performance. See [Optimal usage of remote runners](#optimal-usage-of-remote-runners). The universal snapshot can be helpful as a fallback,
+but performance will not be as good.
+
+When `allow-universal-snapshot=true` and `remote-snapshot-save-policy=none-available`,
+runs won't write remote snapshots if a universal snapshot is available.
 
 #### Recommended configuration
 
@@ -257,7 +260,8 @@ Valid values are:
     snapshot. It will not resume from the second run of the `my-feature` branch, and
     it will not save a snapshot.
 - `none-available`: A snapshot on a non-default ref will only be saved if
-  there are no snapshots available. If there is any fallback snapshot,
+  there are no snapshots available. If there is any fallback snapshot (including the
+  [universal snapshot](#the-universal-snapshot)),
   a snapshot will not be saved. All runs on default refs will still save a snapshot.
   - Every run on the default branch (Ex. `main` or `master`) will save a snapshot.
   - For the first run on your feature branch `my-feature`, if there is snapshot

--- a/docs/remote-runner-introduction.md
+++ b/docs/remote-runner-introduction.md
@@ -151,24 +151,36 @@ the following snapshot keys in order:
    the run.
 1. The latest snapshot matching the default branch of the repo associated
    with the run.
+1. The latest snapshot that was saved by any branch (the "universal"
+   snapshot).
 
 For example, consider a remote run that runs on pull requests
-(PRs). Given a PR that is attempting to merge the branch `users-ui` into a
-PR base branch `users-api`, BuildBuddy will first try to resume the latest
-snapshot associated with the `users-ui` branch. If that doesn't exist,
-we'll try to resume from the snapshot associated with the `users-api`
-branch. If that doesn't exist, we'll look for a snapshot for the `main`
-branch (the repo's default branch). If all of that fails, only then do we
-boot a new VM from scratch. When the remote run finishes and we save a
-snapshot, we only overwrite the snapshot for the `users-ui` branch,
-meaning that the `users-api` and `main` branch snapshots will not be
-affected.
+(PRs). Imagine a PR that is attempting to merge the branch `users-ui` into a
+PR base branch `users-api`:
 
-One common issue is not running any remote runs on your default branch.
-Every time there is a new PR branch, for example, the remote run will start from
-scratch because there is not a shared default snapshot for them to start from. One
-solution is to trigger a remote run on every push to the default branch, to make sure
-the default snapshot stays up to date.
+1. BuildBuddy will first try to resume the latest snapshot associated with the `users-ui` branch.
+1. If that doesn't exist, we'll try to resume from the snapshot associated with the `users-api` branch.
+1. If that doesn't exist, we'll look for a snapshot for the `main`
+   branch (the repo's default branch).
+1. If that doesn't exist, we'll look for the universal snapshot - the most
+   recent snapshot saved by any branch of the repo.
+1. If all of that fails, only then do we boot a new VM from scratch.
+1. When the remote run finishes and we save a
+   snapshot, we only overwrite the snapshot for the `users-ui` branch.
+   The `users-api` and `main` branch snapshots will not be
+   affected.
+
+##### The universal snapshot
+
+The universal snapshot exists so that repos which never run on their default
+branch still have something to resume from. Without it, every new PR branch
+boots a VM from scratch.
+
+**NOTE:** We strongly recommend triggering a remote run on every push to the default branch to improve performance. See [Optimal usage of remote runners](#optimal-usage-of-remote-runners). The universal snapshot can be helpful as a fallback,
+but performance will not be as good.
+
+Resuming from the universal snapshot is enabled by default. To opt out, set the
+`allow-universal-snapshot=false` platform property.
 
 For more technical details on our VM implementation, see our BazelCon
 talk [Reusing Bazel's Analysis Cache by Cloning Micro-VMs](https://www.youtube.com/watch?v=YycEXBlv7ZA).
@@ -414,6 +426,16 @@ on disks for remote runners.
 
 It's more effective when a smaller remote runner is used to orchestrate farming out most computation to
 traditional Bazel remote executors.
+
+### Running on the default branch
+
+We strongly recommend triggering a remote run on every push to the default branch (typically `main` or `master`) to improve performance.
+
+When a run starts on a PR branch, it will attempt to resume from a snapshot on the default branch. If there is not a snapshot to resume from, new workloads will always start from new slow runners and may incur higher snapshot write costs. See more details in the [Runner recycling](#runner-recycling) section.
+
+The more recent your default branch snapshot, the smaller the delta for the incoming workload and the less work each PR run repeats. For example, git only fetches code that has changed, Bazel only re-analyzes targets that have changed, and Bazel outputs and external artifacts that are unchanged will already be on disk.
+
+If your builds use remote caching, execution on the default branch run is cached and reused by future runs, so nothing is executed twice, even with the additional run.
 
 ### Reducing disk snapshot size
 

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -188,6 +188,7 @@ go_test(
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1199,7 +1199,7 @@ func (c *FirecrackerContainer) shouldSaveRemoteSnapshot(ctx context.Context) boo
 			return true
 		}
 		minWriteDuration := snapshotWriteInterval(ctx, c.task)
-		age := c.env.GetClock().Now().Sub(snapshotLastSavedTime.AsTime())
+		age := c.env.GetClock().Since(snapshotLastSavedTime.AsTime())
 		if age > minWriteDuration {
 			log.CtxInfof(ctx, "Should write remote snapshot for key %+v; existing snapshot is %s old (> %s)", c.SnapshotKeySet().GetWriteKey(), age, minWriteDuration)
 			return true
@@ -1249,7 +1249,7 @@ func (c *FirecrackerContainer) shouldSaveLocalSnapshot(ctx context.Context) bool
 			return true
 		}
 		minWriteDuration := snapshotWriteInterval(ctx, c.task)
-		age := c.env.GetClock().Now().Sub(snapshotLastSavedTime.AsTime())
+		age := c.env.GetClock().Since(snapshotLastSavedTime.AsTime())
 		if age > minWriteDuration {
 			log.CtxInfof(ctx, "Should write local snapshot for key %+v; existing snapshot is %s old (> %s)", c.SnapshotKeySet().GetWriteKey(), age, minWriteDuration)
 			return true
@@ -3695,6 +3695,7 @@ func (c *FirecrackerContainer) hasRemoteSnapshotForKey(ctx context.Context, load
 	}
 	return loader.ValidateSnapshot(ctx, manifest, key, opts, true /*isRemote*/, isFallback)
 }
+
 func (c *FirecrackerContainer) hasLocalSnapshotForKey(ctx context.Context, loader *snaploader.FileCacheLoader, key *fcpb.SnapshotKey) bool {
 	_, err := loader.GetLocalManifest(ctx, key, c.supportsRemoteSnapshots)
 	return err == nil

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1104,17 +1104,27 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	writeManifestLocally := snapshotDetails.saveLocalSnapshot && (!snapshotDetails.saveRemoteSnapshot ||
 		readPolicy != platform.AlwaysReadNewestSnapshot)
 
+	// Only trunk-based runs that had no better snapshot to resume from update
+	// the universal snapshot, so repos that maintain a default branch snapshot
+	// never write it and pay none of its cost.
+	var resumedFrom *fcpb.SnapshotKey
+	if c.snapshot != nil {
+		resumedFrom = c.snapshot.GetKey()
+	}
+	writeUniversalManifest := snaploader.IsEligibleToUpdateUniversalSnapshot(c.task, resumedFrom)
+
 	opts := &snaploader.CacheSnapshotOptions{
-		VMMetadata:            vmd,
-		VMConfiguration:       c.vmConfig,
-		VMStateSnapshotPath:   filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
-		KernelImagePath:       c.executorConfig.GuestKernelImagePath,
-		InitrdImagePath:       c.executorConfig.InitrdImagePath,
-		ChunkedFiles:          map[string]*copy_on_write.COWStore{},
-		Recycled:              c.recycled,
-		CacheSnapshotRemotely: snapshotDetails.saveRemoteSnapshot,
-		CacheSnapshotLocally:  snapshotDetails.saveLocalSnapshot,
-		WriteManifestLocally:  writeManifestLocally,
+		VMMetadata:                       vmd,
+		VMConfiguration:                  c.vmConfig,
+		VMStateSnapshotPath:              filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
+		KernelImagePath:                  c.executorConfig.GuestKernelImagePath,
+		InitrdImagePath:                  c.executorConfig.InitrdImagePath,
+		ChunkedFiles:                     map[string]*copy_on_write.COWStore{},
+		Recycled:                         c.recycled,
+		CacheSnapshotRemotely:            snapshotDetails.saveRemoteSnapshot,
+		CacheSnapshotLocally:             snapshotDetails.saveLocalSnapshot,
+		WriteManifestLocally:             writeManifestLocally,
+		EligibleToWriteUniversalManifest: writeUniversalManifest,
 	}
 	if snapshotSharingEnabled {
 		if c.rootStore != nil {
@@ -1159,7 +1169,7 @@ func (c *FirecrackerContainer) getVMTask() *fcpb.VMMetadata_VMTask {
 		ActionDigest:          c.task.GetExecuteRequest().GetActionDigest(),
 		ExecuteResponseDigest: d,
 		SnapshotId:            c.snapshotID, // Unique ID pertaining to this execution run
-		CompletedTimestamp:    tspb.Now(),
+		CompletedTimestamp:    tspb.New(c.env.GetClock().Now()),
 	}
 }
 
@@ -1189,16 +1199,17 @@ func (c *FirecrackerContainer) shouldSaveRemoteSnapshot(ctx context.Context) boo
 			return true
 		}
 		minWriteDuration := snapshotWriteInterval(ctx, c.task)
-		if time.Since(snapshotLastSavedTime.AsTime()) > minWriteDuration {
-			log.CtxInfof(ctx, "Should write remote snapshot for key %+v; existing snapshot is %s old (> %s)", c.SnapshotKeySet().GetWriteKey(), time.Since(snapshotLastSavedTime.AsTime()), minWriteDuration)
+		age := c.env.GetClock().Now().Sub(snapshotLastSavedTime.AsTime())
+		if age > minWriteDuration {
+			log.CtxInfof(ctx, "Should write remote snapshot for key %+v; existing snapshot is %s old (> %s)", c.SnapshotKeySet().GetWriteKey(), age, minWriteDuration)
 			return true
 		}
-		log.CtxDebugf(ctx, "Skipping remote snapshot write for key %+v; existing snapshot is %s old (< %s)", c.SnapshotKeySet().GetWriteKey(), time.Since(snapshotLastSavedTime.AsTime()), minWriteDuration)
+		log.CtxDebugf(ctx, "Skipping remote snapshot write for key %+v; existing snapshot is %s old (< %s)", c.SnapshotKeySet().GetWriteKey(), age, minWriteDuration)
 		return false
 	}
 
 	if remoteSavePolicy == platform.OnlySaveFirstNonDefaultSnapshot {
-		return !c.hasRemoteSnapshotForKey(ctx, c.loader, c.SnapshotKeySet().GetWriteKey())
+		return !c.hasRemoteSnapshotForKey(ctx, c.loader, c.SnapshotKeySet().GetWriteKey(), false /*isFallback*/)
 	}
 
 	// By default, savePolicy=OnlySaveNonDefaultSnapshotIfNoneAvailable
@@ -1238,11 +1249,12 @@ func (c *FirecrackerContainer) shouldSaveLocalSnapshot(ctx context.Context) bool
 			return true
 		}
 		minWriteDuration := snapshotWriteInterval(ctx, c.task)
-		if time.Since(snapshotLastSavedTime.AsTime()) > minWriteDuration {
-			log.CtxInfof(ctx, "Should write local snapshot for key %+v; existing snapshot is %s old (> %s)", c.SnapshotKeySet().GetWriteKey(), time.Since(snapshotLastSavedTime.AsTime()), minWriteDuration)
+		age := c.env.GetClock().Now().Sub(snapshotLastSavedTime.AsTime())
+		if age > minWriteDuration {
+			log.CtxInfof(ctx, "Should write local snapshot for key %+v; existing snapshot is %s old (> %s)", c.SnapshotKeySet().GetWriteKey(), age, minWriteDuration)
 			return true
 		}
-		log.CtxDebugf(ctx, "Skipping local snapshot write for key %+v; existing snapshot is %s old (< %s)", c.SnapshotKeySet().GetWriteKey(), time.Since(snapshotLastSavedTime.AsTime()), minWriteDuration)
+		log.CtxDebugf(ctx, "Skipping local snapshot write for key %+v; existing snapshot is %s old (< %s)", c.SnapshotKeySet().GetWriteKey(), age, minWriteDuration)
 		return false
 	}
 
@@ -1347,25 +1359,11 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 	}
 	log.CtxDebugf(ctx, "Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(machine)).FieldByName("cmd")).FieldByName("Args"))
 
-	readPolicy, err := snapshotReadPolicy(c.task)
+	getSnapshotOpts, err := c.getSnapshotOptions()
 	if err != nil {
 		return err
 	}
-	maxFallbackAgeStr := platform.FindEffectiveValue(c.task, platform.MaxStaleFallbackSnapshotAgePropertyName)
-	maxFallbackAge := snaputil.DefaultMaxStaleFallbackSnapshotAge
-	if maxFallbackAgeStr != "" {
-		d, err := time.ParseDuration(maxFallbackAgeStr)
-		if err != nil {
-			return status.InvalidArgumentErrorf("invalid max fallback snapshot age %s: %s", maxFallbackAgeStr, err)
-		}
-		maxFallbackAge = d
-	}
-	snap, err := c.loader.GetSnapshot(ctx, c.snapshotKeySet, &snaploader.GetSnapshotOptions{
-		SupportsRemoteChunks:        c.supportsRemoteSnapshots,
-		SupportsRemoteManifest:      c.supportsRemoteSnapshots,
-		ReadPolicy:                  readPolicy,
-		MaxStaleFallbackSnapshotAge: maxFallbackAge,
-	})
+	snap, err := c.loader.GetSnapshot(ctx, c.snapshotKeySet, getSnapshotOpts)
 	if err != nil {
 		return error_util.SnapshotNotFoundError(fmt.Sprintf("failed to get snapshot %s: %s", snaploader.KeysetDebugString(ctx, c.env, c.snapshotKeySet, c.supportsRemoteSnapshots), err))
 	}
@@ -3637,6 +3635,30 @@ func (c *FirecrackerContainer) machineHasBalloon(ctx context.Context) bool {
 	return err == nil
 }
 
+// getSnapshotOptions builds the options describing which snapshots this task
+// is willing to read
+func (c *FirecrackerContainer) getSnapshotOptions() (*snaploader.GetSnapshotOptions, error) {
+	readPolicy, err := snapshotReadPolicy(c.task)
+	if err != nil {
+		return nil, err
+	}
+	maxFallbackAgeStr := platform.FindEffectiveValue(c.task, platform.MaxStaleFallbackSnapshotAgePropertyName)
+	maxFallbackAge := snaputil.DefaultMaxStaleFallbackSnapshotAge
+	if maxFallbackAgeStr != "" {
+		d, err := time.ParseDuration(maxFallbackAgeStr)
+		if err != nil {
+			return nil, status.InvalidArgumentErrorf("invalid max fallback snapshot age %s: %s", maxFallbackAgeStr, err)
+		}
+		maxFallbackAge = d
+	}
+	return &snaploader.GetSnapshotOptions{
+		SupportsRemoteChunks:        c.supportsRemoteSnapshots,
+		SupportsRemoteManifest:      c.supportsRemoteSnapshots,
+		ReadPolicy:                  readPolicy,
+		MaxStaleFallbackSnapshotAge: maxFallbackAge,
+	}, nil
+}
+
 // hasRemoteSnapshot returns whether a remote snapshot exists for any
 // valid snapshot keys, including fallback keys.
 func (c *FirecrackerContainer) hasRemoteSnapshot(ctx context.Context, loader *snaploader.FileCacheLoader) bool {
@@ -3649,11 +3671,11 @@ func (c *FirecrackerContainer) hasRemoteSnapshot(ctx context.Context, loader *sn
 	// branch. Merge queue snapshots are never written under the
 	// gh-readonly-queue/... ref, so checking the branch key would always miss and
 	// incorrectly make us think no remote snapshot exists yet.
-	allKeys := []*fcpb.SnapshotKey{c.SnapshotKeySet().GetWriteKey()}
-	allKeys = append(allKeys, c.SnapshotKeySet().GetFallbackKeys()...)
-
-	for _, k := range allKeys {
-		if hasSnapshot := c.hasRemoteSnapshotForKey(ctx, loader, k); hasSnapshot {
+	if c.hasRemoteSnapshotForKey(ctx, loader, c.SnapshotKeySet().GetWriteKey(), false /*isFallback*/) {
+		return true
+	}
+	for _, k := range c.SnapshotKeySet().GetFallbackKeys() {
+		if c.hasRemoteSnapshotForKey(ctx, loader, k, true /*isFallback*/) {
 			return true
 		}
 	}
@@ -3661,9 +3683,17 @@ func (c *FirecrackerContainer) hasRemoteSnapshot(ctx context.Context, loader *sn
 	return false
 }
 
-func (c *FirecrackerContainer) hasRemoteSnapshotForKey(ctx context.Context, loader *snaploader.FileCacheLoader, key *fcpb.SnapshotKey) bool {
-	_, _, err := loader.FetchRemoteManifest(ctx, key)
-	return err == nil
+func (c *FirecrackerContainer) hasRemoteSnapshotForKey(ctx context.Context, loader *snaploader.FileCacheLoader, key *fcpb.SnapshotKey, isFallback bool) bool {
+	manifest, _, err := loader.FetchRemoteManifest(ctx, key)
+	if err != nil {
+		return false
+	}
+	opts, err := c.getSnapshotOptions()
+	if err != nil {
+		log.CtxWarningf(ctx, "Failed to compute snapshot options: %s", err)
+		return false
+	}
+	return loader.ValidateSnapshot(ctx, manifest, key, opts, true /*isRemote*/, isFallback)
 }
 func (c *FirecrackerContainer) hasLocalSnapshotForKey(ctx context.Context, loader *snaploader.FileCacheLoader, key *fcpb.SnapshotKey) bool {
 	_, err := loader.GetLocalManifest(ctx, key, c.supportsRemoteSnapshots)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1508,6 +1508,8 @@ func TestFirecracker_SnapshotSharing_UniversalFallback(t *testing.T) {
 
 func TestFirecracker_SnapshotSharing_UniversalFallback_SavePolicy(t *testing.T) {
 	// Disable local snapshot sharing with filecache to simplify the setup.
+	// We're testing remote cache behavior, so there's no need to also write snapshots to the local filecache,
+	// especially because we'd need to clear it to guarantee we're hitting the remote cache.
 	flags.Set(t, "executor.enable_local_snapshot_sharing", false)
 
 	for _, tc := range []struct {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -63,6 +63,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1380,6 +1381,235 @@ func TestFirecracker_SnapshotSharing_ReadPolicy(t *testing.T) {
 
 			// Resume from snapshot on executor 1.
 			resumeFromSnapshot(getEnvWithFC(fc), workDir1, "Resume", tc.expectedOutputAfterResume)
+		})
+	}
+}
+
+func TestFirecracker_SnapshotSharing_UniversalFallback(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+	tests := []struct {
+		name              string
+		testStaleSnapshot bool
+	}{
+		{
+			name: "Successful resume from universal snapshot",
+		},
+		{
+			name:              "Failure - Universal snapshot was too old",
+			testStaleSnapshot: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			env := getTestEnv(ctx, t, envOpts{})
+			env.SetClock(fakeClock)
+			rootDir := testfs.MakeTempDir(t)
+			cfg := getExecutorConfig(t)
+
+			env.SetAuthenticator(testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1")))
+			filecacheRoot := testfs.MakeTempDir(t)
+			fc, err := filecache.NewFileCache(filecacheRoot, fileCacheSize, false)
+			require.NoError(t, err)
+			fc.WaitForDirectoryScanToComplete()
+			env.SetFileCache(fc)
+
+			var containersToCleanup []*firecracker.FirecrackerContainer
+			t.Cleanup(func() {
+				for _, vm := range containersToCleanup {
+					err := vm.Remove(ctx)
+					assert.NoError(t, err)
+				}
+			})
+
+			workDir := testfs.MakeDirAll(t, rootDir, "work")
+			opts := firecracker.ContainerOpts{
+				ContainerImage:         busyboxImage,
+				ActionWorkingDirectory: workDir,
+				VMConfiguration: &fcpb.VMConfiguration{
+					NumCpus:           1,
+					MemSizeMb:         minMemSizeMB, // small to make snapshotting faster.
+					NetworkMode:       fcpb.NetworkMode_NETWORK_MODE_OFF,
+					ScratchDiskSizeMb: 100,
+				},
+				ExecutorConfig: cfg,
+			}
+
+			instanceName := "test-instance-name"
+			taskTemplate := &repb.ExecutionTask{
+				Command: &repb.Command{
+					Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+						{Name: "recycle-runner", Value: "true"},
+					}},
+					Arguments: []string{"./buildbuddy_ci_runner"},
+					EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+						{Name: "GIT_REPO_DEFAULT_BRANCH", Value: "main"},
+					},
+				},
+				ExecuteRequest: &repb.ExecuteRequest{
+					InstanceName: instanceName,
+				},
+			}
+
+			// pr-1 saves a snapshot
+			taskPR1 := taskTemplate.CloneVT()
+			taskPR1.Command.EnvironmentVariables = append(taskPR1.Command.EnvironmentVariables, &repb.Command_EnvironmentVariable{
+				Name: "GIT_BRANCH", Value: "pr-1",
+			})
+			vm, err := firecracker.NewContainer(ctx, env, taskPR1, opts)
+			require.NoError(t, err)
+			containersToCleanup = append(containersToCleanup, vm)
+			require.NoError(t, container.PullImageIfNecessary(ctx, env, vm, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher))
+			err = vm.Create(ctx, workDir)
+			require.NoError(t, err)
+			cmd := appendToLog("pr-1")
+			res := vm.Exec(ctx, cmd, nil /*=stdio*/)
+			require.NoError(t, res.Error)
+			require.Equal(t, "pr-1\n", string(res.Stdout))
+			err = vm.Pause(ctx)
+			require.NoError(t, err)
+
+			if tc.testStaleSnapshot {
+				fakeClock.Advance(snaputil.DefaultMaxStaleFallbackSnapshotAge + 1*time.Hour)
+			}
+
+			// pr-2 tries to resume from a snapshot. Should only succeed if the universal
+			// snapshot is still valid.
+			taskPR2 := taskTemplate.CloneVT()
+			taskPR2.Command.EnvironmentVariables = append(taskPR2.Command.EnvironmentVariables, &repb.Command_EnvironmentVariable{
+				Name: "GIT_BRANCH", Value: "pr-2",
+			})
+			vm2, err := firecracker.NewContainer(ctx, env, taskPR2, opts)
+			require.NoError(t, err)
+			containersToCleanup = append(containersToCleanup, vm2)
+			require.NoError(t, container.PullImageIfNecessary(ctx, env, vm2, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher))
+
+			if tc.testStaleSnapshot {
+				// The universal snapshot is too old to read, so pr-2 should have to boot cold.
+				err = vm2.Create(ctx, workDir)
+				require.NoError(t, err)
+				cmd = appendToLog("pr-2")
+				res = vm2.Exec(ctx, cmd, nil /*=stdio*/)
+				require.NoError(t, res.Error)
+				require.Equal(t, "pr-2\n", string(res.Stdout))
+			} else {
+				// The universal snapshot is still valid, so pr-2 should be able to resume from it.
+				err = vm2.Unpause(ctx)
+				require.NoError(t, err)
+				cmd = appendToLog("pr-2")
+				res = vm2.Exec(ctx, cmd, nil /*=stdio*/)
+				require.NoError(t, res.Error)
+				require.Equal(t, "pr-1\npr-2\n", string(res.Stdout))
+			}
+		})
+	}
+}
+
+func TestFirecracker_SnapshotSharing_UniversalFallback_SavePolicy(t *testing.T) {
+	// Disable local snapshot sharing with filecache to simplify the setup.
+	flags.Set(t, "executor.enable_local_snapshot_sharing", false)
+
+	for _, tc := range []struct {
+		name                    string
+		expireUniversalSnapshot bool
+		expectedFinalLogs       string
+	}{
+		{
+			// pr-2 resumes from the universal snapshot and does not save one
+			// of its own, so re-running it resumes from the universal snapshot
+			// again and prints exactly what it printed the first time.
+			name:                    "valid universal snapshot, don't write another one",
+			expireUniversalSnapshot: false,
+			expectedFinalLogs:       "pr-1\npr-2\n",
+		},
+		{
+			// The universal snapshot is too stale to read, so pr-2 boots cold
+			// and saves a new snapshot. Re-running it resumes from that newly written snapshot.
+			name:                    "stale universal snapshot, should save a snapshot",
+			expireUniversalSnapshot: true,
+			expectedFinalLogs:       "pr-2\npr-2\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			env := getTestEnv(ctx, t, envOpts{})
+			cfg := getExecutorConfig(t)
+			env.SetAuthenticator(testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1")))
+
+			fakeClock := clockwork.NewFakeClock()
+			env.SetClock(fakeClock)
+
+			var containersToCleanup []*firecracker.FirecrackerContainer
+			t.Cleanup(func() {
+				for _, vm := range containersToCleanup {
+					assert.NoError(t, vm.Remove(ctx))
+				}
+			})
+
+			const defaultBranch = "main"
+			prTask := func(branch string) *repb.ExecutionTask {
+				return &repb.ExecutionTask{
+					Command: &repb.Command{
+						Arguments: []string{"./buildbuddy_ci_runner"},
+						Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+							{Name: "recycle-runner", Value: "true"},
+							{Name: platform.SnapshotSavePolicyPropertyName, Value: platform.OnlySaveNonDefaultSnapshotIfNoneAvailable},
+						}},
+						EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+							{Name: "GIT_BRANCH", Value: branch},
+							{Name: "GIT_REPO_DEFAULT_BRANCH", Value: defaultBranch},
+						},
+					},
+				}
+			}
+
+			rootDir := testfs.MakeTempDir(t)
+			run := func(name, branch, expectedLogs string) {
+				workDir := testfs.MakeDirAll(t, rootDir, name)
+				opts := firecracker.ContainerOpts{
+					ContainerImage:         busyboxImage,
+					ActionWorkingDirectory: workDir,
+					VMConfiguration: &fcpb.VMConfiguration{
+						NumCpus:           1,
+						MemSizeMb:         minMemSizeMB, // small to make snapshotting faster.
+						NetworkMode:       fcpb.NetworkMode_NETWORK_MODE_OFF,
+						ScratchDiskSizeMb: 100,
+					},
+					ExecutorConfig: cfg,
+				}
+				vm, err := firecracker.NewContainer(ctx, env, prTask(branch), opts)
+				require.NoError(t, err)
+				containersToCleanup = append(containersToCleanup, vm)
+				require.NoError(t, container.PullImageIfNecessary(ctx, env, vm, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher))
+				require.NoError(t, vm.Create(ctx, workDir))
+				res := vm.Exec(ctx, appendToLog(branch), nil /*=stdio*/)
+				require.NoError(t, res.Error)
+				require.NoError(t, vm.Pause(ctx))
+				assert.Equal(t, expectedLogs, string(res.Stdout))
+			}
+
+			// pr-1 has nothing to resume from, so it boots cold. It should save a universal snapshot.
+			run("pr-1", "pr-1", "pr-1\n")
+
+			if tc.expireUniversalSnapshot {
+				fakeClock.Advance(snaputil.DefaultMaxStaleFallbackSnapshotAge + time.Hour)
+			}
+
+			// Start a run from pr-2.
+			if tc.expireUniversalSnapshot {
+				// The universal snapshot is too old to read, so pr-2 boots cold.
+				run("pr-2", "pr-2", "pr-2\n")
+			} else {
+				// The universal snapshot is still valid, so pr-2 should be able to resume from it.
+				// The snapshot should contain the log from pr-1.
+				run("pr-2", "pr-2", "pr-1\npr-2\n")
+			}
+
+			// Start a second run from pr-2.
+			// Depending on the test case, it should either resume from the universal snapshot written by pr-1,
+			// or the newly written snapshot written by pr-2.
+			run("pr-2-again", "pr-2", tc.expectedFinalLogs)
 		})
 	}
 }

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -186,10 +186,7 @@ func gitRefs(task *repb.ExecutionTask) (branchRef string, fallbackRefs []string)
 
 func universalFallbackEnabled(task *repb.ExecutionTask) bool {
 	v := platform.FindEffectiveValue(task, platform.EnableUniversalSnapshotPropertyName)
-	if v == "" {
-		return true
-	}
-	return platform.IsTrue(v)
+	return v == "" || platform.IsTrue(v)
 }
 
 // IsEligibleToUpdateUniversalSnapshot returns whether this run is allowed to
@@ -207,7 +204,7 @@ func IsEligibleToUpdateUniversalSnapshot(task *repb.ExecutionTask, resumedFrom *
 	}
 	branch := getEnv(task, "GIT_BRANCH")
 	if branch == "" {
-		// Fallback behavior is intended to optimize runs on GH branches.
+		// Fallback behavior is intended to optimize runs on git branches.
 		return false
 	}
 	// If we resumed from a non-universal snapshot, a better fallback exists.
@@ -556,6 +553,8 @@ func (l *FileCacheLoader) getSnapshot(ctx context.Context, key *fcpb.SnapshotKey
 	return manifest, snaputil.ChunkSourceRemoteCache, nil
 }
 
+// ValidateSnapshot checks that a snapshot is still valid to use - i.e. is not too stale, given the
+// configured max staleness.
 func (l *FileCacheLoader) ValidateSnapshot(ctx context.Context, manifest *fcpb.SnapshotManifest, key *fcpb.SnapshotKey, opts *GetSnapshotOptions, isRemote bool, isFallback bool) bool {
 	if !isFallback {
 		return true
@@ -575,8 +574,7 @@ func (l *FileCacheLoader) ValidateSnapshot(ctx context.Context, manifest *fcpb.S
 		return false
 	}
 
-	now := l.env.GetClock().Now()
-	age := now.Sub(snapshotLastSavedTime.AsTime())
+	age := l.env.GetClock().Since(snapshotLastSavedTime.AsTime())
 	if age > opts.MaxStaleFallbackSnapshotAge {
 		log.CtxInfof(ctx, "Fallback snapshot was created %s ago, which is longer than the max age %s - not using", age, opts.MaxStaleFallbackSnapshotAge)
 		return false
@@ -940,12 +938,12 @@ func (l *FileCacheLoader) cacheManifestLocally(ctx context.Context, key *fcpb.Sn
 	if err != nil {
 		return err
 	}
-	b, err := proto.Marshal(manifestACResult)
+	manifestBytes, err := proto.Marshal(manifestACResult)
 	if err != nil {
 		return err
 	}
 	manifestNode := &repb.FileNode{Digest: d}
-	if _, err := l.env.GetFileCache().Write(ctx, manifestNode, b); err != nil {
+	if _, err := l.env.GetFileCache().Write(ctx, manifestNode, manifestBytes); err != nil {
 		return err
 	}
 	log.CtxInfof(ctx, "Cached local snapshot manifest %s", snapshotDebugString(ctx, l.env, key, false /*remote*/, "" /*=snapshotID*/))
@@ -964,7 +962,7 @@ func (l *FileCacheLoader) cacheManifestLocally(ctx context.Context, key *fcpb.Sn
 		}
 
 		snapshotSpecificManifestNode := &repb.FileNode{Digest: snapshotSpecificManifestKey}
-		if _, err := l.env.GetFileCache().Write(ctx, snapshotSpecificManifestNode, b); err != nil {
+		if _, err := l.env.GetFileCache().Write(ctx, snapshotSpecificManifestNode, manifestBytes); err != nil {
 			log.Warningf("Failed to cache local snapshot manifest for snapshot ID %s: %s", snapshotID, err)
 			return nil
 		}
@@ -983,7 +981,7 @@ func (l *FileCacheLoader) cacheManifestLocally(ctx context.Context, key *fcpb.Sn
 			return nil
 		}
 		universalManifestNode := &repb.FileNode{Digest: universalD}
-		if _, err := l.env.GetFileCache().Write(ctx, universalManifestNode, b); err != nil {
+		if _, err := l.env.GetFileCache().Write(ctx, universalManifestNode, manifestBytes); err != nil {
 			log.CtxWarningf(ctx, "Failed to cache local universal snapshot manifest: %s", err)
 			return nil
 		}
@@ -1543,8 +1541,8 @@ func IsLikelyDefaultSnapshot(keys *fcpb.SnapshotKeySet, task *repb.ExecutionTask
 	}
 
 	// The default snapshot is the fallback key for non-default branches,
-	// so if a run does not have a fallback key, it's likely running on
-	// the default branch.
+	// so if a run does not have a fallback key (or if its only fallback is the
+	// universal snapshot), it's likely running on the default branch.
 	for _, k := range keys.GetFallbackKeys() {
 		if k.GetRef() != snaputil.UniversalSnapshotRef {
 			return false

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -173,7 +173,50 @@ func gitRefs(task *repb.ExecutionTask) (branchRef string, fallbackRefs []string)
 			fallbackRefs = append(fallbackRefs, v)
 		}
 	}
+
+	// As a last resort, fall back to a snapshot saved by any branch. This is
+	// what keeps repos that never run on their default branch from booting a
+	// cold VM on every run.
+	if universalFallbackEnabled(task) {
+		fallbackRefs = append(fallbackRefs, snaputil.UniversalSnapshotRef)
+	}
+
 	return branchRef, fallbackRefs
+}
+
+func universalFallbackEnabled(task *repb.ExecutionTask) bool {
+	v := platform.FindEffectiveValue(task, platform.EnableUniversalSnapshotPropertyName)
+	if v == "" {
+		return true
+	}
+	return platform.IsTrue(v)
+}
+
+// IsEligibleToUpdateUniversalSnapshot returns whether this run is allowed to
+// update the universal snapshot - the last-resort fallback for runs that have
+// no other snapshot available.
+//
+// This is an eligibility check, not an outcome: the universal manifest is only
+// updated if this returns true *and* the save policy decides to write a
+// snapshot at all.
+//
+// resumedFrom is the key this run resumed from, or nil if it booted cold.
+func IsEligibleToUpdateUniversalSnapshot(task *repb.ExecutionTask, resumedFrom *fcpb.SnapshotKey) bool {
+	if !universalFallbackEnabled(task) {
+		return false
+	}
+	branch := getEnv(task, "GIT_BRANCH")
+	if branch == "" {
+		// Fallback behavior is intended to optimize runs on GH branches.
+		return false
+	}
+	// If we resumed from a non-universal snapshot, a better fallback exists.
+	// Don't write a universal snapshot.
+	if resumedFrom != nil && resumedFrom.GetRef() != snaputil.UniversalSnapshotRef {
+		return false
+	}
+
+	return true
 }
 
 func getEnv(task *repb.ExecutionTask, name string) string {
@@ -369,6 +412,12 @@ type CacheSnapshotOptions struct {
 	// even if there is a newer manifest for the snapshot key available in the
 	// remote cache.
 	WriteManifestLocally bool
+
+	// EligibleToWriteUniversalManifest is whether the universal snapshot manifest
+	// is eligible to be updated.
+	//
+	// The snapshot write policy determines whether the snapshot is actually written.
+	EligibleToWriteUniversalManifest bool
 }
 
 type UnpackedSnapshot struct {
@@ -463,7 +512,7 @@ func (l *FileCacheLoader) getSnapshot(ctx context.Context, key *fcpb.SnapshotKey
 		supportsRemoteFallback := opts.SupportsRemoteChunks && *snaputil.EnableRemoteSnapshotSharing
 		manifest, err := l.GetLocalManifest(ctx, key, supportsRemoteFallback)
 		if err == nil {
-			if validateLocalSnapshot(ctx, manifest, opts, isFallback) {
+			if l.ValidateSnapshot(ctx, manifest, key, opts, false /*isRemote*/, isFallback) {
 				log.CtxInfof(ctx, "Using local manifest for key %s", key)
 				return manifest, snaputil.ChunkSourceLocalFilecache, nil
 			}
@@ -489,13 +538,16 @@ func (l *FileCacheLoader) getSnapshot(ctx context.Context, key *fcpb.SnapshotKey
 	if err != nil {
 		return nil, snaputil.ChunkSourceUnmapped, status.WrapError(err, "fetch remote manifest")
 	}
+	if !l.ValidateSnapshot(ctx, manifest, key, opts, true /*isRemote*/, isFallback) {
+		return nil, snaputil.ChunkSourceUnmapped, status.NotFoundErrorf("remote snapshot for key %s is stale", key)
+	}
 
 	// Unless reading the newest snapshot from the remote cache is requested,
 	// save the newly fetched manifest locally. This will increase the odds that
 	// future runs on this executor will use that snapshot, which will already
 	// have snapshot chunks locally.
 	if opts.ReadPolicy != platform.AlwaysReadNewestSnapshot {
-		if err := l.cacheManifestLocally(ctx, key, acResult, "" /* snapshotID */); err != nil {
+		if err := l.cacheManifestLocally(ctx, key, acResult, "" /* snapshotID */, false /*writeUniversal*/); err != nil {
 			log.Warningf("Failed to cache snapshot manifest locally during get %s: %s", snapshotDebugString(ctx, l.env, key, false, ""), err)
 		}
 	}
@@ -504,17 +556,29 @@ func (l *FileCacheLoader) getSnapshot(ctx context.Context, key *fcpb.SnapshotKey
 	return manifest, snaputil.ChunkSourceRemoteCache, nil
 }
 
-func validateLocalSnapshot(ctx context.Context, manifest *fcpb.SnapshotManifest, opts *GetSnapshotOptions, isFallback bool) bool {
+func (l *FileCacheLoader) ValidateSnapshot(ctx context.Context, manifest *fcpb.SnapshotManifest, key *fcpb.SnapshotKey, opts *GetSnapshotOptions, isRemote bool, isFallback bool) bool {
 	if !isFallback {
 		return true
 	}
+
+	// For local snapshots, we check the staleness of the snapshot because we may be able to fallback to a fresher remote snapshot
+	// that was written by a different executor.
+	// For universal snapshots, we check for staleness to prevent environment drift from very old snapshots.
+	shouldCheckAge := !isRemote || key.GetRef() == snaputil.UniversalSnapshotRef
+	if !shouldCheckAge {
+		return true
+	}
+
 	snapshotLastSavedTime := manifest.GetVmMetadata().GetLastExecutedTask().GetCompletedTimestamp()
 	if snapshotLastSavedTime == nil {
 		log.CtxErrorf(ctx, "snapshot last saved timestamp for %+v is unexpectedly nil", manifest.GetVmMetadata().GetSnapshotKey())
 		return false
 	}
-	if time.Since(snapshotLastSavedTime.AsTime()) > opts.MaxStaleFallbackSnapshotAge {
-		log.CtxInfof(ctx, "local fallback snapshot was created %s ago, which is longer than the max age %s - not using", time.Since(snapshotLastSavedTime.AsTime()), opts.MaxStaleFallbackSnapshotAge)
+
+	now := l.env.GetClock().Now()
+	age := now.Sub(snapshotLastSavedTime.AsTime())
+	if age > opts.MaxStaleFallbackSnapshotAge {
+		log.CtxInfof(ctx, "Fallback snapshot was created %s ago, which is longer than the max age %s - not using", age, opts.MaxStaleFallbackSnapshotAge)
 		return false
 	}
 	return true
@@ -850,16 +914,24 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 			}
 			log.CtxInfof(ctx, "Cached remote snapshot manifest %s", snapshotDebugString(ctx, l.env, snapshotSpecificKey, true /*remote*/, snapshotID))
 		}
+
+		// Cache a universal snapshot as a last-resort fallback for runs that
+		// have no other fallback snapshot available.
+		if opts.EligibleToWriteUniversalManifest {
+			if err := l.cacheUniversalManifestRemotely(ctx, key, ar); err != nil {
+				log.CtxWarningf(ctx, "Failed to cache remote universal snapshot manifest: %s", err)
+			}
+		}
 	}
 
 	if !opts.WriteManifestLocally || !opts.CacheSnapshotLocally {
 		return nil
 	}
 
-	return l.cacheManifestLocally(ctx, key, ar, opts.VMMetadata.GetSnapshotId())
+	return l.cacheManifestLocally(ctx, key, ar, opts.VMMetadata.GetSnapshotId(), opts.EligibleToWriteUniversalManifest)
 }
 
-func (l *FileCacheLoader) cacheManifestLocally(ctx context.Context, key *fcpb.SnapshotKey, manifestACResult *repb.ActionResult, snapshotID string) error {
+func (l *FileCacheLoader) cacheManifestLocally(ctx context.Context, key *fcpb.SnapshotKey, manifestACResult *repb.ActionResult, snapshotID string, writeUniversal bool) error {
 	gid, err := groupID(ctx, l.env)
 	if err != nil {
 		return err
@@ -900,6 +972,40 @@ func (l *FileCacheLoader) cacheManifestLocally(ctx context.Context, key *fcpb.Sn
 		log.CtxInfof(ctx, "Cached local snapshot manifest %s", snapshotDebugString(ctx, l.env, snapshotSpecificKey, false /*remote*/, snapshotID))
 	}
 
+	// Cache a universal snapshot as a last-resort fallback for runs that
+	// have no other fallback snapshot available.
+	if writeUniversal {
+		universalKey := key.CloneVT()
+		universalKey.Ref = snaputil.UniversalSnapshotRef
+		universalD, err := LocalManifestKey(gid, universalKey)
+		if err != nil {
+			log.CtxWarningf(ctx, "Failed to generate local universal manifest key: %s", err)
+			return nil
+		}
+		universalManifestNode := &repb.FileNode{Digest: universalD}
+		if _, err := l.env.GetFileCache().Write(ctx, universalManifestNode, b); err != nil {
+			log.CtxWarningf(ctx, "Failed to cache local universal snapshot manifest: %s", err)
+			return nil
+		}
+		log.CtxInfof(ctx, "Updated local universal snapshot manifest %s", snapshotDebugString(ctx, l.env, universalKey, false /*remote*/, "" /*=snapshotID*/))
+	}
+	return nil
+}
+
+// cacheUniversalManifestRemotely points the universal snapshot key at the
+// manifest that was just saved for key.
+func (l *FileCacheLoader) cacheUniversalManifestRemotely(ctx context.Context, key *fcpb.SnapshotKey, ar *repb.ActionResult) error {
+	universalKey := key.CloneVT()
+	universalKey.Ref = snaputil.UniversalSnapshotRef
+	universalD, err := RemoteManifestKey(universalKey)
+	if err != nil {
+		return status.WrapError(err, "generate universal remote manifest key")
+	}
+	universalDigest := digest.NewACResourceName(universalD, universalKey.InstanceName, repb.DigestFunction_BLAKE3)
+	if err := cachetools.UploadActionResult(ctx, l.env.GetActionCacheClient(), universalDigest, ar); err != nil {
+		return status.WrapError(err, "upload universal manifest")
+	}
+	log.CtxInfof(ctx, "Updated remote universal snapshot manifest %s", snapshotDebugString(ctx, l.env, universalKey, true /*remote*/, "" /*=snapshotID*/))
 	return nil
 }
 
@@ -1439,5 +1545,10 @@ func IsLikelyDefaultSnapshot(keys *fcpb.SnapshotKeySet, task *repb.ExecutionTask
 	// The default snapshot is the fallback key for non-default branches,
 	// so if a run does not have a fallback key, it's likely running on
 	// the default branch.
-	return len(keys.GetFallbackKeys()) == 0
+	for _, k := range keys.GetFallbackKeys() {
+		if k.GetRef() != snaputil.UniversalSnapshotRef {
+			return false
+		}
+	}
+	return true
 }

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -111,6 +111,63 @@ func TestPackAndUnpackChunkedFiles(t *testing.T) {
 	}
 }
 
+func gitTask(branch, base, defaultBranch string, props ...*repb.Platform_Property) *repb.ExecutionTask {
+	env := []*repb.Command_EnvironmentVariable{
+		{Name: "GIT_BRANCH", Value: branch},
+		{Name: "GIT_BASE_BRANCH", Value: base},
+		{Name: "GIT_REPO_DEFAULT_BRANCH", Value: defaultBranch},
+	}
+	return &repb.ExecutionTask{
+		Command: &repb.Command{
+			EnvironmentVariables: env,
+			Platform:             &repb.Platform{Properties: props},
+		},
+	}
+}
+
+func TestIsLikelyDefaultSnapshot(t *testing.T) {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+	ctx := context.Background()
+	loader, err := snaploader.New(setupEnv(t))
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name                    string
+		branch, base, defaultBr string
+		want                    bool
+	}{
+		{name: "only GIT_BRANCH set", branch: "main", want: true},
+		{name: "pushed branch equals default branch", branch: "main", defaultBr: "main", want: true},
+		{name: "pushed branch is not default branch", branch: "pr-1", base: "main", defaultBr: "main", want: false},
+		{name: "stacked PR", branch: "pr-2", base: "pr-1", defaultBr: "main", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			task := gitTask(tc.branch, tc.base, tc.defaultBr)
+			keys, err := loader.SnapshotKeySet(ctx, task, "config-hash", "")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, snaploader.IsLikelyDefaultSnapshot(keys, task))
+		})
+	}
+}
+
+// Disabling the property removes the universal key from the read path too.
+func TestUniversalFallbackDisabled(t *testing.T) {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+	ctx := context.Background()
+	loader, err := snaploader.New(setupEnv(t))
+	require.NoError(t, err)
+
+	task := gitTask("pr-1", "main", "main",
+		&repb.Platform_Property{Name: platform.EnableUniversalSnapshotPropertyName, Value: "false"})
+	keys, err := loader.SnapshotKeySet(ctx, task, "config-hash", "")
+	require.NoError(t, err)
+	for _, k := range keys.GetFallbackKeys() {
+		require.NotEqual(t, snaputil.UniversalSnapshotRef, k.GetRef())
+	}
+	require.Len(t, keys.GetFallbackKeys(), 1)
+	require.Equal(t, "main", keys.GetFallbackKeys()[0].GetRef())
+}
+
 func TestUnpackFallbackKey(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 
@@ -133,7 +190,8 @@ func TestUnpackFallbackKey(t *testing.T) {
 	keys, err := loader.SnapshotKeySet(ctx, task, "config-hash", "")
 	require.NoError(t, err)
 	require.Equal(t, "main", keys.GetBranchKey().GetRef())
-	require.Empty(t, keys.GetFallbackKeys())
+	require.Equal(t, 1, len(keys.GetFallbackKeys()))
+	require.Equal(t, snaputil.UniversalSnapshotRef, keys.GetFallbackKeys()[0].Ref)
 
 	opts := makeFakeSnapshot(t, workDir, true /*=enableRemote*/, nil, "")
 	err = loader.CacheSnapshot(ctx, keys.GetBranchKey(), opts)
@@ -154,9 +212,10 @@ func TestUnpackFallbackKey(t *testing.T) {
 	forkKeys, err := loader.SnapshotKeySet(ctx, forkTask, "config-hash", "")
 	require.NoError(t, err)
 	require.Equal(t, "my-cool-pr", forkKeys.GetBranchKey().GetRef())
-	require.Len(t, forkKeys.GetFallbackKeys(), 2)
+	require.Len(t, forkKeys.GetFallbackKeys(), 3)
 	require.Equal(t, "my-cool-stacked-pr-base-branch", forkKeys.FallbackKeys[0].Ref)
 	require.Equal(t, "main", forkKeys.FallbackKeys[1].Ref)
+	require.Equal(t, snaputil.UniversalSnapshotRef, forkKeys.FallbackKeys[2].Ref)
 
 	// Sanity check that the branch key is not found in cache, to make sure
 	// we're actually falling back.

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -50,6 +50,14 @@ const (
 	// change!
 	MemoryFileName = "memory"
 
+	// UniversalSnapshotRef is a sentinel git ref for the "universal"
+	// snapshot. It is used as a last-resort fallback for runs that have no other
+	// fallback snapshots available, and can be written from any git branch.
+	//
+	// This must not collide with a real git ref. In particular, non-workflow
+	// tasks have an empty Ref, so the empty string cannot be used here.
+	UniversalSnapshotRef = "BB_UNIVERSAL_SNAPSHOT"
+
 	// DefaultMaxStaleFallbackSnapshotAge is the max age of a valid fallback snapshot.
 	// This is used to prevent using very stale local snapshots that may cause performance degradation.
 	DefaultMaxStaleFallbackSnapshotAge = 24 * time.Hour

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -77,6 +77,7 @@ const (
 	runnerCrashedExitCodesPropertyName       = "runner-crashed-exit-codes"
 	transientErrorExitCodes                  = "transient-error-exit-codes"
 	AllowRemoteSnapshotsPropertyName         = "allow-remote-snapshots"
+	EnableUniversalSnapshotPropertyName      = "allow-universal-snapshot"
 	SnapshotSavePolicyPropertyName           = "remote-snapshot-save-policy"
 	SnapshotReadPolicyPropertyName           = "snapshot-read-policy"
 	MaxStaleFallbackSnapshotAgePropertyName  = "max-stale-fallback-snapshot-age"
@@ -327,6 +328,13 @@ type Properties struct {
 	HostedBazelAffinityKey   string
 	RemoteSnapshotSavePolicy string
 	SnapshotReadPolicy       string
+
+	// EnableUniversalSnapshot controls whether a run may resume from, and
+	// write to, the "universal" snapshot. It is only ever consulted as a last resort,
+	// for remote runs that don't write default branch snapshots and have no other fallback snapshots available.
+	//
+	// Defaults to true if unset.
+	EnableUniversalSnapshot bool
 
 	// DisableMeasuredTaskSize disables measurement-based task sizing, even if
 	// it is enabled via flag, and instead uses the default / platform based
@@ -594,6 +602,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		Retry:                     boolProp(m, RetryPropertyName, true),
 		PersistentVolumes:         persistentVolumes,
 		SnapshotReadPolicy:        snapshotReadPolicy,
+		EnableUniversalSnapshot:   boolProp(m, EnableUniversalSnapshotPropertyName, true),
 		RemoteSnapshotSavePolicy:  snapshotSavePolicy,
 		ContainerRegistryBypass:   boolProp(m, containerRegistryBypassPropertyName, false),
 		UseOCIFetcher:             boolProp(m, useOCIFetcherPropertyName, false),


### PR DESCRIPTION
[Customers may never run workflows on their main branch.](https://metrics.buildbuddy.io/explore?schemaVersion=1&panes=%7B%22ur6%22:%7B%22datasource%22:%22clickhouse%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22grafana-clickhouse-datasource%22,%22uid%22:%22clickhouse%22%7D,%22editorType%22:%22sql%22,%22queryType%22:%22table%22,%22rawSql%22:%22%20WITH%20workflow_runs%20AS%20%28%5Cn%20%20%20%20SELECT%5Cn%20%20%20%20%20%20invocation_uuid,%5Cn%20%20%20%20%20%20argMax%28group_id,%20updated_at_usec%29%20AS%20group_id,%5Cn%20%20%20%20%20%20argMax%28repo_url,%20updated_at_usec%29%20AS%20repo_url,%5Cn%20%20%20%20%20%20argMax%28pattern,%20updated_at_usec%29%20AS%20workflow_action,%5Cn%20%20%20%20%20%20argMax%28role,%20updated_at_usec%29%20AS%20role,%5Cn%20%20%20%20%20%20lowerUTF8%28%5Cn%20%20%20%20%20%20%20%20replaceRegexpOne%28%5Cn%20%20%20%20%20%20%20%20%20%20argMax%28branch_name,%20updated_at_usec%29,%5Cn%20%20%20%20%20%20%20%20%20%20%27%5Erefs%2Fheads%2F%27,%5Cn%20%20%20%20%20%20%20%20%20%20%27%27%5Cn%20%20%20%20%20%20%20%20%29%5Cn%20%20%20%20%20%20%29%20AS%20branch,%5Cn%20%20%20%20%20%20max%28updated_at_usec%29%20AS%20latest_updated_at_usec%5Cn%20%20%20%20FROM%20%5C%22buildbuddy_prod%5C%22.%5C%22Invocations%5C%22%5Cn%20%20%20%20WHERE%20updated_at_usec%20%3E%3D%5Cn%20%20%20%20%20%20toUnixTimestamp64Micro%28now64%286%29%20-%20INTERVAL%201%20DAY%29%5Cn%20%20%20%20GROUP%20BY%20invocation_uuid%5Cn%20%20%29%5Cn%20%20SELECT%5Cn%20%20%20%20group_id,%5Cn%20%20%20%20repo_url,%5Cn%20%20%20%20workflow_action,%5Cn%20%20%20%20count%28%29%20AS%20total_runs,%5Cn%20%20%20%20countIf%28branch%20IN%20%28%27main%27,%20%27master%27%29%29%20AS%20main_branch_runs,%5Cn%20%20%20%20groupUniqArray%2810%29%28branch%29%20AS%20observed_branches,%5Cn%20%20%20%20fromUnixTimestamp64Micro%28max%28latest_updated_at_usec%29%29%20AS%20last_run%5Cn%20%20FROM%20workflow_runs%5Cn%20%20WHERE%20role%20%3D%20%27CI_RUNNER%27%5Cn%20%20%20%20AND%20repo_url%20%21%3D%20%27%27%5Cn%20%20%20%20AND%20workflow_action%20%21%3D%20%27%27%5Cn%20%20GROUP%20BY%20group_id,%20repo_url,%20workflow_action%5Cn%20%20HAVING%20main_branch_runs%20%3D%200%5Cn%20%20ORDER%20BY%20total_runs%20DESC;%5Cn%22,%22format%22:1,%22meta%22:%7B%22builderOptions%22:%7B%22database%22:%22%22,%22table%22:%22%22,%22queryType%22:%22table%22,%22columns%22:%5B%5D,%22mode%22:%22list%22,%22limit%22:1000%7D%7D,%22pluginVersion%22:%224.11.2%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1) This means that no fallback snapshots are generated. Then, every time there is a workflow on a new branch, it will start from a clean machine.

Add a platform property to enable universal snapshot fallbacks, which lets workflows fallback to local snapshots that ran on any branch as a last resort. This will likely still be faster than starting from a new runner. This behavior is enabled by default