### PR TITLE
ci_runner: disable Bazel idle shutdown

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2259,6 +2259,10 @@ func writeBazelrc(path, invocationID, runID, rootDir string) error {
 	defer f.Close()
 
 	lines := []string{
+		// ci_runner tasks intentionally preserve Bazel server state across runs.
+		// Disable idle shutdown so a recycled runner doesn't resume a Bazel server
+		// whose idle timer is already expired.
+		"startup --max_idle_secs=0",
 		"common --build_metadata=PARENT_INVOCATION_ID=" + invocationID,
 		"common --build_metadata=PARENT_RUN_ID=" + runID,
 		// Note: these pieces of metadata are set to match the WorkspaceStatus event

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -227,19 +227,36 @@ type result struct {
 	DoNotRecycle bool
 }
 
+type invokeRunnerOpts struct {
+	Env               []string
+	WorkDir           string
+	BazelStartupFlags string
+}
+
 func invokeRunner(t *testing.T, args []string, env []string, workDir string) *result {
+	return invokeRunnerWithOpts(t, args, invokeRunnerOpts{
+		Env:     env,
+		WorkDir: workDir,
+	})
+}
+
+func invokeRunnerWithOpts(t *testing.T, args []string, opts invokeRunnerOpts) *result {
 	binPath, err := runfiles.Rlocation(ciRunnerRunfilePath)
 	if err != nil {
 		t.Fatal(err)
 	}
+	startupFlags := bazelStartupFlags
+	if opts.BazelStartupFlags != "" {
+		startupFlags = opts.BazelStartupFlags
+	}
 	args = append([]string{
 		"--bazel_command=" + testbazel.BinaryPath(t),
-		"--bazel_startup_flags=" + bazelStartupFlags,
+		"--bazel_startup_flags=" + startupFlags,
 	}, args...)
 
 	cmd := exec.Command(binPath, args...)
-	cmd.Dir = workDir
-	cmd.Env = env
+	cmd.Dir = opts.WorkDir
+	cmd.Env = opts.Env
 	outputBytes, err := cmd.CombinedOutput()
 	exitCode := -1
 	signal := syscall.Signal(-1)
@@ -270,7 +287,7 @@ func invokeRunner(t *testing.T, args []string, env []string, workDir string) *re
 		ExitCode:      exitCode,
 		Signal:        signal,
 		InvocationIDs: invocationIDs,
-		DoNotRecycle:  testfs.Exists(t, workDir, ".BUILDBUDDY_DO_NOT_RECYCLE"),
+		DoNotRecycle:  testfs.Exists(t, opts.WorkDir, ".BUILDBUDDY_DO_NOT_RECYCLE"),
 	}
 }
 
@@ -556,21 +573,10 @@ actions:
 			for _, sf := range tc.expectedStartupOptions {
 				missingStartupFlags[sf] = struct{}{}
 			}
-
-			for _, cl := range innerInvocation.StructuredCommandLine {
-				for _, s := range cl.Sections {
-					if s.SectionLabel == "startup options" {
-						optionList, ok := s.SectionType.(*clpb.CommandLineSection_OptionList)
-						if !ok {
-							continue
-						}
-						for _, o := range optionList.OptionList.Option {
-							for _, so := range tc.expectedStartupOptions {
-								if strings.Contains(o.CombinedForm, so) {
-									delete(missingStartupFlags, so)
-								}
-							}
-						}
+			for _, o := range findStructuredCommandLineOptions(t, innerInvocation, "original", "startup options") {
+				for so := range missingStartupFlags {
+					if strings.Contains(o.CombinedForm, so) {
+						delete(missingStartupFlags, so)
 					}
 				}
 			}
@@ -586,6 +592,25 @@ actions:
 			}
 		})
 	}
