### PR TITLE
feat(CDC): support CAS.SpliceChunks

### DIFF
--- a/cli/sidecar_proxy/sidecar_proxy.go
+++ b/cli/sidecar_proxy/sidecar_proxy.go
@@ -310,8 +310,57 @@ func (p *CacheProxy) SpliceBlob(ctx context.Context, req *repb.SpliceBlobRequest
 	return p.casClient.SpliceBlob(ctx, req)
 }
 
+func (p *CacheProxy) SpliceChunks(stream repb.ContentAddressableStorage_SpliceChunksServer) error {
+	clientStream, err := p.casClient.SpliceChunks(stream.Context())
+	if err != nil {
+		return err
+	}
+	finish := func() error {
+		resp, err := clientStream.CloseAndRecv()
+		if err != nil {
+			return err
+		}
+		return stream.SendAndClose(resp)
+	}
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return finish()
+		}
+		if err != nil {
+			return err
+		}
+		if err := clientStream.Send(req); err != nil {
+			if err == io.EOF {
+				// Read the final response to return the remote status.
+				return finish()
+			}
+			return err
+		}
+	}
+}
+
 func (p *CacheProxy) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest) (*repb.SplitBlobResponse, error) {
 	return p.casClient.SplitBlob(ctx, req)
+}
+
+func (p *CacheProxy) SplitChunks(req *repb.SplitBlobRequest, stream repb.ContentAddressableStorage_SplitChunksServer) error {
+	clientStream, err := p.casClient.SplitChunks(stream.Context(), req)
+	if err != nil {
+		return err
+	}
+	for {
+		resp, err := clientStream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
 }
 
 func logContextFromMetadata(ctx context.Context, md metadata.MD) context.Context {

--- a/enterprise/server/atime_updater/atime_updater_test.go
+++ b/enterprise/server/atime_updater/atime_updater_test.go
@@ -133,9 +133,19 @@ func (f *fakeCAS) SpliceBlob(ctx context.Context, req *repb.SpliceBlobRequest) (
 	return nil, status.InternalError("SpliceBlob RPC is not currently implemented")
 }
 
+func (f *fakeCAS) SpliceChunks(stream repb.ContentAddressableStorage_SpliceChunksServer) error {
+	f.t.Fatal("Unexpected call to SpliceChunks")
+	return status.InternalError("SpliceChunks RPC is not currently implemented")
+}
+
 func (f *fakeCAS) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest) (*repb.SplitBlobResponse, error) {
 	f.t.Fatal("Unexpected call to SplitBlob")
 	return nil, status.InternalError("SplitBlob RPC is not currently implemented")
+}
+
+func (f *fakeCAS) SplitChunks(req *repb.SplitBlobRequest, stream repb.ContentAddressableStorage_SplitChunksServer) error {
+	f.t.Fatal("Unexpected call to SplitChunks")
+	return status.InternalError("SplitChunks RPC is not currently implemented")
 }
 
 func runFakeCAS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (*fakeCAS, repb.ContentAddressableStorageClient) {

--- a/enterprise/server/batch_operator/batch_operator_test.go
+++ b/enterprise/server/batch_operator/batch_operator_test.go
@@ -132,9 +132,19 @@ func (f *fakeCAS) SpliceBlob(ctx context.Context, req *repb.SpliceBlobRequest) (
 	return nil, status.InternalError("SpliceBlob RPC is not currently implemented")
 }
 
+func (f *fakeCAS) SpliceChunks(stream repb.ContentAddressableStorage_SpliceChunksServer) error {
+	f.t.Fatal("Unexpected call to SpliceChunks")
+	return status.InternalError("SpliceChunks RPC is not currently implemented")
+}
+
 func (f *fakeCAS) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest) (*repb.SplitBlobResponse, error) {
 	f.t.Fatal("Unexpected call to SplitBlob")
 	return nil, status.InternalError("SplitBlob RPC is not currently implemented")
+}
+
+func (f *fakeCAS) SplitChunks(req *repb.SplitBlobRequest, stream repb.ContentAddressableStorage_SplitChunksServer) error {
+	f.t.Fatal("Unexpected call to SplitChunks")
+	return status.InternalError("SplitChunks RPC is not currently implemented")
 }
 
 func runFakeCAS(ctx context.Context, env *testenv.TestEnv, t testing.TB) (*fakeCAS, repb.ContentAddressableStorageClient) {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -47,6 +49,10 @@ import (
 
 const (
 	defaultChunkTransferConcurrency = 32
+
+	// Keep each request below common gRPC message limits. A serialized
+	// SHA256 chunk digest is ~73 bytes.
+	streamedSpliceMaxDigestsPerRequest = 10_000
 )
 
 var (
@@ -1266,7 +1272,14 @@ func (s *ByteStreamServerProxy) writeChunked(ctx context.Context, stream bspb.By
 	// Tag outgoing chunk uploads so intermediaries downstream of this proxy
 	// do not re-chunk them.
 	chunkUploadCtx := cdc.ContextWithChunked(ctx)
-	uploader, err := newChunkUploader(chunkUploadCtx, s, instanceName, digestFunction)
+	var splicer *streamedSplicer
+	if s.shouldStreamSpliceBlob(ctx, rn) {
+		splicer, err = newStreamedSplicer(chunkUploadCtx, s.remoteCAS, rn, digestFunction)
+		if err != nil {
+			return writeChunkedResult{}, status.WrapErrorf(err, "start streamed splice")
+		}
+	}
+	uploader, err := newChunkUploader(chunkUploadCtx, s, instanceName, digestFunction, splicer)
 	if err != nil {
 		return writeChunkedResult{}, err
 	}
@@ -1312,8 +1325,7 @@ func (s *ByteStreamServerProxy) writeChunked(ctx context.Context, stream bspb.By
 			}
 			localWriteSpn.End()
 		}
-		uploader.addChunk(compressedData, poolBuf, chunkDigest)
-		return nil
+		return uploader.addChunk(compressedData, poolBuf, chunkDigest)
 	}
 
 	chunker, err := chunking.NewChunker(ctx, int(chunking.AvgChunkSizeBytes(ctx, s.efp)), chunkWriteFn)
@@ -1413,24 +1425,213 @@ func (s *ByteStreamServerProxy) writeChunked(ctx context.Context, stream bspb.By
 
 	remoteStart := time.Now()
 
-	_, flushSpn := tracing.StartNamedSpan(ctx, "flushChunkUploads")
-	if err := uploader.flush(); err != nil {
+	_, flushSpn := tracing.StartNamedSpan(ctx, "flushChunkedWrite")
+	if err := uploader.flush(ctx, manifest); err != nil {
 		flushSpn.End()
-		return writeChunkedResult{}, status.WrapErrorf(err, "uploading missing chunks to remote")
+		return writeChunkedResult{}, err
 	}
 	flushSpn.End()
 	result.chunksDeduped = int(uploader.dedupedChunks.Load())
 	result.chunkBytesDeduped = uploader.dedupedChunkBytes.Load()
 
-	spliceCtx, spliceSpn := tracing.StartNamedSpan(ctx, "remote.SpliceBlob")
-	_, err = s.remoteCAS.SpliceBlob(spliceCtx, manifest.ToSpliceBlobRequest())
-	spliceSpn.End()
-	if err != nil {
-		return writeChunkedResult{}, status.WrapErrorf(err, "splice blob on remote")
-	}
-
 	result.remoteDuration = time.Since(remoteStart)
 	return result, stream.SendAndClose(&bspb.WriteResponse{CommittedSize: bytesReceived})
+}
+
+func (s *ByteStreamServerProxy) shouldStreamSpliceBlob(ctx context.Context, rn *digest.CASResourceName) bool {
+	if s.remoteCAS == nil || s.efp == nil {
+		return false
+	}
+	threshold := s.efp.Int64(ctx, "cache_proxy.splice_stream_threshold_bytes", math.MaxInt64)
+	return rn.GetDigest().GetSizeBytes() >= threshold
+}
+
+func isStreamedSpliceFallbackError(err error) bool {
+	return status.IsUnimplementedError(err) || status.IsUnavailableError(err)
+}
+
+// streamedSplicer sends digests in blob order as chunks become available.
+// One goroutine owns the stream because concurrent sends are not safe.
+type streamedSplicer struct {
+	stream         repb.ContentAddressableStorage_SpliceChunksClient
+	instanceName   string
+	blobDigest     *repb.Digest
+	digestFunction repb.DigestFunction_Value
+	metadataSent   bool
+
+	events chan streamedSpliceEvent
+	done   chan struct{}
+	// The sender records the error before notifying waiters. This ordering makes concurrent reads safe.
+	err error
+}
+
+type streamedSpliceEvent struct {
+	chunk     *repb.Digest
+	available []*repb.Digest
+	commit    bool
+}
+
+// A nil result means that the caller should use the unary RPC.
+func newStreamedSplicer(ctx context.Context, client repb.ContentAddressableStorageClient, rn *digest.CASResourceName, digestFunction repb.DigestFunction_Value) (*streamedSplicer, error) {
+	stream, err := client.SpliceChunks(ctx)
+	if err != nil {
+		if isStreamedSpliceFallbackError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	s := &streamedSplicer{
+		stream:         stream,
+		instanceName:   rn.GetInstanceName(),
+		blobDigest:     rn.GetDigest(),
+		digestFunction: digestFunction,
+		events:         make(chan streamedSpliceEvent, defaultChunkTransferConcurrency),
+		done:           make(chan struct{}),
+	}
+	go s.run(ctx)
+	return s, nil
+}
+
+// addChunk must be called once per chunk in blob order, including repeats
+// of the same digest.
+func (s *streamedSplicer) addChunk(d *repb.Digest) error {
+	return s.enqueue(streamedSpliceEvent{chunk: d})
+}
+
+func (s *streamedSplicer) markRemoteAvailable(digests []*repb.Digest) error {
+	if len(digests) == 0 {
+		return nil
+	}
+	// Copy the list because it may be processed after the caller returns.
+	return s.enqueue(streamedSpliceEvent{available: slices.Clone(digests)})
+}
+
+// A false result with no error means that the caller should use the unary RPC.
+func (s *streamedSplicer) commit(ctx context.Context) (spliced bool, err error) {
+	_, spn := tracing.StartNamedSpan(ctx, "remote.SpliceChunks")
+	defer spn.End()
+
+	if err := s.enqueue(streamedSpliceEvent{commit: true}); err != nil {
+		return false, err
+	}
+	<-s.done
+	terminalErr := s.err
+	if terminalErr == nil {
+		return true, nil
+	}
+	if isStreamedSpliceFallbackError(terminalErr) {
+		return false, nil
+	}
+	return false, terminalErr
+}
+
+func (s *streamedSplicer) enqueue(event streamedSpliceEvent) error {
+	// Give the final status priority when the sender has stopped.
+	select {
+	case <-s.done:
+		return fatalOnly(s.err)
+	default:
+	}
+
+	select {
+	case <-s.done:
+		return fatalOnly(s.err)
+	case s.events <- event:
+	}
+
+	// The sender can stop while an event is queued. Check again before returning.
+	select {
+	case <-s.done:
+		return fatalOnly(s.err)
+	default:
+		return nil
+	}
+}
+
+// Hide fallback errors until commit so the write can use the unary RPC.
+func fatalOnly(err error) error {
+	if isStreamedSpliceFallbackError(err) {
+		return nil
+	}
+	return err
+}
+
+func (s *streamedSplicer) run(ctx context.Context) {
+	// Chunks can become available out of order. Send only the available prefix
+	// so that the blob order stays correct.
+	var digests []*repb.Digest
+	available := make(map[digest.Key]bool)
+	nextSendIndex := 0
+	committing := false
+
+	for {
+		start := nextSendIndex
+		for nextSendIndex < len(digests) &&
+			nextSendIndex-start < streamedSpliceMaxDigestsPerRequest &&
+			available[digest.NewKey(digests[nextSendIndex])] {
+			nextSendIndex++
+		}
+		if start != nextSendIndex {
+			if err := s.send(&repb.SpliceChunksRequest{ChunkDigests: digests[start:nextSendIndex]}); err != nil {
+				s.closeWithErr(err)
+				return
+			}
+		} else if committing {
+			if nextSendIndex != len(digests) {
+				s.closeWithErr(status.InternalErrorf("streamed splice has sent %d of %d chunks", nextSendIndex, len(digests)))
+				return
+			}
+			if err := s.send(&repb.SpliceChunksRequest{BlobDigest: s.blobDigest}); err != nil {
+				s.closeWithErr(err)
+				return
+			}
+			_, err := s.stream.CloseAndRecv()
+			s.closeWithErr(err)
+			return
+		} else {
+			select {
+			case event := <-s.events:
+				if event.chunk != nil {
+					digests = append(digests, event.chunk)
+				}
+				for _, d := range event.available {
+					available[digest.NewKey(d)] = true
+				}
+				if event.commit {
+					committing = true
+				}
+			case <-ctx.Done():
+				s.closeWithErr(ctx.Err())
+				return
+			}
+		}
+	}
+}
+
+func (s *streamedSplicer) send(req *repb.SpliceChunksRequest) error {
+	if !s.metadataSent {
+		req = &repb.SpliceChunksRequest{
+			InstanceName:     s.instanceName,
+			BlobDigest:       req.GetBlobDigest(),
+			ChunkDigests:     req.GetChunkDigests(),
+			DigestFunction:   s.digestFunction,
+			ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+		}
+		s.metadataSent = true
+	}
+	if err := s.stream.Send(req); err != nil {
+		if err == io.EOF {
+			_, err = s.stream.CloseAndRecv()
+		}
+		return err
+	}
+	return nil
+}
+
+// Called at most once, from run().
+func (s *streamedSplicer) closeWithErr(err error) {
+	s.err = err
+	close(s.done)
 }
 
 type pendingChunk struct {
@@ -1458,10 +1659,12 @@ type chunkUploader struct {
 	pendingBatchUploadSize int64
 	dedupedChunks          atomic.Int64
 	dedupedChunkBytes      atomic.Int64
+	splicer                *streamedSplicer
 }
 
-// newChunkUploader batches chunks into FMB groups and upload requests of up to 2 MiB.
-func newChunkUploader(ctx context.Context, s *ByteStreamServerProxy, instanceName string, digestFunction repb.DigestFunction_Value) (*chunkUploader, error) {
+// Missing chunk checks are grouped by upload concurrency. Upload requests are
+// capped at 2 MiB. A nil splicer means flush uses unary SpliceBlob.
+func newChunkUploader(ctx context.Context, s *ByteStreamServerProxy, instanceName string, digestFunction repb.DigestFunction_Value, splicer *streamedSplicer) (*chunkUploader, error) {
 	concurrency := defaultChunkTransferConcurrency
 	if s.efp != nil {
 		concurrency = int(s.efp.Int64(ctx, "cache_proxy.chunk_upload_concurrency", defaultChunkTransferConcurrency))
@@ -1483,16 +1686,22 @@ func newChunkUploader(ctx context.Context, s *ByteStreamServerProxy, instanceNam
 		batchG:         batchG,
 		batchCtx:       batchCtx,
 		seen:           make(map[digest.Key]int),
+		splicer:        splicer,
 	}, nil
 }
 
-// addChunk transfers ownership of poolBuf to the uploader. The uploader returns
-// it to the pool once the chunk is deduped or its upload completes.
-func (c *chunkUploader) addChunk(compressedData []byte, poolBuf []byte, d *repb.Digest) {
+// The uploader owns the buffer until the chunk is deduplicated or uploaded.
+func (c *chunkUploader) addChunk(compressedData []byte, poolBuf []byte, d *repb.Digest) error {
 	chunk := pendingChunk{
 		digest:         d,
 		compressedData: compressedData,
 		poolBuf:        poolBuf,
+	}
+	if c.splicer != nil {
+		if err := c.splicer.addChunk(d); err != nil {
+			c.s.bufPool.Put(chunk.poolBuf)
+			return status.WrapErrorf(err, "send chunk to streamed splice")
+		}
 	}
 	dk := digest.NewKey(d)
 
@@ -1502,16 +1711,24 @@ func (c *chunkUploader) addChunk(compressedData []byte, poolBuf []byte, d *repb.
 	c.mu.Unlock()
 	if seenCount > 1 {
 		c.s.bufPool.Put(chunk.poolBuf)
-		return
+		return nil
 	}
 
 	c.pendingFMB = append(c.pendingFMB, chunk)
 	if len(c.pendingFMB) >= c.concurrency {
 		c.flushPendingFMB()
 	}
+	return nil
 }
 
-func (c *chunkUploader) flush() error {
+func (c *chunkUploader) flush(ctx context.Context, manifest *chunking.Manifest) error {
+	if err := c.flushUploads(); err != nil {
+		return status.WrapErrorf(err, "uploading missing chunks to remote")
+	}
+	return c.splice(ctx, manifest)
+}
+
+func (c *chunkUploader) flushUploads() error {
 	c.flushPendingFMB()
 	fmbErr := c.fmbG.Wait()
 	if fmbErr == nil {
@@ -1530,6 +1747,25 @@ func (c *chunkUploader) flush() error {
 		return fmbErr
 	}
 	return batchErr
+}
+
+func (c *chunkUploader) splice(ctx context.Context, manifest *chunking.Manifest) error {
+	if c.splicer != nil {
+		spliced, err := c.splicer.commit(ctx)
+		if err != nil {
+			return status.WrapErrorf(err, "streamed splice chunks on remote")
+		}
+		if spliced {
+			return nil
+		}
+	}
+	spliceCtx, spn := tracing.StartNamedSpan(ctx, "remote.SpliceBlob")
+	defer spn.End()
+	_, err := c.s.remoteCAS.SpliceBlob(spliceCtx, manifest.ToSpliceBlobRequest())
+	if err != nil {
+		return status.WrapErrorf(err, "splice blob on remote")
+	}
+	return nil
 }
 
 func (c *chunkUploader) flushPendingFMB() {
@@ -1568,6 +1804,7 @@ func (c *chunkUploader) processFMBGroup(group []pendingChunk) error {
 		missingSet.Add(d.GetHash())
 	}
 
+	var availableDigests []*repb.Digest
 	for _, chunk := range group {
 		if missingSet.Contains(chunk.digest.GetHash()) {
 			c.queueUploadChunk(chunk)
@@ -1575,8 +1812,9 @@ func (c *chunkUploader) processFMBGroup(group []pendingChunk) error {
 		}
 		c.recordDedupedChunk(chunk.digest)
 		c.s.bufPool.Put(chunk.poolBuf)
+		availableDigests = append(availableDigests, chunk.digest)
 	}
-	return nil
+	return c.markChunksRemoteAvailable(availableDigests)
 }
 
 func (c *chunkUploader) queueUploadChunk(chunk pendingChunk) {
@@ -1636,7 +1874,21 @@ func (c *chunkUploader) uploadBatch(batch []pendingChunk) error {
 	metrics.ByteStreamChunkedWriteUploadSizeBytes.With(prometheus.Labels{
 		metrics.StatusLabel: status.MetricsLabel(err),
 	}).Observe(float64(uploadSizeBytes))
-	return err
+	if err != nil {
+		return err
+	}
+	digests := make([]*repb.Digest, 0, len(batch))
+	for _, chunk := range batch {
+		digests = append(digests, chunk.digest)
+	}
+	return c.markChunksRemoteAvailable(digests)
+}
+
+func (c *chunkUploader) markChunksRemoteAvailable(digests []*repb.Digest) error {
+	if c.splicer == nil {
+		return nil
+	}
+	return c.splicer.markRemoteAvailable(digests)
 }
 
 func (c *chunkUploader) recordDedupedChunk(d *repb.Digest) {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -126,9 +126,18 @@ func (c *noOpCAS) SpliceBlob(ctx context.Context, req *repb.SpliceBlobRequest) (
 	return nil, status.InternalError("SpliceBlob RPC is not currently implemented")
 }
 
+func (c *noOpCAS) SpliceChunks(stream repb.ContentAddressableStorage_SpliceChunksServer) error {
+	return status.UnimplementedError("SpliceChunks not implemented")
+}
+
 func (c *noOpCAS) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest) (*repb.SplitBlobResponse, error) {
 	c.t.Fatal("Unexpected call to SplitBlob")
 	return nil, status.InternalError("SplitBlob RPC is not currently implemented")
+}
+
+func (c *noOpCAS) SplitChunks(req *repb.SplitBlobRequest, stream repb.ContentAddressableStorage_SplitChunksServer) error {
+	c.t.Fatal("Unexpected call to SplitChunks")
+	return status.InternalError("SplitChunks RPC is not currently implemented")
 }
 
 func TestWriteChunkedFallsBackAboveMaxSize(t *testing.T) {
@@ -269,6 +278,283 @@ func TestWriteChunkingEnabledRequiresExperimentInterceptFlag(t *testing.T) {
 	}
 }
 
+type unexpectedSpliceCAS struct {
+	repb.ContentAddressableStorageClient
+	t *testing.T
+}
+
+func (c *unexpectedSpliceCAS) SpliceBlob(ctx context.Context, req *repb.SpliceBlobRequest, opts ...grpc.CallOption) (*repb.SpliceBlobResponse, error) {
+	c.t.Fatal("Unexpected call to SpliceBlob")
+	return nil, status.InternalError("Unexpected call to SpliceBlob")
+}
+
+type failingSpliceChunksCAS struct {
+	repb.ContentAddressableStorageClient
+	err             error
+	spliceBlobCalls atomic.Int64
+}
+
+func (c *failingSpliceChunksCAS) SpliceBlob(ctx context.Context, req *repb.SpliceBlobRequest, opts ...grpc.CallOption) (*repb.SpliceBlobResponse, error) {
+	c.spliceBlobCalls.Add(1)
+	return c.ContentAddressableStorageClient.SpliceBlob(ctx, req, opts...)
+}
+
+func (c *failingSpliceChunksCAS) SpliceChunks(ctx context.Context, opts ...grpc.CallOption) (repb.ContentAddressableStorage_SpliceChunksClient, error) {
+	return &failingSpliceChunksClient{err: c.err}, nil
+}
+
+type failingSpliceChunksClient struct {
+	grpc.ClientStream
+	err error
+}
+
+func (c *failingSpliceChunksClient) Send(req *repb.SpliceChunksRequest) error {
+	return c.err
+}
+
+func (c *failingSpliceChunksClient) CloseAndRecv() (*repb.SpliceBlobResponse, error) {
+	return nil, c.err
+}
+
+type recordingSpliceChunksCAS struct {
+	repb.ContentAddressableStorageClient
+	stream *recordingSpliceChunksClient
+}
+
+func (c *recordingSpliceChunksCAS) SpliceChunks(ctx context.Context, opts ...grpc.CallOption) (repb.ContentAddressableStorage_SpliceChunksClient, error) {
+	return c.stream, nil
+}
+
+type recordingSpliceChunksClient struct {
+	grpc.ClientStream
+	sendErr error
+
+	mu       sync.Mutex
+	requests []*repb.SpliceChunksRequest
+	closed   bool
+}
+
+func (c *recordingSpliceChunksClient) Send(req *repb.SpliceChunksRequest) error {
+	if c.sendErr != nil {
+		return c.sendErr
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.requests = append(c.requests, req)
+	return nil
+}
+
+func (c *recordingSpliceChunksClient) CloseAndRecv() (*repb.SpliceBlobResponse, error) {
+	if c.sendErr != nil {
+		return nil, c.sendErr
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	return &repb.SpliceBlobResponse{}, nil
+}
+
+func (c *recordingSpliceChunksClient) recordedRequests() []*repb.SpliceChunksRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]*repb.SpliceChunksRequest(nil), c.requests...)
+}
+
+func testSplicerResourceName(t *testing.T) *digest.CASResourceName {
+	return digest.NewCASResourceName(
+		&repb.Digest{Hash: strings.Repeat("a", 64), SizeBytes: 100},
+		"test-instance",
+		repb.DigestFunction_SHA256,
+	)
+}
+
+func testSplicerChunkDigests(n int) []*repb.Digest {
+	digests := make([]*repb.Digest, n)
+	for i := range digests {
+		digests[i] = &repb.Digest{Hash: fmt.Sprintf("%064d", i), SizeBytes: 10}
+	}
+	return digests
+}
+
+func requireSplicedInOrder(t *testing.T, fake *recordingSpliceChunksClient, want []*repb.Digest, rn *digest.CASResourceName) {
+	t.Helper()
+	requests := fake.recordedRequests()
+	require.GreaterOrEqual(t, len(requests), 2)
+	firstRequest := requests[0]
+	lastRequest := requests[len(requests)-1]
+	require.Equal(t, rn.GetInstanceName(), firstRequest.GetInstanceName())
+	require.Equal(t, repb.DigestFunction_SHA256, firstRequest.GetDigestFunction())
+	require.Equal(t, repb.ChunkingFunction_FAST_CDC_2020, firstRequest.GetChunkingFunction())
+	require.True(t, digest.Equal(rn.GetDigest(), lastRequest.GetBlobDigest()))
+	for _, req := range requests[:len(requests)-1] {
+		require.Nil(t, req.GetBlobDigest(), "blob digest must only be set on the final request")
+	}
+	for _, req := range requests[1:] {
+		require.Empty(t, req.GetInstanceName(), "metadata must only be set on the first request")
+	}
+	var sent []*repb.Digest
+	for _, req := range requests {
+		require.LessOrEqual(t, len(req.GetChunkDigests()), streamedSpliceMaxDigestsPerRequest)
+		sent = append(sent, req.GetChunkDigests()...)
+	}
+	require.Equal(t, len(want), len(sent))
+	for i := range want {
+		require.True(t, digest.Equal(want[i], sent[i]), "chunk %d out of order", i)
+	}
+	require.True(t, fake.closed)
+}
+
+func TestStreamedSplicerSendsChunksInOrder(t *testing.T) {
+	fake := &recordingSpliceChunksClient{}
+	rn := testSplicerResourceName(t)
+	splicer, err := newStreamedSplicer(context.Background(), &recordingSpliceChunksCAS{stream: fake}, rn, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	digests := testSplicerChunkDigests(5)
+	for _, d := range digests {
+		require.NoError(t, splicer.addChunk(d))
+	}
+	// Chunks must keep their original order when availability is reported out of order.
+	require.NoError(t, splicer.markRemoteAvailable([]*repb.Digest{digests[3], digests[4]}))
+	require.NoError(t, splicer.markRemoteAvailable([]*repb.Digest{digests[0], digests[2]}))
+	require.NoError(t, splicer.markRemoteAvailable([]*repb.Digest{digests[1]}))
+
+	spliced, err := splicer.commit(context.Background())
+	require.NoError(t, err)
+	require.True(t, spliced)
+	requireSplicedInOrder(t, fake, digests, rn)
+}
+
+func TestStreamedSplicerRepeatsDuplicateChunks(t *testing.T) {
+	fake := &recordingSpliceChunksClient{}
+	rn := testSplicerResourceName(t)
+	splicer, err := newStreamedSplicer(context.Background(), &recordingSpliceChunksCAS{stream: fake}, rn, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	digests := testSplicerChunkDigests(2)
+	// One availability report must unblock every use of the same chunk.
+	require.NoError(t, splicer.addChunk(digests[0]))
+	require.NoError(t, splicer.addChunk(digests[1]))
+	require.NoError(t, splicer.addChunk(digests[0]))
+	require.NoError(t, splicer.markRemoteAvailable(digests))
+
+	spliced, err := splicer.commit(context.Background())
+	require.NoError(t, err)
+	require.True(t, spliced)
+	requireSplicedInOrder(t, fake, []*repb.Digest{digests[0], digests[1], digests[0]}, rn)
+}
+
+func TestStreamedSplicerBatchesLargeDigestLists(t *testing.T) {
+	fake := &recordingSpliceChunksClient{}
+	rn := testSplicerResourceName(t)
+	splicer, err := newStreamedSplicer(context.Background(), &recordingSpliceChunksCAS{stream: fake}, rn, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	digests := testSplicerChunkDigests(streamedSpliceMaxDigestsPerRequest + 1)
+	require.NoError(t, splicer.markRemoteAvailable(digests))
+	for _, d := range digests {
+		require.NoError(t, splicer.addChunk(d))
+	}
+
+	spliced, err := splicer.commit(context.Background())
+	require.NoError(t, err)
+	require.True(t, spliced)
+	requireSplicedInOrder(t, fake, digests, rn)
+	require.GreaterOrEqual(t, len(fake.recordedRequests()), 3)
+}
+
+func TestStreamedSplicerCommitFailsWhenChunksNeverAvailable(t *testing.T) {
+	fake := &recordingSpliceChunksClient{}
+	rn := testSplicerResourceName(t)
+	splicer, err := newStreamedSplicer(context.Background(), &recordingSpliceChunksCAS{stream: fake}, rn, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	digests := testSplicerChunkDigests(1)
+	require.NoError(t, splicer.addChunk(digests[0]))
+
+	spliced, err := splicer.commit(context.Background())
+	require.False(t, spliced)
+	require.True(t, status.IsInternalError(err))
+	require.Contains(t, err.Error(), "streamed splice has sent")
+}
+
+func TestStreamedSplicerSurfacesFatalErrorsAtCommit(t *testing.T) {
+	fake := &recordingSpliceChunksClient{sendErr: status.InternalError("stream broken")}
+	rn := testSplicerResourceName(t)
+	splicer, err := newStreamedSplicer(context.Background(), &recordingSpliceChunksCAS{stream: fake}, rn, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	digests := testSplicerChunkDigests(2)
+	for _, d := range digests {
+		require.NoError(t, splicer.addChunk(d))
+	}
+	// The send can fail before or after this call returns. The final result must
+	// always report the failure.
+	_ = splicer.markRemoteAvailable(digests)
+
+	spliced, err := splicer.commit(context.Background())
+	require.False(t, spliced)
+	require.True(t, status.IsInternalError(err))
+}
+
+func TestStreamedSplicerReturnsFatalErrorAfterStopping(t *testing.T) {
+	fake := &recordingSpliceChunksClient{sendErr: status.InternalError("stream broken")}
+	rn := testSplicerResourceName(t)
+	splicer, err := newStreamedSplicer(context.Background(), &recordingSpliceChunksCAS{stream: fake}, rn, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	digests := testSplicerChunkDigests(2)
+	require.NoError(t, splicer.addChunk(digests[0]))
+	_ = splicer.markRemoteAvailable(digests[:1])
+	<-splicer.done
+
+	require.True(t, status.IsInternalError(splicer.addChunk(digests[1])))
+	require.True(t, status.IsInternalError(splicer.markRemoteAvailable(digests)))
+	spliced, err := splicer.commit(context.Background())
+	require.False(t, spliced)
+	require.True(t, status.IsInternalError(err))
+}
+
+func TestStreamedSplicerBlockedEnqueueStopsOnError(t *testing.T) {
+	splicer := &streamedSplicer{
+		events: make(chan streamedSpliceEvent, 1),
+		done:   make(chan struct{}),
+	}
+	require.NoError(t, splicer.enqueue(streamedSpliceEvent{commit: true}))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- splicer.enqueue(streamedSpliceEvent{commit: true})
+	}()
+	select {
+	case <-errCh:
+		t.Fatal("enqueue should wait while the event buffer is full")
+	default:
+	}
+
+	splicer.closeWithErr(status.InternalError("stream broken"))
+	require.True(t, status.IsInternalError(<-errCh))
+}
+
+func TestStreamedSplicerAbsorbsFallbackErrors(t *testing.T) {
+	fake := &recordingSpliceChunksClient{sendErr: status.UnimplementedError("SpliceChunks not implemented")}
+	rn := testSplicerResourceName(t)
+	splicer, err := newStreamedSplicer(context.Background(), &recordingSpliceChunksCAS{stream: fake}, rn, repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	digests := testSplicerChunkDigests(2)
+	require.NoError(t, splicer.addChunk(digests[0]))
+	require.NoError(t, splicer.markRemoteAvailable(digests))
+	// Fallback errors stay hidden until commit.
+	<-splicer.done
+	require.NoError(t, splicer.addChunk(digests[1]))
+	require.NoError(t, splicer.markRemoteAvailable(digests))
+
+	spliced, err := splicer.commit(context.Background())
+	require.NoError(t, err)
+	require.False(t, spliced)
+}
+
 type casRPCRecorder struct {
 	mu           sync.Mutex
 	fmbGroups    [][]string
@@ -341,7 +627,7 @@ func TestChunkUploaderGroupsFindMissingAndDedupesWithinBlob(t *testing.T) {
 		bufPool:   bytebufferpool.VariableSize(int(compression.ZstdCompressBound(chunking.MaxSupportedChunkSizeBytes()))),
 		efp:       fp,
 	}
-	uploader, err := newChunkUploader(context.Background(), s, "instance", repb.DigestFunction_BLAKE3)
+	uploader, err := newChunkUploader(context.Background(), s, "instance", repb.DigestFunction_BLAKE3, nil)
 	require.NoError(t, err)
 
 	type chunkData struct {
@@ -383,10 +669,10 @@ func TestChunkUploaderGroupsFindMissingAndDedupesWithinBlob(t *testing.T) {
 		require.NotNil(t, rawData)
 		buf := s.bufPool.Get(int64(len(rawData)))
 		compressedData := compression.CompressZstd(buf, rawData)
-		uploader.addChunk(compressedData, buf, d)
+		require.NoError(t, uploader.addChunk(compressedData, buf, d))
 	}
 
-	require.NoError(t, uploader.flush())
+	require.NoError(t, uploader.flushUploads())
 
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
@@ -2620,6 +2906,13 @@ func TestWriteChunked(t *testing.T) {
 				"false": false,
 			},
 		},
+		"cache_proxy.splice_stream_threshold_bytes": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "zero",
+			Variants: map[string]any{
+				"zero": 0,
+			},
+		},
 	})
 	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
 
@@ -2665,6 +2958,7 @@ func TestWriteChunked(t *testing.T) {
 	proxyEnv.SetLocalByteStreamServer(proxyBSS)
 	proxyServer, err := New(proxyEnv)
 	require.NoError(t, err)
+	proxyServer.remoteCAS = &unexpectedSpliceCAS{ContentAddressableStorageClient: casClient, t: t}
 	proxyGRPC, proxyRun, proxyLis := testenv.RegisterLocalGRPCServer(t, proxyEnv)
 	bspb.RegisterByteStreamServer(proxyGRPC, proxyServer)
 	go proxyRun()
@@ -2769,6 +3063,145 @@ func TestWriteChunked(t *testing.T) {
 		reconstructedData = append(reconstructedData, res.Data...)
 	}
 
+	require.Equal(t, originalData, reconstructedData)
+}
+
+func TestWriteChunkedFallsBackToSpliceBlobWhenSpliceChunksUnsupported(t *testing.T) {
+	for name, spliceErr := range map[string]error{
+		"Unimplemented": status.UnimplementedError("SpliceChunks not implemented"),
+		"Unavailable":   status.UnavailableError("SpliceChunks unavailable"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			testWriteChunkedFallsBackToSpliceBlob(t, spliceErr)
+		})
+	}
+}
+
+func testWriteChunkedFallsBackToSpliceBlob(t *testing.T, spliceErr error) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+		"cache_proxy.intercept_and_chunk_large_writes": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+		"cache_proxy.splice_stream_threshold_bytes": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "zero",
+			Variants: map[string]any{
+				"zero": 0,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+
+	flags.Set(t, "cache.zstd_transcoding_enabled", true)
+
+	ctx := testContext()
+	remoteEnv := testenv.GetTestEnv(t)
+	proxyEnv := testenv.GetTestEnv(t)
+
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+	remoteEnv.SetExperimentFlagProvider(fp)
+	proxyEnv.SetExperimentFlagProvider(fp)
+
+	pc, err := pebble_cache.NewPebbleCache(proxyEnv, &pebble_cache.Options{
+		RootDirectory: testfs.MakeTempDir(t),
+		MaxSizeBytes:  1_000_000_000,
+	})
+	require.NoError(t, err)
+	require.NoError(t, pc.Start())
+	t.Cleanup(func() { pc.Stop() })
+	proxyEnv.SetCache(pc)
+
+	remoteBSS, err := byte_stream_server.NewByteStreamServer(remoteEnv)
+	require.NoError(t, err)
+	remoteCAS, err := content_addressable_storage_server.NewContentAddressableStorageServer(remoteEnv)
+	require.NoError(t, err)
+	remoteGRPC, remoteRun, remoteLis := testenv.RegisterLocalGRPCServer(t, remoteEnv)
+	bspb.RegisterByteStreamServer(remoteGRPC, remoteBSS)
+	repb.RegisterContentAddressableStorageServer(remoteGRPC, remoteCAS)
+	go remoteRun()
+	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis)
+	require.NoError(t, err)
+	t.Cleanup(func() { remoteConn.Close() })
+	bsClient := bspb.NewByteStreamClient(remoteConn)
+	casClient := repb.NewContentAddressableStorageClient(remoteConn)
+
+	proxyEnv.SetByteStreamClient(bsClient)
+	proxyEnv.SetContentAddressableStorageClient(casClient)
+	proxyBSS, err := byte_stream_server.NewByteStreamServer(proxyEnv)
+	require.NoError(t, err)
+	proxyEnv.SetLocalByteStreamServer(proxyBSS)
+	proxyServer, err := New(proxyEnv)
+	require.NoError(t, err)
+	failingCAS := &failingSpliceChunksCAS{
+		ContentAddressableStorageClient: casClient,
+		err:                             spliceErr,
+	}
+	proxyServer.remoteCAS = failingCAS
+	proxyGRPC, proxyRun, proxyLis := testenv.RegisterLocalGRPCServer(t, proxyEnv)
+	bspb.RegisterByteStreamServer(proxyGRPC, proxyServer)
+	go proxyRun()
+	proxyConn, err := testenv.LocalGRPCConn(ctx, proxyLis)
+	require.NoError(t, err)
+	t.Cleanup(func() { proxyConn.Close() })
+	proxy := bspb.NewByteStreamClient(proxyConn)
+
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
+	require.NoError(t, err)
+
+	_, originalData := testdigest.RandomCASResourceBuf(t, 10*1024*1024)
+	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+
+	compressedData := compression.CompressZstd(nil, originalData)
+	blobRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
+	blobRN.SetCompressor(repb.Compressor_ZSTD)
+
+	uploadStream, err := proxy.Write(ctx)
+	require.NoError(t, err)
+	remaining := compressedData
+	written := int64(0)
+	for len(remaining) > 0 {
+		chunkSize := min(1_000_000, len(remaining))
+		require.NoError(t, uploadStream.Send(&bspb.WriteRequest{
+			ResourceName: blobRN.NewUploadString(),
+			WriteOffset:  written,
+			Data:         remaining[:chunkSize],
+			FinishWrite:  chunkSize == len(remaining),
+		}))
+		written += int64(chunkSize)
+		remaining = remaining[chunkSize:]
+	}
+	_, err = uploadStream.CloseAndRecv()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), failingCAS.spliceBlobCalls.Load())
+
+	downloadRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
+	downloadStream, err := proxy.Read(ctx, &bspb.ReadRequest{ResourceName: downloadRN.DownloadString()})
+	require.NoError(t, err)
+
+	var reconstructedData []byte
+	for {
+		res, err := downloadStream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		reconstructedData = append(reconstructedData, res.Data...)
+	}
 	require.Equal(t, originalData, reconstructedData)
 }
 

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -585,6 +585,44 @@ func (s *CASServerProxy) SpliceBlob(ctx context.Context, req *repb.SpliceBlobReq
 	return s.remote.SpliceBlob(ctx, req)
 }
 
+func (s *CASServerProxy) SpliceChunks(stream repb.ContentAddressableStorage_SpliceChunksServer) error {
+	ctx := stream.Context()
+	if proxy_util.SkipRemote(ctx) {
+		return status.UnimplementedErrorf("SpliceChunks RPC is not supported for skipping remote")
+	}
+
+	ctx, spn := tracing.StartSpan(ctx)
+	defer spn.End()
+
+	remoteStream, err := s.remote.SpliceChunks(ctx)
+	if err != nil {
+		return err
+	}
+	finish := func() error {
+		resp, err := remoteStream.CloseAndRecv()
+		if err != nil {
+			return err
+		}
+		return stream.SendAndClose(resp)
+	}
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return finish()
+		}
+		if err != nil {
+			return err
+		}
+		if err := remoteStream.Send(req); err != nil {
+			if err == io.EOF {
+				// Read the final response to return the remote status.
+				return finish()
+			}
+			return err
+		}
+	}
+}
+
 func (s *CASServerProxy) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest) (*repb.SplitBlobResponse, error) {
 	ctx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
@@ -594,4 +632,31 @@ func (s *CASServerProxy) SplitBlob(ctx context.Context, req *repb.SplitBlobReque
 	}
 
 	return s.remote.SplitBlob(ctx, req)
+}
+
+func (s *CASServerProxy) SplitChunks(req *repb.SplitBlobRequest, stream repb.ContentAddressableStorage_SplitChunksServer) error {
+	ctx := stream.Context()
+	if proxy_util.SkipRemote(ctx) {
+		return status.UnimplementedErrorf("SplitChunks RPC is not supported for skipping remote")
+	}
+
+	ctx, spn := tracing.StartSpan(ctx)
+	defer spn.End()
+
+	remoteStream, err := s.remote.SplitChunks(ctx, req)
+	if err != nil {
+		return err
+	}
+	for {
+		resp, err := remoteStream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
 }

--- a/enterprise/server/routing/migration_operators/migration_operators_test.go
+++ b/enterprise/server/routing/migration_operators/migration_operators_test.go
@@ -353,8 +353,16 @@ func (m *mockCASClient) SpliceBlob(ctx context.Context, req *repb.SpliceBlobRequ
 	return nil, status.UnimplementedError("SpliceBlob not implemented")
 }
 
+func (m *mockCASClient) SpliceChunks(ctx context.Context, opts ...grpc.CallOption) (repb.ContentAddressableStorage_SpliceChunksClient, error) {
+	return nil, status.UnimplementedError("SpliceChunks not implemented")
+}
+
 func (m *mockCASClient) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest, opts ...grpc.CallOption) (*repb.SplitBlobResponse, error) {
 	return nil, status.UnimplementedError("SplitBlob not implemented")
+}
+
+func (m *mockCASClient) SplitChunks(ctx context.Context, req *repb.SplitBlobRequest, opts ...grpc.CallOption) (repb.ContentAddressableStorage_SplitChunksClient, error) {
+	return nil, status.UnimplementedError("SplitChunks not implemented")
 }
 
 type mockACClient struct {

--- a/enterprise/server/routing/routing_content_addressable_storage_client/routing_content_addressable_storage_client.go
+++ b/enterprise/server/routing/routing_content_addressable_storage_client/routing_content_addressable_storage_client.go
@@ -234,10 +234,26 @@ func (r *RoutingCASClient) SpliceBlob(ctx context.Context, req *repb.SpliceBlobR
 	return primaryClient.SpliceBlob(ctx, req, opts...)
 }
 
+func (r *RoutingCASClient) SpliceChunks(ctx context.Context, opts ...grpc.CallOption) (repb.ContentAddressableStorage_SpliceChunksClient, error) {
+	primaryClient, _, err := r.router.GetCASClients(ctx)
+	if err != nil {
+		return nil, status.InternalErrorf("Failed to get primary CAS client: %s", err)
+	}
+	return primaryClient.SpliceChunks(ctx, opts...)
+}
+
 func (r *RoutingCASClient) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest, opts ...grpc.CallOption) (*repb.SplitBlobResponse, error) {
 	primaryClient, _, err := r.router.GetCASClients(ctx)
 	if err != nil {
 		return nil, status.InternalErrorf("Failed to get primary CAS client: %s", err)
 	}
 	return primaryClient.SplitBlob(ctx, req, opts...)
+}
+
+func (r *RoutingCASClient) SplitChunks(ctx context.Context, req *repb.SplitBlobRequest, opts ...grpc.CallOption) (repb.ContentAddressableStorage_SplitChunksClient, error) {
+	primaryClient, _, err := r.router.GetCASClients(ctx)
+	if err != nil {
+		return nil, status.InternalErrorf("Failed to get primary CAS client: %s", err)
+	}
+	return primaryClient.SplitChunks(ctx, req, opts...)
 }

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -487,6 +487,11 @@ service ContentAddressableStorage {
   // Clients SHOULD verify that the digest of the blob assembled by the fetched
   // chunks is equal to the requested blob digest.
   //
+  // The unary response size is limited by the maximum message size of the
+  // protocol in use, e.g. gRPC. Clients that expect the list of chunks to
+  // exceed that limit SHOULD use
+  // [SplitChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitChunks].
+  //
   // The lifetimes of the generated chunk blobs MAY be independent of the
   // lifetime of the original blob. In particular:
   //  * A blob and any chunk derived from it MAY be evicted from the CAS at
@@ -516,6 +521,39 @@ service ContentAddressableStorage {
     option (google.api.http) = { get: "/v2/{instance_name=**}/blobs/{blob_digest.hash}/{blob_digest.size_bytes}:splitBlob" };
   }
 
+  // SplitChunks is a streaming variant of SplitBlob.
+  //
+  // This RPC is equivalent to
+  // [ContentAddressableStorage.SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob],
+  // except that the list of chunk digests is streamed across response messages
+  // to avoid exceeding protocol message size limits. The complete list of
+  // chunks is the concatenation of `chunk_digests` across all responses in
+  // stream order. The server indicates that there are no more chunks by closing
+  // the response stream.
+  //
+  // The maximum message size is not negotiated by this API. Servers SHOULD limit
+  // the number of chunk digests in each response to remain below the maximum
+  // message size accepted by the client/server pair.
+  //
+  // Starting in RE API v2.13, servers that set
+  // [CacheCapabilities.split_blob_support][build.bazel.remote.execution.v2.CacheCapabilities.split_blob_support]
+  // MUST implement this RPC. Clients MUST check that the server supports this
+  // capability and supports RE API v2.13 or newer before using this RPC.
+  //
+  // Errors:
+  //
+  // * `NOT_FOUND`: The requested blob is not present in the CAS, OR there is no
+  //   split information available for the blob, OR at least one chunk needed to
+  //   reconstruct the blob is missing from the CAS.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the blob
+  //   chunks.
+  //
+  // NOTE: This API is proposed upstream in
+  // https://github.com/bazelbuild/remote-apis/pull/377 and has not merged yet.
+  // If the merged version differs, update this definition (including field
+  // numbers) to match it.
+  rpc SplitChunks(SplitBlobRequest) returns (stream SplitChunksResponse);
+
   // SpliceBlob tells the CAS how chunks can compose a blob.
   //
   // This is the complementary operation to the
@@ -527,6 +565,11 @@ service ContentAddressableStorage {
   // all chunks to the CAS, then call this RPC to tell the server how those chunks
   // compose the original blob. The chunks referenced in the SpliceBlob call SHOULD be
   // available in the CAS before calling this RPC.
+  //
+  // The unary request size is limited by the maximum message size of the
+  // protocol in use, e.g. gRPC. Clients that expect the list of chunks to
+  // exceed that limit SHOULD use
+  // [SpliceChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceChunks].
   //
   // If a client needs to upload a large blob and is able to split a blob into
   // chunks in such a way that reusable chunks are obtained, e.g., by means of
@@ -570,10 +613,57 @@ service ContentAddressableStorage {
   //   extend the lifetime of the chunks specified in the request, e.g. because
   //   it prefers a different chunking and extended those instead. Clients can
   //   call [SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob]
+  //   or [SplitChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitChunks]
   //   to check what chunk mapping the server is using.
+  //
+  // New in v2.12 and removed in v2.13, use
+  // [SpliceChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceChunks]
+  // instead.
   rpc SpliceBlob(SpliceBlobRequest) returns (SpliceBlobResponse) {
     option (google.api.http) = { post: "/v2/{instance_name=**}/blobs:spliceBlob" body: "*" };
   }
+
+  // SpliceChunks is a streaming variant of SpliceBlob.
+  //
+  // This RPC is equivalent to
+  // [ContentAddressableStorage.SpliceBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob],
+  // except that the list of chunk digests is streamed across request messages
+  // to avoid exceeding protocol message size limits. Clients stream chunk
+  // digests as they become available, MUST set the expected blob digest on the
+  // final request, then close the request stream to commit the splice. The
+  // server MUST use `instance_name`, `digest_function`, and `chunking_function`
+  // from the first request and ignore values for those fields on subsequent
+  // requests. Clients SHOULD omit those fields on subsequent requests.
+  //
+  // The maximum message size is not negotiated by this API. Clients SHOULD limit
+  // the number of chunk digests in each request to remain below the maximum
+  // message size accepted by the client/server pair.
+  //
+  // Starting in RE API v2.13, servers that set
+  // [CacheCapabilities.splice_blob_support][build.bazel.remote.execution.v2.CacheCapabilities.splice_blob_support]
+  // MUST implement this RPC. Clients MUST check that the server supports this
+  // capability and supports RE API v2.13 or newer before using this RPC.
+  //
+  // Errors:
+  //
+  // * `NOT_FOUND`: At least one of the blob chunks is not present in the CAS.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the
+  //   spliced blob.
+  // * `INVALID_ARGUMENT`: The digest of the spliced blob is different from the
+  //   provided expected digest, OR the stream contains an invalid sequence of
+  //   splice requests.
+  // * `ALREADY_EXISTS`: The blob already exists in CAS and the server did not
+  //   extend the lifetime of the chunks specified in the request, e.g. because
+  //   it prefers a different chunking and extended those instead. Clients can
+  //   call [SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob]
+  //   or [SplitChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitChunks]
+  //   to check what chunk mapping the server is using.
+  //
+  // NOTE: This API is proposed upstream in
+  // https://github.com/bazelbuild/remote-apis/pull/377 and has not merged yet.
+  // If the merged version differs, update this definition (including field
+  // numbers) to match it.
+  rpc SpliceChunks(stream SpliceChunksRequest) returns (SpliceBlobResponse);
 }
 
 // The Capabilities service may be used by remote execution clients to query
@@ -2187,6 +2277,30 @@ message SplitBlobResponse {
   ChunkingFunction.Value chunking_function = 2;
 }
 
+// A response message for
+// [ContentAddressableStorage.SplitChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitChunks].
+message SplitChunksResponse {
+  // The ordered list of digests of the chunks into which the blob was split.
+  // The original blob is assembled by concatenating the chunk data according to
+  // the order of the digests in this field, across all responses in stream
+  // order.
+  //
+  // Servers SHOULD limit the number of digests in each response to remain below
+  // the maximum message size accepted by the client/server pair.
+  //
+  // An empty list is allowed in any response. It contributes no chunks to the
+  // assembled chunk list; clients MUST continue reading until the stream closes.
+  //
+  // The server MUST use the same digest function as the one explicitly or
+  // implicitly (through hash length) specified in the split request.
+  repeated Digest chunk_digests = 1;
+
+  // The chunking function used to split the blob. Clients MUST use the value
+  // from the first response and ignore values sent on subsequent responses.
+  // Servers SHOULD omit this field on subsequent responses.
+  ChunkingFunction.Value chunking_function = 2;
+}
+
 // A request message for
 // [ContentAddressableStorage.SpliceBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob].
 message SpliceBlobRequest {
@@ -2225,6 +2339,51 @@ message SpliceBlobRequest {
   DigestFunction.Value digest_function = 4;
 
   // The chunking function that the client used to split the blob.
+  ChunkingFunction.Value chunking_function = 5;
+}
+
+// A request message for
+// [ContentAddressableStorage.SpliceChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceChunks].
+message SpliceChunksRequest {
+  // The instance of the execution system to operate against. A server may
+  // support multiple instances of the execution system (with their own workers,
+  // storage, caches, etc.). The server MAY require use of this field to select
+  // between them in an implementation-defined fashion, otherwise it can be
+  // omitted. Servers MUST use the value from the first request and ignore
+  // values sent on subsequent requests.
+  string instance_name = 1;
+
+  // Expected digest of the spliced blob. Clients MUST set this on the final
+  // request and MUST NOT set it on earlier requests.
+  Digest blob_digest = 2;
+
+  // The ordered list of digests of the chunks which need to be concatenated to
+  // assemble the original blob. Chunk digests may be split across multiple
+  // stream requests. The original blob is assembled by concatenating chunks in
+  // the order of these digests across all requests in stream order.
+  //
+  // Clients SHOULD limit the number of digests in each request to remain below
+  // the maximum message size accepted by the client/server pair.
+  //
+  // An empty list is allowed in any request. It contributes no chunks to the
+  // assembled chunk list; servers MUST validate the final concatenated chunk
+  // sequence against `blob_digest`.
+  repeated Digest chunk_digests = 3;
+
+  // The digest function of all chunks to be concatenated and of the blob to be
+  // spliced. The server MUST use the same digest function for both cases.
+  // Servers MUST use the value from the first request and ignore values sent on
+  // subsequent requests.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256, SHA384,
+  // SHA512, or VSO, the client MAY leave this field unset. In that case the
+  // server SHOULD infer the digest function using the length of the blob digest
+  // hashes and the digest functions announced in the server's capabilities.
+  DigestFunction.Value digest_function = 4;
+
+  // The chunking function that the client used to split the blob. Servers MUST
+  // use the value from the first request and ignore values sent on subsequent
+  // requests.
   ChunkingFunction.Value chunking_function = 5;
 }
 
@@ -2508,14 +2667,18 @@ message CacheCapabilities {
   // yes, the server/instance implements the specified behavior for blob
   // splitting and a meaningful result can be expected from the
   // [ContentAddressableStorage.SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob]
-  // operation.
+  // operation for RE API v2.12 and from the
+  // [ContentAddressableStorage.SplitChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitChunks]
+  // operation for RE API v2.13 or higher.
   bool split_blob_support = 9;
 
   // Whether blob splicing is supported for the particular server/instance. If
   // yes, the server/instance implements the specified behavior for blob
   // splicing and a meaningful result can be expected from the
   // [ContentAddressableStorage.SpliceBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob]
-  // operation.
+  // operation for RE API v2.12 and from the
+  // [ContentAddressableStorage.SpliceChunks][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceChunks]
+  // operation for RE API v2.13 or higher.
   bool splice_blob_support = 10;
 
   // The parameters for the FastCDC 2020 chunking algorithm.

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1104,6 +1104,16 @@ var (
 		StatusLabel,
 	})
 
+	SpliceChunksDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "splice_chunks_duration_usec",
+		Buckets:   durationUsecBuckets(20*time.Millisecond, 10*time.Minute, 1.4),
+		Help:      "Duration of the full SpliceChunks RPC handler, in **microseconds**.",
+	}, []string{
+		StatusLabel,
+	})
+
 	ChunkedManifestValidationCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -431,11 +431,19 @@ func (f *fakeCasClient) SpliceBlob(ctx context.Context, req *repb.SpliceBlobRequ
 	panic("unimplemented")
 }
 
+func (f *fakeCasClient) SpliceChunks(ctx context.Context, opts ...grpc.CallOption) (repb.ContentAddressableStorage_SpliceChunksClient, error) {
+	return nil, status.UnimplementedError("SpliceChunks not implemented")
+}
+
 func (f *fakeCasClient) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest, opts ...grpc.CallOption) (*repb.SplitBlobResponse, error) {
 	if f.splitBlobFn != nil {
 		return f.splitBlobFn(ctx, req)
 	}
 	panic("unimplemented")
+}
+
+func (f *fakeCasClient) SplitChunks(ctx context.Context, req *repb.SplitBlobRequest, opts ...grpc.CallOption) (repb.ContentAddressableStorage_SplitChunksClient, error) {
+	return nil, status.UnimplementedError("SplitChunks not implemented")
 }
 
 func TestFindMissingBlobs_AppliesCASRPCTimeout(t *testing.T) {

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -368,6 +368,21 @@ func (cm *Manifest) StoreWithoutVerification(ctx context.Context, cache interfac
 	return cm.store(ctx, cache)
 }
 
+// StoreVerified stores a manifest after the caller has verified the chunk order
+// and contents. It also stores a shared validation marker.
+func (cm *Manifest) StoreVerified(ctx context.Context, cache interfaces.Cache) error {
+	if cm.BlobDigest == nil {
+		return status.InvalidArgumentError("blob digest is required")
+	}
+	if len(cm.ChunkDigests) == 0 {
+		return status.InvalidArgumentError("chunked manifest must have at least one chunk")
+	}
+	if err := cm.setSharedValidationMarker(ctx, cache); err != nil {
+		log.CtxWarningf(ctx, "Failed to set shared validation marker for blob %s: %v", cm.BlobDigest.GetHash(), err)
+	}
+	return cm.store(ctx, cache)
+}
+
 func (cm *Manifest) store(ctx context.Context, cache interfaces.Cache) error {
 	ar := &repb.ActionResult{
 		OutputFiles: make([]*repb.OutputFile, 0, len(cm.ChunkDigests)),
@@ -474,6 +489,17 @@ func (cm *Manifest) checkOrVerifyChunks(ctx context.Context, cache interfaces.Ca
 		log.CtxWarningf(ctx, "Failed to set shared validation marker for blob %s: %v", cm.BlobDigest.GetHash(), err)
 	}
 	return nil
+}
+
+func (cm *Manifest) setSharedValidationMarker(ctx context.Context, cache interfaces.Cache) error {
+	if *chunkedManifestSalt == "" {
+		return nil
+	}
+	sharedValRN, sharedValContent, err := sharedValidationResourceName(cm)
+	if err != nil {
+		return err
+	}
+	return cache.Set(ctx, sharedValRN, sharedValContent)
 }
 
 // verifyChunks pipelines chunk verification using 2 goroutines:

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//server/util/quota",
         "//server/util/rpcutil",
         "//server/util/status",
+        "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//codes",

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"io"
+	"math"
 	"math/rand"
 	"os"
 	"slices"
@@ -35,6 +37,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/quota"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
@@ -70,6 +73,10 @@ var (
 	getTreeSubtreeSupport     = flag.Bool("cache.get_tree_subtree_support", true, "If true, respect the 'send_cache_subtrees' field on GetTree")
 	getTreeSubtreeMinDirCount = flag.Int("cache.get_tree_subtree_min_dir_count", 10, "The minimum number of directory children a subtree must have before we're willing to tell the client to cache it (inclusive).")
 )
+
+// Keep each response below common gRPC message limits. A serialized SHA256
+// chunk digest is ~73 bytes.
+const splitChunksMaxDigestsPerResponse = 10_000
 
 type ContentAddressableStorageServer struct {
 	env   environment.Env
@@ -1265,6 +1272,176 @@ func (s *ContentAddressableStorageServer) spliceBlob(ctx context.Context, req *r
 	}, nil
 }
 
+func (s *ContentAddressableStorageServer) SpliceChunks(stream repb.ContentAddressableStorage_SpliceChunksServer) error {
+	start := time.Now()
+	err := s.spliceChunks(stream)
+	if err != nil {
+		log.CtxInfof(stream.Context(), "SpliceChunks failed: %v", err)
+	}
+	metrics.SpliceChunksDurationUsec.With(prometheus.Labels{
+		metrics.StatusHumanReadableLabel: status.MetricsLabel(err),
+	}).Observe(float64(time.Since(start).Microseconds()))
+	return err
+}
+
+func (s *ContentAddressableStorageServer) spliceChunks(stream repb.ContentAddressableStorage_SpliceChunksServer) error {
+	ctx, spn := tracing.StartSpan(stream.Context())
+	defer spn.End()
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, s.env.GetAuthenticator())
+	if err != nil {
+		return err
+	}
+	canWrite, err := capabilities.IsGranted(ctx, s.env.GetAuthenticator(), cappb.Capability_CACHE_WRITE|cappb.Capability_CAS_WRITE)
+	if err != nil {
+		return err
+	}
+	if !chunking.Enabled(ctx, s.env.GetExperimentFlagProvider()) {
+		return status.UnimplementedError("SpliceChunks RPC is not currently enabled")
+	}
+
+	firstReq, err := stream.Recv()
+	if err == io.EOF {
+		return status.InvalidArgumentError("blob_digest is required")
+	}
+	if err != nil {
+		return err
+	}
+
+	if !canWrite {
+		req := firstReq
+		for {
+			nextReq, err := stream.Recv()
+			if err == io.EOF {
+				return stream.SendAndClose(&repb.SpliceBlobResponse{BlobDigest: req.GetBlobDigest()})
+			}
+			if err != nil {
+				return err
+			}
+			req = nextReq
+		}
+	}
+
+	if cf := firstReq.GetChunkingFunction(); cf != repb.ChunkingFunction_UNKNOWN && cf != repb.ChunkingFunction_FAST_CDC_2020 {
+		return status.InvalidArgumentErrorf("unsupported chunking function %v", cf)
+	}
+	instanceName := firstReq.GetInstanceName()
+	digestFunction := firstReq.GetDigestFunction()
+	hasher, err := digest.HashForDigestType(digestFunction)
+	if err != nil {
+		return status.InvalidArgumentErrorf("invalid digest function: %s", err)
+	}
+
+	const cacheReadBatchSize = 20
+	readCompressed := s.cache.SupportsCompressor(repb.Compressor_ZSTD)
+	var decompressedData []byte
+	var chunkDigests []*repb.Digest
+	var totalSize int64
+	req := firstReq
+	for {
+		for batch := range slices.Chunk(req.GetChunkDigests(), cacheReadBatchSize) {
+			resources := make([]*rspb.ResourceName, 0, len(batch))
+			for _, chunkDigest := range batch {
+				chunkRN := digest.NewCASResourceName(chunkDigest, instanceName, digestFunction)
+				if readCompressed {
+					chunkRN.SetCompressor(repb.Compressor_ZSTD)
+				}
+				if err := chunkRN.Validate(); err != nil {
+					return status.InvalidArgumentErrorf("invalid chunk resource name %v: %s", chunkRN, err)
+				}
+				if digestFunction == repb.DigestFunction_UNKNOWN {
+					digestFunction = chunkRN.GetDigestFunction()
+					hasher, err = digest.HashForDigestType(digestFunction)
+					if err != nil {
+						return status.InvalidArgumentErrorf("invalid digest function: %s", err)
+					}
+				}
+				chunkSize := chunkDigest.GetSizeBytes()
+				if chunkSize == 0 {
+					return status.InvalidArgumentErrorf("zero-size chunk %s is not allowed", chunkDigest.GetHash())
+				}
+				if chunkSize > math.MaxInt64-totalSize {
+					return status.InvalidArgumentError("spliced chunks size exceeds the maximum supported size")
+				}
+				totalSize += chunkSize
+				resources = append(resources, chunkRN.ToProto())
+			}
+
+			chunks, err := s.cache.GetMulti(ctx, resources)
+			if err != nil {
+				return status.WrapError(err, "read chunks from CAS")
+			}
+			for _, resource := range resources {
+				chunkData, ok := chunks[resource.GetDigest()]
+				if !ok {
+					return status.NotFoundErrorf("chunk %s missing from CAS", resource.GetDigest().GetHash())
+				}
+				if readCompressed {
+					decompressedData, err = compression.DecompressZstd(decompressedData, chunkData)
+					if err != nil {
+						return status.WrapErrorf(err, "decompress chunk %s", resource.GetDigest().GetHash())
+					}
+					chunkData = decompressedData
+				}
+				if int64(len(chunkData)) != resource.GetDigest().GetSizeBytes() {
+					return status.InvalidArgumentErrorf("read %d bytes for chunk %s, expected %d", len(chunkData), resource.GetDigest().GetHash(), resource.GetDigest().GetSizeBytes())
+				}
+				if _, err := hasher.Write(chunkData); err != nil {
+					return status.WrapErrorf(err, "hash chunk %s", resource.GetDigest().GetHash())
+				}
+				chunkDigests = append(chunkDigests, resource.GetDigest())
+			}
+		}
+
+		nextReq, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		req = nextReq
+	}
+
+	// BlobDigest is attached to the final frame, so it'll be
+	// populated on EOF
+	blobDigest := req.GetBlobDigest()
+	if blobDigest == nil {
+		return status.InvalidArgumentError("blob_digest is required on the final request")
+	}
+	blobRN := digest.NewCASResourceName(blobDigest, instanceName, digestFunction)
+	if err := blobRN.Validate(); err != nil {
+		return status.InvalidArgumentErrorf("invalid blob resource name %v: %s", blobRN, err)
+	}
+	if totalSize != blobDigest.GetSizeBytes() {
+		return status.InvalidArgumentErrorf("spliced chunks size mismatch: got %d bytes, expected %d", totalSize, blobDigest.GetSizeBytes())
+	}
+
+	if len(chunkDigests) == 0 {
+		return status.InvalidArgumentError("chunk_digests cannot be empty")
+	}
+	if len(chunkDigests) == 1 {
+		return status.UnimplementedError("SpliceChunks with only one chunk is not supported")
+	}
+	computedDigest := &repb.Digest{
+		Hash:      hex.EncodeToString(hasher.Sum(nil)),
+		SizeBytes: totalSize,
+	}
+	if !digest.Equal(computedDigest, blobDigest) {
+		return status.InvalidArgumentErrorf("computed digest %s does not match expected %s", digest.String(computedDigest), digest.String(blobDigest))
+	}
+	manifest := &chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   chunkDigests,
+		InstanceName:   instanceName,
+		DigestFunction: digestFunction,
+	}
+	if err := manifest.StoreVerified(ctx, s.cache); err != nil {
+		return err
+	}
+	return stream.SendAndClose(&repb.SpliceBlobResponse{BlobDigest: blobDigest})
+}
+
 func (s *ContentAddressableStorageServer) readChunkedBlob(ctx context.Context, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, readZstd bool) ([]byte, error) {
 	if blobDigest.GetSizeBytes() > rpcutil.GRPCMaxSizeBytes {
 		return nil, status.NotFoundErrorf("blob %s not found", blobDigest.GetHash())
@@ -1338,4 +1515,32 @@ func (s *ContentAddressableStorageServer) splitBlob(ctx context.Context, req *re
 		return nil, status.NotFoundErrorf("required chunks not found in CAS: %s", chunking.DigestsSummary(resp.GetMissingBlobDigests()))
 	}
 	return manifest.ToSplitBlobResponse(), nil
+}
+
+func (s *ContentAddressableStorageServer) SplitChunks(req *repb.SplitBlobRequest, stream repb.ContentAddressableStorage_SplitChunksServer) error {
+	ctx := stream.Context()
+	resp, err := s.splitBlob(ctx, req)
+	if err != nil {
+		log.CtxInfof(ctx, "SplitChunks failed: %v", err)
+		return err
+	}
+	return sendSplitChunksResponses(resp.GetChunkDigests(), resp.GetChunkingFunction(), splitChunksMaxDigestsPerResponse, stream.Send)
+}
+
+func sendSplitChunksResponses(chunks []*repb.Digest, chunkingFunction repb.ChunkingFunction_Value, maxPerResponse int, send func(*repb.SplitChunksResponse) error) error {
+	maxPerResponse = max(maxPerResponse, 1)
+	for start := 0; ; start += maxPerResponse {
+		end := min(start+maxPerResponse, len(chunks))
+		resp := &repb.SplitChunksResponse{ChunkDigests: chunks[start:end]}
+		if start == 0 {
+			// Only the first response includes the chunking function.
+			resp.ChunkingFunction = chunkingFunction
+		}
+		if err := send(resp); err != nil {
+			return err
+		}
+		if end == len(chunks) {
+			return nil
+		}
+	}
 }

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -72,6 +72,423 @@ func runCASServer(ctx context.Context, t *testing.T, env *testenv.TestEnv) *grpc
 	return clientConn
 }
 
+func TestSpliceChunks(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		digestFunction   repb.DigestFunction_Value
+		compressionCache bool
+	}{
+		{
+			name:           "Identity",
+			digestFunction: repb.DigestFunction_SHA256,
+		},
+		{
+			name:           "InferredDigestFunction",
+			digestFunction: repb.DigestFunction_UNKNOWN,
+		},
+		{
+			name:             "Zstd",
+			digestFunction:   repb.DigestFunction_SHA256,
+			compressionCache: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testenv.GetTestEnv(t)
+			if tc.compressionCache {
+				env.SetCache(&casCompressionCache{
+					Cache:       env.GetCache(),
+					requireZstd: true,
+				})
+			}
+
+			ctx := context.Background()
+			ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+			require.NoError(t, err)
+
+			clientConn := runCASServer(ctx, t, env)
+			t.Cleanup(func() { clientConn.Close() })
+			client := repb.NewContentAddressableStorageClient(clientConn)
+
+			chunks := [][]byte{
+				[]byte("chunk one "),
+				[]byte("chunk two "),
+				[]byte("chunk three"),
+			}
+			blob := bytes.Join(chunks, nil)
+			blobDigest, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+			require.NoError(t, err)
+
+			var chunkDigests []*repb.Digest
+			for _, chunk := range chunks {
+				chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
+				require.NoError(t, err)
+				chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_SHA256)
+				require.NoError(t, env.GetCache().Set(ctx, chunkRN.ToProto(), chunk))
+				chunkDigests = append(chunkDigests, chunkDigest)
+			}
+
+			stream, err := client.SpliceChunks(ctx)
+			require.NoError(t, err)
+			require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+				ChunkDigests:     chunkDigests[:1],
+				DigestFunction:   tc.digestFunction,
+				ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+			}))
+			require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+				ChunkDigests: chunkDigests[1:],
+				BlobDigest:   blobDigest,
+			}))
+			resp, err := stream.CloseAndRecv()
+			require.NoError(t, err)
+			require.True(t, digest.Equal(blobDigest, resp.GetBlobDigest()))
+
+			manifest, err := chunking.LoadManifest(ctx, env.GetCache(), blobDigest, "", repb.DigestFunction_SHA256)
+			require.NoError(t, err)
+			require.Equal(t, chunkDigests, manifest.ChunkDigests)
+		})
+	}
+}
+
+func TestSpliceChunksRejectsSizeMismatch(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	ctx := context.Background()
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, env)
+	t.Cleanup(func() { clientConn.Close() })
+	client := repb.NewContentAddressableStorageClient(clientConn)
+
+	chunks := [][]byte{
+		[]byte("chunk one "),
+		[]byte("chunk two"),
+	}
+	blob := bytes.Join(chunks, nil)
+	blobDigest, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	blobDigest.SizeBytes++
+
+	var chunkDigests []*repb.Digest
+	for _, chunk := range chunks {
+		chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_SHA256)
+		require.NoError(t, env.GetCache().Set(ctx, chunkRN.ToProto(), chunk))
+		chunkDigests = append(chunkDigests, chunkDigest)
+	}
+
+	stream, err := client.SpliceChunks(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests:     chunkDigests[:1],
+		DigestFunction:   repb.DigestFunction_SHA256,
+		ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+	}))
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests: chunkDigests[1:],
+		BlobDigest:   blobDigest,
+	}))
+	_, err = stream.CloseAndRecv()
+	require.Equal(t, gcodes.InvalidArgument, gstatus.Code(err))
+	require.Contains(t, err.Error(), "spliced chunks size mismatch")
+}
+
+func TestSpliceChunksMissingChunk(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	ctx := context.Background()
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, env)
+	t.Cleanup(func() { clientConn.Close() })
+	client := repb.NewContentAddressableStorageClient(clientConn)
+
+	stored := []byte("chunk one ")
+	missing := []byte("chunk two")
+	blobDigest, err := digest.Compute(bytes.NewReader(append(append([]byte{}, stored...), missing...)), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	storedDigest, err := digest.Compute(bytes.NewReader(stored), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	storedRN := digest.NewCASResourceName(storedDigest, "", repb.DigestFunction_SHA256)
+	require.NoError(t, env.GetCache().Set(ctx, storedRN.ToProto(), stored))
+	missingDigest, err := digest.Compute(bytes.NewReader(missing), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	stream, err := client.SpliceChunks(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests:     []*repb.Digest{storedDigest, missingDigest},
+		BlobDigest:       blobDigest,
+		DigestFunction:   repb.DigestFunction_SHA256,
+		ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+	}))
+	_, err = stream.CloseAndRecv()
+	require.Equal(t, gcodes.NotFound, gstatus.Code(err))
+}
+
+func TestSpliceChunksRejectsContentHashMismatch(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	ctx := context.Background()
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, env)
+	t.Cleanup(func() { clientConn.Close() })
+	client := repb.NewContentAddressableStorageClient(clientConn)
+
+	// The size matches. Only the final digest can detect the changed content.
+	chunks := [][]byte{
+		[]byte("chunk one "),
+		[]byte("chunk twX"),
+	}
+	expectedBlob := []byte("chunk one chunk two")
+	blobDigest, err := digest.Compute(bytes.NewReader(expectedBlob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	var chunkDigests []*repb.Digest
+	for _, chunk := range chunks {
+		chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_SHA256)
+		require.NoError(t, env.GetCache().Set(ctx, chunkRN.ToProto(), chunk))
+		chunkDigests = append(chunkDigests, chunkDigest)
+	}
+
+	stream, err := client.SpliceChunks(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests:     chunkDigests,
+		BlobDigest:       blobDigest,
+		DigestFunction:   repb.DigestFunction_SHA256,
+		ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+	}))
+	_, err = stream.CloseAndRecv()
+	require.Equal(t, gcodes.InvalidArgument, gstatus.Code(err))
+	require.Contains(t, err.Error(), "computed digest")
+}
+
+func TestSpliceChunksRejectsZeroSizeChunk(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	ctx := context.Background()
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, env)
+	t.Cleanup(func() { clientConn.Close() })
+	client := repb.NewContentAddressableStorageClient(clientConn)
+
+	chunks := [][]byte{
+		[]byte("chunk one "),
+		[]byte("chunk two"),
+	}
+	blob := bytes.Join(chunks, nil)
+	blobDigest, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	var chunkDigests []*repb.Digest
+	for _, chunk := range chunks {
+		chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_SHA256)
+		require.NoError(t, env.GetCache().Set(ctx, chunkRN.ToProto(), chunk))
+		chunkDigests = append(chunkDigests, chunkDigest)
+	}
+	emptyDigest, err := digest.Compute(bytes.NewReader(nil), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	stream, err := client.SpliceChunks(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests:     []*repb.Digest{chunkDigests[0], emptyDigest, chunkDigests[1]},
+		BlobDigest:       blobDigest,
+		DigestFunction:   repb.DigestFunction_SHA256,
+		ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+	}))
+	_, err = stream.CloseAndRecv()
+	require.Equal(t, gcodes.InvalidArgument, gstatus.Code(err))
+	require.Contains(t, err.Error(), "zero-size chunk")
+}
+
+func TestSpliceChunksFailsWhenChunksExceedBlobSize(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	ctx := context.Background()
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, env)
+	t.Cleanup(func() { clientConn.Close() })
+	client := repb.NewContentAddressableStorageClient(clientConn)
+
+	chunks := [][]byte{
+		[]byte("chunk one "),
+		[]byte("chunk two"),
+	}
+	blob := bytes.Join(chunks, nil)
+	blobDigest, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	blobDigest.SizeBytes--
+
+	var chunkDigests []*repb.Digest
+	for _, chunk := range chunks {
+		chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_SHA256)
+		require.NoError(t, env.GetCache().Set(ctx, chunkRN.ToProto(), chunk))
+		chunkDigests = append(chunkDigests, chunkDigest)
+	}
+
+	stream, err := client.SpliceChunks(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests:     chunkDigests,
+		BlobDigest:       blobDigest,
+		DigestFunction:   repb.DigestFunction_SHA256,
+		ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+	}))
+	_, err = stream.CloseAndRecv()
+	require.Equal(t, gcodes.InvalidArgument, gstatus.Code(err))
+	require.Contains(t, err.Error(), "spliced chunks size mismatch")
+}
+
+func TestSpliceChunksSingleChunk(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	ctx := context.Background()
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, env)
+	t.Cleanup(func() { clientConn.Close() })
+	client := repb.NewContentAddressableStorageClient(clientConn)
+
+	chunk := []byte("the only chunk")
+	chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_SHA256)
+	require.NoError(t, env.GetCache().Set(ctx, chunkRN.ToProto(), chunk))
+
+	stream, err := client.SpliceChunks(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests:     []*repb.Digest{chunkDigest},
+		BlobDigest:       chunkDigest,
+		DigestFunction:   repb.DigestFunction_SHA256,
+		ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+	}))
+	_, err = stream.CloseAndRecv()
+	require.Equal(t, gcodes.Unimplemented, gstatus.Code(err))
+}
+
+func TestSpliceChunksMetadataOnlyFirstRequest(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	ctx := context.Background()
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, env)
+	t.Cleanup(func() { clientConn.Close() })
+	client := repb.NewContentAddressableStorageClient(clientConn)
+
+	chunks := [][]byte{
+		[]byte("chunk one "),
+		[]byte("chunk two "),
+		[]byte("chunk three"),
+	}
+	blob := bytes.Join(chunks, nil)
+	blobDigest, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	var chunkDigests []*repb.Digest
+	for _, chunk := range chunks {
+		chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_SHA256)
+		require.NoError(t, env.GetCache().Set(ctx, chunkRN.ToProto(), chunk))
+		chunkDigests = append(chunkDigests, chunkDigest)
+	}
+
+	stream, err := client.SpliceChunks(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		DigestFunction:   repb.DigestFunction_SHA256,
+		ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+	}))
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests: chunkDigests[:2],
+	}))
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests: chunkDigests[2:],
+		BlobDigest:   blobDigest,
+	}))
+	resp, err := stream.CloseAndRecv()
+	require.NoError(t, err)
+	require.True(t, digest.Equal(blobDigest, resp.GetBlobDigest()))
+
+	manifest, err := chunking.LoadManifest(ctx, env.GetCache(), blobDigest, "", repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	require.Equal(t, chunkDigests, manifest.ChunkDigests)
+}
+
+func TestSpliceChunksReadOnlyKey(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+
+	readOnlyUser := &testauth.TestUser{
+		UserID:       "US1",
+		GroupID:      "GR1",
+		Capabilities: []cappb.Capability{},
+	}
+	ta := testauth.NewTestAuthenticator(t, map[string]interfaces.UserInfo{readOnlyUser.UserID: readOnlyUser})
+	env.SetAuthenticator(ta)
+
+	ctx := testauth.WithAuthenticatedUserInfo(context.Background(), readOnlyUser)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, env)
+	t.Cleanup(func() { clientConn.Close() })
+	client := repb.NewContentAddressableStorageClient(clientConn)
+
+	chunks := [][]byte{
+		[]byte("chunk one "),
+		[]byte("chunk two"),
+	}
+	blob := bytes.Join(chunks, nil)
+	blobDigest, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	var chunkDigests []*repb.Digest
+	for _, chunk := range chunks {
+		chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		chunkDigests = append(chunkDigests, chunkDigest)
+	}
+
+	// Read only keys get the same no op success as other cache writes.
+	stream, err := client.SpliceChunks(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests:     chunkDigests[:1],
+		DigestFunction:   repb.DigestFunction_SHA256,
+		ChunkingFunction: repb.ChunkingFunction_FAST_CDC_2020,
+	}))
+	require.NoError(t, stream.Send(&repb.SpliceChunksRequest{
+		ChunkDigests: chunkDigests[1:],
+		BlobDigest:   blobDigest,
+	}))
+	resp, err := stream.CloseAndRecv()
+	require.NoError(t, err)
+	require.True(t, digest.Equal(blobDigest, resp.GetBlobDigest()))
+
+	_, err = chunking.LoadManifest(ctx, env.GetCache(), blobDigest, "", repb.DigestFunction_SHA256)
+	require.True(t, status.IsNotFoundError(err))
+}
+
 type evilCache struct {
 	interfaces.Cache
 }
