### PR TITLE
Propagate impersonation bit for api keys.

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -188,6 +188,7 @@ type apiKeyGroup struct {
 	UseGroupOwnedExecutors bool
 	CacheEncryptionEnabled bool
 	EnforceIPRules         bool
+	Impersonation          bool
 	Status                 int32
 }
 
@@ -227,6 +228,10 @@ func (g *apiKeyGroup) GetEnforceIPRules() bool {
 	return g.EnforceIPRules
 }
 
+func (g *apiKeyGroup) IsImpersonating() bool {
+	return g.Impersonation
+}
+
 func (g *apiKeyGroup) GetGroupStatus() grpb.Group_GroupStatus {
 	return grpb.Group_GroupStatus(g.Status)
 }
@@ -261,6 +266,7 @@ func (r *apiKeyGroupRow) toAPIKeyGroup() *apiKeyGroup {
 		UseGroupOwnedExecutors: r.UseGroupOwnedExecutors,
 		CacheEncryptionEnabled: r.CacheEncryptionEnabled,
 		EnforceIPRules:         r.EnforceIPRules,
+		Impersonation:          r.Impersonation,
 		Status:                 r.GroupStatus,
 	}
 }

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -150,9 +150,19 @@ func TestImpersonationKeys(t *testing.T) {
 	rsp, err := env.GetBuildBuddyServer().CreateImpersonationApiKey(serverAdminCtx, req)
 	require.NoError(t, err)
 
-	// Verify the new API key is usable.
-	_, err = adb.GetAPIKeyGroupFromAPIKey(ctx, rsp.GetApiKey().GetValue())
+	// Verify the new API key is usable and marked as impersonating.
+	akg, err := adb.GetAPIKeyGroupFromAPIKey(ctx, rsp.GetApiKey().GetValue())
 	require.NoError(t, err)
+	require.True(t, akg.IsImpersonating(), "impersonation key should have IsImpersonating() == true")
+
+	// Verify a regular (non-impersonation) API key is not marked as impersonating.
+	adminGroupID := admin.Groups[0].Group.GroupID
+	regularKeys, err := adb.GetAPIKeys(serverAdminCtx, adminGroupID)
+	require.NoError(t, err)
+	require.NotEmpty(t, regularKeys)
+	regularAKG, err := adb.GetAPIKeyGroupFromAPIKey(ctx, regularKeys[0].Value)
+	require.NoError(t, err)
+	require.False(t, regularAKG.IsImpersonating(), "regular key should have IsImpersonating() == false")
 
 	fakeClock.Advance(2 * time.Hour)
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -464,6 +464,7 @@ type APIKeyGroup interface {
 	GetUseGroupOwnedExecutors() bool
 	GetCacheEncryptionEnabled() bool
 	GetEnforceIPRules() bool
+	IsImpersonating() bool
 	GetGroupStatus() grpb.Group_GroupStatus
 }
 

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -321,6 +321,7 @@ func APIKeyGroupClaims(ctx context.Context, akg interfaces.APIKeyGroup) (*Claims
 		UseGroupOwnedExecutors:     akg.GetUseGroupOwnedExecutors(),
 		CacheEncryptionEnabled:     akg.GetCacheEncryptionEnabled(),
 		EnforceIPRules:             akg.GetEnforceIPRules(),
+		Impersonating:              akg.IsImpersonating(),
 		GroupStatus:                akg.GetGroupStatus(),
 	}, nil
 }

--- a/server/util/claims/claims_test.go
+++ b/server/util/claims/claims_test.go
@@ -86,6 +86,7 @@ type fakeAPIKeyGroup struct {
 	useGroupOwnedExecutors bool
 	cacheEncryptionEnabled bool
 	enforceIPRules         bool
+	impersonation          bool
 	groupStatus            grpb.Group_GroupStatus
 }
 
@@ -119,6 +120,10 @@ func (f *fakeAPIKeyGroup) GetCacheEncryptionEnabled() bool {
 
 func (f *fakeAPIKeyGroup) GetEnforceIPRules() bool {
 	return f.enforceIPRules
+}
+
+func (f *fakeAPIKeyGroup) IsImpersonating() bool {
+	return f.impersonation
 }
 
 func (f *fakeAPIKeyGroup) GetGroupStatus() grpb.Group_GroupStatus {


### PR DESCRIPTION
I happened to notice that we only currently populate the bit for the web flow but not for the API key flow.