### PR TITLE
Add new fields for RBE execution and workflow snapshot pricing

### DIFF
--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -753,29 +753,29 @@ func countsToMap(tu *tables.UsageCounts) (map[string]int64, error) {
 	if tu.MemoryGBUsec > 0 {
 		counts["memory_gb_usec"] = tu.MemoryGBUsec
 	}
-	if tu.LinuxArmExecutionBurstableComputeDurationUsec > 0 {
-		counts["linux_arm_execution_burstable_compute_duration_usec"] = tu.LinuxArmExecutionBurstableComputeDurationUsec
+	if tu.LinuxArm64ExecutionBurstableComputeDurationUsec > 0 {
+		counts["linux_arm64_execution_burstable_compute_duration_usec"] = tu.LinuxArm64ExecutionBurstableComputeDurationUsec
 	}
-	if tu.LinuxArmExecutionComputeDurationUsec > 0 {
-		counts["linux_arm_execution_compute_duration_usec"] = tu.LinuxArmExecutionComputeDurationUsec
+	if tu.LinuxArm64ExecutionComputeDurationUsec > 0 {
+		counts["linux_arm64_execution_compute_duration_usec"] = tu.LinuxArm64ExecutionComputeDurationUsec
 	}
-	if tu.LinuxX86ExecutionBurstableComputeDurationUsec > 0 {
-		counts["linux_x86_execution_burstable_compute_duration_usec"] = tu.LinuxX86ExecutionBurstableComputeDurationUsec
+	if tu.LinuxX86_64ExecutionBurstableComputeDurationUsec > 0 {
+		counts["linux_x86_64_execution_burstable_compute_duration_usec"] = tu.LinuxX86_64ExecutionBurstableComputeDurationUsec
 	}
-	if tu.LinuxX86ExecutionComputeDurationUsec > 0 {
-		counts["linux_x86_execution_compute_duration_usec"] = tu.LinuxX86ExecutionComputeDurationUsec
+	if tu.LinuxX86_64ExecutionComputeDurationUsec > 0 {
+		counts["linux_x86_64_execution_compute_duration_usec"] = tu.LinuxX86_64ExecutionComputeDurationUsec
 	}
-	if tu.DarwinArmExecutionBurstableComputeDurationUsec > 0 {
-		counts["darwin_arm_execution_burstable_compute_duration_usec"] = tu.DarwinArmExecutionBurstableComputeDurationUsec
+	if tu.DarwinArm64ExecutionBurstableComputeDurationUsec > 0 {
+		counts["darwin_arm64_execution_burstable_compute_duration_usec"] = tu.DarwinArm64ExecutionBurstableComputeDurationUsec
 	}
-	if tu.DarwinArmExecutionComputeDurationUsec > 0 {
-		counts["darwin_arm_execution_compute_duration_usec"] = tu.DarwinArmExecutionComputeDurationUsec
+	if tu.DarwinArm64ExecutionComputeDurationUsec > 0 {
+		counts["darwin_arm64_execution_compute_duration_usec"] = tu.DarwinArm64ExecutionComputeDurationUsec
 	}
-	if tu.DarwinX86ExecutionBurstableComputeDurationUsec > 0 {
-		counts["darwin_x86_execution_burstable_compute_duration_usec"] = tu.DarwinX86ExecutionBurstableComputeDurationUsec
+	if tu.DarwinX86_64ExecutionBurstableComputeDurationUsec > 0 {
+		counts["darwin_x86_64_execution_burstable_compute_duration_usec"] = tu.DarwinX86_64ExecutionBurstableComputeDurationUsec
 	}
-	if tu.DarwinX86ExecutionComputeDurationUsec > 0 {
-		counts["darwin_x86_execution_compute_duration_usec"] = tu.DarwinX86ExecutionComputeDurationUsec
+	if tu.DarwinX86_64ExecutionComputeDurationUsec > 0 {
+		counts["darwin_x86_64_execution_compute_duration_usec"] = tu.DarwinX86_64ExecutionComputeDurationUsec
 	}
 	if tu.LocalSnapshotSavedBytes > 0 {
 		counts["local_snapshot_saved_bytes"] = tu.LocalSnapshotSavedBytes
@@ -798,28 +798,28 @@ func stringMapToCounts(h map[string]string) (*tables.UsageCounts, error) {
 		hInt64[k] = count
 	}
 	return &tables.UsageCounts{
-		Invocations:                                    hInt64["invocations"],
-		CASCacheHits:                                   hInt64["cas_cache_hits"],
-		ActionCacheHits:                                hInt64["action_cache_hits"],
-		TotalDownloadSizeBytes:                         hInt64["total_download_size_bytes"],
-		LinuxExecutionDurationUsec:                     hInt64["linux_execution_duration_usec"],
-		MacExecutionDurationUsec:                       hInt64["mac_execution_duration_usec"],
-		SelfHostedLinuxExecutionDurationUsec:           hInt64["self_hosted_linux_execution_duration_usec"],
-		SelfHostedMacExecutionDurationUsec:             hInt64["self_hosted_mac_execution_duration_usec"],
-		TotalUploadSizeBytes:                           hInt64["total_upload_size_bytes"],
-		TotalCachedActionExecUsec:                      hInt64["total_cached_action_exec_usec"],
-		CPUNanos:                                       hInt64["cpu_nanos"],
-		MemoryGBUsec:                                   hInt64["memory_gb_usec"],
-		LinuxArmExecutionBurstableComputeDurationUsec:  hInt64["linux_arm_execution_burstable_compute_duration_usec"],
-		LinuxArmExecutionComputeDurationUsec:           hInt64["linux_arm_execution_compute_duration_usec"],
-		LinuxX86ExecutionBurstableComputeDurationUsec:  hInt64["linux_x86_execution_burstable_compute_duration_usec"],
-		LinuxX86ExecutionComputeDurationUsec:           hInt64["linux_x86_execution_compute_duration_usec"],
-		DarwinArmExecutionBurstableComputeDurationUsec: hInt64["darwin_arm_execution_burstable_compute_duration_usec"],
-		DarwinArmExecutionComputeDurationUsec:          hInt64["darwin_arm_execution_compute_duration_usec"],
-		DarwinX86ExecutionBurstableComputeDurationUsec: hInt64["darwin_x86_execution_burstable_compute_duration_usec"],
-		DarwinX86ExecutionComputeDurationUsec:          hInt64["darwin_x86_execution_compute_duration_usec"],
-		LocalSnapshotSavedBytes:                        hInt64["local_snapshot_saved_bytes"],
-		RemoteSnapshotSavedBytes:                       hInt64["remote_snapshot_saved_bytes"],
+		Invocations:                          hInt64["invocations"],
+		CASCacheHits:                         hInt64["cas_cache_hits"],
+		ActionCacheHits:                      hInt64["action_cache_hits"],
+		TotalDownloadSizeBytes:               hInt64["total_download_size_bytes"],
+		LinuxExecutionDurationUsec:           hInt64["linux_execution_duration_usec"],
+		MacExecutionDurationUsec:             hInt64["mac_execution_duration_usec"],
+		SelfHostedLinuxExecutionDurationUsec: hInt64["self_hosted_linux_execution_duration_usec"],
+		SelfHostedMacExecutionDurationUsec:   hInt64["self_hosted_mac_execution_duration_usec"],
+		TotalUploadSizeBytes:                 hInt64["total_upload_size_bytes"],
+		TotalCachedActionExecUsec:            hInt64["total_cached_action_exec_usec"],
+		CPUNanos:                             hInt64["cpu_nanos"],
+		MemoryGBUsec:                         hInt64["memory_gb_usec"],
+		LinuxArm64ExecutionBurstableComputeDurationUsec:   hInt64["linux_arm64_execution_burstable_compute_duration_usec"],
+		LinuxArm64ExecutionComputeDurationUsec:            hInt64["linux_arm64_execution_compute_duration_usec"],
+		LinuxX86_64ExecutionBurstableComputeDurationUsec:  hInt64["linux_x86_64_execution_burstable_compute_duration_usec"],
+		LinuxX86_64ExecutionComputeDurationUsec:           hInt64["linux_x86_64_execution_compute_duration_usec"],
+		DarwinArm64ExecutionBurstableComputeDurationUsec:  hInt64["darwin_arm64_execution_burstable_compute_duration_usec"],
+		DarwinArm64ExecutionComputeDurationUsec:           hInt64["darwin_arm64_execution_compute_duration_usec"],
+		DarwinX86_64ExecutionBurstableComputeDurationUsec: hInt64["darwin_x86_64_execution_burstable_compute_duration_usec"],
+		DarwinX86_64ExecutionComputeDurationUsec:          hInt64["darwin_x86_64_execution_compute_duration_usec"],
+		LocalSnapshotSavedBytes:                           hInt64["local_snapshot_saved_bytes"],
+		RemoteSnapshotSavedBytes:                          hInt64["remote_snapshot_saved_bytes"],
 	}, nil
 }
 
@@ -949,60 +949,60 @@ func toOLAPLabeledSKUCounts(labels *tables.UsageLabels, counts *tables.UsageCoun
 			Count:  counts.MemoryGBUsec * 1000,
 		})
 	}
-	if counts.LinuxArmExecutionComputeDurationUsec > 0 {
+	if counts.LinuxArm64ExecutionComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteComputeNanos,
 			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchArm64, sku.SelfHostedFalse),
-			Count:  counts.LinuxArmExecutionComputeDurationUsec * 1000,
+			Count:  counts.LinuxArm64ExecutionComputeDurationUsec * 1000,
 		})
 	}
-	if counts.LinuxArmExecutionBurstableComputeDurationUsec > 0 {
+	if counts.LinuxArm64ExecutionBurstableComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
 			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchArm64, sku.SelfHostedFalse),
-			Count:  counts.LinuxArmExecutionBurstableComputeDurationUsec * 1000,
+			Count:  counts.LinuxArm64ExecutionBurstableComputeDurationUsec * 1000,
 		})
 	}
-	if counts.LinuxX86ExecutionComputeDurationUsec > 0 {
+	if counts.LinuxX86_64ExecutionComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteComputeNanos,
-			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchAmd64, sku.SelfHostedFalse),
-			Count:  counts.LinuxX86ExecutionComputeDurationUsec * 1000,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchX86_64, sku.SelfHostedFalse),
+			Count:  counts.LinuxX86_64ExecutionComputeDurationUsec * 1000,
 		})
 	}
