### PR TITLE
Extract NewBlobFetchKey for consistent deduping

### DIFF
--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -50,30 +50,6 @@ var (
 	blobBufPool = bytebufferpool.VariableSize(blobChunkSize)
 )
 
-// blobFetchKey identifies a blob fetch for deduplication.
-// Includes registry, repository, digest, and credentials hash.
-type blobFetchKey struct {
-	registry   string
-	repository string
-	digest     string
-	credsHash  string
-}
-
-func makeBlobFetchKey(repo gcrname.Repository, h gcr.Hash, creds *rgpb.Credentials) blobFetchKey {
-	var credsHash string
-	if creds == nil {
-		credsHash = hash.Strings("", "")
-	} else {
-		credsHash = hash.Strings(creds.GetUsername(), creds.GetPassword())
-	}
-	return blobFetchKey{
-		registry:   repo.RegistryStr(),
-		repository: repo.RepositoryStr(),
-		digest:     h.String(),
-		credsHash:  credsHash,
-	}
-}
-
 type ociFetcherServer struct {
 	allowedPrivateIPs []*net.IPNet
 	mirrors           []interfaces.MirrorConfig
@@ -87,7 +63,7 @@ type ociFetcherServer struct {
 	// blobFetchGroup deduplicates concurrent blob fetch requests.
 	// Only one request fetches from upstream and writes to cache;
 	// other requests wait and then read from cache.
-	blobFetchGroup singleflight.Group[blobFetchKey, struct{}]
+	blobFetchGroup singleflight.Group[ocicache.BlobFetchKey, struct{}]
 }
 
 // NewServer constructs an OCIFetcherServer that
@@ -188,7 +164,7 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 	}
 
 	start := time.Now()
