### PR TITLE
Add a Cache Proxies page and cache proxy API key creation flow

### DIFF
--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -44,6 +44,7 @@ export class Capabilities {
   action: boolean = false;
   userOwnedExecutors: boolean = false;
   executorKeyCreation: boolean = false;
+  cacheProxyKeyCreation: boolean = false;
   code: boolean = false;
   sso: boolean = false;
   usage: boolean = false;
@@ -72,6 +73,7 @@ export class Capabilities {
     this.executors = this.config.remoteExecutionEnabled;
     this.userOwnedExecutors = this.config.userOwnedExecutorsEnabled;
     this.executorKeyCreation = this.config.executorKeyCreationEnabled;
+    this.cacheProxyKeyCreation = this.config.cacheProxyKeyCreationEnabled;
     this.code = this.config.codeEditorEnabled;
     this.usage = this.config.usageEnabled;
     this.readOnlyGitHubApp = this.config.readOnlyGithubAppEnabled;

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -247,6 +247,10 @@ class Router {
     this.navigateTo(Path.executorsPath);
   }
 
+  navigateToCacheProxies() {
+    this.navigateTo(Path.cacheProxiesPath);
+  }
+
   navigateToTap() {
     this.navigateTo(Path.tapPath);
   }
@@ -429,6 +433,10 @@ class Router {
     return capabilities.executors && Boolean(user?.canCall("getExecutionNodes"));
   }
 
+  canAccessCacheProxiesPage(user?: User) {
+    return Boolean(user?.canCall("getCacheProxies"));
+  }
+
   canAccessUsagePage(user?: User) {
     return capabilities.usage && Boolean(user?.canCall("getUsage"));
   }
@@ -551,6 +559,9 @@ class Router {
     if (path === Path.executorsPath && !this.canAccessExecutorsPage(user)) {
       return new URL(Path.home, window.location.href);
     }
+    if (path === Path.cacheProxiesPath && !this.canAccessCacheProxiesPage(user)) {
+      return new URL(Path.home, window.location.href);
+    }
     if (path === Path.workflowsPath && !this.canAccessWorkflowsPage()) {
       return new URL(Path.home, window.location.href);
     }
@@ -640,6 +651,7 @@ export class Path {
   static usageAlertingPath = "/usage/alerting";
   static auditLogsPath = "/audit-logs/";
   static executorsPath = "/executors/";
+  static cacheProxiesPath = "/cache-proxies/";
   static tapPath = "/tests/";
   static workflowsPath = "/workflows/";
   static codePath = "/code/";
@@ -676,6 +688,7 @@ function getUnavailableMessage(matchedPath: string) {
     case Path.trendsPath:
     case Path.targetsPath:
     case Path.executorsPath:
+    case Path.cacheProxiesPath:
     case Path.tapPath:
     case Path.userHistoryPath:
     case Path.hostHistoryPath:

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -556,10 +556,10 @@ class Router {
     if (path === Path.orgAccessDeniedPath) {
       return new URL(Path.home, window.location.href);
     }
-    if (path === Path.executorsPath && !this.canAccessExecutorsPage(user)) {
+    if (path.startsWith(Path.executorsPath) && !this.canAccessExecutorsPage(user)) {
       return new URL(Path.home, window.location.href);
     }
-    if (path === Path.cacheProxiesPath && !this.canAccessCacheProxiesPage(user)) {
+    if (path.startsWith(Path.cacheProxiesPath) && !this.canAccessCacheProxiesPage(user)) {
       return new URL(Path.home, window.location.href);
     }
     if (path === Path.workflowsPath && !this.canAccessWorkflowsPage()) {

--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -59,6 +59,7 @@ genrule(
         "//enterprise/app/code:monaco.css",
         "//enterprise/app/codesearch:codesearch.css",
         "//enterprise/app/executors:executors.css",
+        "//enterprise/app/cache_proxies:cache_proxies.css",
         "//enterprise/app/filter:css",
         "//app:style.css",
     ],

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -315,6 +315,10 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
     onChange("capability", [capability.Capability.CACHE_WRITE, capability.Capability.REGISTER_EXECUTOR]);
   }
 
+  private onSelectCacheProxy(onChange: (name: string, value: any) => any) {
+    onChange("capability", [capability.Capability.CACHE_WRITE, capability.Capability.REGISTER_CACHE_PROXY]);
+  }
+
   private onSelectOrgAdmin(onChange: (name: string, value: any) => any) {
     onChange("capability", [capability.Capability.ORG_ADMIN]);
   }
@@ -440,6 +444,21 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                     />
                     <span>
                       Executor key <span className="field-description">(for self-hosted executors)</span>
+                    </span>
+                  </label>
+                </div>
+              )}
+              {/* User-owned keys cannot be used to register cache proxies. */}
+              {capabilities.cacheProxyKeyCreation && !this.props.userOwnedOnly && (
+                <div className="field-container">
+                  <label className="checkbox-row">
+                    <input
+                      type="radio"
+                      onChange={this.onSelectCacheProxy.bind(this, onChange)}
+                      checked={isCacheProxyKey(request)}
+                    />
+                    <span>
+                      Cache proxy key <span className="field-description">(for self-hosted cache proxies)</span>
                     </span>
                   </label>
                 </div>
@@ -688,6 +707,10 @@ function isExecutorKey<T extends ApiKeyFields>(apiKey: T | null) {
   return hasExactCapabilities(apiKey, [capability.Capability.CACHE_WRITE, capability.Capability.REGISTER_EXECUTOR]);
 }
 
+function isCacheProxyKey<T extends ApiKeyFields>(apiKey: T | null) {
+  return hasExactCapabilities(apiKey, [capability.Capability.CACHE_WRITE, capability.Capability.REGISTER_CACHE_PROXY]);
+}
+
 function isOrgAdminKey<T extends ApiKeyFields>(apiKey: T | null) {
   return hasExactCapabilities(apiKey, [capability.Capability.ORG_ADMIN]);
 }
@@ -708,6 +731,8 @@ function describeCapabilities<T extends ApiKeyFields>(apiKey: T) {
     capabilities = "CAS-only";
   } else if (isExecutorKey(apiKey)) {
     capabilities = "Executor";
+  } else if (isCacheProxyKey(apiKey)) {
+    capabilities = "Cache Proxy";
   } else if (isOrgAdminKey(apiKey)) {
     capabilities = "Org admin";
   } else if (isAuditLogReader(apiKey)) {

--- a/enterprise/app/cache_proxies/BUILD
+++ b/enterprise/app/cache_proxies/BUILD
@@ -1,0 +1,40 @@
+load("//rules/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+exports_files(["cache_proxies.css"])
+
+ts_library(
+    name = "cache_proxies",
+    srcs = ["cache_proxies.tsx"],
+    deps = [
+        "//:node_modules/@types/react",
+        "//:node_modules/lucide-react",
+        "//:node_modules/react",
+        "//:node_modules/rxjs",
+        "//:node_modules/tslib",
+        "//app/auth:auth_service",
+        "//app/components/breadcrumbs",
+        "//app/components/button:link_button",
+        "//app/router",
+        "//app/service:rpc_service",
+        "//app/util:errors",
+        "//enterprise/app/cache_proxies:cache_proxy_card",
+        "//proto:api_key_ts_proto",
+        "//proto:cache_proxy_ts_proto",
+        "//proto:capability_ts_proto",
+    ],
+)
+
+ts_library(
+    name = "cache_proxy_card",
+    srcs = ["cache_proxy_card.tsx"],
+    deps = [
+        "//:node_modules/@types/react",
+        "//:node_modules/lucide-react",
+        "//:node_modules/react",
+        "//app/format",
+        "//proto:cache_proxy_ts_proto",
+        "//proto:timestamp_ts_proto",
+    ],
+)

--- a/enterprise/app/cache_proxies/cache_proxies.css
+++ b/enterprise/app/cache_proxies/cache_proxies.css
@@ -1,0 +1,41 @@
+/* CACHE PROXIES PAGE */
+
+.cache-proxies-page .title {
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.cache-proxies-page .cache-proxy-section {
+  display: flex;
+}
+
+.cache-proxies-page .cache-proxy-section div {
+  flex-grow: 1;
+  min-width: 0;
+}
+
+.cache-proxy-section div.cache-proxy-section-title {
+  width: 200px;
+  flex-grow: 0;
+  flex-shrink: 0;
+  text-align: left;
+  margin-right: 16px;
+  font-weight: 700;
+}
+
+.cache-proxies-page .cache-proxy-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.cache-proxies-page .cache-proxy-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cache-proxies-page .empty-state {
+  margin-top: 32px;
+}

--- a/enterprise/app/cache_proxies/cache_proxies.tsx
+++ b/enterprise/app/cache_proxies/cache_proxies.tsx
@@ -1,0 +1,257 @@
+import { Hash } from "lucide-react";
+import React from "react";
+import { Subscription } from "rxjs";
+import { User } from "../../../app/auth/auth_service";
+import Breadcrumbs from "../../../app/components/breadcrumbs/breadcrumbs";
+import LinkButton from "../../../app/components/button/link_button";
+import router from "../../../app/router/router";
+import rpcService from "../../../app/service/rpc_service";
+import { BuildBuddyError } from "../../../app/util/errors";
+import { api_key } from "../../../proto/api_key_ts_proto";
+import { cache_proxy } from "../../../proto/cache_proxy_ts_proto";
+import { capability } from "../../../proto/capability_ts_proto";
+import CacheProxyCardComponent from "./cache_proxy_card";
+
+enum FetchType {
+  Proxies,
+  ApiKeys,
+}
+
+interface CacheProxySetupProps {
+  user: User;
+  proxyKeys: api_key.IApiKey[];
+}
+
+class CacheProxySetup extends React.Component<CacheProxySetupProps> {
+  render() {
+    return (
+      <>
+        <h1>Set up self-hosted cache proxies</h1>
+        <hr />
+        <h2>1. Create an API key for cache proxy registration</h2>
+        {this.props.proxyKeys.length == 0 && (
+          <div>
+            <p>There are no API keys with the cache proxy capability configured for your organization.</p>
+            <p>API keys are used to authorize self-hosted cache proxies.</p>
+            {this.props.user.canCall("createApiKey") && (
+              <LinkButton href="/settings/org/api-keys" className="manage-keys-button">
+                Manage keys
+              </LinkButton>
+            )}
+          </div>
+        )}
+        {this.props.proxyKeys.length > 0 && (
+          <>
+            <div>
+              {this.props.proxyKeys.length == 1 && <p>You have a Cache Proxy API key available.</p>}
+              {this.props.proxyKeys.length > 1 && (
+                <p>You have {this.props.proxyKeys.length} Cache Proxy API keys available.</p>
+              )}
+              <p>These API keys can be used to register your cache proxies.</p>
+            </div>
+            <h2>2. Deploy cache proxies</h2>
+            <p>
+              Start each cache proxy with <code>--cache_proxy.api_key=&lt;key&gt;</code> and{" "}
+              <code>--cache_proxy.app_target=&lt;app gRPC target&gt;</code>. Once running, the proxy will appear on the
+              Status tab.
+            </p>
+          </>
+        )}
+      </>
+    );
+  }
+}
+
+interface CacheProxiesListProps {
+  proxies: cache_proxy.GetCacheProxiesResponse.ICacheProxy[];
+}
+
+class CacheProxiesList extends React.Component<CacheProxiesListProps> {
+  render() {
+    return (
+      <div className="cache-proxy-cards">
+        <div className="cache-proxy-summary">
+          <Hash className="icon" />
+          <span>
+            <b>
+              {this.props.proxies.length} {this.props.proxies.length === 1 ? "cache proxy" : "cache proxies"}
+            </b>
+          </span>
+        </div>
+        {this.props.proxies.map(
+          (proxy) =>
+            proxy.node && (
+              <CacheProxyCardComponent
+                key={proxy.node.proxyId}
+                node={proxy.node as cache_proxy.CacheProxyNode}
+                lastCheckInTime={proxy.lastCheckInTime}
+              />
+            )
+        )}
+      </div>
+    );
+  }
+}
+
+type TabId = "status" | "setup";
+
+interface Props {
+  user: User;
+  path: string;
+}
+
+interface State {
+  proxies: cache_proxy.GetCacheProxiesResponse.ICacheProxy[];
+  proxyKeys: api_key.IApiKey[];
+  loading: FetchType[];
+  error: BuildBuddyError | null;
+}
+
+export default class CacheProxiesComponent extends React.Component<Props, State> {
+  state: State = {
+    proxies: [],
+    proxyKeys: [],
+    loading: [],
+    error: null,
+  };
+
+  subscription?: Subscription;
+
+  componentWillMount() {
+    document.title = `Cache Proxies | BuildBuddy`;
+  }
+
+  componentDidMount() {
+    this.fetch();
+    this.subscription = rpcService.events.subscribe({
+      next: (name) => name == "refresh" && this.fetch(),
+    });
+  }
+
+  componentWillUnmount() {
+    this.subscription?.unsubscribe();
+  }
+
+  async fetchApiKeys() {
+    if (!this.props.user) return;
+    this.setState((prevState) => ({
+      loading: [...prevState.loading, FetchType.ApiKeys],
+    }));
+    try {
+      const response = await rpcService.service.getApiKeys(
+        api_key.GetApiKeysRequest.create({ groupId: this.props.user.selectedGroup.id })
+      );
+      const proxyKeys = response.apiKey.filter((key) =>
+        key.capability.some((cap) => cap == capability.Capability.REGISTER_CACHE_PROXY)
+      );
+      this.setState({ proxyKeys });
+    } catch (e) {
+      this.setState({ error: BuildBuddyError.parse(e) });
+    } finally {
+      this.setState((prevState) => ({
+        loading: [...prevState.loading].filter((f) => f != FetchType.ApiKeys),
+      }));
+    }
+  }
+
+  async fetchCacheProxies() {
+    this.setState((prevState) => ({
+      loading: [...prevState.loading, FetchType.Proxies],
+    }));
+    try {
+      const response = await rpcService.service.getCacheProxies(cache_proxy.GetCacheProxiesRequest.create({}));
+      this.setState({ proxies: response.cacheProxy });
+    } catch (e) {
+      this.setState({ error: BuildBuddyError.parse(e) });
+    } finally {
+      this.setState((prevState) => ({
+        loading: [...prevState.loading].filter((f) => f != FetchType.Proxies),
+      }));
+    }
+  }
+
+  fetch() {
+    this.fetchCacheProxies();
+    this.fetchApiKeys();
+  }
+
+  onClickTab(tabId: TabId) {
+    router.navigateTo(`/cache-proxies/${tabId}`);
+  }
+
+  renderEmpty() {
+    return (
+      <div className="empty-state">
+        <h1>No cache proxies found!</h1>
+        <p>
+          Cache proxies are self-hosted gRPC proxies that sit in front of the BuildBuddy cache to reduce latency and
+          bandwidth.
+          <br />
+          <br />
+          <a className="button" href="https://www.buildbuddy.io/docs/cache-proxy">
+            Read the docs to get started
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  render() {
+    const hasProxies = this.state.proxies.length > 0;
+    const hasKeys = this.state.proxyKeys.length > 0;
+    // When neither proxies nor cache-proxy API keys exist, skip the tab UI
+    // and show a single clean empty-state view (matching the executors page
+    // pattern when nothing has been set up).
+    const showTabs = hasProxies || hasKeys;
+    const defaultTabId: TabId = hasProxies ? "status" : "setup";
+    const activeTab = (this.props.path.substring("/cache-proxies/".length) || defaultTabId) as TabId;
+    return (
+      <div className="cache-proxies-page">
+        <div className="shelf">
+          <div className="container">
+            <Breadcrumbs>
+              {this.props.user && <span>{this.props.user?.selectedGroupName()}</span>}
+              <span>Cache Proxies</span>
+            </Breadcrumbs>
+            <div className="title">Cache Proxies</div>
+          </div>
+        </div>
+        {this.state.error && <div className="error-message">{this.state.error.message}</div>}
+        {this.state.loading.length > 0 && <div className="loading"></div>}
+        {this.state.loading.length == 0 && this.state.error == null && (
+          <div className="container">
+            {!showTabs && this.renderEmpty()}
+            {showTabs && (
+              <>
+                <div className="tabs">
+                  <div
+                    className={`tab ${activeTab === "status" ? "selected" : ""}`}
+                    onClick={this.onClickTab.bind(this, "status")}>
+                    Status
+                  </div>
+                  <div
+                    className={`tab ${activeTab === "setup" ? "selected" : ""}`}
+                    onClick={this.onClickTab.bind(this, "setup")}>
+                    Setup
+                  </div>
+                </div>
+                {activeTab === "status" && (
+                  <>
+                    {!hasProxies && (
+                      <div className="empty-state">
+                        <h1>No cache proxies are registered.</h1>
+                        <p>Click the "Setup" tab for instructions on self-hosting cache proxies.</p>
+                      </div>
+                    )}
+                    {hasProxies && <CacheProxiesList proxies={this.state.proxies} />}
+                  </>
+                )}
+                {activeTab === "setup" && <CacheProxySetup user={this.props.user} proxyKeys={this.state.proxyKeys} />}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/enterprise/app/cache_proxies/cache_proxies.tsx
+++ b/enterprise/app/cache_proxies/cache_proxies.tsx
@@ -43,7 +43,7 @@ class CacheProxySetup extends React.Component<CacheProxySetupProps> {
         {this.props.proxyKeys.length > 0 && (
           <>
             <div>
-              {this.props.proxyKeys.length == 1 && <p>You have a Cache Proxy API key available.</p>}
+              {this.props.proxyKeys.length == 1 && <p>You have one Cache Proxy API key available.</p>}
               {this.props.proxyKeys.length > 1 && (
                 <p>You have {this.props.proxyKeys.length} Cache Proxy API keys available.</p>
               )}
@@ -138,9 +138,7 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
       loading: [...prevState.loading, FetchType.ApiKeys],
     }));
     try {
-      const response = await rpcService.service.getApiKeys(
-        api_key.GetApiKeysRequest.create({ groupId: this.props.user.selectedGroup.id })
-      );
+      const response = await rpcService.service.getApiKeys(api_key.GetApiKeysRequest.create({}));
       const proxyKeys = response.apiKey.filter((key) =>
         key.capability.some((cap) => cap == capability.Capability.REGISTER_CACHE_PROXY)
       );

--- a/enterprise/app/cache_proxies/cache_proxy_card.tsx
+++ b/enterprise/app/cache_proxies/cache_proxy_card.tsx
@@ -1,0 +1,68 @@
+import { Cloud } from "lucide-react";
+import React from "react";
+import format from "../../../app/format/format";
+import { cache_proxy } from "../../../proto/cache_proxy_ts_proto";
+import { google as google_timestamp } from "../../../proto/timestamp_ts_proto";
+
+interface Props {
+  node: cache_proxy.CacheProxyNode;
+  lastCheckInTime?: google_timestamp.protobuf.Timestamp | null;
+}
+
+export default class CacheProxyCardComponent extends React.Component<Props> {
+  render() {
+    return (
+      <div className="card card-neutral">
+        <Cloud className="icon" />
+        <div className="content">
+          <div className="details">
+            <div className="cache-proxy-section">
+              <div className="cache-proxy-section-title">Hostname:</div>
+              <div>{this.props.node.host}</div>
+            </div>
+            <div className="cache-proxy-section">
+              <div className="cache-proxy-section-title">Proxy ID:</div>
+              <div>{this.props.node.proxyId}</div>
+            </div>
+            {this.props.node.proxyHostId && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Host ID:</div>
+                <div>{this.props.node.proxyHostId}</div>
+              </div>
+            )}
+            {this.props.node.osFamily && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Operating System:</div>
+                <div>{this.props.node.osFamily}</div>
+              </div>
+            )}
+            {this.props.node.arch && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Architecture:</div>
+                <div>{this.props.node.arch}</div>
+              </div>
+            )}
+            {this.props.node.version && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Version:</div>
+                <div>{this.props.node.version}</div>
+              </div>
+            )}
+            {this.props.node.startTime && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Uptime:</div>
+                <div>{format.durationSince(this.props.node.startTime)}</div>
+              </div>
+            )}
+            {this.props.lastCheckInTime && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Last Check-in:</div>
+                <div>{format.relativeTimeSeconds(this.props.lastCheckInTime)}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/enterprise/app/root/BUILD.bazel
+++ b/enterprise/app/root/BUILD.bazel
@@ -33,6 +33,7 @@ ts_library(
         "//app/shortcuts",
         "//app/util:clipboard",
         "//enterprise/app/auditlogs",
+        "//enterprise/app/cache_proxies",
         "//enterprise/app/cli_login",
         "//enterprise/app/code",
         "//enterprise/app/code:code_v2",

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -42,6 +42,7 @@ import UserPreferences from "../../../app/preferences/preferences";
 import rpc_service from "../../../app/service/rpc_service";
 import { copyToClipboard } from "../../../app/util/clipboard";
 import { api_key } from "../../../proto/api_key_ts_proto";
+import CacheProxiesComponent from "../cache_proxies/cache_proxies";
 import CliLoginComponent from "../cli_login/cli_login";
 import CodeSearchComponent from "../codesearch/codesearch";
 import ExecutorsComponent from "../executors/executors";
@@ -70,6 +71,7 @@ capabilities.register("BuildBuddy Enterprise", true, [
   Path.trendsPath,
   Path.targetsPath,
   Path.executorsPath,
+  Path.cacheProxiesPath,
   Path.tapPath,
   Path.codePath,
   Path.codesearchPath,
@@ -240,6 +242,7 @@ export default class EnterpriseRootComponent extends React.Component {
     let usage = this.state.user && this.state.path.startsWith("/usage/");
     let auditLogs = this.state.user && this.state.path.startsWith("/audit-logs/");
     let executors = this.state.user && this.state.path.startsWith("/executors");
+    let cacheProxies = this.state.user && this.state.path.startsWith("/cache-proxies");
     let tests = this.state.user && this.state.path.startsWith("/tests");
     let workflows = this.state.user && this.state.path.startsWith("/workflows");
     let code = this.state.user && this.state.path.startsWith("/code");
@@ -259,6 +262,7 @@ export default class EnterpriseRootComponent extends React.Component {
       !targets &&
       !usage &&
       !executors &&
+      !cacheProxies &&
       !tests &&
       !invocationId &&
       !compareInvocationIds &&
@@ -428,6 +432,9 @@ export default class EnterpriseRootComponent extends React.Component {
                   {usage && this.state.user && <UsageComponent path={this.state.path} user={this.state.user} />}
                   {auditLogs && this.state.user && <AuditLogsComponent user={this.state.user} />}
                   {executors && this.state.user && <ExecutorsComponent path={this.state.path} user={this.state.user} />}
+                  {cacheProxies && this.state.user && (
+                    <CacheProxiesComponent path={this.state.path} user={this.state.user} />
+                  )}
                   {home && <HistoryComponent user={this.state.user} tab={this.state.tab} search={this.state.search} />}
                   {workflows && this.state.user && <WorkflowsComponent path={this.state.path} user={this.state.user} />}
                   {repo && <RepoComponent path={this.state.path} search={this.state.search} user={this.state.user} />}

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   LayoutGrid,
   List,
   MessageCircle,
+  Network,
   PanelLeftClose,
   PanelLeftOpen,
   PlayCircle,
@@ -70,6 +71,10 @@ export default class SidebarComponent extends React.Component<Props, State> {
 
   isExecutorsSelected() {
     return this.props.path.startsWith("/executors/");
+  }
+
+  isCacheProxiesSelected() {
+    return this.props.path.startsWith("/cache-proxies/");
   }
 
   isTapSelected() {
@@ -217,6 +222,12 @@ export default class SidebarComponent extends React.Component<Props, State> {
             <SidebarLink selected={this.isExecutorsSelected()} href={Path.executorsPath} title="Executors">
               <Cloud className="icon" />
               <span className="sidebar-item-text">Executors</span>
+            </SidebarLink>
+          )}
+          {router.canAccessCacheProxiesPage(this.props.user) && (
+            <SidebarLink selected={this.isCacheProxiesSelected()} href={Path.cacheProxiesPath} title="Cache Proxies">
+              <Network className="icon" />
+              <span className="sidebar-item-text">Cache Proxies</span>
             </SidebarLink>
           )}
           {router.canAccessWorkflowsPage() && (

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -213,6 +213,9 @@ message FrontendConfig {
 
   // Maximum timing profile size that the UI will load.
   int64 timing_profile_max_size_bytes = 69;
+
+  // Whether cache proxy keys can be created.
+  bool cache_proxy_key_creation_enabled = 70;
 }
 
 message Region {

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -104,6 +104,7 @@ var (
 		"/usage/",
 		"/workflows/",
 		"/executors/",
+		"/cache-proxies/",
 		"/code/",
 		"/search/",
 		"/audit-logs/",

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -47,6 +47,7 @@ var (
 	expandedSuggestionsEnabled             = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")
 	enableWorkflows                        = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
 	enableExecutorKeyCreation              = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
+	enableCacheProxyKeyCreation            = flag.Bool("cache_proxy.enable_cache_proxy_key_creation", false, "If enabled, UI will allow cache proxy keys to be created.")
 	testOutputManifestsEnabled             = flag.Bool("app.test_output_manifests_enabled", true, "If set, the target page will render the contents of test output zips.")
 	patternFilterEnabled                   = flag.Bool("app.pattern_filter_enabled", true, "If set, allow filtering by pattern in the client.")
 	executionSearchEnabled                 = flag.Bool("app.execution_search_enabled", true, "If set, fetch lists of executions from the OLAP DB in the trends UI.")
@@ -186,6 +187,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		TestDashboardEnabled:                   target_tracker.TargetTrackingEnabled(),
 		UserOwnedExecutorsEnabled:              remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.UserOwnedExecutorsEnabled(),
 		ExecutorKeyCreationEnabled:             remote_execution_config.RemoteExecutionEnabled() && *enableExecutorKeyCreation,
+		CacheProxyKeyCreationEnabled:           *enableCacheProxyKeyCreation,
 		WorkflowsEnabled:                       remote_execution_config.RemoteExecutionEnabled() && *enableWorkflows,
 		CodeEditorEnabled:                      *features.CodeEditorEnabled || *features.CodeEditorV2Enabled,
 		RemoteExecutionEnabled:                 remote_execution_config.RemoteExecutionEnabled(),


### PR DESCRIPTION
This is the UI side of the cache proxy registry that the app server and proxy binary have been building toward. The new `/cache-proxies` route lists live proxies (host, OS/arch, version, uptime, last check-in) by calling `GetCacheProxies`, with the now-familiar Status / Setup tab structure copied from the Executors page. When the org has no registered proxies and no cache-proxy API keys, the page collapses to a single empty state with a call to action to the new cache proxy docs, rather than showing tabs with nothing in them.

API key management gets a new 'Cache proxy key (for self-hosted cache proxies)' radio option in the org-level create-key modal, parallel to the existing Executor key option and gated by a new `--cache_proxy.enable_cache_proxy_key_creation` flag exposed through the FrontendConfig proto and the frontend capabilities object. The flag plumbing follows the executor convention exactly so the gating story is consistent.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/6869