@@ -86,6 +503,7 @@ func (e *evilCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName
 
 type casCompressionCache struct {
 	interfaces.Cache
+	requireZstd bool
 }
 
 func (c *casCompressionCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
@@ -98,6 +516,9 @@ func (c *casCompressionCache) Get(ctx context.Context, r *rspb.ResourceName) ([]
 func (c *casCompressionCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	foundMap := make(map[*repb.Digest][]byte, len(resources))
 	for _, r := range resources {
+		if c.requireZstd && r.GetCacheType() == rspb.CacheType_CAS && r.GetCompressor() != repb.Compressor_ZSTD {
+			return nil, status.InternalError("expected zstd CAS read")
+		}
 		data, err := c.Get(ctx, r)
 		if status.IsNotFoundError(err) {
 			continue
@@ -981,6 +1402,19 @@ func TestSpliceAndSplitBlob(t *testing.T) {
 		assert.Equal(t, expectedDigest.Hash, actualDigest.Hash)
 		assert.Equal(t, expectedDigest.SizeBytes, actualDigest.SizeBytes)
 	}
+
+	splitChunksStream, err := casClient.SplitChunks(ctx, splitReq)
+	require.NoError(t, err)
+	var streamedChunkDigests []*repb.Digest
+	for {
+		resp, err := splitChunksStream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		streamedChunkDigests = append(streamedChunkDigests, resp.GetChunkDigests()...)
+	}
+	require.Equal(t, chunkDigests, streamedChunkDigests)
 }
 
 func TestSplitBlobNotFound(t *testing.T) {


### PR DESCRIPTION
`SpliceBlob` currently happens after we upload all the chunks, and in that situation the server has to start from the first chunk and hash them all together.

Hashing only requires keeping a few bytes in memory, so it makes much more sense to hash chunks on the server as they become available.

This PR implements the streaming `SpliceChunks` API proposed upstream in https://github.com/bazelbuild/remote-apis/pull/377, so we can kick that off at the beginning of the write and hash on the server while we're still uploading.

The win is mostly for writes with many chunks, so an experiment flag (`cache_proxy.splice_stream_threshold_bytes`) keeps the non-stream API for small blobs.
