### PR TITLE
app: add target edges accordion

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -79,6 +79,221 @@
   padding-top: 1px;
 }
 
+.target-edges-card .content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.target-edges-header {
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.target-edges-subtitle {
+  color: var(--color-text-secondary);
+  margin-top: 4px;
+}
+
+.target-edges-empty-state {
+  color: var(--color-text-secondary);
+}
+
+.target-edges-accordion {
+  border: 1px solid var(--color-border-primary);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.target-edges-accordion-item {
+  border-bottom: 1px solid var(--color-border-primary);
+}
+
+.target-edges-accordion-item:last-child {
+  border-bottom: 0;
+}
+
+.target-edges-accordion-header {
+  align-items: flex-start;
+  background: var(--color-bg-card);
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+  outline: none;
+  padding: 14px 16px;
+}
+
+.target-edges-accordion-header.success {
+  box-shadow: inset 3px 0 0 var(--color-status-success);
+}
+
+.target-edges-accordion-header.cached {
+  box-shadow: inset 3px 0 0 var(--color-text-tertiary);
+}
+
+.target-edges-accordion-header.failure {
+  box-shadow: inset 3px 0 0 var(--color-status-error);
+}
+
+.target-edges-accordion-header:hover {
+  background: var(--color-bg-hover);
+}
+
+.target-edges-accordion-item.expanded .target-edges-accordion-header {
+  border-bottom: 1px solid var(--color-border-primary);
+  background: var(--color-bg-secondary);
+}
+
+.target-edges-accordion-header:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--color-primary);
+}
+
+.target-edges-accordion-chevron {
+  color: var(--color-text-secondary);
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.target-edges-accordion-chevron .icon {
+  height: 18px;
+  width: 18px;
+}
+
+.target-edges-accordion-label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.target-edges-accordion-body {
+  background: var(--color-bg-secondary);
+  padding: 14px 16px 16px 42px;
+}
+
+.target-edges-accordion-sections {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.target-edges-accordion-section {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.target-edges-accordion-section-title {
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.target-edges-related-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.target-edges-related-action {
+  color: var(--color-text-primary);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.target-edge-action-summary {
+  align-items: flex-start;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
+}
+
+.target-edge-result-indicator {
+  border-radius: 999px;
+  flex-shrink: 0;
+  height: 8px;
+  margin-top: 6px;
+  width: 8px;
+}
+
+.target-edge-result-indicator.success {
+  background: var(--color-status-success);
+}
+
+.target-edge-result-indicator.cached {
+  background: var(--color-text-tertiary);
+}
+
+.target-edge-result-indicator.failure {
+  background: var(--color-status-error);
+}
+
+.target-edge-combined-label {
+  align-items: baseline;
+  display: flex;
+  gap: 0;
+  min-width: 0;
+  overflow: hidden;
+  width: 100%;
+  white-space: nowrap;
+}
+
+.target-edge-arrow {
+  flex-shrink: 0;
+}
+
+.target-edge-inline-link {
+  font-weight: 500;
+  max-width: 100%;
+  pointer-events: auto;
+  position: relative;
+  z-index: 2;
+}
+
+.target-edge-target-label {
+  display: inline-block;
+  flex: 0 1 auto;
+  max-width: min(48ch, 60%);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
+.target-edge-action-link {
+  display: inline-block;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.target-edge-inline-link-disabled {
+  color: var(--color-link);
+  cursor: default;
+  text-decoration: underline;
+}
+
+.target-edge-current-target {
+  color: var(--color-text-secondary);
+}
+
+.target-edge-arrow {
+  color: var(--color-text-secondary);
+  padding: 0 4px;
+}
+
+@media (max-width: 720px) {
+  .target-edges-header {
+    flex-direction: column;
+  }
+}
+
 .invocation-action-card .text-link {
   font-weight: 600;
   text-decoration: underline;

--- a/app/target/BUILD
+++ b/app/target/BUILD
@@ -1,4 +1,4 @@
-load("//rules/typescript:index.bzl", "ts_library")
+load("//rules/typescript:index.bzl", "ts_jasmine_node_test", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -202,6 +202,7 @@ ts_library(
         "//app/target:action_card",
         "//app/target:flaky_target_chip",
         "//app/target:target_artifacts_card",
+        "//app/target:target_edges_card",
         "//app/target:target_test_coverage_card",
         "//app/target:target_test_document_card",
         "//app/target:target_test_log_card",
@@ -211,5 +212,39 @@ ts_library(
         "//proto:build_event_stream_ts_proto",
         "//proto:target_ts_proto",
         "//proto/api/v1:common_ts_proto",
+    ],
+)
+
+ts_library(
+    name = "compact_exec_log_edges",
+    srcs = ["compact_exec_log_edges.ts"],
+    deps = [
+        "//:node_modules/tslib",
+        "//proto:spawn_ts_proto",
+    ],
+)
+
+ts_jasmine_node_test(
+    name = "compact_exec_log_edges_test",
+    srcs = ["compact_exec_log_edges_test.ts"],
+    deps = [
+        ":compact_exec_log_edges",
+        "//:node_modules/tslib",
+    ],
+)
+
+ts_library(
+    name = "target_edges_card",
+    srcs = ["target_edges_card.tsx"],
+    deps = [
+        "//:node_modules/@types/react",
+        "//:node_modules/lucide-react",
+        "//:node_modules/react",
+        "//:node_modules/tslib",
+        "//app/components/link",
+        "//app/invocation:invocation_model",
+        "//app/router",
+        "//app/target:compact_exec_log_edges",
+        "//proto:build_event_stream_ts_proto",
     ],
 )

--- a/app/target/compact_exec_log_edges.ts
+++ b/app/target/compact_exec_log_edges.ts
@@ -1,0 +1,859 @@
+import { tools } from "../../proto/spawn_ts_proto";
+
+const CACHE_VERSION = 8;
+const DB_NAME = "buildbuddy-compact-exec-log-cache";
+const DB_VERSION = 2;
+const STORE_NAME = "target-edges";
+
+const memoryCache = new Map<string, CompactExecLogEdgesIndex>();
+const pendingLoads = new Map<string, Promise<CompactExecLogEdgesIndex>>();
+
+export interface RelatedTargetSummary {
+  targetLabel: string;
+  actionIds: string[];
+}
+
+export interface CompactExecLogActionSummary {
+  id: string;
+  kind: "spawn" | "symlink";
+  targetLabel: string;
+  label: string;
+  mnemonic: string;
+  cached: boolean;
+  result: "succeeded" | "failed";
+  primaryOutputPath?: string;
+  digestHash?: string;
+  digestSizeBytes?: string;
+  parents: RelatedTargetSummary[];
+  children: RelatedTargetSummary[];
+}
+
+export interface CompactExecLogTargetSummary {
+  label: string;
+  actionIds: string[];
+  parents: RelatedTargetSummary[];
+  children: RelatedTargetSummary[];
+}
+
+export interface CompactExecLogEdgesIndex {
+  version: number;
+  cacheKey: string;
+  createdAtMs: number;
+  actions: Record<string, CompactExecLogActionSummary>;
+  targets: Record<string, CompactExecLogTargetSummary>;
+}
+
+type ActionKind = CompactExecLogActionSummary["kind"];
+
+interface IndexBuildState {
+  files: Map<number, tools.protos.ExecLogEntry.File>;
+  directories: Map<number, tools.protos.ExecLogEntry.Directory>;
+  symlinks: Map<number, tools.protos.ExecLogEntry.UnresolvedSymlink>;
+  runfilesTrees: Map<number, tools.protos.ExecLogEntry.RunfilesTree>;
+  inputSets: Map<number, tools.protos.ExecLogEntry.InputSet>;
+  symlinkEntrySets: Map<number, tools.protos.ExecLogEntry.SymlinkEntrySet>;
+  spawns: Map<number, tools.protos.ExecLogEntry.Spawn>;
+  symlinkActions: Map<number, tools.protos.ExecLogEntry.SymlinkAction>;
+  actions: Map<string, MutableActionSummary>;
+  targets: Map<string, MutableTargetSummary>;
+  pathToArtifactId: Map<string, number>;
+  artifactProducers: Map<number, string>;
+  expandedInputSets: Map<number, Set<number>>;
+  expandedSymlinkEntrySets: Map<number, Map<string, number>>;
+}
+
+interface MutableActionSummary {
+  id: string;
+  kind: ActionKind;
+  rawOrder: number;
+  targetLabel: string;
+  label: string;
+  mnemonic: string;
+  cached: boolean;
+  result: "succeeded" | "failed";
+  primaryOutputPath?: string;
+  digestHash?: string;
+  digestSizeBytes?: string;
+  parentMap: Map<string, Set<string>>;
+  childMap: Map<string, Set<string>>;
+}
+
+interface MutableTargetSummary {
+  label: string;
+  actionIds: Set<string>;
+  parentMap: Map<string, Set<string>>;
+  childMap: Map<string, Set<string>>;
+}
+
+interface ActionLabelMeta {
+  actionId: string;
+  mnemonic: string;
+  filename: string;
+  platform: string;
+}
+
+let dbPromise: Promise<IDBDatabase | null> | undefined;
+
+export async function getCompactExecLogEdgesIndex(
+  executionLogUri: string,
+  loadEntries: () => Promise<tools.protos.ExecLogEntry[]>
+): Promise<CompactExecLogEdgesIndex> {
+  const cacheKey = `v${CACHE_VERSION}:${executionLogUri}`;
+
+  const memoryHit = memoryCache.get(cacheKey);
+  if (memoryHit) {
+    return memoryHit;
+  }
+
+  const pending = pendingLoads.get(cacheKey);
+  if (pending) {
+    return pending;
+  }
+
+  const loadPromise = (async () => {
+    const cached = await readCachedIndex(cacheKey);
+    if (cached) {
+      memoryCache.set(cacheKey, cached);
+      return cached;
+    }
+
+    const entries = await loadEntries();
+    const index = buildCompactExecLogEdgesIndex(entries, cacheKey);
+    memoryCache.set(cacheKey, index);
+    await writeCachedIndex(index);
+    return index;
+  })().finally(() => {
+    pendingLoads.delete(cacheKey);
+  });
+
+  pendingLoads.set(cacheKey, loadPromise);
+  return loadPromise;
+}
+
+function buildCompactExecLogEdgesIndex(
+  entries: tools.protos.ExecLogEntry[],
+  cacheKey: string
+): CompactExecLogEdgesIndex {
+  const state: IndexBuildState = {
+    files: new Map(),
+    directories: new Map(),
+    symlinks: new Map(),
+    runfilesTrees: new Map(),
+    inputSets: new Map(),
+    symlinkEntrySets: new Map(),
+    spawns: new Map(),
+    symlinkActions: new Map(),
+    actions: new Map(),
+    targets: new Map(),
+    pathToArtifactId: new Map(),
+    artifactProducers: new Map(),
+    expandedInputSets: new Map(),
+    expandedSymlinkEntrySets: new Map(),
+  };
+
+  let nextSpawnId = 1;
+  let nextSymlinkActionId = 1;
+
+  entries.forEach((entry, rawOrder) => {
+    const id = Number(entry.id || 0);
+
+    if (entry.file) {
+      if (id) {
+        state.files.set(id, entry.file);
+      }
+      if (id && entry.file.path) {
+        state.pathToArtifactId.set(entry.file.path, id);
+      }
+      return;
+    }
+
+    if (entry.directory) {
+      if (id) {
+        state.directories.set(id, entry.directory);
+      }
+      if (id && entry.directory.path) {
+        state.pathToArtifactId.set(entry.directory.path, id);
+      }
+      return;
+    }
+
+    if (entry.unresolvedSymlink) {
+      if (id) {
+        state.symlinks.set(id, entry.unresolvedSymlink);
+      }
+      if (id && entry.unresolvedSymlink.path) {
+        state.pathToArtifactId.set(entry.unresolvedSymlink.path, id);
+      }
+      return;
+    }
+
+    if (entry.runfilesTree) {
+      if (id) {
+        state.runfilesTrees.set(id, entry.runfilesTree);
+      }
+      if (id && entry.runfilesTree.path) {
+        state.pathToArtifactId.set(entry.runfilesTree.path, id);
+      }
+      return;
+    }
+
+    if (entry.inputSet) {
+      if (id) {
+        state.inputSets.set(id, entry.inputSet);
+      }
+      return;
+    }
+
+    if (entry.symlinkEntrySet) {
+      if (id) {
+        state.symlinkEntrySets.set(id, entry.symlinkEntrySet);
+      }
+      return;
+    }
+
+    if (entry.spawn) {
+      const spawnId = id || nextSpawnId++;
+      const actionId = makeActionId("spawn", spawnId);
+      state.spawns.set(spawnId, entry.spawn);
+      const action = createSpawnSummary(actionId, entry.spawn, rawOrder);
+      state.actions.set(actionId, action);
+      registerTargetAction(action.targetLabel, actionId, state);
+
+      for (const output of entry.spawn.outputs || []) {
+        const outputId =
+          Number(output.outputId || 0) ||
+          Number(output.fileId || 0) ||
+          Number(output.directoryId || 0) ||
+          Number(output.unresolvedSymlinkId || 0);
+        if (outputId) {
+          state.artifactProducers.set(outputId, actionId);
+        }
+      }
+      return;
+    }
+
+    if (entry.symlinkAction) {
+      const symlinkActionId = id || nextSymlinkActionId++;
+      const actionId = makeActionId("symlink", symlinkActionId);
+      state.symlinkActions.set(symlinkActionId, entry.symlinkAction);
+      const action = createSymlinkSummary(actionId, entry.symlinkAction, rawOrder);
+      state.actions.set(actionId, action);
+      registerTargetAction(action.targetLabel, actionId, state);
+    }
+  });
+
+  for (const [actionId, action] of state.actions.entries()) {
+    populatePrimaryOutputPath(actionId, action, state);
+  }
+
+  for (const [actionId, action] of state.actions.entries()) {
+    if (action.kind !== "symlink") {
+      continue;
+    }
+    const symlinkArtifactId = resolveSymlinkOutputArtifactId(actionId, state);
+    if (symlinkArtifactId) {
+      state.artifactProducers.set(symlinkArtifactId, actionId);
+    }
+  }
+
+  for (const [actionId, action] of state.actions.entries()) {
+    if (!action.targetLabel) {
+      continue;
+    }
+
+    const consumedArtifactIds =
+      action.kind === "spawn"
+        ? getConsumedArtifactsForSpawn(actionId, state)
+        : getConsumedArtifactsForSymlinkAction(actionId, state);
+
+    for (const artifactId of consumedArtifactIds) {
+      const producerActionId = state.artifactProducers.get(artifactId);
+      if (!producerActionId || producerActionId === actionId) {
+        continue;
+      }
+      const producer = state.actions.get(producerActionId);
+      if (!producer?.targetLabel) {
+        continue;
+      }
+
+      addRelation(action.parentMap, producer.targetLabel, producerActionId);
+      addRelation(producer.childMap, action.targetLabel, actionId);
+
+      const consumerTarget = getOrCreateTarget(action.targetLabel, state);
+      addRelation(consumerTarget.parentMap, producer.targetLabel, actionId);
+
+      const producerTarget = getOrCreateTarget(producer.targetLabel, state);
+      addRelation(producerTarget.childMap, action.targetLabel, producerActionId);
+    }
+  }
+
+  applyDisambiguatedActionLabels(state);
+
+  const serializedActions: Record<string, CompactExecLogActionSummary> = {};
+  const serializedTargets: Record<string, CompactExecLogTargetSummary> = {};
+
+  Array.from(state.actions.values())
+    .sort(compareActions)
+    .forEach((action) => {
+      serializedActions[action.id] = {
+        id: action.id,
+        kind: action.kind,
+        targetLabel: action.targetLabel,
+        label: action.label,
+        mnemonic: action.mnemonic,
+        cached: action.cached,
+        result: action.result,
+        primaryOutputPath: action.primaryOutputPath,
+        digestHash: action.digestHash,
+        digestSizeBytes: action.digestSizeBytes,
+        parents: serializeRelations(action.parentMap),
+        children: serializeRelations(action.childMap),
+      };
+    });
+
+  Array.from(state.targets.values())
+    .sort((a, b) => a.label.localeCompare(b.label))
+    .forEach((target) => {
+      serializedTargets[target.label] = {
+        label: target.label,
+        actionIds: Array.from(target.actionIds),
+        parents: serializeRelations(target.parentMap),
+        children: serializeRelations(target.childMap),
+      };
+    });
+
+  return {
+    version: CACHE_VERSION,
+    cacheKey,
+    createdAtMs: Date.now(),
+    actions: serializedActions,
+    targets: serializedTargets,
+  };
+}
+
+function createSpawnSummary(
+  actionId: string,
+  spawn: tools.protos.ExecLogEntry.Spawn,
+  rawOrder: number
+): MutableActionSummary {
+  const mnemonic = getSpawnDisplayMnemonic(spawn);
+  return {
+    id: actionId,
+    kind: "spawn",
+    rawOrder,
+    targetLabel: spawn.targetLabel || "",
+    label: mnemonic,
+    mnemonic,
+    cached: Boolean(spawn.cacheHit),
+    result: isFailedSpawn(spawn) ? "failed" : "succeeded",
+    primaryOutputPath: undefined,
+    digestHash: spawn.digest?.hash || undefined,
+    digestSizeBytes: spawn.digest ? `${spawn.digest.sizeBytes || 0}` : undefined,
+    parentMap: new Map(),
+    childMap: new Map(),
+  };
+}
+
+function createSymlinkSummary(
+  actionId: string,
+  action: tools.protos.ExecLogEntry.SymlinkAction,
+  rawOrder: number
+): MutableActionSummary {
+  const mnemonic = (action.mnemonic || "Symlink").trim();
+  return {
+    id: actionId,
+    kind: "symlink",
+    rawOrder,
+    targetLabel: action.targetLabel || "",
+    label: mnemonic,
+    mnemonic,
+    cached: false,
+    result: "succeeded",
+    primaryOutputPath: undefined,
+    parentMap: new Map(),
+    childMap: new Map(),
+  };
+}
+
+function populatePrimaryOutputPath(actionId: string, action: MutableActionSummary, state: IndexBuildState) {
+  if (action.kind === "spawn") {
+    const spawn = state.spawns.get(parseActionNumericId(actionId));
+    action.primaryOutputPath = spawn ? getSpawnPrimaryOutputPath(spawn, state) : undefined;
+    return;
+  }
+
+  const symlinkAction = state.symlinkActions.get(parseActionNumericId(actionId));
+  action.primaryOutputPath = symlinkAction?.outputPath || undefined;
+}
+
+function isFailedSpawn(spawn: tools.protos.ExecLogEntry.Spawn): boolean {
+  return Boolean(spawn.status) || Number(spawn.exitCode || 0) !== 0;
+}
+
+function getSpawnDisplayMnemonic(spawn: tools.protos.ExecLogEntry.Spawn): string {
+  const mnemonic = spawn.mnemonic || "Action";
+  const details: string[] = [];
+
+  const runNumber = getEnvNumber(spawn, "TEST_RUN_NUMBER");
+  if (runNumber && runNumber > 1) {
+    details.push(`run ${runNumber}`);
+  }
+
+  const shardIndex = getEnvNumber(spawn, "TEST_SHARD_INDEX");
+  const totalShards = getEnvNumber(spawn, "TEST_TOTAL_SHARDS");
+  if (shardIndex !== undefined && totalShards && totalShards > 0) {
+    details.push(`shard ${shardIndex + 1}/${totalShards}`);
+  }
+
+  return details.length ? `${mnemonic} (${details.join(", ")})` : mnemonic;
+}
+
+function getEnvNumber(spawn: tools.protos.ExecLogEntry.Spawn, name: string): number | undefined {
+  const raw = (spawn.envVars || []).find((value) => value.name === name)?.value;
+  if (!raw) {
+    return undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? Math.floor(value) : undefined;
+}
+
+function applyDisambiguatedActionLabels(state: IndexBuildState) {
+  for (const target of state.targets.values()) {
+    const metas = Array.from(target.actionIds)
+      .map((actionId) => getActionLabelMeta(actionId, state))
+      .filter(Boolean) as ActionLabelMeta[];
+
+    metas.sort(
+      (a, b) =>
+        a.mnemonic.localeCompare(b.mnemonic) ||
+        a.filename.localeCompare(b.filename) ||
+        a.platform.localeCompare(b.platform) ||
+        a.actionId.localeCompare(b.actionId)
+    );
+
+    const byMnemonic = new Map<string, ActionLabelMeta[]>();
+    for (const meta of metas) {
+      if (!byMnemonic.has(meta.mnemonic)) {
+        byMnemonic.set(meta.mnemonic, []);
+      }
+      byMnemonic.get(meta.mnemonic)!.push(meta);
+    }
+
+    for (const [mnemonic, list] of byMnemonic.entries()) {
+      if (list.length === 1) {
+        const action = state.actions.get(list[0].actionId);
+        if (action) {
+          action.label = mnemonic;
+        }
+        continue;
+      }
+
+      const byFilename = new Map<string, ActionLabelMeta[]>();
+      for (const meta of list) {
+        if (!byFilename.has(meta.filename)) {
+          byFilename.set(meta.filename, []);
+        }
+        byFilename.get(meta.filename)!.push(meta);
+      }
+
+      for (const [filename, fileList] of byFilename.entries()) {
+        if (filename && fileList.length === 1) {
+          const action = state.actions.get(fileList[0].actionId);
+          if (action) {
+            action.label = `${mnemonic} (${filename})`;
+          }
+          continue;
+        }
+
+        for (const meta of fileList) {
+          const action = state.actions.get(meta.actionId);
+          if (!action) {
+            continue;
+          }
+          action.label = meta.platform ? `${mnemonic} (${meta.platform})` : mnemonic;
+        }
+      }
+    }
+  }
+}
+
+function getActionLabelMeta(actionId: string, state: IndexBuildState): ActionLabelMeta | undefined {
+  const action = state.actions.get(actionId);
+  if (!action) {
+    return undefined;
+  }
+
+  if (action.kind === "spawn") {
+    const spawn = state.spawns.get(parseActionNumericId(actionId));
+    if (!spawn) {
+      return undefined;
+    }
+    const primaryOutputPath = getSpawnPrimaryOutputPath(spawn, state);
+    return {
+      actionId,
+      mnemonic: action.mnemonic,
+      filename: extractFilename(primaryOutputPath),
+      platform: extractPlatform(primaryOutputPath) || getSpawnPlatformSummary(spawn),
+    };
+  }
+
+  const symlinkAction = state.symlinkActions.get(parseActionNumericId(actionId));
+  if (!symlinkAction) {
+    return undefined;
+  }
+  const outputPath = symlinkAction.outputPath || symlinkAction.inputPath;
+  return {
+    actionId,
+    mnemonic: action.mnemonic,
+    filename: extractFilename(outputPath),
+    platform: extractPlatform(outputPath),
+  };
+}
+
+function resolveOutputPath(output: tools.protos.ExecLogEntry.Output, state: IndexBuildState): string | undefined {
+  if (output.invalidOutputPath) {
+    return output.invalidOutputPath;
+  }
+
+  const outputId =
+    Number(output.outputId || 0) ||
+    Number(output.fileId || 0) ||
+    Number(output.directoryId || 0) ||
+    Number(output.unresolvedSymlinkId || 0);
+  if (!outputId) {
+    return undefined;
+  }
+
+  return (
+    state.files.get(outputId)?.path ||
+    state.directories.get(outputId)?.path ||
+    state.symlinks.get(outputId)?.path ||
+    state.runfilesTrees.get(outputId)?.path
+  );
+}
+
+function getSpawnPrimaryOutputPath(spawn: tools.protos.ExecLogEntry.Spawn, state: IndexBuildState): string | undefined {
+  let primaryOutputPath: string | undefined;
+  let sawFile = false;
+
+  for (const output of spawn.outputs || []) {
+    const path = resolveOutputPath(output, state);
+    if (!path) {
+      continue;
+    }
+
+    const outputId =
+      Number(output.outputId || 0) ||
+      Number(output.fileId || 0) ||
+      Number(output.directoryId || 0) ||
+      Number(output.unresolvedSymlinkId || 0);
+
+    if (outputId && state.files.has(outputId)) {
+      if (!primaryOutputPath) {
+        primaryOutputPath = path;
+      }
+      sawFile = true;
+      continue;
+    }
+
+    if (!sawFile && !primaryOutputPath) {
+      primaryOutputPath = path;
+    }
+  }
+
+  return primaryOutputPath;
+}
+
+function extractPlatform(path: string | undefined): string {
+  if (!path) {
+    return "";
+  }
+  const match = path.match(/^bazel-out\/([^/]+)\//);
+  return match?.[1] || "";
+}
+
+function extractFilename(path: string | undefined): string {
+  if (!path) {
+    return "";
+  }
+  const parts = path.split("/");
+  return parts[parts.length - 1] || "";
+}
+
+function getSpawnPlatformSummary(spawn: tools.protos.ExecLogEntry.Spawn): string {
+  const properties = (spawn.platform?.properties || []).map((property) => [property.name || "", property.value || ""]);
+  const relevant = properties
+    .filter(([name, value]) => name && value)
+    .filter(([name]) => ["OSFamily", "cpu", "container-image", "Pool", "Arch"].includes(name));
+
+  if (!relevant.length) {
+    return "";
+  }
+
+  return relevant.map(([name, value]) => `${name}=${value}`).join(", ");
+}
+
+function getConsumedArtifactsForSpawn(actionId: string, state: IndexBuildState): Set<number> {
+  const action = state.actions.get(actionId);
+  if (!action || action.kind !== "spawn") {
+    return new Set();
+  }
+  const spawn = state.spawns.get(parseActionNumericId(actionId));
+  if (!spawn) {
+    return new Set();
+  }
+
+  const result = new Set<number>();
+  mergeInto(result, expandInputSet(spawn.inputSetId, state));
+  mergeInto(result, expandInputSet(spawn.toolSetId, state));
+  return result;
+}
+
+function getConsumedArtifactsForSymlinkAction(actionId: string, state: IndexBuildState): Set<number> {
+  const action = state.actions.get(actionId);
+  if (!action || action.kind !== "symlink") {
+    return new Set();
+  }
+  const symlinkAction = state.symlinkActions.get(parseActionNumericId(actionId));
+  if (!symlinkAction?.inputPath) {
+    return new Set();
+  }
+
+  const artifactId = state.pathToArtifactId.get(symlinkAction.inputPath);
+  return artifactId ? new Set([artifactId]) : new Set();
+}
+
+export function getExecConfiguredPathLookupCandidates(path: string): string[] {
+  // Preserve the exact exec-configured path first. Some compact exec logs only
+  // record the canonical `*-exec/` artifact path, so also try a lossy fallback
+  // that strips the ST hash segment if present.
+  const canonicalFallbackPath = path.replace(/-exec-ST-[^/]+\//, "-exec/");
+  return canonicalFallbackPath === path ? [path] : [path, canonicalFallbackPath];
+}
+
+function resolveSymlinkOutputArtifactId(actionId: string, state: IndexBuildState): number | undefined {
+  const symlinkAction = state.symlinkActions.get(parseActionNumericId(actionId));
+  if (!symlinkAction?.outputPath) {
+    return undefined;
+  }
+
+  for (const candidatePath of getExecConfiguredPathLookupCandidates(symlinkAction.outputPath)) {
+    const artifactId = state.pathToArtifactId.get(candidatePath);
+    if (artifactId) {
+      return artifactId;
+    }
+  }
+  return undefined;
+}
+
+function expandInputSet(inputSetId: number | undefined, state: IndexBuildState): Set<number> {
+  if (!inputSetId) {
+    return new Set();
+  }
+
+  const cached = state.expandedInputSets.get(inputSetId);
+  if (cached) {
+    return cached;
+  }
+
+  const inputSet = state.inputSets.get(inputSetId);
+  if (!inputSet) {
+    return new Set();
+  }
+
+  const result = new Set<number>();
+  for (const transitiveId of inputSet.transitiveSetIds || []) {
+    mergeInto(result, expandInputSet(transitiveId, state));
+  }
+
+  const directArtifactIds = [
+    ...(inputSet.inputIds || []),
+    ...(inputSet.fileIds || []),
+    ...(inputSet.directoryIds || []),
+    ...(inputSet.unresolvedSymlinkIds || []),
+  ];
+  for (const artifactId of directArtifactIds) {
+    collectArtifactDependencies(artifactId, state, result);
+  }
+
+  state.expandedInputSets.set(inputSetId, result);
+  return result;
+}
+
+function collectArtifactDependencies(artifactId: number, state: IndexBuildState, result: Set<number>) {
+  if (!artifactId || result.has(artifactId)) {
+    return;
+  }
+
+  result.add(artifactId);
+
+  const runfilesTree = state.runfilesTrees.get(artifactId);
+  if (!runfilesTree) {
+    return;
+  }
+
+  mergeInto(result, expandInputSet(runfilesTree.inputSetId, state));
+  for (const entryId of expandSymlinkEntrySet(runfilesTree.symlinksId, state).values()) {
+    collectArtifactDependencies(entryId, state, result);
+  }
+  for (const entryId of expandSymlinkEntrySet(runfilesTree.rootSymlinksId, state).values()) {
+    collectArtifactDependencies(entryId, state, result);
+  }
+}
+
+function expandSymlinkEntrySet(entrySetId: number | undefined, state: IndexBuildState): Map<string, number> {
+  if (!entrySetId) {
+    return new Map();
+  }
+
+  const cached = state.expandedSymlinkEntrySets.get(entrySetId);
+  if (cached) {
+    return cached;
+  }
+
+  const result = new Map<string, number>();
+  const visited = new Set<number>();
+
+  const visit = (currentId: number) => {
+    if (!currentId || visited.has(currentId)) {
+      return;
+    }
+    visited.add(currentId);
+
+    const entrySet = state.symlinkEntrySets.get(currentId);
+    if (!entrySet) {
+      return;
+    }
+
+    for (const transitiveId of entrySet.transitiveSetIds || []) {
+      visit(transitiveId);
+    }
+
+    if (entrySet.directEntries) {
+      for (const [relativePath, artifactId] of Object.entries(entrySet.directEntries)) {
+        result.set(relativePath, Number(artifactId));
+      }
+    }
+  };
+
+  visit(entrySetId);
+  state.expandedSymlinkEntrySets.set(entrySetId, result);
+  return result;
+}
+
+function addRelation(relationMap: Map<string, Set<string>>, targetLabel: string, actionId: string) {
+  let relationSet = relationMap.get(targetLabel);
+  if (!relationSet) {
+    relationSet = new Set();
+    relationMap.set(targetLabel, relationSet);
+  }
+  relationSet.add(actionId);
+}
+
+function getOrCreateTarget(targetLabel: string, state: IndexBuildState): MutableTargetSummary {
+  let target = state.targets.get(targetLabel);
+  if (!target) {
+    target = {
+      label: targetLabel,
+      actionIds: new Set(),
+      parentMap: new Map(),
+      childMap: new Map(),
+    };
+    state.targets.set(targetLabel, target);
+  }
+  return target;
+}
+
+function registerTargetAction(targetLabel: string, actionId: string, state: IndexBuildState) {
+  if (!targetLabel) {
+    return;
+  }
+  getOrCreateTarget(targetLabel, state).actionIds.add(actionId);
+}
+
+function serializeRelations(relationMap: Map<string, Set<string>>): RelatedTargetSummary[] {
+  return Array.from(relationMap.entries())
+    .map(([targetLabel, actionIds]) => ({
+      targetLabel,
+      actionIds: Array.from(actionIds),
+    }))
+    .sort((a, b) => a.targetLabel.localeCompare(b.targetLabel));
+}
+
+function compareActions(a: MutableActionSummary, b: MutableActionSummary): number {
+  if (a.targetLabel !== b.targetLabel) {
+    return a.targetLabel.localeCompare(b.targetLabel);
+  }
+  if (a.rawOrder !== b.rawOrder) {
+    return a.rawOrder - b.rawOrder;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+function makeActionId(kind: ActionKind, id: number): string {
+  return `${kind}:${id}`;
+}
+
+function parseActionNumericId(actionId: string): number {
+  return Number(actionId.split(":")[1] || 0);
+}
+
+function mergeInto(destination: Set<number>, source: Set<number>) {
+  source.forEach((value) => destination.add(value));
+}
+
+async function readCachedIndex(cacheKey: string): Promise<CompactExecLogEdgesIndex | undefined> {
+  const db = await openDb();
+  if (!db) {
+    return undefined;
+  }
+
+  return new Promise((resolve) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(cacheKey);
+    request.onsuccess = () => resolve(request.result as CompactExecLogEdgesIndex | undefined);
+    request.onerror = () => resolve(undefined);
+  });
+}
+
+async function writeCachedIndex(index: CompactExecLogEdgesIndex): Promise<void> {
+  const db = await openDb();
+  if (!db) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    store.put(index, index.cacheKey);
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => resolve();
+    transaction.onabort = () => resolve();
+  });
+}
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) {
+    return dbPromise;
+  }
+
+  if (typeof window === "undefined" || !window.indexedDB) {
+    dbPromise = Promise.resolve(null);
+    return dbPromise;
+  }
+
+  dbPromise = new Promise((resolve) => {
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(null);
+  });
+
+  return dbPromise;
+}

--- a/app/target/compact_exec_log_edges_test.ts
+++ b/app/target/compact_exec_log_edges_test.ts
@@ -1,0 +1,25 @@
+import { getExecConfiguredPathLookupCandidates } from "./compact_exec_log_edges";
+
+describe("getExecConfiguredPathLookupCandidates", () => {
+  it("keeps the exact ST path and adds a canonical fallback for opt exec outputs", () => {
+    expect(
+      getExecConfiguredPathLookupCandidates("bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/pkg/foo")
+    ).toEqual([
+      "bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/pkg/foo",
+      "bazel-out/darwin_arm64-opt-exec/bin/pkg/foo",
+    ]);
+  });
+
+  it("keeps the exact ST path and adds a canonical fallback for non-default exec outputs", () => {
+    expect(getExecConfiguredPathLookupCandidates("bazel-out/k8-dbg-exec-ST-abcd1234/bin/pkg/foo")).toEqual([
+      "bazel-out/k8-dbg-exec-ST-abcd1234/bin/pkg/foo",
+      "bazel-out/k8-dbg-exec/bin/pkg/foo",
+    ]);
+  });
+
+  it("uses the canonical path as the only lookup candidate when there is no ST hash", () => {
+    expect(getExecConfiguredPathLookupCandidates("bazel-out/my-platform-fastbuild-exec/bin/pkg/foo")).toEqual([
+      "bazel-out/my-platform-fastbuild-exec/bin/pkg/foo",
+    ]);
+  });
+});

--- a/app/target/target_edges_card.tsx
+++ b/app/target/target_edges_card.tsx
@@ -1,0 +1,490 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import React from "react";
+import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
+import { TextLink } from "../components/link/link";
+import InvocationModel from "../invocation/invocation_model";
+import router from "../router/router";
+import {
+  CompactExecLogActionSummary,
+  CompactExecLogEdgesIndex,
+  CompactExecLogTargetSummary,
+  getCompactExecLogEdgesIndex,
+} from "./compact_exec_log_edges";
+
+interface Props {
+  invocationId: string;
+  model: InvocationModel;
+  search: URLSearchParams;
+  targetLabel: string;
+  targetFiles: build_event_stream.File[];
+}
+
+interface State {
+  loading: boolean;
+  error?: string;
+  index?: CompactExecLogEdgesIndex;
+  expandedActionId?: string;
+}
+
+export default class TargetEdgesCardComponent extends React.Component<Props, State> {
+  state: State = {
+    loading: true,
+  };
+
+  private fetchRequestId = 0;
+  private isComponentMounted = false;
+  private actionHeaderRefs = new Map<string, HTMLDivElement>();
+
+  componentDidMount() {
+    this.isComponentMounted = true;
+    this.fetchIndex();
+  }
+
+  componentWillUnmount() {
+    this.isComponentMounted = false;
+    this.fetchRequestId++;
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    const prevUri = prevProps.model.getExecutionLogFileUri();
+    const nextUri = this.props.model.getExecutionLogFileUri();
+
+    if (prevProps.model !== this.props.model || prevUri !== nextUri) {
+      this.fetchIndex();
+      return;
+    }
+
+    const prevExpandedActionId = prevProps.search.get("edgeAction");
+    const nextExpandedActionId = this.props.search.get("edgeAction");
+    if (prevProps.targetLabel !== this.props.targetLabel || prevExpandedActionId !== nextExpandedActionId) {
+      this.setState({ expandedActionId: this.getExpandedActionId(this.state.index) });
+    }
+
+    if (
+      prevProps.targetLabel !== this.props.targetLabel ||
+      prevState.expandedActionId !== this.state.expandedActionId
+    ) {
+      this.scrollExpandedActionIntoView();
+    }
+  }
+
+  private getExpandedActionId(index?: CompactExecLogEdgesIndex): string | undefined {
+    const actionId = this.props.search.get("edgeAction");
+    if (!index || !actionId) {
+      return undefined;
+    }
+    if (!this.getResolvedCurrentTarget(index).actions.some((action) => action.id === actionId)) {
+      return undefined;
+    }
+    return actionId;
+  }
+
+  private isStaleFetch(requestId: number, model: InvocationModel, executionLogUri: string | undefined): boolean {
+    return (
+      !this.isComponentMounted ||
+      this.fetchRequestId !== requestId ||
+      this.props.model !== model ||
+      this.props.model.getExecutionLogFileUri() !== executionLogUri
+    );
+  }
+
+  private fetchIndex() {
+    const requestId = ++this.fetchRequestId;
+    const model = this.props.model;
+    const executionLogUri = model.getExecutionLogFileUri();
+    if (!executionLogUri) {
+      if (!this.isStaleFetch(requestId, model, executionLogUri)) {
+        this.setState({ loading: false, error: undefined, index: undefined, expandedActionId: undefined });
+      }
+      return;
+    }
+
+    this.setState({ loading: true, error: undefined });
+    getCompactExecLogEdgesIndex(executionLogUri, () => model.getExecutionLog())
+      .then((index) => {
+        if (this.isStaleFetch(requestId, model, executionLogUri)) {
+          return;
+        }
+        this.setState({ index, loading: false, expandedActionId: this.getExpandedActionId(index) });
+      })
+      .catch((error) => {
+        if (this.isStaleFetch(requestId, model, executionLogUri)) {
+          return;
+        }
+        console.error("Failed to load compact execution log edges", error);
+        this.setState({
+          loading: false,
+          error: error instanceof Error ? error.message : "Failed to load compact execution log edges.",
+          expandedActionId: undefined,
+        });
+      });
+  }
+
+  private getCurrentTarget(): CompactExecLogTargetSummary | undefined {
+    return this.state.index?.targets[this.props.targetLabel];
+  }
+
+  private getTargetFilePaths(): string[] {
+    return this.props.targetFiles.map(getBuildEventFilePath).filter((path): path is string => Boolean(path));
+  }
+
+  private getFallbackTargetActions(index?: CompactExecLogEdgesIndex): CompactExecLogActionSummary[] {
+    if (!index) {
+      return [];
+    }
+
+    const filePaths = new Set(this.getTargetFilePaths());
+    if (!filePaths.size) {
+      return [];
+    }
+
+    return Object.values(index.actions)
+      .filter((action) => action.primaryOutputPath && filePaths.has(action.primaryOutputPath))
+      .sort(compareActionSummaries);
+  }
+
+  private getResolvedCurrentTarget(index = this.state.index): {
+    actions: CompactExecLogActionSummary[];
+    effectiveTargetLabel?: string;
+  } {
+    const currentTarget = index?.targets[this.props.targetLabel];
+    if (currentTarget) {
+      return {
+        actions: this.getCurrentTargetActions(currentTarget, index),
+        effectiveTargetLabel: currentTarget.label,
+      };
+    }
+
+    const fallbackActions = this.getFallbackTargetActions(index);
+    const effectiveTargetLabel =
+      fallbackActions.length && fallbackActions.every((action) => action.targetLabel === fallbackActions[0].targetLabel)
+        ? fallbackActions[0].targetLabel
+        : undefined;
+    return { actions: fallbackActions, effectiveTargetLabel };
+  }
+
+  private getAction(actionId: string): CompactExecLogActionSummary | undefined {
+    return this.state.index?.actions[actionId];
+  }
+
+  private getCurrentTargetActions(
+    currentTarget: CompactExecLogTargetSummary,
+    index = this.state.index
+  ): CompactExecLogActionSummary[] {
+    return currentTarget.actionIds
+      .map((actionId) => index?.actions[actionId])
+      .filter((action): action is CompactExecLogActionSummary => Boolean(action))
+      .sort(compareActionSummaries);
+  }
+
+  private getRelatedActions(
+    action: CompactExecLogActionSummary,
+    direction: "parents" | "children"
+  ): CompactExecLogActionSummary[] {
+    const relations = direction === "parents" ? action.parents : action.children;
+    const relatedActions = new Map<string, CompactExecLogActionSummary>();
+
+    for (const relation of relations) {
+      for (const relatedActionId of relation.actionIds) {
+        const relatedAction = this.getAction(relatedActionId);
+        if (!relatedAction) {
+          continue;
+        }
+        relatedActions.set(relatedAction.id, relatedAction);
+      }
+    }
+
+    return Array.from(relatedActions.values()).sort(compareRelatedActions);
+  }
+
+  private toggleExpandedAction(actionId: string) {
+    this.setState((prevState) => ({
+      expandedActionId: prevState.expandedActionId === actionId ? undefined : actionId,
+    }));
+  }
+
+  private handleAccordionKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, actionId: string) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+    event.preventDefault();
+    this.toggleExpandedAction(actionId);
+  };
+
+  private stopAccordionToggle = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
+
+  private setActionHeaderRef = (actionId: string, element: HTMLDivElement | null) => {
+    if (!element) {
+      this.actionHeaderRefs.delete(actionId);
+      return;
+    }
+    this.actionHeaderRefs.set(actionId, element);
+  };
+
+  private scrollExpandedActionIntoView() {
+    const expandedActionId = this.state.expandedActionId;
+    if (!expandedActionId) {
+      return;
+    }
+
+    const header = this.actionHeaderRefs.get(expandedActionId);
+    if (!header) {
+      return;
+    }
+
+    const { top, bottom } = header.getBoundingClientRect();
+    if (top >= 0 && bottom <= window.innerHeight) {
+      return;
+    }
+
+    header.scrollIntoView({ block: "nearest" });
+  }
+
+  private getActionHref(action: CompactExecLogActionSummary): string | undefined {
+    if (!action.targetLabel) {
+      return undefined;
+    }
+    const search = new URLSearchParams();
+    search.set("target", action.targetLabel);
+    search.set("edgeAction", action.id);
+    return `${router.getInvocationUrl(this.props.invocationId)}?${search.toString()}#edges`;
+  }
+
+  private getTargetHref(targetLabel: string): string {
+    return `${router.getInvocationUrl(this.props.invocationId)}?target=${encodeURIComponent(targetLabel)}#edges`;
+  }
+
+  private getActionText(action: CompactExecLogActionSummary): string {
+    return action.cached ? `${action.label} (Cached)` : action.label;
+  }
+
+  private renderTargetLink(targetLabel: string) {
+    const { effectiveTargetLabel } = this.getResolvedCurrentTarget();
+    const truncatedTargetLabel = truncateTargetLabel(targetLabel);
+    if (!targetLabel) {
+      return <span className="target-edge-current-target target-edge-target-label">&lt;unknown target&gt;</span>;
+    }
+    if (targetLabel === effectiveTargetLabel || (!effectiveTargetLabel && targetLabel === this.props.targetLabel)) {
+      return (
+        <span className="target-edge-current-target target-edge-target-label" title={targetLabel}>
+          {truncatedTargetLabel}
+        </span>
+      );
+    }
+    return (
+      <TextLink
+        className="target-edge-inline-link target-edge-target-label"
+        href={this.getTargetHref(targetLabel)}
+        title={targetLabel}
+        onClick={this.stopAccordionToggle}>
+        {truncatedTargetLabel}
+      </TextLink>
+    );
+  }
+
+  private renderActionLink(action: CompactExecLogActionSummary) {
+    const label = this.getActionText(action);
+    const href = this.getActionHref(action);
+    if (!href) {
+      return (
+        <span
+          className="target-edge-inline-link target-edge-action-link target-edge-inline-link-disabled"
+          title={label}>
+          {label}
+        </span>
+      );
+    }
+    return (
+      <TextLink
+        className="target-edge-inline-link target-edge-action-link"
+        href={href}
+        onClick={this.stopAccordionToggle}
+        title={label}>
+        {label}
+      </TextLink>
+    );
+  }
+
+  private renderCombinedActionLabel(action: CompactExecLogActionSummary) {
+    const actionStatusClass = getActionStatusClass(action);
+    return (
+      <span className="target-edge-action-summary">
+        <span className={`target-edge-result-indicator ${actionStatusClass}`} />
+        <span className="target-edge-combined-label">
+          {this.renderTargetLink(action.targetLabel)}
+          <span className="target-edge-arrow">{" -> "}</span>
+          {this.renderActionLink(action)}
+        </span>
+      </span>
+    );
+  }
+
+  private renderRelatedActionsSection(
+    title: string,
+    actions: CompactExecLogActionSummary[],
+    emptyState: string
+  ): React.ReactNode {
+    return (
+      <div className="target-edges-accordion-section">
+        <div className="target-edges-accordion-section-title">{title}</div>
+        {actions.length ? (
+          <div className="target-edges-related-actions">
+            {actions.map((action) => (
+              <div className="target-edges-related-action" key={action.id}>
+                {this.renderCombinedActionLabel(action)}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="target-edges-empty-state">{emptyState}</div>
+        )}
+      </div>
+    );
+  }
+
+  private renderActionAccordion(action: CompactExecLogActionSummary): React.ReactNode {
+    const expanded = this.state.expandedActionId === action.id;
+    const parents = this.getRelatedActions(action, "parents");
+    const children = this.getRelatedActions(action, "children");
+    const Chevron = expanded ? ChevronDown : ChevronRight;
+    const actionStatusClass = getActionStatusClass(action);
+
+    return (
+      <div className={`target-edges-accordion-item ${expanded ? "expanded" : ""}`} key={action.id}>
+        <div
+          className={`target-edges-accordion-header ${actionStatusClass}`}
+          onClick={() => this.toggleExpandedAction(action.id)}
+          onKeyDown={(event) => this.handleAccordionKeyDown(event, action.id)}
+          ref={(element) => this.setActionHeaderRef(action.id, element)}
+          role="button"
+          tabIndex={0}>
+          <span className="target-edges-accordion-chevron">
+            <Chevron className="icon" />
+          </span>
+          <span className="target-edges-accordion-label">{this.renderCombinedActionLabel(action)}</span>
+        </div>
+        {expanded && (
+          <div className="target-edges-accordion-body">
+            <div className="target-edges-accordion-sections">
+              {this.renderRelatedActionsSection("Parent actions", parents, "No upstream actions found.")}
+              {this.renderRelatedActionsSection("Child actions", children, "No downstream actions found.")}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <div className="loading loading-slim invocation-tab-loading" />;
+    }
+
+    if (this.state.error) {
+      return <div className="invocation-execution-empty-state">{this.state.error}</div>;
+    }
+
+    if (!this.props.model.hasExecutionLog()) {
+      return (
+        <div className="invocation-execution-empty-state">No compact execution log found for this invocation.</div>
+      );
+    }
+
+    const currentTarget = this.getCurrentTarget();
+    const { actions: currentTargetActions } = this.getResolvedCurrentTarget();
+
+    return (
+      <div className="card expanded target-edges-card">
+        <div className="content">
+          <div className="invocation-content-header target-edges-header">
+            <div>
+              <div className="title">Build graph edges</div>
+              <div className="target-edges-subtitle">
+                Expand an action to inspect its parent and child actions from the compact execution log.
+              </div>
+            </div>
+          </div>
+
+          {!currentTarget && !currentTargetActions.length && (
+            <div className="invocation-execution-empty-state">
+              No compact execution log edges were recorded for {this.props.targetLabel}.
+            </div>
+          )}
+
+          {currentTarget && !currentTargetActions.length && (
+            <div className="target-edges-empty-state">No actions were recorded for this target.</div>
+          )}
+
+          {currentTargetActions.length > 0 && (
+            <div className="target-edges-accordion">
+              {currentTargetActions.map((action) => this.renderActionAccordion(action))}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+function compareLabels(a: string, b: string): number {
+  const bucket = (s: string) => (s.startsWith("//") ? 0 : s.startsWith("@") ? 1 : 2);
+  const bucketA = bucket(a);
+  const bucketB = bucket(b);
+  if (bucketA !== bucketB) {
+    return bucketA - bucketB;
+  }
+  return a.localeCompare(b);
+}
+
+function compareRelatedActions(a: CompactExecLogActionSummary, b: CompactExecLogActionSummary): number {
+  const targetCmp = compareLabels(a.targetLabel || "", b.targetLabel || "");
+  if (targetCmp !== 0) {
+    return targetCmp;
+  }
+  return compareActionSummaries(a, b);
+}
+
+function compareActionSummaries(a: CompactExecLogActionSummary, b: CompactExecLogActionSummary): number {
+  if (a.cached !== b.cached) {
+    return Number(a.cached) - Number(b.cached);
+  }
+  const mnemonicCmp = (a.mnemonic || "").localeCompare(b.mnemonic || "");
+  if (mnemonicCmp !== 0) {
+    return mnemonicCmp;
+  }
+  const labelCmp = (a.label || "").localeCompare(b.label || "");
+  if (labelCmp !== 0) {
+    return labelCmp;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+function getBuildEventFilePath(file: build_event_stream.File): string | undefined {
+  const components = [...(file.pathPrefix || []), file.name || ""].filter(Boolean);
+  return components.length ? components.join("/") : undefined;
+}
+
+function getActionStatusClass(action: CompactExecLogActionSummary): "cached" | "failure" | "success" {
+  if (action.result === "failed") {
+    return "failure";
+  }
+  return action.cached ? "cached" : "success";
+}
+
+const MAX_TARGET_LABEL_LENGTH = 48;
+
+function truncateTargetLabel(targetLabel: string): string {
+  if (targetLabel.length <= MAX_TARGET_LABEL_LENGTH) {
+    return targetLabel;
+  }
+
+  const targetNameIndex = targetLabel.lastIndexOf(":");
+  const suffix = targetNameIndex >= 0 ? targetLabel.slice(targetNameIndex) : "";
+  const prefixBudget = MAX_TARGET_LABEL_LENGTH - suffix.length - 3;
+  if (prefixBudget <= 8) {
+    return `${targetLabel.slice(0, MAX_TARGET_LABEL_LENGTH - 3)}...`;
+  }
+  return `${targetLabel.slice(0, prefixBudget)}...${suffix}`;
+}

--- a/app/target/target_v2.tsx
+++ b/app/target/target_v2.tsx
@@ -36,13 +36,23 @@ import { commandWithRemoteRunnerFlags, supportsRemoteRun, triggerRemoteRun } fro
 import ActionCardComponent from "./action_card";
 import FlakyTargetChipComponent from "./flaky_target_chip";
 import TargetArtifactsCardComponent from "./target_artifacts_card";
+import TargetEdgesCardComponent from "./target_edges_card";
 import TargetTestCoverageCardComponent from "./target_test_coverage_card";
 import TargetTestDocumentCardComponent from "./target_test_document_card";
 import TargetTestLogCardComponent from "./target_test_log_card";
 
 const Status = api_common.v1.Status;
 
-type SectionFilter = "all" | "documents" | "logs" | "coverage" | "actions" | "artifacts" | "cache" | "executions";
+type SectionFilter =
+  | "all"
+  | "documents"
+  | "logs"
+  | "coverage"
+  | "actions"
+  | "artifacts"
+  | "cache"
+  | "executions"
+  | "edges";
 
 interface SectionTab {
   id: SectionFilter;
@@ -278,8 +288,18 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
   // Parses hash like "#coverage-2", "#coverage", "#2", or "#".
   private parseHash(): { section: SectionFilter; run?: number } {
     const parts = (this.props.tab?.replace("#", "") || "").split("-");
-    const sections: string[] = ["documents", "logs", "coverage", "actions", "artifacts", "cache", "executions"];
-    const section = sections.includes(parts[0]) ? (parts[0] as SectionFilter) : "all";
+    const sections: string[] = [
+      "documents",
+      "logs",
+      "coverage",
+      "actions",
+      "artifacts",
+      "cache",
+      "executions",
+      "edges",
+    ];
+    const normalizedSection = parts[0] === "links" ? "edges" : parts[0];
+    const section = sections.includes(normalizedSection) ? (normalizedSection as SectionFilter) : "all";
     const runStr = section !== "all" ? parts[1] : parts[0];
     const run = runStr && /^\d+$/.test(runStr) ? Number(runStr) : undefined;
     return { section, run };
@@ -349,6 +369,9 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
     }
     if (this.props.model.getIsRBEEnabled()) {
       sectionTabs.push({ id: "executions", label: "Executions" });
+    }
+    if (this.props.model.hasExecutionLog()) {
+      sectionTabs.push({ id: "edges", label: "Edges" });
     }
     const sectionFromHash = this.getSectionFromHash();
     const activeSection = sectionTabs.some((tab) => tab.id === sectionFromHash) ? sectionFromHash : "all";
@@ -559,6 +582,15 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
               search={this.props.search}
               filter=""
               targetLabel={this.props.label}
+            />
+          )}
+          {activeSection === "edges" && this.props.model.hasExecutionLog() && (
+            <TargetEdgesCardComponent
+              invocationId={this.props.invocationId}
+              model={this.props.model}
+              search={this.props.search}
+              targetLabel={this.props.label}
+              targetFiles={target.files as build_event_stream.File[]}
             />
           )}
         </div>


### PR DESCRIPTION
Render compact-exec-log edges on the target page instead of
adding a separate invocation graph surface.

This keeps the producer and consumer view scoped to the selected
target, caches the reduced client-side index, and adds deep links to
specific edge actions.

The card now uses consistent edge naming, a grouped accordion UI,
and per-action status markers while preserving the existing target and
action navigation.
