### PR TITLE
Embed CLI version via stamping

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -160,6 +160,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           path: buildbuddy
+          fetch-depth: 0
 
       - name: Build Artifacts
         id: build
@@ -183,7 +184,7 @@ jobs:
           bazelisk build \
               --repository_cache='~/repo-cache/' \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              --//cli/version:cli_version="$VERSION" \
+              --stamp \
               --compilation_mode=opt \
               --strip=always \
               ${{ matrix.flags }} \

--- a/cli/version/BUILD
+++ b/cli/version/BUILD
@@ -1,24 +1,25 @@
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("//rules/flags:index.bzl", "write_flag_to_file")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
-string_flag(
-    name = "cli_version",
-    build_setting_default = "unknown",
-)
-
-write_flag_to_file(
-    name = "version_flag",
-    out = "version_flag.txt",
-    flag = ":cli_version",
+genrule(
+    name = "populate_version",
+    outs = ["version.txt"],
+    cmd_bash = select({
+        "//:fastbuild": "touch $@",
+        "//conditions:default": """
+            version=$$(grep ^STABLE_CLI_VERSION_TAG bazel-out/stable-status.txt 2>/dev/null | cut -d' ' -f2 || true); \
+            if [ -z "$$version" ]; then version=unknown; fi; \
+            printf '%s' "$$version" > $@;
+        """,
+    }),
+    stamp = 1,
 )
 
 go_library(
     name = "version",
     srcs = ["version.go"],
-    embedsrcs = [":version_flag"],  # keep
+    embedsrcs = ["version.txt"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/version",
 )
 

--- a/cli/version/BUILD
+++ b/cli/version/BUILD
@@ -14,12 +14,13 @@ genrule(
         """,
     }),
     stamp = 1,
+    tags = ["manual"],
 )
 
 go_library(
     name = "version",
     srcs = ["version.go"],
-    embedsrcs = ["version.txt"],
+    embedsrcs = ["version.txt"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/version",
 )
 

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -4,12 +4,14 @@ import (
 	_ "embed"
 )
 
-// The bb cli "version" var is generated in this package according to the
-// Bazel flag value --//cli/version:cli_version
+// This is populated by the populate_version genrule.
 //
-//go:embed version_flag.txt
-var cliVersionFlag string
+//go:embed version.txt
+var versionTag string
 
 func String() string {
-	return cliVersionFlag
+	if versionTag == "" {
+		return "unknown"
+	}
+	return versionTag
 }

--- a/cli/version/version_test.go
+++ b/cli/version/version_test.go
@@ -8,5 +8,6 @@ import (
 )
 
 func TestEmbeddedVersion(t *testing.T) {
-	require.Contains(t, version.String(), "unknown")
+	v := version.String()
+	require.Regexp(t, `^(unknown|\d+\.\d+\.\d+)$`, v)
 }

--- a/tools/latest_cli_version_tag.sh
+++ b/tools/latest_cli_version_tag.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+# Prints the latest BuildBuddy CLI version, like "5.0.328".
+git tag -l 'cli-v*' --sort=creatordate |
+    perl -nle 'if (/^cli-v(\d+\.\d+\.\d+)$/) { print $1 }' |
+    tail -n1

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -21,6 +21,7 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
   echo "GIT_TREE_STATUS Unknown"
   echo "STABLE_VERSION_TAG dev"
   echo "STABLE_COMMIT_SHA dev"
+  echo "STABLE_CLI_VERSION_TAG unknown"
   exit 0
 fi
 
@@ -46,3 +47,6 @@ echo "GIT_TREE_STATUS $git_tree_status"
 latest_version_tag=$(./tools/latest_version_tag.sh)
 echo "STABLE_VERSION_TAG $latest_version_tag"
 echo "STABLE_COMMIT_SHA $commit_sha"
+
+latest_cli_version_tag=$(./tools/latest_cli_version_tag.sh)
+echo "STABLE_CLI_VERSION_TAG $latest_cli_version_tag"


### PR DESCRIPTION
When we [distribute the CLI via the apps](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/util/ci_runner_util/ci_runner_util.go#L93), the version isn't being set properly. Set it via stamping, rather than manually passing it in via a flag, so that the version is set both in the embedded version and the version we release on its own