### PR TITLE
Remove network dependencies from remote_bazel_test

### DIFF
--- a/enterprise/server/test/integration/remote_bazel/BUILD
+++ b/enterprise/server/test/integration/remote_bazel/BUILD
@@ -4,28 +4,9 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_test(
     name = "remote_bazel_test",
-    size = "enormous",
     srcs = ["remote_bazel_test.go"],
-    exec_properties = {
-        "test.include-secrets": "true",
-        "test.workload-isolation-type": "firecracker",
-        # Use an image with bazelisk installed
-        "test.container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:271e5e3704d861159c75b8dd6713dbe5a12272ec8ee73d17f89ed7be8026553f",
-        # The tests clone git repos, so make sure they have enough resources to do so
-        "test.EstimatedComputeUnits": "3",
-        "test.EstimatedFreeDiskBytes": "4GB",
-        "test.recycle-runner": "true",
-        "test.runner-recycling-key": "remote-bazel-integration",
-    },
     shard_count = 7,
-    tags = [
-        # Use the "docker" tag to only run this on authenticated BB workflows
-        # to support runner recycling
-        "docker",
-        # Use the "secrets" tag to prevent building this on unauthenticated
-        # builds
-        "secrets",
-    ],
+    tags = ["block-network"],
     deps = [
         "//cli/remotebazel",
         "//cli/testutil/testcli",
@@ -59,7 +40,6 @@ go_test(
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/testutil/testgit",
-        "//server/testutil/testshell",
         "//server/util/bazel",
         "//server/util/bb",
         "//server/util/git",

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,7 +36,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testshell"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -129,36 +129,7 @@ func waitForInvocationStatus(t *testing.T, ctx context.Context, bb bbspb.BuildBu
 	require.FailNowf(t, "timeout", "Timed out waiting for invocation to reach expected status %v", expectedStatus)
 }
 
-func clonePrivateTestRepo(t *testing.T) string {
-	repoName := "private-test-repo"
-	// If you need to re-generate this PAT, it should only have read access to
-	// `private-test-repo`, and should be saved as a BB secret in all environments.
-	username := "maggie-lou"
-	personalAccessToken := os.Getenv("PRIVATE_TEST_REPO_GIT_ACCESS_TOKEN")
-	repoURLWithToken := fmt.Sprintf("https://%s:%s@github.com/buildbuddy-io/private-test-repo.git", username, personalAccessToken)
-
-	// Use a dir that is persisted on recycled runners
-	rootDir := "/root/workspace/remote-bazel-integration-test"
-	err := os.Setenv("HOME", rootDir)
-	require.NoError(t, err)
-
-	err = os.MkdirAll(rootDir, 0755)
-	require.NoError(t, err)
-
-	if _, err := os.Stat(fmt.Sprintf("%s/%s", rootDir, repoName)); os.IsNotExist(err) {
-		output := testshell.Run(t, rootDir, fmt.Sprintf("git clone %s --filter=blob:none --depth=1", repoURLWithToken))
-		require.NotContains(t, output, "fatal")
-	}
-
-	repoDir := fmt.Sprintf("%s/%s", rootDir, repoName)
-	t.Chdir(repoDir)
-	require.NoError(t, err)
-	testshell.Run(t, repoDir, "git pull")
-	return repoDir
-}
-
-// makeLocalGitRepo creates a local git repo to use for tests. This is faster
-// than using `clonePrivateTestRepo` which fetches from the remote GitHub server.
+// makeLocalGitRepo creates a local git repo to use for tests.
 func makeLocalGitRepo(t *testing.T, contents map[string]string) (path, commitSHA string) {
 	// Make the repo contents globally unique so that this makeGitRepo func can be
 	// called more than once to create unique repos with incompatible commit
@@ -198,15 +169,30 @@ func runRemoteBazelInSeparateProcess(t *testing.T, workDir string, serverAddress
 }
 
 func TestWithPrivateRepo(t *testing.T) {
-	repoDir := clonePrivateTestRepo(t)
+	gitRemote := testgit.StartServer(t, testgit.ServerOptions{})
+	repoDir := testbazel.MakeTempModule(t, map[string]string{
+		"BUILD": `
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+sh_binary(
+    name = "hello_world",
+    srcs = ["hello_world.sh"],
+)
+`,
+		"hello_world.sh": `echo "FUTURE OF BUILDS!"`,
+		".bazelversion":  testbazel.BinaryPath(t),
+	})
+	testfs.MakeExecutable(t, repoDir, "hello_world.sh")
+	testgit.Init(t, repoDir)
+	gitRemote.CreateProject("test-org", "test-repo", &testgit.ProjectSettings{Public: false})
+	gitRemote.Push("test-org", "test-repo", gitRemote.AccessToken(), repoDir)
+	repoURL := gitRemote.RepoURL("test-org", "test-repo", "" /* accessToken */)
 
 	// Run a server and executor locally to run remote bazel against
-	env, bbServer, _ := runLocalServerAndExecutor(t, true, nil)
+	env, bbServer, _ := runLocalServerAndExecutor(t, repoURL, gitRemote.AccessToken(), nil)
 
 	runRemoteBazelInSeparateProcess(t, repoDir, bbServer.GRPCAddress(),
 		"run",
 		":hello_world",
-		"--noenable_bzlmod",
 		fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1))
 
 	// Check the invocation logs to ensure the bazel command successfully ran
@@ -222,8 +208,6 @@ func TestWithPrivateRepo(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(searchRsp.GetInvocation()))
-	// Find outer invocation because it will contain run output
 	var inv *inpb.Invocation
 	for _, i := range searchRsp.GetInvocation() {
 		if i.GetRole() == "HOSTED_BAZEL" {
@@ -241,19 +225,12 @@ func TestWithPrivateRepo(t *testing.T) {
 	require.Contains(t, string(logResp.GetBuffer()), "FUTURE OF BUILDS!")
 }
 
-func runLocalServerAndExecutor(t *testing.T, mockPrivateGithubToken bool, envModifier func(rbeEnv *rbetest.Env, e *testenv.TestEnv)) (*rbetest.Env, *rbetest.BuildBuddyServer, *rbetest.Executor) {
+func runLocalServerAndExecutor(t *testing.T, repoURL, githubToken string, envModifier func(rbeEnv *rbetest.Env, e *testenv.TestEnv)) (*rbetest.Env, *rbetest.BuildBuddyServer, *rbetest.Executor) {
 	// Avoid uploading embedded CI runner binaries to the in-memory cache in
 	// each test because it's very slow. The executor will add these binaries locally instead.
 	flags.Set(t, "remote_execution.init_ci_runner_from_cache", false)
 	flags.Set(t, "executor.enable_bare_runner", true)
 	flags.Set(t, "github.app.enabled", true)
-
-	githubToken := ""
-	repoURL := ""
-	if mockPrivateGithubToken {
-		githubToken = os.Getenv("PRIVATE_TEST_REPO_GIT_ACCESS_TOKEN")
-		repoURL = "https://github.com/buildbuddy-io/private-test-repo"
-	}
 
 	env := rbetest.NewRBETestEnv(t)
 	mockGithubAppID := int64(1234)
@@ -291,13 +268,16 @@ func runLocalServerAndExecutor(t *testing.T, mockPrivateGithubToken bool, envMod
 	if repoURL != "" {
 		dbh := env.GetDBHandle()
 		require.NotNil(t, dbh)
-		err := dbh.NewQuery(context.Background(), "create_git_repo_for_test").Create(&tables.GitRepository{
-			RepoURL: repoURL,
+		u, err := url.Parse(repoURL)
+		require.NoError(t, err)
+		flags.Set(t, "github.host", u.Host)
+		parsedRepo, err := git.ParseGitHubRepoURL(repoURL)
+		require.NoError(t, err)
+		err = dbh.NewQuery(context.Background(), "create_git_repo_for_test").Create(&tables.GitRepository{
+			RepoURL: parsedRepo.String(),
 			GroupID: env.GroupID1,
 			AppID:   mockGithubAppID,
 		})
-		require.NoError(t, err)
-		parsedRepo, err := git.ParseGitHubRepoURL(repoURL)
 		require.NoError(t, err)
 		err = dbh.NewQuery(context.Background(), "create_github_app_install_for_test").Create(&tables.GitHubAppInstallation{
 			GroupID: env.GroupID1,
@@ -314,7 +294,7 @@ func TestCancel(t *testing.T) {
 	repoDir, _ := makeLocalGitRepo(t, map[string]string{})
 
 	// Run a server and executor locally to run remote bazel against
-	env, bbServer, _ := runLocalServerAndExecutor(t, false, nil)
+	env, bbServer, _ := runLocalServerAndExecutor(t, "", "", nil)
 	ctx := env.WithUserID(context.Background(), env.UserID1)
 	reqCtx := &ctxpb.RequestContext{
 		UserId:  &uidpb.UserId{Id: env.UserID1},
@@ -392,7 +372,7 @@ int main() {
 	})
 
 	// Run a server and executor locally to run remote bazel against
-	env, bbServer, _ := runLocalServerAndExecutor(t, false, nil)
+	env, bbServer, _ := runLocalServerAndExecutor(t, "", "", nil)
 
 	randomStr := fmt.Sprintf("%d", time.Now().UnixMilli())
 	runRemoteBazelInSeparateProcess(t, repoDir, bbServer.GRPCAddress(),
@@ -462,7 +442,7 @@ int main() {
 	})
 
 	// Run a server and executor locally to run remote bazel against
-	env, bbServer, _ := runLocalServerAndExecutor(t, false, nil)
+	env, bbServer, _ := runLocalServerAndExecutor(t, "", "", nil)
 
 	// Run remote bazel
 	randomStr := fmt.Sprintf("%d", time.Now().UnixMilli())
@@ -523,7 +503,7 @@ sh_binary(
 	initSecretService, pubKey := setupSecrets(t)
 
 	// Run a server and executor locally to run remote bazel against
-	env, bbServer, _ := runLocalServerAndExecutor(t, false, initSecretService)
+	env, bbServer, _ := runLocalServerAndExecutor(t, "", "", initSecretService)
 
 	bbClient := env.GetBuildBuddyServiceClient()
 	ctx := env.WithUserID(context.Background(), env.UserID1)
@@ -641,7 +621,7 @@ func TestBashScript(t *testing.T) {
 	repoDir, _ := makeLocalGitRepo(t, map[string]string{})
 
 	// Run a server and executor locally to run remote bazel against
-	env, bbServer, _ := runLocalServerAndExecutor(t, false, nil)
+	env, bbServer, _ := runLocalServerAndExecutor(t, "", "", nil)
 
 	runRemoteBazelInSeparateProcess(t, repoDir, bbServer.GRPCAddress(),
 		"--script=echo $VAL",
@@ -678,7 +658,7 @@ func TestBashScript(t *testing.T) {
 // This test enables the behavior and verifies the binaries can be used correctly.
 func TestEmbeddedBinariesFromApp(t *testing.T) {
 	repoDir, _ := makeLocalGitRepo(t, map[string]string{})
-	env, bbServer, _ := runLocalServerAndExecutor(t, false, nil)
+	env, bbServer, _ := runLocalServerAndExecutor(t, "", "", nil)
 	ctx := env.WithUserID(context.Background(), env.UserID1)
 
 	// The flag is disabled in `runLocalServerAndExecutor`. Enable it here.

--- a/server/testutil/testgit/BUILD
+++ b/server/testutil/testgit/BUILD
@@ -11,7 +11,9 @@ go_library(
         "//server/interfaces",
         "//server/testutil/testfs",
         "//server/testutil/testshell",
+        "//server/util/mockgitserver",
         "//server/util/status",
         "@com_github_google_go_github_v59//github",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/testutil/testgit/testgit.go
+++ b/server/testutil/testgit/testgit.go
@@ -3,9 +3,12 @@ package testgit
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13,8 +16,10 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testshell"
+	"github.com/buildbuddy-io/buildbuddy/server/util/mockgitserver"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/go-github/v59/github"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -172,6 +177,86 @@ func configure(t testing.TB, repoPath string) {
 	testshell.Run(t, repoPath, `
 		git config user.name "Test"
 		git config user.email "test@buildbuddy.io"
+	`)
+}
+
+// Server simulates a git forge such as GitHub. It allows creating git projects
+// associated with orgs. Repos can be private, requiring authorization via a
+// statically configured access token (which defaults to "test-access-token").
+//
+// Example usage:
+//
+//	remote := testgit.StartServer(t, testgit.ServerOptions{})
+//	repo := testgit.MakeTempRepo(t, map[string]string{"README": ""})
+//	remote.CreateProject("foo-org", "bar-repo", testgit.ProjectSettings{Public: false})
+//	remote.Push("foo-org", "bar-repo", "test-access-token", repo)
+type Server struct {
+	t              testing.TB
+	gitProjectRoot string
+	accessToken    string
+
+	server *httptest.Server
+}
+
+type ServerOptions = mockgitserver.Options
+
+type ProjectSettings = mockgitserver.ProjectSettings
+
+// StartServer starts a git remote for testing.
+// The server is automatically cleaned up when the test is complete.
+func StartServer(t testing.TB, opts ServerOptions) *Server {
+	if opts.AccessToken == "" {
+		opts.AccessToken = "test-access-token"
+	}
+	gitProjectRoot := testfs.MakeTempDir(t)
+	handler := mockgitserver.NewHandler(gitProjectRoot, opts)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return &Server{
+		t:              t,
+		server:         server,
+		gitProjectRoot: gitProjectRoot,
+		accessToken:    opts.AccessToken,
+	}
+}
+
+// RepoURL returns the URL of the given owner/repo with an optional access token
+// encoded in the URL for basic auth.
+//
+// If the test server is bound to 127.0.0.1, RepoURL rewrites the host to
+// localhost. Remote Bazel preserves plain HTTP for localhost URLs, but coerces
+// HTTP 127.0.0.1 URLs to HTTPS before the remote checkout, which breaks tests
+// that intentionally use this local HTTP git server without TLS.
+func (s *Server) RepoURL(owner, repo, accessToken string) string {
+	u, err := url.Parse(s.server.URL)
+	require.NoError(s.t, err)
+	if u.Scheme == "http" && u.Hostname() == "127.0.0.1" {
+		u.Host = net.JoinHostPort("localhost", u.Port())
+	}
+	u.Path = path.Join(owner, repo)
+	if accessToken != "" {
+		u.User = url.UserPassword("x-testgit-access-token", accessToken)
+	}
+	return u.String()
+}
+
+// AccessToken returns a token that grants access to all test repositories.
+func (s *Server) AccessToken() string {
+	return s.accessToken
+}
+
+// CreateProject initializes a git repository on the server.
+func (s *Server) CreateProject(owner, repo string, settings *ProjectSettings) {
+	err := mockgitserver.CreateProject(s.gitProjectRoot, owner, repo, settings)
+	require.NoError(s.t, err)
+}
+
+// Push pushes the local repo to a project created with CreateProject.
+func (s *Server) Push(owner, repo, accessToken, localPath string) {
+	testshell.Run(s.t, localPath, `
+		git remote add origin `+s.RepoURL(owner, repo, accessToken)+`
+		export GIT_ASKPASS=/usr/bin/true
+		git push --set-upstream origin "$(git branch --show-current)"
 	`)
 }
 

--- a/server/util/git/BUILD
+++ b/server/util/git/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/git",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/util/flag",
         "//server/util/log",
         "//server/util/status",
     ],

--- a/server/util/git/git.go
+++ b/server/util/git/git.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
@@ -15,6 +16,10 @@ const (
 	// DefaultUser is the default user set in a repo URL when the username is not
 	// known.
 	DefaultUser = "buildbuddy"
+)
+
+var (
+	githubHost = flag.String("github.host", "github.com", "github host. Currently only github.com is supported.", flag.Internal)
 )
 
 var (
@@ -90,7 +95,7 @@ func ParseGitHubRepoURL(repoURL string) (*RepoURL, error) {
 	if u.Scheme == "file" {
 		return &RepoURL{Repo: repoURL, Scheme: u.Scheme}, nil
 	}
-	if u.Host != "github.com" {
+	if u.Host != *githubHost {
 		return nil, status.InvalidArgumentError("unexpected non-GitHub URL")
 	}
 	pathParts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")


### PR DESCRIPTION
- Use the new `mockgitserver` instead of github for the private repo test
- Stop running the test in firecracker. Instead, use the default isolation, with networking disabled

Before, running this test with `--config=remote --runs_per_test=10` takes ~60-100 seconds. After, it takes ~13-20 seconds.