### PR TITLE
Render executor labels on the executor card

### DIFF
--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -38,6 +38,20 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                 <div>{this.props.node.osDisplayName}</div>
               </div>
             )}
+            {this.props.node.labels && Object.keys(this.props.node.labels).length > 0 && (
+              <div className="executor-section">
+                <div className="executor-section-title">Labels:</div>
+                <div>
+                  {Object.entries(this.props.node.labels)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([k, v]) => (
+                      <div key={k}>
+                        <b>{k}</b>: {v}
+                      </div>
+                    ))}
+                </div>
+              </div>
+            )}
             {this.props.node.startTime && (
               <div className="executor-section">
                 <div className="executor-section-title">Uptime:</div>


### PR DESCRIPTION
These just render as a bunch of simple key:value entries each on their own line:
<img width="1011" height="523" alt="Screenshot 2026-05-29 at 2 14 31 PM" src="https://github.com/user-attachments/assets/5d93ab58-9bc5-4c0b-a7d9-21428ba228c7" />
