### PR TITLE
Stop using execution ID read from clickhouse.

### DIFF
--- a/enterprise/server/execution_search_service/execution_search_service_test.go
+++ b/enterprise/server/execution_search_service/execution_search_service_test.go
@@ -137,8 +137,9 @@ func TestSearchExecutions(t *testing.T) {
 			UpdatedAtUsec:    testTimestampUsec + 2000,
 		},
 	}
-	for _, execution := range executions {
-		require.NoError(t, clickhouse.FillExecutionResourceFields(execution))
+	executionIDs := []string{exid1, exid2, exid3}
+	for i, execution := range executions {
+		require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(execution, executionIDs[i]))
 		err := env.GetOLAPDBHandle().GORM(ctx, "test_create_execution").Create(execution).Error
 		require.NoError(t, err)
 	}
@@ -152,13 +153,13 @@ func TestSearchExecutions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, rsp.Execution, 2, "should return 2 executions for GR1")
 
-	executionIDs := make([]string, len(rsp.Execution))
+	gotExecutionIDs := make([]string, len(rsp.Execution))
 	for i, ex := range rsp.Execution {
-		executionIDs[i] = ex.Execution.ExecutionId
+		gotExecutionIDs[i] = ex.Execution.ExecutionId
 	}
-	assert.Contains(t, executionIDs, exid1)
-	assert.Contains(t, executionIDs, exid2)
-	assert.NotContains(t, executionIDs, exid3, "should not contain execution from GR2")
+	assert.Contains(t, gotExecutionIDs, exid1)
+	assert.Contains(t, gotExecutionIDs, exid2)
+	assert.NotContains(t, gotExecutionIDs, exid3, "should not contain execution from GR2")
 
 	for _, ex := range rsp.Execution {
 		assert.NotEmpty(t, ex.InvocationMetadata.Id)
@@ -254,8 +255,9 @@ func TestSearchExecutions_SkipsEmptyInvocationUUID(t *testing.T) {
 			UpdatedAtUsec:    testTimestampUsec + 1000,
 		},
 	}
-	for _, execution := range executions {
-		require.NoError(t, clickhouse.FillExecutionResourceFields(execution))
+	executionIDs := []string{exid1, exid2}
+	for i, execution := range executions {
+		require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(execution, executionIDs[i]))
 		err := env.GetOLAPDBHandle().GORM(ctx, "test_create_execution").Create(execution).Error
 		require.NoError(t, err)
 	}
@@ -288,8 +290,9 @@ func TestSearchExecutions_Pagination(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		hash := fmt.Sprintf("a948904f2f0f479b8f8564cbf12dac6b5c8c3c1f7e8b4d6a3c2e1f0a9b8c7d%02x", i)
 		actionDigest := &repb.Digest{Hash: hash, SizeBytes: int64(100 + i*10)}
+		executionID := makeExecutionID(actionDigest)
 		executions[i] = &olaptables.Execution{
-			ExecutionID:      makeExecutionID(actionDigest),
+			ExecutionID:      executionID,
 			GroupID:          "GR1",
 			InvocationUUID:   strings.ReplaceAll(uuid.New(), "-", ""),
 			User:             "ci-runner",
@@ -305,9 +308,9 @@ func TestSearchExecutions_Pagination(t *testing.T) {
 			CreatedAtUsec:    testTimestampUsec + int64(i*1000),
 			UpdatedAtUsec:    testTimestampUsec + int64(i*1000),
 		}
+		require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(executions[i], executionID))
 	}
 	for _, execution := range executions {
-		require.NoError(t, clickhouse.FillExecutionResourceFields(execution))
 		err := env.GetOLAPDBHandle().GORM(ctx, "test_create_execution").Create(execution).Error
 		require.NoError(t, err)
 	}
@@ -352,12 +355,13 @@ func TestSearchExecutions_PaginationWithEmptyInvocationUUIDs(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		hash := fmt.Sprintf("b948904f2f0f479b8f8564cbf12dac6b5c8c3c1f7e8b4d6a3c2e1f0a9b8c7d%02x", i)
 		actionDigest := &repb.Digest{Hash: hash, SizeBytes: int64(100 + i*10)}
+		executionID := makeExecutionID(actionDigest)
 		invocationUUID := strings.ReplaceAll(uuid.New(), "-", "")
 		if i%4 == 0 {
 			invocationUUID = ""
 		}
 		executions[i] = &olaptables.Execution{
-			ExecutionID:      makeExecutionID(actionDigest),
+			ExecutionID:      executionID,
 			GroupID:          "GR1",
 			InvocationUUID:   invocationUUID,
 			User:             "ci-runner",
@@ -373,9 +377,9 @@ func TestSearchExecutions_PaginationWithEmptyInvocationUUIDs(t *testing.T) {
 			CreatedAtUsec:    testTimestampUsec + int64(i*1000),
 			UpdatedAtUsec:    testTimestampUsec + int64(i*1000),
 		}
+		require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(executions[i], executionID))
 	}
 	for _, execution := range executions {
-		require.NoError(t, clickhouse.FillExecutionResourceFields(execution))
 		err := env.GetOLAPDBHandle().GORM(ctx, "test_create_execution").Create(execution).Error
 		require.NoError(t, err)
 	}

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -291,7 +291,7 @@ func (es *ExecutionService) getInvocationExecutionsFromOLAPDB(ctx context.Contex
 	}
 
 	// Combine the in-progress, buffered and flushed executions. Dedupe by
