### PR TITLE
Force compressed reads in cachetools.GetBlob for large blobs

### DIFF
--- a/server/cache/dirtools/dirtools_test.go
+++ b/server/cache/dirtools/dirtools_test.go
@@ -1747,7 +1747,11 @@ func TestDownloadTree_ChunkedInputFiles_ReusesCachedChunksAndUpdatesLocations(t 
 	}
 
 	chunkReadCount := func(d *repb.Digest) int {
-		return byteStream.readCount(digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256).DownloadString())
+		// cachetools.GetBlob upgrades large reads to ZSTD regardless of the
+		// enable_download_compression flag, so look up the compressed name.
+		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_SHA256)
+		rn.SetCompressor(repb.Compressor_ZSTD)
+		return byteStream.readCount(rn.DownloadString())
 	}
 
 	download(fileNode1, blob1)

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -11,7 +11,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"slices"
 	"strings"
 	"sync"
@@ -173,11 +172,11 @@ func getBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.CASR
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	if r.GetCompressor() == repb.Compressor_IDENTITY && *log.LogLevel == "debug" {
-		stack := debug.Stack()
-		if !bytes.Contains(stack, []byte("ocicache.FetchBlobMetadataFromCache")) {
-			log.CtxDebugf(ctx, "cachetools.GetBlob called with identity compressor for resource %v. Stack trace:\n%s", r.ToProto().String(), stack)
-		}
+	if r.GetCompressor() == repb.Compressor_IDENTITY && r.GetDigest().GetSizeBytes() > 100 {
+		// Force compressed download for large blobs since the server accepts
+		// both formats and this can save bandwidth and time.
+		r = r.Clone()
+		r.SetCompressor(repb.Compressor_ZSTD)
 	}
 
 	req := &bspb.ReadRequest{

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -796,10 +796,12 @@ func TestGetBlobChunked_ManyChunksPartialLocal(t *testing.T) {
 		},
 	}
 
+	// Chunks are 1 MiB, so cachetools.GetBlob will upgrade reads to ZSTD.
 	bsData := make(map[string][]byte, numChunks)
 	for i, cd := range chunkDigests {
 		rn := digest.NewCASResourceName(cd, testInstance, repb.DigestFunction_BLAKE3)
-		bsData[rn.DownloadString()] = chunks[i]
+		rn.SetCompressor(repb.Compressor_ZSTD)
+		bsData[rn.DownloadString()] = compression.CompressZstd(nil, chunks[i])
 	}
 	bs := &fakeBytestreamClient{mu: &sync.Mutex{}, data: bsData}
 

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -270,6 +270,10 @@ func (r *CASResourceName) NewUploadString() string {
 	return r.UploadString(guuid.New().String())
 }
 
+func (r *CASResourceName) Clone() *CASResourceName {
+	return &CASResourceName{ResourceName{rn: r.ToProto().CloneVT()}}
+}
+
 type ACResourceName struct {
 	ResourceName
 }


### PR DESCRIPTION
This will save bandwidth. The bytestream server will compress the blob if the cache doesn't support compression.

The only callers I found without compression come from cachetools.GetBlobAsProto, coming from `ocicache.FetchBlobMetadataFromCache`, and when executors fetch trees (`cachetools.getSubtree`).

I removed my debug lines since I don't think I can get much more from dev.