### PR TITLE
Unquarantine TestServerBypassRegistry and fix gRPC server stop race

### DIFF
--- a/enterprise/server/oci/ocifetcher/BUILD
+++ b/enterprise/server/oci/ocifetcher/BUILD
@@ -44,7 +44,6 @@ go_test(
         "//proto:registry_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
-        "//server/testutil/quarantine",
         "//server/testutil/testauth",
         "//server/testutil/testcache",
         "//server/testutil/testenv",

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testregistry"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcache"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
@@ -811,8 +810,6 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 }
 
 func TestServerBypassRegistry(t *testing.T) {
-	// TODO(dan): https://github.com/buildbuddy-io/buildbuddy-internal/issues/6877
-	quarantine.SkipQuarantinedTest(t)
 	const adminGroupID = "GR123"
 
 	adminUser := &claims.Claims{

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -135,7 +135,7 @@ func localGRPCConn(ctx context.Context, lis *bufconn.Listener, opts ...grpc.Dial
 func GRPCServer(env environment.Env, lis net.Listener) (*grpc.Server, func()) {
 	srv := grpc.NewServer(grpc_server.CommonGRPCServerOptions(env)...)
 	runFunc := func() {
-		if err := srv.Serve(lis); err != nil {
+		if err := srv.Serve(lis); err != nil && err != grpc.ErrServerStopped {
 			log.Fatal(err.Error())
 		}
 	}


### PR DESCRIPTION
The test was quarantined due to a flake where the gRPC server's Serve() goroutine would call log.Fatal when called on an already-stopped server.

The race: setupCacheEnv() starts 'go runServer()' but the subtest can finish and run t.Cleanup (which calls srv.Stop()) before the goroutine is scheduled. When Serve() finally runs on the stopped server, it returns grpc.ErrServerStopped, triggering log.Fatal and crashing the test process.

Fix: tolerate grpc.ErrServerStopped in GRPCServer's runFunc, since this is an expected outcome when Stop() is called before Serve() starts.

Verified: 150 consecutive runs (50 + 100) with zero failures.