### PR TITLE
compute metric total values for each cell in a heatmap.

### DIFF
--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -985,7 +985,7 @@ func (i *InvocationStatService) generateQueryInputs(ctx context.Context, table s
 	}
 
 	pbq := fmt.Sprintf(`
-	  SELECT toInt64(timestamp) as timestamp, toInt64(bucket) as bucket, 0 as v FROM (
+	  SELECT toInt64(timestamp) as timestamp, toInt64(bucket) as bucket, 0 as v, 0 as t FROM (
 			SELECT arrayElement(%s, number + 1) AS timestamp FROM numbers(%d)) AS a
 		CROSS JOIN (
 			SELECT arrayElement(%s, number + 1) AS bucket FROM numbers(%d)) AS b
@@ -1048,18 +1048,19 @@ func (i *InvocationStatService) getHeatmapQueryAndBuckets(ctx context.Context, r
 		return nil, nil
 	}
 	qStr := fmt.Sprintf(`
-		SELECT timestamp, groupArray(v) AS value FROM (
-			SELECT timestamp, bucket, CAST(SUM(v) AS Int64) AS v FROM (
+		SELECT timestamp, groupArray(v) AS value, groupArray(t) AS total FROM (
+			SELECT timestamp, bucket, CAST(SUM(v) AS Int64) AS v, CAST(SUM(t) AS Int64) AS t FROM (
 				%s UNION ALL
 				SELECT
 					roundDown(updated_at_usec, CAST(%s AS Array(Int64))) AS timestamp,
 					roundDown(%s, CAST(%s AS Array(Int64))) AS bucket,
-					count(*) AS v
+					count(*) AS v,
+					sum(%s) AS t
 					FROM "%s" %s
 					GROUP BY timestamp, bucket)
 			GROUP BY timestamp, bucket ORDER BY timestamp, bucket)
 		GROUP BY timestamp ORDER BY timestamp`,
-		qi.PlaceholderBucketQuery, qi.TimestampArrayStr, metric, qi.MetricArrayStr, table, whereClauseStr)
+		qi.PlaceholderBucketQuery, qi.TimestampArrayStr, metric, qi.MetricArrayStr, metric, table, whereClauseStr)
 
 	return &QueryAndBuckets{
 			TimestampBuckets:        qi.TimestampBuckets,
@@ -1103,11 +1104,13 @@ func (i *InvocationStatService) GetStatHeatmap(ctx context.Context, req *stpb.Ge
 	type stat struct {
 		Timestamp int64
 		Value     []int64 `gorm:"type:int64[]"`
+		Total     []int64 `gorm:"type:int64[]"`
 	}
 	err = db.ScanEach(rq, func(ctx context.Context, stat *stat) error {
 		column := &stpb.HeatmapColumn{
 			TimestampUsec: stat.Timestamp,
 			Value:         stat.Value,
+			Total:         stat.Total,
 		}
 		rsp.Column = append(rsp.Column, column)
 		return nil

--- a/enterprise/server/invocation_stat_service/invocation_stat_service_test.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service_test.go
@@ -207,5 +207,5 @@ func TestGetStatHeatmap_LogScale(t *testing.T) {
 		}
 	}
 	require.Equal(t, int64(len(durations)), valueCount)
-	require.Equal(t, 5555, totalCount)
+	require.Equal(t, int64(5555), totalCount)
 }

--- a/enterprise/server/invocation_stat_service/invocation_stat_service_test.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service_test.go
@@ -194,11 +194,18 @@ func TestGetStatHeatmap_LogScale(t *testing.T) {
 	require.False(t, rsp.GetMetricHadNegativeValues())
 
 	// Every invocation should be counted exactly once across all buckets.
-	var total int64
+	var valueCount int64
 	for _, col := range rsp.GetColumn() {
 		for _, v := range col.GetValue() {
-			total += v
+			valueCount += v
 		}
 	}
-	require.Equal(t, int64(len(durations)), total)
+	var totalCount int64
+	for _, col := range rsp.GetColumn() {
+		for _, t := range col.GetTotal() {
+			totalCount += t
+		}
+	}
+	require.Equal(t, int64(len(durations)), valueCount)
+	require.Equal(t, 5555, totalCount)
 }

--- a/proto/stats.proto
+++ b/proto/stats.proto
@@ -242,6 +242,7 @@ message GetStatHeatmapRequest {
 message HeatmapColumn {
   int64 timestamp_usec = 1;
   repeated int64 value = 2;
+  repeated int64 total = 3;
 }
 
 message GetStatHeatmapResponse {


### PR DESCRIPTION
will be including this in the tooltip and to compute the total amount selected when drag-selecting an area in the heatmap on the client.

"total" makes sense to render directly for most metrics (execution time, cpu cycles, download amount), but not all.  because we have the number of entries for each heatmap cell as well, we can back out useful values for things like "avg millicores" client-side, too.