### PR TITLE
Optimize rangecache.go a bit

### DIFF
--- a/enterprise/server/raft/rangecache/BUILD
+++ b/enterprise/server/raft/rangecache/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//server/metrics",
         "//server/util/log",
         "//server/util/rangemap",
-        "//server/util/status",
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@io_opentelemetry_go_otel//attribute",

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rangemap"
-	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
@@ -17,42 +17,27 @@ import (
 )
 
 // RangeCache is a synchronous map from ranges to their descriptors.
+//
+// Descriptors are stored behind atomic pointers so SetPreferredReplica can
+// swap in a new descriptor without holding the cache-wide write lock. The
+// stored *rfpb.RangeDescriptor is treated as immutable; mutators must clone,
+// modify, then Store a new pointer.
 type RangeCache struct {
 	rangeMu sync.RWMutex
 
-	// Keep a rangemap that maps from ranges to descriptors.
-	rangeMap *rangemap.RangeMap[*lockingRangeDescriptor]
+	rangeMap *rangemap.RangeMap[*atomic.Pointer[rfpb.RangeDescriptor]]
 }
 
 func New() *RangeCache {
 	return &RangeCache{
-		rangeMu:  sync.RWMutex{},
-		rangeMap: rangemap.New[*lockingRangeDescriptor](),
+		rangeMap: rangemap.New[*atomic.Pointer[rfpb.RangeDescriptor]](),
 	}
 }
 
