### PR TITLE
Link to target when spawn doesn't have digest

### DIFF
--- a/app/invocation/invocation_spawn_card.tsx
+++ b/app/invocation/invocation_spawn_card.tsx
@@ -144,13 +144,20 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
   }
 
   getActionPageLink(entry: tools.protos.ExecLogEntry) {
-    if (!entry.spawn?.digest) {
-      return undefined;
+    if (entry.spawn?.digest) {
+      const search = new URLSearchParams();
+      search.set("actionDigest", digestToString(entry.spawn.digest));
+      return `/invocation/${this.props.model.getInvocationId()}?${search}#action`;
     }
 
-    const search = new URLSearchParams();
-    search.set("actionDigest", digestToString(entry.spawn.digest));
-    return `/invocation/${this.props.model.getInvocationId()}?${search}#action`;
+    if (entry.spawn?.targetLabel) {
+      const search = new URLSearchParams();
+      search.set("target", entry.spawn.targetLabel);
+      search.set("targetStatus", String(entry.spawn.exitCode === 0 ? 2 : 3));
+      return `/invocation/${this.props.model.getInvocationId()}?${search}`;
+    }
+
+    return undefined;
   }
 
   getPlatformProperties(platform?: any): Map<string, string> {


### PR DESCRIPTION
In the case you have a failing spawn that is missing a digest,
previously it linked to nothing. Now it links to the overall details of
the failing target it is a part of. If a target has multiple actions it
might not show the right one since we don't seem to surface every action
from a failing target, but this is still nicer than linking no where.
Otherwise you have to go back to the main build page and navigate to the
failed target.

I'm not sure all the cases you can be missing a digest, but at least 1
case is if the target is set to `tags = ["no-cache"],` (useful for
testing)
