### PR TITLE
Pass bazel workspace subdirectory to remote runner

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -138,6 +138,7 @@ type RunOpts struct {
 	RunOutputLocally bool
 	// If RunOutputLocally=true, execution arguments for running the target locally.
 	ExecArgs          []string
+	WorkingDirectory  string
 	WorkspaceFilePath string
 }
 
@@ -845,6 +846,38 @@ func downloadOutputs(ctx context.Context, env environment.Env, mainOutputs []*be
 	return mainLocalArtifacts, nil
 }
 
+func getWorkingDirectory(workspaceFilePath string) (string, error) {
+	repoRootPath, err := storage.RepoRootPath()
+	if err != nil {
+		return "", status.WrapError(err, "locate git repo root")
+	}
+	return workingDirectory(repoRootPath, workspaceFilePath)
+}
+
+func workingDirectory(repoRootPath, workspaceFilePath string) (string, error) {
+	repoRootPath, err := filepath.Abs(repoRootPath)
+	if err != nil {
+		return "", status.WrapError(err, "compute repo root absolute path")
+	}
+	workspaceFilePath, err = filepath.Abs(workspaceFilePath)
+	if err != nil {
+		return "", status.WrapError(err, "compute bazel workspace absolute path")
+	}
+	workspaceDirPath := filepath.Dir(workspaceFilePath)
+	relPath, err := filepath.Rel(repoRootPath, workspaceDirPath)
+	if err != nil {
+		return "", status.WrapError(err, "compute bazel workspace path relative to repo root")
+	}
+	relPath = filepath.Clean(relPath)
+	if relPath == "." {
+		return "", nil
+	}
+	if strings.Contains(relPath, "..") {
+		return "", status.InvalidArgumentErrorf("bazel workspace %q is outside repo root %q", workspaceDirPath, repoRootPath)
+	}
+	return relPath, nil
+}
+
 func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error) {
 	env := real_environment.NewBatchEnv()
 
@@ -931,7 +964,8 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	}
 
 	req := &rnpb.RunRequest{
-		Name: opts.Name,
+		Name:             opts.Name,
+		WorkingDirectory: opts.WorkingDirectory,
 		GitRepo: &gitpb.GitRepo{
 			RepoUrl:                 repoConfig.URL,
 			UseSystemGitCredentials: *useSystemGitCredentials,
@@ -1211,6 +1245,10 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 	if err != nil {
 		return 1, status.WrapError(err, "finding workspace")
 	}
+	workingDirectory, err := getWorkingDirectory(wsFilePath)
+	if err != nil {
+		return 1, status.WrapError(err, "determine working directory")
+	}
 
 	runner := *remoteRunner
 	if !strings.HasPrefix(runner, "grpc") {
@@ -1286,6 +1324,7 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 		Command:           cmd,
 		RunOutputLocally:  runOutputLocally,
 		ExecArgs:          localExecArgs,
+		WorkingDirectory:  workingDirectory,
 		FetchOutputs:      fetchOutputs,
 		WorkspaceFilePath: wsFilePath,
 	}, repoConfig)

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -3,6 +3,7 @@ package remotebazel
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -390,6 +391,53 @@ func TestGeneratingPatches(t *testing.T) {
 		} else {
 			require.FailNowf(t, "unexpected patch %s", p)
 		}
+	}
+}
+
+func TestWorkingDirectory(t *testing.T) {
+	rootDir := t.TempDir()
+	repoRoot := filepath.Join(rootDir, "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "subdir", "nested"), 0755))
+
+	testCases := []struct {
+		name              string
+		workspaceFilePath string
+		expectedDir       string
+		expectedError     string
+	}{
+		{
+			name:              "Repo root workspace",
+			workspaceFilePath: filepath.Join(repoRoot, "MODULE.bazel"),
+			expectedDir:       "",
+		},
+		{
+			name:              "Nested workspace",
+			workspaceFilePath: filepath.Join(repoRoot, "subdir", "MODULE.bazel"),
+			expectedDir:       "subdir",
+		},
+		{
+			name:              "Deeply nested workspace",
+			workspaceFilePath: filepath.Join(repoRoot, "subdir", "nested", "MODULE.bazel"),
+			expectedDir:       filepath.Join("subdir", "nested"),
+		},
+		{
+			name:              "Workspace outside repo root",
+			workspaceFilePath: filepath.Join(rootDir, "outside", "MODULE.bazel"),
+			expectedError:     "outside repo root",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, err := workingDirectory(repoRoot, tc.workspaceFilePath)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedDir, dir)
+		})
 	}
 }
 

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -81,6 +81,36 @@ func (r *runnerService) checkPreconditions(req *rnpb.RunRequest) error {
 	return nil
 }
 
