### PR TITLE
Show warning/error level suggestions at the top of the page

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -42,7 +42,7 @@ import InvocationOverviewComponent from "./invocation_overview";
 import QueryGraphCardComponent from "./invocation_query_graph_card";
 import RawLogsCardComponent from "./invocation_raw_logs_card";
 import SpawnCardComponent from "./invocation_spawn_card";
-import SuggestionCardComponent, { getSuggestions } from "./invocation_suggestion_card";
+import SuggestionCardComponent, { getSuggestions, hasSuggestionAboveInfo } from "./invocation_suggestion_card";
 import InvocationTabsComponent, { getActiveTab } from "./invocation_tabs";
 import TargetsComponent from "./invocation_targets";
 import TimingCardComponent from "./invocation_timing_card";
@@ -601,6 +601,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
       runnerExecution: this.state.runnerExecution,
       user: this.props.user,
     });
+    const showSuggestionsAboveBuildLogs = activeTab === "all" && hasSuggestionAboveInfo(suggestions);
 
     return (
       <div className="invocation">
@@ -671,6 +672,10 @@ export default class InvocationComponent extends React.Component<Props, State> {
             <QueryGraphCardComponent buildLogs={this.getBuildLogs(this.state.model)} />
           )}
 
+          {showSuggestionsAboveBuildLogs && (
+            <SuggestionCardComponent suggestions={suggestions} overview user={this.props.user} />
+          )}
+
           {(activeTab === "all" || activeTab === "log") && (
             <BuildLogsCardComponent
               title={!isRemoteRunnerInvocation ? "Build logs" : "Runner logs"}
@@ -695,13 +700,14 @@ export default class InvocationComponent extends React.Component<Props, State> {
               />
             )}
 
-          {(activeTab === "all" || activeTab === "log" || activeTab === "suggestions") && (
-            <SuggestionCardComponent
-              suggestions={suggestions}
-              overview={activeTab !== "suggestions"}
-              user={this.props.user}
-            />
-          )}
+          {!showSuggestionsAboveBuildLogs &&
+            (activeTab === "all" || activeTab === "log" || activeTab === "suggestions") && (
+              <SuggestionCardComponent
+                suggestions={suggestions}
+                overview={activeTab !== "suggestions"}
+                user={this.props.user}
+              />
+            )}
 
           {!isRemoteRunnerInvocation && (activeTab === "all" || activeTab === "targets") && (
             <TargetsComponent

--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -38,6 +38,14 @@ export enum SuggestionLevel {
   ERROR,
 }
 
+function sortSuggestionsByLevel<T extends { level: SuggestionLevel }>(suggestions: T[]): T[] {
+  return [...suggestions].sort((a, b) => b.level - a.level);
+}
+
+export function hasSuggestionAboveInfo<T extends { level: SuggestionLevel }>(suggestions: T[]): boolean {
+  return suggestions.some((suggestion) => suggestion.level > SuggestionLevel.INFO);
+}
+
 /** Given some data about an invocation, optionally returns a suggestion. */
 type SuggestionMatcher = (params: MatchParams) => Suggestion | null;
 
@@ -665,7 +673,7 @@ export function getSuggestions({
     const suggestion = matcher({ buildLogs, model, runnerExecution });
     if (suggestion) suggestions.push(suggestion);
   }
-  return suggestions;
+  return sortSuggestionsByLevel(suggestions);
 }
 
 export default class SuggestionCardComponent extends React.Component<Props> {


### PR DESCRIPTION
WARNING/ERROR level suggestions are intended to be used for high-confidence issues that are important for us to surface because they aren't otherwise obvious - e.g. VM is out of memory/disk.

However, these errors are not immediately visible when loading the invocation page (they are buried below the Build Logs and some scrolling is needed to be able to see them).

Putting these above the Build Logs should be more helpful, and also save us a bit of support time, based on some past conversations.