### PR TITLE
[FC] Stop cloning SnapshotKeySet

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1026,7 +1026,7 @@ func alignToMultiple(n int64, multiple int64) int64 {
 }
 
 func (c *FirecrackerContainer) SnapshotKeySet() *fcpb.SnapshotKeySet {
-	return c.snapshotKeySet.CloneVT()
+	return c.snapshotKeySet
 }
 
 func (c *FirecrackerContainer) SnapshotID() string {


### PR DESCRIPTION
We frequently read the snapshot keys, and cloning every time is expensive. Currently, every time we use this function is read-only and the clone is unnecessary. Only firecracker code and tests are referencing this