### PR TITLE
Support returning build_tool_logs from GetInvocations API

### DIFF
--- a/docs/enterprise-api.md
+++ b/docs/enterprise-api.md
@@ -79,6 +79,10 @@ message GetInvocationRequest {
   // If true, include artifacts attached to the invocation.
   bool include_artifacts = 4;
 
+  // If true, include build tool logs, such as the timing profile and compact
+  // execution log if available.
+  bool include_build_tool_logs = 6;
+
   // If true, include child invocations (if this invocation was a workflow).
   bool include_child_invocations = 5;
 
@@ -199,6 +203,10 @@ message Invocation {
   // Any artifacts that were attached to this invocation.
   // Only included if include_artifacts = true.
   repeated File artifacts = 24;
+
+  // Build tool logs, such as timing profiles and compact execution logs. Only
+  // included if include_build_tool_logs = true.
+  repeated File build_tool_logs = 27;
 
   // The state of the build event stream for the invocation.
   InvocationStatus invocationStatus = 25;
@@ -860,6 +868,10 @@ message File {
   string uri = 2;
   string hash = 3;
   int64 size_bytes = 4;
+
+  // Inline file contents, if present in the build event stream. In JSON
+  // responses, this is base64-encoded.
+  bytes contents = 5;
 }
 ```
 

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -39,9 +39,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	api_common "github.com/buildbuddy-io/buildbuddy/server/api/common"
-	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
-
 	apipb "github.com/buildbuddy-io/buildbuddy/proto/api/v1"
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
@@ -51,6 +48,8 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
+	api_common "github.com/buildbuddy-io/buildbuddy/server/api/common"
+	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 )
 
 var (
@@ -155,7 +154,7 @@ func (s *APIServer) GetInvocation(ctx context.Context, req *apipb.GetInvocationR
 		return nil, err
 	}
 
-	if req.IncludeMetadata || req.IncludeArtifacts || req.IncludeChildInvocations {
+	if req.IncludeMetadata || req.IncludeArtifacts || req.IncludeChildInvocations || req.IncludeBuildToolLogs {
 		for _, i := range invocations {
 			_, err := build_event_handler.LookupInvocationWithCallback(ctx, s.env, i.Id.InvocationId, func(event *inpb.InvocationEvent) error {
 				switch p := event.GetBuildEvent().GetPayload().(type) {
@@ -196,10 +195,13 @@ func (s *APIServer) GetInvocation(ctx context.Context, req *apipb.GetInvocationR
 				case *bespb.BuildEvent_NamedSetOfFiles:
 					if req.IncludeArtifacts {
 						for _, file := range p.NamedSetOfFiles.GetFiles() {
-							i.Artifacts = append(i.Artifacts, &apipb.File{
-								Name: file.GetName(),
-								Uri:  file.GetUri(),
-							})
+							i.Artifacts = append(i.Artifacts, api_common.FileFromBESFile(file))
+						}
+					}
+				case *bespb.BuildEvent_BuildToolLogs:
+					if req.IncludeBuildToolLogs {
+						for _, file := range p.BuildToolLogs.GetLog() {
+							i.BuildToolLogs = append(i.BuildToolLogs, api_common.FileFromBESFile(file))
 						}
 					}
 				}

--- a/enterprise/server/api/api_test.go
+++ b/enterprise/server/api/api_test.go
@@ -83,6 +83,50 @@ func TestGetInvocationWithMetadata(t *testing.T) {
 	assert.Equal(t, 2, len(resp.Invocation[0].WorkspaceStatus))
 }
 
+func TestGetInvocationWithBuildToolLogs(t *testing.T) {
+	const (
+		executionLogDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		executionLogURI    = "bytestream://localhost/blobs/" + executionLogDigest + "/123"
+	)
+
+	testUUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+	testInvocationID := testUUID.String()
+	env, ctx := getEnvAndCtx(t, "user1")
+	streamBuildWithToolLogs(t, env, testInvocationID)
+	s := NewAPIServer(env)
+
+	// First fetch the invocation without requesting build tool logs. The API
+	// should keep build tool log files out of the response by default.
+	resp, err := s.GetInvocation(ctx, &apipb.GetInvocationRequest{
+		Selector: &apipb.InvocationSelector{InvocationId: testInvocationID},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetInvocation(), 1)
+	require.Empty(t, resp.GetInvocation()[0].GetBuildToolLogs())
+
+	// Now request build tool logs. Both inline and URI-backed BuildToolLogs
+	// entries should be exposed so callers can read small contents directly or
+	// pass the URI to GetFile.
+	resp, err = s.GetInvocation(ctx, &apipb.GetInvocationRequest{
+		Selector:             &apipb.InvocationSelector{InvocationId: testInvocationID},
+		IncludeBuildToolLogs: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetInvocation(), 1)
+	require.Len(t, resp.GetInvocation()[0].GetBuildToolLogs(), 2)
+
+	inlineLog := resp.GetInvocation()[0].GetBuildToolLogs()[0]
+	assert.Equal(t, "elapsed time", inlineLog.GetName())
+	assert.Empty(t, inlineLog.GetUri())
+	assert.Equal(t, []byte("1.23s"), inlineLog.GetContents())
+
+	toolLog := resp.GetInvocation()[0].GetBuildToolLogs()[1]
+	assert.Equal(t, "execution_log.binpb.zst", toolLog.GetName())
+	assert.Equal(t, executionLogURI, toolLog.GetUri())
+	assert.Empty(t, toolLog.GetContents())
+}
+
 func TestGetInvocationNotFound(t *testing.T) {
 	env, ctx := getEnvAndCtx(t, "user1")
 	testUUID, err := uuid.NewRandom()
@@ -935,6 +979,27 @@ func streamBuild(t *testing.T, te *testenv.TestEnv, iid string) {
 	assert.NoError(t, err)
 }
 
+func streamBuildWithToolLogs(t *testing.T, te *testenv.TestEnv, iid string) {
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel, err := handler.OpenChannel(context.Background(), iid)
+	require.NoError(t, err)
+	defer channel.Close()
+
+	events := []*anypb.Any{
+		startedEvent("--remote_header='" + authutil.APIKeyHeader + "=user1'"),
+		buildToolLogsEvent(),
+		finishedEvent(),
+	}
+
+	for idx, evt := range events {
+		err := channel.HandleEvent(streamRequest(evt, iid, int64(idx+1)))
+		require.NoError(t, err)
+	}
+
+	err = channel.FinalizeInvocation(iid)
+	require.NoError(t, err)
+}
+
 func streamRequest(anyEvent *anypb.Any, iid string, sequenceNumer int64) *pepb.PublishBuildToolEventStreamRequest {
 	return &pepb.PublishBuildToolEventStreamRequest{
 		OrderedBuildEvent: &pepb.OrderedBuildEvent{
@@ -1130,6 +1195,38 @@ func workspaceStatusEvent() *anypb.Any {
 		},
 	})
 	return workspaceStatusAny
+}
+
+func buildToolLogsEvent() *anypb.Any {
+	const (
+		executionLogDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		executionLogURI    = "bytestream://localhost/blobs/" + executionLogDigest + "/123"
+	)
+
+	buildToolLogsAny := &anypb.Any{}
+	buildToolLogsAny.MarshalFrom(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_BuildToolLogs{
+			BuildToolLogs: &build_event_stream.BuildToolLogs{
+				Log: []*build_event_stream.File{
+					{
+						Name: "elapsed time",
+						File: &build_event_stream.File_Contents{
+							Contents: []byte("1.23s"),
+						},
+					},
+					{
+						Name: "execution_log.binpb.zst",
+						File: &build_event_stream.File_Uri{
+							Uri: executionLogURI,
+						},
+						Digest: executionLogDigest,
+						Length: 123,
+					},
+				},
+			},
+		},
+	})
+	return buildToolLogsAny
 }
 
 func finishedEvent() *anypb.Any {

--- a/proto/api/v1/file.proto
+++ b/proto/api/v1/file.proto
@@ -63,6 +63,10 @@ message File {
   string uri = 2;
   string hash = 3;
   int64 size_bytes = 4;
+
+  // Inline file contents, if present in the build event stream. In JSON
+  // responses, this is base64-encoded.
+  bytes contents = 5;
 }
 
 // Request object for DeleteFile

--- a/proto/api/v1/invocation.proto
+++ b/proto/api/v1/invocation.proto
@@ -5,7 +5,7 @@ package api.v1;
 import "proto/api/v1/file.proto";
 
 // Request passed into GetInvocation.
-// Next tag: 6
+// Next tag: 7
 message GetInvocationRequest {
   // Required: The selector object defining which invocations(s) to retrieve.
   // The selector must specify either `invocation_id` or `commit_sha`.
@@ -16,6 +16,10 @@ message GetInvocationRequest {
 
   // If true, include artifacts attached to the invocation.
   bool include_artifacts = 4;
+
+  // If true, include build tool logs, such as the timing profile and compact
+  // execution log if available.
+  bool include_build_tool_logs = 6;
 
   // If true, include child invocations (if this invocation was a workflow).
   bool include_child_invocations = 5;
@@ -101,6 +105,10 @@ message Invocation {
   // Any artifacts that were attached to this invocation.
   // Only included if include_artifacts = true.
   repeated File artifacts = 24;
+
+  // Build tool logs, such as timing profiles and compact execution logs. Only
+  // included if include_build_tool_logs = true.
+  repeated File build_tool_logs = 27;
 
   // The state of the build event stream for the invocation.
   InvocationStatus invocationStatus = 25;

--- a/server/api/common/common.go
+++ b/server/api/common/common.go
@@ -39,28 +39,37 @@ func ActionLabelKey(groupID, iid, targetLabel string) string {
 	return groupID + "/api/a/" + base64.RawURLEncoding.EncodeToString([]byte(iid+targetLabel))
 }
 
-func filesFromOutput(output []*bespb.File) []*apipb.File {
+// FileFromBESFile converts a build event stream File to the public API proto.
+func FileFromBESFile(besFile *bespb.File) *apipb.File {
+	f := &apipb.File{
+		Name: besFile.GetName(),
+	}
+	switch file := besFile.GetFile().(type) {
+	case *bespb.File_Uri:
+		f.Uri = file.Uri
+	case *bespb.File_Contents:
+		f.Contents = file.Contents
+	}
+	return f
+}
+
+func fillFileDigestFromURI(f *apipb.File) {
+	if u, err := url.Parse(f.Uri); err == nil {
+		if r, err := digest.ParseDownloadResourceName(u.Path); err == nil {
+			f.Hash = r.GetDigest().GetHash()
+			f.SizeBytes = r.GetDigest().GetSizeBytes()
+		}
+	}
+}
+
+func filesFromOutput(besFiles []*bespb.File) []*apipb.File {
 	files := []*apipb.File{}
-	for _, output := range output {
-		if output == nil {
+	for _, besFile := range besFiles {
+		if besFile == nil {
 			continue
 		}
-		uri := ""
-		switch file := output.GetFile().(type) {
-		case *bespb.File_Uri:
-			uri = file.Uri
-			// Contents files are not currently supported - only the file name will be appended without a uri.
-		}
-		f := &apipb.File{
-			Name: output.GetName(),
-			Uri:  uri,
-		}
-		if u, err := url.Parse(uri); err == nil {
-			if r, err := digest.ParseDownloadResourceName(u.Path); err == nil {
-				f.Hash = r.GetDigest().GetHash()
-				f.SizeBytes = r.GetDigest().GetSizeBytes()
-			}
-		}
+		f := FileFromBESFile(besFile)
+		fillFileDigestFromURI(f)
 		files = append(files, f)
 	}
 	return files


### PR DESCRIPTION
Currently the data powering the "Files" tab (compact exec log) and "Timing" tab (trace profile) are not accessible via the API. This fixes that.

Context: https://buildbuddy-corp.slack.com/archives/C09GAJTMW1E/p1777562641360189?thread_ts=1777496008.821789&cid=C09GAJTMW1E