### PR TITLE
Add CLI command to expand bazelrcs in a list of bazel args

### DIFF
--- a/cli/cli_command/register/BUILD
+++ b/cli/cli_command/register/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//cli/download",
         "//cli/execute",
         "//cli/execution",
+        "//cli/expand_bazelrc",
         "//cli/explain",
         "//cli/fix",
         "//cli/index",

--- a/cli/cli_command/register/register.go
+++ b/cli/cli_command/register/register.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/download"
 	"github.com/buildbuddy-io/buildbuddy/cli/execute"
 	"github.com/buildbuddy-io/buildbuddy/cli/execution"
+	"github.com/buildbuddy-io/buildbuddy/cli/expand_bazelrc"
 	"github.com/buildbuddy-io/buildbuddy/cli/explain"
 	"github.com/buildbuddy-io/buildbuddy/cli/fix"
 	"github.com/buildbuddy-io/buildbuddy/cli/index"
@@ -150,6 +151,11 @@ func register() {
 			Name:    "explain",
 			Help:    "Explains the difference between two compact execution logs.",
 			Handler: explain.HandleExplain,
+		},
+		{
+			Name:    "expand-bazelrc",
+			Help:    "Expands bazelrc/config args to a list of Bazel flags.",
+			Handler: expand_bazelrc.HandleExpandBazelrc,
 		},
 	}
 	cli_command.CommandsByName = make(

--- a/cli/expand_bazelrc/BUILD
+++ b/cli/expand_bazelrc/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_library(
+    name = "expand_bazelrc",
+    srcs = ["expand_bazelrc.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/expand_bazelrc",
+    deps = [
+        "//cli/arg",
+        "//cli/log",
+        "//cli/parser",
+    ],
+)
+
+go_test(
+    name = "expand_bazelrc_test",
+    srcs = ["expand_bazelrc_test.go"],
+    embed = [":expand_bazelrc"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/cli/expand_bazelrc/expand_bazelrc.go
+++ b/cli/expand_bazelrc/expand_bazelrc.go
@@ -1,0 +1,87 @@
+package expand_bazelrc
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+)
+
+const usage = `
+usage: bb expand-bazelrc --args='["--bazelrc=custom.bazelrc", "build","//...", "--config=ci"]' [--workspace=/path/to/workspace]
+
+Expands --bazelrc and --config options from the given Bazel argument array.
+
+The original --bazelrc and --config options are removed from the output, after they've been expanded.
+--ignore_all_rc_files is appended to the output, so Bazel does not re-load rc files.
+
+If --ignore_all_rc_files is already present in input args, rc parsing is skipped.
+
+Arguments:
+  --args: Required JSON array of Bazel args.
+  --workspace: Optional workspace root. If set, this is used for resolving
+               workspace-relative bazelrc imports such as %workspace%/...
+
+Output:
+  Prints a JSON array of expanded args to stdout.
+`
+
+func HandleExpandBazelrc(args []string) (int, error) {
+	flags := flag.NewFlagSet("expand-bazelrc", flag.ContinueOnError)
+	argsJSON := flags.String("args", "", "Required JSON array of bazel args.")
+	workspaceDir := flags.String("workspace", "", "Optional workspace root used to resolve workspace-relative bazelrc imports.")
+	if err := arg.ParseFlagSet(flags, args); err != nil {
+		if err == flag.ErrHelp {
+			log.Print(usage)
+			return 1, nil
+		}
+		return -1, err
+	}
+
+	if flags.NArg() > 0 {
+		return -1, fmt.Errorf("unexpected positional args: %s", strings.Join(flags.Args(), " "))
+	}
+	if strings.TrimSpace(*argsJSON) == "" {
+		return -1, fmt.Errorf("--args is required")
+	}
+
+	expandedArgs, err := expandArgs(*argsJSON, *workspaceDir)
+	if err != nil {
+		return -1, err
+	}
+
+	b, err := json.Marshal(expandedArgs)
+	if err != nil {
+		return -1, err
+	}
+	if _, err := fmt.Fprintln(os.Stdout, string(b)); err != nil {
+		return -1, err
+	}
+	return 0, nil
+}
+
+func expandArgs(argsJSON, workspaceDir string) ([]string, error) {
+	var bazelArgs []string
+	if err := json.Unmarshal([]byte(argsJSON), &bazelArgs); err != nil {
+		return nil, fmt.Errorf("--args_json must be a JSON array of strings: %s", err)
+	}
+
+	parsedArgs, err := parser.ParseArgs(bazelArgs)
+	if err != nil {
+		return nil, err
+	}
+	if workspaceDir != "" {
+		parsedArgs, err = parser.ResolveArgsWithWorkspace(parsedArgs, workspaceDir)
+	} else {
+		parsedArgs, err = parser.ResolveArgs(parsedArgs)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return parsedArgs.Format(), nil
+}

--- a/cli/expand_bazelrc/expand_bazelrc_test.go
+++ b/cli/expand_bazelrc/expand_bazelrc_test.go
@@ -1,0 +1,141 @@
+package expand_bazelrc
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandsConfigsFromBazelrc(t *testing.T) {
+	ws := t.TempDir()
+	rc1Path := filepath.Join(ws, "one.bazelrc")
+	rc2Path := filepath.Join(ws, "two.bazelrc")
+	require.NoError(t, os.WriteFile(rc1Path, []byte(`
+common --build_metadata=FROM_RC1=1
+build:ci --build_metadata=CI_FROM_RC1=1
+build:multi --build_metadata=MULTI_FROM_RC1=1
+`), 0644))
+	require.NoError(t, os.WriteFile(rc2Path, []byte(`
+common --build_metadata=FROM_RC2=1
+build:dbg --build_metadata=DBG_FROM_RC2=1
+build:multi --build_metadata=MULTI_FROM_RC2=1
+`), 0644))
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name: "single bazelrc and config",
+			args: []string{"--bazelrc=" + rc1Path, "build", "--config=ci", "//:target"},
+			expected: []string{
+				"--ignore_all_rc_files",
+				"build",
+				"--build_metadata=FROM_RC1=1",
+				"--build_metadata=CI_FROM_RC1=1",
+				"//:target",
+			},
+		},
+		{
+			name: "expands multiple bazelrcs",
+			args: []string{"--bazelrc=" + rc1Path, "--bazelrc=" + rc2Path, "build", "//:target"},
+			expected: []string{
+				"--ignore_all_rc_files",
+				"build",
+				"--build_metadata=FROM_RC1=1",
+				"--build_metadata=FROM_RC2=1",
+				"//:target",
+			},
+		},
+		{
+			name: "expands multiple configs",
+			args: []string{"--bazelrc=" + rc1Path, "build", "--config=ci", "--config=multi", "//:target"},
+			expected: []string{
+				"--ignore_all_rc_files",
+				"build",
+				"--build_metadata=FROM_RC1=1",
+				"--build_metadata=CI_FROM_RC1=1",
+				"--build_metadata=MULTI_FROM_RC1=1",
+				"//:target",
+			},
+		},
+		{
+			name: "expands multiple configs from multiple bazelrcs",
+			args: []string{"--bazelrc=" + rc1Path, "--bazelrc=" + rc2Path, "build", "--config=multi", "--config=dbg", "//:target"},
+			expected: []string{
+				"--ignore_all_rc_files",
+				"build",
+				"--build_metadata=FROM_RC1=1",
+				"--build_metadata=FROM_RC2=1",
+				"--build_metadata=MULTI_FROM_RC1=1",
+				"--build_metadata=MULTI_FROM_RC2=1",
+				"--build_metadata=DBG_FROM_RC2=1",
+				"//:target",
+			},
+		},
+		{
+			name: "test command does not apply build config",
+			args: []string{"--bazelrc=" + rc1Path, "test", "//:target"},
+			expected: []string{
+				"--ignore_all_rc_files",
+				"test",
+				"--build_metadata=FROM_RC1=1",
+				"//:target",
+			},
+		},
+		{
+			name: "if ignore_all_rc_files already set does not expand bazelrc",
+			args: []string{"--ignore_all_rc_files", "--bazelrc=" + rc1Path, "build", "//:target"},
+			expected: []string{
+				"--bazelrc=" + rc1Path,
+				"--ignore_all_rc_files",
+				"build",
+				"//:target",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expandedArgs, err := expandArgs(hermeticArgsJSON(t, tc.args), ws)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, expandedArgs)
+		})
+	}
+}
+
+func hermeticArgsJSON(t *testing.T, args []string) string {
+	t.Helper()
+	withNoRcFlags := append(
+		[]string{"--nosystem_rc", "--nohome_rc", "--noworkspace_rc"},
+		args...,
+	)
+	b, err := json.Marshal(withNoRcFlags)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestWorkspaceImports(t *testing.T) {
+	ws := t.TempDir()
+	mainRC := filepath.Join(ws, "main.bazelrc")
+	importedRC := filepath.Join(ws, "imported.bazelrc")
+	require.NoError(t, os.WriteFile(mainRC, []byte(`
+import %workspace%/imported.bazelrc
+`), 0644))
+	require.NoError(t, os.WriteFile(importedRC, []byte(`
+build:ci --disk_cache=/tmp/cache
+`), 0644))
+
+	args := fmt.Sprintf(`["--bazelrc=%s","build","--config=ci","//:target"]`, mainRC)
+
+	_, err := expandArgs(args, "")
+	require.Error(t, err)
+
+	expandedArgs, err := expandArgs(args, ws)
+	require.NoError(t, err)
+	require.True(t, slices.Contains(expandedArgs, "--disk_cache=/tmp/cache"))
+}

--- a/cli/help/help_test.go
+++ b/cli/help/help_test.go
@@ -121,6 +121,7 @@ func TestHelpForBBCommands(t *testing.T) {
 		"ask",
 		"download",
 		"execute",
+		"expand-bazelrc",
 		"explain",
 		"fix",
 		"index",

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -768,6 +768,17 @@ func resolveArgs(parsedArgs *parsed.OrderedArgs, ws string) (*parsed.OrderedArgs
 	return p.resolveArgs(parsedArgs, ws)
 }
 
+// ResolveArgsWithWorkspace behaves like ResolveArgs, but uses the explicitly
+// provided workspace dir to resolve workspace-relative rc paths such as
+// `%workspace%/...`.
+func ResolveArgsWithWorkspace(parsedArgs *parsed.OrderedArgs, workspaceDir string) (*parsed.OrderedArgs, error) {
+	p, err := GetParser()
+	if err != nil {
+		return nil, err
+	}
+	return p.resolveArgs(parsedArgs, workspaceDir)
+}
+
 // ResolveArgs removes all rc-file options from the args, appends an
 // `ignore_all_rc_files` option to the startup options, parses those rc-files
 // into Configs, and expands all config options (as well as any
@@ -779,6 +790,13 @@ func (p *Parser) ResolveArgs(parsedArgs *parsed.OrderedArgs) (*parsed.OrderedArg
 		log.Debugf("Could not determine workspace dir: %s", err)
 	}
 	return p.resolveArgs(parsedArgs, ws)
+}
+
+// ResolveArgsWithWorkspace behaves like ResolveArgs, but uses the explicitly
+// provided workspace dir to resolve workspace-relative rc paths such as
+// `%workspace%/...`.
+func (p *Parser) ResolveArgsWithWorkspace(parsedArgs *parsed.OrderedArgs, workspaceDir string) (*parsed.OrderedArgs, error) {
+	return p.resolveArgs(parsedArgs, workspaceDir)
 }
 
 func (p *Parser) resolveArgs(parsedArgs *parsed.OrderedArgs, ws string) (*parsed.OrderedArgs, error) {


### PR DESCRIPTION
The CLI expands all .bazelrcs and configs, and then adds `--ignore_all_rc_files`. It then uses the expanded list of args internally. This is done so .bazelrcs aren't double expanded, first by the CLI, and then by bazel.

However this can cause issues for users who want to programatically add --bazelrcs. For example, they might add a bazelrc in a pre_bazel plugin, which run after the original args have been expanded. Or they may use a tools/wrapper with bazelisk that adds additional args, including bazelrc files

This PR adds a CLI sub-command that expands bazelrcs in an input list of args, using the same logic that is used during CLI setup. Using this, customers can manually expand bazelrcs they want to add later in the flow