### PR TITLE
[CLI] Add a wrapper for bazel args

### DIFF
--- a/cli/arg/BUILD
+++ b/cli/arg/BUILD
@@ -13,5 +13,11 @@ go_test(
     name = "arg_test",
     srcs = ["arg_test.go"],
     embed = [":arg"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//cli/parser",
+        "//cli/parser/test_data",
+        "//cli/workspace",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/cli/arg/BUILD
+++ b/cli/arg/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "arg",
     srcs = ["arg.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/arg",
+    deps = ["//cli/parser"],
 )
 
 go_test(

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -46,8 +46,7 @@ func (a *BazelArgs) Set(args []string) error {
 func (a *BazelArgs) Append(arg string) error {
 	// TODO(#7216): Set the Forwarded args field.
 
-	// If the arg is a --config or --bazelrc flag, we need to recompute the resolved args.
-	if strings.HasPrefix(arg, "--config") || strings.HasPrefix(arg, "--bazelrc") {
+	if requiresResolve(arg) {
 		return a.Set(append(a.Resolved, arg))
 	}
 	a.Resolved = append(a.Resolved, arg)
@@ -61,7 +60,7 @@ func (a *BazelArgs) Prepend(arg string) error {
 	// TODO(#7216): Set the Forwarded args field.
 
 	updatedResolvedArgs := prepend(a.Resolved, arg)
-	if strings.HasPrefix(arg, "--config") || strings.HasPrefix(arg, "--bazelrc") {
+	if requiresResolve(arg) {
 		return a.Set(updatedResolvedArgs)
 	}
 	a.Resolved = updatedResolvedArgs
@@ -78,6 +77,13 @@ func prepend(args []string, arg string) []string {
 	out = append(out, arg)
 	out = append(out, args[commandIndex+1:]...)
 	return out
+}
+
+// requiresResolve returns true if the arg can change rc/config expansion.
+func requiresResolve(arg string) bool {
+	flagName, _ := SplitOptionValue(arg)
+	flagName = strings.TrimPrefix(flagName, "--")
+	return flagName == "config" || flagName == "bazelrc"
 }
 
 // Get returns the value of a flag.
@@ -174,7 +180,7 @@ func (a *BazelArgs) Pop(flagName string) (string, error) {
 		return "", nil
 	}
 
-	if strings.HasPrefix(flagName, "--config") || strings.HasPrefix(flagName, "--bazelrc") {
+	if requiresResolve(flagName) {
 		if err := a.Set(newArgs); err != nil {
 			return "", err
 		}

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -6,7 +6,179 @@ import (
 	"io"
 	"slices"
 	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 )
+
+type BazelArgs struct {
+	// TODO(#7216): Add a Forwarded args fields that represents the non-expanded args
+	// that are eventually passed to Bazelisk.
+
+	// Resolved are the Bazel args that are used internally within the bb parser.
+	// --config and --bazelrc flags are expanded, so the parser has a complete view of the args.
+	Resolved []string
+}
+
+// New returns a BazelArgs struct from a slice of bazel args.
+func NewBazelArgs(args []string) (*BazelArgs, error) {
+	parsed := &BazelArgs{}
+	if err := parsed.Set(args); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+// Set updates the BazelArgs struct with a new slice of bazel args.
+// It also recomputes the resolved args.
+func (a *BazelArgs) Set(args []string) error {
+	// Normalize args - apply stable sorting and consistent option representation.
+	normalizedArgs, err := parser.CanonicalizeArgs(args)
+	if err != nil {
+		return err
+	}
+	// TODO(#7216): Set the Forwarded args field.
+	return a.resolve(normalizedArgs)
+}
+
+// Append adds a new bazel arg.
+func (a *BazelArgs) Append(arg string) error {
+	// TODO(#7216): Set the Forwarded args field.
+
+	// If the arg is a --config or --bazelrc flag, we need to recompute the resolved args.
+	if strings.HasPrefix(arg, "--config") || strings.HasPrefix(arg, "--bazelrc") {
+		return a.Set(append(a.Resolved, arg))
+	}
+	a.Resolved = append(a.Resolved, arg)
+	return nil
+}
+
+// Prepend adds a new bazel arg to the beginning of the list of args, just after the bazel command.
+// If the same flag is specified multiple times, Bazel will use the last value. This is useful for adding flags that should
+// be overriden by later flags.
+func (a *BazelArgs) Prepend(arg string) error {
+	// TODO(#7216): Set the Forwarded args field.
+
+	updatedResolvedArgs := prepend(a.Resolved, arg)
+	if strings.HasPrefix(arg, "--config") || strings.HasPrefix(arg, "--bazelrc") {
+		return a.Set(updatedResolvedArgs)
+	}
+	a.Resolved = updatedResolvedArgs
+	return nil
+}
+
+func prepend(args []string, arg string) []string {
+	_, commandIndex := parser.GetBazelCommandAndIndex(args)
+	if commandIndex == -1 {
+		return append([]string{arg}, args...)
+	}
+	args = args[:commandIndex+1]
+	args = append(args, arg)
+	args = append(args, args[commandIndex+1:]...)
+	return args
+}
+
+// Get returns the value of a flag.
+// It reads from the resolved args to ensure that flags expanded from --config or --bazelrc are included.
+func (a *BazelArgs) Get(flagName string) string {
+	return Get(a.Resolved, flagName)
+}
+
+func (a *BazelArgs) Has(flagName string) bool {
+	return a.Get(flagName) != ""
+}
+
+// TODO(#7216): Read the Forwarded args field, instead of passing in args.
+// resolve re-evaluates the args and expands all flags.
+func (a *BazelArgs) resolve(args []string) error {
+	// Expand --config and --bazelrc flags, then normalize the result.
+	resolved, err := parser.ResolveAndCanonicalizeArgs(args)
+	if err != nil {
+		return err
+	}
+	a.Resolved = resolved
+	return nil
+}
+
+func (a *BazelArgs) GetTargets() []string {
+	return GetTargets(a.Resolved)
+}
+
+func (a *BazelArgs) GetCommand() string {
+	return GetCommand(a.Resolved)
+}
+
+func (a *BazelArgs) GetAllFlagsWithName(flagName string) []string {
+	return GetMulti(a.Resolved, flagName)
+}
+
+// StripBBFlag removes a CLI-only string flag from the args (so it is
+// not passed to Bazelisk) and returns its value.
+func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
+	// TODO(#7216): Read the Forwarded args field - we can't strip a field set in a rc file.
+	parsed, err := parser.ParseArgs(a.Resolved)
+	if err != nil {
+		return "", err
+	}
+	if _, err := parser.GetCLICommandOptionVal(parsed, flagName); err != nil {
+		return "", err
+	}
+	if err := a.Set(parsed.Format()); err != nil {
+		return "", err
+	}
+	return a.Get(flagName), nil
+}
+
+// StripBBBoolFlag removes a CLI-only bool flag from the forwarded args (so it
+// is not passed to Bazelisk) and returns whether it was set.
+func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
+	// TODO(#7216): Read the Forwarded args field - we can't strip a field set in a rc file.
+	parsed, err := parser.ParseArgs(a.Resolved)
+	if err != nil {
+		return false, err
+	}
+	set, err := parser.IsCLICommandOptionSet(parsed, flagName)
+	if err != nil {
+		return false, err
+	}
+	if err := a.Set(parsed.Format()); err != nil {
+		return false, err
+	}
+	return set, nil
+}
+
+// GetRemoteHeaderVal returns the value of a --remote_header flag matching the
+// given key, reading from the resolved args.
+func (a *BazelArgs) GetRemoteHeaderVal(key string) string {
+	parsed, err := parser.ParseArgs(a.Resolved)
+	if err != nil {
+		return ""
+	}
+	return parser.GetRemoteHeaderVal(parsed, key)
+}
+
+// TODO(#7216): Add a test where the resolved flags add another version of flagName at the end of the args.
+// We shouldn't pop the newly resolved arg.
+//
+// Pop removes a flag and returns its value.
+// NOTE: Pop does not remove boolean flags.
+func (a *BazelArgs) Pop(flagName string) (string, error) {
+	value, newArgs := Pop(a.Resolved, flagName)
+
+	if value == "" {
+		return "", nil
+	}
+
+	if strings.HasPrefix(flagName, "--config") || strings.HasPrefix(flagName, "--bazelrc") {
+		if err := a.Set(newArgs); err != nil {
+			return "", err
+		}
+	} else {
+		a.Resolved = newArgs
+	}
+	// TODO(#7216): Return an error if the flag is only present in the resolved args (i.e. set
+	// via a config file), since it cannot be removed from the forwarded args in that case.
+	return value, nil
+}
 
 // Returns true if the list of args contains desiredArg
 func Has(args []string, desiredArg string) bool {
@@ -35,6 +207,8 @@ func GetMulti(args []string, name string) []string {
 }
 
 // Returns the value of the given desiredArg and a slice with that arg removed
+//
+// NOTE: Pop does not remove boolean flags.
 func Pop(args []string, desiredArg string) (string, []string) {
 	arg, i, length := Find(args, desiredArg)
 	if i < 0 {

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -48,7 +48,11 @@ func (a *BazelArgs) Append(arg string) error {
 
 	newArgs := Append(a.Resolved, arg)
 
-	if requiresResolve(arg) {
+	resolve, err := requiresResolve(arg)
+	if err != nil {
+		return err
+	}
+	if resolve {
 		return a.Set(newArgs)
 	}
 	a.Resolved = newArgs
@@ -62,7 +66,11 @@ func (a *BazelArgs) Prepend(arg string) error {
 	// TODO(#7216): Set the Forwarded args field.
 
 	updatedResolvedArgs := prepend(a.Resolved, arg)
-	if requiresResolve(arg) {
+	resolve, err := requiresResolve(arg)
+	if err != nil {
+		return err
+	}
+	if resolve {
 		return a.Set(updatedResolvedArgs)
 	}
 	a.Resolved = updatedResolvedArgs
@@ -82,10 +90,16 @@ func prepend(args []string, arg string) []string {
 }
 
 // requiresResolve returns true if the arg can change rc/config expansion.
-func requiresResolve(arg string) bool {
+func requiresResolve(arg string) (bool, error) {
 	flagName, _ := SplitOptionValue(arg)
 	flagName = strings.TrimPrefix(flagName, "--")
-	return flagName == "config" || flagName == "bazelrc"
+
+	// TODO(#7216): Remove this check once we add the Forwarded args field and can safely resolve --bazelrc.
+	if flagName == "bazelrc" {
+		return false, fmt.Errorf("cannot resolve --bazelrc with BazelArgs")
+	}
+
+	return flagName == "config" || flagName == "bazelrc", nil
 }
 
 // Get returns the value of a flag.
@@ -185,7 +199,11 @@ func (a *BazelArgs) Pop(flagName string) (string, error) {
 		return "", nil
 	}
 
-	if requiresResolve(flagName) {
+	resolve, err := requiresResolve(flagName)
+	if err != nil {
+		return "", err
+	}
+	if resolve {
 		if err := a.Set(newArgs); err != nil {
 			return "", err
 		}

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -33,7 +33,7 @@ func NewBazelArgs(args []string) (*BazelArgs, error) {
 // Set updates the BazelArgs struct with a new slice of bazel args.
 // It also recomputes the resolved args.
 func (a *BazelArgs) Set(args []string) error {
-	// Normalize args - apply stable sorting and consistent option representation.
+	// Normalize args - apply consistent option representation.
 	normalizedArgs, err := parser.CanonicalizeArgs(args)
 	if err != nil {
 		return err
@@ -46,10 +46,12 @@ func (a *BazelArgs) Set(args []string) error {
 func (a *BazelArgs) Append(arg string) error {
 	// TODO(#7216): Set the Forwarded args field.
 
+	newArgs := Append(a.Resolved, arg)
+
 	if requiresResolve(arg) {
-		return a.Set(append(a.Resolved, arg))
+		return a.Set(newArgs)
 	}
-	a.Resolved = append(a.Resolved, arg)
+	a.Resolved = newArgs
 	return nil
 }
 

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -10,6 +10,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 )
 
+// TODO(#7216): Add getters for these fields, so they can't be modified directly, potentially breaking
+// the contract for how they should be simultaneously updated.
 type BazelArgs struct {
 	// TODO(#7216): Add a Forwarded args fields that represents the non-expanded args
 	// that are eventually passed to Bazelisk.
@@ -54,7 +56,7 @@ func (a *BazelArgs) Append(arg string) error {
 
 // Prepend adds a new bazel arg to the beginning of the list of args, just after the bazel command.
 // If the same flag is specified multiple times, Bazel will use the last value. This is useful for adding flags that should
-// be overriden by later flags.
+// be overridden by later flags.
 func (a *BazelArgs) Prepend(arg string) error {
 	// TODO(#7216): Set the Forwarded args field.
 
@@ -71,10 +73,11 @@ func prepend(args []string, arg string) []string {
 	if commandIndex == -1 {
 		return append([]string{arg}, args...)
 	}
-	args = args[:commandIndex+1]
-	args = append(args, arg)
-	args = append(args, args[commandIndex+1:]...)
-	return args
+
+	out := append([]string{}, args[:commandIndex+1]...)
+	out = append(out, arg)
+	out = append(out, args[commandIndex+1:]...)
+	return out
 }
 
 // Get returns the value of a flag.
@@ -119,13 +122,16 @@ func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if _, err := parser.GetCLICommandOptionVal(parsed, flagName); err != nil {
+	// Remove the flag from the parsed args and return its value.
+	flagVal, err := parser.GetCLICommandOptionVal(parsed, flagName)
+	if err != nil {
 		return "", err
 	}
+	// Update the args to not have the removed flag.
 	if err := a.Set(parsed.Format()); err != nil {
 		return "", err
 	}
-	return a.Get(flagName), nil
+	return flagVal, nil
 }
 
 // StripBBBoolFlag removes a CLI-only bool flag from the forwarded args (so it

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -134,9 +134,10 @@ func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
 		return "", err
 	}
 	// Update the args to not have the removed flag.
-	if err := a.Set(parsed.Format()); err != nil {
-		return "", err
-	}
+	// Use direct assignment rather than Set() to avoid re-resolving rc/config
+	// flags, which would fail if a plugin added a  --config flag.
+	// TODO(#7216): This will be cleaner when we can safely re-resolve the Forwarded args.
+	a.Resolved = parsed.Format()
 	return flagVal, nil
 }
 
@@ -152,9 +153,11 @@ func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if err := a.Set(parsed.Format()); err != nil {
-		return false, err
-	}
+	// Update the args to not have the removed flag.
+	// Use direct assignment rather than Set() to avoid re-resolving rc/config
+	// flags, which would fail if a plugin added a  --config flag.
+	// TODO(#7216): This will be cleaner when we can safely re-resolve the Forwarded args.
+	a.Resolved = parsed.Format()
 	return set, nil
 }
 

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -63,6 +63,23 @@ build:ci --remote_cache=grpc://ci-cache
 // 	require.Equal(t, "a", args.Get("configuration"))
 // }
 
+func TestAppend_ExecutableArgs(t *testing.T) {
+	setupWorkspace(t, ``)
+
+	args, err := NewBazelArgs([]string{"run", ":target", "--", "--flag=value"})
+	require.NoError(t, err)
+
+	err = args.Append("--build_metadata=ROLE=CI")
+	require.NoError(t, err)
+
+	require.Equal(t, "ROLE=CI", args.Get("build_metadata"))
+	require.Equal(t, []string{":target"}, args.GetTargets())
+
+	bazelArgs, execArgs := SplitExecutableArgs(args.Resolved)
+	require.NotContains(t, execArgs, "--build_metadata=ROLE=CI")
+	require.Contains(t, bazelArgs, "--build_metadata=ROLE=CI")
+}
+
 func TestPrepend(t *testing.T) {
 	setupWorkspace(t, `
 build:ci --remote_cache=grpc://ci-cache

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -1,65 +1,177 @@
 package arg
 
 import (
-	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/test_data"
+	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestFindLast(t *testing.T) {
-	repr := func(val string, idx, length int) string {
-		return fmt.Sprintf("val=%q, idx=%d, len=%d", val, idx, length)
-	}
+func init() {
+	parser.SetBazelHelpForTesting(test_data.BazelHelpFlagsAsProtoOutput)
+}
 
+func TestNewBazelArgs(t *testing.T) {
+	setupWorkspace(t, `
+build --bes_backend=grpc://default-bes
+build:ci --remote_cache=grpc://ci-cache
+`)
+
+	args, err := NewBazelArgs([]string{
+		"build",
+		"--config=ci",
+		"-c", "opt",
+		"//foo",
+	})
+	require.NoError(t, err)
+
+	// Config and bazelrc flags should be expanded.
+	require.Equal(t, "grpc://default-bes", args.Get("bes_backend"))
+	require.Equal(t, "grpc://ci-cache", args.Get("remote_cache"))
+	require.NotContains(t, args.Resolved, "--config=ci")
+	require.Contains(t, args.Resolved, "--ignore_all_rc_files")
+
+	// Flags should be canonicalized (-c expanded to --compilation_mode).
+	require.Equal(t, "opt", args.Get("compilation_mode"))
+
+	require.Equal(t, []string{"//foo"}, args.GetTargets())
+	require.Equal(t, "build", args.GetCommand())
+}
+
+// TODO(#7216): Uncomment once we support appending config flags with late resolution.
+// func TestAppend_Config(t *testing.T) {
+// 	setupWorkspace(t, `
+// build:ci --remote_cache=grpc://ci-cache
+// `)
+// 	args, err := NewBazelArgs([]string{"build", "//foo"})
+// 	require.NoError(t, err)
+// 	err = args.Append("--config=ci")
+// 	require.NoError(t, err)
+// 	err = args.Append("--configuration=a")
+// 	require.NoError(t, err)
+
+// 	// Config flag should be expanded.
+// 	require.Equal(t, "grpc://ci-cache", args.Get("remote_cache"))
+// 	require.NotContains(t, args.Resolved, "--config=ci")
+
+// 	// Make sure that we don't try to expand flags that start with config but don't match exactly.
+// 	require.Equal(t, "a", args.Get("configuration"))
+// }
+
+func TestPrepend(t *testing.T) {
+	setupWorkspace(t, `
+build:ci --remote_cache=grpc://ci-cache
+`)
+	args, err := NewBazelArgs([]string{"--output_base=/tmp/output", "build", "--flag=initial", "//foo"})
+	require.NoError(t, err)
+
+	err = args.Prepend("--build_metadata=ROLE=CI")
+	require.NoError(t, err)
+
+	require.Equal(t, []string{
+		"--output_base=/tmp/output",
+		"--ignore_all_rc_files",
+		"build",
+		"--build_metadata=ROLE=CI",
+		"--flag=initial",
+		"//foo",
+	}, args.Resolved)
+
+	// TODO(#7216): Uncomment once we support adding config flags with late resolution.
+	// err = args.Prepend("--config=ci")
+	// require.NoError(t, err)
+
+	require.Equal(t, []string{
+		"--output_base=/tmp/output",
+		"--ignore_all_rc_files",
+		"build",
+		// Config flag should be expanded.
+		// "--remote_cache=grpc://ci-cache",
+		"--build_metadata=ROLE=CI",
+		"--flag=initial",
+		"//foo",
+	}, args.Resolved)
+}
+
+func TestPop(t *testing.T) {
+	setupWorkspace(t, `
+build --bes_backend=grpc://default-bes
+`)
+	args, err := NewBazelArgs([]string{"build", "--flag=val", "//foo"})
+	require.NoError(t, err)
+
+	value, err := args.Pop("flag")
+	require.NoError(t, err)
+
+	require.Equal(t, "val", value)
+	require.Equal(t, "grpc://default-bes", args.Get("bes_backend"))
+	require.NotContains(t, args.Resolved, "--flag=val")
+}
+
+func TestFindLast(t *testing.T) {
 	for _, tc := range []struct {
-		Args                          []string
-		ExpectedValue                 string
-		ExpectedIndex, ExpectedLength int
+		Name          string
+		Args          []string
+		ExpectedValue string
+		ExpectedIndex int
+		SetWithSpace  bool
 	}{
 		{
+			"Value is set with =",
 			[]string{"--foo=bar"},
-			"bar", 0, 1,
+			"bar", 0, false,
 		},
 		{
+			"Value is set with space",
 			[]string{"--foo", "bar"},
-			"bar", 0, 2,
+			"bar", 0, true,
 		},
 		{
+			"Arg set multiple times",
 			[]string{"--foo=bar", "--foo=baz"},
-			"baz", 1, 1,
+			"baz", 1, false,
 		},
 		{
+			"Arg set multiple times with space",
 			[]string{"--foo=bar", "--foo", "baz"},
-			"baz", 1, 2,
+			"baz", 1, true,
+		},
+		{
+			"Preceding args",
+			[]string{"--fee=fum", "--foo=bar", "--foo", "baz"},
+			"baz", 2, true,
 		},
 	} {
 		val, idx, length := FindLast(tc.Args, "foo")
-		assert.Equal(
-			t,
-			repr(tc.ExpectedValue, tc.ExpectedIndex, tc.ExpectedLength),
-			repr(val, idx, length),
-			"incorrect return value for %s", tc.Args,
-		)
+		require.Equal(t, tc.ExpectedValue, val, tc.Name)
+		require.Equal(t, tc.ExpectedIndex, idx, tc.Name)
+		expectedLength := 1
+		if tc.SetWithSpace {
+			expectedLength = 2
+		}
+		require.Equal(t, expectedLength, length, tc.Name)
 	}
 }
 
 func TestGetMulti(t *testing.T) {
 	args := []string{"--build_metadata=COMMIT_SHA=abc123", "--foo", "--build_metadata=ROLE=CI"}
-
 	values := GetMulti(args, "build_metadata")
-
 	assert.Equal(t, []string{"COMMIT_SHA=abc123", "ROLE=CI"}, values)
 }
 
 func TestGetTargets(t *testing.T) {
-	args := []string{"build", "foo"}
+	args := []string{"build", "//foo"}
 	targets := GetTargets(args)
-	assert.Equal(t, []string{"foo"}, targets)
+	assert.Equal(t, []string{"//foo"}, targets)
 
-	args = []string{"build", "foo", "bar"}
+	args = []string{"build", "//foo", ":bar", "baz"}
 	targets = GetTargets(args)
-	assert.Equal(t, []string{"foo", "bar"}, targets)
+	assert.Equal(t, []string{"//foo", ":bar", "baz"}, targets)
 
 	args = []string{"build", "--opt=val", "foo", "bar", "--anotheropt=anotherval"}
 	targets = GetTargets(args)
@@ -69,7 +181,7 @@ func TestGetTargets(t *testing.T) {
 	targets = GetTargets(args)
 	assert.Equal(t, []string{"foo", "bar"}, targets)
 
-	// Support subtractive patterns https://bazel.build/run/build#specifying-build-targets
+	// Don't include subtractive patterns.
 	args = []string{"build", "--opt=val", "--", "foo", "bar", "-baz"}
 	targets = GetTargets(args)
 	assert.Equal(t, []string{"foo", "bar"}, targets)
@@ -89,18 +201,20 @@ func TestGetCommand(t *testing.T) {
 	assert.Equal(t, "", command)
 	assert.Equal(t, -1, index)
 
-	args = []string{"command"}
+	args = []string{"build"}
 	command, index = GetCommandAndIndex(args)
-	assert.Equal(t, "command", command)
+	assert.Equal(t, "build", command)
 	assert.Equal(t, 0, index)
 
-	args = []string{"command", "notcommand"}
+	args = []string{"--ouput_base=notcommand", "build", "--foo", "bar"}
 	command, index = GetCommandAndIndex(args)
-	assert.Equal(t, "command", command)
-	assert.Equal(t, 0, index)
-
-	args = []string{"--ouput_base=notcommand", "command", "--foo", "bar", "baz"}
-	command, index = GetCommandAndIndex(args)
-	assert.Equal(t, "command", command)
+	assert.Equal(t, "build", command)
 	assert.Equal(t, 1, index)
+}
+
+func setupWorkspace(t *testing.T, bazelrc string) {
+	ws := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(ws, "WORKSPACE"), nil, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(ws, ".bazelrc"), []byte(bazelrc), 0644))
+	workspace.SetForTest(t, ws)
 }

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -338,7 +338,10 @@ func handleBazelCommand(start time.Time, args []string, originalArgs []string) (
 	// - For "run" commands, if there is no target pattern, then the first arg
 	//   after "--" is treated as the pattern.
 	if len(execArgs) == 0 {
-		bazelArgs = picker.HandlePicker(bazelArgs)
+		bazelArgs, err = picker.HandlePicker(bazelArgs)
+		if err != nil {
+			return 1, err
+		}
 	}
 
 	bazelArgs, streamRunLogsOpts, err = stream_run_logs.Configure(bazelArgs, setupResult.OriginalBESBackend)
@@ -364,8 +367,9 @@ func handleBazelCommand(start time.Time, args []string, originalArgs []string) (
 	// plugins to control how the output is rendered to the terminal.
 	log.Debugf("bb initialized in %s", time.Since(start))
 	outputPath := filepath.Join(tempDir, "bazel.log")
+	// TODO(#7216): Use the forwarded args here.
 	exitCode, err = plugin.RunBazeliskWithPlugins(
-		arg.JoinExecutableArgs(bazelArgs, execArgs),
+		arg.JoinExecutableArgs(bazelArgs.Resolved, execArgs),
 		outputPath, plugins)
 	if err != nil {
 		return 1, err

--- a/cli/flaghistory/BUILD
+++ b/cli/flaghistory/BUILD
@@ -22,6 +22,8 @@ go_test(
     embed = [":flaghistory"],
     deps = [
         "//cli/arg",
+        "//cli/parser",
+        "//cli/parser/test_data",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/cli/flaghistory/flaghistory.go
+++ b/cli/flaghistory/flaghistory.go
@@ -21,14 +21,21 @@ const (
 	besBackendFlagName = "bes_backend"
 )
 
-func SaveFlags(args []string) []string {
-	command := arg.GetCommand(args)
+func SaveFlags(args *arg.BazelArgs) (*arg.BazelArgs, error) {
+	command := args.GetCommand()
 	if command == "build" || command == "test" || command == "run" || command == "query" || command == "cquery" {
-		saveFlag(args, besBackendFlagName, "", 1)
-		saveFlag(args, BesResultsUrlFlagName, "", 1)
-		args = saveFlag(args, InvocationIDFlagName, uuid.New(), 2)
+		saveFlag(besBackendFlagName, args.Get(besBackendFlagName), 1)
+		saveFlag(BesResultsUrlFlagName, args.Get(BesResultsUrlFlagName), 1)
+		invocationID := args.Get(InvocationIDFlagName)
+		if invocationID == "" {
+			invocationID = uuid.New()
+			if err := args.Append("--" + InvocationIDFlagName + "=" + invocationID); err != nil {
+				return nil, err
+			}
+		}
+		saveFlag(InvocationIDFlagName, invocationID, 2)
 	}
-	return args
+	return args, nil
 }
 
 // GetPreviousFlag returns the previous value of a flag, or an empty string if
@@ -64,16 +71,11 @@ func GetLastBackend() (string, error) {
 	return lastBackend, nil
 }
 
-func saveFlag(args []string, flag, backup string, maxValues int) []string {
-	value := arg.Get(args, flag)
-	if value == "" {
-		value = backup
-	}
-	args = arg.Append(args, "--"+flag+"="+value)
+func saveFlag(flag, value string, maxValues int) {
 	path := getPreviousFlagPath(flag)
 	if path == "" {
 		log.Debugf("Failed to get path for flag %q", flag)
-		return args
+		return
 	}
 	var newContent string
 	oldContent, err := os.ReadFile(path)
@@ -88,7 +90,6 @@ func saveFlag(args []string, flag, backup string, maxValues int) []string {
 		}
 	}
 	os.WriteFile(path, []byte(newContent), 0777)
-	return args
 }
 
 func getPreviousFlagPath(flagName string) string {

--- a/cli/flaghistory/flaghistory_test.go
+++ b/cli/flaghistory/flaghistory_test.go
@@ -7,9 +7,17 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/test_data"
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	parser.SetBazelHelpForTesting(test_data.BazelHelpFlagsAsProtoOutput)
+}
+
+// This isn't in init, because for tests that run multiple times in a loop,
+// this should be reset for each loop iteration and init() would only run once.
 func setup(t *testing.T) {
 	// Flag history is written to this dir.
 	t.Setenv("BUILDBUDDY_CACHE_DIR", t.TempDir())
@@ -70,15 +78,19 @@ func TestPreviousFlagStorage(t *testing.T) {
 func TestSaveFlags(t *testing.T) {
 	setup(t)
 
-	args := SaveFlags([]string{
+	args, err := arg.NewBazelArgs([]string{
 		"build",
 		"--bes_backend=grpc://backend.example",
 		"--bes_results_url=https://app.buildbuddy.io/invocation/abc",
 		"--invocation_id=explicit-invocation-id",
 		"//foo",
 	})
+	require.NoError(t, err)
 
-	require.Equal(t, "explicit-invocation-id", arg.Get(args, InvocationIDFlagName))
+	args, err = SaveFlags(args)
+	require.NoError(t, err)
+
+	require.Equal(t, "explicit-invocation-id", args.Get(InvocationIDFlagName))
 	requirePreviousFlag(t, besBackendFlagName, "grpc://backend.example")
 	requirePreviousFlag(t, BesResultsUrlFlagName, "https://app.buildbuddy.io/invocation/abc")
 	requirePreviousFlag(t, InvocationIDFlagName, "explicit-invocation-id")
@@ -88,26 +100,33 @@ func TestSaveFlags_ClearsStaleHistory(t *testing.T) {
 	setup(t)
 
 	// Save some flags originally.
-	SaveFlags([]string{
+	args, err := arg.NewBazelArgs([]string{
 		"build",
 		"--bes_backend=grpc://backend.example",
 		"--bes_results_url=https://app.buildbuddy.io/invocation/abc",
 		"--invocation_id=explicit-invocation-id",
 		"//foo",
 	})
+	require.NoError(t, err)
+	_, err = SaveFlags(args)
+	require.NoError(t, err)
+
 	requirePreviousFlag(t, besBackendFlagName, "grpc://backend.example")
 	requirePreviousFlag(t, BesResultsUrlFlagName, "https://app.buildbuddy.io/invocation/abc")
 	requirePreviousFlag(t, InvocationIDFlagName, "explicit-invocation-id")
 
 	// Run another build that does not set --bes_backend or --bes_results_url.
 	// This should clear the old flags.
-	args := SaveFlags([]string{"build", "//foo"})
+	args2, err := arg.NewBazelArgs([]string{"build", "//foo"})
+	require.NoError(t, err)
+	args2, err = SaveFlags(args2)
+	require.NoError(t, err)
 
 	requirePreviousFlag(t, besBackendFlagName, "")
 	requirePreviousFlag(t, BesResultsUrlFlagName, "")
 	// The invocation ID should be set to an automatically generated one.
 	// It should not be the value that was saved from the original run.
-	invocationID := arg.Get(args, InvocationIDFlagName)
+	invocationID := args2.Get(InvocationIDFlagName)
 	require.NotEmpty(t, invocationID)
 	require.NotEqual(t, "explicit-invocation-id", invocationID)
 	requirePreviousFlag(t, InvocationIDFlagName, invocationID)
@@ -117,16 +136,22 @@ func TestSaveFlags_NonBazelCommands(t *testing.T) {
 	setup(t)
 
 	// Save some bazel flags.
-	SaveFlags([]string{
+	args, err := arg.NewBazelArgs([]string{
 		"build",
 		"--bes_backend=grpc://backend.example",
 		"//foo",
 	})
+	require.NoError(t, err)
+	_, err = SaveFlags(args)
+	require.NoError(t, err)
 
 	// Run another command that doesn't support flag history.
-	args := SaveFlags([]string{"install", "--bes_backend=shouldnt_apply"})
+	args2, err := arg.NewBazelArgs([]string{"fetch", "--bes_backend=shouldnt_apply"})
+	require.NoError(t, err)
+	_, err = SaveFlags(args2)
+	require.NoError(t, err)
 
-	require.Equal(t, []string{"install", "--bes_backend=shouldnt_apply"}, args)
+	require.Equal(t, []string{"--ignore_all_rc_files", "fetch", "--bes_backend=shouldnt_apply"}, args2.Resolved)
 	requirePreviousFlag(t, besBackendFlagName, "grpc://backend.example")
 }
 

--- a/cli/flaghistory/flaghistory_test.go
+++ b/cli/flaghistory/flaghistory_test.go
@@ -2,7 +2,6 @@ package flaghistory
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"strconv"
 	"testing"
@@ -41,7 +40,6 @@ func TestPreviousFlagStorage(t *testing.T) {
 			setup(t)
 
 			flag := "flag" + strconv.Itoa(maxValues)
-			rng := rand.New(rand.NewSource(int64(maxValues)))
 
 			for numStores := 0; numStores <= 3*maxValues; numStores++ {
 				var expectedValues []string
@@ -62,19 +60,7 @@ func TestPreviousFlagStorage(t *testing.T) {
 				require.Equalf(t, expectedValues, actualValues, "numStores=%d", numStores)
 
 				value := fmt.Sprintf("value_%d", numStores+1)
-				flagAndValue := fmt.Sprintf("--%s=%s", flag, value)
-				var argsIn []string
-				var backup string
-				// Deterministically vary whether the flag is specified explicitly.
-				if rng.Int()%2 == 0 {
-					argsIn = []string{flagAndValue}
-					backup = ""
-				} else {
-					argsIn = []string{}
-					backup = value
-				}
-				argsOut := saveFlag(argsIn, flag, backup, maxValues)
-				require.Equal(t, flagAndValue, argsOut[len(argsOut)-1])
+				saveFlag(flag, value, maxValues)
 			}
 		})
 	}

--- a/cli/login/BUILD
+++ b/cli/login/BUILD
@@ -25,6 +25,8 @@ go_test(
     embed = [":login"],
     deps = [
         "//cli/arg",
+        "//cli/parser",
+        "//cli/parser/test_data",
         "//cli/storage",
         "//server/testutil/testgit",
         "//server/util/status",

--- a/cli/login/BUILD
+++ b/cli/login/BUILD
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//cli/arg",
         "//cli/log",
-        "//cli/parser",
         "//cli/storage",
         "//cli/terminal",
         "//proto:buildbuddy_service_go_proto",
@@ -25,6 +24,7 @@ go_test(
     srcs = ["login_test.go"],
     embed = [":login"],
     deps = [
+        "//cli/arg",
         "//cli/storage",
         "//server/testutil/testgit",
         "//server/util/status",

--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/cli/terminal"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -333,14 +332,14 @@ func openInBrowser(url string) error {
 	return exec.Command(cmd, url).Run()
 }
 
-func ConfigureAPIKey(args []string) ([]string, error) {
-	if cmd, _ := parser.GetBazelCommandAndIndex(args); !isSupportedCommand(cmd) {
-		return args, nil
+func ConfigureAPIKey(args *arg.BazelArgs) error {
+	if cmd := args.GetCommand(); !isSupportedCommand(cmd) {
+		return nil
 	}
 
 	// TODO(siggisim): find a more graceful way of finding headers if we change the way we parse flags.
-	if arg.Has(args, apiKeyHeader) {
-		return args, nil
+	if args.Get(apiKeyHeader) != "" {
+		return nil
 	}
 
 	// TODO: consider always starting an interactive login, or maybe only when
@@ -352,13 +351,16 @@ func ConfigureAPIKey(args []string) ([]string, error) {
 		// Making this fatal would be inconvenient for new workspaces,
 		// so just log a debug message and move on.
 		log.Debugf("Failed to read API key from .git/config: %s", err)
-		return args, nil
+		return nil
 	}
 	if apiKey == "" {
-		return args, nil
+		return nil
 	}
 
-	return arg.Append(args, "--"+apiKeyHeader+"="+strings.TrimSpace(apiKey)), nil
+	if err := args.Append("--" + apiKeyHeader + "=" + strings.TrimSpace(apiKey)); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Commands that support the `--remote_header` bazel flag

--- a/cli/login/login_test.go
+++ b/cli/login/login_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -86,10 +87,12 @@ func TestAPIKeyDiscovery(t *testing.T) {
 			}
 
 			// Supported Bazel commands should receive the discovered API key.
-			args, err := ConfigureAPIKey([]string{"build", "//foo:bar"})
+			args, err := arg.NewBazelArgs([]string{"build", "//foo:bar"})
+			require.NoError(t, err)
+			err = ConfigureAPIKey(args)
 
 			require.NoError(t, err)
-			require.Equal(t, testCase.expectedArgs, args)
+			require.Equal(t, testCase.expectedArgs, args.Resolved)
 		})
 	}
 }

--- a/cli/login/login_test.go
+++ b/cli/login/login_test.go
@@ -5,11 +5,17 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/test_data"
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	parser.SetBazelHelpForTesting(test_data.BazelHelpFlagsAsProtoOutput)
+}
 
 func TestAPIKeyDiscovery(t *testing.T) {
 	for _, testCase := range []struct {
@@ -25,6 +31,7 @@ func TestAPIKeyDiscovery(t *testing.T) {
 			envAPIKey:      "env-api-key",
 			expectedAPIKey: "env-api-key",
 			expectedArgs: []string{
+				"--ignore_all_rc_files",
 				"build",
 				"//foo:bar",
 				"--remote_header=x-buildbuddy-api-key=env-api-key",
@@ -35,6 +42,7 @@ func TestAPIKeyDiscovery(t *testing.T) {
 			repoAPIKey:     "repo-api-key",
 			expectedAPIKey: "repo-api-key",
 			expectedArgs: []string{
+				"--ignore_all_rc_files",
 				"build",
 				"//foo:bar",
 				"--remote_header=x-buildbuddy-api-key=repo-api-key",
@@ -46,6 +54,7 @@ func TestAPIKeyDiscovery(t *testing.T) {
 			repoAPIKey:     "repo-api-key",
 			expectedAPIKey: "env-api-key",
 			expectedArgs: []string{
+				"--ignore_all_rc_files",
 				"build",
 				"//foo:bar",
 				"--remote_header=x-buildbuddy-api-key=env-api-key",
@@ -53,7 +62,7 @@ func TestAPIKeyDiscovery(t *testing.T) {
 		},
 		{
 			name:              "neither env nor .git/config defined",
-			expectedArgs:      []string{"build", "//foo:bar"},
+			expectedArgs:      []string{"--ignore_all_rc_files", "build", "//foo:bar"},
 			expectedGetAPIErr: true,
 		},
 	} {

--- a/cli/metadata/BUILD
+++ b/cli/metadata/BUILD
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//cli/arg",
         "//cli/log",
-        "//cli/parser",
         "//cli/workspace",
         "//server/util/git",
     ],

--- a/cli/metadata/BUILD
+++ b/cli/metadata/BUILD
@@ -20,6 +20,8 @@ go_test(
     embed = [":metadata"],
     deps = [
         "//cli/arg",
+        "//cli/parser",
+        "//cli/parser/test_data",
         "//cli/workspace",
         "//server/testutil/testgit",
         "@com_github_stretchr_testify//require",

--- a/cli/metadata/metadata.go
+++ b/cli/metadata/metadata.go
@@ -10,12 +10,11 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 )
 
-func AppendBuildMetadata(args, originalArgs []string) ([]string, error) {
+func AppendBuildMetadata(args *arg.BazelArgs, originalArgs []string) (*arg.BazelArgs, error) {
 	originalArgs = append(
 		// os.Args[0] might be something like /usr/local/bin/bb.
 		// filepath.Base gets just the "bb" part.
@@ -37,7 +36,7 @@ func AppendBuildMetadata(args, originalArgs []string) ([]string, error) {
 	// script.
 	// TODO: Maybe respect existing env vars as well, since those would also
 	// get overridden by build metadata.
-	if arg.Get(args, "workspace_status_command") == "" {
+	if args.Get("workspace_status_command") == "" {
 		gitMdFlags, err := gitMetadataFlags()
 		if err != nil {
 			log.Debugf("Failed to compute git metadata flags: %s", err)
@@ -47,7 +46,11 @@ func AppendBuildMetadata(args, originalArgs []string) ([]string, error) {
 	}
 	// Append default metadata just after the bazel command and before other
 	// flags, so that it can be overridden by user metadata flags if needed.
-	args = appendBazelCommandArgs(args, metadataFlags)
+	for _, flag := range metadataFlags {
+		if err := args.Prepend(flag); err != nil {
+			return nil, err
+		}
+	}
 	// TODO: Add metadata to help understand how config files were expanded,
 	// and how plugins modified args (maybe not as build_metadata, but
 	// rather as some sort of artifact we attach to the invocation ID).
@@ -97,19 +100,4 @@ func runGit(dir string, args ...string) (output string, err error) {
 		return "", fmt.Errorf("command `git %s` failed: %s", strings.Join(args, " "), string(b))
 	}
 	return strings.TrimSpace(string(b)), nil
-}
-
-// appendBazelCommmandArgs appends the given command args just after the bazel
-// command, so that the args have lower priority than existing command args.
-func appendBazelCommandArgs(args, commandArgs []string) []string {
-	_, commandIndex := parser.GetBazelCommandAndIndex(args)
-	if commandIndex == -1 {
-		log.Debugf("Failed to append metadata: not a bazel command")
-		return args
-	}
-	var out []string
-	out = append(out, args[:commandIndex+1]...)
-	out = append(out, commandArgs...)
-	out = append(out, args[commandIndex+1:]...)
-	return out
 }

--- a/cli/metadata/metadata_test.go
+++ b/cli/metadata/metadata_test.go
@@ -5,17 +5,23 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/test_data"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	parser.SetBazelHelpForTesting(test_data.BazelHelpFlagsAsProtoOutput)
+}
 
 func TestAppendBuildMetadata(t *testing.T) {
 	ws, commitSHA := testgit.MakeTempRepo(t, map[string]string{"WORKSPACE": ""})
 	testgit.ConfigureRemoteOrigin(t, ws, "https://user:secret@example.com/org/repo.git")
 	workspace.SetForTest(t, ws)
 
-	args := []string{
+	argStr := []string{
 		"build",
 		// Even though AppendBuildMetadata sets branch metadata, the user value should take precedence.
 		"--build_metadata=BRANCH_NAME=user-provided-branch",
@@ -23,14 +29,15 @@ func TestAppendBuildMetadata(t *testing.T) {
 		"--build_metadata=USER=1",
 		"//foo",
 	}
-	updatedArgs, err := AppendBuildMetadata(args, append([]string{"/usr/local/bin/bb"}, args...))
+	args, err := arg.NewBazelArgs(argStr)
+	require.NoError(t, err)
+	updatedArgs, err := AppendBuildMetadata(args, append([]string{"/usr/local/bin/bb"}, argStr...))
 	require.NoError(t, err)
 
-	expectedOriginalArgsJSON, err := json.Marshal(append([]string{"bb"}, args...))
+	expectedOriginalArgsJSON, err := json.Marshal(append([]string{"bb"}, argStr...))
 	require.NoError(t, err)
 
-	// All metadata should be appended after the bazel command.
-	require.Equal(t, "build", updatedArgs[0])
+	require.Equal(t, "build", updatedArgs.GetCommand())
 
 	// Check all the expected metadata flags are present.
 	require.ElementsMatch(t, []string{
@@ -40,8 +47,8 @@ func TestAppendBuildMetadata(t *testing.T) {
 		"BRANCH_NAME=master",
 		"BRANCH_NAME=user-provided-branch",
 		"USER=1",
-	}, arg.GetMulti(updatedArgs, "build_metadata"))
+	}, updatedArgs.GetAllFlagsWithName("build_metadata"))
 
 	// The user-provided branch name should take precedence.
-	require.Equal(t, "user-provided-branch", arg.Get(updatedArgs, "build_metadata=BRANCH_NAME"))
+	require.Equal(t, "user-provided-branch", updatedArgs.Get("build_metadata=BRANCH_NAME"))
 }

--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -39,6 +39,7 @@ var (
 		"info":               {},
 		"license":            {},
 		"mobile-install":     {},
+		"mod":                {},
 		"print_action":       {},
 		"query":              {},
 		"run":                {},

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -616,6 +616,20 @@ func CanonicalizeArgs(args []string) ([]string, error) {
 	return p.canonicalizeArgs(args)
 }
 
+// ResolveAndCanonicalizeArgs expands rc / config settings for internal
+// consumption, then canonicalizes the resulting argument list.
+func ResolveAndCanonicalizeArgs(args []string) ([]string, error) {
+	parsedArgs, err := ParseArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	parsedArgs, err = ResolveArgs(parsedArgs)
+	if err != nil {
+		return nil, err
+	}
+	return parsedArgs.Canonicalized().Format(), nil
+}
+
 func (p *Parser) canonicalizeArgs(args []string) ([]string, error) {
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		if !p.StartupOptionParser.Subcommands.Contains(args[0]) {

--- a/cli/picker/picker.go
+++ b/cli/picker/picker.go
@@ -12,34 +12,36 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
-func HandlePicker(args []string) []string {
+func HandlePicker(args *arg.BazelArgs) (*arg.BazelArgs, error) {
 	// If targets are already specified, don't do anything.
-	if len(arg.GetTargets(args)) > 0 {
-		return args
+	if len(args.GetTargets()) > 0 {
+		return args, nil
 	}
 
 	// If the command is build, test, or query without a specified target - apply to all targets.
-	command := arg.GetCommand(args)
+	command := args.GetCommand()
 
 	// Skip using the picker if the user has specified a query file.
-	if strings.Contains(command, "query") && arg.Has(args, "query_file") {
-		return args
+	if strings.Contains(command, "query") && args.Has("query_file") {
+		return args, nil
 	}
 
 	// Skip using the picker if the user has specified a target pattern file.
-	if (command == "build" || command == "test") && arg.Has(args, "target_pattern_file") {
-		return args
+	if (command == "build" || command == "test") && args.Has("target_pattern_file") {
+		return args, nil
 	}
 
 	// If it's a build, test, or query - apply to all targets.
 	if command == "build" || command == "test" || command == "query" {
-		args = append(args, "//...")
-		return args
+		if err := args.Append("//..."); err != nil {
+			return nil, err
+		}
+		return args, nil
 	}
 
 	// If it's not a run command, we're done here.
 	if command != "run" {
-		return args
+		return args, nil
 	}
 
 	// If it's a run, query executable targets.
@@ -54,18 +56,20 @@ func HandlePicker(args []string) []string {
 	// We didn't find any executable targets to run.
 	if len(targets) == 0 || targets[0] == "" {
 		log.Printf("No runnable targets found!")
-		return args
+		return args, nil
 	}
 
 	// If there is only one executable target, run it.
 	if len(targets) == 1 {
-		args = append(args, targets[0])
-		return args
+		if err := args.Append(targets[0]); err != nil {
+			return nil, err
+		}
+		return args, nil
 	}
 
 	// If not running interactively, we can't show a prompt.
 	if !terminal.IsTTY(os.Stdin) || !terminal.IsTTY(os.Stderr) {
-		return args
+		return args, nil
 	}
 
 	// If there are more than one executable targets, show a picker.
@@ -87,11 +91,12 @@ func HandlePicker(args []string) []string {
 	_, result, err := prompt.Run()
 	if err != nil {
 		log.Printf("Failed to select target: %v", err)
-		return args
+		return args, nil
 	}
-	args = append(args, result)
-
-	return args
+	if err := args.Append(result); err != nil {
+		return nil, err
+	}
+	return args, nil
 }
 
 func searcher(targets []string) func(input string, index int) bool {

--- a/cli/plugin/BUILD
+++ b/cli/plugin/BUILD
@@ -29,6 +29,7 @@ go_test(
     srcs = ["plugin_test.go"],
     embed = [":plugin"],
     deps = [
+        "//cli/arg",
         "//cli/config",
         "//cli/log",
         "//cli/parser",

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -40,6 +40,9 @@ const (
 	// invoked by BB as a plugin.
 	isPluginEnvVar = "IS_BB_PLUGIN"
 
+	execArgsFileEnvVar          = "EXEC_ARGS_FILE"
+	resolvedBazelArgsFileEnvVar = "RESOLVED_BAZEL_ARGS_FILE"
+
 	installCommandUsage = `
 Usage: bb install [REPO[@VERSION]][:PATH] [--user]
 
@@ -623,14 +626,18 @@ func (p *Plugin) commandEnv() []string {
 // plugin to return a set of transformed bazel arguments.
 //
 // Plugins receive as their first argument a path to a file containing the
-// arguments to be passed to bazel. The plugin can read and write that file to
-// modify the args (most commonly, just appending to the file), which will then
-// be fed to the next plugin in the pipeline, or passed to Bazel if this is the
-// last plugin.
+// arguments to be passed to bazel (--config and --bazelrc flags are not expanded).
+// The plugin can read and write that file to modify the args (most commonly, just appending to the file), which
+// will then be fed to the next plugin in the pipeline, or passed to Bazel if
+// this is the last plugin.
+//
+// Plugins can also read the resolved arg view (i.e. all --config flags expanded) from the
+// file at RESOLVED_BAZEL_ARGS_FILE, but changes to that file are ignored.
 //
 // See cli/example_plugins/ping-remote/pre_bazel.sh for an example.
-func (p *Plugin) PreBazel(args, execArgs []string) ([]string, []string, error) {
-	// Write args to a file so the plugin can manipulate them.
+func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.BazelArgs, []string, error) {
+	// Write bazel args to a file that the plugin can manipulate.
+	// Any changes are passed through to bazelisk.
 	argsFile, err := os.CreateTemp("", "bazelisk-args-*")
 	if err != nil {
 		return nil, nil, status.InternalErrorf("failed to create args file for pre-bazel hook: %s", err)
@@ -639,7 +646,23 @@ func (p *Plugin) PreBazel(args, execArgs []string) ([]string, []string, error) {
 		argsFile.Close()
 		os.Remove(argsFile.Name())
 	}()
-	if err := writeArgsFile(argsFile.Name(), args); err != nil {
+	// TODO(#7216): Write the forwarded args to the file.
+	if err := writeArgsFile(argsFile.Name(), bazelArgs.Resolved); err != nil {
+		return nil, nil, err
+	}
+
+	// Write resolved bazel args to a separate read-only file. The plugin may
+	// read this to see rc/config-expanded values, but only the forwarded args
+	// file is read back after the plugin runs. Any edits to this file are ignored.
+	resolvedArgsFile, err := os.CreateTemp("", "bazelisk-resolved-args-*")
+	if err != nil {
+		return nil, nil, status.InternalErrorf("failed to create resolved args file for pre-bazel hook: %s", err)
+	}
+	defer func() {
+		resolvedArgsFile.Close()
+		os.Remove(resolvedArgsFile.Name())
+	}()
+	if err := writeArgsFile(resolvedArgsFile.Name(), bazelArgs.Resolved); err != nil {
 		return nil, nil, err
 	}
 
@@ -667,7 +690,7 @@ func (p *Plugin) PreBazel(args, execArgs []string) ([]string, []string, error) {
 	}
 	if !exists {
 		log.Debugf("Bazel hook not found at %s", scriptPath)
-		return args, execArgs, nil
+		return bazelArgs, execArgs, nil
 	}
 	log.Debugf("Running pre-bazel hook for %s/%s", p.config.Repo, p.config.Path)
 	// TODO: support "pre_bazel.<any-extension>" as long as the file is
@@ -678,7 +701,8 @@ func (p *Plugin) PreBazel(args, execArgs []string) ([]string, []string, error) {
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Env = p.commandEnv()
-	cmd.Env = append(cmd.Env, "EXEC_ARGS_FILE="+execArgsFile.Name())
+	cmd.Env = append(cmd.Env, execArgsFileEnvVar+"="+execArgsFile.Name())
+	cmd.Env = append(cmd.Env, resolvedBazelArgsFileEnvVar+"="+resolvedArgsFile.Name())
 	if err := cmd.Run(); err != nil {
 		return nil, nil, status.InternalErrorf("Pre-bazel hook for %s/%s failed: %s", p.config.Repo, p.config.Path, err)
 	}
@@ -696,13 +720,12 @@ func (p *Plugin) PreBazel(args, execArgs []string) ([]string, []string, error) {
 	log.Debugf("New bazel args: %s", shlex.Quote(newArgs...))
 	log.Debugf("New executable args: %s", shlex.Quote(newExecArgs...))
 
-	// Canonicalize args after each plugin is run, so that every plugin gets
-	// canonicalized args as input.
-	canonicalizedArgs, err := parser.CanonicalizeArgs(newArgs)
-	if err != nil {
+	// Resolve bazel args after each plugin is run, so every following plugin gets
+	// a refreshed resolved view of the bazel args (i.e. all --config flags expanded).
+	if err := bazelArgs.Set(newArgs); err != nil {
 		return nil, nil, err
 	}
-	return canonicalizedArgs, newExecArgs, nil
+	return bazelArgs, newExecArgs, nil
 }
 
 // PostBazel executes the plugin's post-bazel hook if it exists, allowing it to

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -626,13 +626,10 @@ func (p *Plugin) commandEnv() []string {
 // plugin to return a set of transformed bazel arguments.
 //
 // Plugins receive as their first argument a path to a file containing the
-// arguments to be passed to bazel (--config and --bazelrc flags are not expanded).
-// The plugin can read and write that file to modify the args (most commonly, just appending to the file), which
-// will then be fed to the next plugin in the pipeline, or passed to Bazel if
-// this is the last plugin.
-//
-// Plugins can also read the resolved arg view (i.e. all --config flags expanded) from the
-// file at RESOLVED_BAZEL_ARGS_FILE, but changes to that file are ignored.
+// arguments to be passed to bazel. The plugin can read and write that file to
+// modify the args (most commonly, just appending to the file), which will then
+// be fed to the next plugin in the pipeline, or passed to Bazel if this is the
+// last plugin.
 //
 // See cli/example_plugins/ping-remote/pre_bazel.sh for an example.
 func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.BazelArgs, []string, error) {
@@ -720,11 +717,10 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 	log.Debugf("New bazel args: %s", shlex.Quote(newArgs...))
 	log.Debugf("New executable args: %s", shlex.Quote(newExecArgs...))
 
-	// Resolve bazel args after each plugin is run, so every following plugin gets
+	// TODO(#7216): Resolve bazel args after each plugin is run, so every following plugin gets
 	// a refreshed resolved view of the bazel args (i.e. all --config flags expanded).
-	if err := bazelArgs.Set(newArgs); err != nil {
-		return nil, nil, err
-	}
+	bazelArgs.Resolved = newArgs
+
 	return bazelArgs, newExecArgs, nil
 }
 

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -717,9 +717,15 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 	log.Debugf("New bazel args: %s", shlex.Quote(newArgs...))
 	log.Debugf("New executable args: %s", shlex.Quote(newExecArgs...))
 
-	// TODO(#7216): Resolve bazel args after each plugin is run, so every following plugin gets
+	// Canonicalize args after each plugin is run, so that every plugin gets
+	// canonicalized args as input.
+	canonicalizedArgs, err := parser.CanonicalizeArgs(newArgs)
+	if err != nil {
+		return nil, nil, err
+	}
+	// TODO(#7216): Resolve bazel args after each plugin is run (using bazelArgs.Set), so every following plugin gets
 	// a refreshed resolved view of the bazel args (i.e. all --config flags expanded).
-	bazelArgs.Resolved = newArgs
+	bazelArgs.Resolved = canonicalizedArgs
 
 	return bazelArgs, newExecArgs, nil
 }

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/config"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
@@ -263,8 +264,10 @@ EOF
 	})
 
 	plugin1 := testPlugin(t, ws, "./plugins/plugin1")
+	args, err := arg.NewBazelArgs([]string{"test", "//initial"})
+	require.NoError(t, err)
 
-	args, execArgs, err := plugin1.PreBazel([]string{"test", "//initial"}, []string{"--exec"})
+	args, execArgs, err := plugin1.PreBazel(args, []string{"--exec"})
 	require.NoError(t, err)
 
 	// We expect the output args to be canonicalized.
@@ -276,7 +279,7 @@ EOF
 		"--remote_header=x-buildbuddy-bar=2",
 		"//foo",
 	}
-	require.Equal(t, expectedArgs, args)
+	require.Equal(t, expectedArgs, args.Resolved)
 	// Exec args should be passed through unchanged.
 	require.Equal(t, []string{"--exec"}, execArgs)
 }
@@ -290,12 +293,14 @@ func TestPreBazel_AddConfig(t *testing.T) {
 		"plugins/config/pre_bazel.sh": `echo '--config=plugin-cfg' >> "$1"`,
 	})
 	p := testPlugin(t, ws, "./plugins/config")
-
-	args, execArgs, err := p.PreBazel([]string{"test", "//initial"}, nil)
+	args, err := arg.NewBazelArgs([]string{"test", "//initial"})
 	require.NoError(t, err)
-	require.Equal(t, []string{"test", "--config=plugin-cfg", "//initial"}, args)
+
+	args, execArgs, err := p.PreBazel(args, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"--ignore_all_rc_files", "test", "--config=plugin-cfg", "//initial"}, args.Resolved)
 	require.Empty(t, execArgs)
-	require.NotContains(t, args, "--test_output=all")
+	require.NotContains(t, args.Resolved, "--test_output=all")
 }
 
 // TestPipelineWriter_HandlesFinalLine guards against a regression in which

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1351,14 +1351,10 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 	// to expand --config and --bazelrc flags for an internal view of resolved flags.
 	// (Attempting to use the parser would actually fail, because we add --config flags that
 	// are only defined on the remote runners.)
-	// The login code expects the arg.BazelArgs struct though, so artificially construct one here.
+	// Manually construct a BazelArgs struct because the login code expects it.
 	// TODO: Find a less hacky way to handle this.
-
-	// Use BazelArgs only for ConfigureAPIKey, which needs the resolved view to
-	// check whether an API key is already present.
-	bazelArgsStruct, err := arg.NewBazelArgs(bazelArgs)
-	if err != nil {
-		return nil, nil, fmt.Errorf("resolve bazel args: %w", err)
+	bazelArgsStruct := &arg.BazelArgs{
+		Resolved: bazelArgs,
 	}
 	if err := login.ConfigureAPIKey(bazelArgsStruct); err != nil {
 		return nil, nil, fmt.Errorf("configure api key: %w", err)

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1337,17 +1337,33 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 	return exitCode, err
 }
 
-func parseArgs(commandLineArgs []string) (bazelArgs []string, execArgs []string, err error) {
-	bazelArgs, execArgs = arg.SplitExecutableArgs(commandLineArgs)
+func parseArgs(commandLineArgs []string) ([]string, []string, error) {
+	bazelArgs, execArgs := arg.SplitExecutableArgs(commandLineArgs)
 
-	bazelArgs, err = login.ConfigureAPIKey(bazelArgs)
-	if err != nil {
-		return nil, nil, fmt.Errorf("configure api key: %w", err)
-	}
+	var err error
 	bazelArgs, err = parser.CanonicalizeArgs(bazelArgs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("canonicalize bazel args: %w", err)
 	}
+
+	// Because Remote Bazel just forwards the command to a remote runner, it
+	// doesn't need to use the traditional CLI parser, which attempts
+	// to expand --config and --bazelrc flags for an internal view of resolved flags.
+	// (Attempting to use the parser would actually fail, because we add --config flags that
+	// are only defined on the remote runners.)
+	// The login code expects the arg.BazelArgs struct though, so artificially construct one here.
+	// TODO: Find a less hacky way to handle this.
+
+	// Use BazelArgs only for ConfigureAPIKey, which needs the resolved view to
+	// check whether an API key is already present.
+	bazelArgsStruct, err := arg.NewBazelArgs(bazelArgs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve bazel args: %w", err)
+	}
+	if err := login.ConfigureAPIKey(bazelArgsStruct); err != nil {
+		return nil, nil, fmt.Errorf("configure api key: %w", err)
+	}
+	bazelArgs = bazelArgsStruct.Resolved
 
 	// Ensure all bazel remote runs use the remote cache.
 	// The goal is to keep remote workloads close to our servers, so use the same

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -484,9 +484,9 @@ func TestParseArgs(t *testing.T) {
 		"--config=remote_only",
 		// Remote headers should be preserved.
 		"--remote_header=x-custom=1",
+		"//foo",
 		// API key should be set.
 		"--remote_header=x-buildbuddy-api-key=test-api-key",
-		"//foo",
 		// Remote flags should be removed and replaced by the CLI.
 		"--config=buildbuddy_bes_backend",
 		"--config=buildbuddy_bes_results_url",

--- a/cli/runscript/runscript.go
+++ b/cli/runscript/runscript.go
@@ -10,13 +10,13 @@ import (
 
 // Configure adds `--script_path` to a bazel run command so that we can
 // invoke the build and the run separately.
-func Configure(args []string) (newArgs []string, scriptPath string, err error) {
-	if arg.GetCommand(args) != "run" {
+func Configure(args *arg.BazelArgs) (newArgs *arg.BazelArgs, scriptPath string, err error) {
+	if args.GetCommand() != "run" {
 		return args, "", nil
 	}
 	// If --script_path is already set, don't create a run script ourselves,
 	// since the caller probably has the intention to invoke it on their own.
-	existingScript := arg.Get(args, "script_path")
+	existingScript := args.Get("script_path")
 	if existingScript != "" {
 		return args, "", nil
 	}
@@ -26,7 +26,9 @@ func Configure(args []string) (newArgs []string, scriptPath string, err error) {
 	}
 	defer script.Close()
 	scriptPath = script.Name()
-	args = arg.Append(args, "--script_path="+scriptPath)
+	if err := args.Append("--script_path=" + scriptPath); err != nil {
+		return nil, "", err
+	}
 	return args, scriptPath, nil
 }
 

--- a/cli/setup/BUILD
+++ b/cli/setup/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//cli/arg",
         "//cli/flaghistory",
         "//cli/login",
-        "//cli/parser",
         "//cli/plugin",
         "//cli/sidecar",
         "//cli/tooltag",

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -4,17 +4,26 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/flaghistory"
 	"github.com/buildbuddy-io/buildbuddy/cli/login"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/plugin"
 	"github.com/buildbuddy-io/buildbuddy/cli/sidecar"
 	"github.com/buildbuddy-io/buildbuddy/cli/tooltag"
 )
 
 type Result struct {
-	Plugins            []*plugin.Plugin
-	BazelArgs          []string
-	ExecArgs           []string
-	Sidecar            *sidecar.Instance
+	// Plugins are the loaded CLI plugins that should run with this invocation.
+	Plugins []*plugin.Plugin
+
+	// BazelArgs contains the forwarded args passed to Bazelisk and the resolved
+	// args used internally for setup decisions.
+	BazelArgs *arg.BazelArgs
+
+	// ExecArgs are args to pass to the executable produced by `bazel run`.
+	ExecArgs []string
+
+	// Sidecar is the sidecar instance started for this invocation, if any.
+	Sidecar *sidecar.Instance
+
+	// OriginalBESBackend is the resolved BES backend before sidecar rewrites.
 	OriginalBESBackend string
 }
 
@@ -27,35 +36,26 @@ func Setup(args []string, tempDir string) (*Result, error) {
 		return nil, err
 	}
 
-	// Parse args.
-	parsedArgs, err := parser.ParseArgs(args)
+	bazelArgsStr, execArgs := arg.SplitExecutableArgs(args)
+	bazelArgs, err := arg.NewBazelArgs(bazelArgsStr)
 	if err != nil {
 		return nil, err
 	}
 
-	parsedArgs, err = parser.ResolveArgs(parsedArgs)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Expanding configs results in a long explicit command line in the BB
-	// UI. Need to find a way to override the explicit command line in the UI so
-	// that it reflects the args passed to the CLI, not the wrapped Bazel
-	// process.
-	args = parsedArgs.Format()
-
-	bazelArgs, execArgs := arg.SplitExecutableArgs(args)
 	// Save some flags from the current invocation for non-Bazel commands such
-	// as `bb ask`.
-	// Args are saved before the sidecar rewrites them as API requests require
-	// the original --bes_backend value.
-	bazelArgs = flaghistory.SaveFlags(bazelArgs)
+	// as `bb ask`. Flags are saved before the sidecar rewrites them, since API
+	// requests require the original resolved values.
+	bazelArgs, err = flaghistory.SaveFlags(bazelArgs)
+	if err != nil {
+		return nil, err
+	}
 
 	// Fiddle with Bazel args
 	// TODO(bduffany): model these as "built-in" plugins
-	bazelArgs = tooltag.ConfigureToolTag(bazelArgs)
-	bazelArgs, err = login.ConfigureAPIKey(bazelArgs)
-	if err != nil {
+	if err := tooltag.ConfigureToolTag(bazelArgs); err != nil {
+		return nil, err
+	}
+	if err := login.ConfigureAPIKey(bazelArgs); err != nil {
 		return nil, err
 	}
 
@@ -64,11 +64,7 @@ func Setup(args []string, tempDir string) (*Result, error) {
 		return nil, err
 	}
 
-	// Run plugin pre-bazel hooks
-	bazelArgs, err = parser.CanonicalizeArgs(bazelArgs)
-	if err != nil {
-		return nil, err
-	}
+	// Run plugin pre-bazel hooks.
 	for _, p := range plugins {
 		bazelArgs, execArgs, err = p.PreBazel(bazelArgs, execArgs)
 		if err != nil {
@@ -77,15 +73,15 @@ func Setup(args []string, tempDir string) (*Result, error) {
 	}
 
 	// Save the original BES backend value before it is rewritten by the sidecar.
-	originalBESBackend, err := parser.GetBazelCommandOptionVal(parsedArgs, "bes_backend")
-	if err != nil {
-		return nil, err
-	}
+	originalBESBackend := bazelArgs.Get("bes_backend")
 
 	// Note: sidecar is configured after pre-bazel plugins, since pre-bazel
 	// plugins may change the value of bes_backend, remote_cache,
 	// remote_instance_name, etc.
-	bazelArgs, sidecarInstance := sidecar.ConfigureSidecar(bazelArgs)
+	sidecarInstance, err := sidecar.ConfigureSidecar(bazelArgs)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Result{
 		Plugins:            plugins,

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -310,7 +310,9 @@ func ConfigureSidecar(args *arg.BazelArgs) (*Instance, error) {
 	if synchronousWriteFlag == "1" || synchronousWriteFlag == "true" {
 		sidecarArgs = append(sidecarArgs, "--local_cache_proxy.synchronous_write")
 		sidecarArgs = append(sidecarArgs, "--bes_synchronous")
-		args.Append("--bes_upload_mode=wait_for_upload_complete")
+		if err := args.Append("--bes_upload_mode=wait_for_upload_complete"); err != nil {
+			return nil, err
+		}
 	}
 
 	sidecarArgs = append(sidecarArgs, []string{
@@ -351,14 +353,20 @@ func ConfigureSidecar(args *arg.BazelArgs) (*Instance, error) {
 			continue
 		}
 		if sidecarBESEnabled {
-			args.Append(fmt.Sprintf("--bes_backend=unix://%s", instance.SockPath))
+			if err := args.Append(fmt.Sprintf("--bes_backend=unix://%s", instance.SockPath)); err != nil {
+				return nil, err
+			}
 		}
 		if sidecarCacheEnabled {
-			args.Append(fmt.Sprintf("--remote_cache=unix://%s", instance.SockPath))
+			if err := args.Append(fmt.Sprintf("--remote_cache=unix://%s", instance.SockPath)); err != nil {
+				return nil, err
+			}
 			// Set bytestream URI prefix to match the actual remote cache
 			// backend, rather than the sidecar socket.
 			instanceName := args.Get("remote_instance_name")
-			args.Append(fmt.Sprintf("--remote_bytestream_uri_prefix=%s", bytestreamURIPrefix(remoteCacheFlag, instanceName)))
+			if err := args.Append(fmt.Sprintf("--remote_bytestream_uri_prefix=%s", bytestreamURIPrefix(remoteCacheFlag, instanceName))); err != nil {
+				return nil, err
+			}
 		}
 		return instance, nil
 	}

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -175,11 +176,11 @@ func isFlagTrue(flag string) bool {
 	return false
 }
 
-func isCI(args []string) bool {
+func isCI(args *arg.BazelArgs) bool {
 	if isFlagTrue(os.Getenv("CI")) {
 		return true
 	}
-	for _, md := range arg.GetMulti(args, "build_metadata") {
+	for _, md := range args.GetAllFlagsWithName("build_metadata") {
 		if md == "ROLE=CI" {
 			return true
 		}
@@ -241,22 +242,14 @@ func parseLogTimestamp(line string) (time.Time, bool) {
 	return t, true
 }
 
-func ConfigureSidecar(args []string) ([]string, *Instance) {
+func ConfigureSidecar(args *arg.BazelArgs) (*Instance, error) {
 	// Allow an escape hatch to disable all sidecar features.
 	if os.Getenv("BB_DISABLE_SIDECAR") == "1" || os.Getenv("BB_DISABLE_SIDECAR") == "true" {
-		return args, nil
+		return nil, nil
 	}
 
-	originalArgs := args
-
-	if isCI(args) {
-		log.Debugf("CI build detected.")
-		syncFlag := arg.Get(args, "sync")
-		if !isFlagTrue(syncFlag) {
-			log.Debugf("CI build detected. add --sync=true")
-			args = arg.Append(args, "--sync=true")
-		}
-	}
+	// TODO(#7216): Use the forwarded args here.
+	originalArgs := slices.Clone(args.Resolved)
 
 	log.Debugf("Configuring sidecar")
 
@@ -265,26 +258,33 @@ func ConfigureSidecar(args []string) ([]string, *Instance) {
 	cacheDir, err := storage.CacheDir()
 	if err != nil {
 		log.Warnf("Sidecar could not be initialized, continuing without sidecar: %s", err)
-		return args, nil
+		return nil, nil
 	}
 
 	// Re(Start) the sidecar if the flags set don't match.
 	sidecarArgs := []string{}
-	besBackendFlag := arg.Get(args, "bes_backend")
-	remoteCacheFlag := arg.Get(args, "remote_cache")
-	remoteExecFlag := arg.Get(args, "remote_executor")
-	synchronousWriteFlag, args := arg.Pop(args, "sync")
+	besBackendFlag := args.Get("bes_backend")
+	remoteCacheFlag := args.Get("remote_cache")
+	remoteExecFlag := args.Get("remote_executor")
+	synchronousWriteFlag, err := args.Pop("sync")
+	if err != nil {
+		return nil, err
+	}
+	if !isFlagTrue(synchronousWriteFlag) && isCI(args) {
+		log.Debugf("CI build detected, enabling sync.")
+		synchronousWriteFlag = "true"
+	}
 
 	// Read config YAML.
 	ws, err := workspace.Path()
 	if err != nil {
 		// Not in a bazel workspace
-		return args, nil
+		return nil, nil
 	}
 	cf, err := config.LoadFile(filepath.Join(ws, config.WorkspaceRelativeConfigPath))
 	if err != nil {
 		log.Warnf("Failed to load buildbuddy.yaml: %s", err)
-		return args, nil
+		return nil, nil
 	}
 
 	sidecarBESEnabled := false
@@ -304,13 +304,13 @@ func ConfigureSidecar(args []string) ([]string, *Instance) {
 
 	if !sidecarBESEnabled && !sidecarCacheEnabled {
 		// Sidecar is not needed for this invocation; don't start it.
-		return args, nil
+		return nil, nil
 	}
 
 	if synchronousWriteFlag == "1" || synchronousWriteFlag == "true" {
 		sidecarArgs = append(sidecarArgs, "--local_cache_proxy.synchronous_write")
 		sidecarArgs = append(sidecarArgs, "--bes_synchronous")
-		args = arg.Append(args, "--bes_upload_mode=wait_for_upload_complete")
+		args.Append("--bes_upload_mode=wait_for_upload_complete")
 	}
 
 	sidecarArgs = append(sidecarArgs, []string{
@@ -334,7 +334,10 @@ func ConfigureSidecar(args []string) ([]string, *Instance) {
 		instance, err := restartSidecarIfNecessary(ctx, cacheDir, sidecarArgs)
 		if err != nil {
 			log.Warnf("Sidecar could not be initialized, continuing without sidecar: %s", err)
-			return originalArgs, nil
+			if err := args.Set(originalArgs); err != nil {
+				return nil, err
+			}
+			return nil, nil
 		}
 		if err := keepaliveSidecar(ctx, instance.SockPath); err != nil {
 			// If we fail to connect, the sidecar might have been abruptly
@@ -348,19 +351,22 @@ func ConfigureSidecar(args []string) ([]string, *Instance) {
 			continue
 		}
 		if sidecarBESEnabled {
-			args = arg.Append(args, fmt.Sprintf("--bes_backend=unix://%s", instance.SockPath))
+			args.Append(fmt.Sprintf("--bes_backend=unix://%s", instance.SockPath))
 		}
 		if sidecarCacheEnabled {
-			args = arg.Append(args, fmt.Sprintf("--remote_cache=unix://%s", instance.SockPath))
+			args.Append(fmt.Sprintf("--remote_cache=unix://%s", instance.SockPath))
 			// Set bytestream URI prefix to match the actual remote cache
 			// backend, rather than the sidecar socket.
-			instanceName := arg.Get(args, "remote_instance_name")
-			args = arg.Append(args, fmt.Sprintf("--remote_bytestream_uri_prefix=%s", bytestreamURIPrefix(remoteCacheFlag, instanceName)))
+			instanceName := args.Get("remote_instance_name")
+			args.Append(fmt.Sprintf("--remote_bytestream_uri_prefix=%s", bytestreamURIPrefix(remoteCacheFlag, instanceName)))
 		}
-		return args, instance
+		return instance, nil
 	}
 	log.Warnf("Could not connect to sidecar, continuing without sidecar: %s", connectionErr)
-	return originalArgs, nil
+	if err := args.Set(originalArgs); err != nil {
+		return nil, err
+	}
+	return nil, nil
 }
 
 func bytestreamURIPrefix(cacheTarget, instanceName string) string {

--- a/cli/stream_run_logs/BUILD
+++ b/cli/stream_run_logs/BUILD
@@ -11,9 +11,8 @@ go_library(
     srcs = ["stream_run_logs.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/stream_run_logs",
     deps = [
+        "//cli/arg",
         "//cli/log",
-        "//cli/parser",
-        "//cli/parser/parsed",
         "//cli/stream_run_logs/option_definitions",
         "//cli/terminal",
         "//proto:buildbuddy_service_go_proto",

--- a/cli/stream_run_logs/stream_run_logs.go
+++ b/cli/stream_run_logs/stream_run_logs.go
@@ -11,9 +11,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser"
-	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
 	"github.com/buildbuddy-io/buildbuddy/cli/stream_run_logs/option_definitions"
 	"github.com/buildbuddy-io/buildbuddy/cli/terminal"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -58,30 +57,25 @@ type Opts struct {
 }
 
 // If streaming run logs is requested with --stream_run_logs, parse required args.
-func Configure(args []string, besBackend string) ([]string, *Opts, error) {
-	parsedArgs, err := parser.ParseArgs(args)
+func Configure(args *arg.BazelArgs, besBackend string) (*arg.BazelArgs, *Opts, error) {
+	enabled, onFailure, err := parseFlags(args)
 	if err != nil {
-		return args, nil, status.WrapErrorf(err, "failed to parse args")
-	}
-
-	enabled, onFailure, err := parseFlags(parsedArgs)
-	if err != nil {
-		return parsedArgs.Format(), nil, err
+		return args, nil, err
 	} else if !enabled {
-		return parsedArgs.Format(), nil, nil
+		return args, nil, nil
 	}
 
 	// If output is being written to a pipe or file, it likely doesn't need to be streamed to the server and displayed in the UI.
 	// TODO: Handle the case where one of either stderr or stdout is connected to a terminal and the other is not.
 	if !terminal.IsTTY(os.Stdout) || !terminal.IsTTY(os.Stderr) {
-		return parsedArgs.Format(), nil, handleErr("streaming run logs is only supported when both stdout and stderr are connected to a terminal", onFailure)
+		return args, nil, handleErr("streaming run logs is only supported when both stdout and stderr are connected to a terminal", onFailure)
 	}
 
-	apiKey := parser.GetRemoteHeaderVal(parsedArgs, "x-buildbuddy-api-key")
+	apiKey := args.GetRemoteHeaderVal("x-buildbuddy-api-key")
 	if apiKey == "" {
 		log.Warnf("To stream run logs, authenticate your request with `bb login` or add an API key to your run with " +
 			"`--remote_header=x-buildbuddy-api-key=XXX`")
-		return parsedArgs.Format(), nil, handleErr("unauthenticated request", onFailure)
+		return args, nil, handleErr("unauthenticated request", onFailure)
 	}
 
 	if besBackend == "" {
@@ -90,23 +84,19 @@ func Configure(args []string, besBackend string) ([]string, *Opts, error) {
 
 	// In order to stream run logs to the same invocation URL as the build, we must pre-generate the
 	// invocation ID to pass it to `Execute`.
-	iid, _ := parser.GetBazelCommandOptionVal(parsedArgs, "invocation_id")
+	iid := args.Get("invocation_id")
 	if iid == "" {
 		invocationUUID, err := guuid.NewRandom()
 		if err != nil {
-			return parsedArgs.Format(), nil, handleErr(fmt.Sprintf("failed to generate invocation ID: %s", err), onFailure)
+			return args, nil, handleErr(fmt.Sprintf("failed to generate invocation ID: %s", err), onFailure)
 		}
 		iid = invocationUUID.String()
-		opt, err := parser.MakeCommandOption("invocation_id", &iid)
-		if err != nil {
-			return parsedArgs.Format(), nil, handleErr(fmt.Sprintf("failed to make invocation ID option: %s", err), onFailure)
+		if err := args.Append("--invocation_id=" + iid); err != nil {
+			return args, nil, handleErr(fmt.Sprintf("failed to append invocation ID: %s", err), onFailure)
 		}
-		parsedArgs.Append(opt)
 	}
 
-	updatedArgs := parsedArgs.Format()
-
-	return updatedArgs, &Opts{
+	return args, &Opts{
 		BesBackend:   besBackend,
 		InvocationID: iid,
 		ApiKey:       apiKey,
@@ -114,14 +104,14 @@ func Configure(args []string, besBackend string) ([]string, *Opts, error) {
 	}, nil
 }
 
-func parseFlags(parsedArgs *parsed.OrderedArgs) (enabled bool, onFailure FailureMode, err error) {
-	enabled, err = parser.IsCLICommandOptionSet(parsedArgs, option_definitions.StreamRunLogs.Name())
+func parseFlags(args *arg.BazelArgs) (enabled bool, onFailure FailureMode, err error) {
+	enabled, err = args.StripBBBoolFlag(option_definitions.StreamRunLogs.Name())
 	if err != nil {
 		return false, "", err
 	}
 
 	onFailure = FailureModeFail
-	onFailureVal, err := parser.GetCLICommandOptionVal(parsedArgs, option_definitions.OnStreamRunLogsFailure.Name())
+	onFailureVal, err := args.StripBBFlag(option_definitions.OnStreamRunLogsFailure.Name())
 	if err != nil {
 		return false, "", err
 	} else if !isValidFailureMode(onFailureVal) {

--- a/cli/tooltag/tooltag.go
+++ b/cli/tooltag/tooltag.go
@@ -8,15 +8,17 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/version"
 )
 
-func ConfigureToolTag(args []string) []string {
+func ConfigureToolTag(args *arg.BazelArgs) error {
 	log.Debugf("BuildBuddy CLI version %s invoked as %s", version.String(), os.Args[0])
 
 	v := "development"
 	if version.String() != "" {
 		v = version.String()
 	}
-	if arg.GetCommand(args) != "" && !arg.Has(args, "tool_tag") {
-		return arg.Append(args, "--tool_tag=buildbuddy-cli-"+v)
+	if args.GetCommand() != "" && !args.Has("tool_tag") {
+		if err := args.Append("--tool_tag=buildbuddy-cli-" + v); err != nil {
+			return err
+		}
 	}
-	return args
+	return nil
 }

--- a/cli/versioncmd/versioncmd.go
+++ b/cli/versioncmd/versioncmd.go
@@ -44,7 +44,8 @@ func runBazelVersion(args []string) (int, error) {
 	}
 
 	outputPath := filepath.Join(tempDir, "bazel.log")
+	// TODO(#7216): Use the forwarded args here.
 	return plugin.RunBazeliskWithPlugins(
-		arg.JoinExecutableArgs(setupResult.BazelArgs, setupResult.ExecArgs),
+		arg.JoinExecutableArgs(setupResult.BazelArgs.Resolved, setupResult.ExecArgs),
 		outputPath, setupResult.Plugins)
 }

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -117,18 +117,36 @@ path/to/plugin/
 
 The `pre_bazel.sh` script will be called before Bazel is run.
 
-It is called with a single argument, which is the path to a file
-containing all arguments that will be passed to Bazel (including the
-arguments specified in your `.bazelrc` and expanded via any `--config=`
-flags). **Each line in this file contains a single argument.**
+It is called with a single argument, which is the path to a file containing the
+arguments that will be passed to Bazel (i.e. the forwarded args). Your plugin can modify this
+file to add, remove, or change flags that will ultimately be passed to Bazel.
+**Each line in this file contains a single argument.**
+
+In this file, `--config` flags are not expanded, and flags imported from `.bazelrc` files are not included.
+These are the raw args that will be passed to Bazel.
+
+The CLI also exposes a second args file via the `RESOLVED_BAZEL_ARGS_FILE`
+environment variable. This file contains the resolved view of the Bazel args.
+Flags imported from `.bazelrc` files are explicitly included, and `--config` flags are expanded.
+This file is read-only. It's useful if a plugin needs to read an expanded flag. However
+changes to it are ignored. If you'd like to modify the args, modify the forwarded args file instead.
 
 The script will be called like this:
 
 ```bash
-/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/bazel-args
+/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/forwarded-bazel-args
 ```
 
-Here's an example of what the Bazel args file might look like:
+Here's an example of what the forwarded Bazel args file might look like:
+
+```bash
+run
+//server
+--config=remote
+```
+
+Here's an example of what the resolved Bazel args file might look like (--config=remote
+was expanded to BuildBuddy remote cache flags):
 
 ```bash
 --ignore_all_rc_files
@@ -136,37 +154,24 @@ run
 //server
 --bes_results_url=https://app.buildbuddy.io/invocation/
 --bes_backend=grpcs://remote.buildbuddy.io
---noremote_upload_local_results
---workspace_status_command=$(pwd)/workspace_status.sh
---incompatible_remote_build_event_upload_respect_no_cache
---experimental_remote_cache_async
---incompatible_strict_action_env
---enable_runfiles=1
---build_tag_filters=-docker
---bes_results_url=https://app.buildbuddy.io/invocation/
---bes_backend=grpcs://remote.buildbuddy.io
 --remote_cache=grpcs://remote.buildbuddy.io
 --remote_upload_local_results
---experimental_remote_cache_compression
---noremote_upload_local_results
---noincompatible_remote_build_event_upload_respect_no_cache
 ```
-
-Your plugin can modify this file to add, remove, or change that flags that will ultimately be passed to Bazel.
 
 Your `pre_bazel.sh` script can also accept user input, spawn other processes, or anything else you'd like.
 
 Here's an example of a simple `pre_bazel.sh` plugin that disables remote execution if it's unable to ping `remote.buildbuddy.io` within 500ms.
 
 ```bash title="pre_bazel.sh"
-if ! grep -E '^--remote_executor=.*\.buildbuddy\.io$' "$1" &>/dev/null; then
+if ! grep -E '^--remote_executor=.*\.buildbuddy\.io$' "$RESOLVED_BAZEL_ARGS_FILE" &>/dev/null; then
   # BB remote execution is not enabled; do nothing.
   exit 0
 fi
 
 # Make sure we can ping the remote execution service in 500ms.
 if ! timeout 0.5 ping -c 1 remote.buildbuddy.io &>/dev/null; then
-  # Network is spotty; disable remote execution.
+  # Network is spotty; disable remote execution by appending to the forwarded
+  # args file.
   echo "--remote_executor=" >>"$1"
 fi
 ```
@@ -354,7 +359,7 @@ following a `--` in the argument list passed to bazel, if any.
 
 This environment variable will only be set for the `pre_bazel.sh` script in the
 plugin. Plugins can change this file to change the arguments
-passed to Bazel.
+passed to the executable produced by `bazel run`.
 
 The file in question is formatted very similarly to the bazel args file, except
 that the arguments will be split across lines based solely as a result of shell
@@ -371,6 +376,20 @@ positional_arg
 positional_arg3
 --option4
 ```
+
+#### $RESOLVED_BAZEL_ARGS_FILE
+
+This is the path of a file that contains the resolved Bazel args for the current
+invocation. This includes args loaded from `.bazelrc` files and args expanded
+from any `--config=` flags. The file uses the same one-argument-per-line format
+as the forwarded Bazel args file passed as the first argument to
+`pre_bazel.sh`.
+
+This environment variable will only be set for the `pre_bazel.sh` script in the
+plugin. Plugins can read this file to make decisions based on the effective
+Bazel configuration, but should not modify it. Changes to this file are ignored.
+To change the args passed to Bazel, modify the forwarded Bazel args file passed
+as `$1`.
 
 ### Examples
 

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -117,36 +117,18 @@ path/to/plugin/
 
 The `pre_bazel.sh` script will be called before Bazel is run.
 
-It is called with a single argument, which is the path to a file containing the
-arguments that will be passed to Bazel (i.e. the forwarded args). Your plugin can modify this
-file to add, remove, or change flags that will ultimately be passed to Bazel.
-**Each line in this file contains a single argument.**
-
-In this file, `--config` flags are not expanded, and flags imported from `.bazelrc` files are not included.
-These are the raw args that will be passed to Bazel.
-
-The CLI also exposes a second args file via the `RESOLVED_BAZEL_ARGS_FILE`
-environment variable. This file contains the resolved view of the Bazel args.
-Flags imported from `.bazelrc` files are explicitly included, and `--config` flags are expanded.
-This file is read-only. It's useful if a plugin needs to read an expanded flag. However
-changes to it are ignored. If you'd like to modify the args, modify the forwarded args file instead.
+It is called with a single argument, which is the path to a file
+containing all arguments that will be passed to Bazel (including the
+arguments specified in your `.bazelrc` and expanded via any `--config=`
+flags). **Each line in this file contains a single argument.**
 
 The script will be called like this:
 
 ```bash
-/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/forwarded-bazel-args
+/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/bazel-args
 ```
 
-Here's an example of what the forwarded Bazel args file might look like:
-
-```bash
-run
-//server
---config=remote
-```
-
-Here's an example of what the resolved Bazel args file might look like (--config=remote
-was expanded to BuildBuddy remote cache flags):
+Here's an example of what the Bazel args file might look like:
 
 ```bash
 --ignore_all_rc_files
@@ -154,24 +136,37 @@ run
 //server
 --bes_results_url=https://app.buildbuddy.io/invocation/
 --bes_backend=grpcs://remote.buildbuddy.io
+--noremote_upload_local_results
+--workspace_status_command=$(pwd)/workspace_status.sh
+--incompatible_remote_build_event_upload_respect_no_cache
+--experimental_remote_cache_async
+--incompatible_strict_action_env
+--enable_runfiles=1
+--build_tag_filters=-docker
+--bes_results_url=https://app.buildbuddy.io/invocation/
+--bes_backend=grpcs://remote.buildbuddy.io
 --remote_cache=grpcs://remote.buildbuddy.io
 --remote_upload_local_results
+--experimental_remote_cache_compression
+--noremote_upload_local_results
+--noincompatible_remote_build_event_upload_respect_no_cache
 ```
+
+Your plugin can modify this file to add, remove, or change that flags that will ultimately be passed to Bazel.
 
 Your `pre_bazel.sh` script can also accept user input, spawn other processes, or anything else you'd like.
 
 Here's an example of a simple `pre_bazel.sh` plugin that disables remote execution if it's unable to ping `remote.buildbuddy.io` within 500ms.
 
 ```bash title="pre_bazel.sh"
-if ! grep -E '^--remote_executor=.*\.buildbuddy\.io$' "$RESOLVED_BAZEL_ARGS_FILE" &>/dev/null; then
+if ! grep -E '^--remote_executor=.*\.buildbuddy\.io$' "$1" &>/dev/null; then
   # BB remote execution is not enabled; do nothing.
   exit 0
 fi
 
 # Make sure we can ping the remote execution service in 500ms.
 if ! timeout 0.5 ping -c 1 remote.buildbuddy.io &>/dev/null; then
-  # Network is spotty; disable remote execution by appending to the forwarded
-  # args file.
+  # Network is spotty; disable remote execution.
   echo "--remote_executor=" >>"$1"
 fi
 ```
@@ -359,7 +354,7 @@ following a `--` in the argument list passed to bazel, if any.
 
 This environment variable will only be set for the `pre_bazel.sh` script in the
 plugin. Plugins can change this file to change the arguments
-passed to the executable produced by `bazel run`.
+passed to Bazel.
 
 The file in question is formatted very similarly to the bazel args file, except
 that the arguments will be split across lines based solely as a result of shell
@@ -376,20 +371,6 @@ positional_arg
 positional_arg3
 --option4
 ```
-
-#### $RESOLVED_BAZEL_ARGS_FILE
-
-This is the path of a file that contains the resolved Bazel args for the current
-invocation. This includes args loaded from `.bazelrc` files and args expanded
-from any `--config=` flags. The file uses the same one-argument-per-line format
-as the forwarded Bazel args file passed as the first argument to
-`pre_bazel.sh`.
-
-This environment variable will only be set for the `pre_bazel.sh` script in the
-plugin. Plugins can read this file to make decisions based on the effective
-Bazel configuration, but should not modify it. Changes to this file are ignored.
-To change the args passed to Bazel, modify the forwarded Bazel args file passed
-as `$1`.
 
 ### Examples
 


### PR DESCRIPTION
To prepare for [this](https://github.com/buildbuddy-io/buildbuddy-internal/issues/7216), use a BazelArgs wrapper in the CLI. In the next step, I'll add a 'Forwarded' args field that represents the non-expanded args we'll forward to Bazel. When we modify the args, we need to make sure to modify both the Forwarded and Resolved args using the helper functions on the struct

This PR shouldn't have any behavioral changes

Once we complete the refactor though, the one non-backwards compatible change will affect plugins. Currently, plugins can read the expanded args from a file and write back to that same file. Moving forward, we will have two files: a read-only file that contains the expanded args, and a writable file that contains non-expanded args. We can't let users modify the resolved args, because Bazelisk will be reading those values from .bazelrc files that we can't change