### PR TITLE
cachetools: verify chunked downloads

### DIFF
--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -344,13 +344,45 @@ func GetBlobChunked(
 	if err := f.Truncate(size); err != nil {
 		return err
 	}
+	checksum, err := digest.HashForDigestType(r.GetDigestFunction())
+	if err != nil {
+		return err
+	}
+	chunkDone := make([]chan struct{}, len(chunks))
+	for i := range chunkDone {
+		chunkDone[i] = make(chan struct{})
+	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(chunkedFileDownloadConcurrency)
+	// Keep the verifier outside the chunk download concurrency budget.
+	g.SetLimit(chunkedFileDownloadConcurrency + 1)
+	g.Go(func() error {
+		for i, c := range chunks {
+			select {
+			case <-chunkDone[i]:
+			case <-gctx.Done():
+				return gctx.Err()
+			}
+			if _, err := io.Copy(checksum, io.NewSectionReader(f, offsets[i], c.GetSizeBytes())); err != nil {
+				return status.DataLossErrorf("compute chunked download digest: %s", err)
+			}
+		}
+		computedDigest := &repb.Digest{
+			Hash:      hex.EncodeToString(checksum.Sum(nil)),
+			SizeBytes: size,
+		}
+		if !digest.Equal(computedDigest, r.GetDigest()) {
+			return status.DataLossErrorf("Downloaded chunked content (digest %q) did not match expected (digest %q)", digest.String(computedDigest), digest.String(r.GetDigest()))
+		}
+		return nil
+	})
 	for i, c := range chunks {
-		offset, c := offsets[i], c
 		g.Go(func() error {
-			return writeChunk(gctx, bsClient, r, c, offset, openLocal, f)
+			if err := writeChunk(gctx, bsClient, r, c, offsets[i], openLocal, f); err != nil {
+				return err
+			}
+			close(chunkDone[i])
+			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -678,7 +678,7 @@ func TestGetBlobChunked_FallsBackWithoutManifest(t *testing.T) {
 	require.Equal(t, []byte("keep me"), got)
 }
 
-func TestGetBlobChunked_AcceptsMismatchedParentDigest(t *testing.T) {
+func TestGetBlobChunked_RejectsMismatchedParentDigest(t *testing.T) {
 	ctx := context.Background()
 	compute := func(data []byte) *repb.Digest {
 		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_BLAKE3)
@@ -712,7 +712,9 @@ func TestGetBlobChunked_AcceptsMismatchedParentDigest(t *testing.T) {
 	defer out.Close()
 
 	err = cachetools.GetBlobChunked(ctx, bs, cas, rn, &repb.FileNode{Digest: expectedDigest}, out, nil)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Equal(t, codes.DataLoss, gstatus.Code(err))
+	require.ErrorContains(t, err, "Downloaded chunked content")
 
 	got, err := os.ReadFile(out.Name())
 	require.NoError(t, err)

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -678,6 +678,47 @@ func TestGetBlobChunked_FallsBackWithoutManifest(t *testing.T) {
 	require.Equal(t, []byte("keep me"), got)
 }
 
+func TestGetBlobChunked_AcceptsMismatchedParentDigest(t *testing.T) {
+	ctx := context.Background()
+	compute := func(data []byte) *repb.Digest {
+		d, err := digest.Compute(bytes.NewReader(data), repb.DigestFunction_BLAKE3)
+		require.NoError(t, err)
+		return d
+	}
+
+	expectedBlob := []byte("GOODGOOD")
+	mismatchedChunks := [][]byte{[]byte("EVIL"), []byte("DATA")}
+	expectedDigest := compute(expectedBlob)
+	chunkDigests := make([]*repb.Digest, 0, len(mismatchedChunks))
+	bsData := make(map[string][]byte, len(mismatchedChunks))
+	for _, chunk := range mismatchedChunks {
+		chunkDigest := compute(chunk)
+		chunkDigests = append(chunkDigests, chunkDigest)
+		chunkRN := digest.NewCASResourceName(chunkDigest, testInstance, repb.DigestFunction_BLAKE3)
+		bsData[chunkRN.DownloadString()] = chunk
+	}
+
+	rn := digest.NewCASResourceName(expectedDigest, testInstance, repb.DigestFunction_BLAKE3)
+	cas := &fakeCasClient{
+		splitBlobFn: func(ctx context.Context, req *repb.SplitBlobRequest) (*repb.SplitBlobResponse, error) {
+			require.Equal(t, expectedDigest.GetHash(), req.GetBlobDigest().GetHash())
+			require.Equal(t, expectedDigest.GetSizeBytes(), req.GetBlobDigest().GetSizeBytes())
+			return &repb.SplitBlobResponse{ChunkDigests: chunkDigests}, nil
+		},
+	}
+	bs := &fakeBytestreamClient{mu: &sync.Mutex{}, data: bsData}
+	out, err := os.CreateTemp(t.TempDir(), "chunked-download-*")
+	require.NoError(t, err)
+	defer out.Close()
+
+	err = cachetools.GetBlobChunked(ctx, bs, cas, rn, &repb.FileNode{Digest: expectedDigest}, out, nil)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(out.Name())
+	require.NoError(t, err)
+	require.Equal(t, []byte("EVILDATA"), got)
+}
+
 func TestGetBlobChunked_ReusesWholeFileChunks_ZstdBLAKE3(t *testing.T) {
 	ctx := context.Background()
 	chunk1 := bytes.Repeat([]byte("a"), 1024)


### PR DESCRIPTION
A chunked executor input download can materialize bytes that do not
match the requested FileNode digest when SplitBlob returns a forged or
corrupt manifest. GetBlobChunked verifies each chunk but not the
assembled parent blob, so the success path bypasses the normal
ByteStream digest check.

Add a characterization test for the vulnerable behavior, then recompute
the parent digest from the assembled file because manifest trust is not
enough to prove the requested blob was materialized. This turns a forged
or corrupt manifest into DataLoss and keeps the chunked path from
accepting mismatched executor inputs.

Closes https://github.com/buildbuddy-io/buildbuddy-internal/issues/7415
