### PR TITLE
[WF] Support canceling duplicate workflows on the same branch

### DIFF
--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -20,6 +20,7 @@ go_test(
         "//proto:user_id_go_proto",
         "//proto:workflow_go_proto",
         "//server/backends/github",
+        "//server/backends/memory_kvstore",
         "//server/backends/repo_downloader",
         "//server/endpoint_urls/build_buddy_url",
         "//server/interfaces",

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -29,6 +29,7 @@ go_test(
         "//server/testutil/testenv",
         "//server/testutil/testgit",
         "//server/testutil/testhttp",
+        "//server/util/lib/set",
         "//server/util/perms",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/github"
+	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_kvstore"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/repo_downloader"
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -161,6 +162,9 @@ func setup(t *testing.T, gp interfaces.GitProvider) (*rbetest.Env, interfaces.Wo
 			gh, err := githubapp.NewAppService(e, &testgit.FakeGitHubApp{MockAppID: mockGithubAppID}, nil)
 			require.NoError(t, err)
 			e.SetGitHubAppService(gh)
+			keyValStore, err := memory_kvstore.NewMemoryKeyValStore()
+			require.NoError(t, err)
+			e.SetKeyValStore(keyValStore)
 		},
 	})
 
@@ -210,17 +214,22 @@ func createWorkflow(t *testing.T, env *rbetest.Env, repoURL string) *tables.GitR
 // TODO(Maggie): Modify integration test to hit the /webhooks/github/app endpoint
 // by mocking out more selective parts of the github app
 func triggerWebhook(t *testing.T, ctx context.Context, gitProvider *testgit.FakeProvider, workflowService interfaces.WorkflowService, repo *tables.GitRepository, repoContents map[string]string, repoURL string, commitSHA string) {
+	triggerWebhookOnBranch(t, ctx, gitProvider, workflowService, repo, repoContents, repoURL, "master", commitSHA)
+}
+
+func triggerWebhookOnBranch(t *testing.T, ctx context.Context, gitProvider *testgit.FakeProvider, workflowService interfaces.WorkflowService, repo *tables.GitRepository, repoContents map[string]string, repoURL string, branch string, commitSHA string) {
 	// Set up the fake git provider so that GetFileContents can return the
 	// buildbuddy.yaml from our test repo
 	gitProvider.FileContents = repoContents
 	// Configure the fake webhook data to be parsed from the response
 	gitProvider.WebhookData = &interfaces.WebhookData{
-		EventName:     "push",
-		PushedRepoURL: repoURL,
-		PushedBranch:  "master",
-		SHA:           commitSHA,
-		TargetRepoURL: repoURL,
-		TargetBranch:  "master",
+		EventName:               "push",
+		PushedRepoURL:           repoURL,
+		PushedBranch:            branch,
+		SHA:                     commitSHA,
+		TargetRepoURL:           repoURL,
+		TargetBranch:            "master",
+		TargetRepoDefaultBranch: "master",
 	}
 	err := workflowService.HandleRepositoryEvent(ctx, repo, gitProvider.WebhookData, "faketoken")
 	require.NoError(t, err)
@@ -269,6 +278,33 @@ func waitForAnyWorkflowInvocationCreated(t *testing.T, ctx context.Context, bb b
 	return ""
 }
 
+func waitForAnyInvocationCreatedMatching(t *testing.T, ctx context.Context, bb bbspb.BuildBuddyServiceClient, reqCtx *ctxpb.RequestContext, query *inpb.InvocationQuery, excludeInvocationIDs ...string) string {
+	excluded := make(map[string]struct{}, len(excludeInvocationIDs))
+	for _, invocationID := range excludeInvocationIDs {
+		excluded[invocationID] = struct{}{}
+	}
+	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
+		searchResp, err := bb.SearchInvocation(ctx, &inpb.SearchInvocationRequest{
+			RequestContext: reqCtx,
+			Query:          query,
+		})
+		if err != nil && !strings.Contains(err.Error(), "not found") {
+			require.NoError(t, err)
+		}
+		for _, in := range searchResp.GetInvocation() {
+			if _, ok := excluded[in.GetInvocationId()]; ok {
+				continue
+			}
+			return in.GetInvocationId()
+		}
+
+		time.Sleep(delay)
+	}
+
+	require.FailNowf(t, "timeout", "Timed out waiting for matching invocation to be created")
+	return ""
+}
+
 func waitForInvocationStatus(t *testing.T, ctx context.Context, bb bbspb.BuildBuddyServiceClient, reqCtx *ctxpb.RequestContext, invocationID string, expectedStatus inspb.InvocationStatus) *inpb.Invocation {
 	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
 		inv := getInvocation(t, ctx, bb, reqCtx, invocationID, false /*fetchChildren*/)
@@ -279,8 +315,9 @@ func waitForInvocationStatus(t *testing.T, ctx context.Context, bb bbspb.BuildBu
 				InvocationId: invocationID,
 				MinLines:     math.MaxInt32,
 			})
-			require.NoError(t, err)
-			inv.ConsoleBuffer = string(logResp.Buffer)
+			if err == nil {
+				inv.ConsoleBuffer = string(logResp.Buffer)
+			}
 			return inv
 		}
 
