### PR TITLE
ocifetcher: do not read from or write to AC/CAS for anonymous requests

### DIFF
--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -134,10 +134,6 @@ func RegisterServer(env *real_environment.RealEnv) error {
 func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
 	ctx := stream.Context()
 
-	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return err
-	}
-
 	blobRef, err := gcrname.ParseReference(req.GetRef())
 	if err != nil {
 		return status.InvalidArgumentErrorf("invalid blob reference %q: %s", req.GetRef(), err)
@@ -152,6 +148,14 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 	hash, err := gcr.NewHash(digestRef.DigestStr())
 	if err != nil {
 		return status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+	}
+
+	if claims.IsAnonymousUser(ctx) {
+		return s.fetchBlobFromRemoteWriteToResponse(ctx, digestRef, req.GetCredentials(), stream)
+	}
+
+	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return err
 	}
 
 	err = s.fetchBlobFromCache(ctx, stream, repo, hash)
@@ -218,10 +222,6 @@ func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
 // Server admins can bypass the registry: the metadata will be served from the action cache
 // if present. If not present, FetchBlobMetadata will not fall back to the remote registry.
 func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.FetchBlobMetadataRequest) (*ofpb.FetchBlobMetadataResponse, error) {
-	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-
 	blobRef, err := gcrname.ParseReference(req.GetRef())
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid blob reference %q: %s", req.GetRef(), err)
@@ -236,6 +236,14 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 	hash, err := gcr.NewHash(digestRef.DigestStr())
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+	}
+
+	if claims.IsAnonymousUser(ctx) {
+		return s.fetchBlobMetadataFromRemote(ctx, blobRef, digestRef, req.GetCredentials())
+	}
+
+	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
 	}
 
 	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
@@ -253,11 +261,15 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", blobRef)
 	}
 
+	return s.fetchBlobMetadataFromRemote(ctx, blobRef, digestRef, req.GetCredentials())
+}
+
+func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, blobRef gcrname.Reference, digestRef gcrname.Digest, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
 	type blobMeta struct {
 		size      int64
 		mediaType string
 	}
-	meta, err := withPullerRetry(ctx, s, blobRef, req.GetCredentials(), func(puller *remote.Puller) (*blobMeta, error) {
+	meta, err := withPullerRetry(ctx, s, blobRef, creds, func(puller *remote.Puller) (*blobMeta, error) {
 		layer, err := puller.Layer(ctx, digestRef)
 		if err != nil {
 			return nil, err
@@ -290,13 +302,17 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 // Server admins can bypass the registry: the manifest will be served from the action cache
 // if present. If not present, FetchManifest will not fall back to the remote registry.
 func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchManifestRequest) (*ofpb.FetchManifestResponse, error) {
-	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-
 	imageRef, err := gcrname.ParseReference(req.GetRef())
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", req.GetRef(), err)
+	}
+
+	if claims.IsAnonymousUser(ctx) {
+		return s.fetchManifestFromRemote(ctx, imageRef, req.GetCredentials())
+	}
+
+	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
 	}
 
 	var hash gcr.Hash
@@ -340,15 +356,23 @@ func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchMan
 		return nil, status.NotFoundErrorf("bypassing registry, but manifest for %q not found in cache", imageRef)
 	}
 
-	remoteDesc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*remote.Descriptor, error) {
-		return puller.Get(ctx, imageRef)
-	})
+	resp, err := s.fetchManifestFromRemote(ctx, imageRef, req.GetCredentials())
 	if err != nil {
 		return nil, err
 	}
 
-	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, repo, hash, string(remoteDesc.MediaType), imageRef); err != nil {
+	if err := ocicache.WriteManifestToAC(ctx, resp.GetManifest(), s.acClient, repo, hash, resp.GetMediaType(), imageRef); err != nil {
 		log.CtxWarningf(ctx, "Error writing manifest to cache: %s", err)
+	}
+	return resp, nil
+}
+
+func (s *ociFetcherServer) fetchManifestFromRemote(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
+	remoteDesc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
+		return puller.Get(ctx, imageRef)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &ofpb.FetchManifestResponse{
@@ -365,18 +389,53 @@ func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchMan
 // FetchManifestMetadata does not read from or write to the action cache or byte stream server.
 // Callers may rely on FetchManifestMetadata returning successfully as an indication
 // that the input credentials grant access to the OCI image in the remote registry.
-// Bypassing the registry is not possible. Requests that set the bypass_registry flag
-// will fail with an error.
+// Bypassing the registry is not possible for identified requests. Identified
+// requests that set the bypass_registry flag will fail with an error.
 func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.FetchManifestMetadataRequest) (*ofpb.FetchManifestMetadataResponse, error) {
-	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
 	imageRef, err := gcrname.ParseReference(req.GetRef())
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", req.GetRef(), err)
 	}
 
-	desc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*gcr.Descriptor, error) {
+	if claims.IsAnonymousUser(ctx) {
+		return s.fetchManifestMetadataFromRemote(ctx, imageRef, req.GetCredentials())
+	}
+
+	if req.GetBypassRegistry() {
+		if err := claims.AuthorizeServerAdmin(ctx); err != nil {
+			return nil, status.PermissionDeniedErrorf("authorize bypass_registry: %s", err)
+		}
+		return s.fetchManifestMetadataFromCache(ctx, imageRef)
+	}
+
+	return s.fetchManifestMetadataFromRemote(ctx, imageRef, req.GetCredentials())
+}
+
+func (s *ociFetcherServer) fetchManifestMetadataFromCache(ctx context.Context, imageRef gcrname.Reference) (*ofpb.FetchManifestMetadataResponse, error) {
+	digestRef, ok := imageRef.(gcrname.Digest)
+	if !ok {
+		return nil, status.NotFoundErrorf("bypassing registry, but manifest metadata for %q not found in cache", imageRef)
+	}
+	hash, err := gcr.NewHash(digestRef.DigestStr())
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+	}
+	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, imageRef.Context(), hash, imageRef)
+	if err != nil {
+		if status.IsNotFoundError(err) {
+			return nil, status.NotFoundErrorf("bypassing registry, but manifest metadata for %q not found in cache", imageRef)
+		}
+		return nil, err
+	}
+	return &ofpb.FetchManifestMetadataResponse{
+		Digest:    hash.String(),
+		Size:      int64(len(cached.GetRaw())),
+		MediaType: cached.GetContentType(),
+	}, nil
+}
+
+func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*ofpb.FetchManifestMetadataResponse, error) {
+	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
 		return puller.Head(ctx, imageRef)
 	})
 	if err != nil {
@@ -448,6 +507,23 @@ func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.O
 	}
 	w := &grpcStreamWriter{stream: stream}
 	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, hash, metadata.GetContentLength())
