### PR TITLE
feat(CDC): add a max size cutoff experiment

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -1161,8 +1161,8 @@ func (s *ByteStreamServerProxy) writeChunked(ctx context.Context, stream bspb.By
 	}
 
 	blobSize := rn.GetDigest().GetSizeBytes()
-	if blobSize <= chunking.MaxChunkSizeBytes() {
-		return writeChunkedResult{firstReq: firstReq}, status.UnimplementedError("blob too small for chunking")
+	if !chunking.ShouldUploadChunked(ctx, s.efp, rn.GetDigest()) {
+		return writeChunkedResult{firstReq: firstReq}, status.UnimplementedError("blob outside chunking size range")
 	}
 
 	if spn.IsRecording() {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -102,6 +102,36 @@ func (c *noOpCAS) SplitBlob(ctx context.Context, req *repb.SplitBlobRequest) (*r
 	return nil, status.InternalError("SplitBlob RPC is not currently implemented")
 }
 
+func TestWriteChunkedFallsBackAboveMaxSize(t *testing.T) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_max_write_size_bytes": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "max",
+			Variants: map[string]any{
+				"max": 5 * 1024 * 1024,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	rn := digest.NewCASResourceName(
+		&repb.Digest{Hash: strings.Repeat("a", 64), SizeBytes: 6 * 1024 * 1024},
+		"",
+		repb.DigestFunction_BLAKE3,
+	)
+	s := &ByteStreamServerProxy{efp: fp}
+	result, err := s.writeChunked(ctx, &rawWriteStream{
+		ctx:          ctx,
+		resourceName: rn.NewUploadString(),
+		data:         []byte("x"),
+	})
+	require.True(t, status.IsUnimplementedError(err))
+	require.NotNil(t, result.firstReq)
+}
+
 type casRPCRecorder struct {
 	mu           sync.Mutex
 	fmbGroups    [][]string

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1462,7 +1462,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 	missingDigests := rsp.GetMissingBlobDigests()
 
 	eg, ctx := errgroup.WithContext(ctx)
-	u := cachetools.NewBatchCASUploader(ctx, env, *remoteInstanceName, repb.DigestFunction_SHA256, 0 /*=avgChunkSizeBytes*/)
+	u := cachetools.NewBatchCASUploader(ctx, env, *remoteInstanceName, repb.DigestFunction_SHA256, nil /*=chunkingParams*/)
 
 	for _, d := range missingDigests {
 		runfilePath, ok := fileDigestMap[digest.NewKey(d)]

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -873,7 +873,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	efp := s.env.GetExperimentFlagProvider()
 	if cdc.EnabledViaHeader(ctx) || (chunking.Enabled(ctx, efp) && efp != nil && efp.Boolean(ctx, "executor.upload_outputs_chunked", false)) {
 		executionTask.Experiments = append(executionTask.Experiments, "executor.upload_outputs_chunked")
-		executionTask.FastCdc_2020Params = chunking.FastCDCParams()
+		executionTask.FastCdc_2020Params = chunking.FastCDCWriteParams(ctx, efp)
 	}
 	if cdc.EnabledViaHeader(ctx) || (chunking.Enabled(ctx, efp) && efp != nil && efp.Boolean(ctx, "executor.download_inputs_chunked", false)) {
 		executionTask.Experiments = append(executionTask.Experiments, "executor.download_inputs_chunked")

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -198,6 +198,72 @@ func TestDispatch(t *testing.T) {
 	assert.Equal(t, iid, task.GetRequestMetadata().GetToolInvocationId(), "invocation ID should be passed along")
 }
 
+func TestDispatch_UploadOutputsChunkedMaxWriteSize(t *testing.T) {
+	env, _, _ := setupEnv(t)
+
+	tmp := testfs.MakeTempDir(t)
+	offlineFlagPath := testfs.WriteFile(t, tmp, "config.flagd.json", `
+{
+  "$schema": "https://flagd.dev/schema/v0/flags.json",
+  "flags": {
+    "cache.chunking_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true
+      },
+      "defaultVariant": "on"
+    },
+    "executor.upload_outputs_chunked": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true
+      },
+      "defaultVariant": "on"
+    },
+    "cache.chunking_max_write_size_bytes": {
+      "state": "ENABLED",
+      "variants": {
+        "limited": 123456789
+      },
+      "defaultVariant": "limited"
+    }
+  }
+}
+`)
+	provider, err := flagd.NewProvider(flagd.WithInProcessResolver(), flagd.WithOfflineFilePath(offlineFlagPath))
+	require.NoError(t, err)
+	openfeature.SetProviderAndWait(provider)
+	fp, err := experiments.NewFlagProvider("test")
+	require.NoError(t, err)
+	env.SetExperimentFlagProvider(fp)
+
+	ctx := context.Background()
+	s := env.GetRemoteExecutionService()
+
+	const iid = "10243d8a-a329-4f46-abfb-bfbceed12baa"
+	ctx = withIncomingMetadata(t, ctx, &repb.RequestMetadata{
+		ToolDetails:      &repb.ToolDetails{ToolName: "bazel", ToolVersion: "6.3.0"},
+		ToolInvocationId: iid,
+	})
+	ctx, err = env.GetAuthenticator().(*testauth.TestAuthenticator).WithAuthenticatedUser(ctx, "US1")
+	require.NoError(t, err)
+
+	action := &repb.Action{}
+	arn := uploadAction(ctx, t, env, "" /*=instanceName*/, repb.DigestFunction_SHA256, action)
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+	err = s.Dispatch(ctx, &repb.ExecuteRequest{ActionDigest: arn.GetDigest()}, action, arn.NewUploadString())
+	require.NoError(t, err)
+
+	sched := env.GetSchedulerService().(*schedulerServerMock)
+	require.Equal(t, 1, len(sched.scheduleReqs))
+	task := &repb.ExecutionTask{}
+	err = proto.Unmarshal(sched.scheduleReqs[0].SerializedTask, task)
+	require.NoError(t, err)
+	require.Contains(t, task.GetExperiments(), "executor.upload_outputs_chunked")
+	require.Equal(t, int64(123456789), task.GetFastCdc_2020Params().GetBuildbuddyMaxChunkedWriteSizeBytes())
+}
+
 func TestDispatch_RecordsClientIP(t *testing.T) {
 	flags.Set(t, "remote_execution.write_execution_progress_state_to_redis", true)
 	env, _, _ := setupEnv(t)

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -525,7 +525,7 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, cmd *repb.Command, execu
 			cmd,
 			executeResponse.Result,
 			addToFileCache,
-			int64(ws.task.GetFastCdc_2020Params().GetAvgChunkSizeBytes()),
+			ws.task.GetFastCdc_2020Params(),
 		)
 		return err
 	})

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2518,6 +2518,10 @@ message FastCdc2020Params {
   // All clients sharing a cache SHOULD use the same seed to maximize
   // chunk reuse.
   uint32 seed = 2;
+
+  // BuildBuddy-only: maximum blob size eligible for chunked writes.
+  // If unset or <= 0, no maximum is applied.
+  int64 buildbuddy_max_chunked_write_size_bytes = 1000;
 }
 
 // Parameters for the RepMaxCDC content-defined chunking algorithm.

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -465,7 +465,7 @@ func handleSymlink(dirHelper *DirHelper, rootDir string, cmd *repb.Command, acti
 	return nil
 }
 
-func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, instanceName string, digestFunction repb.DigestFunction_Value, rootDir string, cmd *repb.Command, actionResult *repb.ActionResult, addToFileCache bool, avgChunkSizeBytes int64) (*TransferInfo, error) {
+func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, instanceName string, digestFunction repb.DigestFunction_Value, rootDir string, cmd *repb.Command, actionResult *repb.ActionResult, addToFileCache bool, chunkingParams *repb.FastCdc2020Params) (*TransferInfo, error) {
 	startTime := time.Now()
 	outputDirectoryPaths := make([]string, 0)
 	filesToUpload := make([]*fileToUpload, 0)
@@ -551,7 +551,7 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 		return nil, err
 	}
 
-	uploader := cachetools.NewBatchCASUploader(ctx, env, instanceName, digestFunction, avgChunkSizeBytes)
+	uploader := cachetools.NewBatchCASUploader(ctx, env, instanceName, digestFunction, chunkingParams)
 
 	// Upload output files to the remote cache and also add them to the local
 	// cache since they are likely to be used as inputs to subsequent actions.

--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -666,7 +666,7 @@ func TestUploadTree(t *testing.T) {
 			dirHelper := dirtools.NewDirHelper(rootDir, tc.cmd, fs.FileMode(0o755))
 
 			actionResult := &repb.ActionResult{}
-			txInfo, err := dirtools.UploadTree(ctx, env, dirHelper, "", repb.DigestFunction_SHA256, rootDir, tc.cmd, actionResult, true /*=addToFileCache*/, 0 /*=avgChunkSizeBytes*/)
+			txInfo, err := dirtools.UploadTree(ctx, env, dirHelper, "", repb.DigestFunction_SHA256, rootDir, tc.cmd, actionResult, true /*=addToFileCache*/, nil /*=chunkingParams*/)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedInfo.FileCount, txInfo.FileCount)

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -605,10 +605,10 @@ func uploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 
 // uploadFromReaderWithChunking uploads a blob to the CAS using FastCDC if
 // the blob is large enough. Missing chunks are uploaded and then SpliceBlob
-// is used to tell the server how to reassemble them. Blobs less than the
-// threshold are uploaded normally.
-func uploadFromReaderWithChunking(ctx context.Context, env environment.Env, r *digest.CASResourceName, in readAtSeeker, avgChunkSizeBytes int64) (*repb.Digest, int64, error) {
-	if !shouldUploadChunked(env, r.GetDigest(), avgChunkSizeBytes) {
+// is used to tell the server how to reassemble them. Blobs outside the chunked
+// upload size range are uploaded normally.
+func uploadFromReaderWithChunking(ctx context.Context, env environment.Env, r *digest.CASResourceName, in readAtSeeker, chunkingParams *repb.FastCdc2020Params) (*repb.Digest, int64, error) {
+	if !shouldUploadChunked(env, r.GetDigest(), chunkingParams) {
 		return UploadFromReader(ctx, env.GetByteStreamClient(), r, in)
 	}
 	if _, err := in.Seek(0, io.SeekStart); err != nil {
@@ -616,7 +616,7 @@ func uploadFromReaderWithChunking(ctx context.Context, env environment.Env, r *d
 	}
 
 	var chunkDigests []*repb.Digest
-	chunker, err := chunking.NewChunker(ctx, int(avgChunkSizeBytes), func(chunkData []byte) error {
+	chunker, err := chunking.NewChunker(ctx, int(chunkingParams.GetAvgChunkSizeBytes()), func(chunkData []byte) error {
 		d, err := digest.Compute(bytes.NewReader(chunkData), r.GetDigestFunction())
 		if err != nil {
 			return err
@@ -713,12 +713,20 @@ func uploadFromReaderWithChunking(ctx context.Context, env environment.Env, r *d
 	return r.GetDigest(), uploadedBytes.Load(), nil
 }
 
-func shouldUploadChunked(env environment.Env, d *repb.Digest, avgChunkSizeBytes int64) bool {
-	return env != nil &&
-		env.GetByteStreamClient() != nil &&
-		env.GetContentAddressableStorageClient() != nil &&
-		avgChunkSizeBytes > 0 &&
-		d.GetSizeBytes() > avgChunkSizeBytes*4
+func shouldUploadChunked(env environment.Env, d *repb.Digest, chunkingParams *repb.FastCdc2020Params) bool {
+	if env == nil || env.GetByteStreamClient() == nil || env.GetContentAddressableStorageClient() == nil {
+		return false
+	}
+	avgChunkSizeBytes := int64(chunkingParams.GetAvgChunkSizeBytes())
+	if avgChunkSizeBytes <= 0 {
+		return false
+	}
+	sizeBytes := d.GetSizeBytes()
+	if sizeBytes <= avgChunkSizeBytes*4 {
+		return false
+	}
+	maxWriteSizeBytes := chunkingParams.GetBuildbuddyMaxChunkedWriteSizeBytes()
+	return maxWriteSizeBytes <= 0 || sizeBytes <= maxWriteSizeBytes
 }
 
 type uploadRetryResult = struct {
@@ -953,32 +961,32 @@ func UploadProtoToCAS(ctx context.Context, cache interfaces.Cache, instanceName 
 // BatchCASUploader uploads many files to CAS concurrently, batching small
 // uploads together and falling back to bytestream uploads for large files.
 type BatchCASUploader struct {
-	ctx               context.Context
-	env               environment.Env
-	eg                *errgroup.Group
-	unsentBatchReq    *repb.BatchUpdateBlobsRequest
-	uploads           map[digest.Key]struct{}
-	instanceName      string
-	digestFunction    repb.DigestFunction_Value
-	unsentBatchSize   int64
-	stats             UploadStats
-	avgChunkSizeBytes int64
+	ctx             context.Context
+	env             environment.Env
+	eg              *errgroup.Group
+	unsentBatchReq  *repb.BatchUpdateBlobsRequest
+	uploads         map[digest.Key]struct{}
+	instanceName    string
+	digestFunction  repb.DigestFunction_Value
+	unsentBatchSize int64
+	stats           UploadStats
+	chunkingParams  *repb.FastCdc2020Params
 }
 
 // NewBatchCASUploader returns an uploader to be used only for the given request
 // context (it should not be used outside the lifecycle of the request).
-func NewBatchCASUploader(ctx context.Context, env environment.Env, instanceName string, digestFunction repb.DigestFunction_Value, avgChunkSizeBytes int64) *BatchCASUploader {
+func NewBatchCASUploader(ctx context.Context, env environment.Env, instanceName string, digestFunction repb.DigestFunction_Value, chunkingParams *repb.FastCdc2020Params) *BatchCASUploader {
 	eg, ctx := errgroup.WithContext(ctx)
 	return &BatchCASUploader{
-		ctx:               ctx,
-		env:               env,
-		eg:                eg,
-		unsentBatchReq:    &repb.BatchUpdateBlobsRequest{InstanceName: instanceName, DigestFunction: digestFunction},
-		unsentBatchSize:   0,
-		instanceName:      instanceName,
-		digestFunction:    digestFunction,
-		uploads:           make(map[digest.Key]struct{}),
-		avgChunkSizeBytes: avgChunkSizeBytes,
+		ctx:             ctx,
+		env:             env,
+		eg:              eg,
+		unsentBatchReq:  &repb.BatchUpdateBlobsRequest{InstanceName: instanceName, DigestFunction: digestFunction},
+		unsentBatchSize: 0,
+		instanceName:    instanceName,
+		digestFunction:  digestFunction,
+		uploads:         make(map[digest.Key]struct{}),
+		chunkingParams:  chunkingParams,
 	}
 }
 
@@ -1013,10 +1021,10 @@ func (ul *BatchCASUploader) Upload(d *repb.Digest, rsc io.ReadSeekCloser) error 
 		resourceName := digest.NewCASResourceName(d, ul.instanceName, ul.digestFunction)
 		resourceName.SetCompressor(compressor)
 
-		if ras, ok := rsc.(readAtSeeker); ok && ul.avgChunkSizeBytes > 0 {
+		if ras, ok := rsc.(readAtSeeker); ok && ul.chunkingParams.GetAvgChunkSizeBytes() > 0 {
 			ul.eg.Go(func() error {
 				defer r.Close()
-				_, _, err := uploadFromReaderWithChunking(ul.ctx, ul.env, resourceName, ras, ul.avgChunkSizeBytes)
+				_, _, err := uploadFromReaderWithChunking(ul.ctx, ul.env, resourceName, ras, ul.chunkingParams)
 				return err
 			})
 			return nil
@@ -1203,7 +1211,7 @@ func (*bytesReadSeekCloser) Close() error { return nil }
 // as well as the directory structure, and returns the digest of the root
 // Directory proto that can be used to fetch the uploaded contents.
 func UploadDirectoryToCAS(ctx context.Context, env environment.Env, instanceName string, digestFunction repb.DigestFunction_Value, rootDirPath string) (*repb.Digest, *repb.Digest, error) {
-	ul := NewBatchCASUploader(ctx, env, instanceName, digestFunction, 0 /*=avgChunkSizeBytes*/)
+	ul := NewBatchCASUploader(ctx, env, instanceName, digestFunction, nil /*=chunkingParams*/)
 
 	// Recursively find and upload all descendant dirs.
 	visited, rootDirectoryDigest, err := uploadDir(ul, rootDirPath, nil /*=visited*/)

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -1035,7 +1035,7 @@ func TestConcurrentMutationDuringUpload(t *testing.T) {
 			// simulating a concurrent mutation.
 			b[0] = 'x'
 			ctx := context.Background()
-			ul := cachetools.NewBatchCASUploader(ctx, te, "", df, 0 /*=avgChunkSizeBytes*/)
+			ul := cachetools.NewBatchCASUploader(ctx, te, "", df, nil /*=chunkingParams*/)
 			_ = ul.Upload(d, cachetools.NewBytesReadSeekCloser(b))
 			err = ul.Wait()
 			require.Error(t, err)
@@ -1057,7 +1057,7 @@ func TestBatchCASUploader_DedupesUploads(t *testing.T) {
 	ctx := context.Background()
 	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
 	require.NoError(t, err)
-	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), df, 0 /*=avgChunkSizeBytes*/)
+	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), df, nil /*=chunkingParams*/)
 
 	require.NoError(t, ul.Upload(rn.GetDigest(), cachetools.NewBytesReadSeekCloser(buf)))
 	require.NoError(t, ul.Upload(rn.GetDigest(), cachetools.NewBytesReadSeekCloser(buf)))
@@ -1473,7 +1473,7 @@ func TestBatchCASUploader_ChunkedUpload(t *testing.T) {
 	blobSize := int64(3 * 1024 * 1024)
 	rn, buf := testdigest.RandomCASResourceBuf(t, blobSize)
 
-	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), rn.GetDigestFunction(), chunking.AvgChunkSizeBytes())
+	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), rn.GetDigestFunction(), chunking.FastCDCParams())
 	require.NoError(t, ul.Upload(rn.GetDigest(), cachetools.NewBytesReadSeekCloser(buf)))
 	require.NoError(t, ul.Wait())
 
@@ -1482,4 +1482,49 @@ func TestBatchCASUploader_ChunkedUpload(t *testing.T) {
 	err = cachetools.GetBlob(ctx, te.GetByteStreamClient(), casRN, out)
 	require.NoError(t, err)
 	require.Equal(t, buf, out.Bytes())
+}
+
+func TestBatchCASUploader_SkipsChunkedUploadAboveMaxSize(t *testing.T) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
+	te := testenv.GetTestEnv(t)
+	te.SetExperimentFlagProvider(fp)
+	_, runServer, localGRPClis := testenv.RegisterLocalGRPCServer(t, te)
+	testcache.Setup(t, te, localGRPClis)
+	go runServer()
+
+	ctx := context.Background()
+	blobSize := int64(3 * 1024 * 1024)
+	rn, buf := testdigest.RandomCASResourceBuf(t, blobSize)
+
+	chunkingParams := chunking.FastCDCParams()
+	chunkingParams.BuildbuddyMaxChunkedWriteSizeBytes = 2 * 1024 * 1024
+	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), rn.GetDigestFunction(), chunkingParams)
+	require.NoError(t, ul.Upload(rn.GetDigest(), cachetools.NewBytesReadSeekCloser(buf)))
+	require.NoError(t, ul.Wait())
+
+	casRN := digest.NewCASResourceName(rn.GetDigest(), rn.GetInstanceName(), rn.GetDigestFunction())
+	out := &bytes.Buffer{}
+	err = cachetools.GetBlob(ctx, te.GetByteStreamClient(), casRN, out)
+	require.NoError(t, err)
+	require.Equal(t, buf, out.Bytes())
+
+	_, err = te.GetContentAddressableStorageClient().SplitBlob(ctx, &repb.SplitBlobRequest{
+		InstanceName:   rn.GetInstanceName(),
+		BlobDigest:     rn.GetDigest(),
+		DigestFunction: rn.GetDigestFunction(),
+	})
+	require.True(t, status.IsNotFoundError(err))
 }

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -39,6 +39,9 @@ const (
 	chunkedManifestPrefix        = "_bb_chunked_manifest_v3_/"
 	chunkOutputFilePrefix        = "chunk_"
 	sharedValidationMarkerDomain = "cas-validation-marker-v1"
+
+	// Default max blob size eligible for chunked writes. Values <= 0 mean no maximum.
+	defaultMaxChunkedWriteSizeBytes = -1
 )
 
 func AvgChunkSizeBytes() int64 {
@@ -57,8 +60,36 @@ func FastCDCParams() *repb.FastCdc2020Params {
 	}
 }
 
+func FastCDCWriteParams(ctx context.Context, efp interfaces.ExperimentFlagProvider) *repb.FastCdc2020Params {
+	params := FastCDCParams()
+	if params != nil {
+		params.BuildbuddyMaxChunkedWriteSizeBytes = MaxWriteSizeBytes(ctx, efp)
+	}
+	return params
+}
+
 func MaxChunkSizeBytes() int64 {
 	return *avgChunkSizeBytes * 4
+}
+
+func MaxWriteSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
+	if efp == nil {
+		return defaultMaxChunkedWriteSizeBytes
+	}
+	return efp.Int64(ctx, "cache.chunking_max_write_size_bytes", defaultMaxChunkedWriteSizeBytes)
+}
+
+func ShouldUploadChunked(ctx context.Context, efp interfaces.ExperimentFlagProvider, d *repb.Digest) bool {
+	return ShouldUploadChunkedWithMax(d, AvgChunkSizeBytes(), MaxWriteSizeBytes(ctx, efp))
+}
+
+// ShouldUploadChunkedWithMax returns whether a blob is eligible for chunked upload.
+func ShouldUploadChunkedWithMax(d *repb.Digest, avgChunkSizeBytes, maxWriteSizeBytes int64) bool {
+	if avgChunkSizeBytes <= 0 {
+		return false
+	}
+	size := d.GetSizeBytes()
+	return size > avgChunkSizeBytes*4 && (maxWriteSizeBytes <= 0 || size <= maxWriteSizeBytes)
 }
 
 func ValidateConfig() error {

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -72,6 +72,47 @@ func TestChunker_ReassemblesOriginalData(t *testing.T) {
 	require.Equal(t, originalData, reassembled.Bytes(), "reassembled data should match original")
 }
 
+func TestShouldUploadChunkedWithMax(t *testing.T) {
+	avgChunkSizeBytes := int64(512 * 1024)
+
+	for _, tc := range []struct {
+		name              string
+		sizeBytes         int64
+		maxWriteSizeBytes int64
+		want              bool
+	}{
+		{
+			name:              "below minimum",
+			sizeBytes:         1 * 1024 * 1024,
+			maxWriteSizeBytes: 5 * 1024 * 1024,
+			want:              false,
+		},
+		{
+			name:              "within range",
+			sizeBytes:         3 * 1024 * 1024,
+			maxWriteSizeBytes: 5 * 1024 * 1024,
+			want:              true,
+		},
+		{
+			name:              "above max",
+			sizeBytes:         6 * 1024 * 1024,
+			maxWriteSizeBytes: 5 * 1024 * 1024,
+			want:              false,
+		},
+		{
+			name:              "unset max",
+			sizeBytes:         3 * 1024 * 1024,
+			maxWriteSizeBytes: 0,
+			want:              true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &repb.Digest{Hash: "hash", SizeBytes: tc.sizeBytes}
+			require.Equal(t, tc.want, chunking.ShouldUploadChunkedWithMax(d, avgChunkSizeBytes, tc.maxWriteSizeBytes))
+		})
+	}
+}
+
 func TestChunker_DeterministicChunking(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
There's a chance that very large blobs have less ROI with CDC because they cost a huge amount of GCS put operations. Although they may still save from de-duplication.

This creates an experiment, defaulting to -1 which means no maximum. We can try lowering this to 1GB or 500MB to see if we get some benefits.