### PR TITLE
Gate distributed cache health on first kubediscovery response

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -125,6 +125,7 @@ type Cache struct {
 	extraConsistentHash  *consistent_hash.ConsistentHash
 	heartbeatChannel     *heartbeat.Channel
 	kubeDiscoveryChannel *kubediscovery.PeerWatcher
+	kubeDiscoveryReady   chan struct{}
 	heartbeatMu          *sync.Mutex
 	shutdownMu           *sync.RWMutex
 	shutDownChan         chan struct{}
@@ -280,11 +281,14 @@ func NewDistributedCache(env environment.Env, c interfaces.Cache, opts Options, 
 		}
 	} else if opts.KubePeerWatcher != nil {
 		dc.kubeDiscoveryChannel = opts.KubePeerWatcher
+		dc.kubeDiscoveryReady = make(chan struct{})
+		var firstUpdate sync.Once
 		dc.kubeDiscoveryChannel.SetUpdateFn(func(peers map[string]string) {
 			dc.log.Infof("distributed cache peer set changed to %v", peers)
 			if err := chash.SetFromMap(peers); err != nil {
 				dc.log.Errorf("Error setting peers in consistent hash: %s", err)
 			}
+			firstUpdate.Do(func() { close(dc.kubeDiscoveryReady) })
 		})
 	} else {
 		// No nodes were hardcoded, use redis for discovery.
@@ -304,7 +308,7 @@ func NewDistributedCache(env environment.Env, c interfaces.Cache, opts Options, 
 	hc.RegisterShutdownFunction(func(ctx context.Context) error {
 		return dc.Shutdown(ctx)
 	})
-	if dc.opts.ClusterSize > 0 {
+	if dc.opts.ClusterSize > 0 || dc.kubeDiscoveryChannel != nil {
 		hc.AddHealthCheck("distributed_cache", dc)
 	}
 	return dc, nil
@@ -319,6 +323,14 @@ func (c *Cache) Check(ctx context.Context) error {
 			return status.UnavailableErrorf("Not enough nodes configured %d to meet replication factor %d.", len(c.opts.Nodes), c.opts.ReplicationFactor)
 		}
 		return nil
+	}
+
+	if c.kubeDiscoveryChannel != nil {
+		select {
+		case <-c.kubeDiscoveryReady:
+		default:
+			return status.UnavailableError("waiting for initial kubernetes peer discovery response")
+		}
 	}
 
 	// First check that the number of nodes in our chash


### PR DESCRIPTION
When the distributed cache uses kubernetes-discovery mode, the pod could previously report itself healthy before the PeerWatcher had received any response from the kubernetes API. This was especially visible when cluster_size was 0, in which case the distributed_cache health check wasn't even registered, so readiness was independent of peer discovery entirely. The fix registers the health check whenever kubediscovery is enabled and gates Check() on a kubeDiscoveryReady channel that is closed (under a sync.Once) the first time the peer-set update callback fires. Until that first response lands, Check() returns Unavailable with a clear message; afterwards the existing chash-size checks take over. A non-blocking select/default is used in Check() so the health check returns immediately rather than blocking on the channel. An atomic.Bool would also have worked, but the channel pattern composes better if we ever want to wait on readiness with a context.