### PR TITLE
Prefer $XDG_CONFIG_HOME/buildbuddy.yaml for CLI

### DIFF
--- a/cli/config/BUILD
+++ b/cli/config/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
@@ -11,4 +11,10 @@ go_library(
         "@com_github_docker_go_units//:go-units",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    embed = [":config"],
 )

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,8 +21,7 @@ const (
 	// root of the Bazel workspace in which the CLI is invoked.
 	WorkspaceRelativeConfigPath = "buildbuddy.yaml"
 
-	// Path where we expect to find the user's plugin configuration, relative
-	// to the user's home directory.
+	// Filename where we expect to find the user's plugin configuration.
 	HomeRelativeUserConfigPath = "buildbuddy.yaml"
 
 	// Environment variable that is set to "1" if we are a sidecar.
@@ -69,13 +69,55 @@ func loadWorkspaceConfig(workspaceDir string) (*File, error) {
 	return LoadFile(filepath.Join(workspaceDir, WorkspaceRelativeConfigPath))
 }
 
-func loadUserConfig() (*File, error) {
-	homeDir := os.Getenv("HOME")
-	if homeDir == "" {
-		log.Debugf("not reading ~/%s: $HOME environment variable is not set", HomeRelativeUserConfigPath)
-		return nil, nil
+// userConfigCandidates returns paths to check for an existing user config, in
+// precedence order. The first candidate is also where a new config should be
+// created when none already exists.
+func userConfigCandidates() ([]string, error) {
+	home := os.Getenv("HOME")
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+	if xdg == "" && home != "" {
+		xdg = filepath.Join(home, ".config")
 	}
-	return LoadFile(filepath.Join(homeDir, HomeRelativeUserConfigPath))
+
+	var paths []string
+	if xdg != "" {
+		paths = append(paths, filepath.Join(xdg, HomeRelativeUserConfigPath))
+	}
+	if home != "" {
+		paths = append(paths, filepath.Join(home, HomeRelativeUserConfigPath))
+	}
+	if len(paths) == 0 {
+		msg := "cannot determine user config path: $HOME and $XDG_CONFIG_HOME are unset"
+		log.Debugf(msg)
+		return nil, errors.New(msg)
+	}
+
+	return paths, nil
+}
+
+func loadUserConfig() (*File, error) {
+	path, err := UserConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	return LoadFile(path)
+}
+
+func UserConfigPath() (string, error) {
+	paths, err := userConfigCandidates()
+	if err != nil {
+		return "", err
+	}
+	for _, p := range paths {
+		_, err := os.Stat(p)
+		if err == nil {
+			return p, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+	}
+	return paths[0], nil
 }
 
 // LoadFile loads a single buildbuddy.yaml from the given path.

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -20,8 +20,13 @@ const (
 	// root of the Bazel workspace in which the CLI is invoked.
 	WorkspaceRelativeConfigPath = "buildbuddy.yaml"
 
-	// Filename where we expect to find the user's plugin configuration.
+	// Path where we historically stored the user's plugin configuration,
+	// relative to the user's home directory.
 	HomeRelativeUserConfigPath = "buildbuddy.yaml"
+
+	// Path where we store the user's plugin configuration, relative to the
+	// user's XDG config directory.
+	XDGRelativeUserConfigPath = "buildbuddy/bb.yaml"
 
 	// Environment variable that is set to "1" if we are a sidecar.
 	BbIsSidecar = "_BB_IS_SIDECAR"
@@ -80,7 +85,7 @@ func userConfigCandidates() []string {
 
 	var paths []string
 	if xdg != "" {
-		paths = append(paths, filepath.Join(xdg, HomeRelativeUserConfigPath))
+		paths = append(paths, filepath.Join(xdg, XDGRelativeUserConfigPath))
 	}
 	if home != "" {
 		paths = append(paths, filepath.Join(home, HomeRelativeUserConfigPath))

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -72,7 +71,7 @@ func loadWorkspaceConfig(workspaceDir string) (*File, error) {
 // userConfigCandidates returns paths to check for an existing user config, in
 // precedence order. The first candidate is also where a new config should be
 // created when none already exists.
-func userConfigCandidates() ([]string, error) {
+func userConfigCandidates() []string {
 	home := os.Getenv("HOME")
 	xdg := os.Getenv("XDG_CONFIG_HOME")
 	if xdg == "" && home != "" {
@@ -87,12 +86,11 @@ func userConfigCandidates() ([]string, error) {
 		paths = append(paths, filepath.Join(home, HomeRelativeUserConfigPath))
 	}
 	if len(paths) == 0 {
-		msg := "cannot determine user config path: $HOME and $XDG_CONFIG_HOME are unset"
-		log.Debugf(msg)
-		return nil, errors.New(msg)
+		log.Debugf("cannot determine user config path: $HOME and $XDG_CONFIG_HOME are unset")
+		return nil
 	}
 
-	return paths, nil
+	return paths
 }
 
 func loadUserConfig() (*File, error) {
@@ -100,13 +98,16 @@ func loadUserConfig() (*File, error) {
 	if err != nil {
 		return nil, err
 	}
+	if path == "" {
+		return nil, nil
+	}
 	return LoadFile(path)
 }
 
 func UserConfigPath() (string, error) {
-	paths, err := userConfigCandidates()
-	if err != nil {
-		return "", err
+	paths := userConfigCandidates()
+	if len(paths) == 0 {
+		return "", nil
 	}
 	for _, p := range paths {
 		_, err := os.Stat(p)

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -23,6 +23,9 @@ func TestLoadAllFiles_NoUserConfigFilesDoesNotFail(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(home, HomeRelativeUserConfigPath)); !os.IsNotExist(err) {
 		t.Fatalf("expected no user config to be created, stat err=%v", err)
 	}
+	if _, err := os.Stat(filepath.Join(home, ".config", XDGRelativeUserConfigPath)); !os.IsNotExist(err) {
+		t.Fatalf("expected no XDG user config to be created, stat err=%v", err)
+	}
 }
 
 func TestLoadAllFiles_NoUserConfigCandidatesDoesNotFail(t *testing.T) {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAllFiles_NoUserConfigFilesDoesNotFail(t *testing.T) {
+	home := t.TempDir()
+	workspaceDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	configs, err := LoadAllFiles(workspaceDir)
+
+	if err != nil {
+		t.Fatalf("LoadAllFiles() returned error: %s", err)
+	}
+	if len(configs) != 0 {
+		t.Fatalf("LoadAllFiles() returned %d configs, want 0", len(configs))
+	}
+	if _, err := os.Stat(filepath.Join(home, HomeRelativeUserConfigPath)); !os.IsNotExist(err) {
+		t.Fatalf("expected no user config to be created, stat err=%v", err)
+	}
+}
+
+func TestLoadAllFiles_NoUserConfigCandidatesDoesNotFail(t *testing.T) {
+	workspaceDir := t.TempDir()
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	configs, err := LoadAllFiles(workspaceDir)
+
+	if err != nil {
+		t.Fatalf("LoadAllFiles() returned error: %s", err)
+	}
+	if len(configs) != 0 {
+		t.Fatalf("LoadAllFiles() returned %d configs, want 0", len(configs))
+	}
+}

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -48,8 +48,10 @@ Usage: bb install [REPO[@VERSION]][:PATH] [--user]
 
 Installs a remote or local CLI plugin for the current bazel workspace.
 
-The --user flag installs the plugin globally for your user in ~/buildbuddy.yaml,
-instead of just for the current workspace.
+The --user flag installs the plugin globally for your user, instead of just for
+the current workspace. The plugin is added to $XDG_CONFIG_HOME/buildbuddy.yaml
+(defaulting to ~/.config/buildbuddy.yaml) or ~/buildbuddy.yaml, whichever
+exists.
 
 A local plugin can be installed by omitting the repo argument and specifying
 just :PATH, or the flag --path=PATH.
@@ -123,12 +125,12 @@ func HandleInstall(args []string) (exitCode int, err error) {
 
 	configPath := ""
 	if *installForUser {
-		home := os.Getenv("HOME")
-		if home == "" {
-			log.Printf("Could not locate user config path: $HOME not set")
+		p, err := config.UserConfigPath()
+		if err != nil {
+			log.Printf("Could not locate user config path: %s", err)
 			return 1, nil
 		}
-		configPath = filepath.Join(home, config.HomeRelativeUserConfigPath)
+		configPath = p
 	} else {
 		ws, err := workspace.Path()
 		if err != nil {
@@ -213,6 +215,9 @@ func installPlugin(plugin *config.PluginConfig, configPath string) error {
 	if _, err := os.Stat(configPath); err != nil {
 		if !os.IsNotExist(err) {
 			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			return fmt.Errorf("failed to create config directory: %s", err)
 		}
 		f, err := os.Create(configPath)
 		if err != nil {
@@ -354,9 +359,9 @@ func LoadAll(tempDir string) ([]*Plugin, error) {
 	return loadAll(ws, tempDir)
 }
 
-// loadAll gets all of the configured plugins from the user's ~/buildbuddy.yaml
-// and workspace buildbuddy.yaml, and prepares them for use by ensuring all
-// files and directories needed for correct operation are present on disk.
+// loadAll gets all of the configured plugins from the user and workspace
+// buildbuddy.yaml files, and prepares them for use by ensuring all files and
+// directories needed for correct operation are present on disk.
 func loadAll(workspaceDir, tempDir string) ([]*Plugin, error) {
 	plugins, err := getConfiguredPlugins(workspaceDir)
 	if err != nil {
@@ -375,9 +380,8 @@ func loadAll(workspaceDir, tempDir string) ([]*Plugin, error) {
 	return plugins, nil
 }
 
-// getConfiguredPlugins parses the user's ~/buildbuddy.yaml as well as the
-// workspace buildbuddy.yaml and returns the set of plugins. The returned
-// plugins are not yet ready to use.
+// getConfiguredPlugins parses the user and workspace buildbuddy.yaml files and
+// returns the set of plugins. The returned plugins are not yet ready to use.
 func getConfiguredPlugins(workspaceDir string) ([]*Plugin, error) {
 	configFiles, err := config.LoadAllFiles(workspaceDir)
 	if err != nil {

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -49,9 +49,9 @@ Usage: bb install [REPO[@VERSION]][:PATH] [--user]
 Installs a remote or local CLI plugin for the current bazel workspace.
 
 The --user flag installs the plugin globally for your user, instead of just for
-the current workspace. The plugin is added to $XDG_CONFIG_HOME/buildbuddy.yaml
-(defaulting to ~/.config/buildbuddy.yaml) or ~/buildbuddy.yaml, whichever
-exists.
+the current workspace. The plugin is added to
+$XDG_CONFIG_HOME/buildbuddy/bb.yaml (defaulting to
+~/.config/buildbuddy/bb.yaml) or ~/buildbuddy.yaml, whichever exists.
 
 A local plugin can be installed by omitting the repo argument and specifying
 just :PATH, or the flag --path=PATH.

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -50,9 +50,9 @@ Usage: bb install [REPO[@VERSION]][:PATH] [--user]
 Installs a remote or local CLI plugin for the current bazel workspace.
 
 The --user flag installs the plugin globally for your user, instead of just for
-the current workspace. The plugin is added to $XDG_CONFIG_HOME/buildbuddy.yaml
-(defaulting to ~/.config/buildbuddy.yaml) or ~/buildbuddy.yaml, whichever
-exists.
+the current workspace. The plugin is added to
+$XDG_CONFIG_HOME/buildbuddy/bb.yaml (defaulting to
+~/.config/buildbuddy/bb.yaml) or ~/buildbuddy.yaml, whichever exists.
 
 A local plugin can be installed by omitting the repo argument and specifying
 just :PATH, or the flag --path=PATH.

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -49,8 +49,10 @@ Usage: bb install [REPO[@VERSION]][:PATH] [--user]
 
 Installs a remote or local CLI plugin for the current bazel workspace.
 
-The --user flag installs the plugin globally for your user in ~/buildbuddy.yaml,
-instead of just for the current workspace.
+The --user flag installs the plugin globally for your user, instead of just for
+the current workspace. The plugin is added to $XDG_CONFIG_HOME/buildbuddy.yaml
+(defaulting to ~/.config/buildbuddy.yaml) or ~/buildbuddy.yaml, whichever
+exists.
 
 A local plugin can be installed by omitting the repo argument and specifying
 just :PATH, or the flag --path=PATH.
@@ -124,12 +126,12 @@ func HandleInstall(args []string) (exitCode int, err error) {
 
 	configPath := ""
 	if *installForUser {
-		home := os.Getenv("HOME")
-		if home == "" {
-			log.Printf("Could not locate user config path: $HOME not set")
+		p, err := config.UserConfigPath()
+		if err != nil {
+			log.Printf("Could not locate user config path: %s", err)
 			return 1, nil
 		}
-		configPath = filepath.Join(home, config.HomeRelativeUserConfigPath)
+		configPath = p
 	} else {
 		ws, err := workspace.Path()
 		if err != nil {
@@ -214,6 +216,9 @@ func installPlugin(plugin *config.PluginConfig, configPath string) error {
 	if _, err := os.Stat(configPath); err != nil {
 		if !os.IsNotExist(err) {
 			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			return fmt.Errorf("failed to create config directory: %s", err)
 		}
 		f, err := os.Create(configPath)
 		if err != nil {
@@ -355,9 +360,9 @@ func LoadAll(tempDir string) ([]*Plugin, error) {
 	return loadAll(ws, tempDir)
 }
 
-// loadAll gets all of the configured plugins from the user's ~/buildbuddy.yaml
-// and workspace buildbuddy.yaml, and prepares them for use by ensuring all
-// files and directories needed for correct operation are present on disk.
+// loadAll gets all of the configured plugins from the user and workspace
+// buildbuddy.yaml files, and prepares them for use by ensuring all files and
+// directories needed for correct operation are present on disk.
 func loadAll(workspaceDir, tempDir string) ([]*Plugin, error) {
 	plugins, err := getConfiguredPlugins(workspaceDir)
 	if err != nil {
@@ -376,9 +381,8 @@ func loadAll(workspaceDir, tempDir string) ([]*Plugin, error) {
 	return plugins, nil
 }
 
-// getConfiguredPlugins parses the user's ~/buildbuddy.yaml as well as the
-// workspace buildbuddy.yaml and returns the set of plugins. The returned
-// plugins are not yet ready to use.
+// getConfiguredPlugins parses the user and workspace buildbuddy.yaml files and
+// returns the set of plugins. The returned plugins are not yet ready to use.
 func getConfiguredPlugins(workspaceDir string) ([]*Plugin, error) {
 	configFiles, err := config.LoadAllFiles(workspaceDir)
 	if err != nil {

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -179,14 +179,14 @@ plugins:
 
 func TestInstall_ToUserConfig_CreateNewConfig(t *testing.T) {
 	_, home := setup(t)
-	testfs.MakeDirAll(t, home, ".config/test-plugin")
+	testfs.MakeDirAll(t, home, ".config/buildbuddy/test-plugin")
 
 	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
 
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 
-	config := testfs.ReadFileAsString(t, home, ".config/buildbuddy.yaml")
+	config := testfs.ReadFileAsString(t, home, ".config/buildbuddy/bb.yaml")
 	expectedConfig := `plugins:
   - path: ./test-plugin
 `
@@ -207,8 +207,8 @@ plugins:
 `,
 	})
 	testfs.WriteAllFileContents(t, xdg, map[string]string{
-		"xdg-only/.empty": "",
-		"buildbuddy.yaml": `
+		"buildbuddy/xdg-only/.empty": "",
+		"buildbuddy/bb.yaml": `
 plugins:
   - path: ./xdg-only
 `,
@@ -223,7 +223,7 @@ plugins:
 		require.NoError(t, err)
 		ids = append(ids, id)
 	}
-	require.Equal(t, []string{filepath.Join(xdg, "xdg-only")}, ids)
+	require.Equal(t, []string{filepath.Join(xdg, "buildbuddy", "xdg-only")}, ids)
 }
 
 func TestGetConfiguredPlugins_FallsBackToHomeWhenXDGConfigMissing(t *testing.T) {
@@ -254,8 +254,8 @@ func TestGetConfiguredPlugins_DefaultsXDGConfigHomeToDotConfig(t *testing.T) {
 	ws, home := setup(t)
 	// Leave XDG_CONFIG_HOME unset; loader should default to ~/.config.
 	testfs.WriteAllFileContents(t, home, map[string]string{
-		".config/dot-config-only/.empty": "",
-		".config/buildbuddy.yaml": `
+		".config/buildbuddy/dot-config-only/.empty": "",
+		".config/buildbuddy/bb.yaml": `
 plugins:
   - path: ./dot-config-only
 `,
@@ -270,21 +270,21 @@ plugins:
 		require.NoError(t, err)
 		ids = append(ids, id)
 	}
-	require.Equal(t, []string{filepath.Join(home, ".config", "dot-config-only")}, ids)
+	require.Equal(t, []string{filepath.Join(home, ".config", "buildbuddy", "dot-config-only")}, ids)
 }
 
 func TestInstall_ToUserConfig_PreferExistingXDGConfig(t *testing.T) {
 	_, home := setup(t)
 	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
 	setTestXDGConfigHome(t, xdg)
-	testfs.MakeDirAll(t, xdg, "test-plugin")
-	testfs.WriteAllFileContents(t, xdg, map[string]string{"buildbuddy.yaml": ""})
+	testfs.MakeDirAll(t, xdg, "buildbuddy/test-plugin")
+	testfs.WriteAllFileContents(t, xdg, map[string]string{"buildbuddy/bb.yaml": ""})
 
 	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
 
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
-	require.Equal(t, "plugins:\n  - path: ./test-plugin\n", testfs.ReadFileAsString(t, xdg, "buildbuddy.yaml"))
+	require.Equal(t, "plugins:\n  - path: ./test-plugin\n", testfs.ReadFileAsString(t, xdg, "buildbuddy/bb.yaml"))
 	_, err = os.Stat(filepath.Join(home, "buildbuddy.yaml"))
 	require.True(t, os.IsNotExist(err), "expected ~/buildbuddy.yaml not to be created, stat err=%v", err)
 }
@@ -293,16 +293,16 @@ func TestInstall_ToUserConfig_WriteToExistingXDGConfigWhenHomeConfigExists(t *te
 	_, home := setup(t)
 	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
 	setTestXDGConfigHome(t, xdg)
-	testfs.MakeDirAll(t, xdg, "test-plugin")
+	testfs.MakeDirAll(t, xdg, "buildbuddy/test-plugin")
 	testfs.WriteAllFileContents(t, home, map[string]string{"buildbuddy.yaml": ""})
-	testfs.WriteAllFileContents(t, xdg, map[string]string{"buildbuddy.yaml": ""})
+	testfs.WriteAllFileContents(t, xdg, map[string]string{"buildbuddy/bb.yaml": ""})
 
 	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
 
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 	require.Empty(t, testfs.ReadFileAsString(t, home, "buildbuddy.yaml"))
-	require.Equal(t, "plugins:\n  - path: ./test-plugin\n", testfs.ReadFileAsString(t, xdg, "buildbuddy.yaml"))
+	require.Equal(t, "plugins:\n  - path: ./test-plugin\n", testfs.ReadFileAsString(t, xdg, "buildbuddy/bb.yaml"))
 }
 
 func TestParsePluginSpec(t *testing.T) {

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -179,18 +179,130 @@ plugins:
 
 func TestInstall_ToUserConfig_CreateNewConfig(t *testing.T) {
 	_, home := setup(t)
-	testfs.MakeDirAll(t, home, "test-plugin")
+	testfs.MakeDirAll(t, home, ".config/test-plugin")
 
 	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
 
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 
-	config := testfs.ReadFileAsString(t, home, "buildbuddy.yaml")
+	config := testfs.ReadFileAsString(t, home, ".config/buildbuddy.yaml")
 	expectedConfig := `plugins:
   - path: ./test-plugin
 `
 	require.Equal(t, expectedConfig, config)
+	_, err = os.Stat(filepath.Join(home, "buildbuddy.yaml"))
+	require.True(t, os.IsNotExist(err), "expected ~/buildbuddy.yaml not to be created, stat err=%v", err)
+}
+
+func TestGetConfiguredPlugins_PrefersXDGConfigHomeOverHome(t *testing.T) {
+	ws, home := setup(t)
+	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
+	setTestXDGConfigHome(t, xdg)
+	testfs.WriteAllFileContents(t, home, map[string]string{
+		"home-only/.empty": "",
+		"buildbuddy.yaml": `
+plugins:
+  - path: ./home-only
+`,
+	})
+	testfs.WriteAllFileContents(t, xdg, map[string]string{
+		"xdg-only/.empty": "",
+		"buildbuddy.yaml": `
+plugins:
+  - path: ./xdg-only
+`,
+	})
+
+	plugins, err := getConfiguredPlugins(ws)
+
+	require.NoError(t, err)
+	var ids []string
+	for _, p := range plugins {
+		id, err := p.VersionedID()
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+	require.Equal(t, []string{filepath.Join(xdg, "xdg-only")}, ids)
+}
+
+func TestGetConfiguredPlugins_FallsBackToHomeWhenXDGConfigMissing(t *testing.T) {
+	ws, home := setup(t)
+	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
+	setTestXDGConfigHome(t, xdg)
+	testfs.WriteAllFileContents(t, home, map[string]string{
+		"home-only/.empty": "",
+		"buildbuddy.yaml": `
+plugins:
+  - path: ./home-only
+`,
+	})
+
+	plugins, err := getConfiguredPlugins(ws)
+
+	require.NoError(t, err)
+	var ids []string
+	for _, p := range plugins {
+		id, err := p.VersionedID()
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+	require.Equal(t, []string{filepath.Join(home, "home-only")}, ids)
+}
+
+func TestGetConfiguredPlugins_DefaultsXDGConfigHomeToDotConfig(t *testing.T) {
+	ws, home := setup(t)
+	// Leave XDG_CONFIG_HOME unset; loader should default to ~/.config.
+	testfs.WriteAllFileContents(t, home, map[string]string{
+		".config/dot-config-only/.empty": "",
+		".config/buildbuddy.yaml": `
+plugins:
+  - path: ./dot-config-only
+`,
+	})
+
+	plugins, err := getConfiguredPlugins(ws)
+
+	require.NoError(t, err)
+	var ids []string
+	for _, p := range plugins {
+		id, err := p.VersionedID()
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+	require.Equal(t, []string{filepath.Join(home, ".config", "dot-config-only")}, ids)
+}
+
+func TestInstall_ToUserConfig_PreferExistingXDGConfig(t *testing.T) {
+	_, home := setup(t)
+	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
+	setTestXDGConfigHome(t, xdg)
+	testfs.MakeDirAll(t, xdg, "test-plugin")
+	testfs.WriteAllFileContents(t, xdg, map[string]string{"buildbuddy.yaml": ""})
+
+	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Equal(t, "plugins:\n  - path: ./test-plugin\n", testfs.ReadFileAsString(t, xdg, "buildbuddy.yaml"))
+	_, err = os.Stat(filepath.Join(home, "buildbuddy.yaml"))
+	require.True(t, os.IsNotExist(err), "expected ~/buildbuddy.yaml not to be created, stat err=%v", err)
+}
+
+func TestInstall_ToUserConfig_WriteToExistingXDGConfigWhenHomeConfigExists(t *testing.T) {
+	_, home := setup(t)
+	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
+	setTestXDGConfigHome(t, xdg)
+	testfs.MakeDirAll(t, xdg, "test-plugin")
+	testfs.WriteAllFileContents(t, home, map[string]string{"buildbuddy.yaml": ""})
+	testfs.WriteAllFileContents(t, xdg, map[string]string{"buildbuddy.yaml": ""})
+
+	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Empty(t, testfs.ReadFileAsString(t, home, "buildbuddy.yaml"))
+	require.Equal(t, "plugins:\n  - path: ./test-plugin\n", testfs.ReadFileAsString(t, xdg, "buildbuddy.yaml"))
 }
 
 func TestParsePluginSpec(t *testing.T) {
@@ -416,6 +528,7 @@ func setup(t *testing.T) (ws, home string) {
 	home = testfs.MakeDirAll(t, root, "home")
 
 	setTestHomeDir(t, home)
+	setTestXDGConfigHome(t, "")
 	setTestWorkDir(t, ws)
 	workspace.SetForTest(t, ws)
 
@@ -438,5 +551,21 @@ func setTestHomeDir(t *testing.T, path string) {
 	t.Cleanup(func() {
 		err := os.Setenv("HOME", original)
 		require.NoError(t, err)
+	})
+}
+
+func setTestXDGConfigHome(t *testing.T, path string) {
+	original, hadOriginal := os.LookupEnv("XDG_CONFIG_HOME")
+	if path == "" {
+		require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
+	} else {
+		require.NoError(t, os.Setenv("XDG_CONFIG_HOME", path))
+	}
+	t.Cleanup(func() {
+		if hadOriginal {
+			require.NoError(t, os.Setenv("XDG_CONFIG_HOME", original))
+		} else {
+			require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
+		}
 	})
 }

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -179,18 +179,130 @@ plugins:
 
 func TestInstall_ToUserConfig_CreateNewConfig(t *testing.T) {
 	_, home := setup(t)
-	testfs.MakeDirAll(t, home, "test-plugin")
+	testfs.MakeDirAll(t, home, ".config/test-plugin")
 
 	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
 
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 
-	config := testfs.ReadFileAsString(t, home, "buildbuddy.yaml")
+	config := testfs.ReadFileAsString(t, home, ".config/buildbuddy.yaml")
 	expectedConfig := `plugins:
   - path: ./test-plugin
 `
 	require.Equal(t, expectedConfig, config)
+	_, err = os.Stat(filepath.Join(home, "buildbuddy.yaml"))
+	require.True(t, os.IsNotExist(err), "expected ~/buildbuddy.yaml not to be created, stat err=%v", err)
+}
+
+func TestGetConfiguredPlugins_PrefersXDGConfigHomeOverHome(t *testing.T) {
+	ws, home := setup(t)
+	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
+	setTestXDGConfigHome(t, xdg)
+	testfs.WriteAllFileContents(t, home, map[string]string{
+		"home-only/.empty": "",
+		"buildbuddy.yaml": `
+plugins:
+  - path: ./home-only
+`,
+	})
+	testfs.WriteAllFileContents(t, xdg, map[string]string{
+		"xdg-only/.empty": "",
+		"buildbuddy.yaml": `
+plugins:
+  - path: ./xdg-only
+`,
+	})
+
+	plugins, err := getConfiguredPlugins(ws)
+
+	require.NoError(t, err)
+	var ids []string
+	for _, p := range plugins {
+		id, err := p.VersionedID()
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+	require.Equal(t, []string{filepath.Join(xdg, "xdg-only")}, ids)
+}
+
+func TestGetConfiguredPlugins_FallsBackToHomeWhenXDGConfigMissing(t *testing.T) {
+	ws, home := setup(t)
+	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
+	setTestXDGConfigHome(t, xdg)
+	testfs.WriteAllFileContents(t, home, map[string]string{
+		"home-only/.empty": "",
+		"buildbuddy.yaml": `
+plugins:
+  - path: ./home-only
+`,
+	})
+
+	plugins, err := getConfiguredPlugins(ws)
+
+	require.NoError(t, err)
+	var ids []string
+	for _, p := range plugins {
+		id, err := p.VersionedID()
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+	require.Equal(t, []string{filepath.Join(home, "home-only")}, ids)
+}
+
+func TestGetConfiguredPlugins_DefaultsXDGConfigHomeToDotConfig(t *testing.T) {
+	ws, home := setup(t)
+	// Leave XDG_CONFIG_HOME unset; loader should default to ~/.config.
+	testfs.WriteAllFileContents(t, home, map[string]string{
+		".config/dot-config-only/.empty": "",
+		".config/buildbuddy.yaml": `
+plugins:
+  - path: ./dot-config-only
+`,
+	})
+
+	plugins, err := getConfiguredPlugins(ws)
+
+	require.NoError(t, err)
+	var ids []string
+	for _, p := range plugins {
+		id, err := p.VersionedID()
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+	require.Equal(t, []string{filepath.Join(home, ".config", "dot-config-only")}, ids)
+}
+
+func TestInstall_ToUserConfig_PreferExistingXDGConfig(t *testing.T) {
+	_, home := setup(t)
+	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
+	setTestXDGConfigHome(t, xdg)
+	testfs.MakeDirAll(t, xdg, "test-plugin")
+	testfs.WriteAllFileContents(t, xdg, map[string]string{"buildbuddy.yaml": ""})
+
+	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Equal(t, "plugins:\n  - path: ./test-plugin\n", testfs.ReadFileAsString(t, xdg, "buildbuddy.yaml"))
+	_, err = os.Stat(filepath.Join(home, "buildbuddy.yaml"))
+	require.True(t, os.IsNotExist(err), "expected ~/buildbuddy.yaml not to be created, stat err=%v", err)
+}
+
+func TestInstall_ToUserConfig_WriteToExistingXDGConfigWhenHomeConfigExists(t *testing.T) {
+	_, home := setup(t)
+	xdg := testfs.MakeDirAll(t, filepath.Dir(home), "xdg")
+	setTestXDGConfigHome(t, xdg)
+	testfs.MakeDirAll(t, xdg, "test-plugin")
+	testfs.WriteAllFileContents(t, home, map[string]string{"buildbuddy.yaml": ""})
+	testfs.WriteAllFileContents(t, xdg, map[string]string{"buildbuddy.yaml": ""})
+
+	exitCode, err := HandleInstall([]string{"--path=./test-plugin", "--user"})
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Empty(t, testfs.ReadFileAsString(t, home, "buildbuddy.yaml"))
+	require.Equal(t, "plugins:\n  - path: ./test-plugin\n", testfs.ReadFileAsString(t, xdg, "buildbuddy.yaml"))
 }
 
 func TestParsePluginSpec(t *testing.T) {
@@ -480,6 +592,7 @@ func setup(t *testing.T) (ws, home string) {
 	home = testfs.MakeDirAll(t, root, "home")
 
 	setTestHomeDir(t, home)
+	setTestXDGConfigHome(t, "")
 	setTestWorkDir(t, ws)
 	workspace.SetForTest(t, ws)
 
@@ -502,5 +615,21 @@ func setTestHomeDir(t *testing.T, path string) {
 	t.Cleanup(func() {
 		err := os.Setenv("HOME", original)
 		require.NoError(t, err)
+	})
+}
+
+func setTestXDGConfigHome(t *testing.T, path string) {
+	original, hadOriginal := os.LookupEnv("XDG_CONFIG_HOME")
+	if path == "" {
+		require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
+	} else {
+		require.NoError(t, os.Setenv("XDG_CONFIG_HOME", path))
+	}
+	t.Cleanup(func() {
+		if hadOriginal {
+			require.NoError(t, os.Setenv("XDG_CONFIG_HOME", original))
+		} else {
+			require.NoError(t, os.Unsetenv("XDG_CONFIG_HOME"))
+		}
 	})
 }

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -64,7 +64,7 @@ Sometimes you may want to install a plugin for yourself (like a theme plugin for
 
 Installing a plugin as user-specific is as simple as just tacking the `--user` argument onto your `bb install` command.
 
-When the `--user` argument is present, the plugin will be added to a `$XDG_CONFIG_HOME/buildbuddy.yaml` (defaulting to `~/.config/buildbuddy.yaml`). If present `~/buildbuddy.yaml` will be used instead.
+When the `--user` argument is present, the plugin will be added to `$XDG_CONFIG_HOME/buildbuddy/bb.yaml` (defaulting to `~/.config/buildbuddy/bb.yaml`)
 
 If a plugin is present in both your user-specific and workspace at differnet versions, the one in your workspace will take precedence.
 

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -64,7 +64,7 @@ Sometimes you may want to install a plugin for yourself (like a theme plugin for
 
 Installing a plugin as user-specific is as simple as just tacking the `--user` argument onto your `bb install` command.
 
-When the `--user` argument is present, the plugin will be added to a `~/buildbuddy.yaml` file located in your user directory. That means those plugins will only be applied to you.
+When the `--user` argument is present, the plugin will be added to a `$XDG_CONFIG_HOME/buildbuddy.yaml` (defaulting to `~/.config/buildbuddy.yaml`). If present `~/buildbuddy.yaml` will be used instead.
 
 If a plugin is present in both your user-specific and workspace at differnet versions, the one in your workspace will take precedence.
 


### PR DESCRIPTION
Putting a non-dotfile in the user's home directory feels a bit
aggressive. This still reads that if it exists but prefers
`$XDG_CONFIG_HOME/buildbuddy.yaml` for new uses instead.
