### PR TITLE
Make the capability disabled state more obvious in Firefox.

### DIFF
--- a/enterprise/app/api_keys/api_keys.css
+++ b/enterprise/app/api_keys/api_keys.css
@@ -164,6 +164,11 @@
   align-items: center;
 }
 
+/* Make the disabled state more obvious in Firefox by dimming the entire row. */
+.api-keys-form .checkbox-row:has(input:disabled) {
+  opacity: 0.5;
+}
+
 .api-keys-form .field-description {
   color: var(--color-text-emphasis);
 }


### PR DESCRIPTION
This dims the entire row instead of just the radio button.

Don't know if it's a general issue but on Firefox on my PC,  the disabled radio button is barely distinguishable from an  enabled radio button.

Disabled state in Chrome before this change: 
<img width="836" height="460" alt="image" src="https://github.com/user-attachments/assets/eeff23e4-928d-4e7d-861a-768509e2685a" />

Disabled state in Firefox before this change:
<img width="831" height="468" alt="image" src="https://github.com/user-attachments/assets/5b35e14c-9d41-409e-84b3-5d9e87fe9375" />

Disabled state in Firefox after this change:
<img width="825" height="485" alt="image" src="https://github.com/user-attachments/assets/25d6a222-2d55-4313-95fb-22a61b1cf57a" />
