### PR TITLE
Report GitHub statuses without an authenticated user when access_token is set

### DIFF
--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -141,12 +141,19 @@ func (r *BuildStatusReporter) flushPayloadsIfMetadataLoaded(ctx context.Context)
 		return
 	}
 
+	// If there is no authenticated user (e.g. a self-hosted deployment with no
+	// auth configured), we can still report commit statuses when a hard-coded
+	// github.access_token is configured. Only bail out when status reporting is
+	// not unconditionally enabled, so the webhook/workflow path keeps its group
+	// attribution while the access_token path keeps working. See #12302.
 	userInfo, err := r.env.GetAuthenticator().AuthenticatedUser(ctx)
-	if err != nil {
+	var groupID string
+	if err == nil {
+		groupID = userInfo.GetGroupID()
+	} else if !github.AlwaysEnableStatusReporting() {
 		log.CtxWarningf(ctx, "Failed to get authenticated user: %s", err)
 		return
 	}
-	groupID := userInfo.GetGroupID()
 
 	// Don't report statuses if we don't yet have the metadata, it's explicitly
 	// disabled in build metadata, or it's not enabled for this repo.


### PR DESCRIPTION
## Problem

On self-hosted, **no-auth** (OSS) deployments, GitHub commit statuses stopped being posted for CI builds. Every invocation logs:

```
WRN Failed to get authenticated user: rpc error: code = Unauthenticated desc = Auth not implemented
```

#12099 added a mandatory `AuthenticatedUser(ctx)` lookup to the shared status-reporting path `flushPayloadsIfMetadataLoaded`, returning early on error. For a no-auth deployment the authenticator returns `Unauthenticated`, so the reporter returns before `CreateStatus` and never posts a status.

This regressed #9017 (which fixed #9010): when `github.access_token` is set, `AlwaysEnableStatusReporting()` is true and `IsStatusReportingEnabled` / `getToken` don't require a group — but that path is now unreachable because the auth lookup bails first.

Full analysis in #12302.

## Fix

Don't hard-return when there's no authenticated user. If `github.AlwaysEnableStatusReporting()` is true (i.e. a hard-coded `access_token` is configured), proceed with an empty `groupID`:

```go
userInfo, err := r.env.GetAuthenticator().AuthenticatedUser(ctx)
var groupID string
if err == nil {
    groupID = userInfo.GetGroupID()
} else if !github.AlwaysEnableStatusReporting() {
    log.CtxWarningf(ctx, "Failed to get authenticated user: %s", err)
    return
}
```

The webhook/workflow path keeps its group attribution (it has an authenticated user), while the no-auth + `access_token` path works again. With an empty `groupID`, `IsStatusReportingEnabled` short-circuits to `true` via `AlwaysEnableStatusReporting()` and `getToken` falls back to the configured `access_token`, neither of which needs a group.

## Versions

Regressed in v2.267.0 (first release containing #12099); v2.266.0 was the last working version.

Fixes #12302