### PR TITLE
[FC] Eagerly unmap chunks in COWStores that expect sequential access

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -3258,11 +3258,12 @@ func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDe
 		if err := os.Mkdir(memChunkDir, 0755); err != nil {
 			return nil, status.WrapError(err, "make memory chunk dir")
 		}
-
 		memorySizeBytes := c.vmConfig.GetMemSizeMb() * 1024 * 1024
 		if memorySizeBytes <= 0 {
 			return nil, status.InternalErrorf("invalid memory snapshot size %d bytes", memorySizeBytes)
 		}
+
+		snapshotWriteConcurrency := int64(math.Max(snaputil.WriteSnapshotChunkConcurrency, float64(c.vmConfig.GetNumCpus())))
 		memoryStore, err := copy_on_write.NewCOWStore(c.vmCtx, c.env, memoryChunkDirName, nil, copy_on_write.COWOptions{
 			ChunkSizeBytes:     cowChunkSizeBytes(),
 			TotalSizeBytes:     memorySizeBytes,
@@ -3271,7 +3272,9 @@ func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDe
 			RemoteEnabled:      c.supportsRemoteSnapshots,
 			// Firecracker exports snapshots sequentially, so we should limit the number of chunks mmapped at a time
 			// because they won't be accessed again.
-			UseLimitedPrivateMmapLRU: true,
+			// We use the same concurrency as with snapshot writes (plus a little buffer) because that's the max number of chunks we expect to be
+			// accessed at a time.
+			MaxMmappedChunks: snapshotWriteConcurrency + 4,
 		})
 		if err != nil {
 			return nil, status.WrapError(err, "create memory COWStore")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -3263,7 +3263,16 @@ func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDe
 		if memorySizeBytes <= 0 {
 			return nil, status.InternalErrorf("invalid memory snapshot size %d bytes", memorySizeBytes)
 		}
-		memoryStore, err := copy_on_write.NewCOWStore(c.vmCtx, c.env, memoryChunkDirName, nil, cowChunkSizeBytes(), memorySizeBytes, memChunkDir, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.supportsRemoteSnapshots)
+		memoryStore, err := copy_on_write.NewCOWStore(c.vmCtx, c.env, memoryChunkDirName, nil, copy_on_write.COWOptions{
+			ChunkSizeBytes:     cowChunkSizeBytes(),
+			TotalSizeBytes:     memorySizeBytes,
+			DataDir:            memChunkDir,
+			RemoteInstanceName: c.snapshotKeySet.GetBranchKey().GetInstanceName(),
+			RemoteEnabled:      c.supportsRemoteSnapshots,
+			// Firecracker exports snapshots sequentially, so we should limit the number of chunks mmapped at a time
+			// because they won't be accessed again.
+			UseLimitedPrivateMmapLRU: true,
+		})
 		if err != nil {
 			return nil, status.WrapError(err, "create memory COWStore")
 		}

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -156,13 +156,33 @@ type COWStore struct {
 	// usageLock protects chunkOperationToUsageSummary
 	usageLock                    sync.Mutex
 	chunkOperationToUsageSummary map[string]usageSummary
+
+	// LRU used to limit the number of chunks that can be mmapped at once.
+	mmapLRU *MmapLRU
+}
+
+type COWOptions struct {
+	ChunkSizeBytes     int64
+	TotalSizeBytes     int64
+	DataDir            string
+	RemoteInstanceName string
+	RemoteEnabled      bool
+	// By default, mmapped chunks are managed by the executor-wide shared LRU.
+	//
+	// If UseLimitedPrivateMmapLRU is true, this store uses its own LRU sized to hold
+	// at most 4 chunks. This is useful for sequential access patterns where we
+	// don't want recently touched chunks to stay mmapped longer than necessary.
+	// This is useful when we're writing a snapshot file, for example, but should
+	// never be set for a COWStore that is being used by a guest and will have
+	// non-sequential access patterns.
+	UseLimitedPrivateMmapLRU bool
 }
 
 // NewCOWStore creates a COWStore from the given chunks. The chunks should be
 // open initially, and will be closed when calling Close on the returned
 // COWStore.
-func NewCOWStore(ctx context.Context, env environment.Env, name string, chunks []*Mmap, chunkSizeBytes, totalSizeBytes int64, dataDir string, remoteInstanceName string, remoteEnabled bool) (*COWStore, error) {
-	stat, err := os.Stat(dataDir)
+func NewCOWStore(ctx context.Context, env environment.Env, name string, chunks []*Mmap, opts COWOptions) (*COWStore, error) {
+	stat, err := os.Stat(opts.DataDir)
 	if err != nil {
 		return nil, err
 	}
@@ -170,41 +190,64 @@ func NewCOWStore(ctx context.Context, env environment.Env, name string, chunks [
 	for _, c := range chunks {
 		chunkMap[c.Offset] = c
 	}
-	eagerFetchStack, err := boundedstack.New[int64](eagerFetchBufferCapacity)
-	if err != nil {
-		return nil, err
+
+	var lru *MmapLRU
+	var eagerFetchStack *boundedstack.BoundedStack[int64]
+	if opts.UseLimitedPrivateMmapLRU {
+		// If reads/writes are expected to be sequential, we should only need a max of 2 chunks mmapped when accessing at chunk boundaries.
+		// Set the limit to 4 chunks to add a bit of buffer.
+		lru, err = NewMmapLRU(opts.ChunkSizeBytes * 4)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		lru, err = GetSharedMmapLRU(opts.DataDir)
+		if err != nil {
+			return nil, err
+		}
+		eagerFetchStack, err = boundedstack.New[int64](eagerFetchBufferCapacity)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	s := &COWStore{
 		name:               name,
 		ctx:                ctx,
 		env:                env,
-		remoteInstanceName: remoteInstanceName,
-		remoteEnabled:      remoteEnabled,
+		remoteInstanceName: opts.RemoteInstanceName,
+		remoteEnabled:      opts.RemoteEnabled,
 		chunkLock:          lockmap.New(),
 		chunks:             chunkMap,
 		dirty:              make(map[int64]bool, 0),
 		partiallyMapped:    make(map[int64]bool, 0),
-		dataDir:            dataDir,
+		dataDir:            opts.DataDir,
 		copyBufPool: sync.Pool{
 			New: func() any {
-				b := make([]byte, chunkSizeBytes)
+				b := make([]byte, opts.ChunkSizeBytes)
 				return &b
 			},
 		},
-		zeroBuf:                      make([]byte, chunkSizeBytes),
-		chunkSizeBytes:               chunkSizeBytes,
-		totalSizeBytes:               totalSizeBytes,
+		zeroBuf:                      make([]byte, opts.ChunkSizeBytes),
+		chunkSizeBytes:               opts.ChunkSizeBytes,
+		totalSizeBytes:               opts.TotalSizeBytes,
 		ioBlockSize:                  int64(stat.Sys().(*syscall.Stat_t).Blksize),
 		eagerFetchStack:              eagerFetchStack,
 		eagerFetchEg:                 &errgroup.Group{},
 		quitChan:                     make(chan struct{}),
 		chunkOperationToUsageSummary: make(map[string]usageSummary, 0),
+		mmapLRU:                      lru,
 	}
 
-	s.eagerFetchEg.Go(func() error {
-		s.eagerFetchChunksInBackground()
-		return nil
-	})
+	// Stores using a limited private mmap LRU are expected to be accessed
+	// sequentially. In that case, if chunks are accessed once in order,
+	// pre-fetching farther ahead could cause unnecessary churn in the LRU.
+	if !opts.UseLimitedPrivateMmapLRU {
+		s.eagerFetchEg.Go(func() error {
+			s.eagerFetchChunksInBackground()
+			return nil
+		})
+	}
 
 	return s, nil
 }
@@ -487,6 +530,10 @@ func (s *COWStore) Close() error {
 
 	_ = s.chunkLock.Close()
 
+	if !s.mmapLRU.isShared {
+		s.mmapLRU.Close()
+	}
+
 	return lastErr
 }
 
@@ -660,7 +707,7 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 		}
 		chunkSource = ogChunk.source
 	}
-	newChunk, err = NewMmapFd(s.ctx, s.env, s.DataDir(), true /*=dirty*/, fd, int(size), offset, chunkSource, s.remoteInstanceName, s.remoteEnabled)
+	newChunk, err = NewMmapFd(s.ctx, s.env, s.DataDir(), true /*=dirty*/, fd, int(size), offset, chunkSource, s.remoteInstanceName, s.remoteEnabled, s.mmapLRU)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -803,6 +850,11 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 		return nil, err
 	}
 
+	sharedLRU, err := GetSharedMmapLRU(dataDir)
+	if err != nil {
+		return nil, err
+	}
+
 	createChunk := func(f *os.File, chunkStartOffset int64) (*Mmap, error) {
 		fd := int(f.Fd())
 		// Check if there's any data in the chunk, to avoid writing a file if
@@ -874,7 +926,7 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 				return nil, err
 			}
 		}
-		return NewMmapLocalFile(ctx, env, dataDir, false /*=dirty*/, int(chunkFileSize), chunkStartOffset, remoteInstanceName, remoteEnabled)
+		return NewMmapLocalFile(ctx, env, dataDir, false /*=dirty*/, int(chunkFileSize), chunkStartOffset, remoteInstanceName, remoteEnabled, sharedLRU)
 	}
 
 	eg, egCtx := errgroup.WithContext(ctx)
@@ -921,7 +973,13 @@ chunkLoop:
 	}
 
 	name := filepath.Base(filePath)
