### PR TITLE
Add usage alert evaluator/notifier

### DIFF
--- a/enterprise/server/backends/email/email.go
+++ b/enterprise/server/backends/email/email.go
@@ -40,8 +40,8 @@ type Message struct {
 	// From is the sender address. If empty, the configured default sender is
 	// used.
 	From Address
-	// To is the primary recipient.
-	To Address
+	// ToAddresses are recipients who each receive their own addressed email.
+	ToAddresses []Address
 	// Subject is the email subject.
 	Subject string
 	// Body is the HTML email body.
@@ -121,8 +121,14 @@ func buildEmail(msg *Message) (*sendgridmail.SGMailV3, error) {
 	if from.Email == "" {
 		return nil, status.FailedPreconditionError("SendGrid sender email address is required")
 	}
-	if msg.To.Email == "" {
+	recipients := msg.ToAddresses
+	if len(recipients) == 0 {
 		return nil, status.InvalidArgumentError("recipient is required")
+	}
+	for _, recipient := range recipients {
+		if recipient.Email == "" {
+			return nil, status.InvalidArgumentError("recipient email address is required")
+		}
 	}
 	if msg.Subject == "" {
 		return nil, status.InvalidArgumentError("subject is required")
@@ -136,9 +142,11 @@ func buildEmail(msg *Message) (*sendgridmail.SGMailV3, error) {
 	email.Subject = msg.Subject
 	email.AddContent(sendgridmail.NewContent("text/html", msg.Body))
 
-	personalization := sendgridmail.NewPersonalization()
-	personalization.AddTos(toSendGridAddress(msg.To))
-	email.AddPersonalizations(personalization)
+	for _, recipient := range recipients {
+		personalization := sendgridmail.NewPersonalization()
+		personalization.AddTos(toSendGridAddress(recipient))
+		email.AddPersonalizations(personalization)
+	}
 
 	return email, nil
 }

--- a/enterprise/server/backends/email/email_test.go
+++ b/enterprise/server/backends/email/email_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestSend(t *testing.T) {
 	validMessage := &email.Message{
-		To:      email.Address{Name: "Dev", Email: "dev@example.com"},
-		Subject: "Build complete",
-		Body:    "<p>The build completed.</p>",
+		ToAddresses: []email.Address{{Name: "Dev", Email: "dev@example.com"}},
+		Subject:     "Build complete",
+		Body:        "<p>The build completed.</p>",
 	}
 	validPayload := sendgridPayload{
 		From:    payloadAddress{Name: "BuildBuddy", Email: "notifications@buildbuddy.io"},
@@ -43,6 +43,27 @@ func TestSend(t *testing.T) {
 	messageSenderPayload.From = payloadAddress{Name: "Usage Alerts", Email: "usage@buildbuddy.io"}
 	messageSenderRequest := validRequest
 	messageSenderRequest.payload = messageSenderPayload
+	multiRecipientPayload := sendgridPayload{
+		From:    payloadAddress{Name: "BuildBuddy", Email: "notifications@buildbuddy.io"},
+		Subject: "Build complete",
+		Personalizations: []payloadPersonalization{
+			{
+				To: []payloadAddress{
+					{Name: "Dev", Email: "dev@example.com"},
+				},
+			},
+			{
+				To: []payloadAddress{
+					{Name: "Admin", Email: "admin@example.com"},
+				},
+			},
+		},
+		Content: []payloadContent{
+			{Type: "text/html", Value: "<p>The build completed.</p>"},
+		},
+	}
+	multiRecipientRequest := validRequest
+	multiRecipientRequest.payload = multiRecipientPayload
 
 	for _, testCase := range []struct {
 		name         string
@@ -62,13 +83,26 @@ func TestSend(t *testing.T) {
 		{
 			name: "uses message sender",
 			message: &email.Message{
-				From:    email.Address{Name: "Usage Alerts", Email: "usage@buildbuddy.io"},
-				To:      email.Address{Name: "Dev", Email: "dev@example.com"},
+				From:        email.Address{Name: "Usage Alerts", Email: "usage@buildbuddy.io"},
+				ToAddresses: []email.Address{{Name: "Dev", Email: "dev@example.com"}},
+				Subject:     "Build complete",
+				Body:        "<p>The build completed.</p>",
+			},
+			statusCode:   http.StatusAccepted,
+			wantRequests: []capturedRequest{messageSenderRequest},
+		},
+		{
+			name: "posts multiple individually addressed recipients",
+			message: &email.Message{
+				ToAddresses: []email.Address{
+					{Name: "Dev", Email: "dev@example.com"},
+					{Name: "Admin", Email: "admin@example.com"},
+				},
 				Subject: "Build complete",
 				Body:    "<p>The build completed.</p>",
 			},
 			statusCode:   http.StatusAccepted,
-			wantRequests: []capturedRequest{messageSenderRequest},
+			wantRequests: []capturedRequest{multiRecipientRequest},
 		},
 		{
 			name:         "returns SendGrid failure",
@@ -111,10 +145,20 @@ func TestSend(t *testing.T) {
 			wantErr:    "recipient is required",
 		},
 		{
+			name: "requires non-empty recipient address",
+			message: &email.Message{
+				ToAddresses: []email.Address{{Name: "Admin"}},
+				Subject:     "Build complete",
+				Body:        "<p>The build completed.</p>",
+			},
+			statusCode: http.StatusAccepted,
+			wantErr:    "recipient email address is required",
+		},
+		{
 			name: "requires subject",
 			message: &email.Message{
-				To:   email.Address{Name: "Dev", Email: "dev@example.com"},
-				Body: "<p>The build completed.</p>",
+				ToAddresses: []email.Address{{Name: "Dev", Email: "dev@example.com"}},
+				Body:        "<p>The build completed.</p>",
 			},
 			statusCode: http.StatusAccepted,
 			wantErr:    "subject is required",
@@ -122,8 +166,8 @@ func TestSend(t *testing.T) {
 		{
 			name: "requires body",
 			message: &email.Message{
-				To:      email.Address{Name: "Dev", Email: "dev@example.com"},
-				Subject: "Build complete",
+				ToAddresses: []email.Address{{Name: "Dev", Email: "dev@example.com"}},
+				Subject:     "Build complete",
 			},
 			statusCode: http.StatusAccepted,
 			wantErr:    "body is required",

--- a/enterprise/server/backends/email/sendmail/main.go
+++ b/enterprise/server/backends/email/sendmail/main.go
@@ -72,9 +72,9 @@ func run() error {
 	client := email.NewClient(email.ClientConfig{})
 
 	msg := &email.Message{
-		To:      recipient,
-		Subject: *subject,
-		Body:    *body,
+		ToAddresses: []email.Address{recipient},
+		Subject:     *subject,
+		Body:        *body,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)

--- a/enterprise/server/usage_service/BUILD
+++ b/enterprise/server/usage_service/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/interfaces",
         "//server/real_environment",
         "//server/tables",
+        "//server/usage/sku",
         "//server/util/authutil",
         "//server/util/db",
         "//server/util/log",

--- a/enterprise/server/usage_service/usage_service.go
+++ b/enterprise/server/usage_service/usage_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -41,6 +42,8 @@ type UsageField struct {
 	Name string
 	// PrimaryDBExpression is the SQL aggregation expression for the primary DB.
 	PrimaryDBExpression string
+	// OLAPExpression is the ClickHouse RawUsage aggregation expression.
+	OLAPExpression string
 	// AlertingMetric is the usage alerting enum corresponding to this field.
 	AlertingMetric usagepb.UsageAlertingMetric_Value
 }
@@ -50,93 +53,212 @@ var UsageFields = []UsageField{
 	{
 		Name:                "invocations",
 		PrimaryDBExpression: "SUM(invocations)",
+		OLAPExpression:      rawUsageSum(sku.BuildEventsBESCount),
 		AlertingMetric:      usagepb.UsageAlertingMetric_INVOCATIONS,
 	},
 	{
 		Name:                "action_cache_hits",
 		PrimaryDBExpression: "SUM(action_cache_hits)",
+		OLAPExpression:      rawUsageSum(sku.RemoteCacheACHits),
 		AlertingMetric:      usagepb.UsageAlertingMetric_ACTION_CACHE_HITS,
 	},
 	{
 		Name:                "total_cached_action_exec_usec",
 		PrimaryDBExpression: "SUM(total_cached_action_exec_usec)",
+		OLAPExpression:      rawUsageSumUsec(sku.RemoteCacheACCachedExecDurationNanos),
 		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_CACHED_ACTION_EXEC_USEC,
 	},
 	{
 		Name:                "cas_cache_hits",
 		PrimaryDBExpression: "SUM(cas_cache_hits)",
+		OLAPExpression:      rawUsageSum(sku.RemoteCacheCASHits),
 		AlertingMetric:      usagepb.UsageAlertingMetric_CAS_CACHE_HITS,
 	},
 	{
 		Name:                "total_download_size_bytes",
 		PrimaryDBExpression: "SUM(total_download_size_bytes)",
+		OLAPExpression:      rawUsageSum(sku.RemoteCacheCASDownloadedBytes),
 		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_DOWNLOAD_SIZE_BYTES,
 	},
 	{
 		Name:                "total_external_download_size_bytes",
 		PrimaryDBExpression: "SUM(CASE WHEN origin <> 'internal' THEN total_download_size_bytes ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_DOWNLOAD_SIZE_BYTES,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteCacheCASDownloadedBytes,
+			rawUsageLabelNotEquals(sku.Origin, sku.OriginInternal),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_DOWNLOAD_SIZE_BYTES,
 	},
 	{
 		Name:                "total_internal_download_size_bytes",
 		PrimaryDBExpression: "SUM(CASE WHEN (origin = 'internal' AND NOT (client = 'executor-workflows' OR client = 'bazel')) THEN total_download_size_bytes ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_INTERNAL_DOWNLOAD_SIZE_BYTES,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteCacheCASDownloadedBytes,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelNotIn(sku.Client, sku.ClientExecutorWorkflows, sku.ClientBazel),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_TOTAL_INTERNAL_DOWNLOAD_SIZE_BYTES,
 	},
 	{
 		Name:                "total_workflow_download_size_bytes",
 		PrimaryDBExpression: "SUM(CASE WHEN (origin = 'internal' AND (client = 'executor-workflows' OR client = 'bazel')) THEN total_download_size_bytes ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_DOWNLOAD_SIZE_BYTES,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteCacheCASDownloadedBytes,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelIn(sku.Client, sku.ClientExecutorWorkflows, sku.ClientBazel),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_DOWNLOAD_SIZE_BYTES,
 	},
 	{
 		Name:                "total_upload_size_bytes",
 		PrimaryDBExpression: "SUM(total_upload_size_bytes)",
+		OLAPExpression:      rawUsageSum(sku.RemoteCacheCASUploadedBytes),
 		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_UPLOAD_SIZE_BYTES,
 	},
 	{
 		Name:                "total_external_upload_size_bytes",
 		PrimaryDBExpression: "SUM(CASE WHEN origin <> 'internal' THEN total_upload_size_bytes ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_UPLOAD_SIZE_BYTES,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteCacheCASUploadedBytes,
+			rawUsageLabelNotEquals(sku.Origin, sku.OriginInternal),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_UPLOAD_SIZE_BYTES,
 	},
 	{
 		Name:                "total_internal_upload_size_bytes",
 		PrimaryDBExpression: "SUM(CASE WHEN (origin = 'internal' AND NOT (client = 'executor-workflows' OR client = 'bazel')) THEN total_upload_size_bytes ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_INTERNAL_UPLOAD_SIZE_BYTES,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteCacheCASUploadedBytes,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelNotIn(sku.Client, sku.ClientExecutorWorkflows, sku.ClientBazel),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_TOTAL_INTERNAL_UPLOAD_SIZE_BYTES,
 	},
 	{
 		Name:                "total_workflow_upload_size_bytes",
 		PrimaryDBExpression: "SUM(CASE WHEN (origin = 'internal' AND (client = 'executor-workflows' OR client = 'bazel')) THEN total_upload_size_bytes ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_UPLOAD_SIZE_BYTES,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteCacheCASUploadedBytes,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelIn(sku.Client, sku.ClientExecutorWorkflows, sku.ClientBazel),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_UPLOAD_SIZE_BYTES,
 	},
 	{
 		Name:                "linux_execution_duration_usec",
 		PrimaryDBExpression: "SUM(linux_execution_duration_usec)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_LINUX_EXECUTION_DURATION_USEC,
+		OLAPExpression: rawUsageSumUsec(
+			sku.RemoteExecutionExecuteWorkerDurationNanos,
+			rawUsageLabelEquals(sku.OS, sku.OSLinux),
+			rawUsageLabelEquals(sku.SelfHosted, sku.SelfHostedFalse),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_LINUX_EXECUTION_DURATION_USEC,
 	},
 	{
 		Name:                "cloud_rbe_linux_execution_duration_usec",
 		PrimaryDBExpression: "SUM(CASE WHEN (origin = 'internal' AND NOT (client = 'executor-workflows' OR client = 'bazel')) THEN linux_execution_duration_usec ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_EXECUTION_DURATION_USEC,
+		OLAPExpression: rawUsageSumUsec(
+			sku.RemoteExecutionExecuteWorkerDurationNanos,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelNotIn(sku.Client, sku.ClientExecutorWorkflows, sku.ClientBazel),
+			rawUsageLabelEquals(sku.OS, sku.OSLinux),
+			rawUsageLabelEquals(sku.SelfHosted, sku.SelfHostedFalse),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_EXECUTION_DURATION_USEC,
 	},
 	{
 		Name:                "cloud_workflow_linux_execution_duration_usec",
 		PrimaryDBExpression: "SUM(CASE WHEN (origin = 'internal' AND (client = 'executor-workflows' OR client = 'bazel')) THEN linux_execution_duration_usec ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_EXECUTION_DURATION_USEC,
+		OLAPExpression: rawUsageSumUsec(
+			sku.RemoteExecutionExecuteWorkerDurationNanos,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelIn(sku.Client, sku.ClientExecutorWorkflows, sku.ClientBazel),
+			rawUsageLabelEquals(sku.OS, sku.OSLinux),
+			rawUsageLabelEquals(sku.SelfHosted, sku.SelfHostedFalse),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_EXECUTION_DURATION_USEC,
 	},
 	{
 		Name:                "cloud_cpu_nanos",
 		PrimaryDBExpression: "SUM(CASE WHEN origin = 'internal' THEN cpu_nanos ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_CLOUD_CPU_NANOS,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteExecutionExecuteWorkerCPUNanos,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelEquals(sku.OS, sku.OSLinux),
+			rawUsageLabelEquals(sku.SelfHosted, sku.SelfHostedFalse),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_CLOUD_CPU_NANOS,
 	},
 	{
 		Name:                "cloud_rbe_cpu_nanos",
 		PrimaryDBExpression: "SUM(CASE WHEN (origin = 'internal' AND NOT (client = 'executor-workflows' OR client = 'bazel')) THEN cpu_nanos ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_CLOUD_RBE_CPU_NANOS,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteExecutionExecuteWorkerCPUNanos,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelNotIn(sku.Client, sku.ClientExecutorWorkflows, sku.ClientBazel),
+			rawUsageLabelEquals(sku.OS, sku.OSLinux),
+			rawUsageLabelEquals(sku.SelfHosted, sku.SelfHostedFalse),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_CLOUD_RBE_CPU_NANOS,
 	},
 	{
 		Name:                "cloud_workflow_cpu_nanos",
 		PrimaryDBExpression: "SUM(CASE WHEN (origin = 'internal' AND (client = 'executor-workflows' OR client = 'bazel')) THEN cpu_nanos ELSE 0 END)",
-		AlertingMetric:      usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_CPU_NANOS,
+		OLAPExpression: rawUsageSum(
+			sku.RemoteExecutionExecuteWorkerCPUNanos,
+			rawUsageLabelEquals(sku.Origin, sku.OriginInternal),
+			rawUsageLabelIn(sku.Client, sku.ClientExecutorWorkflows, sku.ClientBazel),
+			rawUsageLabelEquals(sku.OS, sku.OSLinux),
+			rawUsageLabelEquals(sku.SelfHosted, sku.SelfHostedFalse),
+		),
+		AlertingMetric: usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_CPU_NANOS,
 	},
+}
+
+// UsageFieldForAlertingMetric returns the Usage field mapped to an alerting metric.
+func UsageFieldForAlertingMetric(metric usagepb.UsageAlertingMetric_Value) (*UsageField, bool) {
+	for i := range UsageFields {
+		if UsageFields[i].AlertingMetric == metric {
+			return &UsageFields[i], true
+		}
+	}
+	return nil, false
+}
+
+func rawUsageSum(usageSKU sku.SKU, conditions ...string) string {
+	expression := "SUM(CASE WHEN sku = '" + string(usageSKU) + "'"
+	if len(conditions) > 0 {
+		expression += " AND " + strings.Join(conditions, " AND ")
+	}
+	return expression + " THEN count ELSE 0 END)"
+}
+
+func rawUsageSumUsec(usageSKU sku.SKU, conditions ...string) string {
+	return "intDiv(" + rawUsageSum(usageSKU, conditions...) + ", 1000)"
+}
+
+func rawUsageLabelEquals(name sku.LabelName, value sku.LabelValue) string {
+	return "labels['" + string(name) + "'] = '" + string(value) + "'"
+}
+
+func rawUsageLabelNotEquals(name sku.LabelName, value sku.LabelValue) string {
+	return "labels['" + string(name) + "'] != '" + string(value) + "'"
+}
+
+func rawUsageLabelIn(name sku.LabelName, values ...sku.LabelValue) string {
+	return "labels['" + string(name) + "'] IN (" + quotedRawUsageLabelValues(values...) + ")"
+}
+
+func rawUsageLabelNotIn(name sku.LabelName, values ...sku.LabelValue) string {
+	return "labels['" + string(name) + "'] NOT IN (" + quotedRawUsageLabelValues(values...) + ")"
+}
+
+func quotedRawUsageLabelValues(values ...sku.LabelValue) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, "'"+string(value)+"'")
+	}
+	return strings.Join(quoted, ", ")
 }
 
 type usageService struct {
@@ -438,8 +560,7 @@ func (s *usageService) usageAlertingRuleToProto(ctx context.Context, row *tables
 			Window:            row.Window,
 		},
 		Status: &usagepb.UsageAlertingRuleStatus{
-			LastEvaluationTimestamp: timestampFromUsec(row.LastEvaluationUsec),
-			LastFiredTimestamp:      timestampFromUsec(row.LastFiredUsec),
+			LastFiredTimestamp: timestampFromUsec(row.LastFiredUsec),
 		},
 	}, nil
 }

--- a/enterprise/server/usage_service/usage_service_test.go
+++ b/enterprise/server/usage_service/usage_service_test.go
@@ -151,7 +151,10 @@ func TestUsageFields_CoverEveryUsageFieldAndAlertingMetric(t *testing.T) {
 	seenUsageFields := map[string]struct{}{}
 	seenAlertingMetrics := map[usagepb.UsageAlertingMetric_Value]struct{}{}
 	for _, field := range usage_service.UsageFields {
+		// Every usage field should provide both query expressions because GetUsage
+		// reads primary DB rows and usage alert evaluation reads RawUsage rows.
 		require.NotEmpty(t, field.PrimaryDBExpression)
+		require.NotEmpty(t, field.OLAPExpression)
 		require.NotEmpty(t, field.Name)
 
 		usageFieldName := field.Name
@@ -217,13 +220,12 @@ func TestUsageAlertingRules_CreateListDelete(t *testing.T) {
 	assert.Empty(t, cmp.Diff(expectedRule, createRsp.GetUsageAlertingRule(), protocmp.Transform()))
 
 	// Simulate evaluator-controlled status updates and verify listing returns them.
-	lastEvaluation := now.Add(10 * time.Minute)
 	lastFired := now.Add(20 * time.Minute)
 	err = env.GetDBHandle().NewQuery(ctx, "test_update_usage_alerting_rule_status").Raw(`
 		UPDATE "UsageAlertingRules"
-		SET last_evaluation_usec = ?, last_fired_usec = ?
+		SET last_fired_usec = ?
 		WHERE usage_alerting_rule_id = ?
-	`, lastEvaluation.UnixMicro(), lastFired.UnixMicro(), ruleID).Exec().Error
+	`, lastFired.UnixMicro(), ruleID).Exec().Error
 	require.NoError(t, err)
 
 	listRsp, err := service.GetUsageAlertingRules(ctx1, &usagepb.GetUsageAlertingRulesRequest{
@@ -231,8 +233,7 @@ func TestUsageAlertingRules_CreateListDelete(t *testing.T) {
 	})
 	require.NoError(t, err)
 	expectedRule.Status = &usagepb.UsageAlertingRuleStatus{
-		LastEvaluationTimestamp: timestamppb.New(lastEvaluation),
-		LastFiredTimestamp:      timestamppb.New(lastFired),
+		LastFiredTimestamp: timestamppb.New(lastFired),
 	}
 	assert.Empty(t, cmp.Diff(
 		&usagepb.GetUsageAlertingRulesResponse{UsageAlertingRule: []*usagepb.UsageAlertingRule{expectedRule}},

--- a/enterprise/server/usage_service/usage_service_test.go
+++ b/enterprise/server/usage_service/usage_service_test.go
@@ -2,6 +2,7 @@ package usage_service_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -151,8 +152,6 @@ func TestUsageFields_CoverEveryUsageFieldAndAlertingMetric(t *testing.T) {
 	seenUsageFields := map[string]struct{}{}
 	seenAlertingMetrics := map[usagepb.UsageAlertingMetric_Value]struct{}{}
 	for _, field := range usage_service.UsageFields {
-		// Every usage field should provide both query expressions because GetUsage
-		// reads primary DB rows and usage alert evaluation reads RawUsage rows.
 		require.NotEmpty(t, field.PrimaryDBExpression)
 		require.NotEmpty(t, field.OLAPExpression)
 		require.NotEmpty(t, field.Name)
@@ -164,6 +163,7 @@ func TestUsageFields_CoverEveryUsageFieldAndAlertingMetric(t *testing.T) {
 
 		assert.NotEqual(t, usagepb.UsageAlertingMetric_UNKNOWN, field.AlertingMetric)
 		assert.Contains(t, alertingMetrics, field.AlertingMetric)
+		assert.Equal(t, strings.ToUpper(field.Name), field.AlertingMetric.String())
 		assert.NotContains(t, seenAlertingMetrics, field.AlertingMetric)
 		seenAlertingMetrics[field.AlertingMetric] = struct{}{}
 	}

--- a/enterprise/server/usagealert/BUILD
+++ b/enterprise/server/usagealert/BUILD
@@ -1,0 +1,70 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "usagealert_lib",
+    srcs = ["usagealert.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/usagealert",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//enterprise/server/backends/configsecrets",
+        "//enterprise/server/backends/email",
+        "//enterprise/server/usage_service",
+        "//proto:group_go_proto",
+        "//proto:usage_go_proto",
+        "//server/config",
+        "//server/endpoint_urls/build_buddy_url",
+        "//server/interfaces",
+        "//server/real_environment",
+        "//server/tables",
+        "//server/util/clickhouse",
+        "//server/util/db",
+        "//server/util/flag",
+        "//server/util/flagutil",
+        "//server/util/healthcheck",
+        "//server/util/log",
+        "//server/util/role",
+        "//server/util/status",
+        "//server/util/subdomain",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/push",
+    ],
+)
+
+go_binary(
+    name = "usagealert",
+    embed = [":usagealert_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "usagealert_test",
+    srcs = ["usagealert_test.go"],
+    embed = [":usagealert_lib"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "true",
+        "test.runner-recycling-key": "clickhouse25.3",
+    },
+    tags = ["docker"],
+    deps = [
+        "//enterprise/server/backends/email",
+        "//enterprise/server/usage_service",
+        "//proto:group_go_proto",
+        "//proto:usage_go_proto",
+        "//server/interfaces",
+        "//server/tables",
+        "//server/testutil/testenv",
+        "//server/usage/sku",
+        "//server/util/clickhouse/schema",
+        "//server/util/role",
+        "//server/util/testing/flags",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_prometheus_client_golang//prometheus/testutil",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/usagealert/BUILD
+++ b/enterprise/server/usagealert/BUILD
@@ -48,7 +48,9 @@ go_test(
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
         "test.runner-recycling-key": "clickhouse25.3",
+        "test.EstimatedComputeUnits": "4",
     },
+    shard_count = 4,
     tags = ["docker"],
     deps = [
         "//enterprise/server/backends/email",
@@ -63,6 +65,7 @@ go_test(
         "//server/util/role",
         "//server/util/testing/flags",
         "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/usagealert/usagealert.go
+++ b/enterprise/server/usagealert/usagealert.go
@@ -1,0 +1,713 @@
+// Usage alerting rule evaluator and notifier.
+//
+// This should run as a cronjob. It queries usage alerting rules and recipients,
+// then compares each rule's configured threshold against the current usage data
+// in ClickHouse. For any alerts that haven't already fired for the current
+// window, it sends email alerts to all org admins.
+//
+// Example run:
+//
+//	bb run -- //enterprise/server/usagealert:usagealert \
+//	  --app.build_buddy_url=https://app.buildbuddy.example.com \
+//	  --app.enable_subdomain_matching=true \
+//	  --database.data_source='mysql://user:password@tcp(mysql:3306)/buildbuddy' \
+//	  --olap_database.data_source='clickhouse://default:password@clickhouse:9000/buildbuddy' \
+//	  --notifications.email.sendgrid.api_key=$SENDGRID_API_KEY \
+//	  --notifications.email.default_from_address='{"name":"BuildBuddy","email":"notifications@buildbuddy.example.com"}' \
+//	  --usagealert.push_gateway=http://pushgateway.example.com:9091
+//
+// The buildbuddy_usage_alert_errors_total metric is pushed to a configured
+// prometheus push gateway.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"html/template"
+	"math"
+	"os"
+	"os/signal"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/email"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/usage_service"
+	"github.com/buildbuddy-io/buildbuddy/server/config"
+	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse"
+	"github.com/buildbuddy-io/buildbuddy/server/util/db"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/role"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
+	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
+	usagepb "github.com/buildbuddy-io/buildbuddy/proto/usage"
+)
+
+const (
+	errorStageQueryRulesAndRecipients = "query_rules_and_recipients"
+	errorStageMissingMetric           = "missing_metric"
+	errorStageUnsupportedWindow       = "unsupported_window"
+	errorStageQueryUsage              = "query_usage"
+	errorStageSendEmail               = "send_email"
+	errorStageUpdateRule              = "update_rule"
+)
+
+var (
+	evaluatorConcurrency = flag.Int("usagealert.concurrency", 4, "Maximum number of usage alerting rules to evaluate concurrently.")
+	pushGateway          = flag.String("usagealert.push_gateway", "", "Prometheus Pushgateway address used to publish evaluator error metrics.")
+
+	alertEmailBodyTemplate = sync.OnceValues(func() (*template.Template, error) {
+		return template.New("usage_alert_email").Parse(`<p><strong>{{.WindowLabel}} {{.MetricDisplay}}</strong> usage alert fired for organization <strong>{{.GroupDisplayName}}</strong>.</p>
+<p>Usage for <strong>{{.MetricDisplay}}</strong> is <strong>{{.Value}}</strong>, which exceeds the configured threshold of <strong>{{.Threshold}}</strong>.</p>
+<p>Window: {{.Start}} to {{.End}} UTC</p>
+<p>See usage at <a href="{{.UsageURL}}">{{.UsageURL}}</a></p>`)
+	})
+)
+
+func main() {
+	if err := disableAutoMigration(); err != nil {
+		log.Fatalf("disable auto-migration: %s", err)
+	}
+	flag.Parse()
+	if err := run(); err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := configsecrets.Configure(); err != nil {
+		return fmt.Errorf("prepare config secrets provider: %w", err)
+	}
+	if err := config.Load(); err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if err := log.Configure(); err != nil {
+		return fmt.Errorf("configure log: %w", err)
+	}
+	if !email.IsConfigured() {
+		return fmt.Errorf("email is not configured")
+	}
+
+	env := real_environment.NewRealEnv(healthcheck.NewHealthChecker("usagealert"))
+	dbh, err := db.GetConfiguredDatabase(ctx, env)
+	if err != nil {
+		return fmt.Errorf("configure SQL database: %w", err)
+	}
+	env.SetDBHandle(dbh)
+	if err := clickhouse.Register(env); err != nil {
+		return fmt.Errorf("configure ClickHouse: %w", err)
+	}
+	if env.GetOLAPDBHandle() == nil {
+		return fmt.Errorf("clickhouse database is required")
+	}
+
+	metrics, err := newEvaluatorMetrics()
+	if err != nil {
+		return fmt.Errorf("configure metrics: %w", err)
+	}
+	evaluator := NewEvaluator(
+		env.GetDBHandle(),
+		env.GetOLAPDBHandle(),
+		email.NewClient(email.ClientConfig{}),
+		clockwork.NewRealClock(),
+		metrics,
+	)
+	result, err := runEvaluator(ctx, evaluator, &pushGatewayPusher{gatherer: metrics.registry})
+	if result != nil {
+		log.Infof("Evaluated %d usage alerting rules and sent %d alert emails.", result.RulesEvaluated, result.AlertsSent)
+	}
+	return err
+}
+
+// disableAutoMigration disables schema migration for the evaluator process.
+func disableAutoMigration() error {
+	if err := flagutil.SetValueForFlagName("auto_migrate_db", false, nil, false); err != nil {
+		return err
+	}
+	if err := flagutil.SetValueForFlagName("olap_database.auto_migrate_db", false, nil, false); err != nil {
+		return err
+	}
+	return nil
+}
+
+// emailSender sends alert emails.
+type emailSender interface {
+	Send(ctx context.Context, msg *email.Message) error
+}
+
+// metricsPusher publishes evaluator metrics after a run.
+type metricsPusher interface {
+	Push() error
+}
+
+// runEvaluator runs the evaluator and then pushes metrics even if evaluation fails.
+func runEvaluator(ctx context.Context, evaluator *Evaluator, pusher metricsPusher) (*EvaluationResult, error) {
+	result, evalErr := evaluator.Run(ctx)
+	pushErr := pusher.Push()
+	if pushErr != nil {
+		pushErr = fmt.Errorf("push evaluator metrics: %w", pushErr)
+	}
+	return result, errors.Join(evalErr, pushErr)
+}
+
+// Evaluator checks usage alerting rules and emails admins for newly fired alerts.
+type Evaluator struct {
+	dbh     interfaces.DBHandle
+	usage   *usageQuerier
+	email   emailSender
+	clock   clockwork.Clock
+	metrics *evaluatorMetrics
+}
+
+// EvaluationResult summarizes an evaluator run.
+type EvaluationResult struct {
+	// RulesEvaluated is the number of attempted alert rules.
+	RulesEvaluated int
+	// AlertsSent is the number of alert emails sent.
+	AlertsSent int
+}
+
+// alertRule pairs a rule row with its current admin recipients.
+type alertRule struct {
+	rule               *tables.UsageAlertingRule
+	groupName          string
+	groupURLIdentifier string
+	recipients         []email.Address
+}
+
+// NewEvaluator constructs an evaluator using explicit dependencies for tests.
+func NewEvaluator(dbh interfaces.DBHandle, olapDBH interfaces.OLAPDBHandle, email emailSender, clock clockwork.Clock, metrics *evaluatorMetrics) *Evaluator {
+	return &Evaluator{
+		dbh:     dbh,
+		usage:   &usageQuerier{dbh: olapDBH},
+		email:   email,
+		clock:   clock,
+		metrics: metrics,
+	}
+}
+
+// Run evaluates alert rules in the database.
+func (e *Evaluator) Run(ctx context.Context) (*EvaluationResult, error) {
+	rules, err := e.queryRulesAndRecipients(ctx)
+	if err != nil {
+		e.recordError(errorStageQueryRulesAndRecipients)
+		return nil, fmt.Errorf("query usage alerting rules and recipients: %w", err)
+	}
+
+	now := e.clock.Now().UTC()
+	result := &EvaluationResult{RulesEvaluated: len(rules)}
+	if len(rules) == 0 {
+		return result, nil
+	}
+
+	concurrency := min(*evaluatorConcurrency, len(rules))
+	if concurrency < 1 {
+		return nil, fmt.Errorf("evaluator concurrency must be >= 1")
+	}
+
+	jobs := make(chan *alertRule)
+	results := make(chan ruleEvaluationResult, len(rules))
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Go(func() {
+			for rule := range jobs {
+				alertsSent, err := e.evaluateRule(ctx, now, rule)
+				results <- ruleEvaluationResult{alertsSent: alertsSent, err: err}
+			}
+		})
+	}
+	for _, rule := range rules {
+		jobs <- rule
+	}
+	close(jobs)
+	wg.Wait()
+	close(results)
+
+	var errs []error
+	for r := range results {
+		result.AlertsSent += r.alertsSent
+		if r.err != nil {
+			errs = append(errs, r.err)
+		}
+	}
+	return result, errors.Join(errs...)
+}
+
+// ruleEvaluationResult contains the outcome of evaluating an alert rule.
+type ruleEvaluationResult struct {
+	alertsSent int
+	err        error
+}
+
+// evaluateRule evaluates an alert rule and sends emails if it newly fires.
+func (e *Evaluator) evaluateRule(ctx context.Context, now time.Time, alert *alertRule) (int, error) {
+	rule := alert.rule
+	metric, ok := metricDefinitions[rule.UsageAlertingMetric]
+	usageField, fieldOK := usage_service.UsageFieldForAlertingMetric(rule.UsageAlertingMetric)
+	if !ok || !fieldOK {
+		e.recordError(errorStageMissingMetric)
+		return 0, fmt.Errorf("rule %q has unsupported metric %s", rule.UsageAlertingRuleID, rule.UsageAlertingMetric)
+	}
+	start, end, err := windowRange(now, rule.Window)
+	if err != nil {
+		e.recordError(errorStageUnsupportedWindow)
+		return 0, fmt.Errorf("rule %q has unsupported window %s", rule.UsageAlertingRuleID, rule.Window)
+	}
+
+	value, err := e.usage.QueryUsage(ctx, usageField, rule.GroupID, start, end)
+	if err != nil {
+		e.recordError(errorStageQueryUsage)
+		return 0, fmt.Errorf("query usage for rule %q: %w", rule.UsageAlertingRuleID, err)
+	}
+
+	if value <= rule.AbsoluteThreshold || usecInRange(rule.LastFiredUsec, start, end) {
+		return 0, nil
+	}
+
+	alertsSent := 0
+	var retErr error
+	for _, recipient := range alert.recipients {
+		msg, err := buildAlertEmail(alert, metric, recipient, value, start, end)
+		if err != nil {
+			e.recordError(errorStageSendEmail)
+			retErr = errors.Join(retErr, fmt.Errorf("build usage alert email for rule %q to %q: %w", rule.UsageAlertingRuleID, recipient.Email, err))
+			continue
+		}
+		if err := e.email.Send(ctx, msg); err != nil {
+			e.recordError(errorStageSendEmail)
+			retErr = errors.Join(retErr, fmt.Errorf("send usage alert email for rule %q to %q: %w", rule.UsageAlertingRuleID, recipient.Email, err))
+			continue
+		}
+		alertsSent++
+	}
+	if retErr != nil {
+		return alertsSent, retErr
+	}
+
+	lastFiredUsec := now.UnixMicro()
+	if err := e.updateRuleFired(ctx, rule.UsageAlertingRuleID, lastFiredUsec); err != nil {
+		e.recordError(errorStageUpdateRule)
+		return alertsSent, fmt.Errorf("update usage alerting rule %q status: %w", rule.UsageAlertingRuleID, err)
+	}
+	return alertsSent, nil
+}
+
+// recordError increments the evaluator error counter for stage.
+func (e *Evaluator) recordError(stage string) {
+	if e.metrics != nil {
+		e.metrics.errors.WithLabelValues(stage).Inc()
+	}
+}
+
+// queryRulesAndRecipients loads alert rules and their current admin recipients.
+func (e *Evaluator) queryRulesAndRecipients(ctx context.Context) ([]*alertRule, error) {
+	// Query rules + recipients together so we only evaluate deliverable rules.
+	type ruleRecipientRow struct {
+		tables.UsageAlertingRule
+		GroupName          string
+		GroupURLIdentifier string
+		RecipientEmail     string
+		RecipientFirstName string
+		RecipientLastName  string
+	}
+	rq := e.dbh.NewQuery(ctx, "usage_alert_query_rules_and_recipients").Raw(`
+		SELECT r.*,
+		COALESCE(g.name, '') AS group_name,
+		COALESCE(g.url_identifier, '') AS group_url_identifier,
+		u.email AS recipient_email,
+		u.first_name AS recipient_first_name,
+		u.last_name AS recipient_last_name
+		FROM "UsageAlertingRules" AS r
+		LEFT JOIN "Groups" AS g ON g.group_id = r.group_id
+		JOIN "UserGroups" AS ug ON ug.group_group_id = r.group_id
+		JOIN "Users" AS u ON u.user_id = ug.user_user_id
+		WHERE ug.membership_status = ?
+		AND (ug.role & ?) = ?
+		AND TRIM(u.email) <> ''
+		ORDER BY r.group_id ASC, r.usage_alerting_rule_id ASC, u.user_id ASC
+	`, int32(grpb.GroupMembershipStatus_MEMBER), uint32(role.Admin), uint32(role.Admin))
+	rows, err := db.ScanAll(rq, &ruleRecipientRow{})
+	if err != nil {
+		return nil, err
+	}
+
+	var rules []*alertRule
+	byID := make(map[string]*alertRule)
+	for _, row := range rows {
+		rule := byID[row.UsageAlertingRuleID]
+		if rule == nil {
+			r := row.UsageAlertingRule
+			rule = &alertRule{
+				rule:               &r,
+				groupName:          row.GroupName,
+				groupURLIdentifier: row.GroupURLIdentifier,
+			}
+			byID[row.UsageAlertingRuleID] = rule
+			rules = append(rules, rule)
+		}
+		rule.recipients = append(rule.recipients, email.Address{
+			Name:  strings.TrimSpace(row.RecipientFirstName + " " + row.RecipientLastName),
+			Email: row.RecipientEmail,
+		})
+	}
+	return rules, nil
+}
+
+// updateRuleFired records that an alert rule fired.
+func (e *Evaluator) updateRuleFired(ctx context.Context, ruleID string, lastFiredUsec int64) error {
+	return e.dbh.NewQuery(ctx, "usage_alert_update_fired_rule").Raw(`
+		UPDATE "UsageAlertingRules"
+		SET last_fired_usec = ?
+		WHERE usage_alerting_rule_id = ?
+	`, lastFiredUsec, ruleID).Exec().Error
+}
+
+// usageQuerier queries usage rows from ClickHouse.
+type usageQuerier struct {
+	dbh interfaces.OLAPDBHandle
+}
+
+// QueryUsage returns aggregate usage for the field and time window.
+func (q *usageQuerier) QueryUsage(ctx context.Context, field *usage_service.UsageField, groupID string, start, end time.Time) (int64, error) {
+	row := &struct {
+		Value int64
+	}{}
+	if err := q.dbh.NewQuery(ctx, "usage_alert_query_raw_usage").Raw(`
+		SELECT ifNull(`+field.OLAPExpression+`, 0) AS value
+		FROM RawUsage FINAL
+		WHERE group_id = ?
+		AND period_start >= ?
+		AND period_start < ?
+	`, groupID, start, end).Take(row); err != nil {
+		return 0, err
+	}
+	return row.Value, nil
+}
+
+// metricDefinition maps an alerting metric to email display metadata.
+type metricDefinition struct {
+	// Metric is the user-facing alerting metric enum value.
+	Metric usagepb.UsageAlertingMetric_Value
+	// Display is the label used in alert emails.
+	Display string
+	// Unit is the usage unit used by the UI for thresholds and display.
+	Unit metricUnit
+}
+
+// metricUnit mirrors the unit names used by usage_alerts_model.ts.
+type metricUnit string
+
+const (
+	countMetricUnit         metricUnit = "count"
+	bytesMetricUnit         metricUnit = "bytes"
+	durationNanosMetricUnit metricUnit = "duration_nanos"
+)
+
+// metricDefinitions contains evaluator mappings for alerting metrics.
+// TODO: define these as protos and share with the UI.
+var metricDefinitions = map[usagepb.UsageAlertingMetric_Value]*metricDefinition{
+	usagepb.UsageAlertingMetric_INVOCATIONS: {
+		Metric:  usagepb.UsageAlertingMetric_INVOCATIONS,
+		Display: "Invocations",
+		Unit:    countMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_ACTION_CACHE_HITS: {
+		Metric:  usagepb.UsageAlertingMetric_ACTION_CACHE_HITS,
+		Display: "Action cache hits",
+		Unit:    countMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_CACHED_BUILD_DURATION: {
+		Metric:  usagepb.UsageAlertingMetric_CACHED_BUILD_DURATION,
+		Display: "Cached build minutes",
+		Unit:    durationNanosMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_CAS_CACHE_HITS: {
+		Metric:  usagepb.UsageAlertingMetric_CAS_CACHE_HITS,
+		Display: "Content addressable storage cache hits",
+		Unit:    countMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_TOTAL_DOWNLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_DOWNLOAD_SIZE_BYTES,
+		Display: "Total bytes downloaded from cache (All)",
+		Unit:    bytesMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_EXTERNAL_DOWNLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_EXTERNAL_DOWNLOAD_SIZE_BYTES,
+		Display: "Total bytes downloaded from cache (External)",
+		Unit:    bytesMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_INTERNAL_DOWNLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_INTERNAL_DOWNLOAD_SIZE_BYTES,
+		Display: "Total bytes downloaded from cache (Internal)",
+		Unit:    bytesMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_WORKFLOW_DOWNLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_WORKFLOW_DOWNLOAD_SIZE_BYTES,
+		Display: "Total bytes downloaded from cache (Workflows)",
+		Unit:    bytesMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_TOTAL_UPLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_UPLOAD_SIZE_BYTES,
+		Display: "Total bytes uploaded to cache (All)",
+		Unit:    bytesMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_EXTERNAL_UPLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_EXTERNAL_UPLOAD_SIZE_BYTES,
+		Display: "Total bytes uploaded to cache (External)",
+		Unit:    bytesMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_INTERNAL_UPLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_INTERNAL_UPLOAD_SIZE_BYTES,
+		Display: "Total bytes uploaded to cache (Internal)",
+		Unit:    bytesMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_WORKFLOW_UPLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_WORKFLOW_UPLOAD_SIZE_BYTES,
+		Display: "Total bytes uploaded to cache (Workflows)",
+		Unit:    bytesMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_LINUX_EXECUTION_DURATION: {
+		Metric:  usagepb.UsageAlertingMetric_LINUX_EXECUTION_DURATION,
+		Display: "Linux remote execution duration (All)",
+		Unit:    durationNanosMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_EXECUTION_DURATION: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_EXECUTION_DURATION,
+		Display: "Linux remote execution duration (Cloud RBE)",
+		Unit:    durationNanosMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_EXECUTION_DURATION: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_EXECUTION_DURATION,
+		Display: "Linux remote execution duration (Workflows)",
+		Unit:    durationNanosMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_LINUX_CPU_DURATION: {
+		Metric:  usagepb.UsageAlertingMetric_LINUX_CPU_DURATION,
+		Display: "Linux CPU duration (All)",
+		Unit:    durationNanosMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_CPU_DURATION: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_CPU_DURATION,
+		Display: "Linux CPU duration (Cloud RBE)",
+		Unit:    durationNanosMetricUnit,
+	},
+	usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_CPU_DURATION: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_CPU_DURATION,
+		Display: "Linux CPU duration (Workflows)",
+		Unit:    durationNanosMetricUnit,
+	},
+}
+
+// windowRange returns the UTC bounds for an alerting window containing now.
+func windowRange(now time.Time, window usagepb.UsageAlertingWindow_Value) (time.Time, time.Time, error) {
+	now = now.UTC()
+	switch window {
+	case usagepb.UsageAlertingWindow_DAY:
+		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		return start, start.AddDate(0, 0, 1), nil
+	case usagepb.UsageAlertingWindow_WEEK:
+		weekdayOffset := (int(now.Weekday()) + 6) % 7
+		start := time.Date(now.Year(), now.Month(), now.Day()-weekdayOffset, 0, 0, 0, 0, time.UTC)
+		return start, start.AddDate(0, 0, 7), nil
+	case usagepb.UsageAlertingWindow_MONTH:
+		start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		return start, start.AddDate(0, 1, 0), nil
+	default:
+		return time.Time{}, time.Time{}, status.InvalidArgumentErrorf("unsupported usage alerting window: %s", window)
+	}
+}
+
+// usecInRange reports whether a microsecond timestamp is inside [start, end).
+func usecInRange(usec int64, start, end time.Time) bool {
+	if usec == 0 {
+		return false
+	}
+	t := time.UnixMicro(usec).UTC()
+	return !t.Before(start) && t.Before(end)
+}
+
+// buildAlertEmail builds the HTML notification for a fired alert.
+func buildAlertEmail(alert *alertRule, metric *metricDefinition, recipient email.Address, value int64, start, end time.Time) (*email.Message, error) {
+	rule := alert.rule
+	groupName := strings.TrimSpace(alert.groupName)
+	groupDisplayName := groupName
+	if groupDisplayName == "" {
+		groupDisplayName = rule.GroupID
+	}
+	subjectGroupName := groupName
+	if subjectGroupName == "" {
+		subjectGroupName = strings.TrimSpace(alert.groupURLIdentifier)
+	}
+	if subjectGroupName == "" {
+		subjectGroupName = rule.GroupID
+	}
+	usageURL := build_buddy_url.WithPath("/usage").String()
+	if alert.groupURLIdentifier != "" && subdomain.Enabled() {
+		usageURL = subdomain.ReplaceURLSubdomainForGroup(usageURL, &tables.Group{URLIdentifier: alert.groupURLIdentifier})
+	}
+	subject := fmt.Sprintf("[BuildBuddy Usage Alert] [%s] %s %s threshold reached", subjectGroupName, usageAlertingWindowLabel(rule.Window), metric.Display)
+	bodyTemplate, err := alertEmailBodyTemplate()
+	if err != nil {
+		return nil, fmt.Errorf("load email body template: %w", err)
+	}
+	var body strings.Builder
+	if err := bodyTemplate.Execute(&body, struct {
+		WindowLabel      string
+		MetricDisplay    string
+		GroupDisplayName string
+		Value            string
+		Threshold        string
+		Start            string
+		End              string
+		UsageURL         string
+	}{
+		WindowLabel:      usageAlertingWindowLabel(rule.Window),
+		MetricDisplay:    metric.Display,
+		GroupDisplayName: groupDisplayName,
+		Value:            formatMetricValue(metric, value),
+		Threshold:        formatMetricValue(metric, rule.AbsoluteThreshold),
+		Start:            start.Format(time.RFC3339),
+		End:              end.Format(time.RFC3339),
+		UsageURL:         usageURL,
+	}); err != nil {
+		return nil, fmt.Errorf("render email body template: %w", err)
+	}
+	return &email.Message{
+		To:      recipient,
+		Subject: subject,
+		Body:    body.String(),
+	}, nil
+}
+
+// usageAlertingWindowLabel returns the user-facing label for an alerting window.
+func usageAlertingWindowLabel(window usagepb.UsageAlertingWindow_Value) string {
+	switch window {
+	case usagepb.UsageAlertingWindow_DAY:
+		return "Daily"
+	case usagepb.UsageAlertingWindow_WEEK:
+		return "Weekly"
+	case usagepb.UsageAlertingWindow_MONTH:
+		return "Monthly"
+	default:
+		return ""
+	}
+}
+
+// formatMetricValue formats usage values using the same unit categories as the UI.
+func formatMetricValue(metric *metricDefinition, value int64) string {
+	switch metric.Unit {
+	case bytesMetricUnit:
+		return formatBytes(value)
+	case durationNanosMetricUnit:
+		minutes := int64(math.Round(float64(value) / 60e9))
+		return formatCount(minutes) + " " + pluralize("minute", minutes)
+	case countMetricUnit:
+		return formatCount(value)
+	default:
+		return formatCount(value)
+	}
+}
+
+// formatBytes formats decimal byte units to match the usage alerting UI.
+func formatBytes(value int64) string {
+	units := []string{"B", "KB", "MB", "GB", "TB", "PB"}
+	v := float64(value)
+	for i, unit := range units {
+		if v < math.Pow(1000, float64(i+1)) || i == len(units)-1 {
+			return strconv.FormatFloat(v/math.Pow(1000, float64(i)), 'g', 4, 64) + unit
+		}
+	}
+	return strconv.FormatInt(value, 10) + "B"
+}
+
+// formatCount formats compact counts to match the usage alerting UI.
+func formatCount(value int64) string {
+	if value < 1000 {
+		return strconv.FormatInt(value, 10)
+	}
+	if value < 1e6 {
+		return strconv.FormatFloat(float64(value)/1e3, 'g', 4, 64) + "K"
+	}
+	if value < 1e9 {
+		return strconv.FormatFloat(float64(value)/1e6, 'g', 4, 64) + "M"
+	}
+	return strconv.FormatFloat(float64(value)/1e9, 'g', 4, 64) + "B"
+}
+
+// pluralize returns singular or plural text for count.
+func pluralize(singular string, count int64) string {
+	if count == 1 {
+		return singular
+	}
+	return singular + "s"
+}
+
+// evaluatorMetrics owns the registry pushed by this binary.
+type evaluatorMetrics struct {
+	registry *prometheus.Registry
+	errors   *prometheus.CounterVec
+}
+
+// newEvaluatorMetrics registers metrics used by the evaluator.
+func newEvaluatorMetrics() (*evaluatorMetrics, error) {
+	registry := prometheus.NewRegistry()
+	errors := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "buildbuddy_usage_alert_errors_total",
+		Help: "Number of usage alert errors.",
+	}, []string{"stage"})
+	if err := registry.Register(errors); err != nil {
+		return nil, fmt.Errorf("register usage alert errors metric: %w", err)
+	}
+	return &evaluatorMetrics{
+		registry: registry,
+		errors:   errors,
+	}, nil
+}
+
+// pushGatewayPusher pushes metrics to Prometheus Pushgateway when configured.
+type pushGatewayPusher struct {
+	gatherer prometheus.Gatherer
+}
+
+// Push publishes metrics or no-ops when no Pushgateway address is set.
+func (p *pushGatewayPusher) Push() error {
+	address := strings.TrimSpace(*pushGateway)
+	if address == "" {
+		return nil
+	}
+	return push.New(address, "usagealert").Gatherer(p.gatherer).Push()
+}
+
+// alertingMetricValues returns non-UNKNOWN alerting metric enum values.
+func alertingMetricValues() []usagepb.UsageAlertingMetric_Value {
+	values := make([]usagepb.UsageAlertingMetric_Value, 0, len(usagepb.UsageAlertingMetric_Value_name))
+	for value := range usagepb.UsageAlertingMetric_Value_name {
+		metric := usagepb.UsageAlertingMetric_Value(value)
+		if metric == usagepb.UsageAlertingMetric_UNKNOWN {
+			continue
+		}
+		values = append(values, metric)
+	}
+	slices.Sort(values)
+	return values
+}

--- a/enterprise/server/usagealert/usagealert.go
+++ b/enterprise/server/usagealert/usagealert.go
@@ -16,7 +16,7 @@
 //	  --notifications.email.default_from_address='{"name":"BuildBuddy","email":"notifications@buildbuddy.example.com"}' \
 //	  --usagealert.push_gateway=http://pushgateway.example.com:9091
 //
-// The buildbuddy_usage_alert_errors_total metric is pushed to a configured
+// Usage alert metrics and the common default metrics are pushed to a configured
 // prometheus push gateway.
 package main
 
@@ -132,7 +132,8 @@ func run() error {
 		clockwork.NewRealClock(),
 		metrics,
 	)
-	result, err := runEvaluator(ctx, evaluator, &pushGatewayPusher{gatherer: metrics.registry})
+	pusher := &pushGatewayPusher{gatherer: newPushGatewayGatherer(metrics)}
+	result, err := runEvaluator(ctx, evaluator, pusher)
 	if result != nil {
 		log.Infof("Evaluated %d usage alerting rules and sent %d alert emails.", result.RulesEvaluated, result.AlertsSent)
 	}
@@ -160,6 +161,11 @@ type metricsPusher interface {
 	Push() error
 }
 
+// usageReader queries aggregate usage values for alert evaluation.
+type usageReader interface {
+	QueryUsage(ctx context.Context, field *usage_service.UsageField, groupID string, start, end time.Time) (int64, error)
+}
+
 // runEvaluator runs the evaluator and then pushes metrics even if evaluation fails.
 func runEvaluator(ctx context.Context, evaluator *Evaluator, pusher metricsPusher) (*EvaluationResult, error) {
 	result, evalErr := evaluator.Run(ctx)
@@ -173,7 +179,7 @@ func runEvaluator(ctx context.Context, evaluator *Evaluator, pusher metricsPushe
 // Evaluator checks usage alerting rules and emails admins for newly fired alerts.
 type Evaluator struct {
 	dbh     interfaces.DBHandle
-	usage   *usageQuerier
+	usage   usageReader
 	email   emailSender
 	clock   clockwork.Clock
 	metrics *evaluatorMetrics
@@ -193,6 +199,7 @@ type alertRule struct {
 	groupName          string
 	groupURLIdentifier string
 	recipients         []email.Address
+	recipientEmails    map[string]struct{}
 }
 
 // NewEvaluator constructs an evaluator using explicit dependencies for tests.
@@ -262,54 +269,68 @@ type ruleEvaluationResult struct {
 // evaluateRule evaluates an alert rule and sends emails if it newly fires.
 func (e *Evaluator) evaluateRule(ctx context.Context, now time.Time, alert *alertRule) (int, error) {
 	rule := alert.rule
+	// Resolve the user-selected metric into the email metadata and Usage API
+	// field that should be queried.
 	metric, ok := metricDefinitions[rule.UsageAlertingMetric]
-	usageField, fieldOK := usage_service.UsageFieldForAlertingMetric(rule.UsageAlertingMetric)
-	if !ok || !fieldOK {
+	if !ok {
 		e.recordError(errorStageMissingMetric)
 		return 0, fmt.Errorf("rule %q has unsupported metric %s", rule.UsageAlertingRuleID, rule.UsageAlertingMetric)
 	}
+	usageField, ok := usage_service.UsageFieldForAlertingMetric(rule.UsageAlertingMetric)
+	if !ok {
+		e.recordError(errorStageMissingMetric)
+		return 0, fmt.Errorf("rule %q has unsupported metric %s", rule.UsageAlertingRuleID, rule.UsageAlertingMetric)
+	}
+	// Evaluate each rule against the complete current day, week, or month
+	// window containing now.
 	start, end, err := windowRange(now, rule.Window)
 	if err != nil {
 		e.recordError(errorStageUnsupportedWindow)
 		return 0, fmt.Errorf("rule %q has unsupported window %s", rule.UsageAlertingRuleID, rule.Window)
 	}
 
+	// Query the aggregate usage value for the rule's group and window.
 	value, err := e.usage.QueryUsage(ctx, usageField, rule.GroupID, start, end)
 	if err != nil {
 		e.recordError(errorStageQueryUsage)
 		return 0, fmt.Errorf("query usage for rule %q: %w", rule.UsageAlertingRuleID, err)
 	}
 
+	// Fire only when usage exceeds the threshold and this rule has not already
+	// fired in the current window.
 	if value <= rule.AbsoluteThreshold || usecInRange(rule.LastFiredUsec, start, end) {
 		return 0, nil
 	}
 
-	alertsSent := 0
-	var retErr error
-	for _, recipient := range alert.recipients {
-		msg, err := buildAlertEmail(alert, metric, recipient, value, start, end)
-		if err != nil {
-			e.recordError(errorStageSendEmail)
-			retErr = errors.Join(retErr, fmt.Errorf("build usage alert email for rule %q to %q: %w", rule.UsageAlertingRuleID, recipient.Email, err))
-			continue
-		}
-		if err := e.email.Send(ctx, msg); err != nil {
-			e.recordError(errorStageSendEmail)
-			retErr = errors.Join(retErr, fmt.Errorf("send usage alert email for rule %q to %q: %w", rule.UsageAlertingRuleID, recipient.Email, err))
-			continue
-		}
-		alertsSent++
+	msg, err := buildAlertEmail(alert, metric, alert.recipients, value, start, end)
+	if err != nil {
+		e.recordError(errorStageSendEmail)
+		return 0, fmt.Errorf("build usage alert email for rule %q: %w", rule.UsageAlertingRuleID, err)
 	}
-	if retErr != nil {
-		return alertsSent, retErr
+	// Send before recording the fired timestamp so we do not miss alerts if
+	// this process exits before delivery. Kubernetes CronJobs can overlap (even
+	// with concurrencyPolicy `Forbid`), so this can send duplicate emails
+	// before one run records that the rule fired.
+	//
+	// TODO: Maybe have a separate email outbox table so delivery can be retried
+	// without this duplicate-send tradeoff, or use an email provider that
+	// supports idempotent delivery.
+	if err := e.email.Send(ctx, msg); err != nil {
+		e.recordError(errorStageSendEmail)
+		return 0, fmt.Errorf("send usage alert email for rule %q: %w", rule.UsageAlertingRuleID, err)
 	}
-
+	// After the email send succeeds, remember that this rule fired for the
+	// window so future runs can skip it.
 	lastFiredUsec := now.UnixMicro()
-	if err := e.updateRuleFired(ctx, rule.UsageAlertingRuleID, lastFiredUsec); err != nil {
+	recorded, err := e.recordRuleFired(ctx, rule.UsageAlertingRuleID, lastFiredUsec, start, end)
+	if err != nil {
 		e.recordError(errorStageUpdateRule)
-		return alertsSent, fmt.Errorf("update usage alerting rule %q status: %w", rule.UsageAlertingRuleID, err)
+		return len(alert.recipients), fmt.Errorf("record usage alerting rule %q fired: %w", rule.UsageAlertingRuleID, err)
 	}
-	return alertsSent, nil
+	if !recorded {
+		return len(alert.recipients), nil
+	}
+	return len(alert.recipients), nil
 }
 
 // recordError increments the evaluator error counter for stage.
@@ -361,25 +382,42 @@ func (e *Evaluator) queryRulesAndRecipients(ctx context.Context) ([]*alertRule, 
 				rule:               &r,
 				groupName:          row.GroupName,
 				groupURLIdentifier: row.GroupURLIdentifier,
+				recipientEmails:    make(map[string]struct{}),
 			}
 			byID[row.UsageAlertingRuleID] = rule
 			rules = append(rules, rule)
 		}
+		recipientEmail := strings.TrimSpace(row.RecipientEmail)
+		recipientKey := strings.ToLower(recipientEmail)
+		if _, ok := rule.recipientEmails[recipientKey]; ok {
+			continue
+		}
+		rule.recipientEmails[recipientKey] = struct{}{}
 		rule.recipients = append(rule.recipients, email.Address{
 			Name:  strings.TrimSpace(row.RecipientFirstName + " " + row.RecipientLastName),
-			Email: row.RecipientEmail,
+			Email: recipientEmail,
 		})
 	}
 	return rules, nil
 }
 
-// updateRuleFired records that an alert rule fired.
-func (e *Evaluator) updateRuleFired(ctx context.Context, ruleID string, lastFiredUsec int64) error {
-	return e.dbh.NewQuery(ctx, "usage_alert_update_fired_rule").Raw(`
+// recordRuleFired records that an alert rule fired if it has not already fired
+// in the evaluated window.
+func (e *Evaluator) recordRuleFired(ctx context.Context, ruleID string, lastFiredUsec int64, start, end time.Time) (bool, error) {
+	result := e.dbh.NewQuery(ctx, "usage_alert_record_fired_rule").Raw(`
 		UPDATE "UsageAlertingRules"
 		SET last_fired_usec = ?
 		WHERE usage_alerting_rule_id = ?
-	`, lastFiredUsec, ruleID).Exec().Error
+		AND (
+			last_fired_usec = 0 OR
+			last_fired_usec < ? OR
+			last_fired_usec >= ?
+		)
+	`, lastFiredUsec, ruleID, start.UnixMicro(), end.UnixMicro()).Exec()
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
 }
 
 // usageQuerier queries usage rows from ClickHouse.
@@ -420,6 +458,7 @@ type metricUnit string
 const (
 	countMetricUnit         metricUnit = "count"
 	bytesMetricUnit         metricUnit = "bytes"
+	durationUsecMetricUnit  metricUnit = "duration_usec"
 	durationNanosMetricUnit metricUnit = "duration_nanos"
 )
 
@@ -436,10 +475,10 @@ var metricDefinitions = map[usagepb.UsageAlertingMetric_Value]*metricDefinition{
 		Display: "Action cache hits",
 		Unit:    countMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_CACHED_BUILD_DURATION: {
-		Metric:  usagepb.UsageAlertingMetric_CACHED_BUILD_DURATION,
+	usagepb.UsageAlertingMetric_TOTAL_CACHED_ACTION_EXEC_USEC: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_CACHED_ACTION_EXEC_USEC,
 		Display: "Cached build minutes",
-		Unit:    durationNanosMetricUnit,
+		Unit:    durationUsecMetricUnit,
 	},
 	usagepb.UsageAlertingMetric_CAS_CACHE_HITS: {
 		Metric:  usagepb.UsageAlertingMetric_CAS_CACHE_HITS,
@@ -451,18 +490,18 @@ var metricDefinitions = map[usagepb.UsageAlertingMetric_Value]*metricDefinition{
 		Display: "Total bytes downloaded from cache (All)",
 		Unit:    bytesMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_EXTERNAL_DOWNLOAD_SIZE_BYTES: {
-		Metric:  usagepb.UsageAlertingMetric_EXTERNAL_DOWNLOAD_SIZE_BYTES,
+	usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_DOWNLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_DOWNLOAD_SIZE_BYTES,
 		Display: "Total bytes downloaded from cache (External)",
 		Unit:    bytesMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_INTERNAL_DOWNLOAD_SIZE_BYTES: {
-		Metric:  usagepb.UsageAlertingMetric_INTERNAL_DOWNLOAD_SIZE_BYTES,
+	usagepb.UsageAlertingMetric_TOTAL_INTERNAL_DOWNLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_INTERNAL_DOWNLOAD_SIZE_BYTES,
 		Display: "Total bytes downloaded from cache (Internal)",
 		Unit:    bytesMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_WORKFLOW_DOWNLOAD_SIZE_BYTES: {
-		Metric:  usagepb.UsageAlertingMetric_WORKFLOW_DOWNLOAD_SIZE_BYTES,
+	usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_DOWNLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_DOWNLOAD_SIZE_BYTES,
 		Display: "Total bytes downloaded from cache (Workflows)",
 		Unit:    bytesMetricUnit,
 	},
@@ -471,48 +510,48 @@ var metricDefinitions = map[usagepb.UsageAlertingMetric_Value]*metricDefinition{
 		Display: "Total bytes uploaded to cache (All)",
 		Unit:    bytesMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_EXTERNAL_UPLOAD_SIZE_BYTES: {
-		Metric:  usagepb.UsageAlertingMetric_EXTERNAL_UPLOAD_SIZE_BYTES,
+	usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_UPLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_UPLOAD_SIZE_BYTES,
 		Display: "Total bytes uploaded to cache (External)",
 		Unit:    bytesMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_INTERNAL_UPLOAD_SIZE_BYTES: {
-		Metric:  usagepb.UsageAlertingMetric_INTERNAL_UPLOAD_SIZE_BYTES,
+	usagepb.UsageAlertingMetric_TOTAL_INTERNAL_UPLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_INTERNAL_UPLOAD_SIZE_BYTES,
 		Display: "Total bytes uploaded to cache (Internal)",
 		Unit:    bytesMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_WORKFLOW_UPLOAD_SIZE_BYTES: {
-		Metric:  usagepb.UsageAlertingMetric_WORKFLOW_UPLOAD_SIZE_BYTES,
+	usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_UPLOAD_SIZE_BYTES: {
+		Metric:  usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_UPLOAD_SIZE_BYTES,
 		Display: "Total bytes uploaded to cache (Workflows)",
 		Unit:    bytesMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_LINUX_EXECUTION_DURATION: {
-		Metric:  usagepb.UsageAlertingMetric_LINUX_EXECUTION_DURATION,
+	usagepb.UsageAlertingMetric_LINUX_EXECUTION_DURATION_USEC: {
+		Metric:  usagepb.UsageAlertingMetric_LINUX_EXECUTION_DURATION_USEC,
 		Display: "Linux remote execution duration (All)",
-		Unit:    durationNanosMetricUnit,
+		Unit:    durationUsecMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_EXECUTION_DURATION: {
-		Metric:  usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_EXECUTION_DURATION,
+	usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_EXECUTION_DURATION_USEC: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_EXECUTION_DURATION_USEC,
 		Display: "Linux remote execution duration (Cloud RBE)",
-		Unit:    durationNanosMetricUnit,
+		Unit:    durationUsecMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_EXECUTION_DURATION: {
-		Metric:  usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_EXECUTION_DURATION,
+	usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_EXECUTION_DURATION_USEC: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_EXECUTION_DURATION_USEC,
 		Display: "Linux remote execution duration (Workflows)",
-		Unit:    durationNanosMetricUnit,
+		Unit:    durationUsecMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_LINUX_CPU_DURATION: {
-		Metric:  usagepb.UsageAlertingMetric_LINUX_CPU_DURATION,
+	usagepb.UsageAlertingMetric_CLOUD_CPU_NANOS: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_CPU_NANOS,
 		Display: "Linux CPU duration (All)",
 		Unit:    durationNanosMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_CPU_DURATION: {
-		Metric:  usagepb.UsageAlertingMetric_CLOUD_RBE_LINUX_CPU_DURATION,
+	usagepb.UsageAlertingMetric_CLOUD_RBE_CPU_NANOS: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_RBE_CPU_NANOS,
 		Display: "Linux CPU duration (Cloud RBE)",
 		Unit:    durationNanosMetricUnit,
 	},
-	usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_CPU_DURATION: {
-		Metric:  usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_LINUX_CPU_DURATION,
+	usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_CPU_NANOS: {
+		Metric:  usagepb.UsageAlertingMetric_CLOUD_WORKFLOW_CPU_NANOS,
 		Display: "Linux CPU duration (Workflows)",
 		Unit:    durationNanosMetricUnit,
 	},
@@ -547,25 +586,24 @@ func usecInRange(usec int64, start, end time.Time) bool {
 }
 
 // buildAlertEmail builds the HTML notification for a fired alert.
-func buildAlertEmail(alert *alertRule, metric *metricDefinition, recipient email.Address, value int64, start, end time.Time) (*email.Message, error) {
+func buildAlertEmail(alert *alertRule, metric *metricDefinition, recipients []email.Address, value int64, start, end time.Time) (*email.Message, error) {
+	if len(recipients) == 0 {
+		return nil, status.InvalidArgumentError("at least one recipient is required")
+	}
 	rule := alert.rule
-	groupName := strings.TrimSpace(alert.groupName)
-	groupDisplayName := groupName
+	// Group display name: prefer group name, slug, then group ID.
+	groupDisplayName := strings.TrimSpace(alert.groupName)
+	if groupDisplayName == "" {
+		groupDisplayName = alert.groupURLIdentifier
+	}
 	if groupDisplayName == "" {
 		groupDisplayName = rule.GroupID
-	}
-	subjectGroupName := groupName
-	if subjectGroupName == "" {
-		subjectGroupName = strings.TrimSpace(alert.groupURLIdentifier)
-	}
-	if subjectGroupName == "" {
-		subjectGroupName = rule.GroupID
 	}
 	usageURL := build_buddy_url.WithPath("/usage").String()
 	if alert.groupURLIdentifier != "" && subdomain.Enabled() {
 		usageURL = subdomain.ReplaceURLSubdomainForGroup(usageURL, &tables.Group{URLIdentifier: alert.groupURLIdentifier})
 	}
-	subject := fmt.Sprintf("[BuildBuddy Usage Alert] [%s] %s %s threshold reached", subjectGroupName, usageAlertingWindowLabel(rule.Window), metric.Display)
+	subject := fmt.Sprintf("[BuildBuddy Usage Alert] [%s] %s %s threshold reached", groupDisplayName, usageAlertingWindowLabel(rule.Window), metric.Display)
 	bodyTemplate, err := alertEmailBodyTemplate()
 	if err != nil {
 		return nil, fmt.Errorf("load email body template: %w", err)
@@ -593,9 +631,9 @@ func buildAlertEmail(alert *alertRule, metric *metricDefinition, recipient email
 		return nil, fmt.Errorf("render email body template: %w", err)
 	}
 	return &email.Message{
-		To:      recipient,
-		Subject: subject,
-		Body:    body.String(),
+		ToAddresses: recipients,
+		Subject:     subject,
+		Body:        body.String(),
 	}, nil
 }
 
@@ -618,6 +656,9 @@ func formatMetricValue(metric *metricDefinition, value int64) string {
 	switch metric.Unit {
 	case bytesMetricUnit:
 		return formatBytes(value)
+	case durationUsecMetricUnit:
+		minutes := int64(math.Round(float64(value) / 60e6))
+		return formatCount(minutes) + " " + pluralize("minute", minutes)
 	case durationNanosMetricUnit:
 		minutes := int64(math.Round(float64(value) / 60e9))
 		return formatCount(minutes) + " " + pluralize("minute", minutes)
@@ -662,7 +703,7 @@ func pluralize(singular string, count int64) string {
 	return singular + "s"
 }
 
-// evaluatorMetrics owns the registry pushed by this binary.
+// evaluatorMetrics owns evaluator-specific metrics.
 type evaluatorMetrics struct {
 	registry *prometheus.Registry
 	errors   *prometheus.CounterVec
@@ -682,6 +723,14 @@ func newEvaluatorMetrics() (*evaluatorMetrics, error) {
 		registry: registry,
 		errors:   errors,
 	}, nil
+}
+
+// newPushGatewayGatherer combines common process metrics with evaluator metrics.
+func newPushGatewayGatherer(metrics *evaluatorMetrics) prometheus.Gatherer {
+	if metrics == nil {
+		return prometheus.DefaultGatherer
+	}
+	return prometheus.Gatherers{prometheus.DefaultGatherer, metrics.registry}
 }
 
 // pushGatewayPusher pushes metrics to Prometheus Pushgateway when configured.

--- a/enterprise/server/usagealert/usagealert_test.go
+++ b/enterprise/server/usagealert/usagealert_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"sync"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,12 +27,15 @@ import (
 	usagepb "github.com/buildbuddy-io/buildbuddy/proto/usage"
 )
 
-func TestEvaluatorSendsAlertsToAllAdminAccounts(t *testing.T) {
+func TestEvaluatorSendsAlertsToUniqueAdminEmailRecipients(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
 
-	// Create an over-threshold rule with three admin accounts, including two
-	// accounts that share the same email address.
+	// Create a rule whose usage exceeds the threshold, with three admin
+	// accounts. Two admins share an email address (this can happen e.g. if a
+	// gmail address is registered through both Google OIDC and GitHub OIDC).
+	// Also create some users that shouldn't receive emails (non-admins /
+	// missing email).
 	sender := &fakeEmailSender{}
 	metrics := testEvaluatorMetrics(t)
 	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, metrics)
@@ -41,21 +46,24 @@ func TestEvaluatorSendsAlertsToAllAdminAccounts(t *testing.T) {
 		AbsoluteThreshold:   100,
 		Window:              usagepb.UsageAlertingWindow_DAY,
 	})
-	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "One", "admin1@example.com")
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "One", " admin1@example.com ")
 	createAdminRecipient(t, ctx, dbh, "GR1", "UA2", "Admin", "One GitHub", "admin1@example.com")
 	createAdminRecipient(t, ctx, dbh, "GR1", "UA3", "Admin", "Two", "admin2@example.com")
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA4", "Admin", "No Email", "")
+	createUserAndMembership(t, ctx, dbh, "GR1", "UD1", "Developer", "", "developer@example.com", uint32(role.Developer), int32(grpb.GroupMembershipStatus_MEMBER))
 	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.RemoteCacheCASHits, nil, 101)
 
 	result, err := evaluator.Run(ctx)
 	require.NoError(t, err)
 
-	// Admin accounts should receive email, and the rule should record that it
-	// fired for the day window that was queried.
-	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 3}, result)
-	require.Len(t, sender.messages, 3)
-	assert.Equal(t, "admin1@example.com", sender.messages[0].To.Email)
-	assert.Equal(t, "admin1@example.com", sender.messages[1].To.Email)
-	assert.Equal(t, "admin2@example.com", sender.messages[2].To.Email)
+	// Unique admin email addresses should receive a shared email, and the rule
+	// should record that it fired for the day window that was queried.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 2}, result)
+	require.Len(t, sender.messages, 1)
+	assert.Equal(t, []email.Address{
+		{Name: "Admin One", Email: "admin1@example.com"},
+		{Name: "Admin Two", Email: "admin2@example.com"},
+	}, sender.messages[0].ToAddresses)
 	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
 	assert.Equal(t, now.UnixMicro(), rule.LastFiredUsec)
 }
@@ -65,8 +73,8 @@ func TestEvaluatorDoesNotRefireWithinSameWindow(t *testing.T) {
 	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
 	lastFiredUsec := time.Date(2026, 5, 11, 1, 0, 0, 0, time.UTC).UnixMicro()
 
-	// The rule is still over threshold, but it already fired inside the current
-	// week window.
+	// The rule usage still exceeds the threshold, but the rule already fired
+	// inside the current week window.
 	sender := &fakeEmailSender{}
 	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, testEvaluatorMetrics(t))
 	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
@@ -83,27 +91,74 @@ func TestEvaluatorDoesNotRefireWithinSameWindow(t *testing.T) {
 	result, err := evaluator.Run(ctx)
 	require.NoError(t, err)
 
-	// The evaluator should not send a duplicate alert or move the existing fire
-	// timestamp.
+	// The evaluator should not send a duplicate alert or change the existing
+	// fire timestamp.
 	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 0}, result)
 	assert.Empty(t, sender.messages)
 	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
 	assert.Equal(t, lastFiredUsec, rule.LastFiredUsec)
 }
 
+func TestEvaluatorFiresAgainInNextWindow(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+
+	// Run the evaluator once for a daily rule, then advance the clock into the
+	// next UTC day with fresh usage that exceeds the threshold.
+	sender := &fakeEmailSender{}
+	flags.Set(t, "testenv.use_clickhouse", true)
+	flags.Set(t, "testenv.reuse_server", true)
+	te := testenv.GetTestEnv(t)
+	clock := clockwork.NewFakeClockAt(now)
+	evaluator := NewEvaluator(te.GetDBHandle(), te.GetOLAPDBHandle(), sender, clock, testEvaluatorMetrics(t))
+	dbh := te.GetDBHandle()
+	olapDBH := te.GetOLAPDBHandle()
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+		AbsoluteThreshold:   10,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.BuildEventsBESCount, nil, 11)
+
+	firstResult, err := evaluator.Run(ctx)
+	require.NoError(t, err)
+
+	// The first run should send the initial alert and mark the current day as
+	// fired.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 1}, firstResult)
+	require.Len(t, sender.messages, 1)
+
+	clock.Advance(24 * time.Hour)
+	nextNow := clock.Now()
+	createRawUsage(t, ctx, olapDBH, "GR1", nextNow, sku.BuildEventsBESCount, nil, 11)
+
+	secondResult, err := evaluator.Run(ctx)
+	require.NoError(t, err)
+
+	// Once the clock reaches the next window, the daily rule can fire again.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 1}, secondResult)
+	require.Len(t, sender.messages, 2)
+	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
+	assert.Equal(t, nextNow.UnixMicro(), rule.LastFiredUsec)
+}
+
 func TestEvaluatorFormatsDurationAlertsAsMinutes(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
 
-	// Cached build duration thresholds are stored as nanoseconds, but the UI
-	// presents them as minutes.
+	// Cached build duration is stored in RawUsage as nanoseconds, but alert
+	// thresholds and emails should use the same microsecond unit as the Usage
+	// API.
 	sender := &fakeEmailSender{}
 	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, testEvaluatorMetrics(t))
 	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
 		UsageAlertingRuleID: "UR1",
 		GroupID:             "GR1",
-		UsageAlertingMetric: usagepb.UsageAlertingMetric_CACHED_BUILD_DURATION,
-		AbsoluteThreshold:   60e9,
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_TOTAL_CACHED_ACTION_EXEC_USEC,
+		AbsoluteThreshold:   60e6,
 		Window:              usagepb.UsageAlertingWindow_DAY,
 	})
 	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
@@ -112,8 +167,8 @@ func TestEvaluatorFormatsDurationAlertsAsMinutes(t *testing.T) {
 	result, err := evaluator.Run(ctx)
 	require.NoError(t, err)
 
-	// The email should use the same label and minute formatting as the UI, with
-	// no raw nanosecond values leaked to the recipient.
+	// The email should use the same label and minute formatting as the UI, and
+	// it should not show raw nanosecond values to the recipient.
 	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 1}, result)
 	require.Len(t, sender.messages, 1)
 	assert.Equal(t, "[BuildBuddy Usage Alert] [GR1] Daily Cached build minutes threshold reached", sender.messages[0].Subject)
@@ -121,7 +176,7 @@ func TestEvaluatorFormatsDurationAlertsAsMinutes(t *testing.T) {
 	assert.Contains(t, sender.messages[0].Body, "2 minutes")
 	assert.Contains(t, sender.messages[0].Body, "1 minute")
 	assert.NotContains(t, sender.messages[0].Body, "120000000000")
-	assert.NotContains(t, sender.messages[0].Body, "60000000000")
+	assert.NotContains(t, sender.messages[0].Body, "60000000")
 }
 
 func TestEvaluatorBelowThresholdDoesNotUpdateRule(t *testing.T) {
@@ -152,6 +207,72 @@ func TestEvaluatorBelowThresholdDoesNotUpdateRule(t *testing.T) {
 	assert.Zero(t, rule.LastFiredUsec)
 }
 
+func TestEvaluatorDoesNotRecordRuleAfterSendFailure(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+	previousLastFiredUsec := now.Add(-48 * time.Hour).UnixMicro()
+
+	// The rule usage exceeds the threshold, but the email backend reports a
+	// send failure. The evaluator should leave the previous fire timestamp so a
+	// later cron run can retry the alert.
+	sender := &fakeEmailSender{err: errors.New("test send failure")}
+	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, testEvaluatorMetrics(t))
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+		AbsoluteThreshold:   10,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+		LastFiredUsec:       previousLastFiredUsec,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.BuildEventsBESCount, nil, 11)
+
+	result, err := evaluator.Run(ctx)
+	require.ErrorContains(t, err, "test send failure")
+
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 0}, result)
+	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
+	assert.Equal(t, previousLastFiredUsec, rule.LastFiredUsec)
+}
+
+func TestEvaluatorSendsWhenRuleRecordedAfterQuery(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+
+	// Simulate a second evaluator run loading the rule before the first run
+	// records that it fired. The second run should still send the alert so a
+	// process exit between send and record does not drop alerts.
+	sender := &fakeEmailSender{}
+	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, testEvaluatorMetrics(t))
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+		AbsoluteThreshold:   10,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.BuildEventsBESCount, nil, 11)
+	rules, err := evaluator.queryRulesAndRecipients(ctx)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	start, end, err := windowRange(now, usagepb.UsageAlertingWindow_DAY)
+	require.NoError(t, err)
+	recorded, err := evaluator.recordRuleFired(ctx, "UR1", now.UnixMicro(), start, end)
+	require.NoError(t, err)
+	require.True(t, recorded)
+
+	alertsSent, err := evaluator.evaluateRule(ctx, now, rules[0])
+	require.NoError(t, err)
+
+	// The stale rule loaded in memory has usage above the threshold, so the
+	// evaluator should send the alert even though recording the fire timestamp
+	// sees that another evaluator already recorded this window.
+	assert.Equal(t, 1, alertsSent)
+	require.Len(t, sender.messages, 1)
+}
+
 func TestEvaluatorQueriesLabeledUsageFromClickHouse(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
@@ -163,7 +284,7 @@ func TestEvaluatorQueriesLabeledUsageFromClickHouse(t *testing.T) {
 	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
 		UsageAlertingRuleID: "UR1",
 		GroupID:             "GR1",
-		UsageAlertingMetric: usagepb.UsageAlertingMetric_EXTERNAL_DOWNLOAD_SIZE_BYTES,
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_TOTAL_EXTERNAL_DOWNLOAD_SIZE_BYTES,
 		AbsoluteThreshold:   100,
 		Window:              usagepb.UsageAlertingWindow_DAY,
 	})
@@ -193,7 +314,7 @@ func TestAlertEmailUsesGroupNameAndSubdomainUsageURL(t *testing.T) {
 	start := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)
 
-	// URL-identified groups should get their own subdomain link when
+	// Groups with URL identifiers should get their own subdomain link when
 	// subdomains are enabled.
 	msg, err := buildAlertEmail(&alertRule{
 		rule: &tables.UsageAlertingRule{
@@ -204,7 +325,7 @@ func TestAlertEmailUsesGroupNameAndSubdomainUsageURL(t *testing.T) {
 		},
 		groupName:          "Acme <Corp>",
 		groupURLIdentifier: "acme",
-	}, metricDefinitions[usagepb.UsageAlertingMetric_INVOCATIONS], email.Address{Email: "admin@example.com"}, 2, start, end)
+	}, metricDefinitions[usagepb.UsageAlertingMetric_INVOCATIONS], []email.Address{{Email: "admin@example.com"}}, 2, start, end)
 	require.NoError(t, err)
 
 	assert.Equal(t, "[BuildBuddy Usage Alert] [Acme <Corp>] Weekly Invocations threshold reached", msg.Subject)
@@ -232,11 +353,11 @@ func TestAlertEmailUsesGroupSlugAndBaseUsageURL(t *testing.T) {
 			Window:              usagepb.UsageAlertingWindow_MONTH,
 		},
 		groupURLIdentifier: "acme",
-	}, metricDefinitions[usagepb.UsageAlertingMetric_INVOCATIONS], email.Address{Email: "admin@example.com"}, 2, start, end)
+	}, metricDefinitions[usagepb.UsageAlertingMetric_INVOCATIONS], []email.Address{{Email: "admin@example.com"}}, 2, start, end)
 	require.NoError(t, err)
 
 	assert.Equal(t, "[BuildBuddy Usage Alert] [acme] Monthly Invocations threshold reached", msg.Subject)
-	assert.Equal(t, `<p><strong>Monthly Invocations</strong> usage alert fired for organization <strong>GR1</strong>.</p>
+	assert.Equal(t, `<p><strong>Monthly Invocations</strong> usage alert fired for organization <strong>acme</strong>.</p>
 <p>Usage for <strong>Invocations</strong> is <strong>2</strong>, which exceeds the configured threshold of <strong>1</strong>.</p>
 <p>Window: 2026-05-11T00:00:00Z to 2026-05-18T00:00:00Z UTC</p>
 <p>See usage at <a href="http://localhost:8080/usage">http://localhost:8080/usage</a></p>`, msg.Body)
@@ -247,10 +368,13 @@ func TestEvaluatorRecordsErrorMetric(t *testing.T) {
 	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
 	metrics := testEvaluatorMetrics(t)
 
-	// Break the metric SQL after the rule and recipient rows have been loaded
-	// from SQL.
-	evaluator, dbh, _ := newTestEvaluator(t, now, &fakeEmailSender{}, metrics)
-	setOLAPExpressionForMetric(t, usagepb.UsageAlertingMetric_INVOCATIONS, "invalid_clickhouse_expression(")
+	// Make the usage query fail after the rule and recipient rows have been
+	// loaded from SQL.
+	evaluator, dbh := newTestEvaluatorWithUsage(t, now, &fakeEmailSender{}, metrics, &fakeUsageReader{
+		errors: map[usagepb.UsageAlertingMetric_Value]error{
+			usagepb.UsageAlertingMetric_INVOCATIONS: errors.New("test usage query"),
+		},
+	})
 	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
 		UsageAlertingRuleID: "UR1",
 		GroupID:             "GR1",
@@ -263,12 +387,57 @@ func TestEvaluatorRecordsErrorMetric(t *testing.T) {
 	result, err := evaluator.Run(ctx)
 	require.Error(t, err)
 
-	// The query failure should increment the query-stage metric and leave the
-	// rule status unchanged because evaluation did not complete.
+	// The query failure should increment the metric for the query stage and
+	// leave the rule status unchanged because evaluation did not complete.
 	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 0}, result)
 	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.errors.WithLabelValues(errorStageQueryUsage)))
 	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
 	assert.Zero(t, rule.LastFiredUsec)
+}
+
+func TestEvaluatorContinuesAfterRuleEvaluationError(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+
+	// Make a metric query fail, then create another valid rule with usage above
+	// the threshold. The evaluator should report the failure and keep evaluating
+	// the rest of the run.
+	sender := &fakeEmailSender{}
+	metrics := testEvaluatorMetrics(t)
+	evaluator, dbh := newTestEvaluatorWithUsage(t, now, sender, metrics, &fakeUsageReader{
+		values: map[usagepb.UsageAlertingMetric_Value]int64{
+			usagepb.UsageAlertingMetric_CAS_CACHE_HITS: 101,
+		},
+		errors: map[usagepb.UsageAlertingMetric_Value]error{
+			usagepb.UsageAlertingMetric_INVOCATIONS: errors.New("test usage query"),
+		},
+	})
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+		AbsoluteThreshold:   10,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR2",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_CAS_CACHE_HITS,
+		AbsoluteThreshold:   100,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+
+	result, err := evaluator.Run(ctx)
+	require.Error(t, err)
+
+	// The rule whose query failed should return an error, while the valid rule
+	// should still send and record its fire timestamp.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 2, AlertsSent: 1}, result)
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.errors.WithLabelValues(errorStageQueryUsage)))
+	assert.Len(t, sender.messages, 1)
+	assert.Zero(t, getUsageAlertingRule(t, ctx, dbh, "UR1").LastFiredUsec)
+	assert.Equal(t, now.UnixMicro(), getUsageAlertingRule(t, ctx, dbh, "UR2").LastFiredUsec)
 }
 
 func TestRunEvaluatorPushesMetricsAfterEvaluationError(t *testing.T) {
@@ -277,8 +446,11 @@ func TestRunEvaluatorPushesMetricsAfterEvaluationError(t *testing.T) {
 
 	// The wrapped runner should push metrics even when evaluation itself
 	// returns an error.
-	evaluator, dbh, _ := newTestEvaluator(t, now, &fakeEmailSender{}, testEvaluatorMetrics(t))
-	setOLAPExpressionForMetric(t, usagepb.UsageAlertingMetric_INVOCATIONS, "invalid_clickhouse_expression(")
+	evaluator, dbh := newTestEvaluatorWithUsage(t, now, &fakeEmailSender{}, testEvaluatorMetrics(t), &fakeUsageReader{
+		errors: map[usagepb.UsageAlertingMetric_Value]error{
+			usagepb.UsageAlertingMetric_INVOCATIONS: errors.New("test usage query"),
+		},
+	})
 	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
 		UsageAlertingRuleID: "UR1",
 		GroupID:             "GR1",
@@ -298,17 +470,18 @@ func TestRunEvaluatorPushesMetricsAfterEvaluationError(t *testing.T) {
 	assert.Equal(t, 1, pusher.calls)
 }
 
-func TestEvaluatorQueryRulesAndRecipientsReturnsAllAdminAccounts(t *testing.T) {
+func TestEvaluatorQueryRulesAndRecipientsReturnsUniqueAdminEmails(t *testing.T) {
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
 	dbh := te.GetDBHandle()
 	evaluator := newDBOnlyEvaluator(dbh)
 
 	// Seed a group with multiple active admins, plus users that should not
-	// receive alerts because they have no email, wrong role, or pending status.
+	// receive alerts because they duplicate another email, have no email, have
+	// the wrong role, or have a pending status.
 	require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_group").Create(&tables.Group{GroupID: "GR1", Name: "Acme Corp", URLIdentifier: "acme"}))
 	for _, row := range []*tables.User{
-		{UserID: "UA1", FirstName: "Admin", LastName: "One", Email: "admin@example.com"},
+		{UserID: "UA1", FirstName: "Admin", LastName: "One", Email: " admin@example.com "},
 		{UserID: "UA2", FirstName: "Admin", LastName: "Two", Email: "admin@example.com"},
 		{UserID: "UA3", FirstName: "Blank", LastName: "Email"},
 		{UserID: "UC1", FirstName: "Role", LastName: "Combo", Email: "combo@example.com"},
@@ -340,15 +513,14 @@ func TestEvaluatorQueryRulesAndRecipientsReturnsAllAdminAccounts(t *testing.T) {
 	rules, err := evaluator.queryRulesAndRecipients(ctx)
 	require.NoError(t, err)
 
-	// Only active admins with non-empty email addresses in the rule's group
-	// should be attached as recipients.
+	// Only active admins with unique, non-empty email addresses in the rule's
+	// group should be attached as recipients.
 	require.Len(t, rules, 1)
 	assert.Equal(t, "UR1", rules[0].rule.UsageAlertingRuleID)
 	assert.Equal(t, "Acme Corp", rules[0].groupName)
 	assert.Equal(t, "acme", rules[0].groupURLIdentifier)
 	assert.Equal(t, []email.Address{
 		{Name: "Admin One", Email: "admin@example.com"},
-		{Name: "Admin Two", Email: "admin@example.com"},
 		{Name: "Role Combo", Email: "combo@example.com"},
 	}, rules[0].recipients)
 }
@@ -420,14 +592,14 @@ func TestEvaluatorQueryRulesAndRecipientsOnlyReturnsGroupsWithAdminRecipients(t 
 	rules, err := evaluator.queryRulesAndRecipients(ctx)
 	require.NoError(t, err)
 
-	// Rules without recipients should not be evaluated.
+	// Only rules with deliverable admin recipients should be evaluated.
 	require.Len(t, rules, 1)
 	assert.Equal(t, "UR1", rules[0].rule.UsageAlertingRuleID)
 }
 
 func TestMetricDefinitionsCoverEveryAlertingMetric(t *testing.T) {
 	for _, metric := range alertingMetricValues() {
-		// Every user-selectable alerting metric should have email display
+		// Every alerting metric users can select should have email display
 		// metadata.
 		_, ok := metricDefinitions[metric]
 		assert.True(t, ok, "missing metric definition for %s", metric)
@@ -435,16 +607,26 @@ func TestMetricDefinitionsCoverEveryAlertingMetric(t *testing.T) {
 	assert.Len(t, metricDefinitions, len(alertingMetricValues()))
 }
 
+func TestPushGatewayGathererIncludesCommonAndEvaluatorMetrics(t *testing.T) {
+	metrics := testEvaluatorMetrics(t)
+	metrics.errors.WithLabelValues(errorStageQueryUsage).Inc()
+
+	names := gathererMetricNames(t, newPushGatewayGatherer(metrics))
+
+	assert.Contains(t, names, "go_goroutines")
+	assert.Contains(t, names, "buildbuddy_usage_alert_errors_total")
+}
+
 func TestWindowRange(t *testing.T) {
-	// Wednesday, May 13, 2026 should fall in the Monday-start UTC week
+	// Wednesday, May 13, 2026 should fall in the UTC week that starts on Monday,
 	// beginning May 11 and ending May 18.
 	now := time.Date(2026, 5, 13, 15, 30, 0, 0, time.UTC)
 
 	start, end, err := windowRange(now, usagepb.UsageAlertingWindow_WEEK)
 	require.NoError(t, err)
 
-	// The evaluator uses half-open ranges, so the end is the first instant
-	// after the active week.
+	// The evaluator includes the start and excludes the end, so the end is the
+	// first instant after the active week.
 	assert.Equal(t, time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC), start)
 	assert.Equal(t, time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC), end)
 }
@@ -456,20 +638,29 @@ func newTestEvaluator(t testing.TB, now time.Time, sender emailSender, metrics *
 	return NewEvaluator(te.GetDBHandle(), te.GetOLAPDBHandle(), sender, clockwork.NewFakeClockAt(now), metrics), te.GetDBHandle(), te.GetOLAPDBHandle()
 }
 
+func newTestEvaluatorWithUsage(t testing.TB, now time.Time, sender emailSender, metrics *evaluatorMetrics, usage usageReader) (*Evaluator, interfaces.DBHandle) {
+	t.Helper()
+	te := testenv.GetTestEnv(t)
+	evaluator := NewEvaluator(te.GetDBHandle(), nil, sender, clockwork.NewFakeClockAt(now), metrics)
+	evaluator.usage = usage
+	return evaluator, te.GetDBHandle()
+}
+
 func testEvaluatorMetrics(t testing.TB) *evaluatorMetrics {
 	metrics, err := newEvaluatorMetrics()
 	require.NoError(t, err)
 	return metrics
 }
 
-func setOLAPExpressionForMetric(t testing.TB, metric usagepb.UsageAlertingMetric_Value, expression string) {
-	field, ok := usage_service.UsageFieldForAlertingMetric(metric)
-	require.True(t, ok)
-	originalExpression := field.OLAPExpression
-	field.OLAPExpression = expression
-	t.Cleanup(func() {
-		field.OLAPExpression = originalExpression
-	})
+func gathererMetricNames(t testing.TB, gatherer prometheus.Gatherer) map[string]struct{} {
+	t.Helper()
+	metricFamilies, err := gatherer.Gather()
+	require.NoError(t, err)
+	names := make(map[string]struct{}, len(metricFamilies))
+	for _, metricFamily := range metricFamilies {
+		names[metricFamily.GetName()] = struct{}{}
+	}
+	return names
 }
 
 func newDBOnlyEvaluator(dbh interfaces.DBHandle) *Evaluator {
@@ -493,6 +684,10 @@ func createRawUsage(t testing.TB, ctx context.Context, olapDBH interfaces.OLAPDB
 }
 
 func createAdminRecipient(t testing.TB, ctx context.Context, dbh interfaces.DBHandle, groupID, userID, firstName, lastName, emailAddress string) {
+	createUserAndMembership(t, ctx, dbh, groupID, userID, firstName, lastName, emailAddress, uint32(role.Admin), int32(grpb.GroupMembershipStatus_MEMBER))
+}
+
+func createUserAndMembership(t testing.TB, ctx context.Context, dbh interfaces.DBHandle, groupID, userID, firstName, lastName, emailAddress string, userRole uint32, membershipStatus int32) {
 	require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_user").Create(&tables.User{
 		UserID:    userID,
 		FirstName: firstName,
@@ -502,8 +697,8 @@ func createAdminRecipient(t testing.TB, ctx context.Context, dbh interfaces.DBHa
 	require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_user_group").Create(&tables.UserGroup{
 		UserUserID:       userID,
 		GroupGroupID:     groupID,
-		Role:             uint32(role.Admin),
-		MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER),
+		Role:             userRole,
+		MembershipStatus: membershipStatus,
 	}))
 }
 
@@ -541,4 +736,16 @@ type fakeMetricsPusher struct {
 func (p *fakeMetricsPusher) Push() error {
 	p.calls++
 	return p.err
+}
+
+type fakeUsageReader struct {
+	values map[usagepb.UsageAlertingMetric_Value]int64
+	errors map[usagepb.UsageAlertingMetric_Value]error
+}
+
+func (r *fakeUsageReader) QueryUsage(ctx context.Context, field *usage_service.UsageField, groupID string, start, end time.Time) (int64, error) {
+	if err := r.errors[field.AlertingMetric]; err != nil {
+		return 0, err
+	}
+	return r.values[field.AlertingMetric], nil
 }

--- a/enterprise/server/usagealert/usagealert_test.go
+++ b/enterprise/server/usagealert/usagealert_test.go
@@ -1,0 +1,544 @@
+package main
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/email"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/usage_service"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
+	"github.com/buildbuddy-io/buildbuddy/server/util/role"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
+	usagepb "github.com/buildbuddy-io/buildbuddy/proto/usage"
+)
+
+func TestEvaluatorSendsAlertsToAllAdminAccounts(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+
+	// Create an over-threshold rule with three admin accounts, including two
+	// accounts that share the same email address.
+	sender := &fakeEmailSender{}
+	metrics := testEvaluatorMetrics(t)
+	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, metrics)
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_CAS_CACHE_HITS,
+		AbsoluteThreshold:   100,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "One", "admin1@example.com")
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA2", "Admin", "One GitHub", "admin1@example.com")
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA3", "Admin", "Two", "admin2@example.com")
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.RemoteCacheCASHits, nil, 101)
+
+	result, err := evaluator.Run(ctx)
+	require.NoError(t, err)
+
+	// Admin accounts should receive email, and the rule should record that it
+	// fired for the day window that was queried.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 3}, result)
+	require.Len(t, sender.messages, 3)
+	assert.Equal(t, "admin1@example.com", sender.messages[0].To.Email)
+	assert.Equal(t, "admin1@example.com", sender.messages[1].To.Email)
+	assert.Equal(t, "admin2@example.com", sender.messages[2].To.Email)
+	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
+	assert.Equal(t, now.UnixMicro(), rule.LastFiredUsec)
+}
+
+func TestEvaluatorDoesNotRefireWithinSameWindow(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+	lastFiredUsec := time.Date(2026, 5, 11, 1, 0, 0, 0, time.UTC).UnixMicro()
+
+	// The rule is still over threshold, but it already fired inside the current
+	// week window.
+	sender := &fakeEmailSender{}
+	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, testEvaluatorMetrics(t))
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+		AbsoluteThreshold:   10,
+		Window:              usagepb.UsageAlertingWindow_WEEK,
+		LastFiredUsec:       lastFiredUsec,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.BuildEventsBESCount, nil, 11)
+
+	result, err := evaluator.Run(ctx)
+	require.NoError(t, err)
+
+	// The evaluator should not send a duplicate alert or move the existing fire
+	// timestamp.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 0}, result)
+	assert.Empty(t, sender.messages)
+	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
+	assert.Equal(t, lastFiredUsec, rule.LastFiredUsec)
+}
+
+func TestEvaluatorFormatsDurationAlertsAsMinutes(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+
+	// Cached build duration thresholds are stored as nanoseconds, but the UI
+	// presents them as minutes.
+	sender := &fakeEmailSender{}
+	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, testEvaluatorMetrics(t))
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_CACHED_BUILD_DURATION,
+		AbsoluteThreshold:   60e9,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.RemoteCacheACCachedExecDurationNanos, nil, 2*60e9)
+
+	result, err := evaluator.Run(ctx)
+	require.NoError(t, err)
+
+	// The email should use the same label and minute formatting as the UI, with
+	// no raw nanosecond values leaked to the recipient.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 1}, result)
+	require.Len(t, sender.messages, 1)
+	assert.Equal(t, "[BuildBuddy Usage Alert] [GR1] Daily Cached build minutes threshold reached", sender.messages[0].Subject)
+	assert.Contains(t, sender.messages[0].Body, "Cached build minutes")
+	assert.Contains(t, sender.messages[0].Body, "2 minutes")
+	assert.Contains(t, sender.messages[0].Body, "1 minute")
+	assert.NotContains(t, sender.messages[0].Body, "120000000000")
+	assert.NotContains(t, sender.messages[0].Body, "60000000000")
+}
+
+func TestEvaluatorBelowThresholdDoesNotUpdateRule(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+
+	// Usage equal to the threshold is not a firing condition; alerts fire only
+	// when usage exceeds the configured value.
+	sender := &fakeEmailSender{}
+	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, testEvaluatorMetrics(t))
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_TOTAL_DOWNLOAD_SIZE_BYTES,
+		AbsoluteThreshold:   100,
+		Window:              usagepb.UsageAlertingWindow_MONTH,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.RemoteCacheCASDownloadedBytes, nil, 100)
+
+	result, err := evaluator.Run(ctx)
+	require.NoError(t, err)
+
+	// The rule should not send email or update its fire timestamp.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 0}, result)
+	assert.Empty(t, sender.messages)
+	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
+	assert.Zero(t, rule.LastFiredUsec)
+}
+
+func TestEvaluatorQueriesLabeledUsageFromClickHouse(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+
+	// External download alerts should count only RawUsage rows whose origin
+	// label is external, even when the same SKU has larger internal usage.
+	sender := &fakeEmailSender{}
+	evaluator, dbh, olapDBH := newTestEvaluator(t, now, sender, testEvaluatorMetrics(t))
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_EXTERNAL_DOWNLOAD_SIZE_BYTES,
+		AbsoluteThreshold:   100,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.RemoteCacheCASDownloadedBytes, map[sku.LabelName]sku.LabelValue{
+		sku.Origin: sku.OriginExternal,
+	}, 101)
+	createRawUsage(t, ctx, olapDBH, "GR1", now, sku.RemoteCacheCASDownloadedBytes, map[sku.LabelName]sku.LabelValue{
+		sku.Origin: sku.OriginInternal,
+	}, 1000)
+
+	result, err := evaluator.Run(ctx)
+	require.NoError(t, err)
+
+	// The alert should fire based on the external value, not the total SKU count.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 1}, result)
+	require.Len(t, sender.messages, 1)
+	assert.Contains(t, sender.messages[0].Body, "101B")
+	assert.NotContains(t, sender.messages[0].Body, "1.101KB")
+}
+
+func TestAlertEmailUsesGroupNameAndSubdomainUsageURL(t *testing.T) {
+	u, err := url.Parse("https://app.buildbuddy.io")
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "app.enable_subdomain_matching", true)
+	start := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)
+
+	// URL-identified groups should get their own subdomain link when
+	// subdomains are enabled.
+	msg, err := buildAlertEmail(&alertRule{
+		rule: &tables.UsageAlertingRule{
+			UsageAlertingRuleID: "UR1",
+			GroupID:             "GR1",
+			AbsoluteThreshold:   1,
+			Window:              usagepb.UsageAlertingWindow_WEEK,
+		},
+		groupName:          "Acme <Corp>",
+		groupURLIdentifier: "acme",
+	}, metricDefinitions[usagepb.UsageAlertingMetric_INVOCATIONS], email.Address{Email: "admin@example.com"}, 2, start, end)
+	require.NoError(t, err)
+
+	assert.Equal(t, "[BuildBuddy Usage Alert] [Acme <Corp>] Weekly Invocations threshold reached", msg.Subject)
+	assert.Equal(t, `<p><strong>Weekly Invocations</strong> usage alert fired for organization <strong>Acme &lt;Corp&gt;</strong>.</p>
+<p>Usage for <strong>Invocations</strong> is <strong>2</strong>, which exceeds the configured threshold of <strong>1</strong>.</p>
+<p>Window: 2026-05-11T00:00:00Z to 2026-05-18T00:00:00Z UTC</p>
+<p>See usage at <a href="https://acme.buildbuddy.io/usage">https://acme.buildbuddy.io/usage</a></p>`, msg.Body)
+}
+
+func TestAlertEmailUsesGroupSlugAndBaseUsageURL(t *testing.T) {
+	u, err := url.Parse("http://localhost:8080")
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "app.enable_subdomain_matching", false)
+	start := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)
+
+	// Without a group name, the subject should fall back to the group slug. With
+	// subdomains disabled, the email should still link to the base usage page.
+	msg, err := buildAlertEmail(&alertRule{
+		rule: &tables.UsageAlertingRule{
+			UsageAlertingRuleID: "UR1",
+			GroupID:             "GR1",
+			AbsoluteThreshold:   1,
+			Window:              usagepb.UsageAlertingWindow_MONTH,
+		},
+		groupURLIdentifier: "acme",
+	}, metricDefinitions[usagepb.UsageAlertingMetric_INVOCATIONS], email.Address{Email: "admin@example.com"}, 2, start, end)
+	require.NoError(t, err)
+
+	assert.Equal(t, "[BuildBuddy Usage Alert] [acme] Monthly Invocations threshold reached", msg.Subject)
+	assert.Equal(t, `<p><strong>Monthly Invocations</strong> usage alert fired for organization <strong>GR1</strong>.</p>
+<p>Usage for <strong>Invocations</strong> is <strong>2</strong>, which exceeds the configured threshold of <strong>1</strong>.</p>
+<p>Window: 2026-05-11T00:00:00Z to 2026-05-18T00:00:00Z UTC</p>
+<p>See usage at <a href="http://localhost:8080/usage">http://localhost:8080/usage</a></p>`, msg.Body)
+}
+
+func TestEvaluatorRecordsErrorMetric(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+	metrics := testEvaluatorMetrics(t)
+
+	// Break the metric SQL after the rule and recipient rows have been loaded
+	// from SQL.
+	evaluator, dbh, _ := newTestEvaluator(t, now, &fakeEmailSender{}, metrics)
+	setOLAPExpressionForMetric(t, usagepb.UsageAlertingMetric_INVOCATIONS, "invalid_clickhouse_expression(")
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+		AbsoluteThreshold:   10,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+
+	result, err := evaluator.Run(ctx)
+	require.Error(t, err)
+
+	// The query failure should increment the query-stage metric and leave the
+	// rule status unchanged because evaluation did not complete.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 0}, result)
+	assert.Equal(t, float64(1), testutil.ToFloat64(metrics.errors.WithLabelValues(errorStageQueryUsage)))
+	rule := getUsageAlertingRule(t, ctx, dbh, "UR1")
+	assert.Zero(t, rule.LastFiredUsec)
+}
+
+func TestRunEvaluatorPushesMetricsAfterEvaluationError(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 11, 15, 30, 0, 0, time.UTC)
+
+	// The wrapped runner should push metrics even when evaluation itself
+	// returns an error.
+	evaluator, dbh, _ := newTestEvaluator(t, now, &fakeEmailSender{}, testEvaluatorMetrics(t))
+	setOLAPExpressionForMetric(t, usagepb.UsageAlertingMetric_INVOCATIONS, "invalid_clickhouse_expression(")
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+		AbsoluteThreshold:   10,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+	createAdminRecipient(t, ctx, dbh, "GR1", "UA1", "Admin", "", "admin@example.com")
+	pusher := &fakeMetricsPusher{}
+
+	result, err := runEvaluator(ctx, evaluator, pusher)
+	require.Error(t, err)
+
+	// A failed run still returns the partial evaluation result and attempts to
+	// push metrics.
+	require.Equal(t, &EvaluationResult{RulesEvaluated: 1, AlertsSent: 0}, result)
+	assert.Equal(t, 1, pusher.calls)
+}
+
+func TestEvaluatorQueryRulesAndRecipientsReturnsAllAdminAccounts(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	dbh := te.GetDBHandle()
+	evaluator := newDBOnlyEvaluator(dbh)
+
+	// Seed a group with multiple active admins, plus users that should not
+	// receive alerts because they have no email, wrong role, or pending status.
+	require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_group").Create(&tables.Group{GroupID: "GR1", Name: "Acme Corp", URLIdentifier: "acme"}))
+	for _, row := range []*tables.User{
+		{UserID: "UA1", FirstName: "Admin", LastName: "One", Email: "admin@example.com"},
+		{UserID: "UA2", FirstName: "Admin", LastName: "Two", Email: "admin@example.com"},
+		{UserID: "UA3", FirstName: "Blank", LastName: "Email"},
+		{UserID: "UC1", FirstName: "Role", LastName: "Combo", Email: "combo@example.com"},
+		{UserID: "UD1", FirstName: "Developer", Email: "developer@example.com"},
+		{UserID: "UI1", FirstName: "Invited", Email: "invited@example.com"},
+		{UserID: "UO1", FirstName: "Other", Email: "other@example.com"},
+	} {
+		require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_user").Create(row))
+	}
+	for _, row := range []*tables.UserGroup{
+		{UserUserID: "UA1", GroupGroupID: "GR1", Role: uint32(role.Admin), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+		{UserUserID: "UA2", GroupGroupID: "GR1", Role: uint32(role.Admin), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+		{UserUserID: "UA3", GroupGroupID: "GR1", Role: uint32(role.Admin), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+		{UserUserID: "UC1", GroupGroupID: "GR1", Role: uint32(role.Admin | role.Developer), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+		{UserUserID: "UD1", GroupGroupID: "GR1", Role: uint32(role.Developer), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+		{UserUserID: "UI1", GroupGroupID: "GR1", Role: uint32(role.Admin), MembershipStatus: int32(grpb.GroupMembershipStatus_REQUESTED)},
+		{UserUserID: "UO1", GroupGroupID: "GR2", Role: uint32(role.Admin), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+	} {
+		require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_user_group").Create(row))
+	}
+	createUsageAlertingRule(t, ctx, dbh, &tables.UsageAlertingRule{
+		UsageAlertingRuleID: "UR1",
+		GroupID:             "GR1",
+		UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+		AbsoluteThreshold:   1,
+		Window:              usagepb.UsageAlertingWindow_DAY,
+	})
+
+	rules, err := evaluator.queryRulesAndRecipients(ctx)
+	require.NoError(t, err)
+
+	// Only active admins with non-empty email addresses in the rule's group
+	// should be attached as recipients.
+	require.Len(t, rules, 1)
+	assert.Equal(t, "UR1", rules[0].rule.UsageAlertingRuleID)
+	assert.Equal(t, "Acme Corp", rules[0].groupName)
+	assert.Equal(t, "acme", rules[0].groupURLIdentifier)
+	assert.Equal(t, []email.Address{
+		{Name: "Admin One", Email: "admin@example.com"},
+		{Name: "Admin Two", Email: "admin@example.com"},
+		{Name: "Role Combo", Email: "combo@example.com"},
+	}, rules[0].recipients)
+}
+
+func TestEvaluatorQueryRulesAndRecipientsOnlyReturnsGroupsWithAdminRecipients(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	dbh := te.GetDBHandle()
+	evaluator := newDBOnlyEvaluator(dbh)
+
+	// Create rules across groups where only GR1 has a member admin with a
+	// deliverable email address.
+	for _, row := range []*tables.User{
+		{UserID: "UA1", Email: "admin@example.com"},
+		{UserID: "UB1"},
+		{UserID: "UD1", Email: "developer@example.com"},
+		{UserID: "UR1", Email: "requested@example.com"},
+	} {
+		require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_user").Create(row))
+	}
+	for _, row := range []*tables.UserGroup{
+		{UserUserID: "UA1", GroupGroupID: "GR1", Role: uint32(role.Admin), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+		{UserUserID: "UB1", GroupGroupID: "GR2", Role: uint32(role.Admin), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+		{UserUserID: "UD1", GroupGroupID: "GR3", Role: uint32(role.Developer), MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER)},
+		{UserUserID: "UR1", GroupGroupID: "GR4", Role: uint32(role.Admin), MembershipStatus: int32(grpb.GroupMembershipStatus_REQUESTED)},
+	} {
+		require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_user_group").Create(row))
+	}
+	for _, row := range []*tables.UsageAlertingRule{
+		{
+			UsageAlertingRuleID: "UR1",
+			GroupID:             "GR1",
+			UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+			AbsoluteThreshold:   1,
+			Window:              usagepb.UsageAlertingWindow_DAY,
+		},
+		{
+			UsageAlertingRuleID: "UR2",
+			GroupID:             "GR2",
+			UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+			AbsoluteThreshold:   1,
+			Window:              usagepb.UsageAlertingWindow_DAY,
+		},
+		{
+			UsageAlertingRuleID: "UR3",
+			GroupID:             "GR3",
+			UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+			AbsoluteThreshold:   1,
+			Window:              usagepb.UsageAlertingWindow_DAY,
+		},
+		{
+			UsageAlertingRuleID: "UR4",
+			GroupID:             "GR4",
+			UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+			AbsoluteThreshold:   1,
+			Window:              usagepb.UsageAlertingWindow_DAY,
+		},
+		{
+			UsageAlertingRuleID: "UR5",
+			GroupID:             "GR5",
+			UsageAlertingMetric: usagepb.UsageAlertingMetric_INVOCATIONS,
+			AbsoluteThreshold:   1,
+			Window:              usagepb.UsageAlertingWindow_DAY,
+		},
+	} {
+		createUsageAlertingRule(t, ctx, dbh, row)
+	}
+
+	rules, err := evaluator.queryRulesAndRecipients(ctx)
+	require.NoError(t, err)
+
+	// Rules without recipients should not be evaluated.
+	require.Len(t, rules, 1)
+	assert.Equal(t, "UR1", rules[0].rule.UsageAlertingRuleID)
+}
+
+func TestMetricDefinitionsCoverEveryAlertingMetric(t *testing.T) {
+	for _, metric := range alertingMetricValues() {
+		// Every user-selectable alerting metric should have email display
+		// metadata.
+		_, ok := metricDefinitions[metric]
+		assert.True(t, ok, "missing metric definition for %s", metric)
+	}
+	assert.Len(t, metricDefinitions, len(alertingMetricValues()))
+}
+
+func TestWindowRange(t *testing.T) {
+	// Wednesday, May 13, 2026 should fall in the Monday-start UTC week
+	// beginning May 11 and ending May 18.
+	now := time.Date(2026, 5, 13, 15, 30, 0, 0, time.UTC)
+
+	start, end, err := windowRange(now, usagepb.UsageAlertingWindow_WEEK)
+	require.NoError(t, err)
+
+	// The evaluator uses half-open ranges, so the end is the first instant
+	// after the active week.
+	assert.Equal(t, time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC), start)
+	assert.Equal(t, time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC), end)
+}
+
+func newTestEvaluator(t testing.TB, now time.Time, sender emailSender, metrics *evaluatorMetrics) (*Evaluator, interfaces.DBHandle, interfaces.OLAPDBHandle) {
+	flags.Set(t, "testenv.use_clickhouse", true)
+	flags.Set(t, "testenv.reuse_server", true)
+	te := testenv.GetTestEnv(t)
+	return NewEvaluator(te.GetDBHandle(), te.GetOLAPDBHandle(), sender, clockwork.NewFakeClockAt(now), metrics), te.GetDBHandle(), te.GetOLAPDBHandle()
+}
+
+func testEvaluatorMetrics(t testing.TB) *evaluatorMetrics {
+	metrics, err := newEvaluatorMetrics()
+	require.NoError(t, err)
+	return metrics
+}
+
+func setOLAPExpressionForMetric(t testing.TB, metric usagepb.UsageAlertingMetric_Value, expression string) {
+	field, ok := usage_service.UsageFieldForAlertingMetric(metric)
+	require.True(t, ok)
+	originalExpression := field.OLAPExpression
+	field.OLAPExpression = expression
+	t.Cleanup(func() {
+		field.OLAPExpression = originalExpression
+	})
+}
+
+func newDBOnlyEvaluator(dbh interfaces.DBHandle) *Evaluator {
+	return NewEvaluator(dbh, nil, nil, clockwork.NewFakeClockAt(time.Unix(0, 0).UTC()), nil)
+}
+
+func createUsageAlertingRule(t testing.TB, ctx context.Context, dbh interfaces.DBHandle, rule *tables.UsageAlertingRule) {
+	require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_usage_alerting_rule").Create(rule))
+}
+
+func createRawUsage(t testing.TB, ctx context.Context, olapDBH interfaces.OLAPDBHandle, groupID string, periodStart time.Time, usageSKU sku.SKU, labels map[sku.LabelName]sku.LabelValue, count int64) {
+	require.NoError(t, olapDBH.FlushUsages(ctx, []*schema.RawUsage{
+		{
+			GroupID:     groupID,
+			SKU:         usageSKU,
+			Labels:      labels,
+			PeriodStart: periodStart,
+			Count:       count,
+		},
+	}))
+}
+
+func createAdminRecipient(t testing.TB, ctx context.Context, dbh interfaces.DBHandle, groupID, userID, firstName, lastName, emailAddress string) {
+	require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_user").Create(&tables.User{
+		UserID:    userID,
+		FirstName: firstName,
+		LastName:  lastName,
+		Email:     emailAddress,
+	}))
+	require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_create_user_group").Create(&tables.UserGroup{
+		UserUserID:       userID,
+		GroupGroupID:     groupID,
+		Role:             uint32(role.Admin),
+		MembershipStatus: int32(grpb.GroupMembershipStatus_MEMBER),
+	}))
+}
+
+func getUsageAlertingRule(t testing.TB, ctx context.Context, dbh interfaces.DBHandle, ruleID string) *tables.UsageAlertingRule {
+	rule := &tables.UsageAlertingRule{}
+	require.NoError(t, dbh.NewQuery(ctx, "usagealert_test_get_usage_alerting_rule").Raw(`
+		SELECT *
+		FROM "UsageAlertingRules"
+		WHERE usage_alerting_rule_id = ?
+	`, ruleID).Take(rule))
+	return rule
+}
+
+type fakeEmailSender struct {
+	mu       sync.Mutex
+	messages []*email.Message
+	err      error
+}
+
+func (s *fakeEmailSender) Send(ctx context.Context, msg *email.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.messages = append(s.messages, msg)
+	return nil
+}
+
+type fakeMetricsPusher struct {
+	calls int
+	err   error
+}
+
+func (p *fakeMetricsPusher) Push() error {
+	p.calls++
+	return p.err
+}

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -898,9 +898,6 @@ type UsageAlertingRule struct {
 	// Window is the usage alerting window enum value.
 	Window usagepb.UsageAlertingWindow_Value `gorm:"not null;default:0;uniqueIndex:usage_alerting_rule_group_config_idx,priority:4"`
 
-	// LastEvaluationUsec is the last time this rule was evaluated.
-	LastEvaluationUsec int64 `gorm:"not null;default:0"`
-
 	// LastFiredUsec is the last time this rule fired.
 	LastFiredUsec int64 `gorm:"not null;default:0"`
 }


### PR DESCRIPTION
Add a binary that will run as a k8s cronjob, and evaluate every usage alert matching the following criteria:
- At least one recipient user (org admin user attached to the group that owns the alerting rule)
- Alert has not already fired for the current window

For each rule, query ClickHouse usage. If the usage exceeds the alerting threshold, send an email alert to all matching recipients.

The ClickHouse usage table should be much faster than trying to query the old MySQL table. Alerts are evaluated concurrently (4 workers by default) so I expect that each run should take at most a few seconds for the foreseeable future. Later, if needed, we can probably optimize this by skipping inactive groups.

Also, get rid of the `UsageAlertingRule.last_evaluated_usec` column. I thought it would be nice to show in the UI, but it's probably too much write load to place on MySQL.

Tested E2E locally - was able to successfully send a test email via sendgrid.