### PR TITLE
Skip registering task sizer if RBE is disabled

### DIFF
--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/real_environment",
+        "//server/remote_execution/config",
         "//server/util/authutil",
         "//server/util/log",
         "//server/util/platform",

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_execution/config"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
@@ -119,6 +120,10 @@ const (
 
 // Register registers the task sizer with the env.
 func Register(env *real_environment.RealEnv) error {
+	if !config.RemoteExecutionEnabled() {
+		// Task sizer is not needed if RBE is disabled.
+		return nil
+	}
 	sizer, err := NewSizer(env)
 	if err != nil {
 		return err


### PR DESCRIPTION
I would like to enable the auto-sizer by default for on-prem installations ([context](https://buildbuddy-corp.slack.com/archives/C0ALDM97US0/p1777063625092449))

This change should allow setting the default value of `use_measured_task_sizes` to `true` in the helm charts (and possibly also in the app code as well) without throwing an error if `enable_remote_exec` is not also enabled (it's disabled by default)