### PR TITLE
Revert "Revert "turn off remote repo contents cache""

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -9,10 +9,6 @@ startup --digest_function=BLAKE3
 # in non-hermeticity.
 startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 
-# Use the remote cache to store fetched repo rule results across invocations.
-startup --experimental_remote_repo_contents_cache
-
-
 ################
 # COMMON FLAGS #
 ################


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#12034

Seeing issues like https://github.com/buildbuddy-io/buildbuddy/actions/runs/25186153486/job/73845932492?pr=12048

They get fixed with this flag off: https://github.com/buildbuddy-io/buildbuddy/actions/runs/25187205167/job/73847519305?pr=12048