-	if counts.LinuxX86ExecutionBurstableComputeDurationUsec > 0 {
+	if counts.LinuxX86_64ExecutionBurstableComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
-			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchAmd64, sku.SelfHostedFalse),
-			Count:  counts.LinuxX86ExecutionBurstableComputeDurationUsec * 1000,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchX86_64, sku.SelfHostedFalse),
+			Count:  counts.LinuxX86_64ExecutionBurstableComputeDurationUsec * 1000,
 		})
 	}
-	if counts.DarwinArmExecutionComputeDurationUsec > 0 {
+	if counts.DarwinArm64ExecutionComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteComputeNanos,
 			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchArm64, sku.SelfHostedFalse),
-			Count:  counts.DarwinArmExecutionComputeDurationUsec * 1000,
+			Count:  counts.DarwinArm64ExecutionComputeDurationUsec * 1000,
 		})
 	}
-	if counts.DarwinArmExecutionBurstableComputeDurationUsec > 0 {
+	if counts.DarwinArm64ExecutionBurstableComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
 			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchArm64, sku.SelfHostedFalse),
-			Count:  counts.DarwinArmExecutionBurstableComputeDurationUsec * 1000,
+			Count:  counts.DarwinArm64ExecutionBurstableComputeDurationUsec * 1000,
 		})
 	}
