### PR TITLE
workflow: enable scheduled tests

### DIFF
--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -2032,6 +2032,7 @@ actions:
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			te := newTestEnv(t)
+			enableScheduledWorkflows(t, te)
 			provider := setupFakeGitProvider(t, te)
 			repoURL := makeTempRepo(t)
 			_ = runBBServer(ctx, t, te)
@@ -2070,6 +2071,7 @@ actions:
 func TestScheduledWorkflow_GitProviderError_Retries(t *testing.T) {
 	ctx := context.Background()
 	te := newTestEnv(t)
+	enableScheduledWorkflows(t, te)
 	authCtx, _, gid := authenticate(t, ctx, te)
 	repoURL := makeTempRepo(t)
 	provider := setupFakeGitProvider(t, te)


### PR DESCRIPTION
These tests were failing because RunScheduledWorkflows returned early
when the scheduled workflows experiment flag was unset. Enable the flag
in the test environments so the scheduler path exercises stale schedule
cleanup and transient Git provider retries.
