### PR TITLE
Default new groups to free tier

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -281,9 +281,11 @@ func (d *UserDB) CreateGroup(ctx context.Context, g *tables.Group) (string, erro
 		return "", status.UnauthenticatedErrorf("You don't have permission to create a group")
 	}
 
-	// Group status is inherited.
-	g.Status = u.GetGroupStatus()
-	if g.Status == grpb.Group_UNKNOWN_GROUP_STATUS {
+	// Group status defaults to free tier, unless the user is already blocked.
+	currentStatus := u.GetGroupStatus()
+	if currentStatus == grpb.Group_BLOCKED_GROUP_STATUS {
+		g.Status = currentStatus
+	} else {
 		g.Status = grpb.Group_FREE_TIER_GROUP_STATUS
 	}
 

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -533,22 +533,22 @@ func TestCreateGroup_StatusInheritance(t *testing.T) {
 			expectedStatus: grpb.Group_FREE_TIER_GROUP_STATUS,
 		},
 		{
-			name:           "FREE_TIER -> FREE_TIER (inherit)",
+			name:           "FREE_TIER -> FREE_TIER",
 			urlID:          "test-free",
 			parentStatus:   grpb.Group_FREE_TIER_GROUP_STATUS,
 			expectedStatus: grpb.Group_FREE_TIER_GROUP_STATUS,
 		},
 		{
-			name:           "ENTERPRISE -> ENTERPRISE (inherit)",
+			name:           "ENTERPRISE -> FREE_TIER",
 			urlID:          "test-ent",
 			parentStatus:   grpb.Group_ENTERPRISE_GROUP_STATUS,
-			expectedStatus: grpb.Group_ENTERPRISE_GROUP_STATUS,
+			expectedStatus: grpb.Group_FREE_TIER_GROUP_STATUS,
 		},
 		{
-			name:           "ENTERPRISE_TRIAL -> ENTERPRISE_TRIAL (inherit)",
+			name:           "ENTERPRISE_TRIAL -> FREE_TIER",
 			urlID:          "test-trial",
 			parentStatus:   grpb.Group_ENTERPRISE_TRIAL_GROUP_STATUS,
-			expectedStatus: grpb.Group_ENTERPRISE_TRIAL_GROUP_STATUS,
+			expectedStatus: grpb.Group_FREE_TIER_GROUP_STATUS,
 		},
 		{
 			name:           "BLOCKED -> BLOCKED (inherit)",


### PR DESCRIPTION
Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/7428#event-26013412445

This is a safer default. We can re-evaluate or find a cleaner way to automatically upgrade enterprise groups if it becomes an issue