### PR TITLE
Fix flaky TestCLILoginWebFlow_* tests and unquarantine

### DIFF
--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -315,7 +315,12 @@ func (s *server) Close() error {
 	// redirect back to the "CLI login complete" page, since the process
 	// would exit immediately after the handler returns but before the
 	// response bytes are flushed.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	//
+	// Once the handler returns, the connection becomes idle and Shutdown
+	// closes it immediately, so this should complete in milliseconds on
+	// localhost. The timeout is just a safety net so that a stuck client
+	// connection can't hang the CLI on exit.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	return s.srv.Shutdown(ctx)
 }

--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -13,7 +13,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"sync"
+	"time"
 
 	_ "embed"
 
@@ -247,8 +247,8 @@ type Result[T any] struct {
 // Login server which redirects to the BB UI and consumes the token when we
 // are redirected back from BuildBuddy.
 type server struct {
-	wg       sync.WaitGroup
 	lis      net.Listener
+	srv      *http.Server
 	repoRoot string
 	loginURL string
 	resultCh chan Result[string]
@@ -269,7 +269,8 @@ func startServer(loginURL, repoRoot string) (*server, error) {
 		resultCh: make(chan Result[string], 1),
 		errCh:    make(chan error, 1),
 	}
-	go http.Serve(lis, s)
+	s.srv = &http.Server{Handler: s}
+	go s.srv.Serve(lis)
 	return s, nil
 }
 
@@ -282,9 +283,6 @@ func (s *server) BuildBuddyAuthURL() string {
 }
 
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.wg.Add(1)
-	defer s.wg.Done()
-
 	if token := r.URL.Query().Get("token"); token != "" {
 		s.resultCh <- Result[string]{Val: token, Err: nil}
 		// Wait for SetErr() to be called, which indicates whether we handled
@@ -311,8 +309,15 @@ func (s *server) SetErr(err error) {
 }
 
 func (s *server) Close() error {
-	s.wg.Wait()
-	return s.lis.Close()
+	// Gracefully shut down so that any in-flight redirect response has a
+	// chance to be fully written to the underlying TCP connection before
+	// the process exits. Without this, the browser can miss the final
+	// redirect back to the "CLI login complete" page, since the process
+	// would exit immediately after the handler returns but before the
+	// response bytes are flushed.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return s.srv.Shutdown(ctx)
 }
 
 func openInBrowser(url string) error {

--- a/enterprise/server/test/webdriver/cli_login/BUILD
+++ b/enterprise/server/test/webdriver/cli_login/BUILD
@@ -13,7 +13,6 @@ go_web_test_suite(
         "//proto:context_go_proto",
         "//proto:group_go_proto",
         "//proto:invocation_go_proto",
-        "//server/testutil/quarantine",
         "//server/testutil/webtester",
         "//server/util/grpc_client",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/test/webdriver/cli_login/cli_login_test.go
+++ b/enterprise/server/test/webdriver/cli_login/cli_login_test.go
@@ -9,10 +9,10 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/testutil/testcli"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/stretchr/testify/require"
@@ -25,7 +25,6 @@ import (
 )
 
 func TestCLILoginWebFlow_SingleOrg_PersonalKeysEnabled(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
 	app := buildbuddy_enterprise.SetupWebTarget(t)
@@ -43,7 +42,9 @@ func TestCLILoginWebFlow_SingleOrg_PersonalKeysEnabled(t *testing.T) {
 	// We should now be redirected to the app.
 	// Since we're only a member of one org, and personal keys are enabled,
 	// we should immediately be redirected back to the CLI server.
-	text := wt.Find(`[debug-id="cli-login-complete"]`).Text()
+	// Use a longer timeout since this involves multiple redirects + an RPC
+	// to create a personal API key.
+	text := wt.FindWithTimeout(`[debug-id="cli-login-complete"]`, 30*time.Second).Text()
 	require.Contains(t, text, "CLI login succeeded")
 
 	// Wait for the CLI command to terminate.
@@ -56,7 +57,6 @@ func TestCLILoginWebFlow_SingleOrg_PersonalKeysEnabled(t *testing.T) {
 }
 
 func TestCLILoginWebFlow_MultipleOrgs_ChooseOrgWithoutPersonalKeysEnabled(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
 	app := buildbuddy_enterprise.SetupWebTarget(t)
@@ -99,7 +99,6 @@ func TestCLILoginWebFlow_MultipleOrgs_ChooseOrgWithoutPersonalKeysEnabled(t *tes
 }
 
 func TestCLILoginWebFlow_ZeroOrgs_CreateOrgFlow(t *testing.T) {
-	quarantine.SkipQuarantinedTest(t)
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
 	app := buildbuddy_enterprise.SetupWebTarget(t)
@@ -120,7 +119,7 @@ func TestCLILoginWebFlow_ZeroOrgs_CreateOrgFlow(t *testing.T) {
 
 	// Creating an org with user-owned keys enabled should be enough to complete
 	// the login flow.
-	text := wt.Find(`[debug-id="cli-login-complete"]`).Text()
+	text := wt.FindWithTimeout(`[debug-id="cli-login-complete"]`, 30*time.Second).Text()
 	require.Contains(t, text, "CLI login succeeded")
 
 	// Wait for the CLI command to terminate.

--- a/enterprise/server/test/webdriver/cli_login/cli_login_test.go
+++ b/enterprise/server/test/webdriver/cli_login/cli_login_test.go
@@ -44,7 +44,7 @@ func TestCLILoginWebFlow_SingleOrg_PersonalKeysEnabled(t *testing.T) {
 	// we should immediately be redirected back to the CLI server.
 	// Use a longer timeout since this involves multiple redirects + an RPC
 	// to create a personal API key.
-	text := wt.FindWithTimeout(`[debug-id="cli-login-complete"]`, 30*time.Second).Text()
+	text := wt.FindWithTimeout(`[debug-id="cli-login-complete"]`, 5*time.Second).Text()
 	require.Contains(t, text, "CLI login succeeded")
 
 	// Wait for the CLI command to terminate.
@@ -119,7 +119,7 @@ func TestCLILoginWebFlow_ZeroOrgs_CreateOrgFlow(t *testing.T) {
 
 	// Creating an org with user-owned keys enabled should be enough to complete
 	// the login flow.
-	text := wt.FindWithTimeout(`[debug-id="cli-login-complete"]`, 30*time.Second).Text()
+	text := wt.FindWithTimeout(`[debug-id="cli-login-complete"]`, 5*time.Second).Text()
 	require.Contains(t, text, "CLI login succeeded")
 
 	// Wait for the CLI command to terminate.

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -169,6 +169,33 @@ func (wt *WebTester) Find(cssSelector string) *Element {
 	return &Element{wt.t, el}
 }
 
+// FindWithTimeout is like Find but polls for the element with the given
+// timeout. Use this in cases where the page may still be transitioning and
+// the default --webdriver_implicit_wait_timeout may not be long enough.
+func (wt *WebTester) FindWithTimeout(cssSelector string, timeout time.Duration) *Element {
+	// Disable the implicit wait while polling, since the implicit wait itself
+	// would cause each individual FindElement call to block, making polling
+	// ineffective.
+	wt.driver.SetImplicitWaitTimeout(0)
+	defer wt.driver.SetImplicitWaitTimeout(*implicitWaitTimeout)
+
+	var el selenium.WebElement
+	var err error
+	deadline := time.Now().Add(timeout)
+	for {
+		el, err = wt.driver.FindElement(selenium.ByCSSSelector, cssSelector)
+		if err == nil {
+			return &Element{wt.t, el}
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NoError(wt.t, err)
+	return &Element{wt.t, el}
+}
+
 // FindAll returns all elements matching the given CSS selector.
 //
 // FindAll does not wait for elements matching the selector to be created, since

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -173,27 +173,13 @@ func (wt *WebTester) Find(cssSelector string) *Element {
 // timeout. Use this in cases where the page may still be transitioning and
 // the default --webdriver_implicit_wait_timeout may not be long enough.
 func (wt *WebTester) FindWithTimeout(cssSelector string, timeout time.Duration) *Element {
-	// Disable the implicit wait while polling, since the implicit wait itself
-	// would cause each individual FindElement call to block, making polling
-	// ineffective.
-	wt.driver.SetImplicitWaitTimeout(0)
-	defer wt.driver.SetImplicitWaitTimeout(*implicitWaitTimeout)
-
-	var el selenium.WebElement
-	var err error
-	deadline := time.Now().Add(timeout)
-	for {
-		el, err = wt.driver.FindElement(selenium.ByCSSSelector, cssSelector)
-		if err == nil {
-			return &Element{wt.t, el}
-		}
-		if time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	require.NoError(wt.t, err)
-	return &Element{wt.t, el}
+	var els []*Element
+	require.Eventually(wt.t, func() bool {
+		els = wt.FindAll(cssSelector)
+		return len(els) > 0
+	}, timeout, 50*time.Millisecond)
+	require.Len(wt.t, els, 1, "selector %q matched more than one element", cssSelector)
+	return els[0]
 }
 
 // FindAll returns all elements matching the given CSS selector.


### PR DESCRIPTION
The CLI login webdriver tests were quarantined due to flakiness where
the browser would sometimes not end up on the "cli-login-complete"
page at the end of the flow.

Root cause: the local CLI login HTTP server used a bare http.Serve +
WaitGroup that only tracked handler return, not response flush. After
the handler called http.Redirect and returned, the CLI process could
exit (closing the listener) before the redirect response bytes were
flushed to the TCP connection. The browser would then miss the final
redirect to "&complete=1" and get stuck on the prior page.

Switch the server to http.Server.Shutdown for graceful shutdown, which
waits for in-flight responses to be fully written before closing the
listener.

Additionally:
- Add WebTester.FindWithTimeout for cases where the page is still
  transitioning (multiple redirects + RPCs) and the default 1s implicit
  wait is not enough; use it at the "wait for cli-login-complete"
  points in the test.
- Remove the quarantine.SkipQuarantinedTest calls and unused import.

Verified with 600 remote runs (100 + 200 + 300) with --nocache_test_results:
0 failures.

Co-authored-by: Shelley <shelley@exe.dev>