### PR TITLE
saml: expire IdP metadata cache

### DIFF
--- a/enterprise/server/saml/BUILD
+++ b/enterprise/server/saml/BUILD
@@ -16,16 +16,22 @@ go_library(
         "//server/util/cookie",
         "//server/util/flag",
         "//server/util/log",
+        "//server/util/lru",
         "//server/util/status",
         "@com_github_crewjam_saml//:saml",
         "@com_github_crewjam_saml//samlsp",
         "@com_github_golang_jwt_jwt_v4//:jwt",
+        "@com_github_jonboulle_clockwork//:clockwork",
     ],
 )
 
 go_test(
     name = "saml_test",
-    srcs = ["saml_test.go"],
+    srcs = [
+        "saml_cache_test.go",
+        "saml_test.go",
+    ],
+    embed = [":saml"],
     deps = [
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//proto:group_go_proto",
@@ -34,6 +40,8 @@ go_test(
         "//server/testutil/testport",
         "@com_github_beevik_etree//:etree",
         "@com_github_crewjam_saml//:saml",
+        "@com_github_crewjam_saml//samlsp",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
@@ -24,10 +23,17 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/jonboulle/clockwork"
+)
+
+const (
+	samlProviderCacheSize = 10_000
+	samlProviderCacheTTL  = 2 * time.Minute
 )
 
 var (
@@ -209,8 +215,7 @@ func (p cookieSessionProvider) GetSession(r *http.Request) (samlsp.Session, erro
 
 type SAMLAuthenticator struct {
 	env           environment.Env
-	mu            sync.Mutex
-	samlProviders map[string]*samlsp.Middleware
+	samlProviders lru.LRU[*samlsp.Middleware]
 }
 
 func IsEnabled(env environment.Env) bool {
@@ -227,10 +232,28 @@ func NewSAMLAuthenticator(env environment.Env) (*SAMLAuthenticator, error) {
 	if *key != "" && *keyFile != "" {
 		return nil, status.FailedPreconditionError("only one of SAML 'key' and 'key_file' may be set")
 	}
+	cache, err := newSAMLProviderCache(env.GetClock())
+	if err != nil {
+		return nil, err
+	}
 	return &SAMLAuthenticator{
 		env:           env,
-		samlProviders: make(map[string]*samlsp.Middleware),
+		samlProviders: cache,
 	}, nil
+}
+
+func newSAMLProviderCache(clock clockwork.Clock) (lru.LRU[*samlsp.Middleware], error) {
+	cache, err := lru.New[*samlsp.Middleware](&lru.Config[*samlsp.Middleware]{
+		MaxSize:    samlProviderCacheSize,
+		SizeFn:     func(*samlsp.Middleware) int64 { return 1 },
+		TTL:        samlProviderCacheTTL,
+		ThreadSafe: true,
+		Clock:      clock,
+	})
+	if err != nil {
+		return nil, status.InternalErrorf("error initializing SAML provider cache: %s", err)
+	}
+	return cache, nil
 }
 
 func (a *SAMLAuthenticator) SSOEnabled() bool {
@@ -362,9 +385,7 @@ func (a *SAMLAuthenticator) serviceProviderFromRequest(r *http.Request) (*samlsp
 	if slug == "" {
 		return nil, status.FailedPreconditionError("Organization slug not set")
 	}
-	a.mu.Lock()
-	provider, ok := a.samlProviders[slug]
-	a.mu.Unlock()
+	provider, ok := a.samlProviders.Get(slug)
 	if ok {
 		return provider, nil
 	}
@@ -477,9 +498,7 @@ func (a *SAMLAuthenticator) serviceProviderFromRequest(r *http.Request) (*samlsp
 		csp.oldDomain = opts.URL.Host
 	}
 	samlSP.Session = csp
-	a.mu.Lock()
-	a.samlProviders[slug] = samlSP
-	a.mu.Unlock()
+	a.samlProviders.Add(slug, samlSP)
 	return samlSP, nil
 }
 

--- a/enterprise/server/saml/saml_cache_test.go
+++ b/enterprise/server/saml/saml_cache_test.go
@@ -1,0 +1,26 @@
+package saml
+
+import (
+	"testing"
+
+	"github.com/crewjam/saml/samlsp"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSAMLProviderCacheExpiresEntries(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	cache, err := newSAMLProviderCache(clock)
+	require.NoError(t, err)
+
+	provider := &samlsp.Middleware{}
+	cache.Add("slug", provider)
+
+	got, ok := cache.Get("slug")
+	require.True(t, ok)
+	require.Same(t, provider, got)
+
+	clock.Advance(samlProviderCacheTTL)
+	_, ok = cache.Get("slug")
+	require.False(t, ok)
+}

--- a/enterprise/server/saml/saml_test.go
+++ b/enterprise/server/saml/saml_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -37,11 +38,16 @@ const testSlug = "saml-int-test-org"
 // metadata over HTTP and exposes the underlying *saml.IdentityProvider so
 // tests can synthesize signed SAML responses without driving a browser.
 type testIDP struct {
-	HTTPServer *httptest.Server
-	IDP        *saml.IdentityProvider
+	HTTPServer       *httptest.Server
+	IDP              *saml.IdentityProvider
+	metadataRequests atomic.Int64
 }
 
 func (i *testIDP) MetadataURL() string { return i.HTTPServer.URL + "/metadata" }
+
+func (i *testIDP) MetadataRequests() int64 {
+	return i.metadataRequests.Load()
+}
 
 func startTestIDP(t *testing.T) *testIDP {
 	t.Helper()
@@ -51,8 +57,10 @@ func startTestIDP(t *testing.T) *testIDP {
 		Key:         key,
 		Certificate: cert,
 	}
+	testIDP := &testIDP{IDP: idp}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/metadata", func(w http.ResponseWriter, r *http.Request) {
+		testIDP.metadataRequests.Add(1)
 		w.Header().Set("Content-Type", "application/samlmetadata+xml")
 		body, err := xml.Marshal(idp.Metadata())
 		if err != nil {
@@ -68,7 +76,8 @@ func startTestIDP(t *testing.T) *testIDP {
 	require.NoError(t, err)
 	idp.MetadataURL = url.URL{Scheme: listener.Scheme, Host: listener.Host, Path: "/metadata"}
 	idp.SSOURL = url.URL{Scheme: listener.Scheme, Host: listener.Host, Path: "/sso"}
-	return &testIDP{HTTPServer: httpServer, IDP: idp}
+	testIDP.HTTPServer = httpServer
+	return testIDP
 }
 
 func generateSelfSignedCert(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
@@ -99,17 +108,21 @@ func encodeKeyPEM(key *rsa.PrivateKey) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
 }
 
-func startBuildBuddy(t *testing.T, idp *testIDP) *app.App {
+func startBuildBuddy(t *testing.T, idp *testIDP, extraArgs ...string) *app.App {
 	t.Helper()
 	spCert, spKey := generateSelfSignedCert(t)
 	appConfig := buildbuddy_enterprise.DefaultAppConfig(t)
 	appConfig.HttpPort = testport.FindFree(t)
 	bbURL := fmt.Sprintf("http://localhost:%d", appConfig.HttpPort)
+	args := []string{
+		"--auth.saml.cert=" + string(encodeCertPEM(spCert)),
+		"--auth.saml.key=" + string(encodeKeyPEM(spKey)),
+		"--app.build_buddy_url=" + bbURL,
+	}
+	args = append(args, extraArgs...)
 	bb := buildbuddy_enterprise.RunWithConfig(
 		t, appConfig, buildbuddy_enterprise.DefaultConfig,
-		"--auth.saml.cert="+string(encodeCertPEM(spCert)),
-		"--auth.saml.key="+string(encodeKeyPEM(spKey)),
-		"--app.build_buddy_url="+bbURL,
+		args...,
 	)
 
 	wc := buildbuddy_enterprise.LoginAsDefaultSelfAuthUser(t, bb)
@@ -126,6 +139,20 @@ func startBuildBuddy(t *testing.T, idp *testIDP) *app.App {
 	require.Greaterf(t, res.RowsAffected, int64(0),
 		"failed to set saml_idp_metadata_url: no Groups row matched url_identifier=%q", testSlug)
 	return bb
+}
+
+func TestSAMLProviderCacheReusesProvider(t *testing.T) {
+	idp := startTestIDP(t)
+	bb := startBuildBuddy(t, idp)
+
+	fetchSPMetadata(t, bb)
+	require.Equal(t, int64(1), idp.MetadataRequests())
+
+	fetchSPMetadata(t, bb)
+	require.Equal(t, int64(1), idp.MetadataRequests())
+
+	fetchSPMetadata(t, bb)
+	require.Equal(t, int64(1), idp.MetadataRequests())
 }
 
 // fetchSPMetadata GETs BuildBuddy's SAML SP metadata via /auth/saml/metadata.


### PR DESCRIPTION
Updating a group's SAML IdP metadata URL currently leaves any app
process that has already handled that org's SAML flow using the provider
built from the old URL until restart. Add a fixed TTL to the per-slug
SAML provider cache so that each pod refreshes IdP metadata without
requiring a distributed invalidation signal.

Use the shared BuildBuddy LRU for the cache so the TTL and locking
behavior match existing server caches. Set the TTL to two minutes to
bound stale login behavior while still avoiding a metadata fetch on
every SAML request. Keep the TTL as an internal constant instead of
adding a new auth flag.