-	// execution ID, since an execution's transitions between these lists are
+	// execution UUID, since an execution's transitions between these lists are
 	// not atomic. Prefer flushed executions, then buffered, then in-progress.
 	executions := slices.Concat(flushedExecutions, bufferedExecutions, inProgressExecutions)
 	executionIDs := make(map[string]bool)

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -3,6 +3,7 @@ package execution_service
 import (
 	"cmp"
 	"context"
+	"encoding/hex"
 	"flag"
 	"io"
 	"path"
@@ -258,10 +259,18 @@ func (es *ExecutionService) getInvocationExecutionsFromOLAPDB(ctx context.Contex
 		q.AddWhereClause(`group_id = ?`, inv.GroupID)
 		q.AddWhereClause(`invocation_uuid = ?`, strings.ReplaceAll(invocationID, "-", ""))
 		if actionDigestHash != "" {
-			q.AddWhereClause(`execution_id LIKE ?`, "%/"+actionDigestHash+"/%")
+			hashBytes, err := hex.DecodeString(actionDigestHash)
+			if err != nil {
+				return status.InvalidArgumentErrorf("invalid action digest hash %q: %s", actionDigestHash, err)
+			}
+			q.AddWhereClause(`action_digest_hash = ?`, string(hashBytes))
 		}
 		if executionID != "" {
-			q.AddWhereClause(`execution_id = ?`, executionID)
+			_, executionUUID, err := digest.ParseUploadResourceNameWithUUID(executionID)
+			if err != nil {
+				return status.InvalidArgumentErrorf("invalid execution ID %q: %s", executionID, err)
+			}
+			q.AddWhereClause(`execution_uuid = ?`, executionUUID)
 		}
 		if targetLabel != "" {
 			q.AddWhereClause(`target_label = ?`, targetLabel)
@@ -288,10 +297,11 @@ func (es *ExecutionService) getInvocationExecutionsFromOLAPDB(ctx context.Contex
 	executionIDs := make(map[string]bool)
 	dedupedExecutions := make([]*olaptables.Execution, 0, len(executions))
 	for _, e := range executions {
-		if _, ok := executionIDs[e.ExecutionID]; !ok {
-			executionIDs[e.ExecutionID] = true
-			dedupedExecutions = append(dedupedExecutions, e)
+		if executionIDs[e.ExecutionUUID] {
+			continue
 		}
+		executionIDs[e.ExecutionUUID] = true
+		dedupedExecutions = append(dedupedExecutions, e)
 	}
 
 	return dedupedExecutions, nil
@@ -386,7 +396,7 @@ func (es *ExecutionService) lookupExecutions(ctx context.Context, lookup *espb.E
 			return nil, status.WrapError(err, "convert OLAP execution to client proto")
 		}
 		executions = append(executions, proto)
-		olapExecutionIDs[e.ExecutionID] = true
+		olapExecutionIDs[proto.GetExecutionId()] = true
 	}
 	for _, e := range primaryDBExecutions {
 		if olapExecutionIDs[e.ExecutionID] {

--- a/enterprise/server/execution_service/execution_service_test.go
+++ b/enterprise/server/execution_service/execution_service_test.go
@@ -75,7 +75,6 @@ func TestGetExecution_OLAPOnly(t *testing.T) {
 			},
 			executions: []*olaptables.Execution{
 				{
-					ExecutionID:    exid1,
 					InvocationUUID: strings.ReplaceAll(iid1, "-", ""),
 					CreatedAtUsec:  testTimestampUsec,
 					UpdatedAtUsec:  testTimestampUsec,
@@ -104,7 +103,6 @@ func TestGetExecution_OLAPOnly(t *testing.T) {
 			},
 			executions: []*olaptables.Execution{
 				{
-					ExecutionID:    exid1,
 					GroupID:        "GR1",
 					InvocationUUID: strings.ReplaceAll(iid1, "-", ""),
 					CreatedAtUsec:  testTimestampUsec,
@@ -135,7 +133,6 @@ func TestGetExecution_OLAPOnly(t *testing.T) {
 			},
 			executions: []*olaptables.Execution{
 				{
-					ExecutionID:    exid1,
 					GroupID:        "GR1",
 					InvocationUUID: strings.ReplaceAll(iid1, "-", ""),
 					CreatedAtUsec:  testTimestampUsec,
@@ -173,7 +170,7 @@ func TestGetExecution_OLAPOnly(t *testing.T) {
 			for _, execution := range test.executions {
 				execution.CreatedAtUsec = testTimestampUsec
 				execution.UpdatedAtUsec = testTimestampUsec
-				require.NoError(t, clickhouse.FillExecutionResourceFields(execution))
+				require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(execution, exid1))
 				err := env.GetOLAPDBHandle().GORM(ctx, "test_create_execution").Create(execution).Error
 				require.NoError(t, err)
 			}
@@ -435,4 +432,206 @@ func TestGetExecutionDownloads(t *testing.T) {
 			require.Empty(t, rsp.GetNextPageToken())
 		})
 	}
+}
+
+func TestGetExecution_OLAPOnly_ExactFilters(t *testing.T) {
+	flags.Set(t, "testenv.use_clickhouse", true)
+	flags.Set(t, "testenv.reuse_server", true)
+	flags.Set(t, "remote_execution.primary_db_reads_enabled", false)
+	flags.Set(t, "remote_execution.olap_reads_enabled", true)
+
+	env := testenv.GetTestEnv(t)
+	redis := testredis.Start(t)
+	env.SetDefaultRedisClient(redis.Client())
+	redis_execution_collector.Register(env)
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1"))
+	env.SetAuthenticator(ta)
+	es := execution_service.NewExecutionService(env)
+
+	ctx := context.Background()
+	iid := uuid.New()
+	nowUsec := time.Now().UnixMicro()
+	invocation := &tables.Invocation{
+		InvocationID:     iid,
+		GroupID:          "GR1",
+		InvocationStatus: int64(inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS),
+		Perms:            perms.GROUP_READ,
+		Model:            tables.Model{CreatedAtUsec: nowUsec, UpdatedAtUsec: nowUsec},
+	}
+	require.NoError(t, env.GetDBHandle().GORM(ctx, "test_create_invocation").Create(invocation).Error)
+
+	ad1 := &repb.Digest{Hash: strings.Repeat("1", 64), SizeBytes: 10}
+	ad2 := &repb.Digest{Hash: strings.Repeat("2", 64), SizeBytes: 20}
+	exid1 := digest.NewCASResourceName(ad1, "test-instance-name", repb.DigestFunction_SHA256).NewUploadString()
+	exid2 := digest.NewCASResourceName(ad2, "test-instance-name", repb.DigestFunction_SHA256).NewUploadString()
+	for _, executionID := range []string{exid1, exid2} {
+		execution := &olaptables.Execution{
+			GroupID:        "GR1",
+			InvocationUUID: strings.ReplaceAll(iid, "-", ""),
+			CreatedAtUsec:  nowUsec,
+			UpdatedAtUsec:  nowUsec,
+		}
+		require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(execution, executionID))
+		require.NoError(t, env.GetOLAPDBHandle().GORM(ctx, "test_create_execution").Create(execution).Error)
+	}
+
+	ctx, err := ta.WithAuthenticatedUser(ctx, "US1")
+	require.NoError(t, err)
+
+	rsp, err := es.GetExecution(ctx, &espb.GetExecutionRequest{
+		ExecutionLookup: &espb.ExecutionLookup{
+			InvocationId: iid,
+			ExecutionId:  exid2,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, rsp.GetExecution(), 1)
+	require.Equal(t, exid2, rsp.GetExecution()[0].GetExecutionId())
+
+	rsp, err = es.GetExecution(ctx, &espb.GetExecutionRequest{
+		ExecutionLookup: &espb.ExecutionLookup{
+			InvocationId:     iid,
+			ActionDigestHash: ad1.GetHash(),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, rsp.GetExecution(), 1)
+	require.Equal(t, exid1, rsp.GetExecution()[0].GetExecutionId())
+
+	// Malformed action digest hash → InvalidArgument.
+	_, err = es.GetExecution(ctx, &espb.GetExecutionRequest{
+		ExecutionLookup: &espb.ExecutionLookup{
+			InvocationId:     iid,
+			ActionDigestHash: "not-hex",
+		},
+	})
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got %v", err)
+
+	// Malformed execution ID → InvalidArgument.
+	_, err = es.GetExecution(ctx, &espb.GetExecutionRequest{
+		ExecutionLookup: &espb.ExecutionLookup{
+			InvocationId: iid,
+			ExecutionId:  "not-a-resource-name",
+		},
+	})
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got %v", err)
+}
+
+func TestGetExecution_OLAPOnly_DoesNotCollapseDistinctExecutions(t *testing.T) {
+	flags.Set(t, "testenv.use_clickhouse", true)
+	flags.Set(t, "testenv.reuse_server", true)
+	flags.Set(t, "remote_execution.primary_db_reads_enabled", false)
+	flags.Set(t, "remote_execution.olap_reads_enabled", true)
+
+	env := testenv.GetTestEnv(t)
+	redis := testredis.Start(t)
+	env.SetDefaultRedisClient(redis.Client())
+	redis_execution_collector.Register(env)
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1"))
+	env.SetAuthenticator(ta)
+	es := execution_service.NewExecutionService(env)
+
+	ctx := context.Background()
+	iid := uuid.New()
+	nowUsec := time.Now().UnixMicro()
+	invocation := &tables.Invocation{
+		InvocationID:     iid,
+		GroupID:          "GR1",
+		InvocationStatus: int64(inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS),
+		Perms:            perms.GROUP_READ,
+		Model:            tables.Model{CreatedAtUsec: nowUsec, UpdatedAtUsec: nowUsec},
+	}
+	require.NoError(t, env.GetDBHandle().GORM(ctx, "test_create_invocation").Create(invocation).Error)
+
+	ad1 := &repb.Digest{Hash: strings.Repeat("1", 64), SizeBytes: 10}
+	ad2 := &repb.Digest{Hash: strings.Repeat("2", 64), SizeBytes: 20}
+	exid1 := digest.NewCASResourceName(ad1, "test-instance-name", repb.DigestFunction_SHA256).NewUploadString()
+	exid2 := digest.NewCASResourceName(ad2, "test-instance-name", repb.DigestFunction_SHA256).NewUploadString()
+	for i, executionID := range []string{exid1, exid2} {
+		execution := &olaptables.Execution{
+			GroupID:             "GR1",
+			InvocationUUID:      strings.ReplaceAll(iid, "-", ""),
+			CreatedAtUsec:       nowUsec,
+			UpdatedAtUsec:       nowUsec,
+			QueuedTimestampUsec: nowUsec + int64(i),
+		}
+		require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(execution, executionID))
+		require.NoError(t, env.GetOLAPDBHandle().GORM(ctx, "test_create_execution").Create(execution).Error)
+	}
+
+	ctx, err := ta.WithAuthenticatedUser(ctx, "US1")
+	require.NoError(t, err)
+
+	rsp, err := es.GetExecution(ctx, &espb.GetExecutionRequest{
+		ExecutionLookup: &espb.ExecutionLookup{InvocationId: iid},
+	})
+	require.NoError(t, err)
+	require.Len(t, rsp.GetExecution(), 2)
+	require.ElementsMatch(t, []string{exid1, exid2}, []string{
+		rsp.GetExecution()[0].GetExecutionId(),
+		rsp.GetExecution()[1].GetExecutionId(),
+	})
+}
+
+func TestGetExecution_PrefersOLAPWithoutDuplicatingPrimary(t *testing.T) {
+	flags.Set(t, "testenv.use_clickhouse", true)
+	flags.Set(t, "testenv.reuse_server", true)
+	flags.Set(t, "remote_execution.primary_db_reads_enabled", true)
+	flags.Set(t, "remote_execution.olap_reads_enabled", true)
+
+	env := testenv.GetTestEnv(t)
+	redis := testredis.Start(t)
+	env.SetDefaultRedisClient(redis.Client())
+	redis_execution_collector.Register(env)
+	ta := testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1"))
+	env.SetAuthenticator(ta)
+	es := execution_service.NewExecutionService(env)
+
+	ctx := context.Background()
+	iid := uuid.New()
+	nowUsec := time.Now().UnixMicro()
+	invocation := &tables.Invocation{
+		InvocationID:     iid,
+		GroupID:          "GR1",
+		InvocationStatus: int64(inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS),
+		Perms:            perms.GROUP_READ,
+		Model:            tables.Model{CreatedAtUsec: nowUsec, UpdatedAtUsec: nowUsec},
+	}
+	require.NoError(t, env.GetDBHandle().GORM(ctx, "test_create_invocation").Create(invocation).Error)
+
+	ad := &repb.Digest{Hash: strings.Repeat("3", 64), SizeBytes: 30}
+	executionID := digest.NewCASResourceName(ad, "test-instance-name", repb.DigestFunction_SHA256).NewUploadString()
+	require.NoError(t, env.GetDBHandle().GORM(ctx, "test_create_execution").Create(&tables.Execution{
+		ExecutionID:         executionID,
+		InvocationID:        iid,
+		GroupID:             "GR1",
+		Perms:               perms.GROUP_READ,
+		Model:               tables.Model{CreatedAtUsec: nowUsec, UpdatedAtUsec: nowUsec},
+		QueuedTimestampUsec: nowUsec,
+	}).Error)
+	require.NoError(t, env.GetDBHandle().GORM(ctx, "test_create_invocation_execution").Create(&tables.InvocationExecution{
+		InvocationID: iid,
+		ExecutionID:  executionID,
+		Type:         1,
+	}).Error)
+
+	olapExecution := &olaptables.Execution{
+		GroupID:             "GR1",
+		InvocationUUID:      strings.ReplaceAll(iid, "-", ""),
+		CreatedAtUsec:       nowUsec,
+		UpdatedAtUsec:       nowUsec,
+		QueuedTimestampUsec: nowUsec,
+	}
+	require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(olapExecution, executionID))
+	require.NoError(t, env.GetOLAPDBHandle().GORM(ctx, "test_create_olap_execution").Create(olapExecution).Error)
+
+	ctx, err := ta.WithAuthenticatedUser(ctx, "US1")
+	require.NoError(t, err)
+
+	rsp, err := es.GetExecution(ctx, &espb.GetExecutionRequest{
+		ExecutionLookup: &espb.ExecutionLookup{InvocationId: iid},
+	})
+	require.NoError(t, err)
+	require.Len(t, rsp.GetExecution(), 1)
+	require.Equal(t, executionID, rsp.GetExecution()[0].GetExecutionId())
 }

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -1336,12 +1336,12 @@ func (i *InvocationStatService) GetTargetTrends(ctx context.Context, req *stpb.G
 		return nil, err
 	}
 
-	// Merged actions appear in clickhouse as multiple rows with the same
-	// execution_id, but a different invocation_uuid.  This inner query dedupes
-	// by execution_id and takes the highest value (though all rows should have
-	// the same value).
+	// Merged actions appear in ClickHouse as multiple rows with the same
+	// execution_uuid, but a different invocation_uuid. This inner query
+	// dedupes by execution_uuid and takes the highest value (though all rows
+	// should have the same value).
 	innerQ := query_builder.NewQuery(fmt.Sprintf(`
-		SELECT target_label, execution_id, MAX(%s) as v
+		SELECT target_label, MAX(%s) as v
 		FROM "Executions"`, metric))
 
 	// Add where clauses from the trend query, including execution dimension filters
@@ -1351,7 +1351,7 @@ func (i *InvocationStatService) GetTargetTrends(ctx context.Context, req *stpb.G
 
 	innerQ.AddWhereClause("cached_result = FALSE")
 	innerQ.AddWhereClause("target_label != ''")
-	innerQ.SetGroupBy("target_label, execution_id")
+	innerQ.SetGroupBy("target_label, execution_uuid")
 
 	innerQStr, innerQArgs := innerQ.Build()
 

--- a/enterprise/server/util/execution/BUILD
+++ b/enterprise/server/util/execution/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -17,5 +17,18 @@ go_library(
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)
+
+go_test(
+    name = "execution_test",
+    srcs = ["execution_test.go"],
+    deps = [
+        ":execution",
+        "//proto:remote_execution_go_proto",
+        "//server/remote_cache/digest",
+        "//server/util/clickhouse",
+        "//server/util/clickhouse/schema",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/util/execution/execution.go
+++ b/enterprise/server/util/execution/execution.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"context"
+	"encoding/hex"
 	"strings"
 	"time"
 
@@ -17,6 +18,32 @@ import (
 	olaptables "github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 )
+
+func actionDigestFromOLAPExec(in *olaptables.Execution) (*repb.Digest, repb.DigestFunction_Value, error) {
+	d := &repb.Digest{
+		Hash:      hex.EncodeToString([]byte(in.ActionDigestHash)),
+		SizeBytes: int64(in.ActionDigestSize),
+	}
+	df, err := digest.DigestFunctionFromSegment(in.DigestFunction, d)
+	if err != nil {
+		return nil, 0, err
+	}
+	return d, df, nil
+}
+
+func resourceNameFromOLAPExec(in *olaptables.Execution) (*digest.CASResourceName, error) {
+	d, df, err := actionDigestFromOLAPExec(in)
+	if err != nil {
+		return nil, err
+	}
+	rn := digest.NewCASResourceName(d, in.InstanceName, df)
+	compressor, err := digest.CompressorFromSegment(in.Compressor)
+	if err != nil {
+		return nil, err
+	}
+	rn.SetCompressor(compressor)
+	return rn, nil
+}
 
 func TableExecToProto(in *tables.Execution, invLink *sipb.StoredInvocationLink) *repb.StoredExecution {
 	ex := &repb.StoredExecution{
@@ -116,20 +143,21 @@ func TableExecToClientProto(in *tables.Execution) (*espb.Execution, error) {
 }
 
 func OLAPExecToClientProto(in *olaptables.Execution) (*espb.Execution, error) {
-	r, err := digest.ParseUploadResourceName(in.ExecutionID)
+	rn, err := resourceNameFromOLAPExec(in)
 	if err != nil {
 		return nil, err
 	}
+	executionID := rn.UploadString(in.ExecutionUUID)
 
-	executeResponseDigest, err := digest.Compute(strings.NewReader(in.ExecutionID), r.GetDigestFunction())
+	executeResponseDigest, err := digest.Compute(strings.NewReader(executionID), rn.GetDigestFunction())
 	if err != nil {
 		return nil, status.WrapError(err, "compute execute response digest")
 	}
 
 	// NOTE: keep in sync with ExecutionListingColumns
 	out := &espb.Execution{
-		ExecutionId:           in.ExecutionID,
-		ActionDigest:          r.GetDigest(),
+		ExecutionId:           executionID,
+		ActionDigest:          rn.GetDigest(),
 		ExecuteResponseDigest: executeResponseDigest,
 		Status: &statuspb.Status{
 			Code:    in.StatusCode,
@@ -183,7 +211,12 @@ func OLAPExecToClientProto(in *olaptables.Execution) (*espb.Execution, error) {
 func ExecutionListingColumns() []string {
 	// NOTE: keep in sync with OLAPExecToClientProto
 	return []string{
-		"execution_id",
+		"instance_name",
+		"execution_uuid",
+		"compressor",
+		"digest_function",
+		"action_digest_hash",
+		"action_digest_size",
 		"status_code",
 		"status_message",
 		"exit_code",

--- a/enterprise/server/util/execution/execution_test.go
+++ b/enterprise/server/util/execution/execution_test.go
@@ -1,0 +1,62 @@
+package execution_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/execution"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse"
+	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	olaptables "github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
+)
+
+// TestOLAPExecToClientProto_ExecuteResponseDigest_Invariant locks in that
+// OLAPExecToClientProto produces an ExecuteResponseDigest equal to
+// digest.Compute(originalExecutionID), even though the function reconstructs
+// the execution ID from the split columns instead of reading the dropped
+// execution_id column. If this ever diverges, clients will fail to fetch the
+// cached ExecuteResponse from the Action Cache (proto/execution_stats.proto:99).
+func TestOLAPExecToClientProto_ExecuteResponseDigest_Invariant(t *testing.T) {
+	const sha256Hash = "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d"
+
+	for _, tc := range []struct {
+		name           string
+		instanceName   string
+		digestFunction repb.DigestFunction_Value
+		compressor     repb.Compressor_Value
+		sizeBytes      int64
+	}{
+		{name: "OldStyleSha256", instanceName: "instance_name", digestFunction: repb.DigestFunction_SHA256, compressor: repb.Compressor_IDENTITY, sizeBytes: 1234},
+		{name: "Blake3", instanceName: "instance_name", digestFunction: repb.DigestFunction_BLAKE3, compressor: repb.Compressor_IDENTITY, sizeBytes: 9876},
+		{name: "Sha256Zstd", instanceName: "instance_name", digestFunction: repb.DigestFunction_SHA256, compressor: repb.Compressor_ZSTD, sizeBytes: 4321},
+		{name: "Blake3Zstd", instanceName: "instance_name", digestFunction: repb.DigestFunction_BLAKE3, compressor: repb.Compressor_ZSTD, sizeBytes: 55},
+		{name: "EmptyInstanceName", instanceName: "", digestFunction: repb.DigestFunction_SHA256, compressor: repb.Compressor_IDENTITY, sizeBytes: 7},
+		{name: "InstanceNameContainingUploads", instanceName: "bad/uploads/instance", digestFunction: repb.DigestFunction_SHA256, compressor: repb.Compressor_IDENTITY, sizeBytes: 42},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rn := digest.NewCASResourceName(
+				&repb.Digest{Hash: sha256Hash, SizeBytes: tc.sizeBytes},
+				tc.instanceName,
+				tc.digestFunction,
+			)
+			rn.SetCompressor(tc.compressor)
+			executionID := rn.NewUploadString()
+
+			expected, err := digest.Compute(strings.NewReader(executionID), tc.digestFunction)
+			require.NoError(t, err)
+
+			row := &olaptables.Execution{}
+			require.NoError(t, clickhouse.FillExecutionResourceFieldsFromExecutionID(row, executionID))
+
+			out, err := execution.OLAPExecToClientProto(row)
+			require.NoError(t, err)
+
+			require.Equal(t, executionID, out.GetExecutionId())
+			require.Equal(t, expected.GetHash(), out.GetExecuteResponseDigest().GetHash())
+			require.Equal(t, expected.GetSizeBytes(), out.GetExecuteResponseDigest().GetSizeBytes())
+		})
+	}
+}

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -253,16 +253,21 @@ func (r *CASResourceName) DownloadString() string {
 	return casDownloadString(r.rn)
 }
 
+// UploadString returns the upload-form resource name using the supplied upload
+// UUID.
+func (r *CASResourceName) UploadString(uploadID string) string {
+	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
+	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
+	if isOldStyleDigestFunction(r.rn.DigestFunction) {
+		return instanceName + "/uploads/" + uploadID + "/" + blobTypeSegment(r.GetCompressor()) + "/" + r.GetDigest().GetHash() + "/" + strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)
+	}
+	return instanceName + "/uploads/" + uploadID + "/" + blobTypeSegment(r.GetCompressor()) + "/" + lowerFunctionName(r.rn.DigestFunction) + "/" + r.GetDigest().GetHash() + "/" + strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)
+}
+
 // NewUploadString returns a new string representing the resource name for
 // upload purposes each time it is called.
 func (r *CASResourceName) NewUploadString() string {
-	// Normalize slashes, e.g. "//foo/bar//"" becomes "/foo/bar".
-	instanceName := filepath.Join(filepath.SplitList(r.GetInstanceName())...)
-	u := guuid.New().String()
-	if isOldStyleDigestFunction(r.rn.DigestFunction) {
-		return instanceName + "/uploads/" + u + "/" + blobTypeSegment(r.GetCompressor()) + "/" + r.GetDigest().GetHash() + "/" + strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)
-	}
-	return instanceName + "/uploads/" + u + "/" + blobTypeSegment(r.GetCompressor()) + "/" + lowerFunctionName(r.rn.DigestFunction) + "/" + r.GetDigest().GetHash() + "/" + strconv.FormatInt(r.GetDigest().GetSizeBytes(), 10)
+	return r.UploadString(guuid.New().String())
 }
 
 type ACResourceName struct {
@@ -668,6 +673,34 @@ func CompressorSegment(c repb.Compressor_Value) string {
 		return "zstd"
 	default:
 		return ""
+	}
+}
+
+// DigestFunctionFromSegment is the inverse of DigestFunctionSegment. When
+// segment is empty, it falls back to InferOldStyleDigestFunctionInDesperation
+// against d. Returns InvalidArgumentError if neither path produces a known
+// function.
+func DigestFunctionFromSegment(segment string, d *repb.Digest) (repb.DigestFunction_Value, error) {
+	if segment == "" {
+		df := InferOldStyleDigestFunctionInDesperation(d)
+		if df == repb.DigestFunction_UNKNOWN {
+			return 0, status.InvalidArgumentErrorf("infer digest function for hash %q", d.GetHash())
+		}
+		return df, nil
+	}
+	return ParseFunction(segment)
+}
+
+// CompressorFromSegment is the inverse of CompressorSegment. "" → IDENTITY,
+// "zstd" → ZSTD, anything else → InvalidArgumentError.
+func CompressorFromSegment(segment string) (repb.Compressor_Value, error) {
+	switch segment {
+	case "":
+		return repb.Compressor_IDENTITY, nil
+	case "zstd":
+		return repb.Compressor_ZSTD, nil
+	default:
+		return 0, status.InvalidArgumentErrorf("unknown compressor %q", segment)
 	}
 }
 

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -330,31 +330,31 @@ func (h *DBHandle) FlushInvocationStats(ctx context.Context, ti *tables.Invocati
 	return nil
 }
 
-// FillExecutionResourceFields populates the split columns (InstanceName,
-// ExecutionUUID, Compressor, DigestFunction, ActionDigestHash,
-// ActionDigestSize) on out by parsing out.ExecutionID. Returns
-// InvalidArgumentError when ExecutionID is empty or unparseable.
-func FillExecutionResourceFields(out *schema.Execution) error {
-	if out.ExecutionID == "" {
+// FillExecutionResourceFieldsFromExecutionID populates the split columns
+// (InstanceName, ExecutionUUID, Compressor, DigestFunction, ActionDigestHash,
+// ActionDigestSize) on out by parsing executionID. Returns
+// InvalidArgumentError when executionID is empty or unparseable.
+func FillExecutionResourceFieldsFromExecutionID(out *schema.Execution, executionID string) error {
+	if executionID == "" {
 		return status.InvalidArgumentError("execution ID is empty")
 	}
 
-	rn, uploadID, err := digest.ParseUploadResourceNameWithUUID(out.ExecutionID)
+	rn, executionUUID, err := digest.ParseUploadResourceNameWithUUID(executionID)
 	if err != nil {
-		return status.InvalidArgumentErrorf("parse execution ID %q: %s", out.ExecutionID, err)
+		return status.InvalidArgumentErrorf("parse execution ID %q: %s", executionID, err)
 	}
 	d := rn.GetDigest()
 	digestBytes, err := hex.DecodeString(d.GetHash())
 	if err != nil {
-		return status.InvalidArgumentErrorf("decode action digest for execution %q: %s", out.ExecutionID, err)
+		return status.InvalidArgumentErrorf("decode action digest for execution %q: %s", executionID, err)
 	}
 	sizeBytes := d.GetSizeBytes()
 	if sizeBytes < 0 || sizeBytes > math.MaxUint32 {
-		return status.InvalidArgumentErrorf("action digest size out of range for execution %q: %d", out.ExecutionID, sizeBytes)
+		return status.InvalidArgumentErrorf("action digest size out of range for execution %q: %d", executionID, sizeBytes)
 	}
 
 	out.InstanceName = rn.GetInstanceName()
-	out.ExecutionUUID = uploadID
+	out.ExecutionUUID = executionUUID
 	out.Compressor = digest.CompressorSegment(rn.GetCompressor())
 	out.DigestFunction = digest.DigestFunctionSegment(rn.GetDigestFunction())
 	out.ActionDigestHash = string(digestBytes)
@@ -368,8 +368,11 @@ func FillExecutionResourceFields(out *schema.Execution) error {
 // logic.
 func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*schema.Execution, error) {
 	out := &schema.Execution{
-		GroupID:                            in.GetGroupId(),
-		UpdatedAtUsec:                      in.GetUpdatedAtUsec(),
+		GroupID:       in.GetGroupId(),
+		UpdatedAtUsec: in.GetUpdatedAtUsec(),
+		// ExecutionID is no longer read on the OLAP path, but we keep
+		// dual-writing it so the column stays populated in case we need
+		// to roll back the read migration.
 		ExecutionID:                        in.GetExecutionId(),
 		InvocationUUID:                     in.GetInvocationUuid(),
 		CreatedAtUsec:                      in.GetCreatedAtUsec(),
@@ -459,7 +462,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*
 		EffectivePool:                      in.GetEffectivePool(),
 	}
 
-	if err := FillExecutionResourceFields(out); err != nil {
+	if err := FillExecutionResourceFieldsFromExecutionID(out, in.GetExecutionId()); err != nil {
 		return out, err
 	}
 	return out, nil

--- a/server/util/clickhouse/clickhouse_test.go
+++ b/server/util/clickhouse/clickhouse_test.go
@@ -3,7 +3,6 @@ package clickhouse_test
 import (
 	"context"
 	"encoding/hex"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -55,26 +54,23 @@ func TestExecutionIDRoundTripThroughClickHouseSchema(t *testing.T) {
 			execution, err := clickhouse.ExecutionFromProto(&repb.StoredExecution{ExecutionId: executionID}, nil)
 			require.NoError(t, err)
 
-			require.Equal(t, executionID, reconstructExecutionID(execution))
+			require.Equal(t, executionID, reconstructExecutionID(t, execution))
 		})
 	}
 }
 
-// reconstructExecutionID rebuilds the execution ID from the split columns
-// populated on schema.Execution. Intended to match the exact string produced
-// by (*digest.CASResourceName).NewUploadString.
-func reconstructExecutionID(e *schema.Execution) string {
-	blobType := "blobs"
-	if e.Compressor != "" {
-		blobType = "compressed-blobs/" + e.Compressor
+func reconstructExecutionID(t *testing.T, e *schema.Execution) string {
+	d := &repb.Digest{
+		Hash:      hex.EncodeToString([]byte(e.ActionDigestHash)),
+		SizeBytes: int64(e.ActionDigestSize),
 	}
-	id := strings.Join([]string{e.InstanceName, "uploads", e.ExecutionUUID, blobType}, "/")
-	if e.DigestFunction != "" {
-		id += "/" + e.DigestFunction
-	}
-	id += "/" + hex.EncodeToString([]byte(e.ActionDigestHash))
-	id += "/" + strconv.FormatUint(uint64(e.ActionDigestSize), 10)
-	return id
+	df, err := digest.DigestFunctionFromSegment(e.DigestFunction, d)
+	require.NoError(t, err)
+	compressor, err := digest.CompressorFromSegment(e.Compressor)
+	require.NoError(t, err)
+	rn := digest.NewCASResourceName(d, e.InstanceName, df)
+	rn.SetCompressor(compressor)
+	return rn.UploadString(e.ExecutionUUID)
 }
 
 func TestFlushExecutionStats_SkipsMalformedExecutionIDs(t *testing.T) {
@@ -127,7 +123,7 @@ func TestFlushExecutionStats_SkipsMalformedExecutionIDs(t *testing.T) {
 	).Find(&rows).Error
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	require.Equal(t, validExecutionID, reconstructExecutionID(&rows[0]))
+	require.Equal(t, validExecutionID, reconstructExecutionID(t, &rows[0]))
 }
 
 func TestFlushExecutionStats_AllMalformedExecutionIDs_SkipsInsert(t *testing.T) {


### PR DESCRIPTION
This is to prepare for dropping execution id column.

This PR still writes execution id to clickhouse. So that if there is an
issue we can still roll back the change.
