### PR TITLE
Combine Action Cache Get + Metadata Fetch in the cache proxy fast path

### DIFF
--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -92,7 +92,9 @@ func isDefaultGetActionResultRequest(req *repb.GetActionResultRequest) bool {
 }
 
 // getActionResultFromLocalCAS returns a locally cached action result saved via
-// `cacheActionResultToLocalCAS`.
+// `cacheActionResultToLocalCAS`, along with the CacheMetadata of the AC pointer
+// entry (so callers can do a TTL freshness check without a separate Metadata
+// roundtrip).
 //
 // This function should only be used when also fetching a remote action result.
 // Unlike typical action cache implementations, it doesn't validate that all blobs
@@ -101,25 +103,26 @@ func isDefaultGetActionResultRequest(req *repb.GetActionResultRequest) bool {
 // so there is digest validation on its value.
 // The remote result is always the source of truth. If the values do not
 // match, the local result should be discarded.
-func (s *ActionCacheServerProxy) getActionResultFromLocalCAS(ctx context.Context, key *digest.ACResourceName) (*repb.Digest, *repb.ActionResult, error) {
+func (s *ActionCacheServerProxy) getActionResultFromLocalCAS(ctx context.Context, key *digest.ACResourceName) (*repb.Digest, *repb.ActionResult, *interfaces.CacheMetadata, error) {
 	// NOTE: To avoid double-counting AC hits, we deliberately don't track
 	// download for these reads.  The remote server will count the full response
 	// size when checking the cached value.
 	ptr := &rspb.ResourceName{}
-	if err := cachetools.ReadProtoFromAC(ctx, s.localCache, key, ptr); err != nil {
-		return nil, nil, err
+	acMD, err := cachetools.ReadProtoFromACWithMetadata(ctx, s.localCache, key, ptr)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	casRN, err := digest.CASResourceNameFromProto(ptr)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	out := &repb.ActionResult{}
 	err = cachetools.ReadProtoFromCAS(ctx, s.localCache, casRN, out)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return ptr.GetDigest(), out, nil
+	return ptr.GetDigest(), out, acMD, nil
 }
 
 // cacheActionResultToLocalCAS stores the ActionResult `resp` in the CAS and then
@@ -157,12 +160,8 @@ func (s *ActionCacheServerProxy) actionCacheTTL(ctx context.Context) time.Durati
 	return time.Duration(ttlSeconds) * time.Second
 }
 
-func (s *ActionCacheServerProxy) isLocalActionResultFresh(ctx context.Context, key *digest.ACResourceName, ttl time.Duration) bool {
-	if ttl <= 0 {
-		return false
-	}
-	md, err := s.localCache.Metadata(ctx, key.ToProto())
-	if err != nil || md.LastModifyTimeUsec <= 0 {
+func (s *ActionCacheServerProxy) isLocalActionResultFresh(md *interfaces.CacheMetadata, ttl time.Duration) bool {
+	if ttl <= 0 || md == nil || md.LastModifyTimeUsec <= 0 {
 		return false
 	}
 
@@ -254,14 +253,14 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 			return nil, err
 		}
 		var err error
-		localDigest, localResult, err := s.getActionResultFromLocalCAS(ctx, localKey)
+		localDigest, localResult, localACMD, err := s.getActionResultFromLocalCAS(ctx, localKey)
 		if err != nil && !status.IsNotFoundError(err) {
 			return nil, err
 		}
 		if localDigest != nil {
 			// TODO: Consider async app revalidation of TTL hits, updating or deleting
 			// the local AC entry if the authoritative result changed.
-			if isDefaultGetActionResultRequest(req) && s.isLocalActionResultFresh(ctx, localKey, ttl) {
+			if isDefaultGetActionResultRequest(req) && s.isLocalActionResultFresh(localACMD, ttl) {
 				// Skip checking for existence of output files. The app recently
 				// validated or updated this result, which refreshed the referenced
 				// outputs' atime. With remote_download_minimal, this proxy

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -835,6 +835,28 @@ func (c *Cache) remoteMetadata(ctx context.Context, peer string, r *rspb.Resourc
 	return c.distributedProxy.RemoteMetadata(ctx, peer, r)
 }
 
+func (c *Cache) remoteGetWithMetadata(ctx context.Context, peer string, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	if !c.opts.DisableLocalLookup && peer == c.opts.ListenAddr {
+		if gm, ok := c.local.(interfaces.GetterWithMetadata); ok {
+			return gm.GetWithMetadata(ctx, r)
+		}
+		// Fallback: the local backend doesn't implement GetterWithMetadata, so
+		// the data and metadata reads aren't atomic. Don't fail the whole call
+		// on a Metadata-only error — return nil metadata so the caller can
+		// still use the data.
+		data, err := c.local.Get(ctx, r)
+		if err != nil {
+			return nil, nil, err
+		}
+		md, err := c.local.Metadata(ctx, r)
+		if err != nil {
+			log.Warningf("Error getting metadata for resource %q: %s. Returning data with nil metadata.", r, err)
+		}
+		return data, md, nil
+	}
+	return c.distributedProxy.RemoteGetWithMetadata(ctx, peer, r)
+}
+
 func (c *Cache) remoteFindMissing(ctx context.Context, peer string, rns []*rspb.ResourceName) ([]*repb.Digest, error) {
 	if !c.opts.DisableLocalLookup && peer == c.opts.ListenAddr {
 		return c.local.FindMissing(ctx, rns)
@@ -1167,6 +1189,50 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces
 
 	c.log.CtxDebugf(ctx, "Exhausted all peers attempting to query metadata %q. Peerset: %+v", d.GetHash(), ps)
 	return nil, status.NotFoundErrorf("Exhausted all peers attempting to query metadata %q.", d.GetHash())
+}
+
+// GetWithMetadata implements interfaces.GetterWithMetadata. It fuses the Get
+// and Metadata roundtrips by extending the Read RPC to also carry CacheMetadata
+// on the first stream response.
+//
+// Metadata is best-effort: the returned CacheMetadata may be nil even on a
+// successful data fetch (e.g., the responding peer's backend couldn't produce
+// metadata atomically). Callers must nil-check before reading metadata fields.
+func (c *Cache) GetWithMetadata(ctx context.Context, rn *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	d := rn.GetDigest()
+	ps := c.readPeers(rn)
+	backfill := func() {
+		if err := c.backfillPeers(ctx, c.getBackfillOrders(rn, ps)); err != nil {
+			c.log.CtxDebugf(ctx, "Error backfilling peers: %s", err)
+		}
+	}
+
+	lookups := 0
+	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
+		lookups++
+		data, md, err := c.remoteGetWithMetadata(ctx, peer, rn)
+		if err == nil {
+			backfill()
+			metrics.DistributedCachePeerLookups.WithLabelValues(
+				"GetWithMetadata",
+				metrics.HitStatusLabel,
+			).Observe(float64(lookups))
+			return data, md, nil
+		}
+		if status.IsNotFoundError(err) {
+			c.log.CtxDebugf(ctx, "GetWithMetadata(%q) not found on peer %s", distributed_client.ResourceIsolationString(rn), peer)
+			continue
+		}
+		c.log.CtxDebugf(ctx, "GetWithMetadata(%q) lookup failed on peer %s: (err: %v)", distributed_client.ResourceIsolationString(rn), peer, err)
+		ps.MarkPeerAsFailed(peer)
+	}
+
+	metrics.DistributedCachePeerLookups.WithLabelValues(
+		"GetWithMetadata",
+		metrics.MissStatusLabel,
+	).Observe(float64(lookups))
+	c.log.CtxDebugf(ctx, "Exhausted all peers attempting to GetWithMetadata %q. Peerset: %+v", d.GetHash(), ps)
+	return nil, nil, status.NotFoundErrorf("Exhausted all peers attempting to GetWithMetadata %q.", d.GetHash())
 }
 
 func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName) ([]*repb.Digest, error) {

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -850,7 +850,7 @@ func (c *Cache) remoteGetWithMetadata(ctx context.Context, peer string, r *rspb.
 		}
 		md, err := c.local.Metadata(ctx, r)
 		if err != nil {
-			log.Warningf("Error getting metadata for resource %q: %s. Returning data with nil metadata.", r, err)
+			log.Warningf("Error getting metadata for resource %q: %s. Returning data with nil metadata.", distributed_client.ResourceIsolationString(r), err)
 		}
 		return data, md, nil
 	}

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -3256,3 +3256,183 @@ func TestKubeDiscoveryPodJoins(t *testing.T) {
 		return len(dc2.consistentHash.GetItems()) == 2
 	}, 5*time.Second, 50*time.Millisecond, "dc2 should discover 2 peers")
 }
+
+func TestGetWithMetadata(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	metrics.DistributedCachePeerLookups.Reset()
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer3 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := Options{
+		ReplicationFactor:  3,
+		Nodes:              []string{peer1, peer2, peer3},
+		DisableLocalLookup: true,
+	}
+
+	memoryCache1 := newMemoryCache(t, singleCacheSizeBytes)
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := newMemoryCache(t, singleCacheSizeBytes)
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	dc2 := startNewDCache(t, env, config2, memoryCache2)
+
+	memoryCache3 := newMemoryCache(t, singleCacheSizeBytes)
+	config3 := baseConfig
+	config3.ListenAddr = peer3
+	dc3 := startNewDCache(t, env, config3, memoryCache3)
+
+	waitForReady(t, config1.ListenAddr)
+	waitForReady(t, config2.ListenAddr)
+	waitForReady(t, config3.ListenAddr)
+
+	distributedCaches := []*Cache{dc1, dc2, dc3}
+
+	testSizes := []int64{1, 100, 10000}
+	for i, testSize := range testSizes {
+		rn, buf := testdigest.NewRandomResourceAndBuf(t, testSize, rspb.CacheType_CAS, "")
+		require.NoError(t, distributedCaches[i%3].Set(ctx, rn, buf))
+
+		for _, dc := range distributedCaches {
+			data, md, err := dc.GetWithMetadata(ctx, rn)
+			require.NoError(t, err)
+			assert.Equal(t, buf, data)
+			require.NotNil(t, md)
+			// Queried with the right digest, StoredSizeBytes matches the
+			// uncompressed payload size since memory_cache doesn't compress.
+			assert.Equal(t, testSize, md.StoredSizeBytes)
+		}
+	}
+
+	// For each of the resources written, we did a GetWithMetadata on all 3
+	// distributed caches; each finds the data on the first peer it tries
+	// (1 lookup) since replication factor 3 puts the data on every node.
+	peerLookupMetrics := testmetrics.HistogramVecValues(t, metrics.DistributedCachePeerLookups)
+	assert.Equal(t, []testmetrics.HistogramValues{
+		{
+			Labels: map[string]string{
+				"op":                       "GetWithMetadata",
+				metrics.CacheHitMissStatus: metrics.HitStatusLabel,
+			},
+			Buckets: map[float64]uint64{1: uint64(len(testSizes) * len(distributedCaches))},
+		},
+	}, peerLookupMetrics)
+}
+
+func TestGetWithMetadata_NotFound(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	metrics.DistributedCachePeerLookups.Reset()
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := Options{
+		ReplicationFactor:  2,
+		Nodes:              []string{peer1, peer2},
+		DisableLocalLookup: true,
+	}
+
+	memoryCache1 := newMemoryCache(t, singleCacheSizeBytes)
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := newMemoryCache(t, singleCacheSizeBytes)
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	_ = startNewDCache(t, env, config2, memoryCache2)
+
+	waitForReady(t, config1.ListenAddr)
+	waitForReady(t, config2.ListenAddr)
+
+	rn, _ := testdigest.NewRandomResourceAndBuf(t, 100, rspb.CacheType_CAS, "")
+	data, md, err := dc1.GetWithMetadata(ctx, rn)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+	assert.Nil(t, data)
+	assert.Nil(t, md)
+
+	// Should have recorded a miss across the available peers.
+	peerLookupMetrics := testmetrics.HistogramVecValues(t, metrics.DistributedCachePeerLookups)
+	var foundMiss bool
+	for _, hv := range peerLookupMetrics {
+		if hv.Labels["op"] == "GetWithMetadata" && hv.Labels[metrics.CacheHitMissStatus] == metrics.MissStatusLabel {
+			foundMiss = true
+		}
+	}
+	assert.True(t, foundMiss, "expected miss metric for GetWithMetadata")
+}
+
+func TestGetWithMetadata_Backfill(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer3 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := Options{
+		ReplicationFactor:    3,
+		Nodes:                []string{peer1, peer2, peer3},
+		DisableLocalLookup:   true,
+		RPCHeartbeatInterval: 100 * time.Millisecond,
+	}
+
+	memoryCache1 := newMemoryCache(t, singleCacheSizeBytes)
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := newMemoryCache(t, singleCacheSizeBytes)
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	dc2 := startNewDCache(t, env, config2, memoryCache2)
+
+	memoryCache3 := newMemoryCache(t, singleCacheSizeBytes)
+	config3 := baseConfig
+	config3.ListenAddr = peer3
+	dc3 := startNewDCache(t, env, config3, memoryCache3)
+
+	waitForReady(t, config1.ListenAddr)
+	waitForReady(t, config2.ListenAddr)
+	waitForReady(t, config3.ListenAddr)
+
+	baseCaches := []interfaces.Cache{memoryCache1, memoryCache2, memoryCache3}
+	distributedCaches := []*Cache{dc1, dc2, dc3}
+
+	resourcesWritten := make([]*rspb.ResourceName, 0, 100)
+	for i := 0; i < 100; i++ {
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		require.NoError(t, distributedCaches[i%3].Set(ctx, rn, buf))
+		resourcesWritten = append(resourcesWritten, rn)
+		for _, baseCache := range baseCaches {
+			exists, err := baseCache.Contains(ctx, rn)
+			require.NoError(t, err)
+			require.True(t, exists)
+		}
+	}
+
+	// Zero out one of the base caches.
+	for _, r := range resourcesWritten {
+		require.NoError(t, memoryCache3.Delete(ctx, r))
+	}
+
+	// GetWithMetadata should find the data on the surviving peers and
+	// backfill memoryCache3.
+	for _, r := range resourcesWritten {
+		for _, dc := range distributedCaches {
+			data, md, err := dc.GetWithMetadata(ctx, r)
+			require.NoError(t, err)
+			assert.NotEmpty(t, data)
+			require.NotNil(t, md)
+		}
+	}
+
+	for _, r := range resourcesWritten {
+		for i, baseCache := range baseCaches {
+			exists, err := baseCache.Contains(ctx, r)
+			require.NoError(t, err, "basecache %d missing digest", i)
+			require.True(t, exists, "basecache %d missing digest", i)
+		}
+	}
+}

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1732,6 +1732,31 @@ func (p *PebbleCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, er
 	return buf.Bytes(), err
 }
 
+func (p *PebbleCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	db, err := p.leaser.DB()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer db.Close()
+
+	rc, fileMetadata, err := p.readerAndMetadata(ctx, db, r, 0, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rc.Close()
+	bufSize := digest.SafeBufferSize(r, maxReadBufferSize)
+	buf := bytes.NewBuffer(make([]byte, 0, bufSize))
+	if _, err := io.Copy(buf, rc); err != nil {
+		return nil, nil, err
+	}
+	return buf.Bytes(), &interfaces.CacheMetadata{
+		StoredSizeBytes:    fileMetadata.GetStoredSizeBytes(),
+		DigestSizeBytes:    fileMetadata.GetFileRecord().GetDigest().GetSizeBytes(),
+		LastModifyTimeUsec: fileMetadata.GetLastModifyUsec(),
+		LastAccessTimeUsec: fileMetadata.GetLastAccessUsec(),
+	}, nil
+}
+
 func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	db, err := p.leaser.DB()
 	if err != nil {
@@ -2937,13 +2962,18 @@ func (p *PebbleCache) Partition(ctx context.Context, remoteInstanceName string) 
 }
 
 func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.ResourceName, uncompressedOffset int64, uncompressedLimit int64) (io.ReadCloser, error) {
+	rc, _, err := p.readerAndMetadata(ctx, db, r, uncompressedOffset, uncompressedLimit)
+	return rc, err
+}
+
+func (p *PebbleCache) readerAndMetadata(ctx context.Context, db pebble.IPebbleDB, r *rspb.ResourceName, uncompressedOffset int64, uncompressedLimit int64) (io.ReadCloser, *sgpb.FileMetadata, error) {
 	fileRecord, err := p.makeFileRecord(ctx, r)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	key, err := p.fileStorer.PebbleKey(fileRecord)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	unlockFn := p.locker.RLock(key.LockID())
@@ -2953,7 +2983,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 	err = p.lookupFileMetadata(ctx, db, key, fileMetadata)
 	unlockFn()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// If this object is somehow stored as a zero-length file, pretend it
@@ -2961,14 +2991,14 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 	md := fileMetadata.GetStorageMetadata()
 	if fileMetadata.GetStoredSizeBytes() == 0 {
 		log.Infof("Ignoring zero-length file. Key: %q, md: %+v", key, fileMetadata)
-		return nil, status.NotFoundError("object not found (zero-length)")
+		return nil, nil, status.NotFoundError("object not found (zero-length)")
 	}
 	// If this is a GCS object, ensure the custom time is relatively recent
 	// so that we avoid saying something exists when it's been deleted by
 	// a GCS lifecycle rule.
 	if gcsMetadata := fileMetadata.GetStorageMetadata().GetGcsMetadata(); gcsMetadata != nil {
 		if gcsutil.ObjectIsPastTTL(p.clock, gcsMetadata, p.gcsTTLDays) {
-			return nil, status.NotFoundError("backing object may have expired")
+			return nil, nil, status.NotFoundError("backing object may have expired")
 		}
 	}
 
@@ -2977,17 +3007,17 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 	if requestedCompression == cachedCompression &&
 		requestedCompression != repb.Compressor_IDENTITY &&
 		(uncompressedOffset != 0 || uncompressedLimit != 0) {
-		return nil, status.FailedPreconditionError("passthrough compression does not support offset/limit")
+		return nil, nil, status.FailedPreconditionError("passthrough compression does not support offset/limit")
 	}
 
 	shouldDecrypt := fileMetadata.EncryptionMetadata != nil
 	if shouldDecrypt {
 		encryptionEnabled, err := p.encryptionEnabled(ctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !encryptionEnabled {
-			return nil, status.NotFoundError("decryption key not available")
+			return nil, nil, status.NotFoundError("decryption key not available")
 		}
 	}
 
@@ -3010,7 +3040,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 			p.handleMetadataMismatch(ctx, err, key, fileMetadata)
 			unlockFn()
 		}
-		return nil, err
+		return nil, nil, err
 	}
 	p.sendAtimeUpdate(ctx, key, fileMetadata.GetLastAccessUsec())
 
@@ -3018,21 +3048,21 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 		if shouldDecrypt {
 			d, err := p.env.GetCrypter().NewDecryptor(ctx, fileMetadata.GetFileRecord().GetDigest(), reader, fileMetadata.GetEncryptionMetadata())
 			if err != nil {
-				return nil, status.UnavailableErrorf("decryptor not available: %s", err)
+				return nil, nil, status.UnavailableErrorf("decryptor not available: %s", err)
 			}
 			reader = d
 		}
 		if shouldDecompress {
 			dr, err := compression.NewZstdDecompressingReader(reader)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			reader = dr
 		}
 		if uncompressedOffset != 0 {
 			if _, err := io.CopyN(io.Discard, reader, uncompressedOffset); err != nil {
 				_ = reader.Close()
-				return nil, err
+				return nil, nil, err
 			}
 		}
 		if uncompressedLimit != 0 {
@@ -3042,11 +3072,14 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 
 	if requestedCompression == repb.Compressor_ZSTD && cachedCompression == repb.Compressor_IDENTITY {
 		bufSize := digest.SafeBufferSize(r, CompressorBufSizeBytes)
-
-		return compression.NewZstdCompressingReader(reader, p.bufferPool, int64(bufSize))
+		rc, err := compression.NewZstdCompressingReader(reader, p.bufferPool, int64(bufSize))
+		if err != nil {
+			return nil, nil, err
+		}
+		return rc, fileMetadata, nil
 	}
 
-	return reader, nil
+	return reader, fileMetadata, nil
 }
 
 func (p *PebbleCache) Start() error {

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -346,12 +346,15 @@ func (c *Proxy) openReadWithMetadata(ctx context.Context, req *dcpb.ReadRequest)
 	rn := req.GetResource()
 
 	if req.GetIncludeMetadata() && req.GetOffset() == 0 && req.GetLimit() == 0 {
-		if gm, ok := c.cache.(interfaces.GetterWithMetadata); ok {
-			data, md, err := gm.GetWithMetadata(ctx, rn)
-			if err != nil {
-				return nil, nil, err
+		// Avoid buffering large blobs in memory just to include metadata.
+		if d := rn.GetDigest(); d != nil && d.GetSizeBytes() <= int64(readResponseInitialBufSize) {
+			if gm, ok := c.cache.(interfaces.GetterWithMetadata); ok {
+				data, md, err := gm.GetWithMetadata(ctx, rn)
+				if err != nil {
+					return nil, nil, err
+				}
+				return io.NopCloser(bytes.NewReader(data)), cacheMetadataToProto(md), nil
 			}
-			return io.NopCloser(bytes.NewReader(data)), cacheMetadataToProto(md), nil
 		}
 	}
 

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -1,6 +1,7 @@
 package distributed_client
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -47,6 +48,12 @@ const (
 	// should be slightly smaller than 2^N, to allow for proto and gRPC
 	// overhead.
 	writeBufSizeBytes = 512 * 1000 // 512 KB
+
+	// readResponseInitialBufSize bounds the initial capacity of the buffer
+	// used to accumulate bytes from a Read RPC. Match the distributed cache's
+	// own initial-allocation cap so a crafted digest size can't trick us into
+	// a giant up-front allocation.
+	readResponseInitialBufSize = 4 * 1024 * 1024
 )
 
 var (
@@ -285,7 +292,8 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 	}
 	up, _ := prefix.UserPrefixFromContext(ctx)
 	rn := req.GetResource()
-	reader, err := c.cache.Reader(ctx, rn, req.GetOffset(), req.GetLimit())
+
+	reader, pendingMetadata, err := c.openReadWithMetadata(ctx, req)
 	if err != nil {
 		c.log.Debugf("Read(%q) failed (user prefix: %s), err: %s", ResourceIsolationString(rn), up, err)
 		return err
@@ -304,13 +312,74 @@ func (c *Proxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_ReadSer
 		if err != nil {
 			return err
 		}
-		if err := stream.Send(&dcpb.ReadResponse{Data: copyBuf[:n]}); err != nil {
+		rsp := &dcpb.ReadResponse{Data: copyBuf[:n]}
+		if pendingMetadata != nil {
+			rsp.Metadata = pendingMetadata
+			pendingMetadata = nil
+		}
+		if err := stream.Send(rsp); err != nil {
+			return err
+		}
+	}
+	// Handle the zero-byte case where the loop above sent nothing: still
+	// deliver the metadata.
+	if pendingMetadata != nil {
+		if err := stream.Send(&dcpb.ReadResponse{Metadata: pendingMetadata}); err != nil {
 			return err
 		}
 	}
 
 	c.log.Debugf("Read(%q) succeeded (user prefix: %s)", ResourceIsolationString(rn), up)
 	return nil
+}
+
+// openReadWithMetadata opens an io.ReadCloser for the requested resource and,
+// when the request opts in via IncludeMetadata, also returns its
+// MetadataResponse. When the underlying cache implements GetterWithMetadata
+// and the request is a whole-blob read, both are fetched in a single backend
+// op (true server-side fuse). Otherwise we open a streaming Reader and follow
+// it with a best-effort Metadata call — a Metadata-only failure here is
+// logged and turned into a nil metadata response rather than failing the
+// stream, since callers can still use the data without the side-channel
+// info.
+func (c *Proxy) openReadWithMetadata(ctx context.Context, req *dcpb.ReadRequest) (io.ReadCloser, *dcpb.MetadataResponse, error) {
+	rn := req.GetResource()
+
+	if req.GetIncludeMetadata() && req.GetOffset() == 0 && req.GetLimit() == 0 {
+		if gm, ok := c.cache.(interfaces.GetterWithMetadata); ok {
+			data, md, err := gm.GetWithMetadata(ctx, rn)
+			if err != nil {
+				return nil, nil, err
+			}
+			return io.NopCloser(bytes.NewReader(data)), cacheMetadataToProto(md), nil
+		}
+	}
+
+	reader, err := c.cache.Reader(ctx, rn, req.GetOffset(), req.GetLimit())
+	if err != nil {
+		return nil, nil, err
+	}
+	if !req.GetIncludeMetadata() {
+		return reader, nil, nil
+	}
+	md, err := c.cache.Metadata(ctx, rn)
+	if err != nil {
+		c.log.Warningf("Read(%q): include_metadata Metadata() failed, returning data without metadata: %s", ResourceIsolationString(rn), err)
+		return reader, nil, nil
+	}
+	return reader, cacheMetadataToProto(md), nil
+}
+
+func cacheMetadataToProto(md *interfaces.CacheMetadata) *dcpb.MetadataResponse {
+	if md == nil {
+		return nil
+	}
+	return &dcpb.MetadataResponse{
+		StoredSizeBytes: md.StoredSizeBytes,
+		DigestSizeBytes: md.DigestSizeBytes,
+		LastModifyUsec:  md.LastModifyTimeUsec,
+		LastAccessUsec:  md.LastAccessTimeUsec,
+	}
 }
 
 func (c *Proxy) callHintedHandoffCB(ctx context.Context, peer string, r *rspb.ResourceName) {
@@ -490,6 +559,64 @@ func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, resources []*rs
 		resultMap[d] = buf
 	}
 	return resultMap, nil
+}
+
+// RemoteGetWithMetadata fetches a resource and its CacheMetadata from a peer
+// in a single Read RPC. Compressed-on-disk reads are decompressed here, mirroring
+// RemoteReader's behavior.
+func (c *Proxy) RemoteGetWithMetadata(ctx context.Context, peer string, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	client, err := c.getClient(ctx, peer)
+	if err != nil {
+		return nil, nil, err
+	}
+	decompress := c.shouldReadCompressed(r)
+	rn := r
+	if decompress {
+		rn = r.CloneVT()
+		rn.Compressor = repb.Compressor_ZSTD
+	}
+	req := &dcpb.ReadRequest{
+		Resource:        rn,
+		IncludeMetadata: true,
+	}
+	stream, err := client.Read(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var md *interfaces.CacheMetadata
+	buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(rn, readResponseInitialBufSize)))
+	for {
+		rsp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		if md == nil && rsp.GetMetadata() != nil {
+			md = &interfaces.CacheMetadata{
+				StoredSizeBytes:    rsp.GetMetadata().GetStoredSizeBytes(),
+				DigestSizeBytes:    rsp.GetMetadata().GetDigestSizeBytes(),
+				LastAccessTimeUsec: rsp.GetMetadata().GetLastAccessUsec(),
+				LastModifyTimeUsec: rsp.GetMetadata().GetLastModifyUsec(),
+			}
+		}
+		if len(rsp.GetData()) > 0 {
+			if _, err := buf.Write(rsp.GetData()); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	data := buf.Bytes()
+	if decompress {
+		data, err = compression.DecompressZstd(make([]byte, r.GetDigest().GetSizeBytes()), data)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return data, md, nil
 }
 
 func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -15,11 +15,20 @@ message ReadRequest {
   int64 offset = 3;
   int64 limit = 5;
   resource.ResourceName resource = 6;
+
+  // If true, the server includes the entry's CacheMetadata on the first
+  // ReadResponse in the stream. Used by clients that want to fuse a Get +
+  // Metadata roundtrip.
+  bool include_metadata = 7;
 }
 
 message ReadResponse {
   option (vtproto.mempool) = true;
   bytes data = 1;
+
+  // Set on the first ReadResponse in the stream when the request set
+  // include_metadata. Subsequent responses leave this unset.
+  MetadataResponse metadata = 2;
 }
 
 // Next Tag: 9

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -322,6 +322,13 @@ type StoppableCache interface {
 	Stop() error
 }
 
+// GetterWithMetadata is an optional interface a Cache may implement to fetch
+// data and metadata in a single backend operation. Callers should type-assert
+// against it and fall back to separate Get + Metadata calls when absent.
+type GetterWithMetadata interface {
+	GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *CacheMetadata, error)
+}
+
 type PooledByteStreamClient interface {
 	StreamBytestreamFile(ctx context.Context, url *url.URL, writer io.Writer) error
 	FetchBytestreamZipManifest(ctx context.Context, url *url.URL) (*zipb.Manifest, error)

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -914,8 +914,44 @@ func ReadProtoFromCAS(ctx context.Context, cache interfaces.Cache, r *digest.CAS
 	return readProtoFromCache(ctx, cache, r.ToProto(), out)
 }
 
-func ReadProtoFromAC(ctx context.Context, cache interfaces.Cache, r *digest.ACResourceName, out proto.Message) error {
-	return readProtoFromCache(ctx, cache, r.ToProto(), out)
+// ReadProtoFromACWithMetadata reads an AC entry and returns its CacheMetadata.
+// If the cache implements interfaces.GetterWithMetadata, both are fetched in a
+// single backend call; otherwise falls back to separate Get + Metadata calls.
+//
+// Metadata is best-effort: the returned CacheMetadata may be nil even when the
+// data was read successfully (e.g., the entry was evicted between the Get and
+// Metadata calls on the fallback path, or the underlying backend returned the
+// data but couldn't produce metadata). Callers must nil-check before reading
+// metadata fields.
+func ReadProtoFromACWithMetadata(ctx context.Context, cache interfaces.Cache, r *digest.ACResourceName, out proto.Message) (*interfaces.CacheMetadata, error) {
+	rn := r.ToProto()
+	var data []byte
+	var md *interfaces.CacheMetadata
+	if gm, ok := cache.(interfaces.GetterWithMetadata); ok {
+		var err error
+		data, md, err = gm.GetWithMetadata(ctx, rn)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		data, err = cache.Get(ctx, rn)
+		if err != nil {
+			return nil, err
+		}
+		// Don't fail the read just because Metadata couldn't be fetched —
+		// callers that need it can nil-check. This avoids turning transient
+		// metadata-only backend errors into a failure for callers (e.g., the
+		// AC proxy) that only need metadata for an optional TTL fast path.
+		md, err = cache.Metadata(ctx, rn)
+		if err != nil {
+			log.Warningf("ReadProtoFromACWithMetadata: Metadata call failed for %q: %s", rn.GetDigest().GetHash(), err)
+		}
+	}
+	if err := proto.Unmarshal(data, out); err != nil {
+		return nil, err
+	}
+	return md, nil
 }
 
 func UploadBytesToCache(ctx context.Context, cache interfaces.Cache, cacheType rspb.CacheType, remoteInstanceName string, digestFunction repb.DigestFunction_Value, in io.ReadSeeker) (*repb.Digest, error) {

--- a/server/remote_cache/cachetools/cachetools_test.go
+++ b/server/remote_cache/cachetools/cachetools_test.go
@@ -1530,3 +1530,203 @@ func TestBatchCASUploader_SkipsChunkedUploadAboveMaxSize(t *testing.T) {
 	})
 	require.True(t, status.IsNotFoundError(err))
 }
+
+// readProtoFromACTestCache fakes the bare minimum of interfaces.Cache used by
+// ReadProtoFromACWithMetadata: Get and Metadata. By default it does NOT
+// implement GetterWithMetadata, so ReadProtoFromACWithMetadata routes through
+// the Get + Metadata fallback path.
+type readProtoFromACTestCache struct {
+	interfaces.Cache
+	data     []byte
+	getErr   error
+	md       *interfaces.CacheMetadata
+	mdErr    error
+	getCalls int
+	mdCalls  int
+}
+
+func (c *readProtoFromACTestCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
+	c.getCalls++
+	if c.getErr != nil {
+		return nil, c.getErr
+	}
+	return c.data, nil
+}
+
+func (c *readProtoFromACTestCache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces.CacheMetadata, error) {
+	c.mdCalls++
+	if c.mdErr != nil {
+		return nil, c.mdErr
+	}
+	return c.md, nil
+}
+
+// readProtoAndMDFromACTestCache additionally implements GetterWithMetadata, so
+// ReadProtoFromACWithMetadata routes through the fused path and never invokes
+// the embedded Get/Metadata methods.
+type readProtoAndMDFromACTestCache struct {
+	readProtoFromACTestCache
+	gwmData  []byte
+	gwmMD    *interfaces.CacheMetadata
+	gwmErr   error
+	gwmCalls int
+}
+
+func (c *readProtoAndMDFromACTestCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	c.gwmCalls++
+	if c.gwmErr != nil {
+		return nil, nil, c.gwmErr
+	}
+	return c.gwmData, c.gwmMD, nil
+}
+
+func newTestACResourceName(t *testing.T) *digest.ACResourceName {
+	d, err := digest.Compute(bytes.NewReader([]byte("test-action")), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	return digest.NewACResourceName(d, testInstance, repb.DigestFunction_SHA256)
+}
+
+func marshalDigestProto(t *testing.T, hash string, size int64) []byte {
+	b, err := (&repb.Digest{Hash: hash, SizeBytes: size}).MarshalVT()
+	require.NoError(t, err)
+	return b
+}
+
+func TestReadProtoFromACWithMetadata_FusedPath(t *testing.T) {
+	ctx := context.Background()
+	want := &repb.Digest{Hash: "abc", SizeBytes: 42}
+	wantBytes, err := want.MarshalVT()
+	require.NoError(t, err)
+
+	wantMD := &interfaces.CacheMetadata{
+		StoredSizeBytes:    int64(len(wantBytes)),
+		DigestSizeBytes:    int64(len(wantBytes)),
+		LastModifyTimeUsec: 12345,
+		LastAccessTimeUsec: 67890,
+	}
+	cache := &readProtoAndMDFromACTestCache{
+		gwmData: wantBytes,
+		gwmMD:   wantMD,
+	}
+
+	var got repb.Digest
+	md, err := cachetools.ReadProtoFromACWithMetadata(ctx, cache, newTestACResourceName(t), &got)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cache.gwmCalls)
+	assert.Equal(t, 0, cache.getCalls, "fused path should not invoke Get")
+	assert.Equal(t, 0, cache.mdCalls, "fused path should not invoke Metadata")
+	assert.Empty(t, cmp.Diff(want, &got, protocmp.Transform()))
+	assert.Equal(t, wantMD, md)
+}
+
+func TestReadProtoFromACWithMetadata_FusedPath_BestEffortMetadata(t *testing.T) {
+	ctx := context.Background()
+	want := &repb.Digest{Hash: "abc", SizeBytes: 42}
+	wantBytes, err := want.MarshalVT()
+	require.NoError(t, err)
+
+	// GetWithMetadata implementations are allowed to return (data, nil, nil)
+	// when the backend produced the data but couldn't atomically produce
+	// metadata. ReadProtoFromACWithMetadata must pass that through.
+	cache := &readProtoAndMDFromACTestCache{
+		gwmData: wantBytes,
+		gwmMD:   nil,
+	}
+
+	var got repb.Digest
+	md, err := cachetools.ReadProtoFromACWithMetadata(ctx, cache, newTestACResourceName(t), &got)
+	require.NoError(t, err)
+	assert.Nil(t, md)
+	assert.Empty(t, cmp.Diff(want, &got, protocmp.Transform()))
+}
+
+func TestReadProtoFromACWithMetadata_FusedPath_Error(t *testing.T) {
+	ctx := context.Background()
+	cache := &readProtoAndMDFromACTestCache{
+		gwmErr: status.NotFoundError("nope"),
+	}
+
+	var got repb.Digest
+	md, err := cachetools.ReadProtoFromACWithMetadata(ctx, cache, newTestACResourceName(t), &got)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+	assert.Nil(t, md)
+}
+
+func TestReadProtoFromACWithMetadata_FallbackPath(t *testing.T) {
+	ctx := context.Background()
+	want := &repb.Digest{Hash: "abc", SizeBytes: 42}
+	wantBytes, err := want.MarshalVT()
+	require.NoError(t, err)
+	wantMD := &interfaces.CacheMetadata{
+		StoredSizeBytes:    int64(len(wantBytes)),
+		DigestSizeBytes:    int64(len(wantBytes)),
+		LastModifyTimeUsec: 12345,
+		LastAccessTimeUsec: 67890,
+	}
+	cache := &readProtoFromACTestCache{
+		data: wantBytes,
+		md:   wantMD,
+	}
+
+	var got repb.Digest
+	md, err := cachetools.ReadProtoFromACWithMetadata(ctx, cache, newTestACResourceName(t), &got)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cache.getCalls)
+	assert.Equal(t, 1, cache.mdCalls)
+	assert.Empty(t, cmp.Diff(want, &got, protocmp.Transform()))
+	assert.Equal(t, wantMD, md)
+}
+
+func TestReadProtoFromACWithMetadata_FallbackPath_MetadataErrorSwallowed(t *testing.T) {
+	ctx := context.Background()
+	want := &repb.Digest{Hash: "abc", SizeBytes: 42}
+	wantBytes := marshalDigestProto(t, "abc", 42)
+
+	// Get succeeds, but Metadata returns a transient error. The function
+	// should still return the unmarshaled proto and a nil metadata pointer
+	// instead of failing — this is the regression we want to lock in, since
+	// callers like the AC proxy rely on it to keep the TTL fast path
+	// optional rather than load-bearing.
+	cache := &readProtoFromACTestCache{
+		data:  wantBytes,
+		mdErr: status.UnavailableError("transient"),
+	}
+
+	var got repb.Digest
+	md, err := cachetools.ReadProtoFromACWithMetadata(ctx, cache, newTestACResourceName(t), &got)
+	require.NoError(t, err)
+	assert.Nil(t, md)
+	assert.Empty(t, cmp.Diff(want, &got, protocmp.Transform()))
+	assert.Equal(t, 1, cache.getCalls)
+	assert.Equal(t, 1, cache.mdCalls)
+}
+
+func TestReadProtoFromACWithMetadata_FallbackPath_GetError(t *testing.T) {
+	ctx := context.Background()
+	cache := &readProtoFromACTestCache{
+		getErr: status.NotFoundError("nope"),
+	}
+
+	var got repb.Digest
+	md, err := cachetools.ReadProtoFromACWithMetadata(ctx, cache, newTestACResourceName(t), &got)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+	assert.Nil(t, md)
+	assert.Equal(t, 1, cache.getCalls)
+	assert.Equal(t, 0, cache.mdCalls, "Metadata should not run when Get failed")
+}
+
+func TestReadProtoFromACWithMetadata_UnmarshalError(t *testing.T) {
+	ctx := context.Background()
+	// Garbage bytes that won't parse as a repb.Digest.
+	cache := &readProtoAndMDFromACTestCache{
+		gwmData: []byte{0xff, 0xff, 0xff, 0xff},
+		gwmMD:   &interfaces.CacheMetadata{LastModifyTimeUsec: 1},
+	}
+
+	var got repb.Digest
+	md, err := cachetools.ReadProtoFromACWithMetadata(ctx, cache, newTestACResourceName(t), &got)
+	require.Error(t, err)
+	assert.Nil(t, md)
+}


### PR DESCRIPTION
The action_cache_server_proxy's TTL fast path used to read the AC pointer with a separate Get followed by a Metadata call to check freshness, which is two roundtrips into the local cache (and, in proxy-to-proxy setups, two RPCs that might even hit different peers). This change adds an optional GetterWithMetadata interface that PebbleCache and the distributed cache implement, extends the distributed Read RPC with an include_metadata field that piggybacks a MetadataResponse on the first stream message, and routes the AC proxy through the new fused path via a new ReadProtoFromACWithMetadata helper. On the proxy server side we type-assert to GetterWithMetadata when the request is whole-blob so the fuse is real on PebbleCache, not just on the wire.

Metadata is treated as best-effort everywhere: if the backend returns the data but can't produce metadata, we return nil metadata rather than failing. That preserves the pre-change behavior where a flaky Metadata call just meant the TTL fast path was skipped, instead of escalating into a failed GetActionResult RPC. An alternative would have been a brand-new RPC dedicated to AC pointer reads, but extending Read keeps the surface area small and lets future callers opt in with one extra bool.

In order to safely roll this out we will need to:
1. Disable the fastpath entirely
2. Roll out
3. Re-enable the fastpath