### PR TITLE
Reduce tracing overhead a bit

### DIFF
--- a/enterprise/server/clientidentity/BUILD
+++ b/enterprise/server/clientidentity/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//server/util/authutil",
         "//server/util/flag",
         "//server/util/status",
-        "//server/util/tracing",
         "@com_github_golang_jwt_jwt_v4//:jwt",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@org_golang_google_grpc//metadata",

--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -10,7 +10,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc/metadata"
@@ -129,10 +128,6 @@ func (s *Service) AddIdentityToContext(ctx context.Context) (context.Context, er
 }
 
 func (s *Service) ValidateIncomingIdentity(ctx context.Context) (context.Context, error) {
-	// Don't save the trace context so that this isn't a parent of the calls
-	// that use the returned context.
-	_, span := tracing.StartSpan(ctx)
-	defer span.End()
 	vals := metadata.ValueFromIncomingContext(ctx, authutil.ClientIdentityHeaderName)
 	if len(vals) == 0 {
 		if !*required {

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -92,7 +92,7 @@ func contextReplacingUnaryClientInterceptor(ctxFn func(ctx context.Context) cont
 func AddAuthToContext(env environment.Env, ctx context.Context) context.Context {
 	// Don't save the trace context so that this isn't a parent of the calls
 	// that use the returned context.
-	_, span := tracing.StartSpan(ctx)
+	_, span := tracing.StartNamedSpan(ctx, "interceptors.AddAuthToContext")
 	defer span.End()
 	ctx = env.GetAuthenticator().AuthenticatedGRPCContext(ctx)
 	if c, err := claims.ClaimsFromContext(ctx); err == nil {


### PR DESCRIPTION
clientidentity.ValidateIncomingIdentity doesn't make an RPC and is always fast, so remove the span.

interceptors.AddAuthToContext can make an RPC, and it's useful to have the group and user IDs in span attributes, but it happens on every incoming RPC, so reduce the overhead by using a named span instead of having to get the call stack.