### PR TITLE
Set up internal service wiring

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//enterprise/server/backends/s3_cache",
         "//enterprise/server/backends/userdb",
         "//enterprise/server/clientidentity",
+        "//enterprise/server/cmd/server/wiring",
         "//enterprise/server/crypter_service",
         "//enterprise/server/execution_search_service",
         "//enterprise/server/execution_service",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/s3_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/userdb"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/server/wiring"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/crypter_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_search_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_service"
@@ -355,6 +356,10 @@ func main() {
 
 	if err := ocifetcher.RegisterServer(realEnv); err != nil {
 		log.Fatalf("%v", err)
+	}
+
+	if err := wiring.ApplyInternalEnvWiring(realEnv); err != nil {
+		log.Fatalf("Error applying internal env wiring: %s", err)
 	}
 
 	trafficHandler, err := trafficstats.NewServerHandler()

--- a/enterprise/server/cmd/server/wiring/BUILD
+++ b/enterprise/server/cmd/server/wiring/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "@buildbuddy_internal//:__subpackages__",
+])
+
+go_library(
+    name = "wiring",
+    srcs = ["wiring.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/server/wiring",
+    deps = [
+        "//server/real_environment",
+    ],
+)

--- a/enterprise/server/cmd/server/wiring/wiring.go
+++ b/enterprise/server/cmd/server/wiring/wiring.go
@@ -1,0 +1,39 @@
+package wiring
+
+import (
+	"sync"
+
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+)
+
+type InternalEnvWiringFunc func(env *real_environment.RealEnv) error
+
+var (
+	mu                 sync.Mutex
+	internalEnvWirings []InternalEnvWiringFunc
+)
+
+// RegisterInternalEnvWiring is called by buildbuddy-internal (typically from
+// init()) to register callbacks that wire internal services into env.
+func RegisterInternalEnvWiring(fn InternalEnvWiringFunc) {
+	if fn == nil {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	internalEnvWirings = append(internalEnvWirings, fn)
+}
+
+// ApplyInternalEnvWiring is called by public server startup to run all
+// registered internal wiring callbacks against the configured env.
+func ApplyInternalEnvWiring(env *real_environment.RealEnv) error {
+	mu.Lock()
+	wirings := append([]InternalEnvWiringFunc(nil), internalEnvWirings...)
+	mu.Unlock()
+	for _, fn := range wirings {
+		if err := fn(env); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This adds a small enterprise-only startup hook that lets internal packages wire services into `RealEnv` during enterprise server startup.

The hook is intentionally generic. Internal packages can use it to register HTTP handlers on the mux, wrap or configure quota usage management, and attach other internal services after the public enterprise server has finished setting up its standard dependencies such as billing-related logic.

## How

- Internal code registers callbacks with `wiring.RegisterInternalEnvWiring(...)`, typically from `init()`.
- Enterprise server startup calls `wiring.ApplyInternalEnvWiring(realEnv)` after public service registration.
- Each registered callback receives the configured `*real_environment.RealEnv`.
- Internal callbacks can set implementations on `env`, wrap existing services, or register HTTP handlers via `env.GetMux()`.

## Why

- Gives internal services a narrow, explicit startup integration point.
- Lets internal wiring run late enough to read already-configured dependencies from `env`.
- Allows internal packages to add mux handlers without adding one-off public handler hooks.
- Allows internal packages to layer usage management on top of existing quota call sites.