### PR TITLE
Use `test.no-sandbox` exec property

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -131,11 +131,11 @@ go_test(
         # because of OCI image conversion. Size the task manually to avoid OOM.
         # TODO: include test ext4 images as deps to avoid conversion.
         "test.EstimatedComputeUnits": "10",
+        "test.no-sandbox": "true",  # Firecracker is not compatible with Bazel's sandbox environment
     },
     shard_count = 30,
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
-        "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment
     ],
     target_compatible_with = [
         "@platforms//os:linux",

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -131,7 +131,7 @@ go_test(
         # because of OCI image conversion. Size the task manually to avoid OOM.
         # TODO: include test ext4 images as deps to avoid conversion.
         "test.EstimatedComputeUnits": "10",
-        "test.no-sandbox": "true",  # Firecracker is not compatible with Bazel's sandbox environment
+        "test.no-sandbox": "",  # Firecracker is not compatible with Bazel's sandbox environment
     },
     shard_count = 30,
     tags = [

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -77,7 +77,7 @@ go_test(
         "test.container-image": "docker://" + NET_TOOLS_IMAGE,
         "test.EstimatedComputeUnits": "2",
         "test.EstimatedFreeDiskBytes": "10GB",
-        "test.no-sandbox": "true",
+        "test.no-sandbox": "",
     },
     # NOTE: if testing locally, use --test_sharding_strategy=disabled to work
     # around the networking package not supporting cross-process locks.

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -77,13 +77,13 @@ go_test(
         "test.container-image": "docker://" + NET_TOOLS_IMAGE,
         "test.EstimatedComputeUnits": "2",
         "test.EstimatedFreeDiskBytes": "10GB",
+        "test.no-sandbox": "true",
     },
     # NOTE: if testing locally, use --test_sharding_strategy=disabled to work
     # around the networking package not supporting cross-process locks.
     shard_count = 4,
     tags = [
         "docker",
-        "no-sandbox",
     ],
     target_compatible_with = [
         "@platforms//os:linux",


### PR DESCRIPTION
These targets were failing to build with the `no-sandbox` tag set with the error: 

```
ERROR: no usable strategy found: GoTestGenTest <path/to/test/source.go> failed: GoTestGenTest spawn, which requires sandboxing due to path mapping, cannot be executed with any of the available strategies: [worker, linux-sandbox, standalone]. Your --spawn_strategy, --genrule_strategy, --strategy and/or --allowed_strategies_by_exec_platform flags are probably too strict.
```

Per Fabian's suggestion, switch to using the `test.no-sandbox` exec property.
