### PR TITLE
[SS] Support finalizing each chunk during sequential export

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -85,6 +85,11 @@ type usageSummary struct {
 	totalDuration time.Duration
 }
 
+// ChunkFinalizer is a function that should be called on a chunk after no more data
+// will be written to it. This is useful for sequential access patterns where we
+// can guarantee chunks previously written will not be touched again, and can be finalized.
+type ChunkFinalizer func(*Mmap) error
+
 // COWStore To enable copy-on-write support for a file, it can be split into
 // chunks of equal size. Just before a chunk is first written to, the chunk is first
 // copied, and the write is then applied to the copy.
@@ -160,6 +165,20 @@ type COWStore struct {
 
 	// LRU used to limit the number of chunks that can be mmapped at once.
 	mmapLRU *MmapLRU
+
+	// Optional callback used by sequential writers to process a chunk once
+	// writes move on to another chunk.
+	//
+	// This should never be set for a COWStore that is being used by a guest and will
+	// have non-sequential access patterns.
+	chunkFinalizer ChunkFinalizer
+	// The offset of the last chunk that was written to.
+	lastChunkWritten int64
+	finalizeErrGroup *errgroup.Group
+	finalizeEgCtx    context.Context
+	finalizerCh      chan *Mmap
+	// Whether all chunks in the store have been finalized.
+	finalized bool
 }
 
 type COWOptions struct {
@@ -452,6 +471,12 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 	c.eagerFetchNextChunks(chunkOffset)
 
 	for len(p) > 0 {
+		if c.chunkFinalizer != nil && c.lastChunkWritten != chunkOffset {
+			if err := c.finalizeChunk(c.lastChunkWritten); err != nil {
+				return 0, status.WrapErrorf(err, "failed to finalize chunk %d", c.lastChunkWritten)
+			}
+		}
+
 		// On each iteration, write to one chunk, first copying the readonly
 		// chunk if needed.
 		if err := c.copyChunkIfNotDirty(chunkOffset); err != nil {
@@ -469,6 +494,7 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 		if err != nil {
 			return n, err
 		}
+		c.lastChunkWritten = chunkOffset
 		p = p[writeSize:]
 		chunkOffset += c.chunkSizeBytes
 	}
@@ -631,6 +657,116 @@ func (s *COWStore) LimitMmappedChunks(maxMmappedChunks int64) error {
 	}
 	s.mmapLRU = lru
 	s.eagerFetchStack = nil
+	return nil
+}
+
+func (s *COWStore) PrepareForSequentialExport(maxFinalizeConcurrency int, finalizer ChunkFinalizer) {
+	// During sequential export, we only need to fetch chunks that are being written to.
+	// Eager fetching chunks may be wasteful, so just disable it.
+	s.quitOnce.Do(func() { close(s.quitChan) })
+	s.eagerFetchEg.Wait()
+	s.eagerFetchStack = nil
+
+	// When sequentially exporting, we manually manage unmaps. Disable eviction.
+	s.mmapLRU = nil
+	for _, chunk := range s.chunks {
+		chunk.lru = nil
+	}
+
+	eg, egCtx := errgroup.WithContext(s.ctx)
+	s.finalizeErrGroup = eg
+	s.finalizeEgCtx = egCtx
+	s.finalizerCh = make(chan *Mmap)
+	s.chunkFinalizer = finalizer
+
+	for range maxFinalizeConcurrency {
+		eg.Go(s.processFinalizerQueue)
+	}
+}
+
+func (s *COWStore) processFinalizerQueue() error {
+	for chunk := range s.finalizerCh {
+		// If one chunk failed to finalize, unmap the rest of the chunks.
+		if s.finalizeEgCtx.Err() != nil {
+			chunk.Unmap()
+			continue
+		}
+
+		// Call the chunk finalizer on each chunk, then unmap the chunk.
+		err := s.chunkFinalizer(chunk)
+		chunk.Unmap()
+		if err != nil {
+			log.CtxErrorf(s.ctx, "failed to finalize chunk at offset %d: %s", chunk.Offset, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *COWStore) finalizeLastWrittenChunk() error {
+	if s.chunkFinalizer == nil {
+		return nil
+	}
+	return s.finalizeChunk(s.lastChunkWritten)
+}
+
+func (s *COWStore) finalizeChunk(chunkOffset int64) error {
+	s.storeLock.RLock()
+	chunk := s.chunks[chunkOffset]
+	s.storeLock.RUnlock()
+	if chunk == nil {
+		return nil
+	}
+
+	if err := chunk.finalizeWrite(); err != nil {
+		return err
+	}
+
+	select {
+	// If another chunk failed to finalize, unmap and return the error.
+	case <-s.finalizeEgCtx.Done():
+		chunk.Unmap()
+		return s.finalizeEgCtx.Err()
+	// Add the chunk to the queue to be finalized.
+	case s.finalizerCh <- chunk:
+		return nil
+	}
+}
+
+// Finish finalizes the last written chunk, closes the finalizer queue, and
+// waits for all in-flight finalizer workers to complete. It returns the first
+// error from any finalizer, if any.
+func (s *COWStore) Finalize() error {
+	if s.finalized || s.chunkFinalizer == nil {
+		return nil
+	}
+
+	if s.finalizeEgCtx.Err() != nil {
+		return s.finalizeEgCtx.Err()
+	}
+
+	// After the last write, there is no subsequent write to trigger finalization of the last chunk.
+	// Finalize it here.
+	if err := s.finalizeLastWrittenChunk(); err != nil {
+		return err
+	}
+
+	close(s.finalizerCh)
+
+	// Wait for all in-flight finalizer workers to complete.
+	if err := s.finalizeErrGroup.Wait(); err != nil {
+		return err
+	}
+
+	// Unmap all chunks.
+	for _, chunk := range s.chunks {
+		if err := chunk.Unmap(); err != nil {
+			log.CtxWarningf(s.ctx, "failed to unmap chunk at offset %d: %s", chunk.Offset, err)
+		}
+	}
+
+	s.chunkFinalizer = nil
+	s.finalized = true
 	return nil
 }
 
@@ -856,6 +992,10 @@ func (c *COWStore) EmitUsageMetrics(stage string) {
 	c.chunkOperationToUsageSummary = make(map[string]usageSummary, 0)
 
 	log.CtxDebug(c.ctx, logStr.String())
+}
+
+func (c *COWStore) Finalized() bool {
+	return c.finalized
 }
 
 // ConvertFileToCOW reads a file sequentially, splitting it into fixed size,
@@ -1286,6 +1426,20 @@ func (m *Mmap) Sync() error {
 	return unix.Msync(m.data, unix.MS_SYNC)
 }
 
+// finalizeWrite prepares a chunk for finalization by setting the final digest and syncing the data to disk.
+func (m *Mmap) finalizeWrite() error {
+	_, err := m.Digest()
+	if err != nil {
+		return err
+	}
+
+	if err := m.Sync(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Unmap unmaps the chunk without marking it closed.
 // It returns nil if the chunk is already unmapped.
 func (m *Mmap) Unmap() error {
@@ -1379,6 +1533,12 @@ func (m *Mmap) Digest() (*repb.Digest, error) {
 	}
 	m.SetDigest(d)
 	return d, nil
+}
+
+func (m *Mmap) Data() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.data
 }
 
 // MmapLRU limits the number of Mmap instances that can be mapped in memory at

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -2,7 +2,6 @@ package copy_on_write
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -87,8 +86,17 @@ type usageSummary struct {
 }
 
 // ChunkFinalizer is a function that should be called on a chunk after no more data
-// will be written to it. This is useful for sequential access patterns where we
-// can guarantee chunks previously written will not be touched again, and can be finalized.
+// will be written to it. This is useful for access patterns where we
+// can guarantee chunks previously written will not be touched again, and we
+// need to run some finalization logic (e.g. flushing to cache).
+//
+// WARNING: The finalizer can read chunk.Data(), but must not retain it after returning.
+// Data() returns the mmap-backed byte slice directly; it does not copy the
+// chunk contents in an effort to reduce expensive copies of a lot of data.
+// Once the finalizer returns, the finalizer worker may call
+// Unmap(), which releases that mmap and sets the chunk's data slice to nil.
+// Any retained slice would still point at memory that has been unmapped,
+// so reading or writing it after return is unsafe.
 type ChunkFinalizer func(*Mmap) error
 
 // COWStore To enable copy-on-write support for a file, it can be split into
@@ -178,7 +186,7 @@ type COWStore struct {
 	finalizeErrGroup *errgroup.Group
 	finalizeEgCtx    context.Context
 	finalizerCh      chan *Mmap
-	// Whether all chunks in the store have been finalized.
+	// Whether Finalize has been called and the store no longer accepts writes.
 	finalized bool
 }
 
@@ -462,6 +470,10 @@ func (c *COWStore) readChunk(p []byte, readRelativeOffset int64, chunkStartOffse
 }
 
 func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
+	if c.finalized {
+		return 0, status.FailedPreconditionError("COWStore is finalized")
+	}
+
 	if err := checkBounds("write", c.totalSizeBytes, p, off); err != nil {
 		return 0, err
 	}
@@ -553,8 +565,7 @@ func (c *COWStore) Sync() error {
 
 func (s *COWStore) Close() error {
 	// Close background goroutine eagerly fetching chunks
-	s.quitOnce.Do(func() { close(s.quitChan) })
-	s.eagerFetchEg.Wait()
+	s.stopEagerFetching()
 
 	var lastErr error
 	// TODO: maybe parallelize
@@ -648,8 +659,7 @@ func (s *COWStore) LimitMmappedChunks(maxMmappedChunks int64) error {
 	// Stop eager fetching chunks. With a limited LRU, it could cause unnecessary LRU churn.
 	// Note that eager fetching chunks acquires the storeLock, so we must stop this
 	// before acquiring the lock below.
-	s.quitOnce.Do(func() { close(s.quitChan) })
-	s.eagerFetchEg.Wait()
+	s.stopEagerFetching()
 
 	s.storeLock.Lock()
 	defer s.storeLock.Unlock()
@@ -665,24 +675,23 @@ func (s *COWStore) LimitMmappedChunks(maxMmappedChunks int64) error {
 	return nil
 }
 
-// PrepareForSequentialExport configures the store for sequential export writes,
-// where chunks are written in order and each chunk is guaranteed to be fully
-// written before the next chunk is started.
-//
-// The caller must ensure that WriteAt is not called concurrently with or after
-// Finalize(). Violating this contract may result in a send on a closed channel.
-func (s *COWStore) PrepareForSequentialExport(maxFinalizeConcurrency int, finalizer ChunkFinalizer) error {
+// PrepareForFinalExport configures the store for final export.
+// Each chunk is expected to only be written once. Once writes switch to another chunk,
+// the finalizer will be run on the previously written chunk. Any future writes to that chunk
+// will be ignored by the finalizer.
+func (s *COWStore) PrepareForFinalExport(maxFinalizeConcurrency int, finalizer ChunkFinalizer) error {
 	if maxFinalizeConcurrency <= 0 {
 		return status.InvalidArgumentErrorf("max finalize concurrency must be positive")
+	}
+	if finalizer == nil {
+		return status.InvalidArgumentErrorf("finalizer cannot be nil")
 	}
 
 	s.storeLock.Lock()
 
 	// During sequential export, we only need to fetch chunks that are being written to.
 	// Eager fetching chunks may be wasteful, so just disable it.
-	s.quitOnce.Do(func() { close(s.quitChan) })
-	s.eagerFetchEg.Wait()
-	s.eagerFetchStack = nil
+	s.stopEagerFetching()
 
 	// When sequentially exporting, we manually manage unmaps. Disable eviction.
 	s.mmapLRU = nil
@@ -698,6 +707,8 @@ func (s *COWStore) PrepareForSequentialExport(maxFinalizeConcurrency int, finali
 
 	s.storeLock.Unlock()
 
+	// Use a fixed worker pool instead of finalizing each chunk in a separate goroutine to avoid per-chunk
+	// goroutine allocation overhead.
 	for range maxFinalizeConcurrency {
 		eg.Go(s.processFinalizerQueue)
 	}
@@ -706,32 +717,38 @@ func (s *COWStore) PrepareForSequentialExport(maxFinalizeConcurrency int, finali
 
 func (s *COWStore) processFinalizerQueue() error {
 	for chunk := range s.finalizerCh {
-		if chunk == nil {
-			continue
-		}
-
-		// If one chunk failed to finalize, unmap the rest of the chunks.
+		// If one chunk failed to finalize, unmap the rest of the chunks,
+		// since we won't be able to use the exported snapshot anyway.
 		if s.finalizeEgCtx.Err() != nil {
 			chunk.Unmap()
 			continue
 		}
 
-		// Lock the chunk.
-		// This is especially necessary to ensure nothing releases the backing memory
-		// with Unmap() while the finalizer holds a reference to chunk.Data().
-		chunkUnlockFn := s.chunkLock.RLock(fmt.Sprintf("%d", chunk.Offset))
-		defer chunkUnlockFn()
+		if err := s.finalizeChunk(chunk); err != nil {
+			return err
+		}
 
-		if err := chunk.finalizeWrite(); err != nil {
-			return err
-		}
-		err := s.chunkFinalizer(chunk)
-		chunk.release()
-		chunk.Unmap()
-		if err != nil {
-			log.CtxErrorf(s.ctx, "failed to finalize chunk at offset %d: %s", chunk.Offset, err)
-			return err
-		}
+	}
+	return nil
+}
+
+// WARNING: The finalizer can read chunk.Data(), but must not retain it after returning.
+// Data() returns the mmap-backed byte slice directly; it does not copy the
+// chunk contents in an effort to reduce expensive copies of a lot of data.
+// Once the finalizer returns, the finalizer worker calls
+// Unmap(), which releases that mmap and sets the chunk's data slice to nil.
+// Any retained slice would still point at memory that has been unmapped,
+// so reading or writing it after return is unsafe.
+// If finalizers become async, explicit synchronization must be added.
+func (s *COWStore) finalizeChunk(chunk *Mmap) error {
+	if err := chunk.finalizeWrite(); err != nil {
+		return err
+	}
+	err := s.chunkFinalizer(chunk)
+	chunk.Unmap()
+	if err != nil {
+		log.CtxErrorf(s.ctx, "failed to finalize chunk at offset %d: %s", chunk.Offset, err)
+		return err
 	}
 	return nil
 }
@@ -752,15 +769,19 @@ func (s *COWStore) queueFinalizeChunk(chunkOffset int64) {
 	}
 
 	// Add the chunk to the queue to be finalized.
-	s.finalizerCh <- chunk
+	if s.finalizeEgCtx.Err() == nil {
+		s.finalizerCh <- chunk
+	}
 }
 
 // Finalize finalizes the last written chunk, closes the finalizer queue, and
 // waits for all in-flight finalizer workers to complete. It returns the first
 // error from any finalizer, if any.
 //
-// Finalize must only be called after all WriteAt calls have completed.
-// Calling WriteAt after or concurrently with Finalize is not safe.
+// Note: This function must be called after all WriteAt calls have completed.
+// There is currently no synchronization between concurrent WriteAt calls and Finalize,
+// because that is currently not possible.
+// If usage patterns change and they might be called concurrently, additional locking must be added.
 func (s *COWStore) Finalize() error {
 	if s.finalized || s.chunkFinalizer == nil {
 		return nil
@@ -771,21 +792,24 @@ func (s *COWStore) Finalize() error {
 	s.finalizeLastWrittenChunk()
 
 	close(s.finalizerCh)
+	s.finalized = true
 
 	// Wait for all in-flight finalizer workers to complete.
 	if err := s.finalizeErrGroup.Wait(); err != nil {
 		return err
 	}
 
-	// Unmap all chunks.
+	s.chunkFinalizer = nil
+
+	// Defensively unmap all chunks to avoid leaking memory.
+	// processFinalizerQueue unmaps all chunks that were written after PrepareForSequentialExport
+	// was called, but won't unmap chunks that had previously been mapped.
 	for _, chunk := range s.chunks {
 		if err := chunk.Unmap(); err != nil {
 			log.CtxWarningf(s.ctx, "failed to unmap chunk at offset %d: %s", chunk.Offset, err)
 		}
 	}
 
-	s.chunkFinalizer = nil
-	s.finalized = true
 	return nil
 }
 
@@ -1017,6 +1041,14 @@ func (c *COWStore) Finalized() bool {
 	return c.finalized
 }
 
+func (c *COWStore) stopEagerFetching() {
+	c.quitOnce.Do(func() {
+		close(c.quitChan)
+		c.eagerFetchEg.Wait()
+	})
+	c.eagerFetchStack = nil
+}
+
 // ConvertFileToCOW reads a file sequentially, splitting it into fixed size,
 // read-only chunks. Any newly created chunks will be written to dataDir. The
 // backing files are named according to their starting byte offset (in base 10).
@@ -1243,10 +1275,6 @@ type Mmap struct {
 	fetched    bool
 	closed     bool
 	lazyDigest *repb.Digest
-
-	// dataReferenced is set while external code holds a reference to the data.
-	// Unmap() will not release the backing memory while this is true.
-	dataReferenced bool
 }
 
 // NewLazyMmap returns an mmap that is set up only when the file is read or
@@ -1484,9 +1512,6 @@ func (m *Mmap) Unmap() error {
 
 // Note: caller is expected to hold the lock.
 func (m *Mmap) unmap() (unmapped bool, err error) {
-	if m.dataReferenced {
-		return false, errors.New("data is still being referenced")
-	}
 	if m.data == nil {
 		return false, nil
 	}
@@ -1566,15 +1591,7 @@ func (m *Mmap) Digest() (*repb.Digest, error) {
 // It sets dataReferenced=true to prevent Unmap() from releasing the backing memory while a caller
 // might still be using the data..
 func (m *Mmap) Data() []byte {
-	m.dataReferenced = true
 	return m.data
-}
-
-// release clears the external reference, allowing Unmap() to proceed.
-func (m *Mmap) release() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.dataReferenced = false
 }
 
 // MmapLRU limits the number of Mmap instances that can be mapped in memory at

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -2,6 +2,7 @@ package copy_on_write
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -472,9 +473,7 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 
 	for len(p) > 0 {
 		if c.chunkFinalizer != nil && c.lastChunkWritten != chunkOffset {
-			if err := c.finalizeChunk(c.lastChunkWritten); err != nil {
-				return 0, status.WrapErrorf(err, "failed to finalize chunk %d", c.lastChunkWritten)
-			}
+			c.queueFinalizeChunk(c.lastChunkWritten)
 		}
 
 		// On each iteration, write to one chunk, first copying the readonly
@@ -494,7 +493,13 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 		if err != nil {
 			return n, err
 		}
-		c.lastChunkWritten = chunkOffset
+
+		// lastChunkWritten is used to track whether the current chunk is ready to be finalized
+		// if chunkFinalizer is set.
+		if c.chunkFinalizer != nil {
+			c.lastChunkWritten = chunkOffset
+		}
+
 		p = p[writeSize:]
 		chunkOffset += c.chunkSizeBytes
 	}
@@ -660,7 +665,19 @@ func (s *COWStore) LimitMmappedChunks(maxMmappedChunks int64) error {
 	return nil
 }
 
-func (s *COWStore) PrepareForSequentialExport(maxFinalizeConcurrency int, finalizer ChunkFinalizer) {
+// PrepareForSequentialExport configures the store for sequential export writes,
+// where chunks are written in order and each chunk is guaranteed to be fully
+// written before the next chunk is started.
+//
+// The caller must ensure that WriteAt is not called concurrently with or after
+// Finalize(). Violating this contract may result in a send on a closed channel.
+func (s *COWStore) PrepareForSequentialExport(maxFinalizeConcurrency int, finalizer ChunkFinalizer) error {
+	if maxFinalizeConcurrency <= 0 {
+		return status.InvalidArgumentErrorf("max finalize concurrency must be positive")
+	}
+
+	s.storeLock.Lock()
+
 	// During sequential export, we only need to fetch chunks that are being written to.
 	// Eager fetching chunks may be wasteful, so just disable it.
 	s.quitOnce.Do(func() { close(s.quitChan) })
@@ -679,21 +696,37 @@ func (s *COWStore) PrepareForSequentialExport(maxFinalizeConcurrency int, finali
 	s.finalizerCh = make(chan *Mmap)
 	s.chunkFinalizer = finalizer
 
+	s.storeLock.Unlock()
+
 	for range maxFinalizeConcurrency {
 		eg.Go(s.processFinalizerQueue)
 	}
+	return nil
 }
 
 func (s *COWStore) processFinalizerQueue() error {
 	for chunk := range s.finalizerCh {
+		if chunk == nil {
+			continue
+		}
+
 		// If one chunk failed to finalize, unmap the rest of the chunks.
 		if s.finalizeEgCtx.Err() != nil {
 			chunk.Unmap()
 			continue
 		}
 
-		// Call the chunk finalizer on each chunk, then unmap the chunk.
+		// Lock the chunk.
+		// This is especially necessary to ensure nothing releases the backing memory
+		// with Unmap() while the finalizer holds a reference to chunk.Data().
+		chunkUnlockFn := s.chunkLock.RLock(fmt.Sprintf("%d", chunk.Offset))
+		defer chunkUnlockFn()
+
+		if err := chunk.finalizeWrite(); err != nil {
+			return err
+		}
 		err := s.chunkFinalizer(chunk)
+		chunk.release()
 		chunk.Unmap()
 		if err != nil {
 			log.CtxErrorf(s.ctx, "failed to finalize chunk at offset %d: %s", chunk.Offset, err)
@@ -703,53 +736,39 @@ func (s *COWStore) processFinalizerQueue() error {
 	return nil
 }
 
-func (s *COWStore) finalizeLastWrittenChunk() error {
+func (s *COWStore) finalizeLastWrittenChunk() {
 	if s.chunkFinalizer == nil {
-		return nil
+		return
 	}
-	return s.finalizeChunk(s.lastChunkWritten)
+	s.queueFinalizeChunk(s.lastChunkWritten)
 }
 
-func (s *COWStore) finalizeChunk(chunkOffset int64) error {
+func (s *COWStore) queueFinalizeChunk(chunkOffset int64) {
 	s.storeLock.RLock()
 	chunk := s.chunks[chunkOffset]
 	s.storeLock.RUnlock()
 	if chunk == nil {
-		return nil
+		return
 	}
 
-	if err := chunk.finalizeWrite(); err != nil {
-		return err
-	}
-
-	select {
-	// If another chunk failed to finalize, unmap and return the error.
-	case <-s.finalizeEgCtx.Done():
-		chunk.Unmap()
-		return s.finalizeEgCtx.Err()
 	// Add the chunk to the queue to be finalized.
-	case s.finalizerCh <- chunk:
-		return nil
-	}
+	s.finalizerCh <- chunk
 }
 
-// Finish finalizes the last written chunk, closes the finalizer queue, and
+// Finalize finalizes the last written chunk, closes the finalizer queue, and
 // waits for all in-flight finalizer workers to complete. It returns the first
 // error from any finalizer, if any.
+//
+// Finalize must only be called after all WriteAt calls have completed.
+// Calling WriteAt after or concurrently with Finalize is not safe.
 func (s *COWStore) Finalize() error {
 	if s.finalized || s.chunkFinalizer == nil {
 		return nil
 	}
 
-	if s.finalizeEgCtx.Err() != nil {
-		return s.finalizeEgCtx.Err()
-	}
-
-	// After the last write, there is no subsequent write to trigger finalization of the last chunk.
-	// Finalize it here.
-	if err := s.finalizeLastWrittenChunk(); err != nil {
-		return err
-	}
+	// After the last write, there is no subsequent write to trigger finalization
+	// of the last chunk. Finalize it here.
+	s.finalizeLastWrittenChunk()
 
 	close(s.finalizerCh)
 
@@ -1224,6 +1243,10 @@ type Mmap struct {
 	fetched    bool
 	closed     bool
 	lazyDigest *repb.Digest
+
+	// dataReferenced is set while external code holds a reference to the data.
+	// Unmap() will not release the backing memory while this is true.
+	dataReferenced bool
 }
 
 // NewLazyMmap returns an mmap that is set up only when the file is read or
@@ -1461,6 +1484,9 @@ func (m *Mmap) Unmap() error {
 
 // Note: caller is expected to hold the lock.
 func (m *Mmap) unmap() (unmapped bool, err error) {
+	if m.dataReferenced {
+		return false, errors.New("data is still being referenced")
+	}
 	if m.data == nil {
 		return false, nil
 	}
@@ -1535,10 +1561,20 @@ func (m *Mmap) Digest() (*repb.Digest, error) {
 	return d, nil
 }
 
+// Data returns the mapped memory.
+// Because COWStores can be very large, it doesn't copy the data.
+// It sets dataReferenced=true to prevent Unmap() from releasing the backing memory while a caller
+// might still be using the data..
 func (m *Mmap) Data() []byte {
+	m.dataReferenced = true
+	return m.data
+}
+
+// release clears the external reference, allowing Unmap() to proceed.
+func (m *Mmap) release() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.data
+	m.dataReferenced = false
 }
 
 // MmapLRU limits the number of Mmap instances that can be mapped in memory at

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -54,6 +54,10 @@ const (
 
 	// Number of goroutines to run concurrently to handle LRU evictions.
 	lruEvictionConcurrency = 2
+
+	// Sentinel value for COWStore.lastChunkWritten indicating that no chunk has
+	// been written yet since the store was prepared for final export.
+	noChunkWrittenYet = int64(-1)
 )
 
 var (
@@ -90,13 +94,10 @@ type usageSummary struct {
 // can guarantee chunks previously written will not be touched again, and we
 // need to run some finalization logic (e.g. flushing to cache).
 //
-// WARNING: The finalizer can read chunk.Data(), but must not retain it after returning.
-// Data() returns the mmap-backed byte slice directly; it does not copy the
-// chunk contents in an effort to reduce expensive copies of a lot of data.
-// Once the finalizer returns, the finalizer worker may call
-// Unmap(), which releases that mmap and sets the chunk's data slice to nil.
-// Any retained slice would still point at memory that has been unmapped,
-// so reading or writing it after return is unsafe.
+// The chunk's data is synced to disk before the finalizer runs, so the finalizer
+// should read the chunk's bytes from its backing file (e.g. to upload to cache)
+// rather than holding them in memory. The finalizer must not retain the *Mmap:
+// once it returns, the finalizer worker unmaps the chunk.
 type ChunkFinalizer func(*Mmap) error
 
 // COWStore To enable copy-on-write support for a file, it can be split into
@@ -181,7 +182,9 @@ type COWStore struct {
 	// This should never be set for a COWStore that is being used by a guest and will
 	// have non-sequential access patterns.
 	chunkFinalizer ChunkFinalizer
-	// The offset of the last chunk that was written to.
+	// The offset of the last chunk that was written to since
+	// PrepareForFinalExport was called, or noChunkWrittenYet if no chunk has
+	// been written yet.
 	lastChunkWritten int64
 	finalizeErrGroup *errgroup.Group
 	finalizeEgCtx    context.Context
@@ -484,7 +487,7 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 	c.eagerFetchNextChunks(chunkOffset)
 
 	for len(p) > 0 {
-		if c.chunkFinalizer != nil && c.lastChunkWritten != chunkOffset {
+		if c.chunkFinalizer != nil && c.lastChunkWritten != noChunkWrittenYet && c.lastChunkWritten != chunkOffset {
 			c.queueFinalizeChunk(c.lastChunkWritten)
 		}
 
@@ -696,7 +699,7 @@ func (s *COWStore) PrepareForFinalExport(maxFinalizeConcurrency int, finalizer C
 	// When sequentially exporting, we manually manage unmaps. Disable eviction.
 	s.mmapLRU = nil
 	for _, chunk := range s.chunks {
-		chunk.lru = nil
+		chunk.unsetLRU()
 	}
 
 	eg, egCtx := errgroup.WithContext(s.ctx)
@@ -704,6 +707,7 @@ func (s *COWStore) PrepareForFinalExport(maxFinalizeConcurrency int, finalizer C
 	s.finalizeEgCtx = egCtx
 	s.finalizerCh = make(chan *Mmap)
 	s.chunkFinalizer = finalizer
+	s.lastChunkWritten = noChunkWrittenYet
 
 	s.storeLock.Unlock()
 
@@ -727,18 +731,14 @@ func (s *COWStore) processFinalizerQueue() error {
 		if err := s.finalizeChunk(chunk); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }
 
-// WARNING: The finalizer can read chunk.Data(), but must not retain it after returning.
-// Data() returns the mmap-backed byte slice directly; it does not copy the
-// chunk contents in an effort to reduce expensive copies of a lot of data.
-// Once the finalizer returns, the finalizer worker calls
-// Unmap(), which releases that mmap and sets the chunk's data slice to nil.
-// Any retained slice would still point at memory that has been unmapped,
-// so reading or writing it after return is unsafe.
+// finalizeChunk syncs the chunk to disk (via finalizeWrite), runs the finalizer
+// on it, then unmaps it. The finalizer should read the chunk's bytes from its backing
+// file, so it must not retain the *Mmap after returning; the chunk is unmapped
+// here once the finalizer completes.
 // If finalizers become async, explicit synchronization must be added.
 func (s *COWStore) finalizeChunk(chunk *Mmap) error {
 	if err := chunk.finalizeWrite(); err != nil {
@@ -754,7 +754,7 @@ func (s *COWStore) finalizeChunk(chunk *Mmap) error {
 }
 
 func (s *COWStore) finalizeLastWrittenChunk() {
-	if s.chunkFinalizer == nil {
+	if s.chunkFinalizer == nil || s.lastChunkWritten == noChunkWrittenYet {
 		return
 	}
 	s.queueFinalizeChunk(s.lastChunkWritten)
@@ -769,8 +769,9 @@ func (s *COWStore) queueFinalizeChunk(chunkOffset int64) {
 	}
 
 	// Add the chunk to the queue to be finalized.
-	if s.finalizeEgCtx.Err() == nil {
-		s.finalizerCh <- chunk
+	select {
+	case s.finalizerCh <- chunk:
+	case <-s.finalizeEgCtx.Done():
 	}
 }
 
@@ -802,7 +803,7 @@ func (s *COWStore) Finalize() error {
 	s.chunkFinalizer = nil
 
 	// Defensively unmap all chunks to avoid leaking memory.
-	// processFinalizerQueue unmaps all chunks that were written after PrepareForSequentialExport
+	// processFinalizerQueue unmaps all chunks that were written after PrepareForFinalExport
 	// was called, but won't unmap chunks that had previously been mapped.
 	for _, chunk := range s.chunks {
 		if err := chunk.Unmap(); err != nil {
@@ -1524,6 +1525,12 @@ func (m *Mmap) unmap() (unmapped bool, err error) {
 	return true, nil
 }
 
+func (m *Mmap) unsetLRU() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lru = nil
+}
+
 func (m *Mmap) Close() error {
 	m.mu.Lock()
 	alreadyClosed := m.closed
@@ -1586,12 +1593,11 @@ func (m *Mmap) Digest() (*repb.Digest, error) {
 	return d, nil
 }
 
-// Data returns the mapped memory.
-// Because COWStores can be very large, it doesn't copy the data.
-// It sets dataReferenced=true to prevent Unmap() from releasing the backing memory while a caller
-// might still be using the data..
-func (m *Mmap) Data() []byte {
-	return m.data
+// Mapped returns whether the chunk is currently mmapped into memory.
+func (m *Mmap) Mapped() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.data != nil
 }
 
 // MmapLRU limits the number of Mmap instances that can be mapped in memory at

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -138,6 +138,49 @@ func TestCOW_Basic(t *testing.T) {
 	testStore(t, s, "" /*=path*/)
 }
 
+func TestCOW_ChunkFinalizer(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	dataDir := testfs.MakeTempDir(t)
+	const chunkSizeBytes = 4
+	cow, err := copy_on_write.NewCOWStore(ctx, env, "test", nil, copy_on_write.COWOptions{
+		ChunkSizeBytes: chunkSizeBytes,
+		TotalSizeBytes: chunkSizeBytes * 3,
+		DataDir:        dataDir,
+	})
+	require.NoError(t, err)
+	defer cow.Close()
+
+	var mu sync.Mutex
+	var chunksFinalized []int64
+	cow.PrepareForSequentialExport(2, func(chunk *copy_on_write.Mmap) error {
+		mu.Lock()
+		chunksFinalized = append(chunksFinalized, chunk.Offset)
+		mu.Unlock()
+		return nil
+	})
+
+	// Write to the same chunk multiple times.
+	_, err = cow.WriteAt([]byte{1, 2}, 0)
+	require.NoError(t, err)
+	_, err = cow.WriteAt([]byte{3, 4}, 2)
+	require.NoError(t, err)
+
+	// Write to a different chunk. Skip one chunk.
+	_, err = cow.WriteAt([]byte{5, 6}, 8)
+	require.NoError(t, err)
+
+	require.NoError(t, cow.Finalize())
+
+	require.ElementsMatch(t, []int64{0, 8}, chunksFinalized)
+	require.True(t, cow.Finalized())
+
+	for _, c := range cow.SortedChunks() {
+		// All chunks should be unmapped
+		require.Empty(t, c.Data())
+	}
+}
+
 func TestCOW_Concurrency(t *testing.T) {
 	const chunkSizeBytes = 1024 * 512
 	const fileSizeBytes = chunkSizeBytes * 20

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -153,7 +153,7 @@ func TestCOW_ChunkFinalizer(t *testing.T) {
 
 	var mu sync.Mutex
 	var chunksFinalized []int64
-	err = cow.PrepareForSequentialExport(2, func(chunk *copy_on_write.Mmap) error {
+	err = cow.PrepareForFinalExport(2, func(chunk *copy_on_write.Mmap) error {
 		mu.Lock()
 		chunksFinalized = append(chunksFinalized, chunk.Offset)
 		mu.Unlock()
@@ -202,7 +202,7 @@ func TestCOW_ChunkFinalizerError(t *testing.T) {
 
 	t.Run("ErrorFromNonLastChunk", func(t *testing.T) {
 		cow := newStore(t)
-		err := cow.PrepareForSequentialExport(2, func(chunk *copy_on_write.Mmap) error {
+		err := cow.PrepareForFinalExport(2, func(chunk *copy_on_write.Mmap) error {
 			if chunk.Offset == 0 {
 				return finalizeErr
 			}
@@ -221,7 +221,7 @@ func TestCOW_ChunkFinalizerError(t *testing.T) {
 
 	t.Run("ErrorFromLastChunk", func(t *testing.T) {
 		cow := newStore(t)
-		err := cow.PrepareForSequentialExport(2, func(chunk *copy_on_write.Mmap) error {
+		err := cow.PrepareForFinalExport(2, func(chunk *copy_on_write.Mmap) error {
 			return finalizeErr
 		})
 		require.NoError(t, err)

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -153,12 +153,13 @@ func TestCOW_ChunkFinalizer(t *testing.T) {
 
 	var mu sync.Mutex
 	var chunksFinalized []int64
-	cow.PrepareForSequentialExport(2, func(chunk *copy_on_write.Mmap) error {
+	err = cow.PrepareForSequentialExport(2, func(chunk *copy_on_write.Mmap) error {
 		mu.Lock()
 		chunksFinalized = append(chunksFinalized, chunk.Offset)
 		mu.Unlock()
 		return nil
 	})
+	require.NoError(t, err)
 
 	// Write to the same chunk multiple times.
 	_, err = cow.WriteAt([]byte{1, 2}, 0)
@@ -179,6 +180,58 @@ func TestCOW_ChunkFinalizer(t *testing.T) {
 		// All chunks should be unmapped
 		require.Empty(t, c.Data())
 	}
+}
+
+func TestCOW_ChunkFinalizerError(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	const chunkSizeBytes = 4
+
+	newStore := func(t *testing.T) *copy_on_write.COWStore {
+		cow, err := copy_on_write.NewCOWStore(ctx, env, "test", nil, copy_on_write.COWOptions{
+			ChunkSizeBytes: chunkSizeBytes,
+			TotalSizeBytes: chunkSizeBytes * 3,
+			DataDir:        testfs.MakeTempDir(t),
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { cow.Close() })
+		return cow
+	}
+
+	finalizeErr := fmt.Errorf("finalize error")
+
+	t.Run("ErrorFromNonLastChunk", func(t *testing.T) {
+		cow := newStore(t)
+		err := cow.PrepareForSequentialExport(2, func(chunk *copy_on_write.Mmap) error {
+			if chunk.Offset == 0 {
+				return finalizeErr
+			}
+			return nil
+		})
+		require.NoError(t, err)
+
+		_, err = cow.WriteAt([]byte{1, 2}, 0)
+		require.NoError(t, err)
+
+		// Writing to the next chunk triggers finalization of chunk 0.
+		// Finalize should return the error.
+		cow.WriteAt([]byte{5, 6}, 8)
+		require.ErrorIs(t, cow.Finalize(), finalizeErr)
+	})
+
+	t.Run("ErrorFromLastChunk", func(t *testing.T) {
+		cow := newStore(t)
+		err := cow.PrepareForSequentialExport(2, func(chunk *copy_on_write.Mmap) error {
+			return finalizeErr
+		})
+		require.NoError(t, err)
+
+		_, err = cow.WriteAt([]byte{1, 2}, 0)
+		require.NoError(t, err)
+
+		// Finalize() triggers finalization of the last written chunk and should return an error.
+		require.ErrorIs(t, cow.Finalize(), finalizeErr)
+	})
 }
 
 func TestCOW_Concurrency(t *testing.T) {

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -11,8 +11,10 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil"
@@ -178,7 +180,7 @@ func TestCOW_ChunkFinalizer(t *testing.T) {
 
 	for _, c := range cow.SortedChunks() {
 		// All chunks should be unmapped
-		require.Empty(t, c.Data())
+		require.False(t, c.Mapped(), "chunk at offset %d should be unmapped", c.Offset)
 	}
 }
 
@@ -232,6 +234,93 @@ func TestCOW_ChunkFinalizerError(t *testing.T) {
 		// Finalize() triggers finalization of the last written chunk and should return an error.
 		require.ErrorIs(t, cow.Finalize(), finalizeErr)
 	})
+}
+
+func TestCOW_ChunkFinalizer_FirstWriteToNonZeroChunk(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	const chunkSizeBytes = 4
+	const numChunks = 3
+
+	// Build the store from a non-zero backing file so that all chunk offsets
+	// (including 0) are initialized.
+	content := bytes.Repeat([]byte{0xab}, chunkSizeBytes*numChunks)
+	path := makeTempFile(t, content)
+	dataDir := testfs.MakeTempDir(t)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, env, path, chunkSizeBytes, dataDir, "", false, snaputil.ConvertToCOWConcurrency)
+	require.NoError(t, err)
+	defer cow.Close()
+
+	var mu sync.Mutex
+	var chunksFinalized []int64
+	err = cow.PrepareForFinalExport(2, func(chunk *copy_on_write.Mmap) error {
+		mu.Lock()
+		chunksFinalized = append(chunksFinalized, chunk.Offset)
+		mu.Unlock()
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Don't start writing from chunk 0.
+	_, err = cow.WriteAt([]byte{5, 6}, 2*chunkSizeBytes)
+	require.NoError(t, err)
+	require.NoError(t, cow.Finalize())
+
+	// Only the written chunk should be finalized. Chunk 0 was never written.
+	require.ElementsMatch(t, []int64{2 * chunkSizeBytes}, chunksFinalized)
+}
+
+func TestCOW_ChunkFinalizer_DrainOnError(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	const chunkSizeBytes = 4
+	const numChunks = 50
+	dataDir := testfs.MakeTempDir(t)
+	cow, err := copy_on_write.NewCOWStore(ctx, env, "test", nil, copy_on_write.COWOptions{
+		ChunkSizeBytes: chunkSizeBytes,
+		TotalSizeBytes: chunkSizeBytes * numChunks,
+		DataDir:        dataDir,
+	})
+	require.NoError(t, err)
+	defer cow.Close()
+
+	finalizeErr := fmt.Errorf("finalize error")
+	var count atomic.Int64
+	// Succeed for the first few chunks, then fail for all subsequent chunks to test
+	// error handling while some writes are still in progress.
+	err = cow.PrepareForFinalExport(4, func(chunk *copy_on_write.Mmap) error {
+		if count.Add(1) > 5 {
+			return finalizeErr
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Write to each chunk in order in a goroutine, with a watchdog timeout, so a
+	// deadlock on the finalizer queue surfaces as a test failure rather than
+	// hanging the whole package.
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		for i := int64(0); i < numChunks; i++ {
+			_, err := cow.WriteAt([]byte{1, 2}, i*chunkSizeBytes)
+			require.NoError(t, err)
+		}
+	}()
+	select {
+	case <-writeDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out writing chunks; producer likely deadlocked on the finalizer queue")
+	}
+
+	finalizeDone := make(chan error, 1)
+	go func() { finalizeDone <- cow.Finalize() }()
+	select {
+	case err := <-finalizeDone:
+		require.ErrorIs(t, err, finalizeErr)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out finalizing; likely deadlocked draining the finalizer queue")
+	}
 }
 
 func TestCOW_Concurrency(t *testing.T) {


### PR DESCRIPTION
We can pass the Cache() function as the finalizer, so each memory chunk can be cached in one pass as the snapshot as being exported