### PR TITLE
interfaces: extract GossipService/GossipListener into own package

### DIFF
--- a/enterprise/server/raft/bringup/BUILD
+++ b/enterprise/server/raft/bringup/BUILD
@@ -15,7 +15,7 @@ go_library(
         "//enterprise/server/raft/sender",
         "//enterprise/server/raft/txn",
         "//proto:raft_go_proto",
-        "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/metrics",
         "//server/util/disk",
         "//server/util/log",

--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -19,7 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/txn"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -51,7 +51,7 @@ type ClusterStarter struct {
 	// the set of hosts passed to the Join arg
 	listenAddr    string
 	join          []string
-	gossipManager interfaces.GossipService
+	gossipManager gossip.Service
 
 	bootstrapped bool
 
@@ -67,7 +67,7 @@ type ClusterStarter struct {
 	rangesToCreate   []*rfpb.RangeDescriptor
 }
 
-func New(grpcAddr string, gossipMan interfaces.GossipService, store IStore, partitions []disk.Partition) (*ClusterStarter, error) {
+func New(grpcAddr string, gossipMan gossip.Service, store IStore, partitions []disk.Partition) (*ClusterStarter, error) {
 	joinList := gossipMan.JoinList()
 	var defaultPartition disk.Partition
 	for _, partition := range partitions {

--- a/enterprise/server/raft/config/BUILD
+++ b/enterprise/server/raft/config/BUILD
@@ -8,7 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/config",
     deps = [
         "//enterprise/server/filestore",
-        "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/util/alert",
         "//server/util/disk",
         "@com_github_lni_dragonboat_v4//config",

--- a/enterprise/server/raft/config/config.go
+++ b/enterprise/server/raft/config/config.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	dbConfig "github.com/lni/dragonboat/v4/config"
@@ -91,5 +91,5 @@ type ServerConfig struct {
 	Partitions      []disk.Partition
 	LogDBConfigType LogDBConfigType
 	FileStorer      filestore.Store
-	GossipManager   interfaces.GossipService
+	GossipManager   gossip.Service
 }

--- a/enterprise/server/raft/driver/BUILD
+++ b/enterprise/server/raft/driver/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
         "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/metrics",
         "//server/util/alert",
         "//server/util/disk",

--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -39,6 +39,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/storemap"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
@@ -441,7 +442,7 @@ type Queue struct {
 	efp interfaces.ExperimentFlagProvider
 }
 
-func NewQueue(store IStore, sender *sender.Sender, gossipManager interfaces.GossipService, nhlog log.Logger, apiClient IClient, clock clockwork.Clock, efp interfaces.ExperimentFlagProvider) *Queue {
+func NewQueue(store IStore, sender *sender.Sender, gossipManager gossip.Service, nhlog log.Logger, apiClient IClient, clock clockwork.Clock, efp interfaces.ExperimentFlagProvider) *Queue {
 	storeMap := storemap.New(gossipManager, clock, nhlog, *minReplicasPerRange, *minMetaRangeReplicas, *missingLeaseCountThreshold)
 	q := &Queue{
 		storeMap:             storeMap,

--- a/enterprise/server/raft/registry/BUILD
+++ b/enterprise/server/raft/registry/BUILD
@@ -9,7 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/raft/constants",
         "//proto:raft_go_proto",
-        "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/proto",

--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -345,7 +345,7 @@ func (n *StaticRegistry) String() string {
 // DynamicNodeRegistry is a node registry backed by gossip. It is capable of
 // supporting NodeHosts with dynamic RaftAddress values.
 type DynamicNodeRegistry struct {
-	gossipManager interfaces.GossipService
+	gossipManager gossip.Service
 	sReg          *StaticRegistry
 }
 
@@ -353,7 +353,7 @@ type DynamicNodeRegistry struct {
 // hand this to the raft library when we set things up. It will create a single
 // DynamicNodeRegistry and use it to resolve all other raft nodes until the
 // process shuts down.
-func NewDynamicNodeRegistry(gossipManager interfaces.GossipService, streamConnections uint64, v dbConfig.TargetValidator, nhlog log.Logger) *DynamicNodeRegistry {
+func NewDynamicNodeRegistry(gossipManager gossip.Service, streamConnections uint64, v dbConfig.TargetValidator, nhlog log.Logger) *DynamicNodeRegistry {
 	dnr := &DynamicNodeRegistry{
 		gossipManager: gossipManager,
 		sReg:          NewStaticNodeRegistry(streamConnections, v, nhlog),

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//proto:raft_service_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/metrics",
         "//server/resources",
         "//server/util/alert",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -43,6 +43,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
@@ -105,7 +106,7 @@ type Store struct {
 	partitionsAllInitialized bool
 
 	nodeHost      *dragonboat.NodeHost
-	gossipManager interfaces.GossipService
+	gossipManager gossip.Service
 	sender        *sender.Sender
 	registry      registry.NodeRegistry
 	grpcServer    *grpc.Server
@@ -173,7 +174,7 @@ type Store struct {
 type registryHolder struct {
 	raftAddr string
 	grpcAddr string
-	g        interfaces.GossipService
+	g        gossip.Service
 	r        registry.NodeRegistry
 }
 

--- a/enterprise/server/raft/storemap/BUILD
+++ b/enterprise/server/raft/storemap/BUILD
@@ -10,7 +10,7 @@ go_library(
     deps = [
         "//enterprise/server/raft/constants",
         "//proto:raft_go_proto",
-        "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
@@ -26,7 +26,7 @@ go_test(
     deps = [
         "//enterprise/server/raft/constants",
         "//proto:raft_go_proto",
-        "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/util/log",
         "//server/util/proto",
         "@com_github_hashicorp_serf//serf",

--- a/enterprise/server/raft/storemap/storemap.go
+++ b/enterprise/server/raft/storemap/storemap.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -67,7 +67,7 @@ type StoreDetail struct {
 }
 
 type StoreMap struct {
-	gossipManager interfaces.GossipService
+	gossipManager gossip.Service
 
 	mu *sync.RWMutex
 	// NHID to StoreDetail
@@ -85,7 +85,7 @@ type StoreMap struct {
 	allStoresStableSince time.Time
 }
 
-func New(gossipManager interfaces.GossipService, clock clockwork.Clock, nhLogger log.Logger, minReplicasPerRange, minMetaRangeReplicas, missingLeaseCountThreshold int) *StoreMap {
+func New(gossipManager gossip.Service, clock clockwork.Clock, nhLogger log.Logger, minReplicasPerRange, minMetaRangeReplicas, missingLeaseCountThreshold int) *StoreMap {
 	sm := &StoreMap{
 		mu:                         &sync.RWMutex{},
 		startTime:                  time.Now(),

--- a/enterprise/server/raft/storemap/storemap_test.go
+++ b/enterprise/server/raft/storemap/storemap_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/hashicorp/serf/serf"
@@ -137,7 +137,7 @@ func TestMissingUsageTag(t *testing.T) {
 type mockGossipManager struct {
 	mu       sync.Mutex
 	members  map[string]serf.Member
-	listener interfaces.GossipListener
+	listener gossip.Listener
 
 	t *testing.T
 }
@@ -165,7 +165,7 @@ func (m *mockGossipManager) setMemberTags(nhid string, tags map[string]string) {
 	m.members[nhid] = member
 }
 
-func (m *mockGossipManager) AddListener(l interfaces.GossipListener) {
+func (m *mockGossipManager) AddListener(l gossip.Listener) {
 	m.listener = l
 }
 

--- a/enterprise/server/raft/usagetracker/BUILD
+++ b/enterprise/server/raft/usagetracker/BUILD
@@ -17,7 +17,7 @@ go_library(
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
         "//proto:storage_go_proto",
-        "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/metrics",
         "//server/util/alert",
         "//server/util/approxlru",

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -18,7 +18,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/approxlru"
@@ -79,7 +79,7 @@ const (
 )
 
 type Tracker struct {
-	gossipManager interfaces.GossipService
+	gossipManager gossip.Service
 	node          *rfpb.NodeDescriptor
 	partitions    []disk.Partition
 	sender        *sender.Sender
@@ -550,7 +550,7 @@ func (pu *partitionUsage) updateMetrics() {
 	pu.metrics.evictionGCSChanSize.Set(float64(len(pu.gcsDeletes)))
 }
 
-func New(sender *sender.Sender, dbGetter pebble.Leaser, gossipManager interfaces.GossipService, node *rfpb.NodeDescriptor, partitions []disk.Partition, clock clockwork.Clock, fileStorer filestore.Store) (*Tracker, error) {
+func New(sender *sender.Sender, dbGetter pebble.Leaser, gossipManager gossip.Service, node *rfpb.NodeDescriptor, partitions []disk.Partition, clock clockwork.Clock, fileStorer filestore.Store) (*Tracker, error) {
 	ut := &Tracker{
 		gossipManager: gossipManager,
 		node:          node,

--- a/server/gossip/BUILD
+++ b/server/gossip/BUILD
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/gossip",
     visibility = ["//visibility:public"],
     deps = [
-        "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/util/flag",
         "//server/util/log",
         "//server/util/network",
@@ -24,7 +24,7 @@ go_test(
     srcs = ["gossip_test.go"],
     deps = [
         ":gossip",
-        "//server/interfaces",
+        "//server/interfaces/gossip",
         "//server/testutil/testport",
         "//server/util/testing/flags",
         "@com_github_hashicorp_serf//serf",

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	gossipiface "github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/network"
@@ -51,7 +51,7 @@ type GossipManager struct {
 	join       []string
 
 	mu        sync.Mutex
-	listeners []interfaces.GossipListener
+	listeners []gossipiface.Listener
 	tags      map[string]string
 }
 
@@ -78,7 +78,7 @@ func (gm *GossipManager) JoinList() []string {
 	return joinList
 }
 
-func (gm *GossipManager) AddListener(listener interfaces.GossipListener) {
+func (gm *GossipManager) AddListener(listener gossipiface.Listener) {
 	if listener == nil {
 		log.Error("listener cannot be nil")
 		return
@@ -270,7 +270,7 @@ func NewWithArgs(nodeName, listenAddress string, join []string) (*GossipManager,
 		join:          join,
 		serfEventChan: make(chan serf.Event, 16),
 		mu:            sync.Mutex{},
-		listeners:     make([]interfaces.GossipListener, 0),
+		listeners:     make([]gossipiface.Listener, 0),
 		tags:          make(map[string]string, 0),
 	}
 	serfConfig.EventCh = gossipMan.serfEventChan

--- a/server/gossip/gossip_test.go
+++ b/server/gossip/gossip_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/gossip"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	gossipiface "github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/hashicorp/serf/serf"
@@ -30,7 +30,7 @@ func localAddr(t *testing.T) string {
 	return fmt.Sprintf("127.0.0.1:%d", testport.FindFree(t))
 }
 
-func newGossipManager(t *testing.T, addr string, seeds []string, broker interfaces.GossipListener) *gossip.GossipManager {
+func newGossipManager(t *testing.T, addr string, seeds []string, broker gossipiface.Listener) *gossip.GossipManager {
 	node, err := gossip.NewWithArgs("name-"+addr, addr, seeds)
 	require.NoError(t, err)
 	require.NotNil(t, node)

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -48,7 +48,6 @@ go_library(
         "//server/util/proto",
         "@com_github_golang_jwt_jwt_v4//:jwt",
         "@com_github_google_go_github_v59//github",
-        "@com_github_hashicorp_serf//serf",
         "@com_github_miekg_dns//:dns",
         "@com_github_prometheus_client_model//io/prometheus/client:go",
         "@com_google_cloud_go_longrunning//autogen/longrunningpb",

--- a/server/interfaces/gossip/BUILD
+++ b/server/interfaces/gossip/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "gossip",
+    srcs = ["gossip.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/interfaces/gossip",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_hashicorp_serf//serf"],
+)

--- a/server/interfaces/gossip/gossip.go
+++ b/server/interfaces/gossip/gossip.go
@@ -1,0 +1,32 @@
+// Package gossip defines the gossip-related service interfaces used by
+// the BuildBuddy server. It is a small leaf package so that consumers of
+// the umbrella //server/interfaces package don't have to drag
+// hashicorp/serf + memberlist (and their transitive msgpack, go-metrics,
+// immutable-radix, etc. dependencies) into their build closures.
+package gossip
+
+import (
+	"context"
+
+	"github.com/hashicorp/serf/serf"
+)
+
+// Listener receives gossip events from the GossipService.
+type Listener interface {
+	OnEvent(eventType serf.EventType, event serf.Event)
+}
+
+// Service is the gossip/membership manager exposed to the rest of the server.
+type Service interface {
+	ListenAddr() string
+	JoinList() []string
+	AddListener(listener Listener)
+	LocalMember() serf.Member
+	Members() []serf.Member
+	SetTags(tags map[string]string) error
+	SendUserEvent(name string, payload []byte, coalesce bool) error
+	Query(name string, payload []byte, params *serf.QueryParam) (*serf.QueryResponse, error)
+	Statusz(ctx context.Context) string
+	Leave() error
+	Shutdown() error
+}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -18,7 +18,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-github/v59/github"
-	"github.com/hashicorp/serf/serf"
 	"github.com/miekg/dns"
 	"google.golang.org/grpc/credentials"
 	"gorm.io/gorm"
@@ -1730,23 +1729,12 @@ type SCIMService interface {
 	RegisterHandlers(mux HttpServeMux)
 }
 
-type GossipListener interface {
-	OnEvent(eventType serf.EventType, event serf.Event)
-}
-
-type GossipService interface {
-	ListenAddr() string
-	JoinList() []string
-	AddListener(listener GossipListener)
-	LocalMember() serf.Member
-	Members() []serf.Member
-	SetTags(tags map[string]string) error
-	SendUserEvent(name string, payload []byte, coalesce bool) error
-	Query(name string, payload []byte, params *serf.QueryParam) (*serf.QueryResponse, error)
-	Statusz(ctx context.Context) string
-	Leave() error
-	Shutdown() error
-}
+// GossipListener and GossipService used to live here; they moved to
+// //server/interfaces/gossip so that the umbrella interfaces package
+// doesn't drag hashicorp/serf + memberlist + msgpack into every
+// consumer's build closure. Call sites should import
+// //server/interfaces/gossip and reference gossip.Listener /
+// gossip.Service directly.
 
 type CodesearchService interface {
 	Search(ctx context.Context, req *cssrpb.SearchRequest) (*cssrpb.SearchResponse, error)

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -133,7 +133,6 @@ type RealEnv struct {
 	gcpService                           interfaces.GCPService
 	mcpService                           interfaces.MCPService
 	scimService                          interfaces.SCIMService
-	gossipService                        interfaces.GossipService
 	commandRunner                        interfaces.CommandRunner
 	codesearchService                    interfaces.CodesearchService
 	snapshotService                      interfaces.SnapshotService


### PR DESCRIPTION
Move the GossipListener/GossipService interfaces from the umbrella //server/interfaces package into a new leaf //server/interfaces/gossip package so that consumers of interfaces.* don't have to drag hashicorp/serf + memberlist + msgpack + go-metrics + immutable-radix into their build closures.

Also drops an unused gossipService field from real_environment, which was the only thing pulling serf into the CLI transitive closure.

Call sites that referenced interfaces.GossipService / interfaces.GossipListener now import
//server/interfaces/gossip directly and use gossip.Service / gossip.Listener.

Cold-build analysis actions:
  //enterprise/server/cmd/executor:executor  5302 -> 5235  (-67)
  //cli/cmd/bb:bb                             1558 -> 1535  (-23)

Also lifts hashicorp/serf + memberlist (and their msgpack, go-metrics, immutable-radix, sockaddr transitive deps) out of every CLI build. See DO_LESS.md.