### PR TITLE
remote_execution: fail fast on capped output

### DIFF
--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -47,20 +48,33 @@ var (
 )
 
 func LimitStdOutErrWriter(w io.Writer) io.Writer {
+	return LimitStdOutErrWriterWithCallback(w, nil)
+}
+
+func LimitStdOutErrWriterWithCallback(w io.Writer, onLimitExceeded func(error)) io.Writer {
 	if *StdOutErrMaxSize == 0 {
 		return w
 	}
-	return &limitWriter{w: w, limit: *StdOutErrMaxSize}
+	return &limitWriter{w: w, limit: *StdOutErrMaxSize, onLimitExceeded: onLimitExceeded}
 }
 
 // limitWriter limits the number of bytes written to it.
 // It returns a ResourceExhausted error if a write occurs that would exceed the limit.
 // Before returning a ResourceExhausted error, it writes as many bytes as possible before the limit would be reached.
 type limitWriter struct {
-	w     io.Writer
-	limit uint64
+	w               io.Writer
+	limit           uint64
+	onLimitExceeded func(error)
 
 	n uint64
+}
+
+func (lw *limitWriter) resourceExhaustedError(totalRequested uint64) error {
+	err := status.ResourceExhaustedErrorf("stdout/stderr output size limit exceeded: %d bytes requested (limit: %d bytes)", totalRequested, lw.limit)
+	if lw.onLimitExceeded != nil {
+		lw.onLimitExceeded(err)
+	}
+	return err
 }
 
 func (lw *limitWriter) Write(p []byte) (int, error) {
@@ -71,19 +85,19 @@ func (lw *limitWriter) Write(p []byte) (int, error) {
 	totalRequested := lw.n + pSize
 	if lw.n >= lw.limit {
 		// n could have been increased from a previous write and reached limit
-		return 0, status.ResourceExhaustedErrorf("stdout/stderr output size limit exceeded: %d bytes requested (limit: %d bytes)", totalRequested, lw.limit)
+		return 0, lw.resourceExhaustedError(totalRequested)
 	}
 
 	writeSize := min(pSize, lw.limit-lw.n)
 	n, err := lw.w.Write(p[:writeSize])
 	lw.n += uint64(n)
 	if err == nil && writeSize < pSize {
-		return n, status.ResourceExhaustedErrorf("stdout/stderr output size limit exceeded: %d bytes requested (limit: %d bytes)", totalRequested, lw.limit)
+		return n, lw.resourceExhaustedError(totalRequested)
 	}
 	return n, err
 }
 
-func constructExecCommand(command *repb.Command, workDir string, stdio *interfaces.Stdio) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer, error) {
+func constructExecCommand(command *repb.Command, workDir string, stdio *interfaces.Stdio, onOutputLimitExceeded func(error)) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer, error) {
 	if stdio == nil {
 		stdio = &interfaces.Stdio{}
 	}
@@ -96,15 +110,31 @@ func constructExecCommand(command *repb.Command, workDir string, stdio *interfac
 	if workDir != "" {
 		cmd.Dir = workDir
 	}
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
+	var stdoutBuf, stderrBuf *bytes.Buffer
+	var stdout, stderr io.Writer
 	if stdio.Stdout != nil {
-		cmd.Stdout = stdio.Stdout
+		stdout = stdio.Stdout
+	} else {
+		stdoutBuf = &bytes.Buffer{}
+		stdout = stdoutBuf
 	}
-	cmd.Stderr = &stderr
 	if stdio.Stderr != nil {
-		cmd.Stderr = stdio.Stderr
+		stderr = stdio.Stderr
+	} else {
+		stderrBuf = &bytes.Buffer{}
+		stderr = stderrBuf
 	}
+	if *DebugStreamCommandOutputs {
+		logWriter := log.Writer(fmt.Sprintf("[%s] ", executable))
+		stdout = io.MultiWriter(stdout, logWriter)
+		stderr = io.MultiWriter(stderr, logWriter)
+	}
+	if !stdio.DisableOutputLimits {
+		stdout = LimitStdOutErrWriterWithCallback(stdout, onOutputLimitExceeded)
+		stderr = LimitStdOutErrWriterWithCallback(stderr, onOutputLimitExceeded)
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	// Note: We are using StdinPipe() instead of cmd.Stdin here, because the
 	// latter approach results in a bug where cmd.Wait() can hang indefinitely if
 	// the process doesn't consume its stdin. See
@@ -119,16 +149,11 @@ func constructExecCommand(command *repb.Command, workDir string, stdio *interfac
 			io.Copy(inp, stdio.Stdin)
 		}()
 	}
-	if *DebugStreamCommandOutputs {
-		logWriter := log.Writer(fmt.Sprintf("[%s] ", executable))
-		cmd.Stdout = io.MultiWriter(cmd.Stdout, logWriter)
-		cmd.Stderr = io.MultiWriter(cmd.Stderr, logWriter)
-	}
 	cmd.SysProcAttr = getDefaultSysProcAttr()
 	for _, envVar := range command.GetEnvironmentVariables() {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
 	}
-	return cmd, &stdout, &stderr, nil
+	return cmd, stdoutBuf, stderrBuf, nil
 }
 
 // RetryIfTextFileBusy runs a function, retrying "text file busy" errors up to
@@ -196,6 +221,19 @@ func RunWithOpts(ctx context.Context, command *repb.Command, opts *RunOpts) *int
 	if opts == nil {
 		opts = &RunOpts{}
 	}
+	onOutputLimitExceeded := func(error) {}
+	if *StdOutErrMaxSize > 0 && (opts.Stdio == nil || !opts.Stdio.DisableOutputLimits) {
+		var cancel context.CancelCauseFunc
+		ctx, cancel = context.WithCancelCause(ctx)
+		var once sync.Once
+		defer cancel(nil)
+		onOutputLimitExceeded = func(err error) {
+			once.Do(func() {
+				cancel(err)
+			})
+		}
+	}
+
 	var cmd *exec.Cmd
 	var stdoutBuf, stderrBuf *bytes.Buffer
 	var stats *repb.UsageStats
@@ -203,7 +241,7 @@ func RunWithOpts(ctx context.Context, command *repb.Command, opts *RunOpts) *int
 	err := RetryIfTextFileBusy(func() error {
 		// Create a new command on each attempt since commands can only be run once.
 		var err error
-		cmd, stdoutBuf, stderrBuf, err = constructExecCommand(command, opts.Dir, opts.Stdio)
+		cmd, stdoutBuf, stderrBuf, err = constructExecCommand(command, opts.Dir, opts.Stdio, onOutputLimitExceeded)
 		if err != nil {
 			return err
 		}
@@ -212,11 +250,18 @@ func RunWithOpts(ctx context.Context, command *repb.Command, opts *RunOpts) *int
 	})
 
 	exitCode, err := ExitCode(ctx, cmd, err)
+	var stdoutBytes, stderrBytes []byte
+	if stdoutBuf != nil {
+		stdoutBytes = stdoutBuf.Bytes()
+	}
+	if stderrBuf != nil {
+		stderrBytes = stderrBuf.Bytes()
+	}
 	return &interfaces.CommandResult{
 		ExitCode:           exitCode,
 		Error:              err,
-		Stdout:             stdoutBuf.Bytes(),
-		Stderr:             stderrBuf.Bytes(),
+		Stdout:             stdoutBytes,
+		Stderr:             stderrBytes,
 		CommandDebugString: cmd.String(),
 		UsageStats:         stats,
 	}
@@ -313,6 +358,9 @@ func RunWithProcessTreeCleanup(ctx context.Context, cmd *exec.Cmd, opts *RunOpts
 			stats.CpuNanos = max(stats.CpuNanos, rusageCPUNanos(rusage))
 		}
 	}
