### PR TITLE
Default SearchInvocations group_id to the authenticated group ID

### DIFF
--- a/enterprise/server/invocation_search_service/BUILD
+++ b/enterprise/server/invocation_search_service/BUILD
@@ -56,6 +56,7 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/perms",
+        "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -142,16 +142,6 @@ func (s *InvocationSearchService) IndexInvocation(ctx context.Context, invocatio
 	return nil
 }
 
-func (s *InvocationSearchService) checkPreconditions(req *inpb.SearchInvocationRequest) error {
-	if req.Query == nil {
-		return status.InvalidArgumentError("The query field is required")
-	}
-	if req.Query.Host == "" && req.Query.User == "" && req.Query.CommitSha == "" && req.Query.RepoUrl == "" && req.Query.GroupId == "" {
-		return status.InvalidArgumentError("At least one search atom must be set")
-	}
-	return nil
-}
-
 // TODO(tylerw): move this to a common place -- we'll use it a bunch.
 func addPermissionsCheckToQuery(u interfaces.UserInfo, q *query_builder.Query) {
 	o := query_builder.OrClauses{}
@@ -249,9 +239,6 @@ func (s *InvocationSearchService) buildPrimaryQuery(ctx context.Context, fields 
 		}
 	}
 
-	if err := s.checkPreconditions(req); err != nil {
-		return "", nil, err
-	}
 	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return "", nil, err
@@ -578,6 +565,25 @@ func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inp
 		req.Sort = defaultSortParams()
 	} else if req.Sort.SortField == inpb.InvocationSort_UNKNOWN_SORT_FIELD {
 		req.Sort.SortField = defaultSortParams().SortField
+	}
+
+	// Default the query group_id to the authenticated group ID.
+	if req.GetQuery().GetGroupId() == "" {
+		req = req.CloneVT()
+		if req.Query == nil {
+			req.Query = &inpb.InvocationQuery{}
+		}
+		u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
+		// Note: the two cases below should not happen in practice because
+		// capabilities_filter requires that the user is authenticated and that
+		// they are a member of a group.
+		if err != nil {
+			return nil, status.InternalErrorf("user is unexpectedly unauthenticated: %v", err)
+		}
+		if u.GetGroupID() == "" {
+			return nil, status.InternalError("user is unexpectedly missing group ID")
+		}
+		req.Query.GroupId = u.GetGroupID()
 	}
 
 	var invocations []*inpb.Invocation

--- a/enterprise/server/invocation_search_service/invocation_search_service_test.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -158,6 +159,92 @@ func TestNonOLAPQuery(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{getUUIDString(3)}, getInvocationIDSlice(rsp))
+}
+
+func TestGroupIDDefaultsToAuthenticatedGroupID(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+	ta := setUpDB(t.Context(), env, t)
+
+	service := invocation_search_service.NewInvocationSearchService(env, env.GetDBHandle(), env.GetOLAPDBHandle())
+
+	for _, tc := range []struct {
+		name                  string
+		user                  string
+		query                 *inpb.InvocationQuery
+		expectedInvocationIDs []string
+		expectedError         func(err error) bool
+	}{
+		{
+			name:  "nil query",
+			user:  "US1",
+			query: nil,
+			expectedInvocationIDs: []string{
+				getUUIDString(0),
+				getUUIDString(1),
+				getUUIDString(2),
+				getUUIDString(3),
+				// Note: invocation 00..04 is not owned by US1's group
+				getUUIDString(5),
+				getUUIDString(6),
+				getUUIDString(7),
+			},
+		},
+		{
+			name:  "empty query",
+			user:  "US1",
+			query: &inpb.InvocationQuery{},
+			expectedInvocationIDs: []string{
+				getUUIDString(0),
+				getUUIDString(1),
+				getUUIDString(2),
+				getUUIDString(3),
+				getUUIDString(5),
+				getUUIDString(6),
+				getUUIDString(7),
+			},
+		},
+		{
+			name:  "nonempty query",
+			user:  "US1",
+			query: &inpb.InvocationQuery{User: "jdhollen"},
+			expectedInvocationIDs: []string{
+				getUUIDString(0),
+				getUUIDString(1),
+				getUUIDString(2),
+				getUUIDString(5),
+				getUUIDString(6),
+				getUUIDString(7),
+			},
+		},
+		{
+			name:          "unauthenticated",
+			user:          "",
+			query:         nil,
+			expectedError: status.IsInternalError,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tc.user != "" {
+				var err error
+				ctx, err = ta.WithAuthenticatedUser(t.Context(), tc.user)
+				require.NoError(t, err)
+			}
+
+			req := &inpb.SearchInvocationRequest{
+				RequestContext: &ctxpb.RequestContext{GroupId: "GR1"},
+				Query:          tc.query,
+			}
+			rsp, err := service.QueryInvocations(ctx, req)
+
+			if tc.expectedError != nil {
+				require.True(t, tc.expectedError(err))
+			} else {
+				require.NoError(t, err)
+				assert.ElementsMatch(t, tc.expectedInvocationIDs, getInvocationIDSlice(rsp))
+			}
+		})
+	}
 }
 
 func TestBlendedOLAPQuery(t *testing.T) {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -243,9 +243,6 @@ func (s *BuildBuddyServer) SearchInvocation(ctx context.Context, req *inpb.Searc
 	if searcher == nil {
 		return nil, fmt.Errorf("No searcher was configured")
 	}
-	if req.Query == nil {
-		return nil, fmt.Errorf("A query must be provided")
-	}
 	return searcher.QueryInvocations(ctx, req)
 }
 


### PR DESCRIPTION
I'm writing a "CAS explain" tool that calls SearchInvocations for a group and scrapes GetCacheScoreCard + GetExecutionDownloads for the invocations with the highest CAS download. The tool currently requires a `group_id` because otherwise `SearchInvocations` complains about a missing search atom, which is a bit inconvenient.

This PR makes it so that if no search atoms are specified, then we default to searching by the authenticated `group_id`.