### PR TITLE
feat(CDC): short circuit 100% proxy-local reads

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -293,20 +293,12 @@ func (s *ByteStreamServerProxy) readChunked(ctx context.Context, req *bspb.ReadR
 		return m, err
 	}
 
-	splitResp, err := s.remoteCAS.SplitBlob(ctx, &repb.SplitBlobRequest{
-		BlobDigest:     rn.GetDigest(),
-		InstanceName:   rn.GetInstanceName(),
-		DigestFunction: rn.GetDigestFunction(),
-	})
+	chunkDigests, err := s.chunkDigests(ctx, rn, remoteOnly)
 	if err != nil {
-		metrics.ByteStreamProxyChunkedReadFailures.With(prometheus.Labels{
-			metrics.ChunkedFailureReasonLabel: "split_blob_error",
-			metrics.StatusHumanReadableLabel:  status.MetricsLabel(err),
-		}).Inc()
 		return m, err
 	}
 
-	chunkRequests := makeChunkReadRequests(rn, splitResp.GetChunkDigests(), req.GetReadOffset())
+	chunkRequests := makeChunkReadRequests(rn, chunkDigests, req.GetReadOffset())
 	if len(chunkRequests) == 0 {
 		return m, nil
 	}
@@ -383,6 +375,78 @@ func (s *ByteStreamServerProxy) readChunked(ctx context.Context, req *bspb.ReadR
 	}
 	_ = localWriteGroup.Wait()
 	return m, nil
+}
+
+func (s *ByteStreamServerProxy) chunkDigests(ctx context.Context, rn *digest.CASResourceName, remoteOnly bool) ([]*repb.Digest, error) {
+	fastPathEnabled := s.efp != nil && s.efp.Boolean(ctx, "cache_proxy.cdc_read_fast_path", false)
+	if fastPathEnabled && !remoteOnly {
+		if chunkDigests, ok := s.localChunkDigests(ctx, rn); ok {
+			return chunkDigests, nil
+		}
+	}
+	splitResp, err := s.remoteCAS.SplitBlob(ctx, &repb.SplitBlobRequest{
+		BlobDigest:     rn.GetDigest(),
+		InstanceName:   rn.GetInstanceName(),
+		DigestFunction: rn.GetDigestFunction(),
+	})
+	if err != nil {
+		metrics.ByteStreamProxyChunkedReadFailures.With(prometheus.Labels{
+			metrics.ChunkedFailureReasonLabel: "split_blob_error",
+			metrics.StatusHumanReadableLabel:  status.MetricsLabel(err),
+		}).Inc()
+		return nil, err
+	}
+	chunkDigests := splitResp.GetChunkDigests()
+	if !remoteOnly {
+		s.storeLocalChunkedManifest(ctx, rn, chunkDigests)
+	}
+	return chunkDigests, nil
+}
+
+func (s *ByteStreamServerProxy) localChunkDigests(ctx context.Context, rn *digest.CASResourceName) ([]*repb.Digest, bool) {
+	manifest, err := chunking.LoadManifest(ctx, s.localCache, rn.GetDigest(), rn.GetInstanceName(), rn.GetDigestFunction())
+	if err != nil {
+		outcome := "manifest_error"
+		if status.IsNotFoundError(err) {
+			outcome = "manifest_miss"
+		}
+		recordChunkedReadFastPathAttempt(outcome)
+		return nil, false
+	}
+	chunkResourceNames := manifest.ChunkResourceNames()
+	for _, chunkRN := range chunkResourceNames {
+		chunkRN.Compressor = rn.GetCompressor()
+	}
+	missing, err := s.localCache.FindMissing(ctx, chunkResourceNames)
+	if err != nil {
+		recordChunkedReadFastPathAttempt("find_missing_error")
+		return nil, false
+	}
+	if len(missing) > 0 {
+		recordChunkedReadFastPathAttempt("chunks_missing")
+		return nil, false
+	}
+	recordChunkedReadFastPathAttempt("hit")
+	return manifest.ChunkDigests, true
+}
+
+func (s *ByteStreamServerProxy) storeLocalChunkedManifest(ctx context.Context, rn *digest.CASResourceName, chunkDigests []*repb.Digest) {
+	manifest := &chunking.Manifest{
+		BlobDigest:     rn.GetDigest(),
+		ChunkDigests:   chunkDigests,
+		InstanceName:   rn.GetInstanceName(),
+		DigestFunction: rn.GetDigestFunction(),
+	}
+	err := manifest.StoreWithoutVerification(ctx, s.localCache)
+	metrics.ByteStreamChunkedReadLocalManifestStoreAttempts.With(prometheus.Labels{
+		metrics.StatusHumanReadableLabel: status.MetricsLabel(err),
+	}).Inc()
+}
+
+func recordChunkedReadFastPathAttempt(outcome string) {
+	metrics.ByteStreamChunkedReadFastPathAttempts.With(prometheus.Labels{
+		metrics.FastPathOutcomeLabel: outcome,
+	}).Inc()
 }
 
 func makeChunkReadRequests(rn *digest.CASResourceName, chunkDigests []*repb.Digest, readOffset int64) []chunkReadRequest {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -1159,6 +1159,163 @@ func TestReadChunked(t *testing.T) {
 	require.Equal(t, float64(len(originalData)), testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadHitLabels))-proxiedReadHitBytesBefore)
 }
 
