### PR TITLE
Fix dark-terminal loading bg

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1930,10 +1930,6 @@ code .comment {
   background: var(--color-bg-inverted);
 }
 
-.loading.loading-dark-terminal {
-  background: var(--color-bg-inverted);
-}
-
 .loading.loading-dark:before,
 .loading.loading-dark-terminal:before {
   background-image: url("/image/loader-white.svg");


### PR DESCRIPTION
We were applying an unnecessary background to the loader. The loader doesn't need a background (only the spinner color needs to be set)