### PR TITLE
Set up GOMODCACHE in GitHub actions

### DIFF
--- a/.github/actions/setup-bazel-go-mod-cache/action.yml
+++ b/.github/actions/setup-bazel-go-mod-cache/action.yml
@@ -1,0 +1,46 @@
+name: Setup Bazel Go module cache
+description: Configure Gazelle go_repository to use a persisted host GOMODCACHE.
+inputs:
+  bazelrc:
+    description: Bazel rc file to append the repo_env settings to.
+    default: user.bazelrc
+  gomodcache:
+    description: Go module cache path. Defaults to $HOME/go/pkg/mod.
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Configure Bazel Go module cache
+      id: config
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        gomodcache="${{ inputs.gomodcache }}"
+        if [[ -z "$gomodcache" ]]; then
+          gomodcache="$HOME/go/pkg/mod"
+        elif [[ "$gomodcache" == "~/"* ]]; then
+          gomodcache="$HOME/${gomodcache#~/}"
+        fi
+
+        printf -v gomodcache_bazelrc_escaped "%q" "$gomodcache"
+
+        bazelrc="${{ inputs.bazelrc }}"
+        mkdir -p "$gomodcache" "$(dirname "$bazelrc")"
+        {
+          echo "common --repo_env=GO_REPOSITORY_USE_HOST_MODCACHE=1"
+          echo "common --repo_env=GOMODCACHE=$gomodcache_bazelrc_escaped"
+        } >> "$bazelrc"
+
+        echo "gomodcache=$gomodcache" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Go module cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.config.outputs.gomodcache }}
+        # GitHub cache entries are immutable. Hash go.mod and keep separate
+        # caches per OS/arch: dependency changes restore an older cache via
+        # restore-keys, then save a new cache populated with any new modules.
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-v1-${{ hashFiles('go.mod') }}
+        restore-keys: |
+          go-mod-${{ runner.os }}-${{ runner.arch }}-v1-

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -75,6 +75,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Bazel Go module cache
+        uses: ./.github/actions/setup-bazel-go-mod-cache
+        with:
+          gomodcache: C:/Users/runneradmin/go/pkg/mod
+
       # This step would list out all files under $vs2022Path for debugging purposes.
       # Uncomment if GitHub released a new Windows image and you need to find the new path of cl.exe.
       # TODO(sluongng): Make buildbuddy-toolchains detect the path automatically.

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Bazel Go module cache
+        uses: ./.github/actions/setup-bazel-go-mod-cache
+
       - name: Coverage
         run: |
           bazelisk coverage \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Bazel Go module cache
+        uses: ./.github/actions/setup-bazel-go-mod-cache
+
       - name: Test
         run: |
           bazelisk test \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Bazel Go module cache
+        uses: ./.github/actions/setup-bazel-go-mod-cache
+
       - name: Test
         run: |
           bazelisk test \

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Bazel Go module cache
+        uses: ./.github/actions/setup-bazel-go-mod-cache
+
       # podman_test installs its own version of podman under / in order to test
       # the same version that we use in the executor while not having to
       # configure various podman directory paths. For now just uninstall the
@@ -29,7 +32,7 @@ jobs:
 
       - name: Run tests
         run: |
-          echo > user.bazelrc "
+          cat >> user.bazelrc <<'EOF'
           common --config=cache
           common --repository_cache=~/repo-cache
           common --bes_backend=remote.buildbuddy.io
@@ -41,7 +44,7 @@ jobs:
           common --build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true
           common --color=yes
           common --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
-          "
+          EOF
 
           bazel test --test_tag_filters=-performance,-docker \
             -- \

--- a/.github/workflows/website-pr.yaml
+++ b/.github/workflows/website-pr.yaml
@@ -19,12 +19,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Bazel Go module cache
+        uses: ./.github/actions/setup-bazel-go-mod-cache
+
       - name: Build Website
         run: |
           API_KEY="${{ secrets.BUILDBUDDY_ORG_API_KEY }}"
           if [[ "$API_KEY" ]]; then
-            echo >user.bazelrc "common --config=ci --remote_header=x-buildbuddy-api-key=$API_KEY"
+            echo >>user.bazelrc "common --config=ci --remote_header=x-buildbuddy-api-key=$API_KEY"
           else
-            echo >user.bazelrc "common --config=ci-anon"
+            echo >>user.bazelrc "common --config=ci-anon"
           fi
           bazelisk build --repository_cache='~/repo-cache/' //website:website

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -21,6 +21,9 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Setup Bazel Go module cache
+        uses: ./.github/actions/setup-bazel-go-mod-cache
+
       - name: Build Website
         run: |
           bazelisk build --repository_cache='~/repo-cache/' //website:website --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}

--- a/docs/rbe-setup.md
+++ b/docs/rbe-setup.md
@@ -267,9 +267,9 @@ It's commonly used to set environment variables that are used to augment how too
 # This requires you to declare and register a CC toolchain explicitly.
 --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
-# Tell Gazelle's go_repository rule to use the path set in GOMODCACHE (or GOPATH) as a local cache directory.
+# Tell Gazelle's go_repository rule to use the path set in GOMODCACHE as a local cache directory.
 # This can be useful to speed up Go modules downloads.
---repo_env=GO_REPOSITORY_USE_HOST_CACHE=1
+--repo_env=GO_REPOSITORY_USE_HOST_MODCACHE=1
 --repo_env=GOMODCACHE=/some-path/my-go-mod-cache
 ```
 

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -353,6 +353,7 @@ common:ci-shared --config=download-minimal
 common:ci-shared --build_metadata=ROLE=CI
 common:ci-shared --flaky_test_attempts=2
 common:ci-shared --repository_cache=~/repo-cache/
+common:ci-shared --announce_rc
 common:ci-shared --color=yes
 
 # Configuration used for untrusted GitHub actions-based CI

--- a/template-user.bazelrc
+++ b/template-user.bazelrc
@@ -33,7 +33,8 @@
 #common --experimental_repository_cache_hardlinks
 #
 # Cache your Go module downloads using the host Go module cache
-#common --repo_env=GO_REPOSITORY_USE_HOST_CACHE=1
+#common --repo_env=GO_REPOSITORY_USE_HOST_MODCACHE=1
+#common --repo_env=GOMODCACHE=/ABSOLUTE_PATH_TO_YOUR_GO_MODULE_CACHE
 #
 # Print out test logs if there is any error
 #common --test_output=errors


### PR DESCRIPTION
Github CI sometimes gets stuck downloading go modules. Let's cache them so we don't need to worry about that.