+}
+
+func findStructuredCommandLineOptions(t *testing.T, inv *inpb.Invocation, label, section string) []*clpb.Option {
+	t.Helper()
+	for _, cl := range inv.StructuredCommandLine {
+		if cl.GetCommandLineLabel() != label {
+			continue
+		}
+		for _, s := range cl.GetSections() {
+			if s.GetSectionLabel() != section {
+				continue
+			}
+			optionList, ok := s.SectionType.(*clpb.CommandLineSection_OptionList)
+			require.Truef(t, ok, "structured command line %q section %q was not an option list", label, section)
+			return optionList.OptionList.GetOption()
+		}
+	}
+	require.FailNowf(t, "structured command line section not found", "label=%q section=%q command_lines=%v", label, section, inv.StructuredCommandLine)
+	return nil
 }
 
 func TestCIRunner_StartupOptionsDontRestartBazelServer(t *testing.T) {
@@ -625,6 +650,65 @@ actions:
 	// Check that the bazel server wasn't restarted.
 	runnerInvocation := getRunnerInvocation(t, app, result)
 	require.NotContains(t, runnerInvocation.ConsoleBuffer, "Running Bazel server needs to be killed, because the startup options are different.")
+}
+
+func TestCIRunner_SetsMaxIdleSecsToZero(t *testing.T) {
+	wsPath := testfs.MakeTempDir(t)
+	workspaceContents := map[string]string{
+		"BUILD":         `sh_binary(name = "print_args", srcs = ["print_args.sh"])`,
+		"print_args.sh": "echo 'args: {{' $@ '}}'",
+		"buildbuddy.yaml": `
+actions:
+  - name: "Test action"
+    steps:
+      - run: bazel build //:print_args
+`,
+	}
+
+	repoPath, _ := makeGitRepo(t, workspaceContents)
+	runnerFlags := []string{
+		"--workflow_id=test-workflow",
+		"--action_name=Test action",
+		"--pushed_repo_url=file://" + repoPath,
+		"--pushed_branch=master",
+	}
+	app := buildbuddy.Run(t)
+	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
+
+	// This needs a dedicated test because the shared ci_runner harness injects
+	// --max_idle_secs=5, which would override the generated rc's
+	// startup --max_idle_secs=0 and mask the canonical startup option we want
+	// to assert here. Keep workflow_id so the action_name path still publishes
+	// a runner invocation to BES. Since ci_runner now disables idle shutdown for
+	// all Bazel runs, clean it up explicitly so the local Bazel server does not
+	// stay alive after the test.
+	startupFlags := "--noblock_for_lock"
+	t.Cleanup(func() {
+		shutdownFlags := append(append([]string{}, runnerFlags...), "--shutdown_and_exit")
+		result := invokeRunnerWithOpts(t, shutdownFlags, invokeRunnerOpts{
+			Env:               []string{},
+			WorkDir:           wsPath,
+			BazelStartupFlags: startupFlags,
+		})
+		require.Equalf(t, 0, result.ExitCode, "shutdown runner returned exit code %d\noutput:\n%s", result.ExitCode, result.Output)
+	})
+
+	result := invokeRunnerWithOpts(t, runnerFlags, invokeRunnerOpts{
+		Env:               []string{},
+		WorkDir:           wsPath,
+		BazelStartupFlags: startupFlags,
+	})
+	checkRunnerResult(t, result)
+
+	canonicalStartupOptions := findStructuredCommandLineOptions(t, getInnerInvocation(t, app, result), "canonical", "startup options")
+	foundMaxIdleSecs := false
+	for _, option := range canonicalStartupOptions {
+		if option.GetOptionName() == "max_idle_secs" && option.GetOptionValue() == "0" {
+			foundMaxIdleSecs = true
+			break
+		}
+	}
+	require.Truef(t, foundMaxIdleSecs, "canonical startup options did not include --max_idle_secs=0: %v", canonicalStartupOptions)
 }
 
 func TestCIRunner_Push_WorkspaceWithCustomConfig_RunsAndUploadsResultsToBES(t *testing.T) {


### PR DESCRIPTION
Fix a flake where `ci_runner` can reconnect to a Bazel server whose
idle deadline is already expired.

## Example Failure

```text
Server terminated abruptly (error code: 14, error message:
'failed to connect to all addresses; last error: UNKNOWN:
ipv4:127.0.0.1:42521: Failed to connect to remote host:
Connection refused', log file:
'/root/workspace/output-base/server/jvm.out')
260414 06:13:11.478:I 35
[com.google.devtools.build.lib.server.ServerWatcherRunnable.run]
About to shutdown due to idleness
```

## Root Cause

The underlying action is healthy because Bazel's idle watcher can shut
down a preserved server just after runner resume. Even when there is no
resume race, `ci_runner` wants to keep Bazel warm across repeated runs,
so letting Bazel shut itself down every three hours adds churn without
helping correctness.

Workflow and hosted Bazel runners can preserve Bazel's output base
across snapshot and resume, and our Firecracker restore path resets the
guest wall clock without restarting preserved background processes
[(1)](#user-content-ref-1). That leaves an inherited Bazel server
running with stale idle-shutdown state.

Bazel has defaulted `--max_idle_secs` to three hours since Bazel `0.1.0`,
where Bazel commit
[`d08b27fa9701fecfdb69e1b0d1ac2459efc2129b`](https://github.com/bazelbuild/bazel/commit/d08b27fa9701fecfdb69e1b0d1ac2459efc2129b)
introduced `BlazeServerStartupOptions`. Bazel `9.0.0`, via Bazel commit
[`0c674b05737da591b7d4f829893553f3f1ea3fd2`](https://github.com/bazelbuild/bazel/commit/0c674b05737da591b7d4f829893553f3f1ea3fd2),
switched the idle watcher from `nanoTime()` to `currentTimeMillis()` so
system sleep counts toward that budget [(2)](#user-content-ref-2).

When a runner is resumed more than three hours after the previous Bazel
command, the inherited server can exit a few seconds after restore and
race the next client connection.

## Change

- Always write `startup --max_idle_secs=0` in `buildbuddy.bazelrc` for `ci_runner` Bazel runs.
- Keep Bazel servers warm across all ci_runner-managed runner types, including Docker, Podman, macOS, and Firecracker.
- Keep the dedicated `ci_runner` integration test asserting canonical `max_idle_secs=0`.

## Reproduction

This was reproduced by resuming snapshot
`ac73ace2-4a96-4cbc-b61f-9b7182b1daa2` from the workflow invocation
chain in [(3)](#user-content-ref-3) with the following probe:

```bash
bb remote --remote_runner=grpcs://remote.buildbuddy.io \
  --remote_header=x-buildbuddy-api-key=<redacted> \
  --os=linux --arch=amd64 \
  --runner_exec_properties=recycle-runner=true \
  --run_from_snapshot='{"instanceName":"bb-snapshot/3faa2d8ad8910b5a477e3291053a187a28f16c1c6a7572ac7482e2e1bddbde10","snapshotId":"ac73ace2-4a96-4cbc-b61f-9b7182b1daa2"}' \
  --skip_auto_checkout --disable_retry --timeout=10m \
  --script='set -eux; sudo -n bash -lc '\''
    cd /root/workspace/repo-root
    PID=$(cat /root/workspace/output-base/server/server.pid.txt)
    for i in 0 1 2 3 4 5 6; do
      echo TICK=$i TIME=$(date -u +%FT%TZ)
      ps -p $PID -o pid=,ppid=,stat=,etimes=,cmd= || true
      sleep 1
    done
    printf "=== java.log tail ===\n"
    tail -n 80 /root/workspace/output-base/java.log || true
  '\'''
```

Important output from that probe:

```text
PID=11880 PORT=42521
TICK=0 TIME=2026-04-14T06:13:07Z
11880     1 Ssl      308 bazel(repo-root) ...
TICK=5 TIME=2026-04-14T06:13:12Z
260414 06:13:11.478:I 35
[com.google.devtools.build.lib.server.ServerWatcherRunnable.run]
About to shutdown due to idleness
```

## Testing

- `bazel test --config=remote-minimal //enterprise/server/util/ci_runner_util:ci_runner_util_test`
- `bazel test --config=remote-minimal //enterprise/server/hostedrunner:hostedrunner_test //enterprise/server/workflow/service:service_test //enterprise/server/test/integration/ci_runner:ci_runner_test --test_filter=TestCIRunner_SetsMaxIdleSecsToZero`
- `bazel test --config=remote-minimal //...`

## References

<a id="ref-1"></a>
### (1) BuildBuddy snapshot and bazelrc paths

- https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/remote_execution/containers/firecracker/firecracker.go#L2657-L2671
- https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/vmexec/vmexec.go#L239-L252
- https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/cmd/ci_runner/main.go#L2281-L2288

<a id="ref-2"></a>
### (2) Bazel idle-timeout behavior

- Bazel `0.1.0` startup default: https://github.com/bazelbuild/bazel/blob/d08b27fa9701fecfdb69e1b0d1ac2459efc2129b/src/main/java/com/google/devtools/build/lib/runtime/BlazeServerStartupOptions.java#L126-L133
- Bazel `9.0.0` wall-clock idle change: https://github.com/bazelbuild/bazel/commit/0c674b05737da591b7d4f829893553f3f1ea3fd2
- Bazel `9.0.0` idle watcher source: https://github.com/bazelbuild/bazel/blob/0c674b05737da591b7d4f829893553f3f1ea3fd2/src/main/java/com/google/devtools/build/lib/server/ServerWatcherRunnable.java#L173-L200

<a id="ref-3"></a>
### (3) BuildBuddy invocations

- https://buildbuddy.buildbuddy.io/invocation/ec45525f-b2f0-4baf-a49d-d7a86c91f928#@51
- https://buildbuddy.buildbuddy.io/invocation/d725123a-dcee-497c-93ad-8d92d9797990?actionDigest=f15a1c18dfb2684c40c8f7af303385fcf33420fc7697e1b74e70fa16460e15c9/769&executeResponseDigest=863f4a8aa8fe1918c00bd507de0cb072bd4cec359497306917c7a9ed01e37c26/203#action

