### PR TITLE
[CLI] Only parse and resolve args through BazelArgs struct

### DIFF
--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -165,6 +165,8 @@ func (a *BazelArgs) GetAllFlagsWithName(flagName string) []string {
 
 // StripBBFlag removes a CLI-only string flag from the args (so it is
 // not passed to Bazelisk) and returns its value.
+// TODO(#7389): If we support setting CLI flags via config, make sure we support reading them correctly
+// from the resolved args.
 func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
 	// GetCLICommandOptionVal removes the flag from a.forwarded in place.
 	flagVal, err := parser.GetCLICommandOptionVal(a.forwarded, flagName)
@@ -177,6 +179,8 @@ func (a *BazelArgs) StripBBFlag(flagName string) (string, error) {
 
 // StripBBBoolFlag removes a CLI-only bool flag from the forwarded args (so it
 // is not passed to Bazelisk) and returns whether it was set.
+// TODO(#7389): If we support setting CLI flags via config, make sure we support reading them correctly
+// from the resolved args.
 func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
 	// IsCLICommandOptionSet removes the flag from a.forwarded in place.
 	set, err := parser.IsCLICommandOptionSet(a.forwarded, flagName)
@@ -185,6 +189,14 @@ func (a *BazelArgs) StripBBBoolFlag(flagName string) (bool, error) {
 	}
 	a.resolved.RemoveCommandOptions(flagName)
 	return set, nil
+}
+
+// StripBBStartupOptions removes CLI-only startup options and returns the removed options.
+// TODO(#7389): If we support setting CLI flags via config, make sure we support reading them correctly.
+func (a *BazelArgs) StripBBStartupOptions(optionNames ...string) []*parsed.IndexedOption {
+	a.forwarded.RemoveStartupOptions(optionNames...)
+	removed := a.resolved.RemoveStartupOptions(optionNames...)
+	return removed
 }
 
 // GetRemoteHeaderVal returns the value of a --remote_header flag matching the

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -296,6 +296,27 @@ func TestStripBBFlag(t *testing.T) {
 	}
 }
 