-	if counts.DarwinX86ExecutionComputeDurationUsec > 0 {
+	if counts.DarwinX86_64ExecutionComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteComputeNanos,
-			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchAmd64, sku.SelfHostedFalse),
-			Count:  counts.DarwinX86ExecutionComputeDurationUsec * 1000,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchX86_64, sku.SelfHostedFalse),
+			Count:  counts.DarwinX86_64ExecutionComputeDurationUsec * 1000,
 		})
 	}
-	if counts.DarwinX86ExecutionBurstableComputeDurationUsec > 0 {
+	if counts.DarwinX86_64ExecutionBurstableComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
-			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchAmd64, sku.SelfHostedFalse),
-			Count:  counts.DarwinX86ExecutionBurstableComputeDurationUsec * 1000,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchX86_64, sku.SelfHostedFalse),
+			Count:  counts.DarwinX86_64ExecutionBurstableComputeDurationUsec * 1000,
 		})
 	}
 	if counts.LocalSnapshotSavedBytes > 0 {

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -753,6 +753,36 @@ func countsToMap(tu *tables.UsageCounts) (map[string]int64, error) {
 	if tu.MemoryGBUsec > 0 {
 		counts["memory_gb_usec"] = tu.MemoryGBUsec
 	}
+	if tu.LinuxArmExecutionBurstableComputeDurationUsec > 0 {
+		counts["linux_arm_execution_burstable_compute_duration_usec"] = tu.LinuxArmExecutionBurstableComputeDurationUsec
+	}
+	if tu.LinuxArmExecutionComputeDurationUsec > 0 {
+		counts["linux_arm_execution_compute_duration_usec"] = tu.LinuxArmExecutionComputeDurationUsec
+	}
+	if tu.Linuxx86ExecutionBurstableComputeDurationUsec > 0 {
+		counts["linuxx86_execution_burstable_compute_duration_usec"] = tu.Linuxx86ExecutionBurstableComputeDurationUsec
+	}
+	if tu.Linuxx86ExecutionComputeDurationUsec > 0 {
+		counts["linuxx86_execution_compute_duration_usec"] = tu.Linuxx86ExecutionComputeDurationUsec
+	}
+	if tu.DarwinArmExecutionBurstableComputeDurationUsec > 0 {
+		counts["darwin_arm_execution_burstable_compute_duration_usec"] = tu.DarwinArmExecutionBurstableComputeDurationUsec
+	}
+	if tu.DarwinArmExecutionComputeDurationUsec > 0 {
+		counts["darwin_arm_execution_compute_duration_usec"] = tu.DarwinArmExecutionComputeDurationUsec
+	}
+	if tu.Darwinx86ExecutionBurstableComputeDurationUsec > 0 {
+		counts["darwinx86_execution_burstable_compute_duration_usec"] = tu.Darwinx86ExecutionBurstableComputeDurationUsec
+	}
+	if tu.Darwinx86ExecutionComputeDurationUsec > 0 {
+		counts["darwinx86_execution_compute_duration_usec"] = tu.Darwinx86ExecutionComputeDurationUsec
+	}
+	if tu.LocalSnapshotSavedBytes > 0 {
+		counts["local_snapshot_saved_bytes"] = tu.LocalSnapshotSavedBytes
+	}
+	if tu.RemoteSnapshotSavedBytes > 0 {
+		counts["remote_snapshot_saved_bytes"] = tu.RemoteSnapshotSavedBytes
+	}
 	return counts, nil
 }
 
@@ -768,18 +798,28 @@ func stringMapToCounts(h map[string]string) (*tables.UsageCounts, error) {
 		hInt64[k] = count
 	}
 	return &tables.UsageCounts{
-		Invocations:                          hInt64["invocations"],
-		CASCacheHits:                         hInt64["cas_cache_hits"],
-		ActionCacheHits:                      hInt64["action_cache_hits"],
-		TotalDownloadSizeBytes:               hInt64["total_download_size_bytes"],
-		LinuxExecutionDurationUsec:           hInt64["linux_execution_duration_usec"],
-		MacExecutionDurationUsec:             hInt64["mac_execution_duration_usec"],
-		SelfHostedLinuxExecutionDurationUsec: hInt64["self_hosted_linux_execution_duration_usec"],
-		SelfHostedMacExecutionDurationUsec:   hInt64["self_hosted_mac_execution_duration_usec"],
-		TotalUploadSizeBytes:                 hInt64["total_upload_size_bytes"],
-		TotalCachedActionExecUsec:            hInt64["total_cached_action_exec_usec"],
-		CPUNanos:                             hInt64["cpu_nanos"],
-		MemoryGBUsec:                         hInt64["memory_gb_usec"],
+		Invocations:                                    hInt64["invocations"],
+		CASCacheHits:                                   hInt64["cas_cache_hits"],
+		ActionCacheHits:                                hInt64["action_cache_hits"],
+		TotalDownloadSizeBytes:                         hInt64["total_download_size_bytes"],
+		LinuxExecutionDurationUsec:                     hInt64["linux_execution_duration_usec"],
+		MacExecutionDurationUsec:                       hInt64["mac_execution_duration_usec"],
+		SelfHostedLinuxExecutionDurationUsec:           hInt64["self_hosted_linux_execution_duration_usec"],
+		SelfHostedMacExecutionDurationUsec:             hInt64["self_hosted_mac_execution_duration_usec"],
+		TotalUploadSizeBytes:                           hInt64["total_upload_size_bytes"],
+		TotalCachedActionExecUsec:                      hInt64["total_cached_action_exec_usec"],
+		CPUNanos:                                       hInt64["cpu_nanos"],
+		MemoryGBUsec:                                   hInt64["memory_gb_usec"],
+		LinuxArmExecutionBurstableComputeDurationUsec:  hInt64["linux_arm_execution_burstable_compute_duration_usec"],
+		LinuxArmExecutionComputeDurationUsec:           hInt64["linux_arm_execution_compute_duration_usec"],
+		Linuxx86ExecutionBurstableComputeDurationUsec:  hInt64["linuxx86_execution_burstable_compute_duration_usec"],
+		Linuxx86ExecutionComputeDurationUsec:           hInt64["linuxx86_execution_compute_duration_usec"],
+		DarwinArmExecutionBurstableComputeDurationUsec: hInt64["darwin_arm_execution_burstable_compute_duration_usec"],
+		DarwinArmExecutionComputeDurationUsec:          hInt64["darwin_arm_execution_compute_duration_usec"],
+		Darwinx86ExecutionBurstableComputeDurationUsec: hInt64["darwinx86_execution_burstable_compute_duration_usec"],
+		Darwinx86ExecutionComputeDurationUsec:          hInt64["darwinx86_execution_compute_duration_usec"],
+		LocalSnapshotSavedBytes:                        hInt64["local_snapshot_saved_bytes"],
+		RemoteSnapshotSavedBytes:                       hInt64["remote_snapshot_saved_bytes"],
 	}, nil
 }
 