@@ -538,6 +575,83 @@ func TestCancel(t *testing.T) {
 
 		if !found {
 			require.FailNowf(t, "timeout", "Timed out waiting for child to either complete or be disconeccted")
+		}
+	}
+}
+
+func TestCancelOlderRunsOnSameBranch(t *testing.T) {
+	flags.Set(t, "workflows.cancel_duplicates", true)
+
+	for _, branch := range []string{"test-branch", "master"} {
+		for _, newCommit := range []bool{true, false} {
+			fakeGitProvider := testgit.NewFakeProvider()
+			env, workflowService := setup(t, fakeGitProvider)
+
+			bb := env.GetBuildBuddyServiceClient()
+
+			// Set up a workflow that hangs, so the workflow doesn't accidentally complete before we can cancel it.
+			repoContentsMap := repoWithSlowScript()
+			repoPath, commitSHA := makeRepo(t, repoContentsMap)
+			repoURL := fmt.Sprintf("file://%s", repoPath)
+
+			ctx := env.WithUserID(context.Background(), env.UserID1)
+			reqCtx := &ctxpb.RequestContext{
+				UserId:  &uidpb.UserId{Id: env.UserID1},
+				GroupId: env.GroupID1,
+			}
+			repo := createWorkflow(t, env, repoURL)
+
+			// Trigger run #1 of the workflow on a branch.
+			triggerWebhookOnBranch(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, branch, commitSHA)
+			firstOuterIID := waitForAnyInvocationCreatedMatching(t, ctx, bb, reqCtx, &inpb.InvocationQuery{
+				GroupId: reqCtx.GetGroupId(),
+				RepoUrl: repoURL,
+				Role:    []string{"CI_RUNNER"},
+			})
+			waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+
+			if newCommit {
+				// Make sure that a second workflow on a different commit but same branch still cancels the first workflow.
+				commitSHA = testgit.CommitFiles(t, repoPath, map[string]string{
+					"rerun.txt": "new commit on the same branch\n",
+				})
+			}
+
+			// Trigger a second workflow on the same branch.
+			triggerWebhookOnBranch(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, branch, commitSHA)
+			secondOuterIID := waitForAnyInvocationCreatedMatching(t, ctx, bb, reqCtx, &inpb.InvocationQuery{
+				GroupId: reqCtx.GetGroupId(),
+				RepoUrl: repoURL,
+				Role:    []string{"CI_RUNNER"},
+			}, firstOuterIID)
+
+			// On feature branches, we expect the second workflow to cancel the first workflow.
+			if branch == "test-branch" {
+				waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS)
+			}
+
+			// Make sure the second workflow was not accidentally cancelled too.
+			waitForInvocationStatus(t, ctx, bb, reqCtx, secondOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+
+			// On the default branch, we expect the second workflow to not cancel the first workflow.
+			if branch == "master" {
+				waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+			}
+
+			// Kill the second workflow. Otherwise the shutdown functions will waste some time waiting for it to complete.
+			_, err := bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
+				RequestContext: reqCtx,
+				InvocationId:   secondOuterIID,
+			})
+			require.NoError(t, err)
+
+			if branch == "master" {
+				_, err = bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
+					RequestContext: reqCtx,
+					InvocationId:   firstOuterIID,
+				})
+				require.NoError(t, err)
+			}
 		}
 	}
 }

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -269,6 +269,33 @@ func waitForAnyWorkflowInvocationCreated(t *testing.T, ctx context.Context, bb b
 	return ""
 }
 
+func waitForAnyInvocationCreatedMatching(t *testing.T, ctx context.Context, bb bbspb.BuildBuddyServiceClient, reqCtx *ctxpb.RequestContext, query *inpb.InvocationQuery, excludeInvocationIDs ...string) string {
+	excluded := make(map[string]struct{}, len(excludeInvocationIDs))
+	for _, invocationID := range excludeInvocationIDs {
+		excluded[invocationID] = struct{}{}
+	}
+	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
+		searchResp, err := bb.SearchInvocation(ctx, &inpb.SearchInvocationRequest{
+			RequestContext: reqCtx,
+			Query:          query,
+		})
+		if err != nil && !strings.Contains(err.Error(), "not found") {
+			require.NoError(t, err)
+		}
+		for _, in := range searchResp.GetInvocation() {
+			if _, ok := excluded[in.GetInvocationId()]; ok {
+				continue
+			}
+			return in.GetInvocationId()
+		}
+
+		time.Sleep(delay)
+	}
+
+	require.FailNowf(t, "timeout", "Timed out waiting for matching invocation to be created")
+	return ""
+}
+
 func waitForInvocationStatus(t *testing.T, ctx context.Context, bb bbspb.BuildBuddyServiceClient, reqCtx *ctxpb.RequestContext, invocationID string, expectedStatus inspb.InvocationStatus) *inpb.Invocation {
 	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
 		inv := getInvocation(t, ctx, bb, reqCtx, invocationID, false /*fetchChildren*/)
@@ -279,8 +306,9 @@ func waitForInvocationStatus(t *testing.T, ctx context.Context, bb bbspb.BuildBu
 				InvocationId: invocationID,
 				MinLines:     math.MaxInt32,
 			})
-			require.NoError(t, err)
-			inv.ConsoleBuffer = string(logResp.Buffer)
+			if err == nil {
+				inv.ConsoleBuffer = string(logResp.Buffer)
+			}
 			return inv
 		}
 
@@ -540,6 +568,61 @@ func TestCancel(t *testing.T) {
 			require.FailNowf(t, "timeout", "Timed out waiting for child to either complete or be disconeccted")
 		}
 	}
