### PR TITLE
Fix pty output race in `plugin.Pipe()`

### DIFF
--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
@@ -766,12 +767,14 @@ func (p *Plugin) Pipe(r io.Reader) (io.Reader, error) {
 	pr, pw := io.Pipe()
 	cmd.Dir = path
 	// Write command output to a pty to ensure line buffering.
-	ptmx, tty, err := pty.Open()
+	// pty.Open returns a pair: ptmx (the controller side that we read from)
+	// and childTTY (the process side that the child writes to).
+	ptmx, childTTY, err := pty.Open()
 	if err != nil {
 		return nil, status.InternalErrorf("failed to open pty: %s", err)
 	}
-	cmd.Stdout = tty
-	cmd.Stderr = tty
+	cmd.Stdout = childTTY
+	cmd.Stderr = childTTY
 	cmd.Stdin = r
 	// Prevent output handlers from receiving Ctrl+C, to prevent things like
 	// "KeyboardInterrupt" being printed in Python plugins. Instead, plugins
@@ -784,30 +787,32 @@ func (p *Plugin) Pipe(r io.Reader) (io.Reader, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, status.InternalErrorf("failed to start plugin bazel output handler: %s", err)
 	}
+	// Close our reference to the child side of the pty now that the child
+	// process has inherited it. The child holds its own fd. When the child
+	// exits, it will be the last holder, and the kernel will signal EOF on
+	// the controller side (ptmx) after all buffered data is drained.
+	// This avoids https://github.com/creack/pty/issues/127 where closing
+	// the child side after the process exits can race with the read side.
+	childTTY.Close()
+	var copyDone sync.WaitGroup
+	copyDone.Add(1)
 	go func() {
+		defer copyDone.Done()
 		// Copy pty output to the next pipeline stage.
 		io.Copy(pw, ptmx)
 	}()
 	go func() {
-		// TODO: Properly clean up the tty here. We disable the cleanup since it
-		// seems to cause some plugin output to get dropped in rare cases.
-		// See: https://github.com/creack/pty/issues/127
-		//
-		// The cleanup being disabled is not a problem for the CLI because it
-		// should get cleaned up automatically when the CLI process exits, but
-		// if we want to reuse this code for other things then we should
-		// probably fix this so the tty can get cleaned up sooner.
-
-		// defer tty.Close()
-
-		defer ptmx.Close()
-		defer pw.Close()
 		log.Debugf("Running bazel output handler for %s/%s", p.config.Repo, p.config.Path)
 		if err := cmd.Wait(); err != nil {
 			log.Debugf("Command failed: %s", err)
 		} else {
 			log.Debugf("Command %s completed", cmd.Args)
 		}
+		// Wait for the copy goroutine to finish draining all pty output
+		// before closing ptmx and pw, so no output is lost.
+		copyDone.Wait()
+		ptmx.Close()
+		pw.Close()
 		// Flush any remaining data from the preceding stage, to prevent
 		// the output writer for the preceding stage from getting stuck.
 		io.Copy(io.Discard, r)

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -1,8 +1,11 @@
 package plugin
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/config"
@@ -266,4 +269,56 @@ func setTestHomeDir(t *testing.T, path string) {
 		err := os.Setenv("HOME", original)
 		require.NoError(t, err)
 	})
+}
+
+func TestPipelineWriter_AllOutputCaptured(t *testing.T) {
+	// Regression test: output produced by handle_bazel_output.sh must not be
+	// dropped due to pty teardown races. We run the pipeline many times with
+	// a script that emits a known number of lines, and verify every line
+	// arrives.
+	const numLines = 200
+	const iterations = 20
+
+	pluginDir := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, pluginDir, map[string]string{
+		// The script reads stdin (to satisfy the pipeline), then prints
+		// numLines lines to stdout right before exiting. This stresses the
+		// "output at exit" path where the pty teardown race used to drop data.
+		"handle_bazel_output.sh": fmt.Sprintf(`#!/usr/bin/env bash
+cat > /dev/null
+for i in $(seq 1 %d); do
+  echo "OUTPUT_LINE_$i"
+done
+`, numLines),
+	})
+	testfs.MakeExecutable(t, pluginDir, "handle_bazel_output.sh")
+
+	for i := 0; i < iterations; i++ {
+		t.Run(fmt.Sprintf("iteration_%d", i), func(t *testing.T) {
+			p := &Plugin{
+				config:   &config.PluginConfig{Path: pluginDir},
+				tempDir:  t.TempDir(),
+			}
+			p.configFile = &config.File{Path: filepath.Join(pluginDir, "buildbuddy.yaml")}
+
+			var out bytes.Buffer
+			wc, err := PipelineWriter(&out, []*Plugin{p})
+			require.NoError(t, err)
+
+			// Write some input and immediately close to trigger plugin exit.
+			_, err = wc.Write([]byte("hello\n"))
+			require.NoError(t, err)
+			err = wc.Close()
+			require.NoError(t, err)
+
+			output := out.String()
+			for line := 1; line <= numLines; line++ {
+				expected := fmt.Sprintf("OUTPUT_LINE_%d", line)
+				if !strings.Contains(output, expected) {
+					t.Fatalf("missing %s in output (got %d bytes, %d lines)",
+						expected, len(output), strings.Count(output, "\n"))
+				}
+			}
+		})
+	}
 }

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -296,8 +296,8 @@ done
 	for i := 0; i < iterations; i++ {
 		t.Run(fmt.Sprintf("iteration_%d", i), func(t *testing.T) {
 			p := &Plugin{
-				config:   &config.PluginConfig{Path: pluginDir},
-				tempDir:  t.TempDir(),
+				config:  &config.PluginConfig{Path: pluginDir},
+				tempDir: t.TempDir(),
 			}
 			p.configFile = &config.File{Path: filepath.Join(pluginDir, "buildbuddy.yaml")}
 


### PR DESCRIPTION
Two problems with the previous goroutine lifecycle:

1. ptmx was closed (via defer) immediately after cmd.Wait(), racing with the goroutine still reading from ptmx. If ptmx closed before all buffered data was read, the plugin's output was silently lost.

2. The child side of the pty (tty) was never closed by the parent, only by the child process on exit. As noted in creack/pty#127, closing the child side *after* the process exits can race with reads on the controller side, causing EIO and dropped output on macOS.

Fix: Close our reference to the child side of the pty right after cmd.Start() — the child inherits its own fd. When the child exits, the kernel signals EOF on the controller side after all buffered data is drained. Then wait for the copy goroutine to finish before closing ptmx and pw.

Add TestPipelineWriter_AllOutputCaptured as a regression test that stresses the output-at-exit path with 200 lines x 20 iterations.