### PR TITLE
[cli] fix race in plugin output handler that drops final output

### DIFF
--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -784,30 +784,41 @@ func (p *Plugin) Pipe(r io.Reader) (io.Reader, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, status.InternalErrorf("failed to start plugin bazel output handler: %s", err)
 	}
+	doneCopying := make(chan struct{})
 	go func() {
+		defer close(doneCopying)
 		// Copy pty output to the next pipeline stage.
 		io.Copy(pw, ptmx)
+		// Signal EOF to downstream now that all pty data has been
+		// forwarded. This is the happy-path close; the redundant
+		// pw.Close() in the other goroutine handles the case where
+		// this write is stuck on a dead downstream reader.
+		pw.Close()
 	}()
 	go func() {
-		// TODO: Properly clean up the tty here. We disable the cleanup since it
-		// seems to cause some plugin output to get dropped in rare cases.
-		// See: https://github.com/creack/pty/issues/127
-		//
-		// The cleanup being disabled is not a problem for the CLI because it
-		// should get cleaned up automatically when the CLI process exits, but
-		// if we want to reuse this code for other things then we should
-		// probably fix this so the tty can get cleaned up sooner.
-
-		// defer tty.Close()
-
 		defer ptmx.Close()
-		defer pw.Close()
 		log.Debugf("Running bazel output handler for %s/%s", p.config.Repo, p.config.Path)
 		if err := cmd.Wait(); err != nil {
 			log.Debugf("Command failed: %s", err)
 		} else {
 			log.Debugf("Command %s completed", cmd.Args)
 		}
+		// Close the pty subsidiary to signal no more writes.
+		// After cmd.Wait(), the child process has exited and released
+		// its reference to tty, so this closes the last open handle.
+		// The copy goroutine reading from ptmx will drain any remaining
+		// buffered data and then receive EIO, causing it to exit
+		// cleanly without data loss. This is safe to do after
+		// cmd.Wait() — the creack/pty#127 concern about dropped output
+		// only applies when closing tty while the child is still
+		// writing.
+		tty.Close()
+		// Close pw to unblock the copy goroutine if it's stuck writing
+		// to a downstream reader that exited early. This is safe to
+		// call concurrently with the copy goroutine's pw.Close()
+		// because io.Pipe's Close is concurrency-safe and idempotent.
+		pw.Close()
+		<-doneCopying
 		// Flush any remaining data from the preceding stage, to prevent
 		// the output writer for the preceding stage from getting stuck.
 		io.Copy(io.Discard, r)


### PR DESCRIPTION
In Pipe(), two goroutines coordinate to forward plugin output through a pty to a pipe:
- Goroutine 1: io.Copy(pw, ptmx) — reads pty, writes to pipe
- Goroutine 2: after cmd.Wait(), closes ptmx and pw via defers

Previously, ptmx.Close() and pw.Close() were both deferred in goroutine
2. Since defers run LIFO, ptmx was closed first (unblocking goroutine 1's read), then pw was closed immediately after. This created two races:

1. Closing ptmx can discard unread data still in the kernel's pty buffer before the copy goroutine has a chance to drain it.
2. pw.Close() (which signals EOF to downstream) could fire before the copy goroutine writes its last chunk.

Fix: after cmd.Wait(), close the pty subsidiary side (tty) instead of the controller (ptmx). Once all subsidiary handles are closed, reads from ptmx will drain remaining buffered data and then receive EIO — a clean, lossless shutdown. We then wait for the copy goroutine to finish before letting the deferred pw.Close() signal EOF downstream.

This also re-enables tty.Close() which was previously disabled due to creack/pty#127. That issue only applies when closing tty while the child is still writing; here we close it after cmd.Wait(), so the child has already exited.

Fixes ~5% flake in TestBazelBuildWithLocalPlugin where handle_bazel_output.sh output was intermittently lost.