### PR TITLE
Set grpc.NumStreamWorkers in grpc_server.go

### DIFF
--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -219,6 +220,7 @@ func CommonGRPCServerOptionsWithConfig(env environment.Env, config GRPCServerCon
 		grpc.UnaryInterceptor(interceptors.TracedUnaryServerInterceptor("grpc_server.MetricsInterceptor", Metrics().UnaryServerInterceptor())),
 		experimental.BufferPool(mem.DefaultBufferPool()),
 		grpc.MaxRecvMsgSize(MaxRecvMsgSizeBytes()),
+		grpc.NumStreamWorkers(uint32(runtime.GOMAXPROCS(0))),
 		KeepaliveEnforcementPolicy(),
 	}
 	for _, h := range config.ExtraStatsHandlers {


### PR DESCRIPTION
This option keeps a pool of N goroutines to service incoming requests. This reduces how often we need to grow goroutine stacks, which is sometimes up to 5% of our CPU.

If the pool doesn't have any available goroutines, it gRPC will just start a new one. See docs in https://github.com/grpc/grpc-go/blob/caf0772c2bcb8bc15d43eb53448e921f34f0b7e8/server.go#L622. They say

> Preliminary experiments suggest that a value equal to the number of CPUs available is most performant.