+}
+
+func TestCancelOlderRunsOnSameBranch(t *testing.T) {
+	flags.Set(t, "workflows.cancel_duplicates", true)
+
+	fakeGitProvider := testgit.NewFakeProvider()
+	env, workflowService := setup(t, fakeGitProvider)
+	bb := env.GetBuildBuddyServiceClient()
+
+	// Set up a workflow that hangs, so the workflow doesn't accidentally complete before we can cancel it.
+	repoContentsMap := repoWithSlowScript()
+	repoPath, commitSHA := makeRepo(t, repoContentsMap)
+	repoURL := fmt.Sprintf("file://%s", repoPath)
+
+	ctx := env.WithUserID(context.Background(), env.UserID1)
+	reqCtx := &ctxpb.RequestContext{
+		UserId:  &uidpb.UserId{Id: env.UserID1},
+		GroupId: env.GroupID1,
+	}
+	repo := createWorkflow(t, env, repoURL)
+
+	// Trigger run #1 of the workflow on a branch.
+	triggerWebhook(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, commitSHA)
+	firstOuterIID := waitForAnyInvocationCreatedMatching(t, ctx, bb, reqCtx, &inpb.InvocationQuery{
+		GroupId: reqCtx.GetGroupId(),
+		RepoUrl: repoURL,
+		Role:    []string{"CI_RUNNER"},
+	})
+	waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+	firstChildIID := waitForAnyInvocationCreatedMatching(t, ctx, bb, reqCtx, &inpb.InvocationQuery{
+		GroupId:    reqCtx.GetGroupId(),
+		RepoUrl:    repoURL,
+		BranchName: "master",
+		Role:       []string{"CI"},
+		Status:     []inspb.OverallStatus{inspb.OverallStatus_IN_PROGRESS},
+	})
+	waitForInvocationStatus(t, ctx, bb, reqCtx, firstChildIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+
+	secondCommitSHA := testgit.CommitFiles(t, repoPath, map[string]string{
+		"rerun.txt": "second commit on the same branch\n",
+	})
+
+	// Trigger run #2 of the workflow on the same branch but at a different commit.
+	triggerWebhook(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, secondCommitSHA)
+	secondOuterIID := waitForAnyInvocationCreatedMatching(t, ctx, bb, reqCtx, &inpb.InvocationQuery{
+		GroupId: reqCtx.GetGroupId(),
+		RepoUrl: repoURL,
+		Role:    []string{"CI_RUNNER"},
+	}, firstOuterIID)
+
+	waitForInvocationStatus(t, ctx, bb, reqCtx, firstChildIID, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS)
+	waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS)
+
+	// Make sure the second workflow was not accidentally cancelled too.
+	waitForInvocationStatus(t, ctx, bb, reqCtx, secondOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
 }
 
 func TestInvalidYAML(t *testing.T) {

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -119,6 +119,7 @@ actions:
     bazel_use_cli: false
     triggers: { push: { branches: [ "*" ] } }
     bazel_commands: [ "run //:sleep_forever_test" ]
+    allow_concurrent_runs: false
     os: ` + runtime.GOOS + `
     arch: ` + runtime.GOARCH + `
 `,
@@ -140,12 +141,14 @@ actions:
     bazel_use_cli: false
     triggers: { push: { branches: [ "*" ] } }
     bazel_commands: [ "run //:sleep_forever_test" ]
+    allow_concurrent_runs: false
     os: ` + runtime.GOOS + `
     arch: ` + runtime.GOARCH + `
   - name: "Action 2"
     bazel_use_cli: false
     triggers: { push: { branches: [ "*" ] } }
     bazel_commands: [ "run //:sleep_forever_test" ]
+    allow_concurrent_runs: false
     os: ` + runtime.GOOS + `
     arch: ` + runtime.GOARCH + `
 `,
@@ -588,8 +591,6 @@ func TestCancel(t *testing.T) {
 }
 
 func TestCancelOlderRunsOnSameBranch(t *testing.T) {
-	flags.Set(t, "remote_execution.workflows_cancel_duplicates", true)
-
 	for _, branch := range []string{"test-branch", "master"} {
 		for _, newCommit := range []bool{true, false} {
 			fakeGitProvider := testgit.NewFakeProvider()
@@ -656,8 +657,6 @@ func TestCancelOlderRunsOnSameBranch(t *testing.T) {
 }
 
 func TestCancelOlderRunsOnSameBranch_MultipleWorkflows(t *testing.T) {
-	flags.Set(t, "remote_execution.workflows_cancel_duplicates", true)
-
 	repoContents := repoWithMultipleSlowActions()
 
 	fakeGitProvider := testgit.NewFakeProvider()

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -125,6 +125,33 @@ actions:
 	}
 }
 
+func repoWithMultipleSlowActions() map[string]string {
+	return map[string]string{
+		"BUILD": `
+sh_binary(
+    name = "sleep_forever_test",
+    srcs = ["sleep_forever_test.sh"],
+)
+`,
+		"sleep_forever_test.sh": "tail -f /dev/null",
+		"buildbuddy.yaml": `
+actions:
+  - name: "Action 1"
+    bazel_use_cli: false
+    triggers: { push: { branches: [ "*" ] } }
+    bazel_commands: [ "run //:sleep_forever_test" ]
+    os: ` + runtime.GOOS + `
+    arch: ` + runtime.GOARCH + `
+  - name: "Action 2"
+    bazel_use_cli: false
+    triggers: { push: { branches: [ "*" ] } }
+    bazel_commands: [ "run //:sleep_forever_test" ]
+    os: ` + runtime.GOOS + `
+    arch: ` + runtime.GOARCH + `
+`,
+	}
+}
+
 func repoWithInvalidConfig() map[string]string {
 	// Note the missing close-quote in the bazel command.
 	return map[string]string{
@@ -628,72 +655,59 @@ func TestCancelOlderRunsOnSameBranch(t *testing.T) {
 	}
 }
 
-func ATestCancelOlderRunsOnSameBranch_MultipleWorkflows(t *testing.T) {
+func TestCancelOlderRunsOnSameBranch_MultipleWorkflows(t *testing.T) {
 	flags.Set(t, "remote_execution.workflows_cancel_duplicates", true)
 
-	for _, branch := range []string{"test-branch"} {
-		for _, newCommit := range []bool{true} {
-			fakeGitProvider := testgit.NewFakeProvider()
-			env, workflowService := setup(t, fakeGitProvider)
+	repoContents := repoWithMultipleSlowActions()
 
-			bb := env.GetBuildBuddyServiceClient()
+	fakeGitProvider := testgit.NewFakeProvider()
+	fakeGitProvider.FileContents = repoContents
+	env, wfService := setup(t, fakeGitProvider)
+	bb := env.GetBuildBuddyServiceClient()
 
-			// Set up a workflow that hangs, so the workflow doesn't accidentally complete before we can cancel it.
-			repoContentsMap := repoWithSlowScript()
-			repoPath, commitSHA := makeRepo(t, repoContentsMap)
-			repoURL := fmt.Sprintf("file://%s", repoPath)
-
-			ctx := env.WithUserID(context.Background(), env.UserID1)
-			reqCtx := &ctxpb.RequestContext{
-				UserId:  &uidpb.UserId{Id: env.UserID1},
-				GroupId: env.GroupID1,
-			}
-			repo := createWorkflow(t, env, repoURL)
-
-			// Trigger run #1 of the workflow on a branch.
-			triggerWebhookOnBranch(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, branch, commitSHA)
-			firstOuterIID := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx)
-			waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
-
-			if newCommit {
-				// Make sure that a second workflow on a different commit but same branch still cancels the first workflow.
-				commitSHA = testgit.CommitFiles(t, repoPath, map[string]string{
-					"rerun.txt": "new commit on the same branch\n",
-				})
-			}
-
-			// Trigger a second workflow on the same branch.
-			triggerWebhookOnBranch(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, branch, commitSHA)
-			secondOuterIID := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx, firstOuterIID)
-			// On feature branches, we expect the second workflow to cancel the first workflow.
-			if branch == "test-branch" {
-				waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS)
-			}
-
-			// Make sure the second workflow was not accidentally cancelled too.
-			waitForInvocationStatus(t, ctx, bb, reqCtx, secondOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
-
-			// On the default branch, we expect the second workflow to not cancel the first workflow.
-			if branch == "master" {
-				waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
-			}
-
-			// Kill any still-running workflows. Otherwise the shutdown functions will waste some time waiting for it to complete.
-			_, err := bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
-				RequestContext: reqCtx,
-				InvocationId:   secondOuterIID,
-			})
-			require.NoError(t, err)
-
-			if branch == "master" {
-				_, err = bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
-					RequestContext: reqCtx,
-					InvocationId:   firstOuterIID,
-				})
-				require.NoError(t, err)
-			}
-		}
+	repoPath, commitSHA := makeRepo(t, repoContents)
+	repoURL := fmt.Sprintf("file://%s", repoPath)
+	ctx := env.WithUserID(context.Background(), env.UserID1)
+	reqCtx := &ctxpb.RequestContext{
+		UserId:  &uidpb.UserId{Id: env.UserID1},
+		GroupId: env.GroupID1,
 	}
+	repo := createWorkflow(t, env, repoURL)
+
+	// Trigger both workflows to run.
+	triggerWebhookOnBranch(t, ctx, fakeGitProvider, wfService, repo, repoContents, repoURL, "my-branch", commitSHA)
+
+	// Both workflows should be running. Neither should have accidentally canceled the other,
+	// even though they're running on the same branch.
+	iidA := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx)
+	waitForInvocationStatus(t, ctx, bb, reqCtx, iidA, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+	iidB := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx, iidA)
+	waitForInvocationStatus(t, ctx, bb, reqCtx, iidB, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+
+	// Trigger another webhook for the same branch. This should cancel the original workflows.
+	triggerWebhookOnBranch(t, ctx, fakeGitProvider, wfService, repo, repoContents, repoURL, "my-branch", commitSHA)
+
+	// Wait for the new workflows to start running.
+	iidA2 := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx, iidA, iidB)
+	waitForInvocationStatus(t, ctx, bb, reqCtx, iidA2, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+	iidB2 := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx, iidA, iidB, iidA2)
+	waitForInvocationStatus(t, ctx, bb, reqCtx, iidB2, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+
+	// The original workflows should be cancelled.
+	waitForInvocationStatus(t, ctx, bb, reqCtx, iidA, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS)
+	waitForInvocationStatus(t, ctx, bb, reqCtx, iidB, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS)
+
+	// Cleanup. Kill any still-running workflows.
+	_, err := bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
+		RequestContext: reqCtx,
+		InvocationId:   iidA2,
+	})
+	require.NoError(t, err)
+	_, err = bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
+		RequestContext: reqCtx,
+		InvocationId:   iidB2,
+	})
+	require.NoError(t, err)
 }
 
 func TestInvalidYAML(t *testing.T) {

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testhttp"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
@@ -116,7 +117,7 @@ sh_binary(
 actions:
   - name: "Slow test action"
     bazel_use_cli: false
-    triggers: { push: { branches: [ master ] } }
+    triggers: { push: { branches: [ "*" ] } }
     bazel_commands: [ "run //:sleep_forever_test" ]
     os: ` + runtime.GOOS + `
     arch: ` + runtime.GOARCH + `
@@ -228,7 +229,7 @@ func triggerWebhookOnBranch(t *testing.T, ctx context.Context, gitProvider *test
 		PushedBranch:            branch,
 		SHA:                     commitSHA,
 		TargetRepoURL:           repoURL,
-		TargetBranch:            "master",
+		TargetBranch:            branch,
 		TargetRepoDefaultBranch: "master",
 	}
 	err := workflowService.HandleRepositoryEvent(ctx, repo, gitProvider.WebhookData, "faketoken")
@@ -256,17 +257,24 @@ func triggerLegacyWebhook(t *testing.T, gitProvider *testgit.FakeProvider, workf
 	workflowService.ServeHTTP(testhttp.NewResponseWriter(t), req)
 }
 
-func waitForAnyWorkflowInvocationCreated(t *testing.T, ctx context.Context, bb bbspb.BuildBuddyServiceClient, reqCtx *ctxpb.RequestContext) string {
+func waitForAnyWorkflowInvocationCreated(t *testing.T, ctx context.Context, bb bbspb.BuildBuddyServiceClient, reqCtx *ctxpb.RequestContext, excludeInvocationIDs ...string) string {
+	excluded := set.From(excludeInvocationIDs...)
+
 	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
 		searchResp, err := bb.SearchInvocation(ctx, &inpb.SearchInvocationRequest{
 			RequestContext: reqCtx,
 			Query:          &inpb.InvocationQuery{GroupId: reqCtx.GetGroupId()},
 		})
-		if err != nil && !strings.Contains(err.Error(), "not found") {
-			require.NoError(t, err)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			continue
 		}
+		require.NoError(t, err)
+
 		for _, in := range searchResp.GetInvocation() {
 			if in.GetRole() == "CI_RUNNER" {
+				if excluded.Contains(in.GetInvocationId()) {
+					continue
+				}
 				return in.GetInvocationId()
 			}
 		}
@@ -275,33 +283,6 @@ func waitForAnyWorkflowInvocationCreated(t *testing.T, ctx context.Context, bb b
 	}
 
 	require.FailNowf(t, "timeout", "Timed out waiting for workflow invocation to be created")
-	return ""
-}
-
-func waitForAnyInvocationCreatedMatching(t *testing.T, ctx context.Context, bb bbspb.BuildBuddyServiceClient, reqCtx *ctxpb.RequestContext, query *inpb.InvocationQuery, excludeInvocationIDs ...string) string {
-	excluded := make(map[string]struct{}, len(excludeInvocationIDs))
-	for _, invocationID := range excludeInvocationIDs {
-		excluded[invocationID] = struct{}{}
-	}
-	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
-		searchResp, err := bb.SearchInvocation(ctx, &inpb.SearchInvocationRequest{
-			RequestContext: reqCtx,
-			Query:          query,
-		})
-		if err != nil && !strings.Contains(err.Error(), "not found") {
-			require.NoError(t, err)
-		}
-		for _, in := range searchResp.GetInvocation() {
-			if _, ok := excluded[in.GetInvocationId()]; ok {
-				continue
-			}
-			return in.GetInvocationId()
-		}
-
-		time.Sleep(delay)
-	}
-
-	require.FailNowf(t, "timeout", "Timed out waiting for matching invocation to be created")
 	return ""
 }
 
@@ -580,7 +561,7 @@ func TestCancel(t *testing.T) {
 }
 
 func TestCancelOlderRunsOnSameBranch(t *testing.T) {
-	flags.Set(t, "workflows.cancel_duplicates", true)
+	flags.Set(t, "remote_execution.workflows_cancel_duplicates", true)
 
 	for _, branch := range []string{"test-branch", "master"} {
 		for _, newCommit := range []bool{true, false} {
@@ -603,11 +584,7 @@ func TestCancelOlderRunsOnSameBranch(t *testing.T) {
 
 			// Trigger run #1 of the workflow on a branch.
 			triggerWebhookOnBranch(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, branch, commitSHA)
-			firstOuterIID := waitForAnyInvocationCreatedMatching(t, ctx, bb, reqCtx, &inpb.InvocationQuery{
-				GroupId: reqCtx.GetGroupId(),
-				RepoUrl: repoURL,
-				Role:    []string{"CI_RUNNER"},
-			})
+			firstOuterIID := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx)
 			waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
 
 			if newCommit {
@@ -619,12 +596,7 @@ func TestCancelOlderRunsOnSameBranch(t *testing.T) {
 
 			// Trigger a second workflow on the same branch.
 			triggerWebhookOnBranch(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, branch, commitSHA)
-			secondOuterIID := waitForAnyInvocationCreatedMatching(t, ctx, bb, reqCtx, &inpb.InvocationQuery{
-				GroupId: reqCtx.GetGroupId(),
-				RepoUrl: repoURL,
-				Role:    []string{"CI_RUNNER"},
-			}, firstOuterIID)
-
+			secondOuterIID := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx, firstOuterIID)
 			// On feature branches, we expect the second workflow to cancel the first workflow.
 			if branch == "test-branch" {
 				waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS)
@@ -638,7 +610,75 @@ func TestCancelOlderRunsOnSameBranch(t *testing.T) {
 				waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
 			}
 
-			// Kill the second workflow. Otherwise the shutdown functions will waste some time waiting for it to complete.
+			// Kill any still-running workflows. Otherwise the shutdown functions will waste some time waiting for it to complete.
+			_, err := bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
+				RequestContext: reqCtx,
+				InvocationId:   secondOuterIID,
+			})
+			require.NoError(t, err)
+
+			if branch == "master" {
+				_, err = bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
+					RequestContext: reqCtx,
+					InvocationId:   firstOuterIID,
+				})
+				require.NoError(t, err)
+			}
+		}
+	}
+}
+
+func ATestCancelOlderRunsOnSameBranch_MultipleWorkflows(t *testing.T) {
+	flags.Set(t, "remote_execution.workflows_cancel_duplicates", true)
+
+	for _, branch := range []string{"test-branch"} {
+		for _, newCommit := range []bool{true} {
+			fakeGitProvider := testgit.NewFakeProvider()
+			env, workflowService := setup(t, fakeGitProvider)
+
+			bb := env.GetBuildBuddyServiceClient()
+
+			// Set up a workflow that hangs, so the workflow doesn't accidentally complete before we can cancel it.
+			repoContentsMap := repoWithSlowScript()
+			repoPath, commitSHA := makeRepo(t, repoContentsMap)
+			repoURL := fmt.Sprintf("file://%s", repoPath)
+
+			ctx := env.WithUserID(context.Background(), env.UserID1)
+			reqCtx := &ctxpb.RequestContext{
+				UserId:  &uidpb.UserId{Id: env.UserID1},
+				GroupId: env.GroupID1,
+			}
+			repo := createWorkflow(t, env, repoURL)
+
+			// Trigger run #1 of the workflow on a branch.
+			triggerWebhookOnBranch(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, branch, commitSHA)
+			firstOuterIID := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx)
+			waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+
+			if newCommit {
+				// Make sure that a second workflow on a different commit but same branch still cancels the first workflow.
+				commitSHA = testgit.CommitFiles(t, repoPath, map[string]string{
+					"rerun.txt": "new commit on the same branch\n",
+				})
+			}
+
+			// Trigger a second workflow on the same branch.
+			triggerWebhookOnBranch(t, ctx, fakeGitProvider, workflowService, repo, repoContentsMap, repoURL, branch, commitSHA)
+			secondOuterIID := waitForAnyWorkflowInvocationCreated(t, ctx, bb, reqCtx, firstOuterIID)
+			// On feature branches, we expect the second workflow to cancel the first workflow.
+			if branch == "test-branch" {
+				waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS)
+			}
+
+			// Make sure the second workflow was not accidentally cancelled too.
+			waitForInvocationStatus(t, ctx, bb, reqCtx, secondOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+
+			// On the default branch, we expect the second workflow to not cancel the first workflow.
+			if branch == "master" {
+				waitForInvocationStatus(t, ctx, bb, reqCtx, firstOuterIID, inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS)
+			}
+
+			// Kill any still-running workflows. Otherwise the shutdown functions will waste some time waiting for it to complete.
 			_, err := bb.CancelExecutions(ctx, &inpb.CancelExecutionsRequest{
 				RequestContext: reqCtx,
 				InvocationId:   secondOuterIID,

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -63,7 +63,7 @@ type Action struct {
 	BazelUseCLI *bool `yaml:"bazel_use_cli"`
 	// By default, if you have multiple workflow runs on the same branch, we'll cancel the old ones.
 	// If AllowConcurrentRuns is set to true, we'll allow multiple runs to continue in parallel.
-	AllowConcurrentRuns bool `yaml:"allow_concurrent_runs"`
+	AllowConcurrentRuns *bool `yaml:"allow_concurrent_runs"`
 
 	// DEPRECATED: Used `Steps` instead
 	DeprecatedBazelCommands []string `yaml:"bazel_commands"`

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -61,6 +61,9 @@ type Action struct {
 	// Whether the BuildBuddy CLI (`bb`) should be used as the bazel command for this action.
 	// If set, this overrides the repo-level setting.
 	BazelUseCLI *bool `yaml:"bazel_use_cli"`
+	// By default, if you have multiple workflow runs on the same branch, we'll cancel the old ones.
+	// If AllowConcurrentRuns is set to true, we'll allow multiple runs to continue in parallel.
+	AllowConcurrentRuns bool `yaml:"allow_concurrent_runs"`
 
 	// DEPRECATED: Used `Steps` instead
 	DeprecatedBazelCommands []string `yaml:"bazel_commands"`

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//enterprise/server/webhooks/webhook_data",
         "//enterprise/server/workflow/config",
         "//proto:context_go_proto",
+        "//proto:invocation_go_proto",
         "//proto:invocation_status_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:user_id_go_proto",

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -83,8 +83,6 @@ var (
 	enableKytheIndexing           = flag.Bool("remote_execution.enable_kythe_indexing", false, "If set, and codesearch is enabled, automatically run a kythe indexing action.")
 	enableCodesearchIndexing      = flag.Bool("remote_execution.enable_codesearch_indexing", false, "If set, and codesearch is enabled, automatically run an incremental indexing action.")
 
-	cancelDuplicateWorkflows = flag.Bool("remote_execution.workflows_cancel_duplicates", false, "Whether to cancel duplicate workflows on the same branch.")
-
 	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
 
 	// ApprovalRequired is an error indicating that a workflow action could not be
@@ -1549,7 +1547,14 @@ func (ws *workflowService) executeWorkflowAction(ctx context.Context, key *table
 			continue // retry
 		}
 
-		if *cancelDuplicateWorkflows && !action.AllowConcurrentRuns {
+		cancelDuplicates := false
+		if efp := ws.env.GetExperimentFlagProvider(); efp != nil {
+			cancelDuplicates = efp.Boolean(ctx, "cancel_duplicate_workflows_default", false)
+		}
+		if action.AllowConcurrentRuns != nil {
+			cancelDuplicates = !*action.AllowConcurrentRuns
+		}
+		if cancelDuplicates {
 			if err := ws.cancelInProgressWorkflowsOnSameBranch(ctx, action.Name, key, wf, wd, invocationID); err != nil {
 				log.CtxWarningf(ctx, "Failed to cancel in-progress workflow invocations on branch %q: %s", wd.PushedBranch, err)
 			}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -59,6 +59,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	inspb "github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
@@ -81,7 +82,11 @@ var (
 	workflowsMaxRetries           = flag.Int("remote_execution.workflows_max_execute_retries", 4, "Number of times to retry a workflow action if it fails to start.")
 	enableKytheIndexing           = flag.Bool("remote_execution.enable_kythe_indexing", false, "If set, and codesearch is enabled, automatically run a kythe indexing action.")
 	enableCodesearchIndexing      = flag.Bool("remote_execution.enable_codesearch_indexing", false, "If set, and codesearch is enabled, automatically run an incremental indexing action.")
-	workflowURLMatcher            = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
+
+	// TODO(Maggie): Make this configurable per-workflow.
+	cancelDuplicateWorkflows = flag.Bool("workflows.cancel_duplicates", false, "Whether to cancel duplicate workflows on the same branch.")
+
+	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
 
 	// ApprovalRequired is an error indicating that a workflow action could not be
 	// run at a commit because it is untrusted. An approving review at the
@@ -1470,6 +1475,49 @@ func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interf
 	return nil
 }
 
+func (ws *workflowService) cancelInProgressWorkflowsOnSameBranch(ctx context.Context, key *tables.APIKey, wf *tables.Workflow, wd *interfaces.WebhookData, newInvocationID string) error {
+	if wd.PushedBranch == "" || ws.env.GetInvocationSearchService() == nil || ws.env.GetRemoteExecutionService() == nil {
+		return nil
+	}
+
+	// Don't cancel workflows on the default branch.
+	if wd.PushedBranch == wd.TargetRepoDefaultBranch || wd.TargetRepoDefaultBranch == "" {
+		return nil
+	}
+
+	authCtx := ws.env.GetAuthenticator().AuthContextFromAPIKey(ctx, key.Value)
+	searchResp, err := ws.env.GetInvocationSearchService().QueryInvocations(authCtx, &inpb.SearchInvocationRequest{
+		Query: &inpb.InvocationQuery{
+			GroupId:    wf.GroupID,
+			RepoUrl:    wf.RepoURL,
+			BranchName: wd.PushedBranch,
+			Role:       []string{"CI_RUNNER"},
+			Status:     []inspb.OverallStatus{inspb.OverallStatus_IN_PROGRESS},
+		},
+	})
+	if err != nil {
+		return status.WrapError(err, "search in-progress workflows")
+	}
+
+	cancelled := 0
+	for _, inv := range searchResp.GetInvocation() {
+		// Don't cancel the workflow that was just started.
+		if inv.GetInvocationId() == newInvocationID {
+			continue
+		}
+		if err := ws.env.GetRemoteExecutionService().Cancel(authCtx, inv.GetInvocationId()); err != nil {
+			log.CtxWarningf(ctx, "Failed to cancel in-progress workflow %s on branch %q: %s", inv.GetInvocationId(), wd.PushedBranch, err)
+			continue
+		}
+		cancelled++
+	}
+
+	if cancelled > 0 {
+		log.CtxInfof(ctx, "Cancelled %d in-progress workflow invocation(s) for repo %q branch %q", cancelled, wf.RepoURL, wd.PushedBranch)
+	}
+	return nil
+}
+
 // Starts a CI runner execution to execute a single workflow action, and returns the execution ID.
 func (ws *workflowService) executeWorkflowAction(ctx context.Context, key *tables.APIKey, wf *tables.Workflow, wd *interfaces.WebhookData, isTrusted bool, action *config.Action, invocationID string, extraCIRunnerArgs []string, env map[string]string, shouldRetry bool) (string, error) {
 	opts := retry.DefaultOptions()
@@ -1496,6 +1544,12 @@ func (ws *workflowService) executeWorkflowAction(ctx context.Context, key *table
 			}
 
 			continue // retry
+		}
+
+		if *cancelDuplicateWorkflows {
+			if err := ws.cancelInProgressWorkflowsOnSameBranch(ctx, key, wf, wd, invocationID); err != nil {
+				log.CtxWarningf(ctx, "Failed to cancel in-progress workflow invocations on branch %q: %s", wd.PushedBranch, err)
+			}
 		}
 
 		return executionID, nil

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -83,7 +83,6 @@ var (
 	enableKytheIndexing           = flag.Bool("remote_execution.enable_kythe_indexing", false, "If set, and codesearch is enabled, automatically run a kythe indexing action.")
 	enableCodesearchIndexing      = flag.Bool("remote_execution.enable_codesearch_indexing", false, "If set, and codesearch is enabled, automatically run an incremental indexing action.")
 
-	// TODO(Maggie): Make this configurable per-workflow.
 	cancelDuplicateWorkflows = flag.Bool("remote_execution.workflows_cancel_duplicates", false, "Whether to cancel duplicate workflows on the same branch.")
 
 	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
@@ -1550,7 +1549,7 @@ func (ws *workflowService) executeWorkflowAction(ctx context.Context, key *table
 			continue // retry
 		}
 
-		if *cancelDuplicateWorkflows {
+		if *cancelDuplicateWorkflows && !action.AllowConcurrentRuns {
 			if err := ws.cancelInProgressWorkflowsOnSameBranch(ctx, action.Name, key, wf, wd, invocationID); err != nil {
 				log.CtxWarningf(ctx, "Failed to cancel in-progress workflow invocations on branch %q: %s", wd.PushedBranch, err)
 			}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1486,6 +1486,9 @@ func (ws *workflowService) cancelInProgressWorkflowsOnSameBranch(ctx context.Con
 	}
 
 	authCtx := ws.env.GetAuthenticator().AuthContextFromAPIKey(ctx, key.Value)
+	// TODO: It seems unlikely that there'd be many in-progress workflows on the same branch,
+	// but for correctness we could use page_token to make sure we don't miss any.
+	// By default, this query returns up to 15 invocations.
 	searchResp, err := ws.env.GetInvocationSearchService().QueryInvocations(authCtx, &inpb.SearchInvocationRequest{
 		Query: &inpb.InvocationQuery{
 			GroupId:    wf.GroupID,

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -84,7 +84,7 @@ var (
 	enableCodesearchIndexing      = flag.Bool("remote_execution.enable_codesearch_indexing", false, "If set, and codesearch is enabled, automatically run an incremental indexing action.")
 
 	// TODO(Maggie): Make this configurable per-workflow.
-	cancelDuplicateWorkflows = flag.Bool("workflows.cancel_duplicates", false, "Whether to cancel duplicate workflows on the same branch.")
+	cancelDuplicateWorkflows = flag.Bool("remote_execution.workflows_cancel_duplicates", false, "Whether to cancel duplicate workflows on the same branch.")
 
 	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
 
@@ -1475,7 +1475,7 @@ func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interf
 	return nil
 }
 
-func (ws *workflowService) cancelInProgressWorkflowsOnSameBranch(ctx context.Context, key *tables.APIKey, wf *tables.Workflow, wd *interfaces.WebhookData, newInvocationID string) error {
+func (ws *workflowService) cancelInProgressWorkflowsOnSameBranch(ctx context.Context, wfName string, key *tables.APIKey, wf *tables.Workflow, wd *interfaces.WebhookData, newInvocationID string) error {
 	if wd.PushedBranch == "" || ws.env.GetInvocationSearchService() == nil || ws.env.GetRemoteExecutionService() == nil {
 		return nil
 	}
@@ -1491,6 +1491,7 @@ func (ws *workflowService) cancelInProgressWorkflowsOnSameBranch(ctx context.Con
 			GroupId:    wf.GroupID,
 			RepoUrl:    wf.RepoURL,
 			BranchName: wd.PushedBranch,
+			Pattern:    wfName,
 			Role:       []string{"CI_RUNNER"},
 			Status:     []inspb.OverallStatus{inspb.OverallStatus_IN_PROGRESS},
 		},
@@ -1547,7 +1548,7 @@ func (ws *workflowService) executeWorkflowAction(ctx context.Context, key *table
 		}
 
 		if *cancelDuplicateWorkflows {
-			if err := ws.cancelInProgressWorkflowsOnSameBranch(ctx, key, wf, wd, invocationID); err != nil {
+			if err := ws.cancelInProgressWorkflowsOnSameBranch(ctx, action.Name, key, wf, wd, invocationID); err != nil {
 				log.CtxWarningf(ctx, "Failed to cancel in-progress workflow invocations on branch %q: %s", wd.PushedBranch, err)
 			}
 		}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -59,6 +59,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	inspb "github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
@@ -81,7 +82,11 @@ var (
 	workflowsMaxRetries           = flag.Int("remote_execution.workflows_max_execute_retries", 4, "Number of times to retry a workflow action if it fails to start.")
 	enableKytheIndexing           = flag.Bool("remote_execution.enable_kythe_indexing", false, "If set, and codesearch is enabled, automatically run a kythe indexing action.")
 	enableCodesearchIndexing      = flag.Bool("remote_execution.enable_codesearch_indexing", false, "If set, and codesearch is enabled, automatically run an incremental indexing action.")
-	workflowURLMatcher            = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
+
+	// TODO(Maggie): Make this configurable per-workflow.
+	cancelDuplicateWorkflows = flag.Bool("workflows.cancel_duplicates", false, "Whether to cancel duplicate workflows on the same branch.")
+
+	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
 
 	// ApprovalRequired is an error indicating that a workflow action could not be
 	// run at a commit because it is untrusted. An approving review at the
@@ -1470,6 +1475,44 @@ func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interf
 	return nil
 }
 
+func (ws *workflowService) cancelInProgressWorkflowsOnSameBranch(ctx context.Context, key *tables.APIKey, wf *tables.Workflow, wd *interfaces.WebhookData, newInvocationID string) error {
+	if wd.PushedBranch == "" || ws.env.GetInvocationSearchService() == nil || ws.env.GetRemoteExecutionService() == nil {
+		return nil
+	}
+
+	authCtx := ws.env.GetAuthenticator().AuthContextFromAPIKey(ctx, key.Value)
+	searchResp, err := ws.env.GetInvocationSearchService().QueryInvocations(authCtx, &inpb.SearchInvocationRequest{
+		Query: &inpb.InvocationQuery{
+			GroupId:    wf.GroupID,
+			RepoUrl:    wf.RepoURL,
+			BranchName: wd.PushedBranch,
+			Role:       []string{"CI_RUNNER"},
+			Status:     []inspb.OverallStatus{inspb.OverallStatus_IN_PROGRESS},
+		},
+	})
+	if err != nil {
+		return status.WrapError(err, "search in-progress workflows")
+	}
+
+	cancelled := 0
+	for _, inv := range searchResp.GetInvocation() {
+		// Don't cancel the workflow that was just started.
+		if inv.GetInvocationId() == newInvocationID {
+			continue
+		}
+		if err := ws.env.GetRemoteExecutionService().Cancel(authCtx, inv.GetInvocationId()); err != nil {
+			log.CtxWarningf(ctx, "Failed to cancel in-progress workflow %s on branch %q: %s", inv.GetInvocationId(), wd.PushedBranch, err)
+			continue
+		}
+		cancelled++
+	}
+
+	if cancelled > 0 {
+		log.CtxInfof(ctx, "Cancelled %d in-progress workflow invocation(s) for repo %q branch %q", cancelled, wf.RepoURL, wd.PushedBranch)
+	}
+	return nil
+}
+
 // Starts a CI runner execution to execute a single workflow action, and returns the execution ID.
 func (ws *workflowService) executeWorkflowAction(ctx context.Context, key *tables.APIKey, wf *tables.Workflow, wd *interfaces.WebhookData, isTrusted bool, action *config.Action, invocationID string, extraCIRunnerArgs []string, env map[string]string, shouldRetry bool) (string, error) {
 	opts := retry.DefaultOptions()
@@ -1496,6 +1539,12 @@ func (ws *workflowService) executeWorkflowAction(ctx context.Context, key *table
 			}
 
 			continue // retry
+		}
+
+		if *cancelDuplicateWorkflows {
+			if err := ws.cancelInProgressWorkflowsOnSameBranch(ctx, key, wf, wd, invocationID); err != nil {
+				log.CtxWarningf(ctx, "Failed to cancel in-progress workflow invocations on branch %q: %s", wd.PushedBranch, err)
+			}
 		}
 
 		return executionID, nil


### PR DESCRIPTION
When rolling this out, we should let our workflow customers know that this will be enabled by default on a specific date. If they want duplicate workflows to keep running, they should update their buildbuddy.yaml