### PR TITLE
SCIM: ignore user list memberships in user APIs

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -924,7 +924,7 @@ func (s *APIServer) CreateUserApiKey(ctx context.Context, req *apipb.CreateUserA
 	}
 
 	// Get user's role-based capabilities within the group.
-	reqUser, err := userdb.GetUserByIDWithoutAuthCheck(ctx, req.GetUserId())
+	reqUser, err := userdb.GetUserByIDWithoutAuthCheck(ctx, req.GetUserId(), &interfaces.GetUserOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/auditlog/auditlog.go
+++ b/enterprise/server/auditlog/auditlog.go
@@ -296,7 +296,7 @@ func (l *Logger) fillIDDescriptors(ctx context.Context, e *alpb.Entry_Request) e
 	}
 
 	for uid := range userIDs {
-		userData, err := l.env.GetUserDB().GetUserByID(ctx, uid)
+		userData, err := l.env.GetUserDB().GetUserByID(ctx, uid, &interfaces.GetUserOpts{})
 		if err != nil {
 			return err
 		}

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -960,7 +960,7 @@ func (d *AuthDB) CreateUserAPIKey(ctx context.Context, groupID, userID, label st
 }
 
 func (d *AuthDB) isGroupMember(ctx context.Context, groupID, userID string) (bool, error) {
-	u, err := d.env.GetUserDB().GetUserByIDWithoutAuthCheck(ctx, userID)
+	u, err := d.env.GetUserDB().GetUserByIDWithoutAuthCheck(ctx, userID, &interfaces.GetUserOpts{})
 	if err != nil {
 		return false, err
 	}

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -500,7 +500,7 @@ func (d *UserDB) addUserToGroup(ctx context.Context, tx interfaces.DB, userID, g
 		r = role.Admin
 	}
 
-	_, err = d.getUserByUserID(ctx, tx, userID)
+	_, err = d.getUserByUserID(ctx, tx, userID, &interfaces.GetUserOpts{})
 	if err != nil {
 		if status.IsNotFoundError(err) {
 			return status.NotFoundErrorf("user %q does not exist", userID)
@@ -558,7 +558,7 @@ func (d *UserDB) RequestToJoinGroup(ctx context.Context, groupID string) (grpb.G
 	}
 	var membershipStatus grpb.GroupMembershipStatus
 	err = d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		tu, err := d.getUserByUserID(ctx, tx, u.GetUserID())
+		tu, err := d.getUserByUserID(ctx, tx, u.GetUserID(), &interfaces.GetUserOpts{})
 		if err != nil {
 			return err
 		}
@@ -994,8 +994,8 @@ func (d *UserDB) InsertUser(ctx context.Context, u *tables.User) error {
 	})
 }
 
-func (d *UserDB) GetUserByID(ctx context.Context, id string) (*tables.User, error) {
-	user, err := d.getUserByUserID(ctx, d.h, id)
+func (d *UserDB) GetUserByID(ctx context.Context, id string, opts *interfaces.GetUserOpts) (*tables.User, error) {
+	user, err := d.getUserByUserID(ctx, d.h, id, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -1012,15 +1012,15 @@ func (d *UserDB) GetUserByID(ctx context.Context, id string) (*tables.User, erro
 	return nil, errUserNotFound
 }
 
-func (d *UserDB) GetUserByIDWithoutAuthCheck(ctx context.Context, id string) (*tables.User, error) {
-	return d.getUserByUserID(ctx, d.h, id)
+func (d *UserDB) GetUserByIDWithoutAuthCheck(ctx context.Context, id string, opts *interfaces.GetUserOpts) (*tables.User, error) {
+	return d.getUserByUserID(ctx, d.h, id, opts)
 }
 
-func (d *UserDB) GetUserBySubIDWithoutAuthCheck(ctx context.Context, subID string) (*tables.User, error) {
+func (d *UserDB) GetUserBySubIDWithoutAuthCheck(ctx context.Context, subID string, opts *interfaces.GetUserOpts) (*tables.User, error) {
 	if subID == "" {
 		return nil, status.FailedPreconditionErrorf("subID not specified")
 	}
-	return d.getUserByID(ctx, d.h, &getUserOpts{subID: subID})
+	return d.getUserByID(ctx, d.h, &getUserOpts{subID: subID, directMembershipsOnly: opts.DirectMembershipsOnly})
 }
 
 // processUserGroupMemberships updates the groupRoles map using the results
@@ -1087,14 +1087,15 @@ func (d *UserDB) GetUser(ctx context.Context) (*tables.User, error) {
 	if u.GetUserID() == "" {
 		return nil, errUserNotFound
 	}
-	return d.getUserByUserID(ctx, d.h, u.GetUserID())
+	return d.getUserByUserID(ctx, d.h, u.GetUserID(), &interfaces.GetUserOpts{})
 }
 
 // getUserOpts specifies query criteria.
-// Only one field must be set.
+// Exactly one of userID or subID must be set.
 type getUserOpts struct {
-	userID string
-	subID  string
+	userID                string
+	subID                 string
+	directMembershipsOnly bool
 }
 
 func (d *UserDB) getUserByID(ctx context.Context, h interfaces.DB, opts *getUserOpts) (*tables.User, error) {
@@ -1133,7 +1134,7 @@ func (d *UserDB) getUserByID(ctx context.Context, h interfaces.DB, opts *getUser
 	}
 
 	// Query indirect membership via user lists, if enabled.
-	if authutil.UserListsEnabled() {
+	if authutil.UserListsEnabled() && !opts.directMembershipsOnly {
 		qb := query_builder.NewQuery(`
 			SELECT u.*, g.*, ug.*
 			FROM "Users" u
@@ -1173,8 +1174,8 @@ func (d *UserDB) getUserByID(ctx context.Context, h interfaces.DB, opts *getUser
 	return user, nil
 }
 
-func (d *UserDB) getUserByUserID(ctx context.Context, h interfaces.DB, userID string) (*tables.User, error) {
-	return d.getUserByID(ctx, h, &getUserOpts{userID: userID})
+func (d *UserDB) getUserByUserID(ctx context.Context, h interfaces.DB, userID string, opts *interfaces.GetUserOpts) (*tables.User, error) {
+	return d.getUserByID(ctx, h, &getUserOpts{userID: userID, directMembershipsOnly: opts.DirectMembershipsOnly})
 }
 
 func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) {
@@ -1214,7 +1215,7 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 
 func (d *UserDB) DeleteUser(ctx context.Context, userID string) error {
 	// Permission check.
-	_, err := d.GetUserByID(ctx, userID)
+	_, err := d.GetUserByID(ctx, userID, &interfaces.GetUserOpts{})
 	if err != nil {
 		return err
 	}
@@ -1245,7 +1246,7 @@ func (d *UserDB) DeleteUser(ctx context.Context, userID string) error {
 
 func (d *UserDB) UpdateUser(ctx context.Context, u *tables.User) error {
 	// Permission check.
-	_, err := d.GetUserByID(ctx, u.UserID)
+	_, err := d.GetUserByID(ctx, u.UserID, &interfaces.GetUserOpts{})
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -121,7 +121,7 @@ func getGroupRole(t *testing.T, ctx context.Context, env environment.Env, groupI
 }
 
 func getGroupRoleByUserID(t *testing.T, ctx context.Context, env environment.Env, userID string, groupID string) *tables.GroupRole {
-	tu, err := env.GetUserDB().GetUserByIDWithoutAuthCheck(ctx, userID)
+	tu, err := env.GetUserDB().GetUserByIDWithoutAuthCheck(ctx, userID, &interfaces.GetUserOpts{})
 	require.NoError(t, err)
 	for _, gr := range tu.Groups {
 		if gr.Group.GroupID == groupID {
@@ -935,6 +935,68 @@ func TestUpdateGroupUsers_UserLists(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, status.IsPermissionDeniedError(err))
 	}
+}
+
+func TestGetUserByID_DirectMembershipsOnly(t *testing.T) {
+	flags.Set(t, "app.create_group_per_user", true)
+	flags.Set(t, "app.no_default_user_group", true)
+	flags.Set(t, "auth.enable_user_lists", true)
+	env := newTestEnv(t)
+	udb := env.GetUserDB()
+	ctx := context.Background()
+
+	createUser(t, ctx, env, "US1", "org1.io")
+	ctx1 := authUserCtx(ctx, env, t, "US1")
+	us1Group := getGroup(t, ctx1, env).Group
+
+	// US1 is a direct admin of their own group. Also place US1 in a user list
+	// that is assigned to the same group with a different role, so the user
+	// has membership in the group via two paths.
+	ul := &tables.UserList{GroupID: us1Group.GroupID, Name: "list1"}
+	err := udb.CreateUserList(ctx1, ul)
+	require.NoError(t, err)
+	err = addUserToUserList(ctx1, udb, ul.UserListID, "US1")
+	require.NoError(t, err)
+	err = udb.UpdateGroupUsers(ctx1, us1Group.GroupID, []*grpb.UpdateGroupUsersRequest_Update{{
+		MembershipAction: grpb.UpdateGroupUsersRequest_Update_ADD,
+		UserListId:       ul.UserListID,
+		Role:             grpb.Group_DEVELOPER_ROLE,
+	}})
+	require.NoError(t, err)
+
+	// Without the option, indirect memberships are merged in and the role is
+	// nilled out as ambiguous.
+	u, err := udb.GetUserByIDWithoutAuthCheck(ctx, "US1", &interfaces.GetUserOpts{})
+	require.NoError(t, err)
+	gr := findGroupRole(u, us1Group.GroupID)
+	require.NotNil(t, gr)
+	require.Nil(t, gr.Role, "role should be nil when membership is ambiguous")
+
+	// With DirectMembershipsOnly, the user-list query is skipped and the
+	// direct admin role is preserved.
+	u, err = udb.GetUserByIDWithoutAuthCheck(ctx, "US1", &interfaces.GetUserOpts{DirectMembershipsOnly: true})
+	require.NoError(t, err)
+	gr = findGroupRole(u, us1Group.GroupID)
+	require.NotNil(t, gr)
+	require.NotNil(t, gr.Role)
+	require.Equal(t, uint32(role.Admin), *gr.Role)
+
+	// GetUserBySubIDWithoutAuthCheck supports the same option.
+	u, err = udb.GetUserBySubIDWithoutAuthCheck(ctx, u.SubID, &interfaces.GetUserOpts{DirectMembershipsOnly: true})
+	require.NoError(t, err)
+	gr = findGroupRole(u, us1Group.GroupID)
+	require.NotNil(t, gr)
+	require.NotNil(t, gr.Role)
+	require.Equal(t, uint32(role.Admin), *gr.Role)
+}
+
+func findGroupRole(u *tables.User, groupID string) *tables.GroupRole {
+	for _, g := range u.Groups {
+		if g.GroupID == groupID {
+			return g
+		}
+	}
+	return nil
 }
 
 func TestUpdateGroupUsers_Role(t *testing.T) {
@@ -2761,7 +2823,7 @@ func TestGetUserBySubID(t *testing.T) {
 	users := enterprise_testauth.CreateRandomGroups(t, env)
 	randUser := users[rand.Intn(len(users))]
 
-	u, err := udb.GetUserBySubIDWithoutAuthCheck(ctx, randUser.SubID)
+	u, err := udb.GetUserBySubIDWithoutAuthCheck(ctx, randUser.SubID, &interfaces.GetUserOpts{})
 	require.NoError(t, err)
 	require.Equal(t, randUser, u)
 
@@ -2785,17 +2847,17 @@ func TestGetUserBySubID(t *testing.T) {
 
 	sort.Slice(user.Groups, func(i, j int) bool { return user.Groups[i].GroupID < user.Groups[j].GroupID })
 
-	u, err = udb.GetUserBySubIDWithoutAuthCheck(ctx, user.SubID)
+	u, err = udb.GetUserBySubIDWithoutAuthCheck(ctx, user.SubID, &interfaces.GetUserOpts{})
 	require.NoError(t, err)
 	require.Equal(t, user, u)
 
 	// Using empty or invalid values should produce an error
-	u, err = udb.GetUserBySubIDWithoutAuthCheck(ctx, "")
+	u, err = udb.GetUserBySubIDWithoutAuthCheck(ctx, "", &interfaces.GetUserOpts{})
 	require.Nil(t, u)
 	require.Truef(
 		t, status.IsFailedPreconditionError(err),
 		"expected FailedPrecondition error; got: %v", err)
-	u, err = udb.GetUserBySubIDWithoutAuthCheck(ctx, "INVALID")
+	u, err = udb.GetUserBySubIDWithoutAuthCheck(ctx, "INVALID", &interfaces.GetUserOpts{})
 	require.Nil(t, u)
 	require.Truef(
 		t, status.IsNotFoundError(err),
@@ -3223,7 +3285,7 @@ func TestGetUserBySubIDNoGroup(t *testing.T) {
 
 	randUser := enterprise_testauth.CreateRandomUser(t, env, fmt.Sprintf("rand-%d.io", rand.Int63n(1e12)))
 
-	u, err := udb.GetUserBySubIDWithoutAuthCheck(ctx, randUser.SubID)
+	u, err := udb.GetUserBySubIDWithoutAuthCheck(ctx, randUser.SubID, &interfaces.GetUserOpts{})
 	require.NoError(t, err)
 	require.Equal(t, randUser, u)
 }

--- a/enterprise/server/scim/scim.go
+++ b/enterprise/server/scim/scim.go
@@ -343,7 +343,7 @@ func (s *SCIMServer) getFilteredUsers(ctx context.Context, g *tables.Group, filt
 	if err != nil {
 		return nil, err
 	}
-	u, err := s.env.GetUserDB().GetUserBySubIDWithoutAuthCheck(ctx, saml.SubIDForUserName(email, g))
+	u, err := s.env.GetUserDB().GetUserBySubIDWithoutAuthCheck(ctx, saml.SubIDForUserName(email, g), &interfaces.GetUserOpts{DirectMembershipsOnly: true})
 	if err != nil {
 		if status.IsNotFoundError(err) {
 			return nil, nil
@@ -455,7 +455,7 @@ func (s *SCIMServer) getUsers(ctx context.Context, r *http.Request, g *tables.Gr
 
 func (s *SCIMServer) getUser(ctx context.Context, r *http.Request, g *tables.Group) (interface{}, error) {
 	id := path.Base(r.URL.Path)
-	u, err := s.env.GetUserDB().GetUserByID(ctx, id)
+	u, err := s.env.GetUserDB().GetUserByID(ctx, id, &interfaces.GetUserOpts{DirectMembershipsOnly: true})
 	if err != nil {
 		return nil, err
 	}
@@ -535,7 +535,7 @@ func (s *SCIMServer) createUser(ctx context.Context, r *http.Request, g *tables.
 	// exist in our system. If we get a create request for such a user then
 	// we need to translate it to an update request.
 	updateExistingUser := false
-	user, err := s.env.GetUserDB().GetUserBySubIDWithoutAuthCheck(ctx, saml.SubIDForUserName(ur.UserName, g))
+	user, err := s.env.GetUserDB().GetUserBySubIDWithoutAuthCheck(ctx, saml.SubIDForUserName(ur.UserName, g), &interfaces.GetUserOpts{DirectMembershipsOnly: true})
 	if err != nil && !status.IsNotFoundError(err) {
 		return nil, err
 	}
@@ -615,7 +615,7 @@ func (s *SCIMServer) patchUser(ctx context.Context, r *http.Request, g *tables.G
 	}
 
 	id := path.Base(r.URL.Path)
-	u, err := s.env.GetUserDB().GetUserByID(ctx, id)
+	u, err := s.env.GetUserDB().GetUserByID(ctx, id, &interfaces.GetUserOpts{DirectMembershipsOnly: true})
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +733,7 @@ func (s *SCIMServer) updateUser(ctx context.Context, r *http.Request, g *tables.
 	}
 
 	id := path.Base(r.URL.Path)
-	u, err := s.env.GetUserDB().GetUserByID(ctx, id)
+	u, err := s.env.GetUserDB().GetUserByID(ctx, id, &interfaces.GetUserOpts{DirectMembershipsOnly: true})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/scim/scim_test.go
+++ b/enterprise/server/scim/scim_test.go
@@ -117,7 +117,7 @@ func verifyRole(t *testing.T, ur scim.UserResource, expectedRole string) {
 }
 
 func updateUserSubID(t *testing.T, ctx context.Context, udb interfaces.UserDB, userID string, g *tables.Group) {
-	u, err := udb.GetUserByID(ctx, userID)
+	u, err := udb.GetUserByID(ctx, userID, &interfaces.GetUserOpts{})
 	require.NoError(t, err)
 	u.SubID = saml.SubIDForUserName(u.Email, g)
 	err = udb.UpdateUser(ctx, u)
@@ -373,7 +373,7 @@ func TestCreateUser(t *testing.T) {
 		verifyRole(t, ur, role.Developer.String())
 		require.True(t, ur.Active)
 
-		u, err := udb.GetUserByID(userCtx, createdUser.ID)
+		u, err := udb.GetUserByID(userCtx, createdUser.ID, &interfaces.GetUserOpts{})
 		require.NoError(t, err)
 		require.Equal(t, "http://localhost:8080/saml/metadata?slug=gr100-slug/user500@org1.io", u.SubID)
 	}
@@ -479,7 +479,7 @@ func TestCreateUser(t *testing.T) {
 		verifyRole(t, ur, role.Developer.String())
 		require.True(t, ur.Active)
 
-		u, err := udb.GetUserByID(userCtx, createdUser.ID)
+		u, err := udb.GetUserByID(userCtx, createdUser.ID, &interfaces.GetUserOpts{})
 		require.NoError(t, err)
 		require.Equal(t, "http://localhost:8080/saml/metadata?slug=gr100-slug/user501@org1.io", u.SubID)
 	}
@@ -562,7 +562,7 @@ func TestDeleteUser(t *testing.T) {
 		err = json.Unmarshal(body, &updatedUser)
 		require.NoError(t, err)
 		require.False(t, updatedUser.Active)
-		_, err = udb.GetUserByID(userCtx, "US101")
+		_, err = udb.GetUserByID(userCtx, "US101", &interfaces.GetUserOpts{})
 		require.Error(t, err)
 		require.True(t, status.IsNotFoundError(err))
 	}
@@ -581,7 +581,7 @@ func TestDeleteUser(t *testing.T) {
 		err = json.Unmarshal(body, &updatedUser)
 		require.NoError(t, err)
 		require.False(t, updatedUser.Active)
-		_, err = udb.GetUserByID(userCtx, "US102")
+		_, err = udb.GetUserByID(userCtx, "US102", &interfaces.GetUserOpts{})
 		require.Error(t, err)
 		require.True(t, status.IsNotFoundError(err))
 	}
@@ -608,7 +608,7 @@ func TestDeleteUser(t *testing.T) {
 		err = json.Unmarshal(body, &updatedUser)
 		require.NoError(t, err)
 		require.False(t, updatedUser.Active)
-		_, err = udb.GetUserByID(userCtx, "US103")
+		_, err = udb.GetUserByID(userCtx, "US103", &interfaces.GetUserOpts{})
 		require.Error(t, err)
 		require.True(t, status.IsNotFoundError(err))
 	}
@@ -618,7 +618,7 @@ func TestDeleteUser(t *testing.T) {
 		code, body := tc.Delete(baseURL + "/scim/Users/US104")
 		require.Equal(tc.t, http.StatusNoContent, code, "body: %s", string(body))
 		require.NoError(t, err)
-		_, err = udb.GetUserByID(userCtx, "US104")
+		_, err = udb.GetUserByID(userCtx, "US104", &interfaces.GetUserOpts{})
 		require.Error(t, err)
 		require.True(t, status.IsNotFoundError(err))
 	}
@@ -701,7 +701,7 @@ func TestUpdateUser(t *testing.T) {
 	verifyRole(t, updatedUser, role.Developer.String())
 
 	// Verify that SubID was updated to reflect the new email.
-	u, err := udb.GetUserByID(userCtx, updatedUser.ID)
+	u, err := udb.GetUserByID(userCtx, updatedUser.ID, &interfaces.GetUserOpts{})
 	require.NoError(t, err)
 	require.Equal(t, "http://localhost:8080/saml/metadata?slug=gr100-slug/puttest@example.domain", u.SubID)
 
@@ -752,7 +752,7 @@ func TestUpdateUser(t *testing.T) {
 		verifyRole(t, updatedUser, role.Developer.String())
 
 		// Verify that SubID was updated to reflect the new email.
-		u, err = udb.GetUserByID(userCtx, updatedUser.ID)
+		u, err = udb.GetUserByID(userCtx, updatedUser.ID, &interfaces.GetUserOpts{})
 		require.NoError(t, err)
 		require.Equal(t, "http://localhost:8080/saml/metadata?slug=gr100-slug/somenewemail@example.domain", u.SubID)
 	}
@@ -809,7 +809,7 @@ func TestUpdateUser(t *testing.T) {
 		verifyRole(t, updatedUser, role.Developer.String())
 
 		// Verify that SubID was updated to reflect the new email.
-		u, err = udb.GetUserByID(userCtx, updatedUser.ID)
+		u, err = udb.GetUserByID(userCtx, updatedUser.ID, &interfaces.GetUserOpts{})
 		require.NoError(t, err)
 		require.Equal(t, "http://localhost:8080/saml/metadata?slug=gr100-slug/"+newEmail, u.SubID)
 	}

--- a/enterprise/server/testutil/enterprise_testauth/enterprise_testauth.go
+++ b/enterprise/server/testutil/enterprise_testauth/enterprise_testauth.go
@@ -127,7 +127,7 @@ func CreateRandomUser(t *testing.T, env environment.Env, domain string) *tables.
 	err := udb.InsertUser(ctx, tu)
 	require.NoError(t, err)
 	// Refresh user to pick up default group.
-	tu, err = udb.GetUserByIDWithoutAuthCheck(ctx, tu.UserID)
+	tu, err = udb.GetUserByIDWithoutAuthCheck(ctx, tu.UserID, &interfaces.GetUserOpts{})
 	require.NoError(t, err)
 	return tu
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -546,6 +546,13 @@ type GetGroupUsersOpts struct {
 	SubIDPrefix string
 }
 
+// GetUserOpts customizes user lookups.
+type GetUserOpts struct {
+	// DirectMembershipsOnly excludes group memberships derived from user
+	// lists, so the returned user's Groups reflect only direct memberships.
+	DirectMembershipsOnly bool
+}
+
 type UserDB interface {
 	// User API
 	InsertUser(ctx context.Context, u *tables.User) error
@@ -554,9 +561,9 @@ type UserDB interface {
 	// valid authenticator is present in the environment and will return
 	// a UserToken given the provided context.
 	GetUser(ctx context.Context) (*tables.User, error)
-	GetUserByID(ctx context.Context, id string) (*tables.User, error)
-	GetUserByIDWithoutAuthCheck(ctx context.Context, id string) (*tables.User, error)
-	GetUserBySubIDWithoutAuthCheck(ctx context.Context, subID string) (*tables.User, error)
+	GetUserByID(ctx context.Context, id string, opts *GetUserOpts) (*tables.User, error)
+	GetUserByIDWithoutAuthCheck(ctx context.Context, id string, opts *GetUserOpts) (*tables.User, error)
+	GetUserBySubIDWithoutAuthCheck(ctx context.Context, subID string, opts *GetUserOpts) (*tables.User, error)
 	UpdateUser(ctx context.Context, u *tables.User) error
 	// DeleteUser deletes a user and associated data.
 	DeleteUser(ctx context.Context, id string) error

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -331,7 +331,7 @@ func ClaimsFromSubID(ctx context.Context, env environment.Env, subID string) (*C
 	if userDB == nil {
 		return nil, status.FailedPreconditionError("UserDB not configured")
 	}
-	u, err := userDB.GetUserBySubIDWithoutAuthCheck(ctx, subID)
+	u, err := userDB.GetUserBySubIDWithoutAuthCheck(ctx, subID, &interfaces.GetUserOpts{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
User SCIM resources should only reflect direct membership information. 

We've seen some occurrences of "scim_nil_role" because as a defensive check we nil out the role if a user is a member in a group via multiple paths since the role is ambigious in that case.