+}
+
+// fetchBlobFromRemoteWriteToResponse fetches a blob from the upstream registry
+// and streams it to the response without reading from or writing to cache.
+func (s *ociFetcherServer) fetchBlobFromRemoteWriteToResponse(ctx context.Context, digestRef gcrname.Digest, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	rc, err := withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (io.ReadCloser, error) {
+		layer, err := puller.Layer(ctx, digestRef)
+		if err != nil {
+			return nil, err
+		}
+		return layer.Compressed()
+	})
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	return s.streamBlob(rc, stream)
 }
 
 // fetchBlobFromRemoteWriteToCacheAndResponse fetches a blob from the upstream
@@ -602,18 +678,6 @@ func authorizeBypassRegistry(ctx context.Context, bypassRegistry bool) error {
 		return status.PermissionDeniedErrorf("not authorized to bypass registry: %s", err)
 	}
 	return nil
-}
-
-// checkBypassRegistry is used by FetchManifestMetadata which does not support
-// bypass_registry at all (it always needs registry access for credential validation).
-func checkBypassRegistry(ctx context.Context, bypassRegistry bool) error {
-	if !bypassRegistry {
-		return nil
-	}
-	if err := claims.AuthorizeServerAdmin(ctx); err != nil {
-		return status.PermissionDeniedErrorf("authorize bypass_registry: %s", err)
-	}
-	return status.NotFoundError("bypass_registry is not yet supported")
 }
 
 type grpcStreamWriter struct {

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -90,6 +90,13 @@ func setupCacheEnv(t *testing.T) (*testenv.TestEnv, bspb.ByteStreamClient, repb.
 	return te, te.GetByteStreamClient(), te.GetActionCacheClient()
 }
 
+func authenticatedContext() context.Context {
+	return testauth.WithAuthenticatedUserInfo(context.Background(), &claims.Claims{
+		UserID:  "US1",
+		GroupID: "GR1",
+	})
+}
+
 // mockFetchBlobServer implements ofpb.OCIFetcher_FetchBlobServer for testing.
 type mockFetchBlobServer struct {
 	grpc.ServerStream
@@ -356,7 +363,8 @@ func TestServerHappyPath(t *testing.T) {
 			expectedData := layerData(t, layer)
 
 			server := newTestServer(t)
-			stream := &mockFetchBlobServer{ctx: context.Background()}
+			ctx := authenticatedContext()
+			stream := &mockFetchBlobServer{ctx: ctx}
 			err = server.FetchBlob(&ofpb.FetchBlobRequest{
 				Ref:         imageName + "@" + digest.String(),
 				Credentials: ac.requestCreds,
@@ -384,7 +392,8 @@ func TestServerHappyPath(t *testing.T) {
 
 			// First fetch - cache miss, should hit registry
 			counter.Reset()
-			stream := &mockFetchBlobServer{ctx: context.Background()}
+			ctx := authenticatedContext()
+			stream := &mockFetchBlobServer{ctx: ctx}
 			err = server.FetchBlob(&ofpb.FetchBlobRequest{
 				Ref:         imageName + "@" + digest.String(),
 				Credentials: ac.requestCreds,
@@ -398,7 +407,7 @@ func TestServerHappyPath(t *testing.T) {
 
 			// Second fetch - cache hit, should NOT hit registry
 			counter.Reset()
-			stream = &mockFetchBlobServer{ctx: context.Background()}
+			stream = &mockFetchBlobServer{ctx: ctx}
 			err = server.FetchBlob(&ofpb.FetchBlobRequest{
 				Ref:         imageName + "@" + digest.String(),
 				Credentials: ac.requestCreds,
@@ -454,7 +463,7 @@ func TestServerMissingAndInvalidCredentials(t *testing.T) {
 				http.MethodHead + " /v2/test-image/manifests/latest": 2,
 			})
 
-			// FetchManifest (uses HEAD to resolve tag to digest first, then fails on auth)
+			// FetchManifest
 			counter.Reset()
 			_, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
 				Ref:         imageName,
@@ -463,8 +472,8 @@ func TestServerMissingAndInvalidCredentials(t *testing.T) {
 			require.Error(t, err)
 			require.True(t, status.IsUnauthenticatedError(err), "FetchManifest: expected Unauthenticated, got: %v", err)
 			assertRequests(t, counter, map[string]int{
-				http.MethodGet + " /v2/":                             2,
-				http.MethodHead + " /v2/test-image/manifests/latest": 2,
+				http.MethodGet + " /v2/":                            2,
+				http.MethodGet + " /v2/test-image/manifests/latest": 2,
 			})
 
 			// FetchBlobMetadata
@@ -607,7 +616,7 @@ func TestFetchBlobRetryOnCompressedError(t *testing.T) {
 	counter.Reset()
 
 	blobRef := imageName + "@" + layerDigest.String()
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
 	require.NoError(t, err, "FetchBlob should succeed after retrying with a fresh puller")
 	require.Equal(t, expectedLayerData, stream.collectData())
@@ -649,7 +658,7 @@ func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
 	blobRef := imageName + "@" + layerDigest.String()
 	failBlobHead.Store(true)
 
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	counter.Reset()
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
 	require.NoError(t, err, "FetchBlob should fall back to direct streaming when metadata lookups fail")
@@ -668,7 +677,7 @@ func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
 
 	// Metadata lookup failures should skip read-through caching, so a subsequent
 	// fetch still needs to hit the upstream registry.
-	stream = &mockFetchBlobServer{ctx: context.Background()}
+	stream = &mockFetchBlobServer{ctx: authenticatedContext()}
 	counter.Reset()
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
 	require.NoError(t, err)
@@ -753,7 +762,7 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected DeadlineExceeded, got: %v", err)
 	require.Equal(t, int32(1), getAttempts.Load(), "should not retry on context error")
 
-	// FetchManifest: Puller should still be cached (but HEAD and GET both happen for tag refs)
+	// FetchManifest: Puller should still be cached
 	blockGet.Store(false)
 	counter.Reset()
 	manifestResp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: imageName})
@@ -763,8 +772,7 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	require.Equal(t, expectedMediaType, manifestResp.GetMediaType())
 	require.Equal(t, expectedManifest, manifestResp.GetManifest())
 	assertRequests(t, counter, map[string]int{
-		http.MethodHead + " /v2/test-image/manifests/latest": 1,
-		http.MethodGet + " /v2/test-image/manifests/latest":  1,
+		http.MethodGet + " /v2/test-image/manifests/latest": 1,
 	})
 
 	// FetchBlobMetadata: establish cached layer access
@@ -791,7 +799,8 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	require.Equal(t, expectedLayerMediaType, blobMetaResp.GetMediaType())
 
 	// FetchBlob: first fetch caches the blob
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	cacheCtx := authenticatedContext()
+	stream := &mockFetchBlobServer{ctx: cacheCtx}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
 	require.NoError(t, err)
 	require.Equal(t, expectedLayerData, stream.collectData())
@@ -799,7 +808,7 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	// FetchBlob: second fetch serves from cache (no network calls), even with short timeout
 	// Since blob is cached, there's no network call to timeout, so this succeeds instantly
 	counter.Reset()
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel = context.WithTimeout(cacheCtx, 10*time.Millisecond)
 	stream = &mockFetchBlobServer{ctx: ctx}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
 	cancel()
@@ -823,6 +832,11 @@ func TestServerBypassRegistry(t *testing.T) {
 			},
 		},
 	}
+	nonAdminUser := &claims.Claims{
+		UserID:        "US2",
+		GroupID:       "GR456",
+		AllowedGroups: []string{"GR456"},
+	}
 
 	for _, tc := range []struct {
 		name       string
@@ -831,7 +845,7 @@ func TestServerBypassRegistry(t *testing.T) {
 	}{
 		{
 			name:       "NonAdmin_PermissionDenied",
-			user:       nil,
+			user:       nonAdminUser,
 			checkError: status.IsPermissionDeniedError,
 		},
 		{
@@ -922,7 +936,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 
 		// First fetch - populate cache
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
 			Ref: imageName + "@" + digest.String(),
 		}, stream)
@@ -999,7 +1013,8 @@ func TestServerBypassRegistry(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 
 		// First, fetch the blob to populate the cache (FetchBlob writes metadata to AC)
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		ctx := authenticatedContext()
+		stream := &mockFetchBlobServer{ctx: ctx}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
 			Ref: imageName + "@" + digest.String(),
 		}, stream)
@@ -1007,7 +1022,7 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// Now fetch metadata - should be served from cache
 		counter.Reset()
-		resp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{
+		resp, err := server.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{
 			Ref: imageName + "@" + digest.String(),
 		})
 		require.NoError(t, err)
@@ -1038,7 +1053,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 
 		// First fetch - populate cache via FetchBlob
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
 			Ref: imageName + "@" + digest.String(),
 		}, stream)
@@ -1108,7 +1123,8 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// First fetch by digest - cache miss, should fetch from registry and cache
 		counter.Reset()
-		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		ctx := authenticatedContext()
+		resp, err := server.FetchManifest(ctx, &ofpb.FetchManifestRequest{
 			Ref: imageName + "@" + digest,
 		})
 		require.NoError(t, err)
@@ -1119,7 +1135,7 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// Second fetch by digest - should serve from cache
 		counter.Reset()
-		resp, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		resp, err = server.FetchManifest(ctx, &ofpb.FetchManifestRequest{
 			Ref: imageName + "@" + digest,
 		})
 		require.NoError(t, err)
@@ -1142,7 +1158,8 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// First fetch by tag - cache miss, should HEAD then GET from registry
 		counter.Reset()
-		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		ctx := authenticatedContext()
+		resp, err := server.FetchManifest(ctx, &ofpb.FetchManifestRequest{
 			Ref: imageName,
 		})
 		require.NoError(t, err)
@@ -1155,7 +1172,7 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// Second fetch by tag - should only HEAD (cache hit avoids GET)
 		counter.Reset()
-		resp, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		resp, err = server.FetchManifest(ctx, &ofpb.FetchManifestRequest{
 			Ref: imageName,
 		})
 		require.NoError(t, err)
@@ -1180,7 +1197,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 
 		// First fetch - populate cache
-		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		resp, err := server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{
 			Ref: imageName + "@" + digest,
 		})
 		require.NoError(t, err)
@@ -1195,6 +1212,39 @@ func TestServerBypassRegistry(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, expectedManifest, resp.GetManifest())
+
+		// Verify no registry requests were made
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	// Test that FetchManifestMetadata with bypass_registry serves from AC when manifest is cached (digest ref)
+	t.Run("FetchManifestMetadata/CacheHit/DigestRef/ServesFromCache", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		reg, counter := setupRegistry(t, nil, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		digest, size, mediaType := imageMetadata(t, img)
+
+		_, bsClient, acClient := setupCacheEnv(t)
+		server := newTestServerWithCache(t, bsClient, acClient)
+
+		// First fetch - populate cache
+		_, err := server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{
+			Ref: imageName + "@" + digest,
+		})
+		require.NoError(t, err)
+
+		// Second fetch with bypass_registry (admin required) - should serve metadata from cache
+		counter.Reset()
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+		resp, err := server.FetchManifestMetadata(ctx, &ofpb.FetchManifestMetadataRequest{
+			Ref:            imageName + "@" + digest,
+			BypassRegistry: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, digest, resp.GetDigest())
+		require.Equal(t, size, resp.GetSize())
+		require.Equal(t, mediaType, resp.GetMediaType())
 
 		// Verify no registry requests were made
 		assertRequests(t, counter, map[string]int{})
@@ -1248,6 +1298,75 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// Verify NO registry requests were made (can't resolve tag without registry)
 		assertRequests(t, counter, map[string]int{})
+	})
+}
+
+func TestAnonymousRequestsSkipCache(t *testing.T) {
+	reg, counter := setupRegistry(t, nil, nil)
+	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	manifestDigest, _, _ := imageMetadata(t, img)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layerDigest, err := layers[0].Digest()
+	require.NoError(t, err)
+	expectedLayerData := layerData(t, layers[0])
+	expectedLayerSize, expectedLayerMediaType := layerMetadata(t, layers[0])
+
+	_, bsClient, acClient := setupCacheEnv(t)
+	server := newTestServerWithCache(t, bsClient, acClient)
+	anonCtx := context.Background()
+
+	counter.Reset()
+	_, err = server.FetchManifest(anonCtx, &ofpb.FetchManifestRequest{Ref: imageName + "@" + manifestDigest})
+	require.NoError(t, err)
+	assertRequests(t, counter, map[string]int{
+		http.MethodGet + " /v2/": 1,
+		http.MethodGet + " /v2/test-image/manifests/" + manifestDigest: 1,
+	})
+
+	counter.Reset()
+	_, err = server.FetchManifest(anonCtx, &ofpb.FetchManifestRequest{Ref: imageName + "@" + manifestDigest})
+	require.NoError(t, err)
+	assertRequests(t, counter, map[string]int{
+		http.MethodGet + " /v2/test-image/manifests/" + manifestDigest: 1,
+	})
+
+	blobRef := imageName + "@" + layerDigest.String()
+	counter.Reset()
+	blobMetadata, err := server.FetchBlobMetadata(anonCtx, &ofpb.FetchBlobMetadataRequest{Ref: blobRef})
+	require.NoError(t, err)
+	require.Equal(t, expectedLayerSize, blobMetadata.GetSize())
+	require.Equal(t, expectedLayerMediaType, blobMetadata.GetMediaType())
+	assertRequests(t, counter, map[string]int{
+		http.MethodHead + " /v2/test-image/blobs/" + layerDigest.String(): 1,
+	})
+
+	counter.Reset()
+	blobMetadata, err = server.FetchBlobMetadata(anonCtx, &ofpb.FetchBlobMetadataRequest{Ref: blobRef})
+	require.NoError(t, err)
+	require.Equal(t, expectedLayerSize, blobMetadata.GetSize())
+	require.Equal(t, expectedLayerMediaType, blobMetadata.GetMediaType())
+	assertRequests(t, counter, map[string]int{
+		http.MethodHead + " /v2/test-image/blobs/" + layerDigest.String(): 1,
+	})
+
+	counter.Reset()
+	stream := &mockFetchBlobServer{ctx: anonCtx}
+	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
+	require.NoError(t, err)
+	require.Equal(t, expectedLayerData, stream.collectData())
+	assertRequests(t, counter, map[string]int{
+		http.MethodGet + " /v2/test-image/blobs/" + layerDigest.String(): 1,
+	})
+
+	counter.Reset()
+	stream = &mockFetchBlobServer{ctx: anonCtx}
+	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
+	require.NoError(t, err)
+	require.Equal(t, expectedLayerData, stream.collectData())
+	assertRequests(t, counter, map[string]int{
+		http.MethodGet + " /v2/test-image/blobs/" + layerDigest.String(): 1,
 	})
 }
 
@@ -1318,7 +1437,7 @@ func TestFetchBlobSingleflightHappyPath(t *testing.T) {
 
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
-			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+			return &concurrentMockFetchBlobServer{ctx: authenticatedContext()}
 		},
 	)
 
@@ -1355,14 +1474,14 @@ func TestFetchBlobSingleflightCacheHit(t *testing.T) {
 		Ref: imageName + "@" + digest.String(),
 	}
 
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	err = server.FetchBlob(req, stream)
 	require.NoError(t, err)
 	counter.Reset()
 
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
-			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+			return &concurrentMockFetchBlobServer{ctx: authenticatedContext()}
 		},
 	)
 
@@ -1409,7 +1528,7 @@ func TestFetchBlobSingleflightLeaderFailsUpstream(t *testing.T) {
 
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
-			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+			return &concurrentMockFetchBlobServer{ctx: authenticatedContext()}
 		},
 	)
 
