### PR TITLE
Create+update `Usage` view during DB migration

### DIFF
--- a/enterprise/server/test/integration/clickhouse_schema/BUILD
+++ b/enterprise/server/test/integration/clickhouse_schema/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_test(
+    name = "clickhouse_schema_test",
+    srcs = ["clickhouse_schema_test.go"],
+    exec_properties = {
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "true",
+        "test.runner-recycling-key": "clickhouse25.3",
+        "test.workload-isolation-type": "firecracker",
+    },
+    tags = ["docker"],
+    deps = [
+        "//server/testutil/testclickhouse",
+        "//server/usage/sku",
+        "//server/util/clickhouse/schema",
+        "@com_github_clickhouse_clickhouse_go_v2//:clickhouse-go",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_gorm_driver_clickhouse//:clickhouse",
+        "@io_gorm_gorm//:gorm",
+    ],
+)

--- a/enterprise/server/test/integration/clickhouse_schema/clickhouse_schema_test.go
+++ b/enterprise/server/test/integration/clickhouse_schema/clickhouse_schema_test.go
@@ -1,0 +1,121 @@
+package clickhouse_schema_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testclickhouse"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	gormclickhouse "gorm.io/driver/clickhouse"
+)
+
+func TestUsageViewMigration_CreateNoopAndReplace(t *testing.T) {
+	db := openClickHouseDB(t)
+
+	// Initial migrations should create both RawUsage and the Usage view.
+	require.NoError(t, schema.RunMigrations(db))
+	insertRawUsage(t, db, 5)
+	assert.Equal(t, int64(5), queryUsageCount(t, db))
+
+	// Running migrations again against the actual ClickHouse-stored view query
+	// should be a no-op. This catches false drift caused by ClickHouse changing
+	// the saved SELECT formatting in system.tables.as_select.
+	initialModifiedAt := usageViewModifiedAt(t, db)
+	waitForNextClickHouseMetadataTick()
+	require.NoError(t, schema.RunMigrations(db))
+	assert.Equal(t, initialModifiedAt, usageViewModifiedAt(t, db))
+
+	// Simulate a manually drifted view definition. The next migration should
+	// detect the different query and replace the view definition.
+	require.NoError(t, db.Exec(`
+		CREATE OR REPLACE VIEW "Usage" AS
+		SELECT
+			group_id,
+			period_start,
+			sku,
+			labels,
+			SUM(count) * 0 AS count
+		FROM RawUsage FINAL
+		GROUP BY
+			group_id,
+			period_start,
+			sku,
+			labels
+	`).Error)
+	assert.Equal(t, int64(0), queryUsageCount(t, db))
+
+	driftedModifiedAt := usageViewModifiedAt(t, db)
+	waitForNextClickHouseMetadataTick()
+	require.NoError(t, schema.RunMigrations(db))
+	assert.True(t, usageViewModifiedAt(t, db).After(driftedModifiedAt))
+	assert.Equal(t, int64(5), queryUsageCount(t, db))
+}
+
+func openClickHouseDB(t *testing.T) *gorm.DB {
+	dsn := testclickhouse.Start(t, true /*=reuseServer*/)
+	options, err := clickhouse.ParseDSN(dsn)
+	require.NoError(t, err)
+	sqlDB := clickhouse.OpenDB(options)
+	t.Cleanup(func() {
+		require.NoError(t, sqlDB.Close())
+	})
+	db, err := gorm.Open(gormclickhouse.New(gormclickhouse.Config{
+		Conn:                         sqlDB,
+		DontSupportEmptyDefaultValue: true,
+	}))
+	require.NoError(t, err)
+	return db
+}
+
+func insertRawUsage(t *testing.T, db *gorm.DB, count int64) {
+	err := db.Create(&schema.RawUsage{
+		GroupID:     "GR1",
+		SKU:         sku.BuildEventsBESCount,
+		Labels:      map[sku.LabelName]sku.LabelValue{},
+		PeriodStart: time.Date(2026, 1, 2, 3, 4, 0, 0, time.UTC),
+		BufferID:    "test:redis",
+		Count:       count,
+	}).Error
+	require.NoError(t, err)
+}
+
+func queryUsageCount(t *testing.T, db *gorm.DB) int64 {
+	row := struct {
+		Count int64 `gorm:"column:count"`
+	}{}
+	err := db.Raw(`
+		SELECT count
+		FROM "Usage"
+		WHERE group_id = ? AND sku = ?
+	`, "GR1", sku.BuildEventsBESCount).Take(&row).Error
+	require.NoError(t, err)
+	return row.Count
+}
+
+func usageViewModifiedAt(t *testing.T, db *gorm.DB) time.Time {
+	row := struct {
+		MetadataModificationTime time.Time `gorm:"column:metadata_modification_time"`
+	}{}
+	err := db.Raw(`
+		SELECT metadata_modification_time
+		FROM system.tables
+		WHERE database = currentDatabase()
+			AND name = ?
+			AND engine = 'View'
+	`, (&schema.Usage{}).ViewName()).Take(&row).Error
+	require.NoError(t, err)
+	return row.MetadataModificationTime
+}
+
+func waitForNextClickHouseMetadataTick() {
+	// system.tables.metadata_modification_time is a DateTime, so it only has
+	// second precision. Wait just long enough for the next timestamp bucket.
+	now := time.Now()
+	time.Sleep(time.Second - time.Duration(now.Nanosecond()) + 10*time.Millisecond)
+}

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -58,20 +58,6 @@ func setupEnv(t *testing.T, opts ...testenv.TestEnvOption) *testenv.TestEnv {
 		flags.Set(t, "app.write_usage_to_olap_db", true)
 		err := clickhouse.Register(te)
 		require.NoError(t, err)
-
-		// Create the Usage view which is how we will actually query
-		// usage.
-		// TODO: move this to clickhouse schema package
-		dbh := te.GetOLAPDBHandle()
-		err = dbh.GORM(context.Background(), "create_usage_view").Exec(`
-			CREATE VIEW "Usage" AS
-			SELECT
-				group_id, period_start, sku, labels, SUM(count) AS count
-			FROM RawUsage FINAL
-			GROUP BY
-				group_id, period_start, sku, labels
-		`).Error
-		require.NoError(t, err)
 	}
 
 	redisTarget := testredis.Start(t).Target

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -2,7 +2,9 @@ package schema
 
 import (
 	"bufio"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -43,6 +45,19 @@ type Table interface {
 	AdditionalFields() []string
 }
 
+// View represents a ClickHouse "normal view", which is essentially just a saved
+// query.
+//
+// To define a new view, declare a new struct implementing this interface, and
+// add it to [getAllViews].
+//
+// For more on views, see:
+// https://clickhouse.com/docs/sql-reference/statements/create/view
+type View interface {
+	ViewName() string
+	ViewQuery() string
+}
+
 func getAllTables() []Table {
 	tbls := []Table{
 		&Invocation{},
@@ -52,6 +67,12 @@ func getAllTables() []Table {
 		&RawUsage{},
 	}
 	return tbls
+}
+
+func getAllViews() []View {
+	return []View{
+		&Usage{},
+	}
 }
 
 func getTableClusterOption() string {
@@ -516,6 +537,92 @@ type Usage struct {
 	Count       int64
 }
 
+func (u *Usage) ViewName() string {
+	return "Usage"
+}
+
+func (u *Usage) ViewQuery() string {
+	return "SELECT group_id, period_start, sku, labels, SUM(count) AS count " +
+		"FROM RawUsage FINAL GROUP BY group_id, period_start, sku, labels"
+}
+
+func execCreateView(gdb *gorm.DB, view View, replace, ifNotExists bool) error {
+	q := "CREATE"
+	if replace {
+		q += " OR REPLACE"
+	}
+	q += " VIEW"
+	if ifNotExists {
+		q += " IF NOT EXISTS"
+	}
+	q += fmt.Sprintf(" %q", view.ViewName())
+	if clusterOption := getTableClusterOption(); clusterOption != "" {
+		q += " " + clusterOption
+	}
+	q += " AS " + view.ViewQuery()
+	return gdb.Exec(q).Error
+}
+
+func ensureView(gdb *gorm.DB, view View) error {
+	expectedQuery := view.ViewQuery()
+	existingView, err := lookupExistingView(gdb, view.ViewName())
+	if err != nil {
+		return err
+	}
+	if existingView == nil {
+		// Another app may create the view after this app observes it as
+		// missing, so use IF NOT EXISTS to make concurrent startup harmless.
+		return execCreateView(gdb, view, false /*=replace*/, true /*=ifNotExists*/)
+	}
+	if sameViewQuery(existingView.SelectQuery, expectedQuery, existingView.Database) {
+		return nil
+	}
+	return execCreateView(gdb, view, true /*=replace*/, false /*=ifNotExists*/)
+}
+
+type viewMetadata struct {
+	// Database is the DB where the view is defined.
+	Database string `gorm:"column:current_database"`
+
+	// SelectQuery is the saved SELECT query for the view. We compare it against
+	// ViewQuery to decide whether startup migrations need to replace the view.
+	SelectQuery string `gorm:"column:as_select"`
+
+	// Engine is the table engine - should always be "View" for views.
+	Engine string `gorm:"column:engine"`
+}
+
+func lookupExistingView(gdb *gorm.DB, viewName string) (*viewMetadata, error) {
+	row := &viewMetadata{}
+	err := gdb.Raw(`
+		SELECT currentDatabase() AS current_database, engine, as_select
+		FROM system.tables
+		WHERE database = currentDatabase() AND name = ?
+	`, viewName).Row().Scan(&row.Database, &row.Engine, &row.SelectQuery)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if row.Engine != "View" {
+		return nil, status.FailedPreconditionErrorf("%q exists but has ClickHouse engine %q, not View", viewName, row.Engine)
+	}
+	return row, nil
+}
+
+func sameViewQuery(a, b, currentDatabase string) bool {
+	return normalizeViewQuery(a, currentDatabase) == normalizeViewQuery(b, currentDatabase)
+}
+
+func normalizeViewQuery(query, currentDatabase string) string {
+	query = strings.ReplaceAll(query, "`", "")
+	if currentDatabase != "" {
+		query = strings.ReplaceAll(query, currentDatabase+".", "")
+	}
+	return strings.ToLower(strings.Join(strings.Fields(query), " "))
+}
+
 // hasProjection checks whether a projection exist in the clickhouse
 // schema.
 // gorm-clickhouse doesn't support migration projection.
@@ -605,6 +712,11 @@ func RunMigrations(gdb *gorm.DB) error {
 		gdb = gdb.Set("gorm:table_options", t.TableOptions(versionStr))
 		if err := gdb.AutoMigrate(t); err != nil {
 			return err
+		}
+	}
+	for _, v := range getAllViews() {
+		if err := ensureView(gdb, v); err != nil {
+			return status.InternalErrorf("ensure view %q: %s", v.ViewName(), err)
 		}
 	}
 	// Add Projection/

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -716,7 +716,7 @@ func RunMigrations(gdb *gorm.DB) error {
 	}
 	for _, v := range getAllViews() {
 		if err := ensureView(gdb, v); err != nil {
-			return status.InternalErrorf("ensure view %q: %s", v.ViewName(), err)
+			return status.WrapErrorf(err, "ensure view %q", v.ViewName())
 		}
 	}
 	// Add Projection/

--- a/server/util/clickhouse/schema/schema_test.go
+++ b/server/util/clickhouse/schema/schema_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/go-faker/faker/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/go-faker/faker/v4"
 )
 
 func TestSchemaInSync(t *testing.T) {
@@ -178,4 +177,31 @@ SETTINGS index_granularity = 8192
 	assert.Contains(t, projectionNames, "projection_commits")
 	assert.Contains(t, projectionNames, "projection_targets")
 
+}
+
+func TestUsageViewQuery(t *testing.T) {
+	const expectedQuery = "SELECT group_id, period_start, sku, labels, SUM(count) AS count " +
+		"FROM RawUsage FINAL GROUP BY group_id, period_start, sku, labels"
+
+	// RawUsage may contain duplicate flushes from Redis buffers, so the view
+	// deduplicates with FINAL before aggregating counts by Usage dimensions.
+	assert.Equal(t, expectedQuery, (&Usage{}).ViewQuery())
+}
+
+func TestSameViewQuery(t *testing.T) {
+	// ClickHouse may store the saved SELECT with different formatting and
+	// function casing, so avoid replacing the view when the query is
+	// semantically the same for this generated view.
+	assert.True(t, sameViewQuery(
+		"SELECT `group_id`, `period_start`, `sku`, `labels`, sum(`count`) AS `count` FROM `db_name`.`RawUsage` FINAL GROUP BY `group_id`, `period_start`, `sku`, `labels`",
+		"SELECT group_id, period_start, sku, labels, SUM(count) AS count FROM RawUsage FINAL GROUP BY group_id, period_start, sku, labels",
+		"db_name",
+	))
+
+	// A different grouping or aggregate expression should trigger replacement.
+	assert.False(t, sameViewQuery(
+		"SELECT group_id, period_start, sku, SUM(count) AS count FROM RawUsage FINAL GROUP BY group_id, period_start, sku",
+		"SELECT group_id, period_start, sku, labels, SUM(count) AS count FROM RawUsage FINAL GROUP BY group_id, period_start, sku, labels",
+		"",
+	))
 }


### PR DESCRIPTION
Create a `Usage` view based on `RawUsage`, using `FINAL` to ensure that we dedupe usage rows to avoid overcounting.

I found that usage queries are extremely fast, even when using final, back when I evaluated this approach initially.