### PR TITLE
bb: do not assume default branch is always pushed to remote

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -433,12 +433,17 @@ func getBaseBranchAndCommit(remoteName string, defaultBranch string) (branch str
 	// If the current branch or commit does not exist remotely, the remote runner will
 	// not be able to fetch it. In this case, use the default branch for the repo.
 	// Your local changes will be applied as a patchset to the remote runner.
+	//
+	// We resolve the commit from the remote tracking ref (e.g. origin/main) rather
+	// than the local branch, because the local branch may have unpushed commits
+	// that the runner won't be able to fetch.
 	if branch == "" || commit == "" {
 		branch = defaultBranch
 
-		defaultBranchCommitHash, err := getHeadCommitForLocalBranch(defaultBranch)
+		remoteBranch := fmt.Sprintf("%s/%s", remoteName, defaultBranch)
+		defaultBranchCommitHash, err := getHeadCommitForLocalBranch(remoteBranch)
 		if err != nil {
-			return "", "", fmt.Errorf("get head commit for local branch %q: %w", defaultBranch, err)
+			return "", "", fmt.Errorf("get head commit for remote branch %q: %w", remoteBranch, err)
 		}
 		commit = defaultBranchCommitHash
 	}


### PR DESCRIPTION
When on the default branch with unpushed local commits, the fallback in getBaseBranchAndCommit() resolved the default branch to the local HEAD SHA via `git rev-parse <defaultBranch>`. This commit doesn't exist on the remote, so the runner fails during git fetch.

Fix: resolve from the remote tracking ref (e.g. origin/main) instead of the local branch, ensuring the base commit is always fetchable.

This is still not bulletproof against all possible cases (e.g. "branch was deleted on the remote", "branch on remote diverged from our tracking ref", etc.) - the fully correct solution would probably look like running a full git push algorithm.