### PR TITLE
Executor publishes post-completion snapshot stats after runner recycling

### DIFF
--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//enterprise/server/remote_execution/executor_auth",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/util/oci",
+        "//proto:execution_stats_go_proto",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",
@@ -41,6 +42,7 @@ go_test(
     deps = [
         ":container",
         "//enterprise/server/util/oci",
+        "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/testutil/testauth",

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
@@ -730,6 +731,8 @@ type TracedCommandContainer struct {
 	mu       sync.RWMutex
 	removed  bool
 	Delegate CommandContainer
+
+	pauseDuration time.Duration
 }
 
 func (t *TracedCommandContainer) IsolationType() string {
@@ -737,6 +740,7 @@ func (t *TracedCommandContainer) IsolationType() string {
 }
 
 func (t *TracedCommandContainer) Run(ctx context.Context, command *repb.Command, workingDir string, creds oci.Credentials) *interfaces.CommandResult {
+	t.pauseDuration = 0
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
 
@@ -789,6 +793,7 @@ func (t *TracedCommandContainer) Create(ctx context.Context, workingDir string) 
 }
 
 func (t *TracedCommandContainer) Exec(ctx context.Context, command *repb.Command, opts *interfaces.Stdio) *interfaces.CommandResult {
+	t.pauseDuration = 0
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
 
@@ -837,7 +842,10 @@ func (t *TracedCommandContainer) Pause(ctx context.Context) error {
 		return ErrRemoved
 	}
 
-	return t.Delegate.Pause(ctx)
+	start := time.Now()
+	err := t.Delegate.Pause(ctx)
+	t.pauseDuration = time.Since(start)
+	return err
 }
 
 func (t *TracedCommandContainer) Remove(ctx context.Context) error {
@@ -875,6 +883,18 @@ func (t *TracedCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, e
 	}
 
 	return t.Delegate.Stats(ctx)
+}
+
+func (t *TracedCommandContainer) PostCompletionStats() *espb.PostCompletionStats {
+	type postCompletionStatsProvider interface {
+		PostCompletionStats() *espb.PostCompletionStats
+	}
+	stats := &espb.PostCompletionStats{}
+	if p, ok := t.Delegate.(postCompletionStatsProvider); ok {
+		stats = p.PostCompletionStats()
+	}
+	stats.PauseDurationUsec = t.pauseDuration.Microseconds()
+	return stats
 }
 
 func NewTracedCommandContainer(delegate CommandContainer) *TracedCommandContainer {

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
@@ -418,6 +419,95 @@ func TestUsageStats_Timeseries(t *testing.T) {
 	}, timestamps, "timestamps")
 	assert.Equal(t, []int64{0, 7000, 9500}, cpuSamples, "cpu samples")
 	assert.Equal(t, []int64{0, 500, 400}, memKBSamples, "memory kb samples")
+}
+
+// fakePausableContainer is a FakeContainer whose Pause sleeps for a
+// configurable duration so tests can assert on TracedCommandContainer's
+// pause timing.
+type fakePausableContainer struct {
+	FakeContainer
+	pauseDelay time.Duration
+}
+
+func (c *fakePausableContainer) Pause(ctx context.Context) error {
+	if c.pauseDelay > 0 {
+		time.Sleep(c.pauseDelay)
+	}
+	return nil
+}
+
+// fakeFirecrackerLikeContainer is a FakeContainer that exposes
+// PostCompletionStats with non-pause-duration fields, simulating what
+// firecracker reports. TracedCommandContainer should preserve those
+// fields and overwrite only PauseDurationUsec.
+type fakeFirecrackerLikeContainer struct {
+	fakePausableContainer
+	stats *espb.PostCompletionStats
+}
+
+func (c *fakeFirecrackerLikeContainer) PostCompletionStats() *espb.PostCompletionStats {
+	return c.stats
+}
+
+func TestTracedCommandContainer_PostCompletionStats_TimesPause(t *testing.T) {
+	delegate := &fakePausableContainer{pauseDelay: 10 * time.Millisecond}
+	tc := container.NewTracedCommandContainer(delegate)
+
+	require.NoError(t, tc.Pause(context.Background()))
+
+	stats := tc.PostCompletionStats()
+	require.NotNil(t, stats)
+	assert.GreaterOrEqual(t, stats.GetPauseDurationUsec(), (10 * time.Millisecond).Microseconds(),
+		"pause duration should reflect time spent in Pause")
+	assert.Nil(t, stats.GetFirecrackerPostExecStats(),
+		"delegate without PostCompletionStats should yield no firecracker stats")
+}
+
+func TestTracedCommandContainer_PostCompletionStats_PreservesDelegateStats(t *testing.T) {
+	delegateStats := &espb.PostCompletionStats{
+		// A stale duration on the delegate's stats; TracedCommandContainer
+		// should overwrite it with the measured value.
+		PauseDurationUsec: 999999,
+		FirecrackerPostExecStats: &espb.FirecrackerPostExecStats{
+			SnapshotSavedLocally: true,
+			SnapshotSavedBytes:   4242,
+		},
+	}
+	delegate := &fakeFirecrackerLikeContainer{
+		fakePausableContainer: fakePausableContainer{pauseDelay: 10 * time.Millisecond},
+		stats:                 delegateStats,
+	}
+	tc := container.NewTracedCommandContainer(delegate)
+
+	require.NoError(t, tc.Pause(context.Background()))
+
+	stats := tc.PostCompletionStats()
+	require.NotNil(t, stats)
+	assert.GreaterOrEqual(t, stats.GetPauseDurationUsec(), (10 * time.Millisecond).Microseconds(),
+		"pause duration should reflect measured time, not the delegate's stale value")
+	require.NotNil(t, stats.GetFirecrackerPostExecStats(), "delegate's firecracker stats should be preserved")
+	assert.True(t, stats.GetFirecrackerPostExecStats().GetSnapshotSavedLocally())
+	assert.Equal(t, int64(4242), stats.GetFirecrackerPostExecStats().GetSnapshotSavedBytes())
+}
+
+func TestTracedCommandContainer_PostCompletionStats_ResetOnRunAndExec(t *testing.T) {
+	delegate := &fakePausableContainer{pauseDelay: 10 * time.Millisecond}
+	tc := container.NewTracedCommandContainer(delegate)
+
+	require.NoError(t, tc.Pause(context.Background()))
+	require.GreaterOrEqual(t, tc.PostCompletionStats().GetPauseDurationUsec(), (10 * time.Millisecond).Microseconds())
+
+	// Run resets the pause duration so the next pause doesn't inherit the
+	// previous value.
+	tc.Run(context.Background(), &repb.Command{}, "", oci.Credentials{})
+	assert.Zero(t, tc.PostCompletionStats().GetPauseDurationUsec(), "Run should reset pause duration")
+
+	require.NoError(t, tc.Pause(context.Background()))
+	require.GreaterOrEqual(t, tc.PostCompletionStats().GetPauseDurationUsec(), (10 * time.Millisecond).Microseconds())
+
+	// Exec also resets.
+	tc.Exec(context.Background(), &repb.Command{}, &interfaces.Stdio{})
+	assert.Zero(t, tc.PostCompletionStats().GetPauseDurationUsec(), "Exec should reset pause duration")
 }
 
 func makePSI(someTotal, fullTotal int64) *repb.PSI {

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//enterprise/server/util/vfs_server",
         "//enterprise/server/util/vsock",
         "//enterprise/vmsupport:bundle",
+        "//proto:execution_stats_go_proto",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -69,6 +69,7 @@ import (
 	"google.golang.org/grpc"
 
 	vmsupport_bundle "github.com/buildbuddy-io/buildbuddy/enterprise/vmsupport"
+	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
@@ -732,6 +733,13 @@ type FirecrackerContainer struct {
 	}
 
 	useOCIFetcher bool
+
+	// postCompletionStats accumulates firecracker snapshot save stats
+	// during Pause so the executor can report them to the execution server
+	// in a follow-up COMPLETED Operation after runner recycling. Nil
+	// until Pause runs. Pause is called from a single goroutine per
+	// container so no synchronization is needed.
+	postCompletionStats *espb.PostCompletionStats
 }
 
 var _ container.VM = (*FirecrackerContainer)(nil)
@@ -2917,6 +2925,7 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
+	c.postCompletionStats = &espb.PostCompletionStats{}
 	start := time.Now()
 	err := c.pause(ctx)
 
@@ -2928,9 +2937,19 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 
 	pauseTime := time.Since(start)
 	log.CtxDebugf(ctx, "Pause took %s", pauseTime)
+	c.postCompletionStats.PauseDurationUsec = pauseTime.Microseconds()
 
 	c.observeStageDuration("pause", pauseTime)
 	return err
+}
+
+// PostCompletionStats returns observability data accumulated during the most
+// recent call to Pause: the resolved local/remote save decisions, whether a
+// diff snapshot was written, the uncompressed bytes written (modified
+// chunks only for diff snapshots), and the wall-clock duration of Pause.
+// Returns nil if Pause has not yet been called on this container.
+func (c *FirecrackerContainer) PostCompletionStats() *espb.PostCompletionStats {
+	return c.postCompletionStats
 }
 
 func (c *FirecrackerContainer) pause(ctx context.Context) error {
@@ -2942,6 +2961,16 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 	snapDetails, err := c.snapshotDetails(ctx)
 	if err != nil {
 		return status.WrapError(err, "prepare snapshot details")
+	}
+
+	// Record the resolved save decisions and snapshot type into the
+	// stats accumulator. We set these before the save attempt so the
+	// reported values match the snapshot bytes accumulated below,
+	// even if the save fails partway through.
+	if c.postCompletionStats != nil {
+		c.postCompletionStats.SnapshotSavedLocally = snapDetails.saveLocalSnapshot
+		c.postCompletionStats.SnapshotSavedRemotely = snapDetails.saveRemoteSnapshot
+		c.postCompletionStats.SnapshotIsDiff = snapDetails.snapshotType == diffSnapshotType
 	}
 
 	shouldSaveSnapshot := snapDetails.saveRemoteSnapshot || snapDetails.saveLocalSnapshot
@@ -3029,11 +3058,17 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context) e
 		chunkedStores[memoryChunkDirName] = c.memoryStore
 	}
 
+	// Sum of uncompressed bytes written by the snapshot save: dirty
+	// chunks only for diff snapshots, all chunks for full snapshots.
+	// Reported back to the execution server via PostCompletionStats.
+	var totalSnapshotBytes int64
+	isDiff := c.postCompletionStats.GetSnapshotIsDiff()
+
 	for name, store := range chunkedStores {
 		chunks := store.SortedChunks()
 		chunkSourceCounter := make(map[snaputil.ChunkSource]int, 0)
 		bytesReadPerSource := make(map[snaputil.ChunkSource]int64, 0)
-		var dirtyBytes, dirtyChunkCount int64
+		var dirtyBytes, dirtyChunkCount, allChunkBytes int64
 		for _, chunk := range chunks {
 			chunkSrc := chunk.Source()
 			chunkSourceCounter[chunkSrc]++
@@ -3044,11 +3079,17 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context) e
 			}
 
 			bytesReadPerSource[chunkSrc] += chunkSize
+			allChunkBytes += chunkSize
 			dirty := store.Dirty(chunk.Offset)
 			if dirty {
 				dirtyBytes += chunkSize
 				dirtyChunkCount++
 			}
+		}
+		if isDiff {
+			totalSnapshotBytes += dirtyBytes
+		} else {
+			totalSnapshotBytes += allChunkBytes
 		}
 
 		var chunkSrcLog strings.Builder
