### PR TITLE
Fix negative values in PendingClientRPCsPerConnection gauge

### DIFF
--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -158,11 +158,12 @@ func (p *ClientConnPool) NewStream(ctx context.Context, desc *grpc.StreamDesc, m
 	gauge := metrics.PendingClientRPCsPerConnection.WithLabelValues(p.targetForLogging, p.id, method, conn.index)
 	decFn := sync.OnceFunc(func() { gauge.Dec() })
 	opts = append(opts, grpc.OnFinish(func(_ error) { decFn() }))
+	gauge.Inc()
 	stream, err := conn.NewStream(ctx, desc, method, opts...)
 	if err != nil {
+		decFn()
 		return stream, err
 	}
-	gauge.Inc()
 	return stream, nil
 }
 


### PR DESCRIPTION
In `ClientConnPool.NewStream`, the gauge's `Inc()` was called after `conn.NewStream` returned, but the `grpc.OnFinish` callback (which calls `Dec()`) was registered before it. If the stream finished very quickly — e.g. the context was already cancelled or the server returned immediately — the `OnFinish` callback could fire before `Inc()` ran, producing a stray `Dec()` with no matching `Inc()` and driving the gauge negative. The error path was also unbalanced: it returned without calling `Inc()`, so any `OnFinish` fired by gRPC for a failed stream would also decrement without a corresponding increment.

This change moves `Inc()` to run before `OnFinish` is registered, and explicitly calls `decFn()` on the error path. `sync.OnceFunc` keeps things safe if both the error path and `OnFinish` fire.