### PR TITLE
indexing profiling infrastructure

### DIFF
--- a/codesearch/cmd/cli/BUILD
+++ b/codesearch/cmd/cli/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//codesearch/github",
         "//codesearch/index",
+        "//codesearch/indexprofile",
         "//codesearch/performance",
         "//codesearch/query",
         "//codesearch/schema",

--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -11,7 +11,6 @@ import (
 	"runtime/pprof"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/github"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/index"
@@ -155,7 +154,6 @@ func extractGitSHA(dir string) string {
 }
 
 func handleIndex(args []string) {
-	profiler := indexprofile.Current()
 	if *reset {
 		os.RemoveAll(indexDir)
 	}
@@ -174,20 +172,13 @@ func handleIndex(args []string) {
 		repoURL := extractRepoURL(dir)
 		commitSHA := extractGitSHA(dir)
 		log.Printf("indexing dir: %q", dir)
-		var walkStart time.Time
-		if profiler != nil {
-			walkStart = time.Now()
-		}
+		stopWalk := indexprofile.Timer(indexprofile.PhaseWalk)
 		_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-			if profiler != nil {
-				profiler.Add(indexprofile.CounterPathsVisited, 1)
-			}
+			indexprofile.Add(indexprofile.CounterPathsVisited, 1)
 			if _, elem := filepath.Split(path); elem != "" {
 				// Skip various temporary or "hidden" files or directories.
 				if elem[0] == '.' || elem[0] == '#' || elem[0] == '~' || elem[len(elem)-1] == '~' {
-					if profiler != nil {
-						profiler.Add(indexprofile.CounterHiddenPathsSkipped, 1)
-					}
+					indexprofile.Add(indexprofile.CounterHiddenPathsSkipped, 1)
 					if info != nil && info.IsDir() {
 						return filepath.SkipDir
 					}
@@ -199,22 +190,15 @@ func handleIndex(args []string) {
 				return nil
 			}
 			if info != nil && info.Mode()&os.ModeType == 0 {
-				var readStart time.Time
-				if profiler != nil {
-					profiler.Add(indexprofile.CounterFilesSeen, 1)
-					readStart = time.Now()
-				}
+				indexprofile.Add(indexprofile.CounterFilesSeen, 1)
+				stopRead := indexprofile.Timer(indexprofile.PhaseReadFile)
 				buf, err := os.ReadFile(path)
-				if profiler != nil {
-					profiler.Record(indexprofile.PhaseReadFile, time.Since(readStart))
-				}
+				stopRead()
 				if err != nil {
 					return err
 				}
-				if profiler != nil {
-					profiler.Add(indexprofile.CounterFilesRead, 1)
-					profiler.Add(indexprofile.CounterBytesRead, int64(len(buf)))
-				}
+				indexprofile.Add(indexprofile.CounterFilesRead, 1)
+				indexprofile.Add(indexprofile.CounterBytesRead, int64(len(buf)))
 
 				if err := github.AddFileToIndex(iw, repoURL, commitSHA, path, buf); err != nil {
 					log.Infof("Skipping file %s: %s", path, err)
@@ -222,9 +206,7 @@ func handleIndex(args []string) {
 			}
 			return nil
 		})
-		if profiler != nil {
-			profiler.Record(indexprofile.PhaseWalk, time.Since(walkStart))
-		}
+		stopWalk()
 		github.SetLastIndexedCommitSha(iw, repoURL, commitSHA)
 	}
 

--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -36,12 +36,11 @@ var (
 		squeryCmd.Name(): squeryCmd,
 	}
 
-	indexDir             string
-	cpuProfile           string
-	heapProfile          string
-	indexProfile         bool
-	indexProfileDetailed bool
-	namespace            string
+	indexDir     string
+	cpuProfile   string
+	heapProfile  string
+	indexProfile bool
+	namespace    string
 
 	reset    = indexCmd.Bool("reset", false, "Delete the index and start fresh")
 	results  = searchCmd.Int("results", 100, "Print this many results")
@@ -68,7 +67,6 @@ func setupCommonFlags() {
 			flagset.StringVar(&namespace, "namespace", "", "Namespace to index/search/squery in")
 			if cmdName == indexCmd.Name() {
 				flagset.BoolVar(&indexProfile, "index_profile", false, "Print indexing phase timing and counters")
-				flagset.BoolVar(&indexProfileDetailed, "index_profile_detailed", false, "Include high-overhead tokenizer internals in the index profile")
 			}
 		}
 	}
@@ -108,7 +106,7 @@ func main() {
 	}
 
 	if indexProfile {
-		p := indexprofile.Start(indexProfileDetailed)
+		p := indexprofile.Start()
 		defer func() {
 			indexprofile.Stop()
 			p.PrettyPrint()

--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -11,9 +11,11 @@ import (
 	"runtime/pprof"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/github"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/index"
+	"github.com/buildbuddy-io/buildbuddy/codesearch/indexprofile"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/performance"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/query"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/schema"
@@ -34,10 +36,12 @@ var (
 		squeryCmd.Name(): squeryCmd,
 	}
 
-	indexDir    string
-	cpuProfile  string
-	heapProfile string
-	namespace   string
+	indexDir             string
+	cpuProfile           string
+	heapProfile          string
+	indexProfile         bool
+	indexProfileDetailed bool
+	namespace            string
 
 	reset    = indexCmd.Bool("reset", false, "Delete the index and start fresh")
 	results  = searchCmd.Int("results", 100, "Print this many results")
@@ -62,6 +66,10 @@ func setupCommonFlags() {
 			flagset.StringVar(&cpuProfile, "cpu_profile", "", "Path to dump a CPU profile")
 			flagset.StringVar(&heapProfile, "heap_profile", "", "Path to dump a heap profile")
 			flagset.StringVar(&namespace, "namespace", "", "Namespace to index/search/squery in")
+			if cmdName == indexCmd.Name() {
+				flagset.BoolVar(&indexProfile, "index_profile", false, "Print indexing phase timing and counters")
+				flagset.BoolVar(&indexProfileDetailed, "index_profile_detailed", false, "Include high-overhead tokenizer internals in the index profile")
+			}
 		}
 	}
 }
@@ -97,6 +105,14 @@ func main() {
 		}
 		defer f.Close()
 		defer pprof.WriteHeapProfile(f)
+	}
+
+	if indexProfile {
+		p := indexprofile.Start(indexProfileDetailed)
+		defer func() {
+			indexprofile.Stop()
+			p.PrettyPrint()
+		}()
 	}
 
 	ctx := performance.WrapContext(context.Background())
@@ -141,6 +157,7 @@ func extractGitSHA(dir string) string {
 }
 
 func handleIndex(args []string) {
+	profiler := indexprofile.Current()
 	if *reset {
 		os.RemoveAll(indexDir)
 	}
@@ -159,11 +176,21 @@ func handleIndex(args []string) {
 		repoURL := extractRepoURL(dir)
 		commitSHA := extractGitSHA(dir)
 		log.Printf("indexing dir: %q", dir)
-		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		var walkStart time.Time
+		if profiler != nil {
+			walkStart = time.Now()
+		}
+		_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if profiler != nil {
+				profiler.Add(indexprofile.CounterPathsVisited, 1)
+			}
 			if _, elem := filepath.Split(path); elem != "" {
 				// Skip various temporary or "hidden" files or directories.
 				if elem[0] == '.' || elem[0] == '#' || elem[0] == '~' || elem[len(elem)-1] == '~' {
-					if info.IsDir() {
+					if profiler != nil {
+						profiler.Add(indexprofile.CounterHiddenPathsSkipped, 1)
+					}
+					if info != nil && info.IsDir() {
 						return filepath.SkipDir
 					}
 					return nil
@@ -174,9 +201,21 @@ func handleIndex(args []string) {
 				return nil
 			}
 			if info != nil && info.Mode()&os.ModeType == 0 {
+				var readStart time.Time
+				if profiler != nil {
+					profiler.Add(indexprofile.CounterFilesSeen, 1)
+					readStart = time.Now()
+				}
 				buf, err := os.ReadFile(path)
+				if profiler != nil {
+					profiler.Record(indexprofile.PhaseReadFile, time.Since(readStart))
+				}
 				if err != nil {
 					return err
+				}
+				if profiler != nil {
+					profiler.Add(indexprofile.CounterFilesRead, 1)
+					profiler.Add(indexprofile.CounterBytesRead, int64(len(buf)))
 				}
 
 				if err := github.AddFileToIndex(iw, repoURL, commitSHA, path, buf); err != nil {
@@ -185,6 +224,9 @@ func handleIndex(args []string) {
 			}
 			return nil
 		})
+		if profiler != nil {
+			profiler.Record(indexprofile.PhaseWalk, time.Since(walkStart))
+		}
 		github.SetLastIndexedCommitSha(iw, repoURL, commitSHA)
 	}
 

--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -173,7 +173,7 @@ func handleIndex(args []string) {
 		commitSHA := extractGitSHA(dir)
 		log.Printf("indexing dir: %q", dir)
 		stopWalk := indexprofile.Timer(indexprofile.PhaseWalk)
-		_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		walkErr := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			indexprofile.Add(indexprofile.CounterPathsVisited, 1)
 			if _, elem := filepath.Split(path); elem != "" {
 				// Skip various temporary or "hidden" files or directories.
@@ -207,6 +207,9 @@ func handleIndex(args []string) {
 			return nil
 		})
 		stopWalk()
+		if walkErr != nil {
+			log.Fatal(err.Error())
+		}
 		github.SetLastIndexedCommitSha(iw, repoURL, commitSHA)
 	}
 

--- a/codesearch/github/BUILD
+++ b/codesearch/github/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/github",
     visibility = ["//visibility:public"],
     deps = [
+        "//codesearch/indexprofile",
         "//codesearch/schema",
         "//codesearch/types",
         "//proto:index_go_proto",

--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/indexprofile"
@@ -75,39 +74,21 @@ func makeLastIndexedDoc(repoURL *git.RepoURL, commitSHA string) types.Document {
 // mimetype, or contains invalid UTF-8 data.
 // This function does not flush the index writer, so the caller is responsible for doing that.
 func AddFileToIndex(w types.IndexWriter, repoURL *git.RepoURL, commitSHA, filename string, fileContent []byte) error {
-	profiler := indexprofile.Current()
-	var totalStart time.Time
-	if profiler != nil {
-		totalStart = time.Now()
-		defer func() {
-			profiler.Record(indexprofile.PhaseAddFileToIndex, time.Since(totalStart))
-		}()
-	}
+	defer indexprofile.Timer(indexprofile.PhaseAddFileToIndex)()
 
-	var validateStart time.Time
-	if profiler != nil {
-		validateStart = time.Now()
-	}
+	stopValidate := indexprofile.Timer(indexprofile.PhaseValidateFile)
 	err := validateFile(fileContent)
-	if profiler != nil {
-		profiler.Record(indexprofile.PhaseValidateFile, time.Since(validateStart))
-	}
+	stopValidate()
 	if err != nil {
-		if profiler != nil {
-			profiler.Add(indexprofile.CounterFilesSkipped, 1)
-			profiler.Add(indexprofile.CounterValidationSkippedFiles, 1)
-		}
+		indexprofile.Add(indexprofile.CounterFilesSkipped, 1)
+		indexprofile.Add(indexprofile.CounterValidationSkippedFiles, 1)
 		return err
 	}
 
-	var langStart time.Time
-	if profiler != nil {
-		langStart = time.Now()
-	}
+	stopLang := indexprofile.Timer(indexprofile.PhaseDetectLanguage)
 	lang := strings.ToLower(enry.GetLanguage(filepath.Base(filename), detectionBuffer(fileContent)))
-	if profiler != nil {
-		profiler.Record(indexprofile.PhaseDetectLanguage, time.Since(langStart))
-	}
+	stopLang()
+
 	fields := map[string][]byte{
 		schema.IDField:       makeFileId(repoURL, filename),
 		schema.FilenameField: []byte(filename),
@@ -118,31 +99,19 @@ func AddFileToIndex(w types.IndexWriter, repoURL *git.RepoURL, commitSHA, filena
 		schema.SHAField:      []byte(commitSHA),
 	}
 
-	var docStart time.Time
-	if profiler != nil {
-		docStart = time.Now()
-	}
+	stopDoc := indexprofile.Timer(indexprofile.PhaseMakeDocument)
 	doc := schema.GitHubFileSchema().MustMakeDocument(fields)
-	if profiler != nil {
-		profiler.Record(indexprofile.PhaseMakeDocument, time.Since(docStart))
-	}
+	stopDoc()
 
-	var updateStart time.Time
-	if profiler != nil {
-		updateStart = time.Now()
-	}
-	if err := w.UpdateDocument(doc.Field(schema.IDField), doc); err != nil {
-		if profiler != nil {
-			profiler.Record(indexprofile.PhaseUpdateDocument, time.Since(updateStart))
-			profiler.Add(indexprofile.CounterFilesSkipped, 1)
-			profiler.Add(indexprofile.CounterAddFileErrors, 1)
-		}
+	stopUpdate := indexprofile.Timer(indexprofile.PhaseUpdateDocument)
+	err = w.UpdateDocument(doc.Field(schema.IDField), doc)
+	stopUpdate()
+	if err != nil {
+		indexprofile.Add(indexprofile.CounterFilesSkipped, 1)
+		indexprofile.Add(indexprofile.CounterAddFileErrors, 1)
 		return status.InternalErrorf("Failed to update file %s: %v", filename, err)
 	}
-	if profiler != nil {
-		profiler.Record(indexprofile.PhaseUpdateDocument, time.Since(updateStart))
-		profiler.Add(indexprofile.CounterFilesIndexed, 1)
-	}
+	indexprofile.Add(indexprofile.CounterFilesIndexed, 1)
 	return nil
 }
 

--- a/codesearch/github/github.go
+++ b/codesearch/github/github.go
@@ -10,8 +10,10 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
+	"github.com/buildbuddy-io/buildbuddy/codesearch/indexprofile"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/schema"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
 	"github.com/buildbuddy-io/buildbuddy/server/util/git"
@@ -73,12 +75,39 @@ func makeLastIndexedDoc(repoURL *git.RepoURL, commitSHA string) types.Document {
 // mimetype, or contains invalid UTF-8 data.
 // This function does not flush the index writer, so the caller is responsible for doing that.
 func AddFileToIndex(w types.IndexWriter, repoURL *git.RepoURL, commitSHA, filename string, fileContent []byte) error {
+	profiler := indexprofile.Current()
+	var totalStart time.Time
+	if profiler != nil {
+		totalStart = time.Now()
+		defer func() {
+			profiler.Record(indexprofile.PhaseAddFileToIndex, time.Since(totalStart))
+		}()
+	}
+
+	var validateStart time.Time
+	if profiler != nil {
+		validateStart = time.Now()
+	}
 	err := validateFile(fileContent)
+	if profiler != nil {
+		profiler.Record(indexprofile.PhaseValidateFile, time.Since(validateStart))
+	}
 	if err != nil {
+		if profiler != nil {
+			profiler.Add(indexprofile.CounterFilesSkipped, 1)
+			profiler.Add(indexprofile.CounterValidationSkippedFiles, 1)
+		}
 		return err
 	}
 
+	var langStart time.Time
+	if profiler != nil {
+		langStart = time.Now()
+	}
 	lang := strings.ToLower(enry.GetLanguage(filepath.Base(filename), detectionBuffer(fileContent)))
+	if profiler != nil {
+		profiler.Record(indexprofile.PhaseDetectLanguage, time.Since(langStart))
+	}
 	fields := map[string][]byte{
 		schema.IDField:       makeFileId(repoURL, filename),
 		schema.FilenameField: []byte(filename),
@@ -89,10 +118,30 @@ func AddFileToIndex(w types.IndexWriter, repoURL *git.RepoURL, commitSHA, filena
 		schema.SHAField:      []byte(commitSHA),
 	}
 
+	var docStart time.Time
+	if profiler != nil {
+		docStart = time.Now()
+	}
 	doc := schema.GitHubFileSchema().MustMakeDocument(fields)
+	if profiler != nil {
+		profiler.Record(indexprofile.PhaseMakeDocument, time.Since(docStart))
+	}
 
+	var updateStart time.Time
+	if profiler != nil {
+		updateStart = time.Now()
+	}
 	if err := w.UpdateDocument(doc.Field(schema.IDField), doc); err != nil {
+		if profiler != nil {
+			profiler.Record(indexprofile.PhaseUpdateDocument, time.Since(updateStart))
+			profiler.Add(indexprofile.CounterFilesSkipped, 1)
+			profiler.Add(indexprofile.CounterAddFileErrors, 1)
+		}
 		return status.InternalErrorf("Failed to update file %s: %v", filename, err)
+	}
+	if profiler != nil {
+		profiler.Record(indexprofile.PhaseUpdateDocument, time.Since(updateStart))
+		profiler.Add(indexprofile.CounterFilesIndexed, 1)
 	}
 	return nil
 }

--- a/codesearch/index/BUILD
+++ b/codesearch/index/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/index",
     visibility = ["//visibility:public"],
     deps = [
+        "//codesearch/indexprofile",
         "//codesearch/performance",
         "//codesearch/posting",
         "//codesearch/types",

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -408,15 +408,9 @@ func (w *Writer) CompactDeletes() error {
 // Note: This implementation does not handle file renames - clients must explicitly
 // delete the old file and add (or update) the new file when renames happen.
 func (w *Writer) UpdateDocument(matchField types.Field, newDoc types.Document) error {
-	profiler := indexprofile.Current()
-	var deleteStart time.Time
-	if profiler != nil {
-		deleteStart = time.Now()
-	}
+	stop := indexprofile.Timer(indexprofile.PhaseDeleteExisting)
 	err := w.DeleteDocumentByMatchField(matchField)
-	if profiler != nil {
-		profiler.Record(indexprofile.PhaseDeleteExisting, time.Since(deleteStart))
-	}
+	stop()
 	if err != nil {
 		return err
 	}
@@ -583,57 +577,37 @@ func (w *Writer) flushBatch() error {
 	}
 	w.log.Infof("Batch size is %d", w.batch.Len())
 	commitSize := w.batch.Len()
-	profiler := indexprofile.Current()
-	var commitStart time.Time
-	if profiler != nil {
-		commitStart = time.Now()
-	}
+	stop := indexprofile.Timer(indexprofile.PhasePebbleBatchCommit)
 	if err := w.batch.Commit(pebble.NoSync); err != nil {
 		return err
 	}
-	if profiler != nil {
-		profiler.Record(indexprofile.PhasePebbleBatchCommit, time.Since(commitStart))
-		profiler.Add(indexprofile.CounterPebbleBatchCommits, 1)
-		profiler.Add(indexprofile.CounterPebbleBatchCommitBytes, int64(commitSize))
-	}
+	stop()
+	indexprofile.Add(indexprofile.CounterPebbleBatchCommits, 1)
+	indexprofile.Add(indexprofile.CounterPebbleBatchCommitBytes, int64(commitSize))
 	w.log.Debugf("flushed batch")
 	w.batch = w.db.NewBatch()
 	return nil
 }
 
 func (w *Writer) updatePostingList(key []byte, pl posting.List, field, ngram string, deferOp func(int, int) *pebble.DeferredBatchOp) error {
-	profiler := indexprofile.Current()
-	var updateStart time.Time
-	if profiler != nil {
-		updateStart = time.Now()
-		defer func() {
-			profiler.Record(indexprofile.PhaseUpdatePostingList, time.Since(updateStart))
-		}()
-	}
+	defer indexprofile.Timer(indexprofile.PhaseUpdatePostingList)()
 
 	valueLength := int(pl.GetSerializedSizeInBytes())
 	keyLength := len(key)
-	if profiler != nil {
-		profiler.Add(indexprofile.CounterPostingListsFlushed, 1)
-		profiler.Add(indexprofile.CounterPostingListKeyBytes, int64(keyLength))
-		profiler.Add(indexprofile.CounterPostingListValueBytes, int64(valueLength))
-		if field != "" {
-			profiler.RecordPostingList(field, ngram, pl.GetCardinality(), int64(keyLength), int64(valueLength))
-		}
+	indexprofile.Add(indexprofile.CounterPostingListsFlushed, 1)
+	indexprofile.Add(indexprofile.CounterPostingListKeyBytes, int64(keyLength))
+	indexprofile.Add(indexprofile.CounterPostingListValueBytes, int64(valueLength))
+	if field != "" {
+		indexprofile.RecordPostingList(field, ngram, pl.GetCardinality(), int64(keyLength), int64(valueLength))
 	}
 
 	op := deferOp(keyLength, valueLength)
 	copy(op.Key, key)
-	var marshalStart time.Time
-	if profiler != nil {
-		marshalStart = time.Now()
-	}
+	stopMarshal := indexprofile.Timer(indexprofile.PhasePostingListMarshal)
 	if err := pl.MarshalInto(op.Value[:0]); err != nil {
 		return err
 	}
-	if profiler != nil {
-		profiler.Record(indexprofile.PhasePostingListMarshal, time.Since(marshalStart))
-	}
+	stopMarshal()
 	if err := op.Finish(); err != nil {
 		return err
 	}
@@ -647,14 +621,7 @@ func (w *Writer) updatePostingList(key []byte, pl posting.List, field, ngram str
 }
 
 func (w *Writer) Flush() error {
-	profiler := indexprofile.Current()
-	var flushStart time.Time
-	if profiler != nil {
-		flushStart = time.Now()
-		defer func() {
-			profiler.Record(indexprofile.PhaseFlush, time.Since(flushStart))
-		}()
-	}
+	defer indexprofile.Timer(indexprofile.PhaseFlush)()
 
 	mu := sync.Mutex{}
 	eg := new(errgroup.Group)

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/codesearch/indexprofile"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/performance"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/posting"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
@@ -387,7 +388,7 @@ func (w *Writer) CompactDeletes() error {
 			w.batch.Delete(iter.Key(), nil)
 			delCount++
 		} else if pl.GetCardinality() != beforeCard {
-			w.updatePostingList(iter.Key(), pl, w.batch.SetDeferred)
+			w.updatePostingList(iter.Key(), pl, "", "", w.batch.SetDeferred)
 			changeCount++
 		} // else unchanged, do nothing
 	}
@@ -407,7 +408,15 @@ func (w *Writer) CompactDeletes() error {
 // Note: This implementation does not handle file renames - clients must explicitly
 // delete the old file and add (or update) the new file when renames happen.
 func (w *Writer) UpdateDocument(matchField types.Field, newDoc types.Document) error {
+	profiler := indexprofile.Current()
+	var deleteStart time.Time
+	if profiler != nil {
+		deleteStart = time.Now()
+	}
 	err := w.DeleteDocumentByMatchField(matchField)
+	if profiler != nil {
+		profiler.Record(indexprofile.PhaseDeleteExisting, time.Since(deleteStart))
+	}
 	if err != nil {
 		return err
 	}
@@ -416,15 +425,65 @@ func (w *Writer) UpdateDocument(matchField types.Field, newDoc types.Document) e
 }
 
 func (w *Writer) AddDocument(doc types.Document) error {
+	profiler := indexprofile.Current()
+	var addDocumentStart time.Time
+	var fieldsIndexed int64
+	var tokenNextCount int64
+	var tokenNextDuration time.Duration
+	var tokensIndexed int64
+	var postingMutationDuration time.Duration
+	var ngramConversionDuration time.Duration
+	var postingListLookupDuration time.Duration
+	var postingListAddDuration time.Duration
+	var postingListsCreated int64
+	var storedFieldsSet int64
+	var storedFieldSetDuration time.Duration
+	var pebbleBatchSets int64
+	var pebbleBatchSetBytes int64
+	var pebbleBatchSetDuration time.Duration
+	if profiler != nil {
+		addDocumentStart = time.Now()
+		defer func() {
+			profiler.Record(indexprofile.PhaseAddDocument, time.Since(addDocumentStart))
+			profiler.RecordN(indexprofile.PhaseTokenizerNext, tokenNextCount, tokenNextDuration)
+			profiler.RecordN(indexprofile.PhasePostingMutation, tokensIndexed, postingMutationDuration)
+			profiler.RecordN(indexprofile.PhaseNgramConversion, tokensIndexed, ngramConversionDuration)
+			profiler.RecordN(indexprofile.PhasePostingListLookup, tokensIndexed, postingListLookupDuration)
+			profiler.RecordN(indexprofile.PhasePostingListAdd, tokensIndexed, postingListAddDuration)
+			profiler.RecordN(indexprofile.PhaseStoredFieldSet, storedFieldsSet, storedFieldSetDuration)
+			profiler.RecordN(indexprofile.PhasePebbleBatchSet, pebbleBatchSets, pebbleBatchSetDuration)
+			profiler.Add(indexprofile.CounterDocsAdded, 1)
+			profiler.Add(indexprofile.CounterFieldsIndexed, fieldsIndexed)
+			profiler.Add(indexprofile.CounterTokensIndexed, tokensIndexed)
+			profiler.Add(indexprofile.CounterPostingListLookups, tokensIndexed)
+			profiler.Add(indexprofile.CounterPostingListsCreated, postingListsCreated)
+			profiler.Add(indexprofile.CounterStoredFieldsSet, storedFieldsSet)
+			profiler.Add(indexprofile.CounterPebbleBatchSets, pebbleBatchSets)
+			profiler.Add(indexprofile.CounterPebbleBatchSetBytes, pebbleBatchSetBytes)
+		}()
+	}
+
 	w.docIndex++
 
 	// **Always store DocID.**
 	docID := uint64(w.generation)<<32 | uint64(w.docIndex)
 	idKey := w.storedFieldKey(docID, types.DocIDField)
+	var batchSetStart time.Time
+	if profiler != nil {
+		batchSetStart = time.Now()
+	}
 	w.batch.Set(idKey, Uint64ToBytes(docID), nil)
+	if profiler != nil {
+		pebbleBatchSetDuration += time.Since(batchSetStart)
+		pebbleBatchSets++
+		pebbleBatchSetBytes += int64(len(idKey) + 8)
+	}
 
 	for _, fieldName := range doc.Fields() {
 		field := doc.Field(fieldName)
+		if profiler != nil {
+			fieldsIndexed++
+		}
 
 		if _, ok := w.fieldPostingLists[field.Name()]; !ok {
 			w.fieldPostingLists[field.Name()] = make(postingLists, 0)
@@ -439,17 +498,75 @@ func (w *Writer) AddDocument(doc types.Document) error {
 
 		tokenizer.Reset(bytes.NewReader(field.Contents()))
 
-		for tokenizer.Next() == nil {
+		for {
+			var tokenizerStart time.Time
+			if profiler != nil {
+				tokenizerStart = time.Now()
+			}
+			err := tokenizer.Next()
+			if profiler != nil {
+				tokenNextDuration += time.Since(tokenizerStart)
+				tokenNextCount++
+			}
+			if err != nil {
+				break
+			}
+
+			var postingStart time.Time
+			if profiler != nil {
+				postingStart = time.Now()
+				tokensIndexed++
+			}
+
+			var ngramConversionStart time.Time
+			if profiler != nil {
+				ngramConversionStart = time.Now()
+			}
 			ngram := string(tokenizer.Ngram())
+			if profiler != nil {
+				ngramConversionDuration += time.Since(ngramConversionStart)
+			}
+
+			var postingListLookupStart time.Time
+			if profiler != nil {
+				postingListLookupStart = time.Now()
+			}
 			if _, ok := postingLists[ngram]; !ok {
 				postingLists[ngram] = posting.NewList()
+				if profiler != nil {
+					postingListsCreated++
+				}
+			}
+			if profiler != nil {
+				postingListLookupDuration += time.Since(postingListLookupStart)
+			}
+
+			var postingListAddStart time.Time
+			if profiler != nil {
+				postingListAddStart = time.Now()
 			}
 			postingLists[ngram].Add(docID)
+			if profiler != nil {
+				postingListAddDuration += time.Since(postingListAddStart)
+				postingMutationDuration += time.Since(postingStart)
+			}
 		}
 
 		if field.Schema().Stored() {
 			storedFieldKey := w.storedFieldKey(docID, field.Name())
+			var storedFieldSetStart time.Time
+			if profiler != nil {
+				storedFieldSetStart = time.Now()
+			}
 			w.batch.Set(storedFieldKey, field.Contents(), nil)
+			if profiler != nil {
+				duration := time.Since(storedFieldSetStart)
+				storedFieldSetDuration += duration
+				storedFieldsSet++
+				pebbleBatchSetDuration += duration
+				pebbleBatchSets++
+				pebbleBatchSetBytes += int64(len(storedFieldKey) + len(field.Contents()))
+			}
 		}
 	}
 	if w.batch.Len() >= batchFlushSizeBytes {
@@ -465,22 +582,57 @@ func (w *Writer) flushBatch() error {
 		return nil
 	}
 	w.log.Infof("Batch size is %d", w.batch.Len())
+	commitSize := w.batch.Len()
+	profiler := indexprofile.Current()
+	var commitStart time.Time
+	if profiler != nil {
+		commitStart = time.Now()
+	}
 	if err := w.batch.Commit(pebble.NoSync); err != nil {
 		return err
+	}
+	if profiler != nil {
+		profiler.Record(indexprofile.PhasePebbleBatchCommit, time.Since(commitStart))
+		profiler.Add(indexprofile.CounterPebbleBatchCommits, 1)
+		profiler.Add(indexprofile.CounterPebbleBatchCommitBytes, int64(commitSize))
 	}
 	w.log.Debugf("flushed batch")
 	w.batch = w.db.NewBatch()
 	return nil
 }
 
-func (w *Writer) updatePostingList(key []byte, pl posting.List, deferOp func(int, int) *pebble.DeferredBatchOp) error {
+func (w *Writer) updatePostingList(key []byte, pl posting.List, field, ngram string, deferOp func(int, int) *pebble.DeferredBatchOp) error {
+	profiler := indexprofile.Current()
+	var updateStart time.Time
+	if profiler != nil {
+		updateStart = time.Now()
+		defer func() {
+			profiler.Record(indexprofile.PhaseUpdatePostingList, time.Since(updateStart))
+		}()
+	}
+
 	valueLength := int(pl.GetSerializedSizeInBytes())
 	keyLength := len(key)
+	if profiler != nil {
+		profiler.Add(indexprofile.CounterPostingListsFlushed, 1)
+		profiler.Add(indexprofile.CounterPostingListKeyBytes, int64(keyLength))
+		profiler.Add(indexprofile.CounterPostingListValueBytes, int64(valueLength))
+		if field != "" {
+			profiler.RecordPostingList(field, ngram, pl.GetCardinality(), int64(keyLength), int64(valueLength))
+		}
+	}
 
 	op := deferOp(keyLength, valueLength)
 	copy(op.Key, key)
+	var marshalStart time.Time
+	if profiler != nil {
+		marshalStart = time.Now()
+	}
 	if err := pl.MarshalInto(op.Value[:0]); err != nil {
 		return err
+	}
+	if profiler != nil {
+		profiler.Record(indexprofile.PhasePostingListMarshal, time.Since(marshalStart))
 	}
 	if err := op.Finish(); err != nil {
 		return err
@@ -495,13 +647,22 @@ func (w *Writer) updatePostingList(key []byte, pl posting.List, deferOp func(int
 }
 
 func (w *Writer) Flush() error {
+	profiler := indexprofile.Current()
+	var flushStart time.Time
+	if profiler != nil {
+		flushStart = time.Now()
+		defer func() {
+			profiler.Record(indexprofile.PhaseFlush, time.Since(flushStart))
+		}()
+	}
+
 	mu := sync.Mutex{}
 	eg := new(errgroup.Group)
 	eg.SetLimit(runtime.GOMAXPROCS(0))
-	writePLs := func(key []byte, pl posting.List) error {
+	writePLs := func(key []byte, pl posting.List, field, ngram string) error {
 		mu.Lock()
 		defer mu.Unlock()
-		w.updatePostingList(key, pl, w.batch.MergeDeferred)
+		w.updatePostingList(key, pl, field, ngram, w.batch.MergeDeferred)
 		return nil
 	}
 
@@ -514,14 +675,14 @@ func (w *Writer) Flush() error {
 			fieldName := fieldName
 			docIDs := docIDs
 			eg.Go(func() error {
-				return writePLs(w.postingListKey(ngram, fieldName), docIDs)
+				return writePLs(w.postingListKey(ngram, fieldName), docIDs, fieldName, ngram)
 			})
 		}
 	}
 	if w.deletes.GetCardinality() > 0 {
 		eg.Go(func() error {
 			plKey := w.postingListKey(types.DeletesField, types.DeletesField)
-			return writePLs(plKey, w.deletes)
+			return writePLs(plKey, w.deletes, "", "")
 		})
 	}
 	if err := eg.Wait(); err != nil {

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -418,66 +418,56 @@ func (w *Writer) UpdateDocument(matchField types.Field, newDoc types.Document) e
 	return w.AddDocument(newDoc)
 }
 
+type addDocStats struct {
+	fields              int64
+	tokens              int64
+	postingListsCreated int64
+	storedFieldsSet     int64
+	pebbleBatchSets     int64
+	pebbleBatchSetBytes int64
+	tokenizerNextDur    time.Duration
+	postingMutationDur  time.Duration
+	storedFieldSetDur   time.Duration
+	pebbleBatchSetDur   time.Duration
+}
+
+func (s *addDocStats) flush(p *indexprofile.Profiler) {
+	p.RecordN(indexprofile.PhaseTokenizerNext, s.tokens, s.tokenizerNextDur)
+	p.RecordN(indexprofile.PhasePostingMutation, s.tokens, s.postingMutationDur)
+	p.RecordN(indexprofile.PhaseStoredFieldSet, s.storedFieldsSet, s.storedFieldSetDur)
+	p.RecordN(indexprofile.PhasePebbleBatchSet, s.pebbleBatchSets, s.pebbleBatchSetDur)
+	p.Add(indexprofile.CounterDocsAdded, 1)
+	p.Add(indexprofile.CounterFieldsIndexed, s.fields)
+	p.Add(indexprofile.CounterTokensIndexed, s.tokens)
+	p.Add(indexprofile.CounterPostingListLookups, s.tokens)
+	p.Add(indexprofile.CounterPostingListsCreated, s.postingListsCreated)
+	p.Add(indexprofile.CounterStoredFieldsSet, s.storedFieldsSet)
+	p.Add(indexprofile.CounterPebbleBatchSets, s.pebbleBatchSets)
+	p.Add(indexprofile.CounterPebbleBatchSetBytes, s.pebbleBatchSetBytes)
+}
+
 func (w *Writer) AddDocument(doc types.Document) error {
 	profiler := indexprofile.Current()
-	var addDocumentStart time.Time
-	var fieldsIndexed int64
-	var tokenNextCount int64
-	var tokenNextDuration time.Duration
-	var tokensIndexed int64
-	var postingMutationDuration time.Duration
-	var ngramConversionDuration time.Duration
-	var postingListLookupDuration time.Duration
-	var postingListAddDuration time.Duration
-	var postingListsCreated int64
-	var storedFieldsSet int64
-	var storedFieldSetDuration time.Duration
-	var pebbleBatchSets int64
-	var pebbleBatchSetBytes int64
-	var pebbleBatchSetDuration time.Duration
+	var s addDocStats
 	if profiler != nil {
-		addDocumentStart = time.Now()
-		defer func() {
-			profiler.Record(indexprofile.PhaseAddDocument, time.Since(addDocumentStart))
-			profiler.RecordN(indexprofile.PhaseTokenizerNext, tokenNextCount, tokenNextDuration)
-			profiler.RecordN(indexprofile.PhasePostingMutation, tokensIndexed, postingMutationDuration)
-			profiler.RecordN(indexprofile.PhaseNgramConversion, tokensIndexed, ngramConversionDuration)
-			profiler.RecordN(indexprofile.PhasePostingListLookup, tokensIndexed, postingListLookupDuration)
-			profiler.RecordN(indexprofile.PhasePostingListAdd, tokensIndexed, postingListAddDuration)
-			profiler.RecordN(indexprofile.PhaseStoredFieldSet, storedFieldsSet, storedFieldSetDuration)
-			profiler.RecordN(indexprofile.PhasePebbleBatchSet, pebbleBatchSets, pebbleBatchSetDuration)
-			profiler.Add(indexprofile.CounterDocsAdded, 1)
-			profiler.Add(indexprofile.CounterFieldsIndexed, fieldsIndexed)
-			profiler.Add(indexprofile.CounterTokensIndexed, tokensIndexed)
-			profiler.Add(indexprofile.CounterPostingListLookups, tokensIndexed)
-			profiler.Add(indexprofile.CounterPostingListsCreated, postingListsCreated)
-			profiler.Add(indexprofile.CounterStoredFieldsSet, storedFieldsSet)
-			profiler.Add(indexprofile.CounterPebbleBatchSets, pebbleBatchSets)
-			profiler.Add(indexprofile.CounterPebbleBatchSetBytes, pebbleBatchSetBytes)
-		}()
+		defer s.flush(profiler)
 	}
+	defer indexprofile.Timer(indexprofile.PhaseAddDocument)()
 
 	w.docIndex++
 
 	// **Always store DocID.**
 	docID := uint64(w.generation)<<32 | uint64(w.docIndex)
 	idKey := w.storedFieldKey(docID, types.DocIDField)
-	var batchSetStart time.Time
-	if profiler != nil {
-		batchSetStart = time.Now()
-	}
+	t := profiler.Now()
 	w.batch.Set(idKey, Uint64ToBytes(docID), nil)
-	if profiler != nil {
-		pebbleBatchSetDuration += time.Since(batchSetStart)
-		pebbleBatchSets++
-		pebbleBatchSetBytes += int64(len(idKey) + 8)
-	}
+	s.pebbleBatchSetDur += profiler.Since(t)
+	s.pebbleBatchSets++
+	s.pebbleBatchSetBytes += int64(len(idKey) + 8)
 
 	for _, fieldName := range doc.Fields() {
 		field := doc.Field(fieldName)
-		if profiler != nil {
-			fieldsIndexed++
-		}
+		s.fields++
 
 		if _, ok := w.fieldPostingLists[field.Name()]; !ok {
 			w.fieldPostingLists[field.Name()] = make(postingLists, 0)
@@ -493,74 +483,34 @@ func (w *Writer) AddDocument(doc types.Document) error {
 		tokenizer.Reset(bytes.NewReader(field.Contents()))
 
 		for {
-			var tokenizerStart time.Time
-			if profiler != nil {
-				tokenizerStart = time.Now()
-			}
+			t := profiler.Now()
 			err := tokenizer.Next()
-			if profiler != nil {
-				tokenNextDuration += time.Since(tokenizerStart)
-				tokenNextCount++
-			}
+			s.tokenizerNextDur += profiler.Since(t)
 			if err != nil {
 				break
 			}
 
-			var postingStart time.Time
-			if profiler != nil {
-				postingStart = time.Now()
-				tokensIndexed++
-			}
-
-			var ngramConversionStart time.Time
-			if profiler != nil {
-				ngramConversionStart = time.Now()
-			}
+			t = profiler.Now()
 			ngram := string(tokenizer.Ngram())
-			if profiler != nil {
-				ngramConversionDuration += time.Since(ngramConversionStart)
-			}
-
-			var postingListLookupStart time.Time
-			if profiler != nil {
-				postingListLookupStart = time.Now()
-			}
 			if _, ok := postingLists[ngram]; !ok {
 				postingLists[ngram] = posting.NewList()
-				if profiler != nil {
-					postingListsCreated++
-				}
-			}
-			if profiler != nil {
-				postingListLookupDuration += time.Since(postingListLookupStart)
-			}
-
-			var postingListAddStart time.Time
-			if profiler != nil {
-				postingListAddStart = time.Now()
+				s.postingListsCreated++
 			}
 			postingLists[ngram].Add(docID)
-			if profiler != nil {
-				postingListAddDuration += time.Since(postingListAddStart)
-				postingMutationDuration += time.Since(postingStart)
-			}
+			s.postingMutationDur += profiler.Since(t)
+			s.tokens++
 		}
 
 		if field.Schema().Stored() {
 			storedFieldKey := w.storedFieldKey(docID, field.Name())
-			var storedFieldSetStart time.Time
-			if profiler != nil {
-				storedFieldSetStart = time.Now()
-			}
+			t := profiler.Now()
 			w.batch.Set(storedFieldKey, field.Contents(), nil)
-			if profiler != nil {
-				duration := time.Since(storedFieldSetStart)
-				storedFieldSetDuration += duration
-				storedFieldsSet++
-				pebbleBatchSetDuration += duration
-				pebbleBatchSets++
-				pebbleBatchSetBytes += int64(len(storedFieldKey) + len(field.Contents()))
-			}
+			d := profiler.Since(t)
+			s.storedFieldSetDur += d
+			s.pebbleBatchSetDur += d
+			s.storedFieldsSet++
+			s.pebbleBatchSets++
+			s.pebbleBatchSetBytes += int64(len(storedFieldKey) + len(field.Contents()))
 		}
 	}
 	if w.batch.Len() >= batchFlushSizeBytes {

--- a/codesearch/indexprofile/BUILD
+++ b/codesearch/indexprofile/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "indexprofile",
+    srcs = ["indexprofile.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/indexprofile",
+    visibility = ["//visibility:public"],
+    deps = ["//server/util/log"],
+)

--- a/codesearch/indexprofile/indexprofile.go
+++ b/codesearch/indexprofile/indexprofile.go
@@ -1,0 +1,551 @@
+package indexprofile
+
+import (
+	"container/heap"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+type Phase string
+
+const (
+	PhaseWalk               Phase = "walk_total"
+	PhaseReadFile           Phase = "read_file"
+	PhaseAddFileToIndex     Phase = "add_file_to_index"
+	PhaseValidateFile       Phase = "validate_file"
+	PhaseDetectLanguage     Phase = "detect_language"
+	PhaseMakeDocument       Phase = "make_document"
+	PhaseUpdateDocument     Phase = "update_document"
+	PhaseDeleteExisting     Phase = "delete_existing"
+	PhaseAddDocument        Phase = "add_document"
+	PhaseTokenizerNext      Phase = "tokenizer_next"
+	PhasePostingMutation    Phase = "posting_mutation"
+	PhaseNgramConversion    Phase = "ngram_conversion"
+	PhasePostingListLookup  Phase = "posting_list_lookup"
+	PhasePostingListAdd     Phase = "posting_list_add"
+	PhaseSparseRefillLine   Phase = "sparse_refill_line"
+	PhaseSparseDecodeLine   Phase = "sparse_decode_line"
+	PhaseSparseBuildNgrams  Phase = "sparse_build_ngrams"
+	PhaseSparseHashBigram   Phase = "sparse_hash_bigram"
+	PhaseSparseToBytes      Phase = "sparse_to_bytes"
+	PhaseSparseTestOrAdd    Phase = "sparse_test_or_add"
+	PhaseSparseStringAppend Phase = "sparse_string_append"
+	PhaseStoredFieldSet     Phase = "stored_field_set"
+	PhaseFlush              Phase = "flush"
+	PhaseUpdatePostingList  Phase = "update_posting_list"
+	PhasePostingListMarshal Phase = "posting_list_marshal"
+	PhasePebbleBatchSet     Phase = "pebble_batch_set"
+	PhasePebbleBatchCommit  Phase = "pebble_batch_commit"
+)
+
+type Counter string
+
+const (
+	CounterPathsVisited           Counter = "paths_visited"
+	CounterFilesSeen              Counter = "files_seen"
+	CounterFilesRead              Counter = "files_read"
+	CounterFilesIndexed           Counter = "files_indexed"
+	CounterFilesSkipped           Counter = "files_skipped"
+	CounterBytesRead              Counter = "bytes_read"
+	CounterDocsAdded              Counter = "docs_added"
+	CounterFieldsIndexed          Counter = "fields_indexed"
+	CounterTokensIndexed          Counter = "tokens_indexed"
+	CounterPostingListLookups     Counter = "posting_list_lookups"
+	CounterPostingListsCreated    Counter = "posting_lists_created"
+	CounterPostingListsFlushed    Counter = "posting_lists_flushed"
+	CounterPostingListKeyBytes    Counter = "posting_list_key_bytes"
+	CounterPostingListValueBytes  Counter = "posting_list_value_bytes"
+	CounterStoredFieldsSet        Counter = "stored_fields_set"
+	CounterPebbleBatchSets        Counter = "pebble_batch_sets"
+	CounterPebbleBatchSetBytes    Counter = "pebble_batch_set_bytes"
+	CounterPebbleBatchCommits     Counter = "pebble_batch_commits"
+	CounterPebbleBatchCommitBytes Counter = "pebble_batch_commit_bytes"
+	CounterHiddenPathsSkipped     Counter = "hidden_paths_skipped"
+	CounterValidationSkippedFiles Counter = "validation_skipped_files"
+	CounterAddFileErrors          Counter = "add_file_errors"
+	CounterSparseLinesScanned     Counter = "sparse_lines_scanned"
+	CounterSparseLineBytes        Counter = "sparse_line_bytes"
+	CounterSparseRunes            Counter = "sparse_runes"
+	CounterSparseCandidates       Counter = "sparse_candidates"
+	CounterSparseNgramsTested     Counter = "sparse_ngrams_tested"
+	CounterSparseNgramsEmitted    Counter = "sparse_ngrams_emitted"
+	CounterTFOccurrences          Counter = "tf_ngram_occurrences"
+	CounterTFUniquePostings       Counter = "tf_unique_postings"
+	CounterTFDuplicateOccurrences Counter = "tf_duplicate_occurrences"
+	CounterTFDuplicatePostings    Counter = "tf_postings_with_freq_gt_1"
+	CounterTFExceptionBytes       Counter = "tf_exception_bytes_estimate"
+	CounterTFCountBytes           Counter = "tf_count_bytes_estimate"
+)
+
+type phaseStats struct {
+	count int64
+	total time.Duration
+}
+
+type postingListAggregate struct {
+	lists      int64
+	postings   int64
+	keyBytes   int64
+	valueBytes int64
+}
+
+type postingListBucketKey struct {
+	field string
+	label string
+	order int
+}
+
+type postingListLengthKey struct {
+	field  string
+	length int
+}
+
+type postingListTopEntry struct {
+	field       string
+	ngram       string
+	cardinality uint64
+	keyBytes    int64
+	valueBytes  int64
+}
+
+type TermFrequencyStats struct {
+	Occurrences            int64
+	UniquePostings         int64
+	DuplicateOccurrences   int64
+	DuplicatePostings      int64
+	ExceptionBytesEstimate int64
+	CountBytesEstimate     int64
+	Count1                 int64
+	Count2                 int64
+	Count3To4              int64
+	Count5To8              int64
+	Count9To16             int64
+	Count17To32            int64
+	Count33To64            int64
+	Count65To128           int64
+	Count129Plus           int64
+}
+
+type topPostingListHeap struct {
+	entries []postingListTopEntry
+	less    func(a, b postingListTopEntry) bool
+}
+
+func (h topPostingListHeap) Len() int           { return len(h.entries) }
+func (h topPostingListHeap) Less(i, j int) bool { return h.less(h.entries[i], h.entries[j]) }
+func (h topPostingListHeap) Swap(i, j int)      { h.entries[i], h.entries[j] = h.entries[j], h.entries[i] }
+
+func (h *topPostingListHeap) Push(x any) {
+	h.entries = append(h.entries, x.(postingListTopEntry))
+}
+
+func (h *topPostingListHeap) Pop() any {
+	old := h.entries
+	n := len(old)
+	x := old[n-1]
+	h.entries = old[:n-1]
+	return x
+}
+
+type Profiler struct {
+	start    time.Time
+	detailed bool
+
+	mu                        sync.Mutex
+	phases                    map[Phase]phaseStats
+	counters                  map[Counter]int64
+	postingListsByCardinality map[postingListBucketKey]postingListAggregate
+	postingListsByNgramLength map[postingListLengthKey]postingListAggregate
+	topContentByValueBytes    topPostingListHeap
+	termFrequencyByField      map[string]TermFrequencyStats
+}
+
+var current atomic.Pointer[Profiler]
+
+func Start(detailed bool) *Profiler {
+	p := &Profiler{
+		start:                     time.Now(),
+		detailed:                  detailed,
+		phases:                    make(map[Phase]phaseStats),
+		counters:                  make(map[Counter]int64),
+		postingListsByCardinality: make(map[postingListBucketKey]postingListAggregate),
+		postingListsByNgramLength: make(map[postingListLengthKey]postingListAggregate),
+		termFrequencyByField:      make(map[string]TermFrequencyStats),
+		topContentByValueBytes: topPostingListHeap{
+			less: lessByValueBytes,
+		},
+	}
+	current.Store(p)
+	return p
+}
+
+func Stop() *Profiler {
+	return current.Swap(nil)
+}
+
+func Current() *Profiler {
+	return current.Load()
+}
+
+func CurrentDetailed() *Profiler {
+	p := Current()
+	if p == nil || !p.detailed {
+		return nil
+	}
+	return p
+}
+
+func Record(phase Phase, duration time.Duration) {
+	if p := Current(); p != nil {
+		p.Record(phase, duration)
+	}
+}
+
+func RecordN(phase Phase, count int64, duration time.Duration) {
+	if p := Current(); p != nil {
+		p.RecordN(phase, count, duration)
+	}
+}
+
+func Add(counter Counter, value int64) {
+	if p := Current(); p != nil {
+		p.Add(counter, value)
+	}
+}
+
+func (p *Profiler) Record(phase Phase, duration time.Duration) {
+	p.RecordN(phase, 1, duration)
+}
+
+func (p *Profiler) RecordN(phase Phase, count int64, duration time.Duration) {
+	if count == 0 {
+		return
+	}
+	p.mu.Lock()
+	stats := p.phases[phase]
+	stats.count += count
+	stats.total += duration
+	p.phases[phase] = stats
+	p.mu.Unlock()
+}
+
+func (p *Profiler) Add(counter Counter, value int64) {
+	p.mu.Lock()
+	p.counters[counter] += value
+	p.mu.Unlock()
+}
+
+func (p *Profiler) Get(counter Counter) int64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.counters[counter]
+}
+
+func (p *Profiler) RecordTermFrequencyStats(field string, stats TermFrequencyStats) {
+	if stats.Occurrences == 0 {
+		return
+	}
+	p.mu.Lock()
+	current := p.termFrequencyByField[field]
+	current.Occurrences += stats.Occurrences
+	current.UniquePostings += stats.UniquePostings
+	current.DuplicateOccurrences += stats.DuplicateOccurrences
+	current.DuplicatePostings += stats.DuplicatePostings
+	current.ExceptionBytesEstimate += stats.ExceptionBytesEstimate
+	current.CountBytesEstimate += stats.CountBytesEstimate
+	current.Count1 += stats.Count1
+	current.Count2 += stats.Count2
+	current.Count3To4 += stats.Count3To4
+	current.Count5To8 += stats.Count5To8
+	current.Count9To16 += stats.Count9To16
+	current.Count17To32 += stats.Count17To32
+	current.Count33To64 += stats.Count33To64
+	current.Count65To128 += stats.Count65To128
+	current.Count129Plus += stats.Count129Plus
+	p.termFrequencyByField[field] = current
+
+	p.counters[CounterTFOccurrences] += stats.Occurrences
+	p.counters[CounterTFUniquePostings] += stats.UniquePostings
+	p.counters[CounterTFDuplicateOccurrences] += stats.DuplicateOccurrences
+	p.counters[CounterTFDuplicatePostings] += stats.DuplicatePostings
+	p.counters[CounterTFExceptionBytes] += stats.ExceptionBytesEstimate
+	p.counters[CounterTFCountBytes] += stats.CountBytesEstimate
+	p.mu.Unlock()
+}
+
+func (p *Profiler) RecordPostingList(field, ngram string, cardinality uint64, keyBytes, valueBytes int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	agg := postingListAggregate{
+		lists:      1,
+		postings:   int64(cardinality),
+		keyBytes:   keyBytes,
+		valueBytes: valueBytes,
+	}
+
+	bucket := postingListCardinalityBucket(cardinality)
+	bucket.field = field
+	addPostingListAggregate(p.postingListsByCardinality, bucket, agg)
+	addPostingListAggregate(p.postingListsByNgramLength, postingListLengthKey{
+		field:  field,
+		length: len(ngram),
+	}, agg)
+
+	if field == "content" {
+		entry := postingListTopEntry{
+			field:       field,
+			ngram:       ngram,
+			cardinality: cardinality,
+			keyBytes:    keyBytes,
+			valueBytes:  valueBytes,
+		}
+		maybeAddTopPostingList(&p.topContentByValueBytes, entry)
+	}
+}
+
+func addPostingListAggregate[K comparable](m map[K]postingListAggregate, key K, value postingListAggregate) {
+	agg := m[key]
+	agg.lists += value.lists
+	agg.postings += value.postings
+	agg.keyBytes += value.keyBytes
+	agg.valueBytes += value.valueBytes
+	m[key] = agg
+}
+
+func maybeAddTopPostingList(h *topPostingListHeap, entry postingListTopEntry) {
+	const maxTopPostingLists = 100
+	if h.Len() < maxTopPostingLists {
+		heap.Push(h, entry)
+		return
+	}
+	if h.less(h.entries[0], entry) {
+		h.entries[0] = entry
+		heap.Fix(h, 0)
+	}
+}
+
+func (p *Profiler) PrettyPrint() {
+	type phaseRow struct {
+		phase Phase
+		stats phaseStats
+	}
+	type counterRow struct {
+		counter Counter
+		value   int64
+	}
+	type cardinalityRow struct {
+		key   postingListBucketKey
+		stats postingListAggregate
+	}
+	type lengthRow struct {
+		key   postingListLengthKey
+		stats postingListAggregate
+	}
+	type termFrequencyRow struct {
+		field string
+		stats TermFrequencyStats
+	}
+
+	p.mu.Lock()
+	phases := make([]phaseRow, 0, len(p.phases))
+	for phase, stats := range p.phases {
+		phases = append(phases, phaseRow{phase: phase, stats: stats})
+	}
+	counters := make([]counterRow, 0, len(p.counters))
+	for counter, value := range p.counters {
+		counters = append(counters, counterRow{counter: counter, value: value})
+	}
+	cardinalityRows := make([]cardinalityRow, 0, len(p.postingListsByCardinality))
+	for key, stats := range p.postingListsByCardinality {
+		cardinalityRows = append(cardinalityRows, cardinalityRow{key: key, stats: stats})
+	}
+	lengthRows := make([]lengthRow, 0, len(p.postingListsByNgramLength))
+	for key, stats := range p.postingListsByNgramLength {
+		lengthRows = append(lengthRows, lengthRow{key: key, stats: stats})
+	}
+	termFrequencyRows := make([]termFrequencyRow, 0, len(p.termFrequencyByField))
+	for field, stats := range p.termFrequencyByField {
+		termFrequencyRows = append(termFrequencyRows, termFrequencyRow{field: field, stats: stats})
+	}
+	topByValueBytes := append([]postingListTopEntry(nil), p.topContentByValueBytes.entries...)
+	p.mu.Unlock()
+
+	sort.Slice(phases, func(i, j int) bool {
+		if phases[i].stats.total == phases[j].stats.total {
+			return phases[i].phase < phases[j].phase
+		}
+		return phases[i].stats.total > phases[j].stats.total
+	})
+	sort.Slice(counters, func(i, j int) bool {
+		return counters[i].counter < counters[j].counter
+	})
+	sort.Slice(cardinalityRows, func(i, j int) bool {
+		if cardinalityRows[i].key.field != cardinalityRows[j].key.field {
+			return cardinalityRows[i].key.field < cardinalityRows[j].key.field
+		}
+		return cardinalityRows[i].key.order < cardinalityRows[j].key.order
+	})
+	sort.Slice(lengthRows, func(i, j int) bool {
+		if lengthRows[i].key.field != lengthRows[j].key.field {
+			return lengthRows[i].key.field < lengthRows[j].key.field
+		}
+		return lengthRows[i].key.length < lengthRows[j].key.length
+	})
+	sort.Slice(termFrequencyRows, func(i, j int) bool {
+		return termFrequencyRows[i].field < termFrequencyRows[j].field
+	})
+	sortPostingListTop(topByValueBytes, lessByValueBytes)
+
+	log.Printf("Index profile elapsed=%s", time.Since(p.start).Round(time.Millisecond))
+	log.Printf("Index profile phases (some rows are inclusive parent phases):")
+	for _, row := range phases {
+		avg := time.Duration(0)
+		if row.stats.count > 0 {
+			avg = row.stats.total / time.Duration(row.stats.count)
+		}
+		log.Printf("  %-24s count=%-10d total=%-12s avg=%s", row.phase, row.stats.count, formatDuration(row.stats.total), formatDuration(avg))
+	}
+
+	log.Printf("Index profile counters:")
+	for _, row := range counters {
+		log.Printf("  %-32s %d", row.counter, row.value)
+	}
+
+	if len(cardinalityRows) > 0 {
+		log.Printf("Index profile posting list cardinality buckets:")
+		for _, row := range cardinalityRows {
+			log.Printf("  field=%-12q bucket=%-12s lists=%-10d postings=%-12d key_bytes=%-12d value_bytes=%d",
+				row.key.field, row.key.label, row.stats.lists, row.stats.postings, row.stats.keyBytes, row.stats.valueBytes)
+		}
+	}
+	if len(lengthRows) > 0 {
+		log.Printf("Index profile posting list ngram length buckets:")
+		for _, row := range lengthRows {
+			log.Printf("  field=%-12q length=%-3d lists=%-10d postings=%-12d key_bytes=%-12d value_bytes=%d",
+				row.key.field, row.key.length, row.stats.lists, row.stats.postings, row.stats.keyBytes, row.stats.valueBytes)
+		}
+	}
+	if len(termFrequencyRows) > 0 {
+		log.Printf("Index profile term frequency storage estimate:")
+		for _, row := range termFrequencyRows {
+			duplicatePostingPct := float64(0)
+			if row.stats.UniquePostings > 0 {
+				duplicatePostingPct = 100 * float64(row.stats.DuplicatePostings) / float64(row.stats.UniquePostings)
+			}
+			log.Printf("  field=%-12q occurrences=%-12d unique_postings=%-12d duplicate_occurrences=%-12d postings_with_tf_gt_1=%-12d (%5.2f%%) exception_bytes_estimate=%-12d count_bytes_estimate=%d",
+				row.field,
+				row.stats.Occurrences,
+				row.stats.UniquePostings,
+				row.stats.DuplicateOccurrences,
+				row.stats.DuplicatePostings,
+				duplicatePostingPct,
+				row.stats.ExceptionBytesEstimate,
+				row.stats.CountBytesEstimate)
+			log.Printf("    tf_buckets: 1=%d 2=%d 3-4=%d 5-8=%d 9-16=%d 17-32=%d 33-64=%d 65-128=%d 129+=%d",
+				row.stats.Count1,
+				row.stats.Count2,
+				row.stats.Count3To4,
+				row.stats.Count5To8,
+				row.stats.Count9To16,
+				row.stats.Count17To32,
+				row.stats.Count33To64,
+				row.stats.Count65To128,
+				row.stats.Count129Plus)
+		}
+	}
+	printTopPostingLists("Index profile top content posting lists by value bytes:", topByValueBytes)
+}
+
+func formatDuration(d time.Duration) time.Duration {
+	if d == 0 {
+		return 0
+	}
+	if d < time.Microsecond {
+		return d.Round(time.Nanosecond)
+	}
+	return d.Round(time.Microsecond)
+}
+
+func postingListCardinalityBucket(cardinality uint64) postingListBucketKey {
+	switch {
+	case cardinality == 0:
+		return postingListBucketKey{label: "0", order: 0}
+	case cardinality == 1:
+		return postingListBucketKey{label: "1", order: 1}
+	case cardinality == 2:
+		return postingListBucketKey{label: "2", order: 2}
+	case cardinality <= 4:
+		return postingListBucketKey{label: "3-4", order: 3}
+	case cardinality <= 8:
+		return postingListBucketKey{label: "5-8", order: 4}
+	case cardinality <= 16:
+		return postingListBucketKey{label: "9-16", order: 5}
+	case cardinality <= 32:
+		return postingListBucketKey{label: "17-32", order: 6}
+	case cardinality <= 64:
+		return postingListBucketKey{label: "33-64", order: 7}
+	case cardinality <= 128:
+		return postingListBucketKey{label: "65-128", order: 8}
+	case cardinality <= 256:
+		return postingListBucketKey{label: "129-256", order: 9}
+	case cardinality <= 512:
+		return postingListBucketKey{label: "257-512", order: 10}
+	case cardinality <= 1024:
+		return postingListBucketKey{label: "513-1K", order: 11}
+	case cardinality <= 2048:
+		return postingListBucketKey{label: "1K-2K", order: 12}
+	case cardinality <= 4096:
+		return postingListBucketKey{label: "2K-4K", order: 13}
+	case cardinality <= 8192:
+		return postingListBucketKey{label: "4K-8K", order: 14}
+	case cardinality <= 16384:
+		return postingListBucketKey{label: "8K-16K", order: 15}
+	case cardinality <= 32768:
+		return postingListBucketKey{label: "16K-32K", order: 16}
+	case cardinality <= 65536:
+		return postingListBucketKey{label: "32K-64K", order: 17}
+	default:
+		return postingListBucketKey{label: "64K+", order: 18}
+	}
+}
+
+func lessByValueBytes(a, b postingListTopEntry) bool {
+	if a.valueBytes != b.valueBytes {
+		return a.valueBytes < b.valueBytes
+	}
+	if a.cardinality != b.cardinality {
+		return a.cardinality < b.cardinality
+	}
+	return a.ngram > b.ngram
+}
+
+func sortPostingListTop(entries []postingListTopEntry, less func(a, b postingListTopEntry) bool) {
+	sort.Slice(entries, func(i, j int) bool {
+		return less(entries[j], entries[i])
+	})
+}
+
+func printTopPostingLists(header string, entries []postingListTopEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	log.Printf("%s", header)
+	for i, entry := range entries {
+		log.Printf("  #%03d ngram=%-12s docs=%-10d key_bytes=%-8d value_bytes=%d",
+			i+1, formatNgram(entry.ngram), entry.cardinality, entry.keyBytes, entry.valueBytes)
+	}
+}
+
+func formatNgram(ngram string) string {
+	const maxNgramPrintBytes = 24
+	if len(ngram) > maxNgramPrintBytes {
+		ngram = ngram[:maxNgramPrintBytes] + "..."
+	}
+	return strconv.QuoteToASCII(ngram)
+}

--- a/codesearch/indexprofile/indexprofile.go
+++ b/codesearch/indexprofile/indexprofile.go
@@ -25,9 +25,6 @@ const (
 	PhaseAddDocument        Phase = "add_document"
 	PhaseTokenizerNext      Phase = "tokenizer_next"
 	PhasePostingMutation    Phase = "posting_mutation"
-	PhaseNgramConversion    Phase = "ngram_conversion"
-	PhasePostingListLookup  Phase = "posting_list_lookup"
-	PhasePostingListAdd     Phase = "posting_list_add"
 	PhaseStoredFieldSet     Phase = "stored_field_set"
 	PhaseFlush              Phase = "flush"
 	PhaseUpdatePostingList  Phase = "update_posting_list"
@@ -218,6 +215,25 @@ func (p *Profiler) Get(counter Counter) int64 {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.counters[counter]
+}
+
+// Now returns time.Now() when profiling is enabled, otherwise the zero Time.
+// Safe to call on a nil receiver — paired with Since this lets hot loops skip
+// time.Now() when profiling is off without an explicit nil check at each site.
+func (p *Profiler) Now() time.Time {
+	if p == nil {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
+// Since returns time.Since(start) when profiling is enabled, otherwise 0.
+// Safe to call on a nil receiver. See Now.
+func (p *Profiler) Since(start time.Time) time.Duration {
+	if p == nil {
+		return 0
+	}
+	return time.Since(start)
 }
 
 func (p *Profiler) RecordPostingList(field, ngram string, cardinality uint64, keyBytes, valueBytes int64) {

--- a/codesearch/indexprofile/indexprofile.go
+++ b/codesearch/indexprofile/indexprofile.go
@@ -28,13 +28,6 @@ const (
 	PhaseNgramConversion    Phase = "ngram_conversion"
 	PhasePostingListLookup  Phase = "posting_list_lookup"
 	PhasePostingListAdd     Phase = "posting_list_add"
-	PhaseSparseRefillLine   Phase = "sparse_refill_line"
-	PhaseSparseDecodeLine   Phase = "sparse_decode_line"
-	PhaseSparseBuildNgrams  Phase = "sparse_build_ngrams"
-	PhaseSparseHashBigram   Phase = "sparse_hash_bigram"
-	PhaseSparseToBytes      Phase = "sparse_to_bytes"
-	PhaseSparseTestOrAdd    Phase = "sparse_test_or_add"
-	PhaseSparseStringAppend Phase = "sparse_string_append"
 	PhaseStoredFieldSet     Phase = "stored_field_set"
 	PhaseFlush              Phase = "flush"
 	PhaseUpdatePostingList  Phase = "update_posting_list"
@@ -68,18 +61,6 @@ const (
 	CounterHiddenPathsSkipped     Counter = "hidden_paths_skipped"
 	CounterValidationSkippedFiles Counter = "validation_skipped_files"
 	CounterAddFileErrors          Counter = "add_file_errors"
-	CounterSparseLinesScanned     Counter = "sparse_lines_scanned"
-	CounterSparseLineBytes        Counter = "sparse_line_bytes"
-	CounterSparseRunes            Counter = "sparse_runes"
-	CounterSparseCandidates       Counter = "sparse_candidates"
-	CounterSparseNgramsTested     Counter = "sparse_ngrams_tested"
-	CounterSparseNgramsEmitted    Counter = "sparse_ngrams_emitted"
-	CounterTFOccurrences          Counter = "tf_ngram_occurrences"
-	CounterTFUniquePostings       Counter = "tf_unique_postings"
-	CounterTFDuplicateOccurrences Counter = "tf_duplicate_occurrences"
-	CounterTFDuplicatePostings    Counter = "tf_postings_with_freq_gt_1"
-	CounterTFExceptionBytes       Counter = "tf_exception_bytes_estimate"
-	CounterTFCountBytes           Counter = "tf_count_bytes_estimate"
 )
 
 type phaseStats struct {
@@ -113,24 +94,6 @@ type postingListTopEntry struct {
 	valueBytes  int64
 }
 
-type TermFrequencyStats struct {
-	Occurrences            int64
-	UniquePostings         int64
-	DuplicateOccurrences   int64
-	DuplicatePostings      int64
-	ExceptionBytesEstimate int64
-	CountBytesEstimate     int64
-	Count1                 int64
-	Count2                 int64
-	Count3To4              int64
-	Count5To8              int64
-	Count9To16             int64
-	Count17To32            int64
-	Count33To64            int64
-	Count65To128           int64
-	Count129Plus           int64
-}
-
 type topPostingListHeap struct {
 	entries []postingListTopEntry
 	less    func(a, b postingListTopEntry) bool
@@ -153,8 +116,7 @@ func (h *topPostingListHeap) Pop() any {
 }
 
 type Profiler struct {
-	start    time.Time
-	detailed bool
+	start time.Time
 
 	mu                        sync.Mutex
 	phases                    map[Phase]phaseStats
@@ -162,20 +124,17 @@ type Profiler struct {
 	postingListsByCardinality map[postingListBucketKey]postingListAggregate
 	postingListsByNgramLength map[postingListLengthKey]postingListAggregate
 	topContentByValueBytes    topPostingListHeap
-	termFrequencyByField      map[string]TermFrequencyStats
 }
 
 var current atomic.Pointer[Profiler]
 
-func Start(detailed bool) *Profiler {
+func Start() *Profiler {
 	p := &Profiler{
 		start:                     time.Now(),
-		detailed:                  detailed,
 		phases:                    make(map[Phase]phaseStats),
 		counters:                  make(map[Counter]int64),
 		postingListsByCardinality: make(map[postingListBucketKey]postingListAggregate),
 		postingListsByNgramLength: make(map[postingListLengthKey]postingListAggregate),
-		termFrequencyByField:      make(map[string]TermFrequencyStats),
 		topContentByValueBytes: topPostingListHeap{
 			less: lessByValueBytes,
 		},
@@ -190,14 +149,6 @@ func Stop() *Profiler {
 
 func Current() *Profiler {
 	return current.Load()
-}
-
-func CurrentDetailed() *Profiler {
-	p := Current()
-	if p == nil || !p.detailed {
-		return nil
-	}
-	return p
 }
 
 func Record(phase Phase, duration time.Duration) {
@@ -244,38 +195,6 @@ func (p *Profiler) Get(counter Counter) int64 {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.counters[counter]
-}
-
-func (p *Profiler) RecordTermFrequencyStats(field string, stats TermFrequencyStats) {
-	if stats.Occurrences == 0 {
-		return
-	}
-	p.mu.Lock()
-	current := p.termFrequencyByField[field]
-	current.Occurrences += stats.Occurrences
-	current.UniquePostings += stats.UniquePostings
-	current.DuplicateOccurrences += stats.DuplicateOccurrences
-	current.DuplicatePostings += stats.DuplicatePostings
-	current.ExceptionBytesEstimate += stats.ExceptionBytesEstimate
-	current.CountBytesEstimate += stats.CountBytesEstimate
-	current.Count1 += stats.Count1
-	current.Count2 += stats.Count2
-	current.Count3To4 += stats.Count3To4
-	current.Count5To8 += stats.Count5To8
-	current.Count9To16 += stats.Count9To16
-	current.Count17To32 += stats.Count17To32
-	current.Count33To64 += stats.Count33To64
-	current.Count65To128 += stats.Count65To128
-	current.Count129Plus += stats.Count129Plus
-	p.termFrequencyByField[field] = current
-
-	p.counters[CounterTFOccurrences] += stats.Occurrences
-	p.counters[CounterTFUniquePostings] += stats.UniquePostings
-	p.counters[CounterTFDuplicateOccurrences] += stats.DuplicateOccurrences
-	p.counters[CounterTFDuplicatePostings] += stats.DuplicatePostings
-	p.counters[CounterTFExceptionBytes] += stats.ExceptionBytesEstimate
-	p.counters[CounterTFCountBytes] += stats.CountBytesEstimate
-	p.mu.Unlock()
 }
 
 func (p *Profiler) RecordPostingList(field, ngram string, cardinality uint64, keyBytes, valueBytes int64) {
@@ -347,10 +266,6 @@ func (p *Profiler) PrettyPrint() {
 		key   postingListLengthKey
 		stats postingListAggregate
 	}
-	type termFrequencyRow struct {
-		field string
-		stats TermFrequencyStats
-	}
 
 	p.mu.Lock()
 	phases := make([]phaseRow, 0, len(p.phases))
@@ -368,10 +283,6 @@ func (p *Profiler) PrettyPrint() {
 	lengthRows := make([]lengthRow, 0, len(p.postingListsByNgramLength))
 	for key, stats := range p.postingListsByNgramLength {
 		lengthRows = append(lengthRows, lengthRow{key: key, stats: stats})
-	}
-	termFrequencyRows := make([]termFrequencyRow, 0, len(p.termFrequencyByField))
-	for field, stats := range p.termFrequencyByField {
-		termFrequencyRows = append(termFrequencyRows, termFrequencyRow{field: field, stats: stats})
 	}
 	topByValueBytes := append([]postingListTopEntry(nil), p.topContentByValueBytes.entries...)
 	p.mu.Unlock()
@@ -396,9 +307,6 @@ func (p *Profiler) PrettyPrint() {
 			return lengthRows[i].key.field < lengthRows[j].key.field
 		}
 		return lengthRows[i].key.length < lengthRows[j].key.length
-	})
-	sort.Slice(termFrequencyRows, func(i, j int) bool {
-		return termFrequencyRows[i].field < termFrequencyRows[j].field
 	})
 	sortPostingListTop(topByValueBytes, lessByValueBytes)
 
@@ -429,34 +337,6 @@ func (p *Profiler) PrettyPrint() {
 		for _, row := range lengthRows {
 			log.Printf("  field=%-12q length=%-3d lists=%-10d postings=%-12d key_bytes=%-12d value_bytes=%d",
 				row.key.field, row.key.length, row.stats.lists, row.stats.postings, row.stats.keyBytes, row.stats.valueBytes)
-		}
-	}
-	if len(termFrequencyRows) > 0 {
-		log.Printf("Index profile term frequency storage estimate:")
-		for _, row := range termFrequencyRows {
-			duplicatePostingPct := float64(0)
-			if row.stats.UniquePostings > 0 {
-				duplicatePostingPct = 100 * float64(row.stats.DuplicatePostings) / float64(row.stats.UniquePostings)
-			}
-			log.Printf("  field=%-12q occurrences=%-12d unique_postings=%-12d duplicate_occurrences=%-12d postings_with_tf_gt_1=%-12d (%5.2f%%) exception_bytes_estimate=%-12d count_bytes_estimate=%d",
-				row.field,
-				row.stats.Occurrences,
-				row.stats.UniquePostings,
-				row.stats.DuplicateOccurrences,
-				row.stats.DuplicatePostings,
-				duplicatePostingPct,
-				row.stats.ExceptionBytesEstimate,
-				row.stats.CountBytesEstimate)
-			log.Printf("    tf_buckets: 1=%d 2=%d 3-4=%d 5-8=%d 9-16=%d 17-32=%d 33-64=%d 65-128=%d 129+=%d",
-				row.stats.Count1,
-				row.stats.Count2,
-				row.stats.Count3To4,
-				row.stats.Count5To8,
-				row.stats.Count9To16,
-				row.stats.Count17To32,
-				row.stats.Count33To64,
-				row.stats.Count65To128,
-				row.stats.Count129Plus)
 		}
 	}
 	printTopPostingLists("Index profile top content posting lists by value bytes:", topByValueBytes)

--- a/codesearch/indexprofile/indexprofile.go
+++ b/codesearch/indexprofile/indexprofile.go
@@ -169,6 +169,29 @@ func Add(counter Counter, value int64) {
 	}
 }
 
+func RecordPostingList(field, ngram string, cardinality uint64, keyBytes, valueBytes int64) {
+	if p := Current(); p != nil {
+		p.RecordPostingList(field, ngram, cardinality, keyBytes, valueBytes)
+	}
+}
+
+var noopTimer = func() {}
+
+// Timer starts a stopwatch and returns a function that records the elapsed
+// time against phase. When profiling is off, the returned function is a shared
+// no-op so callers can use `defer indexprofile.Timer(phase)()` without
+// allocating per call.
+func Timer(phase Phase) func() {
+	p := Current()
+	if p == nil {
+		return noopTimer
+	}
+	start := time.Now()
+	return func() {
+		p.Record(phase, time.Since(start))
+	}
+}
+
 func (p *Profiler) Record(phase Phase, duration time.Duration) {
 	p.RecordN(phase, 1, duration)
 }


### PR DESCRIPTION
Add `codesearch/indexprofile`, behind the `-index_profile` flag, and record indexing phases, counters, posting-list buckets, value-byte top lists, and TF storage estimates.