@@ -3074,6 +3115,9 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context) e
 		}).Add(float64(dirtyBytes))
 
 		log.CtxDebugf(ctx, "For chunked %s snapshot, %d MB (%d chunks) were dirty%s", name, dirtyBytes/(1024*1024), dirtyChunkCount, chunkSrcLog.String())
+	}
+	if c.postCompletionStats != nil {
+		c.postCompletionStats.SnapshotSizeBytes = totalSnapshotBytes
 	}
 	return nil
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2922,7 +2922,9 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	c.postCompletionStats = &espb.PostCompletionStats{}
+	c.postCompletionStats = &espb.PostCompletionStats{
+		FirecrackerPostExecStats: &espb.FirecrackerPostExecStats{},
+	}
 	start := time.Now()
 	err := c.pause(ctx)
 
@@ -3006,7 +3008,7 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 		return status.WrapError(err, "unmount vbds")
 	}
 
-	c.postCompletionStats.SnapshotIsDiff = snapDetails.snapshotType == diffSnapshotType
+	c.postCompletionStats.FirecrackerPostExecStats.SnapshotIsDiff = snapDetails.snapshotType == diffSnapshotType
 	if shouldSaveSnapshot {
 		if err := c.saveSnapshot(ctx, snapDetails); err != nil {
 			if err := c.emitChunkedSnapshotMetrics(ctx, snapDetails.snapshotType == diffSnapshotType); err != nil {
@@ -3014,8 +3016,8 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 			}
 			return err
 		}
-		c.postCompletionStats.SnapshotSavedLocally = snapDetails.saveLocalSnapshot
-		c.postCompletionStats.SnapshotSavedRemotely = snapDetails.saveRemoteSnapshot
+		c.postCompletionStats.FirecrackerPostExecStats.SnapshotSavedLocally = snapDetails.saveLocalSnapshot
+		c.postCompletionStats.FirecrackerPostExecStats.SnapshotSavedRemotely = snapDetails.saveRemoteSnapshot
 	}
 
 	if err := c.emitChunkedSnapshotMetrics(ctx, snapDetails.snapshotType == diffSnapshotType); err != nil {
@@ -3100,7 +3102,7 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context, i
 
 		log.CtxDebugf(ctx, "For chunked %s snapshot, %d MB (%d chunks) were dirty%s", name, dirtyBytes/(1024*1024), dirtyChunkCount, chunkSrcLog.String())
 	}
-	c.postCompletionStats.SnapshotSizeBytes = totalSnapshotBytes
+	c.postCompletionStats.FirecrackerPostExecStats.SnapshotSizeBytes = totalSnapshotBytes
 	return nil
 }
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -3102,7 +3102,7 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context, i
 
 		log.CtxDebugf(ctx, "For chunked %s snapshot, %d MB (%d chunks) were dirty%s", name, dirtyBytes/(1024*1024), dirtyChunkCount, chunkSrcLog.String())
 	}
-	c.postCompletionStats.FirecrackerPostExecStats.SnapshotSizeBytes = totalSnapshotBytes
+	c.postCompletionStats.FirecrackerPostExecStats.SnapshotSavedBytes = totalSnapshotBytes
 	return nil
 }
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2936,7 +2936,6 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 
 	pauseTime := time.Since(start)
 	log.CtxDebugf(ctx, "Pause took %s", pauseTime)
-	c.postCompletionStats.PauseDurationUsec = pauseTime.Microseconds()
 
 	c.observeStageDuration("pause", pauseTime)
 	return err

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -735,10 +735,7 @@ type FirecrackerContainer struct {
 	useOCIFetcher bool
 
 	// postCompletionStats accumulates firecracker snapshot save stats
-	// during Pause so the executor can report them to the execution server
-	// in a follow-up COMPLETED Operation after runner recycling. Nil
-	// until Pause runs. Pause is called from a single goroutine per
-	// container so no synchronization is needed.
+	// during the latest Pause.
 	postCompletionStats *espb.PostCompletionStats
 }
 
@@ -2944,10 +2941,8 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 }
 
 // PostCompletionStats returns observability data accumulated during the most
-// recent call to Pause: the resolved local/remote save decisions, whether a
-// diff snapshot was written, the uncompressed bytes written (modified
-// chunks only for diff snapshots), and the wall-clock duration of Pause.
-// Returns nil if Pause has not yet been called on this container.
+// recent call to Pause. Returns nil if Pause has not yet been called on this
+// container.
 func (c *FirecrackerContainer) PostCompletionStats() *espb.PostCompletionStats {
 	return c.postCompletionStats
 }
@@ -2961,16 +2956,6 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 	snapDetails, err := c.snapshotDetails(ctx)
 	if err != nil {
 		return status.WrapError(err, "prepare snapshot details")
-	}
-
-	// Record the resolved save decisions and snapshot type into the
-	// stats accumulator. We set these before the save attempt so the
-	// reported values match the snapshot bytes accumulated below,
-	// even if the save fails partway through.
-	if c.postCompletionStats != nil {
-		c.postCompletionStats.SnapshotSavedLocally = snapDetails.saveLocalSnapshot
-		c.postCompletionStats.SnapshotSavedRemotely = snapDetails.saveRemoteSnapshot
-		c.postCompletionStats.SnapshotIsDiff = snapDetails.snapshotType == diffSnapshotType
 	}
 
 	shouldSaveSnapshot := snapDetails.saveRemoteSnapshot || snapDetails.saveLocalSnapshot
@@ -3021,16 +3006,19 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 		return status.WrapError(err, "unmount vbds")
 	}
 
+	c.postCompletionStats.SnapshotIsDiff = snapDetails.snapshotType == diffSnapshotType
 	if shouldSaveSnapshot {
 		if err := c.saveSnapshot(ctx, snapDetails); err != nil {
-			if err := c.emitChunkedSnapshotMetrics(ctx); err != nil {
+			if err := c.emitChunkedSnapshotMetrics(ctx, snapDetails.snapshotType == diffSnapshotType); err != nil {
 				log.CtxWarningf(ctx, "Failed to emit snapshot metrics: %s", err)
 			}
 			return err
 		}
+		c.postCompletionStats.SnapshotSavedLocally = snapDetails.saveLocalSnapshot
+		c.postCompletionStats.SnapshotSavedRemotely = snapDetails.saveRemoteSnapshot
 	}
 
-	if err := c.emitChunkedSnapshotMetrics(ctx); err != nil {
+	if err := c.emitChunkedSnapshotMetrics(ctx, snapDetails.snapshotType == diffSnapshotType); err != nil {
 		log.CtxWarningf(ctx, "Failed to emit snapshot metrics: %s", err)
 	}
 
@@ -3042,7 +3030,7 @@ func (c *FirecrackerContainer) pause(ctx context.Context) error {
 	return nil
 }
 
-func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context) error {
+func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context, isDiff bool) error {
 	if !snaputil.IsChunkedSnapshotSharingEnabled() {
 		return nil
 	}
@@ -3058,17 +3046,13 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context) e
 		chunkedStores[memoryChunkDirName] = c.memoryStore
 	}
 
-	// Sum of uncompressed bytes written by the snapshot save: dirty
-	// chunks only for diff snapshots, all chunks for full snapshots.
-	// Reported back to the execution server via PostCompletionStats.
 	var totalSnapshotBytes int64
-	isDiff := c.postCompletionStats.GetSnapshotIsDiff()
 
 	for name, store := range chunkedStores {
 		chunks := store.SortedChunks()
 		chunkSourceCounter := make(map[snaputil.ChunkSource]int, 0)
 		bytesReadPerSource := make(map[snaputil.ChunkSource]int64, 0)
-		var dirtyBytes, dirtyChunkCount, allChunkBytes int64
+		var dirtyBytes, dirtyChunkCount, allBytes int64
 		for _, chunk := range chunks {
 			chunkSrc := chunk.Source()
 			chunkSourceCounter[chunkSrc]++
@@ -3079,7 +3063,7 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context) e
 			}
 
 			bytesReadPerSource[chunkSrc] += chunkSize
-			allChunkBytes += chunkSize
+			allBytes += chunkSize
 			dirty := store.Dirty(chunk.Offset)
 			if dirty {
 				dirtyBytes += chunkSize
@@ -3089,7 +3073,7 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context) e
 		if isDiff {
 			totalSnapshotBytes += dirtyBytes
 		} else {
-			totalSnapshotBytes += allChunkBytes
+			totalSnapshotBytes += allBytes
 		}
 
 		var chunkSrcLog strings.Builder
@@ -3116,9 +3100,7 @@ func (c *FirecrackerContainer) emitChunkedSnapshotMetrics(ctx context.Context) e
 
 		log.CtxDebugf(ctx, "For chunked %s snapshot, %d MB (%d chunks) were dirty%s", name, dirtyBytes/(1024*1024), dirtyChunkCount, chunkSrcLog.String())
 	}
-	if c.postCompletionStats != nil {
-		c.postCompletionStats.SnapshotSizeBytes = totalSnapshotBytes
-	}
+	c.postCompletionStats.SnapshotSizeBytes = totalSnapshotBytes
 	return nil
 }
 

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -651,18 +651,6 @@ type streamLike interface {
 	Send(*longrunningpb.Operation) error
 }
 
-// A streamLike that returns a background context and ignores all packets sent
-// to it, used for waiting on pending executions in the background.
-type dummyStream struct{}
-
-func (s dummyStream) Context() context.Context {
-	return context.Background()
-}
-
-func (s dummyStream) Send(*longrunningpb.Operation) error {
-	return nil
-}
-
 func (s *ExecutionServer) Execute(req *repb.ExecuteRequest, stream repb.Execution_ExecuteServer) error {
 	return s.execute(req, stream)
 }

