### PR TITLE
cli: quarantine TestFix_RunsFromSubdirectory

### DIFF
--- a/cli/test/integration/fix/BUILD
+++ b/cli/test/integration/fix/BUILD
@@ -12,6 +12,7 @@ go_test(
     },
     deps = [
         "//cli/testutil/testcli",
+        "//server/testutil/quarantine",
         "//server/testutil/testfs",
         "@com_github_stretchr_testify//require",
     ],

--- a/cli/test/integration/fix/fix_test.go
+++ b/cli/test/integration/fix/fix_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/testutil/testcli"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/quarantine"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/require"
 )
@@ -220,6 +221,7 @@ func TestFix_Idempotent(t *testing.T) {
 }
 
 func TestFix_RunsFromSubdirectory(t *testing.T) {
+	quarantine.SkipQuarantinedTest(t)
 	ws := fixWorkspace(t, map[string]string{
 		"MODULE.bazel":    "module(name = \"x\")\n",
 		"sub/BUILD.bazel": poorlyFormatted,


### PR DESCRIPTION
The test flakes in CI. Quarantine it so it doesn't block the suite while building confidence in a Gazelle upgrade.