### PR TITLE
Tweak MCP docs title / sidebar label

### DIFF
--- a/docs/enterprise-mcp.md
+++ b/docs/enterprise-mcp.md
@@ -1,7 +1,7 @@
 ---
 id: enterprise-mcp
-title: MCP Server
-sidebar_label: MCP Server
+title: BuildBuddy MCP server
+sidebar_label: Enterprise MCP
 ---
 
 BuildBuddy's MCP server provides a suite of tools that enable agents to


### PR DESCRIPTION
Tweak sidebar label to match 'Enterprise API' and make the page title work more as a standalone title