### PR TITLE
cache: deprecate legacy backends

### DIFF
--- a/docs/config-cache.md
+++ b/docs/config-cache.md
@@ -24,29 +24,11 @@ sidebar_label: Cache
 
 **Enterprise only**
 
-- `redis_target`: A redis target for improved RBE performance.
-
-- `gcs:` The GCS section configures Google Cloud Storage based blob storage.
-
-  - `bucket` The name of the GCS bucket to store files in. Will be created if it does not already exist.
-
-  - `credentials_file` A path to a [JSON credentials file](https://cloud.google.com/docs/authentication/getting-started) that will be used to authenticate to GCS.
-
-  - `project_id` The Google Cloud project ID of the project owning the above credentials and GCS bucket.
-
-  - `ttl_days` The period after which cache files should be TTLd. Disabled if 0.
-
-- `s3:` The AWS section configures AWS S3 storage.
-
-  - `region` The AWS region
-
-  - `bucket` The AWS S3 bucket (will be created automatically)
-
-  - `credentials_profile` If a profile other than default is chosen, use that one.
-
-  - `ttl_days` The period after which cache files should be TTLd. Disabled if 0.
-
-  - By default, the S3 blobstore will rely on environment variables, shared credentials, or IAM roles. See [AWS Go SDK docs](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials) for more information.
+Legacy GCS, S3, Redis, and Memcache cache backends are deprecated for new deployments.
+Prefer `cache.disk.root_directory` for cache storage, and configure `storage.gcs` or
+`storage.aws_s3` for durable blob and build event storage. The legacy cache options
+remain listed in the [all options](config-all-options.mdx) docs and are marked deprecated
+for existing deployments.
 
 ## Example section
 
@@ -57,42 +39,4 @@ cache:
   max_size_bytes: 10000000000 # 10 GB
   disk:
     root_directory: /tmp/buildbuddy-cache
-```
-
-### GCS & Redis (Enterprise only)
-
-```yaml title="config.yaml"
-cache:
-  redis_target: "my-redis.local:6379"
-  gcs:
-    bucket: "buildbuddy_blobs"
-    project_id: "my-cool-project"
-    credentials_file: "enterprise/config/my-cool-project-7a9d15f66e69.json"
-    ttl_days: 30
-```
-
-### S3 (Enterprise only)
-
-```yaml title="config.yaml"
-cache:
-  s3:
-    # required
-    region: "us-west-2"
-    bucket: "buildbuddy-bucket"
-    # optional
-    credentials_profile: "other-profile"
-    ttl_days: 30
-```
-
-### Minio (Enterprise only)
-
-```yaml title="config.yaml"
-cache:
-  s3:
-    static_credentials_id: "YOUR_MINIO_ACCESS_KEY"
-    static_credentials_secret: "YOUR_MINIO_SECRET"
-    endpoint: "http://localhost:9000"
-    s3_force_path_style: true
-    region: "us-east-1"
-    bucket: "buildbuddy-cache-bucket"
 ```

--- a/docs/config-samples.md
+++ b/docs/config-samples.md
@@ -80,12 +80,8 @@ storage:
     project_id: "flame-build"
     credentials_file: "your_service-acct.json"
 cache:
-  redis_target: "12.34.56.79:6379"
-  gcs:
-    bucket: "buildbuddy_cache"
-    project_id: "your_gcs_project_id"
-    credentials_file: "/path/to/your/credential/file.json"
-    ttl_days: 30
+  disk:
+    root_directory: /data/buildbuddy-cache
 auth:
   oauth_providers:
     - issuer_url: "https://your-custom-domain.okta.com"

--- a/docs/enterprise-config.md
+++ b/docs/enterprise-config.md
@@ -35,7 +35,9 @@ If using the [BuildBuddy Enterprise Helm charts](https://github.com/buildbuddy-i
 
 For a BuildBuddy deployment running multiple apps, it is necessary to provide a default redis target for some features to work correctly. Metrics collection, usage tracking, and responsive build logs all depend on this.
 
-If no default redis target is configured, we will fall back to using the cache redis target, if available, and then the remote execution target, if available. The default redis target also acts as the primary fallback if the remote execution redis target is left unspecified. The default redis target does NOT act as a fallback for the cache redis target.
+If no default redis target is configured, we will fall back to using the deprecated cache redis target, if available, and then the remote execution target, if available.
+New deployments should set `app.default_redis_target` explicitly. The default redis target also acts as the primary fallback if the remote execution redis target is left unspecified.
+The default redis target does NOT act as a fallback for the deprecated cache redis target.
 
 The configuration below demostrates a default redis target:
 
@@ -44,15 +46,13 @@ app:
   default_redis_target: "my-redis.local:6379"
 ```
 
-### GCS Based Cache / Object Storage / Redis
+### GCS Object Storage
 
-By default, BuildBuddy will cache objects and store uploaded build events on the local disk. If you want to store them in a shared durable location, like a Google Cloud Storage bucket, you can do that by configuring a GCS cache or storage backend.
+By default, BuildBuddy stores uploaded build events on the local disk. If you want to store uploaded build events in a shared durable location, like a Google Cloud Storage bucket, you can configure a GCS storage backend.
 
 If your BuildBuddy instance is running on a machine with Google Default Credentials, no credentials file will be necessary. If not, you should [create a service account](https://cloud.google.com/docs/authentication/getting-started) with permissions to write to cloud storage, and download the credentials .json file.
 
-We also recommend providing a Redis instance for improved remote build execution & small file performance. This can be configured automatically using the [BuildBuddy Enterprise Helm charts](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-enterprise) with the `redis.enabled` value.
-
-The configuration below configures Redis & GCS storage bucket to act as a storage backend and cache:
+The configuration below configures a GCS storage bucket:
 
 ```yaml title="config.yaml"
 storage:
@@ -62,16 +62,9 @@ storage:
     bucket: "buildbuddy_prod_blobs"
     project_id: "flame-build"
     credentials_file: "your_service-acct.json"
-cache:
-  redis_target: "my-redis.local:6379"
-  gcs:
-    bucket: "buildbuddy_cache"
-    project_id: "your_gcs_project_id"
-    credentials_file: "/path/to/your/credential/file.json"
-    ttl_days: 30
 ```
 
-If using Amazon S3, you can configure your storage and cache similarly:
+If using Amazon S3, you can configure your storage similarly:
 
 ```yaml title="config.yaml"
 storage:
@@ -81,13 +74,6 @@ storage:
     region: "us-west-2"
     bucket: "buildbuddy-bucket"
     credentials_profile: "other-profile"
-cache:
-  redis_target: "my-redis.local:6379"
-  s3:
-    region: "us-west-2"
-    bucket: "buildbuddy-bucket"
-    credentials_profile: "other-profile"
-    ttl_days: 30
 ```
 
 ### Authentication Provider Integration
@@ -162,6 +148,7 @@ app:
   build_buddy_url: "https://app.buildbuddy.mydomain"
   events_api_url: "grpcs://events.buildbuddy.mydomain:1986"
   cache_api_url: "grpcs://cache.buildbuddy.mydomain:1986"
+  default_redis_target: "my-redis.local:6379"
 database:
   data_source: "mysql://user:pass@tcp(12.34.56.78)/database_name"
 storage:
@@ -172,11 +159,8 @@ storage:
     project_id: "flame-build"
     credentials_file: "your_service-acct.json"
 cache:
-  gcs:
-    bucket: "buildbuddy_cache"
-    project_id: "your_gcs_project_id"
-    credentials_file: "/path/to/your/credential/file.json"
-    ttl_days: 30
+  disk:
+    root_directory: "/data/buildbuddy-cache"
 auth:
   oauth_providers:
     - issuer_url: "https://your-custom-domain.okta.com"

--- a/enterprise/server/backends/gcs_cache/BUILD
+++ b/enterprise/server/backends/gcs_cache/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/digest",
         "//server/util/cache_metrics",
+        "//server/util/flag",
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/status",

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -3,7 +3,6 @@ package gcs_cache
 import (
 	"context"
 	"errors"
-	"flag"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/cache_metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -27,11 +27,13 @@ import (
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
+const deprecatedGCSCacheFlagMessage = "The cache.gcs backend is deprecated. Use storage.gcs for durable blob storage and cache.disk.root_directory for cache storage."
+
 var (
-	bucket          = flag.String("cache.gcs.bucket", "", "The name of the GCS bucket to store cache files in.")
-	credentialsFile = flag.String("cache.gcs.credentials_file", "", "A path to a JSON credentials file that will be used to authenticate to GCS.")
-	projectID       = flag.String("cache.gcs.project_id", "", "The Google Cloud project ID of the project owning the above credentials and GCS bucket.")
-	ttlDays         = flag.Int64("cache.gcs.ttl_days", 0, "The period after which cache files should be TTLd. Disabled if 0.")
+	bucket          = flag.String("cache.gcs.bucket", "", "The name of the GCS bucket to store cache files in.", flag.Deprecated(deprecatedGCSCacheFlagMessage))
+	credentialsFile = flag.String("cache.gcs.credentials_file", "", "A path to a JSON credentials file that will be used to authenticate to GCS.", flag.Deprecated(deprecatedGCSCacheFlagMessage))
+	projectID       = flag.String("cache.gcs.project_id", "", "The Google Cloud project ID of the project owning the above credentials and GCS bucket.", flag.Deprecated(deprecatedGCSCacheFlagMessage))
+	ttlDays         = flag.Int64("cache.gcs.ttl_days", 0, "The period after which cache files should be TTLd. Disabled if 0.", flag.Deprecated(deprecatedGCSCacheFlagMessage))
 )
 
 const (

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -24,7 +24,9 @@ import (
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
-var memcacheTargets = flag.Slice("cache.memcache_targets", []string{}, "Deprecated. Use Redis Target instead.")
+const deprecatedMemcacheFlagMessage = "The memcache cache backend is deprecated. Use app.default_redis_target or remote_execution.redis_target for Redis-backed shared state and cache.disk.root_directory for cache storage."
+
+var memcacheTargets = flag.Slice("cache.memcache_targets", []string{}, "Memcache targets.", flag.Deprecated(deprecatedMemcacheFlagMessage))
 
 const (
 	mcCutoffSizeBytes = 134217728 - 1 // 128 MB

--- a/enterprise/server/backends/redis_cache/BUILD
+++ b/enterprise/server/backends/redis_cache/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/digest",
         "//server/util/cache_metrics",
+        "//server/util/flag",
         "//server/util/ioutil",
         "//server/util/log",
         "//server/util/prefix",

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -3,7 +3,6 @@ package redis_cache
 import (
 	"bytes"
 	"context"
-	"flag"
 	"io"
 	"path/filepath"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/cache_metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
@@ -27,7 +27,9 @@ import (
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
-var maxValueSizeBytes = flag.Int64("cache.redis.max_value_size_bytes", 10000000, "The maximum value size to cache in redis (in bytes).")
+const deprecatedRedisCacheFlagMessage = "The cache.redis backend is deprecated. Use app.default_redis_target or remote_execution.redis_target for Redis-backed shared state and cache.disk.root_directory for cache storage."
+
+var maxValueSizeBytes = flag.Int64("cache.redis.max_value_size_bytes", 10000000, "The maximum value size to cache in redis (in bytes).", flag.Deprecated(deprecatedRedisCacheFlagMessage))
 
 const (
 	ttl = 3 * 24 * time.Hour

--- a/enterprise/server/backends/redis_client/redis_client.go
+++ b/enterprise/server/backends/redis_client/redis_client.go
@@ -11,6 +11,8 @@ import (
 	remote_execution_config "github.com/buildbuddy-io/buildbuddy/server/remote_execution/config"
 )
 
+const cacheRedisFlagMessage = "The cache Redis config is deprecated. Use app.default_redis_target or remote_execution.redis_target for Redis-backed shared state."
+
 var (
 	defaultRedisTarget               = flag.String("app.default_redis_target", "", "A Redis target for storing remote shared state. To ease migration, the redis target from the remote execution config will be used if this value is not specified.", flag.Secret)
 	defaultRedisShards               = flag.Slice("app.default_sharded_redis.shards", []string{}, "Ordered list of Redis shard addresses.")
@@ -22,12 +24,11 @@ var (
 	// migration)
 
 	// Cache Redis
-	// TODO: We need to deprecate one of the redis targets here or distinguish them
-	cacheRedisTargetFallback  = flag.String("cache.redis_target", "", "A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **", flag.Secret)
-	cacheRedisTarget          = flag.String("cache.redis.redis_target", "", "A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **", flag.Secret)
-	cacheRedisShards          = flag.Slice("cache.redis.sharded.shards", []string{}, "Ordered list of Redis shard addresses.")
-	cacheShardedRedisUsername = flag.String("cache.redis.sharded.username", "", "Redis username")
-	cacheShardedRedisPassword = flag.String("cache.redis.sharded.password", "", "Redis password", flag.Secret)
+	cacheRedisTargetFallback  = flag.String("cache.redis_target", "", "A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **", flag.Secret, flag.Deprecated(cacheRedisFlagMessage))
+	cacheRedisTarget          = flag.String("cache.redis.redis_target", "", "A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **", flag.Secret, flag.Deprecated(cacheRedisFlagMessage))
+	cacheRedisShards          = flag.Slice("cache.redis.sharded.shards", []string{}, "Ordered list of Redis shard addresses.", flag.Deprecated(cacheRedisFlagMessage))
+	cacheShardedRedisUsername = flag.String("cache.redis.sharded.username", "", "Redis username", flag.Deprecated(cacheRedisFlagMessage))
+	cacheShardedRedisPassword = flag.String("cache.redis.sharded.password", "", "Redis password", flag.Secret, flag.Deprecated(cacheRedisFlagMessage))
 
 	// Remote Execution Redis
 	remoteExecRedisTarget          = flag.String("remote_execution.redis_target", "", "A Redis target for storing remote execution state. Falls back to app.default_redis_target if unspecified. Required for remote execution. To ease migration, the redis target from the cache config will be used if neither this value nor app.default_redis_target are specified.", flag.Secret)

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -36,21 +36,23 @@ import (
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
+const deprecatedS3CacheFlagMessage = "The cache.s3 backend is deprecated. Use storage.aws_s3 for durable blob storage and cache.disk.root_directory for cache storage."
+
 var (
-	region                   = flag.String("cache.s3.region", "", "The AWS region.")
-	bucket                   = flag.String("cache.s3.bucket", "", "The AWS S3 bucket to store files in.")
-	pathPrefix               = flag.String("cache.s3.path_prefix", "", "Prefix inside the AWS S3 bucket to store files")
-	credentialsProfile       = flag.String("cache.s3.credentials_profile", "", "A custom credentials profile to use.")
-	ttlDays                  = flag.Int("cache.s3.ttl_days", 0, "The period after which cache files should be TTLd. Disabled if 0.")
-	webIdentityTokenFilePath = flag.String("cache.s3.web_identity_token_file", "", "The file path to the web identity token file.")
-	roleARN                  = flag.String("cache.s3.role_arn", "", "The role ARN to use for web identity auth.")
-	roleSessionName          = flag.String("cache.s3.role_session_name", "", "The role session name to use for web identity auth.")
-	endpoint                 = flag.String("cache.s3.endpoint", "", "The AWS endpoint to use, useful for configuring the use of MinIO.")
-	staticCredentialsID      = flag.String("cache.s3.static_credentials_id", "", "Static credentials ID to use, useful for configuring the use of MinIO.")
-	staticCredentialsSecret  = flag.String("cache.s3.static_credentials_secret", "", "Static credentials secret to use, useful for configuring the use of MinIO.", flag.Secret)
-	staticCredentialsToken   = flag.String("cache.s3.static_credentials_token", "", "Static credentials token to use, useful for configuring the use of MinIO.")
-	disableSSL               = flag.Bool("cache.s3.disable_ssl", false, "Disables the use of SSL, useful for configuring the use of MinIO.", flag.Deprecated("Specify a non-HTTPS endpoint instead."))
-	forcePathStyle           = flag.Bool("cache.s3.s3_force_path_style", false, "Force path style urls for objects, useful for configuring the use of MinIO.")
+	region                   = flag.String("cache.s3.region", "", "The AWS region.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	bucket                   = flag.String("cache.s3.bucket", "", "The AWS S3 bucket to store files in.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	pathPrefix               = flag.String("cache.s3.path_prefix", "", "Prefix inside the AWS S3 bucket to store files", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	credentialsProfile       = flag.String("cache.s3.credentials_profile", "", "A custom credentials profile to use.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	ttlDays                  = flag.Int("cache.s3.ttl_days", 0, "The period after which cache files should be TTLd. Disabled if 0.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	webIdentityTokenFilePath = flag.String("cache.s3.web_identity_token_file", "", "The file path to the web identity token file.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	roleARN                  = flag.String("cache.s3.role_arn", "", "The role ARN to use for web identity auth.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	roleSessionName          = flag.String("cache.s3.role_session_name", "", "The role session name to use for web identity auth.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	endpoint                 = flag.String("cache.s3.endpoint", "", "The AWS endpoint to use, useful for configuring the use of MinIO.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	staticCredentialsID      = flag.String("cache.s3.static_credentials_id", "", "Static credentials ID to use, useful for configuring the use of MinIO.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	staticCredentialsSecret  = flag.String("cache.s3.static_credentials_secret", "", "Static credentials secret to use, useful for configuring the use of MinIO.", flag.Secret, flag.Deprecated(deprecatedS3CacheFlagMessage))
+	staticCredentialsToken   = flag.String("cache.s3.static_credentials_token", "", "Static credentials token to use, useful for configuring the use of MinIO.", flag.Deprecated(deprecatedS3CacheFlagMessage))
+	disableSSL               = flag.Bool("cache.s3.disable_ssl", false, "Disables the use of SSL, useful for configuring the use of MinIO.", flag.Deprecated(deprecatedS3CacheFlagMessage+" Specify a non-HTTPS endpoint instead."))
+	forcePathStyle           = flag.Bool("cache.s3.s3_force_path_style", false, "Force path style urls for objects, useful for configuring the use of MinIO.", flag.Deprecated(deprecatedS3CacheFlagMessage))
 )
 
 const (


### PR DESCRIPTION
Keep the legacy GCS, S3, Redis, and Memcache cache backends available, but stop recommending them for new deployments.

Update the cache and enterprise config docs to use disk cache together with storage.gcs / storage.aws_s3 and app.default_redis_target.

Mark the legacy cache flags as deprecated so the generated all-options docs point existing users toward the supported storage and cache configuration.
