### PR TITLE
Introduce protos and capability for registering Cache Proxies

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -155,6 +155,16 @@ proto_library(
 )
 
 proto_library(
+    name = "cache_proxy_proto",
+    srcs = ["cache_proxy.proto"],
+    deps = [
+        ":acl_proto",
+        ":context_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
     name = "capability_proto",
     srcs = [
         "capability.proto",
@@ -655,6 +665,7 @@ proto_library(
         ":auditlog_proto",
         ":bazel_config_proto",
         ":cache_proto",
+        ":cache_proxy_proto",
         ":encryption_proto",
         ":eventlog_proto",
         ":execution_stats_proto",
@@ -1476,6 +1487,7 @@ go_proto_library(
         ":auditlog_go_proto",
         ":bazel_config_go_proto",
         ":cache_go_proto",
+        ":cache_proxy_go_proto",
         ":encryption_go_proto",
         ":eventlog_go_proto",
         ":execution_stats_go_proto",
@@ -1575,6 +1587,17 @@ go_proto_library(
         ":remote_execution_go_proto",
         ":resource_go_proto",
         "@org_golang_google_genproto_googleapis_rpc//status",
+    ],
+)
+
+go_proto_library(
+    name = "cache_proxy_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/cache_proxy",
+    mode = "messages_and_services",
+    proto = ":cache_proxy_proto",
+    deps = [
+        ":acl_go_proto",
+        ":context_go_proto",
     ],
 )
 
@@ -2337,6 +2360,16 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "cache_proxy_ts_proto",
+    proto = ":cache_proxy_proto",
+    deps = [
+        ":acl_ts_proto",
+        ":context_ts_proto",
+        ":timestamp_ts_proto",
+    ],
+)
+
+ts_proto_library(
     name = "capability_ts_proto",
     proto = ":capability_proto",
 )
@@ -2378,6 +2411,7 @@ ts_proto_library(
         ":api_key_ts_proto",
         ":auditlog_ts_proto",
         ":bazel_config_ts_proto",
+        ":cache_proxy_ts_proto",
         ":cache_ts_proto",
         ":encryption_ts_proto",
         ":eventlog_ts_proto",

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -4,6 +4,7 @@ import "proto/api_key.proto";
 import "proto/auditlog.proto";
 import "proto/bazel_config.proto";
 import "proto/cache.proto";
+import "proto/cache_proxy.proto";
 import "proto/search.proto";
 import "proto/eventlog.proto";
 import "proto/execution_stats.proto";
@@ -149,6 +150,10 @@ service BuildBuddyService {
       returns (cache.GetExecutionDownloadsResponse);
   rpc GetTreeDirectorySizes(cache.GetTreeDirectorySizesRequest)
       returns (cache.GetTreeDirectorySizesResponse);
+
+  // Cache Proxy API
+  rpc GetCacheProxies(cache_proxy.GetCacheProxiesRequest)
+      returns (cache_proxy.GetCacheProxiesResponse);
 
   // Targets API
   rpc GetTarget(target.GetTargetRequest) returns (target.GetTargetResponse);

--- a/proto/cache_proxy.proto
+++ b/proto/cache_proxy.proto
@@ -1,0 +1,88 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "proto/acl.proto";
+import "proto/context.proto";
+
+package cache_proxy;
+
+// CacheProxyNode is the registration info that a cache proxy sends to the
+// main BuildBuddy server.
+message CacheProxyNode {
+  // Cache proxy host (typically the proxy's hostname or pod name).
+  // Ex. "10.52.6.5" or "cache-proxy-abc123"
+  string host = 1;
+
+  // Unique ID that identifies this cache proxy instance. Set once when the
+  // proxy starts and preserved for the lifetime of the process. Each proxy
+  // generates its own ID on startup.
+  //
+  // Ex. "34c5cf7e-b3b1-4e20-b43c-3e196b30d983"
+  string proxy_id = 2;
+
+  // Unique ID that identifies the host the cache proxy is running on.
+  //
+  // Ex. "23894af6-a540-430a-962e-a14b1f398472"
+  string proxy_host_id = 3;
+
+  // Proxy's operating system family. One of: "darwin", "linux", or "windows".
+  string os_family = 4;
+
+  // Architecture of the cache proxy node.
+  // Ex. "amd64"
+  string arch = 5;
+
+  // Version of the cache proxy binary.
+  string version = 6;
+
+  // Time when this cache proxy process started.
+  google.protobuf.Timestamp start_time = 7;
+}
+
+// RegisterCacheProxyRequest is sent on the client-side stream from the proxy
+// to the server, both initially and as a periodic heartbeat.
+message RegisterCacheProxyRequest {
+  CacheProxyNode node = 1;
+}
+
+// RegisterCacheProxyResponse is returned by the server once the proxy closes
+// the stream (or the stream is broken). Empty for now but kept as a message
+// so we can add fields later without changing the RPC signature.
+message RegisterCacheProxyResponse {}
+
+message GetCacheProxiesRequest {
+  context.RequestContext request_context = 1;
+}
+
+message GetCacheProxiesResponse {
+  context.ResponseContext response_context = 1;
+
+  repeated CacheProxy cache_proxy = 2;
+
+  message CacheProxy {
+    CacheProxyNode node = 1;
+
+    // Last time this cache proxy checked in with the server.
+    google.protobuf.Timestamp last_check_in_time = 2;
+  }
+}
+
+// Persisted information about a connected cache proxy.
+message RegisteredCacheProxy {
+  CacheProxyNode registration = 1;
+  string group_id = 2;
+  acl.ACL acl = 3;
+  google.protobuf.Timestamp last_ping_time = 4;
+}
+
+service CacheProxyAPI {
+  // RegisterAndStreamHeartbeat is opened by the cache proxy on startup. The
+  // proxy sends an initial RegisterCacheProxyRequest with its identifying
+  // info, then re-sends the same message periodically as a heartbeat. The
+  // server uses these heartbeats to maintain a TTL-backed registry of live
+  // proxies, scoped to the group identified by the proxy's API key. The
+  // server returns a single RegisterCacheProxyResponse once the proxy
+  // closes the stream (or the connection drops).
+  rpc RegisterAndStreamHeartbeat(stream RegisterCacheProxyRequest)
+      returns (RegisterCacheProxyResponse) {}
+}

--- a/proto/capability.proto
+++ b/proto/capability.proto
@@ -16,4 +16,6 @@ enum Capability {
   ORG_ADMIN = 8;  // 2^3
   // Allows read-only access to audit logs.
   AUDIT_LOG_READ = 16;  // 2^4
+  // Allows registering a cache proxy with the main BuildBuddy server.
+  REGISTER_CACHE_PROXY = 32;  // 2^5
 }

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:bazel_config_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:cache_go_proto",
+        "//proto:cache_proxy_go_proto",
         "//proto:capability_go_proto",
         "//proto:encryption_go_proto",
         "//proto:eventlog_go_proto",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -57,6 +57,7 @@ import (
 	bzpb "github.com/buildbuddy-io/buildbuddy/proto/bazel_config"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
+	cppb "github.com/buildbuddy-io/buildbuddy/proto/cache_proxy"
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	enpb "github.com/buildbuddy-io/buildbuddy/proto/encryption"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
@@ -1626,6 +1627,10 @@ func (s *BuildBuddyServer) GetExecutionNodes(ctx context.Context, req *scpb.GetE
 		res, err := ss.GetExecutionNodes(ctx, req)
 		return res, err
 	}
+	return nil, status.UnimplementedError("Not implemented")
+}
+
+func (s *BuildBuddyServer) GetCacheProxies(ctx context.Context, req *cppb.GetCacheProxiesRequest) (*cppb.GetCacheProxiesResponse, error) {
 	return nil, status.UnimplementedError("Not implemented")
 }
 

--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -195,6 +195,8 @@ var (
 		buildBuddyServicePrefix + "InvalidateAllSnapshotsForRepo",
 		// RBE deployment view
 		buildBuddyServicePrefix + "GetExecutionNodes",
+		// Cache proxy deployment view
+		buildBuddyServicePrefix + "GetCacheProxies",
 		// BuildBuddy usage data
 		buildBuddyServicePrefix + "GetUsage",
 		buildBuddyServicePrefix + "GetUsageAlertingRules",


### PR DESCRIPTION
Groundwork for a new "cache proxy API key" feature, modeled after the existing executor API key. The plan is that a cache proxy will be started with a --cache_proxy.api_key flag and will open a bidi heartbeat stream to the main app, and the app will track live proxies in Redis and surface them on a new /cache-proxies admin page. This PR is just the proto layer: a new REGISTER_CACHE_PROXY capability bit, the cache_proxy.proto service / messages, and a GetCacheProxies RPC hung off BuildBuddyService for the UI to consume. The server-side registry, the proxy-side registration loop, and the frontend page will follow as separate PRs once the protos are in.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/6869