### PR TITLE
Fix flaky TestLRU by unbuffering the sample channel

### DIFF
--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -474,6 +474,12 @@ func TestLRU(t *testing.T) {
 	// Force the sampler to refresh its pebble iterator on
 	// every read so that samples have up-to-date atimes.
 	flags.Set(t, "cache.raft.samples_per_batch", 0)
+	// Make the sample channel unbuffered so it can't hold stale samples
+	// produced before atime updates from the test's Find() calls were
+	// applied to pebble. Without this, the eviction consumer reads stale
+	// samples whose Timestamp doesn't match the current pebble atime, and
+	// every Delete is rejected with "Atime mismatch".
+	flags.Set(t, "cache.raft.sample_buffer_size", 0)
 	flags.Set(t, "cache.raft.sample_pool_size", 10)
 	flags.Set(t, "cache.raft.eviction_batch_size", 1)
 	flags.Set(t, "cache.raft.local_size_update_period", 100*time.Millisecond)


### PR DESCRIPTION
## Summary
- The eviction sampler can produce up to 100 buffered samples (default `sample_buffer_size`) before the test's atime updates from `Find()` calls are applied to pebble. The eviction consumer then reads these stale samples, sends `Delete` requests with `MatchAtime` set to the old atime, and the replica rejects every one with `Atime mismatch`. Concurrent pebble compaction drops `EstimateDiskUsage` below the threshold, so `TestingWaitForGC` returns success even though zero items were actually evicted, and the post-restart `evictedCount > 0` assertion fails.
- Setting `sample_buffer_size=0` limits in-flight stale samples to at most one, so eviction converges. The previous fix (`samples_per_batch=0`) targeted iterator freshness but missed that the channel buffer itself was the staleness source.

Failure traced to invocations `b7a3f71e-3e1c-4620-ac36-720ac34f600e`, `7a0db5be-eb62-4551-b1be-17e921df73a6`, `3a488f18-177e-447f-a139-994ee9584416`, `e7748653-e713-441c-8976-3bcb15d8ef91`, `f11c2ea7-b47b-418f-ab2b-7a35f12622bd` — all show `Atime mismatch` errors with deltas of exactly 1,200,000,000us = the test's 4×5min fake-clock advances.

## Test plan
- [x] `bazel test //enterprise/server/raft/metadata:metadata_test --config=remote --runs_per_test=500 --test_filter=TestLRU` — 500/500 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)