### PR TITLE
Small improvements to trace loading logic

### DIFF
--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -7,7 +7,7 @@ import LinkButton from "../components/button/link_button";
 import SetupCodeComponent from "../docs/setup_code";
 import errorService from "../errors/error_service";
 import format from "../format/format";
-import rpcService, { FileEncoding } from "../service/rpc_service";
+import rpcService, { CancelablePromise, FileEncoding } from "../service/rpc_service";
 import TimingProfileDropTarget from "../trace/timing_profile_drop_target";
 import { Profile, readProfile } from "../trace/trace_events";
 import TraceViewer from "../trace/trace_viewer";
@@ -76,6 +76,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
   };
 
   private progressRef = React.createRef<HTMLDivElement>();
+  private profileRPC?: CancelablePromise;
 
   componentDidMount() {
     this.fetchProfile();
@@ -83,8 +84,13 @@ export default class InvocationTimingCardComponent extends React.Component<Props
 
   componentDidUpdate(prevProps: Props) {
     if (this.props.model !== prevProps.model) {
+      this.cancelProfileLoad();
       this.setState(createEmptyProfileState(), () => this.fetchProfile());
     }
+  }
+
+  componentWillUnmount() {
+    this.cancelProfileLoad();
   }
 
   getProfileFile(): build_event_stream.File | undefined {
@@ -113,7 +119,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     return Boolean(this.getProfileFile()?.uri?.startsWith("bytestream://"));
   }
 
-  setProgress(bytesLoaded: number, digestSize: number, encoding: FileEncoding) {
+  setProgress(bytesLoaded: number, digestSize: number, encoding: FileEncoding, done = false) {
     const container = this.progressRef.current;
     if (!container) return;
 
@@ -122,7 +128,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
       approxCompressionRatio = 11.3;
     }
 
-    const compressedBytesLoaded = Math.min(bytesLoaded / approxCompressionRatio, digestSize);
+    const compressedBytesLoaded = done ? digestSize : Math.min(bytesLoaded / approxCompressionRatio, digestSize);
     const progressPercent = 100 * Math.min(1, compressedBytesLoaded / digestSize);
 
     const spinner = container.querySelector(".loading") as HTMLElement;
@@ -131,13 +137,16 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     const progressContainer = container.querySelector(".timing-profile-progress")!;
     progressContainer.removeAttribute("hidden");
     const progressLabel = progressContainer.querySelector(".progress-label")!;
-    progressLabel.innerHTML = `Loading profile (${format.bytes(compressedBytesLoaded)} / ${format.bytes(digestSize)})`;
+    const label = done ? "Finalizing profile" : "Loading profile";
+    progressLabel.innerHTML = `${label} (${format.bytes(compressedBytesLoaded)} / ${format.bytes(digestSize)})`;
 
     const progressBarInner = progressContainer.querySelector(".progress-bar-inner") as HTMLElement;
     progressBarInner.style.width = `${progressPercent}%`;
   }
 
   fetchProfile(ignoreSizeLimit = false) {
+    this.cancelProfileLoad();
+
     if (!this.isTimingEnabled()) {
       this.setState({ loading: false });
     }
@@ -166,15 +175,23 @@ export default class InvocationTimingCardComponent extends React.Component<Props
       // Set the stored encoding header to prevent the server from double-gzipping.
       headers: { "X-Stored-Encoding-Hint": storedEncoding },
     };
-    rpcService
+    this.profileRPC = rpcService
       .fetchBytestreamFile(profileFile.uri, this.props.model.getInvocationId(), "stream", { init })
       .then((response) => {
         if (!response.body) throw new Error("response body is null");
-        return readProfile(response.body, (n) => this.setProgress(n, digestSize, storedEncoding));
+        return readProfile(response.body, (n, done) => this.setProgress(n, digestSize, storedEncoding, done));
       })
       .then((profile) => this.updateProfile(profile))
       .catch((e) => errorService.handleError(e))
-      .finally(() => this.setState({ loading: false }));
+      .finally(() => {
+        this.profileRPC = undefined;
+        this.setState({ loading: false });
+      });
+  }
+
+  private cancelProfileLoad() {
+    this.profileRPC?.cancel();
+    this.profileRPC = undefined;
   }
 
   private buildDerivedProfileState(profile: Profile) {

--- a/app/trace/BUILD
+++ b/app/trace/BUILD
@@ -70,6 +70,7 @@ ts_library(
     srcs = ["trace_events.ts"],
     deps = [
         "//:node_modules/tslib",
+        "//app/util:async",
     ],
 )
 

--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -5,6 +5,8 @@
  * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.yr4qxyxotyw
  */
 
+import { nextAnimationFrame } from "../util/async";
+
 /** Represents the profile data for an invocation. */
 export interface Profile {
   traceEvents: TraceEvent[];
@@ -121,7 +123,10 @@ async function isGzipCompressed(blob: Blob): Promise<boolean> {
   return header[0] === GZIP_MAGIC_BYTE_0 && header[1] === GZIP_MAGIC_BYTE_1;
 }
 
-export async function readProfileFile(file: Blob, progress?: (numBytesLoaded: number) => void): Promise<Profile> {
+export async function readProfileFile(
+  file: Blob,
+  progress?: (numBytesLoaded: number, done?: boolean) => void
+): Promise<Profile> {
   let stream = file.stream() as ReadableStream<Uint8Array>;
   if (await isGzipCompressed(file)) {
     if (typeof DecompressionStream === "undefined") {
@@ -134,7 +139,7 @@ export async function readProfileFile(file: Blob, progress?: (numBytesLoaded: nu
 
 export async function readProfile(
   body: ReadableStream<Uint8Array>,
-  progress?: (numBytesLoaded: number) => void
+  progress?: (numBytesLoaded: number, done?: boolean) => void
 ): Promise<Profile> {
   const reader = body.getReader();
   const decoder = new TextDecoder("utf-8");
@@ -170,6 +175,14 @@ export async function readProfile(
       buffer = consumeEvents(buffer, profile);
     }
   }
+  if (progress) {
+    progress(n, true);
+    // Allow drawing the final progress frame. Some heavy CPU work happens while
+    // finalizing the profile, so this helps the UI not appear "stuck" while
+    // this happens.
+    await nextAnimationFrame();
+  }
+
   // Consume last event, which isn't guaranteed to end with ",\n"
   if (buffer) {
     const { chars, suffix } = trailingNonWhitespaceChars(buffer, 2);

--- a/app/trace/trace_events_test.ts
+++ b/app/trace/trace_events_test.ts
@@ -86,6 +86,19 @@ describe("parseProfile", () => {
     expect(profile.traceEvents.length).toBe(7);
     expect(numBytesRead).toBe(INCOMPLETE_PROFILE.length);
   });
+
+  it("should report final progress as done", async () => {
+    const stream = readableStreamFromString(COMPLETE_PROFILE);
+    const progress: { numBytesRead: number; done?: boolean }[] = [];
+    const profile = await readProfile(stream, (numBytesRead, done) => {
+      progress.push({ numBytesRead, done });
+    });
+
+    expect(profile.traceEvents.length).toBe(7);
+    expect(progress.length).toBeGreaterThan(0);
+    expect(progress.slice(0, progress.length - 1).some(({ done }) => done)).toBe(false);
+    expect(progress[progress.length - 1]).toEqual({ numBytesRead: COMPLETE_PROFILE.length, done: true });
+  });
 });
 
 describe("buildTimeSeries", () => {

--- a/app/util/async.ts
+++ b/app/util/async.ts
@@ -68,3 +68,17 @@ export class CancelablePromise<T = unknown> implements Promise<T> {
     if (this.parent) this.parent.cancel();
   }
 }
+
+/**
+ * Returns a promise that resolves after the browser has had a chance to paint
+ * the next frame. For non-browser environments, the returned promise resolves
+ * immediately.
+ */
+export function nextAnimationFrame(): Promise<void> {
+  if (typeof requestAnimationFrame === "undefined") return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    // RAF callbacks run before paint. Queue a timer from inside the callback so
+    // callers resume after the browser has had a chance to paint that frame.
+    requestAnimationFrame(() => setTimeout(resolve, 0));
+  });
+}

--- a/app/util/async_test.ts
+++ b/app/util/async_test.ts
@@ -1,4 +1,4 @@
-import { CancelablePromise } from "./async";
+import { CancelablePromise, nextAnimationFrame } from "./async";
 
 function delayedResolve<T>(value?: T, delayMs: number = 1): Promise<T | undefined> {
   return new Promise((resolve) => setTimeout(() => resolve(value), delayMs));
@@ -146,5 +146,30 @@ describe("CancelablePromise", () => {
       },
     }).cancel();
     expect(value).toBe(1);
+  });
+});
+
+describe("nextAnimationFrame", () => {
+  it("should resolve immediately when requestAnimationFrame is unavailable", async () => {
+    const testGlobal = globalThis as unknown as { requestAnimationFrame?: typeof requestAnimationFrame };
+    const originalRequestAnimationFrame = testGlobal.requestAnimationFrame;
+    testGlobal.requestAnimationFrame = undefined;
+
+    try {
+      let resolved = false;
+      const promise = nextAnimationFrame().then(() => {
+        resolved = true;
+      });
+      await Promise.resolve();
+
+      expect(resolved).toBe(true);
+      await promise;
+    } finally {
+      if (originalRequestAnimationFrame) {
+        testGlobal.requestAnimationFrame = originalRequestAnimationFrame;
+      } else {
+        delete testGlobal.requestAnimationFrame;
+      }
+    }
   });
 });


### PR DESCRIPTION
* Make sure we cancel loading the trace when navigating away from the Timing tab while the trace is loading. If loading a very large trace, currently the UI feels sluggish for a little while after navigating away, because the trace still loads in the background.
* When the trace is 100% loaded, make sure the progress bar appears 100% full, and show "Finalizing profile" while we handle the final trace processing. Currently the progress bar can stop a bit short of 100% because our compression estimate isn't perfect, but this makes it feel like the UI is frozen (when it's actually still alive, processing the profile).