### PR TITLE
cli: move explain runfiles to BUILD

### DIFF
--- a/cli/test/integration/compact/BUILD
+++ b/cli/test/integration/compact/BUILD
@@ -2,15 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
-filegroup(
-    name = "testdata",
-    srcs = glob(["testdata/**"]),
-)
-
 go_test(
     name = "compact_test",
     srcs = ["compact_test.go"],
-    data = [":testdata"],
+    data = glob(["testdata/**"]),
     deps = [
         "//cli/testutil/testcli",
         "@com_github_stretchr_testify//assert",

--- a/cli/test/integration/explain/BUILD
+++ b/cli/test/integration/explain/BUILD
@@ -5,7 +5,14 @@ package(default_visibility = ["//cli:__subpackages__"])
 go_test(
     name = "explain_test",
     srcs = ["explain_test.go"],
-    data = ["//cli/test/integration/compact:testdata"],
+    data = [
+        "//cli/test/integration/compact:testdata/1.binpb.zst",
+        "//cli/test/integration/compact:testdata/2.binpb.zst",
+    ],
+    x_defs = {
+        "oldCompactLogRunfilePath": "$(rlocationpath //cli/test/integration/compact:testdata/1.binpb.zst)",
+        "newCompactLogRunfilePath": "$(rlocationpath //cli/test/integration/compact:testdata/2.binpb.zst)",
+    },
     deps = [
         "//cli/testutil/testcli",
         "//proto:spawn_diff_go_proto",

--- a/cli/test/integration/explain/explain_test.go
+++ b/cli/test/integration/explain/explain_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"path"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/runfiles"
@@ -13,12 +12,16 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const testdataDir = "com_github_buildbuddy_io_buildbuddy/cli/test/integration/compact/testdata"
+// Set via x_defs in the BUILD file.
+var (
+	oldCompactLogRunfilePath string
+	newCompactLogRunfilePath string
+)
 
-func testdataPath(t *testing.T, name string) string {
+func runfilePath(t *testing.T, rlocationPath string) string {
 	t.Helper()
-	p, err := runfiles.Rlocation(path.Join(testdataDir, name))
-	require.NoError(t, err)
+	p, err := runfiles.Rlocation(rlocationPath)
+	require.NoError(t, err, "resolve runfile %q", rlocationPath)
 	return p
 }
 
@@ -26,7 +29,6 @@ func testdataPath(t *testing.T, name string) string {
 // targets but with different output contents, so we expect bb explain to
 // report both spawns as modified.
 func assertExpectedDiff(t *testing.T, result *spawn_diff.DiffResult) {
-	t.Helper()
 	require.Len(t, result.GetSpawnDiffs(), 2)
 	var labels []string
 	for _, sd := range result.GetSpawnDiffs() {
@@ -43,8 +45,8 @@ func assertExpectedDiff(t *testing.T, result *spawn_diff.DiffResult) {
 
 func TestExplainJsonOutputIsClean(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
-	old := testdataPath(t, "1.binpb.zst")
-	new := testdataPath(t, "2.binpb.zst")
+	old := runfilePath(t, oldCompactLogRunfilePath)
+	new := runfilePath(t, newCompactLogRunfilePath)
 
 	stdout, stderr, err := testcli.SplitOutput(
 		testcli.Command(t, ws, "explain",
@@ -63,8 +65,8 @@ func TestExplainJsonOutputIsClean(t *testing.T) {
 
 func TestExplainProtoOutputIsClean(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
-	old := testdataPath(t, "1.binpb.zst")
-	new := testdataPath(t, "2.binpb.zst")
+	old := runfilePath(t, oldCompactLogRunfilePath)
+	new := runfilePath(t, newCompactLogRunfilePath)
 
 	stdout, stderr, err := testcli.SplitOutput(
 		testcli.Command(t, ws, "explain",


### PR DESCRIPTION
Review feedback called out that the explain integration test should not
hardcode a runfiles path for compact execution logs. This matters
because runfile locations are owned by Bazel labels and repository
mapping, not by Go test constants.

Inject the exact runfile labels from the BUILD file instead. The
compact test is now the only owner of its full testdata glob, so
inline that data declaration and drop the extra filegroup.
