### PR TITLE
Update prober regex in cache proxy dashboard

### DIFF
--- a/tools/metrics/grafana/dashboards/cache-proxy.json
+++ b/tools/metrics/grafana/dashboards/cache-proxy.json
@@ -801,7 +801,7 @@
               "expr": "sum(increase(cloudprober_success{region=\"${region}\", probe=~\".*proxy.*\"}[10m])) by (probe) / sum(increase(cloudprober_total{region=\"${region}\", probe=~\".*proxy.*\"}[10m])) by (probe)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Up",
+              "legendFormat": "{{probe}} Up",
               "queryType": "randomWalk",
               "range": true,
               "refId": "A"

--- a/tools/metrics/grafana/dashboards/cache-proxy.json
+++ b/tools/metrics/grafana/dashboards/cache-proxy.json
@@ -798,7 +798,7 @@
                 "uid": "vm"
               },
               "editorMode": "code",
-              "expr": "sum(increase(cloudprober_success{region=\"${region}\", probe=~\".*_proxy_.*\"}[10m])) by (probe) / sum(increase(cloudprober_total{region=\"${region}\", probe=~\".*_proxy_.*\"}[10m])) by (probe)",
+              "expr": "sum(increase(cloudprober_success{region=\"${region}\", probe=~\".*proxy.*\"}[10m])) by (probe) / sum(increase(cloudprober_total{region=\"${region}\", probe=~\".*proxy.*\"}[10m])) by (probe)",
               "hide": false,
               "interval": "",
               "legendFormat": "Up",


### PR DESCRIPTION
The current name doesn't match `dev_bazel_cache_proxy`, for example.