### PR TITLE
Cache unclaimed task list in app memory for a short TTL

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//server/util/random",
         "//server/util/status",
         "//server/util/tracing",
+        "//third_party/singleflight",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_prometheus_client_golang//prometheus",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
+	"github.com/buildbuddy-io/buildbuddy/third_party/singleflight"
 	"github.com/go-redis/redis/v8"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
@@ -62,6 +63,7 @@ var (
 	cgroupSettingsEnabled        = flag.Bool("remote_execution.cgroup_settings_enabled", true, "Apply cgroup2 settings to Linux executions.")
 	proactiveCancellationEnabled = flag.Bool("remote_execution.proactive_cancellation_enabled", false, "If true, the scheduler will proactively cancel task reservations on executors when a task is completed by another executor.")
 	debugExecutorLabelsKey       = flag.String("remote_execution.debug_executor_labels_key", "", "If set, requests using the 'debug-executor-labels' platform property must also set the 'debug-executor-labels-key' platform property to this value, otherwise the requested labels are ignored. If empty, anyone can use 'debug-executor-labels'.", flag.Secret)
+	unclaimedTasksCacheTTL       = flag.Duration("remote_execution.unclaimed_tasks_cache_ttl", 1*time.Second, "If set, cache the unclaimed task list in memory for up to this TTL", flag.Internal)
 )
 
 const (
@@ -836,21 +838,28 @@ func (k *nodePoolKey) redisUnclaimedTasksKey() string {
 }
 
 type nodePool struct {
-	env       environment.Env
-	rdb       redis.UniversalClient
+	rdb   redis.UniversalClient
+	clock clockwork.Clock
+
 	mu        sync.Mutex
 	lastFetch time.Time
 	nodes     []*executionNode
 	key       nodePoolKey
 	// Executors that are currently connected to this instance of the scheduler server.
 	connectedExecutors []*executionNode
+
+	unclaimedTasksSingleFlight singleflight.Group[string, []string]
+
+	unclaimedTasksMu     sync.Mutex
+	unclaimedTasks       []string
+	unclaimedTasksExpiry time.Time
 }
 
 func newNodePool(env environment.Env, key nodePoolKey) *nodePool {
 	np := &nodePool{
-		env: env,
-		key: key,
-		rdb: env.GetRemoteExecutionRedisClient(),
+		key:   key,
+		rdb:   env.GetRemoteExecutionRedisClient(),
+		clock: env.GetClock(),
 	}
 	return np
 }
@@ -1027,9 +1036,10 @@ func (np *nodePool) RemoveUnclaimedTask(ctx context.Context, taskID string) erro
 }
 
 func (np *nodePool) SampleUnclaimedTasks(ctx context.Context, n int) ([]string, error) {
-	// Get all task IDs. Redis >=6.2 has a ZRANDMEMBER command, but we don't want to assume that onprem customers have a
-	// relatively new Redis version.
-	unclaimed, err := np.rdb.ZRange(ctx, np.key.redisUnclaimedTasksKey(), 0, -1).Result()
+	// Get all task IDs using ZRANGE (with short in-memory caching). Redis >=6.2
+	// has a ZRANDMEMBER command, but we don't want to assume that onprem
+	// customers have a relatively new Redis version.
+	unclaimed, err := np.getAllTaskIDs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1039,6 +1049,38 @@ func (np *nodePool) SampleUnclaimedTasks(ctx context.Context, n int) ([]string, 
 		unclaimed[i], unclaimed[j] = unclaimed[j], unclaimed[i]
 	})
 	return unclaimed[:min(n, len(unclaimed))], nil
