### PR TITLE
distributed_cache: skip readthrough AC

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -394,9 +394,6 @@ func isTreeCacheResource(r *rspb.ResourceName) bool {
 	return r.GetCacheType() == rspb.CacheType_AC && strings.HasPrefix(r.GetInstanceName(), digest.TreeCacheRemoteInstanceName)
 }
 
-// Only immutable resources can safely use local read-through caching. Tree
-// cache entries are stored as AC resources but are derived from immutable CAS
-// content.
 func isLocalReadthroughCacheableResource(r *rspb.ResourceName) bool {
 	return r.GetCacheType() == rspb.CacheType_CAS || isTreeCacheResource(r)
 }

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -394,6 +394,13 @@ func isTreeCacheResource(r *rspb.ResourceName) bool {
 	return r.GetCacheType() == rspb.CacheType_AC && strings.HasPrefix(r.GetInstanceName(), digest.TreeCacheRemoteInstanceName)
 }
 
+// Only immutable resources can safely use local read-through caching. Tree
+// cache entries are stored as AC resources but are derived from immutable CAS
+// content.
+func isLocalReadthroughCacheableResource(r *rspb.ResourceName) bool {
+	return r.GetCacheType() == rspb.CacheType_CAS || isTreeCacheResource(r)
+}
+
 // lookasideKey returns the resource's key in the lookaside cache and true,
 // or "" and false if the resource shouldn't be stored in the lookaside cache.
 func (c *Cache) lookasideKey(ctx context.Context, r *rspb.ResourceName) (key string, ok bool) {
@@ -678,7 +685,8 @@ func (c *Cache) peerZone(peer string) string {
 
 // writePeers returns the ordered slice of replicationFactor peers responsible
 // for writing this key. They should be tried in order.
-func (c *Cache) writePeers(d *repb.Digest) (*peerset.PeerSet, error) {
+func (c *Cache) writePeers(r *rspb.ResourceName) (*peerset.PeerSet, error) {
+	d := r.GetDigest()
 	allPeers := c.consistentHash.GetAllReplicas(d.GetHash())
 	if len(c.opts.NewNodes) > 0 && !*newNodesReadOnly {
 		allPeers = c.extraConsistentHash.GetAllReplicas(d.GetHash())
@@ -686,7 +694,7 @@ func (c *Cache) writePeers(d *repb.Digest) (*peerset.PeerSet, error) {
 	if len(allPeers) < c.opts.ReplicationFactor {
 		return nil, status.UnavailableErrorf("Not enough peers (%d) available to satisfy replication factor (%d).", len(allPeers), c.opts.ReplicationFactor)
 	}
-	if c.localReadthroughEnabled() {
+	if c.localReadthroughEnabled() && isLocalReadthroughCacheableResource(r) {
 		return ensureSameZonePrimary(allPeers, c.opts.ReplicationFactor, c.opts.ListenAddr, c.zone, c.peerZone), nil
 	}
 	return peerset.New(allPeers[:c.opts.ReplicationFactor], allPeers[c.opts.ReplicationFactor:]), nil
@@ -734,9 +742,10 @@ func dedupe(in []string) []string {
 }
 
 // readPeers returns a PeerSet for reading, where the order is self, same zone
-// peers, other peers. If local read-through is enabled, it ensures that at
-// least one primary peer is in the local zone.
-func (c *Cache) readPeers(d *repb.Digest) *peerset.PeerSet {
+// peers, other peers. For read-through-cacheable resources, if local read-through
+// is enabled, it ensures that at least one primary peer is in the local zone.
+func (c *Cache) readPeers(r *rspb.ResourceName) *peerset.PeerSet {
+	d := r.GetDigest()
 	peers := c.consistentHash.GetAllReplicas(d.GetHash())
 	var primaryPeers, secondaryPeers []string
 	// To prevent a panic if replication is misconfigured to be higher than peer count.
@@ -765,7 +774,7 @@ func (c *Cache) readPeers(d *repb.Digest) *peerset.PeerSet {
 	}
 
 	var blockBackfills []string
-	if c.localReadthroughEnabled() {
+	if c.localReadthroughEnabled() && isLocalReadthroughCacheableResource(r) {
 		primaryPeers, secondaryPeers, blockBackfills = readThroughPeers(primaryPeers, secondaryPeers, c.opts.ListenAddr, c.zone, c.peerZone)
 	}
 
@@ -917,16 +926,14 @@ func (c *Cache) remoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 
 	var readCloser io.ReadCloser
 
-	// Check if the blob is in the local read-through cache, if that feature
-	// is enabled. If not, configure localWriter so the blob can be written
-	// to the local cache as it is read.
-	if c.localReadthroughEnabled() {
+	// Check if an immutable blob is in the local read-through cache, if that
+	// feature is enabled. If not, configure localWriter so the blob can be
+	// written to the local cache as it is read.
+	if c.localReadthroughEnabled() && isLocalReadthroughCacheableResource(r) {
 		if rc, err := c.local.Reader(ctx, r, offset, limit); err == nil {
 			c.log.CtxDebugf(ctx, "Reader(%q) found locally", distributed_client.ResourceIsolationString(r))
 			readCloser = rc
-		} else if cacheable && (r.GetCacheType() == rspb.CacheType_CAS || isTreeCacheResource(r)) {
-			// AC entries can be updated, so we don't want to hold on to an old
-			// version.
+		} else if cacheable {
 			if local, err := c.local.Writer(ctx, r); err == nil {
 				localWriter = local
 			}
@@ -1120,7 +1127,7 @@ func (c *Cache) Contains(ctx context.Context, r *rspb.ResourceName) (bool, error
 	if _, found := c.getLookasideEntry(ctx, r); found {
 		return true, nil
 	}
-	ps := c.readPeers(r.GetDigest())
+	ps := c.readPeers(r)
 	backfill := func() {
 		if err := c.backfillPeers(ctx, c.getBackfillOrders(r, ps)); err != nil {
 			c.log.CtxDebugf(ctx, "Error backfilling peers: %s", err)
@@ -1147,7 +1154,7 @@ func (c *Cache) Contains(ctx context.Context, r *rspb.ResourceName) (bool, error
 
 func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces.CacheMetadata, error) {
 	d := r.GetDigest()
-	ps := c.readPeers(d)
+	ps := c.readPeers(r)
 
 	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
 		md, err := c.remoteMetadata(ctx, peer, r)
@@ -1183,7 +1190,7 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 		hash := r.GetDigest().GetHash()
 		hashResources[hash] = append(hashResources[hash], r)
 		if _, ok := peerMap[hash]; !ok {
-			peerMap[hash] = c.readPeers(r.GetDigest())
+			peerMap[hash] = c.readPeers(r)
 		}
 	}
 
@@ -1320,7 +1327,7 @@ func getIsolation(resources []*rspb.ResourceName) *dcpb.Isolation {
 //
 // Values found on a non-primary replica will be backfilled to the primary.
 func (c *Cache) distributedReader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64, metricsLabel string) (io.ReadCloser, error) {
-	ps := c.readPeers(rn.GetDigest())
+	ps := c.readPeers(rn)
 	backfill := func() {
 		if err := c.backfillPeers(ctx, c.getBackfillOrders(rn, ps)); err != nil {
 			c.log.CtxDebugf(ctx, "Error backfilling peers: %s", err)
@@ -1389,7 +1396,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 		hash := r.GetDigest().GetHash()
 		hashResources[hash] = append(hashResources[hash], r)
 		if _, ok := peerMap[hash]; !ok {
-			peerMap[hash] = c.readPeers(r.GetDigest())
+			peerMap[hash] = c.readPeers(r)
 		}
 	}
 
@@ -1559,7 +1566,7 @@ func (c *Cache) multiWriter(ctx context.Context, r *rspb.ResourceName) (interfac
 		return nil, err
 	}
 
-	ps, err := c.writePeers(r.GetDigest())
+	ps, err := c.writePeers(r)
 	if err != nil {
 		return nil, err
 	}
@@ -1631,7 +1638,7 @@ func (c *Cache) SetMulti(ctx context.Context, kvs map[*rspb.ResourceName][]byte)
 }
 
 func (c *Cache) Delete(ctx context.Context, r *rspb.ResourceName) error {
-	ps := c.readPeers(r.GetDigest())
+	ps := c.readPeers(r)
 	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
 		err := c.remoteDelete(ctx, peer, r)
 		if err != nil {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -200,7 +200,7 @@ func TestReadPeers_FewerNodesThanReplicationFactor(t *testing.T) {
 	require.NoError(t, err)
 
 	rn, _ := testdigest.RandomCASResourceBuf(t, 100)
-	ps := c.readPeers(rn.GetDigest())
+	ps := c.readPeers(rn)
 	require.ElementsMatch(t, []string{peer1, peer2}, ps.PreferredPeers)
 	require.Empty(t, ps.FallbackPeers)
 }
@@ -1157,7 +1157,7 @@ func TestHintedHandoff(t *testing.T) {
 	// that these were successfully handed off below.
 	hintedHandoffs := make([]*rspb.ResourceName, 0)
 	for _, d := range digestsWritten {
-		ps := dc3.readPeers(d.Digest)
+		ps := dc3.readPeers(d)
 		if slices.Contains(ps.PreferredPeers, peer3) {
 			hintedHandoffs = append(hintedHandoffs, d)
 		}
@@ -2424,7 +2424,7 @@ func digestWithNoSameZonePrimary(t *testing.T, c *Cache) *repb.Digest {
 	return nil
 }
 
-func TestReadThroughPeerSelectionPromotesMutableAC(t *testing.T) {
+func TestReadThroughPeerSelectionSkipsMutableAC(t *testing.T) {
 	c := newReadthroughPeerSelectionCache(t)
 	d := digestWithNoSameZonePrimary(t, c)
 	allPeers := c.consistentHash.GetAllReplicas(d.GetHash())
@@ -2436,32 +2436,34 @@ func TestReadThroughPeerSelectionPromotesMutableAC(t *testing.T) {
 	acResource := digest.NewResourceName(d, "", rspb.CacheType_AC, repb.DigestFunction_SHA256).ToProto()
 	treeResource := digest.NewResourceName(d, digest.GetTreeCacheInstanceName(d), rspb.CacheType_AC, repb.DigestFunction_SHA256).ToProto()
 
-	acWritePeers, err := c.writePeers(acResource.GetDigest())
+	acWritePeers, err := c.writePeers(acResource)
 	require.NoError(t, err)
-	assert.Equal(t, promotedPeers, acWritePeers.PreferredPeers)
+	assert.Equal(t, canonicalPeers, acWritePeers.PreferredPeers)
+	assert.NotContains(t, acWritePeers.PreferredPeers, c.opts.ListenAddr)
 
-	casWritePeers, err := c.writePeers(casResource.GetDigest())
+	casWritePeers, err := c.writePeers(casResource)
 	require.NoError(t, err)
 	assert.Equal(t, promotedPeers, casWritePeers.PreferredPeers)
 
-	treeWritePeers, err := c.writePeers(treeResource.GetDigest())
+	treeWritePeers, err := c.writePeers(treeResource)
 	require.NoError(t, err)
 	assert.Equal(t, promotedPeers, treeWritePeers.PreferredPeers)
 
-	acReadPeers := c.readPeers(acResource.GetDigest())
-	assert.Contains(t, acReadPeers.PreferredPeers, c.opts.ListenAddr)
-	assert.Contains(t, acReadPeers.BlockBackfills, c.opts.ListenAddr)
+	acReadPeers := c.readPeers(acResource)
+	assert.Equal(t, canonicalPeers, acReadPeers.PreferredPeers)
+	assert.Empty(t, acReadPeers.BlockBackfills)
+	assert.NotContains(t, acReadPeers.PreferredPeers, c.opts.ListenAddr)
 
-	casReadPeers := c.readPeers(casResource.GetDigest())
+	casReadPeers := c.readPeers(casResource)
 	assert.Contains(t, casReadPeers.PreferredPeers, c.opts.ListenAddr)
 	assert.Contains(t, casReadPeers.BlockBackfills, c.opts.ListenAddr)
 
-	treeReadPeers := c.readPeers(treeResource.GetDigest())
+	treeReadPeers := c.readPeers(treeResource)
 	assert.Contains(t, treeReadPeers.PreferredPeers, c.opts.ListenAddr)
 	assert.Contains(t, treeReadPeers.BlockBackfills, c.opts.ListenAddr)
 }
 
-func TestRemoteReaderServesLocalReadthroughForMutableAC(t *testing.T) {
+func TestRemoteReaderSkipsLocalReadthroughForMutableAC(t *testing.T) {
 	env, _, ctx := getEnvAuthAndCtx(t)
 	singleCacheSizeBytes := int64(1000000)
 	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
@@ -2497,7 +2499,7 @@ func TestRemoteReaderServesLocalReadthroughForMutableAC(t *testing.T) {
 	got, err := io.ReadAll(reader)
 	require.NoError(t, err)
 	require.NoError(t, reader.Close())
-	assert.Equal(t, stale, got)
+	assert.Equal(t, fresh, got)
 }
 
 func TestReadThroughPeers(t *testing.T) {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -2380,6 +2380,126 @@ func TestReadThroughLocalCache(t *testing.T) {
 
 }
 
+func newReadthroughPeerSelectionCache(t *testing.T) *Cache {
+	env, _, _ := getEnvAuthAndCtx(t)
+	nodes := []string{"b1", "b2", "b3", "a1", "a2", "a3"}
+	c, err := NewDistributedCache(env, newMemoryCache(t, 1000000), Options{
+		ListenAddr:            "a1",
+		ReplicationFactor:     3,
+		Nodes:                 nodes,
+		DisableLocalLookup:    true,
+		ReadThroughLocalCache: true,
+	}, env.GetHealthChecker())
+	require.NoError(t, err)
+	c.zone = "A"
+	c.peerZones = map[string]string{
+		"a1": "A",
+		"a2": "A",
+		"a3": "A",
+		"b1": "B",
+		"b2": "B",
+		"b3": "B",
+	}
+	return c
+}
+
+func digestWithNoSameZonePrimary(t *testing.T, c *Cache) *repb.Digest {
+	for i := 0; i < 10000; i++ {
+		buf := []byte(fmt.Sprintf("readthrough-peer-selection-%d", i))
+		d, err := digest.Compute(bytes.NewReader(buf), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		peers := c.consistentHash.GetAllReplicas(d.GetHash())
+		primaryPeers := peers[:c.opts.ReplicationFactor]
+		if slices.ContainsFunc(primaryPeers, func(peer string) bool {
+			return peer == c.opts.ListenAddr || c.peerZone(peer) == c.zone
+		}) {
+			continue
+		}
+		if !slices.Contains(peers[c.opts.ReplicationFactor:], c.opts.ListenAddr) {
+			continue
+		}
+		return d
+	}
+	t.Fatal("could not find digest with no same-zone primary")
+	return nil
+}
+
+func TestReadThroughPeerSelectionPromotesMutableAC(t *testing.T) {
+	c := newReadthroughPeerSelectionCache(t)
+	d := digestWithNoSameZonePrimary(t, c)
+	allPeers := c.consistentHash.GetAllReplicas(d.GetHash())
+	canonicalPeers := slices.Clone(allPeers[:c.opts.ReplicationFactor])
+	require.NotContains(t, canonicalPeers, c.opts.ListenAddr)
+	promotedPeers := append(slices.Clone(canonicalPeers), c.opts.ListenAddr)
+
+	casResource := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+	acResource := digest.NewResourceName(d, "", rspb.CacheType_AC, repb.DigestFunction_SHA256).ToProto()
+	treeResource := digest.NewResourceName(d, digest.GetTreeCacheInstanceName(d), rspb.CacheType_AC, repb.DigestFunction_SHA256).ToProto()
+
+	acWritePeers, err := c.writePeers(acResource.GetDigest())
+	require.NoError(t, err)
+	assert.Equal(t, promotedPeers, acWritePeers.PreferredPeers)
+
+	casWritePeers, err := c.writePeers(casResource.GetDigest())
+	require.NoError(t, err)
+	assert.Equal(t, promotedPeers, casWritePeers.PreferredPeers)
+
+	treeWritePeers, err := c.writePeers(treeResource.GetDigest())
+	require.NoError(t, err)
+	assert.Equal(t, promotedPeers, treeWritePeers.PreferredPeers)
+
+	acReadPeers := c.readPeers(acResource.GetDigest())
+	assert.Contains(t, acReadPeers.PreferredPeers, c.opts.ListenAddr)
+	assert.Contains(t, acReadPeers.BlockBackfills, c.opts.ListenAddr)
+
+	casReadPeers := c.readPeers(casResource.GetDigest())
+	assert.Contains(t, casReadPeers.PreferredPeers, c.opts.ListenAddr)
+	assert.Contains(t, casReadPeers.BlockBackfills, c.opts.ListenAddr)
+
+	treeReadPeers := c.readPeers(treeResource.GetDigest())
+	assert.Contains(t, treeReadPeers.PreferredPeers, c.opts.ListenAddr)
+	assert.Contains(t, treeReadPeers.BlockBackfills, c.opts.ListenAddr)
+}
+
+func TestRemoteReaderServesLocalReadthroughForMutableAC(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := Options{
+		ReplicationFactor:     1,
+		Nodes:                 []string{peer1, peer2},
+		DisableLocalLookup:    true,
+		ReadThroughLocalCache: true,
+	}
+
+	memoryCache1 := newMemoryCache(t, singleCacheSizeBytes)
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := newMemoryCache(t, singleCacheSizeBytes)
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	startNewDCache(t, env, config2, memoryCache2)
+
+	waitForReady(t, peer1)
+	waitForReady(t, peer2)
+
+	rn, _ := testdigest.RandomACResourceBuf(t, 100)
+	stale := []byte("stale action result")
+	fresh := []byte("fresh action result")
+	require.NoError(t, memoryCache1.Set(ctx, rn, stale))
+	require.NoError(t, memoryCache2.Set(ctx, rn, fresh))
+
+	reader, err := dc1.remoteReader(ctx, peer2, rn, 0, 0)
+	require.NoError(t, err)
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, stale, got)
+}
+
 func TestReadThroughPeers(t *testing.T) {
 	// Zone map: A = zone-a, B = zone-b, "" = unknown.
 	zones := map[string]string{


### PR DESCRIPTION
Mutable Action Cache entries can be overwritten, so local
read-through copies outside the canonical replica set can become stale.
This became possible because 873250b89f (#12137) promoted same-zone
write and read peers based only on the digest. UpdateActionResult can
write a non-canonical local-zone AC replica, a later update from another
zone can update only the canonical replicas, and remoteReader can return
the stale local copy before contacting the selected peer.

This PR adds characterization coverage for the vulnerable behavior, then
passes the full ResourceName into distributed read and write peer
selection. Read-through locality is now limited to immutable resources:
CAS objects and tree-cache entries, which are AC-shaped but derived from
CAS content. Regular AC keys stay on the canonical replica set, and
remoteReader skips local read-through lookup before calling the selected
peer.

Closes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7412
