### PR TITLE
trace_viewer: fit the viewer to the viewport

### DIFF
--- a/app/trace/constants.ts
+++ b/app/trace/constants.ts
@@ -5,8 +5,8 @@
  */
 export const MODEL_X_PER_SECOND = 1_000_000;
 
-export const EVENTS_PANEL_HEIGHT = 540;
-export const LINE_PLOTS_PANEL_HEIGHT = 400;
+export const PANEL_BORDER_WIDTH = 2;
+export const PANEL_GAP = 16;
 
 export const TIMESTAMP_HEADER_SIZE = 16;
 export const TIMESTAMP_FONT_SIZE = "11px";

--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -87,7 +87,7 @@ export const TIME_SERIES_METADATA = new Map<string, SeriesMetadata[]>([
   ["CPU usage (Bazel)", [{ argKey: "cpu", unit: "cores" }]],
   ["Memory usage (Bazel)", [{ argKey: "memory", unit: "MB" }]],
   ["CPU usage (total)", [{ argKey: "system cpu", displayName: "CPU usage (System)", unit: "cores" }]],
-  ["Memory usage (total)", [{ argKey: "system memory", unit: "MB" }]],
+  ["Memory usage (total)", [{ argKey: "system memory", displayName: "Memory usage (System)", unit: "MB" }]],
   ["System load average", [{ argKey: "load" }]],
   [
     "Network Up usage (total)",

--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -87,7 +87,7 @@ export const TIME_SERIES_METADATA = new Map<string, SeriesMetadata[]>([
   ["CPU usage (Bazel)", [{ argKey: "cpu", unit: "cores" }]],
   ["Memory usage (Bazel)", [{ argKey: "memory", unit: "MB" }]],
   ["CPU usage (total)", [{ argKey: "system cpu", displayName: "CPU usage (System)", unit: "cores" }]],
-  ["Memory usage (total)", [{ argKey: "system memory", displayName: "Memory usage (System)", unit: "MB" }]],
+  ["Memory usage (total)", [{ argKey: "system memory", unit: "MB" }]],
   ["System load average", [{ argKey: "load" }]],
   [
     "Network Up usage (total)",

--- a/app/trace/trace_viewer.css
+++ b/app/trace/trace_viewer.css
@@ -52,9 +52,23 @@
 
 .trace-viewer {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  max-height: 100vh;
   /* Disable text selection since it conflicts with mouse panning.
      (Also, canvas text isn't selectable.) */
   user-select: none;
+}
+
+.trace-viewer.fit-to-content {
+  max-height: none;
+}
+
+.trace-viewer .trace-viewer-panels {
+  display: flex;
+  flex-direction: column;
+  gap: var(--trace-panel-gap);
+  min-height: 0;
 }
 
 .trace-viewer .panel {
@@ -65,18 +79,19 @@
 }
 
 .trace-viewer canvas {
+  display: block;
   position: sticky;
   top: 0;
   left: 0;
 }
 
-.trace-viewer .panel-container:not(:last-child) {
-  margin-bottom: 16px;
-}
-
 .trace-viewer .panel-container {
+  /* Events get two shares of the available height, charts get one. Each
+     panel is capped at its content height so unused space goes to the other. */
+  flex-basis: 0;
+  min-height: 0;
   border-radius: 2px;
-  border: 2px solid var(--color-trace-border);
+  border: var(--trace-panel-border-width) solid var(--color-trace-border);
   box-sizing: border-box;
   background: var(--color-bg-primary);
 }
@@ -190,7 +205,8 @@
 }
 
 .trace-viewer .filter {
-  margin-bottom: 16px;
+  flex-shrink: 0;
+  margin-bottom: var(--trace-panel-gap);
 }
 
 .trace-viewer .zoom-factor {

--- a/app/trace/trace_viewer.tsx
+++ b/app/trace/trace_viewer.tsx
@@ -50,7 +50,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
    * uses React state for efficient updates.
    */
 
-  private model = buildTraceViewerModel(this.props.profile, this.props.fitToContent);
+  private model = buildTraceViewerModel(this.props.profile);
   private rootRef = React.createRef<HTMLDivElement>();
   private canvasRefs: React.RefObject<HTMLCanvasElement>[] = this.model.panels.map((_) =>
     React.createRef<HTMLCanvasElement>()
@@ -171,6 +171,10 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
    * @param dt the time elapsed since the previous animation frame.
    */
   private update(dt = 0) {
+    if (!this.panels.length) {
+      this.animation.stop();
+      return;
+    }
     this.canvasXPerModelX.min = this.panels[0].container.clientWidth / this.model.xMax;
     // Don't decrease `max` if it has been increased past the default limit as a
     // result of user interaction (e.g. zooming in after a search match). This
@@ -200,6 +204,10 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
       // appropriately.
       const sizer = panel.container.getElementsByClassName("sizer")[0] as HTMLDivElement;
       sizer.style.width = `${this.canvasXPerModelX.value * this.model.xMax}px`;
+      // The flex layout can resize either panel independently of its content
+      // height. Keep every track reachable as the canvas grows or shrinks.
+      sizer.style.height = `${Math.max(0, panelScrollHeight(panel.model) - panel.canvasHeight)}px`;
+      panel.scrollY = panel.container.scrollTop;
 
       panel.scrollX = clamp(
         panel.scrollX,
@@ -240,6 +248,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
   }
 
   private updateMouse(mouse: MouseEvent | React.MouseEvent) {
+    if (!this.panels.length) return;
     this.mouse = { clientX: mouse.clientX, clientY: mouse.clientY };
     // Update the mouse's model X coordinate (i.e. hovered timestamp).
     // When panning, keep mouseModelX fixed.
@@ -603,10 +612,12 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
     return (
       <div
         ref={this.rootRef}
-        className="trace-viewer"
+        className={`trace-viewer ${this.props.fitToContent ? "fit-to-content" : ""}`}
         style={{
           ...({
             "--scrollbar-size": `${constants.SCROLLBAR_SIZE}px`,
+            "--trace-panel-border-width": `${constants.PANEL_BORDER_WIDTH}px`,
+            "--trace-panel-gap": `${constants.PANEL_GAP}px`,
           } as CSSProperties),
         }}>
         {!this.props.filterHidden && (
@@ -619,16 +630,24 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
             rightElement={counterText} // Read from state
           />
         )}
-        <div className="trace-viewer-panels">
+        <div
+          className="trace-viewer-panels"
+          style={{
+            height:
+              this.model.panels.reduce((sum, panel) => sum + panel.height + 2 * constants.PANEL_BORDER_WIDTH, 0) +
+              Math.max(0, this.model.panels.length - 1) * constants.PANEL_GAP,
+          }}>
           {this.model.panels.map((panel, i) => (
             <div
+              key={i}
               className="panel-container"
               style={{
                 width: "100%",
-                height: `${panel.height}px`,
+                maxHeight: `${panel.height + 2 * constants.PANEL_BORDER_WIDTH}px`,
+                flexGrow: panel.sections[0]?.tracks ? 2 : 1,
                 position: "relative",
               }}>
-              <div key={i} className="panel" onScroll={(e) => this.onScroll(e, i)}>
+              <div className="panel" onScroll={(e) => this.onScroll(e, i)}>
                 <canvas
                   ref={this.canvasRefs[i]}
                   onMouseDown={(e) => this.onCanvasMouseDown(e, i)}
@@ -639,12 +658,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
                  * match the size of the panel contents. We can't use a very
                  * large canvas directly due to browser limitations.
                  */}
-                <div
-                  className="sizer"
-                  style={{
-                    height: `${panelScrollHeight(panel) - panel.height + constants.SCROLLBAR_SIZE}px`,
-                  }}
-                />
+                <div className="sizer" />
               </div>
               <div
                 className="panel-controls"

--- a/app/trace/trace_viewer.tsx
+++ b/app/trace/trace_viewer.tsx
@@ -171,10 +171,6 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
    * @param dt the time elapsed since the previous animation frame.
    */
   private update(dt = 0) {
-    if (!this.panels.length) {
-      this.animation.stop();
-      return;
-    }
     this.canvasXPerModelX.min = this.panels[0].container.clientWidth / this.model.xMax;
     // Don't decrease `max` if it has been increased past the default limit as a
     // result of user interaction (e.g. zooming in after a search match). This
@@ -248,7 +244,6 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
   }
 
   private updateMouse(mouse: MouseEvent | React.MouseEvent) {
-    if (!this.panels.length) return;
     this.mouse = { clientX: mouse.clientX, clientY: mouse.clientY };
     // Update the mouse's model X coordinate (i.e. hovered timestamp).
     // When panning, keep mouseModelX fixed.
@@ -639,7 +634,6 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
           }}>
           {this.model.panels.map((panel, i) => (
             <div
-              key={i}
               className="panel-container"
               style={{
                 width: "100%",
@@ -647,7 +641,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
                 flexGrow: panel.sections[0]?.tracks ? 2 : 1,
                 position: "relative",
               }}>
-              <div className="panel" onScroll={(e) => this.onScroll(e, i)}>
+              <div key={i} className="panel" onScroll={(e) => this.onScroll(e, i)}>
                 <canvas
                   ref={this.canvasRefs[i]}
                   onMouseDown={(e) => this.onCanvasMouseDown(e, i)}

--- a/app/trace/trace_viewer_model.ts
+++ b/app/trace/trace_viewer_model.ts
@@ -12,6 +12,7 @@ export type TraceViewerModel = {
 };
 
 export type PanelModel = {
+  /** Height needed to show all contents, controls, and the horizontal scrollbar. */
   height: number;
   sections: SectionModel[];
 };
@@ -41,8 +42,8 @@ export type LinePlotModel = {
   unit?: string;
 };
 
-export function buildTraceViewerModel(trace: Profile, fitToContent?: boolean): TraceViewerModel {
-  let panels = [buildEventsPanel(trace, fitToContent), buildLinePlotsPanel(trace, fitToContent)];
+export function buildTraceViewerModel(trace: Profile): TraceViewerModel {
+  let panels = [buildEventsPanel(trace), buildLinePlotsPanel(trace)];
   // If there is no data available (e.g. the executor doesn't have timeseries
   // recording enabled yet) then the panel will be empty - just remove the panel
   // in this case since we don't handle this empty state in a good way yet.
@@ -54,7 +55,7 @@ export function buildTraceViewerModel(trace: Profile, fitToContent?: boolean): T
   };
 }
 
-function buildEventsPanel(trace: Profile, fitToContent?: boolean): PanelModel {
+function buildEventsPanel(trace: Profile): PanelModel {
   const sections: SectionModel[] = [];
   let sectionY = 0;
   for (const thread of trace.threads) {
@@ -88,14 +89,12 @@ function buildEventsPanel(trace: Profile, fitToContent?: boolean): PanelModel {
   }
 
   return {
-    height: fitToContent
-      ? constants.TIMESTAMP_HEADER_SIZE + sectionY + constants.BOTTOM_CONTROLS_HEIGHT + constants.SCROLLBAR_SIZE
-      : constants.EVENTS_PANEL_HEIGHT,
+    height: constants.TIMESTAMP_HEADER_SIZE + sectionY + constants.BOTTOM_CONTROLS_HEIGHT + constants.SCROLLBAR_SIZE,
     sections,
   };
 }
 
-function buildLinePlotsPanel(trace: Profile, fitToContent?: boolean): PanelModel {
+function buildLinePlotsPanel(trace: Profile): PanelModel {
   let sectionY = 0;
   let index = 0;
   const sectionHeight =
@@ -105,6 +104,7 @@ function buildLinePlotsPanel(trace: Profile, fitToContent?: boolean): PanelModel
     constants.SECTION_PADDING_BOTTOM;
   const sections: SectionModel[] = [];
   for (const series of trace.timeseries) {
+    if (!series.ts.length) continue;
     let yMax = 0;
     for (let i = 0; i < series.val.length; i++) {
       const y = series.val[i];
@@ -128,9 +128,7 @@ function buildLinePlotsPanel(trace: Profile, fitToContent?: boolean): PanelModel
   }
 
   return {
-    height: fitToContent
-      ? constants.TIMESTAMP_HEADER_SIZE + sectionY + constants.BOTTOM_CONTROLS_HEIGHT + constants.SCROLLBAR_SIZE
-      : constants.LINE_PLOTS_PANEL_HEIGHT,
+    height: constants.TIMESTAMP_HEADER_SIZE + sectionY + constants.BOTTOM_CONTROLS_HEIGHT + constants.SCROLLBAR_SIZE,
     sections,
   };
 }

--- a/app/trace/trace_viewer_model.ts
+++ b/app/trace/trace_viewer_model.ts
@@ -104,7 +104,6 @@ function buildLinePlotsPanel(trace: Profile): PanelModel {
     constants.SECTION_PADDING_BOTTOM;
   const sections: SectionModel[] = [];
   for (const series of trace.timeseries) {
-    if (!series.ts.length) continue;
     let yMax = 0;
     for (let i = 0; i < series.val.length; i++) {
       const y = series.val[i];

--- a/app/trace/trace_viewer_panel.ts
+++ b/app/trace/trace_viewer_panel.ts
@@ -118,7 +118,7 @@ export default class Panel {
 
   private isSectionVisible(section: SectionModel) {
     return !(
-      constants.TIMESTAMP_HEADER_SIZE + section.y > this.scrollY + this.model.height ||
+      constants.TIMESTAMP_HEADER_SIZE + section.y > this.scrollY + this.canvasHeight ||
       constants.TIMESTAMP_HEADER_SIZE + section.y + section.height < this.scrollY
     );
   }
@@ -127,8 +127,7 @@ export default class Panel {
     // TODO: incorporate timestamp header size into section.y instead of having to account for it here
     return (
       section.y + constants.TIMESTAMP_HEADER_SIZE >= this.scrollY + constants.TIMESTAMP_HEADER_SIZE &&
-      section.y + constants.TIMESTAMP_HEADER_SIZE + section.height <=
-        this.scrollY + this.model.height - constants.SCROLLBAR_SIZE
+      section.y + constants.TIMESTAMP_HEADER_SIZE + section.height <= this.scrollY + this.canvasHeight
     );
   }
 


### PR DESCRIPTION
Fixed panel heights leave charts below the viewport on short screens
and waste space when a profile has only a few tracks or counters. Keep
the search bar, events, and charts together so events can be correlated
with resource usage.

Limit the viewer to the viewport height and divide the panel space
between events and charts in a 2:1 ratio. Cap each panel at its
content height and give unused space back to the other panel. Keep
scrolling inside each panel, with canvas sizing and visible-section
checks based on the rendered height. Preserve the execution viewer's
explicit fit-to-content mode.

The screenshots compare the same synthetic profile (18 event lanes and 10
counters) on master and this change. At 1280 x 720, the viewer shrinks from
1,014px to 720px, keeping search and both panels on screen. At 1440 x 1800,
all event lanes and charts fit without internal scrolling.

| Viewport | Before | After |
| --- | --- | --- |
| 1280 x 720 | <img width="480" alt="Before at 1280 x 720" src="https://github.com/user-attachments/assets/e2dec369-7dbf-4d5c-9526-02b631dceeb0" /> | <img width="480" alt="After at 1280 x 720" src="https://github.com/user-attachments/assets/77821c77-5331-4d06-983f-c5e3f86f472a" /> |
| 1440 x 1800 | <img width="480" alt="Before at 1440 x 1800" src="https://github.com/user-attachments/assets/390e0399-b806-4623-bacb-dc4eb7129722" /> | <img width="480" alt="After at 1440 x 1800" src="https://github.com/user-attachments/assets/e6fad53b-2827-4c91-881e-043ad39ca2de" /> |
