### PR TITLE
add range_id to session

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1342,11 +1342,26 @@ func errorEntry(err error) dbsm.Result {
 	}
 }
 
+// sessionPebbleKey returns the pebble key for a session's dedup record.
+// When range_id is set (Sender path), it is appended so each range gets
+// its own (id, range_id) namespace and a retry that crosses ranges on a
+// split does not collide with the destination range's entries. When unset
+// (local-direct callers like rangelease/bringup/deleteSessions), the key
+// stays `session-<id>` — same as before this field existed, so existing
+// entries remain readable across the upgrade.
+func sessionPebbleKey(s *rfpb.Session) []byte {
+	if s.GetRangeId() == 0 {
+		return keys.MakeKey(constants.SessionPrefix, s.GetId())
+	}
+	return keys.MakeKey(constants.SessionPrefix, s.GetId(),
+		[]byte(fmt.Sprintf("-%d", s.GetRangeId())))
+}
+
 func (sm *Replica) getLastRespFromSession(db ReplicaReader, reqSession *rfpb.Session) ([]byte, error) {
 	if reqSession == nil {
 		return nil, nil
 	}
-	sessionKey := keys.MakeKey(constants.SessionPrefix, reqSession.GetId())
+	sessionKey := sessionPebbleKey(reqSession)
 	buf, err := sm.lookup(db, sessionKey)
 	if err != nil {
 		if status.IsNotFoundError(err) {
@@ -1399,7 +1414,7 @@ func (sm *Replica) updateSession(wb pebble.Batch, reqSession *rfpb.Session, rspB
 	if err != nil {
 		return status.InternalErrorf("[%s] failed to marshal session: %w", sm.name(), err)
 	}
-	sessionKey := keys.MakeKey(constants.SessionPrefix, reqSession.GetId())
+	sessionKey := sessionPebbleKey(reqSession)
 	wb.Set(sm.replicaLocalKey(sessionKey), sessionBuf, nil)
 	return nil
 }

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1343,18 +1343,19 @@ func errorEntry(err error) dbsm.Result {
 }
 
 // sessionPebbleKey returns the pebble key for a session's dedup record.
-// When range_id is set (Sender path), it is appended so each range gets
-// its own (id, range_id) namespace and a retry that crosses ranges on a
-// split does not collide with the destination range's entries. When unset
-// (local-direct callers like rangelease/bringup/deleteSessions), the key
-// stays `session-<id>` — same as before this field existed, so existing
-// entries remain readable across the upgrade.
+// When the session has range ID set, the key namespaces the record by
+// session ID and range ID. During a split a retry can land on the right
+// range with range ID still set to the left range — that's fine, since
+// the dedup record for the session ID under the left range ID is a
+// different record than the right range's own entries under the right
+// range ID, so no collision. When unset, the key stays
+// `session-<session ID>`, matching pre-upgrade entries.
 func sessionPebbleKey(s *rfpb.Session) []byte {
 	if s.GetRangeId() == 0 {
 		return keys.MakeKey(constants.SessionPrefix, s.GetId())
 	}
 	return keys.MakeKey(constants.SessionPrefix, s.GetId(),
-		[]byte(fmt.Sprintf("-%d", s.GetRangeId())))
+		[]byte("/"+strconv.Itoa(int(s.GetRangeId()))))
 }
 
 func (sm *Replica) getLastRespFromSession(db ReplicaReader, reqSession *rfpb.Session) ([]byte, error) {

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -478,6 +478,74 @@ func TestSessionIndexMismatchError(t *testing.T) {
 	require.Contains(t, status.String(), fmt.Sprintf("session (id=\\\"%s\\\") index mismatch", session.Id))
 }
 
+// TestSessionRangeIDNamespace verifies that sessions are namespaced by
+// (id, range_id) on the replica: a write with the same id+lower-index but
+// a different range_id does not collide with a prior write. This is what
+// makes cross-range retries (e.g. after a split) safe — they will miss
+// dedup on the destination range rather than getting stuck behind a
+// stored entry that happens to share the same id.
+func TestSessionRangeIDNamespace(t *testing.T) {
+	repl := testutil.NewTestingReplica(t, 1, 1)
+	require.NotNil(t, repl)
+	t.Cleanup(func() {
+		err := repl.Close()
+		require.NoError(t, err)
+	})
+
+	stopc := make(chan struct{})
+	lastAppliedIndex, err := repl.Open(stopc)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), lastAppliedIndex)
+	em := newEntryMaker(t)
+	writeDefaultRangeDescriptor(t, em, repl.Replica)
+
+	id := []byte(uuid.New())
+
+	// errorMessage returns the encoded gRPC status from a state-machine
+	// entry result, or empty string if the result is not an error.
+	errorMessage := func(r dbsm.Result) string {
+		if int(r.Value) != constants.EntryErrorValue {
+			return ""
+		}
+		st := &statuspb.Status{}
+		require.NoError(t, proto.Unmarshal(r.Data, st))
+		return st.String()
+	}
+
+	// Write with (id, idx=5, range_id=2). Stores dedup record under
+	// `session-<id>-2`.
+	sessionA := &rfpb.Session{Id: id, Index: 5, RangeId: 2}
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().SetSession(sessionA).Add(&rfpb.IncrementRequest{
+		Key:   []byte("incr-key-a"),
+		Delta: 1,
+	}))
+	rsp, err := repl.Update([]dbsm.Entry{entry})
+	require.NoError(t, err)
+	require.Empty(t, errorMessage(rsp[0].Result))
+
+	// Write with the same id, lower index, but a different range_id.
+	// Stores under `session-<id>-9` — separate namespace, so this is not
+	// a replay and not stale. Must succeed.
+	sessionB := &rfpb.Session{Id: id, Index: 3, RangeId: 9}
+	entry = em.makeEntry(rbuilder.NewBatchBuilder().SetSession(sessionB).Add(&rfpb.IncrementRequest{
+		Key:   []byte("incr-key-b"),
+		Delta: 1,
+	}))
+	rsp, err = repl.Update([]dbsm.Entry{entry})
+	require.NoError(t, err)
+	require.Empty(t, errorMessage(rsp[0].Result))
+
+	// Within range_id=2's namespace, a lower index is still stale.
+	sessionStale := &rfpb.Session{Id: id, Index: 4, RangeId: 2}
+	entry = em.makeEntry(rbuilder.NewBatchBuilder().SetSession(sessionStale).Add(&rfpb.IncrementRequest{
+		Key:   []byte("incr-key-a"),
+		Delta: 1,
+	}))
+	rsp, err = repl.Update([]dbsm.Entry{entry})
+	require.NoError(t, err)
+	require.Contains(t, errorMessage(rsp[0].Result), "index mismatch")
+}
+
 func TestReplicaCAS(t *testing.T) {
 	repl := testutil.NewTestingReplica(t, 1, 1)
 	require.NotNil(t, repl)

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -248,6 +248,13 @@ message Session {
   // monotonically increasing.
   // Example: 1717100891000000000
   uint64 index = 2;
+  // Optional. The range_id the session is scoped to. When set, the replica
+  // namespaces its dedup record by (id, range_id). This prevents a retry that
+  // crosses ranges (e.g. on a split) from colliding with a destination range's
+  // entries that happen to share the same id. Left unset (0) by callers that
+  // never cross ranges (rangelease, bringup, deleteSessions); set by Sender
+  // in runPropose.
+  uint64 range_id = 3;
   // The timestamp when the session is created.
   int64 created_at_usec = 5;
 


### PR DESCRIPTION
range_id will be part of the key we store in pebble if it is set.

The reason why we need this is, when we move the session up a level; we
can run into a situation where the range_id changes during retry; that
can cause session id clash in the new range. The added range_id is to
prevent the session id clash in this case. Without it, we need to store
session id per range in memory this can be expensive because there can
be hundreds ranges on the store and also we have to garbage collect them
when they were cleaned up or moved away.
