### PR TITLE
Fix thresholds for CDC to work with adjustable sizes

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -118,7 +118,7 @@ func New(env environment.Env) (*ByteStreamServerProxy, error) {
 		efp:                env.GetExperimentFlagProvider(),
 		localCache:         env.GetCache(),
 		remoteCAS:          env.GetContentAddressableStorageClient(),
-		bufPool:            bytebufferpool.VariableSize(int(compression.ZstdCompressBound(chunking.MaxChunkSizeBytes()))),
+		bufPool:            bytebufferpool.VariableSize(int(compression.ZstdCompressBound(chunking.MaxSupportedChunkSizeBytes()))),
 	}, nil
 }
 

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -315,7 +315,7 @@ func TestChunkUploaderGroupsFindMissingAndDedupesWithinBlob(t *testing.T) {
 	require.NoError(t, err)
 	s := &ByteStreamServerProxy{
 		remoteCAS: repb.NewContentAddressableStorageClient(conn),
-		bufPool:   bytebufferpool.VariableSize(int(chunking.MaxChunkSizeBytes())),
+		bufPool:   bytebufferpool.VariableSize(int(compression.ZstdCompressBound(chunking.MaxSupportedChunkSizeBytes()))),
 		efp:       fp,
 	}
 	uploader, err := newChunkUploader(context.Background(), s, "instance", repb.DigestFunction_BLAKE3)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -591,7 +591,7 @@ func (s *ExecutionServer) getActionResultFromCache(ctx context.Context, d *diges
 		return nil, err
 	}
 	chunkingEnabled := chunking.Enabled(ctx, s.env.GetExperimentFlagProvider())
-	if err := action_cache_server.ValidateActionResult(ctx, s.cache, d.GetInstanceName(), d.GetDigestFunction(), chunkingEnabled, actionResult); err != nil {
+	if err := action_cache_server.ValidateActionResult(ctx, s.cache, d.GetInstanceName(), d.GetDigestFunction(), chunkingEnabled, s.env.GetExperimentFlagProvider(), actionResult); err != nil {
 		return nil, err
 	}
 	return actionResult, nil

--- a/server/cache/dirtools/dirtools.go
+++ b/server/cache/dirtools/dirtools.go
@@ -1053,7 +1053,7 @@ func (ff *BatchFileFetcher) shouldDownloadChunked(fileNode *repb.FileNode) bool 
 	return ff.opts != nil &&
 		ff.opts.ChunkedInputFiles &&
 		ff.env.GetContentAddressableStorageClient() != nil &&
-		fileNode.GetDigest().GetSizeBytes() > chunking.MaxChunkSizeBytes()
+		fileNode.GetDigest().GetSizeBytes() > chunking.MaxSupportedChunkSizeBytes()
 }
 
 // downloadBlobToFile writes fileNode into path, creating or truncating it.

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -65,7 +65,7 @@ func NewActionCacheServer(env environment.Env) (*ActionCacheServer, error) {
 	}, nil
 }
 
