### PR TITLE
Add Cache.GetWithMetadata and use it on the AC TTL fast path

### DIFF
--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -101,25 +101,28 @@ func isDefaultGetActionResultRequest(req *repb.GetActionResultRequest) bool {
 // so there is digest validation on its value.
 // The remote result is always the source of truth. If the values do not
 // match, the local result should be discarded.
-func (s *ActionCacheServerProxy) getActionResultFromLocalCAS(ctx context.Context, key *digest.ACResourceName) (*repb.Digest, *repb.ActionResult, error) {
+func (s *ActionCacheServerProxy) getActionResultFromLocalCAS(ctx context.Context, key *digest.ACResourceName) (*repb.Digest, *repb.ActionResult, *interfaces.CacheMetadata, error) {
 	// NOTE: To avoid double-counting AC hits, we deliberately don't track
 	// download for these reads.  The remote server will count the full response
 	// size when checking the cached value.
+	data, acMD, err := s.localCache.GetWithMetadata(ctx, key.ToProto())
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	ptr := &rspb.ResourceName{}
-	if err := cachetools.ReadProtoFromAC(ctx, s.localCache, key, ptr); err != nil {
-		return nil, nil, err
+	if err := proto.Unmarshal(data, ptr); err != nil {
+		return nil, nil, nil, err
 	}
 	casRN, err := digest.CASResourceNameFromProto(ptr)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	out := &repb.ActionResult{}
-	err = cachetools.ReadProtoFromCAS(ctx, s.localCache, casRN, out)
-	if err != nil {
-		return nil, nil, err
+	if err := cachetools.ReadProtoFromCAS(ctx, s.localCache, casRN, out); err != nil {
+		return nil, nil, nil, err
 	}
 
-	return ptr.GetDigest(), out, nil
+	return ptr.GetDigest(), out, acMD, nil
 }
 
 // cacheActionResultToLocalCAS stores the ActionResult `resp` in the CAS and then
@@ -157,12 +160,8 @@ func (s *ActionCacheServerProxy) actionCacheTTL(ctx context.Context) time.Durati
 	return time.Duration(ttlSeconds) * time.Second
 }
 
-func (s *ActionCacheServerProxy) isLocalActionResultFresh(ctx context.Context, key *digest.ACResourceName, ttl time.Duration) bool {
-	if ttl <= 0 {
-		return false
-	}
-	md, err := s.localCache.Metadata(ctx, key.ToProto())
-	if err != nil || md.LastModifyTimeUsec <= 0 {
+func (s *ActionCacheServerProxy) isLocalActionResultFresh(md *interfaces.CacheMetadata, ttl time.Duration) bool {
+	if ttl <= 0 || md == nil || md.LastModifyTimeUsec <= 0 {
 		return false
 	}
 
@@ -254,14 +253,14 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 			return nil, err
 		}
 		var err error
-		localDigest, localResult, err := s.getActionResultFromLocalCAS(ctx, localKey)
+		localDigest, localResult, localACMD, err := s.getActionResultFromLocalCAS(ctx, localKey)
 		if err != nil && !status.IsNotFoundError(err) {
 			return nil, err
 		}
 		if localDigest != nil {
 			// TODO: Consider async app revalidation of TTL hits, updating or deleting
 			// the local AC entry if the authoritative result changed.
-			if isDefaultGetActionResultRequest(req) && s.isLocalActionResultFresh(ctx, localKey, ttl) {
+			if isDefaultGetActionResultRequest(req) && s.isLocalActionResultFresh(localACMD, ttl) {
 				// Skip checking for existence of output files. The app recently
 				// validated or updated this result, which refreshed the referenced
 				// outputs' atime. With remote_download_minimal, this proxy

--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -101,17 +101,25 @@ func isDefaultGetActionResultRequest(req *repb.GetActionResultRequest) bool {
 // so there is digest validation on its value.
 // The remote result is always the source of truth. If the values do not
 // match, the local result should be discarded.
-func (s *ActionCacheServerProxy) getActionResultFromLocalCAS(ctx context.Context, key *digest.ACResourceName) (*repb.Digest, *repb.ActionResult, *interfaces.CacheMetadata, error) {
+func (s *ActionCacheServerProxy) getActionResultFromLocalCAS(ctx context.Context, key *digest.ACResourceName, fetchMetadata bool) (*repb.Digest, *repb.ActionResult, *interfaces.CacheMetadata, error) {
 	// NOTE: To avoid double-counting AC hits, we deliberately don't track
 	// download for these reads.  The remote server will count the full response
 	// size when checking the cached value.
-	data, acMD, err := s.localCache.GetWithMetadata(ctx, key.ToProto())
-	if err != nil {
-		return nil, nil, nil, err
-	}
 	ptr := &rspb.ResourceName{}
-	if err := proto.Unmarshal(data, ptr); err != nil {
-		return nil, nil, nil, err
+	var acMD *interfaces.CacheMetadata
+	if fetchMetadata {
+		data, md, err := s.localCache.GetWithMetadata(ctx, key.ToProto())
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if err := proto.Unmarshal(data, ptr); err != nil {
+			return nil, nil, nil, err
+		}
+		acMD = md
+	} else {
+		if err := cachetools.ReadProtoFromAC(ctx, s.localCache, key, ptr); err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	casRN, err := digest.CASResourceNameFromProto(ptr)
 	if err != nil {
@@ -252,15 +260,18 @@ func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.
 		if err != nil {
 			return nil, err
 		}
+		// Only fetch AC entry metadata when we may serve the TTL fast path.
+		// Otherwise the extra Metadata call is wasted work.
+		ttlFastPathEligible := isDefaultGetActionResultRequest(req) && ttl > 0
 		var err error
-		localDigest, localResult, localACMD, err := s.getActionResultFromLocalCAS(ctx, localKey)
+		localDigest, localResult, localACMD, err := s.getActionResultFromLocalCAS(ctx, localKey, ttlFastPathEligible)
 		if err != nil && !status.IsNotFoundError(err) {
 			return nil, err
 		}
 		if localDigest != nil {
 			// TODO: Consider async app revalidation of TTL hits, updating or deleting
 			// the local AC entry if the authoritative result changed.
-			if isDefaultGetActionResultRequest(req) && s.isLocalActionResultFresh(localACMD, ttl) {
+			if ttlFastPathEligible && s.isLocalActionResultFresh(localACMD, ttl) {
 				// Skip checking for existence of output files. The app recently
 				// validated or updated this result, which refreshed the referenced
 				// outputs' atime. With remote_download_minimal, this proxy

--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy_test.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy_test.go
@@ -111,6 +111,18 @@ func (c *localOnlyCache) Metadata(ctx context.Context, r *rspb.ResourceName) (*i
 	return &interfaces.CacheMetadata{LastModifyTimeUsec: c.mtimes[key]}, nil
 }
 
+func (c *localOnlyCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := c.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := c.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (c *localOnlyCache) Set(ctx context.Context, r *rspb.ResourceName, data []byte) error {
 	c.put(r, data, time.Now().UnixMicro())
 	return nil

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -835,6 +835,13 @@ func (c *Cache) remoteMetadata(ctx context.Context, peer string, r *rspb.Resourc
 	return c.distributedProxy.RemoteMetadata(ctx, peer, r)
 }
 
+func (c *Cache) remoteGetWithMetadata(ctx context.Context, peer string, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	if !c.opts.DisableLocalLookup && peer == c.opts.ListenAddr {
+		return c.local.GetWithMetadata(ctx, r)
+	}
+	return c.distributedProxy.RemoteGetWithMetadata(ctx, peer, r)
+}
+
 func (c *Cache) remoteFindMissing(ctx context.Context, peer string, rns []*rspb.ResourceName) ([]*repb.Digest, error) {
 	if !c.opts.DisableLocalLookup && peer == c.opts.ListenAddr {
 		return c.local.FindMissing(ctx, rns)
@@ -1167,6 +1174,30 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces
 
 	c.log.CtxDebugf(ctx, "Exhausted all peers attempting to query metadata %q. Peerset: %+v", d.GetHash(), ps)
 	return nil, status.NotFoundErrorf("Exhausted all peers attempting to query metadata %q.", d.GetHash())
+}
+
+func (c *Cache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	d := r.GetDigest()
+	ps := c.readPeers(r)
+
+	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
+		data, md, err := c.remoteGetWithMetadata(ctx, peer, r)
+		if err == nil {
+			c.log.CtxDebugf(ctx, "GetWithMetadata(%q) found on peer %q", d, peer)
+			return data, md, nil
+		}
+		if status.IsNotFoundError(err) {
+			c.log.CtxDebugf(ctx, "GetWithMetadata(%q) not found on peer %s", distributed_client.ResourceIsolationString(r), peer)
+			continue
+		}
+		c.log.CtxDebugf(ctx, "GetWithMetadata(%q) lookup failed on peer %s: (err: %v)", distributed_client.ResourceIsolationString(r), peer, err)
+
+		// Got an error -- mark this peer as failed and try the next one.
+		ps.MarkPeerAsFailed(peer)
+	}
+
+	c.log.CtxDebugf(ctx, "Exhausted all peers attempting to GetWithMetadata %q. Peerset: %+v", d.GetHash(), ps)
+	return nil, nil, status.NotFoundErrorf("Exhausted all peers attempting to GetWithMetadata %q.", d.GetHash())
 }
 
 func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName) ([]*repb.Digest, error) {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -3015,6 +3015,9 @@ func (pc *partitionedCache) FindMissing(ctx context.Context, resources []*rspb.R
 func (pc *partitionedCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
 	return pc.partition(ctx).Get(ctx, r)
 }
+func (pc *partitionedCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	return pc.partition(ctx).GetWithMetadata(ctx, r)
+}
 func (pc *partitionedCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	return pc.partition(ctx).GetMulti(ctx, resources)
 }

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -181,6 +181,18 @@ func (g *GCSCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error
 	return b, err
 }
 
+func (g *GCSCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := g.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := g.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (g *GCSCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	lock := sync.RWMutex{} // protects(foundMap)
 	foundMap := make(map[*repb.Digest][]byte, len(resources))

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -192,6 +192,18 @@ func (c *Cache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
 	return c.mcGet(k)
 }
 
+func (c *Cache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := c.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := c.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	keys := make([]string, 0, len(resources))
 	digestsByKey := make(map[string]*repb.Digest, len(resources))

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -578,6 +578,18 @@ func (c *Cache) Get(ctx context.Context, r *rspb.ResourceName) (res []byte, resu
 	return buf.Bytes(), err
 }
 
+func (c *Cache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := c.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := c.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m map[*repb.Digest][]byte, resultErr error) {
 	start := c.opts.Clock.Now()
 	defer c.recordMetrics("GetMulti", resultErr, start)

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -489,6 +489,18 @@ func (mc *MigrationCache) FindMissing(ctx context.Context, resources []*rspb.Res
 	return srcMissing, srcErr
 }
 
+func (mc *MigrationCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := mc.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := mc.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (mc *MigrationCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	conf, err := mc.config(ctx)
 	if err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1732,6 +1732,18 @@ func (p *PebbleCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, er
 	return buf.Bytes(), err
 }
 
+func (p *PebbleCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := p.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := p.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	db, err := p.leaser.DB()
 	if err != nil {

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -229,6 +229,18 @@ func (c *Cache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
 	return b, err
 }
 
+func (c *Cache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := c.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := c.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	if len(resources) == 0 {
 		return nil, nil

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -291,6 +291,18 @@ func (s3c *S3Cache) get(ctx context.Context, d *repb.Digest, key string) ([]byte
 	return buff.Bytes(), err
 }
 
+func (s3c *S3Cache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := s3c.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := s3c.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (s3c *S3Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	lock := sync.RWMutex{} // protects(foundMap)
 	foundMap := make(map[*repb.Digest][]byte, len(resources))

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -84,6 +84,18 @@ func (c *ComposableCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte
 	return innerRsp, nil
 }
 
+func (c *ComposableCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := c.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := c.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (c *ComposableCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	if len(resources) == 0 {
 		return nil, nil

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -226,6 +226,31 @@ func (c *Proxy) Metadata(ctx context.Context, req *dcpb.MetadataRequest) (*dcpb.
 	}, nil
 }
 
+func (c *Proxy) GetWithMetadata(ctx context.Context, req *dcpb.GetWithMetadataRequest) (*dcpb.GetWithMetadataResponse, error) {
+	ctx, err := c.readWriteContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rn := req.GetResource()
+	data, err := c.cache.Get(ctx, rn)
+	if err != nil {
+		return nil, err
+	}
+	md, err := c.cache.Metadata(ctx, rn)
+	if err != nil {
+		return nil, err
+	}
+	return &dcpb.GetWithMetadataResponse{
+		Data: data,
+		Metadata: &dcpb.MetadataResponse{
+			StoredSizeBytes: md.StoredSizeBytes,
+			DigestSizeBytes: md.DigestSizeBytes,
+			LastModifyUsec:  md.LastModifyTimeUsec,
+			LastAccessUsec:  md.LastAccessTimeUsec,
+		},
+	}, nil
+}
+
 type resourceIsolationStringer struct{ *rspb.ResourceName }
 
 func (r resourceIsolationStringer) String() string {
@@ -408,6 +433,24 @@ func (c *Proxy) RemoteMetadata(ctx context.Context, peer string, r *rspb.Resourc
 		return nil, err
 	}
 	return &interfaces.CacheMetadata{
+		StoredSizeBytes:    md.GetStoredSizeBytes(),
+		DigestSizeBytes:    md.GetDigestSizeBytes(),
+		LastAccessTimeUsec: md.GetLastAccessUsec(),
+		LastModifyTimeUsec: md.GetLastModifyUsec(),
+	}, nil
+}
+
+func (c *Proxy) RemoteGetWithMetadata(ctx context.Context, peer string, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	client, err := c.getClient(ctx, peer)
+	if err != nil {
+		return nil, nil, err
+	}
+	rsp, err := client.GetWithMetadata(ctx, &dcpb.GetWithMetadataRequest{Resource: r})
+	if err != nil {
+		return nil, nil, err
+	}
+	md := rsp.GetMetadata()
+	return rsp.GetData(), &interfaces.CacheMetadata{
 		StoredSizeBytes:    md.GetStoredSizeBytes(),
 		DigestSizeBytes:    md.GetDigestSizeBytes(),
 		LastAccessTimeUsec: md.GetLastAccessUsec(),

--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -232,11 +232,7 @@ func (c *Proxy) GetWithMetadata(ctx context.Context, req *dcpb.GetWithMetadataRe
 		return nil, err
 	}
 	rn := req.GetResource()
-	data, err := c.cache.Get(ctx, rn)
-	if err != nil {
-		return nil, err
-	}
-	md, err := c.cache.Metadata(ctx, rn)
+	data, md, err := c.cache.GetWithMetadata(ctx, rn)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -992,6 +992,80 @@ func TestMetadata(t *testing.T) {
 	require.Equal(t, cacheMetadata.LastModifyTimeUsec, cacheproxyMetadata.LastModifyUsec)
 }
 
+func TestGetWithMetadata(t *testing.T) {
+	ctx := context.Background()
+	te := getTestEnv(t, emptyUserMap)
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	peer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	c := distributed_client.New(te, te.GetCache(), peer)
+	require.NoError(t, c.StartListening())
+	waitUntilServerIsAlive(peer)
+
+	r, buf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, te.GetCache().Set(ctx, r, buf))
+
+	// Server handler: data + every metadata field matches the underlying cache.
+	rsp, err := c.GetWithMetadata(ctx, &dcpb.GetWithMetadataRequest{Resource: r})
+	require.NoError(t, err)
+	require.Equal(t, buf, rsp.GetData())
+
+	cacheMD, err := te.GetCache().Metadata(ctx, r)
+	require.NoError(t, err)
+	require.Equal(t, cacheMD.StoredSizeBytes, rsp.GetMetadata().GetStoredSizeBytes())
+	require.Equal(t, cacheMD.DigestSizeBytes, rsp.GetMetadata().GetDigestSizeBytes())
+	require.Equal(t, cacheMD.LastAccessTimeUsec, rsp.GetMetadata().GetLastAccessUsec())
+	require.Equal(t, cacheMD.LastModifyTimeUsec, rsp.GetMetadata().GetLastModifyUsec())
+}
+
+func TestRemoteGetWithMetadata(t *testing.T) {
+	ctx := context.Background()
+	te := getTestEnv(t, emptyUserMap)
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	peer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	c := distributed_client.New(te, te.GetCache(), peer)
+	require.NoError(t, c.StartListening())
+	waitUntilServerIsAlive(peer)
+
+	r, buf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, te.GetCache().Set(ctx, r, buf))
+
+	// Client-side: data and metadata round-trip through the RPC.
+	data, md, err := c.RemoteGetWithMetadata(ctx, peer, r)
+	require.NoError(t, err)
+	require.Equal(t, buf, data)
+
+	cacheMD, err := te.GetCache().Metadata(ctx, r)
+	require.NoError(t, err)
+	require.Equal(t, cacheMD.StoredSizeBytes, md.StoredSizeBytes)
+	require.Equal(t, cacheMD.DigestSizeBytes, md.DigestSizeBytes)
+	require.Equal(t, cacheMD.LastAccessTimeUsec, md.LastAccessTimeUsec)
+	require.Equal(t, cacheMD.LastModifyTimeUsec, md.LastModifyTimeUsec)
+}
+
+func TestRemoteGetWithMetadata_NotFound(t *testing.T) {
+	ctx := context.Background()
+	te := getTestEnv(t, emptyUserMap)
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	peer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	c := distributed_client.New(te, te.GetCache(), peer)
+	require.NoError(t, c.StartListening())
+	waitUntilServerIsAlive(peer)
+
+	// Resource was never written; expect NotFound.
+	r, _ := testdigest.RandomCASResourceBuf(t, 100)
+	_, _, err = c.RemoteGetWithMetadata(ctx, peer, r)
+	require.True(t, status.IsNotFoundError(err), "expected NotFound, got: %v", err)
+}
+
 func copyChunked(t testing.TB, w interfaces.CommittedWriteCloser, data []byte, chunkSize int64) {
 	for len(data) > 0 {
 		if chunkSize > int64(len(data)) {

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -70,6 +70,15 @@ message MetadataResponse {
   int64 digest_size_bytes = 4;
 }
 
+message GetWithMetadataRequest {
+  resource.ResourceName resource = 1;
+}
+
+message GetWithMetadataResponse {
+  bytes data = 1;
+  MetadataResponse metadata = 2;
+}
+
 message KV {
   Key key = 1;
   bytes value = 2;
@@ -97,5 +106,6 @@ service DistributedCache {
   rpc Delete(DeleteRequest) returns (DeleteResponse);
   rpc FindMissing(FindMissingRequest) returns (FindMissingResponse);
   rpc GetMulti(GetMultiRequest) returns (GetMultiResponse);
+  rpc GetWithMetadata(GetWithMetadataRequest) returns (GetWithMetadataResponse);
   rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
 }

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -401,6 +401,18 @@ func (c *DiskCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, erro
 	return p.get(ctx, r)
 }
 
+func (c *DiskCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := c.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := c.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (c *DiskCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	if len(resources) == 0 {
 		return nil, nil

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -164,6 +164,18 @@ func (m *MemoryCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, er
 	return v, nil
 }
 
+func (m *MemoryCache) GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *interfaces.CacheMetadata, error) {
+	data, err := m.Get(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	md, err := m.Metadata(ctx, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, md, nil
+}
+
 func (m *MemoryCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	foundMap := make(map[*repb.Digest][]byte, len(resources))
 	// No parallelism here either. Not necessary for an in-memory cache.

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -297,6 +297,7 @@ type Cache interface {
 	Metadata(ctx context.Context, r *rspb.ResourceName) (*CacheMetadata, error)
 	FindMissing(ctx context.Context, resources []*rspb.ResourceName) ([]*repb.Digest, error)
 	Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error)
+	GetWithMetadata(ctx context.Context, r *rspb.ResourceName) ([]byte, *CacheMetadata, error)
 	GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error)
 	Set(ctx context.Context, r *rspb.ResourceName, data []byte) error
 	SetMulti(ctx context.Context, kvs map[*rspb.ResourceName][]byte) error


### PR DESCRIPTION
Most of this change is adding `GetWithMetadata` to the cache interface. The usages of it are in `action_cache_server_proxy.go`.