### PR TITLE
chore: disable proxy intercept-and-chunk by default

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -1137,11 +1137,9 @@ func (s *ByteStreamServerProxy) writeChunkingEnabled(ctx context.Context) bool {
 	if cdc.IsChunked(ctx) {
 		return false
 	}
-	if cdc.EnabledViaHeader(ctx) {
-		return true
-	}
-	return chunking.Enabled(ctx, s.efp) &&
-		(s.efp == nil || s.efp.Boolean(ctx, "cache_proxy.intercept_and_chunk_large_writes", true))
+	return s.efp != nil &&
+		s.efp.Boolean(ctx, "cache_proxy.intercept_and_chunk_large_writes", false) &&
+		chunking.Enabled(ctx, s.efp)
 }
 
 type writeChunkedResult struct {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -139,11 +139,26 @@ func TestWriteChunkedFallsBackAboveMaxSize(t *testing.T) {
 }
 
 func TestWriteChunkingEnabledSkipsBESUpload(t *testing.T) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache_proxy.intercept_and_chunk_large_writes": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(cdc.EnabledHeaderName, "true"))
 	ctx = bazel_request.OverrideRequestMetadata(ctx, &repb.RequestMetadata{ActionId: "bes-upload"})
 	s := &ByteStreamServerProxy{
 		localCache: testenv.GetTestEnv(t).GetCache(),
 		remoteCAS:  &noOpCASClient{},
+		efp:        fp,
 	}
 	require.False(t, s.writeChunkingEnabled(ctx))
 
@@ -152,6 +167,20 @@ func TestWriteChunkingEnabledSkipsBESUpload(t *testing.T) {
 }
 
 func TestWriteChunkingEnabledSkipsChunkedWrites(t *testing.T) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache_proxy.intercept_and_chunk_large_writes": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
 		cdc.EnabledHeaderName, "true",
 		cdc.ChunkedHeaderName, "true",
@@ -159,8 +188,64 @@ func TestWriteChunkingEnabledSkipsChunkedWrites(t *testing.T) {
 	s := &ByteStreamServerProxy{
 		localCache: testenv.GetTestEnv(t).GetCache(),
 		remoteCAS:  &noOpCASClient{},
+		efp:        fp,
 	}
 	require.False(t, s.writeChunkingEnabled(ctx))
+}
+
+func TestWriteChunkingEnabledRequiresExperimentInterceptFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		hasEFP bool
+		efp    bool
+		want   bool
+	}{
+		{
+			name: "default disabled without experiment flag provider",
+			want: false,
+		},
+		{
+			name:   "experiment flag disabled",
+			hasEFP: true,
+			efp:    false,
+			want:   false,
+		},
+		{
+			name:   "experiment flag enabled",
+			hasEFP: true,
+			efp:    true,
+			want:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var fp interfaces.ExperimentFlagProvider
+			if tc.hasEFP {
+				providerName := t.Name()
+				provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+					"cache_proxy.intercept_and_chunk_large_writes": {
+						State:          memprovider.Enabled,
+						DefaultVariant: strconv.FormatBool(tc.efp),
+						Variants: map[string]any{
+							"true":  true,
+							"false": false,
+						},
+					},
+				})
+				require.NoError(t, openfeature.SetNamedProviderAndWait(providerName, provider))
+				var err error
+				fp, err = experiments.NewFlagProvider(providerName)
+				require.NoError(t, err)
+			}
+
+			ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(cdc.EnabledHeaderName, "true"))
+			s := &ByteStreamServerProxy{
+				localCache: testenv.GetTestEnv(t).GetCache(),
+				remoteCAS:  &noOpCASClient{},
+				efp:        fp,
+			}
+			require.Equal(t, tc.want, s.writeChunkingEnabled(ctx))
+		})
+	}
 }
 
 type casRPCRecorder struct {


### PR DESCRIPTION
For our proxies, lets disable intercept-and-chunk by default for now. Groups can re-enable them manually, and we can flip the default when we're happy with the config.