### PR TITLE
invocation: truncate long target patterns

### DIFF
--- a/app/compare/compare_invocations.tsx
+++ b/app/compare/compare_invocations.tsx
@@ -49,7 +49,7 @@ const FACETS = [
     link: (i?: InvocationModel) => `/invocation/${i?.getInvocationId()}`,
   },
   { name: "Command", facet: (i?: InvocationModel) => i?.getCommand() },
-  { name: "Pattern", facet: (i?: InvocationModel) => i?.getPattern() },
+  { name: "Pattern", facet: (i?: InvocationModel) => i?.getTruncatedPatterns() },
   { name: "Exit code", facet: (i?: InvocationModel) => i?.invocation.bazelExitCode.toLowerCase() },
   { name: "Start date", facet: (i?: InvocationModel) => i?.getFormattedStartedDate() },
   { name: "Duration", facet: (i?: InvocationModel) => i?.getHumanReadableDuration() },

--- a/app/format/BUILD
+++ b/app/format/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "//:node_modules/date-fns",
         "//:node_modules/long",
         "//:node_modules/moment",
+        "//:node_modules/tslib",
         "//app/util:proto",
         "//proto:duration_ts_proto",
     ],

--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -229,11 +229,56 @@ export function sentenceCase(string: string) {
   return string[0].toUpperCase() + string.slice(1);
 }
 
+const ELLIPSIS = "...";
+const MIN_TARGET_PATH_SEGMENTS_TO_COMPACT = 3;
+const DEFAULT_TARGET_PATTERN_PREVIEW_MAX_ITEMS = 3;
+const DEFAULT_TARGET_PATTERN_PREVIEW_MAX_LENGTH = 40;
+
 export function truncateList(list: string[]) {
   if (list.length > 3) {
     return `${list.slice(0, 3).join(", ")} and ${list.length - 3} more`;
   }
   return list.join(", ");
+}
+
+function truncateTargetPatternList(
+  list: string[],
+  {
+    maxItems = DEFAULT_TARGET_PATTERN_PREVIEW_MAX_ITEMS,
+    maxItemLength = DEFAULT_TARGET_PATTERN_PREVIEW_MAX_LENGTH,
+  }: { maxItems?: number; maxItemLength?: number } = {}
+) {
+  const preview = list.slice(0, maxItems).map((pattern) => {
+    let display = pattern;
+
+    // Keep Bazel labels readable by preserving the repo prefix, first package
+    // segment, last package segment, and target name before falling back to a
+    // plain text truncation if the result is still too long.
+    const match = pattern.match(/^([+-]?)(@@?[^/]+)?\/\/([^:]*)(?::(.+))?$/);
+    if (match) {
+      const [, prefix = "", repo = "", packagePath = "", targetName] = match;
+      if (packagePath && !packagePath.includes("...")) {
+        const segments = packagePath.split("/").filter(Boolean);
+        if (segments.length >= MIN_TARGET_PATH_SEGMENTS_TO_COMPACT) {
+          display = `${prefix}${repo}//${segments[0]}/${ELLIPSIS}/${segments[segments.length - 1]}${
+            targetName ? `:${targetName}` : ""
+          }`;
+        }
+      }
+    }
+
+    if (display.length <= maxItemLength) {
+      return display;
+    }
+    if (maxItemLength <= ELLIPSIS.length) {
+      return display.slice(0, maxItemLength);
+    }
+    return `${display.slice(0, maxItemLength - ELLIPSIS.length)}${ELLIPSIS}`;
+  });
+  if (list.length > maxItems) {
+    return `${preview.join(", ")} and ${list.length - maxItems} more`;
+  }
+  return preview.join(", ");
 }
 
 /** Unix epoch expressed in local time. */
