### PR TITLE
[WF] Add error handling for scheduled workflows

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -123,6 +123,14 @@ const (
 	// Given that dispatching a workflow is expected to be quick, this should be more than enough time,
 	// unless the original server goes down (e.g. if it was restarted in a rollout).
 	scheduledWorkflowLeaseDuration = 5 * time.Minute
+
+	// If a scheduled workflow fails, it will be retried up to this many times.
+	// If all retries fail, the current schedule is skipped until the next time the cron fires.
+	ScheduledWorkflowMaxRetries = 5
+
+	// Max number of times a scheduled workflow can exhaust all its retries.
+	// Aftwards, the scheduled workflow will be paused and requires manual re-enabling.
+	ScheduledWorkflowMaxConsecutiveFailures = 20
 )
 
 var (
@@ -1853,7 +1861,6 @@ func (ws *workflowService) RunScheduledWorkflows(ctx context.Context) error {
 		return status.InternalError("database or GitHub app service not available")
 	}
 
-	// TODO(Maggie): Add a max number of retries per task, to avoid hot looping on tasks that can't be scheduled.
 	for {
 		scheduled, err := ws.claimScheduledWorkflow(ctx)
 		if err != nil {
@@ -1865,9 +1872,8 @@ func (ws *workflowService) RunScheduledWorkflows(ctx context.Context) error {
 			break
 		}
 		if err := ws.dispatchScheduledWorkflow(ctx, scheduled); err != nil {
-			log.CtxErrorf(ctx, "Failed to dispatch scheduled workflow %s: %s", scheduled.ScheduleID, err)
-			if err := ws.unclaimScheduledWorkflow(ctx, scheduled.ScheduleID); err != nil {
-				log.CtxWarningf(ctx, "Failed to unclaim scheduled workflow %s: %s", scheduled.ScheduleID, err)
+			if err := ws.handleScheduledWorkflowFailure(ctx, scheduled, err); err != nil {
+				log.CtxWarningf(ctx, "Failed to handle scheduled workflow failure %s: %s", scheduled.ScheduleID, err)
 			}
 			continue
 		}
@@ -1886,8 +1892,9 @@ func (ws *workflowService) claimScheduledWorkflow(ctx context.Context) (*tables.
 			FROM "ScheduledRuns"
 			WHERE next_run_usec <= ?
 			  AND (lease_expires_usec = 0 OR lease_expires_usec <= ?)
+			  AND consecutive_schedule_failure_count < ?
 			ORDER BY next_run_usec ASC
-			LIMIT 1 `+dbh.SelectForUpdateModifier(), nowUsec, nowUsec).Take(scheduled)
+			LIMIT 1 `+dbh.SelectForUpdateModifier(), nowUsec, nowUsec, ScheduledWorkflowMaxConsecutiveFailures).Take(scheduled)
 		if err != nil {
 			if db.IsRecordNotFound(err) {
 				scheduled = nil
@@ -1920,21 +1927,53 @@ func (ws *workflowService) claimScheduledWorkflow(ctx context.Context) (*tables.
 	return scheduled, nil
 }
 
-func (ws *workflowService) unclaimScheduledWorkflow(ctx context.Context, scheduleID string) error {
-	// TODO(Maggie): Consider updating next_run_usec to some time in the future, in case there is a
-	// transient scheduling issue.
-	now := ws.env.GetClock().Now().UnixMicro()
-	result := ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_unclaim_schedule_run").Raw(`
+// handleScheduledWorkflowFailure applies exponential backoff retry logic when a dispatch fails.
+func (ws *workflowService) handleScheduledWorkflowFailure(ctx context.Context, scheduled *tables.ScheduledRun, dispatchErr error) error {
+	currentAttempt := scheduled.FailedAttemptCount
+	if currentAttempt+1 < ScheduledWorkflowMaxRetries {
+		// Multiply the backoff by 2 for each retry, starting at 30 seconds.
+		backoff := 30 * time.Second << uint(currentAttempt)
+		nextRunUsec := ws.env.GetClock().Now().Add(backoff).UnixMicro()
+		log.CtxWarningf(ctx, "Scheduled workflow %s failed attempt %v: %s", scheduled.ScheduleID, currentAttempt, dispatchErr)
+		return ws.unclaimScheduledWorkflow(ctx, scheduled.ScheduleID, nextRunUsec, currentAttempt)
+	}
+
+	// Exhausted all retries for this window - alert and advance to next cron time.
+	msg := fmt.Sprintf("Scheduled workflow %s failed all attempts. Skipping until next scheduled time", scheduled.ScheduleID)
+	log.CtxErrorf(ctx, "%s: %s", msg, dispatchErr)
+	alert.CtxUnexpectedEvent(ctx, msg)
+
+	newConsecutiveFailures := scheduled.ConsecutiveScheduleFailureCount + 1
+	if newConsecutiveFailures >= ScheduledWorkflowMaxConsecutiveFailures {
+		msg := fmt.Sprintf("Scheduled workflow %s has failed %d consecutive scheduled windows. Pausing until manually re-enabled.", scheduled.ScheduleID, newConsecutiveFailures)
+		log.CtxError(ctx, msg)
+		alert.CtxUnexpectedEvent(ctx, msg)
+	}
+
+	nextRunUsec, err := ws.calculateNextRunTimeUsec(scheduled.CronExpr)
+	if err != nil {
+		return err
+	}
+	// Reset the failed attempt count to 0 so that the next time the cron expression fires,
+	// the workflow is retried.
+	return ws.advanceWorkflowSchedule(ctx, scheduled.ScheduleID, nextRunUsec, 0 /*failedAttemptCount*/, newConsecutiveFailures)
+}
+
+// unclaimScheduledWorkflow unclaims the scheduled workflow lease after a dispatch failure, so that another server can retry it.
+func (ws *workflowService) unclaimScheduledWorkflow(ctx context.Context, scheduleID string, nextRunUsec int64, currentAttempt int64) error {
+	newAttempt := currentAttempt + 1
+	result := ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_set_scheduled_workflow_retry").Raw(`
 		UPDATE "ScheduledRuns"
-		SET lease_expires_usec = 0
+		SET next_run_usec = ?,
+		    lease_expires_usec = 0,
+		    failed_attempt_count = ?
 		WHERE schedule_id = ?
-		AND next_run_usec <= ?
-	`, scheduleID, now).Exec()
+	`, nextRunUsec, newAttempt, scheduleID).Exec()
 	if result.Error != nil {
 		return result.Error
 	}
 	if result.RowsAffected == 0 {
-		return status.InternalErrorf("failed to unclaim scheduled workflow %s", scheduleID)
+		return fmt.Errorf("failed to unclaim scheduled workflow %s", scheduleID)
 	}
 	return nil
 }
@@ -2006,7 +2045,7 @@ func (ws *workflowService) dispatchScheduledWorkflow(ctx context.Context, schedu
 		alert.CtxUnexpectedEvent(ctx, "Failed to calculate next run time for scheduled workflow %s: %s", scheduled.ScheduleID, err)
 		return err
 	}
-	if err := ws.advanceWorkflowSchedule(ctx, scheduled.ScheduleID, nextRunUsec); err != nil {
+	if err := ws.advanceWorkflowSchedule(ctx, scheduled.ScheduleID, nextRunUsec, 0 /*failedAttemptCount*/, 0 /*consecutiveScheduleFailureCount*/); err != nil {
 		alert.CtxUnexpectedEvent(ctx, "Failed to advance scheduled workflow %s to %d: %s", scheduled.ScheduleID, nextRunUsec, err)
 		return err
 	}
@@ -2036,11 +2075,20 @@ func (ws *workflowService) calculateNextRunTimeUsec(cronExpr string) (int64, err
 	return sched.Next(now).UnixMicro(), nil
 }
 
-func (ws *workflowService) advanceWorkflowSchedule(ctx context.Context, scheduleID string, nextRunUsec int64) error {
-	return ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_advance_schedule").Raw(`
+func (ws *workflowService) advanceWorkflowSchedule(ctx context.Context, scheduleID string, nextRunUsec int64, failedAttemptCount int64, consecutiveScheduleFailureCount int64) error {
+	result := ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_advance_schedule").Raw(`
 		UPDATE "ScheduledRuns"
 		SET next_run_usec = ?,
-		    lease_expires_usec = 0
+		    lease_expires_usec = 0,
+		    failed_attempt_count = ?,
+		    consecutive_schedule_failure_count = ?
 		WHERE schedule_id = ?
-	`, nextRunUsec, scheduleID).Exec().Error
+	`, nextRunUsec, failedAttemptCount, consecutiveScheduleFailureCount, scheduleID).Exec()
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("failed to advance scheduled workflow %s", scheduleID)
+	}
+	return nil
 }

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -129,7 +129,7 @@ const (
 	ScheduledWorkflowMaxRetries = 5
 
 	// Max number of times a scheduled workflow can exhaust all its retries.
-	// Aftwards, the scheduled workflow will be paused and requires manual re-enabling.
+	// Afterwards, the scheduled workflow will be paused and requires manual re-enabling.
 	ScheduledWorkflowMaxConsecutiveFailures = 20
 )
 
@@ -1941,13 +1941,13 @@ func (ws *workflowService) handleScheduledWorkflowFailure(ctx context.Context, s
 	// Exhausted all retries for this window - alert and advance to next cron time.
 	msg := fmt.Sprintf("Scheduled workflow %s failed all attempts. Skipping until next scheduled time", scheduled.ScheduleID)
 	log.CtxErrorf(ctx, "%s: %s", msg, dispatchErr)
-	alert.CtxUnexpectedEvent(ctx, msg)
+	alert.CtxUnexpectedEvent(ctx, "scheduled workflow dispatch failure", msg)
 
 	newConsecutiveFailures := scheduled.ConsecutiveScheduleFailureCount + 1
 	if newConsecutiveFailures >= ScheduledWorkflowMaxConsecutiveFailures {
 		msg := fmt.Sprintf("Scheduled workflow %s has failed %d consecutive scheduled windows. Pausing until manually re-enabled.", scheduled.ScheduleID, newConsecutiveFailures)
 		log.CtxError(ctx, msg)
-		alert.CtxUnexpectedEvent(ctx, msg)
+		alert.CtxUnexpectedEvent(ctx, "scheduled workflow paused due to consecutive failures", msg)
 	}
 
 	nextRunUsec, err := ws.calculateNextRunTimeUsec(scheduled.CronExpr)

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1935,7 +1935,7 @@ func (ws *workflowService) handleScheduledWorkflowFailure(ctx context.Context, s
 		backoff := 30 * time.Second << uint(currentAttempt)
 		nextRunUsec := ws.env.GetClock().Now().Add(backoff).UnixMicro()
 		log.CtxWarningf(ctx, "Scheduled workflow %s failed attempt %v: %s", scheduled.ScheduleID, currentAttempt, dispatchErr)
-		return ws.unclaimScheduledWorkflow(ctx, scheduled.ScheduleID, nextRunUsec, currentAttempt)
+		return ws.unclaimScheduledWorkflow(ctx, scheduled.ScheduleID, scheduled.LeaseExpiresUsec, nextRunUsec, currentAttempt)
 	}
 
 	// Exhausted all retries for this window - alert and advance to next cron time.
@@ -1956,11 +1956,13 @@ func (ws *workflowService) handleScheduledWorkflowFailure(ctx context.Context, s
 	}
 	// Reset the failed attempt count to 0 so that the next time the cron expression fires,
 	// the workflow is retried.
-	return ws.advanceWorkflowSchedule(ctx, scheduled.ScheduleID, nextRunUsec, 0 /*failedAttemptCount*/, newConsecutiveFailures)
+	return ws.advanceWorkflowSchedule(ctx, scheduled.ScheduleID, scheduled.LeaseExpiresUsec, nextRunUsec, 0 /*failedAttemptCount*/, newConsecutiveFailures)
 }
 
 // unclaimScheduledWorkflow unclaims the scheduled workflow lease after a dispatch failure, so that another server can retry it.
-func (ws *workflowService) unclaimScheduledWorkflow(ctx context.Context, scheduleID string, nextRunUsec int64, currentAttempt int64) error {
+//
+// We filter on expected lease expire time to avoid race conditions if the lease has been acquired by another server.
+func (ws *workflowService) unclaimScheduledWorkflow(ctx context.Context, scheduleID string, expectedLeaseExpiresUsec int64, nextRunUsec int64, currentAttempt int64) error {
 	newAttempt := currentAttempt + 1
 	result := ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_set_scheduled_workflow_retry").Raw(`
 		UPDATE "ScheduledRuns"
@@ -1968,7 +1970,8 @@ func (ws *workflowService) unclaimScheduledWorkflow(ctx context.Context, schedul
 		    lease_expires_usec = 0,
 		    failed_attempt_count = ?
 		WHERE schedule_id = ?
-	`, nextRunUsec, newAttempt, scheduleID).Exec()
+		  AND lease_expires_usec = ?
+	`, nextRunUsec, newAttempt, scheduleID, expectedLeaseExpiresUsec).Exec()
 	if result.Error != nil {
 		return result.Error
 	}
@@ -2045,7 +2048,7 @@ func (ws *workflowService) dispatchScheduledWorkflow(ctx context.Context, schedu
 		alert.CtxUnexpectedEvent(ctx, "Failed to calculate next run time for scheduled workflow %s: %s", scheduled.ScheduleID, err)
 		return err
 	}
-	if err := ws.advanceWorkflowSchedule(ctx, scheduled.ScheduleID, nextRunUsec, 0 /*failedAttemptCount*/, 0 /*consecutiveScheduleFailureCount*/); err != nil {
+	if err := ws.advanceWorkflowSchedule(ctx, scheduled.ScheduleID, scheduled.LeaseExpiresUsec, nextRunUsec, 0 /*failedAttemptCount*/, 0 /*consecutiveScheduleFailureCount*/); err != nil {
 		alert.CtxUnexpectedEvent(ctx, "Failed to advance scheduled workflow %s to %d: %s", scheduled.ScheduleID, nextRunUsec, err)
 		return err
 	}
@@ -2075,7 +2078,10 @@ func (ws *workflowService) calculateNextRunTimeUsec(cronExpr string) (int64, err
 	return sched.Next(now).UnixMicro(), nil
 }
 
-func (ws *workflowService) advanceWorkflowSchedule(ctx context.Context, scheduleID string, nextRunUsec int64, failedAttemptCount int64, consecutiveScheduleFailureCount int64) error {
+// advanceWorkflowSchedule advances the scheduled workflow to the next run time, resetting the failed attempt count and consecutive schedule failure count.
+//
+// We filter on expected lease expire time to avoid race conditions if the lease has been acquired by another server.
+func (ws *workflowService) advanceWorkflowSchedule(ctx context.Context, scheduleID string, expectedLeaseExpiresUsec int64, nextRunUsec int64, failedAttemptCount int64, consecutiveScheduleFailureCount int64) error {
 	result := ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_advance_schedule").Raw(`
 		UPDATE "ScheduledRuns"
 		SET next_run_usec = ?,
@@ -2083,7 +2089,8 @@ func (ws *workflowService) advanceWorkflowSchedule(ctx context.Context, schedule
 		    failed_attempt_count = ?,
 		    consecutive_schedule_failure_count = ?
 		WHERE schedule_id = ?
-	`, nextRunUsec, failedAttemptCount, consecutiveScheduleFailureCount, scheduleID).Exec()
+		  AND lease_expires_usec = ?
+	`, nextRunUsec, failedAttemptCount, consecutiveScheduleFailureCount, scheduleID, expectedLeaseExpiresUsec).Exec()
 	if result.Error != nil {
 		return result.Error
 	}

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -1324,3 +1324,149 @@ actions:
 	require.Equal(t, now.Add(1*time.Hour).UnixMicro(), scheduled2.NextRunUsec)
 	require.Equal(t, int64(0), scheduled2.LeaseExpiresUsec)
 }
+
+func TestScheduledWorkflow_DispatchFailure(t *testing.T) {
+	ctx := context.Background()
+	te := newTestEnv(t)
+	authCtx, _, gid := authenticate(t, ctx, te)
+	repoURL := makeTempRepo(t)
+	provider := setupFakeGitProvider(t, te)
+	_ = runBBServer(ctx, t, te)
+
+	now := time.Date(2026, 1, 2, 15, 0, 0, 0, time.UTC)
+	te.SetClock(clockwork.NewFakeClockAt(now))
+
+	// Use a RepoURL with no matching GitRepository to cause a dispatch failure.
+	insertScheduledRun(t, te, &tables.ScheduledRun{
+		ScheduleID:  "test-backoff",
+		GroupID:     gid,
+		RepoURL:     repoURL,
+		ActionName:  "Test",
+		CronExpr:    "0 * * * *",
+		NextRunUsec: now.UnixMicro(),
+	})
+
+	err := te.GetWorkflowService().RunScheduledWorkflows(t.Context())
+	require.NoError(t, err)
+
+	sr := getScheduledRun(t, te, "test-backoff")
+	require.Equal(t, int64(1), sr.FailedAttemptCount)
+	require.Equal(t, now.Add(30*time.Second).UnixMicro(), sr.NextRunUsec)
+	require.Equal(t, int64(0), sr.LeaseExpiresUsec)
+
+	// Advance clock past the first backoff and trigger a second failure.
+	// The backoff should be twice as long (i.e. 1 min).
+	now2 := now.Add(31 * time.Second)
+	te.SetClock(clockwork.NewFakeClockAt(now2))
+
+	err = te.GetWorkflowService().RunScheduledWorkflows(t.Context())
+	require.NoError(t, err)
+
+	sr = getScheduledRun(t, te, "test-backoff")
+	require.Equal(t, int64(2), sr.FailedAttemptCount)
+	require.Equal(t, now2.Add(60*time.Second).UnixMicro(), sr.NextRunUsec)
+
+	// Create a matching GitRepository to allow the workflow to be scheduled.
+	createWorkflow(t, te, repoURL, gid, false)
+	provider.FileContents = map[string]string{
+		config.FilePath: `
+actions:
+  - name: "Test"
+    bazel_commands: [ "test //..." ]
+`,
+	}
+
+	// Advance clock to the next scheduled time and verify the workflow is scheduled.
+	now3 := now2.Add(61 * time.Second)
+	te.SetClock(clockwork.NewFakeClockAt(now3))
+
+	err = te.GetWorkflowService().RunScheduledWorkflows(t.Context())
+	require.NoError(t, err)
+
+	execClient := te.GetRemoteExecutionClient().(*fakeExecutionClient)
+	select {
+	case execReq := <-execClient.executeRequests:
+		// When fetching the executions, make sure to use the authenticated context.
+		actionName := getExecutedActionName(t, authCtx, te, execReq.Payload)
+		require.Equal(t, "Test", actionName)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for scheduled workflow execution")
+	}
+
+	sr = getScheduledRun(t, te, "test-backoff")
+	require.Equal(t, now.Add(1*time.Hour).UnixMicro(), sr.NextRunUsec)
+	require.Equal(t, int64(0), sr.FailedAttemptCount)
+	require.Equal(t, int64(0), sr.LeaseExpiresUsec)
+}
+
+func TestScheduledWorkflow_FailedMaxAttempts(t *testing.T) {
+	ctx := context.Background()
+	te := newTestEnv(t)
+	_ = runBBServer(ctx, t, te)
+
+	now := time.Date(2026, 1, 2, 15, 0, 0, 0, time.UTC)
+	te.SetClock(clockwork.NewFakeClockAt(now))
+
+	// Use a RepoURL with no matching GitRepository to cause a dispatch failure.
+	insertScheduledRun(t, te, &tables.ScheduledRun{
+		ScheduleID: "test-max-retries",
+		GroupID:    "some-group",
+		RepoURL:    "https://github.com/nonexistent/repo",
+		ActionName: "Test",
+		// Run every hour, on the hour.
+		CronExpr:           "0 * * * *",
+		NextRunUsec:        now.UnixMicro(),
+		FailedAttemptCount: workflow.ScheduledWorkflowMaxRetries - 1, // The next failure will trigger the retry limit
+	})
+
+	err := te.GetWorkflowService().RunScheduledWorkflows(t.Context())
+	require.NoError(t, err)
+
+	// The schedule should advance to the next cron window (4PM), not apply backoff.
+	sr := getScheduledRun(t, te, "test-max-retries")
+	require.Equal(t, now.Add(1*time.Hour).UnixMicro(), sr.NextRunUsec)
+	require.Equal(t, int64(0), sr.FailedAttemptCount)
+	require.Equal(t, int64(1), sr.ConsecutiveScheduleFailureCount)
+	require.Equal(t, int64(0), sr.LeaseExpiresUsec)
+}
+
+func TestScheduledWorkflow_MaxConsecutiveFailures(t *testing.T) {
+	ctx := context.Background()
+	te := newTestEnv(t)
+	_ = runBBServer(ctx, t, te)
+
+	now := time.Date(2026, 1, 2, 15, 0, 0, 0, time.UTC)
+	te.SetClock(clockwork.NewFakeClockAt(now))
+
+	// Pre-populate counters so the next failure triggers a pause.
+	insertScheduledRun(t, te, &tables.ScheduledRun{
+		ScheduleID:                      "test",
+		GroupID:                         "some-group",
+		RepoURL:                         "https://github.com/nonexistent/repo",
+		ActionName:                      "Test",
+		CronExpr:                        "0 * * * *",
+		NextRunUsec:                     now.UnixMicro(),
+		FailedAttemptCount:              workflow.ScheduledWorkflowMaxRetries - 1,
+		ConsecutiveScheduleFailureCount: workflow.ScheduledWorkflowMaxConsecutiveFailures - 1,
+	})
+
+	err := te.GetWorkflowService().RunScheduledWorkflows(t.Context())
+	require.NoError(t, err)
+
+	sr := getScheduledRun(t, te, "test")
+	require.Equal(t, int64(workflow.ScheduledWorkflowMaxConsecutiveFailures), sr.ConsecutiveScheduleFailureCount)
+	require.Equal(t, int64(0), sr.FailedAttemptCount)
+	require.Equal(t, now.Add(1*time.Hour).UnixMicro(), sr.NextRunUsec)
+
+	// Advance the clock to the next scheduled time and verify the workflow is not scheduled.
+	// It should be untouched.
+	te.SetClock(clockwork.NewFakeClockAt(now.Add(1 * time.Hour)))
+
+	err = te.GetWorkflowService().RunScheduledWorkflows(t.Context())
+	require.NoError(t, err)
+
+	sr = getScheduledRun(t, te, "test")
+	require.Equal(t, int64(workflow.ScheduledWorkflowMaxConsecutiveFailures), sr.ConsecutiveScheduleFailureCount)
+	require.Equal(t, int64(0), sr.FailedAttemptCount)
+	require.Equal(t, now.Add(1*time.Hour).UnixMicro(), sr.NextRunUsec)
+}

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -777,6 +777,14 @@ type ScheduledRun struct {
 	// However if the lease duration is long enough, duplicates are unlikely
 	// to happen because the servers only need to dispatch the execution, which should be quick.
 	LeaseExpiresUsec int64
+
+	// Number of consecutive failed dispatch attempts within the current scheduled window.
+	// Reset to 0 when the window is successfully dispatched or the schedule advances.
+	FailedAttemptCount int64
+
+	// Number of consecutive scheduled windows that have exhausted all retries.
+	// If too high, the workflow will be paused and requires manual re-enabling.
+	ConsecutiveScheduleFailureCount int64
 }
 
 func (sr *ScheduledRun) TableName() string {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -780,11 +780,11 @@ type ScheduledRun struct {
 
 	// Number of consecutive failed dispatch attempts within the current scheduled window.
 	// Reset to 0 when the window is successfully dispatched or the schedule advances.
-	FailedAttemptCount int64
+	FailedAttemptCount int64 `gorm:"not null;default:0"`
 
 	// Number of consecutive scheduled windows that have exhausted all retries.
 	// If too high, the workflow will be paused and requires manual re-enabling.
-	ConsecutiveScheduleFailureCount int64
+	ConsecutiveScheduleFailureCount int64 `gorm:"not null;default:0"`
 }
 
 func (sr *ScheduledRun) TableName() string {


### PR DESCRIPTION
For each scheduled time, retry a max of 5 times. Each retry attempt, add a bit of backoff. If all 5 retries fail, just advance to the next scheduled time.

If a scheduled workflow has failed 20 times consecutively (20 attempts with 5 retries each), stop trying to schedule it.