### PR TITLE
Cache Proxies page UI tweaks

### DIFF
--- a/enterprise/app/cache_proxies/cache_proxies.css
+++ b/enterprise/app/cache_proxies/cache_proxies.css
@@ -24,9 +24,6 @@
 }
 
 .cache-proxies-page .cache-proxy-cards {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
   margin-top: 16px;
 }
 

--- a/enterprise/app/cache_proxies/cache_proxy_card.tsx
+++ b/enterprise/app/cache_proxies/cache_proxy_card.tsx
@@ -9,10 +9,24 @@ interface Props {
   lastCheckInTime?: google_timestamp.protobuf.Timestamp | null;
 }
 
+// A proxy is considered "fresh" (green) if its last heartbeat is no more
+// than freshThresholdMs ago; otherwise it's grey. The server-side
+// staleness threshold for removing a proxy from the registry entirely is
+// much longer (10 minutes), so a grey card means "still around but the
+// most recent heartbeat is stale-ish."
+const freshThresholdMs = 60 * 1000;
+
+function isFresh(t?: google_timestamp.protobuf.Timestamp | null): boolean {
+  if (!t) return false;
+  const ms = +(t.seconds || 0) * 1000 + +(t.nanos || 0) / 1_000_000;
+  return Date.now() - ms < freshThresholdMs;
+}
+
 export default class CacheProxyCardComponent extends React.Component<Props> {
   render() {
+    const fresh = isFresh(this.props.lastCheckInTime);
     return (
-      <div className="card card-neutral">
+      <div className={`card ${fresh ? "card-success" : "card-neutral"}`}>
         <Cloud className="icon" />
         <div className="content">
           <div className="details">


### PR DESCRIPTION
1. Make the vertical space between cards match what we do on the executors page
2. Make the colored bar at the left side of the card green if the proxy has checked in recently, grey if it hasn't

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/6869