### PR TITLE
cli: create install directory

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -31,8 +31,11 @@ install_buildbuddy_cli() (
   echo >&2 "Downloading $latest_binary_url"
   curl -fSL "$latest_binary_url" -o "$tempfile"
   chmod 0755 "$tempfile"
-  echo >&2 "Will write the CLI to /usr/local/bin - this may ask for your password."
-  sudo mv "$tempfile" /usr/local/bin/bb
+  install_path="/usr/local/bin/bb"
+  install_dir=$(dirname "$install_path")
+  echo >&2 "Will write the CLI to $install_dir - this may ask for your password."
+  sudo mkdir -p "$install_dir"
+  sudo mv "$tempfile" "$install_path"
 )
 
 install_buildbuddy_cli "$@"


### PR DESCRIPTION
Installing the CLI on a machine without /usr/local/bin failed while
moving the downloaded binary:

    mv: rename buildbuddy.q8JOA to /usr/local/bin/bb:
    No such file or directory

Create the install directory before the move so that the default install
path works even when /usr/local/bin has not been created yet.
