### PR TITLE
Allow overriding the timing profile resource name via URL

### DIFF
--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -88,6 +88,27 @@ export default class InvocationTimingCardComponent extends React.Component<Props
   }
 
   getProfileFile(): build_event_stream.File | undefined {
+    // To override the auto-loaded profile (for debugging):
+    // - Upload a profile with `bb upload --target=grpc://localhost:1985 <profile_path>`
+    // - Copy the resulting resource name that it prints
+    // - Check whether the file is gzipped by running `file <profile_path>`
+    // - If it's gzipped, set ?debug_profile_gz=<resource_name> in the URL.
+    //   Otherwise, set ?debug_profile_json=<resource_name>
+    const debugProfileGzippedRN = new URLSearchParams(window.location.search).get("debug_profile_gz");
+    if (debugProfileGzippedRN) {
+      return new build_event_stream.File({
+        name: "timing_profile.gz",
+        uri: "bytestream://localhost:1985/" + debugProfileGzippedRN.replaceAll("^/", ""),
+      });
+    }
+    const debugProfileRN = new URLSearchParams(window.location.search).get("debug_profile_json");
+    if (debugProfileRN) {
+      return new build_event_stream.File({
+        name: "timing_profile.json",
+        uri: "bytestream://localhost:1985/" + debugProfileRN.replaceAll("^/", ""),
+      });
+    }
+
     // Bazel 8 semi-fixed the profile name with: https://github.com/bazelbuild/bazel/pull/22345
     const version = this.props.model?.getBazelVersion();
     if (version && version.major >= 8) {

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -94,14 +94,15 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     // - Check whether the file is gzipped by running `file <profile_path>`
     // - If it's gzipped, set ?debug_profile_gz=<resource_name> in the URL.
     //   Otherwise, set ?debug_profile_json=<resource_name>
-    const debugProfileGzippedRN = new URLSearchParams(window.location.search).get("debug_profile_gz");
+    const params = new URLSearchParams(window.location.search);
+    const debugProfileGzippedRN = params.get("debug_profile_gz");
     if (debugProfileGzippedRN) {
       return new build_event_stream.File({
         name: "timing_profile.gz",
         uri: "bytestream://localhost:1985/" + debugProfileGzippedRN.replace(/^\/+/, ""),
       });
     }
-    const debugProfileRN = new URLSearchParams(window.location.search).get("debug_profile_json");
+    const debugProfileRN = params.get("debug_profile_json");
     if (debugProfileRN) {
       return new build_event_stream.File({
         name: "timing_profile.json",

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -98,14 +98,14 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     if (debugProfileGzippedRN) {
       return new build_event_stream.File({
         name: "timing_profile.gz",
-        uri: "bytestream://localhost:1985/" + debugProfileGzippedRN.replaceAll("^/", ""),
+        uri: "bytestream://localhost:1985/" + debugProfileGzippedRN.replace(/^\/+/, ""),
       });
     }
     const debugProfileRN = new URLSearchParams(window.location.search).get("debug_profile_json");
     if (debugProfileRN) {
       return new build_event_stream.File({
         name: "timing_profile.json",
-        uri: "bytestream://localhost:1985/" + debugProfileRN.replaceAll("^/", ""),
+        uri: "bytestream://localhost:1985/" + debugProfileRN.replace(/^\/+/, ""),
       });
     }
 


### PR DESCRIPTION
We already support overriding the displayed profile by dragging and dropping a profile into the UI, but this becomes tedious when iterating on changes locally. This PR adds debug URL params to make this easier.