### PR TITLE
fix: add ZSTD overhead to cdc buffers

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -888,7 +888,7 @@ func (s *ByteStreamServerProxy) writeChunked(ctx context.Context, stream bspb.By
 		chunkRN := digest.NewCASResourceName(chunkDigest, instanceName, digestFunction)
 		chunkRN.SetCompressor(repb.Compressor_ZSTD)
 
-		poolBuf := s.bufPool.Get(int64(len(chunkData)))
+		poolBuf := s.bufPool.Get(compression.ZstdCompressBound(int64(len(chunkData))))
 		_, compressSpn := tracing.StartNamedSpan(chunkCtx, "CompressZstd")
 		compressedData := compression.CompressZstd(poolBuf, chunkData)
 		compressSpn.End()

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -1495,7 +1495,7 @@ func NewUploadWriter(ctx context.Context, bsClient bspb.ByteStreamClient, r *dig
 			uploadString: r.NewUploadString(),
 			buf:          uploadBufPool.Get(bufSize),
 			useZstd:      true,
-			cbuf:         uploadBufPool.Get(bufSize),
+			cbuf:         uploadBufPool.Get(compression.ZstdCompressBound(bufSize)),
 		}, nil
 	}
 	return &UploadWriter{

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -39,6 +39,29 @@ func mustGetZstdEncoder() *zstd.Encoder {
 	return enc
 }
 
+// ZstdCompressBound matches zstd's documented ZSTD_COMPRESSBOUND macro:
+// https://github.com/facebook/zstd/blob/v1.5.6/lib/zstd.h#L232
+// srcSize + (srcSize >> 8) + (srcSize < 128 KiB ? ((128 KiB - srcSize) >> 11) : 0).
+// In practice, this is the input size plus about 1/256 of the input size,
+// with up to 64 extra bytes for inputs smaller than 128 KiB.
+//
+// This is the worst-case size because incompressible input falls back to
+// "raw" (uncompressed) blocks: the payload is stored verbatim, so the only
+// overhead is the per-block header (3 bytes per <=128 KiB block, bounded by
+// the >>8 term) plus the fixed frame header/checksum (bounded by the small-
+// input margin).
+//
+// Extra headroom examples:
+// 1 KiB -> +67 bytes
+// 1 MiB -> +4 KiB
+// 1 GiB -> +4 MiB
+func ZstdCompressBound(size int64) int64 {
+	if size < 128<<10 {
+		return size + (size >> 8) + (((128 << 10) - size) >> 11)
+	}
+	return size + (size >> 8)
+}
+
 // CompressZstd compresses a chunk of data into dst using zstd compression at
 // the default level. If dst is not big enough, then a new buffer will be
 // allocated.
@@ -176,7 +199,7 @@ func NewZstdCompressingWriter(writer io.Writer, bufferPool *bytebufferpool.Varia
 	if bufSize <= 0 {
 		return nil, errors.New("bufSize must be > 0")
 	}
-	a, b := bufferPool.Get(bufSize), bufferPool.Get(bufSize)
+	a, b := bufferPool.Get(bufSize), bufferPool.Get(ZstdCompressBound(bufSize))
 	return &ZstdCompressingWriter{
 		writer:         writer,
 		buffer:         a,
@@ -341,7 +364,7 @@ func NewZstdCompressingReader(input io.ReadCloser, bufferPool *bytebufferpool.Va
 	if bufSize <= 0 {
 		return nil, io.ErrShortBuffer
 	}
-	readBuf, compressBuf := bufferPool.Get(bufSize), bufferPool.Get(bufSize)
+	readBuf, compressBuf := bufferPool.Get(bufSize), bufferPool.Get(ZstdCompressBound(bufSize))
 	return &ZstdCompressingReader{
 		inputReader: input,
 		readBuf:     readBuf,


### PR DESCRIPTION
Sometimes, incompressible large files end up causing buffers to grow because the ZSTD compressed chunks are larger than the digest. This is rare, but the headroom is so low we might as well just account for it.

Only do this in the chunking path, since non-chunking files can be super small, where this can add up.