### PR TITLE
Stop propagating the client-identity header through the proxy

### DIFF
--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -218,7 +218,7 @@ func startGRPCServers(env *real_environment.RealEnv) error {
 	if err != nil {
 		return status.WrapError(err, "failed to create traffic stats handler")
 	}
-	// Add the auth-headers propagating interceptor.
+	// Add metadata-propagating interceptors for configured request headers.
 	grpcServerConfig := grpc_server.GRPCServerConfig{
 		ExtraChainedUnaryInterceptors: []grpc.UnaryServerInterceptor{
 			interceptors.PropagateMetadataUnaryInterceptor(proxy_util.HeadersToPropagate...),

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -218,7 +218,7 @@ func startGRPCServers(env *real_environment.RealEnv) error {
 	if err != nil {
 		return status.WrapError(err, "failed to create traffic stats handler")
 	}
-	// Add the API-Key, JWT, client-identity, etc... propagating interceptor.
+	// Add the auth-headers propagating interceptor.
 	grpcServerConfig := grpc_server.GRPCServerConfig{
 		ExtraChainedUnaryInterceptors: []grpc.UnaryServerInterceptor{
 			interceptors.PropagateMetadataUnaryInterceptor(proxy_util.HeadersToPropagate...),

--- a/enterprise/server/util/proxy_util/proxy_util.go
+++ b/enterprise/server/util/proxy_util/proxy_util.go
@@ -25,7 +25,6 @@ var (
 		authutil.ContextTokenStringKey,
 		usageutil.ClientHeaderName,
 		usageutil.OriginHeaderName,
-		authutil.ClientIdentityHeaderName,
 		bazel_request.RequestMetadataKey,
 		cdc.EnabledHeaderName,
 	}


### PR DESCRIPTION
As of yesterday, all Cache Proxies in production enforce IP rules. This means it's no longer necessary to propagate the client-identity header from the caller through the proxy to the backend. Previously this was needed to bypass IP rules for executor --> proxy --> app requests in [this branch](https://github.com/buildbuddy-io/buildbuddy/blob/4d6a02f954d5bdb3fd92676b37e1b2d56d1388b2/enterprise/server/ip_rules_enforcer/ip_rules_enforcer.go#L522-L527). Now, all of those requests will be able to fall through to [this branch](https://github.com/buildbuddy-io/buildbuddy/blob/4d6a02f954d5bdb3fd92676b37e1b2d56d1388b2/enterprise/server/ip_rules_enforcer/ip_rules_enforcer.go#L529-L537) instead. Removing this header propagation will allow us to remove [this flag](https://github.com/buildbuddy-io/buildbuddy/blob/4d6a02f954d5bdb3fd92676b37e1b2d56d1388b2/enterprise/server/clientidentity/clientidentity.go#L34) in a subsequent release.

I'll wait to merge this until after today's release branch cut so that it runs in dev for a little bit longer.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/6797