### PR TITLE
fix: clean up proxy chunked read

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -132,6 +132,8 @@ func (s *ByteStreamServerProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStre
 		chunksTotal:  readMetrics.chunksTotal,
 		chunksLocal:  readMetrics.chunksLocal,
 		chunksRemote: readMetrics.chunksRemote,
+		bytesLocal:   readMetrics.bytesLocal,
+		bytesRemote:  readMetrics.bytesRemote,
 	}
 	recordReadMetrics(bsm, readMetrics.cacheStatus)
 	return err
@@ -145,6 +147,8 @@ type readMetrics struct {
 	chunksTotal  int
 	chunksLocal  int
 	chunksRemote int
+	bytesLocal   int64
+	bytesRemote  int64
 }
 
 func (s *ByteStreamServerProxy) read(ctx context.Context, req *bspb.ReadRequest, stream *meteredReadServerStream) (readMetrics, error) {
@@ -181,47 +185,41 @@ func (s *ByteStreamServerProxy) read(ctx context.Context, req *bspb.ReadRequest,
 		}, nil
 	}
 
+	if s.shouldReadChunked(ctx, req, rn) {
+		chunkMetrics, err := s.readChunked(ctx, req, stream, rn)
+		if err == nil {
+			cacheStatus := metrics.MissStatusLabel
+			if chunkMetrics.chunksRemote == 0 {
+				cacheStatus = metrics.HitStatusLabel
+			}
+			return readMetrics{
+				cacheStatus:  cacheStatus,
+				compressor:   rn.GetCompressor().String(),
+				chunked:      true,
+				blobBytes:    rn.GetDigest().GetSizeBytes(),
+				chunksTotal:  chunkMetrics.chunksLocal + chunkMetrics.chunksRemote,
+				chunksLocal:  chunkMetrics.chunksLocal,
+				chunksRemote: chunkMetrics.chunksRemote,
+				bytesLocal:   chunkMetrics.bytesLocal,
+				bytesRemote:  chunkMetrics.bytesRemote,
+			}, nil
+		}
+
+		if stream.frames > 0 {
+			return readMetrics{
+				cacheStatus: metrics.MissStatusLabel,
+				compressor:  rn.GetCompressor().String(),
+			}, err
+		}
+	}
+
 	localErr := s.local.ReadCASResource(ctx, rn, req.GetReadOffset(), req.GetReadLimit(), stream)
 	// If some responses were streamed to the client, just return the
 	// error. Otherwise, fall-back to remote. We might be able to continue
 	// streaming to the client by doing an offset read from the remote
 	// cache, but keep it simple for now.
 	if localErr != nil && stream.frames == 0 {
-		// Recover from local error if no frames have been sent
-
-		// If the blob does not exist locally, it might exist in chunks.
-		// If chunking is enabled and the blob is large enough, try to read the chunks.
-		// TODO(buildbuddy-internal#6426): Once most large blobs are chunked, consider
-		// attempting the chunked read first.
-		var chunkedErr error
-		if s.shouldReadChunked(ctx, req, rn) {
-			chunkMetrics, err := s.readChunked(ctx, req, stream, rn)
-			chunkedErr = err
-			if chunkedErr == nil {
-				return readMetrics{
-					cacheStatus:  metrics.MissStatusLabel,
-					compressor:   rn.GetCompressor().String(),
-					chunked:      true,
-					blobBytes:    rn.GetDigest().GetSizeBytes(),
-					chunksTotal:  chunkMetrics.chunksLocal + chunkMetrics.chunksRemote,
-					chunksLocal:  chunkMetrics.chunksLocal,
-					chunksRemote: chunkMetrics.chunksRemote,
-				}, nil
-			}
-
-			if stream.frames > 0 {
-				return readMetrics{
-					cacheStatus: metrics.MissStatusLabel,
-					compressor:  rn.GetCompressor().String(),
-				}, chunkedErr
-			}
-		}
-
 		remoteErr := s.readRemoteWriteLocal(req, stream)
-		if remoteErr != nil && chunkedErr != nil {
-			// TODO(buildbuddy-internal#6426): Remove once root cause for missing digests is found.
-			log.CtxWarningf(ctx, "Proxy chunked read failed for %s (remote fallback also failed): chunkedErr=%s remoteErr=%s", rn.DownloadString(), chunkedErr, remoteErr)
-		}
 		return readMetrics{
 			cacheStatus: metrics.MissStatusLabel,
 			compressor:  rn.GetCompressor().String(),
@@ -249,6 +247,8 @@ func (s *ByteStreamServerProxy) shouldReadChunked(ctx context.Context, req *bspb
 type chunkedReadMetrics struct {
 	chunksLocal  int
 	chunksRemote int
+	bytesLocal   int64
+	bytesRemote  int64
 }
 
 func (s *ByteStreamServerProxy) readChunked(ctx context.Context, req *bspb.ReadRequest, stream *meteredReadServerStream, rn *digest.CASResourceName) (chunkedReadMetrics, error) {
@@ -300,6 +300,7 @@ func (s *ByteStreamServerProxy) readChunked(ctx context.Context, req *bspb.ReadR
 		// If we're midway through a chunk (non-zero offset),
 		// read remote only, since we can't cache a partial chunk locally.
 		if intraChunkOffset > 0 {
+			bytesBefore := stream.bytes
 			remoteReq := &bspb.ReadRequest{
 				ResourceName: chunkRN.DownloadString(),
 				ReadOffset:   intraChunkOffset,
@@ -312,6 +313,7 @@ func (s *ByteStreamServerProxy) readChunked(ctx context.Context, req *bspb.ReadR
 				return m, err
 			}
 			m.chunksRemote++
+			m.bytesRemote += stream.bytes - bytesBefore
 			continue
 		}
 
@@ -319,6 +321,7 @@ func (s *ByteStreamServerProxy) readChunked(ctx context.Context, req *bspb.ReadR
 		localErr := s.local.ReadCASResource(ctx, chunkRN, 0, 0, stream)
 		if localErr == nil {
 			m.chunksLocal++
+			m.bytesLocal += stream.bytes - bytesBefore
 			continue
 		}
 
@@ -346,6 +349,8 @@ func (s *ByteStreamServerProxy) readChunked(ctx context.Context, req *bspb.ReadR
 				return m, err
 			}
 			m.chunksRemote++
+			m.bytesLocal += chunkOffset
+			m.bytesRemote += stream.bytes - bytesBefore - chunkOffset
 			continue
 		}
 
@@ -361,6 +366,7 @@ func (s *ByteStreamServerProxy) readChunked(ctx context.Context, req *bspb.ReadR
 			return m, err
 		}
 		m.chunksRemote++
+		m.bytesRemote += stream.bytes - bytesBefore
 	}
 	return m, nil
 }
@@ -507,6 +513,8 @@ type byteStreamMetrics struct {
 	chunksTotal       int
 	chunksLocal       int
 	chunksRemote      int
+	bytesLocal        int64
+	bytesRemote       int64
 	chunksDeduped     int
 	chunkBytesTotal   int64
 	chunkBytesDeduped int64
@@ -550,6 +558,12 @@ func recordReadMetrics(bsm byteStreamMetrics, cacheStatus string) {
 		}
 		if bsm.chunksRemote > 0 {
 			metrics.ByteStreamChunkedReadChunksRemote.With(chunkedLabels).Add(float64(bsm.chunksRemote))
+		}
+		if bsm.bytesLocal > 0 {
+			metrics.ByteStreamChunkedReadBytesLocal.With(chunkedLabels).Add(float64(bsm.bytesLocal))
+		}
+		if bsm.bytesRemote > 0 {
+			metrics.ByteStreamChunkedReadBytesRemote.With(chunkedLabels).Add(float64(bsm.bytesRemote))
 		}
 	}
 }

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -1013,11 +1013,31 @@ func TestReadChunked(t *testing.T) {
 		metrics.StatusLabel:     "OK",
 		metrics.CompressionType: "IDENTITY",
 	}
+	proxiedReadMissLabels := prometheus.Labels{
+		metrics.StatusLabel:           "OK",
+		metrics.CacheHitMissStatus:    metrics.MissStatusLabel,
+		metrics.CacheProxyRequestType: metrics.DefaultCacheProxyRequestLabel,
+		metrics.CompressionType:       "IDENTITY",
+		metrics.ChunkedLabel:          "true",
+		metrics.GroupID:               groupIDForMetrics(ctx),
+	}
+	proxiedReadHitLabels := prometheus.Labels{
+		metrics.StatusLabel:           "OK",
+		metrics.CacheHitMissStatus:    metrics.HitStatusLabel,
+		metrics.CacheProxyRequestType: metrics.DefaultCacheProxyRequestLabel,
+		metrics.CompressionType:       "IDENTITY",
+		metrics.ChunkedLabel:          "true",
+		metrics.GroupID:               groupIDForMetrics(ctx),
+	}
 	readRequestsBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadRequests.With(readLabels))
 	readBlobBytesBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadBlobBytes.With(readLabels))
 	readChunksTotalBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksTotal.With(readLabels))
 	readChunksLocalBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksLocal.With(readLabels))
 	readChunksRemoteBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksRemote.With(readLabels))
