### PR TITLE
app: add disable_oidc_login flow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,7 +43,7 @@ common:ci --remote_instance_name=buildbuddy-io/buildbuddy/ci
 # Configuration used for GitHub actions-based CI for anonymous users (e.g. external contributors)
 common:ci-anon --config=ci
 common:ci-anon --bes_backend=remote.buildbuddy.io
-common:ci-anon --remote_downloader=remote.buildbuddy.io
+common:ci-anon --experimental_remote_downloader=remote.buildbuddy.io
 common:ci-anon --remote_cache=remote.buildbuddy.io
 common:ci-anon --remote_executor=remote.buildbuddy.io
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,6 +20,10 @@ jobs:
           if [[ "$API_KEY" ]]; then
             echo >user.bazelrc "common --config=untrusted-ci --remote_header=x-buildbuddy-api-key=$API_KEY"
           else
-            echo >user.bazelrc "common --config=ci-anon"
+            echo >user.bazelrc "
+            common --bes_backend=
+            common --remote_cache=
+            common --remote_executor=
+            "
           fi
           bazelisk test //...

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,9 +21,9 @@ jobs:
             echo >user.bazelrc "common --config=untrusted-ci --remote_header=x-buildbuddy-api-key=$API_KEY"
           else
             echo >user.bazelrc "
+            common --config=ci-anon
             common --bes_backend=
-            common --remote_cache=
-            common --remote_executor=
+            common --bes_results_url=
             "
           fi
           bazelisk test //...

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,10 @@ jobs:
 
       - name: Test
         run: |
-          bazelisk test \
-            --config=untrusted-ci \
-            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-            //...
+          API_KEY="${{ secrets.BUILDBUDDY_ORG_API_KEY }}"
+          if [[ "$API_KEY" ]]; then
+            echo >user.bazelrc "common --config=untrusted-ci --remote_header=x-buildbuddy-api-key=$API_KEY"
+          else
+            echo >user.bazelrc "common --config=ci-anon"
+          fi
+          bazelisk test //...

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Run tests
         run: |
+          API_KEY="${{ secrets.BUILDBUDDY_ORG_API_KEY }}"
           echo > user.bazelrc "
           common --config=cache
           common --repository_cache=~/repo-cache
@@ -40,8 +41,10 @@ jobs:
           common --build_metadata=ROLE=CI
           common --build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true
           common --color=yes
-          common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           "
+          if [[ "$API_KEY" ]]; then
+            echo >> user.bazelrc "common --remote_header=x-buildbuddy-api-key=$API_KEY"
+          fi
 
           bazel test --test_tag_filters=-performance,-docker \
             -- \

--- a/app/auth/BUILD
+++ b/app/auth/BUILD
@@ -1,4 +1,4 @@
-load("//rules/typescript:index.bzl", "ts_library")
+load("//rules/typescript:index.bzl", "ts_jasmine_node_test", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -18,6 +18,15 @@ ts_library(
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",
         "//proto:user_ts_proto",
+    ],
+)
+
+ts_jasmine_node_test(
+    name = "auth_service_test",
+    srcs = ["auth_service_test.ts"],
+    deps = [
+        ":auth_service",
+        "//:node_modules/tslib",
     ],
 )
 

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -130,7 +130,8 @@ export class AuthService {
     }
     // If we haven't tried to auto-relogin already, try it.
     localStorage.setItem(AUTO_LOGIN_ATTEMPTED_STORAGE_KEY, "true");
