### PR TITLE
Don't log failed attempts when polling for execution

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1177,9 +1177,12 @@ func attemptRun(ctx context.Context, bbClient bbspb.BuildBuddyServiceClient, exe
 	})
 	eg.Go(func() error {
 		execution, err := retry.Do(ctx, &retry.Options{
-			InitialBackoff: 500 * time.Millisecond,
-			MaxBackoff:     5 * time.Second,
-			Multiplier:     2,
+			InitialBackoff:        500 * time.Millisecond,
+			MaxBackoff:            5 * time.Second,
+			Multiplier:            2,
+			// Failed attempts are expected here since we're polling for
+			// existence.
+			DontLogFailedAttempts: true,
 		}, func(ctx context.Context) (*espb.GetExecutionResponse, error) {
 			execution, err := bbClient.GetExecution(ctx, &espb.GetExecutionRequest{ExecutionLookup: &espb.ExecutionLookup{
 				InvocationId: iid,

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1180,6 +1180,9 @@ func attemptRun(ctx context.Context, bbClient bbspb.BuildBuddyServiceClient, exe
 			InitialBackoff: 500 * time.Millisecond,
 			MaxBackoff:     5 * time.Second,
 			Multiplier:     2,
+			// Failed attempts are expected here since we're polling for
+			// existence.
+			DontLogFailedAttempts: true,
 		}, func(ctx context.Context) (*espb.GetExecutionResponse, error) {
 			execution, err := bbClient.GetExecution(ctx, &espb.GetExecutionRequest{ExecutionLookup: &espb.ExecutionLookup{
 				InvocationId: iid,


### PR DESCRIPTION
The suggestion from this issue seemed reasonable: https://github.com/buildbuddy-io/buildbuddy/issues/11927