+	readBytesLocalBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadBytesLocal.With(readLabels))
+	readBytesRemoteBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadBytesRemote.With(readLabels))
+	proxiedReadMissBytesBefore := testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadMissLabels))
+	proxiedReadHitBytesBefore := testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadHitLabels))
 
 	downloadCASRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
 	downloadStream, err := proxy.Read(ctx, &bspb.ReadRequest{ResourceName: downloadCASRN.DownloadString()})
@@ -1040,12 +1060,61 @@ func TestReadChunked(t *testing.T) {
 	readChunksTotalAfter := testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksTotal.With(readLabels))
 	readChunksLocalAfter := testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksLocal.With(readLabels))
 	readChunksRemoteAfter := testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksRemote.With(readLabels))
+	readBytesLocalAfter := testutil.ToFloat64(metrics.ByteStreamChunkedReadBytesLocal.With(readLabels))
+	readBytesRemoteAfter := testutil.ToFloat64(metrics.ByteStreamChunkedReadBytesRemote.With(readLabels))
 
 	require.Equal(t, float64(1), readRequestsAfter-readRequestsBefore, "one chunked read request for the blob")
 	require.Equal(t, float64(len(originalData)), readBlobBytesAfter-readBlobBytesBefore, "blob bytes = original uncompressed size")
 	require.Equal(t, float64(len(chunkDigests)), readChunksTotalAfter-readChunksTotalBefore, "total chunks = number of chunks in manifest")
 	require.Equal(t, float64(0), readChunksLocalAfter-readChunksLocalBefore, "first read: no chunks in local cache yet")
 	require.Equal(t, float64(len(chunkDigests)), readChunksRemoteAfter-readChunksRemoteBefore, "first read: all chunks fetched from remote")
