### PR TITLE
Store recycle-runner in ClickHouse

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -443,6 +443,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 				executionProto.RequestedMilliCpu = properties.EstimatedMilliCPU
 				executionProto.RequestedFreeDiskBytes = properties.EstimatedFreeDiskBytes
 				executionProto.RequestedPool = properties.Pool
+				executionProto.RecycleRunner = properties.RecycleRunner
 			}
 
 			schedulingMeta := auxMeta.GetSchedulingMetadata()

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,14 +47,15 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
+	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
 	gstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/anypb"
-	"google.golang.org/protobuf/types/known/durationpb"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -776,6 +776,11 @@ func TestExecuteAndPublishOperation(t *testing.T) {
 			expectedExecutionUsage: tables.UsageCounts{LinuxExecutionDurationUsec: durationUsec},
 			useDefaultPool:         true,
 		},
+		{
+			name:                   "RecycleRunner",
+			expectedExecutionUsage: tables.UsageCounts{LinuxExecutionDurationUsec: durationUsec},
+			recycleRunner:          true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			testExecuteAndPublishOperation(t, test)
@@ -795,6 +800,7 @@ type publishTest struct {
 	publishMoreMetadata      bool
 	redisRestart             bool
 	useDefaultPool           bool
+	recycleRunner            bool
 }
 
 func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
@@ -834,6 +840,9 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 	}
 	if !test.useDefaultPool {
 		platformProperties = append(platformProperties, &repb.Platform_Property{Name: "pool", Value: "test-pool"})
+	}
+	if test.recycleRunner {
+		platformProperties = append(platformProperties, &repb.Platform_Property{Name: "recycle-runner", Value: "true"})
 	}
 	arn := uploadAction(clientCtx, t, env, instanceName, digestFunction, &repb.Action{
 		Timeout:    &durationpb.Duration{Seconds: 10},
@@ -1059,6 +1068,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		Region:                       "test-region",
 		CommandSnippet:               "test",
 		OutputPath:                   "bazel-out/k8-fastbuild/bin/some/test",
+		RecycleRunner:                test.recycleRunner,
 		QueuedTimestampUsec:          queuedTime.UnixMicro(),
 		WorkerStartTimestampUsec:     workerStartTime.UnixMicro(),
 		WorkerCompletedTimestampUsec: workerEndTime.UnixMicro(),
@@ -1093,7 +1103,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		expectedExecution.IoPressureSomeStallUsec = 1030
 		expectedExecution.IoPressureFullStallUsec = 2030
 	}
-	diff := cmp.Diff(
+	require.Empty(t, cmp.Diff(
 		expectedExecution,
 		collectedExecutions[0],
 		protocmp.Transform(),
@@ -1101,8 +1111,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 			&repb.StoredExecution{},
 			"created_at_usec",
 			"updated_at_usec",
-		))
-	assert.Emptyf(t, diff, "Recorded execution didn't match the expected one: %s", expectedExecution)
+		)))
 }
 
 func TestMarkFailed(t *testing.T) {

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -3028,6 +3028,7 @@ message StoredExecution {
   bool cached_result = 38;
   bool do_not_cache = 39;
   bool skip_cache_lookup = 50;
+  bool recycle_runner = 80;
 
   int32 execution_priority = 51;
   string requested_isolation_type = 52;

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -434,6 +434,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*
 		CachedResult:                       in.GetCachedResult(),
 		DoNotCache:                         in.GetDoNotCache(),
 		SkipCacheLookup:                    in.GetSkipCacheLookup(),
+		RecycleRunner:                      in.GetRecycleRunner(),
 		RequestedIsolationType:             in.GetRequestedIsolationType(),
 		EffectiveIsolationType:             in.GetEffectiveIsolationType(),
 		RequestedTimeoutUsec:               in.GetRequestedTimeoutUsec(),

--- a/server/util/clickhouse/clickhouse_test.go
+++ b/server/util/clickhouse/clickhouse_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	sipb "github.com/buildbuddy-io/buildbuddy/proto/stored_invocation"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse"
@@ -16,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	sipb "github.com/buildbuddy-io/buildbuddy/proto/stored_invocation"
 )
 
 // TestExecutionIDRoundTripThroughClickHouseSchema verifies that an execution
@@ -55,6 +55,56 @@ func TestExecutionIDRoundTripThroughClickHouseSchema(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, executionID, reconstructExecutionID(t, execution))
+		})
+	}
+}
+
+func TestExecutionFromProto(t *testing.T) {
+	executionID := digest.NewCASResourceName(
+		&repb.Digest{
+			Hash:      "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d",
+			SizeBytes: 1234,
+		},
+		"test-instance-name",
+		repb.DigestFunction_SHA256,
+	).NewUploadString()
+
+	for _, testCase := range []struct {
+		name string
+		in   *repb.StoredExecution
+		want *schema.Execution
+	}{
+		{
+			name: "MinimalExecution",
+			in: &repb.StoredExecution{
+				ExecutionId: executionID,
+			},
+			want: &schema.Execution{
+				ExecutionID: executionID,
+			},
+		},
+		{
+			name: "RecycleRunner",
+			in: &repb.StoredExecution{
+				ExecutionId:   executionID,
+				RecycleRunner: true,
+			},
+			want: &schema.Execution{
+				ExecutionID:   executionID,
+				RecycleRunner: true,
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Convert the stored execution as the ClickHouse flush path does.
+			execution, err := clickhouse.ExecutionFromProto(testCase.in, nil)
+			require.NoError(t, err)
+
+			// The row should preserve direct proto fields while also parsing
+			// the execution ID resource fields.
+			require.Equal(t, testCase.want.ExecutionID, execution.ExecutionID)
+			require.Equal(t, testCase.want.RecycleRunner, execution.RecycleRunner)
+			require.Equal(t, testCase.in.GetExecutionId(), reconstructExecutionID(t, execution))
 		})
 	}
 }

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -258,11 +258,14 @@ type Execution struct {
 	DoNotCache      bool
 	SkipCacheLookup bool
 
-	ExecutionPriority      int32  `gorm:"codec:T64,ZSTD(1)"`
+	ExecutionPriority int32 `gorm:"codec:T64,ZSTD(1)"`
+
+	// Platform properties
 	RequestedIsolationType string `gorm:"type:LowCardinality(String)"`
 	EffectiveIsolationType string `gorm:"type:LowCardinality(String)"` // This values comes from the executor
 	RequestedPool          string `gorm:"codec:ZSTD(1)"`
 	EffectivePool          string `gorm:"codec:ZSTD(1)"`
+	RecycleRunner          bool
 
 	// Runner metadata
 	RunnerID            string `gorm:"codec:ZSTD(1)"`
@@ -362,6 +365,7 @@ func (e *Execution) AdditionalFields() []string {
 		"PredictedMilliCPU",
 		"PredictedFreeDiskBytes",
 		"SkipCacheLookup",
+		"RecycleRunner",
 		"ExecutionPriority",
 		"RequestedIsolationType",
 		"EffectiveIsolationType",


### PR DESCRIPTION
It's hard to assess whether https://github.com/buildbuddy-io/buildbuddy-internal/issues/7401 is worth addressing because we don't store `recycle-runner` in ClickHouse. This PR adds it.