-    window.location.href = `/login/?${new URLSearchParams({
+    const loginPath = capabilities.config.disableOidcLogin ? "/" : "/login/";
+    window.location.href = `${loginPath}?${new URLSearchParams({
       redirect_url: window.location.href,
     })}`;
   }

--- a/app/auth/auth_service_test.ts
+++ b/app/auth/auth_service_test.ts
@@ -28,7 +28,7 @@ class FakeStorage {
   }
 }
 
-const testGlobal = globalThis as typeof globalThis & {
+const testGlobal = globalThis as unknown as {
   localStorage: FakeStorage;
   sessionStorage: FakeStorage;
   window: {

--- a/app/auth/auth_service_test.ts
+++ b/app/auth/auth_service_test.ts
@@ -3,12 +3,20 @@ declare function require(path: string): any;
 class FakeStorage {
   private values = new Map<string, string>();
 
+  get length() {
+    return this.values.size;
+  }
+
   clear() {
     this.values.clear();
   }
 
   getItem(key: string) {
     return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
   }
 
   removeItem(key: string) {
@@ -46,10 +54,17 @@ testGlobal.window = {
     pathname: "/invocation/123",
     search: "",
     hash: "",
+  } as Location & {
+    href: string;
+    origin: string;
+    host: string;
+    pathname: string;
+    search: string;
+    hash: string;
   },
 };
-testGlobal.localStorage = new FakeStorage();
-testGlobal.sessionStorage = new FakeStorage();
+testGlobal.localStorage = new FakeStorage() as Storage & FakeStorage;
+testGlobal.sessionStorage = new FakeStorage() as Storage & FakeStorage;
 
 const AuthService = require("./auth_service").AuthService as typeof import("./auth_service").AuthService;
 

--- a/app/auth/auth_service_test.ts
+++ b/app/auth/auth_service_test.ts
@@ -1,0 +1,73 @@
+declare function require(path: string): any;
+
+class FakeStorage {
+  private values = new Map<string, string>();
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const testGlobal = globalThis as typeof globalThis & {
+  localStorage: FakeStorage;
+  sessionStorage: FakeStorage;
+  window: {
+    buildbuddyConfig: Record<string, unknown>;
+    location: {
+      href: string;
+      origin: string;
+      host: string;
+      pathname: string;
+      search: string;
+      hash: string;
+    };
+    opener?: { postMessage: jasmine.Spy };
+  };
+};
+
+testGlobal.window = {
+  buildbuddyConfig: { disableOidcLogin: true },
+  location: {
+    href: "https://app.example.com/invocation/123",
+    origin: "https://app.example.com",
+    host: "app.example.com",
+    pathname: "/invocation/123",
+    search: "",
+    hash: "",
+  },
+};
+testGlobal.localStorage = new FakeStorage();
+testGlobal.sessionStorage = new FakeStorage();
+
+const AuthService = require("./auth_service").AuthService as typeof import("./auth_service").AuthService;
+
+describe("AuthService.handleTokenRefreshError", () => {
+  beforeEach(() => {
+    testGlobal.localStorage.clear();
+    testGlobal.window.location.href = "https://app.example.com/invocation/123";
+  });
+
+  it("uses the SPA login page when OIDC login is disabled", () => {
+    const authService = new AuthService();
+    authService.handleTokenRefreshError();
+
+    expect(testGlobal.localStorage.getItem("auto_login_attempted")).toBe("true");
+    expect(testGlobal.window.location.href).toBe(
+      `/?${new URLSearchParams({
+        redirect_url: "https://app.example.com/invocation/123",
+      })}`
+    );
+  });
+});

--- a/app/menu/menu.tsx
+++ b/app/menu/menu.tsx
@@ -44,6 +44,13 @@ export default class MenuComponent extends React.Component<Props, State> {
   }
 
   handleLoginClicked() {
+    if (capabilities.config.disableOidcLogin) {
+      window.location.href = `/?${new URLSearchParams({
+        redirect_url: window.location.href,
+      })}`;
+      this.dismissMenu();
+      return;
+    }
     authService.login();
     this.dismissMenu();
   }
@@ -72,7 +79,7 @@ export default class MenuComponent extends React.Component<Props, State> {
               </a>
             </div>
             {this.props.showHamburger && (!capabilities.auth || !this.props.user) && (
-              <Menu onClick={this.handleMenuClicked.bind(this)} className="icon white" />
+              <Menu debug-id="menu-button" onClick={this.handleMenuClicked.bind(this)} className="icon white" />
             )}
             {this.props.showHamburger && capabilities.auth && this.props.user && (
               <img
@@ -116,7 +123,11 @@ export default class MenuComponent extends React.Component<Props, State> {
                       </a>
                     </li>
                   )}
-                  {capabilities.auth && !this.props.user && <li onClick={this.handleLoginClicked.bind(this)}>Login</li>}
+                  {capabilities.auth && !this.props.user && (
+                    <li debug-id="login-menu-item" onClick={this.handleLoginClicked.bind(this)}>
+                      Login
+                    </li>
+                  )}
                   {capabilities.auth && this.props.user && (
                     <li onClick={this.handleLogoutClicked.bind(this)}>Logout</li>
                   )}

--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -24,6 +24,8 @@ sidebar_label: App
 
 - `default_to_dense_mode` Enables Dense UI mode by default.
 
+- `disable_oidc_login` Hides OIDC login buttons from the web UI so users must sign in through other configured options such as SSO.
+
 ## Example section
 
 ```yaml title="config.yaml"

--- a/enterprise/app/login/login.tsx
+++ b/enterprise/app/login/login.tsx
@@ -135,6 +135,10 @@ export default class LoginComponent extends React.Component<Props, State> {
     );
   }
 
