### PR TITLE
Reject SAML logins with no identifier attribute set.

### DIFF
--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -172,6 +172,7 @@ use_repo(
     "com_github_bazelbuild_bazelisk",
     "com_github_bazelbuild_buildtools",
     "com_github_bduffany_godemon",
+    "com_github_beevik_etree",
     "com_github_bits_and_blooms_bloom_v3",
     "com_github_bojand_ghz",
     "com_github_bradfitz_gomemcache",

--- a/enterprise/server/saml/BUILD
+++ b/enterprise/server/saml/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -20,5 +20,22 @@ go_library(
         "@com_github_crewjam_saml//:saml",
         "@com_github_crewjam_saml//samlsp",
         "@com_github_golang_jwt_jwt_v4//:jwt",
+    ],
+)
+
+go_test(
+    name = "saml_test",
+    srcs = ["saml_test.go"],
+    deps = [
+        "//enterprise/server/testutil/buildbuddy_enterprise",
+        "//proto:group_go_proto",
+        "//proto:user_go_proto",
+        "//server/testutil/app",
+        "//server/testutil/testport",
+        "@com_github_beevik_etree//:etree",
+        "@com_github_crewjam_saml//:saml",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -277,7 +277,10 @@ func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *h
 			ctx = context.WithValue(ctx, contextSamlEntityIDKey, sp.ServiceProvider.EntityID)
 			ctx = context.WithValue(ctx, contextSamlSlugKey, a.getSlugFromRequest(r))
 
-			s, _ := a.subjectIDAndSessionFromContext(ctx)
+			s, _, err := a.subjectIDAndSessionFromContext(ctx)
+			if err != nil {
+				return authutil.AuthContextWithError(ctx, err)
+			}
 			c, err := claims.ClaimsFromSubID(ctx, a.env, s)
 			if err != nil {
 				return authutil.AuthContextWithError(ctx, status.PermissionDeniedErrorf("error getting SAML claims: %s", err.Error()))
@@ -297,21 +300,22 @@ func (a *SAMLAuthenticator) FillUser(ctx context.Context, user *tables.User) err
 	if err != nil {
 		return err
 	}
-	if subjectID, session := a.subjectIDAndSessionFromContext(ctx); subjectID != "" && session != nil {
-		attributes := session.GetAttributes()
-		user.UserID = pk
-		user.SubID = subjectID
-		user.FirstName = firstSet(attributes, samlFirstNameAttributes)
-		user.LastName = firstSet(attributes, samlLastNameAttributes)
-		user.Email = firstSet(attributes, samlEmailAttributes)
-		if slug, ok := ctx.Value(contextSamlSlugKey).(string); ok && slug != "" {
-			user.Groups = []*tables.GroupRole{
-				{Group: tables.Group{URLIdentifier: slug}},
-			}
-		}
-		return nil
+	subjectID, session, err := a.subjectIDAndSessionFromContext(ctx)
+	if err != nil {
+		return err
 	}
-	return status.UnauthenticatedError("No SAML User found")
+	attributes := session.GetAttributes()
+	user.UserID = pk
+	user.SubID = subjectID
+	user.FirstName = firstSet(attributes, samlFirstNameAttributes)
+	user.LastName = firstSet(attributes, samlLastNameAttributes)
+	user.Email = firstSet(attributes, samlEmailAttributes)
+	if slug, ok := ctx.Value(contextSamlSlugKey).(string); ok && slug != "" {
+		user.Groups = []*tables.GroupRole{
+			{Group: tables.Group{URLIdentifier: slug}},
+		}
+	}
+	return nil
 }
 
 func (a *SAMLAuthenticator) Logout(w http.ResponseWriter, r *http.Request) error {
@@ -323,16 +327,17 @@ func (a *SAMLAuthenticator) Logout(w http.ResponseWriter, r *http.Request) error
 }
 
 func (a *SAMLAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {
-	if s, _ := a.subjectIDAndSessionFromContext(ctx); s != "" {
-		claims, err := claims.ClaimsFromSubID(ctx, a.env, s)
-		if err != nil {
-			return nil, status.UnauthenticatedErrorf(authutil.UserNotFoundMsg)
-		}
-		claims.SAML = true
-		claims.CustomerSSO = true
-		return claims, nil
+	s, _, err := a.subjectIDAndSessionFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return nil, status.UnauthenticatedError("No SAML User found")
+	c, err := claims.ClaimsFromSubID(ctx, a.env, s)
+	if err != nil {
+		return nil, status.UnauthenticatedErrorf(authutil.UserNotFoundMsg)
+	}
+	c.SAML = true
+	c.CustomerSSO = true
+	return c, nil
 }
 
 func (a *SAMLAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error {
@@ -512,15 +517,24 @@ func (a *SAMLAuthenticator) groupForSlug(ctx context.Context, slug string) (*tab
 	return userDB.GetGroupByURLIdentifier(ctx, slug)
 }
 
-func (a *SAMLAuthenticator) subjectIDAndSessionFromContext(ctx context.Context) (string, samlsp.SessionWithAttributes) {
+func (a *SAMLAuthenticator) subjectIDAndSessionFromContext(ctx context.Context) (string, samlsp.SessionWithAttributes, error) {
 	entityID, ok := ctx.Value(contextSamlEntityIDKey).(string)
 	if !ok || entityID == "" {
-		return "", nil
+		return "", nil, status.UnauthenticatedError("No SAML User found")
 	}
-	if sa, ok := ctx.Value(contextSamlSessionKey).(samlsp.SessionWithAttributes); ok {
-		return fmt.Sprintf("%s/%s", entityID, firstSet(sa.GetAttributes(), samlSubjectAttributes)), sa
+	sa, ok := ctx.Value(contextSamlSessionKey).(samlsp.SessionWithAttributes)
+	if !ok {
+		return "", nil, status.UnauthenticatedError("No SAML User found")
 	}
-	return "", nil
+	subject := firstSet(sa.GetAttributes(), samlSubjectAttributes)
+	if subject == "" {
+		return "", sa, status.PermissionDeniedError(
+			"SAML assertion does not contain a subject identifier. " +
+				"Configure your identity provider to include a SAML AttributeStatement " +
+				"with one of: 'email', 'username', 'user_id', or " +
+				"'urn:oasis:names:tc:SAML:attribute:subject-id'.")
+	}
+	return fmt.Sprintf("%s/%s", entityID, subject), sa, nil
 }
 
 func firstSet(attributes samlsp.Attributes, keys []string) string {

--- a/enterprise/server/saml/saml_test.go
+++ b/enterprise/server/saml/saml_test.go
@@ -1,0 +1,326 @@
+package saml_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/beevik/etree"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
+	"github.com/crewjam/saml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
+	uspb "github.com/buildbuddy-io/buildbuddy/proto/user"
+)
+
+const testSlug = "saml-int-test-org"
+
+// testIDP is a minimal in-process SAML IdP. It serves its EntityDescriptor
+// metadata over HTTP and exposes the underlying *saml.IdentityProvider so
+// tests can synthesize signed SAML responses without driving a browser.
+type testIDP struct {
+	HTTPServer *httptest.Server
+	IDP        *saml.IdentityProvider
+}
+
+func (i *testIDP) MetadataURL() string { return i.HTTPServer.URL + "/metadata" }
+
+func startTestIDP(t *testing.T) *testIDP {
+	t.Helper()
+	cert, key := generateSelfSignedCert(t)
+
+	idp := &saml.IdentityProvider{
+		Key:         key,
+		Certificate: cert,
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metadata", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/samlmetadata+xml")
+		body, err := xml.Marshal(idp.Metadata())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(body)
+	})
+	httpServer := httptest.NewServer(mux)
+	t.Cleanup(httpServer.Close)
+
+	listener, err := url.Parse(httpServer.URL)
+	require.NoError(t, err)
+	idp.MetadataURL = url.URL{Scheme: listener.Scheme, Host: listener.Host, Path: "/metadata"}
+	idp.SSOURL = url.URL{Scheme: listener.Scheme, Host: listener.Host, Path: "/sso"}
+	return &testIDP{HTTPServer: httpServer, IDP: idp}
+}
+
+func generateSelfSignedCert(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"buildbuddy-saml-int-test"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func encodeCertPEM(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+func encodeKeyPEM(key *rsa.PrivateKey) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+}
+
+func startBuildBuddy(t *testing.T, idp *testIDP) *app.App {
+	t.Helper()
+	spCert, spKey := generateSelfSignedCert(t)
+	appConfig := buildbuddy_enterprise.DefaultAppConfig(t)
+	appConfig.HttpPort = testport.FindFree(t)
+	bbURL := fmt.Sprintf("http://localhost:%d", appConfig.HttpPort)
+	bb := buildbuddy_enterprise.RunWithConfig(
+		t, appConfig, buildbuddy_enterprise.DefaultConfig,
+		"--auth.saml.cert="+string(encodeCertPEM(spCert)),
+		"--auth.saml.key="+string(encodeKeyPEM(spKey)),
+		"--app.build_buddy_url="+bbURL,
+	)
+
+	wc := buildbuddy_enterprise.LoginAsDefaultSelfAuthUser(t, bb)
+	require.NoError(t, wc.RPC("UpdateGroup", &grpb.UpdateGroupRequest{
+		RequestContext: wc.RequestContext,
+		Id:             wc.RequestContext.GetGroupId(),
+		Name:           "SAML Integration Test Org",
+		UrlIdentifier:  testSlug,
+	}, &grpb.UpdateGroupResponse{}))
+	res := bb.DB().Exec(
+		`UPDATE "Groups" SET saml_idp_metadata_url = ? WHERE url_identifier = ?`,
+		idp.MetadataURL(), testSlug)
+	require.NoError(t, res.Error)
+	require.Greaterf(t, res.RowsAffected, int64(0),
+		"failed to set saml_idp_metadata_url: no Groups row matched url_identifier=%q", testSlug)
+	return bb
+}
+
+// fetchSPMetadata GETs BuildBuddy's SAML SP metadata via /auth/saml/metadata.
+func fetchSPMetadata(t *testing.T, bb *app.App) *saml.EntityDescriptor {
+	t.Helper()
+	resp, err := http.Get(bb.HTTPURL() + "/auth/saml/metadata?slug=" + testSlug)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, resp.StatusCode,
+		"fetch SP metadata: status=%d body=%s", resp.StatusCode, string(body))
+	md := &saml.EntityDescriptor{}
+	require.NoError(t, xml.Unmarshal(body, md))
+	require.NotEmpty(t, md.SPSSODescriptors, "SP metadata has no SPSSODescriptor")
+	return md
+}
+
+// makeSignedSAMLResponse builds an IdP-initiated SAML response containing
+// the given session, signs it with the IdP key, and returns the
+// base64-encoded XML ready to POST to the SP's ACS endpoint.
+func makeSignedSAMLResponse(t *testing.T, idp *testIDP, spMetadata *saml.EntityDescriptor, session *saml.Session) string {
+	t.Helper()
+
+	spsso := &spMetadata.SPSSODescriptors[0]
+	var acsEndpoint *saml.IndexedEndpoint
+	for i := range spsso.AssertionConsumerServices {
+		if spsso.AssertionConsumerServices[i].Binding == saml.HTTPPostBinding {
+			acsEndpoint = &spsso.AssertionConsumerServices[i]
+			break
+		}
+	}
+	require.NotNil(t, acsEndpoint, "SP metadata is missing an HTTP-POST ACS endpoint")
+
+	now := time.Now()
+	req := &saml.IdpAuthnRequest{
+		IDP:         idp.IDP,
+		HTTPRequest: httptest.NewRequest("POST", idp.IDP.SSOURL.String(), nil),
+		Now:         now,
+		Request: saml.AuthnRequest{
+			ID:                          "id-test-authn-request",
+			IssueInstant:                now,
+			Destination:                 idp.IDP.SSOURL.String(),
+			Issuer:                      &saml.Issuer{Format: "urn:oasis:names:tc:SAML:2.0:nameid-format:entity", Value: spMetadata.EntityID},
+			AssertionConsumerServiceURL: acsEndpoint.Location,
+			ProtocolBinding:             saml.HTTPPostBinding,
+		},
+		ServiceProviderMetadata: spMetadata,
+		SPSSODescriptor:         spsso,
+		ACSEndpoint:             acsEndpoint,
+	}
+	require.NoError(t, saml.DefaultAssertionMaker{}.MakeAssertion(req, session))
+	require.NoError(t, req.MakeAssertionEl())
+	require.NoError(t, req.MakeResponse())
+
+	doc := etree.NewDocument()
+	doc.SetRoot(req.ResponseEl)
+	xmlStr, err := doc.WriteToString()
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString([]byte(xmlStr))
+}
+
+// loginViaSAML performs an IdP-initiated POST to the SP's ACS URL with the
+// given (already base64-encoded) SAML response and returns the cookies the
+// SP set in response, including the session cookie an authenticated
+// request would carry on subsequent calls.
+func loginViaSAML(t *testing.T, bb *app.App, samlResponse string) []*http.Cookie {
+	t.Helper()
+	form := url.Values{
+		"SAMLResponse": []string{samlResponse},
+		"RelayState":   []string{""},
+	}
+	resp, err := noFollowClient().PostForm(bb.HTTPURL()+"/auth/saml/acs?slug="+testSlug, form)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	require.Lessf(t, resp.StatusCode, 400,
+		"ACS POST failed: status=%d body=%s", resp.StatusCode, string(body))
+	return resp.Cookies()
+}
+
+func noFollowClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Timeout:       30 * time.Second,
+	}
+}
+
+func callCreateUser(t *testing.T, bb *app.App, cookies []*http.Cookie) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest("POST", bb.HTTPURL()+"/rpc/BuildBuddyService/CreateUser", strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+func callGetUser(t *testing.T, bb *app.App, cookies []*http.Cookie) (*uspb.GetUserResponse, error) {
+	t.Helper()
+	req, err := http.NewRequest("POST", bb.HTTPURL()+"/rpc/BuildBuddyService/GetUser", strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+	res := &uspb.GetUserResponse{}
+	require.NoErrorf(t, protojson.Unmarshal(body, res), "decode GetUser response: %s", body)
+	return res, nil
+}
+
+// Test misconfigured IdP with no usable attributes in the attribute statement.
+// Without a valid identifier we can't create a unique user identity.
+func TestSAMLLogin_NoSubjectAttributes(t *testing.T) {
+	idp := startTestIDP(t)
+	bb := startBuildBuddy(t, idp)
+	spMetadata := fetchSPMetadata(t, bb)
+
+	resp := makeSignedSAMLResponse(t, idp, spMetadata, &saml.Session{NameID: "anon"})
+	cookies := loginViaSAML(t, bb, resp)
+
+	_, err := callGetUser(t, bb, cookies)
+	require.Error(t, err, "expected GetUser to fail")
+	assert.Contains(t, err.Error(), "subject identifier",
+		"error response should explain the missing subject")
+	assert.Contains(t, err.Error(), "identity provider",
+		"error response should mention the IdP so admins know what to fix")
+}
+
+// Happy path with the attribute statement including an email identifier.
+func TestSAMLLogin_EmailAttribute(t *testing.T) {
+	idp := startTestIDP(t)
+	bb := startBuildBuddy(t, idp)
+	spMetadata := fetchSPMetadata(t, bb)
+
+	session := &saml.Session{
+		NameID: "alice",
+		CustomAttributes: []saml.Attribute{{
+			Name:       "email",
+			NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+			Values:     []saml.AttributeValue{{Type: "xs:string", Value: "alice@example.com"}},
+		}},
+	}
+	resp := makeSignedSAMLResponse(t, idp, spMetadata, session)
+	cookies := loginViaSAML(t, bb, resp)
+
+	// First GetUser call returns "user not found" because we haven't
+	// CreateUser'd yet; that's expected for SAML logins where the user
+	// row is created on demand. Use the result of CreateUser to bootstrap.
+	status, body := callCreateUser(t, bb, cookies)
+	require.Equalf(t, http.StatusOK, status, "CreateUser failed: body=%s", body)
+
+	got, err := callGetUser(t, bb, cookies)
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", got.GetDisplayUser().GetEmail(),
+		"GetUser email should reflect the SAML email attribute")
+}
+
+// Attribute statement contains a username instead of e-mail.
+// We can create a user but the user information will not contain an e-mail.
+func TestSAMLLogin_UsernameWithoutEmail(t *testing.T) {
+	idp := startTestIDP(t)
+	bb := startBuildBuddy(t, idp)
+	spMetadata := fetchSPMetadata(t, bb)
+
+	session := &saml.Session{
+		NameID: "alice",
+		CustomAttributes: []saml.Attribute{{
+			Name:       "username",
+			NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
+			Values:     []saml.AttributeValue{{Type: "xs:string", Value: "alice"}},
+		}},
+	}
+	resp := makeSignedSAMLResponse(t, idp, spMetadata, session)
+	cookies := loginViaSAML(t, bb, resp)
+
+	status, body := callCreateUser(t, bb, cookies)
+	require.Equalf(t, http.StatusOK, status, "CreateUser failed: body=%s", body)
+
+	got, err := callGetUser(t, bb, cookies)
+	require.NoError(t, err)
+	assert.Empty(t, got.GetDisplayUser().GetEmail(),
+		"GetUser email should be empty when the IdP did not send one")
+}

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/bazelbuild/rules_go v0.60.0
 	github.com/bazelbuild/rules_webtesting v0.2.1-0.20250911195827-e09c04b7d4d1
 	github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e
+	github.com/beevik/etree v1.6.0
 	github.com/bits-and-blooms/bloom/v3 v3.7.0
 	github.com/bojand/ghz v0.120.0
 	github.com/bradfitz/gomemcache v0.0.0-20230611145640-acc696258285
@@ -249,7 +250,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df // indirect
-	github.com/beevik/etree v1.6.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect


### PR DESCRIPTION
If an identity provider is misconfigured, this can cause login attempts to use an empty suffix when constructing the full SubID.