### PR TITLE
Send shutting-down message via cache proxy registration RPC on proxy shutdown

### DIFF
--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
@@ -148,13 +148,6 @@ func Register(env *real_environment.RealEnv) error {
 func run(ctx context.Context, shutdownCh <-chan struct{}, env environment.Env, target, apiKey string, node *cppb.CacheProxyNode) {
 	ctx = metadata.AppendToOutgoingContext(ctx, authutil.APIKeyHeader, apiKey)
 	for {
-		// If shutdown was signalled while we were between connection
-		// attempts, exit immediately without re-dialing.
-		select {
-		case <-shutdownCh:
-			return
-		default:
-		}
 		conn, err := grpc_client.DialInternalWithPoolSize(env, target, 1)
 		if err == nil {
 			client := cppb.NewCacheProxyRegistryClient(conn)

--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
@@ -63,6 +63,11 @@ var (
 	// How long to wait before retrying after a failed connection or stream.
 	retryInterval = 5 * time.Second
 
+	// Upper bound on how long the health checker's shutdown function will
+	// block waiting for the goodbye message to flush. We don't want to
+	// hold up app shutdown if the stream is wedged.
+	shutdownGoodbyeTimeout = time.Second
+
 	// Limits on the labels reported at registration. Registration fails if a
 	// key or value is longer than maxLabelLen, or if there are more than
 	// maxLabels labels.
@@ -116,37 +121,62 @@ func Register(env *real_environment.RealEnv) error {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	env.GetHealthChecker().RegisterShutdownFunction(func(context.Context) error {
+	// shutdownCh signals the run goroutine to send a final
+	// shutting_down=true message before closing the stream, so the app can
+	// drop us from its registry immediately rather than waiting for the
+	// staleness TTL. doneCh lets the shutdown function wait for that
+	// goodbye to actually flush before we hard-cancel ctx.
+	shutdownCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	env.GetHealthChecker().RegisterShutdownFunction(func(shutdownCtx context.Context) error {
+		close(shutdownCh)
+		select {
+		case <-doneCh:
+		case <-shutdownCtx.Done():
+		case <-time.After(shutdownGoodbyeTimeout):
+		}
 		cancel()
 		return nil
 	})
-	go run(ctx, env, *appTarget, *apiKey, node)
+	go func() {
+		defer close(doneCh)
+		run(ctx, shutdownCh, env, *appTarget, *apiKey, node)
+	}()
 	return nil
 }
 
-func run(ctx context.Context, env environment.Env, target, apiKey string, node *cppb.CacheProxyNode) {
+func run(ctx context.Context, shutdownCh <-chan struct{}, env environment.Env, target, apiKey string, node *cppb.CacheProxyNode) {
 	ctx = metadata.AppendToOutgoingContext(ctx, authutil.APIKeyHeader, apiKey)
 	for {
+		// If shutdown was signalled while we were between connection
+		// attempts, exit immediately without re-dialing.
+		select {
+		case <-shutdownCh:
+			return
+		default:
+		}
 		conn, err := grpc_client.DialInternalWithPoolSize(env, target, 1)
 		if err == nil {
 			client := cppb.NewCacheProxyRegistryClient(conn)
-			if err := streamHeartbeats(ctx, client, node); err != nil && ctx.Err() == nil {
+			if err := streamHeartbeats(ctx, shutdownCh, client, node); err != nil && ctx.Err() == nil {
 				log.Warningf("Cache Proxy registration stream failed, will retry in %s: %s", retryInterval, err)
 			}
 			_ = conn.Close()
 		} else if ctx.Err() == nil {
 			log.Warningf("Cache Proxy registration: dial %q failed, will retry in %s: %s", target, retryInterval, err)
 		}
-		if sleepWithContext(ctx, retryInterval) {
+		if sleepUntilShutdown(ctx, shutdownCh, retryInterval) {
 			return
 		}
 	}
 }
 
 // streamHeartbeats opens the registration stream, sends an initial heartbeat
-// plus one every heartbeatInterval, and returns when the stream breaks or
-// ctx is cancelled.
-func streamHeartbeats(ctx context.Context, client cppb.CacheProxyRegistryClient, node *cppb.CacheProxyNode) error {
+// plus one every heartbeatInterval, and returns when the stream breaks,
+// ctx is cancelled, or shutdownCh is closed. On a clean shutdown signal it
+// also sends a final shutting_down=true message so the server can drop us
+// from its registry immediately instead of waiting for the staleness TTL.
+func streamHeartbeats(ctx context.Context, shutdownCh <-chan struct{}, client cppb.CacheProxyRegistryClient, node *cppb.CacheProxyNode) error {
 	stream, cleanup, err := openStream(ctx, client, node)
 	if err != nil {
 		return err
@@ -163,6 +193,17 @@ func streamHeartbeats(ctx context.Context, client cppb.CacheProxyRegistryClient,
 			// RegisterCacheProxyResponse on EOF, but we don't care about
 			// its contents.
 			stream.CloseAndRecv()
+			return nil
+		case <-shutdownCh:
+			// Best-effort goodbye. If the send fails the server will
+			// eventually drop us via the staleness TTL anyway.
+			if err := sendHeartbeat(stream, &cppb.RegisterCacheProxyRequest{Node: node, ShuttingDown: true}); err == nil {
+				// Send succeeded; close the stream cleanly. On send
+				// failure (io.EOF) sendHeartbeat has already drained
+				// the trailer via its own CloseAndRecv, so we skip it
+				// here to avoid the redundant call.
+				stream.CloseAndRecv()
+			}
 			return nil
 		case <-ticker.C:
 			req := &cppb.RegisterCacheProxyRequest{Node: node, Statistics: collectStatistics()}
@@ -309,9 +350,11 @@ func getProxyHostID() string {
 	return hostid.GetFailsafeHostID(dir)
 }
 
-func sleepWithContext(ctx context.Context, d time.Duration) (cancelled bool) {
+func sleepUntilShutdown(ctx context.Context, shutdownCh <-chan struct{}, d time.Duration) (cancelled bool) {
 	select {
 	case <-ctx.Done():
+		return true
+	case <-shutdownCh:
 		return true
 	case <-time.After(d):
 		return false

--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration_test.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration_test.go
@@ -107,7 +107,7 @@ func TestStreamHeartbeats_RegistersProxy(t *testing.T) {
 	// Run the stream loop in a goroutine; it returns once we cancel.
 	done := make(chan error, 1)
 	go func() {
-		done <- streamHeartbeats(streamCtx, client, node)
+		done <- streamHeartbeats(streamCtx, make(chan struct{}), client, node)
 	}()
 
 	// The initial heartbeat should make the proxy visible to GetCacheProxies
@@ -129,6 +129,56 @@ func TestStreamHeartbeats_RegistersProxy(t *testing.T) {
 	}
 }
 
+// TestStreamHeartbeats_ShutdownRemovesProxy verifies that closing
+// shutdownCh causes streamHeartbeats to send a final shutting_down=true
+// message that the server uses to drop the proxy from its registry
+// immediately, rather than waiting for the heartbeat staleness TTL.
+func TestStreamHeartbeats_ShutdownRemovesProxy(t *testing.T) {
+	// Two distinct Claims with the same group: one is owned by the server's
+	// auth map (read by the streaming RPC goroutine), the other backs the
+	// test goroutine's AuthContextWithJWT call, which mutates the JWT field
+	// on its argument and would race with a shared Claims struct.
+	streamUser := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	readerUser := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	registry, client := startTestRegistry(t, map[string]interfaces.UserInfo{testAPIKey: streamUser})
+
+	node := &cppb.CacheProxyNode{Host: "host-x", ProxyId: "proxy-x", Version: "v1"}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	streamCtx := outgoingCtx(ctx, testAPIKey)
+
+	shutdownCh := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- streamHeartbeats(streamCtx, shutdownCh, client, node)
+	}()
+
+	authedCtx := claims.AuthContextWithJWT(context.Background(), readerUser.(*claims.Claims), nil)
+	require.Eventually(t, func() bool {
+		resp, err := registry.GetCacheProxies(authedCtx, &cppb.GetCacheProxiesRequest{
+			RequestContext: groupReqContext(testGroupID),
+		})
+		return err == nil && len(resp.GetCacheProxy()) == 1
+	}, 2*time.Second, 25*time.Millisecond, "proxy should have registered")
+
+	close(shutdownCh)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamHeartbeats did not return after shutdown signal")
+	}
+
+	// The shutdown message should have removed the proxy from the registry
+	// immediately — we shouldn't have to wait the staleness TTL.
+	resp, err := registry.GetCacheProxies(authedCtx, &cppb.GetCacheProxiesRequest{
+		RequestContext: groupReqContext(testGroupID),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.GetCacheProxy(), "shutting-down proxy should have been removed from registry")
+}
+
 func TestStreamHeartbeats_UnauthorizedReturnsError(t *testing.T) {
 	// Drive heartbeats fast so a buffered first-Send EOF surfaces quickly
 	// on the next tick.
@@ -143,7 +193,7 @@ func TestStreamHeartbeats_UnauthorizedReturnsError(t *testing.T) {
 	defer cancel()
 	streamCtx := outgoingCtx(ctx, "NOCAP_KEY")
 
-	err := streamHeartbeats(streamCtx, client, &cppb.CacheProxyNode{Host: "h", ProxyId: "id"})
+	err := streamHeartbeats(streamCtx, make(chan struct{}), client, &cppb.CacheProxyNode{Host: "h", ProxyId: "id"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "REGISTER_CACHE_PROXY", "expected capability error, got: %v", err)
 }
@@ -175,7 +225,7 @@ func TestStreamHeartbeats_UnreachableTarget(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- streamHeartbeats(context.Background(), client, &cppb.CacheProxyNode{Host: "h", ProxyId: "id"})
+		done <- streamHeartbeats(context.Background(), make(chan struct{}), client, &cppb.CacheProxyNode{Host: "h", ProxyId: "id"})
 	}()
 	select {
 	case err := <-done:

--- a/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server.go
+++ b/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server.go
@@ -166,6 +166,14 @@ func (s *CacheProxyRegistryServer) RegisterAndStreamHeartbeat(stream cppb.CacheP
 				log.CtxInfof(ctx, "Rejecting cache proxy heartbeat from group %q: missing proxy_id", groupID)
 				return status.InvalidArgumentError("registration request missing proxy_id")
 			}
+			if req.GetShuttingDown() {
+				log.CtxInfof(ctx, "Cache proxy %q (group %q) signalled shutdown; removing from registry", node.GetProxyId(), groupID)
+				if err := s.removeProxy(ctx, groupID, node.GetProxyId()); err != nil {
+					log.CtxWarningf(ctx, "Could not remove shutting-down cache proxy %q (group %q): %s", node.GetProxyId(), groupID, err)
+					return err
+				}
+				return stream.SendAndClose(&cppb.RegisterCacheProxyResponse{})
+			}
 			if err := s.insertOrUpdateProxy(ctx, groupID, node, req.GetStatistics()); err != nil {
 				log.CtxInfof(ctx, "Closing cache proxy registration stream for proxy %q (group %q): could not store registration: %s", node.GetProxyId(), groupID, err)
 				return err
@@ -199,6 +207,10 @@ func (s *CacheProxyRegistryServer) insertOrUpdateProxy(ctx context.Context, grou
 		return err
 	}
 	return s.rdb.HSet(ctx, redisKeyForCacheProxies(groupID), node.GetProxyId(), b).Err()
+}
+
+func (s *CacheProxyRegistryServer) removeProxy(ctx context.Context, groupID, proxyID string) error {
+	return s.rdb.HDel(ctx, redisKeyForCacheProxies(groupID), proxyID).Err()
 }
 
 func (s *CacheProxyRegistryServer) GetCacheProxies(ctx context.Context, req *cppb.GetCacheProxiesRequest) (*cppb.GetCacheProxiesResponse, error) {

--- a/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server_test.go
+++ b/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server_test.go
@@ -334,6 +334,64 @@ func TestStreamHeartbeat_PersistsStatistics(t *testing.T) {
 	assert.Equal(t, int64(30), got.GetCasReadMisses())
 }
 
+func TestStreamHeartbeat_ShutDown(t *testing.T) {
+	// Two distinct Claims for the streaming user (read by the server-side
+	// auth goroutine) and the reader user (mutated by AuthContextWithJWT
+	// on the test goroutine), to avoid a race on the JWT field.
+	streamUser := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	readerUser := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, client := startGRPCRegistry(t, map[string]interfaces.UserInfo{"CP_KEY": streamUser})
+
+	// Register two proxies under the same group so we can confirm that
+	// only the one that sent ShuttingDown=true is removed.
+	keepStream, err := client.RegisterAndStreamHeartbeat(ctxWithOutgoingAPIKey("CP_KEY"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = keepStream.CloseSend()
+		_, _ = keepStream.CloseAndRecv()
+	})
+	require.NoError(t, keepStream.Send(&cppb.RegisterCacheProxyRequest{
+		Node: &cppb.CacheProxyNode{Host: "h-keep", ProxyId: "id-keep"},
+	}))
+
+	shutdownStream, err := client.RegisterAndStreamHeartbeat(ctxWithOutgoingAPIKey("CP_KEY"))
+	require.NoError(t, err)
+	require.NoError(t, shutdownStream.Send(&cppb.RegisterCacheProxyRequest{
+		Node: &cppb.CacheProxyNode{Host: "h-bye", ProxyId: "id-bye"},
+	}))
+
+	// stream.Send only buffers — the server-side recv→insertOrUpdateProxy
+	// runs on a separate goroutine, so we have to wait for the registry to
+	// reflect both heartbeats before sending the shutdown signal.
+	ctx := claims.AuthContextWithJWT(context.Background(), readerUser.(*claims.Claims), nil)
+	require.Eventually(t, func() bool {
+		resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+			RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+		})
+		return err == nil && len(resp.GetCacheProxy()) == 2
+	}, 2*time.Second, 25*time.Millisecond, "both proxies should have registered")
+
+	// Now send ShuttingDown=true on the second stream only.
+	require.NoError(t, shutdownStream.Send(&cppb.RegisterCacheProxyRequest{
+		Node:         &cppb.CacheProxyNode{Host: "h-bye", ProxyId: "id-bye"},
+		ShuttingDown: true,
+	}))
+	_, err = shutdownStream.CloseAndRecv()
+	require.NoError(t, err)
+
+	// Wait for the registry to reflect the removal of only the shutting-down
+	// proxy. The other one must still be present.
+	require.Eventually(t, func() bool {
+		resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+			RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+		})
+		if err != nil || len(resp.GetCacheProxy()) != 1 {
+			return false
+		}
+		return resp.GetCacheProxy()[0].GetNode().GetProxyId() == "id-keep"
+	}, 2*time.Second, 25*time.Millisecond, "only the shutting-down proxy should have been removed")
+}
+
 func TestStreamHeartbeat_Anonymous(t *testing.T) {
 	_, client := startGRPCRegistry(t, map[string]interfaces.UserInfo{})
 

--- a/proto/cache_proxy.proto
+++ b/proto/cache_proxy.proto
@@ -69,6 +69,11 @@ message Statistics {
 message RegisterCacheProxyRequest {
   CacheProxyNode node = 1;
   Statistics statistics = 2;
+
+  // When true, the proxy is shutting down cleanly and the server should
+  // remove this proxy from its registry immediately rather than waiting
+  // for the heartbeat staleness TTL.
+  bool shutting_down = 3;
 }
 
 // RegisterCacheProxyResponse is returned by the server once the proxy closes


### PR DESCRIPTION
This best-effort eager removal should remove proxies from the proxy page when they shut down cleanly (which is most of the time).