### PR TITLE
[WF] Fix broken status reporting when handling webhook events

### DIFF
--- a/enterprise/server/webhooks/bitbucket/bitbucket.go
+++ b/enterprise/server/webhooks/bitbucket/bitbucket.go
@@ -131,7 +131,7 @@ func (*bitbucketGitProvider) IsTrusted(ctx context.Context, accessToken, repoURL
 	return false, status.UnimplementedError("Not implemented")
 }
 
-func (*bitbucketGitProvider) CreateStatus(ctx context.Context, accessToken, repoURL, commitSHA string, payload any) error {
+func (*bitbucketGitProvider) CreateStatus(ctx context.Context, accessToken, groupID, repoURL, commitSHA string, payload any) error {
 	return status.UnimplementedError("Not implemented")
 }
 

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -278,7 +278,7 @@ func (*githubGitProvider) IsTrusted(ctx context.Context, accessToken, repoURL, u
 	return level.GetPermission() == "admin" || level.GetPermission() == "write", nil
 }
 
-func (g *githubGitProvider) CreateStatus(ctx context.Context, token, repoURL, commitSHA string, payload any) error {
+func (g *githubGitProvider) CreateStatus(ctx context.Context, token, groupID, repoURL, commitSHA string, payload any) error {
 	s, ok := payload.(*gh_backend.GithubStatusPayload)
 	if !ok {
 		return status.InvalidArgumentErrorf("invalid GitHub status payload type %T (expected %T)", payload, &gh_backend.GithubStatusPayload{})
@@ -288,7 +288,7 @@ func (g *githubGitProvider) CreateStatus(ctx context.Context, token, repoURL, co
 	if err != nil {
 		return err
 	}
-	return client.CreateStatus(ctx, ownerRepo, commitSHA, s)
+	return client.CreateStatus(ctx, groupID, ownerRepo, commitSHA, s)
 }
 
 func webhookJSONPayload(r *http.Request) ([]byte, error) {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1733,7 +1733,7 @@ func (ws *workflowService) createApprovalRequiredStatus(ctx context.Context, wf 
 		return err
 	}
 	ghc := github.NewGithubClient(ws.env, wf.AccessToken)
-	return ghc.CreateStatus(ctx, ownerRepo, wd.SHA, status)
+	return ghc.CreateStatus(ctx, wf.GroupID, ownerRepo, wd.SHA, status)
 }
 
 func (ws *workflowService) createQueuedStatus(ctx context.Context, wf *tables.Workflow, wd *interfaces.WebhookData, actionName, invocationID string) error {
@@ -1748,7 +1748,7 @@ func (ws *workflowService) createQueuedStatus(ctx context.Context, wf *tables.Wo
 	if err != nil {
 		return err
 	}
-	return provider.CreateStatus(ctx, wf.AccessToken, statusReportingURL, wd.SHA, status)
+	return provider.CreateStatus(ctx, wf.AccessToken, wf.GroupID, statusReportingURL, wd.SHA, status)
 }
 
 func (ws *workflowService) createRunnerStartErrorStatus(ctx context.Context, wf *tables.Workflow, wd *interfaces.WebhookData, actionName, invocationID, errorMessage string) error {
@@ -1763,7 +1763,7 @@ func (ws *workflowService) createRunnerStartErrorStatus(ctx context.Context, wf 
 	if err != nil {
 		return err
 	}
-	return provider.CreateStatus(ctx, wf.AccessToken, statusReportingURL, wd.SHA, status)
+	return provider.CreateStatus(ctx, wf.AccessToken, wf.GroupID, statusReportingURL, wd.SHA, status)
 }
 
 // getStatusReportingURL returns the URL the workflow should report statuses to
@@ -1795,7 +1795,7 @@ func (ws *workflowService) createWorkflowConfigErrorStatus(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	return provider.CreateStatus(ctx, wf.AccessToken, statusReportingURL, wd.SHA, status)
+	return provider.CreateStatus(ctx, wf.AccessToken, wf.GroupID, statusReportingURL, wd.SHA, status)
 }
 
 func isGitHubURL(s string) bool {

--- a/server/backends/github/BUILD
+++ b/server/backends/github/BUILD
@@ -1,4 +1,14 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_test(
+    name = "github_test",
+    srcs = ["github_test.go"],
+    deps = [
+        ":github",
+        "//server/testutil/testenv",
+        "@com_github_stretchr_testify//require",
+    ],
+)
 
 go_library(
     name = "github",

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -531,12 +531,12 @@ func (c *OAuthHandler) handleInstallAppCallback(w http.ResponseWriter, r *http.R
 	return false, nil
 }
 
-func (c *GithubClient) CreateStatus(ctx context.Context, ownerRepo string, commitSHA string, payload *GithubStatusPayload) error {
+func (c *GithubClient) CreateStatus(ctx context.Context, groupID string, ownerRepo string, commitSHA string, payload *GithubStatusPayload) error {
 	if ownerRepo == "" {
 		return status.InvalidArgumentErrorf("failed to create GitHub status: ownerRepo argument is empty")
 	}
 
-	enabled, err := c.IsStatusReportingEnabled(ctx, ownerRepo)
+	enabled, err := c.IsStatusReportingEnabled(ctx, groupID, ownerRepo)
 	if err != nil {
 		return status.WrapErrorf(err, "failed to check if status reporting is enabled for %s", ownerRepo)
 	}
@@ -676,7 +676,7 @@ func (c *GithubClient) fetchToken(ctx context.Context, ownerRepo string) error {
 	return nil
 }
 
-func (c *GithubClient) IsStatusReportingEnabled(ctx context.Context, repoURL string) (bool, error) {
+func (c *GithubClient) IsStatusReportingEnabled(ctx context.Context, groupID string, repoURL string) (bool, error) {
 	if AlwaysEnableStatusReporting() {
 		return true, nil
 	}
@@ -686,11 +686,6 @@ func (c *GithubClient) IsStatusReportingEnabled(ctx context.Context, repoURL str
 		return false, status.InternalError("no database handle")
 	}
 
-	userInfo, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
-	if err != nil {
-		return false, status.WrapError(err, "failed to get authenticated user")
-	}
-
 	parsedRepo, err := gitutil.ParseGitHubRepoURL(repoURL)
 	if err != nil {
 		return false, status.InvalidArgumentErrorf("invalid repo URL %s: %s", repoURL, err)
@@ -698,7 +693,7 @@ func (c *GithubClient) IsStatusReportingEnabled(ctx context.Context, repoURL str
 
 	installation := &tables.GitHubAppInstallation{}
 	err = dbh.NewQuery(ctx, "build_status_reporter_get_app_installation").Raw(
-		`SELECT * from "GitHubAppInstallations" WHERE group_id = ? AND owner = ?`, userInfo.GetGroupID(), parsedRepo.Owner).Take(installation)
+		`SELECT * from "GitHubAppInstallations" WHERE group_id = ? AND owner = ?`, groupID, parsedRepo.Owner).Take(installation)
 	if err == nil {
 		return installation.ReportCommitStatusesForCIBuilds, nil
 	} else if !db.IsRecordNotFound(err) {
@@ -720,7 +715,7 @@ func (c *GithubClient) IsStatusReportingEnabled(ctx context.Context, repoURL str
 
 	groupWithLegacyToken := &struct{ Count int64 }{}
 	err = dbh.NewQuery(ctx, "build_status_reporter_get_group").Raw(
-		`SELECT COUNT(*) as count from "Groups" WHERE group_id = ? AND github_token <> '' AND github_token IS NOT NULL`, userInfo.GetGroupID()).Take(groupWithLegacyToken)
+		`SELECT COUNT(*) as count from "Groups" WHERE group_id = ? AND github_token <> '' AND github_token IS NOT NULL`, groupID).Take(groupWithLegacyToken)
 	if err == nil && groupWithLegacyToken.Count > 0 {
 		return true, nil
 	} else if err != nil {

--- a/server/backends/github/github_test.go
+++ b/server/backends/github/github_test.go
@@ -1,0 +1,35 @@
+package github_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/backends/github"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsStatusReportingEnabled(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		te := testenv.GetTestEnv(t)
+
+		groupID := "GR1"
+		repoURL := "https://github.com/acme-inc/acme"
+
+		// Use raw SQL to insert ReportCommitStatusesForCIBuilds: GORM
+		// skips zero-value booleans during Create, so the column default (true)
+		// would be used instead.
+		res := te.GetDBHandle().NewQuery(context.Background(), "test_create_installation").Raw(
+			`INSERT INTO "GitHubAppInstallations" (group_id, owner, user_id, installation_id, perms, app_id, report_commit_statuses_for_ci_builds) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			groupID, "acme-inc", "US1", 12345, 1, 0, enabled,
+		).Exec()
+		require.NoError(t, res.Error)
+
+		client := github.NewGithubClient(te, "" /*token*/)
+
+		// Use an unauthenticated context, as would be used when handling a webhook request.
+		actual, err := client.IsStatusReportingEnabled(t.Context(), groupID, repoURL)
+		require.NoError(t, err)
+		require.Equal(t, enabled, actual)
+	}
+}

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -123,7 +123,7 @@ type FakeGitHubStatus struct {
 	RepoStatus *github.GithubStatusPayload
 }
 
-func (c *FakeGitHubStatusClient) CreateStatus(ctx context.Context, ownerRepo, commitSHA string, p *github.GithubStatusPayload) error {
+func (c *FakeGitHubStatusClient) CreateStatus(ctx context.Context, groupID, ownerRepo, commitSHA string, p *github.GithubStatusPayload) error {
 	s := &FakeGitHubStatus{
 		OwnerRepo:  ownerRepo,
 		CommitSHA:  commitSHA,
@@ -133,7 +133,7 @@ func (c *FakeGitHubStatusClient) CreateStatus(ctx context.Context, ownerRepo, co
 	return nil
 }
 
-func (c *FakeGitHubStatusClient) IsStatusReportingEnabled(ctx context.Context, repoURL string) (bool, error) {
+func (c *FakeGitHubStatusClient) IsStatusReportingEnabled(ctx context.Context, groupID, repoURL string) (bool, error) {
 	return c.StatusReportingEnabled, nil
 }
 

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -64,9 +64,9 @@ func (r *BuildStatusReporter) SetBaseBuildBuddyURL(url string) {
 	r.baseBBURL = url
 }
 
-func (r *BuildStatusReporter) isStatusReportingEnabled(ctx context.Context, repoURL string) bool {
+func (r *BuildStatusReporter) isStatusReportingEnabled(ctx context.Context, groupID, repoURL string) bool {
 	r.once.Do(func() {
-		enabled, err := r.githubClient.IsStatusReportingEnabled(ctx, repoURL)
+		enabled, err := r.githubClient.IsStatusReportingEnabled(ctx, groupID, repoURL)
 		if err != nil {
 			log.CtxInfof(ctx, "Failed to check if GitHub status reporting is enabled: %s", err)
 			return
@@ -141,11 +141,18 @@ func (r *BuildStatusReporter) flushPayloadsIfMetadataLoaded(ctx context.Context)
 		return
 	}
 
+	userInfo, err := r.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		log.CtxWarningf(ctx, "Failed to get authenticated user: %s", err)
+		return
+	}
+	groupID := userInfo.GetGroupID()
+
 	// Don't report statuses if we don't yet have the metadata, it's explicitly
 	// disabled in build metadata, or it's not enabled for this repo.
 	if !r.buildEventAccumulator.MetadataIsLoaded() ||
 		r.buildEventAccumulator.DisableCommitStatusReporting() ||
-		!r.isStatusReportingEnabled(ctx, r.buildEventAccumulator.Invocation().GetRepoUrl()) {
+		!r.isStatusReportingEnabled(ctx, groupID, r.buildEventAccumulator.Invocation().GetRepoUrl()) {
 		return
 	}
 
@@ -165,7 +172,7 @@ func (r *BuildStatusReporter) flushPayloadsIfMetadataLoaded(ctx context.Context)
 		}
 		commitSHA := r.buildEventAccumulator.Invocation().GetCommitSha()
 		if ownerRepo != "" && commitSHA != "" {
-			err = r.githubClient.CreateStatus(ctx, ownerRepo, commitSHA, payload)
+			err = r.githubClient.CreateStatus(ctx, groupID, ownerRepo, commitSHA, payload)
 			if err != nil {
 				// Note: using info-level log since this is often due to client
 				// misconfiguration (e.g. user doesn't have BB GitHub app

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -259,8 +259,8 @@ type GitHubStatusService interface {
 }
 
 type GitHubStatusClient interface {
-	CreateStatus(ctx context.Context, ownerRepo, commitSHA string, payload *github.RepoStatus) error
-	IsStatusReportingEnabled(ctx context.Context, repoURL string) (bool, error)
+	CreateStatus(ctx context.Context, groupID, ownerRepo, commitSHA string, payload *github.RepoStatus) error
+	IsStatusReportingEnabled(ctx context.Context, groupID, repoURL string) (bool, error)
 }
 
 // A Blobstore must allow for reading, writing, and deleting blobs.
@@ -846,7 +846,7 @@ type GitProvider interface {
 
 	// CreateStatus publishes a status payload to the given repo at the given
 	// commit SHA.
-	CreateStatus(ctx context.Context, accessToken, repoURL, commitSHA string, payload any) error
+	CreateStatus(ctx context.Context, accessToken, groupID, repoURL, commitSHA string, payload any) error
 
 	// TODO(bduffany): ListRepos
 }

--- a/server/testutil/testgit/testgit.go
+++ b/server/testutil/testgit/testgit.go
@@ -90,7 +90,7 @@ func (p *FakeProvider) IsTrusted(ctx context.Context, accessToken, repoURL, user
 	}
 	return false, nil
 }
-func (p *FakeProvider) CreateStatus(ctx context.Context, accessToken, repoURL, commitSHA string, payload any) error {
+func (p *FakeProvider) CreateStatus(ctx context.Context, accessToken, groupID, repoURL, commitSHA string, payload any) error {
 	p.Statuses <- &Status{accessToken, repoURL, commitSHA, payload}
 	return nil
 }


### PR DESCRIPTION
When handling webhooks, we don't have an authenticated context (see [logs](https://console.cloud.google.com/logs/query;query=%22Failed%20to%20create%20workflow%20config%20error%20status%22%0A;pinnedLogId=2026-05-05T22:10:32.014936021Z%2Fhjviqptrduooii5n;cursorTimestamp=2026-05-04T17:32:09.335267634Z;histogramBreakdownField=severity;duration=P2D?project=flame-build))