### PR TITLE
Introduce flag.Map()

### DIFF
--- a/server/util/flag/flag.go
+++ b/server/util/flag/flag.go
@@ -84,6 +84,10 @@ func Slice[T any](name string, value []T, usage string, tags ...flagtags.Taggabl
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
+func Map[K comparable, V any](name string, value map[K]V, usage string, tags ...flagtags.Taggable) *map[K]V {
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
+}
+
 func Struct[T any](name string, value T, usage string, tags ...flagtags.Taggable) *T {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }

--- a/server/util/flagutil/common/common.go
+++ b/server/util/flagutil/common/common.go
@@ -80,9 +80,14 @@ type WrappingValue interface {
 	WrappedValue() flag.Value
 }
 
-type Appendable interface {
-	// AppendSlice appends the passed slice to this flag.Value.
-	AppendSlice(any) error
+// Accumulable may be implemented by collection-backed flag types (slices, maps)
+// to indicate that they accumulate entries across repeated set-operations
+// rather than being replaced. When the caller requests append semantics (e.g.
+// append=true on SetValueForFlagName), flags implementing Accumulable have
+// Accumulate called on them with the new value: slice flags append, map flags
+// merge later-wins on key conflicts.
+type Accumulable interface {
+	Accumulate(any) error
 }
 
 // Expandable may be implemented by custom flag types to indicate that they
@@ -159,65 +164,68 @@ func ConvertFlagValue(value flag.Value) (any, error) {
 
 // SetValueForFlagName sets the value for a flag by name. setFlags is the set of
 // flags that have already been set on the command line; those flags will not be
-// set again except to append to them, in the case of slices. To force the
-// setting of a flag, pass a nil map. If appendSlice is true, a slice value will
-// be appended to the current slice value; otherwise, a slice value will replace
-// the current slice value. appendSlice has no effect if the values in question
-// are not slices.
-func SetValueForFlagName(flagset *flag.FlagSet, name string, newValue any, setFlags map[string]struct{}, appendSlice bool) error {
+// set again except to accumulate into them, in the case of collection flags. To
+// force the setting of a flag, pass a nil map. If accumulate is true, a slice
+// value will be appended to the current slice value and a map value will be
+// merged into the current map value; otherwise, the value will replace the
+// current value. accumulate has no effect if the flag is not Accumulable.
+func SetValueForFlagName(flagset *flag.FlagSet, name string, newValue any, setFlags map[string]struct{}, accumulate bool) error {
 	flg := flagset.Lookup(name)
 	if flg == nil {
 		return status.NotFoundErrorf("Undefined flag: %s", name)
 	}
-	return setValueFromFlagName(flagset, flg.Value, name, newValue, setFlags, appendSlice)
+	return setValueFromFlagName(flagset, flg.Value, name, newValue, setFlags, accumulate)
 }
 
-func setValueFromFlagName(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, appendSlice bool, setHooks ...func()) error {
+func setValueFromFlagName(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, accumulate bool, setHooks ...func()) error {
 	if v, ok := flagValue.(SetValueForFlagNameHooked); ok {
 		setHooks = append(setHooks, v.SetValueForFlagNameHook)
 	}
-	return SetValueWithCustomIndirectBehavior(flagset, flagValue, name, newValue, setFlags, appendSlice, setValueFromFlagName, setHooks...)
+	return SetValueWithCustomIndirectBehavior(flagset, flagValue, name, newValue, setFlags, accumulate, setValueFromFlagName, setHooks...)
 }
 
-type SetValueForIndirectFxn func(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, appendSlice bool, setHooks ...func()) error
+type SetValueForIndirectFxn func(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, accumulate bool, setHooks ...func()) error
 
 // SetValueWithCustomIndirectBehavior sets the value for a flag, but if the flag
 // passed is an alias for another flag or wraps another flag.Value, it instead
 // calls setValueForIndirect with the new flag.Value. setFlags is the set of
 // flags that have already been set on the command line; those flags will not be
-// set again except to append to them, in the case of slices. To force the
-// setting of a flag, pass a nil map. If appendSlice is true, a slice value will
-// be appended to the current slice value; otherwise, a slice value will replace
-// the current slice value. appendSlice has no effect if the values in question
-// are not slices. setHooks is a slice of functions to call in order if the
-// flag.Value will be set.
-func SetValueWithCustomIndirectBehavior(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, appendSlice bool, setValueForIndirect SetValueForIndirectFxn, setHooks ...func()) error {
+// set again except to accumulate into them, in the case of collection flags. To
+// force the setting of a flag, pass a nil map. If accumulate is true, a slice
+// value will be appended to the current slice value and a map value will be
+// merged into the current map value; otherwise, the value will replace the
+// current value. accumulate has no effect if the flag is not Accumulable.
+// setHooks is a slice of functions to call in order if the flag.Value will be
+// set.
+func SetValueWithCustomIndirectBehavior(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, accumulate bool, setValueForIndirect SetValueForIndirectFxn, setHooks ...func()) error {
 	if v, ok := flagValue.(NameAliasable); ok && v.IsNameAliasing() {
 		aliasedFlag := flagset.Lookup(v.AliasedName())
 		if aliasedFlag == nil {
 			return status.NotFoundErrorf("Flag %s aliases undefined flag: %s", name, v.AliasedName())
 		}
-		return setValueForIndirect(flagset, aliasedFlag.Value, v.AliasedName(), newValue, setFlags, appendSlice, setHooks...)
+		return setValueForIndirect(flagset, aliasedFlag.Value, v.AliasedName(), newValue, setFlags, accumulate, setHooks...)
 	}
 	// Unwrap any wrapper values (e.g. DeprecatedFlag)
 	if v, ok := flagValue.(WrappingValue); ok {
-		return setValueForIndirect(flagset, v.WrappedValue(), name, newValue, setFlags, appendSlice, setHooks...)
+		return setValueForIndirect(flagset, v.WrappedValue(), name, newValue, setFlags, accumulate, setHooks...)
 	}
-	var appendFlag Appendable
-	// For slice flags, append the values to the existing values if appendSlice is true
-	if v, ok := flagValue.(Appendable); ok && appendSlice {
-		appendFlag = v
+	var accumulateFlag Accumulable
+	if accumulate {
+		// For collection flags (slices, maps), accumulate into the existing value.
+		if v, ok := flagValue.(Accumulable); ok {
+			accumulateFlag = v
+		}
 	}
-	// For non-append flags, skip the value if it has already been set
-	if _, ok := setFlags[name]; appendFlag == nil && ok {
+	// For non-accumulable flags, skip the value if it has already been set
+	if _, ok := setFlags[name]; accumulateFlag == nil && ok {
 		return nil
 	}
 	for _, setHook := range setHooks {
 		setHook()
 	}
-	if appendFlag != nil {
-		if err := appendFlag.AppendSlice(newValue); err != nil {
-			return status.InternalErrorf("Error encountered appending to flag %s: %s", name, err)
+	if accumulateFlag != nil {
+		if err := accumulateFlag.Accumulate(newValue); err != nil {
+			return status.InternalErrorf("Error encountered accumulating into flag %s: %s", name, err)
 		}
 		return nil
 	}

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -7,17 +7,17 @@ import (
 
 // SetValueForFlagName sets the value for a flag by name. setFlags is the set of
 // flags that have already been set on the command line; those flags will not be
-// set again except to append to them, in the case of slices. To force the
-// setting of a flag, pass a nil map. If appendSlice is true, a slice value will
-// be appended to the current slice value; otherwise, a slice value will replace
-// the current slice value. appendSlice has no effect if the values in question
-// are not slices.
-func SetValueForFlagName(name string, newValue any, setFlags map[string]struct{}, appendSlice bool) error {
-	return common.SetValueForFlagName(common.DefaultFlagSet, name, newValue, setFlags, appendSlice)
+// set again except to accumulate into them, in the case of collection flags. To
+// force the setting of a flag, pass a nil map. If accumulate is true, a slice
+// value will be appended to the current slice value and a map value will be
+// merged into the current map value; otherwise, the value will replace the
+// current value. accumulate has no effect if the flag is not Accumulable.
+func SetValueForFlagName(name string, newValue any, setFlags map[string]struct{}, accumulate bool) error {
+	return common.SetValueForFlagName(common.DefaultFlagSet, name, newValue, setFlags, accumulate)
 }
 
-func SetValueForFlagSet(flagset *flag.FlagSet, name string, newValue any, setFlags map[string]struct{}, appendSlice bool) error {
-	return common.SetValueForFlagName(flagset, name, newValue, setFlags, appendSlice)
+func SetValueForFlagSet(flagset *flag.FlagSet, name string, newValue any, setFlags map[string]struct{}, accumulate bool) error {
+	return common.SetValueForFlagName(flagset, name, newValue, setFlags, accumulate)
 }
 
 // SetWithOverride sets the flag's value by creating a new, empty flag.Value of

--- a/server/util/flagutil/types/autoflags/autoflags.go
+++ b/server/util/flagutil/types/autoflags/autoflags.go
@@ -73,6 +73,11 @@ func Var[T any](flagset *flag.FlagSet, value *T, name string, defaultValue T, us
 			Tag[T, *flagtypes.JSONStructFlag[T]](flagset, name, tags...)
 			break
 		}
+		if reflect.TypeOf(value).Elem().Kind() == reflect.Map {
+			flagtypes.JSONMapVar(flagset, value, name, defaultValue, usage)
+			Tag[T, *flagtypes.JSONMapFlag[T]](flagset, name, tags...)
+			break
+		}
 		log.Fatalf("Var was called from flag registry for flag %s with value %v of unrecognized type %T.", name, defaultValue, defaultValue)
 	}
 }

--- a/server/util/flagutil/types/autoflags/autoflags_test.go
+++ b/server/util/flagutil/types/autoflags/autoflags_test.go
@@ -191,4 +191,43 @@ func TestNew(t *testing.T) {
 	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, *structSlice)
+
+	// Map flags: append=true merges the new map into the existing one
+	// (via Accumulable.Accumulate, later-wins on key conflicts).
+	flags = replaceFlagsForTesting(t) //nolint:SA4006
+	defaultStringMap := map[string]string{"a": "1", "b": "2"}
+	stringMap := New(flags, "string_map", defaultStringMap, "")
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, *stringMap)
+	err = common.SetValueForFlagName(flags, "string_map", map[string]string{"b": "20", "c": "3"}, map[string]struct{}{}, true)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "1", "b": "20", "c": "3"}, *stringMap)
+
+	// append=true also merges when the flag is already in setFlags.
+	flags = replaceFlagsForTesting(t) //nolint:SA4006
+	stringMap = New(flags, "string_map", defaultStringMap, "")
+	err = common.SetValueForFlagName(flags, "string_map", map[string]string{"c": "3"}, map[string]struct{}{"string_map": {}}, true)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2", "c": "3"}, *stringMap)
+
+	// append=false replaces when the flag hasn't been set.
+	flags = replaceFlagsForTesting(t) //nolint:SA4006
+	stringMap = New(flags, "string_map", defaultStringMap, "")
+	err = common.SetValueForFlagName(flags, "string_map", map[string]string{"c": "3"}, map[string]struct{}{}, false)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"c": "3"}, *stringMap)
+
+	// append=false does not overwrite when the flag is already in setFlags.
+	flags = replaceFlagsForTesting(t) //nolint:SA4006
+	stringMap = New(flags, "string_map", defaultStringMap, "")
+	err = common.SetValueForFlagName(flags, "string_map", map[string]string{"c": "3"}, map[string]struct{}{"string_map": {}}, false)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, *stringMap)
+
+	// Map flags with struct values also merge.
+	flags = replaceFlagsForTesting(t) //nolint:SA4006
+	defaultStructMap := map[string]testStruct{"a": {Field: 1}}
+	structMap := New(flags, "struct_map", defaultStructMap, "")
+	err = common.SetValueForFlagName(flags, "struct_map", map[string]testStruct{"b": {Field: 2, Meadow: "meadow"}}, map[string]struct{}{}, true)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]testStruct{"a": {Field: 1}, "b": {Field: 2, Meadow: "meadow"}}, *structMap)
 }

--- a/server/util/flagutil/types/types.go
+++ b/server/util/flagutil/types/types.go
@@ -186,7 +186,7 @@ func (f *JSONSliceFlag[T]) Expand(mapping func(string) (string, error)) error {
 	return f.Set(string(exp))
 }
 
-func (f *JSONSliceFlag[T]) AppendSlice(slice any) error {
+func (f *JSONSliceFlag[T]) Accumulate(slice any) error {
 	v := (reflect.Value)(*f)
 	if _, ok := slice.(T); !ok {
 		return status.FailedPreconditionErrorf("Cannot append value %v of type %T to flag of type %s.", slice, slice, v.Type().Elem())
@@ -272,6 +272,112 @@ func (f *JSONStructFlag[T]) Struct() T {
 	return *(reflect.Value)(*f).Interface().(*T)
 }
 
+type JSONMapFlag[T any] reflect.Value
+
+func NewJSONMapFlag[T any](value *T) *JSONMapFlag[T] {
+	v := (JSONMapFlag[T])(reflect.ValueOf(value))
+	return &v
+}
+
+func JSONMap[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string) *T {
+	value := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	JSONMapVar(flagset, value, name, defaultValue, usage)
+	return value
+}
+
+func JSONMapVar[T any](flagset *flag.FlagSet, value *T, name string, defaultValue T, usage string) {
+	src := reflect.ValueOf(defaultValue)
+	if src.Kind() != reflect.Map {
+		log.Fatalf("JSONMapVar called for flag %s with non-map value %v of type %T.", name, defaultValue, defaultValue)
+	}
+	v := reflect.ValueOf(value)
+	// Copy the default into a fresh map so the flag's storage isn't aliased
+	// with the caller's default — subsequent Set/Merge calls must not
+	// mutate the caller's map.
+	m := reflect.MakeMapWithSize(reflect.TypeOf((*T)(nil)).Elem(), src.Len())
+	if !src.IsNil() {
+		iter := src.MapRange()
+		for iter.Next() {
+			m.SetMapIndex(iter.Key(), iter.Value())
+		}
+	}
+	v.Elem().Set(m)
+	flagset.Var((*JSONMapFlag[T])(&v), name, usage)
+}
+
+func (f *JSONMapFlag[T]) String() string {
+	if !(*reflect.Value)(f).IsValid() || (*reflect.Value)(f).IsNil() {
+		return "{}"
+	}
+	b, err := json.Marshal((*reflect.Value)(f).Interface())
+	if err != nil {
+		alert.UnexpectedEvent("config_cannot_marshal_map", "err: %s", err)
+		return "{}"
+	}
+	return string(b)
+}
+
+// Set merges the decoded JSON map into the existing map value (later-wins on
+// key conflicts), mirroring the append semantics of JSONSliceFlag.Set.
+func (f *JSONMapFlag[T]) Set(values string) error {
+	v := (reflect.Value)(*f).Elem()
+	dst := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	if err := json.Unmarshal([]byte(values), dst); err != nil {
+		return err
+	}
+	if v.IsNil() {
+		v.Set(reflect.MakeMap(v.Type()))
+	}
+	src := reflect.ValueOf(*dst)
+	iter := src.MapRange()
+	for iter.Next() {
+		v.SetMapIndex(iter.Key(), iter.Value())
+	}
+	return nil
+}
+
+// Accumulate merges the entries of the passed map into the flag's map value
+// (later-wins on key conflicts), satisfying the Accumulable interface.
+func (f *JSONMapFlag[T]) Accumulate(m any) error {
+	v := (reflect.Value)(*f)
+	if _, ok := m.(T); !ok {
+		return status.FailedPreconditionErrorf("Cannot append value %v of type %T to flag of type %s.", m, m, v.Type().Elem())
+	}
+	if v.Elem().IsNil() {
+		v.Elem().Set(reflect.MakeMap(v.Elem().Type()))
+	}
+	src := reflect.ValueOf(m)
+	iter := src.MapRange()
+	for iter.Next() {
+		v.Elem().SetMapIndex(iter.Key(), iter.Value())
+	}
+	return nil
+}
+
+func (f *JSONMapFlag[T]) Expand(mapping func(string) (string, error)) error {
+	var ov any
+	if err := json.Unmarshal([]byte(f.String()), &ov); err != nil {
+		return err
+	}
+	nv, err := expandValue(ov, mapping)
+	if err != nil {
+		return err
+	}
+	exp, err := json.Marshal(nv)
+	if err != nil {
+		return err
+	}
+	return f.Set(string(exp))
+}
+
+func (f *JSONMapFlag[T]) AliasedType() reflect.Type {
+	return reflect.TypeOf((*T)(nil))
+}
+
+func (f *JSONMapFlag[T]) Map() T {
+	return *(reflect.Value)(*f).Interface().(*T)
+}
+
 type StringSliceFlag []string
 
 func NewStringSliceFlag(slice *[]string) *StringSliceFlag {
@@ -319,7 +425,7 @@ func (f *StringSliceFlag) Expand(mapping func(string) (string, error)) error {
 	return nil
 }
 
-func (f *StringSliceFlag) AppendSlice(slice any) error {
+func (f *StringSliceFlag) Accumulate(slice any) error {
 	s, ok := slice.([]string)
 	if !ok {
 		return status.FailedPreconditionErrorf("Cannot append value %v of type %T to flag of type []string.", slice, slice)

--- a/server/util/flagutil/types/types_test.go
+++ b/server/util/flagutil/types/types_test.go
@@ -64,7 +64,7 @@ func TestStringSliceFlag(t *testing.T) {
 
 	testSlice := []string{"yes", "si", "hai"}
 	testFlag := NewStringSliceFlag(&testSlice)
-	testFlag.AppendSlice(([]string)(*testFlag))
+	testFlag.Accumulate(([]string)(*testFlag))
 	assert.Equal(t, []string{"yes", "si", "hai", "yes", "si", "hai"}, testSlice)
 
 	// `String` should not panic on zero-constructed flag
@@ -113,7 +113,7 @@ func TestStructSliceFlag(t *testing.T) {
 
 	testSlice := []testStruct{{}, {Field: 1}, {Meadow: "Paradise"}}
 	testFlag := NewJSONSliceFlag(&testSlice)
-	testFlag.AppendSlice(testFlag.Slice())
+	testFlag.Accumulate(testFlag.Slice())
 	assert.Equal(t, []testStruct{{}, {Field: 1}, {Meadow: "Paradise"}, {}, {Field: 1}, {Meadow: "Paradise"}}, testSlice)
 
 	// `String` should not panic on zero-constructed flag
@@ -162,7 +162,7 @@ func TestProtoSliceFlag(t *testing.T) {
 
 	testSlice := []*timestamppb.Timestamp{{}, {Seconds: 1}, {Nanos: 99}}
 	testFlag := NewJSONSliceFlag(&testSlice)
-	testFlag.AppendSlice(testFlag.Slice())
+	testFlag.Accumulate(testFlag.Slice())
 	assert.Equal(t, []*timestamppb.Timestamp{{}, {Seconds: 1}, {Nanos: 99}, {}, {Seconds: 1}, {Nanos: 99}}, testSlice)
 
 	// `String` should not panic on zero-constructed flag
@@ -190,6 +190,46 @@ func TestJSONStructFlag(t *testing.T) {
 
 	// `String` should not panic on zero-constructed flag
 	assert.Equal(t, "{}", reflect.New(reflect.TypeOf((*JSONStructFlag[testStruct])(nil)).Elem()).Interface().(flag.Value).String())
+}
+
+func TestJSONMapFlag(t *testing.T) {
+	var err error
+	flags := replaceFlagsForTesting(t)
+	flagName := "foo"
+
+	f := JSONMap(flags, flagName, map[string]string{}, "A flag that should contain a string map")
+	assert.Equal(t, map[string]string{}, *f)
+	assert.Equal(t, map[string]string{}, (flags.Lookup(flagName).Value.(*JSONMapFlag[map[string]string]).Map()))
+
+	err = flags.Set(flagName, `{"a":"1","b":"2"}`)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, *f)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, (flags.Lookup(flagName).Value.(*JSONMapFlag[map[string]string]).Map()))
+
+	// Subsequent Set merges into the existing map (a la JSONSliceFlag).
+	err = flags.Set(flagName, `{"c":"3"}`)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2", "c": "3"}, *f)
+
+	// Conflicting keys: later Set wins.
+	err = flags.Set(flagName, `{"a":"99"}`)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "99", "b": "2", "c": "3"}, *f)
+
+	// Non-empty default value is preserved on registration, and subsequent
+	// Set merges into it.
+	g := JSONMap(flags, "bar", map[string]int{"x": 1, "y": 2}, "A flag with a non-empty default")
+	assert.Equal(t, map[string]int{"x": 1, "y": 2}, *g)
+	err = flags.Set("bar", `{"z":9}`)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]int{"x": 1, "y": 2, "z": 9}, *g)
+
+	// Invalid JSON rejects cleanly.
+	err = flags.Set(flagName, `not json`)
+	assert.Error(t, err)
+
+	// `String` should not panic on zero-constructed flag.
+	assert.Equal(t, "{}", reflect.New(reflect.TypeOf((*JSONMapFlag[map[string]string])(nil)).Elem()).Interface().(flag.Value).String())
 }
 
 func TestFlagAlias(t *testing.T) {

--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -726,7 +726,7 @@ func PopulateFlagsFromYAMLMap(m map[string]any, node *yaml.Node) error {
 	return populateFlagsFromYAML(m, []string{}, node, setFlags, true)
 }
 
-func populateFlagsFromYAML(a any, prefix []string, node *yaml.Node, setFlags map[string]struct{}, appendSlice bool) error {
+func populateFlagsFromYAML(a any, prefix []string, node *yaml.Node, setFlags map[string]struct{}, accumulate bool) error {
 	if m, ok := a.(map[string]any); ok {
 		i := 0
 		for k, v := range m {
@@ -744,7 +744,7 @@ func populateFlagsFromYAML(a any, prefix []string, node *yaml.Node, setFlags map
 			if _, ok := IgnoreSet[strings.Join(p, ".")]; ok {
 				return nil
 			}
-			if err := populateFlagsFromYAML(v, p, n, setFlags, appendSlice); err != nil {
+			if err := populateFlagsFromYAML(v, p, n, setFlags, accumulate); err != nil {
 				return err
 			}
 		}
@@ -759,12 +759,12 @@ func populateFlagsFromYAML(a any, prefix []string, node *yaml.Node, setFlags map
 	if flg == nil {
 		return nil
 	}
-	return setValueForYAML(common.DefaultFlagSet, flg.Value, name, a, setFlags, appendSlice)
+	return setValueForYAML(common.DefaultFlagSet, flg.Value, name, a, setFlags, accumulate)
 }
 
-func setValueForYAML(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, appendSlice bool, setHooks ...func()) error {
+func setValueForYAML(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, accumulate bool, setHooks ...func()) error {
 	if v, ok := flagValue.(YAMLSetValueHooked); ok {
 		setHooks = append(setHooks, v.YAMLSetValueHook)
 	}
-	return common.SetValueWithCustomIndirectBehavior(common.DefaultFlagSet, flagValue, name, newValue, setFlags, appendSlice, setValueForYAML, setHooks...)
+	return common.SetValueWithCustomIndirectBehavior(common.DefaultFlagSet, flagValue, name, newValue, setFlags, accumulate, setValueForYAML, setHooks...)
 }


### PR DESCRIPTION
I have a couple of uses cases in mind for this:
* https://github.com/buildbuddy-io/buildbuddy/pull/11988
* The custom-resource flag