### PR TITLE
Skip AC lookup for in-progress executions in GetExecution

### DIFF
--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -314,6 +314,12 @@ func (es *ExecutionService) GetExecution(ctx context.Context, req *espb.GetExecu
 		var eg errgroup.Group
 		for _, ex := range rsp.Execution {
 			ex := ex
+			// The execute response is only cached once the execution
+			// completes, so skip the lookup for in-progress executions
+			// to avoid unnecessary reads from the distributed cache.
+			if ex.GetStage() != repb.ExecutionStage_COMPLETED {
+				continue
+			}
 			eg.Go(func() error {
 				// TODO: if the authenticated user has access to the group
 				// that owns the execution, switch to that group's ctx.

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -314,9 +314,7 @@ func (es *ExecutionService) GetExecution(ctx context.Context, req *espb.GetExecu
 		var eg errgroup.Group
 		for _, ex := range rsp.Execution {
 			ex := ex
-			// The execute response is only cached once the execution
-			// completes, so skip the lookup for in-progress executions
-			// to avoid unnecessary reads from the distributed cache.
+			// The execute response is only cached once the execution completes.
 			if ex.GetStage() != repb.ExecutionStage_COMPLETED {
 				continue
 			}


### PR DESCRIPTION
The execute response is only cached to the AC once an execution
completes. When the UI polls GetExecution with inlineExecuteResponse
for a workflow invocation that is still running, we were doing an AC
lookup for the runner execution on every poll (~3s), which results in 'Exhausted all peers attempting to read' errors from the
distributed cache.

Skip the GetCachedExecuteResponse call for executions that haven't
reached the COMPLETED stage.