### PR TITLE
Use tracing.StartNamedSpan in funcs where StartSpan dominates

### DIFF
--- a/enterprise/server/raft/nodeliveness/nodeliveness.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness.go
@@ -130,7 +130,7 @@ func (h *Liveness) BlockingGetCurrentNodeLiveness(ctx context.Context) (*rfpb.Ra
 }
 
 func (h *Liveness) BlockingValidateNodeLiveness(ctx context.Context, nl *rfpb.RangeLeaseRecord_NodeLiveness) (returnedErr error) {
-	ctx, span := tracing.StartSpan(ctx)
+	ctx, span := tracing.StartNamedSpan(ctx, "nodeliveness.Liveness.BlockingValidateNodeLiveness")
 	defer func() {
 		tracing.RecordErrorToSpan(span, returnedErr)
 		span.End()
@@ -149,7 +149,7 @@ func (h *Liveness) BlockingValidateNodeLiveness(ctx context.Context, nl *rfpb.Ra
 }
 
 func (h *Liveness) verifyLease(ctx context.Context, l *rfpb.NodeLivenessRecord) (retErr error) {
-	_, span := tracing.StartSpan(ctx)
+	_, span := tracing.StartNamedSpan(ctx, "nodeliveness.Liveness.verifyLease")
 	defer func() {
 		tracing.RecordErrorToSpan(span, retErr)
 		span.End()
@@ -184,7 +184,7 @@ func (h *Liveness) setLastLivenessRecord(nlr *rfpb.NodeLivenessRecord) {
 }
 
 func (h *Liveness) ensureValidLease(ctx context.Context, forceRenewal bool) (returnedRecord *rfpb.NodeLivenessRecord, returnedErr error) {
-	ctx, span := tracing.StartSpan(ctx)
+	ctx, span := tracing.StartNamedSpan(ctx, "nodeliveness.Liveness.ensureValidLease")
 	defer func() {
 		tracing.RecordErrorToSpan(span, returnedErr)
 		span.End()
@@ -240,7 +240,7 @@ func (h *Liveness) ensureValidLease(ctx context.Context, forceRenewal bool) (ret
 }
 
 func (h *Liveness) sendCasRequest(ctx context.Context, expectedValue, newVal []byte) (retKV *rfpb.KV, retErr error) {
-	ctx, span := tracing.StartSpan(ctx)
+	ctx, span := tracing.StartNamedSpan(ctx, "nodeliveness.Liveness.sendCasRequest")
 	defer func() {
 		tracing.RecordErrorToSpan(span, retErr)
 		span.End()
@@ -268,13 +268,8 @@ func (h *Liveness) sendCasRequest(ctx context.Context, expectedValue, newVal []b
 	return nil, err
 }
 
-func (h *Liveness) clearLease() error {
-	h.setLastLivenessRecord(nil)
-	return nil
-}
-
 func (h *Liveness) renewLease(ctx context.Context) (returnedErr error) {
-	ctx, span := tracing.StartSpan(ctx)
+	ctx, span := tracing.StartNamedSpan(ctx, "nodeliveness.Liveness.renewLease")
 	defer func() {
 		tracing.RecordErrorToSpan(span, returnedErr)
 		span.End()

--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -136,7 +136,7 @@ func (l *Lease) GetRangeID() uint64 {
 }
 
 func (l *Lease) verifyLease(ctx context.Context, rl *rfpb.RangeLeaseRecord) (returnedErr error) {
-	ctx, span := tracing.StartSpan(ctx)
+	ctx, span := tracing.StartNamedSpan(ctx, "rangelease.Lease.verifyLease")
 	defer func() {
 		tracing.RecordErrorToSpan(span, returnedErr)
 		span.End()

--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -250,7 +250,7 @@ func (s *StaticRegistry) LookupByNHID(nhid string) (*rfpb.ConnectionInfo, error)
 
 // ResolveGRPC returns the gRPC address and the connection key of the specified node.
 func (n *StaticRegistry) ResolveGRPC(ctx context.Context, nhid string) (returnedAddr string, returnedErr error) {
-	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
+	ctx, spn := tracing.StartNamedSpan(ctx, "registry.StaticRegistry.ResolveGRPC") // nolint:SA4006
 
 	defer func() {
 		tracing.RecordErrorToSpan(spn, returnedErr)
@@ -561,7 +561,7 @@ func (d *DynamicNodeRegistry) Lookup(ctx context.Context, rangeID uint64, replic
 
 // ResolveGRPC returns the gRPC address and the connection key of the specified node.
 func (d *DynamicNodeRegistry) ResolveGRPC(ctx context.Context, nhid string) (addr string, returnedErr error) {
-	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
+	ctx, spn := tracing.StartNamedSpan(ctx, "registry.DynamicNodeRegistry.ResolveGRPC") // nolint:SA4006
 	defer func() {
 		tracing.RecordErrorToSpan(spn, returnedErr)
 		spn.End()


### PR DESCRIPTION
In all of these functions, getting the call stack for the span name is more than half of their CPU.

<img width="2560" height="482" alt="image" src="https://github.com/user-attachments/assets/d36e2476-f491-4c29-8c56-8449628457c1" />
