### PR TITLE
[cli] Improve help with rc parsing

### DIFF
--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -21,6 +21,7 @@ go_test(
     deps = [
         ":help",
         "//cli/cli_command/register",
+        "//cli/parser",
         "//cli/parser/arguments",
         "//cli/parser/parsed",
         "@com_github_stretchr_testify//require",

--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -21,7 +21,6 @@ go_test(
     deps = [
         ":help",
         "//cli/cli_command/register",
-        "//cli/parser",
         "//cli/parser/arguments",
         "//cli/parser/parsed",
         "@com_github_stretchr_testify//require",

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -22,24 +22,21 @@ const (
 // FindTargetCommandFromHelpArgs extracts the target command from "bb help <command>" arguments.
 // Returns the command name if found, empty string otherwise.
 func FindTargetCommandFromHelpArgs(orderedArgs *parsed.OrderedArgs) string {
-	_, command := parsed.Find[*parsed.Command](orderedArgs.Args)
+	commandIndex, command := parsed.Find[*parsed.Command](orderedArgs.Args)
 	if command == nil {
 		return ""
 	}
 
-	// If the command is "help", look for the next positional argument
+	// If the command is "help", the target is the next positional argument
+	// after it. rc-file expansion may have injected options between "help"
+	// and the target, so skip over non-positional arguments.
 	if command.Value == "help" {
-		for i, arg := range orderedArgs.Args {
-			if pos, ok := arg.(*arguments.PositionalArgument); ok && pos.Value == "help" {
-				// Check the next argument
-				if i+1 < len(orderedArgs.Args) {
-					if nextPos, ok := orderedArgs.Args[i+1].(*arguments.PositionalArgument); ok {
-						return nextPos.Value
-					}
-				}
-				break
+		for _, arg := range orderedArgs.Args[commandIndex+1:] {
+			if pos, ok := arg.(*arguments.PositionalArgument); ok {
+				return pos.Value
 			}
 		}
+		return ""
 	}
 
 	// Otherwise return the command itself

--- a/cli/help/help_test.go
+++ b/cli/help/help_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
 	"github.com/buildbuddy-io/buildbuddy/cli/help"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
 	"github.com/stretchr/testify/require"
@@ -142,6 +143,24 @@ func TestHelpForBBCommands(t *testing.T) {
 			testBBCommandAllPatterns(t, cmdName, cmdName)
 		})
 	}
+}
+
+func TestHelpForBBCommandWithInjectedOptions(t *testing.T) {
+	register.Register()
+
+	helpParser, err := parser.GetHelpParser()
+	require.NoError(t, err)
+	orderedArgs, err := helpParser.ParseArgs([]string{
+		"help",
+		"--module_mirrors=https://example.com",
+		"--check_direct_dependencies=error",
+		"remote",
+	})
+	require.NoError(t, err)
+
+	testHelpWithArgs(t, orderedArgs.Args, true, "Usage: bb remote", "bb help remote with injected rc options")
+
+	require.Equal(t, "remote", help.FindTargetCommandFromHelpArgs(orderedArgs))
 }
 
 func TestHelpAliases(t *testing.T) {

--- a/cli/help/help_test.go
+++ b/cli/help/help_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/cli_command/register"
 	"github.com/buildbuddy-io/buildbuddy/cli/help"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
 	"github.com/stretchr/testify/require"
@@ -145,21 +144,24 @@ func TestHelpForBBCommands(t *testing.T) {
 	}
 }
 
+type fakeNonPositionalArg struct{ value string }
+
+func (f *fakeNonPositionalArg) GetValue() string { return f.value }
+func (f *fakeNonPositionalArg) Format() []string { return []string{f.value} }
+
 func TestHelpForBBCommandWithInjectedOptions(t *testing.T) {
 	register.Register()
 
-	helpParser, err := parser.GetHelpParser()
-	require.NoError(t, err)
-	orderedArgs, err := helpParser.ParseArgs([]string{
-		"help",
-		"--module_mirrors=https://example.com",
-		"--check_direct_dependencies=error",
-		"remote",
-	})
-	require.NoError(t, err)
+	args := []arguments.Argument{
+		&arguments.PositionalArgument{Value: "help"},
+		&fakeNonPositionalArg{value: "--module_mirrors=https://example.com"},
+		&fakeNonPositionalArg{value: "--check_direct_dependencies=error"},
+		&arguments.PositionalArgument{Value: "remote"},
+	}
 
-	testHelpWithArgs(t, orderedArgs.Args, true, "Usage: bb remote", "bb help remote with injected rc options")
+	testHelpWithArgs(t, args, true, "Usage: bb remote", "bb help remote with injected rc options")
 
+	orderedArgs := &parsed.OrderedArgs{Args: args}
 	require.Equal(t, "remote", help.FindTargetCommandFromHelpArgs(orderedArgs))
 }
 


### PR DESCRIPTION
Previously in our repo if you ran `bazel run cli -- help remote` it
would actually not work. This is because the args list parsed some rc
file args before parsing the `remote` after `help`. Previously we
were only checking the positional argument directly after `help`, now we
find the first one even if it comes later.
