### PR TITLE
Double chunk size

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -1075,7 +1075,7 @@ func TestReadChunked(t *testing.T) {
 	ctx, err = prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
 	require.NoError(t, err)
 
-	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	_, originalData := testdigest.RandomCASResourceBuf(t, 5*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
 
@@ -1289,7 +1289,7 @@ func TestReadChunkedFastPathSkipsSplitBlob(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write test data directly to the remote cache.
-	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	_, originalData := testdigest.RandomCASResourceBuf(t, 5*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
 
@@ -1451,7 +1451,7 @@ func TestReadChunkedEncryptedRemoteOnly(t *testing.T) {
 	encryptedUserCtx, err := ta.WithAuthenticatedUser(anonCtx, "user")
 	require.NoError(t, err)
 
-	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	_, originalData := testdigest.RandomCASResourceBuf(t, 5*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
 
@@ -1608,7 +1608,7 @@ func TestReadChunkedEncryptedRemoteOnlyFallsBackToFullBlob(t *testing.T) {
 	remoteCtx, err := prefix.AttachUserPrefixToContext(ctx, remoteEnv.GetAuthenticator())
 	require.NoError(t, err)
 
-	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	_, originalData := testdigest.RandomCASResourceBuf(t, 5*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
 	blobRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
@@ -1741,7 +1741,7 @@ func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 	readCtx, err := prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
 	require.NoError(t, err)
 
-	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	_, originalData := testdigest.RandomCASResourceBuf(t, 5*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
 	compressedData := compression.CompressZstd(nil, originalData)
@@ -1938,7 +1938,7 @@ func TestReadChunkedWithOffset(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write the blob as CDC chunks and publish the manifest remotely.
-	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	_, originalData := testdigest.RandomCASResourceBuf(t, 5*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
 
@@ -2119,7 +2119,7 @@ func TestReadChunkedFallsBackToLocalBlob(t *testing.T) {
 	ctx, err = prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
 	require.NoError(t, err)
 
-	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	_, originalData := testdigest.RandomCASResourceBuf(t, 5*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
 	blobRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
@@ -2194,7 +2194,7 @@ func TestReadChunkedPartialLocalFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write the blob as CDC chunks and publish the manifest remotely.
-	_, originalData := testdigest.RandomCASResourceBuf(t, 3*1024*1024)
+	_, originalData := testdigest.RandomCASResourceBuf(t, 5*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
 
@@ -2878,7 +2878,7 @@ func TestWriteChunkedFallbackBelowThreshold(t *testing.T) {
 	ctx, err = prefix.AttachUserPrefixToContext(ctx, proxyEnv.GetAuthenticator())
 	require.NoError(t, err)
 
-	// Create a blob smaller than the threshold (1MB vs 2MB default max)
+	// Create a blob smaller than the threshold.
 	_, originalData := testdigest.RandomCASResourceBuf(t, 1*1024*1024)
 	blobDigest, err := digest.Compute(bytes.NewReader(originalData), repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -79,7 +79,7 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	}
 	checker := chunking.NewMissingChunkChecker(cache)
 	for _, d := range missing {
-		if d.GetSizeBytes() <= chunking.MaxChunkSizeBytes() {
+		if d.GetSizeBytes() <= chunking.MinChunkedReadFallbackSizeBytes() {
 			return status.NotFoundErrorf("ActionResult output file %q not found in cache", digest.String(d))
 		}
 		manifest, err := chunking.LoadManifest(ctx, cache, d, instanceName, digestFunction)

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -1012,11 +1012,9 @@ func (ul *BatchCASUploader) Upload(d *repb.Digest, rsc io.ReadSeekCloser) error 
 		compressor = repb.Compressor_ZSTD
 	}
 
-	// Note: BatchUploadLimitBytes (2 MiB) and the default max chunk size
-	// (avgChunkSizeBytes*4 = 2 MiB) are currently equal, so all chunk-eligible
-	// blobs are also routed to bytestream. If BatchUploadLimitBytes were ever
-	// raised above the max chunk size, large blobs in that range would bypass
-	// chunking via BatchUpdateBlobs.
+	// Note: BatchUploadLimitBytes (2 MiB) is lower than the default max chunk
+	// size (avgChunkSizeBytes*4 = 4 MiB), so all chunk-eligible blobs are
+	// routed to bytestream.
 	if d.GetSizeBytes() > BatchUploadLimitBytes {
 		resourceName := digest.NewCASResourceName(d, ul.instanceName, ul.digestFunction)
 		resourceName.SetCompressor(compressor)

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -1470,7 +1470,7 @@ func TestBatchCASUploader_ChunkedUpload(t *testing.T) {
 	go runServer()
 
 	ctx := context.Background()
-	blobSize := int64(3 * 1024 * 1024)
+	blobSize := int64(5 * 1024 * 1024)
 	rn, buf := testdigest.RandomCASResourceBuf(t, blobSize)
 
 	ul := cachetools.NewBatchCASUploader(ctx, te, rn.GetInstanceName(), rn.GetDigestFunction(), chunking.FastCDCParams())
@@ -1506,7 +1506,7 @@ func TestBatchCASUploader_SkipsChunkedUploadAboveMaxSize(t *testing.T) {
 	go runServer()
 
 	ctx := context.Background()
-	blobSize := int64(3 * 1024 * 1024)
+	blobSize := int64(5 * 1024 * 1024)
 	rn, buf := testdigest.RandomCASResourceBuf(t, blobSize)
 
 	chunkingParams := chunking.FastCDCParams()

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
-	chunkedManifestSalt = flag.String("cache.chunking.ac_key_salt", "", "If set, salt the AC key with this value.")
-	avgChunkSizeBytes   = flag.Int64("cache.avg_chunk_size_bytes", 512*1024, "This is the average size of a chunk. Only blobs larger (non-inclusive) than 4x this value will be chunked. The maximum chunk size will be 4x this value, and the minimum will be 1/4 this value (default 512KB).")
+	chunkedManifestSalt             = flag.String("cache.chunking.ac_key_salt", "", "If set, salt the AC key with this value.")
+	avgChunkSizeBytes               = flag.Int64("cache.avg_chunk_size_bytes", 1024*1024, "This is the average size of a chunk. Only blobs larger (non-inclusive) than 4x this value will be chunked. The maximum chunk size will be 4x this value, and the minimum will be 1/4 this value (default 1MB).")
+	minChunkedReadFallbackSizeBytes = flag.Int64("cache.min_chunked_read_fallback_size_bytes", 2*1024*1024, "Only blobs larger (non-inclusive) than this value will use the server-side chunked read fallback after a normal blob lookup misses.")
 )
 
 const (
@@ -72,6 +73,13 @@ func MaxChunkSizeBytes() int64 {
 	return *avgChunkSizeBytes * 4
 }
 
+// MinChunkedReadFallbackSizeBytes is intentionally independent from the write
+// threshold so server-side miss fallback paths can still read older chunked
+// blobs that were written with a smaller chunk size.
+func MinChunkedReadFallbackSizeBytes() int64 {
+	return *minChunkedReadFallbackSizeBytes
+}
+
 func MaxWriteSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
 	if efp == nil {
 		return defaultMaxChunkedWriteSizeBytes
@@ -97,6 +105,12 @@ func ValidateConfig() error {
 	if v < 1024 || v > 1024*1024 {
 		return fmt.Errorf("cache.avg_chunk_size_bytes must be between 1024 and 1048576, got %d", v)
 	}
+	if *minChunkedReadFallbackSizeBytes < 0 {
+		return fmt.Errorf("cache.min_chunked_read_fallback_size_bytes must be >= 0, got %d", *minChunkedReadFallbackSizeBytes)
+	}
+	if *minChunkedReadFallbackSizeBytes > v*4 {
+		return fmt.Errorf("cache.min_chunked_read_fallback_size_bytes must be <= cache.avg_chunk_size_bytes*4 (%d), got %d", v*4, *minChunkedReadFallbackSizeBytes)
+	}
 	return nil
 }
 
@@ -110,7 +124,7 @@ func Enabled(ctx context.Context, efp interfaces.ExperimentFlagProvider) bool {
 func ShouldReadChunked(ctx context.Context, efp interfaces.ExperimentFlagProvider, digestSizeBytes, offset, limit int64) bool {
 	// Check digest first since it's faster than reading efp flag
 	// and very likely to be false.
-	return digestSizeBytes > MaxChunkSizeBytes() &&
+	return digestSizeBytes > MinChunkedReadFallbackSizeBytes() &&
 		limit == 0 &&
 		Enabled(ctx, efp)
 }

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -113,6 +113,30 @@ func TestShouldUploadChunkedWithMax(t *testing.T) {
 	}
 }
 
+func TestShouldReadChunkedUsesReadFallbackThreshold(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 1024*1024)
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
+
+	ctx := context.Background()
+	assert.False(t, chunking.ShouldUploadChunked(ctx, nil, &repb.Digest{
+		Hash:      "hash",
+		SizeBytes: 3 * 1024 * 1024,
+	}))
+	assert.True(t, chunking.ShouldReadChunked(ctx, nil, 3*1024*1024, 0, 0))
+	assert.False(t, chunking.ShouldReadChunkedOnProxy(ctx, nil, 3*1024*1024, 0, 0))
+	assert.True(t, chunking.ShouldReadChunkedOnProxy(ctx, nil, 5*1024*1024, 0, 0))
+	assert.False(t, chunking.ShouldReadChunked(ctx, nil, 2*1024*1024, 0, 0))
+	assert.False(t, chunking.ShouldReadChunked(ctx, nil, 3*1024*1024, 0, 1024))
+}
+
+func TestValidateConfigRejectsReadFallbackThresholdAboveMaxChunkSize(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 1024*1024)
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 4*1024*1024+1)
+
+	err := chunking.ValidateConfig()
+	require.ErrorContains(t, err, "cache.min_chunked_read_fallback_size_bytes")
+}
+
 func TestChunker_DeterministicChunking(t *testing.T) {
 	ctx := context.Background()
 

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -128,7 +128,7 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 		// https://go.dev/wiki/SliceTricks#filtering-without-allocating
 		stillMissing := missing[:0]
 		for _, d := range missing {
-			if d.GetSizeBytes() <= chunking.MaxChunkSizeBytes() {
+			if d.GetSizeBytes() <= chunking.MinChunkedReadFallbackSizeBytes() {
 				stillMissing = append(stillMissing, d)
 				continue
 			}
@@ -393,7 +393,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 		// It's unexpected, but BatchReadBlobs may be used for blobs that are
 		// large enough to be chunked. If the blob was not found and it's large
 		// enough to be chunked, try to reassemble it from CDC chunks.
-		if (!ok || os.IsNotExist(err)) && rn.GetDigest().GetSizeBytes() > chunking.MaxChunkSizeBytes() && chunkingEnabled {
+		if (!ok || os.IsNotExist(err)) && rn.GetDigest().GetSizeBytes() > chunking.MinChunkedReadFallbackSizeBytes() && chunkingEnabled {
 			if assembled, assembleErr := s.readChunkedBlob(ctx, rn.GetDigest(), req.GetInstanceName(), req.GetDigestFunction(), readZstd); assembleErr == nil {
 				data = assembled
 				ok = true


### PR DESCRIPTION
To reduce GCS costs, we can double chunk size. This is safe because we keep the read threshold.

I ran this on my disk cache: 

  - Files: 924,647
  - Bytes: 985.18 GiB
  - Denominator includes all CAS blobs, including blobs that would not be chunked.

We're only losing a few % of savings, so I think this is worthwhile, to cut GCS costs in half.

  | Config | Chunk threshold | Chunked bytes | Unchunked bytes | Upload/storage bytes | Overall savings | Chunk dedup |
  |---|---:|---:|---:|---:|---:|---:|
  | 512KiB avg | >2MiB | 879.30 GiB | 105.87 GiB | 676.29 GiB upload / 676.50 GiB storage | 31.35% upload / 31.33% storage | 35.13% |
  | 1MiB avg | >4MiB | 813.36 GiB | 171.82 GiB | 724.10 GiB upload / 724.30 GiB storage | 26.50% upload / 26.48% storage | 32.10% |