@@ -1461,7 +1580,7 @@ func TestFetchBlobSingleflightLeaderSendFails(t *testing.T) {
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
 			stream := &concurrentMockFetchBlobServer{
-				ctx:             context.Background(),
+				ctx:             authenticatedContext(),
 				sendErr:         status.InternalError("simulated Send failure"),
 				sendErrAfterN:   0,
 				firstSenderFlag: &firstSenderFlag,
@@ -1479,7 +1598,7 @@ func TestFetchBlobSingleflightLeaderSendFails(t *testing.T) {
 	}
 
 	counter.Reset()
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	err = server.FetchBlob(req, stream)
 	require.NoError(t, err, "subsequent fetch should succeed")
 	require.Equal(t, expectedData, stream.collectData())
@@ -1512,7 +1631,7 @@ func TestFetchBlobSingleflightCacheSetupFailure(t *testing.T) {
 	const numRequests = 4
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
-			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+			return &concurrentMockFetchBlobServer{ctx: authenticatedContext()}
 		},
 	)
 
@@ -1602,9 +1721,5 @@ func TestFetchBlobSingleflightDifferentCredentials(t *testing.T) {
 		// Three blob GETs: one for creds1 (succeeds), two for creds2
 		// (first attempt 401, retry 401).
 		http.MethodGet + " " + blobPath: 3,
-		// Three blob HEADs for layer.Size(): one for creds1 (succeeds),
-		// two for creds2 (Size is fetched before Compressed, so each
-		// attempt calls it before the blob GET fails).
-		http.MethodHead + " " + blobPath: 3,
 	})
 }