-// A lockingRangeDescriptor pointer is stored in the rangeMap to prevent
-// data races when mutating the order of replicas elsewhere.
-type lockingRangeDescriptor struct {
-	mu sync.Mutex
-	rd *rfpb.RangeDescriptor
-}
-
-func newLockingRangeDescriptor(rd *rfpb.RangeDescriptor) *lockingRangeDescriptor {
-	return &lockingRangeDescriptor{
-		mu: sync.Mutex{},
-		rd: rd,
-	}
-}
-func (lr *lockingRangeDescriptor) Get() *rfpb.RangeDescriptor {
-	lr.mu.Lock()
-	defer lr.mu.Unlock()
-	return lr.rd
-}
-func (lr *lockingRangeDescriptor) Update(rd *rfpb.RangeDescriptor) {
-	lr.mu.Lock()
-	defer lr.mu.Unlock()
-	lr.rd = rd
+func newAtomicDescriptor(rd *rfpb.RangeDescriptor) *atomic.Pointer[rfpb.RangeDescriptor] {
+	p := &atomic.Pointer[rfpb.RangeDescriptor]{}
+	p.Store(rd)
+	return p
 }
 
 func (rc *RangeCache) updateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
@@ -66,27 +51,21 @@ func (rc *RangeCache) updateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
 
 	r := rc.rangeMap.Get(start, end)
 	if r == nil {
-		checkFn := func(r *lockingRangeDescriptor) bool {
-			v := r.Get()
-			return v.GetGeneration() < newDescriptor.GetGeneration()
+		checkFn := func(p *atomic.Pointer[rfpb.RangeDescriptor]) bool {
+			return p.Load().GetGeneration() < newDescriptor.GetGeneration()
 		}
-		added, err := rc.rangeMap.AddAndRemoveOverlapping(start, end, newLockingRangeDescriptor(newDescriptor), checkFn)
+		added, err := rc.rangeMap.AddAndRemoveOverlapping(start, end, newAtomicDescriptor(newDescriptor), checkFn)
 		if added {
 			log.Debugf("Adding new range: %d [%q, %q)", newDescriptor.GetRangeId(), start, end)
 		} else {
 			log.Debugf("Ignoring rangeDescriptor %+v, because current has same or later generation", newDescriptor)
 		}
 		return err
-	} else {
-		lr := r.Val
-		if lr == nil {
-			return status.FailedPreconditionError("Val was nil")
-		}
-		v := lr.Get()
-		if newDescriptor.GetGeneration() > v.GetGeneration() {
-			lr.Update(newDescriptor)
-			log.Debugf("Updated rangelease generation: [%q, %q) (%d -> %d)", start, end, v.GetGeneration(), newDescriptor.GetGeneration())
-		}
+	}
+	v := r.Val.Load()
+	if newDescriptor.GetGeneration() > v.GetGeneration() {
+		r.Val.Store(newDescriptor)
+		log.Debugf("Updated rangelease generation: [%q, %q) (%d -> %d)", start, end, v.GetGeneration(), newDescriptor.GetGeneration())
 	}
 	return nil
 }
@@ -118,14 +97,7 @@ func (rc *RangeCache) SetPreferredReplica(ctx context.Context, rep *rfpb.Replica
 		return
 	}
 
-	lr := r.Val
-	if lr == nil {
-		err := fmt.Errorf("locking range descriptor value for range [%q, %q) is nil", r.Start, r.End)
-		log.Error(err.Error())
-		tracing.RecordErrorToSpan(spn, err)
-		return
-	}
-	rd := lr.Get()
+	rd := r.Val.Load()
 	newDescriptor := rd.CloneVT()
 
 	leadReplicaIndex := -1
@@ -144,7 +116,7 @@ func (rc *RangeCache) SetPreferredReplica(ctx context.Context, rep *rfpb.Replica
 	}
 	newDescriptor.Replicas[0], newDescriptor.Replicas[leadReplicaIndex] = newDescriptor.Replicas[leadReplicaIndex], newDescriptor.Replicas[0]
 
-	lr.Update(newDescriptor)
+	r.Val.Store(newDescriptor)
 
 	replica_ids := make([]int64, 0, len(newDescriptor.GetReplicas()))
 	for _, repl := range newDescriptor.GetReplicas() {
@@ -168,7 +140,7 @@ func (rc *RangeCache) Get(key []byte) *rfpb.RangeDescriptor {
 
 	raftRangeCacheLookupCounter[found].Inc()
 	if found {
-		return lr.Get()
+		return lr.Load()
 	}
 	return nil
 }

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -102,8 +102,9 @@ func (rc *RangeCache) UpdateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
 // replica is not included in the range descriptor's replica list.
 func (rc *RangeCache) SetPreferredReplica(ctx context.Context, rep *rfpb.ReplicaDescriptor, rng *rfpb.RangeDescriptor) {
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
-	rangeIDAttr := attribute.Int64("range_id", int64(rep.GetRangeId()))
-	spn.SetAttributes(rangeIDAttr)
+	if spn.IsRecording() {
+		spn.SetAttributes(attribute.Int64("range_id", int64(rep.GetRangeId())))
+	}
 	defer spn.End()
 
 	rc.rangeMu.RLock()
@@ -145,12 +146,13 @@ func (rc *RangeCache) SetPreferredReplica(ctx context.Context, rep *rfpb.Replica
 
 	lr.Update(newDescriptor)
 
-	replica_ids := []int64{}
+	replica_ids := make([]int64, 0, len(newDescriptor.GetReplicas()))
 	for _, repl := range newDescriptor.GetReplicas() {
 		replica_ids = append(replica_ids, int64(repl.GetReplicaId()))
 	}
-	replicaIDAttr := attribute.Int64Slice("replicas", replica_ids)
-	spn.SetAttributes(replicaIDAttr)
+	if spn.IsRecording() {
+		spn.SetAttributes(attribute.Int64Slice("replicas", replica_ids))
+	}
 }
 
 var raftRangeCacheLookupCouter = map[bool]prometheus.Counter{

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -56,16 +56,13 @@ func (lr *lockingRangeDescriptor) Update(rd *rfpb.RangeDescriptor) {
 }
 
 func (rc *RangeCache) updateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
-	rc.rangeMu.Lock()
-	defer rc.rangeMu.Unlock()
-
-	metrics.RaftRangeCacheLookups.With(prometheus.Labels{
-		metrics.RaftRangeCacheEventTypeLabel: "update",
-	}).Inc()
-
+	metrics.RaftRangeCacheLookups.WithLabelValues("update").Inc()
 	start := rangeDescriptor.GetStart()
 	end := rangeDescriptor.GetEnd()
 	newDescriptor := rangeDescriptor.CloneVT()
+
+	rc.rangeMu.Lock()
+	defer rc.rangeMu.Unlock()
 
 	r := rc.rangeMap.Get(start, end)
 	if r == nil {
@@ -156,28 +153,26 @@ func (rc *RangeCache) SetPreferredReplica(ctx context.Context, rep *rfpb.Replica
 	spn.SetAttributes(replicaIDAttr)
 }
 
+var raftRangeCacheLookupCouter = map[bool]prometheus.Counter{
+	true:  metrics.RaftRangeCacheLookups.With(prometheus.Labels{metrics.RaftRangeCacheEventTypeLabel: "hit"}),
+	false: metrics.RaftRangeCacheLookups.With(prometheus.Labels{metrics.RaftRangeCacheEventTypeLabel: "miss"}),
+}
+
 // Get returns a RangeDescriptor that includes the given key within its range.
 func (rc *RangeCache) Get(key []byte) *rfpb.RangeDescriptor {
 	rc.rangeMu.RLock()
-	defer rc.rangeMu.RUnlock()
-
 	lr, found := rc.rangeMap.Lookup(key)
+	rc.rangeMu.RUnlock()
 
-	var rd *rfpb.RangeDescriptor
-	label := "miss"
-
+	raftRangeCacheLookupCouter[found].Inc()
 	if found {
-		rd = lr.Get()
-		label = "hit"
+		return lr.Get()
 	}
-
-	metrics.RaftRangeCacheLookups.With(prometheus.Labels{
-		metrics.RaftRangeCacheEventTypeLabel: label,
-	}).Inc()
-
-	return rd
+	return nil
 }
 
 func (rc *RangeCache) String() string {
+	rc.rangeMu.RLock()
+	defer rc.rangeMu.RUnlock()
 	return rc.rangeMap.String()
 }

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -155,7 +155,7 @@ func (rc *RangeCache) SetPreferredReplica(ctx context.Context, rep *rfpb.Replica
 	}
 }
 
-var raftRangeCacheLookupCouter = map[bool]prometheus.Counter{
+var raftRangeCacheLookupCounter = map[bool]prometheus.Counter{
 	true:  metrics.RaftRangeCacheLookups.With(prometheus.Labels{metrics.RaftRangeCacheEventTypeLabel: "hit"}),
 	false: metrics.RaftRangeCacheLookups.With(prometheus.Labels{metrics.RaftRangeCacheEventTypeLabel: "miss"}),
 }
@@ -166,7 +166,7 @@ func (rc *RangeCache) Get(key []byte) *rfpb.RangeDescriptor {
 	lr, found := rc.rangeMap.Lookup(key)
 	rc.rangeMu.RUnlock()
 
-	raftRangeCacheLookupCouter[found].Inc()
+	raftRangeCacheLookupCounter[found].Inc()
 	if found {
 		return lr.Get()
 	}


### PR DESCRIPTION
- Reduce locked regions
- reduce the metrics overhead
- don't add span attributes if not recording
- Use an atomic pointer instead of a mutex. The mutex was never held across a read-modify-write, so an atomic pointer can do the same.

Also fixed a race condition in RangeCache.String. It was iterating over a map while it could be mutated.