### PR TITLE
dedupe `FetchBlob` requests in cache proxy

### DIFF
--- a/enterprise/server/ocifetcher_server_proxy/BUILD
+++ b/enterprise/server/ocifetcher_server_proxy/BUILD
@@ -8,13 +8,16 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/ocifetcher_server_proxy",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/util/ocicache",
         "//proto:oci_fetcher_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
+        "//server/util/log",
         "//server/util/status",
+        "//third_party/singleflight",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
@@ -44,5 +47,6 @@ go_test(
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
@@ -11,11 +11,14 @@ import (
 	"context"
 	"io"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocicache"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/third_party/singleflight"
 
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -29,6 +32,11 @@ const cacheDigestFunction = repb.DigestFunction_SHA256
 type OCIFetcherServerProxy struct {
 	remote        ofpb.OCIFetcherClient
 	localBSClient bspb.ByteStreamClient
+	// fetchGroup deduplicates concurrent FetchBlob requests for the same
+	// blob and credentials. The leader fetches from the upstream (apps)
+	// and writes to local BSS; waiters block until the leader finishes,
+	// then all callers stream from local BSS.
+	fetchGroup singleflight.Group[ocicache.BlobFetchKey, struct{}]
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -89,8 +97,10 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 	if err != nil {
 		return err
 	}
+	size := metaResp.GetSize()
 
-	err = fetchBlobFromLocalBS(ctx, s.localBSClient, hash, metaResp.GetSize(), &grpcStreamWriter{stream: stream})
+	// Fast path: serve from local BS cache.
+	err = fetchBlobFromLocalBS(ctx, s.localBSClient, hash, size, &grpcStreamWriter{stream: stream})
 	if err == nil {
 		return nil // local cache hit
 	}
@@ -100,12 +110,33 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 		return err
 	}
 
-	return s.fetchBlobFromUpstreamAndCache(ctx, req, stream, hash, metaResp.GetSize())
+	// Deduplicate concurrent upstream fetches for the same blob+creds.
+	// The leader fetches from upstream and writes to local BSS.
+	// After the singleflight completes, all callers stream from local BSS.
+	key := ocicache.NewBlobFetchKey(digestRef.Context(), hash, req.GetCredentials())
+	isLeader := false
+	_, _, err = s.fetchGroup.Do(ctx, key, func(ctx context.Context) (struct{}, error) {
+		isLeader = true
+		return struct{}{}, s.fetchBlobFromUpstreamToLocalBS(ctx, req, hash, size)
+	})
+	if err != nil {
+		return err
+	}
+
+	if isLeader {
+		log.CtxInfof(ctx, "FetchBlob singleflight leader for %s, streaming from local BS", hash.Hex)
+	} else {
+		log.CtxInfof(ctx, "FetchBlob singleflight waiter for %s, streaming from local BS", hash.Hex)
+	}
+
+	// Stream the blob from local BSS to the caller.
+	return fetchBlobFromLocalBS(ctx, s.localBSClient, hash, size, &grpcStreamWriter{stream: stream})
 }
 
-// fetchBlobFromUpstreamAndCache streams a blob from the upstream OCIFetcher,
-// sends each chunk to the caller, and writes the blob to local BS cache.
-func (s *OCIFetcherServerProxy) fetchBlobFromUpstreamAndCache(ctx context.Context, req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer, hash gcr.Hash, size int64) error {
+// fetchBlobFromUpstreamToLocalBS fetches a blob from the upstream OCIFetcher
+// and writes it to the local byte stream cache. It does not stream to any
+// caller; callers read from local BSS after this completes.
+func (s *OCIFetcherServerProxy) fetchBlobFromUpstreamToLocalBS(ctx context.Context, req *ofpb.FetchBlobRequest, hash gcr.Hash, size int64) error {
 	remoteStream, err := s.remote.FetchBlob(ctx, req)
 	if err != nil {
 		return err
@@ -127,33 +158,12 @@ func (s *OCIFetcherServerProxy) fetchBlobFromUpstreamAndCache(ctx context.Contex
 		}
 
 		_, writeErr := cacheWriter.Write(resp.GetData())
-		if writeErr != nil && !status.IsAlreadyExistsError(writeErr) {
-			return writeErr
-		}
-		if err := stream.Send(resp); err != nil {
-			return err
-		}
 		if writeErr != nil {
-			// AlreadyExists: blob was cached by another writer.
-			// Stop writing to cache, relay remaining chunks.
-			cacheWriter.Close()
-			return relayStream(remoteStream, stream)
-		}
-	}
-}
-
-// relayStream drains the remaining responses from upstream to the caller.
-func relayStream(remoteStream ofpb.OCIFetcher_FetchBlobClient, stream ofpb.OCIFetcher_FetchBlobServer) error {
-	for {
-		resp, err := remoteStream.Recv()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if err := stream.Send(resp); err != nil {
-			return err
+			if status.IsAlreadyExistsError(writeErr) {
+				// Blob was cached by another writer; we're done.
+				return nil
+			}
+			return writeErr
 		}
 	}
 }

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
@@ -3,6 +3,8 @@ package ocifetcher_server_proxy
 import (
 	"context"
 	"io"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ocifetcher"
@@ -17,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
@@ -558,6 +561,70 @@ func TestInvalidOrMissingCredentials(t *testing.T) {
 	}
 }
 
+// TestFetchBlob_Singleflight verifies that concurrent FetchBlob requests for
+// the same blob are deduplicated: only one upstream FetchBlob RPC is made and
+// all callers receive the correct data.
+func TestFetchBlob_Singleflight(t *testing.T) {
+	ctx := context.Background()
+
+	reg := setupTestRegistry(t, nil)
+	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layer := layers[0]
+	digest, err := layer.Digest()
+	require.NoError(t, err)
+	expectedData := layerData(t, layer)
+
+	_, bsClient, acClient := setupCacheEnv(t)
+	ociFetcherClient := runOCIFetcherServer(ctx, t, bsClient, acClient)
+	counter := &countingOCIFetcherClient{inner: ociFetcherClient}
+	proxyClient := runOCIFetcherProxy(ctx, t, counter)
+
+	ref := imageName + "@" + digest.String()
+	const numClients = 5
+
+	var wg sync.WaitGroup
+	errs := make([]error, numClients)
+	results := make([][]byte, numClients)
+
+	for i := 0; i < numClients; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: ref})
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			var data []byte
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					errs[idx] = err
+					return
+				}
+				data = append(data, resp.GetData()...)
+			}
+			results[idx] = data
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < numClients; i++ {
+		require.NoError(t, errs[i], "client %d got error", i)
+		require.Equal(t, expectedData, results[i], "client %d got wrong data", i)
+	}
+
+	require.Equal(t, int32(1), counter.fetchBlobCount.Load(),
+		"expected exactly 1 upstream FetchBlob call due to singleflight deduplication")
+}
+
 // These tests exercise the full chain:
 // Test Client -> Proxy -> OCIFetcher Server -> Test Registry
 // with real cache infrastructure (ByteStream + ActionCache)
