### PR TITLE
Respect BUILDBUDDY_API_KEY env var for bazel commands too

### DIFF
--- a/cli/login/BUILD
+++ b/cli/login/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
@@ -17,5 +17,17 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",
+    ],
+)
+
+go_test(
+    name = "login_test",
+    srcs = ["login_test.go"],
+    embed = [":login"],
+    deps = [
+        "//cli/storage",
+        "//server/testutil/testgit",
+        "//server/util/status",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -343,7 +343,9 @@ func ConfigureAPIKey(args []string) ([]string, error) {
 		return args, nil
 	}
 
-	apiKey, err := storage.ReadRepoConfig(apiKeyRepoSetting)
+	// TODO: consider always starting an interactive login, or maybe only when
+	// using an org-specific subdomain.
+	apiKey, err := getAPIKey(false /*=interactive*/)
 	if err != nil {
 		// If we're not in a git repo, we'll fail to read the repo-specific
 		// config.
@@ -401,10 +403,14 @@ func isSupportedCommand(command string) bool {
 // GetAPIKey attempts to read an API key from the
 // BUILDBUDDY_API_KEY environment variable and, if not set, from the buildbuddy
 // config set at the key `buildbuddy.api-key` in .git/config. If neither is set,
-// and we're running in a tty, this will prompt the user to set it.
+// and we're running in a tty, this will start the login flow.
 func GetAPIKey() (string, error) {
+	return getAPIKey(true /*=interactive*/)
+}
+
+func getAPIKey(interactive bool) (string, error) {
 	var err error
-	apiKey := os.Getenv("BUILDBUDDY_API_KEY")
+	apiKey := strings.TrimSpace(os.Getenv("BUILDBUDDY_API_KEY"))
 	if apiKey != "" {
 		return apiKey, nil
 	}
@@ -420,7 +426,7 @@ func GetAPIKey() (string, error) {
 	}
 	// If an API key is not set, and we're running in a terminal, start the
 	// login flow.
-	if terminal.IsTTY(os.Stdin) && terminal.IsTTY(os.Stdout) && terminal.IsTTY(os.Stderr) {
+	if interactive && terminal.IsTTY(os.Stdin) && terminal.IsTTY(os.Stdout) && terminal.IsTTY(os.Stderr) {
 		if _, err = HandleLogin([]string{}); err != nil {
 			return "", status.WrapError(err, "handle login")
 		}

--- a/cli/login/login_test.go
+++ b/cli/login/login_test.go
@@ -1,0 +1,108 @@
+package login
+
+import (
+	"os"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/storage"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIKeyDiscovery(t *testing.T) {
+	for _, testCase := range []struct {
+		name              string
+		envAPIKey         string
+		repoAPIKey        string
+		expectedAPIKey    string
+		expectedArgs      []string
+		expectedGetAPIErr bool
+	}{
+		{
+			name:           "env defined",
+			envAPIKey:      "env-api-key",
+			expectedAPIKey: "env-api-key",
+			expectedArgs: []string{
+				"build",
+				"//foo:bar",
+				"--remote_header=x-buildbuddy-api-key=env-api-key",
+			},
+		},
+		{
+			name:           ".git/config value defined",
+			repoAPIKey:     "repo-api-key",
+			expectedAPIKey: "repo-api-key",
+			expectedArgs: []string{
+				"build",
+				"//foo:bar",
+				"--remote_header=x-buildbuddy-api-key=repo-api-key",
+			},
+		},
+		{
+			name:           "both env and .git/config defined",
+			envAPIKey:      "env-api-key",
+			repoAPIKey:     "repo-api-key",
+			expectedAPIKey: "env-api-key",
+			expectedArgs: []string{
+				"build",
+				"//foo:bar",
+				"--remote_header=x-buildbuddy-api-key=env-api-key",
+			},
+		},
+		{
+			name:              "neither env nor .git/config defined",
+			expectedArgs:      []string{"build", "//foo:bar"},
+			expectedGetAPIErr: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			repoRoot, _ := testgit.MakeTempRepo(t, map[string]string{
+				"README.md": "# test repo",
+			})
+			previousRepoRootPath := storage.RepoRootPath
+			storage.RepoRootPath = func() (string, error) {
+				return repoRoot, nil
+			}
+			t.Cleanup(func() {
+				storage.RepoRootPath = previousRepoRootPath
+			})
+
+			// Simulate either CI-provided credentials, repo-local config, or both.
+			setNonTTYStdin(t)
+			t.Setenv("BUILDBUDDY_API_KEY", testCase.envAPIKey)
+			if testCase.repoAPIKey != "" {
+				require.NoError(t, storage.WriteRepoConfig(apiKeyRepoSetting, testCase.repoAPIKey))
+			}
+
+			// GetAPIKey should return the same key that ConfigureAPIKey will use.
+			apiKey, err := GetAPIKey()
+			if testCase.expectedGetAPIErr {
+				require.True(t, status.IsNotFoundError(err))
+				require.Empty(t, apiKey)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedAPIKey, apiKey)
+			}
+
+			// Supported Bazel commands should receive the discovered API key.
+			args, err := ConfigureAPIKey([]string{"build", "//foo:bar"})
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedArgs, args)
+		})
+	}
+}
+
+func setNonTTYStdin(t *testing.T) {
+	t.Helper()
+
+	stdin, err := os.CreateTemp(t.TempDir(), "stdin")
+	require.NoError(t, err)
+	previousStdin := os.Stdin
+	os.Stdin = stdin
+	t.Cleanup(func() {
+		os.Stdin = previousStdin
+		require.NoError(t, stdin.Close())
+	})
+}


### PR DESCRIPTION
We currently respect BUILDBUDDY_API_KEY for CLI-specific commands; may as well respect it for bazel commands too.