### PR TITLE
chore: remove v2 manifest

### DIFF
--- a/server/remote_cache/chunking/BUILD
+++ b/server/remote_cache/chunking/BUILD
@@ -37,7 +37,6 @@ go_test(
         "//server/util/cdc",
         "//server/util/log",
         "//server/util/prefix",
-        "//server/util/proto",
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -31,15 +31,11 @@ import (
 )
 
 var (
-	chunkedManifestSalt  = flag.String("cache.chunking.ac_key_salt", "", "If set, salt the AC key with this value.")
-	avgChunkSizeBytes    = flag.Int64("cache.avg_chunk_size_bytes", 512*1024, "This is the average size of a chunk. Only blobs larger (non-inclusive) than 4x this value will be chunked. The maximum chunk size will be 4x this value, and the minimum will be 1/4 this value (default 512KB).")
-	checkLegacyManifests = flag.Bool("cache.chunking.check_legacy_manifests", true, "If true, fall back to loading manifests with the legacy AC key scheme when the current scheme returns not found. Disable once metrics confirm no legacy manifests are being loaded, and re-enable when a new manifest scheme is introduced.")
+	chunkedManifestSalt = flag.String("cache.chunking.ac_key_salt", "", "If set, salt the AC key with this value.")
+	avgChunkSizeBytes   = flag.Int64("cache.avg_chunk_size_bytes", 512*1024, "This is the average size of a chunk. Only blobs larger (non-inclusive) than 4x this value will be chunked. The maximum chunk size will be 4x this value, and the minimum will be 1/4 this value (default 512KB).")
 )
 
 const (
-	// When adding a new manifest scheme, update legacyManifestPrefix to
-	// point to the current prefix, then add the new one as the active prefix.
-	legacyManifestPrefix         = "_bb_chunked_manifest_v2_/"
 	chunkedManifestPrefix        = "_bb_chunked_manifest_v3_/"
 	chunkOutputFilePrefix        = "chunk_"
 	sharedValidationMarkerDomain = "cas-validation-marker-v1"
@@ -310,30 +306,16 @@ func (cm *Manifest) Store(ctx context.Context, cache interfaces.Cache) error {
 }
 
 // LoadManifest retrieves a chunked manifest from the cache. It does NOT validate existence of the chunks.
-// It tries the current key first, then falls back to the legacy key.
 func LoadManifest(ctx context.Context, cache interfaces.Cache, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value) (*Manifest, error) {
 	rn, err := acResourceName(blobDigest, instanceName, digestFunction)
 	if err != nil {
 		return nil, err
 	}
 	manifest, err := loadManifestFrom(ctx, cache, blobDigest, instanceName, digestFunction, rn)
-	if err == nil {
-		metrics.ChunkedManifestLoadCount.WithLabelValues(chunkedManifestPrefix).Inc()
-		return manifest, nil
-	}
-	if !status.IsNotFoundError(err) || !*checkLegacyManifests {
-		return nil, err
-	}
-
-	legacyRN, err := legacyACResourceName(blobDigest, instanceName, digestFunction)
 	if err != nil {
 		return nil, err
 	}
-	manifest, err = loadManifestFrom(ctx, cache, blobDigest, instanceName, digestFunction, legacyRN)
-	if err != nil {
-		return nil, err
-	}
-	metrics.ChunkedManifestLoadCount.WithLabelValues(legacyManifestPrefix).Inc()
+	metrics.ChunkedManifestLoadCount.WithLabelValues(chunkedManifestPrefix).Inc()
 	return manifest, nil
 }
 
@@ -511,18 +493,10 @@ func sharedValidationResourceName(cm *Manifest) (*rspb.ResourceName, []byte, err
 }
 
 func acResourceName(blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value) (*rspb.ResourceName, error) {
-	return acResourceNameVersioned(chunkedManifestPrefix, blobToManifestSize(blobDigest.GetSizeBytes()), blobDigest, instanceName, digestFunction)
-}
-
-func legacyACResourceName(blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value) (*rspb.ResourceName, error) {
-	return acResourceNameVersioned(legacyManifestPrefix, blobDigest.GetSizeBytes(), blobDigest, instanceName, digestFunction)
-}
-
-func acResourceNameVersioned(prefix string, sizeBytes int64, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value) (*rspb.ResourceName, error) {
-	acInstanceName := prefix + instanceName
+	acInstanceName := chunkedManifestPrefix + instanceName
 	acDigest := &repb.Digest{
 		Hash:      blobDigest.GetHash(),
-		SizeBytes: sizeBytes,
+		SizeBytes: blobToManifestSize(blobDigest.GetSizeBytes()),
 	}
 
 	// Optionally salt the AC key with a salt value. This is used to prevent someone uploading
@@ -534,7 +508,7 @@ func acResourceNameVersioned(prefix string, sizeBytes int64, blobDigest *repb.Di
 		if err != nil {
 			return nil, err
 		}
-		saltedDigest.SizeBytes = sizeBytes
+		saltedDigest.SizeBytes = acDigest.SizeBytes
 		acDigest = saltedDigest
 	}
 

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/cdc"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
-	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
@@ -198,45 +197,6 @@ func TestStoreAndLoad(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestLoadManifest_LegacyFallback(t *testing.T) {
-	ctx := context.Background()
-	te := testenv.GetTestEnv(t)
-	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
-	require.NoError(t, err)
-	cache := te.GetCache()
-
-	chunk1RN, chunk1Data := testdigest.RandomCASResourceBuf(t, 100)
-	chunk2RN, chunk2Data := testdigest.RandomCASResourceBuf(t, 150)
-	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1Data))
-	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2Data))
-
-	allData := append(chunk1Data, chunk2Data...)
-	blobDigest, err := digest.Compute(bytes.NewReader(allData), repb.DigestFunction_SHA256)
-	require.NoError(t, err)
-
-	manifestBytes, err := proto.Marshal(&repb.ActionResult{
-		OutputFiles: []*repb.OutputFile{
-			{Path: "chunk_0", Digest: chunk1RN.GetDigest()},
-			{Path: "chunk_1", Digest: chunk2RN.GetDigest()},
-		},
-	})
-	require.NoError(t, err)
-
-	legacyACDigest := &repb.Digest{Hash: blobDigest.GetHash(), SizeBytes: blobDigest.GetSizeBytes()}
-	legacyRN := digest.NewACResourceName(legacyACDigest, "_bb_chunked_manifest_v2_/", repb.DigestFunction_SHA256)
-	require.NoError(t, cache.Set(ctx, legacyRN.ToProto(), manifestBytes))
-
-	loaded, err := chunking.LoadManifest(ctx, cache, blobDigest, "", repb.DigestFunction_SHA256)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(loaded.ChunkDigests))
-	assert.Equal(t, chunk1RN.GetDigest().GetHash(), loaded.ChunkDigests[0].GetHash())
-	assert.Equal(t, chunk2RN.GetDigest().GetHash(), loaded.ChunkDigests[1].GetHash())
-
-	flags.Set(t, "cache.chunking.check_legacy_manifests", false)
-	_, err = chunking.LoadManifest(ctx, cache, blobDigest, "", repb.DigestFunction_SHA256)
-	require.True(t, status.IsNotFoundError(err))
 }
 
 func TestStore_MissingChunk(t *testing.T) {


### PR DESCRIPTION
99% of manifests are on v3, remove the v2 so we stop refreshing these legacy entries. 