### PR TITLE
Remove deprecated fields from the distributed cache protocol

### DIFF
--- a/enterprise/server/backends/distributed/BUILD
+++ b/enterprise/server/backends/distributed/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//enterprise/server/util/distributed_client",
         "//enterprise/server/util/heartbeat",
         "//enterprise/server/util/redisutil",
-        "//proto:distributed_cache_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/environment",

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -40,7 +40,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/metadata"
 
-	dcpb "github.com/buildbuddy-io/buildbuddy/proto/distributed_cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	gstatus "google.golang.org/grpc/status"
@@ -99,12 +98,8 @@ type lookasideCacheEntry struct {
 }
 
 func (o *hintedHandoffOrder) String() string {
-	hash := o.r.GetDigest().GetHash()
-	isolation := &dcpb.Isolation{
-		CacheType:          o.r.GetCacheType(),
-		RemoteInstanceName: o.r.GetInstanceName(),
-	}
-	return fmt.Sprintf("{digest:%q isolation:{%s}}", hash, isolation)
+	return fmt.Sprintf("{digest:%q cache_type:%s remote_instance_name:%q}",
+		o.r.GetDigest().GetHash(), o.r.GetCacheType(), o.r.GetInstanceName())
 }
 
 // TODO(go/b/6456): use memory cache instead of LRU for lookaside cache
@@ -840,7 +835,7 @@ func (c *Cache) remoteMetadata(ctx context.Context, peer string, r *rspb.Resourc
 	return c.distributedProxy.RemoteMetadata(ctx, peer, r)
 }
 
