### PR TITLE
Make /dev/shm size configurable

### DIFF
--- a/docs/rbe-platforms.md
+++ b/docs/rbe-platforms.md
@@ -371,6 +371,15 @@ The following execution properties provide more customization.
     that are spawned by the executor which are also running with `"host"`
     network mode. This setting is not available in BuildBuddy cloud or for
     Firecracker VMs.
+- `shm-size`: for `oci` isolation, sets the size of the `/dev/shm` tmpfs mount,
+  which is typically used for shared memory. Values are byte sizes with optional
+  case-insensitive IEC unit suffixes (powers of 1024 bytes). Examples include:
+  `1b` (1 byte), `1k` (1024 bytes), `1m` (`1024^2` bytes), `1g` (`1024^3`
+  bytes), `1MB` (`1024^2` bytes), `2GB` (`2 * 1024^2` bytes). The default value
+  of this property if it is unspecified or empty is `64000k`. The value `0`
+  removes the limit on `/dev/shm` size. Note that `/dev/shm` memory usage always
+  counts towards process memory and is subject to process memory constraints,
+  regardless of this property's value.
 
 The following properties apply to `oci`, `podman` and `docker` isolation,
 and are currently unsupported by `firecracker`. (The `docker` prefix is

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -101,6 +101,9 @@ const (
 	// Default execution root directory path relative to the container rootfs directory.
 	defaultExecrootPath = "/buildbuddy-execroot"
 
+	// Default /dev/shm size in bytes, preserving the historical 64000k.
+	defaultShmSizeBytes = int64(64_000 * 1024)
+
 	// Image cache layout version.
 	//
 	// This should be incremented when making backwards-compatible changes to
@@ -409,6 +412,13 @@ func (p *provider) New(ctx context.Context, args *container.Init) (container.Com
 	if !filepath.IsAbs(execroot) {
 		return nil, status.InvalidArgumentErrorf("execroot-path platform property must be an absolute path, got %q", execroot)
 	}
+	shmSizeBytes := defaultShmSizeBytes
+	if args.Props.ShmSizeBytes != nil {
+		shmSizeBytes = *args.Props.ShmSizeBytes
+		if shmSizeBytes < 0 {
+			return nil, status.InvalidArgumentErrorf("shm-size platform property must be >= 0, got %d", shmSizeBytes)
+		}
+	}
 
 	container := &ociContainer{
 		env:            p.env,
@@ -432,6 +442,7 @@ func (p *provider) New(ctx context.Context, args *container.Init) (container.Com
 		user:               args.Props.DockerUser,
 		forceRoot:          args.Props.DockerForceRoot,
 		execrootPath:       execroot,
+		shmSizeBytes:       shmSizeBytes,
 		persistentVolumes:  args.Props.PersistentVolumes,
 
 		milliCPU:      args.Task.GetSchedulingMetadata().GetTaskSize().GetEstimatedMilliCpu(),
@@ -478,6 +489,7 @@ type ociContainer struct {
 	user           string
 	forceRoot      bool
 	execrootPath   string
+	shmSizeBytes   int64
 
 	milliCPU      int64 // milliCPU allocation from task size
 	memoryBytes   int64 // memory allocation from task size in bytes
@@ -1198,7 +1210,10 @@ func (c *ociContainer) createSpec(ctx context.Context, cmd *repb.Command) (*spec
 				Destination: "/dev/shm",
 				Type:        "tmpfs",
 				Source:      "shm",
-				Options:     []string{"rw", "nosuid", "nodev", "noexec", "relatime", "size=64000k"},
+				Options: []string{
+					"rw", "nosuid", "nodev", "noexec", "relatime",
+					fmt.Sprintf("size=%d", c.shmSizeBytes),
+				},
 			},
 			// TODO: .containerenv
 			// {

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -2093,6 +2093,45 @@ func TestMounts(t *testing.T) {
 	assert.Equal(t, 0, res.ExitCode)
 }
 
+func TestShmSize(t *testing.T) {
+	setupNetworking(t)
+	image := busyboxImage(t)
+
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	installLeaserInEnv(t, env)
+	installFileCacheInEnv(t, env)
+	runtimeRoot := testfs.MakeTempDir(t)
+	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
+	buildRoot := testfs.MakeTempDir(t)
+	cacheRoot := testfs.MakeTempDir(t)
+	provider, err := ociruntime.NewProvider(env, buildRoot, cacheRoot)
+	require.NoError(t, err)
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+
+	// Configure a non-default /dev/shm size for this container.
+	const shmSizeBytes = 777 * 4096
+	c, err := provider.New(ctx, &container.Init{Props: &platform.Properties{
+		ContainerImage: image,
+		ShmSizeBytes:   new(int64(shmSizeBytes)),
+	}})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := c.Remove(ctx)
+		require.NoError(t, err)
+	})
+
+	// Run inside the container and check the kernel-reported mount options.
+	cmd := &repb.Command{
+		Arguments: []string{"grep", " /dev/shm ", "/proc/mounts"},
+	}
+	res := c.Run(ctx, cmd, wd, oci.Credentials{})
+	require.NoError(t, res.Error)
+	assert.Empty(t, string(res.Stderr))
+	assert.Equal(t, 0, res.ExitCode)
+	assert.Contains(t, string(res.Stdout), "size=3108k")
+}
+
 func TestCDIDevicesMountsFromCDISpec(t *testing.T) {
 	setupNetworking(t)
 	image := busyboxImage(t)

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -138,6 +138,10 @@ const (
 	// Using the property defined here: https://github.com/bazelbuild/bazel-toolchains/blob/v5.1.0/rules/exec_properties/exec_properties.bzl#L156
 	dockerNetworkPropertyName = "dockerNetwork"
 
+	// ShmSizePropertyName specifies the size of the /dev/shm tmpfs mount for OCI
+	// containers. Values are parsed as byte sizes, such as "1GB" or "1MB".
+	ShmSizePropertyName = "shm-size"
+
 	// Whether external network access should be enabled. Valid values are:
 	// - "off": no network access
 	// - "external": network access via a network namespace routed thru the host
@@ -250,8 +254,11 @@ type Properties struct {
 	ExecrootPath              string
 	Network                   string
 	NetworkEnableIPv6         bool
-	RecycleRunner             bool
-	RunnerRecyclingMaxWait    time.Duration
+
+	// ShmSizeBytes is the requested size of the /dev/shm tmpfs mount.
+	ShmSizeBytes           *int64
+	RecycleRunner          bool
+	RunnerRecyclingMaxWait time.Duration
 
 	// Exit codes indicating a runner crashed and should not be recycled since
 	// it may be corrupted in some way.
@@ -519,6 +526,15 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		return nil, status.InvalidArgumentErrorf("%s is not a valid value for the `snapshot-read-policy` platform property", snapshotReadPolicy)
 	}
 
+	var shmSizeBytes *int64
+	if shmSizeString := stringProp(m, ShmSizePropertyName, ""); shmSizeString != "" {
+		n, err := parseIECBytes(shmSizeString)
+		if err != nil || strings.HasPrefix(shmSizeString, "-") || n < 0 {
+			return nil, status.InvalidArgumentError("shm-size must be either `0` (for no explicit limit) or a size in bytes like `64k`, `100m`, or `1g`")
+		}
+		shmSizeBytes = &n
+	}
+
 	return &Properties{
 		OS:                        strings.ToLower(stringProp(m, OperatingSystemPropertyName, defaultOperatingSystemName)),
 		Arch:                      strings.ToLower(stringProp(m, CPUArchitecturePropertyName, defaultCPUArchitecture)),
@@ -543,6 +559,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		ExecrootPath:              stringProp(m, execrootPathPropertyName, ""),
 		Network:                   stringProp(m, networkPropertyName, ""),
 		NetworkEnableIPv6:         boolProp(m, NetworkEnableIPv6PropertyName, false),
+		ShmSizeBytes:              shmSizeBytes,
 		RecycleRunner:             recycleRunner,
 		DefaultTimeout:            timeout,
 		TerminationGracePeriod:    terminationGracePeriod,
@@ -655,19 +672,28 @@ func iecBytesProp(props map[string]string, name string, defaultValue int64) int6
 	if val == "" {
 		return defaultValue
 	}
+	n, err := parseIECBytes(val)
+	if err != nil {
+		// TODO: return an error here
+		return defaultValue
+	}
+	return n
+}
+
+func parseIECBytes(val string) (int64, error) {
 	// If it looks like a float (e.g. 1e9), convert to an integer number of
 	// bytes.
 	f, err := strconv.ParseFloat(val, 64)
 	if err == nil {
-		return int64(f)
+		return int64(f), nil
 	}
 	// Otherwise attempt to parse as an IEC number of bytes.
 	// Example: 4GB = 4*(1024^3) bytes
 	n, err := units.RAMInBytes(val)
 	if err != nil {
-		return defaultValue
+		return 0, err
 	}
-	return n
+	return n, nil
 }
 
 func milliCPUProp(props map[string]string, name string, defaultValue int64) int64 {

--- a/server/util/platform/platform_test.go
+++ b/server/util/platform/platform_test.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -181,6 +182,48 @@ func TestParse_EstimatedMemory(t *testing.T) {
 		platformProps, err := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
 		require.NoError(t, err)
 		assert.Equal(t, testCase.expectedValue, platformProps.EstimatedMemoryBytes)
+	}
+}
+
+func TestParse_ShmSize(t *testing.T) {
+	platformProps, err := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: &repb.Platform{}}})
+	require.NoError(t, err)
+	assert.Nil(t, platformProps.ShmSizeBytes)
+
+	// shm-size is parsed using the same IEC byte-size parser as the other
+	// byte-size platform properties.
+	for _, testCase := range []struct {
+		rawValue      string
+		expectedValue *int64
+		errPredicate  func(err error) bool
+	}{
+		{"", nil, nil},
+		{"0", new(int64(0)), nil},
+		{"1b", new(int64(1)), nil},
+		{"1k", new(int64(1024)), nil},
+		{"1m", new(int64(1024 * 1024)), nil},
+		{"1g", new(int64(1024 * 1024 * 1024)), nil},
+		{"1GB", new(int64(1024 * 1024 * 1024)), nil},
+		{"1.5m", new(int64(3 * 1024 * 1024 / 2)), nil},
+		{"-1", nil, status.IsInvalidArgumentError},
+		{"-0.5", nil, status.IsInvalidArgumentError},
+		// Intentionally disallowing percentages so actions to reduce action
+		// dependencies on the physical host machine shape.
+		{"50%", nil, status.IsInvalidArgumentError},
+	} {
+		t.Run(fmt.Sprintf("value=%q", testCase.rawValue), func(t *testing.T) {
+			plat := &repb.Platform{Properties: []*repb.Platform_Property{
+				{Name: ShmSizePropertyName, Value: testCase.rawValue},
+			}}
+			platformProps, err := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+			if testCase.errPredicate != nil {
+				require.True(t, testCase.errPredicate(err), "expected %v, got %v", testCase.errPredicate, err)
+				require.Nil(t, platformProps)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedValue, platformProps.ShmSizeBytes)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The current ~64MB limit is pretty arbitrary. `/dev/shm` is "just memory" and users can already allocate more than 64MB of memory by other means. This memory gets accounted for by the cgroup, so it should mostly work the same as other forms of allocation. So, it should be safe to make it configurable.

https://buildbuddy-corp.slack.com/archives/C0A1KRAFELU/p1776990887697019