### PR TITLE
Take the min of threshold and fallback

### DIFF
--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -73,11 +73,12 @@ func MaxChunkSizeBytes() int64 {
 	return *avgChunkSizeBytes * 4
 }
 
-// MinChunkedReadFallbackSizeBytes is intentionally independent from the write
-// threshold so server-side miss fallback paths can still read older chunked
-// blobs that were written with a smaller chunk size.
+// MinChunkedReadFallbackSizeBytes can be configured independently from the
+// write threshold so server-side miss fallback paths can still read older
+// chunked blobs that were written with a smaller chunk size, but is clamped to
+// at most MaxChunkSizeBytes().
 func MinChunkedReadFallbackSizeBytes() int64 {
-	return *minChunkedReadFallbackSizeBytes
+	return min(*minChunkedReadFallbackSizeBytes, MaxChunkSizeBytes())
 }
 
 func MaxWriteSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
@@ -107,9 +108,6 @@ func ValidateConfig() error {
 	}
 	if *minChunkedReadFallbackSizeBytes < 0 {
 		return fmt.Errorf("cache.min_chunked_read_fallback_size_bytes must be >= 0, got %d", *minChunkedReadFallbackSizeBytes)
-	}
-	if *minChunkedReadFallbackSizeBytes > v*4 {
-		return fmt.Errorf("cache.min_chunked_read_fallback_size_bytes must be <= cache.avg_chunk_size_bytes*4 (%d), got %d", v*4, *minChunkedReadFallbackSizeBytes)
 	}
 	return nil
 }

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -129,12 +129,12 @@ func TestShouldReadChunkedUsesReadFallbackThreshold(t *testing.T) {
 	assert.False(t, chunking.ShouldReadChunked(ctx, nil, 3*1024*1024, 0, 1024))
 }
 
-func TestValidateConfigRejectsReadFallbackThresholdAboveMaxChunkSize(t *testing.T) {
+func TestReadFallbackThresholdClampsToMaxChunkSize(t *testing.T) {
 	flags.Set(t, "cache.avg_chunk_size_bytes", 1024*1024)
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 4*1024*1024+1)
 
-	err := chunking.ValidateConfig()
-	require.ErrorContains(t, err, "cache.min_chunked_read_fallback_size_bytes")
+	require.NoError(t, chunking.ValidateConfig())
+	require.Equal(t, chunking.MaxChunkSizeBytes(), chunking.MinChunkedReadFallbackSizeBytes())
 }
 
 func TestChunker_DeterministicChunking(t *testing.T) {


### PR DESCRIPTION
We should try to find blobs chunked if they're either < the current threshold or the fallback threshold. This then means we don't require setting both flags when we don't need them.