+func TestReadChunkedFastPathSkipsSplitBlob(t *testing.T) {
+	// Setup environment.
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+		"cache_proxy.attempt_chunked_reads": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+		"cache_proxy.cdc_read_fast_path": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+
+	ctx := testContext()
+	remoteEnv := testenv.GetTestEnv(t)
+	proxyEnv := testenv.GetTestEnv(t)
+
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+	remoteEnv.SetExperimentFlagProvider(fp)
+	proxyEnv.SetExperimentFlagProvider(fp)
+
+	remoteBSS, err := byte_stream_server.NewByteStreamServer(remoteEnv)
+	require.NoError(t, err)
+	remoteCAS, err := content_addressable_storage_server.NewContentAddressableStorageServer(remoteEnv)
+	require.NoError(t, err)
+	remoteGRPC, remoteRun, remoteLis := testenv.RegisterLocalGRPCServer(t, remoteEnv)
+	bspb.RegisterByteStreamServer(remoteGRPC, remoteBSS)
+	repb.RegisterContentAddressableStorageServer(remoteGRPC, remoteCAS)
+	go remoteRun()
+
+	var splitBlobCalls atomic.Int32
+	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis, grpc.WithUnaryInterceptor(func(
+		ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+	) error {
+		if strings.HasSuffix(method, "/SplitBlob") {
+			splitBlobCalls.Add(1)
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}))
+	require.NoError(t, err)
+	t.Cleanup(func() { remoteConn.Close() })
+	bsClient := bspb.NewByteStreamClient(remoteConn)
+	casClient := repb.NewContentAddressableStorageClient(remoteConn)
+
+	proxyEnv.SetByteStreamClient(bsClient)
+	proxyEnv.SetContentAddressableStorageClient(casClient)
+	proxyBSS, err := byte_stream_server.NewByteStreamServer(proxyEnv)
+	require.NoError(t, err)
+	proxyEnv.SetLocalByteStreamServer(proxyBSS)
+	proxyServer, err := New(proxyEnv)
+	require.NoError(t, err)
+	proxyGRPC, proxyRun, proxyLis := testenv.RegisterLocalGRPCServer(t, proxyEnv)
+	bspb.RegisterByteStreamServer(proxyGRPC, proxyServer)
+	go proxyRun()
+	proxyConn, err := testenv.LocalGRPCConn(ctx, proxyLis)
+	require.NoError(t, err)
+	t.Cleanup(func() { proxyConn.Close() })
+	proxy := bspb.NewByteStreamClient(proxyConn)
+
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
+	require.NoError(t, err)
+
+	// Write test data directly to the remote cache.
+	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+
+	var chunkDigests []*repb.Digest
+	writeChunkFn := func(chunkData []byte) error {
+		chunkDataCopy := make([]byte, len(chunkData))
+		copy(chunkDataCopy, chunkData)
+		chunkDigest, err := digest.Compute(bytes.NewReader(chunkDataCopy), repb.DigestFunction_BLAKE3)
+		if err != nil {
+			return err
+		}
+		chunkDigests = append(chunkDigests, chunkDigest)
+		chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_BLAKE3)
+		return remoteEnv.GetCache().Set(ctx, chunkRN.ToProto(), chunkDataCopy)
+	}
+	cdcChunker, err := chunking.NewChunker(ctx, 64*1024, writeChunkFn)
+	require.NoError(t, err)
+	_, err = cdcChunker.Write(originalData)
+	require.NoError(t, err)
+	require.NoError(t, cdcChunker.Close())
+	require.Greater(t, len(chunkDigests), 1)
+
+	_, err = casClient.SpliceBlob(ctx, &repb.SpliceBlobRequest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   chunkDigests,
+		DigestFunction: repb.DigestFunction_BLAKE3,
+	})
+	require.NoError(t, err)
+
+	fastPathManifestMissLabels := prometheus.Labels{
+		metrics.FastPathOutcomeLabel: "manifest_miss",
+	}
+	fastPathHitLabels := prometheus.Labels{
+		metrics.FastPathOutcomeLabel: "hit",
+	}
+	storeOKLabels := prometheus.Labels{
+		metrics.StatusHumanReadableLabel: "OK",
+	}
+	fastPathManifestMissBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadFastPathAttempts.With(fastPathManifestMissLabels))
+	fastPathHitBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadFastPathAttempts.With(fastPathHitLabels))
+	storeOKBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadLocalManifestStoreAttempts.With(storeOKLabels))
+
+	downloadCASRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
+	readBlob := func() []byte {
+		downloadStream, err := proxy.Read(ctx, &bspb.ReadRequest{ResourceName: downloadCASRN.DownloadString()})
+		require.NoError(t, err)
+
+		var reconstructedData []byte
+		for {
+			res, err := downloadStream.Recv()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			reconstructedData = append(reconstructedData, res.Data...)
+		}
+		return reconstructedData
+	}
+
+	// Do a single read that will miss the local cache, but should populate it.
+	require.Equal(t, originalData, readBlob())
+	require.Equal(t, int32(1), splitBlobCalls.Load())
+	for _, chunkDigest := range chunkDigests {
+		chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_BLAKE3)
+		require.NoError(t, waitContains(ctx, proxyEnv, chunkRN.ToProto()))
+	}
+
+	// Do a second read and check that it was served through the fast path.
+	require.Equal(t, originalData, readBlob())
+	require.Equal(t, int32(1), splitBlobCalls.Load(), "second read should use the proxy-local manifest and chunks")
+	require.Equal(t, float64(1), testutil.ToFloat64(metrics.ByteStreamChunkedReadFastPathAttempts.With(fastPathManifestMissLabels))-fastPathManifestMissBefore)
+	require.Equal(t, float64(1), testutil.ToFloat64(metrics.ByteStreamChunkedReadFastPathAttempts.With(fastPathHitLabels))-fastPathHitBefore)
+	require.Equal(t, float64(1), testutil.ToFloat64(metrics.ByteStreamChunkedReadLocalManifestStoreAttempts.With(storeOKLabels))-storeOKBefore)
+}
+
 func TestReadChunkedEncryptedRemoteOnly(t *testing.T) {
 	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
 		"cache.chunking_enabled": {
@@ -1170,6 +1327,14 @@ func TestReadChunkedEncryptedRemoteOnly(t *testing.T) {
 			},
 		},
 		"cache_proxy.attempt_chunked_reads": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+		"cache_proxy.cdc_read_fast_path": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
 			Variants: map[string]any{
@@ -1268,6 +1433,15 @@ func TestReadChunkedEncryptedRemoteOnly(t *testing.T) {
 	require.NoError(t, err)
 	splitBlobCalls.Store(0)
 
+	fastPathManifestMissLabels := prometheus.Labels{
+		metrics.FastPathOutcomeLabel: "manifest_miss",
+	}
+	storeOKLabels := prometheus.Labels{
+		metrics.StatusHumanReadableLabel: "OK",
+	}
+	fastPathManifestMissBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadFastPathAttempts.With(fastPathManifestMissLabels))
+	storeOKBefore := testutil.ToFloat64(metrics.ByteStreamChunkedReadLocalManifestStoreAttempts.With(storeOKLabels))
+
 	downloadRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
 	readBlob := func() []byte {
 		downloadStream, err := proxy.Read(encryptedUserCtx, &bspb.ReadRequest{ResourceName: downloadRN.DownloadString()})
@@ -1302,6 +1476,8 @@ func TestReadChunkedEncryptedRemoteOnly(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, found)
 	}
+	require.Equal(t, float64(0), testutil.ToFloat64(metrics.ByteStreamChunkedReadFastPathAttempts.With(fastPathManifestMissLabels))-fastPathManifestMissBefore)
+	require.Equal(t, float64(0), testutil.ToFloat64(metrics.ByteStreamChunkedReadLocalManifestStoreAttempts.With(storeOKLabels))-storeOKBefore)
 }
 
 func TestReadChunkedEncryptedRemoteOnlyFallsBackToFullBlob(t *testing.T) {
@@ -1436,6 +1612,14 @@ func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 				"false": false,
 			},
 		},
