### PR TITLE
[B] Add metronome package

### DIFF
--- a/enterprise/server/billing/metronome/BUILD
+++ b/enterprise/server/billing/metronome/BUILD
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "metronome",
+    srcs = ["metronome.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/billing/metronome",
+    deps = [
+        "//server/http/httpclient",
+        "//server/usage/sku",
+        "//server/util/flag",
+        "//server/util/region",
+        "//server/util/retry",
+        "//server/util/status",
+    ],
+)
+
+go_test(
+    name = "metronome_test",
+    size = "small",
+    srcs = ["metronome_test.go"],
+    deps = [
+        ":metronome",
+        "//server/usage/sku",
+        "//server/util/retry",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/billing/metronome/metronome.go
+++ b/enterprise/server/billing/metronome/metronome.go
@@ -1,0 +1,249 @@
+package metronome
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/http/httpclient"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/region"
+	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+var (
+	apiKey = flag.String("billing.metronome.api_key", "", "Metronome bearer token used to ingest usage events.", flag.Secret)
+	apiURL = flag.String("billing.metronome.api_url", "https://api.metronome.com", "Metronome API base URL.", flag.Internal)
+)
+
+const (
+	ingestPath                = "/v1/ingest"
+	MaxEventsPerIngestRequest = 100
+)
+
+func defaultRetryOptions() *retry.Options {
+	return &retry.Options{
+		MaxRetries:     5,
+		InitialBackoff: 1 * time.Second,
+		MaxBackoff:     30 * time.Second,
+		Multiplier:     2,
+		Name:           "metronome ingest",
+	}
+}
+
+// UsageEvent represents a usage event expressed in BB vocabulary (SKUs, labels).
+// encodeEvent translates it to Metronome's expected format.
+type UsageEvent struct {
+	GroupID     string
+	PeriodStart time.Time
+	SKU         sku.SKU
+	Labels      map[sku.LabelName]sku.LabelValue
+	Count       int64
+	Unit        string
+}
+
+// MetronomeEvent is the JSON payload Metronome's /v1/ingest endpoint expects.
+type MetronomeEvent struct {
+	TransactionID string            `json:"transaction_id"`
+	CustomerID    string            `json:"customer_id"`
+	EventType     string            `json:"event_type"`
+	Timestamp     string            `json:"timestamp"`
+	Properties    map[string]string `json:"properties"`
+}
+
+type Client struct {
+	httpClient   *http.Client
+	retryOptions *retry.Options
+}
+
+func NewClient(httpClient *http.Client, retryOpts *retry.Options) (*Client, error) {
+	if *apiKey == "" {
+		return nil, status.FailedPreconditionError("billing.metronome.api_key is required")
+	}
+	if *apiURL == "" {
+		return nil, status.FailedPreconditionError("billing.metronome.api_url is required")
+	}
+	if httpClient == nil {
+		httpClient = httpclient.New(nil, "metronome")
+		httpClient.Timeout = 30 * time.Second
+	}
+	if retryOpts == nil {
+		retryOpts = defaultRetryOptions()
+	}
+	return &Client{
+		httpClient:   httpClient,
+		retryOptions: retryOpts,
+	}, nil
+}
+
+// ReportUsage posts usage events to Metronome.
+//
+// Events are idempotent: the deterministic transaction_id means re-ingesting
+// the same event is a no-op on Metronome's side.
+func (c *Client) ReportUsage(ctx context.Context, events []UsageEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	encoded := make([]MetronomeEvent, 0, len(events))
+	for _, e := range events {
+		ue, err := encodeEvent(e)
+		if err != nil {
+			return err
+		}
+		encoded = append(encoded, *ue)
+	}
+	for start := 0; start < len(encoded); start += MaxEventsPerIngestRequest {
+		end := start + MaxEventsPerIngestRequest
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		batch := encoded[start:end]
+		err := retry.DoVoid(ctx, c.retryOptions, func(ctx context.Context) error {
+			err := c.ingestToMetronome(ctx, batch)
+			if err == nil {
+				return nil
+			}
+			if !isRetryable(err) {
+				return retry.NonRetryableError(err)
+			}
+			return err
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodeEvent(e UsageEvent) (*MetronomeEvent, error) {
+	if e.GroupID == "" {
+		return nil, status.InvalidArgumentError("group ID is required")
+	}
+	properties := map[string]string{
+		"group_id": e.GroupID,
+		"sku":      e.SKU.String(),
+		"count":    strconv.FormatInt(e.Count, 10),
+		"unit":     e.Unit,
+	}
+	for k, v := range e.Labels {
+		properties[k] = v
+	}
+	return &MetronomeEvent{
+		TransactionID: transactionID(e),
+		CustomerID:    e.GroupID,
+		EventType:     e.SKU.String(),
+		Timestamp:     e.PeriodStart.UTC().Format(time.RFC3339),
+		Properties:    properties,
+	}, nil
+}
+
+// transactionID is a deterministic ID used so Metronome can dedupe
+// retries and overlapping export windows.
+func transactionID(e UsageEvent) string {
+	var b strings.Builder
+	writeField := func(s string) {
+		b.WriteString(strconv.Itoa(len(s)))
+		b.WriteString(":")
+		b.WriteString(s)
+	}
+	writeField(e.GroupID)
+	writeField(region.ConfiguredAppRegion())
+	writeField(e.PeriodStart.UTC().Format(time.RFC3339))
+	writeField(e.SKU.String())
+	keys := make([]string, 0, len(e.Labels))
+	for k := range e.Labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeField(k)
+		writeField(e.Labels[k])
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return "bb:" + hex.EncodeToString(sum[:])
+}
+
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if status.IsInvalidArgumentError(err) ||
+		status.IsUnauthenticatedError(err) ||
+		status.IsPermissionDeniedError(err) ||
+		status.IsNotFoundError(err) ||
+		status.IsFailedPreconditionError(err) {
+		return false
+	}
+	return true
+}
+
+func (c *Client) ingestToMetronome(ctx context.Context, events []MetronomeEvent) error {
+	// The ingest endpoint expects a bare JSON array of events.
+	// See: https://docs.metronome.com/api-reference/usage/ingest-events
+	body, err := json.Marshal(events)
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest(ctx, http.MethodPost, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return errorForStatusCode(resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+func (c *Client) newRequest(ctx context.Context, method string, body io.Reader) (*http.Request, error) {
+	endpoint, err := url.JoinPath(*apiURL, ingestPath)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(*apiKey))
+	return req, nil
+}
+
+func errorForStatusCode(statusCode int, body string) error {
+	message := "Metronome API error: status " + strconv.Itoa(statusCode) + ": " + body
+	switch statusCode {
+	case http.StatusBadRequest:
+		return status.InvalidArgumentError(message)
+	case http.StatusUnauthorized:
+		return status.UnauthenticatedError(message)
+	case http.StatusForbidden:
+		return status.PermissionDeniedError(message)
+	case http.StatusNotFound:
+		return status.NotFoundError(message)
+	case http.StatusTooManyRequests:
+		return status.ResourceExhaustedError(message)
+	}
+	if statusCode >= http.StatusInternalServerError {
+		return status.UnavailableError(message)
+	}
+	return status.InternalError(message)
+}

--- a/enterprise/server/billing/metronome/metronome.go
+++ b/enterprise/server/billing/metronome/metronome.go
@@ -50,7 +50,6 @@ type UsageEvent struct {
 	SKU         sku.SKU
 	Labels      map[sku.LabelName]sku.LabelValue
 	Count       int64
-	Unit        string
 }
 
 // MetronomeEvent is the JSON payload Metronome's /v1/ingest endpoint expects.
@@ -134,7 +133,6 @@ func encodeEvent(e UsageEvent) (*MetronomeEvent, error) {
 		"group_id": e.GroupID,
 		"sku":      e.SKU.String(),
 		"count":    strconv.FormatInt(e.Count, 10),
-		"unit":     e.Unit,
 	}
 	for k, v := range e.Labels {
 		properties[k] = v

--- a/enterprise/server/billing/metronome/metronome_test.go
+++ b/enterprise/server/billing/metronome/metronome_test.go
@@ -1,0 +1,169 @@
+package metronome_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/billing/metronome"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
+	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	testflags "github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+)
+
+func TestIngestEvents(t *testing.T) {
+	var gotEvents []metronome.MetronomeEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var batch []metronome.MetronomeEvent
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&batch))
+		gotEvents = append(gotEvents, batch...)
+	}))
+	defer server.Close()
+
+	testflags.Set(t, "http.client.allow_localhost", true)
+	testflags.Set(t, "billing.metronome.api_key", "test-key")
+	testflags.Set(t, "billing.metronome.api_url", server.URL)
+
+	periodStart := time.Date(2026, 5, 15, 12, 34, 0, 0, time.UTC)
+	events := []metronome.UsageEvent{
+		{GroupID: "GR1", PeriodStart: periodStart, SKU: sku.BuildEventsBESCount, Count: 1, Unit: "count"},
+		{GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASDownloadedBytes, Count: 2_000_000_000, Unit: "bytes",
+			Labels: map[sku.LabelName]sku.LabelValue{sku.Origin: sku.OriginExternal, sku.Client: sku.ClientBazel}},
+	}
+	c, err := metronome.NewClient(nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, c.ReportUsage(t.Context(), events))
+
+	require.Len(t, gotEvents, 2)
+	txids := map[string]bool{}
+	for _, e := range gotEvents {
+		assert.Equal(t, "GR1", e.CustomerID)
+		assert.Equal(t, periodStart.Format(time.RFC3339), e.Timestamp)
+		assert.Equal(t, e.EventType, e.Properties["sku"])
+		assert.Equal(t, 67, len(e.TransactionID)) // "bb:" + 64 hex chars
+		txids[e.TransactionID] = true
+	}
+	assert.Len(t, txids, 2, "transaction IDs should be distinct per (sku, labels)")
+}
+
+func TestIngestEventsBatching(t *testing.T) {
+	var requests int32
+	var totalEvents int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		var batch []metronome.MetronomeEvent
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&batch))
+		atomic.AddInt32(&totalEvents, int32(len(batch)))
+	}))
+	defer server.Close()
+
+	testflags.Set(t, "http.client.allow_localhost", true)
+	testflags.Set(t, "billing.metronome.api_key", "test-key")
+	testflags.Set(t, "billing.metronome.api_url", server.URL)
+
+	const n = metronome.MaxEventsPerIngestRequest*2 + 5
+	events := make([]metronome.UsageEvent, n)
+	for i := range events {
+		events[i] = metronome.UsageEvent{
+			GroupID: "GR1", PeriodStart: time.Unix(int64(i*60), 0).UTC(),
+			SKU: sku.BuildEventsBESCount, Count: 1, Unit: "count",
+		}
+	}
+	c, err := metronome.NewClient(nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, c.ReportUsage(t.Context(), events))
+	assert.EqualValues(t, 3, atomic.LoadInt32(&requests))
+	assert.EqualValues(t, n, atomic.LoadInt32(&totalEvents))
+}
+
+func TestIngestRetriesTransientFailures(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			http.Error(w, "boom", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	testflags.Set(t, "http.client.allow_localhost", true)
+	testflags.Set(t, "billing.metronome.api_key", "test-key")
+	testflags.Set(t, "billing.metronome.api_url", server.URL)
+
+	c, err := metronome.NewClient(nil, &retry.Options{
+		MaxRetries: 5, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, Multiplier: 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.ReportUsage(t.Context(), []metronome.UsageEvent{{
+		GroupID: "GR1", PeriodStart: time.Now(), SKU: sku.BuildEventsBESCount, Count: 1, Unit: "count",
+	}}))
+	assert.EqualValues(t, 3, atomic.LoadInt32(&attempts))
+}
+
+func TestIngestDoesNotRetryClientErrors(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	testflags.Set(t, "http.client.allow_localhost", true)
+	testflags.Set(t, "billing.metronome.api_key", "test-key")
+	testflags.Set(t, "billing.metronome.api_url", server.URL)
+
+	c, err := metronome.NewClient(nil, &retry.Options{
+		MaxRetries: 5, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, Multiplier: 1,
+	})
+	require.NoError(t, err)
+	err = c.ReportUsage(t.Context(), []metronome.UsageEvent{{
+		GroupID: "GR1", PeriodStart: time.Now(), SKU: sku.BuildEventsBESCount, Count: 1, Unit: "count",
+	}})
+	require.Error(t, err)
+	assert.True(t, status.IsInvalidArgumentError(err))
+	assert.EqualValues(t, 1, atomic.LoadInt32(&attempts))
+}
+
+func TestTransactionIDDeterministic(t *testing.T) {
+	var gotEvents []metronome.MetronomeEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var batch []metronome.MetronomeEvent
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&batch))
+		gotEvents = append(gotEvents, batch...)
+	}))
+	defer server.Close()
+
+	testflags.Set(t, "http.client.allow_localhost", true)
+	testflags.Set(t, "billing.metronome.api_key", "test-key")
+	testflags.Set(t, "billing.metronome.api_url", server.URL)
+
+	periodStart := time.Date(2026, 5, 15, 12, 34, 0, 0, time.UTC)
+
+	// Ingest two events with the same period, SKU, and labels, even though the labels are in a different order and the  count is different.
+	c, err := metronome.NewClient(nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, c.ReportUsage(t.Context(), []metronome.UsageEvent{{
+		GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASHits, Count: 1, Unit: "count",
+		Labels: map[sku.LabelName]sku.LabelValue{sku.Origin: sku.OriginExternal, sku.Client: sku.ClientBazel},
+	}}))
+	require.NoError(t, c.ReportUsage(t.Context(), []metronome.UsageEvent{{
+		GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASHits, Count: 999, Unit: "count",
+		Labels: map[sku.LabelName]sku.LabelValue{sku.Client: sku.ClientBazel, sku.Origin: sku.OriginExternal},
+	}}))
+	require.Len(t, gotEvents, 2)
+
+	// Check that the transaction IDs are the same.
+	// Metronome de-dupes duplicate transaction IDs, which it important to prevent double-billing retries.
+	assert.Equal(t, gotEvents[0].TransactionID, gotEvents[1].TransactionID, "transaction ID must be independent of count and label-map iteration order")
+}

