### PR TITLE
[codex] Add OIDC token support for RBE actions

### DIFF
--- a/docs/rbe-platforms.md
+++ b/docs/rbe-platforms.md
@@ -403,6 +403,52 @@ just a historical artifact.)
 
 Please consult [RBE secrets](secrets) for more information on the related properties.
 
+### OpenID Connect tokens
+
+BuildBuddy RBE can expose an OpenID Connect token request flow to an action.
+This is useful for fetching short-lived cloud credentials without passing
+long-lived secrets into the action environment.
+
+To enable this for an action, set `oidc-token-audience` to the default audience
+that requested ID tokens should use. For AWS STS, use `sts.amazonaws.com`:
+
+```python title="BUILD"
+sh_binary(
+    name = "deploy",
+    srcs = ["deploy.sh"],
+    exec_properties = {
+        "oidc-token-audience": "sts.amazonaws.com",
+    },
+)
+```
+
+When the property is set, BuildBuddy injects
+`BUILDBUDDY_OIDC_TOKEN_REQUEST_URL` and
+`BUILDBUDDY_OIDC_TOKEN_REQUEST_TOKEN` into the action environment. The request
+token is redacted from action cache entries and workflow logs. The token
+endpoint accepts an optional `audience` query parameter; if omitted, it uses the
+`oidc-token-audience` value.
+
+Self-hosted BuildBuddy deployments must configure
+`remote_execution.oidc.private_key` on the app and executors to enable this
+feature. The OIDC issuer is `https://YOUR_BUILDBUDDY_URL/oidc`; discovery and
+JWKS are published below that issuer.
+
+For AWS IAM, configure an OIDC identity provider for the BuildBuddy issuer and
+scope the role trust policy to the BuildBuddy group subject. In IAM condition
+keys, use the issuer host and path without the `https://` prefix:
+
+```json
+{
+  "Condition": {
+    "StringEquals": {
+      "buildbuddy.example.com/oidc:aud": "sts.amazonaws.com",
+      "buildbuddy.example.com/oidc:sub": "buildbuddy:group:GR123"
+    }
+  }
+}
+```
+
 ### Docker daemon support
 
 For `firecracker` isolation, we support starting a [Docker daemon](https://docs.docker.com/config/daemon/)

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//enterprise/server/quota",
         "//enterprise/server/registry",
         "//enterprise/server/remote_execution/execution_server",
+        "//enterprise/server/remote_execution/oidc",
         "//enterprise/server/remote_execution/redis_client",
         "//enterprise/server/remote_execution/snaploader",
         "//enterprise/server/scheduling/scheduler_server",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/quota"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/registry"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/execution_server"
+	rbeoidc "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/oidc"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
@@ -348,6 +349,9 @@ func main() {
 	defer executionCleanupService.Stop()
 
 	if err := selfauth.Register(realEnv); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := rbeoidc.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
 

--- a/enterprise/server/remote_execution/executorplatform/BUILD
+++ b/enterprise/server/remote_execution/executorplatform/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["executorplatform.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executorplatform",
     deps = [
+        "//enterprise/server/remote_execution/oidc",
         "//enterprise/server/util/ci_runner_env",
         "//proto:remote_execution_go_proto",
         "//server/environment",
@@ -25,11 +26,14 @@ go_test(
     srcs = ["executorplatform_test.go"],
     embed = [":executorplatform"],
     deps = [
+        "//enterprise/server/remote_execution/oidc",
         "//enterprise/server/util/ci_runner_env",
         "//proto:remote_execution_go_proto",
         "//server/testutil/testenv",
+        "//server/util/claims",
         "//server/util/platform",
         "//server/util/testing/flags",
+        "@com_github_golang_jwt_jwt_v4//:jwt",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/executorplatform/executorplatform.go
+++ b/enterprise/server/remote_execution/executorplatform/executorplatform.go
@@ -3,6 +3,7 @@
 package executorplatform
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	rbeoidc "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/oidc"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ci_runner_env"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -223,10 +225,11 @@ func registerSecretEnvVarNames(command *repb.Command, secretOverrides []string) 
 
 // ApplyOverrides modifies the platformProps and command as needed to match the
 // locally configured executor properties.
-func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, platformProps *platform.Properties, command *repb.Command) error {
+func ApplyOverrides(ctx context.Context, env environment.Env, executorProps *ExecutorProperties, platformProps *platform.Properties, task *repb.ExecutionTask) error {
 	if len(executorProps.SupportedIsolationTypes) == 0 {
 		return status.FailedPreconditionError("No workload isolation types configured.")
 	}
+	command := task.GetCommand()
 
 	// If VFS is not enabled then coerce the platform prop to false.
 	if !*enableVFS {
@@ -316,8 +319,18 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 		command.Arguments = append(tokens, command.Arguments...)
 	}
 
-	additionalEnvVars := append(*extraEnvVars, platformProps.EnvOverrides...)
-	additionalEnvVars = append(additionalEnvVars, platformProps.SecretEnvOverrides...)
+	additionalEnvVars := append([]string{}, *extraEnvVars...)
+	additionalEnvVars = append(additionalEnvVars, platformProps.EnvOverrides...)
+	secretEnvOverrides := append([]string{}, platformProps.SecretEnvOverrides...)
+	if platformProps.OIDCTokenAudience != "" {
+		oidcEnvVars, oidcSecretEnvVars, err := rbeoidc.GenerateRequestEnv(ctx, env, task, platformProps.OIDCTokenAudience)
+		if err != nil {
+			return err
+		}
+		additionalEnvVars = append(additionalEnvVars, oidcEnvVars...)
+		secretEnvOverrides = append(secretEnvOverrides, oidcSecretEnvVars...)
+	}
+	additionalEnvVars = append(additionalEnvVars, secretEnvOverrides...)
 	for _, e := range additionalEnvVars {
 		name, value, hasValue := strings.Cut(e, "=")
 		if !hasValue {
@@ -330,7 +343,7 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 		})
 	}
 
-	if err := registerSecretEnvVarNames(command, platformProps.SecretEnvOverrides); err != nil {
+	if err := registerSecretEnvVarNames(command, secretEnvOverrides); err != nil {
 		return err
 	}
 

--- a/enterprise/server/remote_execution/executorplatform/executorplatform_test.go
+++ b/enterprise/server/remote_execution/executorplatform/executorplatform_test.go
@@ -1,15 +1,24 @@
 package executorplatform
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
+	rbeoidc "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/oidc"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ci_runner_env"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	authclaims "github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +33,10 @@ var (
 	docker               = &ExecutorProperties{SupportedIsolationTypes: []platform.ContainerType{platform.DockerContainerType}}
 	podmanAndFirecracker = &ExecutorProperties{SupportedIsolationTypes: []platform.ContainerType{platform.PodmanContainerType, platform.FirecrackerContainerType}}
 )
+
+func taskForCommand(command *repb.Command) *repb.ExecutionTask {
+	return &repb.ExecutionTask{Command: command}
+}
 
 func TestParse_ContainerImage_Success(t *testing.T) {
 	flags.Set(t, "executor.container_registry_region", "us-test1")
@@ -59,7 +72,7 @@ func TestParse_ContainerImage_Success(t *testing.T) {
 		require.NoError(t, err)
 		env := testenv.GetTestEnv(t)
 		env.SetXcodeLocator(&xcodeLocator{})
-		err = ApplyOverrides(env, testCase.execProps, platformProps, &repb.Command{})
+		err = ApplyOverrides(context.Background(), env, testCase.execProps, platformProps, taskForCommand(&repb.Command{}))
 		require.NoError(t, err)
 		assert.Equal(t, testCase.expected, platformProps.ContainerImage, testCase)
 	}
@@ -84,7 +97,7 @@ func TestParse_ContainerImage_Error(t *testing.T) {
 		require.NoError(t, err)
 		env := testenv.GetTestEnv(t)
 		env.SetXcodeLocator(&xcodeLocator{})
-		err = ApplyOverrides(env, testCase.execProps, platformProps, &repb.Command{})
+		err = ApplyOverrides(context.Background(), env, testCase.execProps, platformProps, taskForCommand(&repb.Command{}))
 		assert.Error(t, err)
 	}
 }
@@ -273,7 +286,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 				"MacOSX11.3": "Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk",
 			},
 		})
-		err = ApplyOverrides(env, execProps, platformProps, command)
+		err = ApplyOverrides(context.Background(), env, execProps, platformProps, taskForCommand(command))
 		if testCase.errorExpected {
 			require.Error(t, err)
 		} else {
@@ -301,7 +314,7 @@ func TestEnvAndArgOverrides(t *testing.T) {
 		},
 	}
 	env := testenv.GetTestEnv(t)
-	err = ApplyOverrides(env, execProps, platformProps, command)
+	err = ApplyOverrides(context.Background(), env, execProps, platformProps, taskForCommand(command))
 	require.NoError(t, err)
 
 	expectedCmd := &repb.Command{
@@ -327,6 +340,63 @@ func TestEnvAndArgOverrides(t *testing.T) {
 	commandText, err := prototext.Marshal(command)
 	require.NoError(t, err)
 	require.Equal(t, expectedCmdText, commandText)
+}
+
+func TestOIDCTokenEnv(t *testing.T) {
+	key := setOIDCSigningKey(t)
+	plat := &repb.Platform{Properties: []*repb.Platform_Property{
+		{Name: platform.OIDCTokenAudiencePropertyName, Value: "sts.amazonaws.com"},
+	}}
+	platformProps, err := platform.ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+	require.NoError(t, err)
+	command := &repb.Command{
+		Arguments: []string{"./some_cmd"},
+		Platform:  plat,
+	}
+	task := &repb.ExecutionTask{
+		Command:      command,
+		InvocationId: "INV123",
+		ExecutionId:  "EXEC123",
+		RequestMetadata: &repb.RequestMetadata{
+			ActionId:       "ACTION123",
+			TargetId:       "//pkg:target",
+			ActionMnemonic: "Genrule",
+		},
+	}
+	ctx := authclaims.AuthContext(context.Background(), &authclaims.Claims{
+		GroupID: "GR123",
+		UserID:  "US456",
+	})
+	env := testenv.GetTestEnv(t)
+	setBuildBuddyURL(t, "https://buildbuddy.example.com")
+	err = ApplyOverrides(ctx, env, bare, platformProps, task)
+	require.NoError(t, err)
+
+	requestURL, ok := envValue(command, rbeoidc.TokenRequestURLEnvVar)
+	require.True(t, ok)
+	require.Equal(t, "https://buildbuddy.example.com/oidc/token?api-version=2", requestURL)
+
+	requestToken, ok := envValue(command, rbeoidc.TokenRequestTokenEnvVar)
+	require.True(t, ok)
+	requestClaims := jwt.MapClaims{}
+	parsed, err := jwt.ParseWithClaims(requestToken, requestClaims, func(token *jwt.Token) (interface{}, error) {
+		return &key.PublicKey, nil
+	})
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	require.Equal(t, "buildbuddy:group:GR123", requestClaims["sub"])
+	require.Equal(t, "sts.amazonaws.com", requestClaims["default_audience"])
+	require.Equal(t, "GR123", requestClaims["buildbuddy_group_id"])
+	require.Equal(t, "US456", requestClaims["buildbuddy_user_id"])
+	require.Equal(t, "INV123", requestClaims["buildbuddy_invocation_id"])
+	require.Equal(t, "EXEC123", requestClaims["buildbuddy_execution_id"])
+	require.Equal(t, "ACTION123", requestClaims["buildbuddy_action_id"])
+	require.Equal(t, "//pkg:target", requestClaims["buildbuddy_target_id"])
+	require.Equal(t, "Genrule", requestClaims["buildbuddy_action_mnemonic"])
+
+	redactedNames, ok := envValue(command, ci_runner_env.BuildBuddySecretEnvVarNamesForRedaction)
+	require.True(t, ok)
+	require.JSONEq(t, `["BUILDBUDDY_OIDC_TOKEN_REQUEST_TOKEN"]`, redactedNames)
 }
 
 func TestRunUnder(t *testing.T) {
@@ -369,11 +439,40 @@ func TestRunUnder(t *testing.T) {
 			require.NoError(t, err)
 			command := &repb.Command{Arguments: tc.initialArgs}
 			env := testenv.GetTestEnv(t)
-			err = ApplyOverrides(env, bare, platformProps, command)
+			err = ApplyOverrides(context.Background(), env, bare, platformProps, taskForCommand(command))
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedArgs, command.Arguments)
 		})
 	}
+}
+
+func envValue(command *repb.Command, name string) (string, bool) {
+	for _, envVar := range command.GetEnvironmentVariables() {
+		if envVar.GetName() == name {
+			return envVar.GetValue(), true
+		}
+	}
+	return "", false
+}
+
+func setOIDCSigningKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: der,
+	})
+	flags.Set(t, "remote_execution.oidc.private_key", string(pemBytes))
+	return key
+}
+
+func setBuildBuddyURL(t *testing.T, rawURL string) {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 }
 
 func TestExtraEnvVars(t *testing.T) {
@@ -411,7 +510,7 @@ func TestExtraEnvVars(t *testing.T) {
 			env := testenv.GetTestEnv(t)
 			cmd := &repb.Command{}
 			platformProps := &platform.Properties{}
-			ApplyOverrides(env, podmanAndFirecracker, platformProps, cmd)
+			ApplyOverrides(context.Background(), env, podmanAndFirecracker, platformProps, taskForCommand(cmd))
 			require.Empty(t, cmp.Diff(
 				tc.expectedEnvVars,
 				cmd.EnvironmentVariables,
@@ -514,7 +613,7 @@ func TestForceNetworkIsolationType(t *testing.T) {
 		require.NoError(t, err)
 		env := testenv.GetTestEnv(t)
 		env.SetXcodeLocator(&xcodeLocator{})
-		err = ApplyOverrides(env, podmanAndFirecracker, platformProps, &repb.Command{})
+		err = ApplyOverrides(context.Background(), env, podmanAndFirecracker, platformProps, taskForCommand(&repb.Command{}))
 		assert.NoError(t, err)
 		assert.Equal(t, testCase.expectedIsolationType, platformProps.WorkloadIsolationType, testCase)
 	}

--- a/enterprise/server/remote_execution/oidc/BUILD
+++ b/enterprise/server/remote_execution/oidc/BUILD
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "oidc",
+    srcs = ["oidc.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/oidc",
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/endpoint_urls/build_buddy_url",
+        "//server/environment",
+        "//server/http/interceptors",
+        "//server/util/claims",
+        "//server/util/flag",
+        "//server/util/platform",
+        "//server/util/status",
+        "@com_github_golang_jwt_jwt_v4//:jwt",
+        "@com_github_google_uuid//:uuid",
+    ],
+)
+
+go_test(
+    name = "oidc_test",
+    size = "small",
+    srcs = ["oidc_test.go"],
+    embed = [":oidc"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/testutil/testenv",
+        "//server/util/claims",
+        "//server/util/testing/flags",
+        "@com_github_golang_jwt_jwt_v4//:jwt",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/remote_execution/oidc/oidc.go
+++ b/enterprise/server/remote_execution/oidc/oidc.go
@@ -1,0 +1,438 @@
+// Package oidc implements an OpenID Connect provider for BuildBuddy RBE actions.
+package oidc
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+const (
+	TokenRequestURLEnvVar   = "BUILDBUDDY_OIDC_TOKEN_REQUEST_URL"
+	TokenRequestTokenEnvVar = "BUILDBUDDY_OIDC_TOKEN_REQUEST_TOKEN"
+
+	issuerPath    = "/oidc"
+	wellKnownPath = issuerPath + "/.well-known/openid-configuration"
+	jwksPath      = issuerPath + "/.well-known/jwks"
+	tokenPath     = issuerPath + "/token"
+
+	requestTokenAudience = "buildbuddy-rbe-oidc-token-request"
+	runnerEnvironment    = "buildbuddy-rbe"
+
+	requestTokenUse = "buildbuddy-rbe-oidc-request-token"
+	idTokenUse      = "id_token"
+)
+
+var (
+	signingKeyPEM        = flag.String("remote_execution.oidc.private_key", "", "PEM-encoded RSA private key used to sign OIDC tokens for RBE actions. Configure this on the app and executors to enable the `oidc-token-audience` platform property.", flag.Secret)
+	tokenLifetime        = flag.Duration("remote_execution.oidc.token_lifetime", 5*time.Minute, "Lifetime of OIDC ID tokens minted for RBE actions.")
+	requestTokenLifetime = flag.Duration("remote_execution.oidc.request_token_lifetime", 15*time.Minute, "Lifetime of bearer tokens injected into RBE actions for requesting OIDC ID tokens.")
+)
+
+type Provider struct {
+	env   environment.Env
+	key   *rsa.PrivateKey
+	keyID string
+}
+
+type configurationJSON struct {
+	Issuer                           string   `json:"issuer"`
+	JwksURI                          string   `json:"jwks_uri"`
+	TokenEndpoint                    string   `json:"token_endpoint,omitempty"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	ClaimsSupported                  []string `json:"claims_supported"`
+	IdTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	ScopesSupported                  []string `json:"scopes_supported"`
+}
+
+type jwksJSON struct {
+	Keys []*jwkJSON `json:"keys"`
+}
+
+type jwkJSON struct {
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+type tokenResponse struct {
+	Value string `json:"value"`
+}
+
+type requestClaims struct {
+	jwt.StandardClaims
+
+	TokenUse          string `json:"token_use,omitempty"`
+	DefaultAudience   string `json:"default_audience,omitempty"`
+	BuildBuddyGroupID string `json:"buildbuddy_group_id,omitempty"`
+	BuildBuddyUserID  string `json:"buildbuddy_user_id,omitempty"`
+	InvocationID      string `json:"buildbuddy_invocation_id,omitempty"`
+	ExecutionID       string `json:"buildbuddy_execution_id,omitempty"`
+	InstanceName      string `json:"buildbuddy_instance_name,omitempty"`
+	ActionDigest      string `json:"buildbuddy_action_digest,omitempty"`
+	ActionID          string `json:"buildbuddy_action_id,omitempty"`
+	TargetID          string `json:"buildbuddy_target_id,omitempty"`
+	ActionMnemonic    string `json:"buildbuddy_action_mnemonic,omitempty"`
+	RunnerEnvironment string `json:"runner_environment,omitempty"`
+}
+
+type idTokenClaims struct {
+	jwt.StandardClaims
+
+	TokenUse          string `json:"token_use,omitempty"`
+	BuildBuddyGroupID string `json:"buildbuddy_group_id,omitempty"`
+	BuildBuddyUserID  string `json:"buildbuddy_user_id,omitempty"`
+	InvocationID      string `json:"buildbuddy_invocation_id,omitempty"`
+	ExecutionID       string `json:"buildbuddy_execution_id,omitempty"`
+	InstanceName      string `json:"buildbuddy_instance_name,omitempty"`
+	ActionDigest      string `json:"buildbuddy_action_digest,omitempty"`
+	ActionID          string `json:"buildbuddy_action_id,omitempty"`
+	TargetID          string `json:"buildbuddy_target_id,omitempty"`
+	ActionMnemonic    string `json:"buildbuddy_action_mnemonic,omitempty"`
+	RunnerEnvironment string `json:"runner_environment,omitempty"`
+}
+
+func Register(env environment.Env) error {
+	if strings.TrimSpace(*signingKeyPEM) == "" {
+		return nil
+	}
+	provider, err := NewProvider(env)
+	if err != nil {
+		return err
+	}
+	mux := env.GetMux()
+	mux.Handle(wellKnownPath, interceptors.SetSecurityHeaders(http.HandlerFunc(provider.WellKnownOpenIDConfiguration)))
+	mux.Handle(jwksPath, interceptors.SetSecurityHeaders(http.HandlerFunc(provider.JWKS)))
+	mux.Handle(tokenPath, interceptors.SetSecurityHeaders(http.HandlerFunc(provider.Token)))
+	return nil
+}
+
+func NewProvider(env environment.Env) (*Provider, error) {
+	key, keyID, err := signingKey()
+	if err != nil {
+		return nil, err
+	}
+	return &Provider{
+		env:   env,
+		key:   key,
+		keyID: keyID,
+	}, nil
+}
+
+func GenerateRequestEnv(ctx context.Context, env environment.Env, task *repb.ExecutionTask, defaultAudience string) ([]string, []string, error) {
+	defaultAudience = strings.TrimSpace(defaultAudience)
+	if defaultAudience == "" {
+		return nil, nil, status.InvalidArgumentErrorf("%s must be set to a non-empty audience", platform.OIDCTokenAudiencePropertyName)
+	}
+	token, err := GenerateRequestToken(ctx, env, task, defaultAudience)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := tokenEndpoint()
+	q := u.Query()
+	q.Set("api-version", "2")
+	u.RawQuery = q.Encode()
+	return []string{
+			fmt.Sprintf("%s=%s", TokenRequestURLEnvVar, u.String()),
+		}, []string{
+			fmt.Sprintf("%s=%s", TokenRequestTokenEnvVar, token),
+		}, nil
+}
+
+func GenerateRequestToken(ctx context.Context, env environment.Env, task *repb.ExecutionTask, defaultAudience string) (string, error) {
+	defaultAudience = strings.TrimSpace(defaultAudience)
+	if defaultAudience == "" {
+		return "", status.InvalidArgumentErrorf("%s must be set to a non-empty audience", platform.OIDCTokenAudiencePropertyName)
+	}
+	if defaultAudience == requestTokenAudience {
+		return "", status.InvalidArgumentErrorf("%s cannot be used as an ID token audience", requestTokenAudience)
+	}
+	key, keyID, err := signingKey()
+	if err != nil {
+		return "", err
+	}
+	authClaims, err := claims.ClaimsFromContext(ctx)
+	if err != nil {
+		return "", status.PermissionDeniedErrorf("OIDC token requests require an authenticated BuildBuddy user: %s", err)
+	}
+	groupID := authClaims.GetGroupID()
+	if groupID == "" {
+		return "", status.PermissionDeniedError("OIDC token requests require an authenticated BuildBuddy group")
+	}
+
+	now := env.GetClock().Now()
+	rc := &requestClaims{
+		StandardClaims: jwt.StandardClaims{
+			Audience:  requestTokenAudience,
+			ExpiresAt: now.Add(*requestTokenLifetime).Unix(),
+			Id:        uuid.NewString(),
+			IssuedAt:  now.Unix(),
+			Issuer:    issuerURL().String(),
+			NotBefore: now.Unix(),
+			Subject:   subject(groupID),
+		},
+		TokenUse:          requestTokenUse,
+		DefaultAudience:   defaultAudience,
+		BuildBuddyGroupID: groupID,
+		BuildBuddyUserID:  authClaims.GetUserID(),
+		RunnerEnvironment: runnerEnvironment,
+	}
+	if task != nil {
+		rc.InvocationID = task.GetInvocationId()
+		rc.ExecutionID = task.GetExecutionId()
+		if req := task.GetExecuteRequest(); req != nil {
+			rc.InstanceName = req.GetInstanceName()
+			if d := req.GetActionDigest(); d != nil {
+				rc.ActionDigest = fmt.Sprintf("%s/%d", d.GetHash(), d.GetSizeBytes())
+			}
+		}
+		if md := task.GetRequestMetadata(); md != nil {
+			rc.ActionID = md.GetActionId()
+			rc.TargetID = md.GetTargetId()
+			rc.ActionMnemonic = md.GetActionMnemonic()
+		}
+	}
+
+	return sign(key, keyID, rc)
+}
+
+func (p *Provider) WellKnownOpenIDConfiguration(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, &configurationJSON{
+		Issuer:        issuerURL().String(),
+		JwksURI:       jwksEndpoint().String(),
+		TokenEndpoint: tokenEndpoint().String(),
+		SubjectTypesSupported: []string{
+			"public",
+		},
+		ResponseTypesSupported: []string{
+			"id_token",
+		},
+		ClaimsSupported: []string{
+			"sub",
+			"aud",
+			"exp",
+			"iat",
+			"iss",
+			"jti",
+			"nbf",
+			"token_use",
+			"runner_environment",
+			"buildbuddy_group_id",
+			"buildbuddy_user_id",
+			"buildbuddy_invocation_id",
+			"buildbuddy_execution_id",
+			"buildbuddy_instance_name",
+			"buildbuddy_action_digest",
+			"buildbuddy_action_id",
+			"buildbuddy_target_id",
+			"buildbuddy_action_mnemonic",
+		},
+		IdTokenSigningAlgValuesSupported: []string{
+			"RS256",
+		},
+		ScopesSupported: []string{
+			"openid",
+		},
+	})
+}
+
+func (p *Provider) JWKS(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, &jwksJSON{
+		Keys: []*jwkJSON{
+			publicJWK(&p.key.PublicKey, p.keyID),
+		},
+	})
+}
+
+func (p *Provider) Token(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	requestToken, ok := bearerToken(r.Header.Get("Authorization"))
+	if !ok {
+		http.Error(w, "missing bearer token", http.StatusUnauthorized)
+		return
+	}
+	rc, err := p.parseRequestToken(requestToken)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	audience := strings.TrimSpace(r.URL.Query().Get("audience"))
+	if audience == "" {
+		audience = rc.DefaultAudience
+	}
+	if audience == "" {
+		http.Error(w, "missing audience", http.StatusBadRequest)
+		return
+	}
+	if audience == requestTokenAudience {
+		http.Error(w, fmt.Sprintf("%s cannot be used as an ID token audience", requestTokenAudience), http.StatusBadRequest)
+		return
+	}
+	idToken, err := p.idToken(rc, audience)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, &tokenResponse{Value: idToken})
+}
+
+func (p *Provider) parseRequestToken(tokenString string) (*requestClaims, error) {
+	rc := &requestClaims{}
+	token, err := jwt.ParseWithClaims(tokenString, rc, func(token *jwt.Token) (interface{}, error) {
+		if token.Method != jwt.SigningMethodRS256 {
+			return nil, fmt.Errorf("unexpected signing method %q", token.Method.Alg())
+		}
+		if kid, _ := token.Header["kid"].(string); kid != "" && kid != p.keyID {
+			return nil, fmt.Errorf("unknown key ID %q", kid)
+		}
+		return &p.key.PublicKey, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !token.Valid {
+		return nil, status.PermissionDeniedError("invalid request token")
+	}
+	if rc.Issuer != issuerURL().String() {
+		return nil, status.PermissionDeniedErrorf("invalid issuer %q", rc.Issuer)
+	}
+	if rc.Audience != requestTokenAudience {
+		return nil, status.PermissionDeniedErrorf("invalid audience %q", rc.Audience)
+	}
+	if rc.TokenUse != requestTokenUse {
+		return nil, status.PermissionDeniedErrorf("invalid token use %q", rc.TokenUse)
+	}
+	if rc.BuildBuddyGroupID == "" {
+		return nil, status.PermissionDeniedError("missing BuildBuddy group ID")
+	}
+	if rc.Subject == "" {
+		rc.Subject = subject(rc.BuildBuddyGroupID)
+	}
+	return rc, nil
+}
+
+func (p *Provider) idToken(rc *requestClaims, audience string) (string, error) {
+	now := p.env.GetClock().Now()
+	idc := &idTokenClaims{
+		StandardClaims: jwt.StandardClaims{
+			Audience:  audience,
+			ExpiresAt: now.Add(*tokenLifetime).Unix(),
+			Id:        uuid.NewString(),
+			IssuedAt:  now.Unix(),
+			Issuer:    issuerURL().String(),
+			NotBefore: now.Unix(),
+			Subject:   rc.Subject,
+		},
+		TokenUse:          idTokenUse,
+		BuildBuddyGroupID: rc.BuildBuddyGroupID,
+		BuildBuddyUserID:  rc.BuildBuddyUserID,
+		InvocationID:      rc.InvocationID,
+		ExecutionID:       rc.ExecutionID,
+		InstanceName:      rc.InstanceName,
+		ActionDigest:      rc.ActionDigest,
+		ActionID:          rc.ActionID,
+		TargetID:          rc.TargetID,
+		ActionMnemonic:    rc.ActionMnemonic,
+		RunnerEnvironment: runnerEnvironment,
+	}
+	return sign(p.key, p.keyID, idc)
+}
+
+func signingKey() (*rsa.PrivateKey, string, error) {
+	pem := strings.TrimSpace(*signingKeyPEM)
+	if pem == "" {
+		return nil, "", status.FailedPreconditionError("remote_execution.oidc.private_key must be configured to use RBE OIDC")
+	}
+	pem = strings.ReplaceAll(pem, `\n`, "\n")
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(pem))
+	if err != nil {
+		return nil, "", status.InvalidArgumentErrorf("parse remote_execution.oidc.private_key: %s", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, "", status.InternalErrorf("marshal OIDC public key: %s", err)
+	}
+	sum := sha256.Sum256(der)
+	return key, base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}
+
+func sign(key *rsa.PrivateKey, keyID string, c jwt.Claims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, c)
+	token.Header["kid"] = keyID
+	token.Header["typ"] = "JWT"
+	return token.SignedString(key)
+}
+
+func issuerURL() *url.URL {
+	return build_buddy_url.WithPath(issuerPath)
+}
+
+func jwksEndpoint() *url.URL {
+	return build_buddy_url.WithPath(jwksPath)
+}
+
+func tokenEndpoint() *url.URL {
+	return build_buddy_url.WithPath(tokenPath)
+}
+
+func publicJWK(key *rsa.PublicKey, keyID string) *jwkJSON {
+	return &jwkJSON{
+		Kty: "RSA",
+		Use: "sig",
+		Kid: keyID,
+		Alg: "RS256",
+		N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	}
+}
+
+func subject(groupID string) string {
+	return "buildbuddy:group:" + escapeSubjectValue(groupID)
+}
+
+func escapeSubjectValue(s string) string {
+	return strings.ReplaceAll(s, ":", "%3A")
+}
+
+func bearerToken(header string) (string, bool) {
+	scheme, token, ok := strings.Cut(strings.TrimSpace(header), " ")
+	if !ok || !strings.EqualFold(scheme, "bearer") || strings.TrimSpace(token) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(token), true
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/enterprise/server/remote_execution/oidc/oidc_test.go
+++ b/enterprise/server/remote_execution/oidc/oidc_test.go
@@ -1,0 +1,237 @@
+package oidc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	authclaims "github.com/buildbuddy-io/buildbuddy/server/util/claims"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestGenerateRequestEnvAndToken(t *testing.T) {
+	key := setSigningKey(t)
+	env := testenv.GetTestEnv(t)
+	setBuildBuddyURL(t, "https://buildbuddy.example.com")
+	ctx := authclaims.AuthContext(context.Background(), &authclaims.Claims{
+		GroupID: "GR123",
+		UserID:  "US456",
+	})
+	task := &repb.ExecutionTask{
+		InvocationId: "INV123",
+		ExecutionId:  "EXEC123",
+		ExecuteRequest: &repb.ExecuteRequest{
+			InstanceName: "remote/instance",
+			ActionDigest: &repb.Digest{Hash: "abc123", SizeBytes: 42},
+		},
+		RequestMetadata: &repb.RequestMetadata{
+			ActionId:       "ACTION123",
+			TargetId:       "//pkg:target",
+			ActionMnemonic: "Genrule",
+		},
+	}
+
+	envVars, secretEnvVars, err := GenerateRequestEnv(ctx, env, task, "sts.amazonaws.com")
+	require.NoError(t, err)
+	require.Len(t, envVars, 1)
+	require.Len(t, secretEnvVars, 1)
+	require.Equal(t, TokenRequestURLEnvVar+"=https://buildbuddy.example.com/oidc/token?api-version=2", envVars[0])
+	require.True(t, strings.HasPrefix(secretEnvVars[0], TokenRequestTokenEnvVar+"="))
+
+	requestToken := strings.TrimPrefix(secretEnvVars[0], TokenRequestTokenEnvVar+"=")
+	provider, err := NewProvider(env)
+	require.NoError(t, err)
+	rc, err := provider.parseRequestToken(requestToken)
+	require.NoError(t, err)
+	require.Equal(t, requestTokenUse, rc.TokenUse)
+	require.Equal(t, "sts.amazonaws.com", rc.DefaultAudience)
+	require.Equal(t, "buildbuddy:group:GR123", rc.Subject)
+	require.Equal(t, "GR123", rc.BuildBuddyGroupID)
+	require.Equal(t, "US456", rc.BuildBuddyUserID)
+	require.Equal(t, "INV123", rc.InvocationID)
+	require.Equal(t, "EXEC123", rc.ExecutionID)
+	require.Equal(t, "remote/instance", rc.InstanceName)
+	require.Equal(t, "abc123/42", rc.ActionDigest)
+	require.Equal(t, "ACTION123", rc.ActionID)
+	require.Equal(t, "//pkg:target", rc.TargetID)
+	require.Equal(t, "Genrule", rc.ActionMnemonic)
+
+	req := httptest.NewRequest(http.MethodGet, "/oidc/token?audience=override-audience", nil)
+	req.Header.Set("Authorization", "bearer "+requestToken)
+	rec := httptest.NewRecorder()
+	provider.Token(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var tokenResp tokenResponse
+	require.NoError(t, jsonDecode(rec.Body.String(), &tokenResp))
+	idClaims := &idTokenClaims{}
+	parsed, err := jwt.ParseWithClaims(tokenResp.Value, idClaims, func(token *jwt.Token) (interface{}, error) {
+		return &key.PublicKey, nil
+	})
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	require.Equal(t, issuerURL().String(), idClaims.Issuer)
+	require.Equal(t, idTokenUse, idClaims.TokenUse)
+	require.Equal(t, "override-audience", idClaims.Audience)
+	require.Equal(t, "buildbuddy:group:GR123", idClaims.Subject)
+	require.Equal(t, "GR123", idClaims.BuildBuddyGroupID)
+	require.Equal(t, "US456", idClaims.BuildBuddyUserID)
+	require.Equal(t, "INV123", idClaims.InvocationID)
+	require.Equal(t, "EXEC123", idClaims.ExecutionID)
+	require.Equal(t, "remote/instance", idClaims.InstanceName)
+	require.Equal(t, "abc123/42", idClaims.ActionDigest)
+	require.Equal(t, "ACTION123", idClaims.ActionID)
+	require.Equal(t, "//pkg:target", idClaims.TargetID)
+	require.Equal(t, "Genrule", idClaims.ActionMnemonic)
+	require.Equal(t, runnerEnvironment, idClaims.RunnerEnvironment)
+}
+
+func TestTokenUsesDefaultAudience(t *testing.T) {
+	key := setSigningKey(t)
+	env := testenv.GetTestEnv(t)
+	setBuildBuddyURL(t, "https://buildbuddy.example.com")
+	ctx := authclaims.AuthContext(context.Background(), &authclaims.Claims{GroupID: "GR123"})
+	requestToken, err := GenerateRequestToken(ctx, env, &repb.ExecutionTask{}, "sts.amazonaws.com")
+	require.NoError(t, err)
+	provider, err := NewProvider(env)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oidc/token", nil)
+	req.Header.Set("Authorization", "Bearer "+requestToken)
+	rec := httptest.NewRecorder()
+	provider.Token(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var tokenResp tokenResponse
+	require.NoError(t, jsonDecode(rec.Body.String(), &tokenResp))
+	idClaims := &idTokenClaims{}
+	parsed, err := jwt.ParseWithClaims(tokenResp.Value, idClaims, func(token *jwt.Token) (interface{}, error) {
+		return &key.PublicKey, nil
+	})
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	require.Equal(t, "sts.amazonaws.com", idClaims.Audience)
+}
+
+func TestTokenRejectsInternalRequestTokenAudience(t *testing.T) {
+	setSigningKey(t)
+	env := testenv.GetTestEnv(t)
+	setBuildBuddyURL(t, "https://buildbuddy.example.com")
+	ctx := authclaims.AuthContext(context.Background(), &authclaims.Claims{GroupID: "GR123"})
+	_, err := GenerateRequestToken(ctx, env, &repb.ExecutionTask{}, requestTokenAudience)
+	require.Error(t, err)
+
+	requestToken, err := GenerateRequestToken(ctx, env, &repb.ExecutionTask{}, "sts.amazonaws.com")
+	require.NoError(t, err)
+	provider, err := NewProvider(env)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oidc/token?audience="+url.QueryEscape(requestTokenAudience), nil)
+	req.Header.Set("Authorization", "Bearer "+requestToken)
+	rec := httptest.NewRecorder()
+	provider.Token(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestIDTokenCannotBeUsedAsRequestToken(t *testing.T) {
+	key := setSigningKey(t)
+	env := testenv.GetTestEnv(t)
+	setBuildBuddyURL(t, "https://buildbuddy.example.com")
+	provider, err := NewProvider(env)
+	require.NoError(t, err)
+
+	now := env.GetClock().Now()
+	idClaims := &idTokenClaims{
+		StandardClaims: jwt.StandardClaims{
+			Audience:  requestTokenAudience,
+			ExpiresAt: now.Add(time.Minute).Unix(),
+			Issuer:    issuerURL().String(),
+			NotBefore: now.Unix(),
+			Subject:   subject("GR123"),
+		},
+		TokenUse:          idTokenUse,
+		BuildBuddyGroupID: "GR123",
+	}
+	idToken, err := sign(key, provider.keyID, idClaims)
+	require.NoError(t, err)
+
+	_, err = provider.parseRequestToken(idToken)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid token use")
+}
+
+func TestGenerateRequestTokenRequiresAuth(t *testing.T) {
+	setSigningKey(t)
+	env := testenv.GetTestEnv(t)
+	_, err := GenerateRequestToken(context.Background(), env, &repb.ExecutionTask{}, "sts.amazonaws.com")
+	require.Error(t, err)
+}
+
+func TestWellKnownAndJWKS(t *testing.T) {
+	setSigningKey(t)
+	env := testenv.GetTestEnv(t)
+	setBuildBuddyURL(t, "https://buildbuddy.example.com")
+	provider, err := NewProvider(env)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	provider.WellKnownOpenIDConfiguration(rec, httptest.NewRequest(http.MethodGet, wellKnownPath, nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var config configurationJSON
+	require.NoError(t, jsonDecode(rec.Body.String(), &config))
+	require.Equal(t, "https://buildbuddy.example.com/oidc", config.Issuer)
+	require.Equal(t, "https://buildbuddy.example.com/oidc/.well-known/jwks", config.JwksURI)
+	require.Contains(t, config.IdTokenSigningAlgValuesSupported, "RS256")
+	require.Contains(t, config.ClaimsSupported, "sub")
+
+	rec = httptest.NewRecorder()
+	provider.JWKS(rec, httptest.NewRequest(http.MethodGet, jwksPath, nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var keySet jwksJSON
+	require.NoError(t, jsonDecode(rec.Body.String(), &keySet))
+	require.Len(t, keySet.Keys, 1)
+	require.Equal(t, "RSA", keySet.Keys[0].Kty)
+	require.Equal(t, "sig", keySet.Keys[0].Use)
+	require.Equal(t, "RS256", keySet.Keys[0].Alg)
+	require.NotEmpty(t, keySet.Keys[0].Kid)
+	require.NotEmpty(t, keySet.Keys[0].N)
+	require.Equal(t, "AQAB", keySet.Keys[0].E)
+}
+
+func setSigningKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: der,
+	})
+	flags.Set(t, "remote_execution.oidc.private_key", string(pemBytes))
+	return key
+}
+
+func setBuildBuddyURL(t *testing.T, rawURL string) {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
+}
+
+func jsonDecode(s string, v interface{}) error {
+	return json.NewDecoder(strings.NewReader(s)).Decode(v)
+}

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -924,7 +924,7 @@ func (p *pool) warmupImage(ctx context.Context, cfg *WarmupConfig) error {
 	if err != nil {
 		return err
 	}
-	executorplatform.ApplyOverrides(p.env, executorplatform.GetExecutorProperties(), platProps, task.GetCommand())
+	executorplatform.ApplyOverrides(ctx, p.env, executorplatform.GetExecutorProperties(), platProps, task)
 	if *resolveImageDigests {
 		if err := p.resolveImageDigest(ctx, platProps); err != nil {
 			return err
@@ -1079,7 +1079,7 @@ func (p *pool) effectivePlatform(ctx context.Context, task *repb.ExecutionTask) 
 		return nil, err
 	}
 	// TODO: This mutates the task; find a cleaner way to do this.
-	if err := executorplatform.ApplyOverrides(p.env, executorplatform.GetExecutorProperties(), props, task.GetCommand()); err != nil {
+	if err := executorplatform.ApplyOverrides(ctx, p.env, executorplatform.GetExecutorProperties(), props, task); err != nil {
 		return nil, err
 	}
 	if *resolveImageDigests {

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -100,6 +100,7 @@ const (
 	EnvOverridesBase64PropertyName           = "env-overrides-base64"
 	SecretEnvOverridesPropertyName           = "secret-env-overrides"
 	SecretEnvOverridesBase64PropertyName     = "secret-env-overrides-base64"
+	OIDCTokenAudiencePropertyName            = "oidc-token-audience"
 	IncludeSecretsPropertyName               = "include-secrets"
 	EnvSecretsPropertyName                   = "env-secrets"
 	DefaultTimeoutPropertyName               = "default-timeout"
@@ -342,6 +343,10 @@ type Properties struct {
 	// applied as overrides to the action. These are always redacted in logs/UI.
 	SecretEnvOverrides []string
 
+	// OIDCTokenAudience enables the BuildBuddy RBE OIDC provider for this
+	// action and sets the default audience for requested ID tokens.
+	OIDCTokenAudience string
+
 	// OverrideSnapshotKey specifies a snapshot key that the action should start
 	// from.
 	// Only applies to recyclable firecracker actions.
@@ -580,6 +585,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		ExtraArgs:                 stringListProp(m, extraArgsPropertyName),
 		EnvOverrides:              envOverrides,
 		SecretEnvOverrides:        secretEnvOverrides,
+		OIDCTokenAudience:         stringProp(m, OIDCTokenAudiencePropertyName, ""),
 		OverrideSnapshotKey:       overrideSnapshotKey,
 		Retry:                     boolProp(m, RetryPropertyName, true),
 		PersistentVolumes:         persistentVolumes,


### PR DESCRIPTION
## Summary

- Adds an RBE OIDC provider with discovery, JWKS, and token endpoints.
- Injects OIDC token request URL and bearer token environment variables for actions that set the `oidc-token-audience` platform property.
- Wires OIDC registration into the enterprise server, updates executor platform handling, and documents the new platform property.

## Impact

RBE actions can request BuildBuddy-issued OIDC ID tokens scoped to an configured audience, with BuildBuddy group, user, invocation, execution, action, and runner metadata included in token claims.

## Validation

Not run, per request.