### PR TITLE
Shard the pebble temp dir to reduce directory inode contention

### DIFF
--- a/enterprise/server/filestore/filestore.go
+++ b/enterprise/server/filestore/filestore.go
@@ -796,7 +796,10 @@ func (fs *fileStorer) FileWriter(ctx context.Context, fileDir string, fileRecord
 	fileName := filepath.Join(fileDir, file)
 	tmpDir := fileDir
 	if fs.tmpDir != "" {
-		tmpDir = fs.tmpDir
+		tmpDir = filepath.Join(fs.tmpDir, fileRecord.GetDigest().GetHash()[:2])
+		if err := disk.EnsureDirectoryExists(tmpDir); err != nil {
+			return nil, err
+		}
 	}
 	wc, err := disk.FileWriterWithTmpDir(ctx, tmpDir, fileName)
 	if err != nil {


### PR DESCRIPTION
When writing to a file during a pebble operation, we open a temp file, write to it, and then rename it to the final path.

open and rename both require exclusive locks on the directory inode. Sometimes we have thousands of concurrent writes, so they contend for this lock. Sharding the temp directory 256 ways should help with the contention.