+	if cause := context.Cause(ctx); status.IsResourceExhaustedError(cause) {
+		err = cause
+	}
 	return stats, err
 }
 
@@ -382,6 +430,9 @@ func ExitCode(ctx context.Context, cmd *exec.Cmd, err error) (int, error) {
 	// - https://github.com/golang/go/blob/fcb9d6b5d0ba6f5606c2b5dfc09f75e2dc5fc1e5/src/os/exec/lp_unix.go#L35
 	if notFoundErr, ok := err.(*exec.Error); ok {
 		return NoExitCode, status.NotFoundError(notFoundErr.Error())
+	}
+	if status.IsResourceExhaustedError(err) {
+		return NoExitCode, err
 	}
 
 	// If we fail to get the exit code of the process for any other reason, it might

--- a/enterprise/server/remote_execution/commandutil/commandutil_test.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -41,6 +42,20 @@ time.sleep(%f)
 func runSh(ctx context.Context, script string) *interfaces.CommandResult {
 	cmd := &repb.Command{Arguments: []string{"sh", "-c", script}}
 	return commandutil.Run(ctx, cmd, ".", nil /*=statsListener*/, &interfaces.Stdio{})
+}
+
+func echoCommand(msg string) *repb.Command {
+	if runtime.GOOS == "windows" {
+		return &repb.Command{Arguments: []string{"powershell", "-Command", fmt.Sprintf("Write-Output '%s'", msg)}}
+	}
+	return &repb.Command{Arguments: []string{"sh", "-c", fmt.Sprintf("printf '%s\\n'", msg)}}
+}
+
+func printAndSleepCommand(msg string, sleepSeconds int) *repb.Command {
+	if runtime.GOOS == "windows" {
+		return &repb.Command{Arguments: []string{"powershell", "-Command", fmt.Sprintf("Write-Host -NoNewline '%s'; Start-Sleep -Seconds %d", msg, sleepSeconds)}}
+	}
+	return &repb.Command{Arguments: []string{"sh", "-c", fmt.Sprintf("printf '%s' && sleep %d", msg, sleepSeconds)}}
 }
 
 func nopStatsListener(*repb.UsageStats) {}
@@ -124,4 +139,41 @@ func TestLimitStdOutErrWriter(t *testing.T) {
 			assert.Equal(t, tt.wantOut, buf.String())
 		})
 	}
+}
+
+func TestCommandWithOutputLimit(t *testing.T) {
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 10)
+	ctx := context.Background()
+
+	// Command succeeds when within limit
+	result := commandutil.Run(ctx, echoCommand("hello"), ".", nil, &interfaces.Stdio{})
+	assert.Equal(t, 0, result.ExitCode)
+	assert.NoError(t, result.Error)
+
+	// Command fails when exceeding limit
+	result = commandutil.Run(ctx, echoCommand("this is too long"), ".", nil, &interfaces.Stdio{})
+	assert.Equal(t, commandutil.NoExitCode, result.ExitCode)
+	assert.Error(t, result.Error)
+	assert.True(t, status.IsResourceExhaustedError(result.Error), "expected resource exhausted error, got: %v", result.Error)
+	assert.Contains(t, result.Error.Error(), "stdout/stderr output size limit exceeded")
+
+	// Command succeeds when exceeding limit if DisableOutputLimits is set
+	result = commandutil.Run(ctx, echoCommand("this is too long"), ".", nil, &interfaces.Stdio{DisableOutputLimits: true})
+	assert.Equal(t, 0, result.ExitCode)
+	assert.NoError(t, result.Error)
+}
+
+func TestCommandWithOutputLimit_LongRunningCommand(t *testing.T) {
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 10)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Reproduce the original regression: overflow stdout immediately, then
+	// keep the process alive long enough that the runner must interrupt it.
+	result := commandutil.Run(ctx, printAndSleepCommand("12345678901234567890", 30), ".", nil, &interfaces.Stdio{})
+
+	assert.Equal(t, commandutil.NoExitCode, result.ExitCode)
+	require.Error(t, result.Error)
+	assert.True(t, status.IsResourceExhaustedError(result.Error), "expected resource exhausted error, got: %v", result.Error)
+	assert.Nil(t, ctx.Err(), "expected command to fail before the context deadline, got: %v", ctx.Err())
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -380,6 +380,44 @@ func TestFirecrackerRunSimple(t *testing.T) {
 	assertCommandResult(t, expectedResult, res)
 }
 
