### PR TITLE
Add compact profile stream loading logic

### DIFF
--- a/app/trace/compact_trace.ts
+++ b/app/trace/compact_trace.ts
@@ -1,11 +1,12 @@
 import { StringInterner } from "../util/intern";
 import { TypedArrayBuilder } from "../util/typed_arrays";
-import type { TraceEvent } from "./trace_events";
+import type { ProfileProgressCallback, TraceEvent } from "./trace_events";
 import {
   TIME_SERIES_EVENT_ORDER,
   TIME_SERIES_METADATA,
   isNumericTimeSeriesValue,
   normalizeThreadName,
+  readProfileEvents,
 } from "./trace_events";
 
 /**
@@ -156,6 +157,24 @@ export class TimeSeries {
     /** Sort order for known Bazel/executor series. */
     readonly order: number | undefined
   ) {}
+}
+
+/** Reads a trace profile stream. */
+export async function readProfile(
+  body: ReadableStream<Uint8Array>,
+  progress?: ProfileProgressCallback
+): Promise<Profile> {
+  const builder = new ProfileBuilder();
+  await readProfileEvents(
+    body,
+    (events) => {
+      for (const event of events) {
+        builder.addEvent(event);
+      }
+    },
+    progress
+  );
+  return builder.build();
 }
 
 /** Mutable builder for a compact trace profile. */

--- a/app/trace/compact_trace_test.ts
+++ b/app/trace/compact_trace_test.ts
@@ -1,4 +1,4 @@
-import { ProfileBuilder } from "./compact_trace";
+import { ProfileBuilder, readProfile } from "./compact_trace";
 import type { TraceEvent } from "./trace_events";
 
 function traceEvent(overrides: Partial<TraceEvent> & Pick<TraceEvent, "name">): TraceEvent {
@@ -16,6 +16,94 @@ function traceEvent(overrides: Partial<TraceEvent> & Pick<TraceEvent, "name">): 
     ...overrides,
   };
 }
