### PR TITLE
Revert "stop dual-writing ExecutionID on the OLAP path"

### DIFF
--- a/enterprise/server/execution_search_service/execution_search_service_test.go
+++ b/enterprise/server/execution_search_service/execution_search_service_test.go
@@ -51,6 +51,7 @@ func TestSearchExecutions(t *testing.T) {
 
 	executions := []*olaptables.Execution{
 		{
+			ExecutionID:                        exid1,
 			GroupID:                            "GR1",
 			InvocationUUID:                     strings.ReplaceAll(iid1, "-", ""),
 			User:                               "ci-runner",
@@ -92,6 +93,7 @@ func TestSearchExecutions(t *testing.T) {
 			UpdatedAtUsec:                      testTimestampUsec,
 		},
 		{
+			ExecutionID:                     exid2,
 			GroupID:                         "GR1",
 			InvocationUUID:                  strings.ReplaceAll(iid2, "-", ""),
 			User:                            "developer",
@@ -120,6 +122,7 @@ func TestSearchExecutions(t *testing.T) {
 			UpdatedAtUsec:                   testTimestampUsec + 1000,
 		},
 		{
+			ExecutionID:      exid3,
 			GroupID:          "GR2",
 			InvocationUUID:   strings.ReplaceAll(uuid.New(), "-", ""),
 			User:             "other-user",
@@ -221,6 +224,7 @@ func TestSearchExecutions_SkipsEmptyInvocationUUID(t *testing.T) {
 
 	executions := []*olaptables.Execution{
 		{
+			ExecutionID:      exid1,
 			GroupID:          "GR1",
 			InvocationUUID:   strings.ReplaceAll(iid1, "-", ""),
 			User:             "ci-runner",
@@ -236,6 +240,7 @@ func TestSearchExecutions_SkipsEmptyInvocationUUID(t *testing.T) {
 			UpdatedAtUsec:    testTimestampUsec,
 		},
 		{
+			ExecutionID:      exid2,
 			GroupID:          "GR1",
 			InvocationUUID:   "",
 			User:             "unknown",
@@ -287,6 +292,7 @@ func TestSearchExecutions_Pagination(t *testing.T) {
 		actionDigest := &repb.Digest{Hash: hash, SizeBytes: int64(100 + i*10)}
 		executionID := makeExecutionID(actionDigest)
 		executions[i] = &olaptables.Execution{
+			ExecutionID:      executionID,
 			GroupID:          "GR1",
 			InvocationUUID:   strings.ReplaceAll(uuid.New(), "-", ""),
 			User:             "ci-runner",
@@ -355,6 +361,7 @@ func TestSearchExecutions_PaginationWithEmptyInvocationUUIDs(t *testing.T) {
 			invocationUUID = ""
 		}
 		executions[i] = &olaptables.Execution{
+			ExecutionID:      executionID,
 			GroupID:          "GR1",
 			InvocationUUID:   invocationUUID,
 			User:             "ci-runner",

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -368,8 +368,12 @@ func FillExecutionResourceFieldsFromExecutionID(out *schema.Execution, execution
 // logic.
 func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*schema.Execution, error) {
 	out := &schema.Execution{
-		GroupID:                            in.GetGroupId(),
-		UpdatedAtUsec:                      in.GetUpdatedAtUsec(),
+		GroupID:       in.GetGroupId(),
+		UpdatedAtUsec: in.GetUpdatedAtUsec(),
+		// ExecutionID is no longer read on the OLAP path, but we keep
+		// dual-writing it so the column stays populated in case we need
+		// to roll back the read migration.
+		ExecutionID:                        in.GetExecutionId(),
 		InvocationUUID:                     in.GetInvocationUuid(),
 		CreatedAtUsec:                      in.GetCreatedAtUsec(),
 		UserID:                             in.GetUserId(),

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -169,6 +169,7 @@ type Execution struct {
 	GroupID        string `gorm:"codec:ZSTD(1)"`
 	UpdatedAtUsec  int64  `gorm:"codec:DoubleDelta,ZSTD(1)"`
 	InvocationUUID string `gorm:"codec:ZSTD(1)"`
+	ExecutionID    string `gorm:"codec:ZSTD(1)"`
 
 	// Resource-name components split out of execution_id.
 	// ActionDigest holds raw hash bytes (incompressible) — default codec.
@@ -308,7 +309,6 @@ func (e *Execution) TableOptions(clickhouseVersion string) string {
 
 func (e *Execution) ExcludedFields() []string {
 	return []string{
-		"ExecutionID",
 		"InvocationID",
 		"Perms",
 		"SerializedOperation",


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#12180

This breaks CI on master https://buildbuddy.buildbuddy.io/invocation/1b65388e-31d9-4f43-aafd-5ccb277c0b36