+func normalizeWorkingDirectory(path string) (string, error) {
+	path = filepath.Clean(path)
+	if filepath.IsAbs(path) {
+		return "", status.InvalidArgumentErrorf("working_directory must be repo-relative: %q", path)
+	}
+	if path == "." {
+		return "", nil
+	}
+	if strings.Contains(path, "..") {
+		return "", status.InvalidArgumentErrorf("working_directory must not have relative components: %q", path)
+	}
+	return path, nil
+}
+
+func actionFromRunRequest(req *rnpb.RunRequest) (*config.Action, error) {
+	name := "remote run"
+	if req.GetName() != "" {
+		name = req.GetName()
+	}
+	workingDirectory, err := normalizeWorkingDirectory(req.GetWorkingDirectory())
+	if err != nil {
+		return nil, err
+	}
+	return &config.Action{
+		Name:              name,
+		Steps:             req.GetSteps(),
+		BazelWorkspaceDir: workingDirectory,
+	}, nil
+}
+
 // createAction creates and uploads an action that will trigger the CI runner
 // to checkout the specified repo and execute the specified bazel action,
 // uploading any logs to an invcocation page with the specified ID.
@@ -142,13 +172,9 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		req.Steps = []*rnpb.Step{{Run: "bazel " + req.GetBazelCommand()}}
 	}
 
-	name := "remote run"
-	if req.GetName() != "" {
-		name = req.GetName()
-	}
-	runAction := &config.Action{
-		Name:  name,
-		Steps: req.GetSteps(),
+	runAction, err := actionFromRunRequest(req)
+	if err != nil {
+		return nil, err
 	}
 	actionBytes, err := yaml.Marshal(runAction)
 	if err != nil {

--- a/enterprise/server/hostedrunner/hostedrunner_test.go
+++ b/enterprise/server/hostedrunner/hostedrunner_test.go
@@ -2,6 +2,7 @@ package hostedrunner
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
@@ -161,5 +162,80 @@ func TestRemoteHeaders_EnvOverrides(t *testing.T) {
 	// Check that credential-related overrides were not overwritten
 	for _, expectedCredential := range []string{"BUILDBUDDY_API_KEY", "REPO_TOKEN", "REPO_USER"} {
 		require.Contains(t, appliedEnvOverrides, expectedCredential)
+	}
+}
+
+func TestNormalizeWorkingDirectory(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		input     string
+		expected  string
+		expectErr bool
+	}{
+		{"empty", "", "", false},
+		{"simple subdir", "subdir", "subdir", false},
+		{"nested", filepath.Join("subdir", "nested"), filepath.Join("subdir", "nested"), false},
+		{"dot cleaned to empty", ".", "", false},
+		{"absolute path rejected", "/tmp/workspace", "", true},
+		{"parent traversal rejected", filepath.Join("..", "subdir"), "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := normalizeWorkingDirectory(tc.input)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestActionFromRunRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name                      string
+		req                       *rnpb.RunRequest
+		expectedName              string
+		expectedBazelWorkspaceDir string
+		expectErr                 bool
+	}{
+		{
+			name: "all fields set",
+			req: &rnpb.RunRequest{
+				Name:             "Test run",
+				Steps:            []*rnpb.Step{{Run: "bazel build //:target"}},
+				WorkingDirectory: filepath.Join("subdir", "nested"),
+			},
+			expectedName:              "Test run",
+			expectedBazelWorkspaceDir: filepath.Join("subdir", "nested"),
+		},
+		{
+			name: "default name",
+			req: &rnpb.RunRequest{
+				Steps: []*rnpb.Step{{Run: "bazel test //..."}},
+			},
+			expectedName:              "remote run",
+			expectedBazelWorkspaceDir: "",
+		},
+		{
+			name: "invalid working directory",
+			req: &rnpb.RunRequest{
+				Steps:            []*rnpb.Step{{Run: "bazel build //..."}},
+				WorkingDirectory: "/absolute/path",
+			},
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			action, err := actionFromRunRequest(tc.req)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedName, action.Name)
+			require.Equal(t, tc.req.GetSteps(), action.Steps)
+			require.Equal(t, tc.expectedBazelWorkspaceDir, action.BazelWorkspaceDir)
+		})
 	}
 }

--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -76,6 +76,10 @@ message RunRequest {
   // For non-idempotent workloads, set to true to disable this behavior.
   bool disable_retry = 19;
 
+  // Repo-relative subdirectory where bazel commands should be run from.
+  // Empty means the repo root.
+  string working_directory = 21;
+
   // DEPRECATED: Use wait_mode instead.
   // If true, start the runner but do not wait for the action to be scheduled.
   bool async = 9 [deprecated = true];


### PR DESCRIPTION
When the bazel root is in a subdirectory of the git repo, `bb remote`
now computes the repo-relative path and passes it through so the runner
runs in the correct place.
