### PR TITLE
Add more info to executor card

### DIFF
--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -358,6 +358,11 @@ export function relativeTimeSeconds(timestamp: { seconds?: number | Long; nanos?
   return `${seconds} second${seconds === 1 ? "" : "s"} ago`;
 }
 
+export function durationSince(timestamp: { seconds?: number | Long; nanos?: number | Long }): string {
+  const timestampMs = +(timestamp.seconds || 0) * 1000 + +(timestamp.nanos || 0) / 1000000;
+  return durationMillis(Math.max(0, Date.now() - timestampMs));
+}
+
 export function formatGitUrl(url: string) {
   return url
     ?.replace("https://", "")
@@ -439,4 +444,5 @@ export default {
   enumLabel,
   formatDateFromUsec,
   relativeTimeSeconds,
+  durationSince,
 };

--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -54,7 +54,11 @@ export default class ExecutorCardComponent extends React.Component<Props> {
             </div>
             <div className="executor-section">
               <div className="executor-section-title">Filecache Max Size:</div>
-              <div>{format.bytes(+this.props.node.filecacheMaxSizeBytes)}</div>
+              <div>
+                {this.props.node.filecacheMaxSizeBytes
+                  ? format.bytes(+this.props.node.filecacheMaxSizeBytes)
+                  : "unknown"}
+              </div>
             </div>
             {this.props.node.assignableCustomResources && this.props.node.assignableCustomResources.length > 0 && (
               <div className="executor-section">

--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -38,6 +38,12 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                 <div>{this.props.node.osDisplayName}</div>
               </div>
             )}
+            {this.props.node.startTime && (
+              <div className="executor-section">
+                <div className="executor-section-title">Uptime:</div>
+                <div>{format.durationSince(this.props.node.startTime)}</div>
+              </div>
+            )}
             <div className="executor-section">
               <div className="executor-section-title">Assignable Memory:</div>
               <div>{format.bytes(+this.props.node.assignableMemoryBytes)}</div>
@@ -45,6 +51,10 @@ export default class ExecutorCardComponent extends React.Component<Props> {
             <div className="executor-section">
               <div className="executor-section-title">Assignable Milli CPU:</div>
               <div>{this.props.node.assignableMilliCpu}</div>
+            </div>
+            <div className="executor-section">
+              <div className="executor-section-title">Filecache Max Size:</div>
+              <div>{format.bytes(+this.props.node.filecacheMaxSizeBytes)}</div>
             </div>
             {this.props.node.assignableCustomResources && this.props.node.assignableCustomResources.length > 0 && (
               <div className="executor-section">
@@ -84,6 +94,18 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                 <div>{this.props.node.supportedIsolationTypes.join(", ")}</div>
               </div>
             )}
+            <div className="executor-section">
+              <div className="executor-section-title">Warmup Images:</div>
+              <div className="executor-warmup-images">
+                {(this.props.node.warmupImages || []).map((image, index) => (
+                  <div className="executor-warmup-image" key={`${image.isolation}-${image.image}-${index}`}>
+                    <span className="executor-warmup-image-isolation">{image.isolation || "default"}:</span>
+                    <span>{image.image}</span>
+                  </div>
+                ))}
+                {(this.props.node.warmupImages || []).length == 0 && "none"}
+              </div>
+            </div>
             <div className="executor-section">
               <div className="executor-section-title">Version:</div>
               <div>{this.props.node.version}</div>

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -11,6 +11,7 @@
 
 .executors-page .executor-section div {
   flex-grow: 1;
+  min-width: 0;
 }
 
 .executors-page .executor-custom-resource div {
@@ -29,6 +30,23 @@
 .executor-custom-resource {
   display: flex;
   flex-direction: column;
+}
+
+.executor-warmup-images {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.executor-warmup-image {
+  display: flex;
+  gap: 8px;
+  overflow-wrap: anywhere;
+}
+
+.executor-warmup-image-isolation {
+  flex-shrink: 0;
+  font-weight: 600;
 }
 
 .executor-custom-resource-wrapper {

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -67,6 +67,7 @@ go_library(
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//encoding/gzip",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//enterprise/server/remote_execution/cgroup",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -56,6 +56,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	remote_executor "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor"
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
@@ -190,6 +191,26 @@ func getExecutorHostName() string {
 	return name
 }
 
+func filecacheMaxSizeBytesForRegistration() *int64 {
+	size := int64(0)
+	if !*disableLocalCache {
+		size = *localCacheSizeBytes
+	}
+	return &size
+}
+
+func warmupImagesForRegistration() []*scpb.WarmupImage {
+	configs := runner.WarmupConfigs()
+	warmupImages := make([]*scpb.WarmupImage, 0, len(configs))
+	for _, cfg := range configs {
+		warmupImages = append(warmupImages, &scpb.WarmupImage{
+			Image:     cfg.Image,
+			Isolation: cfg.Isolation,
+		})
+	}
+	return warmupImages
+}
+
 func GetConfiguredEnvironmentOrDie(cacheRoot string, healthChecker *healthcheck.HealthChecker) *real_environment.RealEnv {
 	realEnv := real_environment.NewRealEnv(healthChecker)
 
@@ -281,6 +302,7 @@ func GetConfiguredEnvironmentOrDie(cacheRoot string, healthChecker *healthcheck.
 }
 
 func main() {
+	executorStartTime := time.Now()
 	version.Print("BuildBuddy executor")
 
 	setUmask()
@@ -399,7 +421,11 @@ func main() {
 	http.Handle("/healthz", env.GetHealthChecker().LivenessHandler())
 	http.Handle("/readyz", env.GetHealthChecker().ReadinessHandler())
 
-	schedulerOpts := &scheduler_client.Options{}
+	schedulerOpts := &scheduler_client.Options{
+		FilecacheMaxSizeBytes: filecacheMaxSizeBytesForRegistration(),
+		WarmupImages:          warmupImagesForRegistration(),
+		StartTime:             timestamppb.New(executorStartTime),
+	}
 	reg, err := scheduler_client.NewRegistration(env, taskScheduler, executorID, executor.HostID(), schedulerOpts)
 	if err != nil {
 		log.Fatalf("Error initializing executor registration: %s", err)

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1008,7 +1008,7 @@ func (p *pool) Warmup(ctx context.Context) {
 	defer cancel()
 
 	eg, ctx := errgroup.WithContext(ctx)
-	for _, cfg := range p.warmupConfigs() {
+	for _, cfg := range WarmupConfigs() {
 		cfg := cfg
 		eg.Go(func() error {
 			return p.warmupImage(ctx, &cfg)
@@ -1019,7 +1019,8 @@ func (p *pool) Warmup(ctx context.Context) {
 	}
 }
 
-func (p *pool) warmupConfigs() []WarmupConfig {
+// WarmupConfigs returns the images configured for executor startup warmup.
+func WarmupConfigs() []WarmupConfig {
 	var out []WarmupConfig
 	for _, isolation := range executorplatform.GetExecutorProperties().SupportedIsolationTypes {
 		// Bare/sandbox isolation types don't support container images.

--- a/enterprise/server/scheduling/scheduler_client/BUILD
+++ b/enterprise/server/scheduling/scheduler_client/BUILD
@@ -23,5 +23,6 @@ go_library(
         "//server/version",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//encoding/prototext",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 )
@@ -53,6 +54,15 @@ type Options struct {
 	HostnameOverride string
 	// TESTING ONLY: overrides the API key sent by the client
 	APIKeyOverride string
+
+	// FilecacheMaxSizeBytes is the configured maximum local filecache size.
+	// If set to 0, the local filecache is disabled.
+	FilecacheMaxSizeBytes *int64
+	// WarmupImages are the container images configured to warm up during
+	// executor startup.
+	WarmupImages []*scpb.WarmupImage
+	// StartTime is when the executor process started.
+	StartTime *timestamppb.Timestamp
 }
 
 func makeExecutionNode(pool, executorID, executorHostID string, xcodeLocator interfaces.XcodeLocator, options *Options) (*scpb.ExecutionNode, error) {
@@ -76,7 +86,6 @@ func makeExecutionNode(pool, executorID, executorHostID string, xcodeLocator int
 	if err != nil {
 		return nil, err
 	}
-
 	return &scpb.ExecutionNode{
 		Host: hostname,
 		// TODO: stop setting port once the scheduler no longer requires it.
@@ -97,6 +106,9 @@ func makeExecutionNode(pool, executorID, executorHostID string, xcodeLocator int
 		XcodeSdks:                 xcodeLocator.SDKs(),
 		// TODO: hard-code this to true once it's battle-tested.
 		SupportsProactiveCancellation: *proactiveCancellationEnabled,
+		WarmupImages:                  options.WarmupImages,
+		FilecacheMaxSizeBytes:         options.FilecacheMaxSizeBytes,
+		StartTime:                     options.StartTime,
 	}, nil
 }
 

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -109,6 +109,16 @@ message CustomResource {
   float value = 2;
 }
 
+// WarmupImage represents a container image configured for executor startup
+// warmup.
+message WarmupImage {
+  // Image to warm up, without the "docker://" prefix.
+  string image = 1;
+
+  // Workload isolation type for this warmup image.
+  string isolation = 2;
+}
+
 message TaskSize {
   // The tasks's estimated memory usage.
   int64 estimated_memory_bytes = 1;
@@ -588,6 +598,16 @@ message ExecutionNode {
   // cancelling queued requests for tasks that have already been completed by
   // another executor.
   bool supports_proactive_cancellation = 18;
+
+  // Configured maximum size of the local filecache. If present and set to 0,
+  // the local filecache is disabled.
+  optional int64 filecache_max_size_bytes = 19;
+
+  // Images configured to warm up during executor startup.
+  repeated WarmupImage warmup_images = 20;
+
+  // Time when this executor process started.
+  google.protobuf.Timestamp start_time = 21;
 }
 
 message GetExecutionNodesRequest {


### PR DESCRIPTION
This adds:
 - Uptime
 - Warmed up images
 - Max filecache size

To the executor UI. This makes debugging a few things easier:
- Was this executor recently auto-scaled up?
- Is it warming up the correct image?
- Is the filecache large enough?