### PR TITLE
fix(CDC): don't attempt chunk read if chunking is disabled

### DIFF
--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -141,7 +141,7 @@ func ShouldReadChunkedOnProxy(ctx context.Context, efp interfaces.ExperimentFlag
 	return digestSizeBytes > MaxChunkSizeBytes() &&
 		limit == 0 &&
 		(efp == nil ||
-			efp.Boolean(ctx, "cache_proxy.attempt_chunked_reads", true))
+			(Enabled(ctx, efp) && efp.Boolean(ctx, "cache_proxy.attempt_chunked_reads", true)))
 }
 
 type WriteFunc func([]byte) error

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -557,8 +557,12 @@ func TestEnabled_UsesExperimentFlag(t *testing.T) {
 
 func TestShouldReadChunkedOnProxy_UsesExperimentFlag(t *testing.T) {
 	ctx := context.Background()
+	assert.True(t, chunking.ShouldReadChunkedOnProxy(ctx, nil, chunking.MaxChunkSizeBytes()+1, 0, 0))
 	assert.False(t, chunking.ShouldReadChunkedOnProxy(ctx, booleanFlagProvider{
 		values: map[string]bool{"cache_proxy.attempt_chunked_reads": false},
+	}, chunking.MaxChunkSizeBytes()+1, 0, 0))
+	assert.False(t, chunking.ShouldReadChunkedOnProxy(ctx, booleanFlagProvider{
+		values: map[string]bool{"cache.chunking_enabled": false},
 	}, chunking.MaxChunkSizeBytes()+1, 0, 0))
 }
 


### PR DESCRIPTION
Turning `chunking_enabled=false` should turn off all CDC paths. No need to attempt chunk reads for a group where it's disabled.

Keep it enabled for BYOP, when efp == nil