### PR TITLE
[FC] Support exporting full snapshots straight to a COWstore

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -699,11 +699,11 @@ type FirecrackerContainer struct {
 	fsLayout  *container.FileSystemLayout
 	vfsServer *vfs_server.Server
 
-	scratchStore *copy_on_write.COWStore
-	scratchVBD   *vbd.FS
-	rootStore    *copy_on_write.COWStore
-	rootVBD      *vbd.FS
-	memoryVBD    *vbd.FS
+	scratchStore            *copy_on_write.COWStore
+	scratchVBD              *vbd.FS
+	rootStore               *copy_on_write.COWStore
+	rootVBD                 *vbd.FS
+	memorySnapshotExportVBD *vbd.FS
 
 	uffdHandler *uffd.Handler
 	memoryStore *copy_on_write.COWStore
@@ -2874,12 +2874,12 @@ func (c *FirecrackerContainer) unmountAllVBDs(ctx context.Context, fromRemove bo
 		}
 		c.rootVBD = nil
 	}
-	if c.memoryVBD != nil {
-		if err := c.memoryVBD.Unmount(ctx); err != nil {
+	if c.memorySnapshotExportVBD != nil {
+		if err := c.memorySnapshotExportVBD.Unmount(ctx); err != nil {
 			logErr("memory", err)
 			lastErr = err
 		}
-		c.memoryVBD = nil
+		c.memorySnapshotExportVBD = nil
 	}
 	return lastErr
 }
@@ -3245,7 +3245,7 @@ func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDe
 		}
 		c.memoryStore = memoryStore
 
-		// Create a virtual block device for the memory snapshot so that we can capture writes
+		// Create a FUSE-backed VBD for the memory snapshot so that we can capture writes
 		// as it's being exported by firecracker and write them directly to the COWStore.
 		d, err := vbd.New(memoryStore)
 		if err != nil {
@@ -3259,7 +3259,7 @@ func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDe
 
 		memSnapshotName = filepath.Join(relVBDPath, vbd.FileName)
 		c.memoryStore = memoryStore
-		c.memoryVBD = d
+		c.memorySnapshotExportVBD = d
 		log.CtxDebugf(ctx, "Mounted memory snapshot VBD to %s", mountPath)
 	}
 
