### PR TITLE
Port a few kernel configs to experimental 6.1 kernel

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -249,8 +249,8 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
     )
     http_file(
         name = "org_kernel_git_linux_kernel-vmlinux-6.1",
-        sha256 = "39c4877e80bdf15c6fbd6b3cf9417a65684a97c204da384c2c01e04b597138bf",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/linux/vmlinux-x86_64-v6.1-39c4877e80bdf15c6fbd6b3cf9417a65684a97c204da384c2c01e04b597138bf"],
+        sha256 = "10ec6f850aff3fe98fdaa603b299fb22ad67d5013b7a28801a7c6b75e4c3406f",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/linux/vmlinux-x86_64-v6.1-10ec6f850aff3fe98fdaa603b299fb22ad67d5013b7a28801a7c6b75e4c3406f"],
         executable = True,
     )
     http_file(

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -122,6 +122,9 @@ go_test(
     args = [
         "--executor.enable_local_snapshot_sharing=true",
         "--executor.enable_remote_snapshot_sharing=true",
+        # Uncomment to test the 6.1 kernel.
+        # TODO: turn this on by default once the 6.1 kernel is used everywhere
+        # "--executor.firecracker_enable_linux_6_1=true",
     ],
     exec_properties = {
         "test.Pool": "bare",

--- a/enterprise/vmsupport/kernel/microvm-kernel-x86_64-v6.1.config
+++ b/enterprise/vmsupport/kernel/microvm-kernel-x86_64-v6.1.config
@@ -1,9 +1,11 @@
 # Config copied from https://github.com/firecracker-microvm/firecracker/blob/main/resources/guest_configs/microvm-kernel-ci-x86_64-6.1.config
 # BuildBuddy-specific modifications:
-# - Set CONFIG_PCI=y (see https://github.com/firecracker-microvm/firecracker/issues/4881)
+# - Set CONFIG_PCI=y, CONFIG_PCIEPORTBUS=y, CONFIG_PCI_MSI=y, and CONFIG_VIRTIO_PCI=y for PCI support
 # - Set CONFIG_FUSE_FS=y for FUSE support
 # - Set CONFIG_TUN=y for networking
 # - Enable CONFIG_NF_TABLES plus IPv4 / IPv6 raw table support for Docker networking
+# - Enable CONFIG_NFT_COUNTER because Docker bridge/port-publish rule setup emits nft `counter` expressions
+# - Enable CONFIG_NFT_FIB_IPV4 because Docker's LOCAL addrtype matching for published ports requires IPv4 fib expressions
 
 #
 # Automatically generated file; DO NOT EDIT.
@@ -1101,6 +1103,7 @@ CONFIG_NF_NAT_MASQUERADE=y
 CONFIG_NETFILTER_SYNPROXY=y
 CONFIG_NF_TABLES=y
 CONFIG_NF_TABLES_INET=y
+CONFIG_NFT_COUNTER=y
 CONFIG_NFT_CT=y
 CONFIG_NFT_MASQ=y
 CONFIG_NFT_REDIR=y
@@ -1200,6 +1203,7 @@ CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
 #
 CONFIG_NF_DEFRAG_IPV4=y
 CONFIG_NF_TABLES_IPV4=y
+CONFIG_NFT_FIB_IPV4=y
 # CONFIG_NF_SOCKET_IPV4 is not set
 # CONFIG_NF_TPROXY_IPV4 is not set
 # CONFIG_NF_DUP_IPV4 is not set
@@ -1434,6 +1438,8 @@ CONFIG_HAVE_EISA=y
 # CONFIG_EISA is not set
 CONFIG_HAVE_PCI=y
 CONFIG_PCI=y
+CONFIG_PCIEPORTBUS=y
+CONFIG_PCI_MSI=y
 # CONFIG_PCCARD is not set
 
 #
@@ -2137,6 +2143,7 @@ CONFIG_VMGENID=y
 CONFIG_VIRTIO_ANCHOR=y
 CONFIG_VIRTIO=y
 CONFIG_VIRTIO_MENU=y
+CONFIG_VIRTIO_PCI=y
 CONFIG_VIRTIO_BALLOON=y
 # CONFIG_VIRTIO_MEM is not set
 # CONFIG_VIRTIO_INPUT is not set


### PR DESCRIPTION
 A customer wants to run some actions that require a newer kernel. Updating the 6.1 kernel to bring it up to speed with the 5.15 kernel. If this goes well, we could also consider enabling this for more customers.