### PR TITLE
Add default URLs for local testing

### DIFF
--- a/enterprise/config/buildbuddy.local.yaml
+++ b/enterprise/config/buildbuddy.local.yaml
@@ -9,6 +9,10 @@ app:
   streaming_http_enabled: true
   invocation_log_streaming_enabled: true
   dark_mode_enabled: true
+  build_buddy_url: "http://localhost:8080"
+  events_api_url: "grpc://localhost:1985"
+  cache_api_url: "grpc://localhost:1985"
+  remote_execution_api_url: "grpc://localhost:1985"
 database:
   data_source: "sqlite3:///tmp/${USER}-buildbuddy-enterprise.db"
 #olap_database:


### PR DESCRIPTION
Without this when testing remote bazel with `bb remote
--remote_runner=grpc://localhost:1985 ...` I got these warnings:

```
Warning: Failed to cancel remote run: rpc error: code = Unknown desc = record not found
Warning: Remote run failed due to a transient error. Retrying: rpc error: code = NotFound desc = streaming logs: get event log chunk: invocation not found
```

And nothing ever ran
