### PR TITLE
trace_viewer: highlight focused stack

### DIFF
--- a/app/trace/BUILD
+++ b/app/trace/BUILD
@@ -92,7 +92,6 @@ ts_jasmine_node_test(
         ":trace_events",
         ":trace_viewer_model",
         ":trace_viewer_search",
-        "//app/util:intern",
     ],
 )
 
@@ -134,8 +133,5 @@ ts_library(
 ts_library(
     name = "trace_viewer_search",
     srcs = ["trace_viewer_search.ts"],
-    deps = [
-        "//app/trace:trace_events",
-        "//app/trace:trace_viewer_model",
-    ],
+    deps = ["//app/trace:trace_viewer_model"],
 )

--- a/app/trace/BUILD
+++ b/app/trace/BUILD
@@ -40,6 +40,7 @@ ts_library(
         "//app/trace:trace_events",
         "//app/trace:trace_viewer_model",
         "//app/trace:trace_viewer_panel",
+        "//app/trace:trace_viewer_search",
         "//app/util:animated_value",
         "//app/util:animation_loop",
         "//app/util:dom",
@@ -83,6 +84,18 @@ ts_jasmine_node_test(
     deps = [":trace_events"],
 )
 
+ts_jasmine_node_test(
+    name = "trace_viewer_search_test",
+    srcs = ["trace_viewer_search_test.ts"],
+    deps = [
+        ":compact_trace",
+        ":trace_events",
+        ":trace_viewer_model",
+        ":trace_viewer_search",
+        "//app/util:intern",
+    ],
+)
+
 ts_library(
     name = "compact_trace",
     srcs = ["compact_trace.ts"],
@@ -115,5 +128,14 @@ ts_library(
         "//app/util:color",
         "//app/util:dom",
         "//app/util:math",
+    ],
+)
+
+ts_library(
+    name = "trace_viewer_search",
+    srcs = ["trace_viewer_search.ts"],
+    deps = [
+        "//app/trace:trace_events",
+        "//app/trace:trace_viewer_model",
     ],
 )

--- a/app/trace/trace_viewer.css
+++ b/app/trace/trace_viewer.css
@@ -1,5 +1,6 @@
 :root {
   --trace-event-chroma: 80;
+  --trace-event-faded-chroma: 24;
   --trace-event-lightness: 65%;
   --color-trace-border: var(--color-gray-200);
   --color-trace-button-active-text: var(--color-black);
@@ -26,6 +27,7 @@
 
 .dark {
   --trace-event-chroma: 55;
+  --trace-event-faded-chroma: 18;
   --trace-event-lightness: 40%;
   --color-trace-border: var(--color-gray-900);
   --color-trace-button-active-text: var(--color-white);

--- a/app/trace/trace_viewer.tsx
+++ b/app/trace/trace_viewer.tsx
@@ -14,6 +14,7 @@ import EventHovercard from "./event_hovercard";
 import { TraceEvent } from "./trace_events";
 import { buildTraceViewerModel, panelScrollHeight } from "./trace_viewer_model";
 import Panel from "./trace_viewer_panel";
+import { collectFocusedTracePathEventIndices } from "./trace_viewer_search";
 
 export interface TraceViewProps {
   profile: Profile;
@@ -403,6 +404,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
     const matchEventIndices = TypedArrayBuilder.of(Uint32Array);
     if (this.panels.length) {
       this.panels[0].highlightEvent = undefined;
+      this.panels[0].highlightPathEventIndices.clear();
     }
 
     // Find all matches for the new filter.
@@ -451,6 +453,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
       // If there are no matches, ensure any existing highlight is cleared.
       if (this.panels.length) {
         this.panels[0].highlightEvent = undefined;
+        this.panels[0].highlightPathEventIndices.clear();
       }
       this.searchIndex = -1;
       this.setState({ currentMatch: 0 });
@@ -488,6 +491,11 @@ export default class TraceViewer extends React.Component<TraceViewProps, TraceVi
     // Highlight the matched event so it is visually selected no matter what.
     const eventsPanel = this.panels[0];
     eventsPanel.highlightEvent = { track, index: eventIndex };
+    eventsPanel.highlightPathEventIndices = collectFocusedTracePathEventIndices(
+      this.model.panels[0].sections[sectionIndex],
+      threadEventIndex,
+      trackIndex
+    );
 
     // Determine whether the matched event is already fully visible in the
     // current viewport. If so, we simply update the highlight without

--- a/app/trace/trace_viewer_panel.ts
+++ b/app/trace/trace_viewer_panel.ts
@@ -7,6 +7,7 @@ import { TraceEvent } from "./trace_events";
 import { LinePlotModel, PanelModel, SectionModel, TrackModel } from "./trace_viewer_model";
 
 type LinePlotColorKey = "lightColor" | "darkColor";
+const FADED_EVENT_OPACITY = 0.45;
 
 type ThemeColors = {
   gridline: string;
@@ -80,9 +81,11 @@ export default class Panel {
 
   // If set, visually highlight this event to indicate that it is the current search match.
   highlightEvent?: { track: TrackModel; index: number };
+  highlightPathEventIndices = new Set<number>();
 
   private theme: ThemeColors;
   private eventColorCache = new Map<string, string>();
+  private eventFadedColorCache = new Map<string, string>();
 
   constructor(
     readonly model: PanelModel,
@@ -101,7 +104,10 @@ export default class Panel {
   }
 
   private buildEventColorCache() {
+    const style = getComputedStyle(document.documentElement);
+    const fadedChroma = style.getPropertyValue("--trace-event-faded-chroma").trim() || "24";
     this.eventColorCache.clear();
+    this.eventFadedColorCache.clear();
     for (const section of this.model.sections) {
       for (const track of section.tracks ?? []) {
         const eventIndices = track.eventIndices;
@@ -110,6 +116,7 @@ export default class Panel {
           const colorKey = thread.getColorKey(eventIndices[i]);
           if (!this.eventColorCache.has(colorKey)) {
             this.eventColorCache.set(colorKey, computeTraceEventColor(colorKey));
+            this.eventFadedColorCache.set(colorKey, computeTraceEventColor(colorKey, fadedChroma));
           }
         }
       }
@@ -489,6 +496,17 @@ export default class Panel {
       let modelWidth = dur[eventIndex];
       if (modelX + modelWidth < xMin) continue;
 
+      const matchesFilter = !lowerFilter || thread.matchesFilter(eventIndex, lowerFilter);
+      const isFocusedPathEvent = !matchesFilter && this.highlightPathEventIndices.has(eventIndex);
+      const colorKey = thread.getColorKey(eventIndex);
+      if (matchesFilter) {
+        this.ctx.fillStyle = this.eventColorCache.get(colorKey)!;
+      } else if (isFocusedPathEvent) {
+        this.ctx.fillStyle = this.eventFadedColorCache.get(colorKey)!;
+      } else {
+        this.ctx.fillStyle = this.theme.eventFiltered;
+      }
+
       // TODO: only apply the horizontal gap if there's an event just after us.
       let width = modelWidth * scale - constants.EVENT_HORIZONTAL_GAP;
       const x = modelX * scale - scrollX;
@@ -506,11 +524,6 @@ export default class Panel {
       }
       lastRenderedPixelRight = pixelRight;
 
-      if (lowerFilter && !thread.matchesFilter(eventIndex, lowerFilter)) {
-        this.ctx.fillStyle = this.theme.eventFiltered;
-      } else {
-        this.ctx.fillStyle = this.eventColorCache.get(thread.getColorKey(eventIndex))!;
-      }
       this.ctx.fillRect(x, y, width, constants.TRACK_HEIGHT);
 
       // If this event is the one currently selected via search, draw a border
@@ -526,6 +539,7 @@ export default class Panel {
         this.ctx.font = `${constants.EVENT_LABEL_FONT_SIZE} ${this.fontFamily}`;
         this.ctx.fillStyle = this.theme.eventLabelFont;
         this.ctx.save();
+        this.ctx.globalAlpha = matchesFilter ? 1 : FADED_EVENT_OPACITY;
         this.ctx.beginPath();
         this.ctx.rect(x, y, width, constants.TRACK_HEIGHT);
         this.ctx.clip();

--- a/app/trace/trace_viewer_search.ts
+++ b/app/trace/trace_viewer_search.ts
@@ -1,20 +1,4 @@
-import { TraceEvent } from "./trace_events";
 import { SectionModel, TrackModel } from "./trace_viewer_model";
-
-function searchableFieldText(value: unknown): string {
-  if (value === undefined || value === null) return "";
-  return String(value).toLowerCase();
-}
-
-export function getTraceEventSearchText(event: TraceEvent): string {
-  return [event.name, event.cat, event.args?.target, event.args?.mnemonic, event.out]
-    .map(searchableFieldText)
-    .join(" ");
-}
-
-export function traceEventMatchesFilter(event: TraceEvent, filter: string): boolean {
-  return !filter || getTraceEventSearchText(event).includes(filter.toLowerCase());
-}
 
 function eventEnd(track: TrackModel, eventIndex: number): number {
   return track.thread.ts[eventIndex] + track.thread.dur[eventIndex];

--- a/app/trace/trace_viewer_search.ts
+++ b/app/trace/trace_viewer_search.ts
@@ -1,0 +1,67 @@
+import { TraceEvent } from "./trace_events";
+import { SectionModel, TrackModel } from "./trace_viewer_model";
+
+function searchableFieldText(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  return String(value).toLowerCase();
+}
+
+export function getTraceEventSearchText(event: TraceEvent): string {
+  return [event.name, event.cat, event.args?.target, event.args?.mnemonic, event.out]
+    .map(searchableFieldText)
+    .join(" ");
+}
+
+export function traceEventMatchesFilter(event: TraceEvent, filter: string): boolean {
+  return !filter || getTraceEventSearchText(event).includes(filter.toLowerCase());
+}
+
+function eventEnd(track: TrackModel, eventIndex: number): number {
+  return track.thread.ts[eventIndex] + track.thread.dur[eventIndex];
+}
+
+function containsEvent(track: TrackModel, outerIndex: number, innerIndex: number): boolean {
+  return (
+    track.thread.ts[outerIndex] <= track.thread.ts[innerIndex] &&
+    eventEnd(track, outerIndex) >= eventEnd(track, innerIndex)
+  );
+}
+
+export function collectFocusedTracePathEventIndices(
+  section: SectionModel,
+  focusedEventIndex: number,
+  focusedTrackIndex: number
+): Set<number> {
+  const focusedPathEventIndices = new Set<number>([focusedEventIndex]);
+  const tracks = section.tracks ?? [];
+  const focusedTrack = tracks[focusedTrackIndex];
+  if (!focusedTrack) return focusedPathEventIndices;
+
+  const thread = focusedTrack.thread;
+  const focusedEnd = eventEnd(focusedTrack, focusedEventIndex);
+
+  for (let trackIndex = 0; trackIndex < tracks.length; trackIndex++) {
+    if (trackIndex === focusedTrackIndex) continue;
+
+    const track = tracks[trackIndex];
+    if (track.thread !== thread) continue;
+
+    for (const eventIndex of track.eventIndices) {
+      if (trackIndex < focusedTrackIndex) {
+        if (thread.ts[eventIndex] > thread.ts[focusedEventIndex]) break;
+        if (containsEvent(track, eventIndex, focusedEventIndex)) {
+          focusedPathEventIndices.add(eventIndex);
+          break;
+        }
+        continue;
+      }
+
+      if (thread.ts[eventIndex] > focusedEnd) break;
+      if (containsEvent(track, focusedEventIndex, eventIndex)) {
+        focusedPathEventIndices.add(eventIndex);
+      }
+    }
+  }
+
+  return focusedPathEventIndices;
+}

--- a/app/trace/trace_viewer_search_test.ts
+++ b/app/trace/trace_viewer_search_test.ts
@@ -1,0 +1,106 @@
+import { StringInterner } from "../util/intern";
+import { Thread } from "./compact_trace";
+import { TraceEvent } from "./trace_events";
+import { SectionModel } from "./trace_viewer_model";
+import { collectFocusedTracePathEventIndices, traceEventMatchesFilter } from "./trace_viewer_search";
+
+function makeTraceEvent(overrides: Partial<TraceEvent> = {}): TraceEvent {
+  return {
+    pid: 1,
+    tid: 1,
+    ts: 0,
+    ph: "X",
+    cat: "category",
+    name: "event",
+    dur: 10,
+    tdur: 0,
+    tts: 0,
+    out: "",
+    args: {},
+    ...overrides,
+  };
+}
+
+describe("traceEventMatchesFilter", () => {
+  it("matches searchable trace event fields case-insensitively", () => {
+    expect(traceEventMatchesFilter(makeTraceEvent({ name: "Compile Target" }), "compile")).toBeTrue();
+    expect(traceEventMatchesFilter(makeTraceEvent({ cat: "Remote Execution" }), "remote")).toBeTrue();
+    expect(traceEventMatchesFilter(makeTraceEvent({ args: { target: "//app:bundle" } }), "bundle")).toBeTrue();
+    expect(traceEventMatchesFilter(makeTraceEvent({ args: { mnemonic: "GoCompilePkg" } }), "gocompilepkg")).toBeTrue();
+    expect(traceEventMatchesFilter(makeTraceEvent({ out: "cache hit" }), "cache")).toBeTrue();
+  });
+
+  it("matches all events for an empty filter", () => {
+    expect(traceEventMatchesFilter(makeTraceEvent(), "")).toBeTrue();
+  });
+
+  it("does not match unrelated fields", () => {
+    expect(traceEventMatchesFilter(makeTraceEvent({ name: "Compile Target" }), "download")).toBeFalse();
+  });
+});
+
+describe("collectFocusedTracePathEventIndices", () => {
+  it("includes ancestors and descendants of the focused event", () => {
+    const root = makeTraceEvent({ name: "root", ts: 0, dur: 100 });
+    const parent = makeTraceEvent({ name: "parent", ts: 10, dur: 70 });
+    const focused = makeTraceEvent({ name: "focused", ts: 20, dur: 40 });
+    const child = makeTraceEvent({ name: "child", ts: 30, dur: 5 });
+    const sibling = makeTraceEvent({ name: "sibling", ts: 80, dur: 10 });
+    const partialOverlap = makeTraceEvent({ name: "partialOverlap", ts: 55, dur: 20 });
+    const events = [root, parent, focused, partialOverlap, sibling, child];
+    const strings = new StringInterner();
+    const catIDs = new Uint32Array(events.length);
+    const nameIDs = new Uint32Array(events.length);
+    const targetIDs = new Uint32Array(events.length);
+    const mnemonicIDs = new Uint32Array(events.length);
+    const outIDs = new Uint32Array(events.length);
+    const ts = new Float64Array(events.length);
+    const dur = new Float64Array(events.length);
+    const depth = new Uint16Array([0, 1, 2, 2, 1, 3]);
+    for (let i = 0; i < events.length; i++) {
+      catIDs[i] = strings.intern(events[i].cat);
+      nameIDs[i] = strings.intern(events[i].name);
+      if (events[i].args?.target) targetIDs[i] = strings.intern(events[i].args.target);
+      if (events[i].args?.mnemonic) mnemonicIDs[i] = strings.intern(events[i].args.mnemonic);
+      if (events[i].out) outIDs[i] = strings.intern(events[i].out);
+      ts[i] = events[i].ts;
+      dur[i] = events[i].dur;
+    }
+    strings.freeze();
+    const thread = new Thread(
+      1,
+      1,
+      "thread",
+      strings,
+      catIDs,
+      nameIDs,
+      ts,
+      dur,
+      depth,
+      targetIDs,
+      mnemonicIDs,
+      outIDs,
+      3
+    );
+    const section: SectionModel = {
+      name: "thread",
+      y: 0,
+      height: 0,
+      tracks: [
+        { thread, eventIndices: new Uint32Array([0]) },
+        { thread, eventIndices: new Uint32Array([1, 4]) },
+        { thread, eventIndices: new Uint32Array([2, 3]) },
+        { thread, eventIndices: new Uint32Array([5]) },
+      ],
+    };
+
+    const focusedPathEventIndices = collectFocusedTracePathEventIndices(section, 2, 2);
+
+    expect(focusedPathEventIndices.has(0)).toBeTrue();
+    expect(focusedPathEventIndices.has(1)).toBeTrue();
+    expect(focusedPathEventIndices.has(2)).toBeTrue();
+    expect(focusedPathEventIndices.has(5)).toBeTrue();
+    expect(focusedPathEventIndices.has(4)).toBeFalse();
+    expect(focusedPathEventIndices.has(3)).toBeFalse();
+  });
+});

--- a/app/trace/trace_viewer_search_test.ts
+++ b/app/trace/trace_viewer_search_test.ts
@@ -1,17 +1,15 @@
-import { StringInterner } from "../util/intern";
-import { Thread } from "./compact_trace";
+import { ProfileBuilder } from "./compact_trace";
 import { TraceEvent } from "./trace_events";
-import { SectionModel } from "./trace_viewer_model";
-import { collectFocusedTracePathEventIndices, traceEventMatchesFilter } from "./trace_viewer_search";
+import { buildTraceViewerModel } from "./trace_viewer_model";
+import { collectFocusedTracePathEventIndices } from "./trace_viewer_search";
 
-function makeTraceEvent(overrides: Partial<TraceEvent> = {}): TraceEvent {
+function makeTraceEvent(overrides: Partial<TraceEvent> & Pick<TraceEvent, "name">): TraceEvent {
   return {
     pid: 1,
     tid: 1,
     ts: 0,
     ph: "X",
     cat: "category",
-    name: "event",
     dur: 10,
     tdur: 0,
     tts: 0,
@@ -20,24 +18,6 @@ function makeTraceEvent(overrides: Partial<TraceEvent> = {}): TraceEvent {
     ...overrides,
   };
 }
-
-describe("traceEventMatchesFilter", () => {
-  it("matches searchable trace event fields case-insensitively", () => {
-    expect(traceEventMatchesFilter(makeTraceEvent({ name: "Compile Target" }), "compile")).toBeTrue();
-    expect(traceEventMatchesFilter(makeTraceEvent({ cat: "Remote Execution" }), "remote")).toBeTrue();
-    expect(traceEventMatchesFilter(makeTraceEvent({ args: { target: "//app:bundle" } }), "bundle")).toBeTrue();
-    expect(traceEventMatchesFilter(makeTraceEvent({ args: { mnemonic: "GoCompilePkg" } }), "gocompilepkg")).toBeTrue();
-    expect(traceEventMatchesFilter(makeTraceEvent({ out: "cache hit" }), "cache")).toBeTrue();
-  });
-
-  it("matches all events for an empty filter", () => {
-    expect(traceEventMatchesFilter(makeTraceEvent(), "")).toBeTrue();
-  });
-
-  it("does not match unrelated fields", () => {
-    expect(traceEventMatchesFilter(makeTraceEvent({ name: "Compile Target" }), "download")).toBeFalse();
-  });
-});
 
 describe("collectFocusedTracePathEventIndices", () => {
   it("includes ancestors and descendants of the focused event", () => {
@@ -48,59 +28,28 @@ describe("collectFocusedTracePathEventIndices", () => {
     const sibling = makeTraceEvent({ name: "sibling", ts: 80, dur: 10 });
     const partialOverlap = makeTraceEvent({ name: "partialOverlap", ts: 55, dur: 20 });
     const events = [root, parent, focused, partialOverlap, sibling, child];
-    const strings = new StringInterner();
-    const catIDs = new Uint32Array(events.length);
-    const nameIDs = new Uint32Array(events.length);
-    const targetIDs = new Uint32Array(events.length);
-    const mnemonicIDs = new Uint32Array(events.length);
-    const outIDs = new Uint32Array(events.length);
-    const ts = new Float64Array(events.length);
-    const dur = new Float64Array(events.length);
-    const depth = new Uint16Array([0, 1, 2, 2, 1, 3]);
-    for (let i = 0; i < events.length; i++) {
-      catIDs[i] = strings.intern(events[i].cat);
-      nameIDs[i] = strings.intern(events[i].name);
-      if (events[i].args?.target) targetIDs[i] = strings.intern(events[i].args.target);
-      if (events[i].args?.mnemonic) mnemonicIDs[i] = strings.intern(events[i].args.mnemonic);
-      if (events[i].out) outIDs[i] = strings.intern(events[i].out);
-      ts[i] = events[i].ts;
-      dur[i] = events[i].dur;
+
+    const builder = new ProfileBuilder();
+    for (const event of events) {
+      builder.addEvent(event);
     }
-    strings.freeze();
-    const thread = new Thread(
-      1,
-      1,
-      "thread",
-      strings,
-      catIDs,
-      nameIDs,
-      ts,
-      dur,
-      depth,
-      targetIDs,
-      mnemonicIDs,
-      outIDs,
-      3
-    );
-    const section: SectionModel = {
-      name: "thread",
-      y: 0,
-      height: 0,
-      tracks: [
-        { thread, eventIndices: new Uint32Array([0]) },
-        { thread, eventIndices: new Uint32Array([1, 4]) },
-        { thread, eventIndices: new Uint32Array([2, 3]) },
-        { thread, eventIndices: new Uint32Array([5]) },
-      ],
+    const section = buildTraceViewerModel(builder.build()).panels[0].sections[0];
+    const tracks = section.tracks ?? [];
+    const thread = tracks[0].thread;
+    const eventIndexByName = (name: string) => {
+      for (let i = 0; i < thread.length; i++) {
+        if (thread.getName(i) === name) return i;
+      }
+      throw new Error(`event not found: ${name}`);
     };
+    const focusedEventIndex = eventIndexByName("focused");
+    const focusedTrackIndex = tracks.findIndex((track) => Array.from(track.eventIndices).includes(focusedEventIndex));
 
-    const focusedPathEventIndices = collectFocusedTracePathEventIndices(section, 2, 2);
+    const focusedPathEventIndices = collectFocusedTracePathEventIndices(section, focusedEventIndex, focusedTrackIndex);
+    const focusedPathEventNames = Array.from(focusedPathEventIndices)
+      .map((eventIndex) => thread.getName(eventIndex))
+      .sort();
 
-    expect(focusedPathEventIndices.has(0)).toBeTrue();
-    expect(focusedPathEventIndices.has(1)).toBeTrue();
-    expect(focusedPathEventIndices.has(2)).toBeTrue();
-    expect(focusedPathEventIndices.has(5)).toBeTrue();
-    expect(focusedPathEventIndices.has(4)).toBeFalse();
-    expect(focusedPathEventIndices.has(3)).toBeFalse();
+    expect(focusedPathEventNames).toEqual(["child", "focused", "parent", "root"]);
   });
 });

--- a/app/util/color.ts
+++ b/app/util/color.ts
@@ -210,11 +210,11 @@ export function getUniformBrightnessColor(id: string) {
   return UNIFORM_BRIGHTNESS_COLORS[Math.abs(hash(id) % UNIFORM_BRIGHTNESS_COLORS.length)];
 }
 
-export function computeTraceEventColor(id: string): string {
+export function computeTraceEventColor(id: string, chromaOverride?: string): string {
   const hue = Math.abs(hash(id) % 360);
   const style = getComputedStyle(document.documentElement);
   const lightness = style.getPropertyValue("--trace-event-lightness").trim() || "65%";
-  const chroma = style.getPropertyValue("--trace-event-chroma").trim() || "80";
+  const chroma = chromaOverride || style.getPropertyValue("--trace-event-chroma").trim() || "80";
   return `lch(${lightness} ${chroma} ${hue})`;
 }
 


### PR DESCRIPTION
Timing-profile search should make the selected match easy to compare
with its stack. Previously, all non-matching spans used one grey
treatment, so focused parents and children looked like unrelated
filtered spans.

Preserve focused ancestors and descendants with opaque, lower-chroma
original colors. Fade labels on non-matching spans so direct search
matches remain visually strongest.

Keep filtering and styling after the tiny-span rendering shortcut, and
scope focused colors to the selected thread. Find ancestors and the
subtree boundary with binary searches over track indices, following the
profile builder's active stack even when spans cross. Cache only the
ancestors and subtree range, so navigating search matches neither scans
preceding events nor allocates a full-subtree set. Keep this state in
sync through the panel's existing selection property. Compute and cache
faded colors only when a visible focused-stack span needs them.

Add ProfileBuilder-based coverage through the public panel draw path for
selection changes, clearing, opaque spans, faded labels, crossing spans,
thread isolation, and collapsed spans. Validated all 17 trace tests and
type checks, app and server builds, and a local multi-thread profile with
match navigation and search clearing.