@@ -3304,7 +3304,7 @@ func (c *FirecrackerContainer) cleanupOldSnapshots(ctx context.Context, snapshot
 
 	// If exporting the snapshot to a COWstore, the mem snapshot path points to a mounted VBD.
 	// Don't remove that, or the export will fail.
-	if c.memoryVBD == nil {
+	if c.memorySnapshotExportVBD == nil {
 		if err := disk.RemoveIfExists(memSnapshotPath); err != nil {
 			return status.WrapError(err, "failed to remove existing memory snapshot")
 		}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -97,6 +97,8 @@ var (
 	enableLinux6_1                        = flag.Bool("executor.firecracker_enable_linux_6_1", false, "Enable the 6.1 guest kernel for firecracker microVMs. x86_64 only.", flag.Internal)
 	dnsOverrides                          = flag.Slice("executor.firecracker_dns_overrides", []*networking.DNSOverride{}, "DNS entries to override in the guest.")
 
+	writeFullSnapshotToCOW = flag.Bool("executor.firecracker_write_full_snapshot_to_cow", false, "Write full Firecracker memory snapshots directly to a VBD-backed COWStore instead of a temporary file on disk that is later converted to a COWStore.", flag.Internal)
+
 	forceRemoteSnapshotting = flag.Bool("debug_force_remote_snapshots", false, "When remote snapshotting is enabled, force remote snapshotting even for tasks which otherwise wouldn't support it.")
 	disableWorkspaceSync    = flag.Bool("debug_disable_firecracker_workspace_sync", false, "Do not sync the action workspace to the guest, instead using the existing workspace from the VM snapshot.")
 	debugDisableCgroup      = flag.Bool("debug_disable_cgroup", false, "Disable firecracker cgroup setup.")
@@ -701,6 +703,7 @@ type FirecrackerContainer struct {
 	scratchVBD   *vbd.FS
 	rootStore    *copy_on_write.COWStore
 	rootVBD      *vbd.FS
+	memoryVBD    *vbd.FS
 
 	uffdHandler *uffd.Handler
 	memoryStore *copy_on_write.COWStore
@@ -1077,9 +1080,10 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		memSnapshotPath = baseMemSnapshotPath
 	}
 
-	// If we're creating a snapshot for the first time, create a COWStore from
-	// the initial full snapshot. (If we have a diff snapshot, then we already
-	// updated the memoryStore in mergeDiffSnapshot above).
+	// For diff snapshots, we updated the COWStore in mergeDiffSnapshot above.
+	// If writeFullSnapshotToCOW=true, the COWStore should've been populated
+	// as firecracker wrote the snapshot.
+	// Otherwise, we need to convert the snapshot file on disk to a COWStore.
 	if snapshotSharingEnabled && c.memoryStore == nil {
 		memChunkDir := filepath.Join(c.getChroot(), memoryChunkDirName)
 		concurrency := snaputil.ConvertToCOWConcurrency
@@ -2870,6 +2874,13 @@ func (c *FirecrackerContainer) unmountAllVBDs(ctx context.Context, fromRemove bo
 		}
 		c.rootVBD = nil
 	}
+	if c.memoryVBD != nil {
+		if err := c.memoryVBD.Unmount(ctx); err != nil {
+			logErr("memory", err)
+			lastErr = err
+		}
+		c.memoryVBD = nil
+	}
 	return lastErr
 }
 
@@ -2936,7 +2947,11 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 
 	log.CtxInfof(ctx, "Pausing VM")
 
-	snapDetails := c.snapshotDetails(ctx)
+	snapDetails, err := c.snapshotDetails(ctx)
+	if err != nil {
+		return status.WrapError(err, "prepare snapshot details")
+	}
+
 	shouldSaveSnapshot := snapDetails.saveRemoteSnapshot || snapDetails.saveLocalSnapshot
 
 	if shouldSaveSnapshot && c.isBalloonEnabled() && c.machineHasBalloon(ctx) {
@@ -3191,7 +3206,7 @@ type snapshotDetails struct {
 	saveLocalSnapshot   bool
 }
 
-func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) *snapshotDetails {
+func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDetails, error) {
 	saveRemoteSnapshot := c.shouldSaveRemoteSnapshot(ctx)
 	saveLocalSnapshot := c.shouldSaveLocalSnapshot(ctx)
 
@@ -3209,15 +3224,52 @@ func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) *snapshotDet
 			vmStateSnapshotName: vmStateSnapshotName,
 			saveRemoteSnapshot:  saveRemoteSnapshot,
 			saveLocalSnapshot:   saveLocalSnapshot,
-		}
+		}, nil
 	}
