### PR TITLE
Extract OIDC issuer util and use for selfauth

### DIFF
--- a/enterprise/server/oidcissuer/BUILD
+++ b/enterprise/server/oidcissuer/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "oidcissuer",
+    srcs = ["oidcissuer.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/oidcissuer",
+    deps = ["@com_github_golang_jwt_jwt_v4//:jwt"],
+)
+
+go_test(
+    name = "oidcissuer_test",
+    size = "small",
+    srcs = ["oidcissuer_test.go"],
+    embed = [":oidcissuer"],
+    deps = [
+        "@com_github_golang_jwt_jwt_v4//:jwt",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/oidcissuer/oidcissuer.go
+++ b/enterprise/server/oidcissuer/oidcissuer.go
@@ -1,0 +1,221 @@
+// Package oidcissuer implements reusable OpenID Provider machinery.
+//
+// It owns issuer metadata, JWKS publication, and RS256 token signing and
+// verification, which are standardized OIDC concerns shared by provider
+// implementations. Consumers of this package handle auth flows, token exchange
+// handlers, and custom claims, which can involve application-specific business
+// logic.
+//
+// Only the RS256 signing algorithm is supported, currently.
+package oidcissuer
+
+import (
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+const (
+	// ConfigurationPath is the standard well-known path for
+	// OpenID Provider Configuration metadata.
+	ConfigurationPath = "/.well-known/openid-configuration"
+
+	signingAlgorithmRS256 = "RS256"
+)
+
+// Config contains key material and OpenID Provider Metadata for an OIDC issuer.
+type Config struct {
+	// PrivateKeyPEM is the PEM-encoded RSA private key used to sign RS256
+	// tokens.
+	PrivateKeyPEM string
+
+	// Standard OpenID Provider Metadata fields.
+	// See https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+
+	IssuerURL              string   // Ex: "https://buildbuddy.example.com/oidc"
+	AuthorizationEndpoint  string   // Ex: "https://buildbuddy.example.com/oauth/authorize"
+	JWKSURI                string   // Ex: "https://buildbuddy.example.com/.well-known/jwks"
+	TokenEndpoint          string   // Ex: "https://buildbuddy.example.com/oauth/token"
+	UserinfoEndpoint       string   // Ex: "https://buildbuddy.example.com/userinfo"
+	SubjectTypesSupported  []string // Ex: []string{"public"}
+	ResponseTypesSupported []string // Ex: []string{"code"}
+	GrantTypesSupported    []string // Ex: []string{"authorization_code"}
+	ClaimsSupported        []string // Ex: []string{"sub", "aud"}
+	ScopesSupported        []string // Ex: []string{"openid"}
+}
+
+// ProviderMetadata contains standard OIDC provider metadata fields.
+// See https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+type ProviderMetadata struct {
+	Issuer                           string   `json:"issuer"`
+	AuthorizationEndpoint            string   `json:"authorization_endpoint,omitempty"`
+	JWKSURI                          string   `json:"jwks_uri"`
+	TokenEndpoint                    string   `json:"token_endpoint,omitempty"`
+	UserinfoEndpoint                 string   `json:"userinfo_endpoint,omitempty"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	ResponseTypesSupported           []string `json:"response_types_supported,omitempty"`
+	GrantTypesSupported              []string `json:"grant_types_supported,omitempty"`
+	ClaimsSupported                  []string `json:"claims_supported,omitempty"`
+	IdTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	ScopesSupported                  []string `json:"scopes_supported,omitempty"`
+}
+
+// JWKS contains standard JSON Web Key Set fields.
+// See https://www.rfc-editor.org/rfc/rfc7517#section-5
+type JWKS struct {
+	Keys []*JWK `json:"keys"`
+}
+
+// JWK contains standard RSA JSON Web Key fields.
+// See https://www.rfc-editor.org/rfc/rfc7517#section-4 and
+// https://www.rfc-editor.org/rfc/rfc7518#section-6.3.1
+type JWK struct {
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	N   string `json:"n,omitempty"`
+	E   string `json:"e,omitempty"`
+}
+
+// Provider is a configured OIDC issuer backed by an RSA signing key.
+//
+// It serves discovery metadata and a JWKS for its issuer URL, and signs or
+// verifies JWTs with the configured key.
+type Provider struct {
+	privateKey *rsa.PrivateKey
+	keyID      string
+
+	issuerURL string
+
+	providerMetadataResponse string
+	jwksResponse             string
+}
+
+// New returns a Provider configured with the given OIDC metadata and signing
+// key.
+func New(cfg Config) (*Provider, error) {
+	key, keyID, err := signingKey(cfg.PrivateKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.IssuerURL == "" {
+		return nil, fmt.Errorf("OIDC issuer URL is required")
+	}
+	if cfg.JWKSURI == "" {
+		return nil, fmt.Errorf("OIDC jwks_uri is required")
+	}
+	if len(cfg.SubjectTypesSupported) == 0 {
+		return nil, fmt.Errorf("OIDC subject_types_supported is required")
+	}
+	// Pre-marshal the static provider configuration and JWKS JSON.
+	providerMetadataJSON, err := json.Marshal(&ProviderMetadata{
+		Issuer:                           cfg.IssuerURL,
+		AuthorizationEndpoint:            cfg.AuthorizationEndpoint,
+		JWKSURI:                          cfg.JWKSURI,
+		TokenEndpoint:                    cfg.TokenEndpoint,
+		UserinfoEndpoint:                 cfg.UserinfoEndpoint,
+		SubjectTypesSupported:            cfg.SubjectTypesSupported,
+		ResponseTypesSupported:           cfg.ResponseTypesSupported,
+		GrantTypesSupported:              cfg.GrantTypesSupported,
+		ClaimsSupported:                  cfg.ClaimsSupported,
+		IdTokenSigningAlgValuesSupported: []string{signingAlgorithmRS256},
+		ScopesSupported:                  cfg.ScopesSupported,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal OIDC provider metadata: %w", err)
+	}
+	jwksJSONBytes, err := json.Marshal(&JWKS{
+		Keys: []*JWK{
+			publicJWK(&key.PublicKey, keyID),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal OIDC JWKS: %w", err)
+	}
+	return &Provider{
+		privateKey: key,
+		keyID:      keyID,
+		issuerURL:  cfg.IssuerURL,
+
+		providerMetadataResponse: string(providerMetadataJSON) + "\n",
+		jwksResponse:             string(jwksJSONBytes) + "\n",
+	}, nil
+}
+
+// Issuer returns this provider's issuer URL.
+func (p *Provider) Issuer() string {
+	return p.issuerURL
+}
+
+// ServeWellKnownOpenIDConfiguration writes this issuer's OpenID Provider
+// Configuration metadata.
+func (p *Provider) ServeWellKnownOpenIDConfiguration(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+	_, _ = io.WriteString(w, p.providerMetadataResponse)
+}
+
+// ServeJWKS writes this issuer's JSON Web Key Set.
+func (p *Provider) ServeJWKS(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+	_, _ = io.WriteString(w, p.jwksResponse)
+}
+
+// Sign signs claims as a JWT using this issuer's key.
+func (p *Provider) Sign(c jwt.Claims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, c)
+	token.Header["kid"] = p.keyID
+	token.Header["typ"] = "JWT"
+	return token.SignedString(p.privateKey)
+}
+
+// ParseClaims verifies tokenString as a JWT signed by this provider and
+// stores the parsed claims in c.
+func (p *Provider) ParseClaims(tokenString string, c jwt.Claims) (*jwt.Token, error) {
+	return jwt.ParseWithClaims(tokenString, c, func(token *jwt.Token) (any, error) {
+		if token.Method != jwt.SigningMethodRS256 {
+			return nil, fmt.Errorf("unexpected signing method %q", token.Method.Alg())
+		}
+		if kid, _ := token.Header["kid"].(string); kid != "" && kid != p.keyID {
+			return nil, fmt.Errorf("unknown key ID %q", kid)
+		}
+		return &p.privateKey.PublicKey, nil
+	})
+}
+
+func signingKey(keyPEM string) (*rsa.PrivateKey, string, error) {
+	if keyPEM == "" {
+		return nil, "", fmt.Errorf("OIDC issuer private key must be configured")
+	}
+	pem := strings.ReplaceAll(keyPEM, `\n`, "\n")
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(pem))
+	if err != nil {
+		return nil, "", fmt.Errorf("parse OIDC RSA private key: %w", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal OIDC public key: %w", err)
+	}
+	sum := sha256.Sum256(der)
+	return key, base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}
+
+func publicJWK(key *rsa.PublicKey, keyID string) *JWK {
+	return &JWK{
+		Kty: "RSA",
+		Use: "sig",
+		Kid: keyID,
+		Alg: signingAlgorithmRS256,
+		N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	}
+}

--- a/enterprise/server/oidcissuer/oidcissuer_test.go
+++ b/enterprise/server/oidcissuer/oidcissuer_test.go
@@ -1,0 +1,154 @@
+package oidcissuer
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_MetadataAndSigning(t *testing.T) {
+	key := testSigningKey(t)
+	provider := testProvider(t, key)
+
+	// The issuer publishes discovery metadata that consumers use to find the
+	// JWKS and token endpoint.
+	rec := httptest.NewRecorder()
+	provider.ServeWellKnownOpenIDConfiguration(rec, httptest.NewRequest(http.MethodGet, "/oidc"+ConfigurationPath, nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var cfg ProviderMetadata
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &cfg))
+	require.Equal(t, ProviderMetadata{
+		Issuer:                           "https://buildbuddy.example.com/issuer",
+		AuthorizationEndpoint:            "https://buildbuddy.example.com/issuer/authorize",
+		JWKSURI:                          "https://buildbuddy.example.com/issuer/keys.json",
+		TokenEndpoint:                    "https://buildbuddy.example.com/issuer/token",
+		SubjectTypesSupported:            []string{"public"},
+		ResponseTypesSupported:           []string{"code"},
+		GrantTypesSupported:              []string{"authorization_code"},
+		ClaimsSupported:                  []string{"sub", "aud"},
+		IdTokenSigningAlgValuesSupported: []string{"RS256"},
+		ScopesSupported:                  []string{"openid"},
+	}, cfg)
+
+	// The issuer publishes its public signing key so token consumers can verify
+	// JWT signatures.
+	rec = httptest.NewRecorder()
+	provider.ServeJWKS(rec, httptest.NewRequest(http.MethodGet, "/oidc/.well-known/jwks", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var keySet JWKS
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &keySet))
+	require.Len(t, keySet.Keys, 1)
+	require.NotEmpty(t, keySet.Keys[0].Kid)
+	require.NotEmpty(t, keySet.Keys[0].N)
+	keySet.Keys[0].Kid = ""
+	keySet.Keys[0].N = ""
+	require.Equal(t, JWKS{
+		Keys: []*JWK{{
+			Kty: "RSA",
+			Use: "sig",
+			Alg: "RS256",
+			E:   "AQAB",
+		}},
+	}, keySet)
+
+	// Tokens signed by the issuer parse with the provider's public key and
+	// preserve the caller supplied claims.
+	claims := &jwt.RegisteredClaims{
+		Audience:  jwt.ClaimStrings{"test-audience"},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute)),
+		Issuer:    provider.Issuer(),
+		Subject:   "test-subject",
+	}
+	tokenString, err := provider.Sign(claims)
+	require.NoError(t, err)
+
+	parsedClaims := &jwt.RegisteredClaims{}
+	parsed, err := provider.ParseClaims(tokenString, parsedClaims)
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	require.Equal(t, claims, parsedClaims)
+}
+
+func testProvider(t *testing.T, key *rsa.PrivateKey) *Provider {
+	t.Helper()
+	provider, err := New(Config{
+		PrivateKeyPEM:          privateKeyPEM(key),
+		IssuerURL:              "https://buildbuddy.example.com/issuer",
+		JWKSURI:                "https://buildbuddy.example.com/issuer/keys.json",
+		AuthorizationEndpoint:  "https://buildbuddy.example.com/issuer/authorize",
+		TokenEndpoint:          "https://buildbuddy.example.com/issuer/token",
+		ClaimsSupported:        []string{"sub", "aud"},
+		ScopesSupported:        []string{"openid"},
+		ResponseTypesSupported: []string{"code"},
+		GrantTypesSupported:    []string{"authorization_code"},
+		SubjectTypesSupported:  []string{"public"},
+	})
+	require.NoError(t, err)
+	return provider
+}
+
+func TestNew_RequiresSubjectTypesSupported(t *testing.T) {
+	key := testSigningKey(t)
+
+	// OpenID Connect Discovery requires issuers to advertise whether their
+	// subjects are public or pairwise, so callers must make that choice
+	// explicitly.
+	_, err := New(Config{
+		PrivateKeyPEM: privateKeyPEM(key),
+		IssuerURL:     "https://buildbuddy.example.com/issuer",
+		JWKSURI:       "https://buildbuddy.example.com/issuer/keys.json",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "subject_types_supported")
+}
+
+func TestProvider_OmitsEmptyOptionalMetadata(t *testing.T) {
+	key := testSigningKey(t)
+	provider, err := New(Config{
+		PrivateKeyPEM: privateKeyPEM(key),
+		IssuerURL:     "https://buildbuddy.example.com/issuer",
+		JWKSURI:       "https://buildbuddy.example.com/issuer/keys.json",
+		SubjectTypesSupported: []string{
+			"public",
+		},
+	})
+	require.NoError(t, err)
+
+	// Empty optional metadata arrays are omitted instead of being served as
+	// null or empty arrays.
+	rec := httptest.NewRecorder()
+	provider.ServeWellKnownOpenIDConfiguration(rec, httptest.NewRequest(http.MethodGet, "/oidc"+ConfigurationPath, nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	require.NotContains(t, raw, "claims_supported")
+	require.NotContains(t, raw, "grant_types_supported")
+	require.NotContains(t, raw, "response_types_supported")
+	require.NotContains(t, raw, "scopes_supported")
+}
+
+func testSigningKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func privateKeyPEM(key *rsa.PrivateKey) string {
+	der := x509.MarshalPKCS1PrivateKey(key)
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: der,
+	}))
+}

--- a/enterprise/server/selfauth/BUILD
+++ b/enterprise/server/selfauth/BUILD
@@ -7,14 +7,13 @@ go_library(
     srcs = ["selfauth.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/selfauth",
     deps = [
+        "//enterprise/server/oidcissuer",
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",
         "//server/http/interceptors",
         "//server/util/log",
         "//server/util/status",
-        "@com_github_lestrrat_go_jwx//jwa",
-        "@com_github_lestrrat_go_jwx//jwk",
-        "@com_github_lestrrat_go_jwx//jwt",
+        "@com_github_golang_jwt_jwt_v4//:jwt",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/enterprise/server/selfauth/selfauth.go
+++ b/enterprise/server/selfauth/selfauth.go
@@ -3,8 +3,10 @@ package selfauth
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
 	"math/big"
 	"net/http"
@@ -12,14 +14,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oidcissuer"
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/lestrrat-go/jwx/jwa"
-	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"golang.org/x/oauth2"
 )
 
@@ -73,17 +74,7 @@ func Enabled() bool {
 }
 
 type selfAuth struct {
-	rsaPrivateKey jwk.RSAPrivateKey
-	rsaPublicKey  jwk.RSAPublicKey
-}
-
-type configurationJSON struct {
-	Issuer                           string   `json:"issuer"`
-	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
-	TokenEndpoint                    string   `json:"token_endpoint"`
-	UserinfoEndpoint                 string   `json:"userinfo_endpoint"`
-	JwksUri                          string   `json:"jwks_uri"`
-	IdTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	issuer *oidcissuer.Provider
 }
 
 type tokenJSON struct {
@@ -94,6 +85,15 @@ type tokenJSON struct {
 	IdToken      string `json:"id_token"`
 }
 
+type idTokenClaims struct {
+	jwt.RegisteredClaims
+
+	Email     string `json:"email,omitempty"`
+	Name      string `json:"name,omitempty"`
+	GivenName string `json:"given_name,omitempty"`
+	AtHash    string `json:"at_hash,omitempty"`
+}
+
 func Register(env environment.Env) error {
 	oauth, err := NewSelfAuth()
 	if err != nil {
@@ -102,8 +102,8 @@ func Register(env environment.Env) error {
 	mux := env.GetMux()
 	mux.Handle(oauth.AuthorizationEndpoint().Path, interceptors.SetSecurityHeaders(http.HandlerFunc(oauth.Authorize)))
 	mux.Handle(oauth.TokenEndpoint().Path, interceptors.SetSecurityHeaders(http.HandlerFunc(oauth.AccessToken)))
-	mux.Handle(oauth.JwksEndpoint().Path, interceptors.SetSecurityHeaders(http.HandlerFunc(oauth.Jwks)))
-	mux.Handle("/.well-known/openid-configuration", interceptors.SetSecurityHeaders(http.HandlerFunc(oauth.WellKnownOpenIDConfiguration)))
+	mux.Handle(oauth.JWKSURI().Path, interceptors.SetSecurityHeaders(http.HandlerFunc(oauth.issuer.ServeJWKS)))
+	mux.Handle(oidcissuer.ConfigurationPath, interceptors.SetSecurityHeaders(http.HandlerFunc(oauth.issuer.ServeWellKnownOpenIDConfiguration)))
 	return nil
 }
 
@@ -125,37 +125,43 @@ func NewSelfAuth() (*selfAuth, error) {
 		Primes: []*big.Int{&p, &q},
 	}
 	privateKey.Precompute()
-	jwkKey, err := jwk.New(privateKey)
-	if err != nil {
-		return nil, status.InternalErrorf("Failed to create private key: %s\n", err)
-	}
-	jwkPrivateKey, ok := jwkKey.(jwk.RSAPrivateKey)
-	if !ok {
-		return nil, status.InternalErrorf("Expected jwk.RSAPrivateKey, got %T\n", jwkKey)
-	}
-
-	jwkKey, err = jwk.New(privateKey.PublicKey)
-	if err != nil {
-		return nil, status.InternalErrorf("Failed to create public key: %s\n", err)
-	}
-	jwkPublicKey, ok := jwkKey.(jwk.RSAPublicKey)
-	if !ok {
-		return nil, status.InternalErrorf("Expected jwk.RSAPublicKey, got %T\n", jwkKey)
-	}
-	return &selfAuth{
-		rsaPrivateKey: jwkPrivateKey,
-		rsaPublicKey:  jwkPublicKey,
-	}, nil
-}
-
-func (o *selfAuth) WellKnownOpenIDConfiguration(w http.ResponseWriter, r *http.Request) {
-	writeJSONResponse(w, r, &configurationJSON{
-		Issuer:                           o.IssuerURL().String(),
-		AuthorizationEndpoint:            o.AuthorizationEndpoint().String(),
-		TokenEndpoint:                    o.TokenEndpoint().String(),
-		JwksUri:                          o.JwksEndpoint().String(),
-		IdTokenSigningAlgValuesSupported: []string{"RS256"},
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
 	})
+	oauth := &selfAuth{}
+	issuer, err := oidcissuer.New(oidcissuer.Config{
+		PrivateKeyPEM:         string(privateKeyPEM),
+		IssuerURL:             IssuerURL(),
+		JWKSURI:               oauth.JWKSURI().String(),
+		AuthorizationEndpoint: oauth.AuthorizationEndpoint().String(),
+		TokenEndpoint:         oauth.TokenEndpoint().String(),
+		ResponseTypesSupported: []string{
+			"code",
+		},
+		GrantTypesSupported: []string{
+			"authorization_code",
+		},
+		SubjectTypesSupported: []string{
+			"public",
+		},
+		ScopesSupported: []string{
+			"openid",
+			"profile",
+			"email",
+		},
+		ClaimsSupported: []string{
+			"sub",
+			"email",
+			"name",
+			"given_name",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	oauth.issuer = issuer
+	return oauth, nil
 }
 
 func (o *selfAuth) IssuerURL() *url.URL {
@@ -174,7 +180,7 @@ func (o *selfAuth) TokenEndpoint() *url.URL {
 	return u
 }
 
-func (o *selfAuth) JwksEndpoint() *url.URL {
+func (o *selfAuth) JWKSURI() *url.URL {
 	u := o.IssuerURL()
 	u.Path = "/.well-known/jwks.json"
 	return u
@@ -226,26 +232,25 @@ func (o *selfAuth) AccessToken(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	token := jwt.New()
-	token.Set(jwt.AudienceKey, "buildbuddy")
-	token.Set(jwt.ExpirationKey, time.Now().Add(time.Hour).Unix())
-	token.Set(jwt.JwtIDKey, base64.StdEncoding.EncodeToString(idKey))
-	token.Set(jwt.IssuedAtKey, time.Now().Unix())
-	token.Set(jwt.IssuerKey, o.IssuerURL().String())
-	token.Set(jwt.SubjectKey, "")
-
-	token.Set("email", "buildbuddy@example.com")
-	token.Set("name", "buildbuddy")
-	token.Set("given_name", "Default")
-
-	// This value is a hash of the access token, so must match. It can be
-	// computed with the following python snippet:
-	//
-	// base64.b64encode(hashlib.sha256("AccessToken").digest()[:16]).rstrip("=")
-	//
-	token.Set("at_hash", "LkjhI6Ijpj638f0mirBH2g")
-
-	signed, err := jwt.Sign(token, jwa.RS256, o.rsaPrivateKey)
+	now := time.Now()
+	signed, err := o.issuer.Sign(&idTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience:  jwt.ClaimStrings{"buildbuddy"},
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			ID:        base64.StdEncoding.EncodeToString(idKey),
+			IssuedAt:  jwt.NewNumericDate(now),
+			Issuer:    o.IssuerURL().String(),
+			Subject:   "",
+		},
+		Email:     "buildbuddy@example.com",
+		Name:      "buildbuddy",
+		GivenName: "Default",
+		// This value is a hash of the access token, so must match. It can be
+		// computed with the following python snippet:
+		//
+		// base64.b64encode(hashlib.sha256("AccessToken").digest()[:16]).rstrip("=")
+		AtHash: "LkjhI6Ijpj638f0mirBH2g",
+	})
 	if err != nil {
 		log.Errorf("Error signing token: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -255,13 +260,6 @@ func (o *selfAuth) AccessToken(w http.ResponseWriter, r *http.Request) {
 		AccessToken:  "AccessToken",
 		RefreshToken: "RefreshToken",
 		ExpiresIn:    3600,
-		IdToken:      string(signed),
+		IdToken:      signed,
 	})
-}
-
-// Jwks handles requests to /.well-known/jwks.json, returning the keyset for our oauth
-func (o *selfAuth) Jwks(w http.ResponseWriter, r *http.Request) {
-	set := jwk.NewSet()
-	set.Add(o.rsaPublicKey)
-	writeJSONResponse(w, r, set)
 }


### PR DESCRIPTION
Context: https://github.com/buildbuddy-io/buildbuddy/pull/12146 adds a prototype implementation of allowing BB to act as an OIDC provider so that actions can pull images using short-lived OIDC tokens.

To narrow the scope of that PR a bit, this PR extracts the standard OIDC issuer machinery into a separate util package, and also uses this new package for `selfauth` which is also an OIDC provider. As a bonus, this lets us shave off a few dependencies from our `go.mod`