### PR TITLE
Speed up DirectoryToImage

### DIFF
--- a/enterprise/server/util/ext4/BUILD
+++ b/enterprise/server/util/ext4/BUILD
@@ -15,6 +15,8 @@ go_library(
             "//server/util/tracing",
             "@com_github_prometheus_client_golang//prometheus",
             "@io_opentelemetry_go_otel//attribute",
+            "@org_golang_x_sync//errgroup",
+            "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],
     }),
@@ -22,6 +24,7 @@ go_library(
 
 go_test(
     name = "ext4_test",
+    timeout = "long",
     srcs = ["ext4_test.go"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = select({

--- a/enterprise/server/util/ext4/ext4.go
+++ b/enterprise/server/util/ext4/ext4.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
@@ -19,6 +21,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -57,9 +61,40 @@ func EnsureDependencies() error {
 	return nil
 }
 
+// MountMethod specifies how to mount the ext4 image for parallel copy.
+type MountMethod int
+
+const (
+	// MountMethodNone disables parallel copy (use mke2fs -d instead).
+	MountMethodNone MountMethod = iota
+	// MountMethodExec uses the mount/umount commands.
+	MountMethodExec
+)
+
+// ImageOptions configures ext4 image creation.
+type ImageOptions struct {
+	// ParallelCopy specifies the mount method to use for parallel file
+	// copying. When set to MountMethodNone (default), mke2fs -d is used.
+	// Other values mount the image and copy files in parallel, which
+	// requires root or CAP_SYS_ADMIN.
+	ParallelCopy MountMethod
+	// CopyWorkers is the number of parallel copy workers to use when
+	// ParallelCopy is enabled. Defaults to runtime.NumCPU() if 0.
+	CopyWorkers int
+}
+
 // DirectoryToImage creates an ext4 image of the specified size from inputDir
 // and writes it to outputFile.
-func DirectoryToImage(ctx context.Context, inputDir, outputFile string, sizeBytes int64) error {
+func DirectoryToImage(ctx context.Context, inputDir, outputFile string, sizeBytes int64, opts ...ImageOptions) error {
+	var opt ImageOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	if opt.ParallelCopy != MountMethodNone {
+		return directoryToImageParallel(ctx, inputDir, outputFile, sizeBytes, opt)
+	}
+
 	if err := checkImageOutputPath(outputFile); err != nil {
 		return err
 	}
@@ -101,6 +136,222 @@ func DirectoryToImage(ctx context.Context, inputDir, outputFile string, sizeByte
 		}
 	}
 	return nil
+}
+
+var copyBufPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 256*1024)
+		return &buf
+	},
+}
+
+type reader struct {
+	r io.Reader
+}
+
+func (r *reader) Read(p []byte) (int, error) {
+	return r.r.Read(p)
+}
+
+type writer struct {
+	w io.Writer
+}
+
+func (w *writer) Write(p []byte) (int, error) {
+	return w.w.Write(p)
+}
+
+// copyFile copies a single file, preserving permissions.
+// It tries sendfile(2) first for zero-copy transfer, then falls back
+// to a pooled-buffer userspace copy.
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	size, err := in.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	if size == 0 {
+		return out.Close()
+	}
+	if _, err := in.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	written, sendfileErr := sendfileAll(int(out.Fd()), int(in.Fd()), size)
+	if sendfileErr == nil {
+		if written < size {
+			return io.ErrShortWrite
+		}
+		return out.Close()
+	}
+	// sendfile failed (e.g. EINVAL, ENOSYS) — fall back to
+	// userspace copy. Reset both file offsets and truncate output
+	// in case sendfile made partial progress.
+	if _, err := in.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := out.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if err := out.Truncate(0); err != nil {
+		return err
+	}
+
+	bufp := copyBufPool.Get().(*[]byte)
+	defer copyBufPool.Put(bufp)
+	if _, err := io.CopyBuffer(&writer{out}, &reader{in}, *bufp); err != nil {
+		return err
+	}
+	return out.Close()
+}
+
+// sendfileAll calls sendfile(2) in a loop until all bytes are transferred.
+func sendfileAll(dstFd, srcFd int, size int64) (int64, error) {
+	var total int64
+	for total < size {
+		n, err := unix.Sendfile(dstFd, srcFd, nil, int(size-total))
+		total += int64(n)
+		if err != nil {
+			return total, err
+		}
+		if n == 0 {
+			return total, io.ErrShortWrite
+		}
+	}
+	return total, nil
+}
+
+func directoryToImageParallel(ctx context.Context, inputDir, outputFile string, sizeBytes int64, opt ImageOptions) error {
+	if err := checkImageOutputPath(outputFile); err != nil {
+		return err
+	}
+
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
+	// Step 1: Create empty ext4 image.
+	if err := MakeEmptyImage(ctx, outputFile, sizeBytes); err != nil {
+		return status.WrapError(err, "create empty image")
+	}
+
+	// Step 2: Mount the image via loop device.
+	mountDir, err := os.MkdirTemp("", "ext4-mount-*")
+	if err != nil {
+		return status.InternalErrorf("create mount dir: %s", err)
+	}
+	defer os.Remove(mountDir)
+
+	unmount, err := mountImage(ctx, opt.ParallelCopy, outputFile, mountDir)
+	if err != nil {
+		return err
+	}
+	defer unmount()
+
+	// Step 3: Walk the source directory and copy files in parallel.
+	// Directories are created synchronously during the walk so they exist
+	// before any file copies land in them. File and symlink copies are
+	// dispatched to workers as the walk progresses.
+	workers := opt.CopyWorkers
+	if workers <= 0 {
+		workers = runtime.NumCPU()
+	}
+
+	eg, _ := errgroup.WithContext(ctx)
+	eg.SetLimit(workers)
+	err = filepath.WalkDir(inputDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(inputDir, path)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		dstPath := filepath.Join(mountDir, relPath)
+
+		if d.Type()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			eg.Go(func() error {
+				return os.Symlink(target, dstPath)
+			})
+			return nil
+		}
+
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode().Perm())
+		}
+
+		mode := info.Mode().Perm()
+		eg.Go(func() error {
+			return copyFile(path, dstPath, mode)
+		})
+		return nil
+	})
+	if err != nil {
+		return status.WrapError(err, "walk source directory")
+	}
+	if err := eg.Wait(); err != nil {
+		return status.WrapError(err, "parallel copy")
+	}
+
+	// Step 4: Unmount (sync data to image).
+	if err := unmount(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// mountImage mounts an ext4 image file at mountDir using the specified method.
+// It returns an unmount function that must be called to clean up. The unmount
+// function is safe to call multiple times; only the first call takes effect.
+func mountImage(ctx context.Context, method MountMethod, imageFile, mountDir string) (unmount func() error, err error) {
+	switch method {
+	case MountMethodExec:
+		return mountImageExec(ctx, imageFile, mountDir)
+	default:
+		return nil, status.InternalErrorf("unsupported mount method: %d", method)
+	}
+}
+
+func mountImageExec(ctx context.Context, imageFile, mountDir string) (func() error, error) {
+	mountCmd := exec.CommandContext(ctx, "mount", "-o", "loop,noatime", imageFile, mountDir)
+	if out, err := mountCmd.CombinedOutput(); err != nil {
+		return nil, status.InternalErrorf("mount: %s: %s", err, out)
+	}
+	done := false
+	return func() error {
+		if done {
+			return nil
+		}
+		done = true
+		umountCmd := exec.Command("umount", mountDir)
+		if out, err := umountCmd.CombinedOutput(); err != nil {
+			return status.InternalErrorf("umount: %s: %s", err, out)
+		}
+		return nil
+	}, nil
 }
 
 // MakeEmptyImage creates a new empty ext4 disk image of the specified size
@@ -240,3 +491,4 @@ func ImageToDirectory(ctx context.Context, inputFile, outputDir string, paths []
 	}
 	return nil
 }
