### PR TITLE
Add space to DB modifier string

### DIFF
--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -907,7 +907,7 @@ func (h *DBHandle) SelectForUpdateModifier() string {
 	if h.driver == sqliteDriver {
 		return ""
 	}
-	return "FOR UPDATE"
+	return " FOR UPDATE"
 }
 
 func (h *DBHandle) DialectName() string {


### PR DESCRIPTION
I've forgotten to add a leading space when using this helper. Unit tests that use sqlite also wouldn't catch a lack of a space (due to L907 in db.go), so it's more likely that invalid queries would be pushed to prod without us realizing

There's no downside to having two spaces for clients that are already adding a space