+		"cache_proxy.cdc_read_fast_path": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
 		"cache_proxy.intercept_and_chunk_large_writes": {
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
@@ -1466,7 +1650,15 @@ func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 	bspb.RegisterByteStreamServer(remoteGRPC, remoteBSS)
 	repb.RegisterContentAddressableStorageServer(remoteGRPC, remoteCAS)
 	go remoteRun()
-	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis)
+	var splitBlobCalls atomic.Int32
+	remoteConn, err := testenv.LocalGRPCConn(ctx, remoteLis, grpc.WithUnaryInterceptor(func(
+		ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+	) error {
+		if strings.HasSuffix(method, "/SplitBlob") {
+			splitBlobCalls.Add(1)
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}))
 	require.NoError(t, err)
 	t.Cleanup(func() { remoteConn.Close() })
 	bsClient := bspb.NewByteStreamClient(remoteConn)
@@ -1518,6 +1710,7 @@ func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 	require.NoError(t, err)
 	chunkDigests := splitResp.GetChunkDigests()
 	require.Greater(t, len(chunkDigests), 1)
+	splitBlobCalls.Store(0)
 
 	readLabels := prometheus.Labels{
 		metrics.StatusLabel:     "OK",
@@ -1550,6 +1743,7 @@ func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 	got, err := compression.DecompressZstd(nil, gotCompressed)
 	require.NoError(t, err)
 	require.Equal(t, originalData, got)
+	require.Equal(t, int32(1), splitBlobCalls.Load())
 
 	readRequestsAfter := testutil.ToFloat64(metrics.ByteStreamChunkedReadRequests.With(readLabels))
 	readChunksTotalAfter := testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksTotal.With(readLabels))
@@ -1576,6 +1770,7 @@ func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 	got, err = compression.DecompressZstd(nil, gotCompressed)
 	require.NoError(t, err)
 	require.Equal(t, originalData, got)
+	require.Equal(t, int32(1), splitBlobCalls.Load(), "second compressed read should use the proxy-local manifest and chunks")
 
 	readRequestsAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadRequests.With(readLabels))
 	readChunksTotalAfter = testutil.ToFloat64(metrics.ByteStreamChunkedReadChunksTotal.With(readLabels))

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -188,6 +188,9 @@ const (
 	// resuming a partial read).
 	ChunkedOffsetReadLabel = "offset_read"
 
+	// Outcome of a cache proxy fast path attempt.
+	FastPathOutcomeLabel = "outcome"
+
 	// The name of the table in Clickhouse
 	ClickhouseTableName = "clickhouse_table_name"
 
@@ -3842,6 +3845,22 @@ var (
 	}, []string{
 		StatusLabel,
 		CompressionType,
+	})
+	ByteStreamChunkedReadFastPathAttempts = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "proxy",
+		Name:      "byte_stream_chunked_read_fast_path_attempts",
+		Help:      "Number of chunked reads where the CDC read fast path was attempted, by outcome.",
+	}, []string{
+		FastPathOutcomeLabel,
+	})
+	ByteStreamChunkedReadLocalManifestStoreAttempts = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "proxy",
+		Name:      "byte_stream_chunked_read_local_manifest_store_attempts",
+		Help:      "Number of attempts to store a CDC manifest in the proxy local cache after a successful remote SplitBlob.",
+	}, []string{
+		StatusHumanReadableLabel,
 	})
 	ByteStreamProxyChunkedReadLocalWriteBackFailures = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -276,6 +276,20 @@ func (cm *Manifest) Store(ctx context.Context, cache interfaces.Cache) error {
 		return err
 	}
 