+	require.Equal(t, float64(0), readBytesLocalAfter-readBytesLocalBefore, "first read: no bytes served from local cache")
+	require.Equal(t, float64(len(originalData)), readBytesRemoteAfter-readBytesRemoteBefore, "first read: all bytes fetched from remote")
+	require.Equal(t, float64(len(originalData)), testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadMissLabels))-proxiedReadMissBytesBefore)
+	require.Equal(t, float64(0), testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadHitLabels))-proxiedReadHitBytesBefore)
+
+	readRequestsBefore = readRequestsAfter
+	readBlobBytesBefore = readBlobBytesAfter
+	readChunksTotalBefore = readChunksTotalAfter
+	readChunksLocalBefore = readChunksLocalAfter
+	readChunksRemoteBefore = readChunksRemoteAfter
+	readBytesLocalBefore = readBytesLocalAfter
+	readBytesRemoteBefore = readBytesRemoteAfter
+	proxiedReadMissBytesBefore = testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadMissLabels))
+	proxiedReadHitBytesBefore = testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadHitLabels))
+
+	downloadStream, err = proxy.Read(ctx, &bspb.ReadRequest{ResourceName: downloadCASRN.DownloadString()})
+	require.NoError(t, err)
+
+	reconstructedData = nil
+	for {
+		res, err := downloadStream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		reconstructedData = append(reconstructedData, res.Data...)
+	}
+
+	require.Equal(t, originalData, reconstructedData)
+
+	readRequestsAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadRequests.With(readLabels))
+	readBlobBytesAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadBlobBytes.With(readLabels))
+	readChunksTotalAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksTotal.With(readLabels))
+	readChunksLocalAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksLocal.With(readLabels))
+	readChunksRemoteAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksRemote.With(readLabels))
+	readBytesLocalAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadBytesLocal.With(readLabels))
+	readBytesRemoteAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadBytesRemote.With(readLabels))
+
+	require.Equal(t, float64(1), readRequestsAfter-readRequestsBefore, "second chunked read request for the blob")
+	require.Equal(t, float64(len(originalData)), readBlobBytesAfter-readBlobBytesBefore, "second read blob bytes = original uncompressed size")
+	require.Equal(t, float64(len(chunkDigests)), readChunksTotalAfter-readChunksTotalBefore, "second read total chunks = number of chunks in manifest")
+	require.Equal(t, float64(len(chunkDigests)), readChunksLocalAfter-readChunksLocalBefore, "second read: all chunks served from local cache")
+	require.Equal(t, float64(0), readChunksRemoteAfter-readChunksRemoteBefore, "second read: no chunks fetched from remote")
+	require.Equal(t, float64(len(originalData)), readBytesLocalAfter-readBytesLocalBefore, "second read: all bytes served from local cache")
+	require.Equal(t, float64(0), readBytesRemoteAfter-readBytesRemoteBefore, "second read: no bytes fetched from remote")
+	require.Equal(t, float64(0), testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadMissLabels))-proxiedReadMissBytesBefore)
+	require.Equal(t, float64(len(originalData)), testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadHitLabels))-proxiedReadHitBytesBefore)
 }
 
 type faultyCache struct {
@@ -1225,6 +1294,98 @@ func TestReadChunkedWithOffset(t *testing.T) {
 		}
 		require.Equal(t, originalData[offset:], got)
 	})
