### PR TITLE
Clean up some spurious dual-writer error logging

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -699,8 +699,7 @@ func (s *ByteStreamServerProxy) dualWrite(ctx context.Context, stream bspb.ByteS
 
 	// In gRPC streaming, io.EOF from Recv() is the normal end-of-stream signal.
 	// Ignore it here so we can forward any frames already received to the
-	// remote and return whatever CloseAndRecv() reports below, including cases
-	// like an AlreadyExists short-circuit with an old Bazel client.
+	// remote and return whatever CloseAndRecv() returns below.
 	if forwarding.recvErr != nil && forwarding.recvErr != io.EOF {
 		return forwarding.recvErr
 	}

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -712,8 +712,8 @@ func (s *ByteStreamServerProxy) dualWrite(ctx context.Context, stream bspb.ByteS
 		return forwarding.remoteSendErr
 	}
 	if !forwarding.finishWriteSent && forwarding.remoteSendErr == nil {
-		// If the local write encountered an error, try to send the remaining
-		// chunks to the remote.
+		// If the remote write is still open, flush any remaining requests to
+		// the remote.
 		if err := flushToRemote(stream, remoteStream); err != nil {
 			return err
 		}

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -697,10 +697,10 @@ func (s *ByteStreamServerProxy) dualWrite(ctx context.Context, stream bspb.ByteS
 	forwarding := &forwardingWriteStream{ByteStream_WriteServer: stream, remote: remoteStream}
 	localErr := s.local.Write(forwarding)
 
-	// Receiving an io.EOF indicates the sender closed the stream early (due to
-	// an error or an AlreadyExists short-circuit with an old Bazel client) not
-	// a real failure. Try to send all frames we've received through to the
-	// remote and return whatever CloseAndRecv() returns below.
+	// In gRPC streaming, io.EOF from Recv() is the normal end-of-stream signal.
+	// Ignore it here so we can forward any frames already received to the
+	// remote and return whatever CloseAndRecv() reports below, including cases
+	// like an AlreadyExists short-circuit with an old Bazel client.
 	if forwarding.recvErr != nil && forwarding.recvErr != io.EOF {
 		return forwarding.recvErr
 	}

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -697,7 +697,11 @@ func (s *ByteStreamServerProxy) dualWrite(ctx context.Context, stream bspb.ByteS
 	forwarding := &forwardingWriteStream{ByteStream_WriteServer: stream, remote: remoteStream}
 	localErr := s.local.Write(forwarding)
 
-	if forwarding.recvErr != nil {
+	// Receiving an io.EOF indicates the sender closed the stream early (due to
+	// an error or an AlreadyExists short-circuit with an old Bazel client) not
+	// a real failure. Try to send all frames we've received through to the
+	// remote and return whatever CloseAndRecv() returns below.
+	if forwarding.recvErr != nil && forwarding.recvErr != io.EOF {
 		return forwarding.recvErr
 	}
 	if localErr != nil {
@@ -708,18 +712,11 @@ func (s *ByteStreamServerProxy) dualWrite(ctx context.Context, stream bspb.ByteS
 		return forwarding.remoteSendErr
 	}
 	if !forwarding.finishWriteSent && forwarding.remoteSendErr == nil {
-		// Local write returned, but remoteSendErr != EOF so we need to forward
-		// the rest.
-		if localErr == nil {
-			log.CtxInfo(ctx, "local write done but remote write is not")
-		}
+		// If the local write encountered an error, try to send the remaining
+		// chunks to the remote.
 		if err := flushToRemote(stream, remoteStream); err != nil {
 			return err
 		}
-	}
-	if localErr == nil && !forwarding.localFinished {
-		// Only log this if the local write didn't fail.
-		log.CtxInfo(ctx, "remote write done but local write is not")
 	}
 	resp, err := remoteStream.CloseAndRecv()
 	if err != nil {


### PR DESCRIPTION
This PR makes three small changes to `dualWrite` in the byte stream server proxy, all motivated by noisy logs and spurious RPC failures we were seeing in production whenever one side of a dual write short-circuited.

The first change is to ignore `io.EOF` in the `recvErr` check. Previously, `dualWrite` returned `forwarding.recvErr` as an RPC error whenever it was non-nil, including when it was `io.EOF`. But `recvErr == io.EOF` just means the client has `CloseSend`'d its side of the stream, which can happen legitimately. In this case we now fall through and attempt to finish the remote write.

The second change removes the `"local write done but remote write is not"` info log. That log was firing in the `!forwarding.finishWriteSent && forwarding.remoteSendErr == nil` branch, which happens when the local write short-circuits (typically because it already has the blob) before forwarding `FinishWrite` to the remote. This happens regularly during normal operation.

The third change removes the `"remote write done but local write is not"` info log. This one was firing when `localErr == nil && !forwarding.localFinished`, which triggers when `forwarding.Recv` returned `io.EOF` to local (either because the client closed its send side or because `remote.Send` had errored and we synthesized an `io.EOF` to unblock local's loop). This happens in production when we receive an `AlreadyExists` error from the remote.