+	return cm.store(ctx, cache)
+}
+
+// StoreWithoutVerification saves the chunked manifest to the cache without
+// checking that all chunks exist or that their combined hash matches the blob
+// digest.
+func (cm *Manifest) StoreWithoutVerification(ctx context.Context, cache interfaces.Cache) error {
+	if len(cm.ChunkDigests) == 0 {
+		return status.InvalidArgumentError("chunked manifest must have at least one chunk")
+	}
+	return cm.store(ctx, cache)
+}
+
+func (cm *Manifest) store(ctx context.Context, cache interfaces.Cache) error {
 	ar := &repb.ActionResult{
 		OutputFiles: make([]*repb.OutputFile, 0, len(cm.ChunkDigests)),
 	}

--- a/tools/metrics/grafana/dashboards/cdc.json
+++ b/tools/metrics/grafana/dashboards/cdc.json
@@ -1643,9 +1643,20 @@
           "legendFormat": "local hit ratio",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(buildbuddy_proxy_byte_stream_chunked_read_fast_path_attempts{region=~\"${proxy_region}\", job=\"cache-proxy\", outcome=\"hit\"}[${window}])) / sum(rate(buildbuddy_proxy_byte_stream_chunked_read_fast_path_attempts{region=~\"${proxy_region}\", job=\"cache-proxy\"}[${window}]))",
+          "legendFormat": "fast path hit ratio",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Chunk Read Local Cache Hit Ratio [proxy]",
+      "title": "Chunk Read Local Cache / Fast Path Hit Ratio [proxy]",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
If all the chunks exist in the proxy, and the manifest is available, we can short circuit and start reading directly. It's not worth doing this if there's any missing chunks - since we'll need to call `FindMissingBlobs` on the remote anyway. instead, we should just stick to the `Split` path.

This should actually happen quite often:
<img width="880" height="263" alt="Screenshot 2026-04-30 at 2 24 53 PM" src="https://github.com/user-attachments/assets/20b16c7c-86ec-447e-9d2d-d28a473a64d6" />