--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -48,7 +48,6 @@ go_test(
     srcs = ["executor_test.go"],
     deps = [
         ":executor",
-        "//enterprise/server/experiments",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/test/integration/remote_execution/rbetest",
@@ -69,9 +68,6 @@ go_test(
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",
         "@com_github_jonboulle_clockwork//:clockwork",
-        "@com_github_open_feature_go_sdk//openfeature",
-        "@com_github_open_feature_go_sdk//openfeature/memprovider",
-        "@com_github_open_feature_go_sdk//openfeature/testing",
         "@com_github_stretchr_testify//require",
         "@com_google_cloud_go_longrunning//autogen/longrunningpb",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",

--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -48,6 +48,7 @@ go_test(
     srcs = ["executor_test.go"],
     deps = [
         ":executor",
+        "//enterprise/server/experiments",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/test/integration/remote_execution/rbetest",
@@ -68,6 +69,9 @@ go_test(
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",
         "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_open_feature_go_sdk//openfeature",
+        "@com_github_open_feature_go_sdk//openfeature/memprovider",
+        "@com_github_open_feature_go_sdk//openfeature/testing",
         "@com_github_stretchr_testify//require",
         "@com_google_cloud_go_longrunning//autogen/longrunningpb",
         "@org_golang_google_genproto_googleapis_rpc//errdetails",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -305,7 +305,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	actionMetrics.Isolation = r.GetIsolationType()
 	reuseRunner := false
 	var cmdResult *interfaces.CommandResult
-	var publishedResponse *repb.ExecuteResponse
+	var publishedCompletedResponse *repb.ExecuteResponse
 	defer func() {
 		// Respect the DoNotRecycle bit set by the container implementation,
 		// since specific implementations will have better knowledge about the
@@ -319,15 +319,17 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		s.runnerPool.TryRecycle(ctx, r, reuseRunner)
 
 		// Recycling can produce observability data that wasn't available at
-		// COMPLETED publish time (e.g. firecracker snapshot save stats from
-		// Container.Pause). Publish a follow-up stage=COMPLETED Operation
-		// with those stats so the execution server can merge them into the
-		// OLAP row before the stream's EOF flush.
-		if stats := r.PostCompletionStats(); stats != nil && publishedResponse != nil {
+		// COMPLETED publish time.
+		if stats := r.PostCompletionStats(); stats != nil && publishedCompletedResponse != nil {
+			// Add post-completion stats to auxMetadata. This requires replacing
+			// the previosly marshalled auxMedata.
 			auxMetadata.PostCompletionStats = stats
-			if err := replaceAuxiliaryMetadata(publishedResponse.GetResult().GetExecutionMetadata(), auxMetadata); err != nil {
+			if err := replaceAuxiliaryMetadata(publishedCompletedResponse.GetResult().GetExecutionMetadata(), auxMetadata); err != nil {
 				log.CtxWarningf(ctx, "Failed to replace ExecutionAuxiliaryMetadata: %s", err)
-			} else if err := opStateChangeFn(repb.ExecutionStage_COMPLETED, publishedResponse); err != nil {
+			} else if err := opStateChangeFn(repb.ExecutionStage_COMPLETED, publishedCompletedResponse); err != nil {
+				// Don't call finishWithErrFn here since the task is already
+				// COMPLETED, and we don't want to change the task's final
+				// status.
 				log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
 			}
 		}
@@ -534,7 +536,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		}
 		return finishWithErrFn(status.WrapError(err, "publish execute response"))
 	}
-	publishedResponse = executeResponse
+	publishedCompletedResponse = executeResponse
 	if cmdResult.Error == nil {
 		log.CtxDebugf(ctx, "Task finished cleanly.")
 		reuseRunner = true

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -305,6 +305,10 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	actionMetrics.Isolation = r.GetIsolationType()
 	reuseRunner := false
 	var cmdResult *interfaces.CommandResult
+	// publishedResponse is the ExecuteResponse that was sent on the first
+	// COMPLETED Operation; captured here so the follow-up post-completion
+	// stats Operation can publish the same full reply.
+	var publishedResponse *repb.ExecuteResponse
 	defer func() {
 		// Respect the DoNotRecycle bit set by the container implementation,
 		// since specific implementations will have better knowledge about the
@@ -326,8 +330,9 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		// flag the server would drop this follow-up anyway since the row
 		// was already flushed inline with the first COMPLETED.
 		if publishPostCompletionStatsEnabled(ctx, s.env) {
-			if stats := r.PostCompletionStats(); stats != nil {
-				if err := publishPostCompletionStatsOp(stream, taskID, adInstanceDigest.GetDigest(), stats); err != nil {
+			if stats := r.PostCompletionStats(); stats != nil && publishedResponse != nil {
+				auxMetadata.PostCompletionStats = stats
+				if err := publishPostCompletionStatsOp(stream, taskID, adInstanceDigest.GetDigest(), publishedResponse, auxMetadata); err != nil {
 					log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
 				}
 			}
@@ -535,6 +540,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		}
 		return finishWithErrFn(status.WrapError(err, "publish execute response"))
 	}
+	publishedResponse = executeResponse
 	if cmdResult.Error == nil {
 		log.CtxDebugf(ctx, "Task finished cleanly.")
 		reuseRunner = true
@@ -556,26 +562,36 @@ func publishPostCompletionStatsEnabled(ctx context.Context, env environment.Env)
 	return fp.Boolean(ctx, "remote_execution.flush_executions_after_cleanup", false)
 }
 
-// publishPostCompletionStatsOp builds a stage=COMPLETED Operation whose only
-// payload is a PostCompletionStats nested inside ExecutionAuxiliaryMetadata
-// in the ExecutedActionMetadata's auxiliary_metadata, and sends it on the
-// publish stream. The execution server recognizes this as a follow-up to
-// the first COMPLETED via its own firstCompletedSeen tracking; the side
-// effects of the first COMPLETED (action-cache write, markTaskComplete,
-// recordResponseMetrics) are skipped server-side.
-func publishPostCompletionStatsOp(stream interfaces.Publisher, taskID string, ad *repb.Digest, stats *espb.PostCompletionStats) error {
-	auxAny, err := anypb.New(&espb.ExecutionAuxiliaryMetadata{
-		PostCompletionStats: stats,
-	})
+// publishPostCompletionStatsOp publishes a follow-up stage=COMPLETED
+// Operation that re-sends the originally published ExecuteResponse with
+// the updated ExecutionAuxiliaryMetadata (which now carries
+// PostCompletionStats). The execution server recognizes this as a
+// follow-up to the first COMPLETED via its own firstCompletedSeen
+// tracking; the side effects of the first COMPLETED (action-cache write,
+// markTaskComplete, recordResponseMetrics) are skipped server-side.
+func publishPostCompletionStatsOp(stream interfaces.Publisher, taskID string, ad *repb.Digest, publishedResponse *repb.ExecuteResponse, auxMetadata *espb.ExecutionAuxiliaryMetadata) error {
+	rsp := proto.Clone(publishedResponse).(*repb.ExecuteResponse)
+	if rsp.Result == nil {
+		rsp.Result = &repb.ActionResult{}
+	}
+	if rsp.Result.ExecutionMetadata == nil {
+		rsp.Result.ExecutionMetadata = &repb.ExecutedActionMetadata{}
+	}
+	auxAny, err := anypb.New(auxMetadata)
 	if err != nil {
 		return status.WrapError(err, "marshal ExecutionAuxiliaryMetadata")
 	}
-	rsp := &repb.ExecuteResponse{
-		Result: &repb.ActionResult{
-			ExecutionMetadata: &repb.ExecutedActionMetadata{
-				AuxiliaryMetadata: []*anypb.Any{auxAny},
-			},
-		},
+	md := rsp.Result.ExecutionMetadata
+	replaced := false
+	for i, a := range md.AuxiliaryMetadata {
+		if a.GetTypeUrl() == auxAny.GetTypeUrl() {
+			md.AuxiliaryMetadata[i] = auxAny
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		md.AuxiliaryMetadata = append(md.AuxiliaryMetadata, auxAny)
 	}
 	op, err := operation.Assemble(taskID, operation.Metadata(repb.ExecutionStage_COMPLETED, ad), rsp)
 	if err != nil {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -315,7 +315,10 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 
 		// Recycling can produce observability data that wasn't available at
 		// COMPLETED publish time. Publish a follow-up stage=COMPLETED Operation
-		// whose auxiliary_metadata carries just the PostCompletionStats.
+		// whose auxiliary_metadata carries just the PostCompletionStats. Only
+		// do this if the peer is ready to handle this partial COMPLETED update,
+		// which is indicated by the presence of
+		// "remote_execution.publish_post_completion_stats" in experiments.
 		if slices.Contains(task.GetExperiments(), "remote_execution.publish_post_completion_stats") {
 			if stats := r.PostCompletionStats(); stats != nil && firstCompletedPublished {
 				statsAny, err := anypb.New(stats)

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -305,9 +305,6 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	actionMetrics.Isolation = r.GetIsolationType()
 	reuseRunner := false
 	var cmdResult *interfaces.CommandResult
-	// publishedResponse is the ExecuteResponse that was sent on the first
-	// COMPLETED Operation; captured here so the follow-up post-completion
-	// stats Operation can publish the same full reply.
 	var publishedResponse *repb.ExecuteResponse
 	defer func() {
 		// Respect the DoNotRecycle bit set by the container implementation,
@@ -562,13 +559,9 @@ func publishPostCompletionStatsEnabled(ctx context.Context, env environment.Env)
 	return fp.Boolean(ctx, "remote_execution.flush_executions_after_cleanup", false)
 }
 
-// publishPostCompletionStatsOp publishes a follow-up stage=COMPLETED
-// Operation that re-sends the originally published ExecuteResponse with
-// the updated ExecutionAuxiliaryMetadata (which now carries
-// PostCompletionStats). The execution server recognizes this as a
-// follow-up to the first COMPLETED via its own firstCompletedSeen
-// tracking; the side effects of the first COMPLETED (action-cache write,
-// markTaskComplete, recordResponseMetrics) are skipped server-side.
+// publishPostCompletionStatsOp re-sends the originally published
+// ExecuteResponse with auxMetadata (now carrying PostCompletionStats)
+// merged into its ExecutionAuxiliaryMetadata entry.
 func publishPostCompletionStatsOp(stream interfaces.Publisher, taskID string, ad *repb.Digest, publishedResponse *repb.ExecuteResponse, auxMetadata *espb.ExecutionAuxiliaryMetadata) error {
 	rsp := proto.Clone(publishedResponse).(*repb.ExecuteResponse)
 	if rsp.Result == nil {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -233,14 +233,14 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	}
 	actionMetrics.AuxMetadata = auxMetadata
 	opStateChangeFn := operation.GetStateChangeFunc(stream, taskID, adInstanceDigest.GetDigest())
-	stateChangeFn := operation.StateChangeFunc(func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {
+	stateChangeFn := func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {
 		if stage == repb.ExecutionStage_COMPLETED {
 			if err := appendAuxiliaryMetadata(execResponse.GetResult().GetExecutionMetadata(), auxMetadata); err != nil {
 				log.CtxWarningf(ctx, "Failed to append ExecutionAuxiliaryMetadata: %s", err)
 			}
 		}
 		return opStateChangeFn(stage, execResponse)
-	})
+	}
 	md := &repb.ExecutedActionMetadata{
 		Worker:                   s.hostID,
 		QueuedTimestamp:          task.QueuedTimestamp,

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -305,7 +305,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	actionMetrics.Isolation = r.GetIsolationType()
 	reuseRunner := false
 	var cmdResult *interfaces.CommandResult
-	var publishedCompletedResponse *repb.ExecuteResponse
+	firstCompletedPublished := false
 	defer func() {
 		// Respect the DoNotRecycle bit set by the container implementation,
 		// since specific implementations will have better knowledge about the
@@ -319,17 +319,22 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		s.runnerPool.TryRecycle(ctx, r, reuseRunner)
 
 		// Recycling can produce observability data that wasn't available at
-		// COMPLETED publish time.
-		if stats := r.PostCompletionStats(); stats != nil && publishedCompletedResponse != nil {
-			// Add post-completion stats to auxMetadata. This requires replacing
-			// the previosly marshalled auxMedata.
-			auxMetadata.PostCompletionStats = stats
-			if err := replaceAuxiliaryMetadata(publishedCompletedResponse.GetResult().GetExecutionMetadata(), auxMetadata); err != nil {
-				log.CtxWarningf(ctx, "Failed to replace ExecutionAuxiliaryMetadata: %s", err)
-			} else if err := opStateChangeFn(repb.ExecutionStage_COMPLETED, publishedCompletedResponse); err != nil {
-				// Don't call finishWithErrFn here since the task is already
-				// COMPLETED, and we don't want to change the task's final
-				// status.
+		// COMPLETED publish time. Publish a follow-up stage=COMPLETED Operation
+		// whose auxiliary_metadata carries just the PostCompletionStats.
+		if stats := r.PostCompletionStats(); stats != nil && firstCompletedPublished {
+			statsAny, err := anypb.New(stats)
+			if err != nil {
+				log.CtxWarningf(ctx, "Failed to marshal PostCompletionStats: %s", err)
+				return
+			}
+			rsp := &repb.ExecuteResponse{
+				Result: &repb.ActionResult{
+					ExecutionMetadata: &repb.ExecutedActionMetadata{
+						AuxiliaryMetadata: []*anypb.Any{statsAny},
+					},
+				},
+			}
+			if err := opStateChangeFn(repb.ExecutionStage_COMPLETED, rsp); err != nil {
 				log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
 			}
 		}
@@ -536,7 +541,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		}
 		return finishWithErrFn(status.WrapError(err, "publish execute response"))
 	}
-	publishedCompletedResponse = executeResponse
+	firstCompletedPublished = true
 	if cmdResult.Error == nil {
 		log.CtxDebugf(ctx, "Task finished cleanly.")
 		reuseRunner = true
@@ -548,24 +553,6 @@ func appendAuxiliaryMetadata(md *repb.ExecutedActionMetadata, message proto.Mess
 	a, err := anypb.New(message)
 	if err != nil {
 		return status.InternalErrorf("marshal message type %T to Any: %s", message, err)
-	}
-	md.AuxiliaryMetadata = append(md.AuxiliaryMetadata, a)
-	return nil
-}
-
-// replaceAuxiliaryMetadata replaces the first auxiliary metadata entry of
-// the same type as message with a freshly-marshaled Any, or appends one if
-// no entry of that type is present.
-func replaceAuxiliaryMetadata(md *repb.ExecutedActionMetadata, message proto.Message) error {
-	a, err := anypb.New(message)
-	if err != nil {
-		return status.InternalErrorf("marshal message type %T to Any: %s", message, err)
-	}
-	for i, existing := range md.GetAuxiliaryMetadata() {
-		if existing.GetTypeUrl() == a.GetTypeUrl() {
-			md.AuxiliaryMetadata[i] = a
-			return nil
-		}
 	}
 	md.AuxiliaryMetadata = append(md.AuxiliaryMetadata, a)
 	return nil

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -325,7 +325,9 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		// OLAP row before the stream's EOF flush.
 		if stats := r.PostCompletionStats(); stats != nil && publishedResponse != nil {
 			auxMetadata.PostCompletionStats = stats
-			if err := publishPostCompletionStatsOp(stream, taskID, adInstanceDigest.GetDigest(), publishedResponse, auxMetadata); err != nil {
+			if err := replaceAuxiliaryMetadata(publishedResponse.GetResult().GetExecutionMetadata(), auxMetadata); err != nil {
+				log.CtxWarningf(ctx, "Failed to replace ExecutionAuxiliaryMetadata: %s", err)
+			} else if err := opStateChangeFn(repb.ExecutionStage_COMPLETED, publishedResponse); err != nil {
 				log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
 			}
 		}
@@ -540,44 +542,28 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	return false, nil
 }
 
-// publishPostCompletionStatsOp re-sends the originally published
-// ExecuteResponse with auxMetadata (now carrying PostCompletionStats)
-// merged into its ExecutionAuxiliaryMetadata entry.
-func publishPostCompletionStatsOp(stream interfaces.Publisher, taskID string, ad *repb.Digest, publishedResponse *repb.ExecuteResponse, auxMetadata *espb.ExecutionAuxiliaryMetadata) error {
-	rsp := proto.Clone(publishedResponse).(*repb.ExecuteResponse)
-	if rsp.Result == nil {
-		rsp.Result = &repb.ActionResult{}
-	}
-	if rsp.Result.ExecutionMetadata == nil {
-		rsp.Result.ExecutionMetadata = &repb.ExecutedActionMetadata{}
-	}
-	auxAny, err := anypb.New(auxMetadata)
-	if err != nil {
-		return status.WrapError(err, "marshal ExecutionAuxiliaryMetadata")
-	}
-	md := rsp.Result.ExecutionMetadata
-	replaced := false
-	for i, a := range md.AuxiliaryMetadata {
-		if a.GetTypeUrl() == auxAny.GetTypeUrl() {
-			md.AuxiliaryMetadata[i] = auxAny
-			replaced = true
-			break
-		}
-	}
-	if !replaced {
-		md.AuxiliaryMetadata = append(md.AuxiliaryMetadata, auxAny)
-	}
-	op, err := operation.Assemble(taskID, operation.Metadata(repb.ExecutionStage_COMPLETED, ad), rsp)
-	if err != nil {
-		return status.WrapError(err, "assemble post-completion Operation")
-	}
-	return stream.Send(op)
-}
-
 func appendAuxiliaryMetadata(md *repb.ExecutedActionMetadata, message proto.Message) error {
 	a, err := anypb.New(message)
 	if err != nil {
 		return status.InternalErrorf("marshal message type %T to Any: %s", message, err)
+	}
+	md.AuxiliaryMetadata = append(md.AuxiliaryMetadata, a)
+	return nil
+}
+
+// replaceAuxiliaryMetadata replaces the first auxiliary metadata entry of
+// the same type as message with a freshly-marshaled Any, or appends one if
+// no entry of that type is present.
+func replaceAuxiliaryMetadata(md *repb.ExecutedActionMetadata, message proto.Message) error {
+	a, err := anypb.New(message)
+	if err != nil {
+		return status.InternalErrorf("marshal message type %T to Any: %s", message, err)
+	}
+	for i, existing := range md.GetAuxiliaryMetadata() {
+		if existing.GetTypeUrl() == a.GetTypeUrl() {
+			md.AuxiliaryMetadata[i] = a
+			return nil
+		}
 	}
 	md.AuxiliaryMetadata = append(md.AuxiliaryMetadata, a)
 	return nil

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -316,6 +316,22 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		// that the runner is fully cleaned up (if applicable) before its
 		// resource claims are freed up by the priority_task_scheduler.
 		s.runnerPool.TryRecycle(ctx, r, reuseRunner)
+
+		// Recycling can produce observability data that wasn't available at
+		// COMPLETED publish time (e.g. firecracker snapshot save stats from
+		// Container.Pause). Publish a follow-up stage=COMPLETED Operation
+		// with those stats so the execution server can merge them into the
+		// OLAP row before the stream's EOF flush. Gated on the same
+		// experiment as the server-side flush timing: under the legacy
+		// flag the server would drop this follow-up anyway since the row
+		// was already flushed inline with the first COMPLETED.
+		if publishPostCompletionStatsEnabled(ctx, s.env) {
+			if stats := r.PostCompletionStats(); stats != nil {
+				if err := publishPostCompletionStatsOp(stream, taskID, adInstanceDigest.GetDigest(), stats); err != nil {
+					log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
+				}
+			}
+		}
 	}()
 
 	log.CtxDebugf(ctx, "Preparing runner for task.")
@@ -524,6 +540,48 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		reuseRunner = true
 	}
 	return false, nil
+}
+
+// publishPostCompletionStatsEnabled returns true if the executor should send
+// a follow-up stage=COMPLETED Operation carrying PostCompletionStats after
+// runner recycling. Gated on the same experiment that controls server-side
+// flush-after-cleanup timing — under the legacy flag the server would drop
+// the follow-up anyway since the OLAP row was already flushed inline with
+// the first COMPLETED.
+func publishPostCompletionStatsEnabled(ctx context.Context, env environment.Env) bool {
+	fp := env.GetExperimentFlagProvider()
+	if fp == nil {
+		return false
+	}
+	return fp.Boolean(ctx, "remote_execution.flush_executions_after_cleanup", false)
+}
+
+// publishPostCompletionStatsOp builds a stage=COMPLETED Operation whose only
+// payload is a PostCompletionStats nested inside ExecutionAuxiliaryMetadata
+// in the ExecutedActionMetadata's auxiliary_metadata, and sends it on the
+// publish stream. The execution server recognizes this as a follow-up to
+// the first COMPLETED via its own firstCompletedSeen tracking; the side
+// effects of the first COMPLETED (action-cache write, markTaskComplete,
+// recordResponseMetrics) are skipped server-side.
+func publishPostCompletionStatsOp(stream interfaces.Publisher, taskID string, ad *repb.Digest, stats *espb.PostCompletionStats) error {
+	auxAny, err := anypb.New(&espb.ExecutionAuxiliaryMetadata{
+		PostCompletionStats: stats,
+	})
+	if err != nil {
+		return status.WrapError(err, "marshal ExecutionAuxiliaryMetadata")
+	}
+	rsp := &repb.ExecuteResponse{
+		Result: &repb.ActionResult{
+			ExecutionMetadata: &repb.ExecutedActionMetadata{
+				AuxiliaryMetadata: []*anypb.Any{auxAny},
+			},
+		},
+	}
+	op, err := operation.Assemble(taskID, operation.Metadata(repb.ExecutionStage_COMPLETED, ad), rsp)
+	if err != nil {
+		return status.WrapError(err, "assemble post-completion Operation")
+	}
+	return stream.Send(op)
 }
 
 func appendAuxiliaryMetadata(md *repb.ExecutedActionMetadata, message proto.Message) error {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auth"
@@ -107,10 +106,6 @@ func (s *Executor) Warmup() {
 		ctx = metadata.AppendToOutgoingContext(ctx, authutil.APIKeyHeader, executor_auth.APIKey())
 	}
 	s.runnerPool.Warmup(ctx)
-}
-
-func timevalDuration(tv syscall.Timeval) time.Duration {
-	return time.Duration(tv.Sec)*time.Second + time.Duration(tv.Usec)*time.Microsecond
 }
 
 type executionTimeouts struct {
@@ -321,21 +316,23 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		// Recycling can produce observability data that wasn't available at
 		// COMPLETED publish time. Publish a follow-up stage=COMPLETED Operation
 		// whose auxiliary_metadata carries just the PostCompletionStats.
-		if stats := r.PostCompletionStats(); stats != nil && firstCompletedPublished {
-			statsAny, err := anypb.New(stats)
-			if err != nil {
-				log.CtxWarningf(ctx, "Failed to marshal PostCompletionStats: %s", err)
-				return
-			}
-			rsp := &repb.ExecuteResponse{
-				Result: &repb.ActionResult{
-					ExecutionMetadata: &repb.ExecutedActionMetadata{
-						AuxiliaryMetadata: []*anypb.Any{statsAny},
+		if slices.Contains(task.GetExperiments(), "remote_execution.publish_post_completion_stats") {
+			if stats := r.PostCompletionStats(); stats != nil && firstCompletedPublished {
+				statsAny, err := anypb.New(stats)
+				if err != nil {
+					log.CtxWarningf(ctx, "Failed to marshal PostCompletionStats: %s", err)
+					return
+				}
+				rsp := &repb.ExecuteResponse{
+					Result: &repb.ActionResult{
+						ExecutionMetadata: &repb.ExecutedActionMetadata{
+							AuxiliaryMetadata: []*anypb.Any{statsAny},
+						},
 					},
-				},
-			}
-			if err := opStateChangeFn(repb.ExecutionStage_COMPLETED, rsp); err != nil {
-				log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
+				}
+				if err := opStateChangeFn(repb.ExecutionStage_COMPLETED, rsp); err != nil {
+					log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
+				}
 			}
 		}
 	}()

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -322,16 +322,11 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		// COMPLETED publish time (e.g. firecracker snapshot save stats from
 		// Container.Pause). Publish a follow-up stage=COMPLETED Operation
 		// with those stats so the execution server can merge them into the
-		// OLAP row before the stream's EOF flush. Gated on the same
-		// experiment as the server-side flush timing: under the legacy
-		// flag the server would drop this follow-up anyway since the row
-		// was already flushed inline with the first COMPLETED.
-		if publishPostCompletionStatsEnabled(ctx, s.env) {
-			if stats := r.PostCompletionStats(); stats != nil && publishedResponse != nil {
-				auxMetadata.PostCompletionStats = stats
-				if err := publishPostCompletionStatsOp(stream, taskID, adInstanceDigest.GetDigest(), publishedResponse, auxMetadata); err != nil {
-					log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
-				}
+		// OLAP row before the stream's EOF flush.
+		if stats := r.PostCompletionStats(); stats != nil && publishedResponse != nil {
+			auxMetadata.PostCompletionStats = stats
+			if err := publishPostCompletionStatsOp(stream, taskID, adInstanceDigest.GetDigest(), publishedResponse, auxMetadata); err != nil {
+				log.CtxWarningf(ctx, "Failed to publish post-completion stats: %s", err)
 			}
 		}
 	}()
@@ -543,20 +538,6 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		reuseRunner = true
 	}
 	return false, nil
-}
-
-// publishPostCompletionStatsEnabled returns true if the executor should send
-// a follow-up stage=COMPLETED Operation carrying PostCompletionStats after
-// runner recycling. Gated on the same experiment that controls server-side
-// flush-after-cleanup timing — under the legacy flag the server would drop
-// the follow-up anyway since the OLAP row was already flushed inline with
-// the first COMPLETED.
-func publishPostCompletionStatsEnabled(ctx context.Context, env environment.Env) bool {
-	fp := env.GetExperimentFlagProvider()
-	if fp == nil {
-		return false
-	}
-	return fp.Boolean(ctx, "remote_execution.flush_executions_after_cleanup", false)
 }
 
 // publishPostCompletionStatsOp re-sends the originally published

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -46,8 +47,10 @@ import (
 
 type mockExecutionServer struct {
 	repb.UnimplementedExecutionServer
-	operations []*longrunningpb.Operation
-	finished   chan struct{}
+	mu              sync.Mutex
+	operations      []*longrunningpb.Operation
+	finished        chan struct{}
+	completedSignal sync.Once
 }
 
 func (s *mockExecutionServer) Execute(req *repb.ExecuteRequest, stream repb.Execution_ExecuteServer) error {
@@ -64,12 +67,23 @@ func (s *mockExecutionServer) PublishOperation(stream repb.Execution_PublishOper
 		if err != nil {
 			return err
 		}
+		s.mu.Lock()
 		s.operations = append(s.operations, op)
+		s.mu.Unlock()
 		stage := operation.ExtractStage(op)
 		if stage == repb.ExecutionStage_COMPLETED {
-			close(s.finished)
+			s.completedSignal.Do(func() { close(s.finished) })
 		}
 	}
+}
+
+// getOperations returns a snapshot of received operations under the mutex.
+// Callers should use this rather than reading s.operations directly to avoid
+// races with the gRPC handler goroutine that appends to the slice.
+func (s *mockExecutionServer) getOperations() []*longrunningpb.Operation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*longrunningpb.Operation(nil), s.operations...)
 }
 
 type mockPublisher struct {
@@ -229,17 +243,18 @@ func TestExecuteTaskAndStreamResults(t *testing.T) {
 				require.Equal(t, 0, mockCounter.countFinishedCleanly)
 			}
 
-			operationStageCount := make(map[repb.ExecutionStage_Value]int, len(mockServer.operations))
-			for _, op := range mockServer.operations {
+			ops := mockServer.getOperations()
+			operationStageCount := make(map[repb.ExecutionStage_Value]int, len(ops))
+			for _, op := range ops {
 				stage := operation.ExtractStage(op)
 				operationStageCount[stage]++
 			}
 
-			require.GreaterOrEqual(t, len(mockServer.operations), 3)
+			require.GreaterOrEqual(t, len(ops), 3)
 			require.GreaterOrEqual(t, operationStageCount[repb.ExecutionStage_EXECUTING], 1)
 			require.Equal(t, 1, operationStageCount[repb.ExecutionStage_COMPLETED])
 
-			completedOp := mockServer.operations[len(mockServer.operations)-1]
+			completedOp := ops[len(ops)-1]
 			require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
 
 			unpackedCompletedOp, err := rexec.UnpackOperation(completedOp)
@@ -291,14 +306,15 @@ func TestExecuteTaskAndStreamResults_CacheHit(t *testing.T) {
 	// No runner should've been created.
 	require.Equal(t, 0, mockCounter.countRecycled)
 
-	operationStageCount := make(map[repb.ExecutionStage_Value]int, len(mockServer.operations))
-	for _, op := range mockServer.operations {
+	ops := mockServer.getOperations()
+	operationStageCount := make(map[repb.ExecutionStage_Value]int, len(ops))
+	for _, op := range ops {
 		stage := operation.ExtractStage(op)
 		operationStageCount[stage]++
 	}
 
-	require.GreaterOrEqual(t, len(mockServer.operations), 1)
-	completedOp := mockServer.operations[len(mockServer.operations)-1]
+	require.GreaterOrEqual(t, len(ops), 1)
+	completedOp := ops[len(ops)-1]
 	require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
 }
 
@@ -308,11 +324,11 @@ func TestExecuteTaskAndStreamResults_CacheHit(t *testing.T) {
 // stats and the flush_executions_after_cleanup experiment is enabled.
 func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 	for _, tc := range []struct {
-		name                 string
-		experimentEnabled    bool
-		postCompletionStats  *espb.PostCompletionStats
-		expectFollowUpOp     bool
-		expectFollowUpStats  *espb.PostCompletionStats
+		name                string
+		experimentEnabled   bool
+		postCompletionStats *espb.PostCompletionStats
+		expectFollowUpOp    bool
+		expectFollowUpStats *espb.PostCompletionStats
 	}{
 		{
 			name:              "ExperimentOnWithStats",
@@ -343,10 +359,10 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 			expectFollowUpOp: false,
 		},
 		{
-			name:              "ExperimentOnWithoutStats",
-			experimentEnabled: true,
+			name:                "ExperimentOnWithoutStats",
+			experimentEnabled:   true,
 			postCompletionStats: nil,
-			expectFollowUpOp:  false,
+			expectFollowUpOp:    false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -403,7 +419,7 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 
 			completedOps := func() []*longrunningpb.Operation {
 				ops := []*longrunningpb.Operation{}
-				for _, op := range mockServer.operations {
+				for _, op := range mockServer.getOperations() {
 					if operation.ExtractStage(op) == repb.ExecutionStage_COMPLETED {
 						ops = append(ops, op)
 					}
@@ -517,13 +533,14 @@ func TestExecuteTaskAndStreamResults_InternalInputDownloadTimeout(t *testing.T) 
 	// We should still recycle the runner if we timed out downloading inputs -
 	// this is a recoverable error.
 	require.Equal(t, 1, mockCounter.countRecycled)
-	operationStageCount := make(map[repb.ExecutionStage_Value]int, len(mockServer.operations))
-	for _, op := range mockServer.operations {
+	ops := mockServer.getOperations()
+	operationStageCount := make(map[repb.ExecutionStage_Value]int, len(ops))
+	for _, op := range ops {
 		stage := operation.ExtractStage(op)
 		operationStageCount[stage]++
 	}
-	require.GreaterOrEqual(t, len(mockServer.operations), 1)
-	completedOp := mockServer.operations[len(mockServer.operations)-1]
+	require.GreaterOrEqual(t, len(ops), 1)
+	completedOp := ops[len(ops)-1]
 	require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
 	// We should still report the input fetch completed timestamp if fetching
 	// inputs fails.
@@ -618,13 +635,14 @@ func TestExecuteTaskAndStreamResults_MissingInput(t *testing.T) {
 			<-mockServer.finished
 			// We should still recycle the runner if inputs are missing.
 			require.Equal(t, 1, mockCounter.countRecycled)
-			operationStageCount := make(map[repb.ExecutionStage_Value]int, len(mockServer.operations))
-			for _, op := range mockServer.operations {
+			ops := mockServer.getOperations()
+			operationStageCount := make(map[repb.ExecutionStage_Value]int, len(ops))
+			for _, op := range ops {
 				stage := operation.ExtractStage(op)
 				operationStageCount[stage]++
 			}
-			require.GreaterOrEqual(t, len(mockServer.operations), 1)
-			completedOp := mockServer.operations[len(mockServer.operations)-1]
+			require.GreaterOrEqual(t, len(ops), 1)
+			completedOp := ops[len(ops)-1]
 			require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
 			// We should still report the input fetch completed timestamp if fetching
 			// inputs fails.
@@ -675,7 +693,8 @@ func TestExecuteTaskAndStreamResults_Timeout(t *testing.T) {
 			require.False(t, retry)
 
 			<-mockServer.finished
-			completedOp := mockServer.operations[len(mockServer.operations)-1]
+			ops := mockServer.getOperations()
+			completedOp := ops[len(ops)-1]
 			require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
 
 			rsp, err := rexec.UnpackOperation(completedOp)

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -443,6 +443,8 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 				return
 			}
 
+			first, err := rexec.UnpackOperation(ops[0])
+			require.NoError(t, err)
 			followUp, err := rexec.UnpackOperation(ops[1])
 			require.NoError(t, err)
 			auxMeta := &espb.ExecutionAuxiliaryMetadata{}
@@ -454,6 +456,15 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 				auxMeta.GetPostCompletionStats(),
 				protocmp.Transform(),
 			))
+			// The follow-up should re-publish the same ExecuteResponse as the
+			// first COMPLETED, with PostCompletionStats added to the
+			// ExecutionAuxiliaryMetadata.
+			require.Empty(t, cmp.Diff(
+				first.ExecuteResponse,
+				followUp.ExecuteResponse,
+				protocmp.Transform(),
+				protocmp.IgnoreFields(&espb.ExecutionAuxiliaryMetadata{}, "post_completion_stats"),
+			), "follow-up should carry the same ExecuteResponse as the first COMPLETED (modulo PostCompletionStats)")
 		})
 	}
 }

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -322,8 +322,6 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 	for _, tc := range []struct {
 		name                string
 		postCompletionStats *espb.PostCompletionStats
-		expectFollowUpOp    bool
-		expectFollowUpStats *espb.PostCompletionStats
 	}{
 		{
 			name: "WithStats",
@@ -334,19 +332,10 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 				SnapshotSizeBytes:     12345,
 				PauseDurationUsec:     67890,
 			},
-			expectFollowUpOp: true,
-			expectFollowUpStats: &espb.PostCompletionStats{
-				SnapshotSavedLocally:  true,
-				SnapshotSavedRemotely: true,
-				SnapshotIsDiff:        true,
-				SnapshotSizeBytes:     12345,
-				PauseDurationUsec:     67890,
-			},
 		},
 		{
 			name:                "WithoutStats",
 			postCompletionStats: nil,
-			expectFollowUpOp:    false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -395,7 +384,7 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 			}
 
 			expectedCount := 1
-			if tc.expectFollowUpOp {
+			if tc.postCompletionStats != nil {
 				expectedCount = 2
 			}
 			require.Eventually(t, func() bool {
@@ -406,7 +395,7 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 
 			ops := completedOps()
 			require.Equal(t, expectedCount, len(ops))
-			if !tc.expectFollowUpOp {
+			if tc.postCompletionStats == nil {
 				return
 			}
 
@@ -419,7 +408,7 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, ok, "follow-up COMPLETED should carry ExecutionAuxiliaryMetadata")
 			require.Empty(t, cmp.Diff(
-				tc.expectFollowUpStats,
+				tc.postCompletionStats,
 				auxMeta.GetPostCompletionStats(),
 				protocmp.Transform(),
 			))

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
@@ -30,9 +29,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
-	"github.com/open-feature/go-sdk/openfeature"
-	"github.com/open-feature/go-sdk/openfeature/memprovider"
-	openfeatureTesting "github.com/open-feature/go-sdk/openfeature/testing"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -321,18 +317,16 @@ func TestExecuteTaskAndStreamResults_CacheHit(t *testing.T) {
 // TestExecuteTaskAndStreamResults_PostCompletionStats verifies that the
 // executor sends a follow-up stage=COMPLETED Operation carrying
 // PostCompletionStats after TryRecycle runs, when the runner exposes such
-// stats and the flush_executions_after_cleanup experiment is enabled.
+// stats.
 func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 	for _, tc := range []struct {
 		name                string
-		experimentEnabled   bool
 		postCompletionStats *espb.PostCompletionStats
 		expectFollowUpOp    bool
 		expectFollowUpStats *espb.PostCompletionStats
 	}{
 		{
-			name:              "ExperimentOnWithStats",
-			experimentEnabled: true,
+			name: "WithStats",
 			postCompletionStats: &espb.PostCompletionStats{
 				SnapshotSavedLocally:  true,
 				SnapshotSavedRemotely: true,
@@ -350,17 +344,7 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 			},
 		},
 		{
-			name:              "ExperimentOffWithStats",
-			experimentEnabled: false,
-			postCompletionStats: &espb.PostCompletionStats{
-				SnapshotSavedLocally: true,
-				SnapshotSizeBytes:    12345,
-			},
-			expectFollowUpOp: false,
-		},
-		{
-			name:                "ExperimentOnWithoutStats",
-			experimentEnabled:   true,
+			name:                "WithoutStats",
 			postCompletionStats: nil,
 			expectFollowUpOp:    false,
 		},
@@ -371,23 +355,6 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 			env.SetAuthenticator(testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1")))
 			clock := clockwork.NewFakeClock()
 			env.SetClock(clock)
-
-			// Set up the experiment provider.
-			if tc.experimentEnabled {
-				testProvider := openfeatureTesting.NewTestProvider()
-				require.NoError(t, openfeature.SetProviderAndWait(testProvider))
-				t.Cleanup(testProvider.Cleanup)
-				testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
-					"remote_execution.flush_executions_after_cleanup": {
-						State:          memprovider.Enabled,
-						DefaultVariant: "on",
-						Variants:       map[string]any{"on": true},
-					},
-				})
-				fp, err := experiments.NewFlagProvider("test-name")
-				require.NoError(t, err)
-				env.SetExperimentFlagProvider(fp)
-			}
 
 			_, runServer, lis := testenv.RegisterLocalGRPCServer(t, env)
 			testcache.Setup(t, env, lis)

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -331,7 +331,7 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 					SnapshotSavedLocally:  true,
 					SnapshotSavedRemotely: true,
 					SnapshotIsDiff:        true,
-					SnapshotSizeBytes:     12345,
+					SnapshotSavedBytes:    12345,
 				},
 			},
 		},
@@ -401,25 +401,13 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 				return
 			}
 
-			first, err := rexec.UnpackOperation(ops[0])
-			require.NoError(t, err)
 			followUp, err := rexec.UnpackOperation(ops[1])
 			require.NoError(t, err)
-			auxMeta := &espb.ExecutionAuxiliaryMetadata{}
-			ok, err := rexec.FindFirstAuxiliaryMetadata(followUp.ExecuteResponse.GetResult().GetExecutionMetadata(), auxMeta)
+			gotStats := &espb.PostCompletionStats{}
+			ok, err := rexec.FindFirstAuxiliaryMetadata(followUp.ExecuteResponse.GetResult().GetExecutionMetadata(), gotStats)
 			require.NoError(t, err)
-			require.True(t, ok, "follow-up COMPLETED should carry ExecutionAuxiliaryMetadata")
-			require.Empty(t, cmp.Diff(
-				tc.postCompletionStats,
-				auxMeta.GetPostCompletionStats(),
-				protocmp.Transform(),
-			))
-			require.Empty(t, cmp.Diff(
-				first.ExecuteResponse,
-				followUp.ExecuteResponse,
-				protocmp.Transform(),
-				protocmp.IgnoreFields(&espb.ExecutionAuxiliaryMetadata{}, "post_completion_stats"),
-			), "follow-up should carry the same ExecuteResponse as the first COMPLETED (modulo PostCompletionStats)")
+			require.True(t, ok, "follow-up COMPLETED should carry PostCompletionStats")
+			require.Empty(t, cmp.Diff(tc.postCompletionStats, gotStats, protocmp.Transform()))
 		})
 	}
 }

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -317,11 +317,14 @@ func TestExecuteTaskAndStreamResults_CacheHit(t *testing.T) {
 // TestExecuteTaskAndStreamResults_PostCompletionStats verifies that the
 // executor sends a follow-up stage=COMPLETED Operation carrying
 // PostCompletionStats after TryRecycle runs, when the runner exposes such
-// stats.
+// stats and the task opts in via the publish_post_completion_stats
+// experiment.
 func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 	for _, tc := range []struct {
 		name                string
 		postCompletionStats *espb.PostCompletionStats
+		experimentEnabled   bool
+		expectFollowUp      bool
 	}{
 		{
 			name: "WithStats",
@@ -334,10 +337,26 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 					SnapshotSavedBytes:    12345,
 				},
 			},
+			experimentEnabled: true,
+			expectFollowUp:    true,
 		},
 		{
 			name:                "WithoutStats",
 			postCompletionStats: nil,
+			experimentEnabled:   true,
+			expectFollowUp:      false,
+		},
+		{
+			name: "ExperimentOff",
+			postCompletionStats: &espb.PostCompletionStats{
+				PauseDurationUsec: 67890,
+				FirecrackerPostExecStats: &espb.FirecrackerPostExecStats{
+					SnapshotSavedLocally: true,
+					SnapshotSavedBytes:   12345,
+				},
+			},
+			experimentEnabled: false,
+			expectFollowUp:    false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -367,6 +386,9 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 			execClient := repb.NewExecutionClient(conn)
 
 			task := getTask()
+			if tc.experimentEnabled {
+				task.ExecutionTask.Experiments = []string{"remote_execution.publish_post_completion_stats"}
+			}
 			publisher, err := operation.Publish(ctx, execClient, task.ExecutionTask.ExecutionId)
 			require.NoError(t, err)
 
@@ -386,7 +408,7 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 			}
 
 			expectedCount := 1
-			if tc.postCompletionStats != nil {
+			if tc.expectFollowUp {
 				expectedCount = 2
 			}
 			require.Eventually(t, func() bool {
@@ -397,7 +419,7 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 
 			ops := completedOps()
 			require.Equal(t, expectedCount, len(ops))
-			if tc.postCompletionStats == nil {
+			if !tc.expectFollowUp {
 				return
 			}
 

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
@@ -28,6 +29,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	openfeatureTesting "github.com/open-feature/go-sdk/openfeature/testing"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -296,6 +300,146 @@ func TestExecuteTaskAndStreamResults_CacheHit(t *testing.T) {
 	require.GreaterOrEqual(t, len(mockServer.operations), 1)
 	completedOp := mockServer.operations[len(mockServer.operations)-1]
 	require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
+}
+
+// TestExecuteTaskAndStreamResults_PostCompletionStats verifies that the
+// executor sends a follow-up stage=COMPLETED Operation carrying
+// PostCompletionStats after TryRecycle runs, when the runner exposes such
+// stats and the flush_executions_after_cleanup experiment is enabled.
+func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		experimentEnabled    bool
+		postCompletionStats  *espb.PostCompletionStats
+		expectFollowUpOp     bool
+		expectFollowUpStats  *espb.PostCompletionStats
+	}{
+		{
+			name:              "ExperimentOnWithStats",
+			experimentEnabled: true,
+			postCompletionStats: &espb.PostCompletionStats{
+				SnapshotSavedLocally:  true,
+				SnapshotSavedRemotely: true,
+				SnapshotIsDiff:        true,
+				SnapshotSizeBytes:     12345,
+				PauseDurationUsec:     67890,
+			},
+			expectFollowUpOp: true,
+			expectFollowUpStats: &espb.PostCompletionStats{
+				SnapshotSavedLocally:  true,
+				SnapshotSavedRemotely: true,
+				SnapshotIsDiff:        true,
+				SnapshotSizeBytes:     12345,
+				PauseDurationUsec:     67890,
+			},
+		},
+		{
+			name:              "ExperimentOffWithStats",
+			experimentEnabled: false,
+			postCompletionStats: &espb.PostCompletionStats{
+				SnapshotSavedLocally: true,
+				SnapshotSizeBytes:    12345,
+			},
+			expectFollowUpOp: false,
+		},
+		{
+			name:              "ExperimentOnWithoutStats",
+			experimentEnabled: true,
+			postCompletionStats: nil,
+			expectFollowUpOp:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			env := enterprise_testenv.New(t)
+			env.SetAuthenticator(testauth.NewTestAuthenticator(t, testauth.TestUsers("US1", "GR1")))
+			clock := clockwork.NewFakeClock()
+			env.SetClock(clock)
+
+			// Set up the experiment provider.
+			if tc.experimentEnabled {
+				testProvider := openfeatureTesting.NewTestProvider()
+				require.NoError(t, openfeature.SetProviderAndWait(testProvider))
+				t.Cleanup(testProvider.Cleanup)
+				testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+					"remote_execution.flush_executions_after_cleanup": {
+						State:          memprovider.Enabled,
+						DefaultVariant: "on",
+						Variants:       map[string]any{"on": true},
+					},
+				})
+				fp, err := experiments.NewFlagProvider("test-name")
+				require.NoError(t, err)
+				env.SetExperimentFlagProvider(fp)
+			}
+
+			_, runServer, lis := testenv.RegisterLocalGRPCServer(t, env)
+			testcache.Setup(t, env, lis)
+			mockServer := &mockExecutionServer{finished: make(chan struct{})}
+			repb.RegisterExecutionServer(env.GetGRPCServer(), mockServer)
+			go runServer()
+
+			cacheRoot := testfs.MakeTempDir(t)
+			runnerPool := rbetest.NewTestRunnerPool(t, env, cacheRoot, rbetest.TestRunnerOverrides{
+				RunInterceptor:      rbetest.RunNoop(),
+				PostCompletionStats: tc.postCompletionStats,
+			})
+			exec, err := executor.NewExecutor(env, "executor-id", "host-id", "hostname", runnerPool)
+			require.NoError(t, err)
+
+			conn, err := testenv.LocalGRPCConn(context.Background(), lis)
+			require.NoError(t, err)
+			t.Cleanup(func() { conn.Close() })
+			execClient := repb.NewExecutionClient(conn)
+
+			task := getTask()
+			publisher, err := operation.Publish(ctx, execClient, task.ExecutionTask.ExecutionId)
+			require.NoError(t, err)
+
+			retry, err := exec.ExecuteTaskAndStreamResults(ctx, task, publisher)
+			require.NoError(t, err)
+			require.False(t, retry)
+			<-mockServer.finished
+
+			completedOps := func() []*longrunningpb.Operation {
+				ops := []*longrunningpb.Operation{}
+				for _, op := range mockServer.operations {
+					if operation.ExtractStage(op) == repb.ExecutionStage_COMPLETED {
+						ops = append(ops, op)
+					}
+				}
+				return ops
+			}
+
+			expectedCount := 1
+			if tc.expectFollowUpOp {
+				expectedCount = 2
+			}
+			require.Eventually(t, func() bool {
+				return len(completedOps()) >= expectedCount
+			}, 5*time.Second, 10*time.Millisecond, "expected %d COMPLETED ops", expectedCount)
+			// Give a brief moment to verify no additional ops sneak in.
+			time.Sleep(50 * time.Millisecond)
+
+			ops := completedOps()
+			require.Equal(t, expectedCount, len(ops))
+			if !tc.expectFollowUpOp {
+				return
+			}
+
+			followUp, err := rexec.UnpackOperation(ops[1])
+			require.NoError(t, err)
+			auxMeta := &espb.ExecutionAuxiliaryMetadata{}
+			ok, err := rexec.FindFirstAuxiliaryMetadata(followUp.ExecuteResponse.GetResult().GetExecutionMetadata(), auxMeta)
+			require.NoError(t, err)
+			require.True(t, ok, "follow-up COMPLETED should carry ExecutionAuxiliaryMetadata")
+			require.Empty(t, cmp.Diff(
+				tc.expectFollowUpStats,
+				auxMeta.GetPostCompletionStats(),
+				protocmp.Transform(),
+			))
+		})
+	}
 }
 
 func TestExecuteTaskAndStreamResults_PublishFailures(t *testing.T) {

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -341,10 +341,13 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 			expectFollowUp:    true,
 		},
 		{
-			name:                "WithoutStats",
-			postCompletionStats: nil,
+			// Empty stats from the runner (e.g. non-firecracker containers
+			// without any container-specific stats to report) should still
+			// produce a follow-up when the experiment is enabled.
+			name:                "EmptyStats",
+			postCompletionStats: &espb.PostCompletionStats{},
 			experimentEnabled:   true,
-			expectFollowUp:      false,
+			expectFollowUp:      true,
 		},
 		{
 			name: "ExperimentOff",

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -456,9 +456,6 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 				auxMeta.GetPostCompletionStats(),
 				protocmp.Transform(),
 			))
-			// The follow-up should re-publish the same ExecuteResponse as the
-			// first COMPLETED, with PostCompletionStats added to the
-			// ExecutionAuxiliaryMetadata.
 			require.Empty(t, cmp.Diff(
 				first.ExecuteResponse,
 				followUp.ExecuteResponse,

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -79,7 +80,15 @@ func (s *mockExecutionServer) PublishOperation(stream repb.Execution_PublishOper
 func (s *mockExecutionServer) getOperations() []*longrunningpb.Operation {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]*longrunningpb.Operation(nil), s.operations...)
+	return slices.Clone(s.operations)
+}
+
+func operationsStageCounts(ops []*longrunningpb.Operation) map[repb.ExecutionStage_Value]int {
+	stages := make(map[repb.ExecutionStage_Value]int)
+	for _, op := range ops {
+		stages[operation.ExtractStage(op)]++
+	}
+	return stages
 }
 
 type mockPublisher struct {
@@ -240,11 +249,7 @@ func TestExecuteTaskAndStreamResults(t *testing.T) {
 			}
 
 			ops := mockServer.getOperations()
-			operationStageCount := make(map[repb.ExecutionStage_Value]int, len(ops))
-			for _, op := range ops {
-				stage := operation.ExtractStage(op)
-				operationStageCount[stage]++
-			}
+			operationStageCount := operationsStageCounts(ops)
 
 			require.GreaterOrEqual(t, len(ops), 3)
 			require.GreaterOrEqual(t, operationStageCount[repb.ExecutionStage_EXECUTING], 1)
@@ -303,11 +308,6 @@ func TestExecuteTaskAndStreamResults_CacheHit(t *testing.T) {
 	require.Equal(t, 0, mockCounter.countRecycled)
 
 	ops := mockServer.getOperations()
-	operationStageCount := make(map[repb.ExecutionStage_Value]int, len(ops))
-	for _, op := range ops {
-		stage := operation.ExtractStage(op)
-		operationStageCount[stage]++
-	}
 
 	require.GreaterOrEqual(t, len(ops), 1)
 	completedOp := ops[len(ops)-1]
@@ -488,11 +488,6 @@ func TestExecuteTaskAndStreamResults_InternalInputDownloadTimeout(t *testing.T) 
 	// this is a recoverable error.
 	require.Equal(t, 1, mockCounter.countRecycled)
 	ops := mockServer.getOperations()
-	operationStageCount := make(map[repb.ExecutionStage_Value]int, len(ops))
-	for _, op := range ops {
-		stage := operation.ExtractStage(op)
-		operationStageCount[stage]++
-	}
 	require.GreaterOrEqual(t, len(ops), 1)
 	completedOp := ops[len(ops)-1]
 	require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))
@@ -590,11 +585,6 @@ func TestExecuteTaskAndStreamResults_MissingInput(t *testing.T) {
 			// We should still recycle the runner if inputs are missing.
 			require.Equal(t, 1, mockCounter.countRecycled)
 			ops := mockServer.getOperations()
-			operationStageCount := make(map[repb.ExecutionStage_Value]int, len(ops))
-			for _, op := range ops {
-				stage := operation.ExtractStage(op)
-				operationStageCount[stage]++
-			}
 			require.GreaterOrEqual(t, len(ops), 1)
 			completedOp := ops[len(ops)-1]
 			require.Equal(t, repb.ExecutionStage_COMPLETED, operation.ExtractStage(completedOp))

--- a/enterprise/server/remote_execution/executor/executor_test.go
+++ b/enterprise/server/remote_execution/executor/executor_test.go
@@ -326,11 +326,13 @@ func TestExecuteTaskAndStreamResults_PostCompletionStats(t *testing.T) {
 		{
 			name: "WithStats",
 			postCompletionStats: &espb.PostCompletionStats{
-				SnapshotSavedLocally:  true,
-				SnapshotSavedRemotely: true,
-				SnapshotIsDiff:        true,
-				SnapshotSizeBytes:     12345,
-				PauseDurationUsec:     67890,
+				PauseDurationUsec: 67890,
+				FirecrackerPostExecStats: &espb.FirecrackerPostExecStats{
+					SnapshotSavedLocally:  true,
+					SnapshotSavedRemotely: true,
+					SnapshotIsDiff:        true,
+					SnapshotSizeBytes:     12345,
+				},
 			},
 		},
 		{

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -507,16 +507,9 @@ func (r *taskRunner) GetIsolationType() string {
 }
 
 // PostCompletionStats returns observability data produced by the underlying
-// Container after Exec or Run have completed. Returns nil for containers that
-// don't expose such stats.
+// Container after Exec or Run have completed.
 func (r *taskRunner) PostCompletionStats() *espb.PostCompletionStats {
-	type postCompletionStatsProvider interface {
-		PostCompletionStats() *espb.PostCompletionStats
-	}
-	if p, ok := r.Container.Delegate.(postCompletionStatsProvider); ok {
-		return p.PostCompletionStats()
-	}
-	return nil
+	return r.Container.PostCompletionStats()
 }
 
 // shutdown runs any manual cleanup required to clean up processes before

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -506,6 +506,20 @@ func (r *taskRunner) GetIsolationType() string {
 	return r.PlatformProperties.WorkloadIsolationType
 }
 
+// PostCompletionStats returns observability data produced by the underlying
+// Container during runner recycling, currently firecracker snapshot save
+// stats from Container.Pause. Returns nil for containers that don't expose
+// such stats.
+func (r *taskRunner) PostCompletionStats() *espb.PostCompletionStats {
+	type postCompletionStatsProvider interface {
+		PostCompletionStats() *espb.PostCompletionStats
+	}
+	if p, ok := r.Container.Delegate.(postCompletionStatsProvider); ok {
+		return p.PostCompletionStats()
+	}
+	return nil
+}
+
 // shutdown runs any manual cleanup required to clean up processes before
 // removing a runner from the pool. This has no effect for isolation types
 // that fully isolate all processes started by the runner and remove them

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -507,9 +507,8 @@ func (r *taskRunner) GetIsolationType() string {
 }
 
 // PostCompletionStats returns observability data produced by the underlying
-// Container during runner recycling, currently firecracker snapshot save
-// stats from Container.Pause. Returns nil for containers that don't expose
-// such stats.
+// Container after Exec or Run have completed. Returns nil for containers that
+// don't expose such stats.
 func (r *taskRunner) PostCompletionStats() *espb.PostCompletionStats {
 	type postCompletionStatsProvider interface {
 		PostCompletionStats() *espb.PostCompletionStats

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -48,6 +48,7 @@ go_library(
         "//proto:buildbuddy_service_go_proto",
         "//proto:capability_go_proto",
         "//proto:context_go_proto",
+        "//proto:execution_stats_go_proto",
         "//proto:iprules_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -1476,7 +1476,7 @@ type testRunnerPool struct {
 type TestRunnerOverrides struct {
 	RunInterceptor     RunInterceptor
 	RecycleInterceptor RecycleInterceptor
-	// PostCompletionStats is returned from the test runner's
+	// PostCompletionStats, if not nil, is returned from the test runner's
 	// PostCompletionStats() method.
 	PostCompletionStats *espb.PostCompletionStats
 }

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -95,6 +95,7 @@ import (
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	iprpb "github.com/buildbuddy-io/buildbuddy/proto/iprules"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -1467,19 +1468,25 @@ func DownloadInputsNoop(ctx context.Context, ioStats *repb.IOStats) error {
 // test.
 type testRunnerPool struct {
 	interfaces.RunnerPool
-	runInterceptor     RunInterceptor
-	recycleInterceptor RecycleInterceptor
+	runInterceptor      RunInterceptor
+	recycleInterceptor  RecycleInterceptor
+	postCompletionStats *espb.PostCompletionStats
 }
 
 type TestRunnerOverrides struct {
 	RunInterceptor     RunInterceptor
 	RecycleInterceptor RecycleInterceptor
+	// PostCompletionStats, if non-nil, is returned from the test runner's
+	// PostCompletionStats() method. Lets tests simulate stats that a real
+	// firecracker Container.Pause would have produced during recycling
+	// without needing actual firecracker infrastructure.
+	PostCompletionStats *espb.PostCompletionStats
 }
 
 func NewTestRunnerPool(t testing.TB, env environment.Env, cacheRoot string, opts TestRunnerOverrides) interfaces.RunnerPool {
 	realPool, err := runner.NewPool(env, cacheRoot, &runner.PoolOptions{})
 	require.NoError(t, err)
-	return &testRunnerPool{realPool, opts.RunInterceptor, opts.RecycleInterceptor}
+	return &testRunnerPool{realPool, opts.RunInterceptor, opts.RecycleInterceptor, opts.PostCompletionStats}
 }
 
 func (p *testRunnerPool) Get(ctx context.Context, task *repb.ScheduledTask) (interfaces.Runner, error) {
@@ -1487,7 +1494,7 @@ func (p *testRunnerPool) Get(ctx context.Context, task *repb.ScheduledTask) (int
 	if err != nil {
 		return nil, err
 	}
-	return &testRunner{realRunner, p.runInterceptor}, nil
+	return &testRunner{realRunner, p.runInterceptor, p.postCompletionStats}, nil
 }
 
 func (p *testRunnerPool) TryRecycle(ctx context.Context, r interfaces.Runner, finishedCleanly bool) {
@@ -1502,7 +1509,8 @@ func (p *testRunnerPool) TryRecycle(ctx context.Context, r interfaces.Runner, fi
 // testRunner is a Runner implementation that allows mocking out its methods.
 type testRunner struct {
 	interfaces.Runner
-	run RunInterceptor
+	run                 RunInterceptor
+	postCompletionStats *espb.PostCompletionStats
 }
 
 func (r *testRunner) Run(ctx context.Context, ioStats *repb.IOStats) *interfaces.CommandResult {
@@ -1510,6 +1518,13 @@ func (r *testRunner) Run(ctx context.Context, ioStats *repb.IOStats) *interfaces
 		return r.Runner.Run(ctx, ioStats)
 	}
 	return r.run(ctx, r.Runner.Run)
+}
+
+func (r *testRunner) PostCompletionStats() *espb.PostCompletionStats {
+	if r.postCompletionStats != nil {
+		return r.postCompletionStats
+	}
+	return r.Runner.PostCompletionStats()
 }
 
 type FakeTaskSizer struct {

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -1476,10 +1476,8 @@ type testRunnerPool struct {
 type TestRunnerOverrides struct {
 	RunInterceptor     RunInterceptor
 	RecycleInterceptor RecycleInterceptor
-	// PostCompletionStats, if non-nil, is returned from the test runner's
-	// PostCompletionStats() method. Lets tests simulate stats that a real
-	// firecracker Container.Pause would have produced during recycling
-	// without needing actual firecracker infrastructure.
+	// PostCompletionStats is returned from the test runner's
+	// PostCompletionStats() method.
 	PostCompletionStats *espb.PostCompletionStats
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1164,10 +1164,10 @@ type Runner interface {
 	// string, such as "none" or "podman".
 	GetIsolationType() string
 
-	// PostCompletionStats returns observability data produced during
-	// runner.Pause that should be reported to the execution server
-	// after the COMPLETED Operation has already been streamed back. Nil
-	// for runners that don't expose any such stats.
+	// PostCompletionStats returns observability data produced Run has finished.
+	// These should be reported to the execution server after the COMPLETED
+	// Operation has already been streamed back. Nil for runners that don't
+	// expose any such stats.
 	PostCompletionStats() *espb.PostCompletionStats
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1164,9 +1164,8 @@ type Runner interface {
 	// string, such as "none" or "podman".
 	GetIsolationType() string
 
-	// PostCompletionStats returns observability data produced during runner
-	// recycling (currently firecracker snapshot save stats from
-	// Container.Pause) that should be reported to the execution server
+	// PostCompletionStats returns observability data produced during
+	// runner.Pause that should be reported to the execution server
 	// after the COMPLETED Operation has already been streamed back. Nil
 	// for runners that don't expose any such stats.
 	PostCompletionStats() *espb.PostCompletionStats

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1164,10 +1164,10 @@ type Runner interface {
 	// string, such as "none" or "podman".
 	GetIsolationType() string
 
-	// PostCompletionStats returns observability data produced Run has finished.
-	// These should be reported to the execution server after the COMPLETED
-	// Operation has already been streamed back. Nil for runners that don't
-	// expose any such stats.
+	// PostCompletionStats returns observability data produced after Run has
+	// finished. These should be reported to the execution server after the
+	// COMPLETED Operation has already been streamed back. Nil for runners that
+	// don't expose any such stats.
 	PostCompletionStats() *espb.PostCompletionStats
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1163,6 +1163,13 @@ type Runner interface {
 	// GetIsolationType returns the runner's effective isolation type as a
 	// string, such as "none" or "podman".
 	GetIsolationType() string
+
+	// PostCompletionStats returns observability data produced during runner
+	// recycling (currently firecracker snapshot save stats from
+	// Container.Pause) that should be reported to the execution server
+	// after the COMPLETED Operation has already been streamed back. Nil
+	// for runners that don't expose any such stats.
+	PostCompletionStats() *espb.PostCompletionStats
 }
 
 type CacheRoutingService interface {


### PR DESCRIPTION
Stacked on #12236. With #12183 and #12236 in place, the server is ready to merge a follow-up `stage=COMPLETED` Operation carrying `PostCompletionStats`. This change has the executor produce and send those stats.

- **Firecracker**: accumulate `SnapshotSavedLocally/Remotely`, `SnapshotIsDiff`, `SnapshotSizeBytes` (summing uncompressed COW chunk bytes — dirty for diff, all for full), and `PauseDurationUsec` during `Pause()`; expose via `FirecrackerContainer.PostCompletionStats()`.
- **Runner**: add `PostCompletionStats()` to `interfaces.Runner`; `taskRunner` forwards via a type assertion so non-firecracker runners return nil.
- **Executor**: after `TryRecycle` returns, if the runner exposes stats and we already publish a regular COMPLETED message, send a separate COMPLETED message with just PostCompletionStats in aux meta. Only do this if the `remote_execution.publish_post_completion_stats` is on. This prevents the executor from sending a COMPLETED message with just PostCompletionStats when the server will treat it as a full COMPLETED message.