### PR TITLE
Implement the CacheProxyRegistry in the apps

### DIFF
--- a/enterprise/server/cache_proxy_registry_server/BUILD
+++ b/enterprise/server/cache_proxy_registry_server/BUILD
@@ -1,0 +1,51 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+# gazelle:default_visibility //enterprise:__subpackages__
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+])
+
+go_library(
+    name = "cache_proxy_registry_server",
+    srcs = ["cache_proxy_registry_server.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cache_proxy_registry_server",
+    deps = [
+        "//proto:cache_proxy_go_proto",
+        "//proto:capability_go_proto",
+        "//server/environment",
+        "//server/interfaces",
+        "//server/real_environment",
+        "//server/util/log",
+        "//server/util/perms",
+        "//server/util/proto",
+        "//server/util/status",
+        "@com_github_go_redis_redis_v8//:redis",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)
+
+go_test(
+    name = "cache_proxy_registry_server_test",
+    srcs = ["cache_proxy_registry_server_test.go"],
+    embed = [":cache_proxy_registry_server"],
+    deps = [
+        "//enterprise/server/testutil/enterprise_testenv",
+        "//enterprise/server/testutil/testredis",
+        "//proto:cache_proxy_go_proto",
+        "//proto:capability_go_proto",
+        "//proto:context_go_proto",
+        "//server/interfaces",
+        "//server/testutil/testauth",
+        "//server/testutil/testenv",
+        "//server/util/authutil",
+        "//server/util/claims",
+        "//server/util/proto",
+        "//server/util/status",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)

--- a/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server.go
+++ b/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server.go
@@ -1,0 +1,262 @@
+// This package implements a gRPC server that tracks the set of live cache
+// proxies connected to the app, scoped by group.
+//
+// Cache proxies authenticate using an API key (which must have the
+// REGISTER_CACHE_PROXY capability) and open a client-streaming RPC
+// (RegisterAndStreamHeartbeat). The server persists each heartbeat as a
+// RegisteredCacheProxy entry in a per-group Redis hash, along with an ACL
+// scoped to that group. While the stream is open, credentials are
+// periodically re-validated so a revoked or downgraded API key terminates
+// the stream rather than continuing to write registrations.
+//
+// The companion GetCacheProxies RPC reads that hash, drops entries that
+// haven't checked in for a while, applies ACL filtering, and returns the
+// survivors.
+package cache_proxy_registry_server
+
+import (
+	"context"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/go-redis/redis/v8"
+	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cppb "github.com/buildbuddy-io/buildbuddy/proto/cache_proxy"
+	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
+)
+
+const (
+	// A cache proxy is removed from the registry if it does not refresh its
+	// registration within this amount of time.
+	maxRegistrationStaleness = 10 * time.Minute
+
+	// How often we revalidate credentials for an open registration stream. We
+	// need to regularly revlidate credentials to handle revoked API keys.
+	checkRegistrationCredentialsInterval = 5 * time.Minute
+)
+
+type CacheProxyRegistryServer struct {
+	authenticator interfaces.Authenticator
+	clock         clockwork.Clock
+	rdb           redis.UniversalClient
+	quit          chan struct{}
+}
+
+func Register(env *real_environment.RealEnv) error {
+	if env.GetDefaultRedisClient() == nil {
+		return nil
+	}
+	s, err := NewCacheProxyRegistryServer(env)
+	if err != nil {
+		return status.InternalErrorf("Error configuring cache proxy registry server: %v", err)
+	}
+	env.SetCacheProxyRegistryService(s)
+	return nil
+}
+
+func NewCacheProxyRegistryServer(env environment.Env) (*CacheProxyRegistryServer, error) {
+	rdb := env.GetDefaultRedisClient()
+	if rdb == nil {
+		return nil, status.FailedPreconditionError("Redis is required for cache proxy registration")
+	}
+	authenticator := env.GetAuthenticator()
+	if authenticator == nil {
+		return nil, status.FailedPreconditionError("Authenticator is required for cache proxy registration")
+	}
+	quit := make(chan struct{})
+	env.GetHealthChecker().RegisterShutdownFunction(func(ctx context.Context) error {
+		close(quit)
+		return nil
+	})
+	return &CacheProxyRegistryServer{
+		authenticator: authenticator,
+		clock:         env.GetClock(),
+		rdb:           rdb,
+		quit:          quit,
+	}, nil
+}
+
+func redisKeyForCacheProxies(groupID string) string {
+	return "cacheProxies/" + groupID
+}
+
+func (s *CacheProxyRegistryServer) authorize(ctx context.Context) (string, error) {
+	// AuthenticateGRPCRequest re-reads credentials so we catch API key
+	// deletions / capability changes while the stream is open.
+	user, err := s.authenticator.AuthenticateGRPCRequest(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !user.HasCapability(cappb.Capability_REGISTER_CACHE_PROXY) {
+		return "", status.PermissionDeniedError("API key is missing REGISTER_CACHE_PROXY capability")
+	}
+	return user.GetGroupID(), nil
+}
+
+func (s *CacheProxyRegistryServer) RegisterAndStreamHeartbeat(stream cppb.CacheProxyRegistry_RegisterAndStreamHeartbeatServer) error {
+	ctx := stream.Context()
+	groupID, err := s.authorize(ctx)
+	if err != nil {
+		log.CtxInfof(ctx, "Rejecting cache proxy registration stream: %s", err)
+		return err
+	}
+
+	requestChan := make(chan *cppb.RegisterCacheProxyRequest, 1)
+	errChan := make(chan error, 1)
+	go func() {
+		for {
+			req, err := stream.Recv()
+			if err == io.EOF {
+				close(requestChan)
+				return
+			}
+			if err != nil {
+				// Bail out instead of blocking on errChan if the main
+				// loop has already returned (which cancels ctx).
+				select {
+				case errChan <- err:
+				case <-ctx.Done():
+				}
+				return
+			}
+			// Likewise, don't block forever on a buffered requestChan
+			// that the main loop will never drain.
+			select {
+			case requestChan <- req:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	checkCredentialsTicker := s.clock.NewTicker(checkRegistrationCredentialsInterval)
+	defer checkCredentialsTicker.Stop()
+
+	var proxyID string
+	for {
+		select {
+		case <-s.quit:
+			log.CtxInfof(ctx, "Closing cache proxy registration stream for proxy %q (group %q): server is shutting down", proxyID, groupID)
+			return status.CanceledError("server is shutting down")
+		case err := <-errChan:
+			log.CtxWarningf(ctx, "Closing cache proxy registration stream for proxy %q (group %q): receive failed: %s", proxyID, groupID, err)
+			return err
+		case req, ok := <-requestChan:
+			if !ok {
+				log.CtxInfof(ctx, "Cache proxy %q (group %q) closed its registration stream", proxyID, groupID)
+				return stream.SendAndClose(&cppb.RegisterCacheProxyResponse{})
+			}
+			node := req.GetNode()
+			if node == nil {
+				log.CtxInfof(ctx, "Rejecting cache proxy heartbeat from group %q: missing node info", groupID)
+				return status.InvalidArgumentError("registration request missing node info")
+			}
+			if node.GetProxyId() == "" {
+				log.CtxInfof(ctx, "Rejecting cache proxy heartbeat from group %q: missing proxy_id", groupID)
+				return status.InvalidArgumentError("registration request missing proxy_id")
+			}
+			if err := s.insertOrUpdateProxy(ctx, groupID, node); err != nil {
+				log.CtxInfof(ctx, "Closing cache proxy registration stream for proxy %q (group %q): could not store registration: %s", node.GetProxyId(), groupID, err)
+				return err
+			}
+			proxyID = node.GetProxyId()
+			log.CtxDebugf(ctx, "Cache proxy %q (host %q) checked in", proxyID, node.GetHost())
+		case <-checkCredentialsTicker.Chan():
+			if _, err := s.authorize(ctx); err != nil {
+				if status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err) {
+					log.CtxInfof(ctx, "Closing cache proxy registration stream for proxy %q (group %q): credentials revoked: %s", proxyID, groupID, err)
+					return err
+				}
+				log.CtxWarningf(ctx, "could not revalidate cache proxy registration: %s", err)
+			}
+		}
+	}
+}
+
+func (s *CacheProxyRegistryServer) insertOrUpdateProxy(ctx context.Context, groupID string, node *cppb.CacheProxyNode) error {
+	acl := perms.ToACLProto(nil /*=userID*/, groupID, perms.GROUP_WRITE|perms.GROUP_READ)
+
+	r := &cppb.RegisteredCacheProxy{
+		Registration: node,
+		GroupId:      groupID,
+		Acl:          acl,
+		LastPingTime: timestamppb.Now(),
+	}
+	b, err := proto.Marshal(r)
+	if err != nil {
+		return err
+	}
+	return s.rdb.HSet(ctx, redisKeyForCacheProxies(groupID), node.GetProxyId(), b).Err()
+}
+
+func (s *CacheProxyRegistryServer) GetCacheProxies(ctx context.Context, req *cppb.GetCacheProxiesRequest) (*cppb.GetCacheProxiesResponse, error) {
+	// The group ID comes from the request context (the UI's "selected
+	// group") rather than the authenticated user, because a user can
+	// belong to several groups. perms.AuthorizeRead below still verifies
+	// that the caller actually has read access to entries owned by this
+	// group, so passing an arbitrary group ID here just yields an empty
+	// response, not a leak.
+	groupID := req.GetRequestContext().GetGroupId()
+	if groupID == "" {
+		return nil, status.InvalidArgumentError("group not specified")
+	}
+
+	user, err := s.authenticator.AuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	redisKey := redisKeyForCacheProxies(groupID)
+	entries, err := s.rdb.HGetAll(ctx, redisKey).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	proxies := make([]*cppb.GetCacheProxiesResponse_CacheProxy, 0, len(entries))
+	for id, data := range entries {
+		reg := &cppb.RegisteredCacheProxy{}
+		if err := proto.Unmarshal([]byte(data), reg); err != nil {
+			return nil, err
+		}
+		if time.Since(reg.GetLastPingTime().AsTime()) > maxRegistrationStaleness {
+			// Racey: a fresh heartbeat could land in this hash field
+			// between our HGetAll above and the HDel below, and we'd
+			// drop a live registration. That's tolerable here because
+			// the next heartbeat from that proxy will reinsert it.
+			log.CtxInfof(ctx, "Removing stale cache proxy %q (group %q)", id, groupID)
+			if err := s.rdb.HDel(ctx, redisKey, id).Err(); err != nil {
+				log.CtxWarningf(ctx, "could not remove stale cache proxy: %s", err)
+			}
+			continue
+		}
+		if err := perms.AuthorizeRead(user, reg.GetAcl()); err != nil {
+			continue
+		}
+		proxies = append(proxies, &cppb.GetCacheProxiesResponse_CacheProxy{
+			Node:            reg.GetRegistration(),
+			LastCheckInTime: reg.GetLastPingTime(),
+		})
+	}
+
+	slices.SortFunc(proxies, func(a, b *cppb.GetCacheProxiesResponse_CacheProxy) int {
+		if c := strings.Compare(a.GetNode().GetHost(), b.GetNode().GetHost()); c != 0 {
+			return c
+		}
+		return strings.Compare(a.GetNode().GetProxyId(), b.GetNode().GetProxyId())
+	})
+
+	return &cppb.GetCacheProxiesResponse{
+		CacheProxy: proxies,
+	}, nil
+}

--- a/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server_test.go
+++ b/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server_test.go
@@ -1,0 +1,330 @@
+package cache_proxy_registry_server
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cppb "github.com/buildbuddy-io/buildbuddy/proto/cache_proxy"
+	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
+	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+)
+
+const (
+	testGroupID = "GR1"
+)
+
+// newServer wires up a registry server backed by a real Redis and the
+// provided test users. Note: the server snapshots env.GetAuthenticator() /
+// env.GetClock() at construction, so everything the test needs from env
+// must be set before calling this.
+func newServer(t *testing.T, users map[string]interfaces.UserInfo) (*CacheProxyRegistryServer, *testenv.TestEnv) {
+	redisTarget := testredis.Start(t).Target
+	env := enterprise_testenv.GetCustomTestEnv(t, &enterprise_testenv.Options{
+		RedisTarget: redisTarget,
+	})
+	env.SetAuthenticator(testauth.NewTestAuthenticator(t, users))
+
+	s, err := NewCacheProxyRegistryServer(env)
+	require.NoError(t, err)
+	env.SetCacheProxyRegistryService(s)
+	return s, env
+}
+
+func userWithCapabilities(userID, groupID string, caps ...cappb.Capability) interfaces.UserInfo {
+	return &claims.Claims{
+		UserID:        userID,
+		GroupID:       groupID,
+		AllowedGroups: []string{groupID},
+		GroupMemberships: []*interfaces.GroupMembership{{
+			GroupID:      groupID,
+			Capabilities: caps,
+		}},
+		Capabilities: caps,
+	}
+}
+
+func ctxWithIncomingAPIKey(apiKey string) context.Context {
+	md := metadata.New(map[string]string{authutil.APIKeyHeader: apiKey})
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+func ctxWithOutgoingAPIKey(apiKey string) context.Context {
+	md := metadata.New(map[string]string{authutil.APIKeyHeader: apiKey})
+	return metadata.NewOutgoingContext(context.Background(), md)
+}
+
+func TestAuthorize_MissingCredentials_Unauthenticated(t *testing.T) {
+	s, _ := newServer(t, map[string]interfaces.UserInfo{})
+
+	_, err := s.authorize(context.Background())
+	require.Error(t, err)
+	assert.True(t, status.IsUnauthenticatedError(err), "expected unauthenticated, got: %v", err)
+}
+
+func TestAuthorize_MissingCapability(t *testing.T) {
+	s, _ := newServer(t, map[string]interfaces.UserInfo{
+		"NOCAP_KEY": userWithCapabilities("U1", testGroupID, cappb.Capability_CACHE_WRITE),
+	})
+
+	_, err := s.authorize(ctxWithIncomingAPIKey("NOCAP_KEY"))
+	require.Error(t, err)
+	assert.True(t, status.IsPermissionDeniedError(err), "expected permission denied, got: %v", err)
+}
+
+func TestAuthorize_Success(t *testing.T) {
+	s, _ := newServer(t, map[string]interfaces.UserInfo{
+		"CP_KEY": userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY),
+	})
+
+	groupID, err := s.authorize(ctxWithIncomingAPIKey("CP_KEY"))
+	require.NoError(t, err)
+	assert.Equal(t, testGroupID, groupID)
+}
+
+func TestGetCacheProxies(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, _ := newServer(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	// Insert two proxies out of host-order; expect them returned alphabetically.
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), testGroupID, &cppb.CacheProxyNode{
+		Host:    "host-b",
+		ProxyId: "id-b",
+		Version: "1.0",
+	}))
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), testGroupID, &cppb.CacheProxyNode{
+		Host:    "host-a",
+		ProxyId: "id-a",
+		Version: "1.0",
+	}))
+
+	ctx := claims.AuthContextWithJWT(context.Background(), user.(*claims.Claims), nil)
+	resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetCacheProxy(), 2)
+	assert.Equal(t, "host-a", resp.GetCacheProxy()[0].GetNode().GetHost())
+	assert.Equal(t, "host-b", resp.GetCacheProxy()[1].GetNode().GetHost())
+}
+
+func TestGetCacheProxies_Isolation(t *testing.T) {
+	const otherGroupID = "GR2"
+	other := userWithCapabilities("U2", otherGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, _ := newServer(t, map[string]interfaces.UserInfo{"OTHER_KEY": other})
+
+	// A proxy was registered for the original test group.
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), testGroupID, &cppb.CacheProxyNode{
+		Host: "host", ProxyId: "id",
+	}))
+
+	// A user in a different group asks for that other group's proxies. The
+	// ACL filter must drop the entry — the response should be empty even
+	// though the entry exists in the queried hash.
+	ctx := claims.AuthContextWithJWT(context.Background(), other.(*claims.Claims), nil)
+	resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.GetCacheProxy(), "user from %q should not see proxies registered under %q", otherGroupID, testGroupID)
+}
+
+func TestGetCacheProxies_Expiration(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, _ := newServer(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	// Insert a fresh proxy and a stale one directly into Redis.
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), testGroupID, &cppb.CacheProxyNode{
+		Host: "fresh", ProxyId: "fresh",
+	}))
+	stale := &cppb.RegisteredCacheProxy{
+		Registration: &cppb.CacheProxyNode{Host: "stale", ProxyId: "stale"},
+		GroupId:      testGroupID,
+		LastPingTime: timestamppb.New(time.Now().Add(-2 * maxRegistrationStaleness)),
+	}
+	b, err := proto.Marshal(stale)
+	require.NoError(t, err)
+	require.NoError(t, s.rdb.HSet(context.Background(), redisKeyForCacheProxies(testGroupID), "stale", b).Err())
+
+	ctx := claims.AuthContextWithJWT(context.Background(), user.(*claims.Claims), nil)
+	resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetCacheProxy(), 1)
+	assert.Equal(t, "fresh", resp.GetCacheProxy()[0].GetNode().GetHost())
+}
+
+func startGRPCRegistry(t *testing.T, users map[string]interfaces.UserInfo) (*CacheProxyRegistryServer, cppb.CacheProxyRegistryClient) {
+	s, env := newServer(t, users)
+
+	server, runFunc, lis := testenv.RegisterLocalGRPCServer(t, env)
+	cppb.RegisterCacheProxyRegistryServer(server, s)
+	go runFunc()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	conn, err := testenv.LocalGRPCConn(ctx, lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return s, cppb.NewCacheProxyRegistryClient(conn)
+}
+func TestStreamHeartbeat_PersistsRegistration(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, client := startGRPCRegistry(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	stream, err := client.RegisterAndStreamHeartbeat(ctxWithOutgoingAPIKey("CP_KEY"))
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&cppb.RegisterCacheProxyRequest{
+		Node: &cppb.CacheProxyNode{
+			Host: "proxy-1", ProxyId: "id-1", Version: "v1",
+		},
+	}))
+	resp, err := stream.CloseAndRecv()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// The heartbeat should be visible via GetCacheProxies (which uses the
+	// AuthenticatedUser context, so we build one directly).
+	ctx := claims.AuthContextWithJWT(context.Background(), user.(*claims.Claims), nil)
+	getResp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+	})
+	require.NoError(t, err)
+	require.Len(t, getResp.GetCacheProxy(), 1)
+	assert.Equal(t, "id-1", getResp.GetCacheProxy()[0].GetNode().GetProxyId())
+}
+
+func TestStreamHeartbeat_Anonymous(t *testing.T) {
+	_, client := startGRPCRegistry(t, map[string]interfaces.UserInfo{})
+
+	stream, err := client.RegisterAndStreamHeartbeat(ctxWithOutgoingAPIKey(""))
+	require.NoError(t, err)
+	_, err = stream.CloseAndRecv()
+	require.Error(t, err)
+	assert.True(t, status.IsUnauthenticatedError(err), "expected unauthenticated, got: %v", err)
+}
+
+func TestStreamHeartbeat_Unauthorized(t *testing.T) {
+	noCap := userWithCapabilities("U1", testGroupID, cappb.Capability_CACHE_WRITE)
+	_, client := startGRPCRegistry(t, map[string]interfaces.UserInfo{"NOCAP_KEY": noCap})
+
+	stream, err := client.RegisterAndStreamHeartbeat(ctxWithOutgoingAPIKey("NOCAP_KEY"))
+	require.NoError(t, err)
+	_, err = stream.CloseAndRecv()
+	require.Error(t, err)
+	assert.True(t, status.IsPermissionDeniedError(err), "expected permission denied, got: %v", err)
+}
+
+func TestStreamHeartbeat_MissingNode(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	_, client := startGRPCRegistry(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	stream, err := client.RegisterAndStreamHeartbeat(ctxWithOutgoingAPIKey("CP_KEY"))
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&cppb.RegisterCacheProxyRequest{}))
+	_, err = stream.CloseAndRecv()
+	require.Error(t, err)
+	assert.True(t, status.IsInvalidArgumentError(err), "expected invalid argument, got: %v", err)
+}
+
+func TestStreamHeartbeat_MissingID(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	_, client := startGRPCRegistry(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	stream, err := client.RegisterAndStreamHeartbeat(ctxWithOutgoingAPIKey("CP_KEY"))
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&cppb.RegisterCacheProxyRequest{
+		Node: &cppb.CacheProxyNode{Host: "h", ProxyId: ""},
+	}))
+	_, err = stream.CloseAndRecv()
+	require.Error(t, err)
+	assert.True(t, status.IsInvalidArgumentError(err), "expected invalid argument, got: %v", err)
+}
+
+func TestStreamHeartbeat_AccessRevoked(t *testing.T) {
+	// The server snapshots authenticator + clock at construction, so wire
+	// the test fakes onto env before calling NewCacheProxyRegistryServer.
+	redisTarget := testredis.Start(t).Target
+	env := enterprise_testenv.GetCustomTestEnv(t, &enterprise_testenv.Options{
+		RedisTarget: redisTarget,
+	})
+
+	fakeClock := clockwork.NewFakeClock()
+	env.SetClock(fakeClock)
+
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	// The authenticator's APIKeyProvider is read by the server goroutine
+	// while the test goroutine flips `revoked` — use atomic.Bool so the
+	// race detector stays happy.
+	var revoked atomic.Bool
+	auth := testauth.NewTestAuthenticator(t, nil)
+	auth.APIKeyProvider = func(ctx context.Context, apiKey string) (interfaces.UserInfo, error) {
+		if revoked.Load() || apiKey != "CP_KEY" {
+			return nil, nil
+		}
+		return user, nil
+	}
+	env.SetAuthenticator(auth)
+
+	s, err := NewCacheProxyRegistryServer(env)
+	require.NoError(t, err)
+	env.SetCacheProxyRegistryService(s)
+
+	server, runFunc, lis := testenv.RegisterLocalGRPCServer(t, env)
+	cppb.RegisterCacheProxyRegistryServer(server, s)
+	go runFunc()
+
+	dialCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	conn, err := testenv.LocalGRPCConn(dialCtx, lis)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	client := cppb.NewCacheProxyRegistryClient(conn)
+
+	stream, err := client.RegisterAndStreamHeartbeat(ctxWithOutgoingAPIKey("CP_KEY"))
+	require.NoError(t, err)
+	// Confirm the stream is up by sending an initial heartbeat.
+	require.NoError(t, stream.Send(&cppb.RegisterCacheProxyRequest{
+		Node: &cppb.CacheProxyNode{Host: "h", ProxyId: "id"},
+	}))
+
+	// Wait until the server-side ticker is registered on the fake clock
+	// before we start poking it.
+	fakeClock.BlockUntil(1)
+
+	// Revoke. Advancing past the revalidation interval should make the
+	// server's next tick fire, fail authorize(), and terminate the stream.
+	revoked.Store(true)
+	fakeClock.Advance(checkRegistrationCredentialsInterval + time.Second)
+
+	// Wait until the server tears down the stream — Send will return io.EOF
+	// once the server has closed its side.
+	require.Eventually(t, func() bool {
+		return stream.Send(&cppb.RegisterCacheProxyRequest{
+			Node: &cppb.CacheProxyNode{Host: "h", ProxyId: "id"},
+		}) == io.EOF
+	}, 5*time.Second, 25*time.Millisecond, "server did not terminate stream after revocation")
+
+	_, err = stream.CloseAndRecv()
+	require.Error(t, err)
+	assert.True(t, status.IsUnauthenticatedError(err), "expected unauthenticated, got: %v", err)
+}

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//enterprise/server/backends/redis_metrics_collector",
         "//enterprise/server/backends/s3_cache",
         "//enterprise/server/backends/userdb",
