### PR TITLE
executor: support windows 386 release builds

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -119,6 +119,14 @@ jobs:
                    //enterprise/server/cmd/executor:executor
           bazelisk --output_user_root=C:/0 `
                    --windows_enable_symlinks `
+                   build `
+                   --config=untrusted-ci-windows `
+                   --platforms=@io_bazel_rules_go//go/toolchain:windows_386 `
+                   @authArgs `
+                   -- `
+                   //enterprise/server/cmd/executor:executor
+          bazelisk --output_user_root=C:/0 `
+                   --windows_enable_symlinks `
                    test `
                    --config=untrusted-ci-windows `
                    --test_tag_filters=-performance `

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -39,9 +39,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bazelisk --output_user_root=C:/0 build --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
+          $commonArgs = @(
+            "--config=release-windows"
+            "--remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}"
+          )
+          $windows386Args = @(
+            "--config=release-windows"
+            "--remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}"
+            "--platforms=@io_bazel_rules_go//go/toolchain:windows_386"
+          )
+          $target = "//enterprise/server/cmd/executor:executor"
+
+          bazelisk --output_user_root=C:/0 build @commonArgs $target
           $execution_root = bazelisk --output_user_root=C:/0 info execution_root
-          $artifact_rel_path = bazelisk --output_user_root=C:/0 cquery --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --output=files //enterprise/server/cmd/executor:executor
+          $artifact_rel_path = bazelisk --output_user_root=C:/0 cquery @commonArgs --output=files $target
           $artifact_abs_path = "${execution_root}\${artifact_rel_path}"
           Copy-Item -Path $artifact_abs_path -Destination executor-enterprise-windows-amd64-beta.exe
-          gh release upload ${{ inputs.version_tag }} executor-enterprise-windows-amd64-beta.exe --clobber
+
+          bazelisk --output_user_root=C:/0 build @windows386Args $target
+          $artifact_rel_path = bazelisk --output_user_root=C:/0 cquery @windows386Args --output=files $target
+          $artifact_abs_path = "${execution_root}\${artifact_rel_path}"
+          Copy-Item -Path $artifact_abs_path -Destination executor-enterprise-windows-386-beta.exe
+
+          gh release upload ${{ inputs.version_tag }} executor-enterprise-windows-amd64-beta.exe executor-enterprise-windows-386-beta.exe --clobber

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -362,7 +362,7 @@ func (c *fileCache) handleTrashNotifications() {
 // removal.
 func (c *fileCache) trash(path string) error {
 	trashDir := c.TempDir()
-	dst := filepath.Join(trashDir, ".trash-"+strconv.Itoa(rand.Intn(1e18))+"-"+filepath.Base(path))
+	dst := filepath.Join(trashDir, ".trash-"+strconv.FormatInt(rand.Int63n(1_000_000_000_000_000_000), 10)+"-"+filepath.Base(path))
 	if err := os.Rename(path, dst); err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/vfs/BUILD
+++ b/enterprise/server/remote_execution/vfs/BUILD
@@ -65,6 +65,10 @@ go_library(
             "//enterprise/server/util/vfscommon",
             "//proto:vfs_go_proto",
         ],
+        "@io_bazel_rules_go//go/platform:windows_386": [
+            "//enterprise/server/util/vfscommon",
+            "//proto:vfs_go_proto",
+        ],
         "@io_bazel_rules_go//go/platform:windows_arm64": [
             "//enterprise/server/util/vfscommon",
             "//proto:vfs_go_proto",

--- a/enterprise/server/remote_execution/vfs/vfs_windows.go
+++ b/enterprise/server/remote_execution/vfs/vfs_windows.go
@@ -1,4 +1,4 @@
-//go:build windows && (amd64 || arm64)
+//go:build windows && (386 || amd64 || arm64)
 
 package vfs
 

--- a/server/util/fspath/fspath.go
+++ b/server/util/fspath/fspath.go
@@ -52,7 +52,7 @@ func IsParent(parent, c string, isCaseInsensitive bool) bool {
 func IsCaseInsensitiveFS(dirPath string) (bool, error) {
 	// Create a test file with a globally unique name and which includes
 	// uppercase characters.
-	nameUpper := fmt.Sprintf(".CASE_SENSITIVITY_CHECK_%d", rand.Intn(1e18))
+	nameUpper := fmt.Sprintf(".CASE_SENSITIVITY_CHECK_%d", rand.Int63n(1_000_000_000_000_000_000))
 	pathUpper := filepath.Join(dirPath, nameUpper)
 	if err := os.WriteFile(pathUpper, nil, 0644); err != nil {
 		return false, fmt.Errorf("write test file: %w", err)


### PR DESCRIPTION
A customer asked for a regular Windows 32-bit executor binary, but the
current release workflow only publishes amd64 artifacts and the
executor fails to build for windows_386 because parts of the dependency
graph still assume 64-bit Windows.

Fix the 32-bit integer overflows in `fspath` and `filecache`, teach the
Windows VFS stub and BUILD metadata about `windows_386`, and extend the
Windows CI and release workflows to build and upload both amd64 and
386 executor artifacts.
