### PR TITLE
Add execution metadata size metrics

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1456,6 +1456,8 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 				// Errors updating the router or recording usage are non-fatal.
 				log.CtxErrorf(ctx, "Could not update post-completion metadata: %s", err)
 			}
+
+			recordResponseMetrics(response, auxMeta, s.getGroupIDForMetrics(ctx))
 		}
 		data, err := proto.Marshal(op)
 		if err != nil {
@@ -1496,6 +1498,20 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 				}
 			}
 		}
+	}
+}
+
+// records prometheus metrics about the response + metadata sizes.
+func recordResponseMetrics(rsp *repb.ExecuteResponse, auxMD *espb.ExecutionAuxiliaryMetadata, groupID string) {
+	if timeline := rsp.GetResult().GetExecutionMetadata().GetUsageStats().GetTimeline(); timeline != nil {
+		metrics.RemoteExecutionResourceUsageTimelineMetadataSizeBytes.With(prometheus.Labels{
+			metrics.GroupID: groupID,
+		}).Observe(float64(proto.Size(timeline)))
+	}
+	if inputFetchMetadata := auxMD.GetInputFetchDetailedStats(); inputFetchMetadata != nil {
+		metrics.RemoteExecutionInputDownloadBitmapMetadataSizeBytes.With(prometheus.Labels{
+			metrics.GroupID: groupID,
+		}).Observe(float64(proto.Size(inputFetchMetadata)))
 	}
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1228,6 +1228,26 @@ var (
 		StatusHumanReadableLabel,
 	})
 
+	RemoteExecutionResourceUsageTimelineMetadataSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "resource_usage_timeline_metadata_size_bytes",
+		Help:      "Total size of resource usage timeline payloads received from executors.",
+		Buckets:   exponentialBucketRange(1, 100e6, 1.5),
+	}, []string{
+		GroupID,
+	})
+
+	RemoteExecutionInputDownloadBitmapMetadataSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "input_download_bitmap_metadata_size_bytes",
+		Help:      "Total size of input download bitmaps received from executors.",
+		Buckets:   exponentialBucketRange(1, 100e6, 1.5),
+	}, []string{
+		GroupID,
+	})
+
 	RemoteExecutionEnqueuedTaskMilliCPU = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",


### PR DESCRIPTION
Add metrics for the input downloads bitmap size, and retroactively add metrics for the usage timeline size as well since those can also get somewhat large.