+
+	memSnapshotName := fullMemSnapshotName
+	if *writeFullSnapshotToCOW {
+		// If the full snapshot should be exported straight to a COWStore, create it here.
+		memChunkDir := filepath.Join(c.getChroot(), memoryChunkDirName)
+		if err := os.Mkdir(memChunkDir, 0755); err != nil {
+			return nil, status.WrapError(err, "make memory chunk dir")
+		}
+
+		memorySizeBytes := c.vmConfig.GetMemSizeMb() * 1024 * 1024
+		if memorySizeBytes <= 0 {
+			return nil, status.InternalErrorf("invalid memory snapshot size %d bytes", memorySizeBytes)
+		}
+		memoryStore, err := copy_on_write.NewCOWStore(c.vmCtx, c.env, memoryChunkDirName, nil, cowChunkSizeBytes(), memorySizeBytes, memChunkDir, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.supportsRemoteSnapshots)
+		if err != nil {
+			return nil, status.WrapError(err, "create memory COWStore")
+		}
+		c.memoryStore = memoryStore
+
+		// Create a virtual block device for the memory snapshot so that we can capture writes
+		// as it's being exported by firecracker and write them directly to the COWStore.
+		d, err := vbd.New(memoryStore)
+		if err != nil {
+			return nil, status.WrapError(err, "create memory snapshot VBD")
+		}
+		relVBDPath := fullMemSnapshotName + vbdMountDirSuffix
+		mountPath := filepath.Join(c.getChroot(), relVBDPath)
+		if err := d.Mount(c.vmCtx, mountPath); err != nil {
+			return nil, status.WrapError(err, "mount memory snapshot VBD")
+		}
+
+		memSnapshotName = filepath.Join(relVBDPath, vbd.FileName)
+		c.memoryStore = memoryStore
+		c.memoryVBD = d
+		log.CtxDebugf(ctx, "Mounted memory snapshot VBD to %s", mountPath)
+	}
+
 	return &snapshotDetails{
 		snapshotType:        fullSnapshotType,
-		memSnapshotName:     fullMemSnapshotName,
+		memSnapshotName:     memSnapshotName,
 		vmStateSnapshotName: vmStateSnapshotName,
 		saveRemoteSnapshot:  saveRemoteSnapshot,
 		saveLocalSnapshot:   saveLocalSnapshot,
-	}
+	}, nil
 }
 
 func (c *FirecrackerContainer) createSnapshot(ctx context.Context, snapshotDetails *snapshotDetails) error {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -3302,8 +3302,12 @@ func (c *FirecrackerContainer) cleanupOldSnapshots(ctx context.Context, snapshot
 	memSnapshotPath := filepath.Join(c.getChroot(), snapshotDetails.memSnapshotName)
 	vmStateSnapshotPath := filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName)
 
-	if err := disk.RemoveIfExists(memSnapshotPath); err != nil {
-		return status.WrapError(err, "failed to remove existing memory snapshot")
+	// If exporting the snapshot to a COWstore, the mem snapshot path points to a mounted VBD.
+	// Don't remove that, or the export will fail.
+	if c.memoryVBD == nil {
+		if err := disk.RemoveIfExists(memSnapshotPath); err != nil {
+			return status.WrapError(err, "failed to remove existing memory snapshot")
+		}
 	}
 	if err := disk.RemoveIfExists(vmStateSnapshotPath); err != nil {
 		return status.WrapError(err, "failed to remove existing VM state snapshot")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -170,7 +171,7 @@ type envOpts struct {
 	runProxy         bool
 }
 
-func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEnv {
+func getTestEnv(ctx context.Context, t testing.TB, opts envOpts) *testenv.TestEnv {
 	// Clean up stale veth devices from previous test runs that were killed
 	// without cleanup (e.g. SIGKILL from the test runner).
 	flags.Set(t, "executor.cleanup_stale_veth_devices", true)
@@ -292,7 +293,7 @@ func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEn
 	return env
 }
 
-func runProxyServers(ctx context.Context, proxyEnv *testenv.TestEnv, t *testing.T) {
+func runProxyServers(ctx context.Context, proxyEnv *testenv.TestEnv, t testing.TB) {
 	server, err := byte_stream_server.NewByteStreamServer(proxyEnv)
 	require.NoError(t, err)
 	acServer, err := action_cache_server.NewActionCacheServer(proxyEnv)
@@ -301,7 +302,7 @@ func runProxyServers(ctx context.Context, proxyEnv *testenv.TestEnv, t *testing.
 	proxyEnv.SetLocalActionCacheServer(acServer)
 }
 
-func executorRootDir(t *testing.T) string {
+func executorRootDir(t testing.TB) string {
 	// When running this test on the bare executor pool, ensure the jailer root
 	// is under /buildbuddy so that it's on the same device as the executor data
 	// dir (with action workspaces and filecache).
@@ -320,7 +321,7 @@ func executorRootDir(t *testing.T) string {
 	return testfs.MakeTempSymlink(t, "/tmp", "buildbuddy-*-jailer", testfs.MakeTempDir(t))
 }
 
-func getExecutorConfig(t *testing.T) *firecracker.ExecutorConfig {
+func getExecutorConfig(t testing.TB) *firecracker.ExecutorConfig {
 	root := executorRootDir(t)
 	buildRoot := filepath.Join(root, "build")
 	cacheRoot := filepath.Join(root, "cache")
@@ -3909,6 +3910,86 @@ func TestFirecrackerStressIO(t *testing.T) {
 	}
 	err := eg.Wait()
 	assert.NoError(t, err)
+}
+
+func Benchmark_FullSnapshotPause(b *testing.B) {
+	for _, memorySizeMb := range []int64{1000, 2000, 4000, 8000} {
+		for _, cowExportEnabled := range []bool{true, false} {
+			b.Run(fmt.Sprintf("memory_size_%d_mb_cow_export_%t", memorySizeMb, cowExportEnabled), func(b *testing.B) {
+				flags.Set(b, "executor.firecracker_write_full_snapshot_to_cow", cowExportEnabled)
+				ctx := context.Background()
+				env := getTestEnv(ctx, b, envOpts{})
+				rootDir := testfs.MakeTempDir(b)
+				cfg := getExecutorConfig(b)
+
+				var containersToCleanup []*firecracker.FirecrackerContainer
+				b.Cleanup(func() {
+					for _, vm := range containersToCleanup {
+						err := vm.Remove(ctx)
+						assert.NoError(b, err)
+					}
+				})
+
+				opts := firecracker.ContainerOpts{
+					ContainerImage: ubuntuImage,
+					VMConfiguration: &fcpb.VMConfiguration{
+						NumCpus:            2,
+						MemSizeMb:          memorySizeMb,
+						NetworkMode:        fcpb.NetworkMode_NETWORK_MODE_OFF,
+						ScratchDiskSizeMb:  500,
+						GuestKernelVersion: cfg.GuestKernelVersion,
+						FirecrackerVersion: cfg.FirecrackerVersion,
+						GuestApiVersion:    cfg.GuestAPIVersion,
+					},
+					ExecutorConfig: cfg,
+				}
+
+				// Don't try to write the full memory size of the VM, or it will OOM.
+				mbToWrite := int(.8 * float64(memorySizeMb))
+				cmd := &repb.Command{
+					// Mount a RAM-based filesystem to /tmp/randomdata to simulate memory usage.
+					Arguments: []string{"sh", "-c", `
+mkdir /tmp/randomdata && mount -t tmpfs -o size=` + strconv.Itoa(mbToWrite) + `M tmpfs /tmp/randomdata
+dd if=/dev/urandom of=/tmp/randomdata/data bs=1M count=` + strconv.Itoa(mbToWrite) + `
+free -h
+		`},
+				}
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					task := &repb.ExecutionTask{
+						Command: &repb.Command{
+							Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+								{Name: "recycle-runner", Value: "true"},
+								// This is testing full snapshot generation, so ensure there's no snapshot sharing between runs.
+								{Name: "salt", Value: fmt.Sprintf("%d_%v_%d", memorySizeMb, cowExportEnabled, i)},
+							}},
+							Arguments: []string{"./buildbuddy_ci_runner"},
+						},
+					}
+
+					workDir := testfs.MakeDirAll(b, rootDir, fmt.Sprintf("work%d", i))
+					opts.ActionWorkingDirectory = workDir
+					c, err := firecracker.NewContainer(ctx, env, task, opts)
+					require.NoError(b, err)
+					containersToCleanup = append(containersToCleanup, c)
+
+					err = container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher)
+					require.NoError(b, err)
+					err = c.Create(ctx, opts.ActionWorkingDirectory)
+					require.NoError(b, err)
+					res := c.Exec(ctx, cmd, nil /*=stdio*/)
+					require.NoError(b, res.Error)
+
+					b.StartTimer()
+					err = c.Pause(ctx)
+					b.StopTimer()
+					require.NoError(b, err)
+				}
+			})
+		}
+	}
 }
 
 func TestBazelBuild(t *testing.T) {

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -217,7 +217,6 @@ func (n *Node) Setattr(ctx context.Context, fh fusefs.FileHandle, in *fuse.SetAt
 		return syscall.ENODEV
 	}
 
-	// TODO: Will firecracker ever try to truncate to 0 to clear the file?
 	if requestedSize, ok := in.GetSize(); ok {
 		currentSize, err := n.file.SizeBytes()
 		if err != nil {

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -190,6 +190,7 @@ type Node struct {
 
 var _ fusefs.NodeOpener = (*Node)(nil)
 var _ fusefs.NodeGetattrer = (*Node)(nil)
+var _ fusefs.NodeSetattrer = (*Node)(nil)
 
 func (n *Node) Open(ctx context.Context, flags uint32) (fusefs.FileHandle, uint32, syscall.Errno) {
 	if n.file == nil {
@@ -209,6 +210,28 @@ func (n *Node) Getattr(ctx context.Context, _ fusefs.FileHandle, out *fuse.AttrO
 		out.Size = uint64(size)
 	}
 	return fusefs.OK
+}
+
+func (n *Node) Setattr(ctx context.Context, fh fusefs.FileHandle, in *fuse.SetAttrIn, out *fuse.AttrOut) syscall.Errno {
+	if n.file == nil {
+		return syscall.ENODEV
+	}
+
+	// TODO: Will firecracker ever try to truncate to 0 to clear the file?
+	if requestedSize, ok := in.GetSize(); ok {
+		currentSize, err := n.file.SizeBytes()
+		if err != nil {
+			log.CtxErrorf(ctx, "VBD size failed: %s", err)
+			return syscall.EIO
+		}
+
+		if requestedSize != uint64(currentSize) {
+			log.CtxErrorf(ctx, "VBD does not support resizing: current size %d, requested size %d", currentSize, requestedSize)
+			return syscall.EOPNOTSUPP
+		}
+	}
+
+	return n.Getattr(ctx, fh, out)
 }
 
 type fileHandle struct {

--- a/server/testutil/testnetworking/testnetworking.go
+++ b/server/testutil/testnetworking/testnetworking.go
@@ -20,7 +20,7 @@ import (
 
 // Setup sets up the test to be able to call networking functions.
 // It skips the test if the required net tools aren't available.
-func Setup(t *testing.T) {
+func Setup(t testing.TB) {
 	// Ensure ip tools are in PATH
 	os.Setenv("PATH", os.Getenv("PATH")+":/usr/sbin:/sbin")
 


### PR DESCRIPTION
Currently, when we generate a full snapshot, Firecracker writes it to a file on disk. Then we read the file and convert it to a COWStore and rewrite a chunked version of it to disk. Then we iterate through all the chunks (i.e. read it again), and cache them.

In this PR, when Firecracker exports the snapshot, we'll use a virtual block device to write the snapshot straight to a COWStore. Thus we'll be able to skip one full write and read.

As a future optimization, we could cache the chunks as they're being exported to remove that final full snapshot read

---
```
Benchmark_FullSnapshotPause/memory_size_1000_mb_cow_export_true-16         	      10	5437656146 ns/op
Benchmark_FullSnapshotPause/memory_size_1000_mb_cow_export_false-16        	      10	6152094468 ns/op
Benchmark_FullSnapshotPause/memory_size_2000_mb_cow_export_true-16         	      10	11828871752 ns/op
Benchmark_FullSnapshotPause/memory_size_2000_mb_cow_export_false-16        	      10	10375013085 ns/op
Benchmark_FullSnapshotPause/memory_size_4000_mb_cow_export_true-16         	      10	17497318216 ns/op
Benchmark_FullSnapshotPause/memory_size_4000_mb_cow_export_false-16        	      10	21961737337 ns/op
Benchmark_FullSnapshotPause/memory_size_8000_mb_cow_export_true-16         	      10	32071391724 ns/op
Benchmark_FullSnapshotPause/memory_size_8000_mb_cow_export_false-16         	  10	44204707634 ns/op

```