### PR TITLE
Add utils for compact trace representation

### DIFF
--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -81,6 +81,29 @@ ts_library(
 )
 
 ts_library(
+    name = "typed_arrays",
+    srcs = ["typed_arrays.ts"],
+    deps = ["//:node_modules/tslib"],
+)
+
+ts_jasmine_node_test(
+    name = "typed_arrays_test",
+    srcs = ["typed_arrays_test.ts"],
+    deps = [":typed_arrays"],
+)
+
+ts_library(
+    name = "intern",
+    srcs = ["intern.ts"],
+)
+
+ts_jasmine_node_test(
+    name = "intern_test",
+    srcs = ["intern_test.ts"],
+    deps = [":intern"],
+)
+
+ts_library(
     name = "math",
     srcs = ["math.ts"],
 )

--- a/app/util/intern.ts
+++ b/app/util/intern.ts
@@ -1,0 +1,37 @@
+/**
+ * Deduplicates repeated strings by assigning each unique string a numeric ID.
+ * Callers can store IDs instead of many copies of the same string, reducing
+ * memory usage.
+ */
+export class StringInterner {
+  private strings: string[] = [];
+  private ids: Map<string, number> | null = new Map();
+
+  /** Returns the interned ID for the given string. */
+  intern(value: string): number {
+    if (!this.ids) {
+      throw new Error("StringInterner is frozen");
+    }
+
+    const id = this.ids.get(value);
+    if (id !== undefined) return id;
+
+    const nextID = this.strings.length;
+    this.strings.push(value);
+    this.ids.set(value, nextID);
+    return nextID;
+  }
+
+  /**
+   * Releases the string to ID lookup map and prevents further calls to intern.
+   * Call this when no more strings will be added to reduce idle memory usage.
+   */
+  freeze(): void {
+    this.ids = null;
+  }
+
+  /** Returns the string for the given interned ID. */
+  get(id: number): string {
+    return this.strings[id];
+  }
+}

--- a/app/util/intern_test.ts
+++ b/app/util/intern_test.ts
@@ -1,0 +1,27 @@
+import { StringInterner } from "./intern";
+
+describe("StringInterner", () => {
+  it("should return stable IDs for interned strings", () => {
+    const interner = new StringInterner();
+
+    const buildID = interner.intern("build");
+    const testID = interner.intern("test");
+
+    expect(buildID).toBe(0);
+    expect(testID).toBe(1);
+    expect(buildID).toBe(interner.intern("build"));
+    expect(testID).toBe(interner.intern("test"));
+    expect(interner.get(buildID)).toBe("build");
+    expect(interner.get(testID)).toBe("test");
+  });
+
+  it("should reject new intern calls after freezing", () => {
+    const interner = new StringInterner();
+
+    const buildID = interner.intern("build");
+    interner.freeze();
+
+    expect(interner.get(buildID)).toBe("build");
+    expect(() => interner.intern("build")).toThrowError("StringInterner is frozen");
+  });
+});