@@ -431,6 +476,7 @@ export default {
   bitsPerSecond,
   count,
   truncateList,
+  truncateTargetPatternList,
   formatDate,
   formatTimestampUsec,
   formatTimestampMillis,

--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -232,7 +232,7 @@ export function sentenceCase(string: string) {
 const ELLIPSIS = "...";
 const MIN_TARGET_PATH_SEGMENTS_TO_COMPACT = 3;
 const DEFAULT_TARGET_PATTERN_PREVIEW_MAX_ITEMS = 3;
-const DEFAULT_TARGET_PATTERN_PREVIEW_MAX_LENGTH = 40;
+const DEFAULT_TARGET_PATTERN_PREVIEW_MAX_LENGTH = 200;
 
 export function truncateList(list: string[]) {
   if (list.length > 3) {
@@ -251,18 +251,20 @@ function truncateTargetPatternList(
   const preview = list.slice(0, maxItems).map((pattern) => {
     let display = pattern;
 
-    // Keep Bazel labels readable by preserving the repo prefix, first package
-    // segment, last package segment, and target name before falling back to a
-    // plain text truncation if the result is still too long.
-    const match = pattern.match(/^([+-]?)(@@?[^/]+)?\/\/([^:]*)(?::(.+))?$/);
-    if (match) {
-      const [, prefix = "", repo = "", packagePath = "", targetName] = match;
-      if (packagePath && !packagePath.includes("...")) {
-        const segments = packagePath.split("/").filter(Boolean);
-        if (segments.length >= MIN_TARGET_PATH_SEGMENTS_TO_COMPACT) {
-          display = `${prefix}${repo}//${segments[0]}/${ELLIPSIS}/${segments[segments.length - 1]}${
-            targetName ? `:${targetName}` : ""
-          }`;
+    if (display.length > maxItemLength) {
+      // Keep oversized Bazel labels readable by preserving the repo prefix,
+      // first package segment, last package segment, and target name before
+      // falling back to a plain text truncation if the result is still too long.
+      const match = pattern.match(/^([+-]?)(@@?[^/]+)?\/\/([^:]*)(?::(.+))?$/);
+      if (match) {
+        const [, prefix = "", repo = "", packagePath = "", targetName] = match;
+        if (packagePath && !packagePath.includes("...")) {
+          const segments = packagePath.split("/").filter(Boolean);
+          if (segments.length >= MIN_TARGET_PATH_SEGMENTS_TO_COMPACT) {
+            display = `${prefix}${repo}//${segments[0]}/${ELLIPSIS}/${segments[segments.length - 1]}${
+              targetName ? `:${targetName}` : ""
+            }`;
+          }
         }
       }
     }

--- a/app/format/format_test.ts
+++ b/app/format/format_test.ts
@@ -148,3 +148,38 @@ describe("count", () => {
     expect(format.count(1e9)).toEqual("1B");
   });
 });
+
+describe("truncateTargetPatternList", () => {
+  it("keeps short labels unchanged", () => {
+    expect(format.truncateTargetPatternList(["//app/invocation:format_test"])).toEqual("//app/invocation:format_test");
+  });
+
+  it("collapses deep bazel labels to first and last package segments", () => {
+    expect(format.truncateTargetPatternList(["//a/really/long/target:pattern"])).toEqual("//a/.../target:pattern");
+  });
+
+  it("preserves repo prefixes while collapsing deep labels", () => {
+    expect(format.truncateTargetPatternList(["@repo//a/really/long/target:pattern"])).toEqual(
+      "@repo//a/.../target:pattern"
+    );
+  });
+
+  it("falls back to text truncation when the target name is still too long", () => {
+    expect(
+      format.truncateTargetPatternList(["//a/really/long/target:pattern_name_that_still_needs_truncation"], {
+        maxItemLength: 30,
+      })
+    ).toEqual("//a/.../target:pattern_name...");
+  });
+
+  it("truncates item count and long labels together", () => {
+    expect(
+      format.truncateTargetPatternList([
+        "//a/really/long/target:pattern",
+        "//app/invocation:format_test",
+        "//foo/bar:baz",
+        "//one/more:target",
+      ])
+    ).toEqual("//a/.../target:pattern, //app/invocation:format_test, //foo/bar:baz and 1 more");
+  });
+});

--- a/app/format/format_test.ts
+++ b/app/format/format_test.ts
@@ -154,14 +154,26 @@ describe("truncateTargetPatternList", () => {
     expect(format.truncateTargetPatternList(["//app/invocation:format_test"])).toEqual("//app/invocation:format_test");
   });
 
-  it("collapses deep bazel labels to first and last package segments", () => {
-    expect(format.truncateTargetPatternList(["//a/really/long/target:pattern"])).toEqual("//a/.../target:pattern");
+  it("keeps readable deep bazel labels unchanged", () => {
+    expect(format.truncateTargetPatternList(["//a/really/long/target:pattern"])).toEqual(
+      "//a/really/long/target:pattern"
+    );
   });
 
-  it("preserves repo prefixes while collapsing deep labels", () => {
-    expect(format.truncateTargetPatternList(["@repo//a/really/long/target:pattern"])).toEqual(
-      "@repo//a/.../target:pattern"
-    );
+  it("collapses oversized deep bazel labels to first and last package segments", () => {
+    expect(
+      format.truncateTargetPatternList(["@repo//a/really/long/target:pattern"], {
+        maxItemLength: 30,
+      })
+    ).toEqual("@repo//a/.../target:pattern");
+  });
+
+  it("collapses labels longer than the default limit", () => {
+    expect(
+      format.truncateTargetPatternList([
+        "//app/invocation/components/history/target/patterns/with/a/very/deep/package/path/that/would/otherwise/render/past/the/available/space/in/the/history/page/and/keep/going/for/more/segments/near/the/end/of/a/very/long/package:target",
+      ])
+    ).toEqual("//app/.../package:target");
   });
 
   it("falls back to text truncation when the target name is still too long", () => {
@@ -180,6 +192,6 @@ describe("truncateTargetPatternList", () => {
         "//foo/bar:baz",
         "//one/more:target",
       ])
-    ).toEqual("//a/.../target:pattern, //app/invocation:format_test, //foo/bar:baz and 1 more");
+    ).toEqual("//a/really/long/target:pattern, //app/invocation:format_test, //foo/bar:baz and 1 more");
   });
 });

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -159,7 +159,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
 
     // Update title and favicon
     if (this.state.model) {
-      document.title = `${this.state.model.getUserPossessivePrefix()}${this.state.model.getCommand()} ${this.state.model.getPattern()} | BuildBuddy`;
+      document.title = `${this.state.model.getUserPossessivePrefix()}${this.state.model.getCommand()} ${this.state.model.getTruncatedPatterns()} | BuildBuddy`;
       faviconService.setFaviconForType(this.state.model.getFaviconType());
     }
     // If in progress or queued, schedule another fetch of the invocation (and

--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -115,7 +115,7 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
               <>
                 <div className="invocation-section">
                   <div className="invocation-section-title">Pattern</div>
-                  <div title={this.props.model.getAllPatterns()}>{this.props.model.getPattern()}</div>
+                  <div title={this.props.model.getAllPatterns()}>{this.props.model.getTruncatedPatterns()}</div>
                 </div>
               </>
             )}

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -28,6 +28,7 @@ import { quote } from "../util/shlex";
 export const CI_RUNNER_ROLE = "CI_RUNNER";
 export const HOSTED_BAZEL_ROLE = "HOSTED_BAZEL";
 export const NINJA_ROLE = "NINJA";
+const DEFAULT_PATTERN_PREVIEW_LIMIT = 3;
 
 export const InvocationStatus = invocation_status.InvocationStatus;
 
@@ -663,8 +664,13 @@ export default class InvocationModel {
     return this.optionsParsed?.toolTag;
   }
 
-  getPattern() {
-    return this.getAllPatterns(3);
+  getTruncatedPatterns() {
+    const patterns =
+      this.invocation.pattern ||
+      this.expanded?.id?.pattern?.pattern ||
+      this.aborted?.[this.aborted.length - 1]?.id?.pattern?.pattern ||
+      [];
+    return format.truncateTargetPatternList(patterns, { maxItems: DEFAULT_PATTERN_PREVIEW_LIMIT });
   }
 
   getAllPatterns(patternLimit?: number) {

--- a/app/invocation/invocation_overview.tsx
+++ b/app/invocation/invocation_overview.tsx
@@ -81,7 +81,7 @@ export default class InvocationOverviewComponent extends React.Component<Props> 
           {(this.props.model.isBazelInvocation() || this.props.model.isHostedBazelInvocation()) && (
             <div className="title" title={this.props.model.getAllPatterns()}>
               {this.props.model.getUserPossessivePrefix()}
-              {this.props.model.getCommand()} {this.props.model.getPattern()}
+              {this.props.model.getCommand()} {this.props.model.getTruncatedPatterns()}
             </div>
           )}
           {this.props.model.workflowConfigured && (
@@ -126,7 +126,7 @@ export default class InvocationOverviewComponent extends React.Component<Props> 
           {isBazelInvocation && (
             <div className="detail" title={this.props.model.getAllPatterns()}>
               <LayoutGrid className="icon" />
-              {this.props.model.getPattern()}
+              {this.props.model.getTruncatedPatterns()}
             </div>
           )}
           {isBazelInvocation && (


### PR DESCRIPTION
A recent user invoked Bazel as:
bazel build '//foo/bar:bar //foo/baz:baz ...'
instead of:
bazel build //foo/bar:bar //foo/baz:baz ...

Bazel treated the quoted argument as one target pattern, which produced
a very long label and broke the Invocation and Builds page UI.

Compact deep target patterns in previews as //first/.../last:target so
one malformed-but-valid pattern cannot dominate those pages. Keep the
full pattern text in tooltips, reuse the same preview in compare
invocations, and cover the formatter behavior in tests.
