### PR TITLE
release: add static linux executor

### DIFF
--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -44,8 +44,16 @@ jobs:
             --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
             //server/cmd/buildbuddy:buildbuddy \
             //enterprise/server/cmd/server:buildbuddy \
-            //enterprise/server/cmd/executor:executor
+            //enterprise/server/cmd/executor:executor \
+            //enterprise/server/cmd/executor:executor_linux_amd64_static
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64
-          gh release upload ${{ inputs.version_tag }} buildbuddy-linux-amd64 buildbuddy-enterprise-linux-amd64 executor-enterprise-linux-amd64 --clobber
+          cp bazel-out/linux_x86_64_musl-opt/bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64-static
+          gh release upload \
+            ${{ inputs.version_tag }} \
+            buildbuddy-linux-amd64 \
+            buildbuddy-enterprise-linux-amd64 \
+            executor-enterprise-linux-amd64 \
+            executor-enterprise-linux-amd64-static \
+            --clobber

--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -1,9 +1,6 @@
 name: "Build Linux amd64 Github Release Artifacts"
 
 on:
-  pull_request:
-    branches:
-      - master
   workflow_dispatch:
     inputs:
       release_branch:
@@ -33,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
-          ref: ${{ inputs.release_branch || github.sha }}
+          ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report
           # the version of the running binary.
           fetch-depth: 0
@@ -53,14 +50,10 @@ jobs:
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64
           cp bazel-out/linux_x86_64_musl-opt/bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64-static
-          stat buildbuddy-linux-amd64
-          stat buildbuddy-enterprise-linux-amd64
-          stat executor-enterprise-linux-amd64
-          stat executor-enterprise-linux-amd64-static
-          # gh release upload \
-          #   ${{ inputs.version_tag }} \
-          #   buildbuddy-linux-amd64 \
-          #   buildbuddy-enterprise-linux-amd64 \
-          #   executor-enterprise-linux-amd64 \
-          #   executor-enterprise-linux-amd64-static \
-          #   --clobber
+          gh release upload \
+            ${{ inputs.version_tag }} \
+            buildbuddy-linux-amd64 \
+            buildbuddy-enterprise-linux-amd64 \
+            executor-enterprise-linux-amd64 \
+            executor-enterprise-linux-amd64-static \
+            --clobber

--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -1,6 +1,9 @@
 name: "Build Linux amd64 Github Release Artifacts"
 
 on:
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       release_branch:
@@ -30,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
-          ref: ${{ inputs.release_branch }}
+          ref: ${{ inputs.release_branch || github.sha }}
           # We need to fetch git tags to obtain the latest version tag to report
           # the version of the running binary.
           fetch-depth: 0
@@ -50,10 +53,14 @@ jobs:
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64
           cp bazel-out/linux_x86_64_musl-opt/bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64-static
-          gh release upload \
-            ${{ inputs.version_tag }} \
-            buildbuddy-linux-amd64 \
-            buildbuddy-enterprise-linux-amd64 \
-            executor-enterprise-linux-amd64 \
-            executor-enterprise-linux-amd64-static \
-            --clobber
+          stat buildbuddy-linux-amd64
+          stat buildbuddy-enterprise-linux-amd64
+          stat executor-enterprise-linux-amd64
+          stat executor-enterprise-linux-amd64-static
+          # gh release upload \
+          #   ${{ inputs.version_tag }} \
+          #   buildbuddy-linux-amd64 \
+          #   buildbuddy-enterprise-linux-amd64 \
+          #   executor-enterprise-linux-amd64 \
+          #   executor-enterprise-linux-amd64-static \
+          #   --clobber

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_layer")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//rules:platform_transitions.bzl", "linux_x86_64_musl_alias")
 load("//rules:utils.bzl", "runfiles_directory")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
@@ -92,6 +93,13 @@ go_binary(
         "//enterprise/config:config_files",
     ],
     embed = [":executor_lib"],
+)
+
+linux_x86_64_musl_alias(
+    name = "executor_linux_amd64_static",
+    actual = ":executor",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
 )
 
 alias(

--- a/tools/check_release_assets_uploaded.py
+++ b/tools/check_release_assets_uploaded.py
@@ -16,6 +16,7 @@ EXPECTED_ASSETS = [
     "executor-enterprise-darwin-amd64",
     "executor-enterprise-darwin-arm64",
     "executor-enterprise-linux-amd64",
+    "executor-enterprise-linux-amd64-static",
     "executor-enterprise-linux-arm64",
     "executor-enterprise-windows-amd64-beta.exe",
 ]
@@ -69,7 +70,7 @@ def main():
         for expected_asset in expected_assets:
             asset_uploaded = False
             for uploaded_asset in asset_urls:
-                if expected_asset in uploaded_asset:
+                if expected_asset == uploaded_asset:
                     asset_uploaded = True
                     break
 


### PR DESCRIPTION
A prospect requested a Linux x86 executor binary that works on
platforms with older glibc, such as RHEL 7. Add a transitioned musl
target so the existing release workflow can build both the regular
glibc executor and static-musl executor in one Bazel invocation.