--- a/app/util/typed_arrays.ts
+++ b/app/util/typed_arrays.ts
@@ -1,0 +1,88 @@
+/**
+ * This module contains utilities for working with `TypedArray` objects.
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+ */
+
+/**
+ * Append-only typed array builder. Useful for consuming a stream of numeric
+ * data whose final length is not known ahead of time, and iteratively building
+ * a typed array from the data.
+ *
+ * Values are stored in chunks of size 1, 2, 4, ... while building, avoiding
+ * repeated full-array copies as the list grows. Calling `toArray` materializes
+ * the final contiguous typed array.
+ *
+ * Example:
+ *
+ * ```ts
+ * const builder = TypedArrayBuilder.of(Uint32Array);
+ * builder.append(1).append(2);
+ * const values = builder.toArray();
+ * ```
+ */
+export class TypedArrayBuilder<T extends NumberTypedArray> {
+  public length = 0;
+
+  private readonly ArrayType: TypedArrayConstructor<T>;
+  private readonly chunks: T[] = [];
+  private currentChunkLength = 0;
+
+  /** Creates an empty builder that materializes values as the given typed array type. */
+  static of<T extends NumberTypedArray>(ArrayType: TypedArrayConstructor<T>): TypedArrayBuilder<T> {
+    return new TypedArrayBuilder(ArrayType);
+  }
+
+  private constructor(ArrayType: TypedArrayConstructor<T>) {
+    this.ArrayType = ArrayType;
+  }
+
+  /** Appends a value to the builder. */
+  append(value: number): this {
+    let chunk = this.chunks[this.chunks.length - 1];
+    if (!chunk || this.currentChunkLength === chunk.length) {
+      chunk = new this.ArrayType(nextCapacity(chunk?.length || 0));
+      this.chunks.push(chunk);
+      this.currentChunkLength = 0;
+    }
+    chunk[this.currentChunkLength++] = value;
+    this.length++;
+    return this;
+  }
+
+  /** Materializes the appended values as one contiguous typed array. */
+  toArray(): T {
+    const values = new this.ArrayType(this.length);
+    let offset = 0;
+    for (let i = 0; i < this.chunks.length; i++) {
+      const chunk = this.chunks[i];
+      const length = i === this.chunks.length - 1 ? this.currentChunkLength : chunk.length;
+      values.set(chunk.subarray(0, length), offset);
+      offset += length;
+    }
+    return values;
+  }
+}
+
+/** Typed array variants whose elements can be assigned from a JavaScript number. */
+export type NumberTypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array;
+
+/**
+ * Constructor signature for types that allocate a new instance from an element
+ * count, such as `new Uint32Array(length)`.
+ */
+export type TypedArrayConstructor<T> = {
+  new (length: number): T;
+};
+
+function nextCapacity(capacity: number): number {
+  return capacity ? capacity * 2 : 1;
+}

--- a/app/util/typed_arrays_test.ts
+++ b/app/util/typed_arrays_test.ts
@@ -1,0 +1,38 @@
+import { NumberTypedArray, TypedArrayBuilder } from "./typed_arrays";
+
+describe("TypedArrayBuilder", () => {
+  it("should preserve initial and appended values", () => {
+    const builder = TypedArrayBuilder.of(Uint32Array);
+
+    builder.append(1).append(2).append(3).append(4);
+
+    expect(builder.length).toBe(4);
+    expectTypedArray(builder.toArray(), new Uint32Array([1, 2, 3, 4]));
+  });
+
+  it("should support NumberTypedArray constructors", () => {
+    expectTypedArray(TypedArrayBuilder.of(Int8Array).append(-1).append(2).toArray(), new Int8Array([-1, 2]));
+    expectTypedArray(TypedArrayBuilder.of(Uint8Array).append(1).append(2).toArray(), new Uint8Array([1, 2]));
+    expectTypedArray(
+      TypedArrayBuilder.of(Uint8ClampedArray).append(1).append(2).toArray(),
+      new Uint8ClampedArray([1, 2])
+    );
+    expectTypedArray(TypedArrayBuilder.of(Int16Array).append(-1).append(2).toArray(), new Int16Array([-1, 2]));
+    expectTypedArray(TypedArrayBuilder.of(Uint16Array).append(1).append(2).toArray(), new Uint16Array([1, 2]));
+    expectTypedArray(TypedArrayBuilder.of(Int32Array).append(-1).append(2).toArray(), new Int32Array([-1, 2]));
+    expectTypedArray(TypedArrayBuilder.of(Uint32Array).append(1).append(2).toArray(), new Uint32Array([1, 2]));
+    expectTypedArray(
+      TypedArrayBuilder.of(Float32Array).append(1.5).append(2.5).toArray(),
+      new Float32Array([1.5, 2.5])
+    );
+    expectTypedArray(
+      TypedArrayBuilder.of(Float64Array).append(1.5).append(2.5).toArray(),
+      new Float64Array([1.5, 2.5])
+    );
+  });
+});
+
+function expectTypedArray<T extends NumberTypedArray>(values: T, expected: T) {
+  expect(values.constructor).toBe(expected.constructor);
+  expect(Array.from(values)).toEqual(Array.from(expected));
+}


### PR DESCRIPTION
These utils are used in https://github.com/buildbuddy-io/buildbuddy/pull/12252 to allow the UI to render larger traces.