### PR TITLE
fix(website): clean up linebreak in changelog

### DIFF
--- a/website/changelog/bazel-remote-cache-cdc.md
+++ b/website/changelog/bazel-remote-cache-cdc.md
@@ -16,7 +16,7 @@ common --experimental_remote_cache_chunking
 common --remote_header=x-buildbuddy-cdc-enabled=true
 ```
 
-To see the download-side savings, you should also set `--disk_cache`, since the downloaded chunks need to be stored somewhere in order to be reused locally. We also recommend setting `--experimental_disk_cache_gc_max_age` to a value below your remote cache TTL—for example, `3h`, or `1d` if your remote TTL is longer.
+To see the download-side savings, you should also set `--disk_cache`, since the downloaded chunks need to be stored somewhere in order to be reused locally. We also recommend setting <code className="flag">--experimental_disk_cache_gc_max_age</code> to a value below your remote cache TTL—for example, `3h`, or `1d` if your remote TTL is longer.
 
 Bazel 9.1 is required today, and this support will also be backported to Bazel 8.7.
 

--- a/website/src/css/general.css
+++ b/website/src/css/general.css
@@ -172,6 +172,10 @@ article svg[aria-hidden="true"] {
   margin-bottom: 32px;
 }
 
+.flag {
+  white-space: nowrap;
+}
+
 @media (min-width: 997px) {
   .table-of-contents:before {
     content: "Contents";


### PR DESCRIPTION
<img width="932" height="275" alt="Screenshot 2026-04-23 at 6 08 43 PM" src="https://github.com/user-attachments/assets/8fd14379-0ea7-4dc0-b13b-651622f4276e" />
