### PR TITLE
Require a key to use `debug-executor-labels`

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//server/util/background",
         "//server/util/bazel_request",
         "//server/util/error_util",
+        "//server/util/flag",
         "//server/util/grpc_client",
         "//server/util/log",
         "//server/util/perms",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -61,7 +61,7 @@ var (
 	maxSchedulingDelay           = flag.Duration("remote_execution.max_scheduling_delay", 5*time.Second, "Max duration that actions can sit in a non-preferred executor's queue before they are executed.")
 	cgroupSettingsEnabled        = flag.Bool("remote_execution.cgroup_settings_enabled", true, "Apply cgroup2 settings to Linux executions.")
 	proactiveCancellationEnabled = flag.Bool("remote_execution.proactive_cancellation_enabled", false, "If true, the scheduler will proactively cancel task reservations on executors when a task is completed by another executor.")
-	debugExecutorLabelsSecret    = flag.String("remote_execution.debug_executor_labels_secret", "", "Shared secret gating use of the 'debug-executor-labels' platform property. Requests must include a 'secret=<value>' entry matching this flag, otherwise the labels are ignored. If empty, the feature is disabled.", flag.Secret)
+	debugExecutorLabelsKey       = flag.String("remote_execution.debug_executor_labels_key", "", "If set, requests using the 'debug-executor-labels' platform property must also set the 'debug-executor-labels-key' platform property to this value, otherwise the requested labels are ignored. If empty, anyone can use 'debug-executor-labels'.", flag.Secret)
 )
 
 const (
@@ -712,13 +712,20 @@ func filterToDebugExecutorID(nodes []*executionNode, task *repb.ExecutionTask) (
 // platform property. The value is a comma-separated list of "key=value" pairs;
 // entries without an "=" are treated as a key with an empty value.
 //
-// The request must include a "secret=<value>" entry matching the
-// remote_execution.debug_executor_labels_secret flag, or the labels are
-// ignored (returns nil). If the flag is unset, the feature is disabled.
+// If the remote_execution.debug_executor_labels_key flag is set, the request
+// must also set the "debug-executor-labels-key" platform property to the
+// configured value, otherwise the labels are ignored (returns nil). If the
+// flag is unset, anyone may use the feature.
 func parseDebugExecutorLabels(ctx context.Context, task *repb.ExecutionTask) map[string]string {
 	raw := platform.FindEffectiveValue(task, "debug-executor-labels")
 	if raw == "" {
 		return nil
+	}
+	if expected := *debugExecutorLabelsKey; expected != "" {
+		if platform.FindEffectiveValue(task, "debug-executor-labels-key") != expected {
+			alert.CtxUnexpectedEvent(ctx, "unauthorized_debug_executor_labels", "debug-executor-labels used without a matching debug-executor-labels-key; ignoring")
+			return nil
+		}
 	}
 	out := make(map[string]string)
 	for entry := range strings.SplitSeq(raw, ",") {
@@ -728,12 +735,6 @@ func parseDebugExecutorLabels(ctx context.Context, task *repb.ExecutionTask) map
 		}
 		k, v, _ := strings.Cut(entry, "=")
 		out[strings.TrimSpace(k)] = strings.TrimSpace(v)
-	}
-	providedSecret, ok := out["secret"]
-	delete(out, "secret")
-	if *debugExecutorLabelsSecret == "" || !ok || providedSecret != *debugExecutorLabelsSecret {
-		alert.CtxUnexpectedEvent(ctx, "unauthorized_debug_executor_labels", "debug-executor-labels used without a matching secret; ignoring")
-		return nil
 	}
 	return out
 }

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -2,7 +2,6 @@ package scheduler_server
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io"
 	"math/rand"
@@ -27,6 +26,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/error_util"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
@@ -61,6 +61,7 @@ var (
 	maxSchedulingDelay           = flag.Duration("remote_execution.max_scheduling_delay", 5*time.Second, "Max duration that actions can sit in a non-preferred executor's queue before they are executed.")
 	cgroupSettingsEnabled        = flag.Bool("remote_execution.cgroup_settings_enabled", true, "Apply cgroup2 settings to Linux executions.")
 	proactiveCancellationEnabled = flag.Bool("remote_execution.proactive_cancellation_enabled", false, "If true, the scheduler will proactively cancel task reservations on executors when a task is completed by another executor.")
+	debugExecutorLabelsSecret    = flag.String("remote_execution.debug_executor_labels_secret", "", "Shared secret gating use of the 'debug-executor-labels' platform property. Requests must include a 'secret=<value>' entry matching this flag, otherwise the labels are ignored. If empty, the feature is disabled.", flag.Secret)
 )
 
 const (
@@ -710,7 +711,11 @@ func filterToDebugExecutorID(nodes []*executionNode, task *repb.ExecutionTask) (
 // Parses the requested executor labels from the "debug-executor-labels"
 // platform property. The value is a comma-separated list of "key=value" pairs;
 // entries without an "=" are treated as a key with an empty value.
-func parseDebugExecutorLabels(task *repb.ExecutionTask) map[string]string {
+//
+// The request must include a "secret=<value>" entry matching the
+// remote_execution.debug_executor_labels_secret flag, or the labels are
+// ignored (returns nil). If the flag is unset, the feature is disabled.
+func parseDebugExecutorLabels(ctx context.Context, task *repb.ExecutionTask) map[string]string {
 	raw := platform.FindEffectiveValue(task, "debug-executor-labels")
 	if raw == "" {
 		return nil
@@ -723,6 +728,12 @@ func parseDebugExecutorLabels(task *repb.ExecutionTask) map[string]string {
 		}
 		k, v, _ := strings.Cut(entry, "=")
 		out[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	providedSecret, ok := out["secret"]
+	delete(out, "secret")
+	if *debugExecutorLabelsSecret == "" || !ok || providedSecret != *debugExecutorLabelsSecret {
+		alert.CtxUnexpectedEvent(ctx, "unauthorized_debug_executor_labels", "debug-executor-labels used without a matching secret; ignoring")
+		return nil
 	}
 	return out
 }
@@ -743,7 +754,7 @@ func executorHasAllLabels(executorLabels, requested map[string]string) bool {
 // nodes match, fires an internal alert and returns an unfiltered list so
 // scheduling can proceed, making the debug-executor-labels best effort.
 func filterToDebugExecutorLabels(ctx context.Context, nodes []*executionNode, task *repb.ExecutionTask) []*executionNode {
-	requested := parseDebugExecutorLabels(task)
+	requested := parseDebugExecutorLabels(ctx, task)
 	if len(requested) == 0 {
 		return nodes
 	}
@@ -1798,7 +1809,7 @@ func (s *SchedulerServer) sampleUnclaimedTasks(ctx context.Context, count int, n
 		if id := platform.FindEffectiveValue(fullTask, "debug-executor-id"); id != "" {
 			continue
 		}
-		if requested := parseDebugExecutorLabels(fullTask); len(requested) > 0 && !executorHasAllLabels(node.GetLabels(), requested) {
+		if requested := parseDebugExecutorLabels(ctx, fullTask); len(requested) > 0 && !executorHasAllLabels(node.GetLabels(), requested) {
 			continue
 		}
 

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -721,11 +721,9 @@ func parseDebugExecutorLabels(ctx context.Context, task *repb.ExecutionTask) map
 	if raw == "" {
 		return nil
 	}
-	if expected := *debugExecutorLabelsKey; expected != "" {
-		if platform.FindEffectiveValue(task, "debug-executor-labels-key") != expected {
-			alert.CtxUnexpectedEvent(ctx, "unauthorized_debug_executor_labels", "debug-executor-labels used without a matching debug-executor-labels-key; ignoring")
-			return nil
-		}
+	if *debugExecutorLabelsKey != "" && platform.FindEffectiveValue(task, "debug-executor-labels-key") != *debugExecutorLabelsKey {
+		alert.CtxUnexpectedEvent(ctx, "unauthorized_debug_executor_labels", "debug-executor-labels used without a matching debug-executor-labels-key; ignoring")
+		return nil
 	}
 	out := make(map[string]string)
 	for entry := range strings.SplitSeq(raw, ",") {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -1189,36 +1189,30 @@ func TestAskForMoreWork_RespectRequestedExecutorID(t *testing.T) {
 	require.Greater(t, rsp.GetAskForMoreWorkResponse().GetDelay().AsDuration(), time.Duration(0))
 }
 
-func TestAskForMoreWork_RespectDebugExecutorLabels(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
-	flags.Set(t, "remote_execution.debug_executor_labels_secret", "shh")
-
-	// Register two nodes with distinct labels.
-	executor1 := newFakeExecutorWithId(ctx, t, "n1", env.GetSchedulerClient())
+// registerLabeledExecutorPair registers two executors whose labels differ.
+// executor1 has foo=1,bar=2; executor2 has foo=a,bar=2. Used by tests that
+// want a "matching" executor and a "non-matching" executor for tasks that
+// request labels foo=1,bar=2.
+func registerLabeledExecutorPair(ctx context.Context, t *testing.T, env environment.Env) (executor1, executor2 *fakeExecutor) {
+	executor1 = newFakeExecutorWithId(ctx, t, "n1", env.GetSchedulerClient())
 	executor1.node.AssignableMilliCpu = 1000
 	executor1.node.Labels = map[string]string{"foo": "1", "bar": "2"}
 	executor1.Register()
 
-	executor2 := newFakeExecutorWithId(ctx, t, "n2", env.GetSchedulerClient())
+	executor2 = newFakeExecutorWithId(ctx, t, "n2", env.GetSchedulerClient())
 	executor2.node.AssignableMilliCpu = 1000
 	executor2.node.Labels = map[string]string{"foo": "a", "bar": "2"}
 	executor2.Register()
+	return executor1, executor2
+}
 
-	var rsp *scpb.RegisterAndStreamWorkResponse
-
-	// Schedule a task that requires labels matching only executor1.
-	taskID := scheduleTask(ctx, t, env, map[string]string{"debug-executor-labels": "secret=shh,foo=1,bar=2"})
-	// Ensure the task was enqueued on executor1, but don't have executor1
-	// claim the task, so that it's eligible to be enqueued as part of
-	// AskForMoreWork.
-	rsp = <-executor1.schedulerMessages
+// assertLabelsHonored asserts that a task with debug-executor-labels matching
+// only executor1 was enqueued on executor1 and that executor2's AskForMoreWork
+// gets only a backoff response (no task), proving the labels filtered.
+func assertLabelsHonored(t *testing.T, taskID string, executor1, executor2 *fakeExecutor) {
+	rsp := <-executor1.schedulerMessages
 	require.Equal(t, taskID, rsp.GetEnqueueTaskReservationRequest().GetTaskId())
 
-	// Have executor2 ask for more work now. The scheduler should not schedule
-	// any work on executor2 because the task's requested labels don't match
-	// executor2's labels. It should only reply with an AskForMoreWorkResponse
-	// to increase the client backoff.
 	executor2.Send(&scpb.RegisterAndStreamWorkRequest{
 		AskForMoreWorkRequest: &scpb.AskForMoreWorkRequest{},
 	})
@@ -1226,30 +1220,69 @@ func TestAskForMoreWork_RespectDebugExecutorLabels(t *testing.T) {
 	require.Greater(t, rsp.GetAskForMoreWorkResponse().GetDelay().AsDuration(), time.Duration(0))
 }
 
-func TestAskForMoreWork_DebugExecutorLabels_WrongSecretIgnoresLabels(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
-	flags.Set(t, "remote_execution.debug_executor_labels_secret", "shh")
-
-	// Register two nodes with distinct labels.
-	executor1 := newFakeExecutorWithId(ctx, t, "n1", env.GetSchedulerClient())
-	executor1.node.AssignableMilliCpu = 1000
-	executor1.node.Labels = map[string]string{"foo": "1", "bar": "2"}
-	executor1.Register()
-
-	executor2 := newFakeExecutorWithId(ctx, t, "n2", env.GetSchedulerClient())
-	executor2.node.AssignableMilliCpu = 1000
-	executor2.node.Labels = map[string]string{"foo": "a", "bar": "2"}
-	executor2.Register()
-
-	// Schedule a task with a WRONG secret. The labels should be ignored, so
-	// executor2 (whose labels don't match the requested ones) should still
-	// be eligible to receive the task. With probesPerTask > number of
-	// executors, both executors should receive an enqueue reservation.
-	taskID := scheduleTask(ctx, t, env, map[string]string{"debug-executor-labels": "secret=wrong,foo=1,bar=2"})
-
+// assertLabelsIgnored asserts that a task with debug-executor-labels was
+// scheduled without filtering, so both executors received an enqueue
+// reservation (probesPerTask=3 > 2 executors).
+func assertLabelsIgnored(taskID string, executor1, executor2 *fakeExecutor) {
 	executor1.WaitForTask(taskID)
 	executor2.WaitForTask(taskID)
+}
+
+// When the debug_executor_labels_key flag is unset, anyone can use
+// debug-executor-labels without supplying a key.
+func TestAskForMoreWork_RespectDebugExecutorLabels(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
+
+	executor1, executor2 := registerLabeledExecutorPair(ctx, t, env)
+
+	taskID := scheduleTask(ctx, t, env, map[string]string{"debug-executor-labels": "foo=1,bar=2"})
+	assertLabelsHonored(t, taskID, executor1, executor2)
+}
+
+// When the flag is set and the request supplies a matching key, labels are
+// honored.
+func TestAskForMoreWork_DebugExecutorLabels_ValidKey(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
+	flags.Set(t, "remote_execution.debug_executor_labels_key", "shh")
+
+	executor1, executor2 := registerLabeledExecutorPair(ctx, t, env)
+
+	taskID := scheduleTask(ctx, t, env, map[string]string{
+		"debug-executor-labels":     "foo=1,bar=2",
+		"debug-executor-labels-key": "shh",
+	})
+	assertLabelsHonored(t, taskID, executor1, executor2)
+}
+
+// When the flag is set and the request supplies the wrong key, the labels are
+// ignored entirely.
+func TestAskForMoreWork_DebugExecutorLabels_WrongKey(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
+	flags.Set(t, "remote_execution.debug_executor_labels_key", "shh")
+
+	executor1, executor2 := registerLabeledExecutorPair(ctx, t, env)
+
+	taskID := scheduleTask(ctx, t, env, map[string]string{
+		"debug-executor-labels":     "foo=1,bar=2",
+		"debug-executor-labels-key": "wrong",
+	})
+	assertLabelsIgnored(taskID, executor1, executor2)
+}
+
+// When the flag is set and the request omits the key, the labels are ignored
+// entirely.
+func TestAskForMoreWork_DebugExecutorLabels_MissingKey(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
+	flags.Set(t, "remote_execution.debug_executor_labels_key", "shh")
+
+	executor1, executor2 := registerLabeledExecutorPair(ctx, t, env)
+
+	taskID := scheduleTask(ctx, t, env, map[string]string{"debug-executor-labels": "foo=1,bar=2"})
+	assertLabelsIgnored(taskID, executor1, executor2)
 }
 
 func TestGetExecutionNodes(t *testing.T) {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -1192,6 +1192,7 @@ func TestAskForMoreWork_RespectRequestedExecutorID(t *testing.T) {
 func TestAskForMoreWork_RespectDebugExecutorLabels(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
+	flags.Set(t, "remote_execution.debug_executor_labels_secret", "shh")
 
 	// Register two nodes with distinct labels.
 	executor1 := newFakeExecutorWithId(ctx, t, "n1", env.GetSchedulerClient())
@@ -1207,7 +1208,7 @@ func TestAskForMoreWork_RespectDebugExecutorLabels(t *testing.T) {
 	var rsp *scpb.RegisterAndStreamWorkResponse
 
 	// Schedule a task that requires labels matching only executor1.
-	taskID := scheduleTask(ctx, t, env, map[string]string{"debug-executor-labels": "foo=1,bar=2"})
+	taskID := scheduleTask(ctx, t, env, map[string]string{"debug-executor-labels": "secret=shh,foo=1,bar=2"})
 	// Ensure the task was enqueued on executor1, but don't have executor1
 	// claim the task, so that it's eligible to be enqueued as part of
 	// AskForMoreWork.
@@ -1223,6 +1224,32 @@ func TestAskForMoreWork_RespectDebugExecutorLabels(t *testing.T) {
 	})
 	rsp = <-executor2.schedulerMessages
 	require.Greater(t, rsp.GetAskForMoreWorkResponse().GetDelay().AsDuration(), time.Duration(0))
+}
+
+func TestAskForMoreWork_DebugExecutorLabels_WrongSecretIgnoresLabels(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
+	flags.Set(t, "remote_execution.debug_executor_labels_secret", "shh")
+
+	// Register two nodes with distinct labels.
+	executor1 := newFakeExecutorWithId(ctx, t, "n1", env.GetSchedulerClient())
+	executor1.node.AssignableMilliCpu = 1000
+	executor1.node.Labels = map[string]string{"foo": "1", "bar": "2"}
+	executor1.Register()
+
+	executor2 := newFakeExecutorWithId(ctx, t, "n2", env.GetSchedulerClient())
+	executor2.node.AssignableMilliCpu = 1000
+	executor2.node.Labels = map[string]string{"foo": "a", "bar": "2"}
+	executor2.Register()
+
+	// Schedule a task with a WRONG secret. The labels should be ignored, so
+	// executor2 (whose labels don't match the requested ones) should still
+	// be eligible to receive the task. With probesPerTask > number of
+	// executors, both executors should receive an enqueue reservation.
+	taskID := scheduleTask(ctx, t, env, map[string]string{"debug-executor-labels": "secret=wrong,foo=1,bar=2"})
+
+	executor1.WaitForTask(taskID)
+	executor2.WaitForTask(taskID)
 }
 
 func TestGetExecutionNodes(t *testing.T) {


### PR DESCRIPTION
Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/5942