### PR TITLE
Add support for 'shared' filecache directories

### DIFF
--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
+        "//server/util/alert",
         "//server/util/claims",
         "//server/util/disk",
         "//server/util/fastcopy",

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -503,9 +503,7 @@ func (c *fileCache) WithSharedDirectory(ctx context.Context, sharedDirectory str
 // context is returned unchanged.
 func withSharedDirectory(ctx context.Context, sharedDirectory string) context.Context {
 	if !isValidSharedDirectory(sharedDirectory) {
-		if sharedDirectory != "" {
-			alert.CtxUnexpectedEvent(ctx, "filecache_invalid_shared_directory", "Invalid shared directory %s", sharedDirectory)
-		}
+		alert.CtxUnexpectedEvent(ctx, "filecache_invalid_shared_directory", "Invalid shared directory %s", sharedDirectory)
 		return ctx
 	}
 	return context.WithValue(ctx, sharedDirectoryContextKey{}, sharedDirectory)

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -21,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/fastcopy"
@@ -40,6 +41,10 @@ const (
 	// and non-executable files which have the same content digests.
 	executableSuffix = "executable"
 
+	// sharedDirectoryPrefix prefixes entries that are explicitly marked as
+	// safe to share across groups.
+	sharedDirectoryPrefix = "_SHARED_"
+
 	// hitMetricLabel is the prometheus metric label applied to filecache hits.
 	hitMetricLabel = "hit"
 	// missMetricLabel is the prometheus metric label applied to filecache misses.
@@ -58,6 +63,11 @@ const (
 	// Threshold at which to log when the trash collection is backing up.
 	trashCollectionLogThreshold = 8
 )
+
+// Context key holding the shared directory name, if any. If set in the ctx,
+// filecache entries will be stored under a shared directory namespace instead
+// of the group-specific namespace.
+type sharedDirectoryContextKey struct{}
 
 var (
 	enableAlwaysClone                = flag.Bool("executor.local_cache_always_clone", false, "If true, files from the filecache will always be cloned instead of hardlinked")
@@ -396,21 +406,21 @@ func (c *fileCache) nodeFromPathAndSize(fullPath string, sizeBytes int64) (strin
 	}
 
 	subdirPath := strings.TrimPrefix(fullPath, c.rootDir)
-	groupID, name := filepath.Split(subdirPath)
-	groupID = strings.Trim(groupID, sep)
+	keyPrefix, name := filepath.Split(subdirPath)
+	keyPrefix = strings.Trim(keyPrefix, sep)
 
 	// Backwards compatible: scan files that are written in the new
 	// format OR the old format.
 	//
 	// old format: GROUP/abcdefghijklmnopqrstuv
 	// new format: GROUP/abcd/abcdefghijklmnopqrstuv
-	if strings.Contains(groupID, sep) {
-		groupID = strings.TrimSuffix(groupID, sep)
-		groupID = strings.Trim(filepath.Dir(groupID), sep)
+	if strings.Contains(keyPrefix, sep) {
+		keyPrefix = strings.TrimSuffix(keyPrefix, sep)
+		keyPrefix = strings.Trim(filepath.Dir(keyPrefix), sep)
 	}
 
 	nameParts := strings.Split(name, ".")
-	return groupID, &repb.FileNode{
+	return keyPrefix, &repb.FileNode{
 		IsExecutable: len(nameParts) > 1 && nameParts[1] == executableSuffix,
 		Digest: &repb.Digest{
 			Hash:      nameParts[0],
@@ -431,14 +441,17 @@ func (c *fileCache) scanDir() {
 			return nil
 		}
 		fileCount += 1
-		// addFileToGroup uses the physical size, not the digest size, so just
+		// addFileWithKeyPrefix uses the physical size, not the digest size, so just
 		// pass 0 for size here.
-		groupID, node, err := c.nodeFromPathAndSize(path, 0)
+		keyPrefix, node, err := c.nodeFromPathAndSize(path, 0)
 		if err != nil {
 			return err
 		}
-		if err := c.addFileToGroup(groupID, node, path); err != nil {
-			// Any errors here are unexpected - this addFileToGroup call should
+		if !isValidScannedCachePath(c.rootDir, path, keyPrefix, node) {
+			return nil
+		}
+		if err := c.addFileWithKeyPrefix(keyPrefix, node, path); err != nil {
+			// Any errors here are unexpected - this addFileWithKeyPrefix call should
 			// just be updating LRU state. There is a chance that it will
 			// trigger an eviction, but any error from the associated unlink
 			// operation is just logged and not returned.
@@ -452,11 +465,10 @@ func (c *fileCache) scanDir() {
 		log.Errorf("Error reading existing filecache dir: %q: %s", c.rootDir, err)
 	}
 	for _, entry := range entries {
-		// Only scan the group-specific dirs (ignore _tmp and other dirs)
-		if entry.Name() != "ANON" && !strings.HasPrefix(entry.Name(), "GR") {
+		if !entry.IsDir() {
 			continue
 		}
-		if !entry.IsDir() {
+		if !isScannableCacheDir(entry.Name()) {
 			continue
 		}
 
@@ -479,11 +491,113 @@ func externalDirectoryKey(path string) string {
 	return "external:" + path
 }
 
-func groupSpecificKey(groupID string, node *repb.FileNode) string {
-	if node.GetIsExecutable() {
-		return groupID + "/" + node.GetDigest().GetHash() + "." + executableSuffix
+func (c *fileCache) WithSharedDirectory(ctx context.Context, sharedDirectory string) context.Context {
+	return withSharedDirectory(ctx, sharedDirectory)
+}
+
+// withSharedDirectory returns a context that stores filecache entries under a
+// shared executor-local directory instead of the current group directory.
+//
+// Shared directories are intended for read-only data that may be safely reused
+// across groups. Invalid shared directory names are ignored and the original
+// context is returned unchanged.
+func withSharedDirectory(ctx context.Context, sharedDirectory string) context.Context {
+	if !isValidSharedDirectory(sharedDirectory) {
+		if sharedDirectory != "" {
+			alert.CtxUnexpectedEvent(ctx, "filecache_invalid_shared_directory", "Invalid shared directory %s", sharedDirectory)
+		}
+		return ctx
 	}
-	return groupID + "/" + node.GetDigest().GetHash()
+	return context.WithValue(ctx, sharedDirectoryContextKey{}, sharedDirectory)
+}
+
+// isValidSharedDirectory returns true if the given shared directory name is
+// valid. This acts as a sanity check both when scanning the filecache directory
+// on startup and when the executor tries to store/link files from a shared
+// directory.
+func isValidSharedDirectory(sharedDirectory string) bool {
+	if sharedDirectory == "" || sharedDirectory == "." || sharedDirectory == ".." {
+		return false
+	}
+	if sharedDirectory == interfaces.AuthAnonymousUser || strings.HasPrefix(sharedDirectory, "GR") || strings.HasPrefix(sharedDirectory, sharedDirectoryPrefix) {
+		return false
+	}
+	return !strings.ContainsAny(sharedDirectory, `/\`)
+}
+
+func sharedDirectoryFromContext(ctx context.Context) (string, bool) {
+	sharedDirectory, ok := ctx.Value(sharedDirectoryContextKey{}).(string)
+	return sharedDirectory, ok && sharedDirectory != ""
+}
+
+// keyPrefixFromContext returns the namespace prefix for filecache keys.
+//
+// The returned string will follow one of these patterns:
+//   - <group_id> for authenticated group-scoped entries
+//   - "ANON" for unauthenticated entries
+//   - _SHARED_<namespace> for explicitly shared directories
+func keyPrefixFromContext(ctx context.Context) string {
+	if sharedDirectory, ok := sharedDirectoryFromContext(ctx); ok {
+		return sharedDirectoryPrefix + sharedDirectory
+	}
+	return groupIDStringFromContext(ctx)
+}
+
+func isScannableCacheDir(name string) bool {
+	if name == interfaces.AuthAnonymousUser || strings.HasPrefix(name, "GR") {
+		return true
+	}
+	if after, ok := strings.CutPrefix(name, sharedDirectoryPrefix); ok {
+		return isValidSharedDirectory(after)
+	}
+	return false
+}
+
+// isValidScannedCachePath returns whether the given on-disk path matches one of
+// the filecache path layouts we support scanning on startup.
+func isValidScannedCachePath(rootDir, fullPath, keyPrefix string, node *repb.FileNode) bool {
+	if strings.HasPrefix(keyPrefix, sharedDirectoryPrefix) && !isValidSharedDirectory(strings.TrimPrefix(keyPrefix, sharedDirectoryPrefix)) {
+		return false
+	}
+
+	relPath, err := filepath.Rel(rootDir, fullPath)
+	if err != nil {
+		return false
+	}
+	relDir, name := filepath.Split(relPath)
+	relDir = strings.Trim(relDir, sep)
+	if relDir == "" || name == "" {
+		return false
+	}
+
+	dirParts := strings.Split(relDir, sep)
+	if len(dirParts) == 0 || len(dirParts) > 2 {
+		return false
+	}
+	if dirParts[0] != keyPrefix {
+		return false
+	}
+	if len(dirParts) == 2 {
+		// Accept subdir-prefixed cache entries written with any historical prefix
+		// length, as long as the directory is still a prefix of the digest hash.
+		prefixDir := dirParts[1]
+		if prefixDir == "" || !strings.HasPrefix(node.GetDigest().GetHash(), prefixDir) {
+			return false
+		}
+	}
+
+	expectedName := node.GetDigest().GetHash()
+	if node.GetIsExecutable() {
+		expectedName += "." + executableSuffix
+	}
+	return name == expectedName
+}
+
+func namespacedKey(keyPrefix string, node *repb.FileNode) string {
+	if node.GetIsExecutable() {
+		return keyPrefix + "/" + node.GetDigest().GetHash() + "." + executableSuffix
+	}
+	return keyPrefix + "/" + node.GetDigest().GetHash()
 }
 
 func groupIDStringFromContext(ctx context.Context) string {
@@ -497,9 +611,7 @@ func groupIDStringFromContext(ctx context.Context) string {
 }
 
 func key(ctx context.Context, node *repb.FileNode) string {
-	groupID := groupIDStringFromContext(ctx)
-	k := groupSpecificKey(groupID, node)
-	return k
+	return namespacedKey(keyPrefixFromContext(ctx), node)
 }
 
 func (c *fileCache) checkClosed() error {
@@ -519,14 +631,14 @@ func (c *fileCache) FastLinkFile(ctx context.Context, node *repb.FileNode, outpu
 		c.requestCounter[hit].Inc()
 	}()
 
-	groupID := groupIDStringFromContext(ctx)
-	key := groupSpecificKey(groupID, node)
+	keyPrefix := keyPrefixFromContext(ctx)
+	key := namespacedKey(keyPrefix, node)
 
 	if !c.containsWithStatFallback(key) {
 		return false
 	}
 	start := time.Now()
-	if err := cloneOrLink(groupID, filecachePath(c.rootDir, key), outputPath); err != nil {
+	if err := cloneOrLink(keyPrefix, filecachePath(c.rootDir, key), outputPath); err != nil {
 		log.Warningf("Failed to link file from cache: %s", err)
 		return false
 	}
@@ -540,8 +652,8 @@ func (c *fileCache) Open(ctx context.Context, node *repb.FileNode) (f *os.File, 
 		c.requestCounter[hit].Inc()
 	}()
 
-	groupID := groupIDStringFromContext(ctx)
-	key := groupSpecificKey(groupID, node)
+	keyPrefix := keyPrefixFromContext(ctx)
+	key := namespacedKey(keyPrefix, node)
 
 	if !c.containsWithStatFallback(key) {
 		return nil, status.NotFoundError("not found")
@@ -549,7 +661,7 @@ func (c *fileCache) Open(ctx context.Context, node *repb.FileNode) (f *os.File, 
 	return os.Open(filecachePath(c.rootDir, key))
 }
 
-func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existingFilePath string) error {
+func (c *fileCache) addFileWithKeyPrefix(keyPrefix string, node *repb.FileNode, existingFilePath string) error {
 	// Remove any existing entry. We can't update in-place because if we
 	// overwrite an existing link with different contents, all pointers
 	// to the old link would suddenly change to point to the new content,
@@ -564,7 +676,7 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 		return wrapOSError(err, "estimate disk usage")
 	}
 
-	k := groupSpecificKey(groupID, node)
+	k := namespacedKey(keyPrefix, node)
 	fp := filecachePath(c.rootDir, k)
 
 	// Ensure the parent directory exists. (We can skip this if the source and
@@ -598,7 +710,7 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 		c.l.Remove(k)
 
 		start := time.Now()
-		if err := cloneOrLink(groupID, existingFilePath, fp); err != nil {
+		if err := cloneOrLink(keyPrefix, existingFilePath, fp); err != nil {
 			return err
 		}
 		c.linkIntoFileCacheLatency.Observe(float64(time.Since(start).Microseconds()))
@@ -618,7 +730,7 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 	}
 	metrics.FileCacheAddedFileSizeBytes.Observe(float64(e.sizeBytes))
 	metrics.FileCacheAddedFileBytesCount.With(prometheus.Labels{
-		metrics.GroupID: groupID,
+		metrics.GroupID: keyPrefix,
 	}).Add(float64(e.sizeBytes))
 	success := c.l.Add(k, e)
 	if !success {
@@ -632,9 +744,9 @@ func (c *fileCache) AddFile(ctx context.Context, node *repb.FileNode, existingFi
 		return err
 	}
 	start := time.Now()
-	groupID := groupIDStringFromContext(ctx)
-	// Locking happens in addFileToGroup().
-	err := c.addFileToGroup(groupID, node, existingFilePath)
+	keyPrefix := keyPrefixFromContext(ctx)
+	// Locking happens in addFileWithKeyPrefix().
+	err := c.addFileWithKeyPrefix(keyPrefix, node, existingFilePath)
 	if err != nil {
 		return err
 	}
@@ -936,8 +1048,8 @@ func (c *fileCache) tempPath(name string) (string, error) {
 	return filepath.Join(c.TempDir(), fmt.Sprintf("%s.%s.tmp", name, randStr)), nil
 }
 
-func cloneOrLink(groupID, source, destination string) error {
-	if groupID == interfaces.AuthAnonymousUser || *enableAlwaysClone {
+func cloneOrLink(keyPrefix, source, destination string) error {
+	if keyPrefix == interfaces.AuthAnonymousUser || *enableAlwaysClone {
 		if err := fastcopy.Clone(source, destination); err != nil {
 			return wrapOSError(err, "clone")
 		}

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -180,6 +180,260 @@ func TestFileCacheGroupIsolation(t *testing.T) {
 	}
 }
 
+func TestFileCacheSharedDirectoryAcrossGroups(t *testing.T) {
+	ctx := context.Background()
+	fcDir := testfs.MakeTempDir(t)
+	baseDir := testfs.MakeTempDir(t)
+	group1Ctx := claims.AuthContextWithJWT(ctx, &claims.Claims{GroupID: "GR12345"}, nil)
+	group2Ctx := claims.AuthContextWithJWT(ctx, &claims.Claims{GroupID: "GR67890"}, nil)
+
+	fc, err := filecache.NewFileCache(fcDir, 100000, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { fc.Close() })
+	fc.WaitForDirectoryScanToComplete()
+	sharedDirectoryCtx1 := fc.WithSharedDirectory(group1Ctx, "ext4_images")
+	sharedDirectoryCtx2 := fc.WithSharedDirectory(group2Ctx, "ext4_images")
+	otherSharedDirectoryCtx := fc.WithSharedDirectory(group2Ctx, "other_images")
+
+	normalPath := writeFileContent(t, baseDir, "normal/file", "normal-content", false)
+	sharedPath := writeFileContent(t, baseDir, "shared/file", "shared-content", false)
+	node := nodeFromString("same-logical-key", false)
+
+	// Seed both a group-local entry and a shared ext4_images entry with the
+	// same logical filecache key.
+	require.NoError(t, fc.AddFile(group1Ctx, node, normalPath))
+	require.NoError(t, fc.AddFile(sharedDirectoryCtx1, node, sharedPath))
+
+	// The shared ext4_images entry does not make the same digest visible via
+	// another group's namespace.
+	require.True(t, fc.ContainsFile(group1Ctx, node))
+	require.False(t, fc.ContainsFile(group2Ctx, node))
+
+	normalLinkPath := filepath.Join(baseDir, "normal-link")
+	require.True(t, fc.FastLinkFile(group1Ctx, node, normalLinkPath))
+	assertFileContents(t, normalLinkPath, "normal-content")
+
+	group2MissPath := filepath.Join(baseDir, "group2-miss-link")
+	require.False(t, fc.FastLinkFile(group2Ctx, node, group2MissPath))
+	assert.NoFileExists(t, group2MissPath)
+
+	// Any group should be able to access the entry when looking it up via
+	// ext4_images.
+	require.True(t, fc.ContainsFile(sharedDirectoryCtx1, node))
+	require.True(t, fc.ContainsFile(sharedDirectoryCtx2, node))
+
+	sharedLinkPath1 := filepath.Join(baseDir, "shared-link-1")
+	require.True(t, fc.FastLinkFile(sharedDirectoryCtx1, node, sharedLinkPath1))
+	assertFileContents(t, sharedLinkPath1, "shared-content")
+
+	sharedLinkPath2 := filepath.Join(baseDir, "shared-link-2")
+	require.True(t, fc.FastLinkFile(sharedDirectoryCtx2, node, sharedLinkPath2))
+	assertFileContents(t, sharedLinkPath2, "shared-content")
+
+	// Other shared directories should not see ext4_images entries.
+	require.False(t, fc.ContainsFile(otherSharedDirectoryCtx, node))
+
+	// Open should respect the same namespace boundaries as linking.
+	_, err = fc.Open(group2Ctx, node)
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err), "expected non-shared group access to miss")
+
+	f, err := fc.Open(sharedDirectoryCtx2, node)
+	require.NoError(t, err)
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, "shared-content", string(data))
+}
+
+func TestFileCacheSharedDirectoryAcrossGroupsAfterRestart(t *testing.T) {
+	ctx := context.Background()
+	fcDir := testfs.MakeTempDir(t)
+	baseDir := testfs.MakeTempDir(t)
+	group1Ctx := claims.AuthContextWithJWT(ctx, &claims.Claims{GroupID: "GR12345"}, nil)
+	group2Ctx := claims.AuthContextWithJWT(ctx, &claims.Claims{GroupID: "GR67890"}, nil)
+	node := nodeFromString("shared-only-key", false)
+	sharedPath := writeFileContent(t, baseDir, "shared/file", "shared-content", false)
+
+	// Seed the cache with a shared entry before recreating the filecache.
+	{
+		fc, err := filecache.NewFileCache(fcDir, 100000, false)
+		require.NoError(t, err)
+		fc.WaitForDirectoryScanToComplete()
+		sharedDirectoryCtx := fc.WithSharedDirectory(group1Ctx, "ext4_images")
+		require.NoError(t, fc.AddFile(sharedDirectoryCtx, node, sharedPath))
+		require.NoError(t, fc.Close())
+	}
+	// Reopen the filecache and verify the shared entry is visible across groups.
+	{
+		fc, err := filecache.NewFileCache(fcDir, 100000, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { fc.Close() })
+		fc.WaitForDirectoryScanToComplete()
+		sharedDirectoryCtx := fc.WithSharedDirectory(group2Ctx, "ext4_images")
+
+		require.False(t, fc.ContainsFile(group2Ctx, node))
+		require.True(t, fc.ContainsFile(sharedDirectoryCtx, node))
+
+		missPath := filepath.Join(baseDir, "group2-link")
+		require.False(t, fc.FastLinkFile(group2Ctx, node, missPath))
+		assert.NoFileExists(t, missPath)
+
+		sharedLinkPath := filepath.Join(baseDir, "shared-link")
+		require.True(t, fc.FastLinkFile(sharedDirectoryCtx, node, sharedLinkPath))
+		assertFileContents(t, sharedLinkPath, "shared-content")
+
+		f, err := fc.Open(sharedDirectoryCtx, node)
+		require.NoError(t, err)
+		defer f.Close()
+		data, err := io.ReadAll(f)
+		require.NoError(t, err)
+		require.Equal(t, "shared-content", string(data))
+	}
+}
+
+func TestFileCacheInvalidSharedDirectoryNamesAreIgnored(t *testing.T) {
+	ctx := context.Background()
+	fcDir := testfs.MakeTempDir(t)
+	baseDir := testfs.MakeTempDir(t)
+	group1Ctx := claims.AuthContextWithJWT(ctx, &claims.Claims{GroupID: "GR12345"}, nil)
+
+	tests := []struct {
+		name                    string
+		sharedDirName           string
+		startupDir              string
+		unexpectedSharedDirName string
+	}{
+		{
+			name:          "empty",
+			sharedDirName: "",
+			startupDir:    "_SHARED_",
+		},
+		{
+			name:          "dot",
+			sharedDirName: ".",
+			startupDir:    "_SHARED_.",
+		},
+		{
+			name:          "dotdot",
+			sharedDirName: "..",
+			startupDir:    "_SHARED_..",
+		},
+		{
+			name:          "anon",
+			sharedDirName: "ANON",
+			startupDir:    "_SHARED_ANON",
+		},
+		{
+			name:          "group_prefix",
+			sharedDirName: "GR_invalid",
+			startupDir:    "_SHARED_GR_invalid",
+		},
+		{
+			name:          "shared_prefix",
+			sharedDirName: "_SHARED_ext4_images",
+			startupDir:    "_SHARED__SHARED_ext4_images",
+		},
+		{
+			name:                    "forward_slash",
+			sharedDirName:           "ext4/images",
+			startupDir:              filepath.Join("_SHARED_ext4", "images"),
+			unexpectedSharedDirName: "ext4",
+		},
+		{
+			name:          "backslash",
+			sharedDirName: `ext4\images`,
+			startupDir:    "_SHARED_ext4\\images",
+		},
+	}
+
+	// Seed malformed shared-directory layouts on disk before startup scanning.
+	for _, test := range tests {
+		node := nodeFromString("invalid-shared-"+test.name, false)
+		writeFileContent(
+			t,
+			fcDir,
+			filepath.Join(test.startupDir, node.GetDigest().GetHash()),
+			"startup-"+test.name,
+			false,
+		)
+	}
+
+	fc, err := filecache.NewFileCache(fcDir, 100000, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { fc.Close() })
+	fc.WaitForDirectoryScanToComplete()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node := nodeFromString("invalid-shared-"+test.name, false)
+			invalidSharedDirectoryCtx := fc.WithSharedDirectory(group1Ctx, test.sharedDirName)
+
+			// Startup scanning should ignore the malformed on-disk entries
+			// completely, regardless of whether lookups use the group's default
+			// namespace or the invalid shared-directory context.
+			require.False(t, fc.ContainsFile(group1Ctx, node))
+			require.False(t, fc.ContainsFile(invalidSharedDirectoryCtx, node))
+
+			group1LinkPath := filepath.Join(baseDir, test.name, "group1-startup-link")
+			require.False(t, fc.FastLinkFile(group1Ctx, node, group1LinkPath))
+			assert.NoFileExists(t, group1LinkPath)
+
+			invalidLinkPath := filepath.Join(baseDir, test.name, "invalid-startup-link")
+			require.False(t, fc.FastLinkFile(invalidSharedDirectoryCtx, node, invalidLinkPath))
+			assert.NoFileExists(t, invalidLinkPath)
+
+			_, err := fc.Open(group1Ctx, node)
+			require.Error(t, err)
+			require.True(t, status.IsNotFoundError(err), "expected group lookup to miss for invalid startup directory")
+
+			_, err = fc.Open(invalidSharedDirectoryCtx, node)
+			require.Error(t, err)
+			require.True(t, status.IsNotFoundError(err), "expected invalid shared-directory lookup to miss after startup scan")
+
+			if test.unexpectedSharedDirName != "" {
+				// Malformed nested paths should not be reinterpreted as some other
+				// valid shared namespace during startup scanning.
+				unexpectedSharedDirectoryCtx := fc.WithSharedDirectory(group1Ctx, test.unexpectedSharedDirName)
+				require.False(t, fc.ContainsFile(unexpectedSharedDirectoryCtx, node))
+
+				unexpectedLinkPath := filepath.Join(baseDir, test.name, "unexpected-shared-link")
+				require.False(t, fc.FastLinkFile(unexpectedSharedDirectoryCtx, node, unexpectedLinkPath))
+				assert.NoFileExists(t, unexpectedLinkPath)
+
+				_, err := fc.Open(unexpectedSharedDirectoryCtx, node)
+				require.Error(t, err)
+				require.True(t, status.IsNotFoundError(err), "expected malformed startup directory to not hydrate another shared namespace")
+			}
+
+			// Supplying an invalid shared-directory name should fall back to the
+			// caller's normal group namespace on writes and subsequent reads.
+			// (This also logs an error, but we don't test for that.)
+			path := writeFileContent(t, baseDir, filepath.Join(test.name, "invalid", "file"), "invalid-"+test.name, false)
+			require.NoError(t, fc.AddFile(invalidSharedDirectoryCtx, node, path))
+
+			require.True(t, fc.ContainsFile(group1Ctx, node))
+			require.True(t, fc.ContainsFile(invalidSharedDirectoryCtx, node))
+
+			group1LinkPath = filepath.Join(baseDir, test.name, "group1-link")
+			require.True(t, fc.FastLinkFile(group1Ctx, node, group1LinkPath))
+			assertFileContents(t, group1LinkPath, "invalid-"+test.name)
+
+			invalidLinkPath = filepath.Join(baseDir, test.name, "invalid-link")
+			require.True(t, fc.FastLinkFile(invalidSharedDirectoryCtx, node, invalidLinkPath))
+			assertFileContents(t, invalidLinkPath, "invalid-"+test.name)
+
+			// Open should follow the same fallback-to-group behavior.
+			f, err := fc.Open(invalidSharedDirectoryCtx, node)
+			require.NoError(t, err)
+			defer f.Close()
+			data, err := io.ReadAll(f)
+			require.NoError(t, err)
+			require.Equal(t, "invalid-"+test.name, string(data))
+		})
+	}
+}
+
 func TestFileCacheOverwrite(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range []struct {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -907,6 +907,16 @@ type FileCache interface {
 	DeleteFile(ctx context.Context, f *repb.FileNode) bool
 	AddFile(ctx context.Context, f *repb.FileNode, existingFilePath string) error
 	ContainsFile(ctx context.Context, node *repb.FileNode) bool
+
+	// WithSharedDirectory returns a context that stores filecache entries under
+	// a shared executor-local directory instead of the current group or ANON
+	// directory.
+	//
+	// NOTE: Authorization for the objects in these shared directories must be
+	// handled by the caller. The caller must also ensure that the objects in
+	// these shared directories are not modified.
+	WithSharedDirectory(ctx context.Context, sharedDirectory string) context.Context
+
 	// Open returns a file handle to a file in the cache, if one exists.
 	Open(ctx context.Context, f *repb.FileNode) (*os.File, error)
 	WaitForDirectoryScanToComplete()

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -487,6 +487,8 @@ type fakeFilecache struct {
 	writeCount int
 }
 
+var _ interfaces.FileCache = (*fakeFilecache)(nil)
+
 func toFileNode(r *rspb.ResourceName) *repb.FileNode {
 	return &repb.FileNode{
 		Digest:       r.GetDigest(),
@@ -515,6 +517,10 @@ func (fc *fakeFilecache) ContainsFile(ctx context.Context, node *repb.FileNode) 
 	defer fc.mu.Unlock()
 	_, ok := fc.files[key(node)]
 	return ok
+}
+
+func (fc *fakeFilecache) WithSharedDirectory(ctx context.Context, sharedDirectory string) context.Context {
+	panic("unimplemented")
 }
 
 func (fc *fakeFilecache) Open(ctx context.Context, f *repb.FileNode) (*os.File, error) {


### PR DESCRIPTION
Planning to use this for the `ext4_images` directory, to support ext4 eviction. It will be visible in the filecache root as `_SHARED_ext4_images`.

Context: https://buildbuddy-corp.slack.com/archives/C06N9AHA4JX/p1776296372155309?thread_ts=1776104411.046799&cid=C06N9AHA4JX