### PR TITLE
Delete the `app.client_identity.override_propagated` flag

### DIFF
--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -29,9 +29,6 @@ var (
 	origin     = flag.String("app.client_identity.origin", "", "The origin identifier to place in the identity header.")
 	expiration = flag.Duration("app.client_identity.expiration", DefaultExpiration, "The expiration time for the identity header.")
 	required   = flag.Bool("app.client_identity.required", false, "If set, a client identity is required.")
-
-	// TODO(iain): delete this flag once all proxies in prod enforce IP rules.
-	overridePropagated = flag.Bool("app.client_identity.override_propagated", true, "If false, AddIdentityToContext will not set a new client identity header when one is already present in the outgoing context.")
 )
 
 type Service struct {
@@ -119,11 +116,9 @@ func (s *Service) getCachedHeader() (string, error) {
 }
 
 func (s *Service) AddIdentityToContext(ctx context.Context) (context.Context, error) {
-	if !*overridePropagated {
-		if md, ok := metadata.FromOutgoingContext(ctx); ok {
-			if vals := md.Get(authutil.ClientIdentityHeaderName); len(vals) > 0 {
-				return ctx, nil
-			}
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if vals := md.Get(authutil.ClientIdentityHeaderName); len(vals) > 0 {
+			return ctx, nil
 		}
 	}
 	header, err := s.getCachedHeader()

--- a/enterprise/server/clientidentity/clientidentity_test.go
+++ b/enterprise/server/clientidentity/clientidentity_test.go
@@ -156,34 +156,9 @@ func TestClearIdentity(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestOverridePropagated_DefaultTrue(t *testing.T) {
+func TestAddIdentityToContext_PreservesExisting(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sis := newService(t, clock)
-	flags.Set(t, "app.client_identity.client", "local")
-	flags.Set(t, "app.client_identity.origin", "local-origin")
-
-	// Start with an existing identity header in the outgoing context.
-	existingHeader, err := sis.IdentityHeader(&interfaces.ClientIdentity{
-		Origin: "upstream-origin",
-		Client: "upstream",
-	}, clientidentity.DefaultExpiration)
-	require.NoError(t, err)
-
-	ctx := metadata.NewOutgoingContext(t.Context(), metadata.Pairs(authutil.ClientIdentityHeaderName, existingHeader))
-	ctx, err = sis.AddIdentityToContext(ctx)
-	require.NoError(t, err)
-
-	// Default behavior (override_propagated=true): a new header should be appended.
-	md, ok := metadata.FromOutgoingContext(ctx)
-	require.True(t, ok)
-	vals := md.Get(authutil.ClientIdentityHeaderName)
-	require.Equal(t, 2, len(vals), "expected both old and new headers")
-}
-
-func TestOverridePropagated_False_PreservesExisting(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-	sis := newService(t, clock)
-	flags.Set(t, "app.client_identity.override_propagated", false)
 	flags.Set(t, "app.client_identity.client", "local")
 	flags.Set(t, "app.client_identity.origin", "local-origin")
 
@@ -197,7 +172,6 @@ func TestOverridePropagated_False_PreservesExisting(t *testing.T) {
 	ctx, err = sis.AddIdentityToContext(ctx)
 	require.NoError(t, err)
 
-	// With override_propagated=false, the existing header should be preserved and no new one added.
 	md, ok := metadata.FromOutgoingContext(ctx)
 	require.True(t, ok)
 	vals := md.Get(authutil.ClientIdentityHeaderName)
@@ -205,19 +179,16 @@ func TestOverridePropagated_False_PreservesExisting(t *testing.T) {
 	require.Equal(t, existingHeader, vals[0])
 }
 
-func TestOverridePropagated_False_AddsWhenMissing(t *testing.T) {
+func TestAddIdentityToContext_AddsWhenMissing(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sis := newService(t, clock)
-	flags.Set(t, "app.client_identity.override_propagated", false)
 	flags.Set(t, "app.client_identity.client", "local")
 	flags.Set(t, "app.client_identity.origin", "local-origin")
 
-	// No existing identity header in the outgoing context.
 	ctx := t.Context()
 	ctx, err := sis.AddIdentityToContext(ctx)
 	require.NoError(t, err)
 
-	// Even with override_propagated=false, a header should be added when none exists.
 	md, ok := metadata.FromOutgoingContext(ctx)
 	require.True(t, ok)
 	vals := md.Get(authutil.ClientIdentityHeaderName)

--- a/enterprise/server/clientidentity/clientidentity_test.go
+++ b/enterprise/server/clientidentity/clientidentity_test.go
@@ -159,8 +159,6 @@ func TestClearIdentity(t *testing.T) {
 func TestAddIdentityToContext_PreservesExisting(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sis := newService(t, clock)
-	flags.Set(t, "app.client_identity.client", "local")
-	flags.Set(t, "app.client_identity.origin", "local-origin")
 
 	existingHeader, err := sis.IdentityHeader(&interfaces.ClientIdentity{
 		Origin: "upstream-origin",

--- a/enterprise/server/test/integration/cache_proxy/cache_proxy_test.go
+++ b/enterprise/server/test/integration/cache_proxy/cache_proxy_test.go
@@ -325,7 +325,6 @@ func TestIPRulesRBE(t *testing.T) {
 	flags.Set(t, "auth.trust_xforwardedfor_header", true)
 	flags.Set(t, "app.client_identity.client", "cache-proxy")
 	flags.Set(t, "app.client_identity.key", "key")
-	flags.Set(t, "app.client_identity.override_propagated", false)
 
 	rbe := rbetest.NewRBETestEnv(t)
 	backend := rbe.AddBuildBuddyServer()


### PR DESCRIPTION
It's not used any more.

Depends on: https://github.com/buildbuddy-io/buildbuddy-internal/pull/7274

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/6797