### PR TITLE
eventlog: trim blank progress tail

### DIFF
--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/backends/chunkstore"
@@ -464,7 +465,8 @@ type WriteWithTailCloser interface {
 // N lines.
 type ANSICursorBufferWriter struct {
 	WriteWithTailCloser
-	terminal *terminal.ScreenWriter
+	terminal          *terminal.ScreenWriter
+	seenCursorControl bool
 }
 
 func NewANSICursorBufferWriter(closer WriteWithTailCloser, terminal *terminal.ScreenWriter) *ANSICursorBufferWriter {
@@ -474,6 +476,9 @@ func NewANSICursorBufferWriter(closer WriteWithTailCloser, terminal *terminal.Sc
 func (w *ANSICursorBufferWriter) Write(ctx context.Context, p []byte) (int, error) {
 	if len(p) == 0 {
 		return w.WriteWithTailCloser.WriteWithTail(ctx, p, nil)
+	}
+	if containsCursorControl(p) {
+		w.seenCursorControl = true
 	}
 	if _, err := w.terminal.Write(p); err != nil {
 		return 0, err
@@ -487,5 +492,72 @@ func (w *ANSICursorBufferWriter) Write(ctx context.Context, p []byte) (int, erro
 }
 
 func (w *ANSICursorBufferWriter) Close(ctx context.Context) error {
+	if w.seenCursorControl {
+		// Bazel curses progress can leave cleared rows in the final terminal
+		// screen. Drop only those trailing blank rows before the volatile tail is
+		// flushed as durable log text.
+		trimmedTail := []byte(trimTrailingBlankANSILines(w.terminal.Render()))
+		if _, err := w.WriteWithTailCloser.WriteWithTail(ctx, []byte{}, trimmedTail); err != nil {
+			return err
+		}
+	}
 	return w.WriteWithTailCloser.Close(ctx)
+}
+
+func containsCursorControl(p []byte) bool {
+	if bytes.Contains(p, []byte{'\r'}) {
+		return true
+	}
+	for i := 0; i < len(p)-1; i++ {
+		if p[i] != '\x1b' || p[i+1] != '[' {
+			continue
+		}
+		for j := i + 2; j < len(p); j++ {
+			if p[j] < 0x40 || p[j] > 0x7e {
+				continue
+			}
+			if strings.ContainsRune("ABCDHJKsu", rune(p[j])) {
+				return true
+			}
+			i = j
+			break
+		}
+	}
+	return false
+}
+
+func trimTrailingBlankANSILines(s string) string {
+	end := len(s)
+	for end > 0 {
+		lineStart := strings.LastIndexByte(s[:end], '\n')
+		line := s[lineStart+1 : end]
+		if !isBlankANSILine(line) {
+			break
+		}
+		if lineStart < 0 {
+			return ""
+		}
+		end = lineStart
+	}
+	return s[:end]
+}
+
+func isBlankANSILine(line string) bool {
+	var b strings.Builder
+	inCSI := false
+	for i := 0; i < len(line); i++ {
+		if inCSI {
+			if line[i] >= 0x40 && line[i] <= 0x7e {
+				inCSI = false
+			}
+			continue
+		}
+		if line[i] == '\x1b' && i+1 < len(line) && line[i+1] == '[' {
+			inCSI = true
+			i++
+			continue
+		}
+		b.WriteByte(line[i])
+	}
+	return strings.TrimSpace(b.String()) == ""
 }

--- a/server/eventlog/eventlog_test.go
+++ b/server/eventlog/eventlog_test.go
@@ -173,7 +173,7 @@ func TestComplexScreenWriting(t *testing.T) {
 	}
 }
 
-func TestANSICursorBufferWriterCloseKeepsCursorControlBlankTail(t *testing.T) {
+func TestANSICursorBufferWriterCloseTrimsCursorControlBlankTail(t *testing.T) {
 	ctx := context.Background()
 	tailLog := &testLog{}
 	screen, err := terminal.NewScreenWriter(math.MaxInt, 4)
@@ -187,10 +187,10 @@ func TestANSICursorBufferWriterCloseKeepsCursorControlBlankTail(t *testing.T) {
 	require.NoError(t, w.Close(ctx))
 
 	assert.Contains(t, tailLog.String(), "INFO:")
-	assert.True(
+	assert.False(
 		t,
 		strings.HasSuffix(tailLog.String(), "\n\n"),
-		"cursor-control tail should show current blank-row behavior: %q",
+		"tail should not end with blank curses rows: %q",
 		tailLog.String(),
 	)
 }

--- a/server/eventlog/eventlog_test.go
+++ b/server/eventlog/eventlog_test.go
@@ -173,6 +173,47 @@ func TestComplexScreenWriting(t *testing.T) {
 	}
 }
 
+func TestANSICursorBufferWriterCloseKeepsCursorControlBlankTail(t *testing.T) {
+	ctx := context.Background()
+	tailLog := &testLog{}
+	screen, err := terminal.NewScreenWriter(math.MaxInt, 4)
+	require.NoError(t, err)
+	w := eventlog.NewANSICursorBufferWriter(tailLog, screen)
+
+	_, err = w.Write(ctx, []byte("INFO: start\n"))
+	require.NoError(t, err)
+	_, err = w.Write(ctx, []byte("\x1b[1A\x1b[K\x1b[32mINFO:\x1b[m\n\n\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close(ctx))
+
+	assert.Contains(t, tailLog.String(), "INFO:")
+	assert.True(
+		t,
+		strings.HasSuffix(tailLog.String(), "\n\n"),
+		"cursor-control tail should show current blank-row behavior: %q",
+		tailLog.String(),
+	)
+}
+
+func TestANSICursorBufferWriterClosePreservesNonCursorBlankTail(t *testing.T) {
+	ctx := context.Background()
+	tailLog := &testLog{}
+	screen, err := terminal.NewScreenWriter(math.MaxInt, 4)
+	require.NoError(t, err)
+	w := eventlog.NewANSICursorBufferWriter(tailLog, screen)
+
+	_, err = w.Write(ctx, []byte("INFO: start\n\n\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close(ctx))
+
+	assert.True(
+		t,
+		strings.HasSuffix(tailLog.String(), "\n\n"),
+		"non-cursor blank rows should be preserved: %q",
+		tailLog.String(),
+	)
+}
+
 // ansiDebugString replaces ANSI escape sequences with a string representation
 // that can be displayed as a diff without messing up the terminal.
 func ansiDebugString(s string) string {


### PR DESCRIPTION
BuildBuddy invocation logs can currently end with a block of empty rows
because Bazel sends curses progress updates. Bazel's --ui_actions_shown
flag controls how many running actions its terminal UI reserves. Larger
values can leave more cleared rows in the final terminal screen.

BuildBuddy flushes that tail when the log closes. If it is mostly empty,
the invocation can open at the bottom and appear blank until the user
scrolls upward.

Add a characterization test for the current tail shape. Then trim only
blank ANSI rows from cursor-control streams at close. Plain log output
still keeps intentional blank lines, so non-terminal output is not
collapsed.