### PR TITLE
[CLI Feature] Add structured output to `bb explain`

### DIFF
--- a/cli/explain/BUILD
+++ b/cli/explain/BUILD
@@ -22,6 +22,8 @@ go_library(
         "@com_github_google_go_cmp//cmp",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -32,6 +32,8 @@ import (
 	"golang.org/x/sync/errgroup"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -74,11 +76,13 @@ func (m MapFlag) Set(s string) error {
 }
 
 var (
-	explainCmd = flag.NewFlagSet("explain", flag.ContinueOnError)
-	oldLog     = explainCmd.String("old", "", "Path to a compact execution log or invocation ID of a build to consider as the baseline for the diff.")
-	newLog     = explainCmd.String("new", "", "Path to a compact execution log or invocation ID of a build to compare against the baseline.")
-	verbose    = explainCmd.Bool("verbose", false, "Print more detailed execution information.")
-	apiTarget  = explainCmd.String("target", "", "The API target to use for fetching logs instead of the last --bes_backend.")
+	explainCmd   = flag.NewFlagSet("explain", flag.ContinueOnError)
+	Flags        = explainCmd
+	oldLog       = explainCmd.String("old", "", "Path to a compact execution log or invocation ID of a build to consider as the baseline for the diff.")
+	newLog       = explainCmd.String("new", "", "Path to a compact execution log or invocation ID of a build to compare against the baseline.")
+	verbose      = explainCmd.Bool("verbose", false, "Print more detailed execution information.")
+	apiTarget    = explainCmd.String("target", "", "The API target to use for fetching logs instead of the last --bes_backend.")
+	outputFormat = explainCmd.String("output_format", "text", "Output format: text, json, or proto.")
 
 	profilePaths = make(MapFlag)
 )
@@ -136,8 +140,26 @@ func HandleExplain(args []string) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	writeHeader(os.Stdout, diffResult.OldInvocationId, diffResult.NewInvocationId)
-	writeSpawnDiffs(os.Stdout, diffResult.SpawnDiffs)
+	switch *outputFormat {
+	case "text":
+		writeHeader(os.Stdout, diffResult.OldInvocationId, diffResult.NewInvocationId)
+		writeSpawnDiffs(os.Stdout, diffResult.SpawnDiffs)
+	case "json":
+		b, err := protojson.MarshalOptions{Multiline: true, UseProtoNames: true}.Marshal(diffResult)
+		if err != nil {
+			return -1, fmt.Errorf("failed to marshal diff result as JSON: %v", err)
+		}
+		_, _ = os.Stdout.Write(b)
+		_, _ = fmt.Fprintln(os.Stdout)
+	case "proto":
+		b, err := proto.Marshal(diffResult)
+		if err != nil {
+			return -1, fmt.Errorf("failed to marshal diff result as proto: %v", err)
+		}
+		_, _ = os.Stdout.Write(b)
+	default:
+		return 1, fmt.Errorf("unknown --output_format %q: must be text, json, or proto", *outputFormat)
+	}
 
 	for profile, p := range profilePaths {
 		if profile == "cpu" {

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -32,11 +32,13 @@ import (
 	"golang.org/x/sync/errgroup"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
 	explainCmdUsage = `
-usage: bb explain [--old {FILE | INVOCATION_ID} [--new {FILE | INVOCATION_ID}]]
+usage: bb explain [--old {FILE | INVOCATION_ID}] [--new {FILE | INVOCATION_ID}] [--output_format {text|json|proto}]
 
 Displays a human-readable, structural diff of two compact execution logs, either
 obtained from the given invocations or located at the given file paths.
@@ -47,6 +49,11 @@ build is used as the "old" log.
 
 Use the --execution_log_compact_file flag to have Bazel produce a compact
 execution log and upload it to the BuildBuddy BES backend.
+
+Output formats:
+  text   Unstructured output (default)
+  json   Structured output as JSON
+  proto  Structured output as binary proto
 `
 )
 
@@ -74,12 +81,13 @@ func (m MapFlag) Set(s string) error {
 }
 
 var (
-	explainCmd = flag.NewFlagSet("explain", flag.ContinueOnError)
-	Flags      = explainCmd
-	oldLog     = explainCmd.String("old", "", "Path to a compact execution log or invocation ID of a build to consider as the baseline for the diff.")
-	newLog     = explainCmd.String("new", "", "Path to a compact execution log or invocation ID of a build to compare against the baseline.")
-	verbose    = explainCmd.Bool("verbose", false, "Print more detailed execution information.")
-	apiTarget  = explainCmd.String("target", "", "The API target to use for fetching logs instead of the last --bes_backend.")
+	explainCmd   = flag.NewFlagSet("explain", flag.ContinueOnError)
+	Flags        = explainCmd
+	oldLog       = explainCmd.String("old", "", "Path to a compact execution log or invocation ID of a build to consider as the baseline for the diff.")
+	newLog       = explainCmd.String("new", "", "Path to a compact execution log or invocation ID of a build to compare against the baseline.")
+	verbose      = explainCmd.Bool("verbose", false, "Print more detailed execution information.")
+	apiTarget    = explainCmd.String("target", "", "The API target to use for fetching logs instead of the last --bes_backend.")
+	outputFormat = explainCmd.String("output_format", "text", "Output format: text, json, or proto.")
 
 	profilePaths = make(MapFlag)
 )
@@ -137,8 +145,26 @@ func HandleExplain(args []string) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	writeHeader(os.Stdout, diffResult.OldInvocationId, diffResult.NewInvocationId)
-	writeSpawnDiffs(os.Stdout, diffResult.SpawnDiffs)
+	switch *outputFormat {
+	case "text":
+		writeHeader(os.Stdout, diffResult.OldInvocationId, diffResult.NewInvocationId)
+		writeSpawnDiffs(os.Stdout, diffResult.SpawnDiffs)
+	case "json":
+		b, err := protojson.MarshalOptions{Multiline: true, UseProtoNames: true}.Marshal(diffResult)
+		if err != nil {
+			return -1, fmt.Errorf("failed to marshal diff result as JSON: %v", err)
+		}
+		_, _ = os.Stdout.Write(b)
+		_, _ = fmt.Fprintln(os.Stdout)
+	case "proto":
+		b, err := proto.Marshal(diffResult)
+		if err != nil {
+			return -1, fmt.Errorf("failed to marshal diff result as proto: %v", err)
+		}
+		_, _ = os.Stdout.Write(b)
+	default:
+		return 1, fmt.Errorf("unknown --output_format %q: must be text, json, or proto", *outputFormat)
+	}
 
 	for profile, p := range profilePaths {
 		if profile == "cpu" {

--- a/cli/test/integration/compact/BUILD
+++ b/cli/test/integration/compact/BUILD
@@ -2,10 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/**"]),
+)
+
 go_test(
     name = "compact_test",
     srcs = ["compact_test.go"],
-    data = glob(["testdata/**"]),
+    data = [":testdata"],
     deps = [
         "//cli/testutil/testcli",
         "@com_github_stretchr_testify//assert",

--- a/cli/test/integration/explain/BUILD
+++ b/cli/test/integration/explain/BUILD
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+package(default_visibility = ["//cli:__subpackages__"])
+
+go_test(
+    name = "explain_test",
+    srcs = ["explain_test.go"],
+    data = ["//cli/test/integration/compact:testdata"],
+    deps = [
+        "//cli/testutil/testcli",
+        "//proto:spawn_diff_go_proto",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/runfiles",
+        "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_google_protobuf//proto",
+    ],
+)

--- a/cli/test/integration/explain/explain_test.go
+++ b/cli/test/integration/explain/explain_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"path"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+	"github.com/buildbuddy-io/buildbuddy/cli/testutil/testcli"
+	spawn_diff "github.com/buildbuddy-io/buildbuddy/proto/spawn_diff"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+const testdataDir = "com_github_buildbuddy_io_buildbuddy/cli/test/integration/compact/testdata"
+
+func testdataPath(t *testing.T, name string) string {
+	t.Helper()
+	p, err := runfiles.Rlocation(path.Join(testdataDir, name))
+	require.NoError(t, err)
+	return p
+}
+
+// The two compact execution logs are for builds of the same two genrule
+// targets but with different output contents, so we expect bb explain to
+// report both spawns as modified.
+func assertExpectedDiff(t *testing.T, result *spawn_diff.DiffResult) {
+	t.Helper()
+	require.Len(t, result.GetSpawnDiffs(), 2)
+	var labels []string
+	for _, sd := range result.GetSpawnDiffs() {
+		labels = append(labels, sd.GetTargetLabel())
+		assert.Equal(t, "Genrule", sd.GetMnemonic())
+		assert.NotNil(t, sd.GetModified(), "expected spawn %q to be modified", sd.GetTargetLabel())
+		assert.NotEmpty(t, sd.GetModified().GetDiffs(), "expected spawn %q to have at least one diff", sd.GetTargetLabel())
+	}
+	assert.ElementsMatch(t, []string{
+		"//server/version:populate_commit",
+		"//server/version:populate_version",
+	}, labels)
+}
+
+func TestExplainJsonOutputIsClean(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	old := testdataPath(t, "1.binpb.zst")
+	new := testdataPath(t, "2.binpb.zst")
+
+	stdout, stderr, err := testcli.SplitOutput(
+		testcli.Command(t, ws, "explain",
+			"--old="+old,
+			"--new="+new,
+			"--output_format=json",
+		),
+	)
+	require.NoError(t, err, "bb explain failed; stderr: %s", stderr)
+
+	var result spawn_diff.DiffResult
+	require.NoError(t, protojson.Unmarshal(stdout, &result),
+		"stdout should be valid protojson with no extra output from the CLI stack; stdout: %q", stdout)
+	assertExpectedDiff(t, &result)
+}
+
+func TestExplainProtoOutputIsClean(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	old := testdataPath(t, "1.binpb.zst")
+	new := testdataPath(t, "2.binpb.zst")
+
+	stdout, stderr, err := testcli.SplitOutput(
+		testcli.Command(t, ws, "explain",
+			"--old="+old,
+			"--new="+new,
+			"--output_format=proto",
+		),
+	)
+	require.NoError(t, err, "bb explain failed; stderr: %s", stderr)
+
+	var result spawn_diff.DiffResult
+	require.NoError(t, proto.Unmarshal(stdout, &result),
+		"stdout should be valid proto binary with no extra output from the CLI stack; stdout len: %d", len(stdout))
+	assertExpectedDiff(t, &result)
+}


### PR DESCRIPTION
Adds option for structured output in the form of json or proto to `bb explain` to be used with other automated tools.