### PR TITLE
[FC] Cleanup unused code

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -98,8 +98,6 @@ var (
 	enablePCI                             = flag.Bool("executor.firecracker_enable_pci", true, "Enable PCI for firecracker VMs. Should only be enabled if firecracker version is v1.14.4+.", flag.Internal)
 	dnsOverrides                          = flag.Slice("executor.firecracker_dns_overrides", []*networking.DNSOverride{}, "DNS entries to override in the guest.")
 
-	exportSnapshotToCOW = flag.Bool("executor.firecracker_export_snapshot_to_cow", true, "Export Firecracker memory snapshots directly to a VBD-backed COWStore instead of a temporary file on disk that is later converted to a COWStore.", flag.Internal)
-
 	forceRemoteSnapshotting = flag.Bool("debug_force_remote_snapshots", false, "When remote snapshotting is enabled, force remote snapshotting even for tasks which otherwise wouldn't support it.")
 	disableWorkspaceSync    = flag.Bool("debug_disable_firecracker_workspace_sync", false, "Do not sync the action workspace to the guest, instead using the existing workspace from the VM snapshot.")
 	debugDisableCgroup      = flag.Bool("debug_disable_cgroup", false, "Disable firecracker cgroup setup.")
@@ -1067,39 +1065,6 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 
 	snapshotSharingEnabled := snaputil.IsChunkedSnapshotSharingEnabled()
 	memSnapshotPath := filepath.Join(c.getChroot(), snapshotDetails.memSnapshotName)
-
-	if snapshotDetails.snapshotType == diffSnapshotType && !*exportSnapshotToCOW {
-		baseMemSnapshotPath := filepath.Join(c.getChroot(), fullMemSnapshotName)
-		mergeStart := time.Now()
-		concurrency := mergeDiffSnapshotConcurrency
-		if *snaputil.ThrottleSnapshotWrites {
-			concurrency = 1
-		}
-		if err := MergeDiffSnapshot(ctx, baseMemSnapshotPath, c.memoryStore, memSnapshotPath, concurrency, mergeDiffSnapshotBlockSize); err != nil {
-			return status.UnknownErrorf("merge diff snapshot failed: %s", err)
-		}
-		log.CtxDebugf(ctx, "VMM merge diff snapshot took %s", time.Since(mergeStart))
-		// Use the merged memory snapshot.
-		memSnapshotPath = baseMemSnapshotPath
-	}
-
-	// If exportSnapshotToCOW=true, the COWStore should've been populated
-	// as firecracker wrote the snapshot.
-	//
-	// Otherwise, for full snapshots, we need to convert the snapshot file on disk to a COWStore.
-	// For diff snapshots, we updated the COWStore in mergeDiffSnapshot above,
-	if snapshotSharingEnabled && c.memoryStore == nil {
-		memChunkDir := filepath.Join(c.getChroot(), memoryChunkDirName)
-		concurrency := snaputil.ConvertToCOWConcurrency
-		if *snaputil.ThrottleSnapshotWrites {
-			concurrency = 1
-		}
-		memoryStore, err := c.convertToCOW(ctx, memSnapshotPath, memChunkDir, concurrency)
-		if err != nil {
-			return status.WrapError(err, "convert memory snapshot to COWStore")
-		}
-		c.memoryStore = memoryStore
-	}
 
 	vmd := c.getVMMetadata().CloneVT()
 	vmd.SavedSnapshotVersionNumber++
@@ -3269,57 +3234,51 @@ func (c *FirecrackerContainer) snapshotDetails(ctx context.Context) (*snapshotDe
 		memSnapshotName = diffMemSnapshotName
 	}
 
-	if *exportSnapshotToCOW {
-		if !snaputil.IsChunkedSnapshotSharingEnabled() {
-			return nil, status.InvalidArgumentErrorf("exportSnapshotToCOW is only supported when chunked snapshot sharing is enabled")
+	// We export full snapshots directly to a COWStore. Create the COWStore here.
+	// For diff snapshots, we'll use the existing memoryStore.
+	if snapshotType == fullSnapshotType {
+		memChunkDir := filepath.Join(c.getChroot(), memoryChunkDirName)
+		if err := os.Mkdir(memChunkDir, 0755); err != nil {
+			return nil, status.WrapError(err, "make memory chunk dir")
+		}
+		memorySizeBytes := c.vmConfig.GetMemSizeMb() * 1024 * 1024
+		if memorySizeBytes <= 0 {
+			return nil, status.InternalErrorf("invalid memory snapshot size %d bytes", memorySizeBytes)
 		}
 
-		// If the full snapshot should be exported straight to a COWStore, create it here.
-		// For diff snapshots, we'll use the existing memoryStore.
-		if snapshotType == fullSnapshotType {
-			memChunkDir := filepath.Join(c.getChroot(), memoryChunkDirName)
-			if err := os.Mkdir(memChunkDir, 0755); err != nil {
-				return nil, status.WrapError(err, "make memory chunk dir")
-			}
-			memorySizeBytes := c.vmConfig.GetMemSizeMb() * 1024 * 1024
-			if memorySizeBytes <= 0 {
-				return nil, status.InternalErrorf("invalid memory snapshot size %d bytes", memorySizeBytes)
-			}
-
-			memoryStore, err := copy_on_write.NewCOWStore(c.vmCtx, c.env, memoryChunkDirName, nil, copy_on_write.COWOptions{
-				ChunkSizeBytes:     cowChunkSizeBytes(),
-				TotalSizeBytes:     memorySizeBytes,
-				DataDir:            memChunkDir,
-				RemoteInstanceName: c.snapshotKeySet.GetBranchKey().GetInstanceName(),
-				RemoteEnabled:      c.supportsRemoteSnapshots,
-				MaxMmappedChunks:   c.snapshotWriteMaxMmappedChunks(),
-			})
-			if err != nil {
-				return nil, status.WrapError(err, "create memory COWStore")
-			}
-			c.memoryStore = memoryStore
-		}
-
-		if c.memoryStore == nil {
-			return nil, status.InternalErrorf("memory store not created when exporting snapshot to COW")
-		}
-
-		// Create a FUSE-backed VBD for the memory snapshot so that we can capture writes
-		// as it's being exported by firecracker and write them directly to the COWStore.
-		d, err := vbd.New(c.memoryStore)
+		memoryStore, err := copy_on_write.NewCOWStore(c.vmCtx, c.env, memoryChunkDirName, nil, copy_on_write.COWOptions{
+			ChunkSizeBytes:     cowChunkSizeBytes(),
+			TotalSizeBytes:     memorySizeBytes,
+			DataDir:            memChunkDir,
+			RemoteInstanceName: c.snapshotKeySet.GetBranchKey().GetInstanceName(),
+			RemoteEnabled:      c.supportsRemoteSnapshots,
+			MaxMmappedChunks:   c.snapshotWriteMaxMmappedChunks(),
+		})
 		if err != nil {
-			return nil, status.WrapError(err, "create memory snapshot VBD")
+			return nil, status.WrapError(err, "create memory COWStore")
 		}
-		relVBDPath := memSnapshotName + vbdMountDirSuffix
-		mountPath := filepath.Join(c.getChroot(), relVBDPath)
-		if err := d.Mount(c.vmCtx, mountPath); err != nil {
-			return nil, status.WrapError(err, "mount memory snapshot VBD")
-		}
-
-		memSnapshotName = filepath.Join(relVBDPath, vbd.FileName)
-		c.memorySnapshotExportVBD = d
-		log.CtxDebugf(ctx, "Mounted memory snapshot VBD to %s", mountPath)
+		c.memoryStore = memoryStore
 	}
+
+	if c.memoryStore == nil {
+		return nil, status.InternalErrorf("memory store not created when exporting snapshot to COW")
+	}
+
+	// Create a FUSE-backed VBD for the memory snapshot so that we can capture writes
+	// as it's being exported by firecracker and write them directly to the COWStore.
+	d, err := vbd.New(c.memoryStore)
+	if err != nil {
+		return nil, status.WrapError(err, "create memory snapshot VBD")
+	}
+	relVBDPath := memSnapshotName + vbdMountDirSuffix
+	mountPath := filepath.Join(c.getChroot(), relVBDPath)
+	if err := d.Mount(c.vmCtx, mountPath); err != nil {
+		return nil, status.WrapError(err, "mount memory snapshot VBD")
+	}
+
+	memSnapshotName = filepath.Join(relVBDPath, vbd.FileName)
+	c.memorySnapshotExportVBD = d
+	log.CtxDebugf(ctx, "Mounted memory snapshot VBD to %s", mountPath)
 
 	return &snapshotDetails{
 		snapshotType:        snapshotType,
@@ -3341,14 +3300,12 @@ func (c *FirecrackerContainer) createSnapshot(ctx context.Context, snapshotDetai
 		metrics.Stage: "create_snapshot",
 	}).Dec()
 
-	if *exportSnapshotToCOW && c.memoryStore != nil && snapshotDetails.snapshotType == diffSnapshotType {
-		// By default, mmapped chunks are managed by the executor-wide shared LRU.
-		//
-		// When exporting the diff snapshot, we should limit the number of chunks mmapped at a time.
-		// Snapshots are exported sequentially, so we don't want recently touched chunks to stay mmapped longer than necessary.
-		if err := c.memoryStore.LimitMmappedChunks(c.snapshotWriteMaxMmappedChunks()); err != nil {
-			return status.WrapError(err, "set limited LRU for diff snapshot export")
-		}
+	// By default, mmapped chunks are managed by the executor-wide shared LRU.
+	//
+	// When exporting snapshots, we should limit the number of chunks mmapped at a time.
+	// Snapshots are exported sequentially, so we don't want recently touched chunks to stay mmapped longer than necessary.
+	if err := c.memoryStore.LimitMmappedChunks(c.snapshotWriteMaxMmappedChunks()); err != nil {
+		return status.WrapError(err, "set limited LRU for snapshot export")
 	}
 
 	machineStart := time.Now()

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -4018,81 +4018,78 @@ func TestFirecrackerStressIO(t *testing.T) {
 
 func Benchmark_FullSnapshotPause(b *testing.B) {
 	for _, memorySizeMb := range []int64{1000, 2000, 4000, 8000} {
-		for _, cowExportEnabled := range []bool{true, false} {
-			b.Run(fmt.Sprintf("memory_size_%d_mb_cow_export_%t", memorySizeMb, cowExportEnabled), func(b *testing.B) {
-				flags.Set(b, "executor.firecracker_export_snapshot_to_cow", cowExportEnabled)
-				ctx := context.Background()
-				env := getTestEnv(ctx, b, envOpts{})
-				rootDir := testfs.MakeTempDir(b)
-				cfg := getExecutorConfig(b)
+		b.Run(fmt.Sprintf("memory_size_%d_mb", memorySizeMb), func(b *testing.B) {
+			ctx := context.Background()
+			env := getTestEnv(ctx, b, envOpts{})
+			rootDir := testfs.MakeTempDir(b)
+			cfg := getExecutorConfig(b)
 
-				var containersToCleanup []*firecracker.FirecrackerContainer
-				b.Cleanup(func() {
-					for _, vm := range containersToCleanup {
-						err := vm.Remove(ctx)
-						assert.NoError(b, err)
-					}
-				})
-
-				opts := firecracker.ContainerOpts{
-					ContainerImage: ubuntuImage,
-					VMConfiguration: &fcpb.VMConfiguration{
-						NumCpus:            2,
-						MemSizeMb:          memorySizeMb,
-						NetworkMode:        fcpb.NetworkMode_NETWORK_MODE_OFF,
-						ScratchDiskSizeMb:  500,
-						GuestKernelVersion: cfg.GuestKernelVersion,
-						FirecrackerVersion: cfg.FirecrackerVersion,
-						GuestApiVersion:    cfg.GuestAPIVersion,
-					},
-					ExecutorConfig: cfg,
+			var containersToCleanup []*firecracker.FirecrackerContainer
+			b.Cleanup(func() {
+				for _, vm := range containersToCleanup {
+					err := vm.Remove(ctx)
+					assert.NoError(b, err)
 				}
+			})
 
-				// Don't try to write the full memory size of the VM, or it will OOM.
-				mbToWrite := int(.8 * float64(memorySizeMb))
-				cmd := &repb.Command{
-					// Mount a RAM-based filesystem to /tmp/randomdata to simulate memory usage.
-					Arguments: []string{"sh", "-c", `
+			opts := firecracker.ContainerOpts{
+				ContainerImage: ubuntuImage,
+				VMConfiguration: &fcpb.VMConfiguration{
+					NumCpus:            2,
+					MemSizeMb:          memorySizeMb,
+					NetworkMode:        fcpb.NetworkMode_NETWORK_MODE_OFF,
+					ScratchDiskSizeMb:  500,
+					GuestKernelVersion: cfg.GuestKernelVersion,
+					FirecrackerVersion: cfg.FirecrackerVersion,
+					GuestApiVersion:    cfg.GuestAPIVersion,
+				},
+				ExecutorConfig: cfg,
+			}
+
+			// Don't try to write the full memory size of the VM, or it will OOM.
+			mbToWrite := int(.8 * float64(memorySizeMb))
+			cmd := &repb.Command{
+				// Mount a RAM-based filesystem to /tmp/randomdata to simulate memory usage.
+				Arguments: []string{"sh", "-c", `
 mkdir /tmp/randomdata && mount -t tmpfs -o size=` + strconv.Itoa(mbToWrite) + `M tmpfs /tmp/randomdata
 dd if=/dev/urandom of=/tmp/randomdata/data bs=1M count=` + strconv.Itoa(mbToWrite) + `
 free -h
 		`},
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				task := &repb.ExecutionTask{
+					Command: &repb.Command{
+						Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+							{Name: "recycle-runner", Value: "true"},
+							// This is testing full snapshot generation, so ensure there's no snapshot sharing between runs.
+							{Name: "salt", Value: fmt.Sprintf("%d_%d", memorySizeMb, i)},
+						}},
+						Arguments: []string{"./buildbuddy_ci_runner"},
+					},
 				}
 
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
-					b.StopTimer()
-					task := &repb.ExecutionTask{
-						Command: &repb.Command{
-							Platform: &repb.Platform{Properties: []*repb.Platform_Property{
-								{Name: "recycle-runner", Value: "true"},
-								// This is testing full snapshot generation, so ensure there's no snapshot sharing between runs.
-								{Name: "salt", Value: fmt.Sprintf("%d_%v_%d", memorySizeMb, cowExportEnabled, i)},
-							}},
-							Arguments: []string{"./buildbuddy_ci_runner"},
-						},
-					}
+				workDir := testfs.MakeDirAll(b, rootDir, fmt.Sprintf("work%d", i))
+				opts.ActionWorkingDirectory = workDir
+				c, err := firecracker.NewContainer(ctx, env, task, opts)
+				require.NoError(b, err)
+				containersToCleanup = append(containersToCleanup, c)
 
-					workDir := testfs.MakeDirAll(b, rootDir, fmt.Sprintf("work%d", i))
-					opts.ActionWorkingDirectory = workDir
-					c, err := firecracker.NewContainer(ctx, env, task, opts)
-					require.NoError(b, err)
-					containersToCleanup = append(containersToCleanup, c)
+				err = container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher)
+				require.NoError(b, err)
+				err = c.Create(ctx, opts.ActionWorkingDirectory)
+				require.NoError(b, err)
+				res := c.Exec(ctx, cmd, nil /*=stdio*/)
+				require.NoError(b, res.Error)
 
-					err = container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher)
-					require.NoError(b, err)
-					err = c.Create(ctx, opts.ActionWorkingDirectory)
-					require.NoError(b, err)
-					res := c.Exec(ctx, cmd, nil /*=stdio*/)
-					require.NoError(b, res.Error)
-
-					b.StartTimer()
-					err = c.Pause(ctx)
-					b.StopTimer()
-					require.NoError(b, err)
-				}
-			})
-		}
+				b.StartTimer()
+				err = c.Pause(ctx)
+				b.StopTimer()
+				require.NoError(b, err)
+			}
+		})
 	}
 }
 
@@ -4101,95 +4098,92 @@ func Benchmark_DiffSnapshotPause(b *testing.B) {
 	flags.Set(b, "executor.enable_remote_snapshot_sharing", false)
 
 	for _, memorySizeMb := range []int64{1000, 2000, 4000, 8000} {
-		for _, cowExportEnabled := range []bool{true, false} {
-			b.Run(fmt.Sprintf("memory_size_%d_mb_cow_export_%t", memorySizeMb, cowExportEnabled), func(b *testing.B) {
-				flags.Set(b, "executor.firecracker_export_snapshot_to_cow", cowExportEnabled)
-				ctx := context.Background()
-				env := getTestEnv(ctx, b, envOpts{})
-				cfg := getExecutorConfig(b)
-				rootDir := testfs.MakeTempDir(b)
-				workDir := testfs.MakeDirAll(b, rootDir, "work")
+		b.Run(fmt.Sprintf("memory_size_%d_mb", memorySizeMb), func(b *testing.B) {
+			ctx := context.Background()
+			env := getTestEnv(ctx, b, envOpts{})
+			cfg := getExecutorConfig(b)
+			rootDir := testfs.MakeTempDir(b)
+			workDir := testfs.MakeDirAll(b, rootDir, "work")
 
-				opts := firecracker.ContainerOpts{
-					ActionWorkingDirectory: workDir,
-					ContainerImage:         ubuntuImage,
-					VMConfiguration: &fcpb.VMConfiguration{
-						NumCpus:            2,
-						MemSizeMb:          memorySizeMb,
-						NetworkMode:        fcpb.NetworkMode_NETWORK_MODE_OFF,
-						ScratchDiskSizeMb:  500,
-						GuestKernelVersion: cfg.GuestKernelVersion,
-						FirecrackerVersion: cfg.FirecrackerVersion,
-						GuestApiVersion:    cfg.GuestAPIVersion,
-					},
-					ExecutorConfig: cfg,
-				}
-				task := &repb.ExecutionTask{
-					Command: &repb.Command{
-						Platform: &repb.Platform{Properties: []*repb.Platform_Property{
-							{Name: "recycle-runner", Value: "true"},
-							{Name: platform.MinTimeBetweenSnapshotWritesPropertyName, Value: "0s"},
-							{Name: platform.SnapshotSavePolicyPropertyName, Value: platform.AlwaysSaveSnapshot},
-						}},
-						Arguments: []string{"./buildbuddy_ci_runner"},
-					},
-				}
+			opts := firecracker.ContainerOpts{
+				ActionWorkingDirectory: workDir,
+				ContainerImage:         ubuntuImage,
+				VMConfiguration: &fcpb.VMConfiguration{
+					NumCpus:            2,
+					MemSizeMb:          memorySizeMb,
+					NetworkMode:        fcpb.NetworkMode_NETWORK_MODE_OFF,
+					ScratchDiskSizeMb:  500,
+					GuestKernelVersion: cfg.GuestKernelVersion,
+					FirecrackerVersion: cfg.FirecrackerVersion,
+					GuestApiVersion:    cfg.GuestAPIVersion,
+				},
+				ExecutorConfig: cfg,
+			}
+			task := &repb.ExecutionTask{
+				Command: &repb.Command{
+					Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+						{Name: "recycle-runner", Value: "true"},
+						{Name: platform.MinTimeBetweenSnapshotWritesPropertyName, Value: "0s"},
+						{Name: platform.SnapshotSavePolicyPropertyName, Value: platform.AlwaysSaveSnapshot},
+					}},
+					Arguments: []string{"./buildbuddy_ci_runner"},
+				},
+			}
 
-				// Don't try to write the full memory size of the VM, or it will OOM.
-				mbToWrite := int(.8 * float64(memorySizeMb))
-				initialCmd := &repb.Command{
-					// Mount a RAM-based filesystem to /tmp/randomdata. Later we'll write to it to simulate memory usage.
-					Arguments: []string{"sh", "-c", `
+			// Don't try to write the full memory size of the VM, or it will OOM.
+			mbToWrite := int(.8 * float64(memorySizeMb))
+			initialCmd := &repb.Command{
+				// Mount a RAM-based filesystem to /tmp/randomdata. Later we'll write to it to simulate memory usage.
+				Arguments: []string{"sh", "-c", `
 mkdir /tmp/randomdata && mount -t tmpfs -o size=` + strconv.Itoa(mbToWrite) + `M tmpfs /tmp/randomdata
 		`},
-				}
+			}
 
-				c, err := firecracker.NewContainer(ctx, env, task, opts)
-				if err != nil {
+			c, err := firecracker.NewContainer(ctx, env, task, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			if err := container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher); err != nil {
+				b.Fatalf("unable to pull image: %s", err)
+			}
+
+			if err := c.Create(ctx, opts.ActionWorkingDirectory); err != nil {
+				b.Fatalf("unable to Create container: %s", err)
+			}
+			b.Cleanup(func() {
+				if err := c.Remove(ctx); err != nil {
 					b.Fatal(err)
 				}
+			})
 
-				if err := container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher); err != nil {
-					b.Fatalf("unable to pull image: %s", err)
-				}
+			// Generate one full snapshot outside of the loop. Within the loop, it will always create a diff snapshot.
+			res := c.Exec(ctx, initialCmd, nil /*=stdio*/)
+			require.NoError(b, res.Error)
+			err = c.Pause(ctx)
+			require.NoError(b, err)
 
-				if err := c.Create(ctx, opts.ActionWorkingDirectory); err != nil {
-					b.Fatalf("unable to Create container: %s", err)
-				}
-				b.Cleanup(func() {
-					if err := c.Remove(ctx); err != nil {
-						b.Fatal(err)
-					}
-				})
-
-				// Generate one full snapshot outside of the loop. Within the loop, it will always create a diff snapshot.
-				res := c.Exec(ctx, initialCmd, nil /*=stdio*/)
-				require.NoError(b, res.Error)
-				err = c.Pause(ctx)
-				require.NoError(b, err)
-
-				cmdOnResumedRunner := &repb.Command{
-					// Write to the RAM-based filesystem to simulate memory usage.
-					Arguments: []string{"sh", "-c", `
+			cmdOnResumedRunner := &repb.Command{
+				// Write to the RAM-based filesystem to simulate memory usage.
+				Arguments: []string{"sh", "-c", `
 dd if=/dev/urandom of=/tmp/randomdata/data bs=1M count=` + strconv.Itoa(mbToWrite) + `
 free -h
 		`},
-				}
+			}
 
-				b.ResetTimer()
+			b.ResetTimer()
+			b.StopTimer()
+			for i := 0; i < b.N; i++ {
+				err = c.Unpause(ctx)
+				require.NoError(b, err)
+				res = c.Exec(ctx, cmdOnResumedRunner, nil /*=stdio*/)
+				require.NoError(b, res.Error)
+				b.StartTimer()
+				err = c.Pause(ctx)
 				b.StopTimer()
-				for i := 0; i < b.N; i++ {
-					err = c.Unpause(ctx)
-					require.NoError(b, err)
-					res = c.Exec(ctx, cmdOnResumedRunner, nil /*=stdio*/)
-					require.NoError(b, res.Error)
-					b.StartTimer()
-					err = c.Pause(ctx)
-					b.StopTimer()
-					require.NoError(b, err)
-				}
-			})
-		}
+				require.NoError(b, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Now that `executor.firecracker_export_snapshot_to_cow=true` for all executors and the [results look good](https://buildbuddy-corp.slack.com/archives/C05GBMP463D/p1779480825900439?thread_ts=1778099410.204429&cid=C05GBMP463D), clean up the now unused code