### PR TITLE
Store container image ref and on-disk size in ClickHouse

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -468,6 +468,13 @@ type CommandContainer interface {
 	Stats(ctx context.Context) (*repb.UsageStats, error)
 }
 
+// ImageSizer is an optional interface implemented by a [CommandContainer]
+// that returns the estimated on-disk size of the pulled container image.
+// This should be called after PullImage.
+type ImageSizer interface {
+	ImageSizeBytes() int64
+}
+
 // StatsRecorder is an optional interface implemented by a [CommandContainer]
 // that allows tracking usage stats outside of normal execution.
 //
@@ -734,6 +741,13 @@ type TracedCommandContainer struct {
 
 func (t *TracedCommandContainer) IsolationType() string {
 	return t.Delegate.IsolationType()
+}
+
+func (t *TracedCommandContainer) ImageSizeBytes() int64 {
+	if sizer, ok := t.Delegate.(ImageSizer); ok {
+		return sizer.ImageSizeBytes()
+	}
+	return 0
 }
 
 func (t *TracedCommandContainer) Run(ctx context.Context, command *repb.Command, workingDir string, creds oci.Credentials) *interfaces.CommandResult {

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -467,8 +467,12 @@ type CommandContainer interface {
 	// pooled runners.
 	Stats(ctx context.Context) (*repb.UsageStats, error)
 
-	// ImageSizeBytes returns the estimated on-disk size of the pulled
-	// container image in bytes. Should be called after PullImage.
+	// ImageSizeBytes returns the estimated disk usage of the prepared container
+	// image in bytes. Should be called after PrepareForTask.
+	//
+	// The exact meaning is runtime-specific: OCI uses the sum of estimated layer
+	// disk usage, Docker and Podman use image inspect size, and Firecracker uses
+	// the logical size of the prepared container filesystem image when present.
 	// Returns 0 if unknown or not applicable.
 	ImageSizeBytes(ctx context.Context) (int64, error)
 }

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -470,7 +470,7 @@ type CommandContainer interface {
 	// ImageSizeBytes returns the estimated on-disk size of the pulled
 	// container image in bytes. Should be called after PullImage.
 	// Returns 0 if unknown or not applicable.
-	ImageSizeBytes(ctx context.Context) int64
+	ImageSizeBytes(ctx context.Context) (int64, error)
 }
 
 // StatsRecorder is an optional interface implemented by a [CommandContainer]
@@ -741,7 +741,7 @@ func (t *TracedCommandContainer) IsolationType() string {
 	return t.Delegate.IsolationType()
 }
 
-func (t *TracedCommandContainer) ImageSizeBytes(ctx context.Context) int64 {
+func (t *TracedCommandContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
 	return t.Delegate.ImageSizeBytes(ctx)
 }
 

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -466,12 +466,10 @@ type CommandContainer interface {
 	// container is paused, for the purposes of computing resources used for
 	// pooled runners.
 	Stats(ctx context.Context) (*repb.UsageStats, error)
-}
 
-// ImageSizer is an optional interface implemented by a [CommandContainer]
-// that returns the estimated on-disk size of the pulled container image.
-// This should be called after PullImage.
-type ImageSizer interface {
+	// ImageSizeBytes returns the estimated on-disk size of the pulled
+	// container image in bytes. Should be called after PullImage.
+	// Returns 0 if unknown or not applicable.
 	ImageSizeBytes(ctx context.Context) int64
 }
 
@@ -744,10 +742,7 @@ func (t *TracedCommandContainer) IsolationType() string {
 }
 
 func (t *TracedCommandContainer) ImageSizeBytes(ctx context.Context) int64 {
-	if sizer, ok := t.Delegate.(ImageSizer); ok {
-		return sizer.ImageSizeBytes(ctx)
-	}
-	return 0
+	return t.Delegate.ImageSizeBytes(ctx)
 }
 
 func (t *TracedCommandContainer) Run(ctx context.Context, command *repb.Command, workingDir string, creds oci.Credentials) *interfaces.CommandResult {

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -472,7 +472,7 @@ type CommandContainer interface {
 // that returns the estimated on-disk size of the pulled container image.
 // This should be called after PullImage.
 type ImageSizer interface {
-	ImageSizeBytes() int64
+	ImageSizeBytes(ctx context.Context) int64
 }
 
 // StatsRecorder is an optional interface implemented by a [CommandContainer]
@@ -743,9 +743,9 @@ func (t *TracedCommandContainer) IsolationType() string {
 	return t.Delegate.IsolationType()
 }
 
-func (t *TracedCommandContainer) ImageSizeBytes() int64 {
+func (t *TracedCommandContainer) ImageSizeBytes(ctx context.Context) int64 {
 	if sizer, ok := t.Delegate.(ImageSizer); ok {
-		return sizer.ImageSizeBytes()
+		return sizer.ImageSizeBytes(ctx)
 	}
 	return 0
 }

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -28,6 +28,8 @@ type FakeContainer struct {
 	RequiredPullCredentials oci.Credentials
 	PullCount               int
 	pullDelay               time.Duration
+	imageSizeBytes          int64
+	imageSizeErr            error
 }
 
 func (c *FakeContainer) IsolationType() string {
@@ -62,7 +64,9 @@ func (c *FakeContainer) Unpause(ctx context.Context) error { return nil }
 func (c *FakeContainer) Stats(context.Context) (*repb.UsageStats, error) {
 	return &repb.UsageStats{}, nil
 }
-func (c *FakeContainer) ImageSizeBytes(context.Context) int64 { return 0 }
+func (c *FakeContainer) ImageSizeBytes(context.Context) (int64, error) {
+	return c.imageSizeBytes, c.imageSizeErr
+}
 
 func userCtx(t *testing.T, ta *testauth.TestAuthenticator, userID string) context.Context {
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), userID)
@@ -421,10 +425,12 @@ func TestUsageStats_Timeseries(t *testing.T) {
 	assert.Equal(t, []int64{0, 500, 400}, memKBSamples, "memory kb samples")
 }
 
-func TestTracedCommandContainer_ImageSizeBytes(t *testing.T) {
-	delegate := &FakeContainer{}
+func TestTracedCommandContainer_ImageSizeBytes_Error(t *testing.T) {
+	delegate := &FakeContainer{imageSizeErr: status.InternalError("image inspect failed")}
 	traced := container.NewTracedCommandContainer(delegate)
-	assert.Equal(t, int64(0), traced.ImageSizeBytes(context.Background()))
+	_, err := traced.ImageSizeBytes(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image inspect failed")
 }
 
 func makePSI(someTotal, fullTotal int64) *repb.PSI {

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -426,7 +426,7 @@ type FakeContainerWithImageSize struct {
 	Size int64
 }
 
-func (c *FakeContainerWithImageSize) ImageSizeBytes() int64 {
+func (c *FakeContainerWithImageSize) ImageSizeBytes(ctx context.Context) int64 {
 	return c.Size
 }
 
@@ -434,14 +434,14 @@ func TestTracedCommandContainer_ImageSizeBytes_WithImageSizer(t *testing.T) {
 	delegate := &FakeContainerWithImageSize{Size: 1234567890}
 	traced := container.NewTracedCommandContainer(delegate)
 
-	assert.Equal(t, int64(1234567890), traced.ImageSizeBytes())
+	assert.Equal(t, int64(1234567890), traced.ImageSizeBytes(context.Background()))
 }
 
 func TestTracedCommandContainer_ImageSizeBytes_WithoutImageSizer(t *testing.T) {
 	delegate := &FakeContainer{}
 	traced := container.NewTracedCommandContainer(delegate)
 
-	assert.Equal(t, int64(0), traced.ImageSizeBytes())
+	assert.Equal(t, int64(0), traced.ImageSizeBytes(context.Background()))
 }
 
 func makePSI(someTotal, fullTotal int64) *repb.PSI {

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -420,6 +420,30 @@ func TestUsageStats_Timeseries(t *testing.T) {
 	assert.Equal(t, []int64{0, 500, 400}, memKBSamples, "memory kb samples")
 }
 
+// FakeContainerWithImageSize is a FakeContainer that also implements ImageSizer.
+type FakeContainerWithImageSize struct {
+	FakeContainer
+	Size int64
+}
+
+func (c *FakeContainerWithImageSize) ImageSizeBytes() int64 {
+	return c.Size
+}
+
+func TestTracedCommandContainer_ImageSizeBytes_WithImageSizer(t *testing.T) {
+	delegate := &FakeContainerWithImageSize{Size: 1234567890}
+	traced := container.NewTracedCommandContainer(delegate)
+
+	assert.Equal(t, int64(1234567890), traced.ImageSizeBytes())
+}
+
+func TestTracedCommandContainer_ImageSizeBytes_WithoutImageSizer(t *testing.T) {
+	delegate := &FakeContainer{}
+	traced := container.NewTracedCommandContainer(delegate)
+
+	assert.Equal(t, int64(0), traced.ImageSizeBytes())
+}
+
 func makePSI(someTotal, fullTotal int64) *repb.PSI {
 	return &repb.PSI{
 		Some: &repb.PSI_Metrics{

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -62,6 +62,7 @@ func (c *FakeContainer) Unpause(ctx context.Context) error { return nil }
 func (c *FakeContainer) Stats(context.Context) (*repb.UsageStats, error) {
 	return &repb.UsageStats{}, nil
 }
+func (c *FakeContainer) ImageSizeBytes(context.Context) int64 { return 0 }
 
 func userCtx(t *testing.T, ta *testauth.TestAuthenticator, userID string) context.Context {
 	ctx, err := ta.WithAuthenticatedUser(context.Background(), userID)
@@ -420,27 +421,9 @@ func TestUsageStats_Timeseries(t *testing.T) {
 	assert.Equal(t, []int64{0, 500, 400}, memKBSamples, "memory kb samples")
 }
 
-// FakeContainerWithImageSize is a FakeContainer that also implements ImageSizer.
-type FakeContainerWithImageSize struct {
-	FakeContainer
-	Size int64
-}
-
-func (c *FakeContainerWithImageSize) ImageSizeBytes(ctx context.Context) int64 {
-	return c.Size
-}
-
-func TestTracedCommandContainer_ImageSizeBytes_WithImageSizer(t *testing.T) {
-	delegate := &FakeContainerWithImageSize{Size: 1234567890}
-	traced := container.NewTracedCommandContainer(delegate)
-
-	assert.Equal(t, int64(1234567890), traced.ImageSizeBytes(context.Background()))
-}
-
-func TestTracedCommandContainer_ImageSizeBytes_WithoutImageSizer(t *testing.T) {
+func TestTracedCommandContainer_ImageSizeBytes(t *testing.T) {
 	delegate := &FakeContainer{}
 	traced := container.NewTracedCommandContainer(delegate)
-
 	assert.Equal(t, int64(0), traced.ImageSizeBytes(context.Background()))
 }
 

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -193,4 +193,4 @@ func (c *bareCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, err
 	return nil, nil
 }
 
-func (c *bareCommandContainer) ImageSizeBytes(ctx context.Context) int64 { return 0 }
+func (c *bareCommandContainer) ImageSizeBytes(ctx context.Context) (int64, error) { return 0, nil }

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -192,3 +192,5 @@ func (c *bareCommandContainer) Unpause(ctx context.Context) error { return nil }
 func (c *bareCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
 	return nil, nil
 }
+
+func (c *bareCommandContainer) ImageSizeBytes(ctx context.Context) int64 { return 0 }

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -202,10 +202,8 @@ func (c *dockerCommandContainer) IsolationType() string {
 	return "docker"
 }
 
-func (c *dockerCommandContainer) ImageSizeBytes() int64 {
-	// ImageSizer interface doesn't take a context; this is only called once
-	// per execution so context.TODO() is acceptable.
-	ii, err := c.client.ImageInspect(context.TODO(), c.image, dockerclient.ImageInspectWithRawResponse(nil))
+func (c *dockerCommandContainer) ImageSizeBytes(ctx context.Context) int64 {
+	ii, err := c.client.ImageInspect(ctx, c.image, dockerclient.ImageInspectWithRawResponse(nil))
 	if err != nil {
 		return 0
 	}

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -203,6 +203,8 @@ func (c *dockerCommandContainer) IsolationType() string {
 }
 
 func (c *dockerCommandContainer) ImageSizeBytes() int64 {
+	// ImageSizer interface doesn't take a context; this is only called once
+	// per execution so context.TODO() is acceptable.
 	ii, err := c.client.ImageInspect(context.TODO(), c.image, dockerclient.ImageInspectWithRawResponse(nil))
 	if err != nil {
 		return 0

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -202,12 +202,12 @@ func (c *dockerCommandContainer) IsolationType() string {
 	return "docker"
 }
 
-func (c *dockerCommandContainer) ImageSizeBytes(ctx context.Context) int64 {
+func (c *dockerCommandContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
 	ii, err := c.client.ImageInspect(ctx, c.image, dockerclient.ImageInspectWithRawResponse(nil))
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return ii.Size
+	return ii.Size, nil
 }
 
 func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds oci.Credentials) *interfaces.CommandResult {

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -202,6 +202,14 @@ func (c *dockerCommandContainer) IsolationType() string {
 	return "docker"
 }
 
+func (c *dockerCommandContainer) ImageSizeBytes() int64 {
+	ii, err := c.client.ImageInspect(context.TODO(), c.image, dockerclient.ImageInspectWithRawResponse(nil))
+	if err != nil {
+		return 0
+	}
+	return ii.Size
+}
+
 func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds oci.Credentials) *interfaces.CommandResult {
 	result := &interfaces.CommandResult{
 		CommandDebugString: fmt.Sprintf("(docker) %s", command.GetArguments()),

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2073,19 +2073,22 @@ func (c *FirecrackerContainer) IsolationType() string {
 	return "firecracker"
 }
 
-func (c *FirecrackerContainer) ImageSizeBytes(ctx context.Context) int64 {
+func (c *FirecrackerContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
 	if !c.pulled {
-		return 0
+		return 0, nil
 	}
 	imagePath, err := ociconv.CachedDiskImagePath(ctx, c.executorConfig.CacheRoot, c.containerImage)
-	if err != nil || imagePath == "" {
-		return 0
+	if err != nil {
+		return 0, err
+	}
+	if imagePath == "" {
+		return 0, nil
 	}
 	info, err := os.Stat(imagePath)
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return info.Size()
+	return info.Size(), nil
 }
 
 // Run the given command within the container and remove the container after

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2077,6 +2077,8 @@ func (c *FirecrackerContainer) ImageSizeBytes() int64 {
 	if !c.pulled {
 		return 0
 	}
+	// ImageSizer interface doesn't take a context; this is only called once
+	// per execution so context.TODO() is acceptable.
 	imagePath, err := ociconv.CachedDiskImagePath(context.TODO(), c.executorConfig.CacheRoot, c.containerImage)
 	if err != nil || imagePath == "" {
 		return 0

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2085,6 +2085,9 @@ func (c *FirecrackerContainer) ImageSizeBytes(ctx context.Context) (int64, error
 		}
 		return 0, err
 	}
+	// This is the logical size of the prepared ext4 container filesystem image.
+	// It may include free-space padding, and snapshot-resumed VMs may return 0
+	// when the container filesystem image is not present.
 	return info.Size(), nil
 }
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2073,6 +2073,21 @@ func (c *FirecrackerContainer) IsolationType() string {
 	return "firecracker"
 }
 
+func (c *FirecrackerContainer) ImageSizeBytes() int64 {
+	if !c.pulled {
+		return 0
+	}
+	imagePath, err := ociconv.CachedDiskImagePath(context.TODO(), c.executorConfig.CacheRoot, c.containerImage)
+	if err != nil || imagePath == "" {
+		return 0
+	}
+	info, err := os.Stat(imagePath)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
 // Run the given command within the container and remove the container after
 // it is done executing.
 //

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2073,13 +2073,11 @@ func (c *FirecrackerContainer) IsolationType() string {
 	return "firecracker"
 }
 
-func (c *FirecrackerContainer) ImageSizeBytes() int64 {
+func (c *FirecrackerContainer) ImageSizeBytes(ctx context.Context) int64 {
 	if !c.pulled {
 		return 0
 	}
-	// ImageSizer interface doesn't take a context; this is only called once
-	// per execution so context.TODO() is acceptable.
-	imagePath, err := ociconv.CachedDiskImagePath(context.TODO(), c.executorConfig.CacheRoot, c.containerImage)
+	imagePath, err := ociconv.CachedDiskImagePath(ctx, c.executorConfig.CacheRoot, c.containerImage)
 	if err != nil || imagePath == "" {
 		return 0
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2077,15 +2077,12 @@ func (c *FirecrackerContainer) ImageSizeBytes(ctx context.Context) (int64, error
 	if !c.pulled {
 		return 0, nil
 	}
-	imagePath, err := ociconv.CachedDiskImagePath(ctx, c.executorConfig.CacheRoot, c.containerImage)
-	if err != nil {
-		return 0, err
-	}
-	if imagePath == "" {
-		return 0, nil
-	}
+	imagePath := filepath.Join(c.getChroot(), containerFSName)
 	info, err := os.Stat(imagePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
 		return 0, err
 	}
 	return info.Size(), nil

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -643,15 +643,15 @@ func (c *ociContainer) IsolationType() string {
 	return "oci" // TODO: make const in platform.go
 }
 
-func (c *ociContainer) ImageSizeBytes(ctx context.Context) int64 {
+func (c *ociContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
 	if c.lockedImage == nil {
-		return 0
+		return 0, nil
 	}
 	var total int64
 	for _, layer := range c.lockedImage.Layers {
 		total += layer.EstimatedDiskUsageBytes
 	}
-	return total
+	return total, nil
 }
 
 func (c *ociContainer) IsImageCached(ctx context.Context) (bool, error) {

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -643,6 +643,17 @@ func (c *ociContainer) IsolationType() string {
 	return "oci" // TODO: make const in platform.go
 }
 
+func (c *ociContainer) ImageSizeBytes() int64 {
+	if c.lockedImage == nil {
+		return 0
+	}
+	var total int64
+	for _, layer := range c.lockedImage.Layers {
+		total += layer.EstimatedDiskUsageBytes
+	}
+	return total
+}
+
 func (c *ociContainer) IsImageCached(ctx context.Context) (bool, error) {
 	if c.lockedImage != nil {
 		return true, nil

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -643,7 +643,7 @@ func (c *ociContainer) IsolationType() string {
 	return "oci" // TODO: make const in platform.go
 }
 
-func (c *ociContainer) ImageSizeBytes() int64 {
+func (c *ociContainer) ImageSizeBytes(ctx context.Context) int64 {
 	if c.lockedImage == nil {
 		return 0
 	}

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -368,17 +368,20 @@ func (c *podmanCommandContainer) IsolationType() string {
 	return "podman"
 }
 
-func (c *podmanCommandContainer) ImageSizeBytes(ctx context.Context) int64 {
+func (c *podmanCommandContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
 	stdout := &bytes.Buffer{}
 	res := c.runPodman(ctx, "image", &interfaces.Stdio{Stdout: stdout}, "inspect", c.image, "--format", "{{.Size}}")
-	if res.Error != nil || res.ExitCode != 0 {
-		return 0
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	if res.ExitCode != 0 {
+		return 0, status.UnknownErrorf("podman image inspect exited with code %d", res.ExitCode)
 	}
 	size, err := strconv.ParseInt(strings.TrimSpace(stdout.String()), 10, 64)
 	if err != nil {
-		return 0
+		return 0, status.WrapError(err, "parse podman image size")
 	}
-	return size
+	return size, nil
 }
 
 func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds oci.Credentials) *interfaces.CommandResult {

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -368,6 +368,19 @@ func (c *podmanCommandContainer) IsolationType() string {
 	return "podman"
 }
 
+func (c *podmanCommandContainer) ImageSizeBytes() int64 {
+	stdout := &bytes.Buffer{}
+	res := c.runPodman(context.TODO(), "image", &interfaces.Stdio{Stdout: stdout}, "inspect", c.image, "--format", "{{.Size}}")
+	if res.Error != nil || res.ExitCode != 0 {
+		return 0
+	}
+	size, err := strconv.ParseInt(strings.TrimSpace(stdout.String()), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return size
+}
+
 func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds oci.Credentials) *interfaces.CommandResult {
 	c.workDir = workDir
 	defer os.RemoveAll(c.cidFilePath())

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -368,9 +368,9 @@ func (c *podmanCommandContainer) IsolationType() string {
 	return "podman"
 }
 
-func (c *podmanCommandContainer) ImageSizeBytes() int64 {
+func (c *podmanCommandContainer) ImageSizeBytes(ctx context.Context) int64 {
 	stdout := &bytes.Buffer{}
-	res := c.runPodman(context.TODO(), "image", &interfaces.Stdio{Stdout: stdout}, "inspect", c.image, "--format", "{{.Size}}")
+	res := c.runPodman(ctx, "image", &interfaces.Stdio{Stdout: stdout}, "inspect", c.image, "--format", "{{.Size}}")
 	if res.Error != nil || res.ExitCode != 0 {
 		return 0
 	}

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -348,4 +348,4 @@ func (c *sandbox) Unpause(ctx context.Context) error                          { 
 func (c *sandbox) Stats(ctx context.Context) (*repb.UsageStats, error) {
 	return nil, nil
 }
-func (c *sandbox) ImageSizeBytes(ctx context.Context) int64 { return 0 }
+func (c *sandbox) ImageSizeBytes(ctx context.Context) (int64, error) { return 0, nil }

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -348,3 +348,4 @@ func (c *sandbox) Unpause(ctx context.Context) error                          { 
 func (c *sandbox) Stats(ctx context.Context) (*repb.UsageStats, error) {
 	return nil, nil
 }
+func (c *sandbox) ImageSizeBytes(ctx context.Context) int64 { return 0 }

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -435,6 +435,9 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 			executionProto.ExecutorHostname = auxMeta.GetExecutorHostname()
 			executionProto.Experiments = auxMeta.GetExperiments()
 
+			executionProto.ContainerImage = auxMeta.GetContainerImage()
+			executionProto.ContainerImageSizeBytes = auxMeta.GetContainerImageSizeBytes()
+
 			executionProto.EffectiveIsolationType = auxMeta.GetIsolationType()
 			executionProto.RunnerId = auxMeta.GetRunnerMetadata().GetRunnerId()
 			executionProto.RunnerTaskNumber = auxMeta.GetRunnerMetadata().GetTaskNumber()

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -436,7 +436,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 			executionProto.Experiments = auxMeta.GetExperiments()
 
 			executionProto.ContainerImageRef = auxMeta.GetContainerImageRef()
-			executionProto.ContainerImageSizeBytes = auxMeta.GetContainerImageSizeBytes()
+			executionProto.ContainerImageDiskUsageBytes = auxMeta.GetContainerImageDiskUsageBytes()
 
 			executionProto.EffectiveIsolationType = auxMeta.GetIsolationType()
 			executionProto.RunnerId = auxMeta.GetRunnerMetadata().GetRunnerId()

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -435,7 +435,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 			executionProto.ExecutorHostname = auxMeta.GetExecutorHostname()
 			executionProto.Experiments = auxMeta.GetExperiments()
 
-			executionProto.ContainerImage = auxMeta.GetContainerImage()
+			executionProto.ContainerImageRef = auxMeta.GetContainerImageRef()
 			executionProto.ContainerImageSizeBytes = auxMeta.GetContainerImageSizeBytes()
 
 			executionProto.EffectiveIsolationType = auxMeta.GetIsolationType()

--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -49,7 +49,10 @@ go_test(
     deps = [
         ":executor",
         "//enterprise/server/remote_execution/commandutil",
+        "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/containers/bare",
         "//enterprise/server/remote_execution/operation",
+        "//enterprise/server/remote_execution/runner",
         "//enterprise/server/test/integration/remote_execution/rbetest",
         "//enterprise/server/testutil/enterprise_testenv",
         "//proto:execution_stats_go_proto",

--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -49,8 +49,6 @@ go_test(
     deps = [
         ":executor",
         "//enterprise/server/remote_execution/commandutil",
-        "//enterprise/server/remote_execution/container",
-        "//enterprise/server/remote_execution/containers/bare",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/runner",
         "//enterprise/server/test/integration/remote_execution/rbetest",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -327,6 +327,9 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		return finishWithErrFn(status.WrapError(err, "prepare runner filesystem"))
 	}
 
+	// Record container image metadata after pulling.
+	auxMetadata.ContainerImage, auxMetadata.ContainerImageSizeBytes = r.ContainerImageInfo()
+
 	md.InputFetchStartTimestamp = timestamppb.New(s.env.GetClock().Now())
 
 	log.CtxDebugf(ctx, "Downloading inputs.")

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -329,7 +329,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 
 	// Record container image metadata after pulling.
 	var imageSizeErr error
-	auxMetadata.ContainerImageRef, auxMetadata.ContainerImageSizeBytes, imageSizeErr = r.ContainerImageInfo(ctx)
+	auxMetadata.ContainerImageRef, auxMetadata.ContainerImageDiskUsageBytes, imageSizeErr = r.ContainerImageInfo(ctx)
 	if imageSizeErr != nil {
 		log.CtxWarningf(ctx, "Failed to get container image size: %s", imageSizeErr)
 	}

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -328,7 +328,11 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	}
 
 	// Record container image metadata after pulling.
-	auxMetadata.ContainerImageRef, auxMetadata.ContainerImageSizeBytes = r.ContainerImageInfo(ctx)
+	var imageSizeErr error
+	auxMetadata.ContainerImageRef, auxMetadata.ContainerImageSizeBytes, imageSizeErr = r.ContainerImageInfo(ctx)
+	if imageSizeErr != nil {
+		log.CtxWarningf(ctx, "Failed to get container image size: %s", imageSizeErr)
+	}
 
 	md.InputFetchStartTimestamp = timestamppb.New(s.env.GetClock().Now())
 

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -328,7 +328,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	}
 
 	// Record container image metadata after pulling.
-	auxMetadata.ContainerImage, auxMetadata.ContainerImageSizeBytes = r.ContainerImageInfo()
+	auxMetadata.ContainerImage, auxMetadata.ContainerImageSizeBytes = r.ContainerImageInfo(ctx)
 
 	md.InputFetchStartTimestamp = timestamppb.New(s.env.GetClock().Now())
 

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -328,7 +328,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	}
 
 	// Record container image metadata after pulling.
-	auxMetadata.ContainerImage, auxMetadata.ContainerImageSizeBytes = r.ContainerImageInfo(ctx)
+	auxMetadata.ContainerImageRef, auxMetadata.ContainerImageSizeBytes = r.ContainerImageInfo(ctx)
 
 	md.InputFetchStartTimestamp = timestamppb.New(s.env.GetClock().Now())
 

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -594,7 +594,7 @@ type imageSizingContainer struct {
 	imageSize int64
 }
 
-func (c *imageSizingContainer) ImageSizeBytes() int64 {
+func (c *imageSizingContainer) ImageSizeBytes(ctx context.Context) int64 {
 	return c.imageSize
 }
 

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -11,8 +11,11 @@ import (
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/bare"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -125,6 +128,45 @@ func getExecutor(t *testing.T, runOverride rbetest.RunInterceptor) (*executor.Ex
 		RunInterceptor: runFunc,
 		RecycleInterceptor: func(ctx context.Context, r interfaces.Runner, finishedCleanly bool, original rbetest.TryRecycleFunc) {
 			// Simulate that recycling takes 1min.
+			clock.Advance(1 * time.Minute)
+			c.countRecycled++
+			if finishedCleanly {
+				c.countFinishedCleanly++
+			}
+		},
+	})
+	exec, err := executor.NewExecutor(env, "executor-id", "host-id", "hostname", runnerPool)
+	require.NoError(t, err)
+
+	conn, err := testenv.LocalGRPCConn(context.Background(), lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	client := repb.NewExecutionClient(conn)
+
+	return exec, env, client, mockServer, c
+}
+
+func getExecutorWithPoolOptions(t *testing.T, runOverride rbetest.RunInterceptor, poolOpts *runner.PoolOptions) (*executor.Executor, *testenv.TestEnv, repb.ExecutionClient, *mockExecutionServer, *counters) {
+	env := enterprise_testenv.New(t)
+	env.SetAuthenticator(testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1")))
+	clock := clockwork.NewFakeClock()
+	env.SetClock(clock)
+	_, runServer, lis := testenv.RegisterLocalGRPCServer(t, env)
+	testcache.Setup(t, env, lis)
+	mockServer := &mockExecutionServer{finished: make(chan struct{})}
+	repb.RegisterExecutionServer(env.GetGRPCServer(), mockServer)
+	go runServer()
+
+	c := &counters{}
+	cacheRoot := testfs.MakeTempDir(t)
+	runFunc := rbetest.RunNoop()
+	if runOverride != nil {
+		runFunc = runOverride
+	}
+	runnerPool := rbetest.NewTestRunnerPool(t, env, cacheRoot, rbetest.TestRunnerOverrides{
+		RunInterceptor: runFunc,
+		PoolOptions:    poolOpts,
+		RecycleInterceptor: func(ctx context.Context, r interfaces.Runner, finishedCleanly bool, original rbetest.TryRecycleFunc) {
 			clock.Advance(1 * time.Minute)
 			c.countRecycled++
 			if finishedCleanly {
@@ -543,4 +585,58 @@ func TestExecuteTaskAndStreamResults_Timeout(t *testing.T) {
 			require.Equal(t, tc.expectedTimeout, auxMeta.GetTimeout().AsDuration())
 		})
 	}
+}
+
+// imageSizingContainer wraps a bare container and also implements
+// container.ImageSizer, reporting a configurable on-disk image size.
+type imageSizingContainer struct {
+	container.CommandContainer
+	imageSize int64
+}
+
+func (c *imageSizingContainer) ImageSizeBytes() int64 {
+	return c.imageSize
+}
+
+type imageSizingContainerProvider struct {
+	imageSize int64
+}
+
+func (p *imageSizingContainerProvider) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
+	return &imageSizingContainer{
+		CommandContainer: bare.NewBareCommandContainer(&bare.Opts{}),
+		imageSize:        p.imageSize,
+	}, nil
+}
+
+func TestExecuteTaskAndStreamResults_ContainerImageInfo(t *testing.T) {
+	ctx := context.Background()
+	const expectedImageSize int64 = 7_500_000_000
+
+	poolOpts := &runner.PoolOptions{
+		ContainerProvider: &imageSizingContainerProvider{imageSize: expectedImageSize},
+	}
+	exec, _, execClient, mockServer, _ := getExecutorWithPoolOptions(t, nil, poolOpts)
+	task := getTask()
+
+	publisher, err := operation.Publish(ctx, execClient, task.ExecutionTask.ExecutionId)
+	require.NoError(t, err)
+
+	retry, err := exec.ExecuteTaskAndStreamResults(ctx, task, publisher)
+	require.NoError(t, err)
+	require.False(t, retry)
+
+	<-mockServer.finished
+
+	completedOp := mockServer.operations[len(mockServer.operations)-1]
+	completedRsp := operation.ExtractExecuteResponse(completedOp)
+	auxMeta := &espb.ExecutionAuxiliaryMetadata{}
+	ok, err := rexec.FindFirstAuxiliaryMetadata(completedRsp.GetResult().GetExecutionMetadata(), auxMeta)
+	require.NoError(t, err)
+	require.True(t, ok)
+	// The bare runner normalizes container-image to "" since no image is
+	// configured. The image size should still come through from the
+	// ImageSizer implementation on the container.
+	require.Equal(t, "", auxMeta.GetContainerImage())
+	require.Equal(t, expectedImageSize, auxMeta.GetContainerImageSizeBytes())
 }

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -637,6 +637,6 @@ func TestExecuteTaskAndStreamResults_ContainerImageInfo(t *testing.T) {
 	// The bare runner normalizes container-image to "" since no image is
 	// configured. The image size should still come through from the
 	// ImageSizer implementation on the container.
-	require.Equal(t, "", auxMeta.GetContainerImage())
+	require.Equal(t, "", auxMeta.GetContainerImageRef())
 	require.Equal(t, expectedImageSize, auxMeta.GetContainerImageSizeBytes())
 }

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -11,8 +11,6 @@ import (
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/bare"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner"
@@ -147,6 +145,10 @@ func getExecutor(t *testing.T, runOverride rbetest.RunInterceptor) (*executor.Ex
 }
 
 func getExecutorWithPoolOptions(t *testing.T, runOverride rbetest.RunInterceptor, poolOpts *runner.PoolOptions) (*executor.Executor, *testenv.TestEnv, repb.ExecutionClient, *mockExecutionServer, *counters) {
+	return getExecutorWithRunnerPoolWrapper(t, runOverride, poolOpts, nil)
+}
+
+func getExecutorWithRunnerPoolWrapper(t *testing.T, runOverride rbetest.RunInterceptor, poolOpts *runner.PoolOptions, wrapRunnerPool func(interfaces.RunnerPool) interfaces.RunnerPool) (*executor.Executor, *testenv.TestEnv, repb.ExecutionClient, *mockExecutionServer, *counters) {
 	env := enterprise_testenv.New(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1")))
 	clock := clockwork.NewFakeClock()
@@ -174,6 +176,9 @@ func getExecutorWithPoolOptions(t *testing.T, runOverride rbetest.RunInterceptor
 			}
 		},
 	})
+	if wrapRunnerPool != nil {
+		runnerPool = wrapRunnerPool(runnerPool)
+	}
 	exec, err := executor.NewExecutor(env, "executor-id", "host-id", "hostname", runnerPool)
 	require.NoError(t, err)
 
@@ -587,36 +592,53 @@ func TestExecuteTaskAndStreamResults_Timeout(t *testing.T) {
 	}
 }
 
-// imageSizingContainer wraps a bare container and also implements
-// container.ImageSizer, reporting a configurable on-disk image size.
-type imageSizingContainer struct {
-	container.CommandContainer
+type containerImageInfoRunner struct {
+	interfaces.Runner
+	imageRef  string
 	imageSize int64
 }
 
-func (c *imageSizingContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
-	return c.imageSize, nil
+func (r *containerImageInfoRunner) ContainerImageInfo(ctx context.Context) (string, int64, error) {
+	return r.imageRef, r.imageSize, nil
 }
 
-type imageSizingContainerProvider struct {
+type containerImageInfoRunnerPool struct {
+	interfaces.RunnerPool
+	imageRef  string
 	imageSize int64
 }
 
-func (p *imageSizingContainerProvider) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
-	return &imageSizingContainer{
-		CommandContainer: bare.NewBareCommandContainer(&bare.Opts{}),
-		imageSize:        p.imageSize,
+func (p *containerImageInfoRunnerPool) Get(ctx context.Context, task *repb.ScheduledTask) (interfaces.Runner, error) {
+	r, err := p.RunnerPool.Get(ctx, task)
+	if err != nil {
+		return nil, err
+	}
+	return &containerImageInfoRunner{
+		Runner:    r,
+		imageRef:  p.imageRef,
+		imageSize: p.imageSize,
 	}, nil
+}
+
+func (p *containerImageInfoRunnerPool) TryRecycle(ctx context.Context, r interfaces.Runner, finishedCleanly bool) {
+	if wrapped, ok := r.(*containerImageInfoRunner); ok {
+		r = wrapped.Runner
+	}
+	p.RunnerPool.TryRecycle(ctx, r, finishedCleanly)
 }
 
 func TestExecuteTaskAndStreamResults_ContainerImageInfo(t *testing.T) {
 	ctx := context.Background()
+	const expectedImageRef = "docker.io/library/busybox:latest"
 	const expectedImageSize int64 = 7_500_000_000
 
-	poolOpts := &runner.PoolOptions{
-		ContainerProvider: &imageSizingContainerProvider{imageSize: expectedImageSize},
-	}
-	exec, _, execClient, mockServer, _ := getExecutorWithPoolOptions(t, nil, poolOpts)
+	exec, _, execClient, mockServer, _ := getExecutorWithRunnerPoolWrapper(t, nil, nil, func(runnerPool interfaces.RunnerPool) interfaces.RunnerPool {
+		return &containerImageInfoRunnerPool{
+			RunnerPool: runnerPool,
+			imageRef:   expectedImageRef,
+			imageSize:  expectedImageSize,
+		}
+	})
 	task := getTask()
 
 	publisher, err := operation.Publish(ctx, execClient, task.ExecutionTask.ExecutionId)
@@ -634,9 +656,6 @@ func TestExecuteTaskAndStreamResults_ContainerImageInfo(t *testing.T) {
 	ok, err := rexec.FindFirstAuxiliaryMetadata(completedRsp.GetResult().GetExecutionMetadata(), auxMeta)
 	require.NoError(t, err)
 	require.True(t, ok)
-	// The bare runner normalizes container-image to "" since no image is
-	// configured. The image size should still come through from the
-	// ImageSizer implementation on the container.
-	require.Equal(t, "", auxMeta.GetContainerImageRef())
+	require.Equal(t, expectedImageRef, auxMeta.GetContainerImageRef())
 	require.Equal(t, expectedImageSize, auxMeta.GetContainerImageSizeBytes())
 }

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -657,5 +657,5 @@ func TestExecuteTaskAndStreamResults_ContainerImageInfo(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, expectedImageRef, auxMeta.GetContainerImageRef())
-	require.Equal(t, expectedImageSize, auxMeta.GetContainerImageSizeBytes())
+	require.Equal(t, expectedImageSize, auxMeta.GetContainerImageDiskUsageBytes())
 }

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -594,8 +594,8 @@ type imageSizingContainer struct {
 	imageSize int64
 }
 
-func (c *imageSizingContainer) ImageSizeBytes(ctx context.Context) int64 {
-	return c.imageSize
+func (c *imageSizingContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
+	return c.imageSize, nil
 }
 
 type imageSizingContainerProvider struct {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -239,6 +239,14 @@ func (r *taskRunner) Metadata() *espb.RunnerMetadata {
 	return r.metadata.CloneVT()
 }
 
+func (r *taskRunner) ContainerImageInfo() (ref string, sizeBytes int64) {
+	ref = r.PlatformProperties.ContainerImage
+	if sizer, ok := r.Container.Delegate.(container.ImageSizer); ok {
+		sizeBytes = sizer.ImageSizeBytes()
+	}
+	return ref, sizeBytes
+}
+
 func (r *taskRunner) String() string {
 	return fmt.Sprintf("%s:%s:%d:%s", r.debugID, r.getState().ShortString(), r.metadata.GetTaskNumber(), keyString(r.key))
 }

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -239,8 +239,9 @@ func (r *taskRunner) Metadata() *espb.RunnerMetadata {
 	return r.metadata.CloneVT()
 }
 
-func (r *taskRunner) ContainerImageInfo(ctx context.Context) (ref string, sizeBytes int64) {
-	return r.PlatformProperties.ContainerImage, r.Container.ImageSizeBytes(ctx)
+func (r *taskRunner) ContainerImageInfo(ctx context.Context) (ref string, sizeBytes int64, err error) {
+	sizeBytes, err = r.Container.ImageSizeBytes(ctx)
+	return r.PlatformProperties.ContainerImage, sizeBytes, err
 }
 
 func (r *taskRunner) String() string {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -239,8 +239,8 @@ func (r *taskRunner) Metadata() *espb.RunnerMetadata {
 	return r.metadata.CloneVT()
 }
 
-func (r *taskRunner) ContainerImageInfo() (ref string, sizeBytes int64) {
-	return r.PlatformProperties.ContainerImage, r.Container.ImageSizeBytes()
+func (r *taskRunner) ContainerImageInfo(ctx context.Context) (ref string, sizeBytes int64) {
+	return r.PlatformProperties.ContainerImage, r.Container.ImageSizeBytes(ctx)
 }
 
 func (r *taskRunner) String() string {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -240,11 +240,7 @@ func (r *taskRunner) Metadata() *espb.RunnerMetadata {
 }
 
 func (r *taskRunner) ContainerImageInfo() (ref string, sizeBytes int64) {
-	ref = r.PlatformProperties.ContainerImage
-	if sizer, ok := r.Container.Delegate.(container.ImageSizer); ok {
-		sizeBytes = sizer.ImageSizeBytes()
-	}
-	return ref, sizeBytes
+	return r.PlatformProperties.ContainerImage, r.Container.ImageSizeBytes()
 }
 
 func (r *taskRunner) String() string {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -233,6 +233,11 @@ type taskRunner struct {
 
 	memoryUsageBytes int64
 	diskUsageBytes   int64
+
+	containerImageInfoOnce          sync.Once
+	containerImageRef               string
+	containerImageDiskUsageBytes    int64
+	containerImageDiskUsageBytesErr error
 }
 
 func (r *taskRunner) Metadata() *espb.RunnerMetadata {
@@ -240,8 +245,11 @@ func (r *taskRunner) Metadata() *espb.RunnerMetadata {
 }
 
 func (r *taskRunner) ContainerImageInfo(ctx context.Context) (ref string, sizeBytes int64, err error) {
-	sizeBytes, err = r.Container.ImageSizeBytes(ctx)
-	return r.PlatformProperties.ContainerImage, sizeBytes, err
+	r.containerImageInfoOnce.Do(func() {
+		r.containerImageRef = r.PlatformProperties.ContainerImage
+		r.containerImageDiskUsageBytes, r.containerImageDiskUsageBytesErr = r.Container.ImageSizeBytes(ctx)
+	})
+	return r.containerImageRef, r.containerImageDiskUsageBytes, r.containerImageDiskUsageBytesErr
 }
 
 func (r *taskRunner) String() string {

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -139,7 +139,7 @@ func (c *fakeContainer) Pause(ctx context.Context) error {
 func (c *fakeContainer) Unpause(ctx context.Context) error {
 	return nil
 }
-func (c *fakeContainer) ImageSizeBytes(ctx context.Context) int64 { return 0 }
+func (c *fakeContainer) ImageSizeBytes(ctx context.Context) (int64, error) { return 0, nil }
 
 // fakeFirecrackerContainer behaves like a bare container except it returns
 // 0 mem / CPU resources, like Firecracker.
@@ -158,11 +158,12 @@ func (*fakeFirecrackerContainer) Stats(context.Context) (*repb.UsageStats, error
 // fakeImageSizingContainer is a bare container that also reports an image size.
 type fakeImageSizingContainer struct {
 	container.CommandContainer
-	imageSize int64
+	imageSize    int64
+	imageSizeErr error
 }
 
-func (c *fakeImageSizingContainer) ImageSizeBytes(ctx context.Context) int64 {
-	return c.imageSize
+func (c *fakeImageSizingContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
+	return c.imageSize, c.imageSizeErr
 }
 
 func (c *fakeImageSizingContainer) Stats(context.Context) (*repb.UsageStats, error) {
@@ -1267,23 +1268,37 @@ func TestContainerImageInfo_WithImageSizer(t *testing.T) {
 	r, err := pool.Get(ctx, task)
 	require.NoError(t, err)
 
-	ref, sizeBytes := r.(*taskRunner).ContainerImageInfo(ctx)
+	ref, sizeBytes, err := r.(*taskRunner).ContainerImageInfo(ctx)
+	require.NoError(t, err)
 	// Bare runner normalizes container-image to "".
 	assert.Equal(t, "", ref)
 	assert.Equal(t, expectedSize, sizeBytes)
 }
 
-func TestContainerImageInfo_WithoutImageSizer(t *testing.T) {
+func TestContainerImageInfo_ImageSizeError(t *testing.T) {
 	env := newTestEnv(t)
-	pool := newRunnerPool(t, env, noLimitsCfg())
+	pool := newRunnerPool(t, env, &RunnerPoolOptions{
+		PoolOptions: &PoolOptions{
+			ContainerProvider: &ImageSizingContainerProvider{
+				ImageSize: 0,
+			},
+		},
+		MaxRunnerCount:            unlimited,
+		MaxRunnerDiskSizeBytes:    unlimited,
+		MaxRunnerMemoryUsageBytes: unlimited,
+	})
 	ctx := withAuthenticatedUser(t, context.Background(), env, "US1")
 
-	// bare container does not implement ImageSizer
 	task := newTask()
 	r, err := pool.Get(ctx, task)
 	require.NoError(t, err)
 
-	ref, sizeBytes := r.(*taskRunner).ContainerImageInfo(ctx)
+	imageSizingContainer := r.(*taskRunner).Container.Delegate.(*fakeImageSizingContainer)
+	imageSizingContainer.imageSizeErr = status.InternalError("image size unavailable")
+
+	ref, sizeBytes, err := r.(*taskRunner).ContainerImageInfo(ctx)
+	require.Error(t, err)
 	assert.Equal(t, "", ref)
 	assert.Equal(t, int64(0), sizeBytes)
+	assert.Contains(t, err.Error(), "image size unavailable")
 }

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -154,6 +154,20 @@ func (*fakeFirecrackerContainer) Stats(context.Context) (*repb.UsageStats, error
 	return &repb.UsageStats{}, nil
 }
 
+// fakeImageSizingContainer is a bare container that also reports an image size.
+type fakeImageSizingContainer struct {
+	container.CommandContainer
+	imageSize int64
+}
+
+func (c *fakeImageSizingContainer) ImageSizeBytes() int64 {
+	return c.imageSize
+}
+
+func (c *fakeImageSizingContainer) Stats(context.Context) (*repb.UsageStats, error) {
+	return &repb.UsageStats{}, nil
+}
+
 type RunnerPoolOptions struct {
 	*PoolOptions
 	MaxRunnerCount                 int
@@ -1217,4 +1231,58 @@ func TestTransientErrorExitCodes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ImageSizingContainerProvider returns a fakeImageSizingContainer that
+// reports the configured image size.
+type ImageSizingContainerProvider struct {
+	ImageSize int64
+}
+
+func (p *ImageSizingContainerProvider) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
+	return &fakeImageSizingContainer{
+		CommandContainer: bare.NewBareCommandContainer(&bare.Opts{}),
+		imageSize:        p.ImageSize,
+	}, nil
+}
+
+func TestContainerImageInfo_WithImageSizer(t *testing.T) {
+	env := newTestEnv(t)
+	const expectedSize int64 = 6_000_000_000
+	pool := newRunnerPool(t, env, &RunnerPoolOptions{
+		PoolOptions: &PoolOptions{
+			ContainerProvider: &ImageSizingContainerProvider{ImageSize: expectedSize},
+		},
+		MaxRunnerCount:            unlimited,
+		MaxRunnerDiskSizeBytes:    unlimited,
+		MaxRunnerMemoryUsageBytes: unlimited,
+	})
+	ctx := withAuthenticatedUser(t, context.Background(), env, "US1")
+
+	// Use a standard task (bare runner with no container-image set).
+	// The image size should still come through from the ImageSizer
+	// implementation, even though the ref is empty for bare.
+	task := newTask()
+	r, err := pool.Get(ctx, task)
+	require.NoError(t, err)
+
+	ref, sizeBytes := r.(*taskRunner).ContainerImageInfo()
+	// Bare runner normalizes container-image to "".
+	assert.Equal(t, "", ref)
+	assert.Equal(t, expectedSize, sizeBytes)
+}
+
+func TestContainerImageInfo_WithoutImageSizer(t *testing.T) {
+	env := newTestEnv(t)
+	pool := newRunnerPool(t, env, noLimitsCfg())
+	ctx := withAuthenticatedUser(t, context.Background(), env, "US1")
+
+	// bare container does not implement ImageSizer
+	task := newTask()
+	r, err := pool.Get(ctx, task)
+	require.NoError(t, err)
+
+	ref, sizeBytes := r.(*taskRunner).ContainerImageInfo()
+	assert.Equal(t, "", ref)
+	assert.Equal(t, int64(0), sizeBytes)
 }

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -139,6 +139,7 @@ func (c *fakeContainer) Pause(ctx context.Context) error {
 func (c *fakeContainer) Unpause(ctx context.Context) error {
 	return nil
 }
+func (c *fakeContainer) ImageSizeBytes(ctx context.Context) int64 { return 0 }
 
 // fakeFirecrackerContainer behaves like a bare container except it returns
 // 0 mem / CPU resources, like Firecracker.

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -160,7 +160,7 @@ type fakeImageSizingContainer struct {
 	imageSize int64
 }
 
-func (c *fakeImageSizingContainer) ImageSizeBytes() int64 {
+func (c *fakeImageSizingContainer) ImageSizeBytes(ctx context.Context) int64 {
 	return c.imageSize
 }
 
@@ -1266,7 +1266,7 @@ func TestContainerImageInfo_WithImageSizer(t *testing.T) {
 	r, err := pool.Get(ctx, task)
 	require.NoError(t, err)
 
-	ref, sizeBytes := r.(*taskRunner).ContainerImageInfo()
+	ref, sizeBytes := r.(*taskRunner).ContainerImageInfo(ctx)
 	// Bare runner normalizes container-image to "".
 	assert.Equal(t, "", ref)
 	assert.Equal(t, expectedSize, sizeBytes)
@@ -1282,7 +1282,7 @@ func TestContainerImageInfo_WithoutImageSizer(t *testing.T) {
 	r, err := pool.Get(ctx, task)
 	require.NoError(t, err)
 
-	ref, sizeBytes := r.(*taskRunner).ContainerImageInfo()
+	ref, sizeBytes := r.(*taskRunner).ContainerImageInfo(ctx)
 	assert.Equal(t, "", ref)
 	assert.Equal(t, int64(0), sizeBytes)
 }

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -158,11 +158,13 @@ func (*fakeFirecrackerContainer) Stats(context.Context) (*repb.UsageStats, error
 // fakeImageSizingContainer is a bare container that also reports an image size.
 type fakeImageSizingContainer struct {
 	container.CommandContainer
-	imageSize    int64
-	imageSizeErr error
+	imageSize      int64
+	imageSizeErr   error
+	imageSizeCalls int
 }
 
 func (c *fakeImageSizingContainer) ImageSizeBytes(ctx context.Context) (int64, error) {
+	c.imageSizeCalls++
 	return c.imageSize, c.imageSizeErr
 }
 
@@ -1273,6 +1275,38 @@ func TestContainerImageInfo_WithImageSizer(t *testing.T) {
 	// Bare runner normalizes container-image to "".
 	assert.Equal(t, "", ref)
 	assert.Equal(t, expectedSize, sizeBytes)
+}
+
+func TestContainerImageInfo_CachesImageSize(t *testing.T) {
+	env := newTestEnv(t)
+	const expectedSize int64 = 6_000_000_000
+	pool := newRunnerPool(t, env, &RunnerPoolOptions{
+		PoolOptions: &PoolOptions{
+			ContainerProvider: &ImageSizingContainerProvider{ImageSize: expectedSize},
+		},
+		MaxRunnerCount:            unlimited,
+		MaxRunnerDiskSizeBytes:    unlimited,
+		MaxRunnerMemoryUsageBytes: unlimited,
+	})
+	ctx := withAuthenticatedUser(t, context.Background(), env, "US1")
+
+	task := newTask()
+	r, err := pool.Get(ctx, task)
+	require.NoError(t, err)
+
+	ref, sizeBytes, err := r.(*taskRunner).ContainerImageInfo(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "", ref)
+	assert.Equal(t, expectedSize, sizeBytes)
+
+	imageSizingContainer := r.(*taskRunner).Container.Delegate.(*fakeImageSizingContainer)
+	imageSizingContainer.imageSize = 1
+
+	ref, sizeBytes, err = r.(*taskRunner).ContainerImageInfo(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "", ref)
+	assert.Equal(t, expectedSize, sizeBytes)
+	assert.Equal(t, 1, imageSizingContainer.imageSizeCalls)
 }
 
 func TestContainerImageInfo_ImageSizeError(t *testing.T) {

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -1474,10 +1474,15 @@ type testRunnerPool struct {
 type TestRunnerOverrides struct {
 	RunInterceptor     RunInterceptor
 	RecycleInterceptor RecycleInterceptor
+	PoolOptions        *runner.PoolOptions
 }
 
 func NewTestRunnerPool(t testing.TB, env environment.Env, cacheRoot string, opts TestRunnerOverrides) interfaces.RunnerPool {
-	realPool, err := runner.NewPool(env, cacheRoot, &runner.PoolOptions{})
+	poolOpts := opts.PoolOptions
+	if poolOpts == nil {
+		poolOpts = &runner.PoolOptions{}
+	}
+	realPool, err := runner.NewPool(env, cacheRoot, poolOpts)
 	require.NoError(t, err)
 	return &testRunnerPool{realPool, opts.RunInterceptor, opts.RecycleInterceptor}
 }

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -177,6 +177,13 @@ message ExecutionAuxiliaryMetadata {
 
   // Metadata containing more detail about the input fetch phase of execution.
   InputFetchMetadata input_fetch_detailed_stats = 11;
+
+  // The container image used for execution.
+  string container_image = 12;
+
+  // The on-disk size of the container image in bytes, after pulling and
+  // extracting.
+  int64 container_image_size_bytes = 13;
 }
 
 message RunnerMetadata {

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -178,7 +178,9 @@ message ExecutionAuxiliaryMetadata {
   // Metadata containing more detail about the input fetch phase of execution.
   InputFetchMetadata input_fetch_detailed_stats = 11;
 
-  // The container image ref used for execution.
+  // The container image ref used for execution, for example:
+  // buildbuddy.bbcr.dev/public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622
+  // index.docker.io/v2/alpine:latest
   string container_image_ref = 12;
 
   // The on-disk size of the container image in bytes, after pulling and

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -178,8 +178,8 @@ message ExecutionAuxiliaryMetadata {
   // Metadata containing more detail about the input fetch phase of execution.
   InputFetchMetadata input_fetch_detailed_stats = 11;
 
-  // The container image used for execution.
-  string container_image = 12;
+  // The container image ref used for execution.
+  string container_image_ref = 12;
 
   // The on-disk size of the container image in bytes, after pulling and
   // extracting.

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -185,7 +185,7 @@ message ExecutionAuxiliaryMetadata {
 
   // The on-disk size of the container image in bytes, after pulling and
   // extracting.
-  int64 container_image_size_bytes = 13;
+  int64 container_image_disk_usage_bytes = 13;
 }
 
 message RunnerMetadata {

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -183,8 +183,10 @@ message ExecutionAuxiliaryMetadata {
   // index.docker.io/v2/alpine:latest
   string container_image_ref = 12;
 
-  // The on-disk size of the container image in bytes, after pulling and
-  // extracting.
+  // Runtime-specific estimated disk usage of the prepared container image in
+  // bytes. OCI uses the sum of estimated layer disk usage, Docker and Podman
+  // use image inspect size, and Firecracker uses the logical size of the
+  // prepared container filesystem image when present.
   int64 container_image_disk_usage_bytes = 13;
 }
 

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -3067,7 +3067,9 @@ message StoredExecution {
   // The container image ref used for execution.
   string container_image_ref = 83;
 
-  // The on-disk size of the container image in bytes, after pulling and
-  // extracting.
+  // Runtime-specific estimated disk usage of the prepared container image in
+  // bytes. OCI uses the sum of estimated layer disk usage, Docker and Podman
+  // use image inspect size, and Firecracker uses the logical size of the
+  // prepared container filesystem image when present.
   int64 container_image_disk_usage_bytes = 84;
 }

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -3063,4 +3063,11 @@ message StoredExecution {
   // CPU architecture that the execution targeted (e.g. "amd64", "arm64").
   // Sourced from the Arch platform property.
   string arch = 82;
+
+  // The container image used for execution.
+  string container_image = 83;
+
+  // The on-disk size of the container image in bytes, after pulling and
+  // extracting.
+  int64 container_image_size_bytes = 84;
 }

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -3064,8 +3064,8 @@ message StoredExecution {
   // Sourced from the Arch platform property.
   string arch = 82;
 
-  // The container image used for execution.
-  string container_image = 83;
+  // The container image ref used for execution.
+  string container_image_ref = 83;
 
   // The on-disk size of the container image in bytes, after pulling and
   // extracting.

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -3069,5 +3069,5 @@ message StoredExecution {
 
   // The on-disk size of the container image in bytes, after pulling and
   // extracting.
-  int64 container_image_size_bytes = 84;
+  int64 container_image_disk_usage_bytes = 84;
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1167,7 +1167,7 @@ type Runner interface {
 	// ContainerImageInfo returns the container image ref used for the
 	// execution, and its estimated on-disk size in bytes.
 	// Should be called after PrepareForTask.
-	ContainerImageInfo(ctx context.Context) (ref string, sizeBytes int64)
+	ContainerImageInfo(ctx context.Context) (ref string, sizeBytes int64, err error)
 }
 
 type CacheRoutingService interface {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1165,7 +1165,7 @@ type Runner interface {
 	GetIsolationType() string
 
 	// ContainerImageInfo returns the container image ref used for the
-	// execution, and its estimated on-disk size in bytes.
+	// execution, and its runtime-specific estimated disk usage in bytes.
 	// Should be called after PrepareForTask.
 	ContainerImageInfo(ctx context.Context) (ref string, sizeBytes int64, err error)
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1167,7 +1167,7 @@ type Runner interface {
 	// ContainerImageInfo returns the container image ref used for the
 	// execution, and its estimated on-disk size in bytes.
 	// Should be called after PrepareForTask.
-	ContainerImageInfo() (ref string, sizeBytes int64)
+	ContainerImageInfo(ctx context.Context) (ref string, sizeBytes int64)
 }
 
 type CacheRoutingService interface {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1163,6 +1163,11 @@ type Runner interface {
 	// GetIsolationType returns the runner's effective isolation type as a
 	// string, such as "none" or "podman".
 	GetIsolationType() string
+
+	// ContainerImageInfo returns the container image ref used for the
+	// execution, and its estimated on-disk size in bytes.
+	// Should be called after PrepareForTask.
+	ContainerImageInfo() (ref string, sizeBytes int64)
 }
 
 type CacheRoutingService interface {

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -460,7 +460,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*
 		RequestedPool:                      in.GetRequestedPool(),
 		EffectivePool:                      in.GetEffectivePool(),
 		ContainerImageRef:                  in.GetContainerImageRef(),
-		ContainerImageSizeBytes:            in.GetContainerImageSizeBytes(),
+		ContainerImageDiskUsageBytes:       in.GetContainerImageDiskUsageBytes(),
 	}
 
 	if err := FillExecutionResourceFieldsFromExecutionID(out, in.GetExecutionId()); err != nil {

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -459,7 +459,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*
 		PersistentWorkerKey:                in.GetPersistentWorkerKey(),
 		RequestedPool:                      in.GetRequestedPool(),
 		EffectivePool:                      in.GetEffectivePool(),
-		ContainerImage:                     in.GetContainerImage(),
+		ContainerImageRef:                  in.GetContainerImageRef(),
 		ContainerImageSizeBytes:            in.GetContainerImageSizeBytes(),
 	}
 

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -459,6 +459,8 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*
 		PersistentWorkerKey:                in.GetPersistentWorkerKey(),
 		RequestedPool:                      in.GetRequestedPool(),
 		EffectivePool:                      in.GetEffectivePool(),
+		ContainerImage:                     in.GetContainerImage(),
+		ContainerImageSizeBytes:            in.GetContainerImageSizeBytes(),
 	}
 
 	if err := FillExecutionResourceFieldsFromExecutionID(out, in.GetExecutionId()); err != nil {

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -286,8 +286,8 @@ type Execution struct {
 	CommandSnippet string `gorm:"codec:ZSTD(1)"`
 
 	// Container image
-	ContainerImageRef            string
-	ContainerImageDiskUsageBytes int64
+	ContainerImageRef            string `gorm:"codec:ZSTD(1)"`
+	ContainerImageDiskUsageBytes int64  `gorm:"codec:T64,ZSTD(1)"`
 
 	// Fields from Invocations
 	User             string `gorm:"codec:ZSTD(1)"`

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -286,7 +286,7 @@ type Execution struct {
 	CommandSnippet string `gorm:"codec:ZSTD(1)"`
 
 	// Container image
-	ContainerImage          string
+	ContainerImageRef       string
 	ContainerImageSizeBytes int64
 
 	// Fields from Invocations
@@ -391,7 +391,7 @@ func (e *Execution) AdditionalFields() []string {
 		"ExecutorHostname",
 		"Experiments",
 		"ClientIP",
-		"ContainerImage",
+		"ContainerImageRef",
 		"ContainerImageSizeBytes",
 	}
 }

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -285,6 +285,10 @@ type Execution struct {
 	StatusMessage  string `gorm:"codec:ZSTD(1)"`
 	CommandSnippet string `gorm:"codec:ZSTD(1)"`
 
+	// Container image
+	ContainerImage          string
+	ContainerImageSizeBytes int64
+
 	// Fields from Invocations
 	User             string `gorm:"codec:ZSTD(1)"`
 	Host             string `gorm:"codec:ZSTD(1)"`
@@ -387,6 +391,8 @@ func (e *Execution) AdditionalFields() []string {
 		"ExecutorHostname",
 		"Experiments",
 		"ClientIP",
+		"ContainerImage",
+		"ContainerImageSizeBytes",
 	}
 }
 

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -286,8 +286,8 @@ type Execution struct {
 	CommandSnippet string `gorm:"codec:ZSTD(1)"`
 
 	// Container image
-	ContainerImageRef       string
-	ContainerImageSizeBytes int64
+	ContainerImageRef            string
+	ContainerImageDiskUsageBytes int64
 
 	// Fields from Invocations
 	User             string `gorm:"codec:ZSTD(1)"`
@@ -392,7 +392,7 @@ func (e *Execution) AdditionalFields() []string {
 		"Experiments",
 		"ClientIP",
 		"ContainerImageRef",
-		"ContainerImageSizeBytes",
+		"ContainerImageDiskUsageBytes",
 	}
 }
 


### PR DESCRIPTION
Eventually we'd like to be able to warn customers when their container images are big and slow (and possibly even not attempt to execute container images above a certain size). Start by collecting the data.