--- a/enterprise/server/ocifetcher_server_proxy/BUILD
+++ b/enterprise/server/ocifetcher_server_proxy/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
+        "//server/util/claims",
         "//server/util/log",
         "//server/util/status",
         "//third_party/singleflight",

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/third_party/singleflight"
@@ -89,6 +90,10 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 		return status.InvalidArgumentErrorf("invalid blob digest in reference %q: %s", req.GetRef(), err)
 	}
 
+	if claims.IsAnonymousUser(ctx) {
+		return s.fetchBlobFromUpstreamToStream(ctx, req, stream)
+	}
+
 	metaResp, err := s.remote.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{
 		Ref:            req.GetRef(),
 		Credentials:    req.GetCredentials(),
@@ -108,6 +113,9 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 	// cache misses as FailedPrecondition via MissingDigestError.
 	if !status.IsNotFoundError(err) && !status.IsFailedPreconditionError(err) {
 		return err
+	}
+	if req.GetBypassRegistry() {
+		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", blobRef)
 	}
 
 	// Deduplicate concurrent upstream fetches for the same blob+creds.
@@ -131,6 +139,25 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 
 	// Stream the blob from local BSS to the caller.
 	return fetchBlobFromLocalBS(ctx, s.localBSClient, hash, size, &grpcStreamWriter{stream: stream})
+}
+
+func (s *OCIFetcherServerProxy) fetchBlobFromUpstreamToStream(ctx context.Context, req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	remoteStream, err := s.remote.FetchBlob(ctx, req)
+	if err != nil {
+		return err
+	}
+	for {
+		resp, err := remoteStream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
 }
 
 // fetchBlobFromUpstreamToLocalBS fetches a blob from the upstream OCIFetcher

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
@@ -115,7 +115,7 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 		return err
 	}
 	if req.GetBypassRegistry() {
-		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", blobRef)
+		return s.fetchBlobFromUpstreamToStream(ctx, req, stream)
 	}
 
 	// Deduplicate concurrent upstream fetches for the same blob+creds.

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
@@ -236,7 +236,7 @@ func TestFetchBlob_ForwardsRequestUnchanged(t *testing.T) {
 	}
 }
 