+  shouldShowOIDCLogin() {
+    return !this.state.defaultToSSO && !capabilities.config.disableOidcLogin;
+  }
+
   render() {
     if (this.isOrgSpecific() && this.state.loading) {
       return (
@@ -149,17 +153,17 @@ export default class LoginComponent extends React.Component<Props, State> {
         <div className="container">
           <div className="login-box">
             <div className="login-buttons">
-              {!this.isGoogleConfigured() && !this.isOktaConfigured() && (
+              {this.shouldShowOIDCLogin() && !this.isGoogleConfigured() && !this.isOktaConfigured() && (
                 <button debug-id="login-button" className="login-button" onClick={this.handleLoginClicked.bind(this)}>
                   <User /> Continue
                 </button>
               )}
-              {this.isGoogleConfigured() && !this.state.defaultToSSO && (
+              {this.shouldShowOIDCLogin() && this.isGoogleConfigured() && (
                 <button debug-id="login-button" className="google-button" onClick={this.handleLoginClicked.bind(this)}>
                   <GoogleIcon /> Continue with Google
                 </button>
               )}
-              {this.isOktaConfigured() && !this.state.defaultToSSO && (
+              {this.shouldShowOIDCLogin() && this.isOktaConfigured() && (
                 <button debug-id="login-button" className="login-button" onClick={this.handleLoginClicked.bind(this)}>
                   <User /> Continue with Okta
                 </button>

--- a/enterprise/server/test/webdriver/saml/BUILD
+++ b/enterprise/server/test/webdriver/saml/BUILD
@@ -17,6 +17,7 @@ go_web_test_suite(
     deps = [
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//enterprise/server/util/mocksaml",
+        "//proto:group_go_proto",
         "//server/testutil/app",
         "//server/testutil/testbazel",
         "//server/testutil/testfs",

--- a/enterprise/server/test/webdriver/saml/saml_test.go
+++ b/enterprise/server/test/webdriver/saml/saml_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/mocksaml"
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
@@ -53,16 +54,24 @@ func startApp(t *testing.T, idpCertPath string, extraArgs ...string) buildbuddy_
 
 // Creates the org with slug "saml-test" and configures the SAML IDP metadata
 // URL in the DB.
-func setupSAMLTestOrg(t *testing.T, wt *webtester.WebTester, bb buildbuddy_enterprise.WebTarget, idp *mocksaml.IDP) {
-	// Temporarily log in with self-auth, then configure an org slug in settings
-	// (it's empty by default).
-	webtester.Login(wt, bb)
-	webtester.UpdateSelectedOrg(wt, bb.HTTPURL(), "SAML Test Org", slug, webtester.EnableUserOwnedAPIKeys)
-	webtester.Logout(wt)
+func setupSAMLTestOrg(t *testing.T, bb buildbuddy_enterprise.WebTarget, idp *mocksaml.IDP) {
+	appTarget := bb.(*app.App)
+	webClient := buildbuddy_enterprise.LoginAsDefaultSelfAuthUser(t, appTarget)
+
+	// Configure the default self-auth org with a stable slug so the SAML login
+	// tests can target it directly, without depending on webdriver bootstrap.
+	err := webClient.RPC("UpdateGroup", &grpb.UpdateGroupRequest{
+		RequestContext:       webClient.RequestContext,
+		Id:                   webClient.RequestContext.GetGroupId(),
+		Name:                 "SAML Test Org",
+		UrlIdentifier:        slug,
+		UserOwnedKeysEnabled: true,
+	}, &grpb.UpdateGroupResponse{})
+	require.NoError(t, err)
 
 	// Now that the org has a slug, set up SAML by manually executing a DB
 	// query. After this is done, we can use SAML login instead of self-auth.
-	res := bb.(*app.App).DB().Exec(`
+	res := appTarget.DB().Exec(`
 		UPDATE "Groups"
 		SET saml_idp_metadata_url = ?
 		WHERE url_identifier = ?
@@ -82,7 +91,7 @@ func TestSAMLBasicLogin(t *testing.T) {
 	idp, idpCertPath := startIDP(t)
 	bb := startApp(t, idpCertPath)
 	wt := webtester.New(t)
-	setupSAMLTestOrg(t, wt, bb, idp)
+	setupSAMLTestOrg(t, bb, idp)
 
 	// Log into the org using SSO login.
 	wt.Get(idp.BuildBuddyLoginURL(bb.HTTPURL(), slug))
@@ -105,7 +114,7 @@ func TestSAMLViewInvocation(t *testing.T) {
 	// accesses via the UI work when logged in with SAML.
 	bb := startApp(t, idpCertPath, "--storage.disable_persist_cache_artifacts=true")
 	wt := webtester.New(t)
-	setupSAMLTestOrg(t, wt, bb, idp)
+	setupSAMLTestOrg(t, bb, idp)
 
 	// Log into the org using SSO login.
 	wt.Get(idp.BuildBuddyLoginURL(bb.HTTPURL(), slug))
@@ -128,6 +137,50 @@ func TestSAMLViewInvocation(t *testing.T) {
 	wt.Get(bb.HTTPURL() + "/invocation/" + buildResult.InvocationID)
 	wt.Find(`[href="#timing"]`).Click()
 	wt.Find(`.trace-viewer`)
+}
+
+func TestSAMLDefaultLoginSlugHidesOIDCLogin(t *testing.T) {
+	buildbuddy_enterprise.MarkTestLocalOnly(t)
+
+	idp, idpCertPath := startIDP(t)
+	bb := startApp(t, idpCertPath, "--app.default_login_slug="+slug)
+	wt := webtester.New(t)
+	setupSAMLTestOrg(t, bb, idp)
+
+	wt.Get(bb.HTTPURL())
+	wt.FindByDebugID("sso-button")
+	wt.AssertNotFound(`[debug-id="login-button"]`)
+}
+
+func TestSAMLDisableOIDCLoginHidesOIDCLogin(t *testing.T) {
+	buildbuddy_enterprise.MarkTestLocalOnly(t)
+
+	idp, idpCertPath := startIDP(t)
+	bb := startApp(t, idpCertPath, "--app.disable_oidc_login=true")
+	wt := webtester.New(t)
+	setupSAMLTestOrg(t, bb, idp)
+
+	wt.Get(bb.HTTPURL())
+	wt.FindByDebugID("sso-button")
+	wt.AssertNotFound(`[debug-id="login-button"]`)
+}
+
+func TestSAMLDisableOIDCLoginMenuUsesSPALogin(t *testing.T) {
+	buildbuddy_enterprise.MarkTestLocalOnly(t)
+
+	idp, idpCertPath := startIDP(t)
+	bb := startApp(t, idpCertPath, "--app.disable_oidc_login=true")
+	wt := webtester.New(t)
+	setupSAMLTestOrg(t, bb, idp)
+
+	wt.Get(bb.HTTPURL() + "/invocation/does-not-exist")
+	wt.FindByDebugID("invocation-not-found")
+	wt.FindByDebugID("menu-button").Click()
+	wt.FindByDebugID("login-menu-item").Click()
+
+	require.Contains(t, wt.CurrentURL(), "/?redirect_url=")
+	wt.FindByDebugID("sso-button")
+	wt.AssertNotFound(`[debug-id="login-button"]`)
 }
 
 func createSelfSignedCert(t *testing.T) (cert, key []byte) {

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -202,6 +202,9 @@ message FrontendConfig {
   // be omitted from read APIs.
   // If this field is absent, clients should treat it as true.
   optional bool api_key_value_readback_enabled = 66;
+
+  // Whether OIDC login options should be hidden from the web UI.
+  bool disable_oidc_login = 67;
 }
 
 message Region {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -73,6 +73,7 @@ var (
 	userListsUIEnabled                     = flag.Bool("app.user_lists_ui_enabled", false, "If set, show show user list management options in the UI.")
 	darkModeEnabled                        = flag.Bool("app.dark_mode_enabled", false, "If set, show dark mode option in user preferences.")
 	defaultLoginSlug                       = flag.String("app.default_login_slug", "", "If set, the login page will default to using this slug.")
+	disableOIDCLogin                       = flag.Bool("app.disable_oidc_login", false, "If set, hide OIDC login options from the web UI.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -234,6 +235,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		TargetsPageEnabled:                     *targetsPageEnabled && env.GetOLAPDBHandle() != nil,
 		UserListsUiEnabled:                     *userListsUIEnabled,
 		DarkModeEnabled:                        *darkModeEnabled,
+		DisableOidcLogin:                       *disableOIDCLogin,
 	}
 
 	if efp := env.GetExperimentFlagProvider(); efp != nil {


### PR DESCRIPTION
On-prem customers running SAML for multiple orgs need a
deployment-wide way to remove the OIDC option from the UI.

Without that flag, users still saw OIDC buttons on the login page,
and some login redirects reached /login/ without an issuer and
failed with "No auth issuer set".

Add app.disable_oidc_login to the frontend config, hide the OIDC
buttons on the login page, and route menu and expired-session
redirects back through the SPA login screen so SSO-only setups do
not fall into the backend OIDC handler.

Add webdriver coverage for default-login-slug and disabled-OIDC
login behavior, plus a focused auth_service test for the token
refresh redirect.
