### PR TITLE
Fix flaky TestLRU: warm up cache after restart, fresh ctx for Find loop

### DIFF
--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -573,9 +573,9 @@ func TestLRU(t *testing.T) {
 		resourceKeys = append(resourceKeys, md.GetFileRecord())
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	err = rc1.TestingWaitForGC(ctx)
+	gcCtx, gcCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer gcCancel()
+	err = rc1.TestingWaitForGC(gcCtx)
 	require.NoError(t, err)
 	waitForShutdown(t, caches...)
 
@@ -599,17 +599,29 @@ func TestLRU(t *testing.T) {
 	keptCount := 0
 	keptAgeTotal := time.Duration(0)
 
+	// Use a fresh context for the post-restart Find loop. The GC context
+	// above can be near expiry by now.
+	findCtx, findCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer findCancel()
+	// Wait for the freshly-restarted cache to acquire range leases before
+	// running the Find loop. Without this, the first few Find()s can fail
+	// with "Range lease invalid", which the loop below would silently
+	// count as "kept" (causing evictedCount=0 false-negative failures).
+	require.Eventually(t, func() bool {
+		_, err := rc1.Find(findCtx, &mdpb.FindRequest{
+			FileRecords: []*sgpb.FileRecord{resourceKeys[0]},
+		})
+		return err == nil
+	}, 10*time.Second, 100*time.Millisecond, "cache did not become ready after restart")
+
 	now := clock.Now()
 	for r, usedAt := range lastUsed {
-		findRsp, err := rc1.Find(ctx, &mdpb.FindRequest{
+		findRsp, err := rc1.Find(findCtx, &mdpb.FindRequest{
 			FileRecords: []*sgpb.FileRecord{r},
 		})
-		evicted := false
-		if err == nil && len(findRsp.GetFindResponses()) == 1 {
-			if !findRsp.GetFindResponses()[0].GetPresent() {
-				evicted = true
-			}
-		}
+		require.NoError(t, err)
+		require.Equal(t, 1, len(findRsp.GetFindResponses()))
+		evicted := !findRsp.GetFindResponses()[0].GetPresent()
 
 		age := now.Sub(usedAt)
 		if evicted {


### PR DESCRIPTION
## Summary

Two new failure modes emerged after dc40fbf9f0 (#12111):

1. **evictedCount=0 false-negative**: After the second `startNodes()`, the freshly-restarted cache often hasn't acquired range leases yet when the Find loop begins. The first few Find()s return \"Range lease invalid\", which the previous code silently treated as \"not evicted\" (`err != nil` → kept). With most/all calls returning errors, the test reported `evictedCount=0` even though eviction had completed successfully.

   **Fix**: probe with `require.Eventually` before the Find loop until the cache is responsive, then assert `require.NoError` on each Find so any real error is surfaced loudly.

2. **Stale ctx during Find loop**: the 30s ctx created for `TestingWaitForGC` was reused for the post-restart Find loop. After WaitForGC + waitForShutdown + startNodes, the ctx is often near or past expiry, compounding failure mode #1.

   **Fix**: use a fresh 30s context for the Find loop.

Also bumps the WaitForGC timeout from 30s to 60s to give pebble's `EstimateDiskUsage` more headroom on slow CI when only the 7 records permitted by `min_eviction_age=18min` are eligible for eviction.

## Test plan

- [x] `bazel test //enterprise/server/raft/metadata:metadata_test --test_filter=TestLRU --runs_per_test=50`: 49/50 pass; the 1 failure is an unrelated `bind: address already in use` port-reuse race in test infrastructure.
- [ ] Verify against the failing CI invocations d3bdd7bb-475b-412e-9559-11ecc6d95dd3 (WaitForGC timeout) and 730ecb90-9cd6-4d03-9ab6-0b0e01f2c966 (evictedCount=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)