### PR TITLE
Fix bugs with delete_filecache_on_unclean_shutdown

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -613,16 +613,13 @@ func key(ctx context.Context, node *repb.FileNode) string {
 	return namespacedKey(keyPrefixFromContext(ctx), node)
 }
 
-func (c *fileCache) checkClosed() error {
+func (c *fileCache) checkClosed() bool {
 	// Close() functionality was added in unclean shutdown detection CL, so disable
 	// any checking of closed filecache when this feature is disabled.
 	if !*deleteFilecacheOnUncleanShutdown {
-		return nil
+		return false
 	}
-	if c.isClosed.Load() {
-		return status.FailedPreconditionError("filecache is closed")
-	}
-	return nil
+	return c.isClosed.Load()
 }
 
 func (c *fileCache) FastLinkFile(ctx context.Context, node *repb.FileNode, outputPath string) (hit bool) {
@@ -739,8 +736,10 @@ func (c *fileCache) addFileWithKeyPrefix(keyPrefix string, node *repb.FileNode, 
 }
 
 func (c *fileCache) AddFile(ctx context.Context, node *repb.FileNode, existingFilePath string) error {
-	if err := c.checkClosed(); err != nil {
-		return err
+	if c.checkClosed() {
+		// During shutdown, treat filecache population as best-effort so callers
+		// don't fail just because the local cache is no longer accepting writes.
+		return nil
 	}
 	start := time.Now()
 	keyPrefix := keyPrefixFromContext(ctx)
@@ -791,10 +790,13 @@ func (c *fileCache) AddFile(ctx context.Context, node *repb.FileNode, existingFi
 // MUST be located on the same filesystem as the filecache. This renaming
 // approach ensures that eviction is both fast and atomic (the atomicity
 // property is required to uphold the invariants described above).
+//
+// This function succeeds even if shutdown has already started, since external
+// directories are not subject to the automatic integrity checks and protections
+// used for internal files. Callers of this function are expected to handle
+// integrity checks themselves (i.e. detecting corrupted directory contents
+// after a power loss).
 func (c *fileCache) TrackExternalDirectory(ctx context.Context, path string, size int64) (unlock func(), err error) {
-	if err := c.checkClosed(); err != nil {
-		return nil, err
-	}
 	path = filepath.Clean(path)
 	key := externalDirectoryKey(path)
 
@@ -876,7 +878,7 @@ func (c *fileCache) ContainsFile(ctx context.Context, node *repb.FileNode) bool 
 }
 
 func (c *fileCache) DeleteFile(ctx context.Context, node *repb.FileNode) bool {
-	if err := c.checkClosed(); err != nil {
+	if c.checkClosed() {
 		return false
 	}
 	k := key(ctx, node)
@@ -909,8 +911,8 @@ func (c *fileCache) Read(ctx context.Context, node *repb.FileNode) ([]byte, erro
 
 // Write atomically writes the given bytes to filecache.
 func (c *fileCache) Write(ctx context.Context, node *repb.FileNode, b []byte) (n int, err error) {
-	if err := c.checkClosed(); err != nil {
-		return 0, err
+	if c.checkClosed() {
+		return 0, nil
 	}
 	tmp, err := c.tempPath(node.GetDigest().GetHash())
 	if err != nil {
@@ -1019,8 +1021,8 @@ func (v *verifiedWriter) Close() error {
 }
 
 func (c *fileCache) Writer(ctx context.Context, node *repb.FileNode, digestFunction repb.DigestFunction_Value) (interfaces.CommittedWriteCloser, error) {
-	if err := c.checkClosed(); err != nil {
-		return nil, err
+	if c.checkClosed() {
+		return nil, status.FailedPreconditionError("filecache is closed")
 	}
 	tmp, err := c.tempPath(node.GetDigest().GetHash())
 	if err != nil {

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -818,6 +818,113 @@ func TestFileCacheUncleanShutdown(t *testing.T) {
 	assert.False(t, linked, "cache should have been wiped after unclean shutdown")
 }
 
+func TestFileCacheAddFileAfterClose(t *testing.T) {
+	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
+	ctx := context.Background()
+	fcDir := testfs.MakeTempDir(t)
+	baseDir := testfs.MakeTempDir(t)
+
+	fc, err := filecache.NewFileCache(fcDir, 100000, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+
+	path := writeFileContent(t, baseDir, "file", "content", false)
+	node := nodeFromString("file", false)
+
+	// Once shutdown starts, cache population should become best-effort instead
+	// of surfacing "filecache is closed" to callers.
+	require.NoError(t, fc.Close())
+	require.NoError(t, fc.AddFile(ctx, node, path))
+}
+
+func TestFileCacheFastLinkFileAfterClose(t *testing.T) {
+	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
+	ctx := context.Background()
+	fcDir := testfs.MakeTempDir(t)
+	baseDir := testfs.MakeTempDir(t)
+
+	fc, err := filecache.NewFileCache(fcDir, 100000, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+
+	path := writeFileContent(t, baseDir, "file", "content", false)
+	node := nodeFromString("file", false)
+	require.NoError(t, fc.AddFile(ctx, node, path))
+
+	// Already-cached files should still be usable after shutdown begins.
+	require.NoError(t, fc.Close())
+
+	linkedPath := filepath.Join(baseDir, "linked-after-close")
+	require.True(t, fc.FastLinkFile(ctx, node, linkedPath))
+	assertFileContents(t, linkedPath, "content")
+}
+
+func TestFileCacheWriterCommitAfterClose(t *testing.T) {
+	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
+	ctx := context.Background()
+	fcDir := testfs.MakeTempDir(t)
+	baseDir := testfs.MakeTempDir(t)
+
+	fc, err := filecache.NewFileCache(fcDir, 100000, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+
+	content := "content"
+	fullPath := writeFileContent(t, baseDir, "file", content, false)
+	d, err := digest.ComputeForFile(fullPath, repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	node := &repb.FileNode{Digest: d}
+
+	w, err := fc.Writer(ctx, node, repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	_, err = w.Write([]byte(content))
+	require.NoError(t, err)
+
+	// A writer opened before shutdown should be able to commit without forcing
+	// the caller to retry just because the filecache is closing.
+	require.NoError(t, fc.Close())
+	require.NoError(t, w.Commit())
+	require.NoError(t, w.Close())
+}
+
+func TestFileCacheTrackExternalDirectoryAfterClose(t *testing.T) {
+	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
+	ctx := context.Background()
+	fcDir := testfs.MakeTempDir(t)
+	fc, err := filecache.NewFileCache(fcDir, 100000, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+
+	extDir := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, extDir, map[string]string{
+		"file.txt": "contents",
+	})
+
+	// External dirs should still be accepted and tracked after shutdown begins,
+	// since callers are responsible for validating their contents after an
+	// unclean shutdown.
+	require.NoError(t, fc.Close())
+
+	unlock, err := fc.TrackExternalDirectory(ctx, extDir, 1000)
+	require.NoError(t, err)
+	require.NotNil(t, unlock)
+
+	// Lookup-only should find the entry that was tracked after Close.
+	unlockLookupOnly, sizeBytes, err := fc.LookupExternalDirectory(ctx, extDir)
+	require.NoError(t, err)
+	require.NotNil(t, unlockLookupOnly)
+	require.Equal(t, int64(1000), sizeBytes)
+	unlockLookupOnly()
+	unlock()
+
+	// Missing dirs should still report NotFound; after-close tracking only skips
+	// internal filecache integrity checks.
+	unlock, err = fc.TrackExternalDirectory(ctx, filepath.Join(extDir, "missing"), 1000)
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got: %v", err)
+	require.Nil(t, unlock)
+}
+
 func TestFileCacheWriter(t *testing.T) {
 	ctx := context.Background()
 	fcDir := testfs.MakeTempDir(t)


### PR DESCRIPTION
1. In AddFile, instead of returning `FailedPrecondition` after shutdown (which fails builds with a non-retryable error), silently drop new filecache additions.

This solution has a few implications for actions that are running during shutdown:
- We have to redownload these dropped files from an upstream cache node on the next executor boot if we need them - but at at least we're not failing the action.
- We'll fail to locally save firecracker snapshots during shutdown, which could result in more cold starts or suboptimal snapshots on the next executor start. But this was already the case with the flag enabled, since we're returning an error.
- `vfs` currently depends on `AddFile` followed by immediate `FastLinkFile` of the same file to succeed. This assumption will break during shutdown, so any actions using VFS that fetch an input after shutdown starts will fail.
- `ociconv` makes a similar assumption, which will break now that the new flag is enabled to store ext4 images in filecache. If we pull and fetch an ext4 image into filecache, the filecache addition will fail.

If these issues become too problematic, a future improvement could be to move these post-shutdown filecache additions to an "unverified" dir (or `.unverified` filename suffix or something) and then treat those specially - e.g. re-verify just those files during initial scan and then move them into the proper filecache dir.

2. In TrackExternalDirectory, don't check shutdown at all. `ociruntime` already has its own logic for preventing corruption after unclean shutdown. The current logic results in unnecessary failures. Allowing these checks to be handled by the filecache is maybe doable, but will require some careful thought.