### PR TITLE
cache_proxy: reject invalid read offsets

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -175,6 +175,12 @@ type readMetrics struct {
 }
 
 func (s *ByteStreamServerProxy) read(ctx context.Context, req *bspb.ReadRequest, stream *meteredReadServerStream) (readMetrics, error) {
+	if err := byte_stream_server.CheckReadPreconditions(req); err != nil {
+		return readMetrics{
+			cacheStatus: metrics.HitStatusLabel,
+			compressor:  "unknown",
+		}, err
+	}
 	rn, err := digest.ParseDownloadResourceName(req.GetResourceName())
 	if err != nil {
 		return readMetrics{

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -6,8 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -1399,28 +1397,41 @@ func TestReadChunked(t *testing.T) {
 	require.Equal(t, float64(len(originalData)), testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadHitLabels))-proxiedReadHitBytesBefore)
 }
 
-func TestReadChunkNegativeOffsetCrashesProcess(t *testing.T) {
-	if os.Getenv("TEST_PROXY_CHUNK_NEGATIVE_OFFSET_CRASH") == "1" {
-		rn := digest.NewCASResourceName(&repb.Digest{
-			Hash:      strings.Repeat("a", 64),
-			SizeBytes: 1,
-		}, "", repb.DigestFunction_SHA256)
-		s := &ByteStreamServerProxy{bufPool: bytebufferpool.VariableSize(1)}
-		resultChans := make([]chan chunkReadResult, 1)
-		s.fillChunkReadWindow(context.Background(), resultChans, []chunkReadRequest{{
-			rn:     rn,
-			offset: -1 << 63,
-		}}, 0, 0, false)
-		<-resultChans[0]
-		return
+func TestReadChecksPreconditions(t *testing.T) {
+	s := &ByteStreamServerProxy{}
+	for _, tc := range []struct {
+		name    string
+		req     *bspb.ReadRequest
+		wantErr func(error) bool
+	}{
+		{
+			name:    "missing_resource_name",
+			req:     &bspb.ReadRequest{},
+			wantErr: status.IsInvalidArgumentError,
+		},
+		{
+			name: "negative_read_offset",
+			req: &bspb.ReadRequest{
+				ResourceName: "invalid-resource-name",
+				ReadOffset:   -1,
+			},
+			wantErr: status.IsOutOfRangeError,
+		},
+		{
+			name: "negative_read_limit",
+			req: &bspb.ReadRequest{
+				ResourceName: "invalid-resource-name",
+				ReadLimit:    -1,
+			},
+			wantErr: status.IsOutOfRangeError,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.read(context.Background(), tc.req, &meteredReadServerStream{})
+			require.Error(t, err)
+			require.True(t, tc.wantErr(err), "unexpected error: %s", err)
+		})
 	}
-
-	cmd := exec.Command(os.Args[0], "-test.run=^TestReadChunkNegativeOffsetCrashesProcess$")
-	cmd.Env = append(os.Environ(), "TEST_PROXY_CHUNK_NEGATIVE_OFFSET_CRASH=1")
-	output, err := cmd.CombinedOutput()
-	require.Error(t, err)
-	require.Contains(t, string(output), "panic: runtime error")
-	require.Contains(t, string(output), "slice bounds out of range")
 }
 
 func TestReadChunkedFastPathSkipsSplitBlob(t *testing.T) {

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -1395,6 +1397,30 @@ func TestReadChunked(t *testing.T) {
 	require.Equal(t, float64(0), readBytesRemoteAfter-readBytesRemoteBefore, "second read: no bytes fetched from remote")
 	require.Equal(t, float64(0), testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadMissLabels))-proxiedReadMissBytesBefore)
 	require.Equal(t, float64(len(originalData)), testutil.ToFloat64(metrics.ByteStreamProxiedReadBytes.With(proxiedReadHitLabels))-proxiedReadHitBytesBefore)
+}
+
+func TestReadChunkNegativeOffsetCrashesProcess(t *testing.T) {
+	if os.Getenv("TEST_PROXY_CHUNK_NEGATIVE_OFFSET_CRASH") == "1" {
+		rn := digest.NewCASResourceName(&repb.Digest{
+			Hash:      strings.Repeat("a", 64),
+			SizeBytes: 1,
+		}, "", repb.DigestFunction_SHA256)
+		s := &ByteStreamServerProxy{bufPool: bytebufferpool.VariableSize(1)}
+		resultChans := make([]chan chunkReadResult, 1)
+		s.fillChunkReadWindow(context.Background(), resultChans, []chunkReadRequest{{
+			rn:     rn,
+			offset: -1 << 63,
+		}}, 0, 0, false)
+		<-resultChans[0]
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestReadChunkNegativeOffsetCrashesProcess$")
+	cmd.Env = append(os.Environ(), "TEST_PROXY_CHUNK_NEGATIVE_OFFSET_CRASH=1")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(output), "panic: runtime error")
+	require.Contains(t, string(output), "slice bounds out of range")
 }
 
 func TestReadChunkedFastPathSkipsSplitBlob(t *testing.T) {

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -101,7 +101,8 @@ func NewByteStreamServer(env environment.Env) (*ByteStreamServer, error) {
 	}, nil
 }
 
-func checkReadPreconditions(req *bspb.ReadRequest) error {
+// CheckReadPreconditions validates a ByteStream ReadRequest before processing it.
+func CheckReadPreconditions(req *bspb.ReadRequest) error {
 	if req.ResourceName == "" {
 		return status.InvalidArgumentError("Missing resource name")
 	}
@@ -128,7 +129,7 @@ func rpcPeerAddr(ctx context.Context) string {
 // of bytes. The bytes are returned in a sequence of responses, and the
 // responses are delivered as the results of a server-side streaming FUNC (S *BYTESTREAMSERVER).
 func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
-	if err := checkReadPreconditions(req); err != nil {
+	if err := CheckReadPreconditions(req); err != nil {
 		return err
 	}
 	rn, err := digest.ParseDownloadResourceName(req.GetResourceName())


### PR DESCRIPTION
A malformed ByteStream ReadRequest can crash cache proxy today.
Chunked reads accepted a client-controlled negative ReadOffset and
carried it into readChunk from a spawned goroutine. An extreme offset
could overflow the chunk buffer capacity to a negative length and
panic inside bytebufferpool.

This fix is needed because gRPC panic recovery does not catch panics
from those child goroutines. The first commit captures the unrecovered
child-process crash in a subprocess, and the second commit reuses the
normal ByteStream read precondition checks at the top of the proxy
read path.

That rejects missing resource names and negative offsets or limits
before the proxy chooses local, remote, or chunked read handling.

Closes https://github.com/buildbuddy-io/buildbuddy-internal/issues/7413
