### PR TITLE
Upgrade GitHub Actions Node runtimes

### DIFF
--- a/.github/actions/setup-bazel-go-mod-cache/action.yml
+++ b/.github/actions/setup-bazel-go-mod-cache/action.yml
@@ -35,7 +35,7 @@ runs:
         echo "gomodcache=$gomodcache" >> "$GITHUB_OUTPUT"
 
     - name: Restore Go module cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.config.outputs.gomodcache }}
         # GitHub cache entries are immutable. Hash go.mod and keep separate

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -73,7 +73,7 @@ jobs:
           }
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Bazel Go module cache
         uses: ./.github/actions/setup-bazel-go-mod-cache

--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04-16cpu
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04-16cpu-arm64-arm-limited
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/build-mac-intel-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-intel-github-release-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-15-intel
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/build-mac-m1-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-m1-github-release-artifacts.yaml
@@ -39,7 +39,7 @@ jobs:
           ls -la ./
 
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.release_branch }}
           # We need to fetch git tags to obtain the latest version tag to report

--- a/.github/workflows/buildbuddy-foss.yaml
+++ b/.github/workflows/buildbuddy-foss.yaml
@@ -19,7 +19,7 @@ jobs:
           destination_repo: "https://${{ secrets.BUILDBUDDY_GITHUB_USER_TOKEN }}@github.com/buildbuddy-io/buildbuddy-foss.git"
           destination_branch: "master"
       - name: Checkout buildbuddy-foss
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: "buildbuddy-io/buildbuddy-foss"
           ref: master

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -71,7 +71,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -100,6 +100,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Bazel Go module cache
         uses: ./.github/actions/setup-bazel-go-mod-cache

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -71,7 +71,7 @@ jobs:
           git commit -F message.txt -a
 
       - name: Push changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           directory: buildbuddy-internal
           repository: buildbuddy-io/buildbuddy-internal

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           path: buildbuddy
 
       - name: Checkout internal
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: "buildbuddy-io/buildbuddy-internal"
           ref: "master"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -52,7 +52,7 @@ jobs:
           git commit -m "Bumping OSS and Executor to ${{ github.event.release.tag_name }}" -a
 
       - name: Push changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           directory: buildbuddy-helm
           repository: buildbuddy-io/buildbuddy-helm
@@ -93,7 +93,7 @@ jobs:
           git commit -m "Bumping Enterprise to ${{ github.event.release.tag_name }}" -a
 
       - name: Push changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           directory: buildbuddy-helm
           repository: buildbuddy-io/buildbuddy-helm
@@ -129,7 +129,7 @@ jobs:
           git commit -m "Bumping Cache Proxy to ${{ github.event.release.tag_name }}" -a
 
       - name: Push changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           directory: buildbuddy-helm
           repository: buildbuddy-io/buildbuddy-helm

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: "buildbuddy-io/buildbuddy-helm"
           ref: "master"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Bazel Go module cache
         uses: ./.github/actions/setup-bazel-go-mod-cache

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Bazel Go module cache
         uses: ./.github/actions/setup-bazel-go-mod-cache

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -16,7 +16,7 @@ jobs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout /buildbuddy
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           # We need to fetch git tags to obtain the latest cli version tag.
           fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
     needs: push-tag
     steps:
       - name: Checkout buildbuddy-io/bazel
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: buildbuddy-io/bazel
           path: bazel-fork
@@ -78,12 +78,12 @@ jobs:
     needs: [push-tag, create-release]
     steps:
       - name: Checkout buildbuddy-io/buildbuddy
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           path: buildbuddy
 
       - name: Checkout buildbuddy-io/plugins
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: buildbuddy-io/plugins
           path: plugins
@@ -157,7 +157,7 @@ jobs:
           ls -la ./
 
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           path: buildbuddy
 

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Bazel Go module cache
         uses: ./.github/actions/setup-bazel-go-mod-cache

--- a/.github/workflows/website-pr.yaml
+++ b/.github/workflows/website-pr.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Bazel Go module cache
         uses: ./.github/actions/setup-bazel-go-mod-cache

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 2
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -34,7 +34,7 @@ jobs:
           touch .nojekyll
 
       - name: Deploy Website 🚀
-        uses: JamesIves/github-pages-deploy-action@3dbacc7e69578703f91f077118b3475862cb09b8 # 4.1.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: website/build


### PR DESCRIPTION
Updates GitHub Actions pins to Node 24-compatible releases where an upstream release is available, to reduce deprecated Node runtime warnings.

Updated actions:
- `actions/checkout` -> `v5.0.1`
- `actions/cache` / `actions/cache/restore` -> `v5.0.5`
- `github/codeql-action` -> `v4.36.1`
- `ad-m/github-push-action` -> `v1.3.0`
- `JamesIves/github-pages-deploy-action` -> `v4.8.0`

Validation:
- Parsed all GitHub workflow/action YAML files locally
- Ran `git diff --check`
- Verified pinned SHAs against upstream tags with `git ls-remote --tags`; for CodeQL's annotated tag, verified the dereferenced `v4.36.1^{}` commit
- PR checks passed on `ubuntu-latest`, `windows-2025`, and `ubuntu-22.04-16cpu-arm64-arm-limited`, confirming Node 24 action startup on those runner labels

Remaining deprecated-runtime actions that are not simple Node 24 pin bumps:
- `8398a7/action-slack`: latest `v3.19.0` still declares `node20`
- `EndBug/add-and-commit`: latest `v9.1.4` still declares `node20`
- `marvinpinto/action-automatic-releases`: latest `v1.2.1` still declares `node12`

Those remaining actions will need replacement or custom script follow-up rather than a straightforward version bump.
