### PR TITLE
Track total bytes of in-flight FileWriter temp files

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -4135,6 +4135,13 @@ var (
 		Help:      "Number of started, but not yet finished, FileWriter operations. This number includes operations that are blocked on the concurrency limiter.",
 	})
 
+	DiskFileWriterTmpFileBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "disk",
+		Name:      "file_writer_tmp_file_bytes",
+		Help:      "Total size, in bytes, of temporary files currently staging writes for in-progress FileWriter operations. Incremented as bytes are written to the temp file, and decremented when the temp file is committed to its final path or deleted.",
+	})
+
 	// ## Container image fetch metrics
 
 	ImageFetchDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -300,6 +300,11 @@ type writeMover struct {
 	// tmpDir is the directory where fallback named temp files are created
 	// (used by the anonymous Commit path on EEXIST).
 	tmpDir string
+	// tmpFileBytes is the number of bytes attributed to this writer's temp
+	// file in the DiskFileWriterTmpFileBytes gauge. Released back to the
+	// gauge when the temp file is committed to its final path or deleted.
+	tmpFileBytes   int64
+	metricReleased bool
 }
 
 func (w *writeMover) Write(p []byte) (int, error) {
@@ -308,7 +313,22 @@ func (w *writeMover) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	defer releaseQuota()
-	return w.File.Write(p)
+	n, err := w.File.Write(p)
+	if n > 0 {
+		w.tmpFileBytes += int64(n)
+		metrics.DiskFileWriterTmpFileBytes.Add(float64(n))
+	}
+	return n, err
+}
+
+func (w *writeMover) releaseTmpFileBytesMetric() {
+	if w.metricReleased {
+		return
+	}
+	w.metricReleased = true
+	if w.tmpFileBytes > 0 {
+		metrics.DiskFileWriterTmpFileBytes.Sub(float64(w.tmpFileBytes))
+	}
 }
 
 func (w *writeMover) Commit() error {
@@ -340,6 +360,7 @@ func (w *writeMover) Commit() error {
 				return err
 			}
 		}
+		w.releaseTmpFileBytesMetric()
 		if err := w.File.Close(); err != nil {
 			return err
 		}
@@ -351,7 +372,11 @@ func (w *writeMover) Commit() error {
 		return err
 	}
 	w.tmpFileIsClosed = true
-	return os.Rename(tmpName, w.finalPath)
+	if err := os.Rename(tmpName, w.finalPath); err != nil {
+		return err
+	}
+	w.releaseTmpFileBytesMetric()
+	return nil
 }
 
 func (w *writeMover) Close() error {
@@ -367,11 +392,14 @@ func (w *writeMover) Close() error {
 	if w.anonymous {
 		// O_TMPFILE inodes are reclaimed automatically when the last fd
 		// reference is closed; nothing else to do.
+		w.releaseTmpFileBytesMetric()
 		return nil
 	}
 	if err := RemoveIfExists(w.File.Name()); err != nil {
 		alert.CtxUnexpectedEvent(w.ctx, "failed_to_delete_tmp_file", "Failed to delete %s: %s", w.File.Name(), err)
+		return nil
 	}
+	w.releaseTmpFileBytesMetric()
 	return nil
 }
 


### PR DESCRIPTION
Adds a `bb_disk_file_writer_tmp_file_bytes` gauge that reflects the live total size of temporary files staging writes for in-progress `disk.FileWriter` operations. The writer adds the bytes it writes to the gauge and releases them when the temp file is either committed to its final path or cleaned up on Close, so the gauge stays correct across both the O_TMPFILE and named-temp fallback paths and across the success/cancel cases. This gives us visibility into how much disk space is currently held in staging temp files, which is useful now that O_TMPFILE means we no longer see them as named entries on the filesystem.