### PR TITLE
Disable gRPC client connection pooling for some Cache Proxy system RPCs

### DIFF
--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -36,7 +36,6 @@ var (
 	maxPendingHitsPerKey         = flag.Int("cache_proxy.remote_hit_tracker.max_pending_hits_per_key", 3_000_000, "The maximum number of pending cache-hit updates to store in memory for a given (group, usagelabels) tuple.")
 	maxHitsPerUpdate             = flag.Int("cache_proxy.remote_hit_tracker.max_hits_per_update", 250_000, "The maximum number of cache-hit updates to send in one request to the hit-tracking backend.")
 	remoteHitTrackerWorkers      = flag.Int("cache_proxy.remote_hit_tracker.workers", 1, "The number of workers to use to send asynchronous remote cache-hit-tracking RPCs.")
-	gRPCClientConnPoolSize       = flag.Int("cache_proxy.remote_hit_tracker.grpc_connection_pool_size", 10, "The size of the gRPC client connection pool to use for sending remote hit tracking updates.")
 )
 
 func Register(env *real_environment.RealEnv) error {
@@ -45,7 +44,7 @@ func Register(env *real_environment.RealEnv) error {
 		return nil
 	}
 
-	conn, err := grpc_client.DialInternalWithPoolSize(env, *remoteHitTrackerTarget, *gRPCClientConnPoolSize)
+	conn, err := grpc_client.DialInternalWithPoolSize(env, *remoteHitTrackerTarget, *remoteHitTrackerWorkers)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -36,6 +36,7 @@ var (
 	maxPendingHitsPerKey         = flag.Int("cache_proxy.remote_hit_tracker.max_pending_hits_per_key", 3_000_000, "The maximum number of pending cache-hit updates to store in memory for a given (group, usagelabels) tuple.")
 	maxHitsPerUpdate             = flag.Int("cache_proxy.remote_hit_tracker.max_hits_per_update", 250_000, "The maximum number of cache-hit updates to send in one request to the hit-tracking backend.")
 	remoteHitTrackerWorkers      = flag.Int("cache_proxy.remote_hit_tracker.workers", 1, "The number of workers to use to send asynchronous remote cache-hit-tracking RPCs.")
+	gRPCClientConnPoolSize       = flag.Int("cache_proxy.remote_hit_tracker.grpc_connection_pool_size", 10, "The size of the gRPC client connection pool to use for sending remote hit tracking updates.")
 )
 
 func Register(env *real_environment.RealEnv) error {
@@ -44,7 +45,7 @@ func Register(env *real_environment.RealEnv) error {
 		return nil
 	}
 
-	conn, err := grpc_client.DialInternal(env, *remoteHitTrackerTarget)
+	conn, err := grpc_client.DialInternalWithPoolSize(env, *remoteHitTrackerTarget, *gRPCClientConnPoolSize)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/ip_rules_enforcer/ip_rules_enforcer.go
+++ b/enterprise/server/ip_rules_enforcer/ip_rules_enforcer.go
@@ -37,6 +37,7 @@ var (
 	cacheTTL                = flag.Duration("auth.ip_rules.cache_ttl", 2*time.Minute, "Duration of time IP rules will be cached in memory.")
 	remoteIPRulesTarget     = flag.String("auth.ip_rules.remote.target", "", "The gRPC target of the backend storing IP rules.")
 	remoteIPRulesRPCTimeout = flag.Duration("auth.ip_rules.remote.rpc_timeout", 15*time.Second, "Timeout for remote IP rules RPCs.")
+	gRPCClientConnPoolSize  = flag.Int("auth.ip_rules.remote.grpc_connection_pool_size", 10, "The size of the gRPC client connection pool to use for remote IP rules RPCs.")
 )
 
 const (
@@ -253,7 +254,7 @@ type remoteIPRulesProvider struct {
 }
 
 func newRemoteIPRulesProvider(env environment.Env, target string) (*remoteIPRulesProvider, error) {
-	conn, err := grpc_client.DialInternal(env, target)
+	conn, err := grpc_client.DialInternalWithPoolSize(env, target, *gRPCClientConnPoolSize)
 	if err != nil {
 		return nil, status.UnavailableErrorf("failed to dial remote IP rules backend %q: %v", target, err)
 	}

--- a/enterprise/server/ip_rules_enforcer/ip_rules_enforcer.go
+++ b/enterprise/server/ip_rules_enforcer/ip_rules_enforcer.go
@@ -37,7 +37,6 @@ var (
 	cacheTTL                = flag.Duration("auth.ip_rules.cache_ttl", 2*time.Minute, "Duration of time IP rules will be cached in memory.")
 	remoteIPRulesTarget     = flag.String("auth.ip_rules.remote.target", "", "The gRPC target of the backend storing IP rules.")
 	remoteIPRulesRPCTimeout = flag.Duration("auth.ip_rules.remote.rpc_timeout", 15*time.Second, "Timeout for remote IP rules RPCs.")
-	gRPCClientConnPoolSize  = flag.Int("auth.ip_rules.remote.grpc_connection_pool_size", 10, "The size of the gRPC client connection pool to use for remote IP rules RPCs.")
 )
 
 const (
@@ -254,7 +253,7 @@ type remoteIPRulesProvider struct {
 }
 
 func newRemoteIPRulesProvider(env environment.Env, target string) (*remoteIPRulesProvider, error) {
-	conn, err := grpc_client.DialInternalWithPoolSize(env, target, *gRPCClientConnPoolSize)
+	conn, err := grpc_client.DialInternalWithoutPooling(env, target)
 	if err != nil {
 		return nil, status.UnavailableErrorf("failed to dial remote IP rules backend %q: %v", target, err)
 	}

--- a/enterprise/server/remote_crypter/remote_crypter.go
+++ b/enterprise/server/remote_crypter/remote_crypter.go
@@ -26,8 +26,7 @@ const (
 )
 
 var (
-	target                 = flag.String("crypter.remote_target", "", "The gRPC target of the remote encryption API.")
-	gRPCClientConnPoolSize = flag.Int("crypter.remote_grpc_connection_pool_size", 10, "The size of the gRPC client connection pool to use for remote encryption RPCs.")
+	target = flag.String("crypter.remote_target", "", "The gRPC target of the remote encryption API.")
 )
 
 type RemoteCrypter struct {
@@ -63,7 +62,7 @@ func Register(env *real_environment.RealEnv) error {
 	if err != nil {
 		return err
 	}
-	conn, err := grpc_client.DialSimpleWithPoolSize(*target, *gRPCClientConnPoolSize)
+	conn, err := grpc_client.DialSimpleWithoutPooling(*target)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_crypter/remote_crypter.go
+++ b/enterprise/server/remote_crypter/remote_crypter.go
@@ -26,7 +26,8 @@ const (
 )
 
 var (
-	target = flag.String("crypter.remote_target", "", "The gRPC target of the remote encryption API.")
+	target                 = flag.String("crypter.remote_target", "", "The gRPC target of the remote encryption API.")
+	gRPCClientConnPoolSize = flag.Int("crypter.remote_grpc_connection_pool_size", 10, "The size of the gRPC client connection pool to use for remote encryption RPCs.")
 )
 
 type RemoteCrypter struct {
@@ -62,7 +63,7 @@ func Register(env *real_environment.RealEnv) error {
 	if err != nil {
 		return err
 	}
-	conn, err := grpc_client.DialSimple(*target)
+	conn, err := grpc_client.DialSimpleWithPoolSize(*target, *gRPCClientConnPoolSize)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remoteauth/remoteauth.go
+++ b/enterprise/server/remoteauth/remoteauth.go
@@ -48,10 +48,11 @@ var (
 	alwaysUseES256SignedJWTs = flag.Bool("auth.remote.use_es256_jwts", false, "Always request and use ES-256 signed JWTs from the remote auth service, regardless of the experiment configuration.")
 	keyRefreshInterval       = flag.Duration("auth.remote.key_refresh_interval", time.Minute, "How long to wait between asynchronous refreshes of cached ES256 public keys.")
 	getKeysTimeout           = flag.Duration("auth.remote.get_keys_timeout", 10*time.Second, "Timeout for GetPublicKeys RPCs.")
+	gRPCClientConnPoolSize   = flag.Int("auth.remote.grpc_connection_pool_size", 10, "The size of the gRPC client connection pool to use for remote authentication RPCs.")
 )
 
 func Register(env *real_environment.RealEnv) error {
-	conn, err := grpc_client.DialInternal(env, *target)
+	conn, err := grpc_client.DialInternalWithPoolSize(env, *target, *gRPCClientConnPoolSize)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remoteauth/remoteauth.go
+++ b/enterprise/server/remoteauth/remoteauth.go
@@ -48,11 +48,10 @@ var (
 	alwaysUseES256SignedJWTs = flag.Bool("auth.remote.use_es256_jwts", false, "Always request and use ES-256 signed JWTs from the remote auth service, regardless of the experiment configuration.")
 	keyRefreshInterval       = flag.Duration("auth.remote.key_refresh_interval", time.Minute, "How long to wait between asynchronous refreshes of cached ES256 public keys.")
 	getKeysTimeout           = flag.Duration("auth.remote.get_keys_timeout", 10*time.Second, "Timeout for GetPublicKeys RPCs.")
-	gRPCClientConnPoolSize   = flag.Int("auth.remote.grpc_connection_pool_size", 10, "The size of the gRPC client connection pool to use for remote authentication RPCs.")
 )
 
 func Register(env *real_environment.RealEnv) error {
-	conn, err := grpc_client.DialInternalWithPoolSize(env, *target, *gRPCClientConnPoolSize)
+	conn, err := grpc_client.DialInternalWithoutPooling(env, *target)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Also make the Hit Tracker Client's pool size set to the number of workers.