### PR TITLE
testport: Probe wildcard ports

### DIFF
--- a/server/testutil/testport/testport.go
+++ b/server/testutil/testport/testport.go
@@ -20,7 +20,7 @@ type freePortLeaser struct {
 }
 
 func (p *freePortLeaser) findAPort(t testing.TB) int {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	addr, err := net.ResolveTCPAddr("tcp", "0.0.0.0:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The CLI integration test flakes because tests reserve a port through
testport and later bind services on `0.0.0.0`. Probing `localhost:0`
can pick a port that is free on loopback but unavailable for the
wildcard listener, so the later bind can fail with `address already in
use`.

Probe `0.0.0.0:0` instead, matching the address used by these listeners
and keeping the fix scoped to the port selection race.

Flakes page:
https://buildbuddy.buildbuddy.io/tests/?target=%2F%2Fcli%2Ftest%2Fintegration%2Fcli%3Acli_test&repo=https%3A%2F%2Fgithub.com%2Fbuildbuddy-io%2Fbuildbuddy#flakes

Reproduced the old behavior by temporarily restoring the localhost
probe and running:

  bazel test //cli/test/integration/cli:cli_test \
    --config=remote-minimal --nocache_test_results \
    --runs_per_test=500 --test_output=errors

That run failed three shard executions out of 2,000, including two
`0.0.0.0` bind races. With this patch, the same command passed all
2,000 shard executions.
