### PR TITLE
Serialize rpcutil.Sender Send and CloseAndRecv on the underlying stream

### DIFF
--- a/server/util/rpcutil/rpcutil.go
+++ b/server/util/rpcutil/rpcutil.go
@@ -111,6 +111,10 @@ type Sender[S proto.Message, R proto.Message] struct {
 	stream   SendStream[S, R]
 	sendChan chan S
 	errChan  chan error
+
+	// done channel that's closed when the sending goroutine exists, to ensure
+	// that there are no in-flight stream.Send calls when calling CloseAndRecv.
+	done chan struct{}
 }
 
 // SendWithTimeoutCause attempts to send a message on the underlying stream,
@@ -153,13 +157,23 @@ func (s *Sender[S, R]) CloseAndRecvWithTimeoutCause(timeout time.Duration, cause
 		close(s.sendChan)
 		s.sendChan = nil
 	}
+	ctx, cancel := context.WithTimeoutCause(s.ctx, timeout, cause)
+	defer cancel()
+
+	// gRPC client streams don't support concurrent Send and Close* operations.
+	// If a previous SendWithTimeoutCause timed out, the sending goroutine may
+	// be stuck in stream.Send — let it exit before touching the stream again.
+	select {
+	case <-s.done:
+	case <-ctx.Done():
+		return *new(R), context.Cause(ctx)
+	}
+
 	ch := make(chan StreamMsg[R], 1)
 	go func() {
 		rsp, err := s.stream.CloseAndRecv()
 		ch <- StreamMsg[R]{rsp, err}
 	}()
-	ctx, cancel := context.WithTimeoutCause(s.ctx, timeout, cause)
-	defer cancel()
 	select {
 	case msg := <-ch:
 		return msg.Data, msg.Error
@@ -182,7 +196,9 @@ func (s *Sender[S, R]) CloseAndRecvWithTimeoutCause(timeout time.Duration, cause
 func NewSender[S proto.Message, R proto.Message](ctx context.Context, stream SendStream[S, R]) Sender[S, R] {
 	sendChan := make(chan S, 1)
 	errChan := make(chan error, 1)
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		for {
 			select {
 			case req, ok := <-sendChan:
@@ -203,7 +219,7 @@ func NewSender[S proto.Message, R proto.Message](ctx context.Context, stream Sen
 			}
 		}
 	}()
-	return Sender[S, R]{ctx, stream, sendChan, errChan}
+	return Sender[S, R]{ctx, stream, sendChan, errChan, done}
 }
 
 // Provides an OpenTelemetry MeterProvider that exports metrics to Prometheus.

--- a/server/util/rpcutil/rpcutil_test.go
+++ b/server/util/rpcutil/rpcutil_test.go
@@ -70,6 +70,27 @@ func (s *stream[T]) CloseAndRecv() (T, error) {
 	return zero, nil
 }
 
+// orderingStream lets a test control/observe the ordering of calls on a stream.
+type orderingStream[T proto.Message] struct {
+	sendBlock        chan struct{}
+	sendReturned     chan struct{}
+	closeRecvStarted chan struct{}
+	closeRecvReturn  chan struct{}
+}
+
+func (s *orderingStream[T]) Send(T) error {
+	<-s.sendBlock
+	close(s.sendReturned)
+	return nil
+}
+
+func (s *orderingStream[T]) CloseAndRecv() (T, error) {
+	close(s.closeRecvStarted)
+	<-s.closeRecvReturn
+	var zero T
+	return zero, nil
+}
+
 func TestReceiver(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -210,4 +231,91 @@ func TestSender_SendTimeoutDoesNotLeakAfterCancel(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for blocked send to return")
 	}
+}
+
+// After a SendWithTimeoutCause times out, CloseAndRecvWithTimeoutCause must
+// not call stream.CloseAndRecv until the background sender goroutine has
+// returned from its in-flight stream.Send — gRPC client streams don't
+// support concurrent Send and CloseSend/CloseAndRecv on the same stream.
+func TestSender_CloseAndRecvWaitsForInFlightSend(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	stream := &orderingStream[*tspb.Timestamp]{
+		sendBlock:        make(chan struct{}),
+		sendReturned:     make(chan struct{}),
+		closeRecvStarted: make(chan struct{}),
+		closeRecvReturn:  make(chan struct{}),
+	}
+	sender := rpcutil.NewSender(t.Context(), stream)
+
+	// Make a Send that times out, blocking the sender goroutine in stream.Send.
+	err := sender.SendWithTimeoutCause(tspb.Now(), time.Millisecond, fmt.Errorf("send-cause"))
+	require.Error(t, err)
+
+	// Start CloseAndRecv in a goroutine; it should wait for the in-flight
+	// Send to return before calling stream.CloseAndRecv.
+	closeDone := make(chan error, 1)
+	go func() {
+		_, err := sender.CloseAndRecvWithTimeoutCause(hugeTimeout, fmt.Errorf("close-cause"))
+		closeDone <- err
+	}()
+
+	// Ensure stream.CloseAndRecv isn't called yet, Send is still blocked.
+	select {
+	case <-stream.closeRecvStarted:
+		t.Fatal("stream.CloseAndRecv was called before the in-flight Send returned")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Unblock Send. The sender goroutine exits, done closes, and
+	// CloseAndRecvWithTimeoutCause now proceeds to call stream.CloseAndRecv.
+	close(stream.sendBlock)
+	select {
+	case <-stream.sendReturned:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Send to return after unblock")
+	}
+	select {
+	case <-stream.closeRecvStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stream.CloseAndRecv was not called after Send returned")
+	}
+
+	// Let stream.CloseAndRecv return so the test cleans up.
+	close(stream.closeRecvReturn)
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("CloseAndRecvWithTimeoutCause did not return")
+	}
+}
+
+// If the background sender goroutine is still stuck in stream.Send (because
+// nobody has canceled the underlying ctx), CloseAndRecvWithTimeoutCause must
+// still honor its own timeout and return the given cause without blocking
+// forever waiting for the sender goroutine to drain.
+func TestSender_CloseAndRecvHonorsTimeoutWhileSendStuck(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stream := &blockingSendStream[*tspb.Timestamp]{
+		ctx:          ctx,
+		sendStarted:  make(chan struct{}),
+		sendReturned: make(chan struct{}),
+	}
+	sender := rpcutil.NewSender(ctx, stream)
+
+	err := sender.SendWithTimeoutCause(tspb.Now(), time.Millisecond, fmt.Errorf("send-cause"))
+	require.Error(t, err)
+	<-stream.sendStarted
+
+	closeCause := fmt.Errorf("close-cause")
+	_, err = sender.CloseAndRecvWithTimeoutCause(time.Millisecond, closeCause)
+	require.Equal(t, closeCause, err)
+
+	// Cancel to let the stuck Send unblock so the test doesn't leak the
+	// background goroutine.
+	cancel()
+	<-stream.sendReturned
 }


### PR DESCRIPTION
gRPC client streams don't support concurrent `Send` and `Close*` operations on the same stream, but rpcutil.Sender can call them concurrently if `SendWithTimeoutCause` times out while the background sender goroutine is parked inside `stream.Send`, and a subsequent `CloseAndRecvWithTimeoutCause` races its `stream.CloseAndRecv` against the still-unwinding Send.

This PR adds a done channel that is closed when the background goroutine exists and makes `CloseAndRecvWithTimeoutCause` wait on it (bounded by its own timeout) before touching the stream.