### PR TITLE
Enable chunking in proxy by default

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -3,6 +3,7 @@ package byte_stream_server_proxy
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"strconv"
@@ -42,6 +43,8 @@ import (
 const (
 	defaultChunkUploadConcurrency = 32
 )
+
+var disableCDC = flag.Bool("cache_proxy.disable_cdc", false, "If true, disable proxy-side CDC behavior, including chunked reads and intercepting/chunking large writes.")
 
 func groupIDForMetrics(ctx context.Context) string {
 	c, err := claims.ClaimsFromContext(ctx)
@@ -232,6 +235,9 @@ func (s *ByteStreamServerProxy) read(ctx context.Context, req *bspb.ReadRequest,
 }
 
 func (s *ByteStreamServerProxy) shouldReadChunked(ctx context.Context, req *bspb.ReadRequest, rn *digest.CASResourceName) bool {
+	if *disableCDC {
+		return false
+	}
 	if authutil.EncryptionEnabled(ctx, s.authenticator) && !s.supportsEncryption(ctx) {
 		// TODO(buildbuddy-internal#6426): Read and write chunked blobs for encrypted requests.
 		return false
@@ -807,14 +813,14 @@ func (s *replayableWriteStream) Recv() (*bspb.WriteRequest, error) {
 }
 
 func (s *ByteStreamServerProxy) writeChunkingEnabled(ctx context.Context) bool {
-	if s.localCache == nil || s.remoteCAS == nil {
+	if *disableCDC || s.localCache == nil || s.remoteCAS == nil {
 		return false
 	}
 	if cdc.EnabledViaHeader(ctx) {
 		return true
 	}
 	return chunking.Enabled(ctx, s.efp) &&
-		s.efp.Boolean(ctx, "cache_proxy.intercept_and_chunk_large_writes", false)
+		(s.efp == nil || s.efp.Boolean(ctx, "cache_proxy.intercept_and_chunk_large_writes", true))
 }
 
 type writeChunkedResult struct {
@@ -1057,7 +1063,10 @@ type chunkUploader struct {
 
 // newChunkUploader batches chunks into FMB groups and upload requests of up to 2 MiB.
 func newChunkUploader(ctx context.Context, s *ByteStreamServerProxy, instanceName string, digestFunction repb.DigestFunction_Value) (*chunkUploader, error) {
-	concurrency := int(s.efp.Int64(ctx, "cache_proxy.chunk_upload_concurrency", defaultChunkUploadConcurrency))
+	concurrency := defaultChunkUploadConcurrency
+	if s.efp != nil {
+		concurrency = int(s.efp.Int64(ctx, "cache_proxy.chunk_upload_concurrency", defaultChunkUploadConcurrency))
+	}
 	if concurrency <= 0 {
 		concurrency = defaultChunkUploadConcurrency
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -871,11 +871,11 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	}
 
 	efp := s.env.GetExperimentFlagProvider()
-	if cdc.EnabledViaHeader(ctx) || (chunking.Enabled(ctx, efp) && efp.Boolean(ctx, "executor.upload_outputs_chunked", false)) {
+	if cdc.EnabledViaHeader(ctx) || (chunking.Enabled(ctx, efp) && efp != nil && efp.Boolean(ctx, "executor.upload_outputs_chunked", false)) {
 		executionTask.Experiments = append(executionTask.Experiments, "executor.upload_outputs_chunked")
 		executionTask.FastCdc_2020Params = chunking.FastCDCParams()
 	}
-	if cdc.EnabledViaHeader(ctx) || (chunking.Enabled(ctx, efp) && efp.Boolean(ctx, "executor.download_inputs_chunked", false)) {
+	if cdc.EnabledViaHeader(ctx) || (chunking.Enabled(ctx, efp) && efp != nil && efp.Boolean(ctx, "executor.download_inputs_chunked", false)) {
 		executionTask.Experiments = append(executionTask.Experiments, "executor.download_inputs_chunked")
 	}
 

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -77,8 +77,7 @@ func Enabled(ctx context.Context, efp interfaces.ExperimentFlagProvider) bool {
 	if cdc.EnabledViaHeader(ctx) {
 		return true
 	}
-	return efp != nil &&
-		efp.Boolean(ctx, "cache.chunking_enabled", false)
+	return efp == nil || efp.Boolean(ctx, "cache.chunking_enabled", true)
 }
 
 func ShouldReadChunked(ctx context.Context, efp interfaces.ExperimentFlagProvider, digestSizeBytes, offset, limit int64) bool {
@@ -93,7 +92,8 @@ func ShouldReadChunkedOnProxy(ctx context.Context, efp interfaces.ExperimentFlag
 	return digestSizeBytes > MaxChunkSizeBytes() &&
 		limit == 0 &&
 		(cdc.EnabledViaHeader(ctx) ||
-			(efp != nil && efp.Boolean(ctx, "cache_proxy.attempt_chunked_reads", false)))
+			efp == nil ||
+			efp.Boolean(ctx, "cache_proxy.attempt_chunked_reads", true))
 }
 
 type WriteFunc func([]byte) error

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -557,7 +557,7 @@ func TestEnabled_HeaderOverridesExperimentFlag(t *testing.T) {
 
 func TestEnabled_FallsBackToExperimentFlag(t *testing.T) {
 	ctx := context.Background()
-	assert.False(t, chunking.Enabled(ctx, nil))
+	assert.True(t, chunking.Enabled(ctx, nil))
 }
 
 func BenchmarkStore(b *testing.B) {


### PR DESCRIPTION
The cache proxy now defaults to enabling its proxy-side CDC behavior: attempting chunked reads and intercepting/chunking large writes.

`cache_proxy.disable_cdc` disables only those proxy-side behaviors. It does not disable app-side `SplitBlob` / `SpliceBlob`, and it does not change app-side CDC gating.

App-side `SplitBlob` / `SpliceBlob` is still controlled by `cache.chunking_enabled` on the app (typically via EFP / flagd). If the app disables chunking for a group while the proxy still attempts proxy-side CDC, the proxy's chunked read / write paths will receive `Unimplemented` from the app. On writes, this happens near the end at `SpliceBlob`, after the chunking/upload work has already been done.

As long as app-side `SplitBlob` / `SpliceBlob` remains enabled everywhere the proxy is allowed to use CDC, this should not be an issue.