-func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, digests []*rspb.ResourceName) error {
+func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, digests []*rspb.ResourceName) error {
 	missing, err := cache.FindMissing(ctx, digests)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	}
 	checker := chunking.NewMissingChunkChecker(cache)
 	for _, d := range missing {
-		if d.GetSizeBytes() <= chunking.MinChunkedReadFallbackSizeBytes() {
+		if d.GetSizeBytes() <= chunking.MinChunkedReadFallbackSizeBytes(ctx, efp) {
 			return status.NotFoundErrorf("ActionResult output file %q not found in cache", digest.String(d))
 		}
 		manifest, err := chunking.LoadManifest(ctx, cache, d, instanceName, digestFunction)
@@ -96,7 +96,7 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	return nil
 }
 
-func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteInstanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, r *repb.ActionResult) error {
+func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteInstanceName string, digestFunction repb.DigestFunction_Value, chunkingEnabled bool, efp interfaces.ExperimentFlagProvider, r *repb.ActionResult) error {
 	outputFileDigests := make([]*rspb.ResourceName, 0, len(r.OutputFiles))
 	mu := &sync.Mutex{}
 	appendDigest := func(d *repb.Digest) {
@@ -139,7 +139,7 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 		return err
 	}
 
-	return checkFilesExist(ctx, cache, remoteInstanceName, digestFunction, chunkingEnabled, outputFileDigests)
+	return checkFilesExist(ctx, cache, remoteInstanceName, digestFunction, chunkingEnabled, efp, outputFileDigests)
 }
 
 func setWorkerMetadata(ar *repb.ActionResult) {
@@ -197,7 +197,7 @@ func (s *ActionCacheServer) fetchActionResult(ctx context.Context, rn *digest.AC
 	}
 
 	chunkingEnabled := chunking.Enabled(ctx, s.env.GetExperimentFlagProvider())
-	if err := ValidateActionResult(ctx, s.cache, req.GetInstanceName(), req.GetDigestFunction(), chunkingEnabled, rsp); err != nil {
+	if err := ValidateActionResult(ctx, s.cache, req.GetInstanceName(), req.GetDigestFunction(), chunkingEnabled, s.env.GetExperimentFlagProvider(), rsp); err != nil {
 		return nil, nil, 0, status.NotFoundErrorf("ActionResult (%s) not found: %s", req.GetActionDigest(), err)
 	}
 	// The default limit on incoming gRPC messages is 4MB and Bazel doesn't

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -639,10 +639,10 @@ func TestValidateActionResult_ChunkedOutputFile(t *testing.T) {
 	}
 
 	chunkingEnabled := true
-	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, chunkingEnabled, ar))
+	require.NoError(t, action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, chunkingEnabled, te.GetExperimentFlagProvider(), ar))
 
 	chunkingDisabled := false