-func (c *Cache) remoteFindMissing(ctx context.Context, peer string, isolation *dcpb.Isolation, rns []*rspb.ResourceName) ([]*repb.Digest, error) {
+func (c *Cache) remoteFindMissing(ctx context.Context, peer string, rns []*rspb.ResourceName) ([]*repb.Digest, error) {
 	if !c.opts.DisableLocalLookup && peer == c.opts.ListenAddr {
 		return c.local.FindMissing(ctx, rns)
 	}
@@ -856,10 +851,10 @@ func (c *Cache) remoteFindMissing(ctx context.Context, peer string, isolation *d
 	if len(stillMissing) == 0 {
 		return nil, nil
 	}
-	return c.distributedProxy.RemoteFindMissing(ctx, peer, isolation, stillMissing)
+	return c.distributedProxy.RemoteFindMissing(ctx, peer, stillMissing)
 }
 
-func (c *Cache) remoteGetMulti(ctx context.Context, peer string, isolation *dcpb.Isolation, rns []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
+func (c *Cache) remoteGetMulti(ctx context.Context, peer string, rns []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	if !c.opts.DisableLocalLookup && peer == c.opts.ListenAddr {
 		return c.local.GetMulti(ctx, rns)
 	}
@@ -877,7 +872,7 @@ func (c *Cache) remoteGetMulti(ctx context.Context, peer string, isolation *dcpb
 		return results, nil
 	}
 
-	remoteResults, err := c.distributedProxy.RemoteGetMulti(ctx, peer, isolation, stillMissing)
+	remoteResults, err := c.distributedProxy.RemoteGetMulti(ctx, peer, stillMissing)
 	if err != nil {
 		return nil, err
 	}
@@ -1175,8 +1170,7 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces
 }
 
 func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName) ([]*repb.Digest, error) {
-	isolation := getIsolation(resources)
-	if isolation == nil {
+	if len(resources) == 0 {
 		return nil, nil
 	}
 
@@ -1235,7 +1229,7 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 			peer := peer
 			resources := resources
 			eg.Go(func() error {
-				peerRsp, err := c.remoteFindMissing(gCtx, peer, isolation, resources)
+				peerRsp, err := c.remoteFindMissing(gCtx, peer, resources)
 				peerMissingHashes := make(map[string]struct{})
 				for _, d := range peerRsp {
 					peerMissingHashes[d.GetHash()] = struct{}{}
@@ -1307,17 +1301,6 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 	return missing, nil
 }
 
-// Returns the isolation from the first resource name, assuming that all resources have the same isolation
-func getIsolation(resources []*rspb.ResourceName) *dcpb.Isolation {
-	if len(resources) == 0 {
-		return nil
-	}
-	return &dcpb.Isolation{
-		CacheType:          resources[0].GetCacheType(),
-		RemoteInstanceName: resources[0].GetInstanceName(),
-	}
-}
-
 // The first reader with a non-empty value will be returned. If all potential
 // peers for the digest are exhausted, then return a NotFoundError.
 //
@@ -1381,8 +1364,7 @@ func (c *Cache) Get(ctx context.Context, rn *rspb.ResourceName) ([]byte, error) 
 }
 
 func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
-	isolation := getIsolation(resources)
-	if isolation == nil {
+	if len(resources) == 0 {
 		return nil, nil
 	}
 
@@ -1428,7 +1410,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 			peer := peer
 			resources := resources
 			eg.Go(func() error {
-				peerRsp, err := c.remoteGetMulti(gCtx, peer, isolation, resources)
+				peerRsp, err := c.remoteGetMulti(gCtx, peer, resources)
 				mu.Lock()
 				defer mu.Unlock()
 				if err != nil {

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -144,13 +144,6 @@ func (c *Proxy) shouldReadCompressed(rn *rspb.ResourceName) bool {
 		c.cache.SupportsCompressor(repb.Compressor_ZSTD)
 }
 
-func digestFromKey(k *dcpb.Key) *repb.Digest {
-	return &repb.Digest{
-		Hash:      k.GetKey(),
-		SizeBytes: k.GetSizeBytes(),
-	}
-}
-
 func digestToKey(d *repb.Digest) *dcpb.Key {
 	return &dcpb.Key{
 		Key:       d.GetHash(),
@@ -199,49 +192,13 @@ func (c *Proxy) readWriteContext(ctx context.Context) (context.Context, error) {
 	return ctx, err
 }
 
-// Distributed cache requests now contain resource.ResourceName structs, replacing usage of the dcpb.Isolation and
-// dcpb.Key structs. However during a rollout, the new resource fields may not be set, and may require fallback to the
-// older deprecated fields
-func getResource(r *rspb.ResourceName, isolation *dcpb.Isolation, digestKey *dcpb.Key) *rspb.ResourceName {
-	if r != nil {
-		return r
-	}
-
-	d := digestFromKey(digestKey)
-	return &rspb.ResourceName{
-		Digest:       d,
-		CacheType:    isolation.GetCacheType(),
-		InstanceName: isolation.GetRemoteInstanceName(),
-		Compressor:   repb.Compressor_IDENTITY,
-	}
-}
-
-func getResources(resources []*rspb.ResourceName, isolation *dcpb.Isolation, digestKeys []*dcpb.Key) []*rspb.ResourceName {
-	if resources != nil {
-		return resources
-	}
-
-	log.Warningf("cacheproxy: falling back to digest keys; this should not happen")
-	instanceName := isolation.GetRemoteInstanceName()
-	cacheType := isolation.GetCacheType()
-	rns := make([]*rspb.ResourceName, 0)
-	for _, k := range digestKeys {
-		d := digestFromKey(k)
-		rn := digest.NewResourceName(d, instanceName, cacheType, repb.DigestFunction_SHA256).ToProto()
-		rns = append(rns, rn)
-	}
-
-	return rns
-}
-
 func (c *Proxy) FindMissing(ctx context.Context, req *dcpb.FindMissingRequest) (*dcpb.FindMissingResponse, error) {
 	ctx, err := c.readWriteContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	r := getResources(req.GetResources(), req.GetIsolation(), req.GetKey())
-	missing, err := c.cache.FindMissing(ctx, r)
+	missing, err := c.cache.FindMissing(ctx, req.GetResources())
 	if err != nil {
 		return nil, err
 	}
@@ -257,8 +214,7 @@ func (c *Proxy) Metadata(ctx context.Context, req *dcpb.MetadataRequest) (*dcpb.
 	if err != nil {
 		return nil, err
 	}
-	r := getResource(req.GetResource(), req.GetIsolation(), req.GetKey())
-	md, err := c.cache.Metadata(ctx, r)
+	md, err := c.cache.Metadata(ctx, req.GetResource())
 	if err != nil {
 		return nil, err
 	}
@@ -293,8 +249,7 @@ func (c *Proxy) Delete(ctx context.Context, req *dcpb.DeleteRequest) (*dcpb.Dele
 	if err != nil {
 		return nil, err
 	}
-	r := getResource(req.GetResource(), req.GetIsolation(), req.GetKey())
-	err = c.cache.Delete(ctx, r)
+	err = c.cache.Delete(ctx, req.GetResource())
 	if err != nil {
 		return nil, err
 	}
@@ -306,20 +261,14 @@ func (c *Proxy) GetMulti(ctx context.Context, req *dcpb.GetMultiRequest) (*dcpb.
 	if err != nil {
 		return nil, err
 	}
-	r := getResources(req.GetResources(), req.GetIsolation(), req.GetKey())
-	found, err := c.cache.GetMulti(ctx, r)
+	found, err := c.cache.GetMulti(ctx, req.GetResources())
 	if err != nil {
 		return nil, err
 	}
 	rsp := &dcpb.GetMultiResponse{}
 	for d, buf := range found {
 		if len(buf) == 0 {
-			rn := &rspb.ResourceName{
-				Digest:       d,
-				InstanceName: req.GetIsolation().GetRemoteInstanceName(),
-				CacheType:    req.GetIsolation().GetCacheType(),
-			}
-			c.log.Warningf("returned a zero-length response for %s", ResourceIsolationString(rn))
+			c.log.Warningf("returned a zero-length response for digest %q", d.GetHash())
 		}
 		rsp.KeyValue = append(rsp.KeyValue, &dcpb.KV{
 			Key:   digestToKey(d),
@@ -335,7 +284,7 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 		return err
 	}
 	up, _ := prefix.UserPrefixFromContext(ctx)
-	rn := getResource(req.GetResource(), req.GetIsolation(), req.GetKey())
+	rn := req.GetResource()
 	reader, err := c.cache.Reader(ctx, rn, req.GetOffset(), req.GetLimit())
 	if err != nil {
 		c.log.Debugf("Read(%q) failed (user prefix: %s), err: %s", ResourceIsolationString(rn), up, err)
@@ -388,7 +337,7 @@ func (c *Proxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 		if err != nil {
 			return err
 		}
-		rn := getResource(req.GetResource(), req.GetIsolation(), req.GetKey())
+		rn := req.GetResource()
 		if writeCloser == nil {
 			if rn.GetCacheType() == rspb.CacheType_CAS && req.GetCheckAlreadyExists() {
 				missing, err := c.cache.FindMissing(ctx, []*rspb.ResourceName{rn})
@@ -438,11 +387,7 @@ func (c *Proxy) Heartbeat(ctx context.Context, req *dcpb.HeartbeatRequest) (*dcp
 }
 
 func (c *Proxy) RemoteContains(ctx context.Context, peer string, r *rspb.ResourceName) (bool, error) {
-	isolation := &dcpb.Isolation{
-		CacheType:          r.GetCacheType(),
-		RemoteInstanceName: r.GetInstanceName(),
-	}
-	missing, err := c.RemoteFindMissing(ctx, peer, isolation, []*rspb.ResourceName{r})
+	missing, err := c.RemoteFindMissing(ctx, peer, []*rspb.ResourceName{r})
 	if err != nil {
 		return false, err
 	}
@@ -450,14 +395,8 @@ func (c *Proxy) RemoteContains(ctx context.Context, peer string, r *rspb.Resourc
 }
 
 func (c *Proxy) RemoteMetadata(ctx context.Context, peer string, r *rspb.ResourceName) (*interfaces.CacheMetadata, error) {
-	isolation := &dcpb.Isolation{
-		CacheType:          r.GetCacheType(),
-		RemoteInstanceName: r.GetInstanceName(),
-	}
 	req := &dcpb.MetadataRequest{
-		Isolation: isolation,
-		Key:       digestToKey(r.GetDigest()),
-		Resource:  r,
+		Resource: r,
 	}
 	client, err := c.getClient(ctx, peer)
 	if err != nil {
@@ -476,14 +415,9 @@ func (c *Proxy) RemoteMetadata(ctx context.Context, peer string, r *rspb.Resourc
 	}, nil
 }
 
-func (c *Proxy) RemoteFindMissing(ctx context.Context, peer string, isolation *dcpb.Isolation, resources []*rspb.ResourceName) ([]*repb.Digest, error) {
+func (c *Proxy) RemoteFindMissing(ctx context.Context, peer string, resources []*rspb.ResourceName) ([]*repb.Digest, error) {
 	req := &dcpb.FindMissingRequest{
-		Isolation: isolation,
-	}
-	for _, r := range resources {
-		key := digestToKey(r.GetDigest())
-		req.Key = append(req.Key, key)
-		req.Resources = append(req.Resources, r)
+		Resources: resources,
 	}
 	client, err := c.getClient(ctx, peer)
 	if err != nil {
@@ -504,14 +438,8 @@ func (c *Proxy) RemoteFindMissing(ctx context.Context, peer string, isolation *d
 }
 
 func (c *Proxy) RemoteDelete(ctx context.Context, peer string, r *rspb.ResourceName) error {
-	isolation := &dcpb.Isolation{
-		CacheType:          r.GetCacheType(),
-		RemoteInstanceName: r.GetInstanceName(),
-	}
 	req := &dcpb.DeleteRequest{
-		Isolation: isolation,
-		Key:       digestToKey(r.GetDigest()),
-		Resource:  r,
+		Resource: r,
 	}
 	client, err := c.getClient(ctx, peer)
 	if err != nil {
@@ -525,16 +453,12 @@ func (c *Proxy) RemoteDelete(ctx context.Context, peer string, r *rspb.ResourceN
 	return nil
 }
 
-func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, isolation *dcpb.Isolation, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
-	req := &dcpb.GetMultiRequest{
-		Isolation: isolation,
-	}
+func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
+	req := &dcpb.GetMultiRequest{}
 	hashDigests := make(map[string]*repb.Digest, len(resources))
 	compressedHashes := make(set.Set[string], len(resources))
 	for _, r := range resources {
-		key := digestToKey(r.GetDigest())
 		hashDigests[r.GetDigest().GetHash()] = r.GetDigest()
-		req.Key = append(req.Key, key)
 		if c.shouldReadCompressed(r) {
 			r = r.CloneVT()
 			r.Compressor = repb.Compressor_ZSTD
@@ -581,11 +505,6 @@ func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 		r.Compressor = repb.Compressor_ZSTD
 	}
 	req := &dcpb.ReadRequest{
-		Isolation: &dcpb.Isolation{
-			CacheType:          r.GetCacheType(),
-			RemoteInstanceName: r.GetInstanceName(),
-		},
-		Key:      digestToKey(r.GetDigest()),
 		Offset:   offset,
 		Limit:    limit,
 		Resource: r,
@@ -676,8 +595,6 @@ type streamWriteCloser struct {
 	cancelFunc        context.CancelFunc
 	sender            rpcutil.Sender[*dcpb.WriteRequest, *dcpb.WriteResponse]
 	r                 *rspb.ResourceName
-	key               *dcpb.Key
-	isolation         *dcpb.Isolation
 	handoffPeer       string
 	sendTimeoutCause  error
 	closeTimeoutCause error
@@ -705,8 +622,6 @@ func (wc *streamWriteCloser) Write(data []byte) (int, error) {
 		return len(data), nil
 	}
 	req := &dcpb.WriteRequest{
-		Isolation:          wc.isolation,
-		Key:                wc.key,
 		Data:               data,
 		FinishWrite:        false,
 		CheckAlreadyExists: true,
@@ -734,8 +649,6 @@ func (wc *streamWriteCloser) Commit() error {
 	}
 
 	req := &dcpb.WriteRequest{
-		Isolation:          wc.isolation,
-		Key:                wc.key,
 		FinishWrite:        true,
 		CheckAlreadyExists: true,
 		HandoffPeer:        wc.handoffPeer,
@@ -772,11 +685,6 @@ func (c *Proxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *r
 		return nil, err
 	}
 
-	isolation := &dcpb.Isolation{
-		CacheType:          r.GetCacheType(),
-		RemoteInstanceName: r.GetInstanceName(),
-	}
-
 	ctx, cancel := context.WithCancel(ctx)
 	stream, err := client.Write(ctx)
 	if err != nil {
@@ -788,9 +696,7 @@ func (c *Proxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *r
 	wc := &streamWriteCloser{
 		cancelFunc:        cancel,
 		sender:            rpcutil.NewSender[*dcpb.WriteRequest, *dcpb.WriteResponse](ctx, stream),
-		isolation:         isolation,
 		handoffPeer:       handoffPeer,
-		key:               digestToKey(r.GetDigest()),
 		r:                 r,
 		sendTimeoutCause:  status.DeadlineExceededErrorf("timed out sending distributed cache write to peer %q for %s", peer, resourceStr),
 		closeTimeoutCause: status.DeadlineExceededErrorf("timed out finalizing distributed cache write to peer %q for %s", peer, resourceStr),

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -769,7 +769,6 @@ func TestFindMissing(t *testing.T) {
 		{numExistingDigests: 10000, numMissingDigests: 10},
 	} {
 		remoteInstanceName := fmt.Sprintf("prefix/%d", tc.numExistingDigests)
-		isolation := &dcpb.Isolation{CacheType: rspb.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
 		existingDigests := make([]*rspb.ResourceName, 0, tc.numExistingDigests)
 		for i := 0; i < tc.numExistingDigests; i++ {
@@ -804,7 +803,7 @@ func TestFindMissing(t *testing.T) {
 			missingDigests = append(missingDigests, r.GetDigest())
 		}
 
-		remoteMissing, err := c.RemoteFindMissing(ctx, peer, isolation, append(existingDigests, missingResources...))
+		remoteMissing, err := c.RemoteFindMissing(ctx, peer, append(existingDigests, missingResources...))
 		require.NoError(t, err)
 		require.Empty(t, cmp.Diff(missingDigests, remoteMissing, protocmp.Transform()))
 	}
@@ -833,7 +832,6 @@ func TestGetMulti(t *testing.T) {
 
 	for _, numDigests := range testSizes {
 		remoteInstanceName := fmt.Sprintf("prefix/%d", numDigests)
-		isolation := &dcpb.Isolation{CacheType: rspb.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
 		digests := make([]*rspb.ResourceName, 0, numDigests)
 		for i := 0; i < numDigests; i++ {
@@ -861,7 +859,7 @@ func TestGetMulti(t *testing.T) {
 		}
 
 		// Ensure key exists.
-		gotMap, err := c.RemoteGetMulti(ctx, peer, isolation, digests)
+		gotMap, err := c.RemoteGetMulti(ctx, peer, digests)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -969,7 +967,6 @@ func TestMetadata(t *testing.T) {
 	}
 	waitUntilServerIsAlive(peer)
 
-	isolation := &dcpb.Isolation{CacheType: rspb.CacheType_CAS}
 	// Write to the cache
 	r, buf := testdigest.RandomCASResourceBuf(t, 100)
 	err = te.GetCache().Set(ctx, r, buf)
@@ -979,11 +976,6 @@ func TestMetadata(t *testing.T) {
 
 	// Verify cacheproxy returns same metadata as underlying cache
 	cacheproxyMetadata, err := c.Metadata(ctx, &dcpb.MetadataRequest{
-		Isolation: isolation,
-		Key: &dcpb.Key{
-			Key:       r.GetDigest().GetHash(),
-			SizeBytes: r.GetDigest().GetSizeBytes(),
-		},
 		Resource: r,
 	})
 	if err != nil {
@@ -1245,8 +1237,7 @@ func TestRemoteGetMulti_PullsCompressedFromPeer(t *testing.T) {
 	require.NoError(t, te.GetCache().Set(ctx, smallRN, smallBuf))
 	require.NoError(t, te.GetCache().Set(ctx, largeRN, largeBuf))
 
-	isolation := &dcpb.Isolation{CacheType: rspb.CacheType_CAS}
-	got, err := c.RemoteGetMulti(ctx, peer, isolation, []*rspb.ResourceName{smallRN, largeRN})
+	got, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{smallRN, largeRN})
 	require.NoError(t, err)
 	require.Equal(t, smallBuf, got[smallRN.GetDigest()])
 	require.Equal(t, largeBuf, got[largeRN.GetDigest()])
@@ -1266,8 +1257,7 @@ func TestRemoteGetMulti_MultipleCompressedBlobs(t *testing.T) {
 		require.NoError(t, te.GetCache().Set(ctx, rns[i], bufs[i]))
 	}
 
-	isolation := &dcpb.Isolation{CacheType: rspb.CacheType_CAS}
-	got, err := c.RemoteGetMulti(ctx, peer, isolation, rns)
+	got, err := c.RemoteGetMulti(ctx, peer, rns)
 	require.NoError(t, err)
 	for i, rn := range rns {
 		require.Equalf(t, bufs[i], got[rn.GetDigest()], "blob %d mismatch", i)

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -5,25 +5,16 @@ import "github.com/planetscale/vtprotobuf/vtproto/ext.proto";
 
 package distributed_cache;
 
-message Isolation {
-  resource.CacheType cache_type = 1;
-  string remote_instance_name = 2;
-}
-
 message Key {
   string key = 1;
   int64 size_bytes = 2;
 }
 
 message ReadRequest {
-  reserved 1;
+  reserved 1, 2, 4;
   int64 offset = 3;
   int64 limit = 5;
   resource.ResourceName resource = 6;
-
-  // Deprecated fields - use resource field instead
-  Isolation isolation = 4;
-  Key key = 2;
 }
 
 message ReadResponse {
@@ -33,7 +24,7 @@ message ReadResponse {
 
 // Next Tag: 9
 message WriteRequest {
-  reserved 1;
+  reserved 1, 2, 6;
   bool finish_write = 3;
 
   // If check_already_exists, the server should return an ALREADY_EXISTS error
@@ -45,10 +36,6 @@ message WriteRequest {
   // A node that this data should eventually be handed off to.
   // Clients should attempt to replicate this data when possible.
   string handoff_peer = 5;
-
-  // Deprecated fields - use resource field instead
-  Isolation isolation = 6;
-  Key key = 2;
 }
 
 message WriteResponse {
@@ -56,21 +43,15 @@ message WriteResponse {
 }
 
 message DeleteRequest {
+  reserved 1, 2;
   resource.ResourceName resource = 3;
-
-  // Deprecated fields - use resource field instead
-  Isolation isolation = 1;
-  Key key = 2;
 }
 
 message DeleteResponse {}
 
 message FindMissingRequest {
+  reserved 1, 2;
   repeated resource.ResourceName resources = 3;
-
-  // Deprecated fields - use resource field instead
-  Isolation isolation = 1;
-  repeated Key key = 2;
 }
 
 message FindMissingResponse {
@@ -78,11 +59,8 @@ message FindMissingResponse {
 }
 
 message MetadataRequest {
+  reserved 1, 2;
   resource.ResourceName resource = 3;
-
-  // Deprecated fields - use resource field instead
-  Isolation isolation = 1;
-  Key key = 2;
 }
 
 message MetadataResponse {
@@ -98,12 +76,8 @@ message KV {
 }
 
 message GetMultiRequest {
-  reserved 1;
+  reserved 1, 2, 3;
   repeated resource.ResourceName resources = 4;
-
-  // Deprecated fields - use resource field instead
-  Isolation isolation = 3;
-  repeated Key key = 2;
 }
 
 message GetMultiResponse {


### PR DESCRIPTION
These haven't been necessary for a long time.