### PR TITLE
[FC] Add metrics for execution error reasons

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2529,7 +2529,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 		c.observeStageDuration("task_lifecycle", timeSinceContainerInit)
 		c.observeStageDuration("exec", execDuration)
 		c.emitCOWAndUFFDMetrics(stage) // Emit metrics for the current stage, even if it failed.
-		c.emitFirecrackerErrorMetric(ctx, result, string(result.AuxiliaryLogs[vmLogTailFileName]))
+		c.emitFirecrackerErrorMetric(result, string(result.AuxiliaryLogs[vmLogTailFileName]))
 	}()
 
 	if c.fsLayout == nil {
@@ -3494,15 +3494,18 @@ func (c *FirecrackerContainer) parseOOMError(logTail string) error {
 	return status.ResourceExhaustedErrorf("some processes ran out of memory, and were killed:\n%s", oomLines.String())
 }
 
-func (c *FirecrackerContainer) emitFirecrackerErrorMetric(ctx context.Context, result *interfaces.CommandResult, logTail string) {
+func (c *FirecrackerContainer) emitFirecrackerErrorMetric(result *interfaces.CommandResult, logTail string) {
 	if result == nil || result.Error == nil {
 		return
 	}
-	if status.IsDeadlineExceededError(result.Error) || status.IsCanceledError(result.Error) {
+	if status.IsDeadlineExceededError(result.Error) ||
+		status.IsCanceledError(result.Error) ||
+		errors.Is(result.Error, context.DeadlineExceeded) ||
+		errors.Is(result.Error, context.Canceled) {
 		return
 	}
 
-	reasons := c.firecrackerErrorReasons(ctx, result.Error, logTail)
+	reasons := c.firecrackerErrorReasons(result.Error, logTail)
 	for _, reason := range reasons {
 		metrics.FirecrackerErrorCount.With(prometheus.Labels{
 			metrics.FirecrackerErrorReason: reason,
@@ -3510,7 +3513,7 @@ func (c *FirecrackerContainer) emitFirecrackerErrorMetric(ctx context.Context, r
 	}
 }
 
-func (c *FirecrackerContainer) firecrackerErrorReasons(ctx context.Context, execErr error, logTail string) []string {
+func (c *FirecrackerContainer) firecrackerErrorReasons(execErr error, logTail string) []string {
 	errorReasons := []string{}
 	msg := strings.ToLower(execErr.Error())
 
@@ -3528,6 +3531,10 @@ func (c *FirecrackerContainer) firecrackerErrorReasons(ctx context.Context, exec
 	}
 	if strings.Contains(logTail, "failed to update balloon stats, missing descriptor.") {
 		errorReasons = append(errorReasons, "balloon_stats_missing_descriptor")
+	}
+
+	if len(errorReasons) == 0 {
+		errorReasons = append(errorReasons, "unknown")
 	}
 
 	return errorReasons

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2529,6 +2529,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 		c.observeStageDuration("task_lifecycle", timeSinceContainerInit)
 		c.observeStageDuration("exec", execDuration)
 		c.emitCOWAndUFFDMetrics(stage) // Emit metrics for the current stage, even if it failed.
+		c.emitFirecrackerErrorMetric(ctx, result, string(result.AuxiliaryLogs[vmLogTailFileName]))
 	}()
 
 	if c.fsLayout == nil {
@@ -3491,6 +3492,45 @@ func (c *FirecrackerContainer) parseOOMError(logTail string) error {
 		}
 	}
 	return status.ResourceExhaustedErrorf("some processes ran out of memory, and were killed:\n%s", oomLines.String())
+}
+
+func (c *FirecrackerContainer) emitFirecrackerErrorMetric(ctx context.Context, result *interfaces.CommandResult, logTail string) {
+	if result == nil || result.Error == nil {
+		return
+	}
+	if status.IsDeadlineExceededError(result.Error) || status.IsCanceledError(result.Error) {
+		return
+	}
+
+	reasons := c.firecrackerErrorReasons(ctx, result.Error, logTail)
+	for _, reason := range reasons {
+		metrics.FirecrackerErrorCount.With(prometheus.Labels{
+			metrics.FirecrackerErrorReason: reason,
+		}).Inc()
+	}
+}
+
+func (c *FirecrackerContainer) firecrackerErrorReasons(ctx context.Context, execErr error, logTail string) []string {
+	errorReasons := []string{}
+	msg := strings.ToLower(execErr.Error())
+
+	if strings.Contains(msg, "vm health check failed") {
+		errorReasons = append(errorReasons, "vm_health_check_failed")
+	}
+	if strings.Contains(msg, "signal: killed") {
+		errorReasons = append(errorReasons, "signal_killed")
+	}
+	if strings.Contains(logTail, "connection reset by peer") {
+		errorReasons = append(errorReasons, "connection_reset_by_peer")
+	}
+	if strings.Contains(logTail, "vsock: error reading from backing stream") {
+		errorReasons = append(errorReasons, "vsock_connection_reset")
+	}
+	if strings.Contains(logTail, "failed to update balloon stats, missing descriptor.") {
+		errorReasons = append(errorReasons, "balloon_stats_missing_descriptor")
+	}
+
+	return errorReasons
 }
 
 // parseSegFault looks for segfaults in the kernel logs and returns an error if found.

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -124,6 +124,9 @@ const (
 	// Reason for a runner not being added to the runner pool.
 	RunnerPoolFailedRecycleReason = "reason"
 
+	// Reason for a Firecracker task execution failure.
+	FirecrackerErrorReason = "reason"
+
 	// Effective workload isolation type used for an executed task, such as
 	// "docker", "podman", "firecracker", or "none".
 	IsolationTypeLabel = "isolation"
@@ -1665,6 +1668,16 @@ var (
 	}, []string{
 		CreatedFromSnapshot,
 	})
+
+	FirecrackerErrorCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "execution_error_count",
+		Help:      "Count of Firecracker task execution errors, labeled by reason.",
+	}, []string{
+		FirecrackerErrorReason,
+	})
+
 
 	SnapshotRemoteCacheUploadSizeBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1678,7 +1678,6 @@ var (
 		FirecrackerErrorReason,
 	})
 
-
 	SnapshotRemoteCacheUploadSizeBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",


### PR DESCRIPTION
I'd like an easier way to correlated specific execution errors with node-level metrics. 

Note that a single alert can emit the metric multiple times, with different reason fields. 