### PR TITLE
Suppress benign Canceled errors when closing distributed peer writers

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -3,6 +3,7 @@ package distributed
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1495,6 +1496,13 @@ func (mc *multiWriteCloser) Commit() error {
 func (mc *multiWriteCloser) Close() error {
 	for peer, wc := range mc.peerClosers {
 		if err := wc.Close(); err != nil {
+			// Cancellation on the close path is benign: it happens when a
+			// writer is Closed without a successful Commit (e.g. the caller
+			// aborted mid-write), which cancels the underlying gRPC stream.
+			if status.IsCanceledError(err) || errors.Is(err, context.Canceled) {
+				mc.log.CtxDebugf(mc.ctx, "Closed peer %q writer with canceled context: %s", peer, err)
+				continue
+			}
 			mc.log.CtxErrorf(mc.ctx, "Error closing peer %q writer: %s", peer, err)
 		}
 	}


### PR DESCRIPTION
When a distributed cache `multiWriteCloser` is Closed without a successful Commit — for example because the caller aborted mid-write after a failure on one peer — each underlying `streamWriteCloser.Close()` cancels its own gRPC context and then calls `CloseAndRecv()`, which promptly returns `code = Canceled desc = context canceled`. That's an expected outcome of the close-path ordering, but we were logging it at Error level, producing noisy `Error closing peer "X:5151" writer: ... context canceled` messages in production (more frequent in clusters with K8s DNS autoscaling, where peers churn and partial-write paths are more common). This change downgrades those specific Canceled errors to Debug so real close failures still surface as Errors.

An alternative would be to flip the order in `streamWriteCloser.Close()` — call `CloseAndRecv()` first, then `cancelFunc()` — but the upfront cancel is probably there to prevent a hung recv on a broken stream, so filtering the benign error at the caller felt safer than reintroducing that hang.