-func TestFetchBlob_BypassRegistryLocalCacheMissDoesNotFetchUpstream(t *testing.T) {
+func TestFetchBlob_BypassRegistryLocalCacheMissForwardsToUpstream(t *testing.T) {
 	const ref = "example.com/repo@sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
 
 	ctx := authenticatedContext()
@@ -247,12 +247,60 @@ func TestFetchBlob_BypassRegistryLocalCacheMissDoesNotFetchUpstream(t *testing.T
 		Ref:            ref,
 		BypassRegistry: true,
 	})
-	if err == nil {
-		_, err = stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), collectBlobData(t, stream))
+	require.NotNil(t, remoteClient.fetchBlobRequest, "bypass_registry with local cache miss should forward to upstream")
+}
+
+func TestFetchBlob_BypassRegistryLocalCacheHit(t *testing.T) {
+	const adminGroupID = "GR123"
+	flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+	adminUser := &claims.Claims{
+		UserID:        "US1",
+		GroupID:       adminGroupID,
+		AllowedGroups: []string{adminGroupID},
+		GroupMemberships: []*interfaces.GroupMembership{
+			{
+				GroupID:      adminGroupID,
+				Capabilities: []cappb.Capability{cappb.Capability_ORG_ADMIN},
+			},
+		},
 	}
-	require.Error(t, err)
-	require.True(t, status.IsNotFoundError(err), "expected NotFound, got: %v", err)
-	require.Nil(t, remoteClient.fetchBlobRequest, "bypass_registry should not fetch from upstream on local cache miss")
+
+	reg := setupTestRegistry(t, nil)
+	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layer := layers[0]
+	digest, err := layer.Digest()
+	require.NoError(t, err)
+	expectedData := layerData(t, layer)
+
+	authCtx := authenticatedContext()
+	_, bsClient, acClient := setupCacheEnv(t)
+	ociFetcherClient := runOCIFetcherServer(authCtx, t, bsClient, acClient)
+	proxyClient := runOCIFetcherProxy(authCtx, t, ociFetcherClient)
+	ref := imageName + "@" + digest.String()
+
+	// First fetch (authenticated, no bypass) → populates upstream AC and local proxy BS.
+	stream, err := proxyClient.FetchBlob(authCtx, &ofpb.FetchBlobRequest{Ref: ref})
+	require.NoError(t, err)
+	require.Equal(t, expectedData, collectBlobData(t, stream))
+
+	// Shut down the registry to prove subsequent calls don't contact it.
+	err = reg.Shutdown()
+	require.NoError(t, err)
+
+	// Admin + bypass_registry + local cache hit → serve from local BS, no registry access.
+	adminCtx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+	stream, err = proxyClient.FetchBlob(adminCtx, &ofpb.FetchBlobRequest{
+		Ref:            ref,
+		BypassRegistry: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedData, collectBlobData(t, stream))
 }
 
 // TestFetchBlob_LocalCacheWriteThrough verifies that after a FetchBlob call,

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
@@ -51,6 +51,13 @@ func TestNew_MissingLocalBSClient(t *testing.T) {
 	require.True(t, status.IsFailedPreconditionError(err), "expected FailedPrecondition, got: %v", err)
 }
 
+func authenticatedContext() context.Context {
+	return testauth.WithAuthenticatedUserInfo(context.Background(), &claims.Claims{
+		UserID:  "US1",
+		GroupID: "GR1",
+	})
+}
+
 // TestHappyPath tests successful FetchBlob, FetchBlobMetadata, FetchManifest,
 // FetchManifestMetadata calls with no credentials and with credentials.
 func TestHappyPath(t *testing.T) {
@@ -229,11 +236,30 @@ func TestFetchBlob_ForwardsRequestUnchanged(t *testing.T) {
 	}
 }
 
+func TestFetchBlob_BypassRegistryLocalCacheMissDoesNotFetchUpstream(t *testing.T) {
+	const ref = "example.com/repo@sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+	ctx := authenticatedContext()
+	remoteClient := &recordingOCIFetcherClient{}
+	proxyClient := runOCIFetcherProxy(ctx, t, remoteClient)
+
+	stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{
+		Ref:            ref,
+		BypassRegistry: true,
+	})
+	if err == nil {
+		_, err = stream.Recv()
+	}
+	require.Error(t, err)
+	require.True(t, status.IsNotFoundError(err), "expected NotFound, got: %v", err)
+	require.Nil(t, remoteClient.fetchBlobRequest, "bypass_registry should not fetch from upstream on local cache miss")
+}
+
 // TestFetchBlob_LocalCacheWriteThrough verifies that after a FetchBlob call,
 // the blob is written to the proxy's local BS cache and can be served from
 // there on a subsequent request.
 func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := authenticatedContext()
 
 	reg := setupTestRegistry(t, nil)
 	imageName, img := reg.PushNamedImage(t, "test-image", nil)
