### PR TITLE
Use orderedmap for RawUsage labels column

### DIFF
--- a/enterprise/server/test/integration/clickhouse_schema/BUILD
+++ b/enterprise/server/test/integration/clickhouse_schema/BUILD
@@ -17,6 +17,7 @@ go_test(
         "//server/usage/sku",
         "//server/util/clickhouse/schema",
         "@com_github_clickhouse_clickhouse_go_v2//:clickhouse-go",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_gorm_driver_clickhouse//:clickhouse",

--- a/enterprise/server/test/integration/clickhouse_schema/clickhouse_schema_test.go
+++ b/enterprise/server/test/integration/clickhouse_schema/clickhouse_schema_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testclickhouse"
 	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
@@ -77,7 +78,7 @@ func insertRawUsage(t *testing.T, db *gorm.DB, count int64) {
 	err := db.Create(&schema.RawUsage{
 		GroupID:     "GR1",
 		SKU:         sku.BuildEventsBESCount,
-		Labels:      map[sku.LabelName]sku.LabelValue{},
+		Labels:      orderedmap.FromMap(map[sku.LabelName]sku.LabelValue(nil)),
 		PeriodStart: time.Date(2026, 1, 2, 3, 4, 0, 0, time.UTC),
 		BufferID:    "test:redis",
 		Count:       count,

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/util/region",
         "//server/util/status",
         "//server/util/usageutil",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
@@ -51,6 +52,7 @@ go_test(
         "//server/util/clickhouse/schema",
         "//server/util/db",
         "//server/util/testing/flags",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_jonboulle_clockwork//:clockwork",
@@ -70,7 +72,7 @@ go_test(
         # TODO(bduffany): Remove test filter, add ClickHouse test logic to all
         # test cases, and enable test sharding before we fully enable
         # ClickHouse in prod.
-        "-test.run=TestUsageTracker_Increment_MultipleGroupsInSameCollectionPeriod",
+        "-test.run=TestUsageTracker_Increment_MultipleGroupsInSameCollectionPeriod|TestClickHouseUsageView_DedupesDuplicateRawUsageRows",
     ],
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
@@ -96,6 +98,7 @@ go_test(
         "//server/util/clickhouse/schema",
         "//server/util/db",
         "//server/util/testing/flags",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_jonboulle_clockwork//:clockwork",
@@ -141,6 +144,7 @@ go_test(
         "//server/util/clickhouse/schema",
         "//server/util/db",
         "//server/util/testing/flags",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_jonboulle_clockwork//:clockwork",
@@ -186,6 +190,7 @@ go_test(
         "//server/util/clickhouse/schema",
         "//server/util/db",
         "//server/util/testing/flags",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_jonboulle_clockwork//:clockwork",

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -520,7 +521,7 @@ func (ut *tracker) flushOLAPBuffer(ctx context.Context, redisCleanupCtx context.
 				olapRows = append(olapRows, &olaptables.RawUsage{
 					GroupID:     collection.GroupID,
 					SKU:         sku.SKU(key),
-					Labels:      collection.Labels,
+					Labels:      orderedmap.FromMap(collection.Labels),
 					PeriodStart: p.Start(),
 					BufferID:    ut.bufferID,
 					Count:       count,

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_metrics_collector"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/usage"
@@ -379,6 +380,58 @@ func TestUsageTracker_Increment_MultipleGroupsInSameCollectionPeriod(t *testing.
 			},
 		}, olapUsages)
 	}
+}
+
+func TestClickHouseUsageView_DedupesDuplicateRawUsageRows(t *testing.T) {
+	if !*clickhouseEnabled {
+		t.Skip("ClickHouse is not enabled")
+	}
+
+	te := setupEnv(t)
+	ctx := context.Background()
+
+	// Insert many duplicate RawUsage rows, recreating the labels map with
+	// different capacities and write orders each time. The Usage view should
+	// use RawUsage FINAL to collapse these duplicated flushes to a single row.
+	const numRows = 100
+	rows := make([]*olaptables.RawUsage, 0, numRows)
+	for i := range numRows {
+		labels := make(map[sku.LabelName]sku.LabelValue, i%11)
+		if i%2 == 0 {
+			labels[sku.Client] = "bazel"
+			labels[sku.Origin] = "internal"
+			labels[sku.Server] = "app"
+		} else {
+			labels[sku.Server] = "app"
+			labels[sku.Origin] = "internal"
+			labels[sku.Client] = "bazel"
+		}
+		rows = append(rows, &olaptables.RawUsage{
+			GroupID:     "GR1",
+			PeriodStart: period1Start,
+			SKU:         sku.RemoteCacheCASHits,
+			Labels:      orderedmap.FromMap(labels),
+			BufferID:    "us-west1:redis",
+			Count:       7,
+		})
+	}
+	require.NoError(t, te.GetOLAPDBHandle().FlushUsages(ctx, rows))
+
+	// The Usage view should read RawUsage FINAL and expose one deduped usage
+	// row, not the sum of every duplicate flush.
+	assert.Equal(t, []*olaptables.Usage{
+		{
+			GroupID:     "GR1",
+			PeriodStart: period1Start,
+			SKU:         sku.RemoteCacheCASHits,
+			Labels: map[sku.LabelName]sku.LabelValue{
+				sku.Client: "bazel",
+				sku.Origin: "internal",
+				sku.Server: "app",
+			},
+			Count: 7,
+		},
+	}, queryAllOLAPUsages(t, te))
 }
 
 func TestUsageTracker_Increment_ImpersonationSuppressesUsage(t *testing.T) {

--- a/enterprise/server/usagealert/BUILD
+++ b/enterprise/server/usagealert/BUILD
@@ -65,6 +65,7 @@ go_test(
         "//server/util/clickhouse/schema",
         "//server/util/role",
         "//server/util/testing/flags",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/testutil",

--- a/enterprise/server/usagealert/usagealert_test.go
+++ b/enterprise/server/usagealert/usagealert_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/email"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/usage_service"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -773,7 +774,7 @@ func createRawUsage(t testing.TB, ctx context.Context, olapDBH interfaces.OLAPDB
 		{
 			GroupID:     groupID,
 			SKU:         usageSKU,
-			Labels:      labels,
+			Labels:      orderedmap.FromMap(labels),
 			PeriodStart: periodStart,
 			Count:       count,
 		},

--- a/server/util/clickhouse/schema/BUILD
+++ b/server/util/clickhouse/schema/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/usage/sku",
         "//server/util/log",
         "//server/util/status",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
         "@io_gorm_gorm//:gorm",
     ],
 )

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/invocation_format"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
@@ -490,8 +491,10 @@ type RawUsage struct {
 	// This should only be used in cases where there may be a large number of
 	// possible dimensions (too many to be represented as a SKU) but the
 	// frequency of usage for each combination of dimensions is expected to be
-	// relatively low.
-	Labels map[sku.LabelName]sku.LabelValue `gorm:"type:Map(LowCardinality(String), LowCardinality(String))"`
+	// relatively low. Since RawUsage.labels is part of the ReplacingMergeTree
+	// ORDER BY key, callers must write labels with a deterministic key order so
+	// FINAL deduplication works reliably.
+	Labels *orderedmap.Map[sku.LabelName, sku.LabelValue] `gorm:"type:Map(LowCardinality(String), LowCardinality(String))"`
 
 	// PeriodStart is the start of the period during which the usage occurred.
 	// Currently, usage is collected in 1-minute intervals.


### PR DESCRIPTION
Since the current schema uses a plain old Go map, which is non-ordered, it's possible to wind up with duplicate usage row flushes which aren't properly deduped via the FINAL query.

This PR includes a test which fails at `master`, demonstrating that improper deduplication can actually happen in practice, and also here is a [query](https://metrics.buildbuddy.io/explore?schemaVersion=1&panes=%7B%22ycn%22:%7B%22datasource%22:%22clickhouse%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22grafana-clickhouse-datasource%22,%22uid%22:%22clickhouse%22%7D,%22editorType%22:%22sql%22,%22rawSql%22:%22SELECT%5Cn%20%20period_start,%5Cn%20%20sku,%5Cn%20%20buffer_id,%5Cn%20%20mapKeys%28labels%29%20AS%20label_key_order,%5Cn%20%20labels,%5Cn%20%20count%28%29%20AS%20rows%5CnFROM%20buildbuddy_prod.RawUsage%5CnWHERE%20period_start%20%3D%20toDateTime64%28%272026-05-14%2023:09:00%27,%206,%20%27UTC%27%29%5Cn%20%20AND%20sku%20%3D%20%27remote_cache.action_cache_hits.hits%27%5Cn%20%20AND%20buffer_id%20%3D%20%27us-west1:redis%27%5Cn%20%20AND%20%28%5Cn%20%20%20%20labels%20%3D%20map%28%27client%27,%20%27bazel%27,%20%27server%27,%20%27app%27%29%5Cn%20%20%20%20OR%20labels%20%3D%20map%28%27server%27,%20%27app%27,%20%27client%27,%20%27bazel%27%29%5Cn%20%20%29%5CnGROUP%20BY%20period_start,%20sku,%20buffer_id,%20labels%5CnORDER%20BY%20label_key_order%5CnLIMIT%202%22,%22queryType%22:%22table%22,%22pluginVersion%22:%224.11.2%22,%22format%22:1,%22meta%22:%7B%7D%7D%5D,%22range%22:%7B%22from%22:%22now-24h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1) demonstrating it. This query shows that there are some `labels` values which should be treated as identical, but are showing up as distinct values, which means they wouldn't be deduped properly under the `FINAL` query (i.e. the `Usage` view).