### PR TITLE
grpc_client: drop blank import of kuberesolver

### DIFF
--- a/server/util/grpc_client/BUILD
+++ b/server/util/grpc_client/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//server/rpc/interceptors",
         "//server/util/canary",
         "//server/util/flag",
-        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/rpcutil",
         "//server/util/status",

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/mem"
 
-	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver"
 	_ "google.golang.org/grpc/xds"
 )
 


### PR DESCRIPTION
Packages that actually dial kube:/// targets (distributed_client, raft/client, raft/store, raft/registry) already import kuberesolver directly, so its init() still registers the resolver where it's needed. Dropping the blank import from grpc_client stops pulling k8s client-go into every gRPC consumer.

Cold-build analysis actions:
  //enterprise/server/cmd/executor:executor  6499 -> 5589  (-910)
  //cli/cmd/bb:bb                             3673 -> 3050  (-623)