@@ -270,6 +296,38 @@ func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
 	require.Equal(t, expectedData, data2)
 }
 
+func TestFetchBlob_AnonymousSkipsLocalCache(t *testing.T) {
+	ctx := context.Background()
+
+	reg := setupTestRegistry(t, nil)
+	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layer := layers[0]
+	digest, err := layer.Digest()
+	require.NoError(t, err)
+	expectedData := layerData(t, layer)
+
+	_, bsClient, acClient := setupCacheEnv(t)
+	ociFetcherClient := runOCIFetcherServer(ctx, t, bsClient, acClient)
+	proxyClient := runOCIFetcherProxy(ctx, t, ociFetcherClient)
+	ref := imageName + "@" + digest.String()
+
+	stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: ref})
+	require.NoError(t, err)
+	require.Equal(t, expectedData, collectBlobData(t, stream))
+
+	err = reg.Shutdown()
+	require.NoError(t, err)
+
+	stream, err = proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: ref})
+	if err == nil {
+		_, err = stream.Recv()
+	}
+	require.Error(t, err, "anonymous proxy request should not read from local BS cache")
+}
+
 // TestBypassRegistry tests the bypass_registry flag crossed with server admin claims
 // for all Fetch methods.
 func TestBypassRegistry(t *testing.T) {
@@ -285,6 +343,11 @@ func TestBypassRegistry(t *testing.T) {
 				Capabilities: []cappb.Capability{cappb.Capability_ORG_ADMIN},
 			},
 		},
