### PR TITLE
Simplify peerset.go using slices.Contains

### DIFF
--- a/server/util/peerset/peerset.go
+++ b/server/util/peerset/peerset.go
@@ -98,7 +98,7 @@ func (p *PeerSet) GetBackfillTargets() (string, []string) {
 	lastUsedIndex := p.i - 1
 
 	source := ""
-	targets := make([]string, 0)
+	var targets []string
 
 	if lastUsedIndex < len(p.PreferredPeers) {
 		source, targets = p.PreferredPeers[lastUsedIndex], p.PreferredPeers[:lastUsedIndex]

--- a/server/util/peerset/peerset.go
+++ b/server/util/peerset/peerset.go
@@ -1,7 +1,6 @@
 package peerset
 
 import (
-	"math/rand"
 	"slices"
 )
 
@@ -23,36 +22,15 @@ type PeerSet struct {
 
 func New(preferredPeers, fallbackPeers []string) *PeerSet {
 	return &PeerSet{
-		i:                   0,
-		PreferredPeers:      preferredPeers,
-		FallbackPeers:       fallbackPeers,
-		FailedPeers:         nil,
-		FailedFallbackPeers: nil,
+		PreferredPeers: preferredPeers,
+		FallbackPeers:  fallbackPeers,
 	}
-}
-
-func NewRead(localhost string, preferredPeers, fallbackPeers []string) *PeerSet {
-	rest := make([]string, 0, len(preferredPeers))
-	first := make([]string, 0, 1)
-	for _, p := range preferredPeers {
-		if p == localhost {
-			first = append(first, p)
-		} else {
-			rest = append(rest, p)
-		}
-	}
-	rand.Shuffle(len(rest), func(i, j int) {
-		rest[i], rest[j] = rest[j], rest[i]
-	})
-	return New(append(first, rest...), fallbackPeers)
 }
 
 func (p *PeerSet) MarkPeerAsFailed(failedPeer string) {
-	for _, peer := range p.PreferredPeers {
-		if peer == failedPeer {
-			p.FailedPeers = append(p.FailedPeers, failedPeer)
-			return
-		}
+	if slices.Contains(p.PreferredPeers, failedPeer) {
+		p.FailedPeers = append(p.FailedPeers, failedPeer)
+		return
 	}
 	p.FailedFallbackPeers = append(p.FailedFallbackPeers, failedPeer)
 }
@@ -131,25 +109,13 @@ func (p *PeerSet) GetBackfillTargets() (string, []string) {
 		}
 	}
 	// Ensure no failed peers are returned.
-	for _, f := range p.FailedPeers {
-		if f == source {
-			return "", []string{}
-		}
+	if slices.Contains(p.FailedPeers, source) {
+		return "", []string{}
 	}
 
 	filteredTargets := make([]string, 0, len(targets))
 	for _, t := range targets {
-		isFailed := false
-		for _, f := range p.FailedPeers {
-			if t == f {
-				isFailed = true
-				break
-			}
-		}
-		if isFailed {
-			continue
-		}
-		if slices.Contains(p.BlockBackfills, t) {
+		if slices.Contains(p.FailedPeers, t) || slices.Contains(p.BlockBackfills, t) {
 			continue
 		}
 		filteredTargets = append(filteredTargets, t)

--- a/server/util/peerset/peerset_test.go
+++ b/server/util/peerset/peerset_test.go
@@ -98,46 +98,6 @@ func TestGetNextPeer(t *testing.T) {
 	}
 }
 
-func TestNewRead(t *testing.T) {
-	localhost := "a"
-
-	tests := []struct {
-		preferred []string
-		fallback  []string
-	}{
-		{
-			[]string{localhost},
-			[]string{"b", "c"},
-		},
-		{
-			[]string{"b", "c", localhost},
-			[]string{},
-		},
-		{
-			[]string{"b", localhost, "c"},
-			[]string{"d", "e", "f", "g"},
-		},
-	}
-
-	for _, test := range tests {
-		p := peerset.NewRead("a", test.preferred, test.fallback)
-		i := 0
-		for peer, handoff := p.GetNextPeerAndHandoff(); peer != ""; peer, handoff = p.GetNextPeerAndHandoff() {
-			// Test that hinted handoffs only refer to preferred nodes.
-			if handoff != "" {
-				assert.Contains(t, test.preferred, handoff)
-			}
-			// Test that if localhost was a peer, it was returned first.
-			if i == 0 && contains(localhost, test.preferred) {
-				assert.Equal(t, localhost, peer)
-			}
-			// Test that the peer came from preferred or fallback.
-			assert.Contains(t, append(test.preferred, test.fallback...), peer)
-			i += 1
-		}
-	}
-}
-
 func TestGetBackfillTargets(t *testing.T) {
 	tests := []struct {
 		p                     *peerset.PeerSet


### PR DESCRIPTION
Also removed NewRead since it's not used anywhere outside of tests.