@@ -909,6 +949,76 @@ func toOLAPLabeledSKUCounts(labels *tables.UsageLabels, counts *tables.UsageCoun
 			Count:  counts.MemoryGBUsec * 1000,
 		})
 	}
+	if counts.LinuxArmExecutionComputeDurationUsec > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteExecutionExecuteComputeNanos,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchArm64, sku.SelfHostedFalse),
+			Count:  counts.LinuxArmExecutionComputeDurationUsec * 1000,
+		})
+	}
+	if counts.LinuxArmExecutionBurstableComputeDurationUsec > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchArm64, sku.SelfHostedFalse),
+			Count:  counts.LinuxArmExecutionBurstableComputeDurationUsec * 1000,
+		})
+	}
+	if counts.Linuxx86ExecutionComputeDurationUsec > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteExecutionExecuteComputeNanos,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchAmd64, sku.SelfHostedFalse),
+			Count:  counts.Linuxx86ExecutionComputeDurationUsec * 1000,
+		})
+	}
+	if counts.Linuxx86ExecutionBurstableComputeDurationUsec > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchAmd64, sku.SelfHostedFalse),
+			Count:  counts.Linuxx86ExecutionBurstableComputeDurationUsec * 1000,
+		})
+	}
+	if counts.DarwinArmExecutionComputeDurationUsec > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteExecutionExecuteComputeNanos,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchArm64, sku.SelfHostedFalse),
+			Count:  counts.DarwinArmExecutionComputeDurationUsec * 1000,
+		})
+	}
+	if counts.DarwinArmExecutionBurstableComputeDurationUsec > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchArm64, sku.SelfHostedFalse),
+			Count:  counts.DarwinArmExecutionBurstableComputeDurationUsec * 1000,
+		})
+	}
+	if counts.Darwinx86ExecutionComputeDurationUsec > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteExecutionExecuteComputeNanos,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchAmd64, sku.SelfHostedFalse),
+			Count:  counts.Darwinx86ExecutionComputeDurationUsec * 1000,
+		})
+	}
+	if counts.Darwinx86ExecutionBurstableComputeDurationUsec > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
+			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchAmd64, sku.SelfHostedFalse),
+			Count:  counts.Darwinx86ExecutionBurstableComputeDurationUsec * 1000,
+		})
+	}
+	if counts.LocalSnapshotSavedBytes > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.LocalSnapshotSavedBytes,
+			Labels: baseLabels,
+			Count:  counts.LocalSnapshotSavedBytes,
+		})
+	}
+	if counts.RemoteSnapshotSavedBytes > 0 {
+		items = append(items, labeledSKUCount{
+			SKU:    sku.RemoteSnapshotSavedBytes,
+			Labels: baseLabels,
+			Count:  counts.RemoteSnapshotSavedBytes,
+		})
+	}
 	return items
 }
 
