### PR TITLE
[FC] Limit mmapped chunks when exporting diff snapshots

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -3232,6 +3232,15 @@ type snapshotDetails struct {
 	saveLocalSnapshot   bool
 }
 
+// Firecracker exports snapshots sequentially, so we should limit the number of chunks mmapped at a time
+// because they won't be accessed again.
+// We use the same concurrency as with snapshot writes (plus a little buffer) because that's the max number of chunks we expect to be
+// accessed at a time.
+func (c *FirecrackerContainer) snapshotWriteMaxMmappedChunks() int64 {
+	snapshotWriteConcurrency := int64(math.Max(snaputil.WriteSnapshotChunkConcurrency, float64(c.vmConfig.GetNumCpus())))
+	return snapshotWriteConcurrency + 4
+}
+
 func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDetails, error) {
 	saveRemoteSnapshot := c.shouldSaveRemoteSnapshot(ctx)
 	saveLocalSnapshot := c.shouldSaveLocalSnapshot(ctx)
@@ -3277,19 +3286,13 @@ func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDe
 				return nil, status.InternalErrorf("invalid memory snapshot size %d bytes", memorySizeBytes)
 			}
 
-			snapshotWriteConcurrency := int64(math.Max(snaputil.WriteSnapshotChunkConcurrency, float64(c.vmConfig.GetNumCpus())))
-
 			memoryStore, err := copy_on_write.NewCOWStore(c.vmCtx, c.env, memoryChunkDirName, nil, copy_on_write.COWOptions{
 				ChunkSizeBytes:     cowChunkSizeBytes(),
 				TotalSizeBytes:     memorySizeBytes,
 				DataDir:            memChunkDir,
 				RemoteInstanceName: c.snapshotKeySet.GetBranchKey().GetInstanceName(),
 				RemoteEnabled:      c.supportsRemoteSnapshots,
-				// Firecracker exports snapshots sequentially, so we should limit the number of chunks mmapped at a time
-				// because they won't be accessed again.
-				// We use the same concurrency as with snapshot writes (plus a little buffer) because that's the max number of chunks we expect to be
-				// accessed at a time.
-				MaxMmappedChunks: snapshotWriteConcurrency + 4,
+				MaxMmappedChunks:   c.snapshotWriteMaxMmappedChunks(),
 			})
 			if err != nil {
 				return nil, status.WrapError(err, "create memory COWStore")
@@ -3337,6 +3340,16 @@ func (c *FirecrackerContainer) createSnapshot(ctx context.Context, snapshotDetai
 	defer metrics.SnapshotSaveWorkloadsExecuting.With(prometheus.Labels{
 		metrics.Stage: "create_snapshot",
 	}).Dec()
+
+	if *exportSnapshotToCOW && c.memoryStore != nil && snapshotDetails.snapshotType == diffSnapshotType {
+		// By default, mmapped chunks are managed by the executor-wide shared LRU.
+		//
+		// When exporting the diff snapshot, we should limit the number of chunks mmapped at a time.
+		// Snapshots are exported sequentially, so we don't want recently touched chunks to stay mmapped longer than necessary.
+		if err := c.memoryStore.LimitMmappedChunks(c.snapshotWriteMaxMmappedChunks()); err != nil {
+			return status.WrapError(err, "set limited LRU for diff snapshot export")
+		}
+	}
 
 	machineStart := time.Now()
 	snapshotTypeOpt := func(params *operations.CreateSnapshotParams) {

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -151,6 +151,7 @@ type COWStore struct {
 	// evicting the least recently added chunk.
 	eagerFetchStack *boundedstack.BoundedStack[int64]
 	eagerFetchEg    *errgroup.Group
+	quitOnce        sync.Once
 	quitChan        chan struct{}
 
 	// usageLock protects chunkOperationToUsageSummary
@@ -521,7 +522,7 @@ func (c *COWStore) Sync() error {
 
 func (s *COWStore) Close() error {
 	// Close background goroutine eagerly fetching chunks
-	close(s.quitChan)
+	s.quitOnce.Do(func() { close(s.quitChan) })
 	s.eagerFetchEg.Wait()
 
 	var lastErr error
@@ -613,16 +614,23 @@ func (s *COWStore) LimitMmappedChunks(maxMmappedChunks int64) error {
 		return err
 	}
 
+	// Stop eager fetching chunks. With a limited LRU, it could cause unnecessary LRU churn.
+	// Note that eager fetching chunks acquires the storeLock, so we must stop this
+	// before acquiring the lock below.
+	s.quitOnce.Do(func() { close(s.quitChan) })
+	s.eagerFetchEg.Wait()
+
 	s.storeLock.Lock()
 	defer s.storeLock.Unlock()
 
 	for _, chunk := range s.chunks {
-		chunk.lru = lru
 		if err := chunk.Unmap(); err != nil {
 			log.CtxWarningf(s.ctx, "failed to unmap chunk at offset %d: %s", chunk.Offset, err)
 		}
+		chunk.lru = lru
 	}
 	s.mmapLRU = lru
+	s.eagerFetchStack = nil
 	return nil
 }
 

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -600,6 +600,32 @@ func (s *COWStore) ChunkSizeBytes() int64 {
 	return s.chunkSizeBytes
 }
 
+// LimitMmappedChunks limits how many chunks can be mmapped at once.
+// This is useful when exporting a snapshot sequentially, when we don't want
+// recently touched chunks to stay mmapped longer than necessary. Existing
+// chunks are unmapped so future accesses enter the new LRU.
+func (s *COWStore) LimitMmappedChunks(maxMmappedChunks int64) error {
+	if maxMmappedChunks <= 0 {
+		return status.InvalidArgumentErrorf("max mmapped chunks must be positive")
+	}
+	lru, err := NewMmapLRU(s.chunkSizeBytes * maxMmappedChunks)
+	if err != nil {
+		return err
+	}
+
+	s.storeLock.Lock()
+	defer s.storeLock.Unlock()
+
+	for _, chunk := range s.chunks {
+		chunk.lru = lru
+		if err := chunk.Unmap(); err != nil {
+			log.CtxWarningf(s.ctx, "failed to unmap chunk at offset %d: %s", chunk.Offset, err)
+		}
+	}
+	s.mmapLRU = lru
+	return nil
+}
+
 // Resize resizes the COWStore to the given size, effectively right-padding the
 // current store with 0-bytes.
 func (s *COWStore) Resize(newSize int64) (oldSize int64, err error) {
@@ -703,6 +729,7 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 
 	s.storeLock.RLock()
 	ogChunk = s.chunks[offset]
+	mmapLRU := s.mmapLRU
 	s.storeLock.RUnlock()
 	chunkSource := snaputil.ChunkSourceHole
 	if ogChunk != nil {
@@ -711,7 +738,7 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 		}
 		chunkSource = ogChunk.source
 	}
-	newChunk, err = NewMmapFd(s.ctx, s.env, s.DataDir(), true /*=dirty*/, fd, int(size), offset, chunkSource, s.remoteInstanceName, s.remoteEnabled, s.mmapLRU)
+	newChunk, err = NewMmapFd(s.ctx, s.env, s.DataDir(), true /*=dirty*/, fd, int(size), offset, chunkSource, s.remoteInstanceName, s.remoteEnabled, mmapLRU)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
I realized that [this](https://github.com/buildbuddy-io/buildbuddy/pull/11959) only affects full snapshots. We need to ensure we use a limited mmap LRU when exporting diff snapshots as well 