### PR TITLE
Add functionality to `cli/parser/parsed` library

### DIFF
--- a/cli/parser/options/options.go
+++ b/cli/parser/options/options.go
@@ -300,6 +300,10 @@ type Option interface {
 	BoolLike() BoolLike
 }
 
+type ValueType interface {
+	string | []string | bool | BoolOrEnum
+}
+
 // The base type for all option types. Handles a lot of formatting and option
 // representation transformations.
 type optionBase struct {
@@ -901,7 +905,7 @@ func NameFilter[O Option](name string) func(O) bool {
 // options in order. It should only be called with opts that all share the same
 // definition, and an initial value that matches the type of value that
 // definition implies. Otherwise, its output will be nonsensical.
-func AccumulateValues[O Option, T string | []string | bool | BoolOrEnum, S seq.Sequenceable[O]](acc T, opts S) (T, error) {
+func AccumulateValues[O Option, T ValueType, S seq.Sequenceable[O]](acc T, opts S) (T, error) {
 	p := any(&acc)
 	for opt := range seq.Sequence[O](opts) {
 		switch p := p.(type) {

--- a/cli/parser/parsed/BUILD
+++ b/cli/parser/parsed/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
@@ -14,5 +14,17 @@ go_library(
         "//cli/parser/options",
         "//server/util/lib/set",
         "//server/util/shlex",
+    ],
+)
+
+go_test(
+    name = "parsed_test",
+    srcs = ["parsed_test.go"],
+    deps = [
+        ":parsed",
+        "//cli/parser/arguments",
+        "//cli/parser/options",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -442,6 +442,11 @@ func (a *OrderedArgs) RemoveStartupOptions(optionNames ...string) []*IndexedOpti
 	return removeOptions[*StartupOption, *Command](a, optionNames...)
 }
 
+// RemoveAndAccumulateStartupOption removes all the startup options with
+// optionName from the passed args and accumulates all of the options into a
+// single value, with the zero value of the type T as the starting accumulator
+// value. It exists primarily to strip options from the arguments that will be
+// passed to bazel and resolve them into a value to be used by the caller.
 func RemoveAndAccumulateStartupOption[T options.ValueType](a *OrderedArgs, optionName string) (T, error) {
 	opts := a.RemoveStartupOptions(optionName)
 	return accumulateHelper[T](opts)
@@ -451,6 +456,11 @@ func (a *OrderedArgs) RemoveCommandOptions(optionNames ...string) []*IndexedOpti
 	return removeOptions[*CommandOption, *DoubleDash](a, optionNames...)
 }
 
+// RemoveAndAccumulateCommandpOption removes all the command options with
+// optionName from the passed args and accumulates all of the options into a
+// single value, with the zero value of the type T as the starting accumulator
+// value. It exists primarily to strip options from the arguments that will be
+// passed to bazel and resolve them into a value to be used by the caller.
 func RemoveAndAccumulateCommandOption[T options.ValueType](a *OrderedArgs, optionName string) (T, error) {
 	opts := a.RemoveCommandOptions(optionName)
 	return accumulateHelper[T](opts)

--- a/cli/parser/parsed/parsed.go
+++ b/cli/parser/parsed/parsed.go
@@ -97,6 +97,12 @@ type Args interface {
 	// location for that type of argument. Startup options
 	Append(...arguments.Argument) error
 
+	// Prepend prepends the given options by inserting them in the first valid
+	// location for that type of option. It does not support arguments because,
+	// due to the nature of the bazel subcommand, it is inherently poorly defined
+	// what prepending an argument would even mean.
+	Prepend(...options.Option) error
+
 	// SplitExecutableArgs returns the args split up between the args that bazel
 	// consumes directly and the args that will passed to the executable bazel is
 	// running. This is a concept that only makes sense when using the `run`
@@ -436,8 +442,18 @@ func (a *OrderedArgs) RemoveStartupOptions(optionNames ...string) []*IndexedOpti
 	return removeOptions[*StartupOption, *Command](a, optionNames...)
 }
 
+func RemoveAndAccumulateStartupOption[T options.ValueType](a *OrderedArgs, optionName string) (T, error) {
+	opts := a.RemoveStartupOptions(optionName)
+	return accumulateHelper[T](opts)
+}
+
 func (a *OrderedArgs) RemoveCommandOptions(optionNames ...string) []*IndexedOption {
 	return removeOptions[*CommandOption, *DoubleDash](a, optionNames...)
+}
+
+func RemoveAndAccumulateCommandOption[T options.ValueType](a *OrderedArgs, optionName string) (T, error) {
+	opts := a.RemoveCommandOptions(optionName)
+	return accumulateHelper[T](opts)
 }
 
 func removeOptions[DesiredOption ClassifiedOption, Terminates Classified](a *OrderedArgs, optionNames ...string) []*IndexedOption {
@@ -459,6 +475,63 @@ func removeOptions[DesiredOption ClassifiedOption, Terminates Classified](a *Ord
 		}
 	}
 	return removed
+}
+
+func accumulateHelper[T options.ValueType, O options.Option](opts []O) (T, error) {
+	acc := *new(T)
+	switch any(acc).(type) {
+	case string:
+		return options.AccumulateValues[O](acc, opts)
+	case []string:
+		return options.AccumulateValues[O](acc, opts)
+	case bool:
+		return options.AccumulateValues[O](acc, opts)
+	case options.BoolOrEnum:
+		return options.AccumulateValues[O](acc, opts)
+	default:
+		return acc, fmt.Errorf("Accumulator is of unsupported type %T.", acc)
+	}
+}
+
+func (a *OrderedArgs) Prepend(opts ...options.Option) error {
+	commandOptionInsertIndex := -1
+	for _, opt := range slices.Backward(opts) {
+		var err error
+		if commandOptionInsertIndex, err = a.prependOption(opt, commandOptionInsertIndex); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *OrderedArgs) prependOption(option options.Option, commandIndex int) (int, error) {
+	if commandIndex == -1 {
+		if commandIndex, _ = Find[*Command](a.Args); commandIndex == -1 {
+			commandIndex = len(a.Args)
+		}
+	}
+	command := "startup"
+	if commandIndex < len(a.Args) {
+		command = a.Args[commandIndex].GetValue()
+	}
+	if option.PluginID() == options.UnknownBuiltinPluginID && !option.HasSupportedCommands() {
+		// If this is an unknown option with no listed supported commands, assume it
+		// supports this command (or "startup" in the rare case that no command was
+		// provided.
+		option.GetDefinition().AddSupportedCommand(command)
+	}
+	if option.Supports("startup") {
+		a.Args = slices.Insert(a.Args, 0, arguments.Argument(option))
+		return commandIndex + 1, nil
+	}
+	if command == "startup" {
+		return commandIndex, fmt.Errorf("Failed to append Option: option '%s' is not a startup option and no command was provided.", option.Name())
+	}
+	if !option.Supports(command) {
+		return commandIndex, fmt.Errorf("Failed to append Option: option '%s' is not a startup option and the command '%s' does not support it.", option.Name(), command)
+	}
+	a.Args = slices.Insert(a.Args, commandIndex+1, arguments.Argument(option))
+	return commandIndex, nil
 }
 
 func (a *OrderedArgs) Append(args ...arguments.Argument) error {
@@ -961,6 +1034,32 @@ func (a *PartitionedArgs) RemoveCommandOptions(optionNames ...string) []*Indexed
 		}
 	}
 	return removed
+}
+
+func (a *PartitionedArgs) Prepend(opts ...options.Option) error {
+	for _, opt := range slices.Backward(opts) {
+		if opt.PluginID() == options.UnknownBuiltinPluginID && !opt.HasSupportedCommands() {
+			// If this is an unknown option with no listed supported commands, assume it
+			// supports this command (or "startup" in the rare case that no command was
+			// provided.
+			command := "startup"
+			if a.Command != nil {
+				command = *a.Command
+			}
+			opt.GetDefinition().AddSupportedCommand(command)
+		}
+		switch {
+		case opt.Supports("startup"):
+			a.StartupOptions = append([]options.Option{opt}, a.StartupOptions...)
+		case a.Command == nil:
+			return fmt.Errorf("Failed to append Option: option '%s' is not a startup option and no command was provided.", opt.Name())
+		case opt.Supports(*a.Command):
+			a.CommandOptions = append([]options.Option{opt}, a.CommandOptions...)
+		default:
+			return fmt.Errorf("Failed to append Option: option '%s' is not a startup option and the command '%s' does not support it.", opt.Name(), *a.Command)
+		}
+	}
+	return nil
 }
 
 func (a *PartitionedArgs) Append(args ...arguments.Argument) error {

--- a/cli/parser/parsed/parsed_test.go
+++ b/cli/parser/parsed/parsed_test.go
@@ -1,0 +1,290 @@
+package parsed_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/arguments"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/options"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser/parsed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustNewOption(t *testing.T, optName string, v *string, d *options.Definition) options.Option {
+	opt, err := options.NewOption(optName, v, d)
+	require.NoError(t, err)
+	return opt
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestRemoveAndAccumulateStartupOption(t *testing.T) {
+	startupOptionBoolName := "startup_option_bool"
+	startupOptionBoolDefinition := options.NewDefinition(
+		startupOptionBoolName,
+		options.WithNegative(),
+		options.WithSupportFor("startup"),
+	)
+	startupOptionMultiName := "startup_option_multi"
+	startupOptionMultiDefinition := options.NewDefinition(
+		startupOptionMultiName,
+		options.WithMulti(),
+		options.WithRequiresValue(),
+		options.WithSupportFor("startup"),
+	)
+	startupOptionRequiresValueName := "startup_option_requires_value"
+	startupOptionRequiresValueDefinition := options.NewDefinition(
+		startupOptionRequiresValueName,
+		options.WithRequiresValue(),
+		options.WithSupportFor("startup"),
+	)
+	commandOptionBoolName := "command_option_bool"
+	commandOptionBoolDefinition := options.NewDefinition(
+		commandOptionBoolName,
+		options.WithNegative(),
+		options.WithSupportFor("command"),
+	)
+	commandOptionMultiName := "command_option_multi"
+	commandOptionMultiDefinition := options.NewDefinition(
+		commandOptionMultiName,
+		options.WithMulti(),
+		options.WithRequiresValue(),
+		options.WithSupportFor("command"),
+	)
+	commandOptionRequiresValueName := "command_option_requires_value"
+	commandOptionRequiresValueDefinition := options.NewDefinition(
+		commandOptionRequiresValueName,
+		options.WithRequiresValue(),
+		options.WithSupportFor("command"),
+	)
+	args := &parsed.OrderedArgs{
+		Args: []arguments.Argument{
+			mustNewOption(t, "no"+startupOptionBoolName, nil, startupOptionBoolDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("foo"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionBoolName, nil, startupOptionBoolDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, ptr("foo"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, ptr("bar"), startupOptionRequiresValueDefinition),
+			&arguments.PositionalArgument{Value: "command"},
+			mustNewOption(t, "no"+commandOptionBoolName, nil, commandOptionBoolDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionBoolName, nil, commandOptionBoolDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("bar"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, ptr("bar"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, ptr("foo"), commandOptionRequiresValueDefinition),
+		},
+	}
+
+	startupOptionBoolValue, err := parsed.RemoveAndAccumulateStartupOption[bool](args, startupOptionBoolName)
+	require.NoError(t, err)
+	assert.Equal(t, startupOptionBoolValue, true)
+
+	startupOptionBoolValue, err = parsed.RemoveAndAccumulateStartupOption[bool](args, startupOptionBoolName)
+	require.NoError(t, err)
+	assert.Equal(t, startupOptionBoolValue, false)
+
+	startupOptionMultiValue, err := parsed.RemoveAndAccumulateStartupOption[[]string](args, startupOptionMultiName)
+	require.NoError(t, err)
+	assert.Equal(t, startupOptionMultiValue, []string{"foo", "bar", "bar"})
+
+	startupOptionMultiValue, err = parsed.RemoveAndAccumulateStartupOption[[]string](args, startupOptionMultiName)
+	require.NoError(t, err)
+	assert.Equal(t, startupOptionMultiValue, []string(nil))
+
+	startupOptionRequiresValueValue, err := parsed.RemoveAndAccumulateStartupOption[string](args, startupOptionRequiresValueName)
+	require.NoError(t, err)
+	assert.Equal(t, startupOptionRequiresValueValue, "bar")
+
+	startupOptionRequiresValueValue, err = parsed.RemoveAndAccumulateStartupOption[string](args, startupOptionRequiresValueName)
+	require.NoError(t, err)
+	assert.Equal(t, startupOptionRequiresValueValue, "")
+
+}
+
+func TestRemoveAndAccumulateCommandOption(t *testing.T) {
+
+	startupOptionBoolName := "startup_option_bool"
+	startupOptionBoolDefinition := options.NewDefinition(
+		startupOptionBoolName,
+		options.WithNegative(),
+		options.WithSupportFor("startup"),
+	)
+	startupOptionMultiName := "startup_option_multi"
+	startupOptionMultiDefinition := options.NewDefinition(
+		startupOptionMultiName,
+		options.WithMulti(),
+		options.WithRequiresValue(),
+		options.WithSupportFor("startup"),
+	)
+	startupOptionRequiresValueName := "startup_option_requires_value"
+	startupOptionRequiresValueDefinition := options.NewDefinition(
+		startupOptionRequiresValueName,
+		options.WithRequiresValue(),
+		options.WithSupportFor("startup"),
+	)
+	commandOptionBoolName := "command_option_bool"
+	commandOptionBoolDefinition := options.NewDefinition(
+		commandOptionBoolName,
+		options.WithNegative(),
+		options.WithSupportFor("command"),
+	)
+	commandOptionMultiName := "command_option_multi"
+	commandOptionMultiDefinition := options.NewDefinition(
+		commandOptionMultiName,
+		options.WithMulti(),
+		options.WithRequiresValue(),
+		options.WithSupportFor("command"),
+	)
+	commandOptionRequiresValueName := "command_option_requires_value"
+	commandOptionRequiresValueDefinition := options.NewDefinition(
+		commandOptionRequiresValueName,
+		options.WithRequiresValue(),
+		options.WithSupportFor("command"),
+	)
+	args := &parsed.OrderedArgs{
+		Args: []arguments.Argument{
+			mustNewOption(t, "no"+startupOptionBoolName, nil, startupOptionBoolDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("foo"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionBoolName, nil, startupOptionBoolDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, ptr("foo"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, ptr("bar"), startupOptionRequiresValueDefinition),
+			&arguments.PositionalArgument{Value: "command"},
+			mustNewOption(t, "no"+commandOptionBoolName, nil, commandOptionBoolDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionBoolName, nil, commandOptionBoolDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("bar"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, ptr("bar"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, ptr("foo"), commandOptionRequiresValueDefinition),
+		},
+	}
+
+	commandOptionBoolValue, err := parsed.RemoveAndAccumulateCommandOption[bool](args, commandOptionBoolName)
+	require.NoError(t, err)
+	assert.Equal(t, commandOptionBoolValue, true)
+
+	commandOptionBoolValue, err = parsed.RemoveAndAccumulateCommandOption[bool](args, commandOptionBoolName)
+	require.NoError(t, err)
+	assert.Equal(t, commandOptionBoolValue, false)
+
+	commandOptionMultiValue, err := parsed.RemoveAndAccumulateCommandOption[[]string](args, commandOptionMultiName)
+	require.NoError(t, err)
+	assert.Equal(t, commandOptionMultiValue, []string{"foo", "bar", "foo"})
+
+	commandOptionMultiValue, err = parsed.RemoveAndAccumulateCommandOption[[]string](args, commandOptionMultiName)
+	require.NoError(t, err)
+	assert.Equal(t, commandOptionMultiValue, []string(nil))
+
+	commandOptionRequiresValueValue, err := parsed.RemoveAndAccumulateCommandOption[string](args, commandOptionRequiresValueName)
+	require.NoError(t, err)
+	assert.Equal(t, commandOptionRequiresValueValue, "foo")
+
+	commandOptionRequiresValueValue, err = parsed.RemoveAndAccumulateCommandOption[string](args, commandOptionRequiresValueName)
+	require.NoError(t, err)
+	assert.Equal(t, commandOptionRequiresValueValue, "")
+
+}
+
+func TestPrepend(t *testing.T) {
+
+	startupOptionBoolName := "startup_option_bool"
+	startupOptionBoolDefinition := options.NewDefinition(
+		startupOptionBoolName,
+		options.WithNegative(),
+		options.WithSupportFor("startup"),
+	)
+	startupOptionMultiName := "startup_option_multi"
+	startupOptionMultiDefinition := options.NewDefinition(
+		startupOptionMultiName,
+		options.WithMulti(),
+		options.WithRequiresValue(),
+		options.WithSupportFor("startup"),
+	)
+	startupOptionRequiresValueName := "startup_option_requires_value"
+	startupOptionRequiresValueDefinition := options.NewDefinition(
+		startupOptionRequiresValueName,
+		options.WithRequiresValue(),
+		options.WithSupportFor("startup"),
+	)
+	commandOptionBoolName := "command_option_bool"
+	commandOptionBoolDefinition := options.NewDefinition(
+		commandOptionBoolName,
+		options.WithNegative(),
+		options.WithSupportFor("command"),
+	)
+	commandOptionMultiName := "command_option_multi"
+	commandOptionMultiDefinition := options.NewDefinition(
+		commandOptionMultiName,
+		options.WithMulti(),
+		options.WithRequiresValue(),
+		options.WithSupportFor("command"),
+	)
+	commandOptionRequiresValueName := "command_option_requires_value"
+	commandOptionRequiresValueDefinition := options.NewDefinition(
+		commandOptionRequiresValueName,
+		options.WithRequiresValue(),
+		options.WithSupportFor("command"),
+	)
+	args := &parsed.OrderedArgs{
+		Args: []arguments.Argument{
+			mustNewOption(t, "no"+startupOptionBoolName, nil, startupOptionBoolDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("foo"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionBoolName, nil, startupOptionBoolDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, ptr("foo"), startupOptionRequiresValueDefinition),
+			mustNewOption(t, startupOptionMultiName, ptr("bar"), startupOptionMultiDefinition),
+			mustNewOption(t, startupOptionRequiresValueName, ptr("bar"), startupOptionRequiresValueDefinition),
+			&arguments.PositionalArgument{Value: "command"},
+			mustNewOption(t, "no"+commandOptionBoolName, nil, commandOptionBoolDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionBoolName, nil, commandOptionBoolDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("bar"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, ptr("bar"), commandOptionRequiresValueDefinition),
+			mustNewOption(t, commandOptionMultiName, ptr("foo"), commandOptionMultiDefinition),
+			mustNewOption(t, commandOptionRequiresValueName, ptr("foo"), commandOptionRequiresValueDefinition),
+		},
+	}
+	args.Prepend(
+		mustNewOption(t, "no"+commandOptionBoolName, nil, commandOptionBoolDefinition),
+		mustNewOption(t, commandOptionMultiName, ptr("foofoo"), commandOptionMultiDefinition),
+		mustNewOption(t, commandOptionBoolName, nil, commandOptionBoolDefinition),
+		mustNewOption(t, "no"+startupOptionBoolName, nil, startupOptionBoolDefinition),
+		mustNewOption(t, startupOptionMultiName, ptr("foobar"), startupOptionMultiDefinition),
+		mustNewOption(t, startupOptionBoolName, nil, startupOptionBoolDefinition),
+	)
+
+	assert.Equal(
+		t,
+		[]string{
+			"--nostartup_option_bool",
+			"--startup_option_multi=foobar",
+			"--startup_option_bool",
+			"--nostartup_option_bool",
+			"--startup_option_multi=foo",
+			"--startup_option_bool",
+			"--startup_option_multi=bar",
+			"--startup_option_requires_value=foo",
+			"--startup_option_multi=bar",
+			"--startup_option_requires_value=bar",
+			"command",
+			"--nocommand_option_bool",
+			"--command_option_multi=foofoo",
+			"--command_option_bool",
+			"--nocommand_option_bool",
+			"--command_option_multi=foo",
+			"--command_option_bool",
+			"--command_option_multi=bar",
+			"--command_option_requires_value=bar",
+			"--command_option_multi=foo",
+			"--command_option_requires_value=foo",
+		},
+		args.Format(),
+	)
+
+}


### PR DESCRIPTION
Adds `RemoveAndAccumulate`, which is useful for bb-cli exclusive options and plugin options, and `Prepend`, which helps with the migration from the old `arg` lib paradigm.
