### PR TITLE
dirtools: handle empty symlink targets

### DIFF
--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
@@ -324,67 +324,6 @@ func TestTransientCacheNotFoundError_Retried(t *testing.T) {
 	assert.Equal(t, 2, GetNumExecutionsFlushedToOLAPDB(t, env))
 }
 
-func TestGeneratedSymlinkToCurrentDirectoryAsRemoteInput(t *testing.T) {
-	env := setup(t)
-	ctx := context.Background()
-
-	ws := testbazel.MakeTempModule(t, map[string]string{
-		"defs.bzl": `
-def _project_symlink_impl(ctx):
-  out = ctx.actions.declare_symlink("PROJ")
-  ctx.actions.symlink(output = out, target_path = ".")
-  return [DefaultInfo(files = depset([out]))]
-
-project_symlink = rule(implementation = _project_symlink_impl)
-
-def _consume_project_symlink_impl(ctx):
-  inputs = ctx.attr.src[DefaultInfo].files.to_list()
-  if len(inputs) != 1:
-    fail("expected exactly one input")
-  proj = inputs[0]
-  out = ctx.actions.declare_file(ctx.label.name + ".txt")
-  ctx.actions.run_shell(
-    inputs = [proj],
-    outputs = [out],
-    arguments = [proj.path, out.path],
-    command = """
-      set -e
-      target="$(readlink "$1")"
-      test "$target" = .
-      printf '%s\n' "$target" > "$2"
-    """,
-  )
-  return [DefaultInfo(files = depset([out]))]
-
-consume_project_symlink = rule(
-  implementation = _consume_project_symlink_impl,
-  attrs = {"src": attr.label(mandatory = True)},
-)
-`,
-		"BUILD": fmt.Sprintf(`load(":defs.bzl", "consume_project_symlink", "project_symlink")
-
-project_symlink(name = "proj")
-
-consume_project_symlink(
-  name = "consume_proj",
-  src = ":proj",
-  exec_properties = {
-    "OSFamily": "%s",
-    "Arch": "%s",
-  },
-)`, runtime.GOOS, runtime.GOARCH),
-	})
-
-	res := testbazel.Invoke(ctx, t, ws, "build",
-		":consume_proj",
-		"--remote_executor="+env.GetRemoteExecutionTarget(),
-		"--bes_backend="+env.GetBuildBuddyServerTarget(),
-		"--remote_retries=0",
-	)
-
-	require.NoError(t, res.Error, "stdout:\n%s\nstderr:\n%s", res.Stdout, res.Stderr)
-}
-
 func TestActionWithContainerImage_InvalidArgument(t *testing.T) {
 	env := setup(t)
 	ctx := context.Background()

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
@@ -324,6 +324,69 @@ func TestTransientCacheNotFoundError_Retried(t *testing.T) {
 	assert.Equal(t, 2, GetNumExecutionsFlushedToOLAPDB(t, env))
 }
 
+func TestGeneratedSymlinkToCurrentDirectoryAsRemoteInput(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+
+	ws := testbazel.MakeTempModule(t, map[string]string{
+		"defs.bzl": `
+def _project_symlink_impl(ctx):
+  out = ctx.actions.declare_symlink("PROJ")
+  ctx.actions.symlink(output = out, target_path = ".")
+  return [DefaultInfo(files = depset([out]))]
+
+project_symlink = rule(implementation = _project_symlink_impl)
+
+def _consume_project_symlink_impl(ctx):
+  inputs = ctx.attr.src[DefaultInfo].files.to_list()
+  if len(inputs) != 1:
+    fail("expected exactly one input")
+  proj = inputs[0]
+  out = ctx.actions.declare_file(ctx.label.name + ".txt")
+  ctx.actions.run_shell(
+    inputs = [proj],
+    outputs = [out],
+    arguments = [proj.path, out.path],
+    command = """
+      set -e
+      target="$(readlink "$1")"
+      test "$target" = .
+      printf '%s\n' "$target" > "$2"
+    """,
+  )
+  return [DefaultInfo(files = depset([out]))]
+
+consume_project_symlink = rule(
+  implementation = _consume_project_symlink_impl,
+  attrs = {"src": attr.label(mandatory = True)},
+)
+`,
+		"BUILD": fmt.Sprintf(`load(":defs.bzl", "consume_project_symlink", "project_symlink")
+
+project_symlink(name = "proj")
+
+consume_project_symlink(
+  name = "consume_proj",
+  src = ":proj",
+  exec_properties = {
+    "OSFamily": "%s",
+    "Arch": "%s",
+  },
+)`, runtime.GOOS, runtime.GOARCH),
+	})
+
+	res := testbazel.Invoke(ctx, t, ws, "build",
+		":consume_proj",
+		"--remote_executor="+env.GetRemoteExecutionTarget(),
+		"--bes_backend="+env.GetBuildBuddyServerTarget(),
+		"--remote_retries=0",
+	)
+
+	require.Error(t, res.Error)
+	assert.Contains(t, res.Stderr, "download inputs: could not start tree fetcher")
+	assert.Contains(t, res.Stderr, "/PROJ: no such file or directory")
+}
+
 func TestActionWithContainerImage_InvalidArgument(t *testing.T) {
 	env := setup(t)
 	ctx := context.Background()

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
@@ -382,9 +382,7 @@ consume_project_symlink(
 		"--remote_retries=0",
 	)
 
-	require.Error(t, res.Error)
-	assert.Contains(t, res.Stderr, "download inputs: could not start tree fetcher")
-	assert.Contains(t, res.Stderr, "/PROJ: no such file or directory")
+	require.NoError(t, res.Error, "stdout:\n%s\nstderr:\n%s", res.Stdout, res.Stderr)
 }
 
 func TestActionWithContainerImage_InvalidArgument(t *testing.T) {

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -1312,14 +1312,20 @@ type symlinkRequest struct {
 }
 
 func (slr *symlinkRequest) Do() error {
-	err := os.Symlink(slr.oldname, slr.newname)
+	oldname := slr.oldname
+	if oldname == "" {
+		// Bazel can encode target_path = "." as an empty REAPI SymlinkNode
+		// target. Linux rejects empty symlink targets.
+		oldname = "."
+	}
+	err := os.Symlink(oldname, slr.newname)
 	if err == nil {
 		return nil
 	}
 	if !os.IsExist(err) {
 		return err
 	}
-	if checkSymlink(slr.oldname, slr.newname) {
+	if checkSymlink(oldname, slr.newname) {
 		return nil
 	}
 	// Attempt to blow away the existing
@@ -1329,7 +1335,7 @@ func (slr *symlinkRequest) Do() error {
 	}
 	// Now that the symlink has been removed
 	// try one more time to link it.
-	if err := os.Symlink(slr.oldname, slr.newname); err != nil {
+	if err := os.Symlink(oldname, slr.newname); err != nil {
 		return err
 	}
 	return nil

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -793,6 +793,29 @@ func TestDownloadTree(t *testing.T) {
 	assert.Equal(t, "mytestdataA", string(targetContents), "symlinked file contents should match target file")
 }
 
+func TestDownloadTreeEmptySymlinkTarget(t *testing.T) {
+	env, ctx := testEnv(t)
+	tmpDir := testfs.MakeTempDir(t)
+
+	tree := &repb.Tree{
+		Root: &repb.Directory{
+			Symlinks: []*repb.SymlinkNode{
+				// Bazel can encode target_path = "." by omitting the target field.
+				{
+					Name: "PROJ",
+				},
+			},
+		},
+	}
+
+	_, err := dirtools.DownloadTree(ctx, env, "", repb.DigestFunction_SHA256, tree, &dirtools.DownloadTreeOpts{RootDir: tmpDir})
+	require.NoError(t, err)
+
+	target, err := os.Readlink(filepath.Join(tmpDir, "PROJ"))
+	require.NoError(t, err)
+	assert.Equal(t, ".", target)
+}
+
 func TestDownloadTreeDedupeInflight(t *testing.T) {
 	env, ctx := testEnv(t)
 	tmpDir := testfs.MakeTempDir(t)


### PR DESCRIPTION
Bazel can encode `target_path = "."` as a `SymlinkNode` whose target is the
proto3 default empty string. The remote execution proto describes symlink
target strings, but it does not define whether a local relative self-link
should be encoded as `"."` or as that empty normalized form.

In JSON, the input tree symlink looks like this because proto3 omits the
empty target:

```json
{
  "symlinks": [
    {
      "name": "PROJ"
    }
  ]
}
```

Our Executor previously passed `SymlinkNode.target` straight to `os.Symlink`
when materializing inputs. On Linux, `os.Symlink("", ".../PROJ")` fails
with `no such file or directory`, which surfaces as:

```text
download inputs: could not start tree fetcher
```

This PR first captures the failure, then fixes it by treating an empty remote
symlink target as `"."` while downloading inputs. The newest commit keeps the
same regression coverage but moves it to `server/cache/dirtools`: `DownloadTree`
now receives the malformed `SymlinkNode{Name: "PROJ"}` message directly and
verifies the materialized link points at `"."`.

Validated with:

```text
./buildfix.sh
bazel test --config=remote-minimal //server/cache/dirtools:dirtools_test
```