+

--- a/enterprise/server/util/ext4/ext4.go
+++ b/enterprise/server/util/ext4/ext4.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -61,25 +60,8 @@ func EnsureDependencies() error {
 	return nil
 }
 
-// MountMethod specifies how to mount the ext4 image for parallel copy.
-type MountMethod int
-
-const (
-	// MountMethodNone disables parallel copy (use mke2fs -d instead).
-	MountMethodNone MountMethod = iota
-	// MountMethodExec uses the mount/umount commands.
-	MountMethodExec
-)
-
 // ImageOptions configures ext4 image creation.
 type ImageOptions struct {
-	// ParallelCopy specifies the mount method to use for parallel file
-	// copying. When set to MountMethodNone (default), mke2fs -d is used.
-	// Other values mount the image and copy files in parallel, which
-	// requires root or CAP_SYS_ADMIN.
-	ParallelCopy MountMethod
-	// CopyWorkers is the number of parallel copy workers to use when
-	// ParallelCopy is enabled. Defaults to runtime.NumCPU() if 0.
 	CopyWorkers int
 }
 
@@ -90,13 +72,12 @@ func DirectoryToImage(ctx context.Context, inputDir, outputFile string, sizeByte
 	if len(opts) > 0 {
 		opt = opts[0]
 	}
-
-	if opt.ParallelCopy != MountMethodNone {
-		return directoryToImageParallel(ctx, inputDir, outputFile, sizeBytes, opt)
-	}
-
 	if err := checkImageOutputPath(outputFile); err != nil {
 		return err
+	}
+
+	if opt.CopyWorkers > 0 {
+		return directoryToImageParallel(ctx, inputDir, outputFile, sizeBytes, opt)
 	}
 
 	ctx, span := tracing.StartSpan(ctx)
@@ -232,10 +213,6 @@ func sendfileAll(dstFd, srcFd int, size int64) (int64, error) {
 }
 
 func directoryToImageParallel(ctx context.Context, inputDir, outputFile string, sizeBytes int64, opt ImageOptions) error {
-	if err := checkImageOutputPath(outputFile); err != nil {
-		return err
-	}
-
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -251,7 +228,7 @@ func directoryToImageParallel(ctx context.Context, inputDir, outputFile string, 
 	}
 	defer os.Remove(mountDir)
 
-	unmount, err := mountImage(ctx, opt.ParallelCopy, outputFile, mountDir)
+	unmount, err := mountImage(ctx, outputFile, mountDir)
 	if err != nil {
 		return err
 	}
@@ -261,13 +238,14 @@ func directoryToImageParallel(ctx context.Context, inputDir, outputFile string, 
 	// Directories are created synchronously during the walk so they exist
 	// before any file copies land in them. File and symlink copies are
 	// dispatched to workers as the walk progresses.
-	workers := opt.CopyWorkers
-	if workers <= 0 {
-		workers = runtime.NumCPU()
+	serial := false
+	if opt.CopyWorkers < 0 {
+		serial = true
+		opt.CopyWorkers = 1
 	}
 
 	eg, _ := errgroup.WithContext(ctx)
-	eg.SetLimit(workers)
+	eg.SetLimit(opt.CopyWorkers)
 	err = filepath.WalkDir(inputDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -292,9 +270,15 @@ func directoryToImageParallel(ctx context.Context, inputDir, outputFile string, 
 			if err != nil {
 				return err
 			}
-			eg.Go(func() error {
-				return os.Symlink(target, dstPath)
-			})
+			if serial {
+				if err := os.Symlink(target, dstPath); err != nil {
+					return err
+				}
+			} else {
+				eg.Go(func() error {
+					return os.Symlink(target, dstPath)
+				})
+			}
 			return nil
 		}
 
@@ -303,6 +287,9 @@ func directoryToImageParallel(ctx context.Context, inputDir, outputFile string, 
 		}
 
 		mode := info.Mode().Perm()
+		if serial {
+			return copyFile(path, dstPath, mode)
+		}
 		eg.Go(func() error {
 			return copyFile(path, dstPath, mode)
 		})
@@ -323,19 +310,7 @@ func directoryToImageParallel(ctx context.Context, inputDir, outputFile string, 
 	return nil
 }
 
-// mountImage mounts an ext4 image file at mountDir using the specified method.
-// It returns an unmount function that must be called to clean up. The unmount
-// function is safe to call multiple times; only the first call takes effect.
-func mountImage(ctx context.Context, method MountMethod, imageFile, mountDir string) (unmount func() error, err error) {
-	switch method {
-	case MountMethodExec:
-		return mountImageExec(ctx, imageFile, mountDir)
-	default:
-		return nil, status.InternalErrorf("unsupported mount method: %d", method)
-	}
-}
-
-func mountImageExec(ctx context.Context, imageFile, mountDir string) (func() error, error) {
+func mountImage(ctx context.Context, imageFile, mountDir string) (func() error, error) {
 	mountCmd := exec.CommandContext(ctx, "mount", "-o", "loop,noatime", imageFile, mountDir)
 	if out, err := mountCmd.CombinedOutput(); err != nil {
 		return nil, status.InternalErrorf("mount: %s: %s", err, out)
@@ -491,4 +466,3 @@ func ImageToDirectory(ctx context.Context, inputFile, outputDir string, paths []
 	}
 	return nil
 }
-

--- a/enterprise/server/util/ext4/ext4_test.go
+++ b/enterprise/server/util/ext4/ext4_test.go
@@ -183,41 +183,51 @@ func BenchmarkDirectoryToImage(b *testing.B) {
 			os.Remove(outputFile)
 		}
 	})
-	b.Run("parallel_mount_exec", func(b *testing.B) {
+	b.Run("parallel_0", func(b *testing.B) {
 		b.SetBytes(imageSize)
-		outputFile := filepath.Join(outputDir, "exec.ext4")
+		outputFile := filepath.Join(outputDir, "exec0.ext4")
 		for b.Loop() {
-			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{ParallelCopy: ext4.MountMethodExec, CopyWorkers: 4}); err != nil {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{CopyWorkers: -1}); err != nil {
 				b.Fatal(err)
 			}
 			os.Remove(outputFile)
 		}
 	})
-	b.Run("parallel_mount_exec_2", func(b *testing.B) {
+	b.Run("parallel_1", func(b *testing.B) {
 		b.SetBytes(imageSize)
-		outputFile := filepath.Join(outputDir, "exec.ext4")
+		outputFile := filepath.Join(outputDir, "exec1.ext4")
 		for b.Loop() {
-			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{ParallelCopy: ext4.MountMethodExec, CopyWorkers: 2}); err != nil {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{CopyWorkers: 1}); err != nil {
 				b.Fatal(err)
 			}
 			os.Remove(outputFile)
 		}
 	})
-	b.Run("parallel_mount_exec_8", func(b *testing.B) {
+	b.Run("parallel_2", func(b *testing.B) {
 		b.SetBytes(imageSize)
-		outputFile := filepath.Join(outputDir, "exec.ext4")
+		outputFile := filepath.Join(outputDir, "exec2.ext4")
 		for b.Loop() {
-			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{ParallelCopy: ext4.MountMethodExec, CopyWorkers: 8}); err != nil {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{CopyWorkers: 2}); err != nil {
 				b.Fatal(err)
 			}
 			os.Remove(outputFile)
 		}
 	})
-	b.Run("parallel_mount_exec_num_cpu", func(b *testing.B) {
+	b.Run("parallel_4", func(b *testing.B) {
 		b.SetBytes(imageSize)
-		outputFile := filepath.Join(outputDir, "exec.ext4")
+		outputFile := filepath.Join(outputDir, "exec4.ext4")
 		for b.Loop() {
-			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{ParallelCopy: ext4.MountMethodExec}); err != nil {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{CopyWorkers: 4}); err != nil {
+				b.Fatal(err)
+			}
+			os.Remove(outputFile)
+		}
+	})
+	b.Run("parallel_8", func(b *testing.B) {
+		b.SetBytes(imageSize)
+		outputFile := filepath.Join(outputDir, "exec8.ext4")
+		for b.Loop() {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{CopyWorkers: 8}); err != nil {
 				b.Fatal(err)
 			}
 			os.Remove(outputFile)

--- a/enterprise/server/util/ext4/ext4_test.go
+++ b/enterprise/server/util/ext4/ext4_test.go
@@ -4,8 +4,10 @@ package ext4_test
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,6 +21,209 @@ import (
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
+
+// writeRandomFile writes a file filled with pseudo-random bytes of the given size.
+func writeRandomFile(b *testing.B, dir, name string, size int, rng *rand.Rand) {
+	b.Helper()
+	buf := make([]byte, size)
+	rng.Read(buf)
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buf, 0644); err != nil {
+		b.Fatal(err)
+	}
+}
+
+// makeDockerImageDir creates a directory structure resembling a ~1GB container
+// image. If parentDir is non-empty, the directory is created under it.
+func makeDockerImageDir(b *testing.B, parentDir string) string {
+	b.Helper()
+	var root string
+	if parentDir != "" {
+		var err error
+		root, err = os.MkdirTemp(parentDir, "dockerimg-*")
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Cleanup(func() { os.RemoveAll(root) })
+	} else {
+		root = testfs.MakeTempDir(b)
+	}
+
+	dirs := []string{
+		"etc", "etc/apt", "etc/default", "etc/security", "etc/ssl/certs",
+		"usr/bin", "usr/sbin",
+		"usr/lib/x86_64-linux-gnu", "usr/lib/python3/dist-packages",
+		"usr/share/doc", "usr/share/man/man1", "usr/share/locale",
+		"var/lib/apt/lists", "var/lib/dpkg/info",
+		"var/cache", "var/log",
+		"opt/app/data", "opt/app/lib",
+		"tmp",
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(root, d), 0755); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	rng := rand.New(rand.NewSource(42))
+	var totalBytes int64
+
+	// /etc: ~200 small config files, 512B-4KB each (~400KB total)
+	for i := 0; i < 200; i++ {
+		size := 512 + rng.Intn(3584)
+		writeRandomFile(b, filepath.Join(root, "etc"), fmt.Sprintf("config_%03d.conf", i), size, rng)
+		totalBytes += int64(size)
+	}
+
+	// /usr/bin: ~300 executables, 50KB-500KB each (~80MB total)
+	for i := 0; i < 300; i++ {
+		size := 50*1024 + rng.Intn(450*1024)
+		writeRandomFile(b, filepath.Join(root, "usr/bin"), fmt.Sprintf("binary_%03d", i), size, rng)
+		totalBytes += int64(size)
+	}
+
+	// /usr/lib shared libraries: ~150 files, 1MB-10MB each (~800MB total)
+	for i := 0; i < 150; i++ {
+		size := 1*1024*1024 + rng.Intn(9*1024*1024)
+		writeRandomFile(b, filepath.Join(root, "usr/lib/x86_64-linux-gnu"), fmt.Sprintf("lib%03d.so.1.0", i), size, rng)
+		totalBytes += int64(size)
+	}
+
+	// /usr/share/doc: ~500 small text files, 1KB-8KB each (~2MB total)
+	for i := 0; i < 500; i++ {
+		subdir := filepath.Join(root, "usr/share/doc", fmt.Sprintf("package-%03d", i))
+		os.MkdirAll(subdir, 0755)
+		size := 1024 + rng.Intn(7*1024)
+		writeRandomFile(b, subdir, "README", size, rng)
+		totalBytes += int64(size)
+	}
+
+	// /var/lib/dpkg/info: ~400 small package metadata files (~2MB total)
+	for i := 0; i < 400; i++ {
+		size := 256 + rng.Intn(4096)
+		writeRandomFile(b, filepath.Join(root, "var/lib/dpkg/info"), fmt.Sprintf("pkg%03d.list", i), size, rng)
+		totalBytes += int64(size)
+	}
+
+	// /opt/app/data: a few large data files to reach ~1GB total
+	remaining := int64(1024*1024*1024) - totalBytes
+	if remaining > 0 {
+		// Split remaining into 2-4 large files
+		nLarge := 2 + rng.Intn(3)
+		for i := 0; i < nLarge; i++ {
+			size := int(remaining) / nLarge
+			writeRandomFile(b, filepath.Join(root, "opt/app/data"), fmt.Sprintf("data_%02d.bin", i), size, rng)
+		}
+	}
+
+	// Symlinks (typical in container images)
+	os.Symlink("/usr/bin/binary_000", filepath.Join(root, "usr/sbin/link_to_binary"))
+	os.Symlink("/etc/ssl/certs", filepath.Join(root, "usr/share/ca-certificates"))
+
+	// b.Logf("Created docker-like directory at %s (~1GB)", root)
+	return root
+}
+
+// makeTmpfs creates a tmpfs mount of the given size and returns its path.
+// The mount is automatically cleaned up when the test finishes.
+func makeTmpfs(b *testing.B, size string) string {
+	b.Helper()
+	dir, err := os.MkdirTemp("", "ext4-bench-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	cmd := exec.Command("mount", "-t", "tmpfs", "-o", "size="+size, "tmpfs", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		os.Remove(dir)
+		b.Fatalf("mount tmpfs: %s: %s", err, out)
+	}
+	b.Cleanup(func() {
+		exec.Command("umount", dir).Run()
+		os.Remove(dir)
+	})
+	return dir
+}
+
+func alignToMultiple(n int64, multiple int64) int64 {
+	remainder := n % multiple
+
+	// If remainder is zero, n is already aligned
+	if remainder == 0 {
+		return n
+	}
+	// Otherwise, adjust n to the next multiple of size
+	return n + multiple - remainder
+}
+
+func BenchmarkDirectoryToImage(b *testing.B) {
+	ctx := context.Background()
+
+	// Use tmpfs for both input and output to eliminate disk I/O noise.
+	tmpfs := makeTmpfs(b, "4G")
+	inputDir := makeDockerImageDir(b, tmpfs)
+	outputDir, err := os.MkdirTemp(tmpfs, "output-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	dirSize, err := ext4.DiskSizeBytes(ctx, inputDir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	imageSize := int64(float64(dirSize)*1.2) + ext4.MinDiskImageSizeBytes
+	imageSize = alignToMultiple(imageSize, int64(os.Getpagesize()))
+
+	b.Run("baseline", func(b *testing.B) {
+		b.SetBytes(imageSize)
+		outputFile := filepath.Join(outputDir, "baseline.ext4")
+		for b.Loop() {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize); err != nil {
+				b.Fatal(err)
+			}
+			os.Remove(outputFile)
+		}
+	})
+	b.Run("parallel_mount_exec", func(b *testing.B) {
+		b.SetBytes(imageSize)
+		outputFile := filepath.Join(outputDir, "exec.ext4")
+		for b.Loop() {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{ParallelCopy: ext4.MountMethodExec, CopyWorkers: 4}); err != nil {
+				b.Fatal(err)
+			}
+			os.Remove(outputFile)
+		}
+	})
+	b.Run("parallel_mount_exec_2", func(b *testing.B) {
+		b.SetBytes(imageSize)
+		outputFile := filepath.Join(outputDir, "exec.ext4")
+		for b.Loop() {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{ParallelCopy: ext4.MountMethodExec, CopyWorkers: 2}); err != nil {
+				b.Fatal(err)
+			}
+			os.Remove(outputFile)
+		}
+	})
+	b.Run("parallel_mount_exec_8", func(b *testing.B) {
+		b.SetBytes(imageSize)
+		outputFile := filepath.Join(outputDir, "exec.ext4")
+		for b.Loop() {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{ParallelCopy: ext4.MountMethodExec, CopyWorkers: 8}); err != nil {
+				b.Fatal(err)
+			}
+			os.Remove(outputFile)
+		}
+	})
+	b.Run("parallel_mount_exec_num_cpu", func(b *testing.B) {
+		b.SetBytes(imageSize)
+		outputFile := filepath.Join(outputDir, "exec.ext4")
+		for b.Loop() {
+			if err := ext4.DirectoryToImage(ctx, inputDir, outputFile, imageSize, ext4.ImageOptions{ParallelCopy: ext4.MountMethodExec}); err != nil {
+				b.Fatal(err)
+			}
+			os.Remove(outputFile)
+		}
+	})
+}
 
 func randomDir(subDirs []string) string {
 	pathParts := []string{}


### PR DESCRIPTION
Create an empty image and then copy to it in parallel. Benchmark results coming soon, but it's almost twice as fast with 4 goroutines.