### PR TITLE
Refactor proto bazel build dependencies

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -144,7 +144,6 @@ proto_library(
     ],
     deps = [
         ":context_proto",
-        ":execution_stats_proto",
         ":remote_execution_proto",
         ":resource_proto",
         "@com_google_protobuf//:duration_proto",
@@ -470,7 +469,6 @@ proto_library(
     ],
     deps = [
         ":context_proto",
-        ":git_proto",
     ],
 )
 
@@ -610,7 +608,6 @@ proto_library(
         "grp.proto",
     ],
     deps = [
-        ":api_key_proto",
         ":capability_proto",
         ":context_proto",
         ":user_id_proto",
@@ -816,7 +813,6 @@ proto_library(
     srcs = ["zip.proto"],
     deps = [
         ":context_proto",
-        ":remote_execution_proto",
         "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_proto",
     ],
 )

--- a/proto/api/v1/BUILD
+++ b/proto/api/v1/BUILD
@@ -11,7 +11,6 @@ proto_library(
     deps = [
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
-        "@googleapis//google/rpc:status_proto",
     ],
 )
 


### PR DESCRIPTION
Re-runs CI with secrets for #11955 by @xuhongxu96 (PRs from forks don't have access to the BuildBuddy API key, so the standard checks can't run).

Same commit, same diff — just pushed to an upstream branch so the workflow can authenticate.

Closes #11955