### PR TITLE
Fix TestTerminalOutput flake

### DIFF
--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -164,6 +164,10 @@ type Terminal struct {
 	output *lockingbuffer.LockingBuffer
 	// File is the file used for writing to the terminal.
 	File *os.File
+
+	// copyDone is closed when the io.Copy goroutine that reads from the
+	// PTY controller (ptmx) finishes (either EOF or error).
+	copyDone chan struct{}
 }
 
 // PTY returns a pseudoterminal for use in tests.
@@ -176,12 +180,16 @@ func PTY(t *testing.T) *Terminal {
 	})
 	term := &Terminal{
 		t: t, File: tty, output: lockingbuffer.New(),
+		copyDone: make(chan struct{}),
 	}
 	w := io.Writer(term.output)
 	if *streamOutputs {
 		w = io.MultiWriter(term.output, os.Stderr)
 	}
-	go io.Copy(w, ptmx)
+	go func() {
+		defer close(term.copyDone)
+		io.Copy(w, ptmx)
+	}()
 	return term
 }
 
@@ -190,6 +198,10 @@ func (t *Terminal) Run(cmd *exec.Cmd) (int, error) {
 	cmd.Stdout = t.File
 	cmd.Stderr = t.File
 	err := cmd.Run()
+	// Close the tty so the ptmx reader gets EOF, then wait for the
+	// io.Copy goroutine to finish draining all output.
+	_ = t.File.Close()
+	<-t.copyDone
 	return cmd.ProcessState.ExitCode(), err
 }
 


### PR DESCRIPTION
The PTY test helper had two issues:

1. Goroutine leak: The io.Copy goroutine reading from the PTY master would block forever because the PTY slave (tty) was never closed after the command exited, so the master never got EOF.

2. Data race: After cmd.Run() returned, the io.Copy goroutine could still be copying data from the PTY buffer. Calling Render()/Raw() immediately could read incomplete output.

Fix by closing the slave side of the PTY after cmd.Run() completes (which causes the master reader to get EOF), then waiting for the io.Copy goroutine to finish draining before returning. This ensures all output is fully captured before the caller reads it.

Verified with 100 runs of --test_filter=TestTerminalOutput: 100/100 pass.