### PR TITLE
Small improvements for jasmine node tests

### DIFF
--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -1,9 +1,12 @@
 import { config } from "../../proto/config_ts_proto";
 
 declare const window: Window & {
-  buildbuddyConfig: config.FrontendConfig;
   gtag?: (method: string, ...args: any[]) => void;
 };
+
+declare global {
+  var buildbuddyConfig: config.FrontendConfig | undefined;
+}
 
 /**
  * Returns the default frontend config, matching the server defaults. During
@@ -54,7 +57,7 @@ export class Capabilities {
 
     this.config = new config.FrontendConfig({
       ...defaultConfig(),
-      ...window.buildbuddyConfig,
+      ...(globalThis.buildbuddyConfig || {}),
     });
 
     // Note: Please don't add any new config fields below;

--- a/app/invocation/invocation_model_test.ts
+++ b/app/invocation/invocation_model_test.ts
@@ -1,21 +1,6 @@
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import { invocation } from "../../proto/invocation_ts_proto";
-
-declare function require(path: string): any;
-
-const testGlobal = globalThis as unknown as { window?: Record<string, unknown> };
-
-testGlobal.window = {
-  buildbuddyConfig: {},
-  location: {
-    host: "localhost",
-    pathname: "/",
-    search: "",
-    hash: "",
-  },
-};
-
-const InvocationModel = require("./invocation_model").default as typeof import("./invocation_model").default;
+import InvocationModel from "./invocation_model";
 
 function newInvocationModelWithBuildMetadata(metadata: Record<string, string>) {
   return new InvocationModel(

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -92,7 +92,7 @@ class RpcService {
       }
     }
 
-    (window as any)._rpcService = this;
+    (globalThis as any)._rpcService = this;
   }
 
   debuggingEnabled(): boolean {


### PR DESCRIPTION
This should reduce the need for tests to use `require()` and monkey-patch `window`, which codex usually does whenever it tries to write certain frontend unit tests.