### PR TITLE
Remove EKS detector

### DIFF
--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -294,7 +294,6 @@ use_repo(
     "io_k8s_client_go",
     "io_kythe",
     "io_opentelemetry_go_contrib_detectors_aws_ec2_v2",
-    "io_opentelemetry_go_contrib_detectors_aws_eks",
     "io_opentelemetry_go_contrib_detectors_gcp",
     "io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc",
     "io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp",

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,6 @@ require (
 	github.com/xiam/s-expr v0.0.0-20240311144413-9d7e25c9d7d1
 	github.com/zeebo/blake3 v0.2.3
 	go.opentelemetry.io/contrib/detectors/aws/ec2/v2 v2.5.0
-	go.opentelemetry.io/contrib/detectors/aws/eks v1.43.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.64.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0

--- a/go.sum
+++ b/go.sum
@@ -1810,8 +1810,6 @@ go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbE
 go.opentelemetry.io/contrib v0.20.0/go.mod h1:G/EtFaa6qaN7+LxqfIAT3GiZa7Wv5DTBUzl5H4LY0Kc=
 go.opentelemetry.io/contrib/detectors/aws/ec2/v2 v2.5.0 h1:pC+kRpB9AEbQ70MN6YQwMpLzVNP4NA3Dn6MujZaPaew=
 go.opentelemetry.io/contrib/detectors/aws/ec2/v2 v2.5.0/go.mod h1:WN02Ocn6WGtcHJihX6YuINcUS4ACjTE7gttukHK4J8M=
-go.opentelemetry.io/contrib/detectors/aws/eks v1.43.0 h1:SKPYPdpUvswTE95Oi50YrVM4G8RsXWUdwxixbDgtey8=
-go.opentelemetry.io/contrib/detectors/aws/eks v1.43.0/go.mod h1:t7nwB9nvG7vmSoFlgJWC7MkNgwggYKHgU67RIS0IUGM=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK26LAGkNFw7RHv1DhE=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0/go.mod h1:oVGt1LRbBOBq1A5BQLlUg9UaU/54aiHw8cgjV3aWZ/E=

--- a/server/util/tracing/BUILD
+++ b/server/util/tracing/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "@io_opentelemetry_go_contrib_detectors_aws_ec2_v2//:ec2",
-        "@io_opentelemetry_go_contrib_detectors_aws_eks//:eks",
         "@io_opentelemetry_go_contrib_detectors_gcp//:gcp",
         "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:otelhttp",
         "@io_opentelemetry_go_otel//:otel",

--- a/server/util/tracing/tracing.go
+++ b/server/util/tracing/tracing.go
@@ -20,7 +20,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"go.opentelemetry.io/contrib/detectors/aws/ec2/v2"
-	"go.opentelemetry.io/contrib/detectors/aws/eks"
 	"go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
@@ -168,8 +167,6 @@ func configuredTraceResourceDetectors(names []string) ([]resource.Detector, erro
 			detectors = append(detectors, &gcp.GKE{})
 		case "ec2":
 			detectors = append(detectors, ec2.NewResourceDetector())
-		case "eks":
-			detectors = append(detectors, eks.NewResourceDetector())
 		default:
 			return nil, status.InvalidArgumentErrorf("unknown trace resource detector %q (supported values: gcp, gke, ec2, eks)", name)
 		}

--- a/server/util/tracing/tracing.go
+++ b/server/util/tracing/tracing.go
@@ -168,7 +168,7 @@ func configuredTraceResourceDetectors(names []string) ([]resource.Detector, erro
 		case "ec2":
 			detectors = append(detectors, ec2.NewResourceDetector())
 		default:
-			return nil, status.InvalidArgumentErrorf("unknown trace resource detector %q (supported values: gcp, gke, ec2, eks)", name)
+			return nil, status.InvalidArgumentErrorf("unknown trace resource detector %q (supported values: gcp, gke, ec2)", name)
 		}
 	}
 	return detectors, nil


### PR DESCRIPTION
For some reason, this seems to add 30MB to goinit :skull: (thanks Dan for discovering this)

We're not using it because it's a bit brittle, as it depends on some CloudWatch stuff. See https://github.com/open-telemetry/opentelemetry-go-contrib/issues/8637