-	return NewCOWStore(ctx, env, name, chunks, chunkSizeBytes, totalSizeBytes, dataDir, remoteInstanceName, remoteEnabled)
+	return NewCOWStore(ctx, env, name, chunks, COWOptions{
+		ChunkSizeBytes:     chunkSizeBytes,
+		TotalSizeBytes:     totalSizeBytes,
+		DataDir:            dataDir,
+		RemoteInstanceName: remoteInstanceName,
+		RemoteEnabled:      remoteEnabled,
+	})
 }
 
 func getFileSize(filePath string) (totalSizeBytes int64, err error) {
@@ -937,9 +995,9 @@ func getFileSize(filePath string) (totalSizeBytes int64, err error) {
 	return stat.Size(), nil
 }
 
-// getMmapLRU returns the shared LRU instance to be used for the mmap,
+// GetSharedMmapLRU returns the shared LRU instance to be used for the mmap,
 // if applicable.
-func getMmapLRU(dataDir string) (*MmapLRU, error) {
+func GetSharedMmapLRU(dataDir string) (*MmapLRU, error) {
 	// We constrain UFFD memory usage by only allowing one chunk to be mapped
 	// at once, so don't use the shared LRU for UFFD.
 	if filepath.Base(dataDir) != snaputil.MemoryFileName {
@@ -988,16 +1046,12 @@ type Mmap struct {
 
 // NewLazyMmap returns an mmap that is set up only when the file is read or
 // written to.
-func NewLazyMmap(ctx context.Context, env environment.Env, dataDir string, offset int64, digest *repb.Digest, remoteInstanceName string, remoteEnabled bool) (*Mmap, error) {
+func NewLazyMmap(ctx context.Context, env environment.Env, dataDir string, offset int64, digest *repb.Digest, remoteInstanceName string, remoteEnabled bool, lru *MmapLRU) (*Mmap, error) {
 	if dataDir == "" {
 		return nil, status.FailedPreconditionError("missing dataDir")
 	}
 	if digest == nil {
 		return nil, status.FailedPreconditionError("missing digest")
-	}
-	lru, err := getMmapLRU(dataDir)
-	if err != nil {
-		return nil, err
 	}
 	return &Mmap{
 		ctx:                ctx,
@@ -1016,15 +1070,11 @@ func NewLazyMmap(ctx context.Context, env environment.Env, dataDir string, offse
 }
 
 // NewMmapFd returns an eagerly mmapped instance from the given fd.
-func NewMmapFd(ctx context.Context, env environment.Env, dataDir string, dirty bool, fd, size int, offset int64, source snaputil.ChunkSource, remoteInstanceName string, remoteEnabled bool) (*Mmap, error) {
+func NewMmapFd(ctx context.Context, env environment.Env, dataDir string, dirty bool, fd, size int, offset int64, source snaputil.ChunkSource, remoteInstanceName string, remoteEnabled bool, lru *MmapLRU) (*Mmap, error) {
 	if source == snaputil.ChunkSourceUnmapped {
 		return nil, status.InvalidArgumentError("ChunkSourceUnmapped is not a valid source when initializing a chunk from a fd")
 	}
 	data, err := mmapDataFromFd(fd, size, filepath.Base(dataDir))
-	if err != nil {
-		return nil, err
-	}
-	lru, err := getMmapLRU(dataDir)
 	if err != nil {
 		return nil, err
 	}
@@ -1051,11 +1101,7 @@ func NewMmapFd(ctx context.Context, env environment.Env, dataDir string, dirty b
 
 // NewMmapLocalFile returns an unmapped instance from the given directory and
 // offset.
-func NewMmapLocalFile(ctx context.Context, env environment.Env, dataDir string, dirty bool, size int, offset int64, remoteInstanceName string, remoteEnabled bool) (*Mmap, error) {
-	lru, err := getMmapLRU(dataDir)
-	if err != nil {
-		return nil, err
-	}
+func NewMmapLocalFile(ctx context.Context, env environment.Env, dataDir string, dirty bool, size int, offset int64, remoteInstanceName string, remoteEnabled bool, lru *MmapLRU) (*Mmap, error) {
 	return &Mmap{
 		ctx:                ctx,
 		env:                env,
@@ -1303,15 +1349,14 @@ type MmapLRU struct {
 
 	mu  sync.Mutex
 	lru lru.LRU[*Mmap]
+
+	// Whether this is the shared LRU instance for all mmapped chunks on an executor.
+	isShared bool
 }
 
-func NewMmapLRU() (*MmapLRU, error) {
-	// Sanity check that the LRU size is not too small.
-	// Just using 64MB here for now as a reasonable threshold.
-	maxSize := resources.GetAllocatedMmapRAMBytes()
-	const threshold = 64 * 1024 * 1024
-	if maxSize < threshold {
-		return nil, status.InvalidArgumentErrorf("configured mmapped bytes limit is too small (%d bytes)", maxSize)
+func NewMmapLRU(maxSize int64) (*MmapLRU, error) {
+	if maxSize <= 0 {
+		return nil, status.InvalidArgumentErrorf("max size must be positive")
 	}
 	ml := &MmapLRU{evictions: make(chan *Mmap, 1024)}
 	l, err := lru.New(&lru.Config[*Mmap]{
@@ -1352,16 +1397,34 @@ func NewMmapLRU() (*MmapLRU, error) {
 	return ml, nil
 }
 
+// NewSharedMmapLRU creates a new shared LRU instance for mmapped chunks.
+// This is shared for all mapped chunks on an executor.
+func NewSharedMmapLRU() (*MmapLRU, error) {
+	// Sanity check that the LRU size is not too small.
+	// Just using 64MB here for now as a reasonable threshold.
+	maxSize := resources.GetAllocatedMmapRAMBytes()
+	const threshold = 64 * 1024 * 1024
+	if maxSize < threshold {
+		return nil, status.InvalidArgumentErrorf("configured mmapped bytes limit is too small (%d bytes)", maxSize)
+	}
+	lru, err := NewMmapLRU(maxSize)
+	if err != nil {
+		return nil, err
+	}
+	lru.isShared = true
+	return lru, nil
+}
+
 // getSharedLRU returns the shared LRU instance to be used for mmapped disk
 // chunks.
-var getSharedLRU = sync.OnceValues(NewMmapLRU)
+var getSharedLRU = sync.OnceValues(NewSharedMmapLRU)
 
 func ResetSharedLRUForTest() {
 	ml, err := getSharedLRU()
 	if err == nil {
 		ml.Close()
 	}
-	getSharedLRU = sync.OnceValues(NewMmapLRU)
+	getSharedLRU = sync.OnceValues(NewSharedMmapLRU)
 }
 
 func (ml *MmapLRU) key(m *Mmap) string {

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -167,15 +167,19 @@ type COWOptions struct {
 	DataDir            string
 	RemoteInstanceName string
 	RemoteEnabled      bool
+
 	// By default, mmapped chunks are managed by the executor-wide shared LRU.
 	//
-	// If UseLimitedPrivateMmapLRU is true, this store uses its own LRU sized to hold
-	// at most 4 chunks. This is useful for sequential access patterns where we
+	// If MaxMmappedChunks is set, this store will create its own LRU sized to hold
+	// a max of that many chunks. This is useful for sequential access patterns where we
 	// don't want recently touched chunks to stay mmapped longer than necessary.
 	// This is useful when we're writing a snapshot file, for example, but should
 	// never be set for a COWStore that is being used by a guest and will have
 	// non-sequential access patterns.
-	UseLimitedPrivateMmapLRU bool
+	//
+	// When this is set, we disable eager fetching. If chunks are expected to be accessed sequentially,
+	// pre-fetching farther ahead could cause unnecessary churn in the LRU.
+	MaxMmappedChunks int64
 }
 
 // NewCOWStore creates a COWStore from the given chunks. The chunks should be
@@ -193,10 +197,10 @@ func NewCOWStore(ctx context.Context, env environment.Env, name string, chunks [
 
 	var lru *MmapLRU
 	var eagerFetchStack *boundedstack.BoundedStack[int64]
-	if opts.UseLimitedPrivateMmapLRU {
+	if opts.MaxMmappedChunks > 0 {
 		// If reads/writes are expected to be sequential, we should only need a max of 2 chunks mmapped when accessing at chunk boundaries.
 		// Set the limit to 4 chunks to add a bit of buffer.
-		lru, err = NewMmapLRU(opts.ChunkSizeBytes * 4)
+		lru, err = NewMmapLRU(opts.ChunkSizeBytes * opts.MaxMmappedChunks)
 		if err != nil {
 			return nil, err
 		}
@@ -239,10 +243,10 @@ func NewCOWStore(ctx context.Context, env environment.Env, name string, chunks [
 		mmapLRU:                      lru,
 	}
 
-	// Stores using a limited private mmap LRU are expected to be accessed
-	// sequentially. In that case, if chunks are accessed once in order,
-	// pre-fetching farther ahead could cause unnecessary churn in the LRU.
-	if !opts.UseLimitedPrivateMmapLRU {
+	// Stores that manage their own LRU (opts.MaxMmappedChunks > 0) are expected to be accessed
+	// sequentially. If chunks are accessed once in order,
+	// pre-fetching farther ahead could cause unnecessary churn in the LRU, so we disable eager fetching.
+	if opts.MaxMmappedChunks == 0 {
 		s.eagerFetchEg.Go(func() error {
 			s.eagerFetchChunksInBackground()
 			return nil
@@ -530,7 +534,7 @@ func (s *COWStore) Close() error {
 
 	_ = s.chunkLock.Close()
 
-	if !s.mmapLRU.isShared {
+	if s.mmapLRU != nil && !s.mmapLRU.isShared {
 		s.mmapLRU.Close()
 	}
 
@@ -721,6 +725,9 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 }
 
 func (s *COWStore) eagerFetchNextChunks(offset int64) {
+	if s.eagerFetchStack == nil {
+		return
+	}
 	currentOffset := offset + s.chunkSizeBytes
 	for i := 0; i < numChunksToEagerFetch; i++ {
 		s.eagerFetchStack.Push(currentOffset)

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -795,7 +795,9 @@ func newMmap(t *testing.T) (*copy_on_write.Mmap, string) {
 	s, err := f.Stat()
 	require.NoError(t, err)
 
-	mmap, err := copy_on_write.NewMmapFd(ctx, env, root, false /*=dirty*/, int(f.Fd()), int(s.Size()), offset, snaputil.ChunkSourceLocalFile, "", false)
+	sharedLRU, err := copy_on_write.GetSharedMmapLRU(root)
+	require.NoError(t, err)
+	mmap, err := copy_on_write.NewMmapFd(ctx, env, root, false /*=dirty*/, int(f.Fd()), int(s.Size()), offset, snaputil.ChunkSourceLocalFile, "", false, sharedLRU)
 	require.NoError(t, err)
 	return mmap, path
 }

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -966,11 +966,11 @@ func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile,
 			c.Close()
 		}
 	}()
+	sharedLRU, err := copy_on_write.GetSharedMmapLRU(dataDir)
+	if err != nil {
+		return nil, status.WrapError(err, "get shared mmap LRU")
+	}
 	for _, chunk := range file.Chunks {
-		sharedLRU, err := copy_on_write.GetSharedMmapLRU(dataDir)
-		if err != nil {
-			return nil, status.WrapError(err, "get shared mmap LRU")
-		}
 		c, err := copy_on_write.NewLazyMmap(ctx, l.env, dataDir, chunk.GetOffset(), chunk.GetDigest(), remoteInstanceName, remoteEnabled, sharedLRU)
 		if err != nil {
 			return nil, status.WrapError(err, "create mmap for chunk")
@@ -1063,7 +1063,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 	if *snaputil.ThrottleSnapshotWrites {
 		eg.SetLimit(chunkedFileWriteConcurrency)
 	} else {
-		writeConcurrency := int(math.Max(8, float64(cacheOpts.VMConfiguration.GetNumCpus())))
+		writeConcurrency := int(math.Max(snaputil.WriteSnapshotChunkConcurrency, float64(cacheOpts.VMConfiguration.GetNumCpus())))
 		eg.SetLimit(writeConcurrency)
 	}
 

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -967,16 +967,23 @@ func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile,
 		}
 	}()
 	for _, chunk := range file.Chunks {
-		// TODO: Make a unit test where there is less data in a chunk than the chunk size
-		// But when we fetch from the remote cache, it will need the actual
-		// data size in the digest
-		c, err := copy_on_write.NewLazyMmap(ctx, l.env, dataDir, chunk.GetOffset(), chunk.GetDigest(), remoteInstanceName, remoteEnabled)
+		sharedLRU, err := copy_on_write.GetSharedMmapLRU(dataDir)
+		if err != nil {
+			return nil, status.WrapError(err, "get shared mmap LRU")
+		}
+		c, err := copy_on_write.NewLazyMmap(ctx, l.env, dataDir, chunk.GetOffset(), chunk.GetDigest(), remoteInstanceName, remoteEnabled, sharedLRU)
 		if err != nil {
 			return nil, status.WrapError(err, "create mmap for chunk")
 		}
 		chunks = append(chunks, c)
 	}
-	cow, err := copy_on_write.NewCOWStore(ctx, l.env, file.GetName(), chunks, file.GetChunkSize(), file.GetSize(), dataDir, remoteInstanceName, remoteEnabled)
+	cow, err := copy_on_write.NewCOWStore(ctx, l.env, file.GetName(), chunks, copy_on_write.COWOptions{
+		ChunkSizeBytes:     file.GetChunkSize(),
+		TotalSizeBytes:     file.GetSize(),
+		DataDir:            dataDir,
+		RemoteInstanceName: remoteInstanceName,
+		RemoteEnabled:      remoteEnabled,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -58,7 +58,8 @@ const (
 	// This is used to prevent writing snapshots too frequently.
 	DefaultSnapshotWriteInterval = 1 * time.Hour
 
-	ConvertToCOWConcurrency = 8
+	ConvertToCOWConcurrency       = 8
+	WriteSnapshotChunkConcurrency = 8
 )
 
 // ChunkSource represents how a snapshot chunk was initialized


### PR DESCRIPTION
When exporting a full snapshot file to a COWStore (introduced [here](https://github.com/buildbuddy-io/buildbuddy/pull/11882)), the data will be written sequentially, so there's no reason to keep the mmapped data around. Add support for a limited LRU that will eagerly unmap chunks in this situation