+// TestLimitedStd tests that the executor enforces a limit on the size of
+// stdout/stderr output from a command, and returns an error if the limit is
+// exceeded.
+func TestLimitedStd(t *testing.T) {
+	ctx := context.Background()
+	env := getTestEnv(ctx, t, envOpts{})
+	rootDir := testfs.MakeTempDir(t)
+	workDir := testfs.MakeDirAll(t, rootDir, "work")
+
+	opts := firecracker.ContainerOpts{
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		VMConfiguration: &fcpb.VMConfiguration{
+			NumCpus:           1,
+			MemSizeMb:         2500,
+			NetworkMode:       fcpb.NetworkMode_NETWORK_MODE_OFF,
+			ScratchDiskSizeMb: 100,
+		},
+		ExecutorConfig: getExecutorConfig(t),
+	}
+	c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 10)
+
+	cmd := &repb.Command{
+		Arguments: []string{"sh", "-c", `echo 'hello world'`},
+	}
+	res := c.Run(ctx, cmd, opts.ActionWorkingDirectory, oci.Credentials{})
+	require.Error(t, res.Error)
+	assert.True(t, status.IsResourceExhaustedError(res.Error), "expected ResourceExhausted error, got %s", res.Error)
+	assert.Contains(t, res.Error.Error(), "stdout/stderr output size limit exceeded")
+	assert.Contains(t, res.Error.Error(), "12 bytes requested")
+	assert.Contains(t, res.Error.Error(), "limit: 10 bytes")
+}
+
 func TestFirecrackerLifecycle(t *testing.T) {
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -1342,34 +1342,78 @@ func (c *ociContainer) invokeRuntime(ctx context.Context, command *repb.Command,
 
 	log.CtxDebugf(ctx, "Running %v", runtimeArgs)
 
-	cmd := exec.CommandContext(ctx, runtimeArgs[0], runtimeArgs[1:]...)
-	cmd.Dir = wd
-	var stdout *bytes.Buffer
-	var stderr *bytes.Buffer
-	// If stdio is nil, the output will be discarded.
-	if stdio != nil {
-		cmd.Stdin = stdio.Stdin
-		if stdio.Stdout == nil {
-			stdout = &bytes.Buffer{}
-			cmd.Stdout = stdout
-			if *commandutil.DebugStreamCommandOutputs {
-				cmd.Stdout = io.MultiWriter(stdout, log.Writer("[crun] "))
-			}
-		} else {
-			stdout = nil
-			cmd.Stdout = stdio.Stdout
-		}
-		if stdio.Stderr == nil {
-			stderr = &bytes.Buffer{}
-			cmd.Stderr = stderr
-			if *commandutil.DebugStreamCommandOutputs {
-				cmd.Stderr = io.MultiWriter(stderr, log.Writer("[crun] "))
-			}
-		} else {
-			stderr = nil
-			cmd.Stderr = stdio.Stderr
+	if stdio == nil {
+		stdio = &interfaces.Stdio{}
+	}
+	outputLimitsEnabled := *commandutil.StdOutErrMaxSize > 0 && !stdio.DisableOutputLimits
+	runCtx := ctx
+	cancelOnOutputLimitExceeded := func(error) {}
+	if outputLimitsEnabled {
+		limitedCtx, cancel := context.WithCancelCause(ctx)
+		var once sync.Once
+		runCtx = limitedCtx
+		defer cancel(nil)
+		cancelOnOutputLimitExceeded = func(err error) {
+			once.Do(func() {
+				cancel(err)
+			})
 		}
 	}
+	onOutputLimitExceeded := cancelOnOutputLimitExceeded
+	if outputLimitsEnabled && len(args) > 0 && args[0] == "exec" && c.cid != "" {
+		var outputLimitOnce sync.Once
+		onOutputLimitExceeded = func(err error) {
+			cancelOnOutputLimitExceeded(err)
+			outputLimitOnce.Do(func() {
+				killCtx, killCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer killCancel()
+				if signalErr := c.Signal(killCtx, syscall.SIGKILL); signalErr != nil {
+					log.CtxWarningf(ctx, "Failed to kill OCI container %q after output limit exceeded: %s", c.cid, signalErr)
+				}
+			})
+		}
+	}
+
+	cmd := exec.CommandContext(runCtx, runtimeArgs[0], runtimeArgs[1:]...)
+	cmd.Dir = wd
+	cmd.Stdin = stdio.Stdin
+	// TODO: Move captured action stdout/stderr to a bounded file-backed sink so
+	// output caps can protect executor memory without depending on in-memory buffers.
+	var stdoutBuf, stderrBuf bytes.Buffer
+	collectStdout := stdio.Stdout == nil
+	collectStderr := stdio.Stderr == nil
+	build := func(primary io.Writer, buf *bytes.Buffer, collect bool) io.Writer {
+		writers := make([]io.Writer, 0, 3)
+		if collect {
+			writers = append(writers, buf)
+		}
+		if primary != nil {
+			writers = append(writers, primary)
+		}
+		if *commandutil.DebugStreamCommandOutputs {
+			writers = append(writers, log.Writer("[crun] "))
+		}
+		switch len(writers) {
+		case 0:
+			if stdio.DisableOutputLimits {
+				return io.Discard
+			}
+			return commandutil.LimitStdOutErrWriterWithCallback(io.Discard, onOutputLimitExceeded)
+		case 1:
+			if stdio.DisableOutputLimits {
+				return writers[0]
+			}
+			return commandutil.LimitStdOutErrWriterWithCallback(writers[0], onOutputLimitExceeded)
+		default:
+			sink := io.MultiWriter(writers...)
+			if stdio.DisableOutputLimits {
+				return sink
+			}
+			return commandutil.LimitStdOutErrWriterWithCallback(sink, onOutputLimitExceeded)
+		}
+	}
+	cmd.Stdout = build(stdio.Stdout, &stdoutBuf, collectStdout)
+	cmd.Stderr = build(stdio.Stderr, &stderrBuf, collectStderr)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	// In the "run" case, start the runtime in its own pid namespace so that
 	// when it is killed, the container process gets killed automatically
@@ -1387,7 +1431,10 @@ func (c *ociContainer) invokeRuntime(ctx context.Context, command *repb.Command,
 		// a risk of shadowing a more important error.
 		runError = nil
 	}
-	code, err := commandutil.ExitCode(ctx, cmd, runError)
+	if cause := context.Cause(runCtx); status.IsResourceExhaustedError(cause) {
+		runError = cause
+	}
+	code, err := commandutil.ExitCode(runCtx, cmd, runError)
 
 	// Some actions are prone to SIGSEGV when running on an executor that is close to its memory limits.
 	// Return a retryable error so we can make sure that the failure is not infrastructure related.
@@ -1401,11 +1448,11 @@ func (c *ociContainer) invokeRuntime(ctx context.Context, command *repb.Command,
 		ExitCode: code,
 		Error:    err,
 	}
-	if stdout != nil {
-		result.Stdout = stdout.Bytes()
+	if collectStdout {
+		result.Stdout = stdoutBuf.Bytes()
 	}
-	if stderr != nil {
-		result.Stderr = stderr.Bytes()
+	if collectStderr {
+		result.Stderr = stderrBuf.Bytes()
 	}
 	return result
 }

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -175,6 +175,211 @@ func TestRun(t *testing.T) {
 	assert.True(t, testfs.Exists(t, wd, "output.txt"), "output.txt should exist")
 }
 
+// TestLimitedStd tests that the executor enforces a limit on the size of
+// stdout/stderr output from a command, and returns an error if the limit is
+// exceeded.
+func TestLimitedStd(t *testing.T) {
+	// OCI Setup
+	setupNetworking(t)
+
+	image := busyboxImage(t)
+
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	installLeaserInEnv(t, env)
+
+	runtimeRoot := testfs.MakeTempDir(t)
+	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
+
+	buildRoot := testfs.MakeTempDir(t)
+	cacheRoot := testfs.MakeTempDir(t)
+
+	provider, err := ociruntime.NewProvider(env, buildRoot, cacheRoot)
+	require.NoError(t, err)
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+
+	c, err := provider.New(ctx, &container.Init{Props: &platform.Properties{
+		ContainerImage: image,
+	}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := c.Remove(ctx)
+		require.NoError(t, err)
+	})
+
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 10)
+
+	// Run
+	cmd := &repb.Command{
+		Arguments: []string{"sh", "-c", `echo 'hello world'`},
+	}
+	res := c.Run(ctx, cmd, wd, oci.Credentials{})
+	require.Error(t, res.Error)
+	assert.True(t, status.IsResourceExhaustedError(res.Error), "expected ResourceExhausted error, got %s", res.Error)
+	assert.Contains(t, res.Error.Error(), "stdout/stderr output size limit exceeded")
+	assert.Contains(t, res.Error.Error(), "12 bytes requested")
+	assert.Contains(t, res.Error.Error(), "limit: 10 bytes")
+}
+
+func TestLimitedStd_LongRunningCommand_Run(t *testing.T) {
+	setupNetworking(t)
+
+	image := busyboxImage(t)
+
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	installLeaserInEnv(t, env)
+
+	runtimeRoot := testfs.MakeTempDir(t)
+	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
+
+	buildRoot := testfs.MakeTempDir(t)
+	cacheRoot := testfs.MakeTempDir(t)
+
+	provider, err := ociruntime.NewProvider(env, buildRoot, cacheRoot)
+	require.NoError(t, err)
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+
+	c, err := provider.New(ctx, &container.Init{Props: &platform.Properties{
+		ContainerImage: image,
+	}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := c.Remove(context.Background())
+		require.NoError(t, err)
+	})
+
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 1)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Trip the output limit first, then keep the container alive so the test
+	// verifies the runtime tears it down instead of waiting for normal exit.
+	cmd := &repb.Command{
+		Arguments: []string{"sh", "-c", `
+			printf buildbuddy
+			sh -c "sleep 1; echo still-running > output.txt" &
+			sleep 600
+		`},
+	}
+	res := c.Run(ctx, cmd, wd, oci.Credentials{})
+
+	require.Error(t, res.Error)
+	assert.True(t, status.IsResourceExhaustedError(res.Error), "expected ResourceExhausted error, got %s", res.Error)
+	assert.Nil(t, ctx.Err(), "expected run to fail before the context deadline, got: %v", ctx.Err())
+
+	// Give the background child enough time to run if cleanup failed.
+	time.Sleep(1500 * time.Millisecond)
+	_, err = os.Stat(filepath.Join(wd, "output.txt"))
+	assert.True(t, os.IsNotExist(err), "expected OCI run command to be terminated after hitting output limit, got err=%v", err)
+}
+
+func TestLimitedStd_LongRunningCommand_Exec(t *testing.T) {
+	setupNetworking(t)
+
+	image := busyboxImage(t)
+
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	installLeaserInEnv(t, env)
+
+	runtimeRoot := testfs.MakeTempDir(t)
+	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
+
+	buildRoot := testfs.MakeTempDir(t)
+	cacheRoot := testfs.MakeTempDir(t)
+
+	provider, err := ociruntime.NewProvider(env, buildRoot, cacheRoot)
+	require.NoError(t, err)
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+
+	c, err := provider.New(ctx, &container.Init{Props: &platform.Properties{
+		ContainerImage: image,
+	}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := c.Remove(context.Background())
+		require.NoError(t, err)
+	})
+
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 1)
+
+	err = c.PullImage(ctx, oci.Credentials{})
+	require.NoError(t, err)
+	err = c.Create(ctx, wd)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	// The background child leaves a marker file behind if the exec path only
+	// cancels output collection and does not actually kill the container work.
+	cmd := &repb.Command{
+		Arguments: []string{"sh", "-c", `
+			printf buildbuddy
+			sh -c "sleep 1; echo still-running > output.txt" &
+			sleep 600
+		`},
+	}
+	res := c.Exec(ctx, cmd, &interfaces.Stdio{})
+
+	require.Error(t, res.Error)
+	assert.True(t, status.IsResourceExhaustedError(res.Error), "expected ResourceExhausted error, got %s", res.Error)
+	assert.Nil(t, ctx.Err(), "expected exec to fail before the context deadline, got: %v", ctx.Err())
+
+	// Give the background child enough time to run if cleanup failed.
+	time.Sleep(1500 * time.Millisecond)
+	_, err = os.Stat(filepath.Join(wd, "output.txt"))
+	assert.True(t, os.IsNotExist(err), "expected OCI exec command to be terminated after hitting output limit, got err=%v", err)
+}
+
+// TestDisableOutputLimits_Exec verifies that when DisableOutputLimits is set
+// on stdio, large outputs do not trigger a ResourceExhausted error for OCI exec.
+func TestDisableOutputLimits_Exec(t *testing.T) {
+	setupNetworking(t)
+
+	image := busyboxImage(t)
+
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	installLeaserInEnv(t, env)
+
+	runtimeRoot := testfs.MakeTempDir(t)
+	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
+
+	buildRoot := testfs.MakeTempDir(t)
+	cacheRoot := testfs.MakeTempDir(t)
+
+	provider, err := ociruntime.NewProvider(env, buildRoot, cacheRoot)
+	require.NoError(t, err)
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+
+	c, err := provider.New(ctx, &container.Init{Props: &platform.Properties{
+		ContainerImage: image,
+	}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = c.Remove(ctx)
+	})
+
+	// Small limit globally, but disabled at stdio level
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 10)
+
+	// Pull and create before exec
+	err = c.PullImage(ctx, oci.Credentials{})
+	require.NoError(t, err)
+	err = c.Create(ctx, wd)
+	require.NoError(t, err)
+
+	// Produce >10B of stdout
+	cmd := &repb.Command{Arguments: []string{"sh", "-c", `echo 'hello world'`}}
+	stdio := &interfaces.Stdio{DisableOutputLimits: true}
+	res := c.Exec(ctx, cmd, stdio)
+
+	require.NoError(t, res.Error)
+	assert.Equal(t, 0, res.ExitCode)
+	assert.Equal(t, "hello world\n", string(res.Stdout))
+}
+
 func TestCgroupSettings(t *testing.T) {
 	setupNetworking(t)
 
@@ -1828,7 +2033,10 @@ func TestPersistentWorker_WorkerCrashesAfterReadingRequest(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	defer worker.Stop()
+	t.Cleanup(func() {
+		err := worker.Stop()
+		require.NoError(t, err)
+	})
 
 	// Send work request.
 	// The command doesn't matter - the test worker always just returns a fixed

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -48,6 +48,7 @@ go_test(
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/util/platform",
+        "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -49,6 +49,7 @@ go_test(
         "//server/testutil/testfs",
         "//server/util/platform",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -643,6 +643,10 @@ func (c *podmanCommandContainer) pullImage(ctx context.Context, creds oci.Creden
 	// corrupted storage.  More details see https://github.com/containers/storage/issues/1136.
 	pullCtx, cancel := context.WithTimeout(c.env.GetServerContext(), *pullTimeout)
 	defer cancel()
+	// TODO: Switch this internal diagnostic capture to a bounded file-backed sink.
+	// We intentionally do not exempt podman pull logs from the output cap in
+	// this change, because leaving this shared in-memory buffer unbounded risks
+	// executor OOMs on noisy/corrupt image pulls.
 	output := lockingbuffer.New()
 	stdio := &interfaces.Stdio{Stderr: output, Stdout: output}
 	if *podmanPullLogLevel != "" {
@@ -734,7 +738,25 @@ func runPodman(ctx context.Context, commandRunner interfaces.CommandRunner, podm
 	command = append(command, args...)
 	// Note: we don't collect stats on the podman process, and instead use
 	// cgroups for stats accounting.
-	result := commandRunner.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, nil /*=statsListener*/, stdio)
+	// Ensure output limits are enforced even if the underlying CommandRunner
+	// does not apply them (for example, in tests with a custom runner). Respect
+	// DisableOutputLimits if set by the caller.
+	wrapped := stdio
+	if wrapped == nil {
+		wrapped = &interfaces.Stdio{}
+	}
+	if !wrapped.DisableOutputLimits {
+		// Copy to avoid mutating the caller's struct.
+		s := &interfaces.Stdio{Stdin: wrapped.Stdin, Stdout: wrapped.Stdout, Stderr: wrapped.Stderr, DisableOutputLimits: wrapped.DisableOutputLimits}
+		if s.Stdout != nil {
+			s.Stdout = commandutil.LimitStdOutErrWriter(s.Stdout)
+		}
+		if s.Stderr != nil {
+			s.Stderr = commandutil.LimitStdOutErrWriter(s.Stderr)
+		}
+		wrapped = s
+	}
+	result := commandRunner.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, nil /*=statsListener*/, wrapped)
 
 	// If the disk is under heavy load, podman may fail with "database is
 	// locked". Detect these and return a retryable error.

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -493,6 +493,15 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, st
 	res := c.doWithStatsTracking(ctx, func(ctx context.Context) *interfaces.CommandResult {
 		return c.runPodman(ctx, "exec", stdio, podmanRunArgs...)
 	})
+	if status.IsResourceExhaustedError(res.Error) {
+		// Killing the local `podman exec` client is not enough to stop the
+		// command running inside the container. Remove the container so the exec
+		// process cannot keep mutating the workspace after we return the limit
+		// error to the runner.
+		if err := c.killContainerIfRunning(ctx); err != nil {
+			log.Warningf("Failed to stop podman container after output limit exceeded: %s", err)
+		}
+	}
 	// Podman doesn't provide a way to find out whether an exec process was
 	// killed. Instead, `podman exec` returns 137 (= 128 + SIGKILL(9)). However,
 	// this exit code is also valid as a regular exit code returned by a command

--- a/enterprise/server/remote_execution/containers/podman/podman_test.go
+++ b/enterprise/server/remote_execution/containers/podman/podman_test.go
@@ -1,8 +1,10 @@
 package podman_test
 
 import (
+	"bytes"
 	"context"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,6 +18,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -86,6 +89,35 @@ func isPodmanSubcommand(command []string, sub string) bool {
 	i1 := slices.Index(command, "podman")
 	i2 := slices.Index(command, sub)
 	return i1 >= 0 && i2 > i1
+}
+
+type OutputCommandRunner struct{}
+
+func (r *OutputCommandRunner) Run(_ context.Context, command *repb.Command, _ string, _ func(*repb.UsageStats), stdio *interfaces.Stdio) *interfaces.CommandResult {
+	// Satisfy version probe performed by NewProvider.
+	if isPodmanVersionCommand(command.GetArguments()) {
+		if stdio != nil && stdio.Stdout != nil {
+			stdio.Stdout.Write([]byte("1.0.0"))
+		}
+		return &interfaces.CommandResult{ExitCode: 0}
+	}
+	// Allow image pull to succeed quietly.
+	if isPodmanSubcommand(command.GetArguments(), "pull") || isPodmanSubcommand(command.GetArguments(), "image") {
+		return &interfaces.CommandResult{ExitCode: 0}
+	}
+	if isPodmanSubcommand(command.GetArguments(), "run") || isPodmanSubcommand(command.GetArguments(), "exec") {
+		var err error
+		if stdio != nil && stdio.Stdout != nil {
+			// One big write over the limit triggers ResourceExhausted when
+			// runPodman wraps the sink with the shared limit writer.
+			_, err = stdio.Stdout.Write([]byte(strings.Repeat("X", 200)))
+		}
+		if err != nil {
+			return &interfaces.CommandResult{ExitCode: -2, Error: err}
+		}
+		return &interfaces.CommandResult{ExitCode: 0}
+	}
+	return &interfaces.CommandResult{ExitCode: 0}
 }
 
 // TrackingOutputCommandRunner records podman subcommands so the test can
@@ -190,6 +222,57 @@ func TestPodmanExec_OutputLimit_KillsContainer(t *testing.T) {
 	require.NotEqual(t, -1, execIndex, "expected podman exec to be invoked; subcommands: %v", subcommands)
 	require.NotEqual(t, -1, rmIndex, "expected podman rm after exec overflow; subcommands: %v", subcommands)
 	assert.Greater(t, rmIndex, execIndex, "expected podman rm after exec overflow; subcommands: %v", subcommands)
+}
+
+func TestPodmanExec_OutputLimit_UsesWrappedStdio(t *testing.T) {
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 10)
+
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	env.SetCommandRunner(&OutputCommandRunner{})
+
+	buildRoot := testfs.MakeTempDir(t)
+	provider, err := podman.NewProvider(env, buildRoot)
+	require.NoError(t, err)
+
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+	props := &platform.Properties{ContainerImage: "docker.io/library/busybox", DockerNetwork: "off"}
+	c, err := provider.New(ctx, &container.Init{Props: props})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Create(ctx, wd))
+
+	var out bytes.Buffer
+	res := c.Exec(ctx, &repb.Command{Arguments: []string{"echo", "hi"}}, &interfaces.Stdio{Stdout: &out})
+
+	require.Error(t, res.Error)
+	assert.True(t, status.IsResourceExhaustedError(res.Error), "expected ResourceExhausted, got: %v", res.Error)
+}
+
+func TestPodmanExec_DisableOutputLimits(t *testing.T) {
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 10)
+
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	env.SetCommandRunner(&OutputCommandRunner{})
+
+	buildRoot := testfs.MakeTempDir(t)
+	provider, err := podman.NewProvider(env, buildRoot)
+	require.NoError(t, err)
+
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+	props := &platform.Properties{ContainerImage: "docker.io/library/busybox", DockerNetwork: "off"}
+	c, err := provider.New(ctx, &container.Init{Props: props})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Create(ctx, wd))
+
+	var out bytes.Buffer
+	res := c.Exec(ctx, &repb.Command{Arguments: []string{"echo", "hi"}}, &interfaces.Stdio{Stdout: &out, DisableOutputLimits: true})
+
+	require.NoError(t, res.Error)
+	assert.Equal(t, 0, res.ExitCode)
+	assert.GreaterOrEqual(t, out.Len(), 200)
 }
 
 func TestImageExists(t *testing.T) {

--- a/enterprise/server/remote_execution/containers/podman/podman_test.go
+++ b/enterprise/server/remote_execution/containers/podman/podman_test.go
@@ -3,6 +3,7 @@ package podman_test
 import (
 	"context"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -78,6 +80,116 @@ func isPodmanVersionCommand(command []string) bool {
 	i1 := slices.Index(command, "podman")
 	i2 := slices.Index(command, "version")
 	return i1 >= 0 && i2 > i1
+}
+
+func isPodmanSubcommand(command []string, sub string) bool {
+	i1 := slices.Index(command, "podman")
+	i2 := slices.Index(command, sub)
+	return i1 >= 0 && i2 > i1
+}
+
+// TrackingOutputCommandRunner records podman subcommands so the test can
+// verify that an overflowing exec escalates to podman rm.
+type TrackingOutputCommandRunner struct {
+	mu          sync.Mutex
+	subcommands []string
+}
+
+func (r *TrackingOutputCommandRunner) record(subcommand string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.subcommands = append(r.subcommands, subcommand)
+}
+
+func (r *TrackingOutputCommandRunner) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.subcommands...)
+}
+
+func (r *TrackingOutputCommandRunner) Run(_ context.Context, command *repb.Command, _ string, _ func(*repb.UsageStats), stdio *interfaces.Stdio) *interfaces.CommandResult {
+	args := command.GetArguments()
+
+	switch {
+	case isPodmanVersionCommand(args):
+		r.record("version")
+		if stdio != nil && stdio.Stdout != nil {
+			stdio.Stdout.Write([]byte("1.0.0"))
+		}
+		return &interfaces.CommandResult{ExitCode: 0}
+	case isPodmanSubcommand(args, "create"):
+		r.record("create")
+		return &interfaces.CommandResult{ExitCode: 0}
+	case isPodmanSubcommand(args, "start"):
+		r.record("start")
+		return &interfaces.CommandResult{ExitCode: 0}
+	case isPodmanSubcommand(args, "rm"):
+		r.record("rm")
+		return &interfaces.CommandResult{ExitCode: 0}
+	case isPodmanSubcommand(args, "exec"):
+		r.record("exec")
+		return &interfaces.CommandResult{
+			ExitCode: -2,
+			Error:    status.ResourceExhaustedError("stdout/stderr output size limit exceeded"),
+		}
+	default:
+		return &interfaces.CommandResult{ExitCode: 0}
+	}
+}
+
+func TestPodmanExec_OutputLimit(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	env.SetCommandRunner(&TrackingOutputCommandRunner{})
+
+	buildRoot := testfs.MakeTempDir(t)
+	provider, err := podman.NewProvider(env, buildRoot)
+	require.NoError(t, err)
+
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+	props := &platform.Properties{ContainerImage: "docker.io/library/busybox", DockerNetwork: "off"}
+	c, err := provider.New(ctx, &container.Init{Props: props})
+	require.NoError(t, err)
+
+	// Create container so we can Exec with custom stdio.
+	require.NoError(t, c.Create(ctx, wd))
+
+	res := c.Exec(ctx, &repb.Command{Arguments: []string{"echo", "hi"}}, &interfaces.Stdio{})
+
+	require.Error(t, res.Error)
+	assert.True(t, status.IsResourceExhaustedError(res.Error), "expected ResourceExhausted, got: %v", res.Error)
+}
+
+func TestPodmanExec_OutputLimit_KillsContainer(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	commandRunner := &TrackingOutputCommandRunner{}
+	env.SetCommandRunner(commandRunner)
+
+	buildRoot := testfs.MakeTempDir(t)
+	provider, err := podman.NewProvider(env, buildRoot)
+	require.NoError(t, err)
+
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+	props := &platform.Properties{ContainerImage: "docker.io/library/busybox", DockerNetwork: "off"}
+	c, err := provider.New(ctx, &container.Init{Props: props})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Create(ctx, wd))
+
+	res := c.Exec(ctx, &repb.Command{Arguments: []string{"echo", "hi"}}, &interfaces.Stdio{})
+
+	require.Error(t, res.Error)
+	assert.True(t, status.IsResourceExhaustedError(res.Error), "expected ResourceExhausted, got: %v", res.Error)
+
+	// podman exec itself is not sufficient here; the overflow path should also
+	// remove the container so the in-container process stops running.
+	subcommands := commandRunner.snapshot()
+	execIndex := slices.Index(subcommands, "exec")
+	rmIndex := slices.Index(subcommands, "rm")
+	require.NotEqual(t, -1, execIndex, "expected podman exec to be invoked; subcommands: %v", subcommands)
+	require.NotEqual(t, -1, rmIndex, "expected podman rm after exec overflow; subcommands: %v", subcommands)
+	assert.Greater(t, rmIndex, execIndex, "expected podman rm after exec overflow; subcommands: %v", subcommands)
 }
 
 func TestImageExists(t *testing.T) {

--- a/enterprise/server/remote_execution/persistentworker/persistentworker.go
+++ b/enterprise/server/remote_execution/persistentworker/persistentworker.go
@@ -143,6 +143,9 @@ func Start(ctx context.Context, workspace *workspace.Workspace, container contai
 			Stdin:  stdinReader,
 			Stdout: stdoutWriter,
 			Stderr: stderr,
+			// Persistent workers currently opt out of stdout/stderr limits; add
+			// dedicated worker protocol limits separately.
+			DisableOutputLimits: true,
 		}
 		res := w.container.Exec(ctx, command, stdio)
 		w.workerStatus = res

--- a/enterprise/server/remote_execution/vmexec_client/BUILD
+++ b/enterprise/server/remote_execution/vmexec_client/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -19,5 +19,24 @@ go_library(
         "//server/util/tracing",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "vmexec_client_test",
+    srcs = ["vmexec_client_test.go"],
+    deps = [
+        ":vmexec_client",
+        "//enterprise/server/remote_execution/commandutil",
+        "//proto:remote_execution_go_proto",
+        "//proto:vmexec_go_proto",
+        "//server/interfaces",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//test/bufconn",
     ],
 )

--- a/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
+++ b/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
@@ -40,23 +40,49 @@ var (
 func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, workDir, user string, statsListener procstats.Listener, stdio *interfaces.Stdio) *interfaces.CommandResult {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
+	ctx, cancelExec := context.WithCancelCause(ctx)
+	defer cancelExec(nil)
 
-	var stderr, stdout bytes.Buffer
 	if stdio == nil {
 		stdio = &interfaces.Stdio{}
 	}
-	stdoutw := io.Writer(&stdout)
-	if stdio.Stdout != nil {
-		stdoutw = stdio.Stdout
+	var stdoutBuf, stderrBuf bytes.Buffer
+	makeWriter := func(primary io.Writer, buf *bytes.Buffer, collect bool, extras ...io.Writer) io.Writer {
+		writers := make([]io.Writer, 0, 2+len(extras))
+		if collect {
+			writers = append(writers, buf)
+		}
+		if primary != nil {
+			writers = append(writers, primary)
+		}
+		writers = append(writers, extras...)
+		switch len(writers) {
+		case 0:
+			if stdio.DisableOutputLimits {
+				return io.Discard
+			}
+			return commandutil.LimitStdOutErrWriter(io.Discard)
+		case 1:
+			if stdio.DisableOutputLimits {
+				return writers[0]
+			}
+			return commandutil.LimitStdOutErrWriter(writers[0])
+		default:
+			sink := io.MultiWriter(writers...)
+			if stdio.DisableOutputLimits {
+				return sink
+			}
+			return commandutil.LimitStdOutErrWriter(sink)
+		}
 	}
-	stderrw := io.Writer(&stderr)
-	if stdio.Stderr != nil {
-		stderrw = stdio.Stderr
-	}
+	extraStdout := []io.Writer{}
+	extraStderr := []io.Writer{}
 	if *commandutil.DebugStreamCommandOutputs {
-		stdoutw = io.MultiWriter(os.Stdout, stdoutw)
-		stderrw = io.MultiWriter(os.Stderr, stderrw)
+		extraStdout = append(extraStdout, os.Stdout)
+		extraStderr = append(extraStderr, os.Stderr)
 	}
+	stdoutw := makeWriter(stdio.Stdout, &stdoutBuf, stdio.Stdout == nil, extraStdout...)
+	stderrw := makeWriter(stdio.Stderr, &stderrBuf, stdio.Stderr == nil, extraStderr...)
 	req := &vmxpb.ExecRequest{
 		WorkingDirectory: workDir,
 		User:             user,
@@ -79,7 +105,7 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 	}
 	var res *vmxpb.ExecResponse
 	var stats *repb.UsageStats
-	eg, ctx := errgroup.WithContext(ctx)
+	eg, egCtx := errgroup.WithContext(ctx)
 	if stdio.Stdin != nil {
 		eg.Go(func() error {
 			if _, err := io.Copy(&stdinWriter{stream}, stdio.Stdin); err != nil {
@@ -97,7 +123,7 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 	}
 
 	eg.Go(func() error {
-		receiver := rpcutil.NewReceiver[*vmxpb.ExecStreamedResponse](ctx, stream)
+		receiver := rpcutil.NewReceiver[*vmxpb.ExecStreamedResponse](egCtx, stream)
 		for {
 			msg, err := receiver.RecvWithTimeoutCause(streamRecvTimeout, errRecvTimeout)
 			if err == io.EOF {
@@ -113,18 +139,28 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 				return err
 			}
 			if err != nil {
-				if ctx.Err() == context.DeadlineExceeded {
+				if egCtx.Err() == context.DeadlineExceeded {
 					return status.DeadlineExceededError("context deadline exceeded")
 				}
-				if ctx.Err() == context.Canceled {
+				if egCtx.Err() == context.Canceled {
 					return status.CanceledError("context canceled")
 				}
 				return status.UnavailableErrorf("failed to receive from stream: %s", status.Message(err))
 			}
 			if _, err := stdoutw.Write(msg.Stdout); err != nil {
+				if status.IsResourceExhaustedError(err) {
+					err = status.WrapError(err, "failed to write stdout")
+					cancelExec(err)
+					return err
+				}
 				return status.UnavailableErrorf("failed to write stdout: %s", status.Message(err))
 			}
 			if _, err := stderrw.Write(msg.Stderr); err != nil {
+				if status.IsResourceExhaustedError(err) {
+					err = status.WrapError(err, "failed to write stderr")
+					cancelExec(err)
+					return err
+				}
 				return status.UnavailableErrorf("failed to write stderr: %s", status.Message(err))
 			}
 			if msg.Response != nil {
@@ -140,14 +176,25 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 	})
 
 	err = eg.Wait()
+	if cause := context.Cause(ctx); status.IsResourceExhaustedError(cause) {
+		err = cause
+	}
 	exitCode := commandutil.NoExitCode
 	if res != nil {
 		exitCode = int(res.GetExitCode())
 	}
+	stdoutBytes := stdoutBuf.Bytes()
+	stderrBytes := stderrBuf.Bytes()
+	if stdio.Stdout != nil {
+		stdoutBytes = nil
+	}
+	if stdio.Stderr != nil {
+		stderrBytes = nil
+	}
 	result := &interfaces.CommandResult{
 		ExitCode:   exitCode,
-		Stderr:     stderr.Bytes(),
-		Stdout:     stdout.Bytes(),
+		Stderr:     stderrBytes,
+		Stdout:     stdoutBytes,
 		Error:      err,
 		UsageStats: stats,
 	}
@@ -155,9 +202,12 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 	// terminated, but if the context was cancelled then the Sync() call may not
 	// have completed yet. Explicitly sync here so that we have a better chance
 	// of collecting output files in this case.
-	if err := ctx.Err(); err != nil {
-		ctxErr := status.FromContextError(ctx)
-		ctx, cancel := background.ExtendContextForFinalization(ctx, syncTimeout)
+	if err := egCtx.Err(); err != nil {
+		ctxErr := status.FromContextError(egCtx)
+		if cause := context.Cause(ctx); status.IsResourceExhaustedError(cause) {
+			ctxErr = cause
+		}
+		ctx, cancel := background.ExtendContextForFinalization(egCtx, syncTimeout)
 		defer cancel()
 		_, err := client.Sync(ctx, &vmxpb.SyncRequest{})
 		if err != nil {

--- a/enterprise/server/remote_execution/vmexec_client/vmexec_client_test.go
+++ b/enterprise/server/remote_execution/vmexec_client/vmexec_client_test.go
@@ -1,0 +1,108 @@
+package vmexec_client_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vmexec_client"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	vmxpb "github.com/buildbuddy-io/buildbuddy/proto/vmexec"
+)
+
+const bufConnSize = 1024 * 1024
+
+type blockingExecServer struct {
+	vmxpb.UnimplementedExecServer
+
+	streamCanceled chan struct{}
+	syncCalled     chan struct{}
+}
+
+func (s *blockingExecServer) ExecStreamed(stream grpc.BidiStreamingServer[vmxpb.ExecStreamedRequest, vmxpb.ExecStreamedResponse]) error {
+	msg, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if msg.GetStart() == nil {
+		return status.InvalidArgumentError("missing exec start request")
+	}
+	// Send one oversized stdout chunk, then keep the stream open until the
+	// client cancels it.
+	if err := stream.Send(&vmxpb.ExecStreamedResponse{Stdout: []byte("1234567890")}); err != nil {
+		return err
+	}
+	<-stream.Context().Done()
+	close(s.streamCanceled)
+	return stream.Context().Err()
+}
+
+func (s *blockingExecServer) Sync(ctx context.Context, req *vmxpb.SyncRequest) (*vmxpb.SyncResponse, error) {
+	close(s.syncCalled)
+	return &vmxpb.SyncResponse{}, nil
+}
+
+func TestExecute_CancelsStreamOnOutputLimit(t *testing.T) {
+	flags.Set(t, "executor.stdouterr_max_size_bytes", 1)
+
+	lis := bufconn.Listen(bufConnSize)
+	server := grpc.NewServer()
+	execServer := &blockingExecServer{
+		streamCanceled: make(chan struct{}),
+		syncCalled:     make(chan struct{}),
+	}
+	vmxpb.RegisterExecServer(server, execServer)
+	go func() { _ = server.Serve(lis) }()
+	t.Cleanup(server.Stop)
+
+	conn, err := grpc.DialContext(
+		t.Context(),
+		"bufnet",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	result := vmexec_client.Execute(
+		t.Context(),
+		vmxpb.NewExecClient(conn),
+		&repb.Command{Arguments: []string{"sh", "-c", "echo ignored"}},
+		"/workspace",
+		"",
+		nil, /*=statsListener*/
+		&interfaces.Stdio{},
+	)
+
+	require.Error(t, result.Error)
+	assert.Equal(t, commandutil.NoExitCode, result.ExitCode)
+	assert.True(t, status.IsResourceExhaustedError(result.Error), "expected ResourceExhaustedError, got %v", result.Error)
+
+	// Execute should cancel the stream before returning the limit error, then
+	// sync the guest filesystem as part of interruption cleanup.
+	select {
+	case <-execServer.streamCanceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected Execute to cancel the vmexec stream before returning output-limit error")
+	}
+	select {
+	case <-execServer.syncCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected Execute to sync the guest filesystem after interrupting execution")
+	}
+}

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//server/testutil/testfs",
         "//server/util/disk",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1187,6 +1187,8 @@ type Stdio struct {
 	Stdout io.Writer
 	// Stderr is an optional stderr sink for the executed process.
 	Stderr io.Writer
+	// DisableOutputLimits prevents any output limits from being enforced.
+	DisableOutputLimits bool
 }
 
 // CommandResult captures the output and details of an executed command.


### PR DESCRIPTION
Bound buffered action stdout/stderr so oversized output returns
RESOURCE_EXHAUSTED instead of growing unbounded executor
memory.

Apply the fail-fast cleanup to the local bare path and the Docker,
Podman, OCI, and Firecracker/vmexec isolation modes so capped
commands do not sit until timeout or keep mutating workspaces
during finalization. This keeps overflowing actions from pinning
executor slots after the runner has already decided to fail them.

Keep DisableOutputLimits as the explicit opt-out, and use it for
persistentworker until a future PR adds worker-protocol-specific
limits.

Teach Podman exec to remove the container after an output-limit
error, since killing the local podman client does not stop the
in-container process. Keep podman pull diagnostics on the capped
in-memory path for now to avoid executor OOMs; the longer-term
fix is bounded file-backed capture.

Add regression tests for Docker exit-code consistency,
long-running overflow, vmexec stream cancellation, and Podman
exec cleanup, and leave TODOs to move these captures to bounded
file-backed sinks.

Replace #9978
