### PR TITLE
In distributed cache, allow reads when peer count < replication factor

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -740,10 +740,9 @@ func (c *Cache) readPeers(d *repb.Digest) *peerset.PeerSet {
 	peers := c.consistentHash.GetAllReplicas(d.GetHash())
 	var primaryPeers, secondaryPeers []string
 	// To prevent a panic if replication is misconfigured to be higher than peer count.
-	if len(peers) >= c.opts.ReplicationFactor {
-		primaryPeers = peers[:c.opts.ReplicationFactor]
-		secondaryPeers = peers[c.opts.ReplicationFactor:]
-	}
+	primaryCount := min(len(peers), c.opts.ReplicationFactor)
+	primaryPeers = peers[:primaryCount]
+	secondaryPeers = peers[primaryCount:]
 
 	if len(c.opts.NewNodes) > 0 {
 		extendedPeerList := c.extraConsistentHash.GetAllReplicas(d.GetHash())

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -185,6 +185,25 @@ func TestBasicReadWrite(t *testing.T) {
 	}, peerLookupMetrics)
 }
 
+func TestReadPeers_FewerNodesThanReplicationFactor(t *testing.T) {
+	env, _, _ := getEnvAuthAndCtx(t)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	memCache := newMemoryCache(t, int64(1000000))
+	c, err := NewDistributedCache(env, memCache, Options{
+		ListenAddr:         peer1,
+		ReplicationFactor:  3,
+		Nodes:              []string{peer1, peer2},
+		DisableLocalLookup: true,
+	}, env.GetHealthChecker())
+	require.NoError(t, err)
+
+	rn, _ := testdigest.RandomCASResourceBuf(t, 100)
+	ps := c.readPeers(rn.GetDigest())
+	require.ElementsMatch(t, []string{peer1, peer2}, ps.PreferredPeers)
+	require.Empty(t, ps.FallbackPeers)
+}
+
 func TestReadWrite_Compression(t *testing.T) {
 	env, _, ctx := getEnvAuthAndCtx(t)
 


### PR DESCRIPTION
There's no reason to block reads completely in this case, especially if nodes are gong down and up with k8s discovery.