+}
+
+func TestReadChunkedFallsBackToLocalBlob(t *testing.T) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+		"cache_proxy.attempt_chunked_reads": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+
+	ctx := testContext()
+	remoteEnv := testenv.GetTestEnv(t)
+	proxyEnv := testenv.GetTestEnv(t)
+
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+	remoteEnv.SetExperimentFlagProvider(fp)
+	proxyEnv.SetExperimentFlagProvider(fp)
+
+	remoteBSS, err := byte_stream_server.NewByteStreamServer(remoteEnv)
+	require.NoError(t, err)
+	remoteCAS, err := content_addressable_storage_server.NewContentAddressableStorageServer(remoteEnv)
+	require.NoError(t, err)
+	remoteGRPC, remoteRun, remoteLis := testenv.RegisterLocalGRPCServer(t, remoteEnv)
+	bspb.RegisterByteStreamServer(remoteGRPC, remoteBSS)
+	repb.RegisterContentAddressableStorageServer(remoteGRPC, remoteCAS)
+	go remoteRun()
+
+	var splitBlobCalls atomic.Int32
+	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis, grpc.WithUnaryInterceptor(func(
+		ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+	) error {
+		if strings.HasSuffix(method, "/SplitBlob") {
+			splitBlobCalls.Add(1)
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}))
+	require.NoError(t, err)
+	t.Cleanup(func() { remoteConn.Close() })
+
+	proxyEnv.SetByteStreamClient(bspb.NewByteStreamClient(remoteConn))
+	proxyEnv.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(remoteConn))
+	proxyBSS, err := byte_stream_server.NewByteStreamServer(proxyEnv)
+	require.NoError(t, err)
+	proxyEnv.SetLocalByteStreamServer(proxyBSS)
+	proxyServer, err := New(proxyEnv)
+	require.NoError(t, err)
+	proxyGRPC, proxyRun, proxyLis := testenv.RegisterLocalGRPCServer(t, proxyEnv)
+	bspb.RegisterByteStreamServer(proxyGRPC, proxyServer)
+	go proxyRun()
+	proxyConn, err := testenv.LocalGRPCConn(ctx, proxyLis)
+	require.NoError(t, err)
+	t.Cleanup(func() { proxyConn.Close() })
+	proxy := bspb.NewByteStreamClient(proxyConn)
+
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
+	require.NoError(t, err)
+
+	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	blobRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
+	require.NoError(t, proxyEnv.GetCache().Set(ctx, blobRN.ToProto(), originalData))
+
+	downloadStream, err := proxy.Read(ctx, &bspb.ReadRequest{ResourceName: blobRN.DownloadString()})
+	require.NoError(t, err)
+
+	var got []byte
+	for {
+		res, err := downloadStream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		got = append(got, res.Data...)
+	}
+
+	require.Equal(t, originalData, got)
+	require.Equal(t, int32(1), splitBlobCalls.Load(), "chunked-eligible reads should try SplitBlob first")
 }
 
 func TestReadChunkedPartialLocalFailure(t *testing.T) {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -3835,6 +3835,24 @@ var (
 		StatusLabel,
 		CompressionType,
 	})
+	ByteStreamChunkedReadBytesLocal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "proxy",
+		Name:      "byte_stream_chunked_read_bytes_local",
+		Help:      "Bytes served from local cache to the client during chunked reads.",
+	}, []string{
+		StatusLabel,
+		CompressionType,
+	})
+	ByteStreamChunkedReadBytesRemote = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "proxy",
+		Name:      "byte_stream_chunked_read_bytes_remote",
+		Help:      "Bytes fetched from remote and served to the client during chunked reads.",
+	}, []string{
+		StatusLabel,
+		CompressionType,
+	})
 
 	ByteStreamProxyChunkedReadFailures = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,


### PR DESCRIPTION
Our metrics get inflated because even blobs that are stored with chunking, are getting the "miss" from the local check first. Let's fix that in two ways:
- First, if 100% of chunks are from local, mark it as a "hit". Otherwise, every CDC file is misses.
- Second, try the CDC read first if `shouldReadChunked` is true, to clean up a TODO