### PR TITLE
Handle missing 'latest' tag in release.py for first-time image pushes

### DIFF
--- a/release.py
+++ b/release.py
@@ -142,9 +142,11 @@ def push_image_for_project(project, version_tag, bazel_target, skip_update_lates
 
     latest_image = get_image(project, "latest")
     if latest_image is None:
-        die(f"Could not fetch image with latest tag from project {project}.")
+        print(f"No 'latest' tag found for {project}; tagging current version as latest.")
+        should_update_latest_tag = True
+    else:
+        should_update_latest_tag = version_image["config"]["digest"] != latest_image["config"]["digest"]
 
-    should_update_latest_tag = version_image["config"]["digest"] != latest_image["config"]["digest"]
     if should_update_latest_tag:
         add_tag_cmd = f"echo 'yes' | gcloud container images add-tag gcr.io/{project}:{version_tag} gcr.io/{project}:latest"
         run_or_die(add_tag_cmd)


### PR DESCRIPTION
When pushing a new container image (e.g. buildbuddy-proxy-enterprise) for the first time, there is no existing 'latest' tag in the registry. The release script was dying with 'Could not fetch image with latest tag' instead of simply creating the tag.

Fix by treating a missing 'latest' tag as a signal to create it, rather than a fatal error.