### PR TITLE
Shrink `bb`, `ci_runner`, app sizes 

### DIFF
--- a/enterprise/server/cmd/cache/BUILD
+++ b/enterprise/server/cmd/cache/BUILD
@@ -36,6 +36,8 @@ go_library(
         "//server/util/authutil",
         "//server/util/bazel_request",
         "//server/util/grpc_client",
+        "//server/util/kuberesolver",
+        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/enterprise/server/cmd/cache/BUILD
+++ b/enterprise/server/cmd/cache/BUILD
@@ -36,10 +36,9 @@ go_library(
         "//server/util/authutil",
         "//server/util/bazel_request",
         "//server/util/grpc_client",
-        "//server/util/kuberesolver",
-        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
+        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/monitoring",
         "//server/util/status",
@@ -49,6 +48,7 @@ go_library(
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//channelz/service",
+        "@org_golang_google_grpc//xds",
     ],
 )
 

--- a/enterprise/server/cmd/cache/cache.go
+++ b/enterprise/server/cmd/cache/cache.go
@@ -40,7 +40,7 @@ import (
 	"google.golang.org/grpc"
 
 	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
+	_ "google.golang.org/grpc/xds"                                   // registers xds:// resolver.
 
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"

--- a/enterprise/server/cmd/cache/cache.go
+++ b/enterprise/server/cmd/cache/cache.go
@@ -39,6 +39,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"google.golang.org/grpc"
 
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
+	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
+
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	http_interceptors "github.com/buildbuddy-io/buildbuddy/server/http/interceptors"

--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -49,10 +49,9 @@ go_library(
         "//server/rpc/interceptors",
         "//server/ssl",
         "//server/util/grpc_client",
-        "//server/util/kuberesolver",
-        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
+        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/monitoring",
         "//server/util/scratchspace",
@@ -64,6 +63,7 @@ go_library(
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//channelz/service",
         "@org_golang_google_grpc//stats",
+        "@org_golang_google_grpc//xds",
     ],
 )
 

--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -49,6 +49,8 @@ go_library(
         "//server/rpc/interceptors",
         "//server/ssl",
         "//server/util/grpc_client",
+        "//server/util/kuberesolver",
+        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -54,7 +54,7 @@ import (
 	"google.golang.org/grpc"
 
 	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
+	_ "google.golang.org/grpc/xds"                                   // registers xds:// resolver.
 
 	cspb "github.com/buildbuddy-io/buildbuddy/proto/cache_service"
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -53,6 +53,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"google.golang.org/grpc"
 
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
+	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
+
 	cspb "github.com/buildbuddy-io/buildbuddy/proto/cache_service"
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -52,10 +52,9 @@ go_library(
         "//server/util/disk",
         "//server/util/flag",
         "//server/util/grpc_client",
-        "//server/util/kuberesolver",
-        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
+        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/monitoring",
         "//server/util/shlex",
@@ -70,6 +69,7 @@ go_library(
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//encoding/gzip",
+        "@org_golang_google_grpc//xds",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -52,6 +52,8 @@ go_library(
         "//server/util/disk",
         "//server/util/flag",
         "//server/util/grpc_client",
+        "//server/util/kuberesolver",
+        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -54,7 +54,6 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
-        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/monitoring",
         "//server/util/shlex",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -62,7 +62,9 @@ import (
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
-	_ "github.com/buildbuddy-io/buildbuddy/server/util/grpc_server" // imported for grpc_port flag definition to avoid breaking old configs; DO NOT REMOVE.
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
+	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"               // imported for grpc_port flag definition to avoid breaking old configs; DO NOT REMOVE.
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	_ "google.golang.org/grpc/encoding/gzip" // imported for side effects; DO NOT REMOVE.
 )

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -62,11 +62,11 @@ import (
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"  // imported for grpc_port flag definition to avoid breaking old configs; DO NOT REMOVE.
 	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
-	_ "github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"               // imported for grpc_port flag definition to avoid breaking old configs; DO NOT REMOVE.
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	_ "google.golang.org/grpc/encoding/gzip" // imported for side effects; DO NOT REMOVE.
+	_ "google.golang.org/grpc/xds"           // registers xds:// resolver.
 )
 
 var (

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -62,8 +62,7 @@ import (
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
-	_ "github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"  // imported for grpc_port flag definition to avoid breaking old configs; DO NOT REMOVE.
-	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/grpc_server" // imported for grpc_port flag definition to avoid breaking old configs; DO NOT REMOVE.
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	_ "google.golang.org/grpc/encoding/gzip" // imported for side effects; DO NOT REMOVE.
 	_ "google.golang.org/grpc/xds"           // registers xds:// resolver.

--- a/enterprise/server/cmd/metadata_server/BUILD
+++ b/enterprise/server/cmd/metadata_server/BUILD
@@ -20,6 +20,8 @@ go_library(
         "//server/http/interceptors",
         "//server/real_environment",
         "//server/ssl",
+        "//server/util/kuberesolver",
+        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/enterprise/server/cmd/metadata_server/BUILD
+++ b/enterprise/server/cmd/metadata_server/BUILD
@@ -20,15 +20,15 @@ go_library(
         "//server/http/interceptors",
         "//server/real_environment",
         "//server/ssl",
-        "//server/util/kuberesolver",
-        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
+        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/monitoring",
         "//server/util/statusz",
         "//server/util/tracing",
         "//server/version",
+        "@org_golang_google_grpc//xds",
     ],
 )
 

--- a/enterprise/server/cmd/metadata_server/BUILD
+++ b/enterprise/server/cmd/metadata_server/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//server/util/statusz",
         "//server/util/tracing",
         "//server/version",
-        "@org_golang_google_grpc//xds",
     ],
 )
 

--- a/enterprise/server/cmd/metadata_server/main.go
+++ b/enterprise/server/cmd/metadata_server/main.go
@@ -26,7 +26,6 @@ import (
 	http_interceptors "github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
 
 	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds"                                   // registers xds:// resolver.
 )
 
 var (

--- a/enterprise/server/cmd/metadata_server/main.go
+++ b/enterprise/server/cmd/metadata_server/main.go
@@ -24,6 +24,9 @@ import (
 
 	mdspb "github.com/buildbuddy-io/buildbuddy/proto/metadata_service"
 	http_interceptors "github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
+
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
+	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
 )
 
 var (

--- a/enterprise/server/cmd/metadata_server/main.go
+++ b/enterprise/server/cmd/metadata_server/main.go
@@ -26,7 +26,7 @@ import (
 	http_interceptors "github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
 
 	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
+	_ "google.golang.org/grpc/xds"                                   // registers xds:// resolver.
 )
 
 var (

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -88,6 +88,8 @@ go_library(
         "//server/remote_cache/capabilities_server",
         "//server/telemetry",
         "//server/util/clickhouse",
+        "//server/util/kuberesolver",
+        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -88,15 +88,15 @@ go_library(
         "//server/remote_cache/capabilities_server",
         "//server/telemetry",
         "//server/util/clickhouse",
-        "//server/util/kuberesolver",
-        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
+        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/tracing",
         "//server/version",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//stats",
+        "@org_golang_google_grpc//xds",
     ],
 )
 

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -96,7 +96,6 @@ go_library(
         "//server/version",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//stats",
-        "@org_golang_google_grpc//xds",
     ],
 )
 

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -88,7 +88,7 @@ import (
 	workflow "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service"
 
 	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
+	_ "google.golang.org/grpc/xds"                                   // registers xds:// resolver.
 )
 
 var serverType = flag.String("server_type", "buildbuddy-server", "The server type to match on health checks")

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -88,7 +88,6 @@ import (
 	workflow "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service"
 
 	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds"                                   // registers xds:// resolver.
 )
 
 var serverType = flag.String("server_type", "buildbuddy-server", "The server type to match on health checks")

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -86,6 +86,9 @@ import (
 	remote_execution_redis_client "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/redis_client"
 	telserver "github.com/buildbuddy-io/buildbuddy/enterprise/server/telemetry"
 	workflow "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service"
+
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
+	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
 )
 
 var serverType = flag.String("server_type", "buildbuddy-server", "The server type to match on health checks")

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -71,11 +71,11 @@ go_library(
         "//server/libmain",
         "//server/remote_cache/capabilities_server",
         "//server/telemetry",
-        "//server/util/kuberesolver",
-        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
+        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/version",
+        "@org_golang_google_grpc//xds",
     ],
 )

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -71,6 +71,8 @@ go_library(
         "//server/libmain",
         "//server/remote_cache/capabilities_server",
         "//server/telemetry",
+        "//server/util/kuberesolver",
+        "@org_golang_google_grpc//xds",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -73,7 +73,6 @@ go_library(
         "//server/telemetry",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
-        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/version",
         "@org_golang_google_grpc//xds",

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -15,6 +15,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 
 	app_bundle "github.com/buildbuddy-io/buildbuddy/app"
+
+	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
+	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
 )
 
 var (

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -17,7 +17,7 @@ import (
 	app_bundle "github.com/buildbuddy-io/buildbuddy/app"
 
 	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
+	_ "google.golang.org/grpc/xds"                                   // registers xds:// resolver.
 )
 
 var (

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -16,8 +16,7 @@ import (
 
 	app_bundle "github.com/buildbuddy-io/buildbuddy/app"
 
-	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver" // registers kube:// resolver.
-	_ "google.golang.org/grpc/xds"                                   // registers xds:// resolver.
+	_ "google.golang.org/grpc/xds" // registers xds:// resolver.
 )
 
 var (

--- a/server/util/grpc_client/BUILD
+++ b/server/util/grpc_client/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//server/rpc/interceptors",
         "//server/util/canary",
         "//server/util/flag",
-        "//server/util/kuberesolver",
         "//server/util/log",
         "//server/util/rpcutil",
         "//server/util/status",
@@ -22,7 +21,6 @@ go_library(
         "@org_golang_google_grpc//experimental",
         "@org_golang_google_grpc//keepalive",
         "@org_golang_google_grpc//mem",
-        "@org_golang_google_grpc//xds",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -27,9 +27,6 @@ import (
 	"google.golang.org/grpc/experimental"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/mem"
-
-	_ "github.com/buildbuddy-io/buildbuddy/server/util/kuberesolver"
-	_ "google.golang.org/grpc/xds"
 )
 
 const (


### PR DESCRIPTION
Move `kube://` and `xds://` resolver registration out of `grpc_client`

Size impact (-c opt, default link flags):

`bb`:             161.8 MB -> 97.7 MB   (-64 MB, -40%)
`ci_runner`:      127.9 MB -> 63.5 MB   (-65 MB, -51%)
enterprise app: 510.3 MB -> 382.4 MB  (-128 MB, -25%)