@@ -920,6 +1030,19 @@ func appendExecutionLabels(m map[sku.LabelName]sku.LabelValue, os, selfHosted sk
 		out[k] = v
 	}
 	out[sku.OS] = os
+	out[sku.SelfHosted] = selfHosted
+	return out
+}
+
+// appendExecutionLabelsWithArch returns a new map which is a clone of the given
+// map with the given OS, arch, and self-hosted labels applied.
+func appendExecutionLabelsWithArch(m map[sku.LabelName]sku.LabelValue, os, arch, selfHosted sku.LabelValue) map[sku.LabelName]sku.LabelValue {
+	out := make(map[sku.LabelName]sku.LabelValue, len(m)+3)
+	for k, v := range m {
+		out[k] = v
+	}
+	out[sku.OS] = os
+	out[sku.Arch] = arch
 	out[sku.SelfHosted] = selfHosted
 	return out
 }

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -759,11 +759,11 @@ func countsToMap(tu *tables.UsageCounts) (map[string]int64, error) {
 	if tu.LinuxArmExecutionComputeDurationUsec > 0 {
 		counts["linux_arm_execution_compute_duration_usec"] = tu.LinuxArmExecutionComputeDurationUsec
 	}
-	if tu.Linuxx86ExecutionBurstableComputeDurationUsec > 0 {
-		counts["linuxx86_execution_burstable_compute_duration_usec"] = tu.Linuxx86ExecutionBurstableComputeDurationUsec
+	if tu.LinuxX86ExecutionBurstableComputeDurationUsec > 0 {
+		counts["linux_x86_execution_burstable_compute_duration_usec"] = tu.LinuxX86ExecutionBurstableComputeDurationUsec
 	}
-	if tu.Linuxx86ExecutionComputeDurationUsec > 0 {
-		counts["linuxx86_execution_compute_duration_usec"] = tu.Linuxx86ExecutionComputeDurationUsec
+	if tu.LinuxX86ExecutionComputeDurationUsec > 0 {
+		counts["linux_x86_execution_compute_duration_usec"] = tu.LinuxX86ExecutionComputeDurationUsec
 	}
 	if tu.DarwinArmExecutionBurstableComputeDurationUsec > 0 {
 		counts["darwin_arm_execution_burstable_compute_duration_usec"] = tu.DarwinArmExecutionBurstableComputeDurationUsec
@@ -771,11 +771,11 @@ func countsToMap(tu *tables.UsageCounts) (map[string]int64, error) {
 	if tu.DarwinArmExecutionComputeDurationUsec > 0 {
 		counts["darwin_arm_execution_compute_duration_usec"] = tu.DarwinArmExecutionComputeDurationUsec
 	}
-	if tu.Darwinx86ExecutionBurstableComputeDurationUsec > 0 {
-		counts["darwinx86_execution_burstable_compute_duration_usec"] = tu.Darwinx86ExecutionBurstableComputeDurationUsec
+	if tu.DarwinX86ExecutionBurstableComputeDurationUsec > 0 {
+		counts["darwin_x86_execution_burstable_compute_duration_usec"] = tu.DarwinX86ExecutionBurstableComputeDurationUsec
 	}
-	if tu.Darwinx86ExecutionComputeDurationUsec > 0 {
-		counts["darwinx86_execution_compute_duration_usec"] = tu.Darwinx86ExecutionComputeDurationUsec
+	if tu.DarwinX86ExecutionComputeDurationUsec > 0 {
+		counts["darwin_x86_execution_compute_duration_usec"] = tu.DarwinX86ExecutionComputeDurationUsec
 	}
 	if tu.LocalSnapshotSavedBytes > 0 {
 		counts["local_snapshot_saved_bytes"] = tu.LocalSnapshotSavedBytes
@@ -812,12 +812,12 @@ func stringMapToCounts(h map[string]string) (*tables.UsageCounts, error) {
 		MemoryGBUsec:                                   hInt64["memory_gb_usec"],
 		LinuxArmExecutionBurstableComputeDurationUsec:  hInt64["linux_arm_execution_burstable_compute_duration_usec"],
 		LinuxArmExecutionComputeDurationUsec:           hInt64["linux_arm_execution_compute_duration_usec"],
-		Linuxx86ExecutionBurstableComputeDurationUsec:  hInt64["linuxx86_execution_burstable_compute_duration_usec"],
-		Linuxx86ExecutionComputeDurationUsec:           hInt64["linuxx86_execution_compute_duration_usec"],
+		LinuxX86ExecutionBurstableComputeDurationUsec:  hInt64["linux_x86_execution_burstable_compute_duration_usec"],
+		LinuxX86ExecutionComputeDurationUsec:           hInt64["linux_x86_execution_compute_duration_usec"],
 		DarwinArmExecutionBurstableComputeDurationUsec: hInt64["darwin_arm_execution_burstable_compute_duration_usec"],
 		DarwinArmExecutionComputeDurationUsec:          hInt64["darwin_arm_execution_compute_duration_usec"],
-		Darwinx86ExecutionBurstableComputeDurationUsec: hInt64["darwinx86_execution_burstable_compute_duration_usec"],
-		Darwinx86ExecutionComputeDurationUsec:          hInt64["darwinx86_execution_compute_duration_usec"],
+		DarwinX86ExecutionBurstableComputeDurationUsec: hInt64["darwin_x86_execution_burstable_compute_duration_usec"],
+		DarwinX86ExecutionComputeDurationUsec:          hInt64["darwin_x86_execution_compute_duration_usec"],
 		LocalSnapshotSavedBytes:                        hInt64["local_snapshot_saved_bytes"],
 		RemoteSnapshotSavedBytes:                       hInt64["remote_snapshot_saved_bytes"],
 	}, nil
@@ -963,18 +963,18 @@ func toOLAPLabeledSKUCounts(labels *tables.UsageLabels, counts *tables.UsageCoun
 			Count:  counts.LinuxArmExecutionBurstableComputeDurationUsec * 1000,
 		})
 	}
-	if counts.Linuxx86ExecutionComputeDurationUsec > 0 {
+	if counts.LinuxX86ExecutionComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteComputeNanos,
 			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchAmd64, sku.SelfHostedFalse),
-			Count:  counts.Linuxx86ExecutionComputeDurationUsec * 1000,
+			Count:  counts.LinuxX86ExecutionComputeDurationUsec * 1000,
 		})
 	}
-	if counts.Linuxx86ExecutionBurstableComputeDurationUsec > 0 {
+	if counts.LinuxX86ExecutionBurstableComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
 			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSLinux, sku.ArchAmd64, sku.SelfHostedFalse),
-			Count:  counts.Linuxx86ExecutionBurstableComputeDurationUsec * 1000,
+			Count:  counts.LinuxX86ExecutionBurstableComputeDurationUsec * 1000,
 		})
 	}
 	if counts.DarwinArmExecutionComputeDurationUsec > 0 {
@@ -991,18 +991,18 @@ func toOLAPLabeledSKUCounts(labels *tables.UsageLabels, counts *tables.UsageCoun
 			Count:  counts.DarwinArmExecutionBurstableComputeDurationUsec * 1000,
 		})
 	}
