### PR TITLE
Add an `enterprise/executor` alias

### DIFF
--- a/enterprise/executor/BUILD
+++ b/enterprise/executor/BUILD
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "executor",
+    actual = "//enterprise/server/cmd/executor:executor",
+)

--- a/enterprise/executor/BUILD
+++ b/enterprise/executor/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 alias(
     name = "executor",


### PR DESCRIPTION
This makes it so you can do `bb run enterprise/executor`

I can never remember this full path:
```
//enterprise/server/cmd/executor:executor
```