### PR TITLE
Fix small race condition with unclaimedTasks

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1060,6 +1060,8 @@ func (np *nodePool) getAllTaskIDs(ctx context.Context) ([]string, error) {
 	// are more likely to happen if the list is large.
 	unclaimed, _, err := np.unclaimedTasksSingleFlight.Do(ctx, "" /*=key*/, func(ctx context.Context) ([]string, error) {
 		if !np.unclaimedTasksExpiry.IsZero() && np.clock.Now().Before(np.unclaimedTasksExpiry) {
+			np.unclaimedTasksMu.Lock()
+			defer np.unclaimedTasksMu.Unlock()
 			return np.unclaimedTasks, nil
 		}
 		unclaimed, err := np.rdb.ZRange(ctx, np.key.redisUnclaimedTasksKey(), 0, -1).Result()


### PR DESCRIPTION
`singleflight` can theoretically have multiple concurrent calls due to context cancellation, so this is technically a race.