-	if counts.Darwinx86ExecutionComputeDurationUsec > 0 {
+	if counts.DarwinX86ExecutionComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteComputeNanos,
 			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchAmd64, sku.SelfHostedFalse),
-			Count:  counts.Darwinx86ExecutionComputeDurationUsec * 1000,
+			Count:  counts.DarwinX86ExecutionComputeDurationUsec * 1000,
 		})
 	}
-	if counts.Darwinx86ExecutionBurstableComputeDurationUsec > 0 {
+	if counts.DarwinX86ExecutionBurstableComputeDurationUsec > 0 {
 		items = append(items, labeledSKUCount{
 			SKU:    sku.RemoteExecutionExecuteBurstableComputeNanos,
 			Labels: appendExecutionLabelsWithArch(baseLabels, sku.OSMac, sku.ArchAmd64, sku.SelfHostedFalse),
-			Count:  counts.Darwinx86ExecutionBurstableComputeDurationUsec * 1000,
+			Count:  counts.DarwinX86ExecutionBurstableComputeDurationUsec * 1000,
 		})
 	}
 	if counts.LocalSnapshotSavedBytes > 0 {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -811,12 +811,12 @@ type UsageCounts struct {
 	MemoryGBUsec                                   int64 `gorm:"not null;default:0"`
 	LinuxArmExecutionBurstableComputeDurationUsec  int64 `gorm:"not null;default:0"`
 	LinuxArmExecutionComputeDurationUsec           int64 `gorm:"not null;default:0"`
-	Linuxx86ExecutionBurstableComputeDurationUsec  int64 `gorm:"not null;default:0"`
-	Linuxx86ExecutionComputeDurationUsec           int64 `gorm:"not null;default:0"`
+	LinuxX86ExecutionBurstableComputeDurationUsec  int64 `gorm:"not null;default:0"`
+	LinuxX86ExecutionComputeDurationUsec           int64 `gorm:"not null;default:0"`
 	DarwinArmExecutionBurstableComputeDurationUsec int64 `gorm:"not null;default:0"`
 	DarwinArmExecutionComputeDurationUsec          int64 `gorm:"not null;default:0"`
-	Darwinx86ExecutionBurstableComputeDurationUsec int64 `gorm:"not null;default:0"`
-	Darwinx86ExecutionComputeDurationUsec          int64 `gorm:"not null;default:0"`
+	DarwinX86ExecutionBurstableComputeDurationUsec int64 `gorm:"not null;default:0"`
+	DarwinX86ExecutionComputeDurationUsec          int64 `gorm:"not null;default:0"`
 	LocalSnapshotSavedBytes                        int64 `gorm:"not null;default:0"`
 	RemoteSnapshotSavedBytes                       int64 `gorm:"not null;default:0"`
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -801,14 +801,24 @@ type UsageCounts struct {
 	// NOTE: New fields added here should be annotated with
 	// `gorm:"not null;default:0"`
 
-	LinuxExecutionDurationUsec           int64 `gorm:"not null;default:0"`
-	MacExecutionDurationUsec             int64 `gorm:"not null;default:0"`
-	SelfHostedLinuxExecutionDurationUsec int64 `gorm:"not null;default:0"`
-	SelfHostedMacExecutionDurationUsec   int64 `gorm:"not null;default:0"`
-	TotalUploadSizeBytes                 int64 `gorm:"not null;default:0"`
-	TotalCachedActionExecUsec            int64 `gorm:"not null;default:0"`
-	CPUNanos                             int64 `gorm:"not null;default:0"`
-	MemoryGBUsec                         int64 `gorm:"not null;default:0"`
+	LinuxExecutionDurationUsec                     int64 `gorm:"not null;default:0"`
+	MacExecutionDurationUsec                       int64 `gorm:"not null;default:0"`
+	SelfHostedLinuxExecutionDurationUsec           int64 `gorm:"not null;default:0"`
+	SelfHostedMacExecutionDurationUsec             int64 `gorm:"not null;default:0"`
+	TotalUploadSizeBytes                           int64 `gorm:"not null;default:0"`
+	TotalCachedActionExecUsec                      int64 `gorm:"not null;default:0"`
+	CPUNanos                                       int64 `gorm:"not null;default:0"`
+	MemoryGBUsec                                   int64 `gorm:"not null;default:0"`
+	LinuxArmExecutionBurstableComputeDurationUsec  int64 `gorm:"not null;default:0"`
+	LinuxArmExecutionComputeDurationUsec           int64 `gorm:"not null;default:0"`
+	Linuxx86ExecutionBurstableComputeDurationUsec  int64 `gorm:"not null;default:0"`
+	Linuxx86ExecutionComputeDurationUsec           int64 `gorm:"not null;default:0"`
+	DarwinArmExecutionBurstableComputeDurationUsec int64 `gorm:"not null;default:0"`
+	DarwinArmExecutionComputeDurationUsec          int64 `gorm:"not null;default:0"`
+	Darwinx86ExecutionBurstableComputeDurationUsec int64 `gorm:"not null;default:0"`
+	Darwinx86ExecutionComputeDurationUsec          int64 `gorm:"not null;default:0"`
+	LocalSnapshotSavedBytes                        int64 `gorm:"not null;default:0"`
+	RemoteSnapshotSavedBytes                       int64 `gorm:"not null;default:0"`
 }
 
 type UsageLabels struct {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -801,24 +801,24 @@ type UsageCounts struct {
 	// NOTE: New fields added here should be annotated with
 	// `gorm:"not null;default:0"`
 
-	LinuxExecutionDurationUsec                     int64 `gorm:"not null;default:0"`
-	MacExecutionDurationUsec                       int64 `gorm:"not null;default:0"`
-	SelfHostedLinuxExecutionDurationUsec           int64 `gorm:"not null;default:0"`
-	SelfHostedMacExecutionDurationUsec             int64 `gorm:"not null;default:0"`
-	TotalUploadSizeBytes                           int64 `gorm:"not null;default:0"`
-	TotalCachedActionExecUsec                      int64 `gorm:"not null;default:0"`
-	CPUNanos                                       int64 `gorm:"not null;default:0"`
-	MemoryGBUsec                                   int64 `gorm:"not null;default:0"`
-	LinuxArmExecutionBurstableComputeDurationUsec  int64 `gorm:"not null;default:0"`
-	LinuxArmExecutionComputeDurationUsec           int64 `gorm:"not null;default:0"`
-	LinuxX86ExecutionBurstableComputeDurationUsec  int64 `gorm:"not null;default:0"`
-	LinuxX86ExecutionComputeDurationUsec           int64 `gorm:"not null;default:0"`
-	DarwinArmExecutionBurstableComputeDurationUsec int64 `gorm:"not null;default:0"`
-	DarwinArmExecutionComputeDurationUsec          int64 `gorm:"not null;default:0"`
-	DarwinX86ExecutionBurstableComputeDurationUsec int64 `gorm:"not null;default:0"`
-	DarwinX86ExecutionComputeDurationUsec          int64 `gorm:"not null;default:0"`
-	LocalSnapshotSavedBytes                        int64 `gorm:"not null;default:0"`
-	RemoteSnapshotSavedBytes                       int64 `gorm:"not null;default:0"`
+	LinuxExecutionDurationUsec                        int64 `gorm:"not null;default:0"`
+	MacExecutionDurationUsec                          int64 `gorm:"not null;default:0"`
+	SelfHostedLinuxExecutionDurationUsec              int64 `gorm:"not null;default:0"`
+	SelfHostedMacExecutionDurationUsec                int64 `gorm:"not null;default:0"`
+	TotalUploadSizeBytes                              int64 `gorm:"not null;default:0"`
+	TotalCachedActionExecUsec                         int64 `gorm:"not null;default:0"`
+	CPUNanos                                          int64 `gorm:"not null;default:0"`
+	MemoryGBUsec                                      int64 `gorm:"not null;default:0"`
+	LinuxArm64ExecutionBurstableComputeDurationUsec   int64 `gorm:"not null;default:0"`
+	LinuxArm64ExecutionComputeDurationUsec            int64 `gorm:"not null;default:0"`
+	LinuxX86_64ExecutionBurstableComputeDurationUsec  int64 `gorm:"column:linux_x86_64_execution_burstable_compute_duration_usec;not null;default:0"`
+	LinuxX86_64ExecutionComputeDurationUsec           int64 `gorm:"column:linux_x86_64_execution_compute_duration_usec;not null;default:0"`
+	DarwinArm64ExecutionBurstableComputeDurationUsec  int64 `gorm:"not null;default:0"`
+	DarwinArm64ExecutionComputeDurationUsec           int64 `gorm:"not null;default:0"`
+	DarwinX86_64ExecutionBurstableComputeDurationUsec int64 `gorm:"column:darwin_x86_64_execution_burstable_compute_duration_usec;not null;default:0"`
+	DarwinX86_64ExecutionComputeDurationUsec          int64 `gorm:"column:darwin_x86_64_execution_compute_duration_usec;not null;default:0"`
+	LocalSnapshotSavedBytes                           int64 `gorm:"not null;default:0"`
+	RemoteSnapshotSavedBytes                          int64 `gorm:"not null;default:0"`
 }
 
 type UsageLabels struct {

--- a/server/usage/sku/sku.go
+++ b/server/usage/sku/sku.go
@@ -91,7 +91,7 @@ const (
 	OSLinux                 LabelValue = "linux"
 	OSMac                   LabelValue = "mac"
 	OSWindows               LabelValue = "windows"
-	ArchAmd64               LabelValue = "amd64"
+	ArchX86_64              LabelValue = "x86_64"
 	ArchArm64               LabelValue = "arm64"
 	SelfHostedFalse         LabelValue = "false"
 	SelfHostedTrue          LabelValue = "true"

--- a/server/usage/sku/sku.go
+++ b/server/usage/sku/sku.go
@@ -25,9 +25,14 @@ const (
 	RemoteCacheACHits                    SKU = "remote_cache.action_cache_hits.hits"
 	RemoteCacheACCachedExecDurationNanos SKU = "remote_cache.action_cache.cached_execution_duration_nanos"
 
-	RemoteExecutionExecuteWorkerDurationNanos SKU = "remote_execution.execute.worker_duration_nanos"
-	RemoteExecutionExecuteWorkerCPUNanos      SKU = "remote_execution.execute.worker_cpu_nanos"
-	RemoteExecutionExecuteWorkerMemoryGBNanos SKU = "remote_execution.execute.worker_memory_gb_nanos"
+	RemoteExecutionExecuteWorkerDurationNanos   SKU = "remote_execution.execute.worker_duration_nanos"
+	RemoteExecutionExecuteWorkerCPUNanos        SKU = "remote_execution.execute.worker_cpu_nanos"
+	RemoteExecutionExecuteWorkerMemoryGBNanos   SKU = "remote_execution.execute.worker_memory_gb_nanos"
+	RemoteExecutionExecuteComputeNanos          SKU = "remote_execution.execute.compute_nanos"
+	RemoteExecutionExecuteBurstableComputeNanos SKU = "remote_execution.execute.burstable_compute_nanos"
+
+	LocalSnapshotSavedBytes  SKU = "remote_execution.local_snapshot_saved_bytes"
+	RemoteSnapshotSavedBytes SKU = "remote_execution.remote_snapshot_saved_bytes"
 )
 
 // LabelName is a usage counter label, which further qualifies the SKU.
@@ -49,10 +54,12 @@ const (
 	Origin LabelName = "origin"
 	// OS identifies the operating system for execution usage.
 	OS LabelName = "os"
+	// Arch identifies the machine architecture for execution usage.
+	Arch LabelName = "arch"
 	// SelfHosted indicates whether the usage was incurred on a self-hosted
 	// instance of the service.
 	SelfHosted LabelName = "self_hosted"
-	// TODO: executor arch, client region (if known), server region
+	// TODO: client region (if known), server region
 )
 
 // LabelValue is the value of a label.
@@ -84,6 +91,8 @@ const (
 	OSLinux                 LabelValue = "linux"
 	OSMac                   LabelValue = "mac"
 	OSWindows               LabelValue = "windows"
+	ArchAmd64               LabelValue = "amd64"
+	ArchArm64               LabelValue = "arm64"
 	SelfHostedFalse         LabelValue = "false"
 	SelfHostedTrue          LabelValue = "true"
 )


### PR DESCRIPTION
For execution, there is a matrix of `(os) * (arch) * (burstable or reserved)` new fields.