### PR TITLE
[CLI] Set the forwarded bazel args

### DIFF
--- a/cli/arg/BUILD
+++ b/cli/arg/BUILD
@@ -6,7 +6,10 @@ go_library(
     name = "arg",
     srcs = ["arg.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/arg",
-    deps = ["//cli/parser"],
+    deps = [
+        "//cli/parser",
+        "//cli/parser/parsed",
+    ],
 )
 
 go_test(

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -13,8 +13,13 @@ import (
 // TODO(#7216): Add getters for these fields, so they can't be modified directly, potentially breaking
 // the contract for how they should be simultaneously updated.
 type BazelArgs struct {
-	// TODO(#7216): Add a Forwarded args fields that represents the non-expanded args
-	// that are eventually passed to Bazelisk.
+	// TODO(#7216): Actually pass the Forwarded args field to Bazelisk.
+	//
+	// Forwarded are the Bazel args that are eventually passed to Bazelisk.
+	// --config and --bazelrc flags are not expanded.
+	// These should look fairly similarly to the user-supplied args, but with some additional args the CLI has
+	// added.
+	Forwarded []string
 
 	// Resolved are the Bazel args that are used internally within the bb parser.
 	// --config and --bazelrc flags are expanded, so the parser has a complete view of the args.
@@ -38,24 +43,19 @@ func (a *BazelArgs) Set(args []string) error {
 	if err != nil {
 		return err
 	}
-	// TODO(#7216): Set the Forwarded args field.
-	return a.resolve(normalizedArgs)
+	a.Forwarded = normalizedArgs
+	return a.resolve()
 }
 
 // Append adds a new bazel arg.
 func (a *BazelArgs) Append(arg string) error {
-	// TODO(#7216): Set the Forwarded args field.
+	a.Forwarded = Append(a.Forwarded, arg)
 
-	newArgs := Append(a.Resolved, arg)
+	if requiresResolve(arg) {
+		return a.resolve()
+	}
 
-	resolve, err := requiresResolve(arg)
-	if err != nil {
-		return err
-	}
-	if resolve {
-		return a.Set(newArgs)
-	}
-	a.Resolved = newArgs
+	a.Resolved = Append(a.Resolved, arg)
 	return nil
 }
 
@@ -63,17 +63,11 @@ func (a *BazelArgs) Append(arg string) error {
 // If the same flag is specified multiple times, Bazel will use the last value. This is useful for adding flags that should
 // be overridden by later flags.
 func (a *BazelArgs) Prepend(arg string) error {
-	// TODO(#7216): Set the Forwarded args field.
-
-	updatedResolvedArgs := prepend(a.Resolved, arg)
-	resolve, err := requiresResolve(arg)
-	if err != nil {
-		return err
+	a.Forwarded = prepend(a.Forwarded, arg)
+	if requiresResolve(arg) {
+		return a.resolve()
 	}
-	if resolve {
-		return a.Set(updatedResolvedArgs)
-	}
-	a.Resolved = updatedResolvedArgs
+	a.Resolved = prepend(a.Resolved, arg)
 	return nil
 }
 
@@ -90,16 +84,10 @@ func prepend(args []string, arg string) []string {
 }
 
 // requiresResolve returns true if the arg can change rc/config expansion.
-func requiresResolve(arg string) (bool, error) {
+func requiresResolve(arg string) bool {
 	flagName, _ := SplitOptionValue(arg)
 	flagName = strings.TrimPrefix(flagName, "--")
-
-	// TODO(#7216): Remove this check once we add the Forwarded args field and can safely resolve --bazelrc.
-	if flagName == "bazelrc" {
-		return false, fmt.Errorf("cannot resolve --bazelrc with BazelArgs")
-	}
-
-	return flagName == "config" || flagName == "bazelrc", nil
+	return flagName == "config" || flagName == "bazelrc"
 }
 
 // Get returns the value of a flag.
@@ -112,11 +100,13 @@ func (a *BazelArgs) Has(flagName string) bool {
 	return a.Get(flagName) != ""
 }
 
-// TODO(#7216): Read the Forwarded args field, instead of passing in args.
-// resolve re-evaluates the args and expands all flags.
-func (a *BazelArgs) resolve(args []string) error {
+// resolve re-evaluates the Forwarded args and expands all flags in the Resolved field.
+//
+// resolve is expensive because it re-parses all rc files and expands configs. It is only necessary
+// when requiresResolve returns true for a flag.
+func (a *BazelArgs) resolve() error {
 	// Expand --config and --bazelrc flags, then normalize the result.
-	resolved, err := parser.ResolveAndCanonicalizeArgs(args)
+	resolved, err := parser.ResolveAndCanonicalizeArgs(a.Forwarded)
 	if err != nil {
 		return err
 	}
@@ -136,44 +126,59 @@ func (a *BazelArgs) GetAllFlagsWithName(flagName string) []string {
 	return GetMulti(a.Resolved, flagName)
 }
 
+func stripBBFlag(args []string, flagName string) (string, []string, error) {
+	parsed, err := parser.ParseArgs(args)
+	if err != nil {
+		return "", nil, err
+	}
+	flagVal, err := parser.GetCLICommandOptionVal(parsed, flagName)
+	if err != nil {
+		return "", nil, err
+	}
+	return flagVal, parsed.Format(), nil
+}
+
 // StripBBFlag removes a CLI-only string flag from the args (so it is
 // not passed to Bazelisk) and returns its value.
 func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
-	// TODO(#7216): Read the Forwarded args field - we can't strip a field set in a rc file.
-	parsed, err := parser.ParseArgs(a.Resolved)
+	flagVal, resolved, err := stripBBFlag(a.Resolved, flagName)
 	if err != nil {
 		return "", err
 	}
-	// Remove the flag from the parsed args and return its value.
-	flagVal, err := parser.GetCLICommandOptionVal(parsed, flagName)
+	_, forwarded, err := stripBBFlag(a.Forwarded, flagName)
 	if err != nil {
 		return "", err
 	}
-	// Update the args to not have the removed flag.
-	// Use direct assignment rather than Set() to avoid re-resolving rc/config
-	// flags, which would fail if a plugin added a  --config flag.
-	// TODO(#7216): This will be cleaner when we can safely re-resolve the Forwarded args.
-	a.Resolved = parsed.Format()
+	a.Resolved = resolved
+	a.Forwarded = forwarded
 	return flagVal, nil
+}
+
+func stripBBBoolFlag(args []string, flagName string) (bool, []string, error) {
+	parsed, err := parser.ParseArgs(args)
+	if err != nil {
+		return false, nil, err
+	}
+	set, err := parser.IsCLICommandOptionSet(parsed, flagName)
+	if err != nil {
+		return false, nil, err
+	}
+	return set, parsed.Format(), nil
 }
 
 // StripBBBoolFlag removes a CLI-only bool flag from the forwarded args (so it
 // is not passed to Bazelisk) and returns whether it was set.
 func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
-	// TODO(#7216): Read the Forwarded args field - we can't strip a field set in a rc file.
-	parsed, err := parser.ParseArgs(a.Resolved)
+	set, resolved, err := stripBBBoolFlag(a.Resolved, flagName)
 	if err != nil {
 		return false, err
 	}
-	set, err := parser.IsCLICommandOptionSet(parsed, flagName)
+	_, forwarded, err := stripBBBoolFlag(a.Forwarded, flagName)
 	if err != nil {
 		return false, err
 	}
-	// Update the args to not have the removed flag.
-	// Use direct assignment rather than Set() to avoid re-resolving rc/config
-	// flags, which would fail if a plugin added a  --config flag.
-	// TODO(#7216): This will be cleaner when we can safely re-resolve the Forwarded args.
-	a.Resolved = parsed.Format()
+	a.Resolved = resolved
+	a.Forwarded = forwarded
 	return set, nil
 }
 
@@ -187,31 +192,34 @@ func (a *BazelArgs) GetRemoteHeaderVal(key string) string {
 	return parser.GetRemoteHeaderVal(parsed, key)
 }
 
-// TODO(#7216): Add a test where the resolved flags add another version of flagName at the end of the args.
-// We shouldn't pop the newly resolved arg.
-//
 // Pop removes a flag and returns its value.
 // NOTE: Pop does not remove boolean flags.
 func (a *BazelArgs) Pop(flagName string) (string, error) {
-	value, newArgs := Pop(a.Resolved, flagName)
+	value, newArgs := Pop(a.Forwarded, flagName)
 
-	if value == "" {
-		return "", nil
-	}
-
-	resolve, err := requiresResolve(flagName)
-	if err != nil {
-		return "", err
-	}
-	if resolve {
-		if err := a.Set(newArgs); err != nil {
-			return "", err
+	if value != "" {
+		a.Forwarded = newArgs
+		if requiresResolve(flagName) {
+			if err := a.resolve(); err != nil {
+				return "", err
+			}
+			return value, nil
 		}
-	} else {
-		a.Resolved = newArgs
+
+		// Remove the flag from the resolved args.
+		// Make sure we remove the correct occurrence (i.e. same flag name and value),
+		// because the resolved args could have an alternate value for the same flag name,
+		// derived from a config file.
+		if i := slices.Index(a.Resolved, "--"+flagName+"="+value); i >= 0 {
+			a.Resolved = slices.Delete(a.Resolved, i, i+1)
+		}
+		return value, nil
 	}
-	// TODO(#7216): Return an error if the flag is only present in the resolved args (i.e. set
-	// via a config file), since it cannot be removed from the forwarded args in that case.
+
+	if a.Has(flagName) {
+		return "", fmt.Errorf("--%s is set via a config file and cannot be removed", flagName)
+	}
+
 	return value, nil
 }
 

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -8,54 +8,80 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
 )
 
-// TODO(#7216): Add getters for these fields, so they can't be modified directly, potentially breaking
-// the contract for how they should be simultaneously updated.
 type BazelArgs struct {
-	// TODO(#7216): Actually pass the Forwarded args field to Bazelisk.
+	// TODO(#7216): Actually pass the forwarded args field to Bazelisk.
 	//
-	// Forwarded are the Bazel args that are eventually passed to Bazelisk.
-	// --config and --bazelrc flags are not expanded.
-	// These should look fairly similarly to the user-supplied args, but with some additional args the CLI has
-	// added.
-	Forwarded []string
+	// forwarded are the Bazel args that are eventually passed to Bazelisk.
+	// bb might add to these, but --config and --bazelrc flags are not expanded.
+	// These should look fairly similarly to the user-supplied args, but with some additional bb-specific args.
+	forwarded *parsed.OrderedArgs
 
-	// Resolved are the Bazel args that are used internally within the bb parser.
+	// resolved are the Bazel args that are used internally within the bb parser.
 	// --config and --bazelrc flags are expanded, so the parser has a complete view of the args.
-	Resolved []string
+	resolved *parsed.OrderedArgs
 }
 
-// New returns a BazelArgs struct from a slice of bazel args.
+// Forwarded returns the forwarded args as a canonicalized []string.
+func (a *BazelArgs) Forwarded() []string {
+	return a.forwarded.Canonicalized().Format()
+}
+
+// Resolved returns the resolved args as a canonicalized []string.
+func (a *BazelArgs) Resolved() []string {
+	return a.resolved.Canonicalized().Format()
+}
+
+// NewBazelArgs returns a BazelArgs struct from a slice of bazel args.
 func NewBazelArgs(args []string) (*BazelArgs, error) {
-	parsed := &BazelArgs{}
-	if err := parsed.Set(args); err != nil {
+	b := &BazelArgs{}
+	if err := b.Set(args); err != nil {
 		return nil, err
 	}
-	return parsed, nil
+	return b, nil
+}
+
+// NewBazelArgsNoResolve creates a BazelArgs from an already-resolved []string
+// without performing config/bazelrc expansion. Both forwarded and resolved are
+// set to the same parsed form of args.
+func NewBazelArgsNoResolve(args []string) (*BazelArgs, error) {
+	parsed, err := parser.ParseArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	return &BazelArgs{forwarded: parsed, resolved: parsed}, nil
 }
 
 // Set updates the BazelArgs struct with a new slice of bazel args.
 // It also recomputes the resolved args.
 func (a *BazelArgs) Set(args []string) error {
-	// Normalize args - apply consistent option representation.
-	normalizedArgs, err := parser.CanonicalizeArgs(args)
+	forwarded, err := parser.ParseArgs(args)
 	if err != nil {
 		return err
 	}
-	a.Forwarded = normalizedArgs
+	a.forwarded = forwarded
 	return a.resolve()
 }
 
 // Append adds a new bazel arg.
 func (a *BazelArgs) Append(arg string) error {
-	a.Forwarded = Append(a.Forwarded, arg)
+	newFwd, err := parser.ParseArgs(Append(a.forwarded.Format(), arg))
+	if err != nil {
+		return err
+	}
+	a.forwarded = newFwd
 
 	if requiresResolve(arg) {
 		return a.resolve()
 	}
 
-	a.Resolved = Append(a.Resolved, arg)
+	newRes, err := parser.ParseArgs(Append(a.resolved.Format(), arg))
+	if err != nil {
+		return err
+	}
+	a.resolved = newRes
 	return nil
 }
 
@@ -63,11 +89,21 @@ func (a *BazelArgs) Append(arg string) error {
 // If the same flag is specified multiple times, Bazel will use the last value. This is useful for adding flags that should
 // be overridden by later flags.
 func (a *BazelArgs) Prepend(arg string) error {
-	a.Forwarded = prepend(a.Forwarded, arg)
+	newFwd, err := parser.ParseArgs(prepend(a.forwarded.Format(), arg))
+	if err != nil {
+		return err
+	}
+	a.forwarded = newFwd
+
 	if requiresResolve(arg) {
 		return a.resolve()
 	}
-	a.Resolved = prepend(a.Resolved, arg)
+
+	newRes, err := parser.ParseArgs(prepend(a.resolved.Format(), arg))
+	if err != nil {
+		return err
+	}
+	a.resolved = newRes
 	return nil
 }
 
@@ -93,125 +129,93 @@ func requiresResolve(arg string) bool {
 // Get returns the value of a flag.
 // It reads from the resolved args to ensure that flags expanded from --config or --bazelrc are included.
 func (a *BazelArgs) Get(flagName string) string {
-	return Get(a.Resolved, flagName)
+	return Get(a.Resolved(), flagName)
 }
 
 func (a *BazelArgs) Has(flagName string) bool {
 	return a.Get(flagName) != ""
 }
 
-// resolve re-evaluates the Forwarded args and expands all flags in the Resolved field.
+// resolve re-evaluates the forwarded args and expands all flags into the resolved field.
 //
 // resolve is expensive because it re-parses all rc files and expands configs. It is only necessary
 // when requiresResolve returns true for a flag.
 func (a *BazelArgs) resolve() error {
-	// Expand --config and --bazelrc flags, then normalize the result.
-	resolved, err := parser.ResolveAndCanonicalizeArgs(a.Forwarded)
+	// Clone to avoid mutation of a.forwarded by ResolveArgs.
+	clone := &parsed.OrderedArgs{Args: slices.Clone(a.forwarded.Args)}
+	resolved, err := parser.ResolveArgs(clone)
 	if err != nil {
 		return err
 	}
-	a.Resolved = resolved
+	a.resolved = resolved
 	return nil
 }
 
 func (a *BazelArgs) GetTargets() []string {
-	return GetTargets(a.Resolved)
+	return GetTargets(a.Resolved())
 }
 
 func (a *BazelArgs) GetCommand() string {
-	return GetCommand(a.Resolved)
+	return GetCommand(a.Resolved())
 }
 
 func (a *BazelArgs) GetAllFlagsWithName(flagName string) []string {
-	return GetMulti(a.Resolved, flagName)
-}
-
-func stripBBFlag(args []string, flagName string) (string, []string, error) {
-	parsed, err := parser.ParseArgs(args)
-	if err != nil {
-		return "", nil, err
-	}
-	flagVal, err := parser.GetCLICommandOptionVal(parsed, flagName)
-	if err != nil {
-		return "", nil, err
-	}
-	return flagVal, parsed.Format(), nil
+	return GetMulti(a.Resolved(), flagName)
 }
 
 // StripBBFlag removes a CLI-only string flag from the args (so it is
 // not passed to Bazelisk) and returns its value.
 func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
-	flagVal, resolved, err := stripBBFlag(a.Resolved, flagName)
+	// GetCLICommandOptionVal removes the flag from a.forwarded in place.
+	flagVal, err := parser.GetCLICommandOptionVal(a.forwarded, flagName)
 	if err != nil {
 		return "", err
 	}
-	_, forwarded, err := stripBBFlag(a.Forwarded, flagName)
-	if err != nil {
-		return "", err
-	}
-	a.Resolved = resolved
-	a.Forwarded = forwarded
+	a.resolved.RemoveCommandOptions(flagName)
 	return flagVal, nil
-}
-
-func stripBBBoolFlag(args []string, flagName string) (bool, []string, error) {
-	parsed, err := parser.ParseArgs(args)
-	if err != nil {
-		return false, nil, err
-	}
-	set, err := parser.IsCLICommandOptionSet(parsed, flagName)
-	if err != nil {
-		return false, nil, err
-	}
-	return set, parsed.Format(), nil
 }
 
 // StripBBBoolFlag removes a CLI-only bool flag from the forwarded args (so it
 // is not passed to Bazelisk) and returns whether it was set.
 func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
-	set, resolved, err := stripBBBoolFlag(a.Resolved, flagName)
+	// IsCLICommandOptionSet removes the flag from a.forwarded in place.
+	set, err := parser.IsCLICommandOptionSet(a.forwarded, flagName)
 	if err != nil {
 		return false, err
 	}
-	_, forwarded, err := stripBBBoolFlag(a.Forwarded, flagName)
-	if err != nil {
-		return false, err
-	}
-	a.Resolved = resolved
-	a.Forwarded = forwarded
+	a.resolved.RemoveCommandOptions(flagName)
 	return set, nil
 }
 
 // GetRemoteHeaderVal returns the value of a --remote_header flag matching the
 // given key, reading from the resolved args.
 func (a *BazelArgs) GetRemoteHeaderVal(key string) string {
-	parsed, err := parser.ParseArgs(a.Resolved)
-	if err != nil {
-		return ""
-	}
-	return parser.GetRemoteHeaderVal(parsed, key)
+	return parser.GetRemoteHeaderVal(a.resolved, key)
 }
 
 // Pop removes a flag and returns its value.
 // NOTE: Pop does not remove boolean flags.
 func (a *BazelArgs) Pop(flagName string) (string, error) {
-	value, newArgs := Pop(a.Forwarded, flagName)
+	value, newFwdSlice := Pop(a.forwarded.Format(), flagName)
 
 	if value != "" {
-		a.Forwarded = newArgs
+		newFwd, err := parser.ParseArgs(newFwdSlice)
+		if err != nil {
+			return "", err
+		}
+		a.forwarded = newFwd
+
 		if requiresResolve(flagName) {
-			if err := a.resolve(); err != nil {
-				return "", err
-			}
-			return value, nil
+			return value, a.resolve()
 		}
 
-		// Remove the flag from the resolved args.
-		// Make sure we remove the correct occurrence (i.e. same flag name and value),
-		// because the resolved args could have an alternate value for the same flag name,
-		// derived from a config file.
-		if i := slices.Index(a.Resolved, "--"+flagName+"="+value); i >= 0 {
-			a.Resolved = slices.Delete(a.Resolved, i, i+1)
+		// Remove the exact occurrence from resolved by matching the flag name and value,
+		// since the same flag name may appear from multiple sources (command line and config files).
+		for _, opt := range a.resolved.GetCommandOptionsByName(flagName) {
+			if opt.GetValue() == value {
+				a.resolved.Args = slices.Delete(a.resolved.Args, opt.Index, opt.Index+1)
+				break
+			}
 		}
 		return value, nil
 	}

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -43,25 +43,24 @@ build:ci --remote_cache=grpc://ci-cache
 	require.Equal(t, "build", args.GetCommand())
 }
 
-// TODO(#7216): Uncomment once we support appending config flags with late resolution.
-// func TestAppend_Config(t *testing.T) {
-// 	setupWorkspace(t, `
-// build:ci --remote_cache=grpc://ci-cache
-// `)
-// 	args, err := NewBazelArgs([]string{"build", "//foo"})
-// 	require.NoError(t, err)
-// 	err = args.Append("--config=ci")
-// 	require.NoError(t, err)
-// 	err = args.Append("--configuration=a")
-// 	require.NoError(t, err)
+func TestAppend_Config(t *testing.T) {
+	setupWorkspace(t, `
+build:ci --remote_cache=grpc://ci-cache
+`)
+	args, err := NewBazelArgs([]string{"build", "//foo"})
+	require.NoError(t, err)
+	err = args.Append("--config=ci")
+	require.NoError(t, err)
+	err = args.Append("--configuration=a")
+	require.NoError(t, err)
 
-// 	// Config flag should be expanded.
-// 	require.Equal(t, "grpc://ci-cache", args.Get("remote_cache"))
-// 	require.NotContains(t, args.Resolved, "--config=ci")
+	// Config flag should be expanded.
+	require.Equal(t, "grpc://ci-cache", args.Get("remote_cache"))
+	require.NotContains(t, args.Resolved, "--config=ci")
 
-// 	// Make sure that we don't try to expand flags that start with config but don't match exactly.
-// 	require.Equal(t, "a", args.Get("configuration"))
-// }
+	// Make sure that we don't try to expand flags that start with config but don't match exactly.
+	require.Equal(t, "a", args.Get("configuration"))
+}
 
 func TestAppend_ExecutableArgs(t *testing.T) {
 	setupWorkspace(t, ``)
@@ -99,16 +98,15 @@ build:ci --remote_cache=grpc://ci-cache
 		"//foo",
 	}, args.Resolved)
 
-	// TODO(#7216): Uncomment once we support adding config flags with late resolution.
-	// err = args.Prepend("--config=ci")
-	// require.NoError(t, err)
+	err = args.Prepend("--config=ci")
+	require.NoError(t, err)
 
 	require.Equal(t, []string{
 		"--output_base=/tmp/output",
 		"--ignore_all_rc_files",
 		"build",
 		// Config flag should be expanded.
-		// "--remote_cache=grpc://ci-cache",
+		"--remote_cache=grpc://ci-cache",
 		"--build_metadata=ROLE=CI",
 		"--flag=initial",
 		"//foo",
@@ -128,6 +126,76 @@ build --bes_backend=grpc://default-bes
 	require.Equal(t, "val", value)
 	require.Equal(t, "grpc://default-bes", args.Get("bes_backend"))
 	require.NotContains(t, args.Resolved, "--flag=val")
+}
+
+func TestPop_DoesNotRemoveFlagsFromConfigs(t *testing.T) {
+	// --build_metadata is only set via config file. Pop should not be able to remove it.
+	setupWorkspace(t, `build:ci --build_metadata=COMMIT_SHA=abc`)
+
+	args, err := NewBazelArgs([]string{"build", "--config=ci", "//foo"})
+	require.NoError(t, err)
+
+	value, err := args.Pop("build_metadata")
+	require.Error(t, err)
+	require.Empty(t, value)
+
+	require.Contains(t, args.Resolved, "--build_metadata=COMMIT_SHA=abc")
+}
+
+func TestPop_SkipsConfigResolvedDuplicates(t *testing.T) {
+	// --config=ci is placed after --build_metadata on the CLI, so the config
+	// expansion appends --build_metadata=COMMIT_SHA=abc at the end of Resolved.
+	// Pop should return the CLI-set value and leave the config-resolved one intact.
+	setupWorkspace(t, `build:ci --build_metadata=COMMIT_SHA=abc`)
+
+	args, err := NewBazelArgs([]string{"build", "--build_metadata=ROLE=CI", "--config=ci", "//foo"})
+	require.NoError(t, err)
+
+	value, err := args.Pop("build_metadata")
+	require.NoError(t, err)
+
+	require.Equal(t, "ROLE=CI", value)
+	require.NotContains(t, args.Resolved, "--build_metadata=ROLE=CI")
+	require.Contains(t, args.Resolved, "--build_metadata=COMMIT_SHA=abc")
+}
+
+func TestStripBBBoolFlag(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		flagToStrip      string
+		expectedStripped bool
+	}{
+		{
+			name:             "flag set",
+			args:             []string{"run", "--stream_run_logs", ":target"},
+			flagToStrip:      "stream_run_logs",
+			expectedStripped: true,
+		},
+		{
+			name:             "flag not set",
+			args:             []string{"run", ":target"},
+			flagToStrip:      "stream_run_logs",
+			expectedStripped: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupWorkspace(t, "")
+			args, err := NewBazelArgs(test.args)
+			require.NoError(t, err)
+			stripped, err := args.StripBBBoolFlag(test.flagToStrip)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedStripped, stripped)
+			require.NotContains(t, args.Forwarded, test.flagToStrip)
+			require.NotContains(t, args.Resolved, test.flagToStrip)
+
+			require.Equal(t, []string{"run", ":target"}, args.Forwarded)
+			require.Equal(t, []string{"--ignore_all_rc_files", "run", ":target"}, args.Resolved)
+			require.Equal(t, []string{":target"}, args.GetTargets())
+		})
+	}
 }
 
 func TestFindLast(t *testing.T) {

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -33,8 +33,8 @@ build:ci --remote_cache=grpc://ci-cache
 	// Config and bazelrc flags should be expanded.
 	require.Equal(t, "grpc://default-bes", args.Get("bes_backend"))
 	require.Equal(t, "grpc://ci-cache", args.Get("remote_cache"))
-	require.NotContains(t, args.Resolved, "--config=ci")
-	require.Contains(t, args.Resolved, "--ignore_all_rc_files")
+	require.NotContains(t, args.Resolved(), "--config=ci")
+	require.Contains(t, args.Resolved(), "--ignore_all_rc_files")
 
 	// Flags should be canonicalized (-c expanded to --compilation_mode).
 	require.Equal(t, "opt", args.Get("compilation_mode"))
@@ -56,7 +56,7 @@ build:ci --remote_cache=grpc://ci-cache
 
 	// Config flag should be expanded.
 	require.Equal(t, "grpc://ci-cache", args.Get("remote_cache"))
-	require.NotContains(t, args.Resolved, "--config=ci")
+	require.NotContains(t, args.Resolved(), "--config=ci")
 
 	// Make sure that we don't try to expand flags that start with config but don't match exactly.
 	require.Equal(t, "a", args.Get("configuration"))
@@ -74,7 +74,7 @@ func TestAppend_ExecutableArgs(t *testing.T) {
 	require.Equal(t, "ROLE=CI", args.Get("build_metadata"))
 	require.Equal(t, []string{":target"}, args.GetTargets())
 
-	bazelArgs, execArgs := SplitExecutableArgs(args.Resolved)
+	bazelArgs, execArgs := SplitExecutableArgs(args.Resolved())
 	require.NotContains(t, execArgs, "--build_metadata=ROLE=CI")
 	require.Contains(t, bazelArgs, "--build_metadata=ROLE=CI")
 }
@@ -96,7 +96,7 @@ build:ci --remote_cache=grpc://ci-cache
 		"--build_metadata=ROLE=CI",
 		"--flag=initial",
 		"//foo",
-	}, args.Resolved)
+	}, args.Resolved())
 
 	err = args.Prepend("--config=ci")
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ build:ci --remote_cache=grpc://ci-cache
 		"--build_metadata=ROLE=CI",
 		"--flag=initial",
 		"//foo",
-	}, args.Resolved)
+	}, args.Resolved())
 }
 
 func TestPop(t *testing.T) {
@@ -125,7 +125,7 @@ build --bes_backend=grpc://default-bes
 
 	require.Equal(t, "val", value)
 	require.Equal(t, "grpc://default-bes", args.Get("bes_backend"))
-	require.NotContains(t, args.Resolved, "--flag=val")
+	require.NotContains(t, args.Resolved(), "--flag=val")
 }
 
 func TestPop_DoesNotRemoveFlagsFromConfigs(t *testing.T) {
@@ -139,7 +139,7 @@ func TestPop_DoesNotRemoveFlagsFromConfigs(t *testing.T) {
 	require.Error(t, err)
 	require.Empty(t, value)
 
-	require.Contains(t, args.Resolved, "--build_metadata=COMMIT_SHA=abc")
+	require.Contains(t, args.Resolved(), "--build_metadata=COMMIT_SHA=abc")
 }
 
 func TestPop_SkipsConfigResolvedDuplicates(t *testing.T) {
@@ -155,28 +155,60 @@ func TestPop_SkipsConfigResolvedDuplicates(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "ROLE=CI", value)
-	require.NotContains(t, args.Resolved, "--build_metadata=ROLE=CI")
-	require.Contains(t, args.Resolved, "--build_metadata=COMMIT_SHA=abc")
+	require.NotContains(t, args.Resolved(), "--build_metadata=ROLE=CI")
+	require.Contains(t, args.Resolved(), "--build_metadata=COMMIT_SHA=abc")
 }
 
 func TestStripBBBoolFlag(t *testing.T) {
 	tests := []struct {
-		name             string
-		args             []string
-		flagToStrip      string
-		expectedStripped bool
+		name              string
+		args              []string
+		flagToStrip       string
+		expectedStripped  bool
+		expectedForwarded []string
+		expectedResolved  []string
 	}{
 		{
-			name:             "flag set",
-			args:             []string{"run", "--stream_run_logs", ":target"},
-			flagToStrip:      "stream_run_logs",
-			expectedStripped: true,
+			name:              "flag set",
+			args:              []string{"run", "--stream_run_logs", ":target"},
+			flagToStrip:       "stream_run_logs",
+			expectedStripped:  true,
+			expectedForwarded: []string{"run", ":target"},
+			expectedResolved:  []string{"--ignore_all_rc_files", "run", ":target"},
 		},
 		{
-			name:             "flag not set",
-			args:             []string{"run", ":target"},
-			flagToStrip:      "stream_run_logs",
-			expectedStripped: false,
+			name: "flag set multiple times",
+			args: []string{
+				"run",
+				"--stream_run_logs",
+				"--stream_run_logs",
+				":target",
+			},
+			flagToStrip:       "stream_run_logs",
+			expectedStripped:  true,
+			expectedForwarded: []string{"run", ":target"},
+			expectedResolved:  []string{"--ignore_all_rc_files", "run", ":target"},
+		},
+		{
+			name: "flag set then unset",
+			args: []string{
+				"run",
+				"--stream_run_logs",
+				"--nostream_run_logs",
+				":target",
+			},
+			flagToStrip:       "stream_run_logs",
+			expectedStripped:  false,
+			expectedForwarded: []string{"run", ":target"},
+			expectedResolved:  []string{"--ignore_all_rc_files", "run", ":target"},
+		},
+		{
+			name:              "flag not set",
+			args:              []string{"run", ":target"},
+			flagToStrip:       "stream_run_logs",
+			expectedStripped:  false,
+			expectedForwarded: []string{"run", ":target"},
+			expectedResolved:  []string{"--ignore_all_rc_files", "run", ":target"},
 		},
 	}
 
@@ -188,11 +220,77 @@ func TestStripBBBoolFlag(t *testing.T) {
 			stripped, err := args.StripBBBoolFlag(test.flagToStrip)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedStripped, stripped)
-			require.NotContains(t, args.Forwarded, test.flagToStrip)
-			require.NotContains(t, args.Resolved, test.flagToStrip)
+			require.NotContains(t, args.Forwarded(), test.flagToStrip)
+			require.NotContains(t, args.Resolved(), test.flagToStrip)
 
-			require.Equal(t, []string{"run", ":target"}, args.Forwarded)
-			require.Equal(t, []string{"--ignore_all_rc_files", "run", ":target"}, args.Resolved)
+			require.Equal(t, test.expectedForwarded, args.Forwarded())
+			require.Equal(t, test.expectedResolved, args.Resolved())
+			require.Equal(t, []string{":target"}, args.GetTargets())
+		})
+	}
+}
+
+func TestStripBBFlag(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              []string
+		flagToStrip       string
+		expectedStripped  string
+		expectedForwarded []string
+		expectedResolved  []string
+	}{
+		{
+			name:              "flag set",
+			args:              []string{"run", "--on_stream_run_logs_failure=fail", ":target"},
+			flagToStrip:       "on_stream_run_logs_failure",
+			expectedStripped:  "fail",
+			expectedForwarded: []string{"run", ":target"},
+			expectedResolved:  []string{"--ignore_all_rc_files", "run", ":target"},
+		},
+		{
+			name: "flag set multiple times",
+			args: []string{
+				"run",
+				"--on_stream_run_logs_failure=ignore",
+				"--on_stream_run_logs_failure=fail",
+				":target",
+			},
+			flagToStrip:       "on_stream_run_logs_failure",
+			expectedStripped:  "fail",
+			expectedForwarded: []string{"run", ":target"},
+			expectedResolved:  []string{"--ignore_all_rc_files", "run", ":target"},
+		},
+		{
+			name:              "flag set with separate value",
+			args:              []string{"run", "--on_stream_run_logs_failure", "fail", ":target"},
+			flagToStrip:       "on_stream_run_logs_failure",
+			expectedStripped:  "fail",
+			expectedForwarded: []string{"run", ":target"},
+			expectedResolved:  []string{"--ignore_all_rc_files", "run", ":target"},
+		},
+		{
+			name:              "flag not set",
+			args:              []string{"run", ":target"},
+			flagToStrip:       "on_stream_run_logs_failure",
+			expectedStripped:  "",
+			expectedForwarded: []string{"run", ":target"},
+			expectedResolved:  []string{"--ignore_all_rc_files", "run", ":target"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setupWorkspace(t, "")
+			args, err := NewBazelArgs(test.args)
+			require.NoError(t, err)
+			stripped, err := args.StripBBFlag(test.flagToStrip)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedStripped, stripped)
+			require.NotContains(t, args.Forwarded(), test.flagToStrip)
+			require.NotContains(t, args.Resolved(), test.flagToStrip)
+
+			require.Equal(t, test.expectedForwarded, args.Forwarded())
+			require.Equal(t, test.expectedResolved, args.Resolved())
 			require.Equal(t, []string{":target"}, args.GetTargets())
 		})
 	}

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -369,7 +369,7 @@ func handleBazelCommand(start time.Time, args []string, originalArgs []string) (
 	outputPath := filepath.Join(tempDir, "bazel.log")
 	// TODO(#7216): Use the forwarded args here.
 	exitCode, err = plugin.RunBazeliskWithPlugins(
-		arg.JoinExecutableArgs(bazelArgs.Resolved, execArgs),
+		arg.JoinExecutableArgs(bazelArgs.Resolved(), execArgs),
 		outputPath, plugins)
 	if err != nil {
 		return 1, err

--- a/cli/example_plugins/ping-remote/pre_bazel.sh
+++ b/cli/example_plugins/ping-remote/pre_bazel.sh
@@ -3,7 +3,7 @@
 # Look for the effective (last) "--remote_executor" flag value,
 # converting "--remote_executor\n<value>" to "--remote_executor=<value>".
 REMOTE_EXECUTOR=$(
-  perl -p -e 's@^--remote_executor\n@--remote_executor=@' "$1" |
+  perl -p -e 's@^--remote_executor\n@--remote_executor=@' "$RESOLVED_BAZEL_ARGS_FILE" |
     grep -E '^--remote_executor=' |
     perl -p -e 's@^--remote_executor=(grpcs?://)?(.*?)(:\d+)?$@\2@' |
     tail -n 1
@@ -20,6 +20,6 @@ function timeout() {
 # Make sure we can ping the remote execution service in 500ms.
 if ! timeout 0.5 ping -c 1 "$REMOTE_EXECUTOR" &>/dev/null; then
   # Network is spotty; disable remote execution.
-  echo "--remote_executor=" >>"$1"
+  echo "--remote_executor=" >>"$FORWARDED_BAZEL_ARGS_FILE"
   echo >&2 -e "\x1b[33mWarning: failed to reach $REMOTE_EXECUTOR. Disabling remote execution.\x1b[m"
 fi

--- a/cli/flaghistory/flaghistory_test.go
+++ b/cli/flaghistory/flaghistory_test.go
@@ -151,7 +151,7 @@ func TestSaveFlags_NonBazelCommands(t *testing.T) {
 	_, err = SaveFlags(args2)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"--ignore_all_rc_files", "fetch", "--bes_backend=shouldnt_apply"}, args2.Resolved)
+	require.Equal(t, []string{"--ignore_all_rc_files", "fetch", "--bes_backend=shouldnt_apply"}, args2.Resolved())
 	requirePreviousFlag(t, besBackendFlagName, "grpc://backend.example")
 }
 

--- a/cli/login/login_test.go
+++ b/cli/login/login_test.go
@@ -33,8 +33,8 @@ func TestAPIKeyDiscovery(t *testing.T) {
 			expectedArgs: []string{
 				"--ignore_all_rc_files",
 				"build",
-				"//foo:bar",
 				"--remote_header=x-buildbuddy-api-key=env-api-key",
+				"//foo:bar",
 			},
 		},
 		{
@@ -44,8 +44,8 @@ func TestAPIKeyDiscovery(t *testing.T) {
 			expectedArgs: []string{
 				"--ignore_all_rc_files",
 				"build",
-				"//foo:bar",
 				"--remote_header=x-buildbuddy-api-key=repo-api-key",
+				"//foo:bar",
 			},
 		},
 		{
@@ -56,8 +56,8 @@ func TestAPIKeyDiscovery(t *testing.T) {
 			expectedArgs: []string{
 				"--ignore_all_rc_files",
 				"build",
-				"//foo:bar",
 				"--remote_header=x-buildbuddy-api-key=env-api-key",
+				"//foo:bar",
 			},
 		},
 		{
@@ -101,7 +101,7 @@ func TestAPIKeyDiscovery(t *testing.T) {
 			err = ConfigureAPIKey(args)
 
 			require.NoError(t, err)
-			require.Equal(t, testCase.expectedArgs, args.Resolved)
+			require.Equal(t, testCase.expectedArgs, args.Resolved())
 		})
 	}
 }

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -40,8 +40,9 @@ const (
 	// invoked by BB as a plugin.
 	isPluginEnvVar = "IS_BB_PLUGIN"
 
-	execArgsFileEnvVar          = "EXEC_ARGS_FILE"
-	resolvedBazelArgsFileEnvVar = "RESOLVED_BAZEL_ARGS_FILE"
+	execArgsFileEnvVar           = "EXEC_ARGS_FILE"
+	forwardedBazelArgsFileEnvVar = "FORWARDED_BAZEL_ARGS_FILE"
+	resolvedBazelArgsFileEnvVar  = "RESOLVED_BAZEL_ARGS_FILE"
 
 	installCommandUsage = `
 Usage: bb install [REPO[@VERSION]][:PATH] [--user]
@@ -625,19 +626,24 @@ func (p *Plugin) commandEnv() []string {
 // PreBazel executes the plugin's pre-bazel hook if it exists, allowing the
 // plugin to return a set of transformed bazel arguments.
 //
-// Plugins receive as their first argument a path to a file containing the
-// arguments to be passed to bazel. The plugin can read and write that file to
-// modify the args (most commonly, just appending to the file), which will then
-// be fed to the next plugin in the pipeline, or passed to Bazel if this is the
-// last plugin.
+// Plugins can read Bazel args from the FORWARDED_BAZEL_ARGS_FILE environment
+// variable. Plugins can write that file to modify the args (most commonly just
+// appending to the file), which will then be fed to the next plugin in the
+// pipeline, or passed to Bazel if this is the last plugin.
 //
-// Plugins can also read the resolved arg view from the
+// Plugins can also read the resolved args (i.e. all --config flags expanded) from the
 // file at RESOLVED_BAZEL_ARGS_FILE, but changes to that file are ignored.
+//
+// DEPRECATED: Plugins receive as their first argument a path to a legacy args
+// file containing the resolved Bazel arguments. Writing changes to this file is
+// still supported for backwards compatibility.
 //
 // See cli/example_plugins/ping-remote/pre_bazel.sh for an example.
 func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.BazelArgs, []string, error) {
-	// Write bazel args to a file that the plugin can manipulate.
-	// Any changes are passed through to bazelisk.
+	initialForwardedArgs := bazelArgs.Forwarded()
+	initialResolvedArgs := bazelArgs.Resolved()
+
+	// Write legacy resolved bazel args to $1 so existing plugins keep working.
 	argsFile, err := os.CreateTemp("", "bazelisk-args-*")
 	if err != nil {
 		return nil, nil, status.InternalErrorf("failed to create args file for pre-bazel hook: %s", err)
@@ -646,7 +652,21 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 		argsFile.Close()
 		os.Remove(argsFile.Name())
 	}()
-	if err := writeArgsFile(argsFile.Name(), bazelArgs.Forwarded()); err != nil {
+	if err := writeArgsFile(argsFile.Name(), initialResolvedArgs); err != nil {
+		return nil, nil, err
+	}
+
+	// Write forwarded bazel args to a separate mutable file. This is the
+	// preferred API for plugins that want their changes passed through to Bazel.
+	forwardedArgsFile, err := os.CreateTemp("", "bazelisk-forwarded-args-*")
+	if err != nil {
+		return nil, nil, status.InternalErrorf("failed to create forwarded args file for pre-bazel hook: %s", err)
+	}
+	defer func() {
+		forwardedArgsFile.Close()
+		os.Remove(forwardedArgsFile.Name())
+	}()
+	if err := writeArgsFile(forwardedArgsFile.Name(), initialForwardedArgs); err != nil {
 		return nil, nil, err
 	}
 
@@ -661,7 +681,7 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 		resolvedArgsFile.Close()
 		os.Remove(resolvedArgsFile.Name())
 	}()
-	if err := writeArgsFile(resolvedArgsFile.Name(), bazelArgs.Resolved()); err != nil {
+	if err := writeArgsFile(resolvedArgsFile.Name(), initialResolvedArgs); err != nil {
 		return nil, nil, err
 	}
 
@@ -701,12 +721,23 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 	cmd.Stdout = os.Stdout
 	cmd.Env = p.commandEnv()
 	cmd.Env = append(cmd.Env, execArgsFileEnvVar+"="+execArgsFile.Name())
+	cmd.Env = append(cmd.Env, forwardedBazelArgsFileEnvVar+"="+forwardedArgsFile.Name())
 	cmd.Env = append(cmd.Env, resolvedBazelArgsFileEnvVar+"="+resolvedArgsFile.Name())
 	if err := cmd.Run(); err != nil {
 		return nil, nil, status.InternalErrorf("Pre-bazel hook for %s/%s failed: %s", p.config.Repo, p.config.Path, err)
 	}
 
-	newArgs, err := readArgsFile(argsFile.Name())
+	newLegacyArgs, err := readArgsFile(argsFile.Name())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newForwardedArgs, err := readArgsFile(forwardedArgsFile.Name())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newResolvedArgs, err := readArgsFile(resolvedArgsFile.Name())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -716,10 +747,39 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 		return nil, nil, err
 	}
 
-	log.Debugf("New bazel args: %s", shlex.Quote(newArgs...))
+	log.Debugf("New forwarded bazel args: %s", shlex.Quote(newForwardedArgs...))
+	log.Debugf("New legacy bazel args: %s", shlex.Quote(newLegacyArgs...))
 	log.Debugf("New executable args: %s", shlex.Quote(newExecArgs...))
 
-	bazelArgs.Set(newArgs)
+	forwardedChanged := !slices.Equal(initialForwardedArgs, newForwardedArgs)
+	legacyChanged := !slices.Equal(initialResolvedArgs, newLegacyArgs)
+	resolvedChanged := !slices.Equal(initialResolvedArgs, newResolvedArgs)
+
+	pluginID, err := p.VersionedID()
+	if err != nil {
+		pluginID = "<unknown>"
+	}
+
+	switch {
+	case forwardedChanged:
+		if legacyChanged {
+			log.Warnf("Plugin %s modified both %s and the legacy resolved Bazel args file passed as $1; using %s and ignoring changes to $1.", pluginID, forwardedBazelArgsFileEnvVar, forwardedBazelArgsFileEnvVar)
+		}
+		if err := bazelArgs.Set(newForwardedArgs); err != nil {
+			return nil, nil, err
+		}
+	case legacyChanged:
+		log.Warnf("Plugin %s modified the legacy resolved Bazel args file passed as $1. This is deprecated; write Bazel arg changes to %s instead, and use %s only for reading rc/config-expanded args.", pluginID, forwardedBazelArgsFileEnvVar, resolvedBazelArgsFileEnvVar)
+		legacyBazelArgs, err := arg.NewBazelArgsNoResolve(newLegacyArgs)
+		if err != nil {
+			return nil, nil, err
+		}
+		bazelArgs = legacyBazelArgs
+	}
+
+	if resolvedChanged {
+		log.Warnf("Plugin %s modified %s, but that file is read-only; ignoring those changes.", pluginID, resolvedBazelArgsFileEnvVar)
+	}
 
 	return bazelArgs, newExecArgs, nil
 }

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -631,6 +631,9 @@ func (p *Plugin) commandEnv() []string {
 // be fed to the next plugin in the pipeline, or passed to Bazel if this is the
 // last plugin.
 //
+// Plugins can also read the resolved arg view from the
+// file at RESOLVED_BAZEL_ARGS_FILE, but changes to that file are ignored.
+//
 // See cli/example_plugins/ping-remote/pre_bazel.sh for an example.
 func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.BazelArgs, []string, error) {
 	// Write bazel args to a file that the plugin can manipulate.
@@ -643,8 +646,7 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 		argsFile.Close()
 		os.Remove(argsFile.Name())
 	}()
-	// TODO(#7216): Write the forwarded args to the file.
-	if err := writeArgsFile(argsFile.Name(), bazelArgs.Resolved); err != nil {
+	if err := writeArgsFile(argsFile.Name(), bazelArgs.Forwarded); err != nil {
 		return nil, nil, err
 	}
 
@@ -717,15 +719,7 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 	log.Debugf("New bazel args: %s", shlex.Quote(newArgs...))
 	log.Debugf("New executable args: %s", shlex.Quote(newExecArgs...))
 
-	// Canonicalize args after each plugin is run, so that every plugin gets
-	// canonicalized args as input.
-	canonicalizedArgs, err := parser.CanonicalizeArgs(newArgs)
-	if err != nil {
-		return nil, nil, err
-	}
-	// TODO(#7216): Resolve bazel args after each plugin is run (using bazelArgs.Set), so every following plugin gets
-	// a refreshed resolved view of the bazel args (i.e. all --config flags expanded).
-	bazelArgs.Resolved = canonicalizedArgs
+	bazelArgs.Set(newArgs)
 
 	return bazelArgs, newExecArgs, nil
 }

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -646,7 +646,7 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 		argsFile.Close()
 		os.Remove(argsFile.Name())
 	}()
-	if err := writeArgsFile(argsFile.Name(), bazelArgs.Forwarded); err != nil {
+	if err := writeArgsFile(argsFile.Name(), bazelArgs.Forwarded()); err != nil {
 		return nil, nil, err
 	}
 
@@ -661,7 +661,7 @@ func (p *Plugin) PreBazel(bazelArgs *arg.BazelArgs, execArgs []string) (*arg.Baz
 		resolvedArgsFile.Close()
 		os.Remove(resolvedArgsFile.Name())
 	}()
-	if err := writeArgsFile(resolvedArgsFile.Name(), bazelArgs.Resolved); err != nil {
+	if err := writeArgsFile(resolvedArgsFile.Name(), bazelArgs.Resolved()); err != nil {
 		return nil, nil, err
 	}
 

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -272,6 +272,7 @@ EOF
 
 	// We expect the output args to be canonicalized.
 	expectedArgs := []string{
+		"--ignore_all_rc_files",
 		"test",
 		"--compilation_mode=opt",
 		"--bes_backend=grpc://new",
@@ -284,12 +285,10 @@ EOF
 	require.Equal(t, []string{"--exec"}, execArgs)
 }
 
-// TODO(#7216): Refactor the CLI to resolve flags after each plugin,
-// so each plugin sees the fully resolved args.
 func TestPreBazel_AddConfig(t *testing.T) {
 	ws, _ := setup(t)
 	testfs.WriteAllFileContents(t, ws, map[string]string{
-		".bazelrc":                    "test:plugin_cfg --test_output=all\n",
+		".bazelrc":                    "test:plugin-cfg --test_output=all\n",
 		"plugins/config/pre_bazel.sh": `echo '--config=plugin-cfg' >> "$1"`,
 	})
 	p := testPlugin(t, ws, "./plugins/config")
@@ -298,9 +297,10 @@ func TestPreBazel_AddConfig(t *testing.T) {
 
 	args, execArgs, err := p.PreBazel(args, nil)
 	require.NoError(t, err)
-	require.Equal(t, []string{"--ignore_all_rc_files", "test", "--config=plugin-cfg", "//initial"}, args.Resolved)
 	require.Empty(t, execArgs)
-	require.NotContains(t, args.Resolved, "--test_output=all")
+
+	require.Equal(t, []string{"test", "--config=plugin-cfg", "//initial"}, args.Forwarded)
+	require.Equal(t, []string{"--ignore_all_rc_files", "test", "--test_output=all", "//initial"}, args.Resolved)
 }
 
 // TestPipelineWriter_HandlesFinalLine guards against a regression in which

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -243,10 +243,52 @@ func TestParsePluginSpec(t *testing.T) {
 }
 
 func TestPreBazel(t *testing.T) {
-	ws, _ := setup(t)
-	testfs.WriteAllFileContents(t, ws, map[string]string{
-		// Plugin 1 sets a bunch of non-canonicalized flags.
-		"plugins/plugin1/pre_bazel.sh": `cat > "$1" <<'EOF'
+	originalArgs := []string{"test", "//initial"}
+	resolvedOriginalArgs := []string{"--ignore_all_rc_files", "test", "//initial"}
+	canonicalizedArgs := []string{
+		"test",
+		"--compilation_mode=opt",
+		"--bes_backend=grpc://new",
+		"--remote_header=x-buildbuddy-foo=1",
+		"--remote_header=x-buildbuddy-bar=2",
+		"//foo",
+	}
+	resolvedArgs := append([]string{"--ignore_all_rc_files"}, canonicalizedArgs...)
+
+	tests := []struct {
+		name                  string
+		fileToWrite           string
+		expectedForwardedArgs []string
+		expectedResolvedArgs  []string
+	}{
+		{
+			name:                  "writes to the forwarded args file",
+			fileToWrite:           "$FORWARDED_BAZEL_ARGS_FILE",
+			expectedForwardedArgs: canonicalizedArgs,
+			expectedResolvedArgs:  resolvedArgs,
+		},
+		{
+			name:                  "writes to the deprecated args file",
+			fileToWrite:           "$1",
+			expectedForwardedArgs: canonicalizedArgs,
+			// In the deprecated flow, we do not re-resolve the args.
+			expectedResolvedArgs: canonicalizedArgs,
+		},
+		// The resolved args file is read-only, so we expect the args to be unchanged.
+		{
+			name:                  "writes to the resolved args file",
+			fileToWrite:           "$RESOLVED_BAZEL_ARGS_FILE",
+			expectedForwardedArgs: originalArgs,
+			expectedResolvedArgs:  resolvedOriginalArgs,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ws, _ := setup(t)
+			testfs.WriteAllFileContents(t, ws, map[string]string{
+				// Plugin 1 sets a bunch of non-canonicalized flags.
+				"plugins/plugin1/pre_bazel.sh": `cat > "` + test.fileToWrite + `" <<'EOF'
 test
 -c
 opt
@@ -261,35 +303,29 @@ x-buildbuddy-bar=2
 //foo
 EOF
 `,
-	})
+			})
 
-	plugin1 := testPlugin(t, ws, "./plugins/plugin1")
-	args, err := arg.NewBazelArgs([]string{"test", "//initial"})
-	require.NoError(t, err)
+			plugin1 := testPlugin(t, ws, "./plugins/plugin1")
+			args, err := arg.NewBazelArgs(originalArgs)
+			require.NoError(t, err)
 
-	args, execArgs, err := plugin1.PreBazel(args, []string{"--exec"})
-	require.NoError(t, err)
+			args, execArgs, err := plugin1.PreBazel(args, []string{"--exec"})
+			require.NoError(t, err)
 
-	// We expect the output args to be canonicalized.
-	expectedArgs := []string{
-		"--ignore_all_rc_files",
-		"test",
-		"--compilation_mode=opt",
-		"--bes_backend=grpc://new",
-		"--remote_header=x-buildbuddy-foo=1",
-		"--remote_header=x-buildbuddy-bar=2",
-		"//foo",
+			// We expect the output args to be canonicalized.
+			require.Equal(t, test.expectedForwardedArgs, args.Forwarded())
+			require.Equal(t, test.expectedResolvedArgs, args.Resolved())
+			// Exec args should be passed through unchanged.
+			require.Equal(t, []string{"--exec"}, execArgs)
+		})
 	}
-	require.Equal(t, expectedArgs, args.Resolved)
-	// Exec args should be passed through unchanged.
-	require.Equal(t, []string{"--exec"}, execArgs)
 }
 
 func TestPreBazel_AddConfig(t *testing.T) {
 	ws, _ := setup(t)
 	testfs.WriteAllFileContents(t, ws, map[string]string{
 		".bazelrc":                    "test:plugin-cfg --test_output=all\n",
-		"plugins/config/pre_bazel.sh": `echo '--config=plugin-cfg' >> "$1"`,
+		"plugins/config/pre_bazel.sh": `echo '--config=plugin-cfg' >> "$FORWARDED_BAZEL_ARGS_FILE"`,
 	})
 	p := testPlugin(t, ws, "./plugins/config")
 	args, err := arg.NewBazelArgs([]string{"test", "//initial"})
@@ -299,8 +335,8 @@ func TestPreBazel_AddConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, execArgs)
 
