### PR TITLE
`bb remote`: support BUILDBUDDY_REMOTE_RUNNER env var

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -52,6 +52,7 @@ go_test(
     srcs = ["remotebazel_test.go"],
     embed = [":remotebazel"],
     deps = [
+        "//cli/login",
         "//cli/parser",
         "//cli/parser/test_data",
         "//cli/storage",

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1224,7 +1224,24 @@ func attemptRun(ctx context.Context, bbClient bbspb.BuildBuddyServiceClient, exe
 	return inRsp, execRsp, nil
 }
 
+// getRemoteRunnerTarget returns the remote runner target to use.
+// If explicitFlag is true (the --remote_runner flag was passed on the command
+// line), the parsed flag value is used. Otherwise, BUILDBUDDY_REMOTE_RUNNER
+// is checked. If neither is set, the default target is used.
+func getRemoteRunnerTarget(explicitFlag bool) string {
+	if explicitFlag {
+		return *remoteRunner
+	}
+	if env := os.Getenv("BUILDBUDDY_REMOTE_RUNNER"); env != "" {
+		return env
+	}
+	return *remoteRunner
+}
+
 func HandleRemoteBazel(commandLineArgs []string) (int, error) {
+	// Check whether --remote_runner was explicitly set *before* parseRemoteCliFlags
+	// strips it from the argument list.
+	explicitRemoteRunner := arg.Has(commandLineArgs, "remote_runner")
 	commandLineArgs, err := parseRemoteCliFlags(commandLineArgs)
 	if err != nil {
 		return 1, status.WrapError(err, "parse cli flags")
@@ -1253,7 +1270,9 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 		return 1, status.WrapError(err, "determine working directory")
 	}
 
-	runner := *remoteRunner
+	// If no remote_runner was explicitly set on the command line, fall back
+	// to the BUILDBUDDY_REMOTE_RUNNER environment variable.
+	runner := getRemoteRunnerTarget(explicitRemoteRunner)
 	if !strings.HasPrefix(runner, "grpc") {
 		runner = "grpcs://" + runner
 	}

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1224,13 +1224,20 @@ func attemptRun(ctx context.Context, bbClient bbspb.BuildBuddyServiceClient, exe
 	return inRsp, execRsp, nil
 }
 
+func normalizeGRPCTarget(target string) string {
+	if strings.HasPrefix(target, "grpc://") || strings.HasPrefix(target, "grpcs://") {
+		return target
+	}
+	return "grpcs://" + target
+}
+
 // getRemoteRunnerTarget returns the remote runner target to use.
-// If explicitFlag is true (the --remote_runner flag was passed on the command
-// line), the parsed flag value is used. Otherwise, BUILDBUDDY_REMOTE_RUNNER
-// is checked. If neither is set, the default target is used.
-func getRemoteRunnerTarget(explicitFlag bool) string {
-	if explicitFlag {
-		return *remoteRunner
+// If --remote_runner was passed on the command line, that value is used.
+// Otherwise, BUILDBUDDY_REMOTE_RUNNER is checked. If neither is set, the
+// default target is used.
+func getRemoteRunnerTarget(commandLineArgs []string) string {
+	if runner := arg.Get(commandLineArgs, "remote_runner"); runner != "" {
+		return runner
 	}
 	if env := os.Getenv("BUILDBUDDY_REMOTE_RUNNER"); env != "" {
 		return env
@@ -1239,9 +1246,8 @@ func getRemoteRunnerTarget(explicitFlag bool) string {
 }
 
 func HandleRemoteBazel(commandLineArgs []string) (int, error) {
-	// Check whether --remote_runner was explicitly set *before* parseRemoteCliFlags
-	// strips it from the argument list.
-	explicitRemoteRunner := arg.Has(commandLineArgs, "remote_runner")
+	runner := normalizeGRPCTarget(getRemoteRunnerTarget(commandLineArgs))
+
 	commandLineArgs, err := parseRemoteCliFlags(commandLineArgs)
 	if err != nil {
 		return 1, status.WrapError(err, "parse cli flags")
@@ -1268,13 +1274,6 @@ func HandleRemoteBazel(commandLineArgs []string) (int, error) {
 	workingDirectory, err := getWorkingDirectory(wsFilePath)
 	if err != nil {
 		return 1, status.WrapError(err, "determine working directory")
-	}
-
-	// If no remote_runner was explicitly set on the command line, fall back
-	// to the BUILDBUDDY_REMOTE_RUNNER environment variable.
-	runner := getRemoteRunnerTarget(explicitRemoteRunner)
-	if !strings.HasPrefix(runner, "grpc") {
-		runner = "grpcs://" + runner
 	}
 
 	cmd := ""

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/login"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser/test_data"
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
@@ -494,4 +495,54 @@ func TestParseArgs(t *testing.T) {
 	}, bazelArgs)
 	// Exec args should be preserved.
 	require.Equal(t, []string{"--exec_arg"}, execArgs)
+}
+
+func TestGetRemoteRunnerTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		envValue   string
+		flagArgs   []string
+		wantRunner string
+	}{
+		{
+			name:       "neither flag nor env set",
+			wantRunner: login.DefaultApiTarget,
+		},
+		{
+			name:       "env set, no flag",
+			envValue:   "env-runner.dev",
+			wantRunner: "env-runner.dev",
+		},
+		{
+			name:       "flag takes precedence over env",
+			envValue:   "env-runner.dev",
+			flagArgs:   []string{"--remote_runner=flag-runner.dev", "build", "//..."},
+			wantRunner: "flag-runner.dev",
+		},
+		{
+			name:       "flag set, no env",
+			flagArgs:   []string{"--remote_runner=flag-runner.dev", "build", "//..."},
+			wantRunner: "flag-runner.dev",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("BUILDBUDDY_REMOTE_RUNNER", tc.envValue)
+
+			// Reset the remoteRunner flag to its default before each subtest so
+			// prior parses don't leak.
+			_ = RemoteFlagset.Set("remote_runner", login.DefaultApiTarget)
+
+			// If the test simulates passing --remote_runner on the command line,
+			// parse it so *remoteRunner reflects the flag value.
+			explicitFlag := false
+			if len(tc.flagArgs) > 0 {
+				explicitFlag = true
+				_, err := parseRemoteCliFlags(tc.flagArgs)
+				require.NoError(t, err)
+			}
+
+			actual := getRemoteRunnerTarget(explicitFlag)
+			require.Equal(t, tc.wantRunner, actual)
+		})
+	}
 }

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -510,19 +510,19 @@ func TestGetRemoteRunnerTarget(t *testing.T) {
 		},
 		{
 			name:       "env set, no flag",
-			envValue:   "env-runner.dev",
-			wantRunner: "env-runner.dev",
+			envValue:   "grpcs://env-runner.dev",
+			wantRunner: "grpcs://env-runner.dev",
 		},
 		{
 			name:       "flag takes precedence over env",
-			envValue:   "env-runner.dev",
-			flagArgs:   []string{"--remote_runner=flag-runner.dev", "build", "//..."},
-			wantRunner: "flag-runner.dev",
+			envValue:   "grpcs://env-runner.dev",
+			flagArgs:   []string{"--remote_runner=grpc://flag-runner.dev", "build", "//..."},
+			wantRunner: "grpc://flag-runner.dev",
 		},
 		{
 			name:       "flag set, no env",
-			flagArgs:   []string{"--remote_runner=flag-runner.dev", "build", "//..."},
-			wantRunner: "flag-runner.dev",
+			flagArgs:   []string{"--remote_runner=grpcs://flag-runner.dev", "build", "//..."},
+			wantRunner: "grpcs://flag-runner.dev",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -532,16 +532,7 @@ func TestGetRemoteRunnerTarget(t *testing.T) {
 			// prior parses don't leak.
 			_ = RemoteFlagset.Set("remote_runner", login.DefaultApiTarget)
 
-			// If the test simulates passing --remote_runner on the command line,
-			// parse it so *remoteRunner reflects the flag value.
-			explicitFlag := false
-			if len(tc.flagArgs) > 0 {
-				explicitFlag = true
-				_, err := parseRemoteCliFlags(tc.flagArgs)
-				require.NoError(t, err)
-			}
-
-			actual := getRemoteRunnerTarget(explicitFlag)
+			actual := getRemoteRunnerTarget(tc.flagArgs)
 			require.Equal(t, tc.wantRunner, actual)
 		})
 	}


### PR DESCRIPTION
The bb remote command now checks the BUILDBUDDY_REMOTE_RUNNER environment variable when --remote_runner is not explicitly passed on the command line. The flag takes precedence over the env var.

This mirrors the existing BUILDBUDDY_API_KEY pass-through behavior already supported by the login package.

Adds TestGetRemoteRunnerTarget to cover flag vs env precedence.