### PR TITLE
Add package-level documentation for all cli packages

### DIFF
--- a/cli/add/add.go
+++ b/cli/add/add.go
@@ -1,3 +1,7 @@
+// Package add implements the `bb add` command, which adds Bazel dependencies
+// to a workspace by fetching module metadata from the Bazel registry and
+// generating appropriate WORKSPACE or MODULE.bazel snippets. It supports
+// interactive disambiguation when multiple modules match a given name.
 package add
 
 import (

--- a/cli/analyze/analyze.go
+++ b/cli/analyze/analyze.go
@@ -1,3 +1,9 @@
+// Package analyze implements the `bb analyze` command, which analyzes Bazel
+// dependency graphs to identify optimization opportunities. It can compute the
+// longest path in the build graph, analyze dependency costs by correlating
+// build graph structure with git history to identify frequently-changed
+// dependencies, and help identify restructuring opportunities to improve build
+// performance.
 package analyze
 
 import (

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -1,3 +1,7 @@
+// Package arg provides utilities for parsing and manipulating command-line
+// arguments, particularly Bazel-style flags. It supports finding, extracting,
+// and modifying flag values in argument lists, handling both single-value and
+// multi-value flags, and parsing flag sets with custom error handling.
 package arg
 
 import (

--- a/cli/ask/ask.go
+++ b/cli/ask/ask.go
@@ -1,3 +1,7 @@
+// Package ask implements the `bb ask` command, which provides AI-powered
+// suggestions about the previous Bazel invocation. It retrieves the most recent
+// invocation ID and sends it to BuildBuddy's suggestion service to get
+// actionable recommendations for improving build performance or fixing issues.
 package ask
 
 import (

--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -1,3 +1,7 @@
+// Package bazelisk provides integration with Bazelisk for managing Bazel
+// versions. It wraps the core Bazelisk functionality to automatically download
+// and invoke the correct Bazel version based on .bazelversion files, with
+// support for custom stdout/stderr redirection and version override handling.
 package bazelisk
 
 import (

--- a/cli/cli_command/cli_command.go
+++ b/cli/cli_command/cli_command.go
@@ -1,3 +1,8 @@
+// Package cli_command defines the structure and registry for BuildBuddy CLI
+// commands. It provides the Command type, which encapsulates a command's name,
+// handler function, help text, aliases, and flags. The package maintains global
+// registries (Commands, CommandsByName, Aliases) that are populated by the
+// register subpackage.
 package cli_command
 
 import "flag"

--- a/cli/cli_command/register/register.go
+++ b/cli/cli_command/register/register.go
@@ -1,3 +1,7 @@
+// Package register initializes and registers all available CLI commands by
+// importing all command packages and populating the global command registries
+// (Commands, CommandsByName, and Aliases) in the parent cli_command package.
+// It ensures registration happens exactly once via sync.Once.
 package register
 
 import (

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -1,3 +1,8 @@
+// Package main provides the entry point for the BuildBuddy CLI (bb). It
+// orchestrates command dispatch, argument parsing, plugin execution, and
+// integration with Bazelisk. It handles special commands (help, setup),
+// delegates to registered CLI commands, and falls back to invoking Bazel via
+// Bazelisk for unrecognized commands.
 package main
 
 import (

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -1,3 +1,8 @@
+// Package config handles loading and parsing BuildBuddy CLI configuration files
+// (buildbuddy.yaml). It supports both workspace-level configuration (at the
+// workspace root) and user-level configuration (in the user's home directory),
+// merging them with appropriate precedence. The configuration controls plugin
+// settings, resource limits, and other CLI behaviors.
 package config
 
 import (

--- a/cli/devnull/devnull.go
+++ b/cli/devnull/devnull.go
@@ -1,3 +1,7 @@
+// Package devnull provides a no-op implementation of BuildEventChannel and
+// BuildEventHandler. It's used when build event publishing needs to be disabled
+// or mocked out, such as in testing scenarios or when running commands that
+// don't require event streaming.
 package devnull
 
 import (

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -1,3 +1,8 @@
+// Package download implements the `bb download` command, which downloads blobs
+// from the Content Addressable Storage (CAS) using their digest and size. It
+// supports downloading both individual files and directory trees, with optional
+// output to a specific path or stdout, and can print metadata about the
+// downloaded content.
 package download
 
 import (

--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -1,3 +1,8 @@
+// Package execute implements the `bb execute` command, which runs arbitrary
+// commands via remote execution. It packages the specified executable and
+// arguments into a remote execution action, uploads inputs to CAS, executes
+// the action on a remote worker, and streams back the results including stdout,
+// stderr, and exit code.
 package execute
 
 import (

--- a/cli/execution/execution.go
+++ b/cli/execution/execution.go
@@ -1,3 +1,7 @@
+// Package execution implements the `bb execution` command, which queries and
+// manages remote execution results. It can fetch cached execution responses by
+// execution ID, display detailed execution metadata, and format output as
+// markdown or JSON for analysis and debugging.
 package execution
 
 import (

--- a/cli/explain/compactgraph/compactgraph.go
+++ b/cli/explain/compactgraph/compactgraph.go
@@ -1,3 +1,8 @@
+// Package compactgraph provides utilities for parsing and analyzing Bazel's
+// compact execution logs. It represents the execution log as a directed acyclic
+// graph of spawns, tracking dependencies between actions through input and
+// output paths. It supports efficient loading, diffing, and querying of large
+// execution logs with zstd compression.
 package compactgraph
 
 import (

--- a/cli/explain/compactgraph/testdata/generate.go
+++ b/cli/explain/compactgraph/testdata/generate.go
@@ -1,3 +1,6 @@
+// Package main generates test data for the compactgraph package by building
+// sample projects with different Bazel versions and capturing their execution
+// logs for use in testing and validation.
 package main
 
 import (

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -1,3 +1,8 @@
+// Package explain implements the `bb explain` command, which analyzes and
+// explains Bazel build performance by examining invocation data, execution logs,
+// and action graphs. It can identify slow actions, compare executions, analyze
+// cache misses, and provide actionable insights for improving build times. It
+// supports multiple output formats and can profile its own performance.
 package explain
 
 import (

--- a/cli/fix/golang/golang.go
+++ b/cli/fix/golang/golang.go
@@ -1,3 +1,8 @@
+// Package golang provides Go-specific functionality for the `bb fix` command.
+// It implements the language interface for detecting Go source and dependency
+// files (go.mod, go.sum), extracting Bazel dependencies needed for Go support
+// (rules_go, gazelle), and registering Go module dependencies in MODULE.bazel
+// using the go_deps extension.
 package golang
 
 import (

--- a/cli/fix/language/language.go
+++ b/cli/fix/language/language.go
@@ -1,3 +1,8 @@
+// Package language defines the interface for language-specific handling in the
+// `bb fix` command. Each language implementation can identify its source files,
+// dependency files (like package.json or go.mod), specify required Bazel
+// dependencies, consolidate dependency files, and register dependencies in
+// MODULE.bazel or WORKSPACE.
 package language
 
 type Language interface {

--- a/cli/fix/typescript/typescript.go
+++ b/cli/fix/typescript/typescript.go
@@ -1,3 +1,8 @@
+// Package typescript provides TypeScript-specific functionality for the `bb fix`
+// command. It implements the language interface for detecting TypeScript source
+// and dependency files (package.json, package-lock.json), extracting required
+// Bazel dependencies (rules_js, aspect_rules_js), and registering npm
+// dependencies in MODULE.bazel using the npm extension.
 package typescript
 
 import (

--- a/cli/flaghistory/flaghistory.go
+++ b/cli/flaghistory/flaghistory.go
@@ -1,3 +1,8 @@
+// Package flaghistory tracks and persists Bazel command-line flags across
+// invocations. It saves important flags like invocation_id and bes_results_url
+// to local storage, allowing subsequent commands to reference previous
+// invocations. This enables features like `bb ask` to analyze the most recent
+// build.
 package flaghistory
 
 import (

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -1,3 +1,7 @@
+// Package help implements the help system for the BuildBuddy CLI. It provides
+// command-specific help messages, a directory of all available commands, and
+// integration with Bazel's native help system for Bazel commands. It formats
+// and displays usage information, flag descriptions, and examples.
 package help
 
 import (

--- a/cli/help/option_definitions/option_definitions.go
+++ b/cli/help/option_definitions/option_definitions.go
@@ -1,3 +1,6 @@
+// Package option_definitions defines the command-line option schemas for
+// help-related flags. It specifies the structure, aliases, and behavior of
+// flags like --help/-h that control help system functionality across the CLI.
 package option_definitions
 
 import (

--- a/cli/index/index.go
+++ b/cli/index/index.go
@@ -1,3 +1,8 @@
+// Package index implements the `bb index` command, which indexes a git
+// repository for code search. It uploads repository contents and metadata to
+// BuildBuddy's code search service, enabling fast searching across the
+// codebase. It supports automatic detection of the git repository and handles
+// authentication.
 package index
 
 import (

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -1,3 +1,7 @@
+// Package log provides logging utilities for the BuildBuddy CLI. It wraps the
+// standard log package with support for verbosity levels, colored output, and
+// debug logging that can be enabled via the --verbose flag or BB_VERBOSE
+// environment variable. It also handles formatting warnings and errors.
 package log
 
 import (

--- a/cli/log/option_definitions/option_definitions.go
+++ b/cli/log/option_definitions/option_definitions.go
@@ -1,3 +1,6 @@
+// Package option_definitions defines the command-line option schemas for
+// logging-related flags. It specifies the structure and behavior of flags like
+// --verbose/-v that control logging verbosity across the CLI.
 package option_definitions
 
 import (

--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -1,3 +1,8 @@
+// Package login implements the `bb login` and `bb logout` commands for
+// authenticating with BuildBuddy. It manages API keys and credentials, provides
+// an OAuth flow with browser-based authentication, and stores credentials
+// securely in git config. It also provides utilities for other commands to
+// access stored credentials and API targets.
 package login
 
 import (

--- a/cli/markdown/markdown.go
+++ b/cli/markdown/markdown.go
@@ -1,3 +1,7 @@
+// Package markdown provides utilities for rendering markdown with terminal
+// formatting. It applies ANSI color codes to markdown headings and other
+// elements, allowing rich text output in the terminal. It supports customizable
+// color schemes and handles escape sequences for proper terminal display.
 package markdown
 
 import (

--- a/cli/metadata/metadata.go
+++ b/cli/metadata/metadata.go
@@ -1,3 +1,7 @@
+// Package metadata collects and appends build metadata to Bazel invocations.
+// It gathers information like git commit SHA, branch, repository URL, and the
+// original command-line arguments, then injects them as --build_metadata flags
+// for tracking and display in BuildBuddy's UI.
 package metadata
 
 import (

--- a/cli/parser/arguments/arguments.go
+++ b/cli/parser/arguments/arguments.go
@@ -1,3 +1,7 @@
+// Package arguments defines types for representing parsed command-line
+// arguments. It provides the Argument interface and implementations for
+// positional arguments and the double-dash separator, enabling type-safe
+// handling and formatting of mixed positional and flag arguments.
 package arguments
 
 // Argument represents parsed command-line argument (or arguments, in the case

--- a/cli/parser/bazelrc/bazelrc.go
+++ b/cli/parser/bazelrc/bazelrc.go
@@ -1,3 +1,7 @@
+// Package bazelrc provides parsing and evaluation of Bazel configuration files
+// (.bazelrc). It handles importing, command-specific options, platform-specific
+// configurations, config expansion, and the full semantics of .bazelrc files
+// including try-import, common options, and config inheritance.
 package bazelrc
 
 import (

--- a/cli/parser/options/flag_form/flag_form.go
+++ b/cli/parser/options/flag_form/flag_form.go
@@ -1,3 +1,7 @@
+// Package flag_form defines the different forms a command-line flag can take,
+// such as standard name, short name, old/experimental name, and their negative
+// variants. It provides utilities for identifying and working with these
+// different flag representations.
 package flag_form
 
 // Form is an enum that describes the form the flag takes. The least-significant

--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -1,3 +1,8 @@
+// Package options provides parsing and representation of command-line options
+// (flags). It defines the Definition type for option schemas, handles both
+// native Bazel flags and Starlark flags, supports various flag forms (boolean,
+// required-value, enum), and manages option metadata like short names, negation,
+// and command support.
 package options
 
 import (

--- a/cli/parser/test_data/test_data.go
+++ b/cli/parser/test_data/test_data.go
@@ -1,3 +1,6 @@
+// Package test_data provides embedded test data for the parser package,
+// including captured Bazel help output in various formats for use in parser
+// tests and validation.
 package test_data
 
 import _ "embed"

--- a/cli/picker/picker.go
+++ b/cli/picker/picker.go
@@ -1,3 +1,7 @@
+// Package picker provides an interactive target picker for Bazel commands.
+// When a build, test, or query command is invoked without explicit targets, it
+// queries available packages and presents an interactive menu for target
+// selection, making it easier to work with Bazel in large repositories.
 package picker
 
 import (

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -1,3 +1,8 @@
+// Package plugin implements the BuildBuddy CLI plugin system. It discovers,
+// configures, and executes plugins defined in buildbuddy.yaml, handling plugin
+// lifecycle (before_run, after_run hooks), argument parsing, and communication
+// with Bazel via a sidecar process. Plugins can modify Bazel invocations, react
+// to build events, and extend CLI functionality.
 package plugin
 
 import (

--- a/cli/printlog/compact/compact.go
+++ b/cli/printlog/compact/compact.go
@@ -1,3 +1,7 @@
+// Package compact provides parsing and pretty-printing of Bazel's compact
+// execution logs. It reads the compressed protobuf format, builds an index of
+// spawns and their dependencies, and outputs a sorted, human-readable
+// representation with configurable detail levels and size limits.
 package compact
 
 import (

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -1,3 +1,8 @@
+// Package printlog implements the `bb print` command, which prints
+// human-readable representations of Bazel log files. It supports parsing and
+// displaying gRPC logs (--experimental_remote_grpc_log) and compact execution
+// logs (--experimental_execution_log_compact_file) with options for sorting,
+// raw output, and size limiting.
 package printlog
 
 import (

--- a/cli/record/record.go
+++ b/cli/record/record.go
@@ -1,3 +1,7 @@
+// Package record implements the `bb record` command, which executes arbitrary
+// commands while capturing their output and streaming it to BuildBuddy as a
+// build event stream. This enables tracking and viewing non-Bazel command
+// executions in the BuildBuddy UI with timing, logs, and exit status.
 package record
 
 import (

--- a/cli/remote_download/remote_download.go
+++ b/cli/remote_download/remote_download.go
@@ -1,3 +1,7 @@
+// Package remote_download implements the `bb remote-download` command, which
+// downloads remote assets via the Remote Asset API. It fetches artifacts by URL,
+// caches them in CAS, and returns the resulting digest. This is useful for
+// downloading artifacts as part of remote execution workflows.
 package remote_download
 
 import (

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1,3 +1,8 @@
+// Package remotebazel implements the `bb remote-bazel` command, which runs
+// Bazel commands on remote workers instead of locally. It packages the workspace,
+// uploads it to CAS, executes Bazel via remote execution, streams build events,
+// and downloads results. This enables running builds without local Bazel
+// installation or powerful hardware.
 package remotebazel
 
 import (

--- a/cli/runscript/runscript.go
+++ b/cli/runscript/runscript.go
@@ -1,3 +1,7 @@
+// Package runscript handles the execution of Bazel run scripts. It configures
+// `bazel run` to generate a script via --script_path, then executes that script
+// with proper signal handling and log streaming. This enables splitting the
+// build and run phases for better control over execution.
 package runscript
 
 import (

--- a/cli/search/search.go
+++ b/cli/search/search.go
@@ -1,3 +1,7 @@
+// Package search implements the `bb search` command, which performs code search
+// queries against BuildBuddy's code search service. It sends search requests,
+// formats and displays results with syntax highlighting, and supports pagination
+// through results with offset and limit controls.
 package search
 
 import (

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -1,3 +1,8 @@
+// Package setup orchestrates the initialization and preparation of the CLI
+// environment before running Bazel commands. It loads plugins, handles
+// authentication, configures the sidecar process, parses arguments, and executes
+// pre-command hooks. It returns a Result containing the configured state for
+// command execution.
 package setup
 
 import (

--- a/cli/shortcuts/shortcuts.go
+++ b/cli/shortcuts/shortcuts.go
@@ -1,3 +1,6 @@
+// Package shortcuts defines command aliases for the BuildBuddy CLI, mapping
+// short command names (like 'b', 't', 'q') to their full command names (build,
+// test, query) for faster typing.
 package shortcuts
 
 var (

--- a/cli/storage/storage.go
+++ b/cli/storage/storage.go
@@ -1,3 +1,8 @@
+// Package storage provides utilities for persisting CLI configuration and state.
+// It manages user-specific config directories, workspace-specific data storage
+// (via .git/config), and temporary file handling. It provides a consistent
+// interface for reading and writing CLI settings across different storage
+// backends.
 package storage
 
 import (

--- a/cli/stream_run_logs/option_definitions/option_definitions.go
+++ b/cli/stream_run_logs/option_definitions/option_definitions.go
@@ -1,3 +1,7 @@
+// Package option_definitions defines the command-line option schemas for
+// run log streaming flags. It specifies flags like --stream_run_logs and
+// --on_stream_run_logs_failure that control whether and how run command logs
+// are streamed to BuildBuddy.
 package option_definitions
 
 import "github.com/buildbuddy-io/buildbuddy/cli/parser/options"

--- a/cli/stream_run_logs/stream_run_logs.go
+++ b/cli/stream_run_logs/stream_run_logs.go
@@ -1,3 +1,7 @@
+// Package stream_run_logs captures and streams logs from `bazel run` commands
+// to BuildBuddy. It executes the run script in a PTY, captures stdout/stderr,
+// and sends the logs to BuildBuddy's event log service in real-time, enabling
+// viewing of run command output in the BuildBuddy UI.
 package stream_run_logs
 
 import (

--- a/cli/terminal/terminal.go
+++ b/cli/terminal/terminal.go
@@ -1,3 +1,8 @@
+// Package terminal provides utilities for terminal-aware output formatting. It
+// handles ANSI escape sequences for colors and styles, detects TTY capabilities,
+// manages terminal width calculation, and provides primitives for building
+// terminal-friendly UI elements. ANSI codes are automatically disabled when
+// output is not a TTY.
 package terminal
 
 import (

--- a/cli/tooltag/tooltag.go
+++ b/cli/tooltag/tooltag.go
@@ -1,3 +1,6 @@
+// Package tooltag adds the --tool_tag flag to Bazel invocations to identify
+// them as originating from the BuildBuddy CLI. The tag includes the CLI version,
+// enabling analytics and debugging of CLI-initiated builds in BuildBuddy.
 package tooltag
 
 import (

--- a/cli/translate/builtins/builtins.go
+++ b/cli/translate/builtins/builtins.go
@@ -1,3 +1,6 @@
+// Package builtins provides a comprehensive list of Bazel's built-in rule names.
+// This list is used by translators to identify valid Bazel rules when converting
+// from other build systems or validating BUILD file syntax.
 package builtins
 
 var Rules = []string{

--- a/cli/translate/js/js.go
+++ b/cli/translate/js/js.go
@@ -1,3 +1,7 @@
+// Package js provides translation of JavaScript-based BUILD files to Bazel's
+// Starlark format. It uses a JavaScript interpreter to evaluate the JS-based
+// BUILD syntax and transforms it into valid Bazel BUILD files, handling imports,
+// rule calls, and other JS idioms.
 package js
 
 import (

--- a/cli/translate/translate.go
+++ b/cli/translate/translate.go
@@ -1,3 +1,7 @@
+// Package translate provides translation of non-Bazel build files to Bazel
+// format. It defines the Translator interface and manages a registry of
+// translators for different file types (like .js, .yaml), enabling `bb fix` to
+// convert existing build configurations to Bazel BUILD files.
 package translate
 
 import (

--- a/cli/translate/yaml/yaml.go
+++ b/cli/translate/yaml/yaml.go
@@ -1,3 +1,7 @@
+// Package yaml provides translation of YAML-based BUILD files to Bazel's
+// Starlark format. It parses YAML representations of Bazel rules and converts
+// them to valid BUILD file syntax, handling load statements, rule invocations,
+// and YAML-specific idioms.
 package yaml
 
 import (

--- a/cli/ui/ui.go
+++ b/cli/ui/ui.go
@@ -1,3 +1,7 @@
+// Package ui implements the `bb ui` command, which provides a terminal-based
+// user interface for browsing BuildBuddy invocations. It displays a list of
+// recent builds with filtering options (by user, repo, branch) and allows
+// interactive navigation through build history using the Bubble Tea framework.
 package ui
 
 import (

--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -1,3 +1,7 @@
+// Package update implements the `bb update` command, which updates the
+// BuildBuddy CLI to the latest version. It supports updating the system-wide
+// installation, updating the workspace's .bazelversion file, or running the
+// install script to fetch and install the latest release from GitHub.
 package update
 
 import (

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -1,3 +1,7 @@
+// Package upload implements the `bb upload` command, which uploads files or
+// directory trees to the Content Addressable Storage (CAS). It supports
+// uploading from files or stdin, computes the content digest, performs the
+// bytestream upload, and outputs the resulting digest for later retrieval.
 package upload
 
 import (

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -1,3 +1,6 @@
+// Package version provides access to the BuildBuddy CLI version string. The
+// version is embedded at build time from a Bazel flag and is used throughout
+// the CLI for version reporting, tool tagging, and update checking.
 package version
 
 import (

--- a/cli/versioncmd/versioncmd.go
+++ b/cli/versioncmd/versioncmd.go
@@ -1,3 +1,7 @@
+// Package versioncmd implements the `bb version` command, which displays the
+// BuildBuddy CLI version and optionally the Bazel version. With --cli, it
+// prints only the CLI version; otherwise, it prints both the CLI version and
+// delegates to `bazel version` for Bazel version information.
 package versioncmd
 
 import (

--- a/cli/view/view.go
+++ b/cli/view/view.go
@@ -1,3 +1,7 @@
+// Package view implements the `bb view` command, which fetches and displays
+// build logs from BuildBuddy. It accepts an invocation ID or BuildBuddy URL,
+// retrieves the event log chunks via the BuildBuddy API, and streams the logs
+// to the terminal with optional line limits.
 package view
 
 import (

--- a/cli/watcher/option_definitions/option_definitions.go
+++ b/cli/watcher/option_definitions/option_definitions.go
@@ -1,3 +1,6 @@
+// Package option_definitions defines the command-line option schemas for
+// file watcher flags. It specifies flags like --watch/-w and --watcher_flags
+// that control file watching behavior and configuration.
 package option_definitions
 
 import (

--- a/cli/watcher/watcher.go
+++ b/cli/watcher/watcher.go
@@ -1,3 +1,7 @@
+// Package watcher implements file watching functionality for the BuildBuddy CLI.
+// When enabled, it monitors source files for changes and automatically re-runs
+// the previous Bazel command, enabling a continuous development workflow. It uses
+// godemon for efficient file system watching.
 package watcher
 
 import (

--- a/cli/workspace/workspace.go
+++ b/cli/workspace/workspace.go
@@ -1,3 +1,7 @@
+// Package workspace provides utilities for locating and working with Bazel
+// workspaces. It finds the workspace root by searching for WORKSPACE, MODULE.bazel,
+// or other indicator files, supports both legacy WORKSPACE and bzlmod MODULE
+// approaches, and provides helpers for reading and creating workspace files.
 package workspace
 
 import (


### PR DESCRIPTION
Added comprehensive package-level doc comments to 62 Go packages under //cli/... that were previously undocumented.

Each doc comment focuses on what the package does (its public contract) rather than implementation details, following the style established in cli/fix/fix.go. The documentation describes:
- The package's primary purpose and functionality
- Key capabilities and use cases
- Integration with other CLI components
- Command-line interfaces where applicable