### PR TITLE
Fail health check instead of erroring when initial JWT ES256 key fetch fails

### DIFF
--- a/enterprise/server/remoteauth/remoteauth.go
+++ b/enterprise/server/remoteauth/remoteauth.go
@@ -60,6 +60,7 @@ func Register(env *real_environment.RealEnv) error {
 		return err
 	}
 	env.SetAuthenticator(authenticator)
+	env.GetHealthChecker().AddHealthCheck("remote_auth_es256_keys", authenticator)
 	return nil
 }
 
@@ -88,9 +89,11 @@ func NewWithTarget(env environment.Env, conn grpc.ClientConnInterface) (*RemoteA
 		quit:   make(chan struct{}),
 	}
 
-	// Fetch the initial keys
+	// Try to fetch the initial keys. If this fails, the registered health
+	// check will keep the server unhealthy until the background refresher
+	// succeeds.
 	if err := provider.refreshES256PublicKeys(); err != nil {
-		return nil, status.WrapError(err, "Error fetching initial JWT ES256 keys")
+		log.Warningf("Error fetching initial JWT ES256 keys: %v", err)
 	}
 
 	claimsParser, err := claims.NewClaimsParser(provider.provide)
@@ -114,6 +117,10 @@ func NewWithTarget(env environment.Env, conn grpc.ClientConnInterface) (*RemoteA
 
 func (a *RemoteAuthenticator) Stop() {
 	a.keyProvider.stop()
+}
+
+func (a *RemoteAuthenticator) Check(ctx context.Context) error {
+	return a.keyProvider.check()
 }
 
 type keyProvider struct {
@@ -170,6 +177,15 @@ func (kp *keyProvider) refreshLoop(refreshInterval time.Duration) {
 			}
 		}
 	}
+}
+
+func (kp *keyProvider) check() error {
+	kp.mu.RLock()
+	defer kp.mu.RUnlock()
+	if kp.keys == nil {
+		return status.UnavailableError("ES256 public keys have not been fetched yet")
+	}
+	return nil
 }
 
 func (kp *keyProvider) refreshES256PublicKeys() error {

--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -471,6 +471,44 @@ func TestES256KeysBackgroundRefreshError(t *testing.T) {
 	require.Equal(t, "bar", user.GetUserID())
 }
 
+func TestES256KeysHealthCheck(t *testing.T) {
+	keyPair := testkeys.GenerateES256KeyPair(t)
+	flags.Set(t, "auth.jwt_es256_private_key", keyPair.PrivateKeyPEM)
+	require.NoError(t, claims.Init())
+
+	flags.Set(t, "auth.remote.key_refresh_interval", 10*time.Millisecond)
+
+	fakeAuth := &fakeAuthService{
+		nextErr: map[string]error{},
+		nextJwt: map[string]string{},
+	}
+	// Make the initial GetPublicKeys call fail.
+	fakeAuth.setPublicKeysErr(status.InternalError("server error"))
+
+	te := testenv.GetTestEnv(t)
+	grpcServer, runServer, lis := testenv.RegisterLocalGRPCServer(t, te)
+	authpb.RegisterAuthServiceServer(grpcServer, fakeAuth)
+	go runServer()
+	conn, err := testenv.LocalGRPCConn(t.Context(), lis)
+	require.NoError(t, err)
+
+	// Construction should succeed even though the initial key fetch fails.
+	authenticator, err := NewWithTarget(te, conn)
+	require.NoError(t, err)
+	t.Cleanup(authenticator.Stop)
+
+	// Health check should fail until keys are fetched.
+	require.Error(t, authenticator.Check(t.Context()))
+
+	// Restore working keys so the background refresher succeeds.
+	fakeAuth.setPublicKeys([]string{keyPair.PublicKeyPEM})
+
+	// Health check should eventually pass.
+	require.Eventually(t, func() bool {
+		return authenticator.Check(t.Context()) == nil
+	}, time.Second, 5*time.Millisecond)
+}
+
 func TestHS256ReauthResultIsCached(t *testing.T) {
 	keyPair := testkeys.GenerateES256KeyPair(t)
 	flags.Set(t, "auth.jwt_es256_private_key", keyPair.PrivateKeyPEM)


### PR DESCRIPTION
Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/4539