### PR TITLE
ociruntime: harden layer extraction

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -13,11 +13,13 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"io/fs"
 	"maps"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -1934,9 +1936,13 @@ func downloadLayer(ctx context.Context, layer ctr.Layer, destDir string) (int64,
 	}
 	defer os.RemoveAll(tempUnpackDir)
 
-	// Track all operations using [fsync.Root] so that once we're done unpacking
-	// the layer we can ensure it gets persisted to disk (to avoid corruption).
-	root := fsync.NewRoot(tempUnpackDir, nil)
+	// Resolve layer paths through [fsync.Root] so symlinks created by the archive
+	// cannot redirect later writes outside the unpack directory.
+	root, err := fsync.NewRoot(tempUnpackDir, nil)
+	if err != nil {
+		return 0, status.UnavailableErrorf("open layer unpack dir: %s", err)
+	}
+	defer root.Close()
 
 	counter := &ioutil.Counter{}
 	tr := tar.NewReader(io.TeeReader(rc, counter))
@@ -1949,12 +1955,11 @@ func downloadLayer(ctx context.Context, layer ctr.Layer, destDir string) (int64,
 			return 0, status.UnavailableErrorf("download and extract layer tarball: %s", err)
 		}
 
-		if slices.Contains(strings.Split(header.Name, string(os.PathSeparator)), "..") {
+		file, err := localLayerPath(header.Name)
+		if err != nil {
 			return 0, status.InvalidArgumentErrorf("invalid tar header: name %q is invalid", header.Name)
 		}
 
-		// filepath.Join applies filepath.Clean to all arguments
-		file := filepath.Join(tempUnpackDir, header.Name)
 		base := filepath.Base(file)
 		dir := filepath.Dir(file)
 
@@ -1963,7 +1968,7 @@ func downloadLayer(ctx context.Context, layer ctr.Layer, destDir string) (int64,
 			header.Typeflag == tar.TypeSymlink ||
 			header.Typeflag == tar.TypeLink {
 			// Ensure that parent dir exists
-			if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			if err := root.MkdirAll(dir, os.ModePerm); err != nil {
 				return 0, status.UnavailableErrorf("create directory: %s", err)
 			}
 		} else {
@@ -1993,22 +1998,33 @@ func downloadLayer(ctx context.Context, layer ctr.Layer, destDir string) (int64,
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := root.MkdirAll(file, os.FileMode(header.Mode), header.Uid, header.Gid); err != nil {
+			mode := header.FileInfo().Mode()
+			if err := root.MkdirAll(file, mode.Perm()); err != nil {
 				return 0, status.UnavailableErrorf("create directory: %s", err)
 			}
+			if err := root.Chown(file, header.Uid, header.Gid); err != nil {
+				return 0, status.UnavailableErrorf("chown directory: %s", err)
+			}
+			if err := root.Chmod(file, mode); err != nil {
+				return 0, status.UnavailableErrorf("chmod directory: %s", err)
+			}
 		case tar.TypeReg:
-			if err := root.CreateFile(file, os.FileMode(header.Mode), tr, header.Uid, header.Gid); err != nil {
+			mode := header.FileInfo().Mode()
+			if err := root.CreateFile(file, mode, tr, header.Uid, header.Gid); err != nil {
 				return 0, status.UnavailableErrorf("create file: %s", err)
 			}
 		case tar.TypeSymlink:
 			// Symlink's target is only evaluated at runtime, inside the container context.
 			// So it's safe to have the symlink targeting paths outside unpackdir.
-			if err := root.Symlink(header.Linkname, file, header.Uid, header.Gid); err != nil {
+			if err := root.Symlink(header.Linkname, file); err != nil {
 				return 0, status.UnavailableErrorf("create symlink: %s", err)
 			}
+			if err := root.Lchown(file, header.Uid, header.Gid); err != nil {
+				return 0, status.UnavailableErrorf("lchown symlink: %s", err)
+			}
 		case tar.TypeLink:
-			target := filepath.Join(tempUnpackDir, header.Linkname)
-			if !strings.HasPrefix(target, tempUnpackDir) {
+			target, err := localLayerPath(header.Linkname)
+			if err != nil {
 				return 0, status.InvalidArgumentErrorf("invalid tar header: link name %q is invalid", header.Linkname)
 			}
 			// Note that this will call linkat(2) without AT_SYMLINK_FOLLOW,
@@ -2039,6 +2055,23 @@ func downloadLayer(ctx context.Context, layer ctr.Layer, destDir string) (int64,
 	}
 
 	return counter.Count(), nil
+}
+
+func localLayerPath(name string) (string, error) {
+	if name == "" {
+		return "", errors.New("empty path")
+	}
+	// OCI layer paths are POSIX-style paths rooted at the image filesystem root.
+	// Normalize them to relative os.Root paths; os.Root still enforces that
+	// later extraction operations cannot escape through symlinks or "..".
+	name = strings.TrimLeft(path.Clean(name), "/")
+	if name == "" {
+		return ".", nil
+	}
+	if !fs.ValidPath(name) {
+		return "", fmt.Errorf("invalid fs path %q", name)
+	}
+	return filepath.Localize(name)
 }
 
 // Statusz returns statusz page contents for the image store.

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -1587,36 +1587,16 @@ func TestPathSanitization(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			te := testenv.GetTestEnv(t)
 			cacheRoot := testfs.MakeTempDir(t)
 			testfs.WriteAllFileContents(t, cacheRoot, map[string]string{
 				"test-link-target": "Hello",
 			})
-			// Set up a filecache for the image store
-			fcDir := testfs.MakeTempDir(t)
-			fc, err := filecache.NewFileCache(fcDir, 1_000_000_000, false)
-			require.NoError(t, err)
-			t.Cleanup(func() { fc.Close() })
-			fc.WaitForDirectoryScanToComplete()
-
-			resolver, err := oci.NewResolver(te)
-			require.NoError(t, err)
-			require.NotNil(t, resolver)
-			imageStore, err := ociruntime.NewImageStore(resolver, cacheRoot, fc)
-			require.NoError(t, err)
-			// Load busybox oci image
-			busyboxImg := testregistry.ImageFromRlocationpath(t, busyboxImageRlocationpath)
-			// Append an invalid layer
 			layer := testregistry.NewBytesLayer(t, test.Tar)
-			mutatedImg, err := mutate.AppendLayers(busyboxImg, layer)
-			require.NoError(t, err)
-			// Start a test registry and push the mutated busybox image to it
-			reg := testregistry.Run(t, testregistry.Opts{})
-			image := reg.Push(t, mutatedImg, "test-file-ownership:latest", nil)
+			image := pushSingleLayerImage(t, "test-path-sanitization:latest", layer)
 
 			// Make sure we get an error when pulling this image.
 			ctx := context.Background()
-			lockedImg, err := imageStore.PullAndLockImage(ctx, image, oci.Credentials{}, false)
+			lockedImg, err := newImageStoreForTest(t, cacheRoot).PullAndLockImage(ctx, image, oci.Credentials{}, false)
 			if lockedImg != nil {
 				defer lockedImg.Unlock()
 			}
@@ -1625,6 +1605,293 @@ func TestPathSanitization(t *testing.T) {
 			assert.Contains(t, err.Error(), test.ExpectedError)
 		})
 	}
+}
+
+func newImageStoreForTest(t *testing.T, layerDir string) *ociruntime.ImageStore {
+	te := testenv.GetTestEnv(t)
+	resolver, err := oci.NewResolver(te)
+	require.NoError(t, err)
+	fcDir := testfs.MakeTempDir(t)
+	fc, err := filecache.NewFileCache(fcDir, 1_000_000_000, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { fc.Close() })
+	fc.WaitForDirectoryScanToComplete()
+	imageStore, err := ociruntime.NewImageStore(resolver, layerDir, fc)
+	require.NoError(t, err)
+	return imageStore
+}
+
+func pushSingleLayerImage(t *testing.T, name string, layer containerregistry.Layer) string {
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	require.NoError(t, err)
+	reg := testregistry.Run(t, testregistry.Opts{})
+	return reg.Push(t, img, name, nil)
+}
+
+func pullSingleLayerImage(t *testing.T, image string) *ociruntime.LockedImage {
+	lockedImg, err := newImageStoreForTest(t, testfs.MakeTempDir(t)).PullAndLockImage(context.Background(), image, oci.Credentials{}, false)
+	require.NoError(t, err)
+	require.NotNil(t, lockedImg)
+	t.Cleanup(lockedImg.Unlock)
+	return lockedImg
+}
+
+func singleLayerPath(t testing.TB, lockedImg *ociruntime.LockedImage) string {
+	t.Helper()
+	require.NotNil(t, lockedImg)
+	require.Len(t, lockedImg.Layers, 1)
+	return lockedImg.Layers[0].Path
+}
+
+// TestImageStoreRejectsLayerSymlinkEscape verifies that layer extraction cannot
+// write through symlinks created by earlier entries in the same archive.
+func TestImageStoreRejectsLayerSymlinkEscape(t *testing.T) {
+	setupNetworking(t)
+
+	// Cover both absolute symlink targets and relative targets that walk out of
+	// the layer unpack directory.
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T) (layerDir, linkname, escapeFile string)
+	}{
+		{
+			name: "absolute link",
+			setup: func(t *testing.T) (string, string, string) {
+				escapeDir := testfs.MakeTempDir(t)
+				escapeFile := filepath.Join(escapeDir, "pwned.txt")
+				return testfs.MakeTempDir(t), escapeFile, escapeFile
+			},
+		},
+		{
+			name: "relative link",
+			setup: func(t *testing.T) (string, string, string) {
+				rootDir := testfs.MakeTempDir(t)
+				layerDir := filepath.Join(rootDir, "layers")
+				escapeDir := filepath.Join(rootDir, "escape")
+				require.NoError(t, os.MkdirAll(escapeDir, 0755))
+				escapeFile := filepath.Join(escapeDir, "pwned.txt")
+				// Extracted layers are unpacked below v2/<algorithm>/<digest>.tmp.
+				// Compute the relative symlink target from that depth so the test
+				// keeps pointing at the escape dir if the root path changes.
+				unpackDir := filepath.Join(layerDir, "v2", "sha256", "layer.tmp")
+				linkname, err := filepath.Rel(unpackDir, escapeFile)
+				require.NoError(t, err)
+				require.Equal(t, escapeFile, filepath.Clean(filepath.Join(unpackDir, linkname)))
+				return layerDir, linkname, escapeFile
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			uid := os.Getuid()
+			gid := os.Getgid()
+			layerDir, linkname, escapeFile := tc.setup(t)
+			// The first entry creates the escape symlink; the second entry tries
+			// to extract a regular file through that same path.
+			layerTar := testtar.EntriesBytes(t, []testtar.Entry{
+				{
+					Header: &tar.Header{
+						Name:     "pwned.txt",
+						Typeflag: tar.TypeSymlink,
+						Linkname: linkname,
+						Uid:      uid,
+						Gid:      gid,
+					},
+				},
+				{
+					Header: &tar.Header{
+						Name:     "pwned.txt",
+						Typeflag: tar.TypeReg,
+						Mode:     0644,
+						Uid:      uid,
+						Gid:      gid,
+					},
+					Data: []byte("pwned"),
+				},
+			})
+			layer := testregistry.NewBytesLayer(t, layerTar)
+			image := pushSingleLayerImage(t, "test-layer-symlink-escape:latest", layer)
+
+			lockedImg, err := newImageStoreForTest(t, layerDir).PullAndLockImage(context.Background(), image, oci.Credentials{}, false)
+			if lockedImg != nil {
+				defer lockedImg.Unlock()
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "create file")
+			assert.Contains(t, err.Error(), "pwned.txt")
+
+			// The pull should fail before anything is written outside the layer
+			// destination, regardless of how the symlink target was spelled.
+			_, err = os.Stat(escapeFile)
+			assert.True(t, os.IsNotExist(err), "file outside layer destination should not be created")
+		})
+	}
+}
+
+// TestImageStorePreservesLayerDirectoryModeBits ensures that the os.Root-backed
+// fsync helpers keep tar special mode bits intact.
+func TestImageStorePreservesLayerDirectoryModeBits(t *testing.T) {
+	setupNetworking(t)
+
+	uid := os.Getuid()
+	gid := os.Getgid()
+	// os.Root create APIs only accept permission bits, so extraction needs to
+	// apply setuid, setgid, and sticky bits after creating each entry.
+	layer := testregistry.NewBytesLayer(t, testtar.EntriesBytes(t, []testtar.Entry{
+		{
+			Header: &tar.Header{
+				Name:     "sticky-dir",
+				Typeflag: tar.TypeDir,
+				Mode:     01777,
+				Uid:      uid,
+				Gid:      gid,
+			},
+		},
+		{
+			Header: &tar.Header{
+				Name:     "setgid-dir",
+				Typeflag: tar.TypeDir,
+				Mode:     02775,
+				Uid:      uid,
+				Gid:      gid,
+			},
+		},
+		{
+			Header: &tar.Header{
+				Name:     "setuid-file",
+				Typeflag: tar.TypeReg,
+				Mode:     04755,
+				Uid:      uid,
+				Gid:      gid,
+			},
+			Data: []byte("setuid"),
+		},
+	}))
+	image := pushSingleLayerImage(t, "test-layer-directory-mode-bits:latest", layer)
+	lockedImg := pullSingleLayerImage(t, image)
+	layerPath := singleLayerPath(t, lockedImg)
+
+	for _, tc := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "sticky-dir", mode: os.ModeSticky | 0777},
+		{name: "setgid-dir", mode: os.ModeSetgid | 0775},
+		{name: "setuid-file", mode: os.ModeSetuid | 0755},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := os.Stat(filepath.Join(layerPath, tc.name))
+			require.NoError(t, err)
+			// Compare only the permission and special bits controlled by the tar
+			// header; other os.FileMode bits describe the file type.
+			assert.Equal(t, tc.mode, info.Mode()&(os.ModePerm|os.ModeSticky|os.ModeSetgid|os.ModeSetuid))
+		})
+	}
+}
+
+// TestImageStoreAppliesLayerRootOwnership covers the tar entry for ".", which
+// represents the extracted layer directory itself.
+func TestImageStoreAppliesLayerRootOwnership(t *testing.T) {
+	setupNetworking(t)
+
+	uid := os.Getuid()
+	gid := os.Getgid()
+	// Pick a group distinct from the process default so the assertion proves that
+	// extraction applied the root directory header instead of leaving defaults.
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+	for _, groupID := range groups {
+		if groupID != gid {
+			gid = groupID
+			break
+		}
+	}
+	if gid == os.Getgid() {
+		if os.Getuid() != 0 {
+			t.Skip("no alternate group available to test layer root ownership")
+		}
+		gid++
+	}
+	layer := testregistry.NewBytesLayer(t, testtar.EntryBytes(t, &tar.Header{
+		Name:     ".",
+		Typeflag: tar.TypeDir,
+		Mode:     0755,
+		Uid:      uid,
+		Gid:      gid,
+	}, nil))
+	image := pushSingleLayerImage(t, "test-layer-root-ownership:latest", layer)
+	lockedImg := pullSingleLayerImage(t, image)
+
+	var st syscall.Stat_t
+	require.NoError(t, syscall.Stat(singleLayerPath(t, lockedImg), &st))
+	assert.Equal(t, uid, int(st.Uid))
+	assert.Equal(t, gid, int(st.Gid))
+}
+
+// TestImageStoreExtractsWhiteouts verifies OCI whiteout translation through
+// the os.Root-backed fsync helpers.
+func TestImageStoreExtractsWhiteouts(t *testing.T) {
+	dir := testfs.MakeTempDir(t)
+	// Whiteout extraction depends on filesystem and privilege support for the
+	// trusted.overlay.opaque xattr and character device nodes.
+	if err := syscall.Setxattr(dir, "trusted.overlay.opaque", []byte{'y'}, 0); err != nil {
+		t.Skipf("setting trusted.overlay.opaque requires whiteout xattr support: %s", err)
+	}
+	if err := syscall.Mknod(filepath.Join(dir, "deleted"), syscall.S_IFCHR, 0); err != nil {
+		t.Skipf("creating overlayfs whiteout marker requires mknod support: %s", err)
+	}
+	setupNetworking(t)
+
+	uid := os.Getuid()
+	gid := os.Getgid()
+	// OCI represents deletions with .wh.* archive entries. Extraction converts
+	// those marker entries into overlayfs metadata in the unpacked layer.
+	layer := testregistry.NewBytesLayer(t, testtar.EntriesBytes(t, []testtar.Entry{
+		{
+			Header: &tar.Header{
+				Name:     "opaque",
+				Typeflag: tar.TypeDir,
+				Mode:     0755,
+				Uid:      uid,
+				Gid:      gid,
+			},
+		},
+		{
+			Header: &tar.Header{
+				Name:     "opaque/.wh..wh..opq",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+				Uid:      uid,
+				Gid:      gid,
+			},
+		},
+		{
+			Header: &tar.Header{
+				Name:     ".wh.deleted",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+				Uid:      uid,
+				Gid:      gid,
+			},
+		},
+	}))
+	image := pushSingleLayerImage(t, "test-layer-whiteouts:latest", layer)
+	lockedImg := pullSingleLayerImage(t, image)
+	layerPath := singleLayerPath(t, lockedImg)
+
+	buf := make([]byte, 1)
+	n, err := syscall.Getxattr(filepath.Join(layerPath, "opaque"), "trusted.overlay.opaque", buf)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{'y'}, buf[:n])
+
+	// File whiteouts should become character-device deletion markers, and the
+	// original .wh.* archive entry should not be left behind.
+	var st syscall.Stat_t
+	whiteoutPath := filepath.Join(layerPath, "deleted")
+	require.NoError(t, syscall.Lstat(whiteoutPath, &st))
+	assert.Equal(t, uint32(syscall.S_IFCHR), st.Mode&syscall.S_IFMT)
+	assert.Equal(t, uint64(0), uint64(st.Rdev))
+	_, err = os.Lstat(filepath.Join(layerPath, ".wh.deleted"))
+	assert.True(t, os.IsNotExist(err), "whiteout marker should be represented as the deleted path")
 }
 
 func TestImageStoreTracksUncompressedLayerSize(t *testing.T) {

--- a/server/util/fsync/BUILD
+++ b/server/util/fsync/BUILD
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "fsync",
-    srcs = ["fsync.go"],
+    srcs = [
+        "fsync.go",
+        "mknod_linux.go",
+        "mknod_unsupported.go",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/fsync",
     visibility = ["//visibility:public"],
     deps = [

--- a/server/util/fsync/fsync.go
+++ b/server/util/fsync/fsync.go
@@ -8,19 +8,18 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"golang.org/x/sys/unix"
 )
 
-// Syncer is a function that syncs a path to disk.
+// Syncer is a function that syncs a path relative to a Root to disk.
 type Syncer func(path string) error
 
 // Root tracks filesystem operations within a root directory and syncs them
 // all at once when Sync is called. This is more efficient than syncing after
-// each operation.
+// each operation. Operation paths are interpreted relative to the root.
 type Root struct {
-	root   string
+	root   *os.Root
 	paths  map[string]struct{}
 	synced map[string]struct{}
 	syncer Syncer
@@ -28,19 +27,35 @@ type Root struct {
 
 // NewRoot creates a Root that will track and sync paths within the given root
 // directory. The root directory itself will be synced when Sync is called.
-// If syncer is nil, SyncPath is used.
-func NewRoot(root string, syncer Syncer) *Root {
-	if syncer == nil {
-		syncer = SyncPath
+// If syncer is nil, paths are synced through os.Root.
+func NewRoot(root string, syncer Syncer) (*Root, error) {
+	or, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
 	}
 	r := &Root{
-		root:   filepath.Clean(root),
+		root:   or,
 		paths:  make(map[string]struct{}),
 		synced: make(map[string]struct{}),
-		syncer: syncer,
 	}
-	r.add(r.root)
-	return r
+	if syncer == nil {
+		syncer = r.syncPath
+	}
+	r.syncer = syncer
+	r.add(".")
+	return r, nil
+}
+
+// Close closes the underlying os.Root.
+func (r *Root) Close() error {
+	return r.root.Close()
+}
+
+func (r *Root) localPath(path string) string {
+	if path == "" {
+		return "."
+	}
+	return filepath.Clean(path)
 }
 
 // add registers a path to be synced when Sync is called.
@@ -55,12 +70,40 @@ func (r *Root) addParent(path string) {
 	r.add(filepath.Dir(path))
 }
 
-// MkdirAll creates a directory (and any necessary parents) and sets ownership.
-func (r *Root) MkdirAll(path string, mode os.FileMode, uid, gid int) error {
-	if err := os.MkdirAll(path, mode); err != nil {
+// MkdirAll creates a directory and any necessary parents.
+func (r *Root) MkdirAll(path string, mode os.FileMode) error {
+	path = r.localPath(path)
+	if err := r.root.MkdirAll(path, mode); err != nil {
 		return err
 	}
-	if err := os.Chown(path, uid, gid); err != nil {
+	r.add(path)
+	return nil
+}
+
+// Chown changes ownership of a file or directory.
+func (r *Root) Chown(path string, uid, gid int) error {
+	path = r.localPath(path)
+	if err := r.root.Chown(path, uid, gid); err != nil {
+		return err
+	}
+	r.add(path)
+	return nil
+}
+
+// Lchown changes ownership of a file or symlink.
+func (r *Root) Lchown(path string, uid, gid int) error {
+	path = r.localPath(path)
+	if err := r.root.Lchown(path, uid, gid); err != nil {
+		return err
+	}
+	r.addParent(path)
+	return nil
+}
+
+// Chmod changes mode bits of a file or directory.
+func (r *Root) Chmod(path string, mode os.FileMode) error {
+	path = r.localPath(path)
+	if err := r.root.Chmod(path, mode); err != nil {
 		return err
 	}
 	r.add(path)
@@ -69,16 +112,25 @@ func (r *Root) MkdirAll(path string, mode os.FileMode, uid, gid int) error {
 
 // CreateFile creates a file, writes data to it, and sets ownership.
 func (r *Root) CreateFile(path string, mode os.FileMode, data io.Reader, uid, gid int) error {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	path = r.localPath(path)
+	f, err := r.root.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	if _, err := io.Copy(f, data); err != nil {
+		f.Close()
 		return err
 	}
 	if err := f.Chown(uid, gid); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Chmod(mode); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
 		return err
 	}
 	r.add(path)
@@ -86,12 +138,10 @@ func (r *Root) CreateFile(path string, mode os.FileMode, data io.Reader, uid, gi
 	return nil
 }
 
-// Symlink creates a symbolic link and sets ownership.
-func (r *Root) Symlink(oldname, newname string, uid, gid int) error {
-	if err := os.Symlink(oldname, newname); err != nil {
-		return err
-	}
-	if err := os.Lchown(newname, uid, gid); err != nil {
+// Symlink creates a symbolic link.
+func (r *Root) Symlink(oldname, newname string) error {
+	newname = r.localPath(newname)
+	if err := r.root.Symlink(oldname, newname); err != nil {
 		return err
 	}
 	r.addParent(newname)
@@ -100,7 +150,9 @@ func (r *Root) Symlink(oldname, newname string, uid, gid int) error {
 
 // Link creates a hard link.
 func (r *Root) Link(oldname, newname string) error {
-	if err := os.Link(oldname, newname); err != nil {
+	oldname = r.localPath(oldname)
+	newname = r.localPath(newname)
+	if err := r.root.Link(oldname, newname); err != nil {
 		return err
 	}
 	r.addParent(newname)
@@ -109,7 +161,16 @@ func (r *Root) Link(oldname, newname string) error {
 
 // Mknod creates a device node.
 func (r *Root) Mknod(path string, mode uint32, dev int) error {
-	if err := unix.Mknod(path, mode, dev); err != nil {
+	path = r.localPath(path)
+	f, err := r.root.OpenFile(filepath.Dir(path), os.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return err
+	}
+	if err := mknodAt(int(f.Fd()), filepath.Base(path), mode, dev); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
 		return err
 	}
 	r.addParent(path)
@@ -118,7 +179,16 @@ func (r *Root) Mknod(path string, mode uint32, dev int) error {
 
 // Setxattr sets an extended attribute.
 func (r *Root) Setxattr(path string, attr string, data []byte, flags int) error {
-	if err := unix.Setxattr(path, attr, data, flags); err != nil {
+	path = r.localPath(path)
+	f, err := r.root.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	if err := unix.Fsetxattr(int(f.Fd()), attr, data, flags); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
 		return err
 	}
 	r.add(path)
@@ -137,30 +207,19 @@ func (r *Root) Sync() error {
 
 func (r *Root) syncUpwards(path string) error {
 	for cur := filepath.Clean(path); ; {
-		if cur == "" || cur == "." {
+		if cur == "" {
 			break
 		}
 		if _, ok := r.synced[cur]; ok {
 			break
 		}
-		if r.root != "" {
-			if cur == r.root {
-				if _, explicitlyTracked := r.paths[cur]; explicitlyTracked {
-					if err := r.syncer(cur); err != nil {
-						return err
-					}
-				}
-				r.synced[cur] = struct{}{}
-				break
-			}
-			if !strings.HasPrefix(cur, r.root+string(os.PathSeparator)) {
-				break
-			}
-		}
 		if err := r.syncer(cur); err != nil {
 			return err
 		}
 		r.synced[cur] = struct{}{}
+		if cur == "." {
+			break
+		}
 
 		parent := filepath.Dir(cur)
 		if parent == cur {
@@ -169,6 +228,15 @@ func (r *Root) syncUpwards(path string) error {
 		cur = parent
 	}
 	return nil
+}
+
+func (r *Root) syncPath(path string) error {
+	f, err := r.root.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
 }
 
 // SyncPath opens a path and syncs it to disk.

--- a/server/util/fsync/fsync_test.go
+++ b/server/util/fsync/fsync_test.go
@@ -12,14 +12,18 @@ import (
 
 func TestRootMkdirAll(t *testing.T) {
 	root := t.TempDir()
-	r := fsync.NewRoot(root, nil)
+	r, err := fsync.NewRoot(root, nil)
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	defer r.Close()
 
-	dir := filepath.Join(root, "subdir")
-	if err := r.MkdirAll(dir, 0755, os.Getuid(), os.Getgid()); err != nil {
+	dir := "subdir"
+	if err := r.MkdirAll(dir, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	info, err := os.Stat(dir)
+	info, err := os.Stat(filepath.Join(root, dir))
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
@@ -34,14 +38,18 @@ func TestRootMkdirAll(t *testing.T) {
 
 func TestRootSymlink(t *testing.T) {
 	root := t.TempDir()
-	r := fsync.NewRoot(root, nil)
+	r, err := fsync.NewRoot(root, nil)
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	defer r.Close()
 
-	link := filepath.Join(root, "link")
-	if err := r.Symlink("target", link, os.Getuid(), os.Getgid()); err != nil {
+	link := "link"
+	if err := r.Symlink("target", link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	target, err := os.Readlink(link)
+	target, err := os.Readlink(filepath.Join(root, link))
 	if err != nil {
 		t.Fatalf("readlink: %v", err)
 	}
@@ -56,21 +64,25 @@ func TestRootSymlink(t *testing.T) {
 
 func TestRootLink(t *testing.T) {
 	root := t.TempDir()
-	r := fsync.NewRoot(root, nil)
+	r, err := fsync.NewRoot(root, nil)
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	defer r.Close()
 
 	// Create original file
-	original := filepath.Join(root, "original")
-	if err := os.WriteFile(original, []byte("data"), 0644); err != nil {
+	original := "original"
+	if err := os.WriteFile(filepath.Join(root, original), []byte("data"), 0644); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
 
-	link := filepath.Join(root, "link")
+	link := "link"
 	if err := r.Link(original, link); err != nil {
 		t.Fatalf("link: %v", err)
 	}
 
 	// Verify link exists and has same content
-	data, err := os.ReadFile(link)
+	data, err := os.ReadFile(filepath.Join(root, link))
 	if err != nil {
 		t.Fatalf("read file: %v", err)
 	}
@@ -85,15 +97,19 @@ func TestRootLink(t *testing.T) {
 
 func TestRootCreateFile(t *testing.T) {
 	root := t.TempDir()
-	r := fsync.NewRoot(root, nil)
+	r, err := fsync.NewRoot(root, nil)
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	defer r.Close()
 
-	path := filepath.Join(root, "file.txt")
+	path := "file.txt"
 	content := []byte("hello world")
 	if err := r.CreateFile(path, 0644, bytes.NewReader(content), os.Getuid(), os.Getgid()); err != nil {
 		t.Fatalf("create file: %v", err)
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Join(root, path))
 	if err != nil {
 		t.Fatalf("read file: %v", err)
 	}
@@ -101,7 +117,7 @@ func TestRootCreateFile(t *testing.T) {
 		t.Fatalf("expected content %q, got %q", content, data)
 	}
 
-	info, err := os.Stat(path)
+	info, err := os.Stat(filepath.Join(root, path))
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
@@ -121,21 +137,23 @@ func TestSyncOrder(t *testing.T) {
 		synced = append(synced, path)
 		return nil
 	}
-	r := fsync.NewRoot(root, syncer)
-
-	uid, gid := os.Getuid(), os.Getgid()
+	r, err := fsync.NewRoot(root, syncer)
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	defer r.Close()
 
 	// Create nested directories in various orders
-	if err := r.MkdirAll(filepath.Join(root, "a"), 0755, uid, gid); err != nil {
+	if err := r.MkdirAll("a", 0755); err != nil {
 		t.Fatalf("mkdir a: %v", err)
 	}
-	if err := r.MkdirAll(filepath.Join(root, "a/b"), 0755, uid, gid); err != nil {
+	if err := r.MkdirAll(filepath.Join("a", "b"), 0755); err != nil {
 		t.Fatalf("mkdir a/b: %v", err)
 	}
-	if err := r.MkdirAll(filepath.Join(root, "a/b/c"), 0755, uid, gid); err != nil {
+	if err := r.MkdirAll(filepath.Join("a", "b", "c"), 0755); err != nil {
 		t.Fatalf("mkdir a/b/c: %v", err)
 	}
-	if err := r.MkdirAll(filepath.Join(root, "x"), 0755, uid, gid); err != nil {
+	if err := r.MkdirAll("x", 0755); err != nil {
 		t.Fatalf("mkdir x: %v", err)
 	}
 
@@ -145,14 +163,35 @@ func TestSyncOrder(t *testing.T) {
 
 	// All tracked paths and their ancestors up to root should be synced.
 	expected := []string{
-		filepath.Join(root, "a/b/c"),
-		filepath.Join(root, "a/b"),
-		filepath.Join(root, "a"),
-		root,
-		filepath.Join(root, "x"),
+		filepath.Join("a", "b", "c"),
+		filepath.Join("a", "b"),
+		"a",
+		".",
+		"x",
 	}
 
 	assert.ElementsMatch(t, expected, synced)
+}
+
+func TestRootRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	escapeDir := t.TempDir()
+	escapeFile := filepath.Join(escapeDir, "pwned.txt")
+	r, err := fsync.NewRoot(root, nil)
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	defer r.Close()
+
+	if err := r.Symlink(escapeDir, "link"); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	err = r.CreateFile(filepath.Join("link", "pwned.txt"), 0644, bytes.NewReader([]byte("pwned")), os.Getuid(), os.Getgid())
+	if err == nil {
+		t.Fatal("expected symlink escape to fail")
+	}
+	_, err = os.Stat(escapeFile)
+	assert.True(t, os.IsNotExist(err), "file outside root should not be created")
 }
 
 // Note: not testing Setxattr or Mknod since they may require certain perms.

--- a/server/util/fsync/mknod_linux.go
+++ b/server/util/fsync/mknod_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package fsync
+
+import "golang.org/x/sys/unix"
+
+func mknodAt(dirfd int, path string, mode uint32, dev int) error {
+	return unix.Mknodat(dirfd, path, mode, dev)
+}

--- a/server/util/fsync/mknod_unsupported.go
+++ b/server/util/fsync/mknod_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package fsync
+
+import "golang.org/x/sys/unix"
+
+func mknodAt(dirfd int, path string, mode uint32, dev int) error {
+	return unix.ENOSYS
+}


### PR DESCRIPTION
A crafted OCI layer can create a symlink that points outside the layer
unpack directory and then write a later file through that symlink. Harden
layer extraction by resolving archive paths through `os.Root` and by
performing whiteout `mknod` and `setxattr` operations through rooted
directory file descriptors.

Addresses these CodeQL code scanning alerts:
- [#53 go/unsafe-unzip-symlink](https://github.com/buildbuddy-io/buildbuddy/security/code-scanning/53)
- [#54 go/unsafe-unzip-symlink](https://github.com/buildbuddy-io/buildbuddy/security/code-scanning/54)
- [#55 go/zipslip](https://github.com/buildbuddy-io/buildbuddy/security/code-scanning/55)