+	}
+	nonAdminUser := &claims.Claims{
+		UserID:        "US2",
+		GroupID:       "GR456",
+		AllowedGroups: []string{"GR456"},
 	}
 
 	for _, tc := range []struct {
@@ -302,7 +365,7 @@ func TestBypassRegistry(t *testing.T) {
 		{
 			name:           "BypassTrue_NonAdmin",
 			bypassRegistry: true,
-			user:           nil,
+			user:           nonAdminUser,
 			checkError:     status.IsPermissionDeniedError,
 		},
 		{
@@ -314,7 +377,7 @@ func TestBypassRegistry(t *testing.T) {
 		{
 			name:           "BypassFalse_NonAdmin",
 			bypassRegistry: false,
-			user:           nil,
+			user:           nonAdminUser,
 			checkError:     nil, // Should succeed
 		},
 	} {
@@ -339,16 +402,9 @@ func TestBypassRegistry(t *testing.T) {
 				BypassRegistry: tc.bypassRegistry,
 			})
 
-			if tc.bypassRegistry {
-				// FetchManifestMetadata always errors with bypass_registry=true
+			if tc.checkError != nil {
 				require.Error(t, err)
-				if tc.user != nil {
-					// Admin gets NotFound
-					require.True(t, status.IsNotFoundError(err), "expected NotFoundError for admin, got: %v", err)
-				} else {
-					// Non-admin gets PermissionDenied
-					require.True(t, status.IsPermissionDeniedError(err), "expected PermissionDeniedError for non-admin, got: %v", err)
-				}
+				require.True(t, tc.checkError(err), "unexpected error type: %v", err)
 			} else {
 				// No bypass - should succeed
 				require.NoError(t, err)
@@ -603,7 +659,7 @@ func TestInvalidOrMissingCredentials(t *testing.T) {
 // the same blob are deduplicated: only one upstream FetchBlob RPC is made and
 // all callers receive the correct data.
 func TestFetchBlob_Singleflight(t *testing.T) {
-	ctx := context.Background()
+	ctx := authenticatedContext()
 
 	reg := setupTestRegistry(t, nil)
 	imageName, img := reg.PushNamedImage(t, "test-image", nil)

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -1520,11 +1520,11 @@ func TestResolveWithOCIFetcher_Layers_DiffIDs(t *testing.T) {
 				require.NoError(t, err)
 				// With OCIFetcher, fetching the config blob uses FetchBlob which:
 				// - Reuses the puller from Resolve() (no additional GET /v2/)
-				// - Makes a HEAD request for the config blob to get size for caching
 				// - Makes a GET request for the config blob data
+				// Anonymous requests (context.Background()) skip the cache, so no
+				// HEAD is made to get size for caching.
 				expected = map[string]int{
-					http.MethodHead + " /v2/" + nameToResolve + "/blobs/" + configDigest.String(): 1,
-					http.MethodGet + " /v2/" + nameToResolve + "/blobs/" + configDigest.String():  1,
+					http.MethodGet + " /v2/" + nameToResolve + "/blobs/" + configDigest.String(): 1,
 				}
 
 				// To make the DiffID() request counts always be zero,

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -1479,8 +1479,6 @@ func TestResolveWithOCIFetcher_Layers_DiffIDs(t *testing.T) {
 	} {
 		name := tc.name
 		t.Run(name, func(t *testing.T) {
-			te := setupTestEnvWithCache(t)
-			flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 			counter := testhttp.NewRequestCounter()
 			registry := testregistry.Run(t, testregistry.Opts{
 				HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
@@ -1498,47 +1496,75 @@ func TestResolveWithOCIFetcher_Layers_DiffIDs(t *testing.T) {
 			})
 			registry.PushIndex(t, index, tc.imageName+"_index", nil)
 
-			for _, nameToResolve := range []string{tc.args.imageName + "_image", tc.args.imageName + "_index"} {
-				pulledImage, err := newResolver(t, te).Resolve(
-					context.Background(),
-					registry.ImageAddress(nameToResolve),
-					tc.args.platform,
-					tc.args.credentials,
-					true, /*=useOCIFetcher*/
-				)
-				require.NoError(t, err)
+			for _, authCase := range []struct {
+				name     string
+				ctx      context.Context
+				wantHead bool // whether FetchBlob makes a HEAD to get size for caching
+			}{
+				{
+					name:     "anonymous",
+					ctx:      context.Background(),
+					wantHead: false,
+				},
+				{
+					name:     "authenticated",
+					ctx:      contextWithUnverifiedJWT(&claims.Claims{UserID: "US123"}),
+					wantHead: true,
+				},
+			} {
+				t.Run(authCase.name, func(t *testing.T) {
+					te := setupTestEnvWithCache(t)
+					flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 
-				counter.Reset()
+					for i, nameToResolve := range []string{tc.args.imageName + "_image", tc.args.imageName + "_index"} {
+						pulledImage, err := newResolver(t, te).Resolve(
+							authCase.ctx,
+							registry.ImageAddress(nameToResolve),
+							tc.args.platform,
+							tc.args.credentials,
+							true, /*=useOCIFetcher*/
+						)
+						require.NoError(t, err)
 
-				layers, err := pulledImage.Layers()
-				require.NoError(t, err)
+						counter.Reset()
 
-				expected := map[string]int{}
-				require.Empty(t, cmp.Diff(expected, counter.Snapshot()))
+						layers, err := pulledImage.Layers()
+						require.NoError(t, err)
+						require.Empty(t, cmp.Diff(map[string]int{}, counter.Snapshot()))
 
-				configDigest, err := pulledImage.ConfigName()
-				require.NoError(t, err)
-				// With OCIFetcher, fetching the config blob uses FetchBlob which:
-				// - Reuses the puller from Resolve() (no additional GET /v2/)
-				// - Makes a GET request for the config blob data
-				// Anonymous requests (context.Background()) skip the cache, so no
-				// HEAD is made to get size for caching.
-				expected = map[string]int{
-					http.MethodGet + " /v2/" + nameToResolve + "/blobs/" + configDigest.String(): 1,
-				}
+						configDigest, err := pulledImage.ConfigName()
+						require.NoError(t, err)
 
-				// To make the DiffID() request counts always be zero,
-				// fetch the config file here. Otherwise the first
-				// Layer.DiffID() call will make a request to fetch the config file.
-				_, err = pulledImage.ConfigFile()
-				require.NoError(t, err)
-				require.Empty(t, cmp.Diff(expected, counter.Snapshot()))
+						// To make DiffID() request counts always be zero,
+						// fetch the config file here. Otherwise the first
+						// Layer.DiffID() call will make a request to fetch the config file.
+						_, err = pulledImage.ConfigFile()
+						require.NoError(t, err)
 
-				for _, layer := range layers {
-					_, err := layer.DiffID()
-					require.NoError(t, err)
-					require.Empty(t, cmp.Diff(expected, counter.Snapshot()))
-				}
+						// For the first image (_image), the cache is always cold.
+						// Assert the exact fetch pattern: anonymous makes only GET
+						// (skips cache), authenticated makes HEAD+GET (size for caching).
+						// For _index the cache state depends on whether the resolver
+						// uses the same repo as _image, so we only assert that DiffID
+						// makes no additional requests beyond what ConfigFile already did.
+						if i == 0 {
+							expected := map[string]int{
+								http.MethodGet + " /v2/" + nameToResolve + "/blobs/" + configDigest.String(): 1,
+							}
+							if authCase.wantHead {
+								expected[http.MethodHead+" /v2/"+nameToResolve+"/blobs/"+configDigest.String()] = 1
+							}
+							require.Empty(t, cmp.Diff(expected, counter.Snapshot()))
+						}
+
+						afterConfig := counter.Snapshot()
+						for _, layer := range layers {
+							_, err := layer.DiffID()
+							require.NoError(t, err)
+							require.Empty(t, cmp.Diff(afterConfig, counter.Snapshot()))
+						}
+					}
+				})
 			}
 		})
 	}

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -532,6 +532,12 @@ func ClaimsFromContext(ctx context.Context) (*Claims, error) {
 	return nil, status.UnauthenticatedErrorf("%s: %s", authutil.UserNotFoundMsg, err.Error())
 }
 
+// IsAnonymousUser returns true if the context has no authenticated claims.
+func IsAnonymousUser(ctx context.Context) bool {
+	_, err := ClaimsFromContext(ctx)
+	return authutil.IsAnonymousUserError(err)
+}
+
 // AuthorizeServerAdmin checks whether the authenticated user is a server admin
 // (a member of the server admin group, with ORG_ADMIN capability).
 func AuthorizeServerAdmin(ctx context.Context) error {


### PR DESCRIPTION
The original `use_oci_fetcher=false` path does not read from or write to the AC/CAS when the request is anonymous. Let's make sure the `use_oci_fetcher=true` path does the same.