### PR TITLE
Wrap breadcrumbs

### DIFF
--- a/app/components/breadcrumbs/breadcrumbs.css
+++ b/app/components/breadcrumbs/breadcrumbs.css
@@ -5,6 +5,7 @@
   color: var(--color);
 
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 4px;
 


### PR DESCRIPTION
Before (this might be a regression from https://github.com/buildbuddy-io/buildbuddy/pull/11941)

<img width="1418" height="122" alt="image" src="https://github.com/user-attachments/assets/75540a60-b9f9-42e3-ac5c-b17cb0a63e20" />

---

After:

<img width="1418" height="122" alt="image" src="https://github.com/user-attachments/assets/e68e0dce-fd34-4de4-b497-652789cb8ecf" />

