### PR TITLE
Remove race in testport on unix

### DIFF
--- a/server/testutil/testport/BUILD
+++ b/server/testutil/testport/BUILD
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "testport",
-    srcs = ["testport.go"],
+    srcs = [
+        "lock_other.go",
+        "lock_unix.go",
+        "testport.go",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testport",
     visibility = ["//visibility:public"],
 )

--- a/server/testutil/testport/lock_other.go
+++ b/server/testutil/testport/lock_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package testport
+
+// lockPort is a no-op on non-Unix systems. Port collisions from parallel test
+// processes are possible but unlikely without flock support.
+func lockPort(port int) bool {
+	return true
+}

--- a/server/testutil/testport/lock_unix.go
+++ b/server/testutil/testport/lock_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package testport
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// lockPort acquires an exclusive cross-process lock for the given port to
+// prevent parallel test processes from choosing the same port. The lock is
+// released automatically when the process exits.
+func lockPort(port int) bool {
+	lockPath := filepath.Join(os.TempDir(), fmt.Sprintf("testport.%d.lock", port))
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return false
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		f.Close()
+		return false
+	}
+	// Intentionally not closing f: the flock is held for the lifetime of the
+	// process, preventing other test processes from claiming this port.
+	return true
+}

--- a/server/testutil/testport/testport.go
+++ b/server/testutil/testport/testport.go
@@ -11,7 +11,7 @@ var (
 )
 
 func FindFree(t testing.TB) int {
-	return portLeaser.Lease(t)
+	return portLeaser.lease(t)
 }
 
 type freePortLeaser struct {
@@ -32,7 +32,7 @@ func (p *freePortLeaser) findAPort(t testing.TB) int {
 	return l.Addr().(*net.TCPAddr).Port
 }
 
-func (p *freePortLeaser) Lease(t testing.TB) int {
+func (p *freePortLeaser) lease(t testing.TB) int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.leasedPorts == nil {
@@ -42,6 +42,9 @@ func (p *freePortLeaser) Lease(t testing.TB) int {
 		port := p.findAPort(t)
 		if _, ok := p.leasedPorts[port]; !ok {
 			p.leasedPorts[port] = struct{}{}
+			if !lockPort(port) {
+				continue
+			}
 			return port
 		}
 	}


### PR DESCRIPTION
Right now, we can find an unused port, close the listener, someone else gets the port, and then we return that to the caller.

Instead, use `flock` when we can to get an exclusive lock on a file. This will prevent other processes from getting the same port.