-	key := makeBlobFetchKey(repo, hash, req.GetCredentials())
+	key := ocicache.NewBlobFetchKey(repo, hash, req.GetCredentials())
 	isLeader := false
 	_, _, err = s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (struct{}, error) {
 		isLeader = true

--- a/enterprise/server/util/ocicache/BUILD
+++ b/enterprise/server/util/ocicache/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocicache",
     deps = [
         "//proto:ociregistry_go_proto",
+        "//proto:registry_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/metrics",
@@ -36,6 +37,7 @@ go_test(
         ":ocicache",
         "//enterprise/server/testutil/enterprise_testenv",
         "//proto:ociregistry_go_proto",
+        "//proto:registry_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/testutil/testcache",

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	ocipb "github.com/buildbuddy-io/buildbuddy/proto/ociregistry"
+	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	gcrname "github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
@@ -466,4 +467,36 @@ func WriteBlobOrManifestToCacheAndWriter(ctx context.Context, upstream io.Reader
 	}
 	tr := io.TeeReader(upstream, w)
 	return WriteBlobToCache(ctx, tr, bsClient, acClient, repo, hash, contentType, contentLength)
+}
+
+// BlobFetchKey identifies a unique OCI blob fetch for singleflight
+// deduplication. Two requests that resolve to the same BlobFetchKey
+// are safe to coalesce: one fetches from upstream while the others wait.
+type BlobFetchKey struct {
+	// repo is the string form of the gcrname.Repository
+	// (e.g. "index.docker.io/library/alpine").
+	repo string
+	// digest is the string form of the gcr.Hash
+	// (e.g. "sha256:abc123").
+	digest string
+	// credsHash is a hash of the credentials used to fetch the blob.
+	// Requests with different credentials must not be coalesced to
+	// prevent cross-auth piggybacking.
+	credsHash string
+}
+
+// NewBlobFetchKey creates a BlobFetchKey from strongly-typed
+// go-containerregistry values and optional proto credentials.
+func NewBlobFetchKey(repo gcrname.Repository, digest gcr.Hash, creds *rgpb.Credentials) BlobFetchKey {
+	var credsHash string
+	if creds == nil {
+		credsHash = hash.Strings("", "")
+	} else {
+		credsHash = hash.Strings(creds.GetUsername(), creds.GetPassword())
+	}
+	return BlobFetchKey{
+		repo:      repo.Name(),
+		digest:    digest.String(),
+		credsHash: credsHash,
+	}
 }

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ocipb "github.com/buildbuddy-io/buildbuddy/proto/ociregistry"
+	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	gcrname "github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
@@ -439,4 +440,75 @@ func fetchAndCheckBlob(t *testing.T, te *testenv.TestEnv, layerBuf []byte, repo 
 	err = ocicache.FetchBlobFromCache(ctx, out, bsClient, hash, contentLength)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(layerBuf, out.Bytes()))
+}
+
+func mustRepo(t *testing.T, name string) gcrname.Repository {
+	t.Helper()
+	repo, err := gcrname.NewRepository(name)
+	require.NoError(t, err)
+	return repo
+}
+
+func mustHash(t *testing.T, s string) gcr.Hash {
+	t.Helper()
+	h, err := gcr.NewHash(s)
+	require.NoError(t, err)
+	return h
+}
+
+const (
+	testDigest1 = "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+	testDigest2 = "sha256:0000000000000000000000000000000000000000000000000000000000000002"
+)
+
+func TestNewBlobFetchKey_NilCreds(t *testing.T) {
+	key := ocicache.NewBlobFetchKey(
+		mustRepo(t, "registry.example.com/repo"),
+		mustHash(t, testDigest1),
+		nil,
+	)
+	// Smoke test: key should be usable as a map key.
+	m := map[ocicache.BlobFetchKey]bool{key: true}
+	require.True(t, m[key])
+}
+
+func TestNewBlobFetchKey_DifferentCredsDifferentKeys(t *testing.T) {
+	repo := mustRepo(t, "registry.example.com/repo")
+	hash := mustHash(t, testDigest1)
+	key1 := ocicache.NewBlobFetchKey(repo, hash, nil)
+	key2 := ocicache.NewBlobFetchKey(repo, hash, &rgpb.Credentials{Username: "user", Password: "pass"})
+	require.NotEqual(t, key1, key2, "different credentials must produce different keys")
+}
+
+func TestNewBlobFetchKey_SameInputsSameKeys(t *testing.T) {
+	repo := mustRepo(t, "registry.example.com/repo")
+	hash := mustHash(t, testDigest1)
+	creds := &rgpb.Credentials{Username: "user", Password: "pass"}
+	key1 := ocicache.NewBlobFetchKey(repo, hash, creds)
+	key2 := ocicache.NewBlobFetchKey(repo, hash, creds)
+	require.Equal(t, key1, key2)
+}
+
+func TestNewBlobFetchKey_NilCredsMatchesEmptyCreds(t *testing.T) {
+	repo := mustRepo(t, "registry.example.com/repo")
+	hash := mustHash(t, testDigest1)
+	nilKey := ocicache.NewBlobFetchKey(repo, hash, nil)
+	emptyKey := ocicache.NewBlobFetchKey(repo, hash, &rgpb.Credentials{})
+	require.Equal(t, nilKey, emptyKey, "nil creds should produce the same key as empty creds")
+}
+
+func TestNewBlobFetchKey_DifferentReposDifferentKeys(t *testing.T) {
+	hash := mustHash(t, testDigest1)
+	creds := &rgpb.Credentials{Username: "user", Password: "pass"}
+	key1 := ocicache.NewBlobFetchKey(mustRepo(t, "registry.example.com/repo1"), hash, creds)
+	key2 := ocicache.NewBlobFetchKey(mustRepo(t, "registry.example.com/repo2"), hash, creds)
+	require.NotEqual(t, key1, key2, "different repos must produce different keys")
+}
+
+func TestNewBlobFetchKey_DifferentDigestsDifferentKeys(t *testing.T) {
+	repo := mustRepo(t, "registry.example.com/repo")
+	creds := &rgpb.Credentials{Username: "user", Password: "pass"}
+	key1 := ocicache.NewBlobFetchKey(repo, mustHash(t, testDigest1), creds)
+	key2 := ocicache.NewBlobFetchKey(repo, mustHash(t, testDigest2), creds)
+	require.NotEqual(t, key1, key2, "different digests must produce different keys")
 }


### PR DESCRIPTION
While adding request deduplication for FetchBlob in the enterprise cache proxy, I found myself wanting to guarantee that the OCIFetcher service and proxy dedupe requests in exactly the same way.