### PR TITLE
feat(CDC): download large chunks in parallel

### DIFF
--- a/server/remote_cache/byte_stream_server/BUILD
+++ b/server/remote_cache/byte_stream_server/BUILD
@@ -42,7 +42,9 @@ go_test(
     deps = [
         "//enterprise/server/experiments",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/backends/memory_metrics_collector",
+        "//server/interfaces",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/chunking",
         "//server/remote_cache/digest",
@@ -52,6 +54,7 @@ go_test(
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/util/bazel_request",
+        "//server/util/bytebufferpool",
         "//server/util/compression",
         "//server/util/prefix",
         "//server/util/random",

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -36,6 +36,8 @@ import (
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
+const defaultChunkedReadMaxInFlight = 32
+
 var compressBufSize = int(4e6) // 4MB
 
 var (
@@ -71,7 +73,7 @@ func NewByteStreamServer(env environment.Env) (*ByteStreamServer, error) {
 	return &ByteStreamServer{
 		env:        env,
 		cache:      cache,
-		bufferPool: bytebufferpool.VariableSize(max(*remote_cache_config.ReadBufSizeBytes, compressBufSize)),
+		bufferPool: bytebufferpool.VariableSize(max(*remote_cache_config.ReadBufSizeBytes, compressBufSize, int(compression.ZstdCompressBound(chunking.MaxChunkSizeBytes())))),
 		warner:     bazel_deprecation.NewWarner(env),
 	}, nil
 }
@@ -245,25 +247,181 @@ func (s *ByteStreamServer) attemptReadChunked(ctx context.Context, rn *digest.CA
 		return nil, status.NotFoundErrorf("chunks missing from manifest for %q: %q", rn.DownloadString(), chunking.DigestsSummary(missing))
 	}
 
-	rcs := make([]io.ReadCloser, 0, len(rns))
-	for _, crn := range rns {
-		rc, err := s.cache.Reader(ctx, crn, remainingOffset, 0)
-		remainingOffset = 0
-		if err != nil {
-			metrics.ByteStreamServerChunkedReadFailures.With(prometheus.Labels{
-				metrics.ChunkedFailureReasonLabel: "chunk_read_error",
-				metrics.StatusHumanReadableLabel:  status.MetricsLabel(err),
-				metrics.ChunkedOffsetReadLabel:    offsetRead,
-			}).Inc()
-			for _, openCloser := range rcs {
-				openCloser.Close()
-			}
-			return nil, err
-		}
-		rcs = append(rcs, rc)
-	}
+	return newChunkedBlobReader(ctx, s.cache, s.bufferPool, rns, remainingOffset, offsetRead), nil
+}
 
-	return ioutil.NewMultiReadCloser(rcs...), nil
+type chunkReadResult struct {
+	data []byte
+	err  error
+}
+
+// chunkedBlobReader reconstructs a chunked blob by reading a bounded window of
+// chunks in parallel while returning bytes to the caller in order. This avoids
+// the per-chunk sequential latency of reading chunk-by-chunk from remote
+// backing storage such as GCS.
+type chunkedBlobReader struct {
+	ctx             context.Context
+	cancel          context.CancelFunc
+	cache           interfaces.Cache
+	bufferPool      *bytebufferpool.VariableSizePool
+	rns             []*rspb.ResourceName
+	firstOffset     int64
+	offsetReadLabel string
+
+	resultChans []chan chunkReadResult
+
+	currentBuf    []byte
+	currentOffset int
+	nextStart     int
+	nextRead      int
+}
+
+func newChunkedBlobReader(ctx context.Context, cache interfaces.Cache, bufferPool *bytebufferpool.VariableSizePool, rns []*rspb.ResourceName, firstOffset int64, offsetReadLabel string) io.ReadCloser {
+	ctx, cancel := context.WithCancel(ctx)
+	r := &chunkedBlobReader{
+		ctx:             ctx,
+		cancel:          cancel,
+		cache:           cache,
+		bufferPool:      bufferPool,
+		rns:             rns,
+		firstOffset:     firstOffset,
+		offsetReadLabel: offsetReadLabel,
+		resultChans:     make([]chan chunkReadResult, len(rns)),
+	}
+	r.fillWindow()
+	return r
+}
+
+func (r *chunkedBlobReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	for {
+		if r.currentBuf == nil {
+			if err := r.advance(); err != nil {
+				return 0, err
+			}
+		}
+		n := copy(p, r.currentBuf[r.currentOffset:])
+		r.currentOffset += n
+		if r.currentOffset == len(r.currentBuf) {
+			r.releaseCurrent()
+		}
+		if n > 0 {
+			return n, nil
+		}
+	}
+}
+
+func (r *chunkedBlobReader) Close() error {
+	r.cancel()
+	r.releaseCurrent()
+	r.drainPendingAsync()
+	return nil
+}
+
+// advance promotes the next chunk in order to the current read buffer and
+// refills the parallel prefetch window.
+func (r *chunkedBlobReader) advance() error {
+	if r.nextRead >= len(r.rns) {
+		return io.EOF
+	}
+	index := r.nextRead
+	resultChan := r.resultChans[index]
+	var result chunkReadResult
+	select {
+	case result = <-resultChan:
+	case <-r.ctx.Done():
+		return r.ctx.Err()
+	}
+	r.resultChans[index] = nil
+	r.nextRead++
+	if result.err != nil {
+		r.bufferPool.Put(result.data)
+		r.cancel()
+		metrics.ByteStreamServerChunkedReadFailures.With(prometheus.Labels{
+			metrics.ChunkedFailureReasonLabel: "chunk_read_error",
+			metrics.StatusHumanReadableLabel:  status.MetricsLabel(result.err),
+			metrics.ChunkedOffsetReadLabel:    r.offsetReadLabel,
+		}).Inc()
+		return result.err
+	}
+	r.currentBuf = result.data
+	r.fillWindow()
+	return nil
+}
+
+func (r *chunkedBlobReader) fillWindow() {
+	for r.nextStart < len(r.rns) && r.nextStart-r.nextRead < defaultChunkedReadMaxInFlight {
+		r.spawn(r.nextStart)
+		r.nextStart++
+	}
+}
+
+func (r *chunkedBlobReader) spawn(index int) {
+	rn := r.rns[index]
+	offset := int64(0)
+	if index == 0 {
+		offset = r.firstOffset
+	}
+	bufSize := rn.GetDigest().GetSizeBytes() - offset
+	if rn.GetCompressor() == repb.Compressor_ZSTD {
+		bufSize = compression.ZstdCompressBound(bufSize)
+	}
+	buf := r.bufferPool.Get(bufSize)
+	resultCh := make(chan chunkReadResult, 1)
+	r.resultChans[index] = resultCh
+	go func() {
+		resultCh <- r.readChunk(rn, offset, buf)
+	}()
+}
+
+func (r *chunkedBlobReader) readChunk(rn *rspb.ResourceName, offset int64, buf []byte) chunkReadResult {
+	rc, err := r.cache.Reader(r.ctx, rn, offset, 0)
+	if err != nil {
+		return chunkReadResult{data: buf, err: err}
+	}
+	defer rc.Close()
+
+	n, err := ioutil.ReadTryFillBuffer(rc, buf)
+	if err != nil {
+		return chunkReadResult{data: buf, err: err}
+	}
+	readSize := rn.GetDigest().GetSizeBytes() - offset
+	if rn.GetCompressor() != repb.Compressor_ZSTD && int64(n) != readSize {
+		return chunkReadResult{data: buf, err: io.ErrUnexpectedEOF}
+	}
+	return chunkReadResult{data: buf[:n]}
+}
+
+func (r *chunkedBlobReader) releaseCurrent() {
+	if r.currentBuf != nil {
+		r.bufferPool.Put(r.currentBuf)
+		r.currentBuf = nil
+	}
+	r.currentOffset = 0
+}
+
+func (r *chunkedBlobReader) drainPendingAsync() {
+	var pending []chan chunkReadResult
+	for i, resultChan := range r.resultChans {
+		if resultChan == nil {
+			continue
+		}
+		pending = append(pending, resultChan)
+		r.resultChans[i] = nil
+	}
+	if len(pending) == 0 {
+		return
+	}
+	go drainChunkReadResults(r.bufferPool, pending)
+}
+
+func drainChunkReadResults(bufferPool *bytebufferpool.VariableSizePool, resultChans []chan chunkReadResult) {
+	for _, resultChan := range resultChans {
+		result := <-resultChan
+		bufferPool.Put(result.data)
+	}
 }
 
 // writeHandler enapsulates an on-going ByteStream write to a cache,

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_metrics_collector"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/chunking"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -19,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bytebufferpool"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
@@ -33,6 +37,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	guuid "github.com/google/uuid"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gstatus "google.golang.org/grpc/status"
@@ -60,6 +65,104 @@ func runByteStreamServer(ctx context.Context, t *testing.T, env *testenv.TestEnv
 	}
 
 	return clientConn
+}
+
+type gatedReadCache struct {
+	interfaces.Cache
+
+	release  chan struct{}
+	started  chan struct{}
+	gateSize int64
+
+	mu         sync.Mutex
+	activeRead int
+	maxRead    int
+}
+
+func (c *gatedReadCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+	if r.GetDigest().GetSizeBytes() != c.gateSize {
+		return c.Cache.Reader(ctx, r, uncompressedOffset, limit)
+	}
+	c.mu.Lock()
+	c.activeRead++
+	c.maxRead = max(c.maxRead, c.activeRead)
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		c.activeRead--
+		c.mu.Unlock()
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case c.started <- struct{}{}:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.release:
+	}
+	return c.Cache.Reader(ctx, r, uncompressedOffset, limit)
+}
+
+func (c *gatedReadCache) maxConcurrentReads() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.maxRead
+}
+
+type closeBlockingReadCloser struct {
+	started     chan struct{}
+	unblock     <-chan struct{}
+	startedOnce sync.Once
+}
+
+func (r *closeBlockingReadCloser) Read(_ []byte) (int, error) {
+	r.startedOnce.Do(func() {
+		r.started <- struct{}{}
+	})
+	<-r.unblock
+	return 0, io.EOF
+}
+
+func (r *closeBlockingReadCloser) Close() error {
+	return nil
+}
+
+type readerFuncCache struct {
+	interfaces.Cache
+	reader func(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error)
+}
+
+func (c *readerFuncCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+	return c.reader(ctx, r, offset, limit)
+}
+
+type casCompressionCache struct {
+	interfaces.Cache
+}
+
+func (c *casCompressionCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
+	if r.GetCacheType() != rspb.CacheType_CAS {
+		return c.Cache.Get(ctx, r)
+	}
+	return (&testcompression.CompressionCache{Cache: c.Cache}).Get(ctx, r)
+}
+
+func (c *casCompressionCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+	if r.GetCacheType() != rspb.CacheType_CAS {
+		return c.Cache.Reader(ctx, r, offset, limit)
+	}
+	return (&testcompression.CompressionCache{Cache: c.Cache}).Reader(ctx, r, offset, limit)
+}
+
+func (c *casCompressionCache) SupportsCompressor(compressor repb.Compressor_Value) bool {
+	switch compressor {
+	case repb.Compressor_IDENTITY, repb.Compressor_ZSTD:
+		return true
+	default:
+		return false
+	}
 }
 
 func TestRPCRead(t *testing.T) {
@@ -729,6 +832,343 @@ func TestReadChunked_NonZeroOffset(t *testing.T) {
 	}
 }
 
+func TestReadChunked_NonZeroOffset_ZstdBLAKE3(t *testing.T) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	flags.Set(t, "cache.zstd_transcoding_enabled", true)
+
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	te.SetExperimentFlagProvider(fp)
+
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runByteStreamServer(ctx, t, te)
+	bsClient := bspb.NewByteStreamClient(clientConn)
+
+	chunkSize := int64(1024 * 1024)
+	_, chunk1 := testdigest.RandomCASResourceBuf(t, chunkSize)
+	_, chunk2 := testdigest.RandomCASResourceBuf(t, chunkSize)
+	_, chunk3 := testdigest.RandomCASResourceBuf(t, chunkSize)
+	fullBlob := append(append(chunk1, chunk2...), chunk3...)
+
+	chunk1Digest, err := digest.Compute(bytes.NewReader(chunk1), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	chunk2Digest, err := digest.Compute(bytes.NewReader(chunk2), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	chunk3Digest, err := digest.Compute(bytes.NewReader(chunk3), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	blobDigest, err := digest.Compute(bytes.NewReader(fullBlob), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+
+	chunk1RN := digest.NewCASResourceName(chunk1Digest, "", repb.DigestFunction_BLAKE3)
+	chunk2RN := digest.NewCASResourceName(chunk2Digest, "", repb.DigestFunction_BLAKE3)
+	chunk3RN := digest.NewCASResourceName(chunk3Digest, "", repb.DigestFunction_BLAKE3)
+	require.NoError(t, te.GetCache().Set(ctx, chunk1RN.ToProto(), chunk1))
+	require.NoError(t, te.GetCache().Set(ctx, chunk2RN.ToProto(), chunk2))
+	require.NoError(t, te.GetCache().Set(ctx, chunk3RN.ToProto(), chunk3))
+
+	manifest := &chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   []*repb.Digest{chunk1Digest, chunk2Digest, chunk3Digest},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_BLAKE3,
+	}
+	require.NoError(t, manifest.Store(ctx, te.GetCache()))
+
+	blobRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
+	blobRN.SetCompressor(repb.Compressor_ZSTD)
+
+	offset := chunkSize + chunkSize/2
+	stream, err := bsClient.Read(ctx, &bspb.ReadRequest{
+		ResourceName: blobRN.DownloadString(),
+		ReadOffset:   offset,
+	})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		buf.Write(resp.GetData())
+	}
+	require.Equal(t, fullBlob[offset:], zstdDecompress(t, buf.Bytes()))
+}
+
+func TestChunkedBlobReaderReadChunk(t *testing.T) {
+	t.Run("identity returns exact bytes", func(t *testing.T) {
+		data := []byte("hello, world")
+		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_BLAKE3)
+		require.NoError(t, err)
+		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_BLAKE3).ToProto()
+		r := &chunkedBlobReader{
+			ctx: context.Background(),
+			cache: &readerFuncCache{
+				reader: func(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader(data[offset:])), nil
+				},
+			},
+			bufferPool: bytebufferpool.VariableSize(len(data)),
+		}
+
+		buf := r.bufferPool.Get(int64(len(data)))
+		result := r.readChunk(rn, 0, buf)
+		require.NoError(t, result.err)
+		require.Equal(t, data, result.data)
+	})
+
+	t.Run("identity rejects short reads", func(t *testing.T) {
+		data := []byte("hello, world")
+		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_BLAKE3)
+		require.NoError(t, err)
+		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_BLAKE3).ToProto()
+		r := &chunkedBlobReader{
+			ctx: context.Background(),
+			cache: &readerFuncCache{
+				reader: func(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader(data[:len(data)-1])), nil
+				},
+			},
+			bufferPool: bytebufferpool.VariableSize(len(data)),
+		}
+
+		buf := r.bufferPool.Get(int64(len(data)))
+		result := r.readChunk(rn, 0, buf)
+		require.ErrorIs(t, result.err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("zstd allows compression overhead", func(t *testing.T) {
+		data := []byte("abc")
+		compressed := compression.CompressZstd(nil, data)
+		require.Greater(t, len(compressed), len(data))
+
+		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_BLAKE3)
+		require.NoError(t, err)
+		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_BLAKE3)
+		rn.SetCompressor(repb.Compressor_ZSTD)
+		r := &chunkedBlobReader{
+			ctx: context.Background(),
+			cache: &readerFuncCache{
+				reader: func(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader(compressed)), nil
+				},
+			},
+			bufferPool: bytebufferpool.VariableSize(int(compression.ZstdCompressBound(int64(len(data))))),
+		}
+
+		buf := r.bufferPool.Get(compression.ZstdCompressBound(int64(len(data))))
+		result := r.readChunk(rn.ToProto(), 0, buf)
+		require.NoError(t, result.err)
+		require.Equal(t, compressed, result.data)
+	})
+}
+
+func TestChunkedBlobReader_ReadReturnsCurrentChunk(t *testing.T) {
+	bufferPool := bytebufferpool.VariableSize(8)
+	buf := bufferPool.Get(5)
+	copy(buf, "hello")
+	r := &chunkedBlobReader{
+		bufferPool: bufferPool,
+		currentBuf: buf,
+	}
+
+	out := make([]byte, 5)
+	n, err := r.Read(out)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", string(out[:n]))
+	require.Nil(t, r.currentBuf)
+	require.Equal(t, 0, r.currentOffset)
+}
+
+func TestChunkedBlobReader_CloseAfterErrorDoesNotBlock(t *testing.T) {
+	chunk1 := []byte("hello")
+	chunk2 := []byte("world")
+	chunk1Digest, err := digest.Compute(bytes.NewReader(chunk1), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	chunk2Digest, err := digest.Compute(bytes.NewReader(chunk2), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+
+	rn1 := digest.NewCASResourceName(chunk1Digest, "", repb.DigestFunction_BLAKE3).ToProto()
+	rn2 := digest.NewCASResourceName(chunk2Digest, "", repb.DigestFunction_BLAKE3).ToProto()
+	reader := newChunkedBlobReader(context.Background(), &readerFuncCache{
+		reader: func(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+			switch r.GetDigest().GetHash() {
+			case chunk1Digest.GetHash():
+				return io.NopCloser(bytes.NewReader(chunk1)), nil
+			case chunk2Digest.GetHash():
+				return io.NopCloser(bytes.NewReader(chunk2[:len(chunk2)-1])), nil
+			default:
+				return nil, status.NotFoundErrorf("unexpected digest %q", r.GetDigest().GetHash())
+			}
+		},
+	}, bytebufferpool.VariableSize(64), []*rspb.ResourceName{rn1, rn2}, 0, "false")
+
+	got, err := io.ReadAll(reader)
+	require.Equal(t, chunk1, got)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+
+	done := make(chan struct{})
+	go func() {
+		_ = reader.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close() hung after a chunk read error")
+	}
+}
+
+func TestChunkedBlobReader_CloseDoesNotWaitForActiveReads(t *testing.T) {
+	started := make(chan struct{}, 2)
+	unblock := make(chan struct{})
+	chunk1Digest, err := digest.Compute(bytes.NewReader([]byte("a")), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	chunk2Digest, err := digest.Compute(bytes.NewReader([]byte("b")), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+
+	rn1 := digest.NewCASResourceName(chunk1Digest, "", repb.DigestFunction_BLAKE3).ToProto()
+	rn2 := digest.NewCASResourceName(chunk2Digest, "", repb.DigestFunction_BLAKE3).ToProto()
+	reader := newChunkedBlobReader(context.Background(), &readerFuncCache{
+		reader: func(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+			return &closeBlockingReadCloser{
+				started: started,
+				unblock: unblock,
+			}, nil
+		},
+	}, bytebufferpool.VariableSize(8), []*rspb.ResourceName{rn1, rn2}, 0, "false")
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("chunk read did not start")
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = reader.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close() waited for active reads")
+	}
+	close(unblock)
+}
+
+func TestNewByteStreamServer_BufferPoolAccommodatesCompressedChunkOverhead(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	s, err := NewByteStreamServer(te)
+	require.NoError(t, err)
+
+	want := compression.ZstdCompressBound(chunking.MaxChunkSizeBytes())
+	buf := s.bufferPool.Get(want)
+	defer s.bufferPool.Put(buf)
+
+	require.Equal(t, want, int64(len(buf)))
+}
+
+func TestReadChunked_ZstdBLAKE3_PassthroughIncompressible(t *testing.T) {
+	chunkSize := int64(1024 * 1024)
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	flags.Set(t, "cache.zstd_transcoding_enabled", true)
+
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	te.SetExperimentFlagProvider(fp)
+	te.SetCache(&casCompressionCache{Cache: te.GetCache()})
+
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runByteStreamServer(ctx, t, te)
+	bsClient := bspb.NewByteStreamClient(clientConn)
+
+	// Random chunks compress to slightly more than the uncompressed size, so
+	// this exercises the zstd compress-bound headroom in the chunk read path.
+	_, chunk1 := testdigest.RandomCASResourceBuf(t, chunkSize)
+	_, chunk2 := testdigest.RandomCASResourceBuf(t, chunkSize)
+	_, chunk3 := testdigest.RandomCASResourceBuf(t, chunkSize)
+	fullBlob := append(append(chunk1, chunk2...), chunk3...)
+
+	chunk1Digest, err := digest.Compute(bytes.NewReader(chunk1), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	chunk2Digest, err := digest.Compute(bytes.NewReader(chunk2), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	chunk3Digest, err := digest.Compute(bytes.NewReader(chunk3), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	blobDigest, err := digest.Compute(bytes.NewReader(fullBlob), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+
+	baseCache := te.GetCache().(*casCompressionCache).Cache
+	chunk1RN := digest.NewCASResourceName(chunk1Digest, "", repb.DigestFunction_BLAKE3)
+	chunk2RN := digest.NewCASResourceName(chunk2Digest, "", repb.DigestFunction_BLAKE3)
+	chunk3RN := digest.NewCASResourceName(chunk3Digest, "", repb.DigestFunction_BLAKE3)
+	require.NoError(t, baseCache.Set(ctx, chunk1RN.ToProto(), chunk1))
+	require.NoError(t, baseCache.Set(ctx, chunk2RN.ToProto(), chunk2))
+	require.NoError(t, baseCache.Set(ctx, chunk3RN.ToProto(), chunk3))
+
+	manifest := &chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   []*repb.Digest{chunk1Digest, chunk2Digest, chunk3Digest},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_BLAKE3,
+	}
+	require.NoError(t, manifest.Store(ctx, baseCache))
+
+	blobRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
+	blobRN.SetCompressor(repb.Compressor_ZSTD)
+
+	stream, err := bsClient.Read(ctx, &bspb.ReadRequest{
+		ResourceName: blobRN.DownloadString(),
+	})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		buf.Write(resp.GetData())
+	}
+	require.Equal(t, fullBlob, zstdDecompress(t, buf.Bytes()))
+}
+
 func TestReadChunked_MissingManifest(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
 		"cache.chunking_enabled": {
@@ -788,4 +1228,97 @@ func TestReadChunked_MissingManifest(t *testing.T) {
 		}
 	}
 	require.True(t, found, "expected MISSING violation with subject %q, got: %s", expectedSubject, err)
+}
+
+func TestReadChunked_UsesParallelReads(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		chunkCount int
+		want       int
+		compressor repb.Compressor_Value
+	}{
+		{name: "identity_few_chunks", chunkCount: 3, want: 3, compressor: repb.Compressor_IDENTITY},
+		{name: "identity_many_chunks", chunkCount: 2 * defaultChunkedReadMaxInFlight, want: defaultChunkedReadMaxInFlight, compressor: repb.Compressor_IDENTITY},
+		{name: "zstd_many_chunks", chunkCount: 2 * defaultChunkedReadMaxInFlight, want: defaultChunkedReadMaxInFlight, compressor: repb.Compressor_ZSTD},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+				"cache.chunking_enabled": {
+					State:          memprovider.Enabled,
+					DefaultVariant: "true",
+					Variants: map[string]any{
+						"true":  true,
+						"false": false,
+					},
+				},
+			})
+			require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+
+			fp, err := experiments.NewFlagProvider(t.Name())
+			require.NoError(t, err)
+			if tc.compressor == repb.Compressor_ZSTD {
+				flags.Set(t, "cache.zstd_transcoding_enabled", true)
+			}
+
+			ctx := context.Background()
+			te := testenv.GetTestEnv(t)
+			te.SetExperimentFlagProvider(fp)
+
+			baseCache := te.GetCache()
+			if tc.compressor == repb.Compressor_ZSTD {
+				baseCache = &casCompressionCache{Cache: baseCache}
+			}
+			cache := &gatedReadCache{
+				Cache:    baseCache,
+				release:  make(chan struct{}),
+				started:  make(chan struct{}, tc.chunkCount),
+				gateSize: 1024 * 1024,
+			}
+			te.SetCache(cache)
+
+			ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+			require.NoError(t, err)
+
+			clientConn := runByteStreamServer(ctx, t, te)
+			bsClient := bspb.NewByteStreamClient(clientConn)
+
+			chunkRN, chunkData := testdigest.RandomCASResourceBuf(t, 1024*1024)
+			require.NoError(t, cache.Set(ctx, chunkRN, chunkData))
+
+			fullBlob := bytes.Repeat(chunkData, tc.chunkCount)
+			blobDigest, err := digest.Compute(bytes.NewReader(fullBlob), repb.DigestFunction_SHA256)
+			require.NoError(t, err)
+
+			chunkDigests := make([]*repb.Digest, tc.chunkCount)
+			for i := range chunkDigests {
+				chunkDigests[i] = chunkRN.GetDigest()
+			}
+			manifest := &chunking.Manifest{
+				BlobDigest:     blobDigest,
+				ChunkDigests:   chunkDigests,
+				InstanceName:   "",
+				DigestFunction: repb.DigestFunction_SHA256,
+			}
+			require.NoError(t, manifest.Store(ctx, cache))
+
+			blobRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_SHA256)
+			errCh := make(chan error, 1)
+			go func() {
+				if tc.compressor == repb.Compressor_ZSTD {
+					blobRN.SetCompressor(repb.Compressor_ZSTD)
+				}
+				errCh <- cachetools.GetBlob(ctx, bsClient, blobRN, io.Discard)
+			}()
+			for i := 0; i < tc.want; i++ {
+				select {
+				case <-cache.started:
+				case <-time.After(time.Second):
+					t.Fatalf("timed out waiting for chunk read %d of %d", i+1, tc.want)
+				}
+			}
+			require.Equal(t, tc.want, cache.maxConcurrentReads())
+			close(cache.release)
+			require.NoError(t, <-errCh)
+		})
+	}
 }


### PR DESCRIPTION
For large blobs there's risk they won't download quickly enough sequentially. We can read chunks in parallel into a memory buffer and then download them faster.

From benchmarks, this is about 30x faster than the current implementation. Most of this is because the lifecycle of reading a chunk from GCS is slow, removing this sequential bottleneck allows us to saturate the network link if we can keep enough in memory. 32 chunks is a decent middleground.