-	require.Equal(t, []string{"test", "--config=plugin-cfg", "//initial"}, args.Forwarded)
-	require.Equal(t, []string{"--ignore_all_rc_files", "test", "--test_output=all", "//initial"}, args.Resolved)
+	require.Equal(t, []string{"test", "--config=plugin-cfg", "//initial"}, args.Forwarded())
+	require.Equal(t, []string{"--ignore_all_rc_files", "test", "--test_output=all", "//initial"}, args.Resolved())
 }
 
 // TestPipelineWriter_HandlesFinalLine guards against a regression in which

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1353,14 +1353,14 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 	// are only defined on the remote runners.)
 	// Manually construct a BazelArgs struct because the login code expects it.
 	// TODO: Find a less hacky way to handle this.
-	bazelArgsStruct := &arg.BazelArgs{
-		Forwarded: bazelArgs,
-		Resolved:  bazelArgs,
+	bazelArgsStruct, err := arg.NewBazelArgsNoResolve(bazelArgs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse bazel args: %w", err)
 	}
 	if err := login.ConfigureAPIKey(bazelArgsStruct); err != nil {
 		return nil, nil, fmt.Errorf("configure api key: %w", err)
 	}
-	bazelArgs = bazelArgsStruct.Resolved
+	bazelArgs = bazelArgsStruct.Resolved()
 
 	// Ensure all bazel remote runs use the remote cache.
 	// The goal is to keep remote workloads close to our servers, so use the same

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -1354,7 +1354,8 @@ func parseArgs(commandLineArgs []string) ([]string, []string, error) {
 	// Manually construct a BazelArgs struct because the login code expects it.
 	// TODO: Find a less hacky way to handle this.
 	bazelArgsStruct := &arg.BazelArgs{
-		Resolved: bazelArgs,
+		Forwarded: bazelArgs,
+		Resolved:  bazelArgs,
 	}
 	if err := login.ConfigureAPIKey(bazelArgsStruct); err != nil {
 		return nil, nil, fmt.Errorf("configure api key: %w", err)

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -484,9 +484,9 @@ func TestParseArgs(t *testing.T) {
 		"--config=remote_only",
 		// Remote headers should be preserved.
 		"--remote_header=x-custom=1",
-		"//foo",
 		// API key should be set.
 		"--remote_header=x-buildbuddy-api-key=test-api-key",
+		"//foo",
 		// Remote flags should be removed and replaced by the CLI.
 		"--config=buildbuddy_bes_backend",
 		"--config=buildbuddy_bes_results_url",

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -243,7 +243,7 @@ func ConfigureSidecar(args *arg.BazelArgs) (*Instance, error) {
 		return nil, nil
 	}
 
-	originalArgs := slices.Clone(args.Forwarded)
+	originalArgs := args.Forwarded()
 
 	log.Debugf("Configuring sidecar")
 

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -243,8 +243,7 @@ func ConfigureSidecar(args *arg.BazelArgs) (*Instance, error) {
 		return nil, nil
 	}
 
-	// TODO(#7216): Use the forwarded args here.
-	originalArgs := slices.Clone(args.Resolved)
+	originalArgs := slices.Clone(args.Forwarded)
 
 	log.Debugf("Configuring sidecar")
 

--- a/cli/versioncmd/versioncmd.go
+++ b/cli/versioncmd/versioncmd.go
@@ -46,6 +46,6 @@ func runBazelVersion(args []string) (int, error) {
 	outputPath := filepath.Join(tempDir, "bazel.log")
 	// TODO(#7216): Use the forwarded args here.
 	return plugin.RunBazeliskWithPlugins(
-		arg.JoinExecutableArgs(setupResult.BazelArgs.Resolved, setupResult.ExecArgs),
+		arg.JoinExecutableArgs(setupResult.BazelArgs.Resolved(), setupResult.ExecArgs),
 		outputPath, setupResult.Plugins)
 }

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -117,16 +117,36 @@ path/to/plugin/
 
 The `pre_bazel.sh` script will be called before Bazel is run.
 
-It is called with a single argument, which is the path to a file
-containing all arguments that will be passed to Bazel (including the
-arguments specified in your `.bazelrc` and expanded via any `--config=`
-flags). **Each line in this file contains a single argument.**
+It is called with a single argument, which is the path to a file containing the
+arguments that will be passed to Bazel (i.e. the forwarded args). Your plugin can modify this
+file to add, remove, or change flags that will ultimately be passed to Bazel.
+**Each line in this file contains a single argument.**
+
+In this file, `--config` flags are not expanded, and flags imported from `.bazelrc` files are not included.
+These are the raw args that will be passed to Bazel.
+
+The CLI also exposes a second args file via the `RESOLVED_BAZEL_ARGS_FILE`
+environment variable. This file contains the resolved view of the Bazel args.
+Flags imported from `.bazelrc` files are explicitly included, and `--config` flags are expanded.
+This file is read-only. It's useful if a plugin needs to read an expanded flag. However
+changes to it are ignored. If you'd like to modify the args, modify the forwarded args file instead.
 
 The script will be called like this:
 
 ```bash
-/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/bazel-args
+/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/forwarded-bazel-args
 ```
+
+Here's an example of what the forwarded Bazel args file might look like:
+
+```bash
+run
+//server
+--config=remote
+```
+
+Here's an example of what the resolved Bazel args file might look like (--config=remote
+was expanded to BuildBuddy remote cache flags):
 
 Here's an example of what the Bazel args file might look like:
 
@@ -136,30 +156,16 @@ run
 //server
 --bes_results_url=https://app.buildbuddy.io/invocation/
 --bes_backend=grpcs://remote.buildbuddy.io
---noremote_upload_local_results
---workspace_status_command=$(pwd)/workspace_status.sh
---incompatible_remote_build_event_upload_respect_no_cache
---experimental_remote_cache_async
---incompatible_strict_action_env
---enable_runfiles=1
---build_tag_filters=-docker
---bes_results_url=https://app.buildbuddy.io/invocation/
---bes_backend=grpcs://remote.buildbuddy.io
 --remote_cache=grpcs://remote.buildbuddy.io
 --remote_upload_local_results
---experimental_remote_cache_compression
---noremote_upload_local_results
---noincompatible_remote_build_event_upload_respect_no_cache
 ```
-
-Your plugin can modify this file to add, remove, or change that flags that will ultimately be passed to Bazel.
 
 Your `pre_bazel.sh` script can also accept user input, spawn other processes, or anything else you'd like.
 
 Here's an example of a simple `pre_bazel.sh` plugin that disables remote execution if it's unable to ping `remote.buildbuddy.io` within 500ms.
 
 ```bash title="pre_bazel.sh"
-if ! grep -E '^--remote_executor=.*\.buildbuddy\.io$' "$1" &>/dev/null; then
+if ! grep -E '^--remote_executor=.*\.buildbuddy\.io$' "$RESOLVED_BAZEL_ARGS_FILE" &>/dev/null; then
   # BB remote execution is not enabled; do nothing.
   exit 0
 fi
@@ -354,7 +360,7 @@ following a `--` in the argument list passed to bazel, if any.
 
 This environment variable will only be set for the `pre_bazel.sh` script in the
 plugin. Plugins can change this file to change the arguments
-passed to Bazel.
+passed to the executable produced by `bazel run`.
 
 The file in question is formatted very similarly to the bazel args file, except
 that the arguments will be split across lines based solely as a result of shell
@@ -371,6 +377,20 @@ positional_arg
 positional_arg3
 --option4
 ```
+
+#### $RESOLVED_BAZEL_ARGS_FILE
+
+This is the path of a file that contains the resolved Bazel args for the current
+invocation. This includes args loaded from `.bazelrc` files and args expanded
+from any `--config=` flags. The file uses the same one-argument-per-line format
+as the forwarded Bazel args file passed as the first argument to
+`pre_bazel.sh`.
+
+This environment variable will only be set for the `pre_bazel.sh` script in the
+plugin. Plugins can read this file to make decisions based on the effective
+Bazel configuration, but should not modify it. Changes to this file are ignored.
+To change the args passed to Bazel, modify the forwarded Bazel args file passed
+as `$1`.
 
 ### Examples
 

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -117,24 +117,31 @@ path/to/plugin/
 
 The `pre_bazel.sh` script will be called before Bazel is run.
 
-It is called with a single argument, which is the path to a file containing the
-arguments that will be passed to Bazel (i.e. the forwarded args). Your plugin can modify this
-file to add, remove, or change flags that will ultimately be passed to Bazel.
+To change the arguments that will be passed to Bazel, read and write the file
+at `FORWARDED_BAZEL_ARGS_FILE`. Your plugin can modify this file to add,
+remove, or change flags that will ultimately be passed to Bazel.
 **Each line in this file contains a single argument.**
 
-In this file, `--config` flags are not expanded, and flags imported from `.bazelrc` files are not included.
-These are the raw args that will be passed to Bazel.
+In the forwarded args file, `--config` flags are not expanded, and flags
+imported from `.bazelrc` files are not included. These are the raw args that
+will be passed to Bazel.
 
-The CLI also exposes a second args file via the `RESOLVED_BAZEL_ARGS_FILE`
+The CLI also exposes a resolved args file via the `RESOLVED_BAZEL_ARGS_FILE`
 environment variable. This file contains the resolved view of the Bazel args.
 Flags imported from `.bazelrc` files are explicitly included, and `--config` flags are expanded.
 This file is read-only. It's useful if a plugin needs to read an expanded flag. However
 changes to it are ignored. If you'd like to modify the args, modify the forwarded args file instead.
 
+For backward compatibility, `pre_bazel.sh` is also called with a single
+argument, `$1`, which points to a legacy resolved args file. Plugins that modify
+`$1` still work for now, but this is deprecated and will print a warning. New
+plugins should use `FORWARDED_BAZEL_ARGS_FILE` for writes and
+`RESOLVED_BAZEL_ARGS_FILE` for reads.
+
 The script will be called like this:
 
 ```bash
-/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/forwarded-bazel-args
+/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/legacy-resolved-bazel-args
 ```
 
 Here's an example of what the forwarded Bazel args file might look like:
@@ -147,8 +154,6 @@ run
 
 Here's an example of what the resolved Bazel args file might look like (--config=remote
 was expanded to BuildBuddy remote cache flags):
-
-Here's an example of what the Bazel args file might look like:
 
 ```bash
 --ignore_all_rc_files
@@ -173,7 +178,7 @@ fi
 # Make sure we can ping the remote execution service in 500ms.
 if ! timeout 0.5 ping -c 1 remote.buildbuddy.io &>/dev/null; then
   # Network is spotty; disable remote execution.
-  echo "--remote_executor=" >>"$1"
+  echo "--remote_executor=" >>"$FORWARDED_BAZEL_ARGS_FILE"
 fi
 ```
 
@@ -378,19 +383,32 @@ positional_arg3
 --option4
 ```
 
+#### $FORWARDED_BAZEL_ARGS_FILE
+
+This is the path of a file that contains the forwarded Bazel args for the
+current invocation. These are the args that will be passed to Bazel after
+plugins run. The file uses a one-argument-per-line format.
+
+This environment variable will only be set for the `pre_bazel.sh` script in the
+plugin. Plugins can read and write this file to change the args passed to Bazel.
+For example, appending a line containing `--remote_executor=` disables remote
+execution for the invocation.
+
+In this file, `--config` flags are preserved as `--config` flags, and args from
+`.bazelrc` files are not expanded inline. To inspect the fully resolved Bazel
+configuration, read `RESOLVED_BAZEL_ARGS_FILE`.
+
 #### $RESOLVED_BAZEL_ARGS_FILE
 
 This is the path of a file that contains the resolved Bazel args for the current
 invocation. This includes args loaded from `.bazelrc` files and args expanded
 from any `--config=` flags. The file uses the same one-argument-per-line format
-as the forwarded Bazel args file passed as the first argument to
-`pre_bazel.sh`.
+as `FORWARDED_BAZEL_ARGS_FILE`.
 
 This environment variable will only be set for the `pre_bazel.sh` script in the
 plugin. Plugins can read this file to make decisions based on the effective
 Bazel configuration, but should not modify it. Changes to this file are ignored.
-To change the args passed to Bazel, modify the forwarded Bazel args file passed
-as `$1`.
+To change the args passed to Bazel, modify `FORWARDED_BAZEL_ARGS_FILE`.
 
 ### Examples
 


### PR DESCRIPTION
Follow up to https://github.com/buildbuddy-io/buildbuddy/pull/12062

In a subsequent PR, we will modify callers to use the forwarded args when invoking Bazelisk.