### PR TITLE
Introduce the concept of executor 'labels' and add a debug header that routes to executors with specific labels

### DIFF
--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -34,6 +34,7 @@ import (
 
 var (
 	pool                         = flag.String("executor.pool", "", "Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified.")
+	labels                       = flag.Map[string, string]("executor.labels", map[string]string{}, "Optional labels identifying this executor, similar to Kubernetes labels (e.g. 'canary=true,experiment-ramfs=control,region=us-east1'). Reported to the scheduler at registration and used for server-side debug routing via the 'debug-executor-labels' platform property.")
 	proactiveCancellationEnabled = flag.Bool("executor.proactive_cancellation_enabled", false, "Whether the executor supports proactive task cancellation.", flag.Internal)
 )
 
@@ -86,6 +87,10 @@ func makeExecutionNode(pool, executorID, executorHostID string, xcodeLocator int
 	if err != nil {
 		return nil, err
 	}
+	trimmedLabels := make(map[string]string, len(*labels))
+	for k, v := range *labels {
+		trimmedLabels[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
 	return &scpb.ExecutionNode{
 		Host: hostname,
 		// TODO: stop setting port once the scheduler no longer requires it.
@@ -109,6 +114,7 @@ func makeExecutionNode(pool, executorID, executorHostID string, xcodeLocator int
 		WarmupImages:                  options.WarmupImages,
 		FilecacheMaxSizeBytes:         options.FilecacheMaxSizeBytes,
 		StartTime:                     options.StartTime,
+		Labels:                        trimmedLabels,
 	}, nil
 }
 

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand"
 	"regexp"
 	"slices"
@@ -705,6 +706,59 @@ func filterToDebugExecutorID(nodes []*executionNode, task *repb.ExecutionTask) (
 		}
 	}
 	return id, nil
+}
+
+// Parses the requested executor labels from the "debug-executor-labels"
+// platform property. The value is a comma-separated list of "key=value" pairs;
+// entries without an "=" are treated as a key with an empty value.
+func parseDebugExecutorLabels(task *repb.ExecutionTask) map[string]string {
+	raw := platform.FindEffectiveValue(task, "debug-executor-labels")
+	if raw == "" {
+		return nil
+	}
+	out := make(map[string]string)
+	for entry := range strings.SplitSeq(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		k, v, _ := strings.Cut(entry, "=")
+		out[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return out
+}
+
+// executorHasAllLabels reports whether the executor's labels contain every
+// requested key with a matching value.
+func executorHasAllLabels(executorLabels, requested map[string]string) bool {
+	for k, v := range requested {
+		if executorLabels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// If the debug-executor-labels platform property is set, filters the given
+// nodes to those whose labels match every requested key=value pair. If no
+// nodes match, fires an internal alert and returns an unfiltered list so
+// scheduling can proceed, making the debug-executor-labels best effort.
+func filterToDebugExecutorLabels(ctx context.Context, nodes []*executionNode, task *repb.ExecutionTask) []*executionNode {
+	requested := parseDebugExecutorLabels(task)
+	if len(requested) == 0 {
+		return nodes
+	}
+	var out []*executionNode
+	for _, n := range nodes {
+		if executorHasAllLabels(n.GetLabels(), requested) {
+			out = append(out, n)
+		}
+	}
+	if len(out) == 0 {
+		alert.CtxUnexpectedEvent(ctx, "unrecognized_debug_executor_labels", "no executors found with debug-executor-labels %v; scheduling without filter", slices.Sorted(maps.Keys(requested)))
+		return nodes
+	}
+	return out
 }
 
 func filterToHostnamePattern(ctx context.Context, nodes []*executionNode, pattern string) []*executionNode {
@@ -1745,6 +1799,9 @@ func (s *SchedulerServer) sampleUnclaimedTasks(ctx context.Context, count int, n
 		if id := platform.FindEffectiveValue(fullTask, "debug-executor-id"); id != "" {
 			continue
 		}
+		if requested := parseDebugExecutorLabels(fullTask); len(requested) > 0 && !executorHasAllLabels(node.GetLabels(), requested) {
+			continue
+		}
 
 		tasksThatFit = append(tasksThatFit, task)
 	}
@@ -2246,6 +2303,7 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 				log.CtxWarningf(ctx, "No executors found matching routing config %q in pool %q with os %q with arch %q", routingConfig, pool, os, arch)
 				return status.UnavailableErrorf("no executors found matching routing config")
 			}
+			candidateNodes = filterToDebugExecutorLabels(ctx, candidateNodes, task)
 			rankedNodes = s.taskRouter.RankNodes(ctx, task.GetAction(), cmd, remoteInstanceName, toNodeInterfaces(candidateNodes))
 		}
 

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -1175,6 +1175,42 @@ func TestAskForMoreWork_RespectRequestedExecutorID(t *testing.T) {
 	require.Greater(t, rsp.GetAskForMoreWorkResponse().GetDelay().AsDuration(), time.Duration(0))
 }
 
+func TestAskForMoreWork_RespectDebugExecutorLabels(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
+
+	// Register two nodes with distinct labels.
+	executor1 := newFakeExecutorWithId(ctx, t, "n1", env.GetSchedulerClient())
+	executor1.node.AssignableMilliCpu = 1000
+	executor1.node.Labels = map[string]string{"foo": "1", "bar": "2"}
+	executor1.Register()
+
+	executor2 := newFakeExecutorWithId(ctx, t, "n2", env.GetSchedulerClient())
+	executor2.node.AssignableMilliCpu = 1000
+	executor2.node.Labels = map[string]string{"foo": "a", "bar": "2"}
+	executor2.Register()
+
+	var rsp *scpb.RegisterAndStreamWorkResponse
+
+	// Schedule a task that requires labels matching only executor1.
+	taskID := scheduleTask(ctx, t, env, map[string]string{"debug-executor-labels": "foo=1,bar=2"})
+	// Ensure the task was enqueued on executor1, but don't have executor1
+	// claim the task, so that it's eligible to be enqueued as part of
+	// AskForMoreWork.
+	rsp = <-executor1.schedulerMessages
+	require.Equal(t, taskID, rsp.GetEnqueueTaskReservationRequest().GetTaskId())
+
+	// Have executor2 ask for more work now. The scheduler should not schedule
+	// any work on executor2 because the task's requested labels don't match
+	// executor2's labels. It should only reply with an AskForMoreWorkResponse
+	// to increase the client backoff.
+	executor2.Send(&scpb.RegisterAndStreamWorkRequest{
+		AskForMoreWorkRequest: &scpb.AskForMoreWorkRequest{},
+	})
+	rsp = <-executor2.schedulerMessages
+	require.Greater(t, rsp.GetAskForMoreWorkResponse().GetDelay().AsDuration(), time.Duration(0))
+}
+
 func TestGetExecutionNodes(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -608,6 +608,9 @@ message ExecutionNode {
 
   // Time when this executor process started.
   google.protobuf.Timestamp start_time = 21;
+
+  // Optional set of key-value labels identifying this executor.
+  map<string, string> labels = 22;
 }
 
 message GetExecutionNodesRequest {


### PR DESCRIPTION
Today, we can't probe RBE in executors in a specific cluster, or route actions to only canary executors, or executors running an experiment. I think it would be nice to be able to do that. This PR introduces the concept of executor "labels" to the scheduler which allows remotely executed actions to target only executors with all of a specified set of labels using `debug-executor-labels`. I plan to use this to configure RBE probers on a per-cluster basis. I took care to not expose the presence or absence of these labels in the RBE request to the end user, as this is for internal use only.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5942