### PR TITLE
Prevent URL secret regex from matching across newlines

### DIFF
--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -54,7 +54,7 @@ var (
 	envVarAnyPattern          = regexp.MustCompile(`(?s)^(--[^=]+=)(.*)$`)
 	envVarAssignmentRegex     = regexp.MustCompile(`^([^=]+)=`)
 
-	urlSecretRegex      = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://[^:@]+:)[^@]*(@[^"\s<>{}|\\^[\]]+)`)
+	urlSecretRegex      = regexp.MustCompile(`(?i)([a-z][a-z0-9+.-]*://[^:@\r\n]+:)[^@\r\n]*(@[^"\s<>{}|\\^[\]]+)`)
 	residualSecretRegex = regexp.MustCompile(`(?i)` + `(^|[^a-z])` + `(api|key|pass|password|secret|token)` + `([^a-z]|$)`)
 
 	// There are some flags that contain multiple sub-flags which are

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -934,6 +934,17 @@ func TestRedactTxt(t *testing.T) {
 			expected: "ERROR: Error computing the main repository mapping: rules_apple@3.16.1 depends on rules_swift@2.1.1 with compatibility level 2, but <root> depends on rules_swift@1.18.0 with compatibility level 1 which is different",
 		},
 		{
+			name: "do not redact diff headers after URL on adjacent line",
+			txt: "INFO: Streaming build results to: https://app.buildbuddy.io/invocation/4e0ee060-5c14-4165-b631-8119e53ecac7\n" +
+				"--- enterprise/server/oci/BUILD\t1970-01-01 00:00:00.000000001 +0000\n" +
+				"+++ enterprise/server/oci/BUILD\t1970-01-01 00:00:00.000000001 +0000\n" +
+				"@@ -14,7 +14,6 @@\n",
+			expected: "INFO: Streaming build results to: https://app.buildbuddy.io/invocation/4e0ee060-5c14-4165-b631-8119e53ecac7\n" +
+				"--- enterprise/server/oci/BUILD\t1970-01-01 00:00:00.000000001 +0000\n" +
+				"+++ enterprise/server/oci/BUILD\t1970-01-01 00:00:00.000000001 +0000\n" +
+				"@@ -14,7 +14,6 @@\n",
+		},
+		{
 			name:     "api key start of line",
 			txt:      "apikeyexactly20chars@mydomain.com",
 			expected: "<REDACTED>@mydomain.com",


### PR DESCRIPTION
The urlSecretRegex was incorrectly matching across line boundaries, causing over-redaction in workflow logs.

For example, output like:
```
  INFO: Streaming build results to: https://app.buildbuddy.io/invocation/UUID
  --- path/to/BUILD  1970-01-01 00:00:00.000000001 +0000
  +++ path/to/BUILD  1970-01-01 00:00:00.000000001 +0000
  @@ -14,7 +14,6 @@
```

Would be redacted to:
```
  ...00:<REDACTED>@@ -14,7 +14,6 @@
```

Fix: add `\r` and `\n` to the exclusion character classes in the URL secret regex so it cannot span multiple lines. URL credentials never legitimately contain newlines, so this does not reduce real secret coverage.