+func TestStripBBStartupOptions(t *testing.T) {
+	setupWorkspace(t, "")
+
+	args, err := NewBazelArgs([]string{"--watch", "--watcher_flags=--from_rc", "--watcher_flags=--from_cli", "test", "//foo"})
+	require.NoError(t, err)
+
+	removed := args.StripBBStartupOptions("watch", "watcher_flags")
+	var removedArgs []string
+	for _, opt := range removed {
+		removedArgs = append(removedArgs, opt.Option.Normalized().Format()...)
+	}
+
+	require.Equal(t, []string{
+		"--watch",
+		"--watcher_flags=--from_rc",
+		"--watcher_flags=--from_cli",
+	}, removedArgs)
+	require.Equal(t, []string{"test", "//foo"}, args.Forwarded())
+	require.Equal(t, []string{"--ignore_all_rc_files", "test", "//foo"}, args.Resolved())
+}
+
 func TestFindLast(t *testing.T) {
 	for _, tc := range []struct {
 		Name          string

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -163,21 +163,17 @@ func run() (exitCode int, err error) {
 
 	// This was neither a bb CLI command nor a help command; interpret it as a
 	// bazel command.
-	parsedArgs, err := parser.ParseArgs(os.Args[1:])
+	bazelArgsStr, execArgs := arg.SplitExecutableArgs(os.Args[1:])
+	bazelArgs, err := arg.NewBazelArgs(bazelArgsStr)
 	if err != nil {
 		return -1, err
 	}
-	Configure(parsedArgs.RemoveStartupOptions(logoptdef.Verbose.Name(), watchoptdef.Watch.Name(), watchoptdef.WatcherFlags.Name()))
+	Configure(bazelArgs.StripBBStartupOptions(logoptdef.Verbose.Name(), watchoptdef.Watch.Name(), watchoptdef.WatcherFlags.Name()))
 	StartupDebug(start)
-	parsedArgs, err = parser.ResolveArgs(parsedArgs)
-	if err != nil {
-		return -1, err
-	}
-	canonicalizedArgs := parsedArgs.Canonicalized()
 
 	// If none of the CLI subcommand handlers were triggered, assume we should
 	// handle it as a bazel command.
-	return handleBazelCommand(start, canonicalizedArgs.Format(), originalArgs)
+	return handleBazelCommand(start, bazelArgs, execArgs, originalArgs)
 }
 
 // interpretAsBBCliCommand strips the bb options from the beginning of a bb
@@ -291,9 +287,9 @@ func runHelp(args *parsed.OrderedArgs) (int, error) {
 //
 // originalArgs contains the command as originally typed. We pass it as
 // EXPLICIT_COMMAND_LINE metadata to the bazel invocation.
-func handleBazelCommand(start time.Time, args []string, originalArgs []string) (exitCode int, err error) {
+func handleBazelCommand(start time.Time, bazelArgs *arg.BazelArgs, execArgs []string, originalArgs []string) (exitCode int, err error) {
 	// Maybe run interactively (watching for changes to files).
-	if exitCode, err := watcher.Watch(append([]string{os.Args[0]}, args...)); exitCode >= 0 || err != nil {
+	if exitCode, err := watcher.Watch(append([]string{os.Args[0]}, arg.JoinExecutableArgs(bazelArgs.Forwarded(), execArgs)...)); exitCode >= 0 || err != nil {
 		return exitCode, err
 	}
 
@@ -320,13 +316,13 @@ func handleBazelCommand(start time.Time, args []string, originalArgs []string) (
 		}
 	}()
 
-	setupResult, err := setup.Setup(args, tempDir)
+	setupResult, err := setup.Setup(bazelArgs, execArgs, tempDir)
 	if err != nil {
 		return 1, err
 	}
 	plugins := setupResult.Plugins
-	bazelArgs := setupResult.BazelArgs
-	execArgs := setupResult.ExecArgs
+	bazelArgs = setupResult.BazelArgs
+	execArgs = setupResult.ExecArgs
 	sidecar := setupResult.Sidecar
 
 	// Show a picker if the target is omitted. Note: we do this after expanding

--- a/cli/setup/setup.go
+++ b/cli/setup/setup.go
@@ -29,15 +29,9 @@ type Result struct {
 
 // Setup prepares us to run a bazel command. It loads plugins, handles auth,
 // configures the sidecar, and runs pre-bazel handlers.
-func Setup(args []string, tempDir string) (*Result, error) {
+func Setup(bazelArgs *arg.BazelArgs, execArgs []string, tempDir string) (*Result, error) {
 	// Load plugins
 	plugins, err := plugin.LoadAll(tempDir)
-	if err != nil {
-		return nil, err
-	}
-
-	bazelArgsStr, execArgs := arg.SplitExecutableArgs(args)
-	bazelArgs, err := arg.NewBazelArgs(bazelArgsStr)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/versioncmd/versioncmd.go
+++ b/cli/versioncmd/versioncmd.go
@@ -38,7 +38,13 @@ func runBazelVersion(args []string) (int, error) {
 	// the command to bazel
 	args = append([]string{"version"}, args...)
 
-	setupResult, err := setup.Setup(args, tempDir)
+	bazelArgsStr, execArgs := arg.SplitExecutableArgs(args)
+	bazelArgs, err := arg.NewBazelArgs(bazelArgsStr)
+	if err != nil {
+		return 1, err
+	}
+
+	setupResult, err := setup.Setup(bazelArgs, execArgs, tempDir)
 	if err != nil {
 		return 1, status.WrapError(err, "bazel setup")
 	}


### PR DESCRIPTION
This PR cleans up the old code that parses and resolves args for the CLI. That should be handled within BazelArgs now