+
+// NOTE: in the following profile data, whitespace is significant (unlike regular JSON):
+// - The `"traceEvents":[` list opening has to end with a newline
+// - Each entry in the traceEvents list has to end with ",\n", except for the last one
+// - The traceEvents list is closed with the exact sequence "\n  ]\n}"
+const INCOMPLETE_PROFILE = `
+{"otherData":{"build_id":"799cc58b-8695-4e70-a772-7a15472aa55b","output_base":"/output-base","date":"Wed Oct 26 20:24:01 UTC 2022"},"traceEvents":[
+  {"name":"thread_name","ph":"M","pid":1,"tid":0,"args":{"name":"Critical Path"}},
+  {"name":"thread_sort_index","ph":"M","pid":1,"tid":0,"args":{"sort_index":0}},
+  {"name":"thread_name","ph":"M","pid":1,"tid":29,"args":{"name":"Main Thread"}},
+  {"name":"thread_sort_index","ph":"M","pid":1,"tid":29,"args":{"sort_index":"1"}},
+  {"cat":"build phase marker","name":"Launch Blaze","ph":"X","ts":-899000,"dur":899000,"pid":1,"tid":29},
+  {"cat":"build phase marker","name":"Initialize command","ph":"i","ts":0,"pid":1,"tid":29},
+  {"cat":"general information","name":"BazelStartupOptionsModule.beforeCommand","ph":"X","ts":200868,"dur":206,"pid":1,"tid":29}`.trim();
+
+const COMPLETE_PROFILE = INCOMPLETE_PROFILE + "\n  ]\n}";
+
+function readableStreamFromString(value: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const reader: ReadableStreamDefaultReader<Uint8Array> = {
+    read() {
+      if (!value) {
+        return Promise.resolve({ done: true });
+      }
+      // Read a small-ish, random length (between 1 and 10 bytes)
+      const length = Math.min(value.length, 1 + Math.floor(Math.random() * 10));
+      const before = value.substring(0, length);
+      const after = value.substring(length);
+      value = after;
+      return Promise.resolve({ value: encoder.encode(before), done: false });
+    },
+    releaseLock() {
+      throw new Error("releaseLock(): not implemented");
+    },
+    cancel() {
+      throw new Error("cancel(): not implemented");
+    },
+    get closed() {
+      return Promise.reject("closed: not implemented");
+    },
+  };
+  const stream = {
+    getReader(): ReadableStreamDefaultReader<Uint8Array> {
+      return reader;
+    },
+  } as ReadableStream<Uint8Array>;
+
+  return stream;
+}
+
+describe("readProfile", () => {
+  it("parses a complete profile", async () => {
+    const stream = readableStreamFromString(COMPLETE_PROFILE);
+    let numBytesRead = 0;
+    const profile = await readProfile(stream, (n) => {
+      numBytesRead = n;
+    });
+
+    expect(profile.eventCount).toBe(7);
+    expect(profile.threads[0].name).toBe("Main Thread");
+    expect(numBytesRead).toBe(COMPLETE_PROFILE.length);
+  });
+
+  it("parses an incomplete profile", async () => {
+    const stream = readableStreamFromString(INCOMPLETE_PROFILE);
+    let numBytesRead = 0;
+    const profile = await readProfile(stream, (n) => {
+      numBytesRead = n;
+    });
+
+    expect(profile.eventCount).toBe(7);
+    expect(profile.threads[0].name).toBe("Main Thread");
+    expect(numBytesRead).toBe(INCOMPLETE_PROFILE.length);
+  });
+
+  it("reports final progress as done", async () => {
+    const stream = readableStreamFromString(COMPLETE_PROFILE);
+    const progress: { numBytesRead: number; done?: boolean }[] = [];
+    const profile = await readProfile(stream, (numBytesRead, done) => {
+      progress.push({ numBytesRead, done });
+    });
+
+    expect(profile.eventCount).toBe(7);
+    expect(progress.length).toBeGreaterThan(0);
+    expect(progress.slice(0, progress.length - 1).some(({ done }) => done)).toBe(false);
+    expect(progress[progress.length - 1]).toEqual({ numBytesRead: COMPLETE_PROFILE.length, done: true });
+  });
+});
 
 describe("ProfileBuilder", () => {
   it("builds duration spans into compact threads", () => {

--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -118,15 +118,15 @@ export const TIME_SERIES_EVENT_ORDER = new Map(Array.from(TIME_SERIES_METADATA).
 const GZIP_MAGIC_BYTE_0 = 0x1f;
 const GZIP_MAGIC_BYTE_1 = 0x8b;
 
+export type ProfileProgressCallback = (numBytesLoaded: number, done?: boolean) => void;
+export type TraceEventBatchCallback = (events: TraceEvent[]) => void;
+
 async function isGzipCompressed(blob: Blob): Promise<boolean> {
   const header = new Uint8Array(await blob.slice(0, 2).arrayBuffer());
   return header[0] === GZIP_MAGIC_BYTE_0 && header[1] === GZIP_MAGIC_BYTE_1;
 }
 
-export async function readProfileFile(
-  file: Blob,
-  progress?: (numBytesLoaded: number, done?: boolean) => void
-): Promise<Profile> {
+export async function readProfileFile(file: Blob, progress?: ProfileProgressCallback): Promise<Profile> {
   let stream = file.stream() as ReadableStream<Uint8Array>;
   if (await isGzipCompressed(file)) {
     if (typeof DecompressionStream === "undefined") {
@@ -139,13 +139,31 @@ export async function readProfileFile(
 
 export async function readProfile(
   body: ReadableStream<Uint8Array>,
-  progress?: (numBytesLoaded: number, done?: boolean) => void
+  progress?: ProfileProgressCallback
 ): Promise<Profile> {
+  const profile: Profile = { traceEvents: [] };
+  await readProfileEvents(
+    body,
+    (events) => {
+      for (const event of events) {
+        profile.traceEvents.push(event);
+      }
+    },
+    progress
+  );
+  return profile;
+}
+
+export async function readProfileEvents(
+  body: ReadableStream<Uint8Array>,
+  consumeEventBatch: TraceEventBatchCallback,
+  progress?: ProfileProgressCallback
+): Promise<void> {
   const reader = body.getReader();
   const decoder = new TextDecoder("utf-8");
   let n = 0;
   let buffer = "";
-  let profile: Profile | null = null;
+  let foundTraceEvents = false;
 
   while (true) {
     const { value, done } = await reader.read();
@@ -159,21 +177,15 @@ export async function readProfile(
     // Keep accumulating into the buffer until we see the "traceEvents" array.
     // Each entry in this array is newline-delimited (a special property of
     // Google's trace event JSON format).
-    if (!profile) {
+    if (!foundTraceEvents) {
       const beginMarker = '"traceEvents":[\n';
       const index = buffer.indexOf(beginMarker);
       if (index < 0) continue;
 
-      const before = buffer.substring(0, index + beginMarker.length);
-      const after = buffer.substring(before.length);
-
-      const outerJSON = before + "]}";
-      profile = JSON.parse(outerJSON) as Profile;
-      buffer = after;
+      buffer = buffer.substring(index + beginMarker.length);
+      foundTraceEvents = true;
     }
-    if (profile) {
-      buffer = consumeEvents(buffer, profile);
-    }
+    buffer = consumeEvents(buffer, consumeEventBatch);
   }
   if (progress) {
     progress(n, true);
@@ -183,23 +195,24 @@ export async function readProfile(
     await nextAnimationFrame();
   }
 
+  buffer += decoder.decode();
+  if (!foundTraceEvents) {
+    throw new Error("failed to parse timing profile JSON");
+  }
+
   // Consume last event, which isn't guaranteed to end with ",\n"
   if (buffer) {
     const { chars, suffix } = trailingNonWhitespaceChars(buffer, 2);
     if (chars === "]}") {
       buffer = buffer.substring(0, buffer.length - suffix.length);
     }
-    if (buffer) {
-      const event = JSON.parse(buffer);
-      profile?.traceEvents.push(event);
-      buffer = "";
+    if (buffer.trim()) {
+      const eventJSON = buffer.trim();
+      consumeEventBatch([
+        JSON.parse(eventJSON.endsWith(",") ? eventJSON.substring(0, eventJSON.length - 1) : eventJSON),
+      ]);
     }
   }
-
-  if (!profile) {
-    throw new Error("failed to parse timing profile JSON");
-  }
-  return profile;
 }
 
 /**
@@ -219,12 +232,16 @@ function trailingNonWhitespaceChars(text: string, count: number) {
   return { chars: out, suffix: text.substring(i + 1) };
 }
 
-function consumeEvents(buffer: string, profile: Profile): string {
+function consumeEvents(buffer: string, consumeEventBatch: TraceEventBatchCallback): string {
   // Each event entry looks like "   { ... },\n"
   const parts = buffer.split(",\n");
   const completeEvents = parts.slice(0, parts.length - 1);
+  const events: TraceEvent[] = [];
   for (const rawEvent of completeEvents) {
-    profile!.traceEvents.push(JSON.parse(rawEvent));
+    events.push(JSON.parse(rawEvent));
+  }
+  if (events.length) {
+    consumeEventBatch(events);
   }
   // If there's a partial event at the end, that partial event becomes the new
   // buffer value.


### PR DESCRIPTION
This PR makes a small refactor to the existing trace profile loading/parsing logic so that it can be shared with the compact trace loading logic, and implements the trace loading logic for the compact profile.

This change does not yet wire up the new trace model to the timing profile; it just reduces the diff needed to wire things up.