### PR TITLE
Reject "." working directory in Execute requests.

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -742,7 +742,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		return nil, err
 	}
 	if wd := command.GetWorkingDirectory(); wd != "" {
-		if filepath.IsAbs(wd) || !filepath.IsLocal(wd) {
+		if filepath.IsAbs(wd) || !filepath.IsLocal(wd) || wd == "." {
 			return nil, status.InvalidArgumentErrorf("working_directory %q must be a relative path within the input root", wd)
 		}
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -314,6 +314,7 @@ func TestDispatch_WorkingDirectoryValidation(t *testing.T) {
 		{name: "nested_path_traversal", wd: "a/../../escape", wantErr: true},
 		{name: "absolute_path", wd: "/etc/passwd", wantErr: true},
 		{name: "dot_dot_only", wd: "..", wantErr: true},
+		{name: "dot_only", wd: ".", wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			env, _, _ := setupEnv(t)


### PR DESCRIPTION
This already fails validation in executors. This surfaces the error earlier.