### PR TITLE
Build the cache proxy image as multi-arch, like the executor

### DIFF
--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -72,6 +72,10 @@ go_binary(
 
 container_image(
     name = "base_image",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
     base = "@buildbuddy_go_image_base//image",
     tags = ["manual"],
     visibility = ["//visibility:public"],
@@ -83,6 +87,10 @@ container_image(
 # This target can be run locally with enterprise/tools/run_proxy_image.sh
 go_image(
     name = "cache_proxy_go_image",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
     base = ":base_image",
     binary = ":cache_proxy",
     tags = ["manual"],
@@ -90,6 +98,10 @@ go_image(
 
 container_image(
     name = "cache_proxy_image",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "//conditions:default": "amd64",
+    }),
     base = ":cache_proxy_go_image",
     entrypoint = [
         "/app/enterprise/server/cmd/cache_proxy/cache_proxy",

--- a/release.py
+++ b/release.py
@@ -168,7 +168,7 @@ def tag_and_push_image_with_docker(bazel_target, project, version_tag):
     run_or_die(f'docker tag {local_image_ref} {remote_image_ref}')
     run_or_die(f'docker push {remote_image_ref}')
 
-def update_docker_images(images, version_tag, skip_update_latest_tag, arch_specific_executor_tag):
+def update_docker_images(images, version_tag, skip_update_latest_tag, arch_specific_executor_tag, arch_specific_proxy_tag):
     clean_cmd = 'bazel clean --expunge'
     run_or_die(clean_cmd)
 
@@ -189,7 +189,13 @@ def update_docker_images(images, version_tag, skip_update_latest_tag, arch_speci
         push_image_for_project("flame-public/buildbuddy-executor-enterprise", executor_tag, '//enterprise/server/cmd/executor:executor_image', skip_latest_tag)
     # Enterprise cache proxy
     if 'buildbuddy-proxy-enterprise' in images:
-        push_image_for_project("flame-public/buildbuddy-proxy-enterprise", 'enterprise-' + version_tag, '//enterprise/server/cmd/cache_proxy:cache_proxy_image', skip_update_latest_tag)
+        proxy_tag = 'enterprise-' + version_tag
+        if arch_specific_proxy_tag:
+            proxy_tag += '-' + get_cpu_architecture()
+        # Skip "latest" tag for arch-specific images, since the latest tag
+        # should only apply to the multiarch one.
+        skip_latest_tag = skip_update_latest_tag or arch_specific_proxy_tag
+        push_image_for_project("flame-public/buildbuddy-proxy-enterprise", proxy_tag, '//enterprise/server/cmd/cache_proxy:cache_proxy_image', skip_latest_tag)
 
 def generate_release_notes(old_version):
     release_notes_cmd = 'git log --max-count=50 --pretty=format:"%ci %cn: %s"' + ' %s...HEAD' % old_version
@@ -227,6 +233,7 @@ def main():
     parser.add_argument('--update_executor_image', default=False, action='store_true')
     parser.add_argument('--update_proxy_image', default=False, action='store_true')
     parser.add_argument('--arch_specific_executor_tag', default=False, action='store_true', help='Suffix the executor image tag with the CPU architecture (amd64 or arm64)')
+    parser.add_argument('--arch_specific_proxy_tag', default=False, action='store_true', help='Suffix the cache proxy image tag with the CPU architecture (amd64 or arm64)')
     parser.add_argument('--version', default='', help='Version tag override, used when pushing docker images. Implies --bump_version_type=none')
     parser.add_argument('--skip_latest_tag', default=False, action='store_true')
     parser.add_argument('--mark_workspace_as_safe', default='')
@@ -293,7 +300,7 @@ def main():
     if images:
         print('Building and pushing docker images', images)
         update_docker_images(
-            images, new_version, args.skip_latest_tag, args.arch_specific_executor_tag
+            images, new_version, args.skip_latest_tag, args.arch_specific_executor_tag, args.arch_specific_proxy_tag
         )
     print("Done -- proceed with the release guide!")
 


### PR DESCRIPTION
The cache_proxy image targets didn't set the `architecture` attribute, so rules_docker tagged the image metadata as amd64 regardless of the host Bazel was running on. Pushing from an arm64 host therefore produced an arm64 binary inside a manifest labeled amd64 — the "mixed architecture" we'd been seeing. This PR mirrors the executor's existing pattern: set `architecture = select(...)` on the base_image, go_image, and container_image targets, and add a `--arch_specific_proxy_tag` flag to release.py that suffixes the pushed tag with the CPU architecture and skips updating the `latest` tag. The final multi-arch manifest is stitched together externally by the release guide, same as we already do for the executor.