--- a/enterprise/server/billing/metronome/metronome_test.go
+++ b/enterprise/server/billing/metronome/metronome_test.go
@@ -36,8 +36,8 @@ func TestIngestEvents(t *testing.T) {
 
 	periodStart := time.Date(2026, 5, 15, 12, 34, 0, 0, time.UTC)
 	events := []metronome.UsageEvent{
-		{GroupID: "GR1", PeriodStart: periodStart, SKU: sku.BuildEventsBESCount, Count: 1, Unit: "count"},
-		{GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASDownloadedBytes, Count: 2_000_000_000, Unit: "bytes",
+		{GroupID: "GR1", PeriodStart: periodStart, SKU: sku.BuildEventsBESCount, Count: 1},
+		{GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASDownloadedBytes, Count: 2_000_000_000,
 			Labels: map[sku.LabelName]sku.LabelValue{sku.Origin: sku.OriginExternal, sku.Client: sku.ClientBazel}},
 	}
 	c, err := metronome.NewClient(nil, nil)
@@ -76,7 +76,7 @@ func TestIngestEventsBatching(t *testing.T) {
 	for i := range events {
 		events[i] = metronome.UsageEvent{
 			GroupID: "GR1", PeriodStart: time.Unix(int64(i*60), 0).UTC(),
-			SKU: sku.BuildEventsBESCount, Count: 1, Unit: "count",
+			SKU: sku.BuildEventsBESCount, Count: 1,
 		}
 	}
 	c, err := metronome.NewClient(nil, nil)
@@ -106,7 +106,7 @@ func TestIngestRetriesTransientFailures(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, c.ReportUsage(t.Context(), []metronome.UsageEvent{{
-		GroupID: "GR1", PeriodStart: time.Now(), SKU: sku.BuildEventsBESCount, Count: 1, Unit: "count",
+		GroupID: "GR1", PeriodStart: time.Now(), SKU: sku.BuildEventsBESCount, Count: 1,
 	}}))
 	assert.EqualValues(t, 3, atomic.LoadInt32(&attempts))
 }
@@ -128,7 +128,7 @@ func TestIngestDoesNotRetryClientErrors(t *testing.T) {
 	})
 	require.NoError(t, err)
 	err = c.ReportUsage(t.Context(), []metronome.UsageEvent{{
-		GroupID: "GR1", PeriodStart: time.Now(), SKU: sku.BuildEventsBESCount, Count: 1, Unit: "count",
+		GroupID: "GR1", PeriodStart: time.Now(), SKU: sku.BuildEventsBESCount, Count: 1,
 	}})
 	require.Error(t, err)
 	assert.True(t, status.IsInvalidArgumentError(err))
@@ -154,11 +154,11 @@ func TestTransactionIDDeterministic(t *testing.T) {
 	c, err := metronome.NewClient(nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, c.ReportUsage(t.Context(), []metronome.UsageEvent{{
-		GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASHits, Count: 1, Unit: "count",
+		GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASHits, Count: 1,
 		Labels: map[sku.LabelName]sku.LabelValue{sku.Origin: sku.OriginExternal, sku.Client: sku.ClientBazel},
 	}}))
 	require.NoError(t, c.ReportUsage(t.Context(), []metronome.UsageEvent{{
-		GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASHits, Count: 999, Unit: "count",
+		GroupID: "GR1", PeriodStart: periodStart, SKU: sku.RemoteCacheCASHits, Count: 999,
 		Labels: map[sku.LabelName]sku.LabelValue{sku.Client: sku.ClientBazel, sku.Origin: sku.OriginExternal},
 	}}))
 	require.Len(t, gotEvents, 2)


### PR DESCRIPTION
Heavily inspired by this [PR](https://github.com/buildbuddy-io/buildbuddy/pull/12174/changes)

Differences are:
* this PR includes retries
* the original PR had Metronome ingestion in the MySQL Usage flush path. Now we plan on running this on Clickhouse data from an external cron, so this PR uses the Clickhouse schema instead