+}
+
+// Gets all currently unclaimed tasks. If a TTL is configured, the result is
+// cached for a short duration to avoid excessive Redis compute, which can
+// become problematic for very large executor pools issuing a steady stream of
+// AskForMoreWorkRequests.
+func (np *nodePool) getAllTaskIDs(ctx context.Context) ([]string, error) {
+	// The singleflight group should help reduce some concurrent lookups which
+	// are more likely to happen if the list is large.
+	unclaimed, _, err := np.unclaimedTasksSingleFlight.Do(ctx, "" /*=key*/, func(ctx context.Context) ([]string, error) {
+		if !np.unclaimedTasksExpiry.IsZero() && np.clock.Now().Before(np.unclaimedTasksExpiry) {
+			return np.unclaimedTasks, nil
+		}
+		unclaimed, err := np.rdb.ZRange(ctx, np.key.redisUnclaimedTasksKey(), 0, -1).Result()
+		if err != nil {
+			return nil, err
+		}
+		if *unclaimedTasksCacheTTL <= 0 {
+			return unclaimed, nil
+		}
+
+		np.unclaimedTasksMu.Lock()
+		defer np.unclaimedTasksMu.Unlock()
+		np.unclaimedTasks = unclaimed
+		np.unclaimedTasksExpiry = np.clock.Now().Add(*unclaimedTasksCacheTTL)
+
+		return unclaimed, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return slices.Clone(unclaimed), nil
 }
 
 type persistedTask struct {
@@ -1133,7 +1175,7 @@ func (c *schedulerClientCache) get(hostPort string) (*schedulerClient, error) {
 type Options struct {
 	LocalPortOverride               int32
 	RequireExecutorAuthorization    bool
-	Clock                           clockwork.Clock
+	Clock                           clockwork.Clock // TODO: get this from env
 	ActionMergingLeaseTTLOverride   time.Duration
 	LeaseDuration, LeaseGracePeriod time.Duration
 }
@@ -1215,7 +1257,7 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 		}
 	}
 
-	clock := clockwork.NewRealClock()
+	clock := env.GetClock()
 	if options.Clock != nil {
 		clock = options.Clock
 	}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -105,6 +105,9 @@ func getEnv(t *testing.T, opts *schedulerOpts, user string) (*testenv.TestEnv, c
 	env := enterprise_testenv.GetCustomTestEnv(t, &enterprise_testenv.Options{
 		RedisTarget: redisTarget,
 	})
+	if opts.options.Clock != nil {
+		env.SetClock(opts.options.Clock)
+	}
 
 	flags.Set(t, "remote_execution.default_pool_name", "defaultPoolName")
 	flags.Set(t, "remote_execution.shared_executor_pool_group_id", "sharedGroupID")
@@ -1103,6 +1106,10 @@ func TestEnqueueTaskReservation_RoutingConfig(t *testing.T) {
 }
 
 func TestAskForMoreWork_OnlyEnqueuesTasksThatFitOnNode(t *testing.T) {
+	// Disable unclaimedTasks cache to simulate the TTL expiring immediately
+	// for the purposes of this test.
+	flags.Set(t, "remote_execution.unclaimed_tasks_cache_ttl", 0*time.Second)
+
 	clock := clockwork.NewFakeClock()
 	env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
 
@@ -1181,6 +1188,59 @@ func TestAskForMoreWork_RespectRequestedExecutorID(t *testing.T) {
 	})
 	rsp = <-executor2.schedulerMessages
 	require.Greater(t, rsp.GetAskForMoreWorkResponse().GetDelay().AsDuration(), time.Duration(0))
+}
+
+func TestAskForMoreWork_CachesResultsToReduceRedisLoad(t *testing.T) {
+	for _, testCase := range []struct {
+		name                string
+		cacheTTL            time.Duration
+		expectedZrangeCount int64
+	}{
+		{
+			name:                "should dedupe ZRANGE calls within cache TTL",
+			cacheTTL:            time.Duration(1 * time.Minute),
+			expectedZrangeCount: 1,
+		},
+		{
+			name:     "should issue individual ZRANGE requests if cache TTL is disabled",
+			cacheTTL: 0,
+			// 1 request on registration + 1 for each AskForMoreWorkRequest
+			expectedZrangeCount: 11,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags.Set(t, "remote_execution.unclaimed_tasks_cache_ttl", testCase.cacheTTL)
+
+			clock := clockwork.NewFakeClock()
+			env, ctx := getEnv(t, &schedulerOpts{options: Options{Clock: clock}}, "user1")
+			zrangeCounter := testredis.NewCommandCounter("ZRANGE")
+			env.GetRemoteExecutionRedisClient().AddHook(zrangeCounter)
+
+			executor := newFakeExecutorWithId(ctx, t, "large", env.GetSchedulerClient())
+			executor.Register()
+
+			// Register an executor and have it ask for more work several times.
+			for range 10 {
+				executor.Send(&scpb.RegisterAndStreamWorkRequest{
+					AskForMoreWorkRequest: &scpb.AskForMoreWorkRequest{},
+				})
+				<-executor.schedulerMessages
+			}
+
+			require.Equal(t, testCase.expectedZrangeCount, zrangeCounter.Count())
+
+			// After advancing past cache TTL and issuing one more
+			// AskForMoreWorkRequest, we should expect to see more ZRANGE calls.
+			clock.Advance(testCase.cacheTTL + 1*time.Nanosecond)
+
+			executor.Send(&scpb.RegisterAndStreamWorkRequest{
+				AskForMoreWorkRequest: &scpb.AskForMoreWorkRequest{},
+			})
+			<-executor.schedulerMessages
+			require.Equal(t, testCase.expectedZrangeCount+1, zrangeCounter.Count())
+		})
+	}
+
 }
 
 // registerLabeledExecutorPair registers two executors whose labels differ.

--- a/enterprise/server/testutil/testredis/testredis.go
+++ b/enterprise/server/testutil/testredis/testredis.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -265,4 +266,51 @@ func (w *logWriter) Write(b []byte) (int, error) {
 		log.Infof("[redis server] %s", line)
 	}
 	return len(b), nil
+}
+
+// CommandCounter counts Redis commands matching a command name.
+//
+// Example usage:
+//
+//	counter := testredis.NewCommandCounter("ZRANGE")
+//	rdb.AddHook(counter)
+//	rdb.ZRange(/* ... */)
+//	counter.Count() // returns 1
+type CommandCounter struct {
+	name  string
+	count atomic.Int64
+}
+
+// NewCommandCounter returns a Redis hook that counts commands matching name.
+func NewCommandCounter(name string) *CommandCounter {
+	return &CommandCounter{name: strings.ToLower(name)}
+}
+
+// Count returns the number of matching Redis commands observed.
+func (c *CommandCounter) Count() int64 {
+	return c.count.Load()
+}
+
+func (c *CommandCounter) countCommand(cmd redis.Cmder) {
+	if cmd.Name() != c.name {
+		return
+	}
+	c.count.Add(1)
+}
+
+func (c *CommandCounter) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+func (c *CommandCounter) AfterProcess(ctx context.Context, cmd redis.Cmder) error {
+	c.countCommand(cmd)
+	return nil
+}
+func (c *CommandCounter) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
+	return ctx, nil
+}
+func (c *CommandCounter) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
+	for _, cmd := range cmds {
+		c.countCommand(cmd)
+	}
+	return nil
 }


### PR DESCRIPTION
This should help reduce the CPU load due to excessive ZRANGE requests.

Context: https://buildbuddy-corp.slack.com/archives/C06N9AHA4JX/p1779825473313449?thread_ts=1779822468.054299&cid=C06N9AHA4JX