### PR TITLE
Fix 'n' value returned by filecache.Write

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -912,7 +912,10 @@ func (c *fileCache) Read(ctx context.Context, node *repb.FileNode) ([]byte, erro
 // Write atomically writes the given bytes to filecache.
 func (c *fileCache) Write(ctx context.Context, node *repb.FileNode, b []byte) (n int, err error) {
 	if c.checkClosed() {
-		return 0, nil
+		// Like AddFile, treat writes as best-effort during shutdown: report
+		// success to avoid failing callers, even though the data is not persisted
+		// to the cache once the filecache is closed.
+		return len(b), nil
 	}
 	tmp, err := c.tempPath(node.GetDigest().GetHash())
 	if err != nil {
@@ -932,7 +935,7 @@ func (c *fileCache) Write(ctx context.Context, node *repb.FileNode, b []byte) (n
 	if err := c.AddFile(ctx, node, tmp); err != nil {
 		return 0, err
 	}
-	return n, nil
+	return len(b), nil
 }
 
 type verifiedWriter struct {

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -1268,13 +1268,44 @@ func TestFileCacheWriteCleansUpTempFile(t *testing.T) {
 	rn, buf := testdigest.RandomCASResourceBuf(t, 1024)
 	node := &repb.FileNode{Digest: rn.GetDigest()}
 
-	_, err = fc.Write(ctx, node, buf)
+	// Write the bytes through the convenience API and expect it to report the
+	// full accepted byte count.
+	n, err := fc.Write(ctx, node, buf)
 	require.NoError(t, err)
+	require.Equal(t, len(buf), n)
 
+	// The temporary staging file should be removed after the file is added to
+	// the cache.
 	pattern := filepath.Join(fc.TempDir(), rn.GetDigest().GetHash()+".*.tmp")
 	matches, err := filepath.Glob(pattern)
 	require.NoError(t, err)
 	require.Empty(t, matches, "expected temp file(s) to be deleted: %v", matches)
+}
+
+func TestFileCacheWriteAfterClose(t *testing.T) {
+	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
+	ctx := context.Background()
+	fcDir := testfs.MakeTempDir(t)
+	outputDir := testfs.MakeTempDir(t)
+	fc, err := filecache.NewFileCache(fcDir, 100000, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+
+	rn, buf := testdigest.RandomCASResourceBuf(t, 1024)
+	node := &repb.FileNode{Digest: rn.GetDigest()}
+
+	// Once the cache is closing, Write should silently accept the bytes so
+	// callers do not fail just because cache population is best-effort.
+	require.NoError(t, fc.Close())
+	n, err := fc.Write(ctx, node, buf)
+	require.NoError(t, err)
+	require.Equal(t, len(buf), n)
+
+	// The accepted bytes are intentionally dropped rather than added to the
+	// cache after shutdown starts.
+	linkedPath := filepath.Join(outputDir, "linked-after-close")
+	require.False(t, fc.FastLinkFile(ctx, node, linkedPath))
+	require.NoFileExists(t, linkedPath)
 }
 
 func TestTrackExternalDirectory_Basic(t *testing.T) {


### PR DESCRIPTION
I don't think any callers rely on this value being correct, but if we're gonna return a value here, it may as well be the correct value?