@@ -660,6 +727,29 @@ func layerData(t *testing.T, layer v1.Layer) []byte {
 	data, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	return data
+}
+
+// countingOCIFetcherClient wraps an OCIFetcherClient and counts FetchBlob calls.
+type countingOCIFetcherClient struct {
+	inner          ofpb.OCIFetcherClient
+	fetchBlobCount atomic.Int32
+}
+
+func (c *countingOCIFetcherClient) FetchManifest(ctx context.Context, req *ofpb.FetchManifestRequest, opts ...grpc.CallOption) (*ofpb.FetchManifestResponse, error) {
+	return c.inner.FetchManifest(ctx, req, opts...)
+}
+
+func (c *countingOCIFetcherClient) FetchManifestMetadata(ctx context.Context, req *ofpb.FetchManifestMetadataRequest, opts ...grpc.CallOption) (*ofpb.FetchManifestMetadataResponse, error) {
+	return c.inner.FetchManifestMetadata(ctx, req, opts...)
+}
+
+func (c *countingOCIFetcherClient) FetchBlob(ctx context.Context, req *ofpb.FetchBlobRequest, opts ...grpc.CallOption) (ofpb.OCIFetcher_FetchBlobClient, error) {
+	c.fetchBlobCount.Add(1)
+	return c.inner.FetchBlob(ctx, req, opts...)
+}
+
+func (c *countingOCIFetcherClient) FetchBlobMetadata(ctx context.Context, req *ofpb.FetchBlobMetadataRequest, opts ...grpc.CallOption) (*ofpb.FetchBlobMetadataResponse, error) {
+	return c.inner.FetchBlobMetadata(ctx, req, opts...)
 }
 
 // collectBlobData reads all data from a FetchBlob stream.


### PR DESCRIPTION
Add singleflight deduplication to the OCI fetcher server proxy so that concurrent FetchBlob requests for the same blob and credentials result in only one upstream fetch. The leader fetches from upstream and writes to local BSS; waiters block until the leader finishes, then all callers stream from local BSS.