-	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, chunkingDisabled, ar)
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, chunkingDisabled, te.GetExperimentFlagProvider(), ar)
 	require.Error(t, err)
 	assert.True(t, status.IsNotFoundError(err))
 }

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -96,7 +96,7 @@ func NewByteStreamServer(env environment.Env) (*ByteStreamServer, error) {
 	return &ByteStreamServer{
 		env:        env,
 		cache:      cache,
-		bufferPool: bytebufferpool.VariableSize(max(*remote_cache_config.ReadBufSizeBytes, compressBufSize, int(compression.ZstdCompressBound(chunking.MaxChunkSizeBytes())))),
+		bufferPool: bytebufferpool.VariableSize(max(*remote_cache_config.ReadBufSizeBytes, compressBufSize, int(compression.ZstdCompressBound(chunking.MaxSupportedChunkSizeBytes())))),
 		warner:     bazel_deprecation.NewWarner(env),
 	}, nil
 }

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -1160,7 +1160,7 @@ func TestNewByteStreamServer_BufferPoolAccommodatesCompressedChunkOverhead(t *te
 	s, err := NewByteStreamServer(te)
 	require.NoError(t, err)
 
-	want := compression.ZstdCompressBound(chunking.MaxChunkSizeBytes())
+	want := compression.ZstdCompressBound(chunking.MaxSupportedChunkSizeBytes())
 	buf := s.bufferPool.Get(want)
 	defer s.bufferPool.Put(buf)
 

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -82,16 +82,24 @@ func FastCDCWriteParams(ctx context.Context, efp interfaces.ExperimentFlagProvid
 	return params
 }
 
-func MaxChunkSizeBytes() int64 {
-	return *avgChunkSizeBytes * 4
+func MaxChunkSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
+	return AvgChunkSizeBytes(ctx, efp) * 4
+}
+
+// MaxSupportedChunkSizeBytes is the process-wide chunk size buffer consumers
+// must support. This supports temporarily doubling cache.avg_chunk_size_override
+// from the default 512KiB to 1MiB; do not set the override higher without
+// increasing this and auditing buffer consumers.
+func MaxSupportedChunkSizeBytes() int64 {
+	return 4 * 1024 * 1024
 }
 
 // MinChunkedReadFallbackSizeBytes can be configured independently from the
 // write threshold so server-side miss fallback paths can still read older
 // chunked blobs that were written with a smaller chunk size, but is clamped to
 // at most MaxChunkSizeBytes().
-func MinChunkedReadFallbackSizeBytes() int64 {
-	return min(*minChunkedReadFallbackSizeBytes, MaxChunkSizeBytes())
+func MinChunkedReadFallbackSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
+	return min(*minChunkedReadFallbackSizeBytes, MaxChunkSizeBytes(ctx, efp))
 }
 
 func MaxWriteSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
@@ -132,13 +140,13 @@ func Enabled(ctx context.Context, efp interfaces.ExperimentFlagProvider) bool {
 func ShouldReadChunked(ctx context.Context, efp interfaces.ExperimentFlagProvider, digestSizeBytes, offset, limit int64) bool {
 	// Check digest first since it's faster than reading efp flag
 	// and very likely to be false.
-	return digestSizeBytes > MinChunkedReadFallbackSizeBytes() &&
+	return digestSizeBytes > MinChunkedReadFallbackSizeBytes(ctx, efp) &&
 		limit == 0 &&
 		Enabled(ctx, efp)
 }
 
 func ShouldReadChunkedOnProxy(ctx context.Context, efp interfaces.ExperimentFlagProvider, digestSizeBytes, offset, limit int64) bool {
-	return digestSizeBytes > MaxChunkSizeBytes() &&
+	return digestSizeBytes > MaxChunkSizeBytes(ctx, efp) &&
 		limit == 0 &&
 		(efp == nil ||
 			(Enabled(ctx, efp) && efp.Boolean(ctx, "cache_proxy.attempt_chunked_reads", true)))
@@ -475,7 +483,15 @@ func (cm *Manifest) verifyChunks(ctx context.Context, cache interfaces.Cache) er
 	readCompressed := cache.SupportsCompressor(repb.Compressor_ZSTD)
 	var decompressedData []byte
 	if readCompressed {
-		decompressedData = make([]byte, 0, MaxChunkSizeBytes())
+		var maxChunkSize int64
+		for _, chunkDigest := range cm.ChunkDigests {
+			chunkSize := chunkDigest.GetSizeBytes()
+			if chunkSize < 0 || chunkSize > MaxSupportedChunkSizeBytes() {
+				return status.InvalidArgumentErrorf("invalid manifest: chunk %v has invalid size %d for blob %v", chunkDigest.GetHash(), chunkSize, cm.BlobDigest.GetHash())
+			}
+			maxChunkSize = max(maxChunkSize, chunkSize)
+		}
+		decompressedData = make([]byte, 0, int(maxChunkSize))
 	}
 	resources := make([]*rspb.ResourceName, 0, batchSize)
 	for chunkDigestsPart := range slices.Chunk(cm.ChunkDigests, batchSize) {
@@ -499,9 +515,13 @@ func (cm *Manifest) verifyChunks(ctx context.Context, cache interfaces.Cache) er
 				return status.InvalidArgumentErrorf("invalid manifest: chunk %v not found in the CAS for blob %v", r.GetDigest().GetHash(), cm.BlobDigest.GetHash())
 			}
 			if readCompressed {
+				chunkSize := r.GetDigest().GetSizeBytes()
 				decompressedData, err = compression.DecompressZstd(decompressedData, chunkData)
 				if err != nil {
 					return status.WrapErrorf(err, "decompress chunk %s for blob %s", r.GetDigest().GetHash(), cm.BlobDigest.GetHash())
+				}
+				if int64(len(decompressedData)) != chunkSize {
+					return status.InvalidArgumentErrorf("invalid manifest: chunk %v decompressed to %d bytes, expected %d bytes for blob %v", r.GetDigest().GetHash(), len(decompressedData), chunkSize, cm.BlobDigest.GetHash())
 				}
 				chunkData = decompressedData
 			}

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -132,7 +132,9 @@ func TestReadFallbackThresholdClampsToMaxChunkSize(t *testing.T) {
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 4*1024*1024+1)
 
 	require.NoError(t, chunking.ValidateConfig())
-	require.Equal(t, chunking.MaxChunkSizeBytes(), chunking.MinChunkedReadFallbackSizeBytes())
+	ctx := context.Background()
+	efp := booleanFlagProvider{}
+	require.Equal(t, chunking.MaxChunkSizeBytes(ctx, efp), chunking.MinChunkedReadFallbackSizeBytes(ctx, efp))
 }
 
 func TestChunker_DeterministicChunking(t *testing.T) {
@@ -540,6 +542,10 @@ func (p booleanFlagProvider) Boolean(ctx context.Context, flagName string, defau
 	return v
 }
 
+func (p booleanFlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
+	return defaultValue
+}
+
 func TestEnabled_FallsBackToExperimentFlag(t *testing.T) {
 	ctx := context.Background()
 	assert.True(t, chunking.Enabled(ctx, nil))
@@ -557,13 +563,14 @@ func TestEnabled_UsesExperimentFlag(t *testing.T) {
 
 func TestShouldReadChunkedOnProxy_UsesExperimentFlag(t *testing.T) {
 	ctx := context.Background()
-	assert.True(t, chunking.ShouldReadChunkedOnProxy(ctx, nil, chunking.MaxChunkSizeBytes()+1, 0, 0))
+	size := chunking.MaxChunkSizeBytes(ctx, nil) + 1
+	assert.True(t, chunking.ShouldReadChunkedOnProxy(ctx, nil, size, 0, 0))
 	assert.False(t, chunking.ShouldReadChunkedOnProxy(ctx, booleanFlagProvider{
 		values: map[string]bool{"cache_proxy.attempt_chunked_reads": false},
-	}, chunking.MaxChunkSizeBytes()+1, 0, 0))
+	}, size, 0, 0))
 	assert.False(t, chunking.ShouldReadChunkedOnProxy(ctx, booleanFlagProvider{
 		values: map[string]bool{"cache.chunking_enabled": false},
-	}, chunking.MaxChunkSizeBytes()+1, 0, 0))
+	}, size, 0, 0))
 }
 
 func BenchmarkStore(b *testing.B) {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -129,13 +129,14 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 	// deploys: without the header, a chunk sized above the server's current
 	// MaxChunkSizeBytes would slip past the size guard below and trigger a
 	// spurious (and expensive) AC manifest lookup.
-	if len(missing) > 0 && !cdc.IsChunked(ctx) && chunking.Enabled(ctx, s.env.GetExperimentFlagProvider()) {
+	if efp := s.env.GetExperimentFlagProvider(); len(missing) > 0 && !cdc.IsChunked(ctx) && chunking.Enabled(ctx, efp) {
 		checker := chunking.NewMissingChunkChecker(s.cache)
+		maxChunkSizeBytes := chunking.MaxChunkSizeBytes(ctx, efp)
 
 		// https://go.dev/wiki/SliceTricks#filtering-without-allocating
 		stillMissing := missing[:0]
 		for _, d := range missing {
-			if d.GetSizeBytes() <= chunking.MaxChunkSizeBytes() {
+			if d.GetSizeBytes() <= maxChunkSizeBytes {
 				stillMissing = append(stillMissing, d)
 				continue
 			}
@@ -367,7 +368,12 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 	cacheRequest := make([]*rspb.ResourceName, 0, len(req.Digests))
 	rsp.Responses = make([]*repb.BatchReadBlobsResponse_Response, 0, len(req.Digests))
 	clientAcceptsZstd := remote_cache_config.ZstdTranscodingEnabled() && clientAcceptsCompressor(req.AcceptableCompressors, repb.Compressor_ZSTD)
-	chunkingEnabled := chunking.Enabled(ctx, s.env.GetExperimentFlagProvider())
+	efp := s.env.GetExperimentFlagProvider()
+	chunkingEnabled := chunking.Enabled(ctx, efp)
+	chunkedReadFallbackSizeBytes := int64(0)
+	if chunkingEnabled {
+		chunkedReadFallbackSizeBytes = chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
+	}
 	readZstd := clientAcceptsZstd && s.cache.SupportsCompressor(repb.Compressor_ZSTD)
 
 	requestedResources := make([]*digest.ResourceName, 0, len(req.GetDigests()))
@@ -407,7 +413,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 		// It's unexpected, but BatchReadBlobs may be used for blobs that are
 		// large enough to be chunked. If the blob was not found and it's large
 		// enough to be chunked, try to reassemble it from CDC chunks.
-		if (!ok || os.IsNotExist(err)) && rn.GetDigest().GetSizeBytes() > chunking.MinChunkedReadFallbackSizeBytes() && chunkingEnabled {
+		if (!ok || os.IsNotExist(err)) && chunkingEnabled && rn.GetDigest().GetSizeBytes() > chunkedReadFallbackSizeBytes {
 			if assembled, assembleErr := s.readChunkedBlob(ctx, rn.GetDigest(), req.GetInstanceName(), req.GetDigestFunction(), readZstd); assembleErr == nil {
 				data = assembled
 				ok = true


### PR DESCRIPTION
## Variables

| Variable / helper | Meaning |
| --- | --- |
| `AvgChunkSizeBytes(ctx, efp)` | Group-specific average chunk size. |
| `MaxChunkSizeBytes(ctx, efp)` | Group-specific max chunk size: avg * 4. |
| `MaxSupportedChunkSizeBytes()` | Process-wide supported max chunk size: `4MiB`. |
| `MinChunkedReadFallbackSizeBytes(ctx, efp)` | Read fallback threshold, clamped to group-specific max chunk size. |

## Threshold Choices

- **BS/Read compression buffer:** `MaxSupportedChunkSizeBytes()` to avoid grow/allocs and `io.ErrShortBuffer`.
- **Proxy BS/Read compression buffer:** `MaxSupportedChunkSizeBytes()` to avoid grow/allocs and `io.ErrShortBuffer`.
- **Dirtools input download SplitBlob eligibility:** `MaxSupportedChunkSizeBytes()` because executors do not have efp.
- **BS/Read fallback:** `MinChunkedReadFallbackSizeBytes(ctx, efp)` to read old smaller writes.
- **BatchReadBlobs fallback:** `MinChunkedReadFallbackSizeBytes(ctx, efp)` to read old smaller writes.
- **ValidateActionResult output file availability:** `MinChunkedReadFallbackSizeBytes(ctx, efp)` so AC results stay valid for old smaller writes.

## Request-Scoped Group-Specific Uses

- Capabilities FastCDC params
- Executor task creation for output upload
- Proxy intercept-and-chunk write eligibility
- Proxy chunked read eligibility
- Whole-blob FindMissingBlobs manifest fallback guard
- Manifest `verifyChunks` compressed buffer

# Testing:

1. Ran app, proxy with flagd, and proxy without flagd.
2. Used separate cache dirs and run roots for master vs. PR branch.
3. Sent ByteStream read/write plus direct `SpliceBlob` / `SplitBlob` traffic through both proxies.
4. Tested `3MiB`, `6MiB`, and `12MiB` blobs, with `3MiB` direct splice chunks.
5. Ran `512KiB -> 1MiB -> 512KiB`: old blobs, old + new blobs, then old + new + even-newer blobs.
6. Verified read byte counts and SHA256 digests to catch short reads or corruption.
7. Reproduced master `SplitBlob` `NotFound` for missing manifests; ByteStream fallback still succeeded.
8. Ran the same sequence on the PR branch; rollout and rollback passed.
9. Observed no buffer overloads, short reads, digest mismatches, or zstd/chunk decompression failures.