### PR TITLE
Allow loading compact traces for dropped files too

### DIFF
--- a/app/trace/compact_trace.ts
+++ b/app/trace/compact_trace.ts
@@ -1,6 +1,6 @@
 import { StringInterner } from "../util/intern";
 import { TypedArrayBuilder } from "../util/typed_arrays";
-import type { ProfileProgressCallback, TraceEvent } from "./trace_events";
+import type { ProfileInput, ProfileProgressCallback, TraceEvent } from "./trace_events";
 import {
   TIME_SERIES_EVENT_ORDER,
   TIME_SERIES_METADATA,
@@ -159,14 +159,11 @@ export class TimeSeries {
   ) {}
 }
 
-/** Reads a trace profile stream. */
-export async function readProfile(
-  body: ReadableStream<Uint8Array>,
-  progress?: ProfileProgressCallback
-): Promise<Profile> {
+/** Reads a trace profile from a local file or stream. */
+export async function readProfile(input: ProfileInput, progress?: ProfileProgressCallback): Promise<Profile> {
   const builder = new ProfileBuilder();
   await readProfileEvents(
-    body,
+    input,
     (events) => {
       for (const event of events) {
         builder.addEvent(event);

--- a/app/trace/compact_trace_test.ts
+++ b/app/trace/compact_trace_test.ts
@@ -79,6 +79,13 @@ describe("readProfile", () => {
     expect(numBytesRead).toBe(COMPLETE_PROFILE.length);
   });
 
+  it("parses a complete profile blob", async () => {
+    const profile = await readProfile(new Blob([COMPLETE_PROFILE]));
+
+    expect(profile.eventCount).toBe(7);
+    expect(profile.threads[0].name).toBe("Main Thread");
+  });
+
   it("parses an incomplete profile", async () => {
     const stream = readableStreamFromString(INCOMPLETE_PROFILE);
     let numBytesRead = 0;

--- a/app/trace/timing_profile_drop_target.tsx
+++ b/app/trace/timing_profile_drop_target.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Profile, readProfileFile } from "./trace_events";
+import { Profile, readProfile } from "./trace_events";
 
 interface Props {
   children: (state: State) => React.ReactNode;
@@ -30,7 +30,7 @@ export default class TimingProfileDropTarget extends React.Component<Props, Stat
     this.setState({ dragActive: false, loadingMessage: `Loading ${file.name}...` });
 
     try {
-      const profile = await readProfileFile(file);
+      const profile = await readProfile(file);
       this.props.onProfileLoaded(profile, file.name);
       this.setState({ loadingMessage: "" });
     } catch (e) {

--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -118,6 +118,7 @@ export const TIME_SERIES_EVENT_ORDER = new Map(Array.from(TIME_SERIES_METADATA).
 const GZIP_MAGIC_BYTE_0 = 0x1f;
 const GZIP_MAGIC_BYTE_1 = 0x8b;
 
+export type ProfileInput = Blob | ReadableStream<Uint8Array>;
 export type ProfileProgressCallback = (numBytesLoaded: number, done?: boolean) => void;
 export type TraceEventBatchCallback = (events: TraceEvent[]) => void;
 
@@ -126,24 +127,10 @@ async function isGzipCompressed(blob: Blob): Promise<boolean> {
   return header[0] === GZIP_MAGIC_BYTE_0 && header[1] === GZIP_MAGIC_BYTE_1;
 }
 
-export async function readProfileFile(file: Blob, progress?: ProfileProgressCallback): Promise<Profile> {
-  let stream = file.stream() as ReadableStream<Uint8Array>;
-  if (await isGzipCompressed(file)) {
-    if (typeof DecompressionStream === "undefined") {
-      throw new Error("This browser can't read gzipped timing profiles from local files.");
-    }
-    stream = stream.pipeThrough(new DecompressionStream("gzip"));
-  }
-  return readProfile(stream, progress);
-}
-
-export async function readProfile(
-  body: ReadableStream<Uint8Array>,
-  progress?: ProfileProgressCallback
-): Promise<Profile> {
+export async function readProfile(input: ProfileInput, progress?: ProfileProgressCallback): Promise<Profile> {
   const profile: Profile = { traceEvents: [] };
   await readProfileEvents(
-    body,
+    input,
     (events) => {
       for (const event of events) {
         profile.traceEvents.push(event);
@@ -155,10 +142,22 @@ export async function readProfile(
 }
 
 export async function readProfileEvents(
-  body: ReadableStream<Uint8Array>,
+  input: ProfileInput,
   consumeEventBatch: TraceEventBatchCallback,
   progress?: ProfileProgressCallback
 ): Promise<void> {
+  let body: ReadableStream<Uint8Array>;
+  if (input instanceof Blob) {
+    body = input.stream() as ReadableStream<Uint8Array>;
+    if (await isGzipCompressed(input)) {
+      if (typeof DecompressionStream === "undefined") {
+        throw new Error("This browser can't read gzipped timing profiles from local files.");
+      }
+      body = body.pipeThrough(new DecompressionStream("gzip"));
+    }
+  } else {
+    body = input;
+  }
   const reader = body.getReader();
   const decoder = new TextDecoder("utf-8");
   let n = 0;

--- a/app/trace/trace_events_test.ts
+++ b/app/trace/trace_events_test.ts
@@ -77,6 +77,11 @@ describe("parseProfile", () => {
     expect(numBytesRead).toBe(COMPLETE_PROFILE.length);
   });
 
+  it("should parse a complete profile blob", async () => {
+    const profile = await readProfile(new Blob([COMPLETE_PROFILE]));
+    expect(profile.traceEvents.length).toBe(7);
+  });
+
   it("should parse an incomplete profile", async () => {
     const stream = readableStreamFromString(INCOMPLETE_PROFILE);
     let numBytesRead = 0;


### PR DESCRIPTION
In https://github.com/buildbuddy-io/buildbuddy/pull/12278 I missed that we need to handle `Blob` (for dropped files), not just `ReadableStream`.