### PR TITLE
In fetch_server.rewriteToCache, read the blob as compressed

### DIFF
--- a/server/remote_asset/fetch_server/BUILD
+++ b/server/remote_asset/fetch_server/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/http/httpclient",
         "//server/real_environment",
         "//server/remote_cache/cachetools",
+        "//server/remote_cache/config",
         "//server/remote_cache/digest",
         "//server/util/flag",
         "//server/util/log",

--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -30,6 +30,7 @@ import (
 	cspb "github.com/buildbuddy-io/buildbuddy/proto/cache_service"
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	remote_cache_config "github.com/buildbuddy-io/buildbuddy/server/remote_cache/config"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gerrdetails "google.golang.org/genproto/googleapis/rpc/errdetails"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
@@ -342,6 +343,9 @@ func (p *FetchServer) rewriteToCache(ctx context.Context, blobDigest *repb.Diges
 	}()
 
 	cacheRN := digest.NewCASResourceName(blobDigest, instanceName, fromFunc)
+	if remote_cache_config.ZstdTranscodingEnabled() {
+		cacheRN.SetCompressor(repb.Compressor_ZSTD)
+	}
 	if err := cachetools.GetBlob(ctx, getByteStreamClient(p.env), cacheRN, tmpFile); err != nil {
 		log.CtxErrorf(ctx, "Failed to read blob from cache for %s: %s", digest.String(blobDigest), err)
 		return nil


### PR DESCRIPTION
This saves network traffic. cachetools.GetBlob will decompress the data before writing it to the output writer.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/7355