+        "//enterprise/server/cache_proxy_registry_server",
         "//enterprise/server/clientidentity",
         "//enterprise/server/crypter_service",
         "//enterprise/server/execution_search_service",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_metrics_collector"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/s3_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/userdb"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/cache_proxy_registry_server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/crypter_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_search_service"
@@ -286,6 +287,9 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 	if err := scheduler_server.Register(realEnv); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := cache_proxy_registry_server.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
 

--- a/proto/cache_proxy.proto
+++ b/proto/cache_proxy.proto
@@ -75,7 +75,9 @@ message RegisteredCacheProxy {
   google.protobuf.Timestamp last_ping_time = 4;
 }
 
-service CacheProxyAPI {
+// CacheProxyRegistry runs on the main BuildBuddy app and tracks the set of
+// live cache proxies for each group, so the deployment view can list them.
+service CacheProxyRegistry {
   // RegisterAndStreamHeartbeat is opened by the cache proxy on startup. The
   // proxy sends an initial RegisterCacheProxyRequest with its identifying
   // info, then re-sends the same message periodically as a heartbeat. The

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1631,7 +1631,11 @@ func (s *BuildBuddyServer) GetExecutionNodes(ctx context.Context, req *scpb.GetE
 }
 
 func (s *BuildBuddyServer) GetCacheProxies(ctx context.Context, req *cppb.GetCacheProxiesRequest) (*cppb.GetCacheProxiesResponse, error) {
-	return nil, status.UnimplementedError("Not implemented")
+	cps := s.env.GetCacheProxyRegistryService()
+	if cps == nil {
+		return nil, status.UnimplementedError("Not implemented")
+	}
+	return cps.GetCacheProxies(ctx, req)
 }
 
 func (s *BuildBuddyServer) SearchExecution(ctx context.Context, req *espb.SearchExecutionRequest) (*espb.SearchExecutionResponse, error) {

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -76,6 +76,7 @@ type Env interface {
 	GetFileCache() interfaces.FileCache
 	GetRemoteExecutionService() interfaces.RemoteExecutionService
 	GetSchedulerService() interfaces.SchedulerService
+	GetCacheProxyRegistryService() interfaces.CacheProxyRegistryService
 	GetCacheRoutingService() interfaces.CacheRoutingService
 	GetTaskRouter() interfaces.TaskRouter
 	GetTaskSizer() interfaces.TaskSizer

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:auth_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:cache_go_proto",
+        "//proto:cache_proxy_go_proto",
         "//proto:capability_go_proto",
         "//proto:encryption_go_proto",
         "//proto:execution_stats_go_proto",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -29,6 +29,7 @@ import (
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
+	cppb "github.com/buildbuddy-io/buildbuddy/proto/cache_proxy"
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	enpb "github.com/buildbuddy-io/buildbuddy/proto/encryption"
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
@@ -976,6 +977,11 @@ type FileCache interface {
 	// as the filecache. The directory is not unique per call. Callers should
 	// generate globally unique file names under this directory.
 	TempDir() string
+}
+
+type CacheProxyRegistryService interface {
+	RegisterAndStreamHeartbeat(stream cppb.CacheProxyRegistry_RegisterAndStreamHeartbeatServer) error
+	GetCacheProxies(ctx context.Context, req *cppb.GetCacheProxiesRequest) (*cppb.GetCacheProxiesResponse, error)
 }
 
 type SchedulerService interface {

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//proto:auth_go_proto",
         "//proto:buildbuddy_service_go_proto",
+        "//proto:cache_proxy_go_proto",
         "//proto:cache_service_go_proto",
         "//proto:encryption_go_proto",
         "//proto:hit_tracker_go_proto",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -58,6 +58,7 @@ import (
 	apipb "github.com/buildbuddy-io/buildbuddy/proto/api/v1"
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
+	cppb "github.com/buildbuddy-io/buildbuddy/proto/cache_proxy"
 	cspb "github.com/buildbuddy-io/buildbuddy/proto/cache_service"
 	enpb "github.com/buildbuddy-io/buildbuddy/proto/encryption"
 	hitpb "github.com/buildbuddy-io/buildbuddy/proto/hit_tracker"
@@ -302,6 +303,9 @@ func registerServices(env *real_environment.RealEnv, grpcServer *grpc.Server) {
 	}
 	if scheduler := env.GetSchedulerService(); scheduler != nil {
 		scpb.RegisterSchedulerServer(grpcServer, scheduler)
+	}
+	if cacheProxyRegistry := env.GetCacheProxyRegistryService(); cacheProxyRegistry != nil {
+		cppb.RegisterCacheProxyRegistryServer(grpcServer, cacheProxyRegistry)
 	}
 	if cacheServer := env.GetCacheServer(); cacheServer != nil {
 		cspb.RegisterCacheServer(grpcServer, cacheServer)

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -40,6 +40,7 @@ func (cc *executionClientConfig) DisableStreaming() bool {
 
 type RealEnv struct {
 	schedulerService                     interfaces.SchedulerService
+	cacheProxyRegistryService            interfaces.CacheProxyRegistryService
 	taskRouter                           interfaces.TaskRouter
 	taskSizer                            interfaces.TaskSizer
 	healthChecker                        interfaces.HealthChecker
@@ -388,6 +389,12 @@ func (r *RealEnv) SetSchedulerService(s interfaces.SchedulerService) {
 }
 func (r *RealEnv) GetSchedulerService() interfaces.SchedulerService {
 	return r.schedulerService
+}
+func (r *RealEnv) SetCacheProxyRegistryService(s interfaces.CacheProxyRegistryService) {
+	r.cacheProxyRegistryService = s
+}
+func (r *RealEnv) GetCacheProxyRegistryService() interfaces.CacheProxyRegistryService {
+	return r.cacheProxyRegistryService
 }
 func (r *RealEnv) SetTaskRouter(tr interfaces.TaskRouter) {
 	r.taskRouter = tr


### PR DESCRIPTION
This adds the server-side half of cache proxy registration. The new `CacheProxyRegistry` gRPC service runs in the app: cache proxies open a client-streaming `RegisterAndStreamHeartbeat` call and re-send their identifying info on a timer, and the server persists each heartbeat into a per-group Redis hash. `GetCacheProxies` now delegates here, reads that hash, drops entries that haven't checked in within 10 minutes, and applies the usual ACL filter so a caller can only see proxies in their own group. Registration requires the `REGISTER_CACHE_PROXY` capability on the API key — there's no opt-out flag, since this is brand-new functionality with no installed base to keep working.

Following the executor pattern, registry liveness is tracked in Redis with read-time staleness cleanup rather than per-key TTLs, which keeps the data model identical to executor pools. Existing cache proxies are unaffected: this PR only adds a server, so no proxy will ever call RegisterAndStreamHeartbeat and cache traffic continues to flow exactly as before.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/6869