### PR TITLE
Make retryingClient in operation.go resend all COMPLETED messages

### DIFF
--- a/enterprise/server/remote_execution/operation/BUILD
+++ b/enterprise/server/remote_execution/operation/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -18,5 +18,21 @@ go_library(
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)
+
+go_test(
+    name = "operation_test",
+    srcs = ["operation_test.go"],
+    embed = [":operation"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/remote_cache/digest",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_google_cloud_go_longrunning//autogen/longrunningpb",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"io"
 	"net/url"
+	"slices"
 	"sync"
 	"time"
 
@@ -103,17 +104,23 @@ func (p *Publisher) CloseAndRecv() (*repb.PublishOperationResponse, error) {
 // the backend; instead it depends on the client connection being terminated by
 // an L7 proxy.
 type retryingClient struct {
-	ctx                       context.Context
-	client                    repb.ExecutionClient
-	clientStream              repb.Execution_PublishOperationClient
-	previousCompletedMessages []*longrunningpb.Operation
+	ctx               context.Context
+	client            repb.ExecutionClient
+	clientStream      repb.Execution_PublishOperationClient
+	republishMessages []*messageWithStage
+}
+
+type messageWithStage struct {
+	msg   *longrunningpb.Operation
+	stage repb.ExecutionStage_Value
 }
 
 // Publish begins a PublishOperation stream and transparently reconnects the
 // stream if disconnected. After a disconnect (either in Send or CloseAndRecv),
-// it will re-publish every COMPLETED message sent so far to ensure the server
-// has acknowledged them. Non-COMPLETED progress updates are not buffered and
-// may be silently dropped on disconnect.
+// it will re-publish previously-sent messages on the new stream to ensure
+// the server has acknowledged them: every COMPLETED message, and the most
+// recent message of each non-COMPLETED stage (so the server sees the
+// latest known progress state).
 func Publish(ctx context.Context, client repb.ExecutionClient, taskID string) (*Publisher, error) {
 	r, err := digest.ParseUploadResourceName(taskID)
 	if err != nil {
@@ -135,56 +142,48 @@ func Publish(ctx context.Context, client repb.ExecutionClient, taskID string) (*
 }
 
 func (c *retryingClient) send(msg *longrunningpb.Operation) error {
-	if err := c.sendWithRetry(msg); err != nil {
+	// Save msg now because even on a successful local Send, the gRPC stream may
+	// have only buffered the message locally without the server receiving it.
+	c.saveMessage(msg)
+	err := c.clientStream.Send(msg)
+	if err != nil && !isRetryablePublishError(err) {
 		return err
 	}
-	// Even though Send returned nil, the gRPC stream may have only buffered the
-	// message locally without the server actually receiving it. To ensure we
-	// don't lose critical updates, save all COMPLETED messages and replay them
-	// after any future reconnect. Other progress updates are not critical.
-	//
-	// Note: the append must happen *after* sendWithRetry succeeds, not before.
-	// sendWithRetry's reconnect path already replays previousCompletedMessages
-	// on the new stream, so appending beforehand would cause the COMPLETED
-	// message to be delivered twice on the same reconnect cycle (once by the
-	// replay, once by sendWithRetry's retry of msg).
-	stage := ExtractStage(msg)
-	if stage == repb.ExecutionStage_COMPLETED {
-		c.previousCompletedMessages = append(c.previousCompletedMessages, msg)
+	if err == nil {
+		return nil
+	}
+	log.CtxInfof(c.ctx, "PublishOperation stream disconnected; attempting to reconnect.")
+	retryCtx, cancel := context.WithTimeout(c.ctx, reconnectTimeout)
+	defer cancel()
+	if err := c.reconnect(retryCtx); err != nil {
+		return status.WrapError(err, "failed to reconnect PublishOperation stream")
 	}
 	return nil
 }
 
-func (c *retryingClient) sendWithRetry(msg *longrunningpb.Operation) error {
-	var lastErr error
-	retryCtx, cancel := context.WithTimeout(c.ctx, reconnectTimeout)
-	defer cancel()
-	r := retry.DefaultWithContext(retryCtx)
-	for r.Next() {
-		err := c.clientStream.Send(msg)
-		if err == nil {
-			return nil
-		}
-		if !isRetryablePublishError(err) {
-			return err
-		}
-		lastErr = err
-		log.CtxInfof(c.ctx, "PublishOperation stream disconnected; attempting to reconnect.")
-		// EOF means we got disconnected; reconnect and retry.
-		if err := c.reconnect(retryCtx); err != nil {
-			return status.WrapError(err, "failed to reconnect PublishOperation stream")
-		}
+func (c *retryingClient) saveMessage(msg *longrunningpb.Operation) {
+	stage := ExtractStage(msg)
+	if stage == repb.ExecutionStage_COMPLETED {
+		// Resend all COMPLETED messages on reconnect.
+		c.republishMessages = append(c.republishMessages, &messageWithStage{
+			msg:   msg,
+			stage: stage,
+		})
+		return
 	}
-	if lastErr != nil {
-		return lastErr
+
+	// Resend the most recent message of each other stage on reconnect.
+	i := slices.IndexFunc(c.republishMessages, func(m *messageWithStage) bool {
+		return m.stage == stage
+	})
+	if i != -1 {
+		c.republishMessages[i].msg = msg
+	} else {
+		c.republishMessages = append(c.republishMessages, &messageWithStage{
+			msg:   msg,
+			stage: stage,
+		})
 	}
-	// Retry loop didn't even execute once; this should only happen if
-	// there is a ctx error. Return that error.
-	if retryCtx.Err() != nil {
-		return retryCtx.Err()
-	}
-	// Should never happen, but make sure we still return an error in this case.
-	return status.UnknownError("Send: unknown error")
 }
 
 func (s *retryingClient) reconnect(retryCtx context.Context) error {
@@ -201,8 +200,8 @@ outer:
 		}
 		log.CtxInfof(s.ctx, "Successfully reconnected PublishOperation stream.")
 		s.clientStream = clientStream
-		for _, msg := range s.previousCompletedMessages {
-			if err := s.clientStream.Send(msg); err != nil {
+		for _, msg := range s.republishMessages {
+			if err := s.clientStream.Send(msg.msg); err != nil {
 				if !isRetryablePublishError(err) {
 					return status.WrapError(err, "failed to resend completed message after reconnect")
 				}
@@ -240,8 +239,8 @@ func (c *retryingClient) closeAndRecv() (*repb.PublishOperationResponse, error) 
 		}
 		lastErr = err
 		log.CtxInfof(c.ctx, "PublishOperation stream disconnected; attempting to reconnect.")
-		// Stream is broken; reconnect and resend COMPLETED messages. If this
-		// fails, return the original error.
+		// Stream is broken; reconnect (which replays buffered messages on
+		// the new stream). If this fails, return the original error.
 		if err := c.reconnect(retryCtx); err != nil {
 			log.CtxWarningf(c.ctx, "Failed to reconnect operation stream: %s", err)
 			break

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"io"
 	"net/url"
-	"slices"
 	"sync"
 	"time"
 
@@ -116,11 +115,14 @@ type messageWithStage struct {
 }
 
 // Publish begins a PublishOperation stream and transparently reconnects the
-// stream if disconnected. After a disconnect (either in Send or CloseAndRecv),
-// it will re-publish previously-sent messages on the new stream to ensure
-// the server has acknowledged them: every COMPLETED message, and the most
-// recent message of each non-COMPLETED stage (so the server sees the
-// latest known progress state).
+// stream if disconnected. After a disconnect (either in Send or CloseAndRecv)
+// it replays previously-sent messages on the new stream:
+//   - Before the first COMPLETED, only the most recent message is replayed
+//     (older progress updates are dropped as new ones arrive — the server
+//     only needs the latest known progress state).
+//   - From the first COMPLETED onward, every message is replayed: the
+//     execution server needs to see all completion-stage updates (e.g.
+//     post-completion stats) to build the final execution record.
 func Publish(ctx context.Context, client repb.ExecutionClient, taskID string) (*Publisher, error) {
 	r, err := digest.ParseUploadResourceName(taskID)
 	if err != nil {
@@ -162,28 +164,13 @@ func (c *retryingClient) send(msg *longrunningpb.Operation) error {
 }
 
 func (c *retryingClient) saveMessage(msg *longrunningpb.Operation) {
-	stage := ExtractStage(msg)
-	if stage == repb.ExecutionStage_COMPLETED {
-		// Resend all COMPLETED messages on reconnect.
-		c.republishMessages = append(c.republishMessages, &messageWithStage{
-			msg:   msg,
-			stage: stage,
-		})
-		return
+	// Drop any buffered messages, unless the execution has completed.
+	// We need to resend all completion updates since the execution server
+	// needs to see all of them in order to properly build the final execution.
+	if len(c.republishMessages) > 0 && c.republishMessages[0].stage != repb.ExecutionStage_COMPLETED {
+		c.republishMessages = c.republishMessages[:0]
 	}
-
-	// Resend the most recent message of each other stage on reconnect.
-	i := slices.IndexFunc(c.republishMessages, func(m *messageWithStage) bool {
-		return m.stage == stage
-	})
-	if i != -1 {
-		c.republishMessages[i].msg = msg
-	} else {
-		c.republishMessages = append(c.republishMessages, &messageWithStage{
-			msg:   msg,
-			stage: stage,
-		})
-	}
+	c.republishMessages = append(c.republishMessages, &messageWithStage{msg, ExtractStage(msg)})
 }
 
 func (s *retryingClient) reconnect(retryCtx context.Context) error {

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -93,6 +93,8 @@ func (p *Publisher) SetState(state repb.ExecutionProgress_ExecutionState) error 
 // CloseAndRecv closes the send direction of the stream and waits for the
 // server to ack.
 func (p *Publisher) CloseAndRecv() (*repb.PublishOperationResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.retryStream.closeAndRecv()
 }
 

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -43,27 +43,19 @@ type Publisher struct {
 	// auxiliary metadata.
 	executionStageProgress repb.ExecutionProgress_ExecutionState
 
-	mu     sync.Mutex
-	stream *retryingClient
-}
-
-func newPublisher(stream *retryingClient, taskID string, taskResourceName *digest.CASResourceName) *Publisher {
-	return &Publisher{
-		stream:           stream,
-		taskID:           taskID,
-		taskResourceName: taskResourceName,
-	}
+	mu          sync.Mutex
+	retryStream *retryingClient
 }
 
 func (p *Publisher) Context() context.Context {
-	return p.stream.Context()
+	return p.retryStream.ctx
 }
 
 // Send publishes a message on the stream. It is safe for concurrent use.
 func (p *Publisher) Send(op *longrunningpb.Operation) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.stream.Send(op)
+	return p.retryStream.send(op)
 }
 
 // Ping re-publishes the current execution progress state.
@@ -101,7 +93,7 @@ func (p *Publisher) SetState(state repb.ExecutionProgress_ExecutionState) error 
 // CloseAndRecv closes the send direction of the stream and waits for the
 // server to ack.
 func (p *Publisher) CloseAndRecv() (*repb.PublishOperationResponse, error) {
-	return p.stream.CloseAndRecv()
+	return p.retryStream.closeAndRecv()
 }
 
 // retryingClient works like a PublishOperationClient but transparently
@@ -109,16 +101,17 @@ func (p *Publisher) CloseAndRecv() (*repb.PublishOperationResponse, error) {
 // the backend; instead it depends on the client connection being terminated by
 // an L7 proxy.
 type retryingClient struct {
-	ctx          context.Context
-	client       repb.ExecutionClient
-	clientStream repb.Execution_PublishOperationClient
-	lastMsg      *longrunningpb.Operation
+	ctx                       context.Context
+	client                    repb.ExecutionClient
+	clientStream              repb.Execution_PublishOperationClient
+	previousCompletedMessages []*longrunningpb.Operation
 }
 
 // Publish begins a PublishOperation stream and transparently reconnects the
 // stream if disconnected. After a disconnect (either in Send or CloseAndRecv),
-// it will re-publish the last sent message if applicable to ensure that the
-// server has acknowledged it.
+// it will re-publish every COMPLETED message sent so far to ensure the server
+// has acknowledged them. Non-COMPLETED progress updates are not buffered and
+// may be silently dropped on disconnect.
 func Publish(ctx context.Context, client repb.ExecutionClient, taskID string) (*Publisher, error) {
 	r, err := digest.ParseUploadResourceName(taskID)
 	if err != nil {
@@ -128,24 +121,36 @@ func Publish(ctx context.Context, client repb.ExecutionClient, taskID string) (*
 	if err != nil {
 		return nil, err
 	}
-	retryingStream := &retryingClient{
-		ctx:          ctx,
-		client:       client,
-		clientStream: clientStream,
+	return &Publisher{
+		retryStream: &retryingClient{
+			ctx:          ctx,
+			client:       client,
+			clientStream: clientStream,
+		},
+		taskID:           taskID,
+		taskResourceName: r,
+	}, nil
+}
+
+func (c *retryingClient) send(msg *longrunningpb.Operation) error {
+	if err := c.sendWithRetry(msg); err != nil {
+		return err
 	}
-	return newPublisher(retryingStream, taskID, r), nil
-}
-
-func (c *retryingClient) Context() context.Context {
-	return c.ctx
-}
-
-func (c *retryingClient) Send(msg *longrunningpb.Operation) error {
-	// If CloseAndRecv fails, this message isn't guaranteed to be ack'd by the
-	// server, so when retrying CloseAndRecv we need to re-send this message
-	// first to ensure it is ack'd.
-	c.lastMsg = msg
-	return c.sendWithRetry(msg)
+	// Even though Send returned nil, the gRPC stream may have only buffered the
+	// message locally without the server actually receiving it. To ensure we
+	// don't lose critical updates, save all COMPLETED messages and replay them
+	// after any future reconnect. Other progress updates are not critical.
+	//
+	// Note: the append must happen *after* sendWithRetry succeeds, not before.
+	// sendWithRetry's reconnect path already replays previousCompletedMessages
+	// on the new stream, so appending beforehand would cause the COMPLETED
+	// message to be delivered twice on the same reconnect cycle (once by the
+	// replay, once by sendWithRetry's retry of msg).
+	stage := ExtractStage(msg)
+	if stage == repb.ExecutionStage_COMPLETED {
+		c.previousCompletedMessages = append(c.previousCompletedMessages, msg)
+	}
+	return nil
 }
 
 func (c *retryingClient) sendWithRetry(msg *longrunningpb.Operation) error {
@@ -183,6 +188,7 @@ func (c *retryingClient) sendWithRetry(msg *longrunningpb.Operation) error {
 func (s *retryingClient) reconnect(retryCtx context.Context) error {
 	r := retry.DefaultWithContext(retryCtx)
 	var lastErr error
+outer:
 	for r.Next() {
 		// Note, we don't use the retryCtx here because it has a timeout, and we
 		// don't want this timeout to affect the RPC once it succeeds.
@@ -193,6 +199,16 @@ func (s *retryingClient) reconnect(retryCtx context.Context) error {
 		}
 		log.CtxInfof(s.ctx, "Successfully reconnected PublishOperation stream.")
 		s.clientStream = clientStream
+		for _, msg := range s.previousCompletedMessages {
+			if err := s.clientStream.Send(msg); err != nil {
+				if !isRetryablePublishError(err) {
+					return status.WrapError(err, "failed to resend completed message after reconnect")
+				}
+				lastErr = err
+				log.CtxWarningf(s.ctx, "Failed to retry un-acknowledged operation update: %s", err)
+				continue outer
+			}
+		}
 		return nil
 	}
 	if lastErr != nil {
@@ -207,7 +223,7 @@ func (s *retryingClient) reconnect(retryCtx context.Context) error {
 	return status.UnknownError("reconnect: unknown error")
 }
 
-func (c *retryingClient) CloseAndRecv() (*repb.PublishOperationResponse, error) {
+func (c *retryingClient) closeAndRecv() (*repb.PublishOperationResponse, error) {
 	var lastErr error
 	retryCtx, cancel := context.WithTimeout(c.ctx, reconnectTimeout)
 	defer cancel()
@@ -222,20 +238,10 @@ func (c *retryingClient) CloseAndRecv() (*repb.PublishOperationResponse, error) 
 		}
 		lastErr = err
 		log.CtxInfof(c.ctx, "PublishOperation stream disconnected; attempting to reconnect.")
-		// Stream is broken; reconnect and retry. If this fails, return the
-		// original error.
+		// Stream is broken; reconnect and resend COMPLETED messages. If this
+		// fails, return the original error.
 		if err := c.reconnect(retryCtx); err != nil {
 			log.CtxWarningf(c.ctx, "Failed to reconnect operation stream: %s", err)
-			break
-		}
-		// Since CloseAndRecv failed, the server isn't guaranteed to have gotten
-		// our last published message, so publish it again. But if that fails,
-		// just return the original error.
-		if c.lastMsg == nil {
-			continue
-		}
-		if err := c.sendWithRetry(c.lastMsg); err != nil {
-			log.CtxWarningf(c.ctx, "Failed to retry un-acknowledged operation update: %s", err)
 			break
 		}
 	}
@@ -304,7 +310,6 @@ type StreamLike interface {
 }
 
 type StateChangeFunc func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error
-type FinishWithErrorFunc func(finalErr error) error
 
 func GetStateChangeFunc(stream StreamLike, taskID string, adInstanceDigest *repb.Digest) StateChangeFunc {
 	return func(stage repb.ExecutionStage_Value, execResponse *repb.ExecuteResponse) error {

--- a/enterprise/server/remote_execution/operation/operation_test.go
+++ b/enterprise/server/remote_execution/operation/operation_test.go
@@ -159,18 +159,17 @@ func TestRetryingClient_Send_BuffersDifferentNonCompletedStagesSeparately(t *tes
 	assert.Equal(t, 2, len(pub.retryStream.republishMessages), "different stages get separate buffer entries")
 }
 
-func TestRetryingClient_Send_NonRetryableError_NotBuffered(t *testing.T) {
-	// The server rejects the message with a non-retryable error code. The
-	// send returns the error and we must NOT buffer the message — replaying
-	// it on a future reconnect would just fail the same way and poison the
-	// reconnect path for the rest of the Publisher's lifetime.
+func TestRetryingClient_Send_NonRetryableError_Surfaces(t *testing.T) {
+	// The server rejects the message with a non-retryable error code; the
+	// error must surface to the caller. The message remains in the buffer
+	// (saveMessage runs before Send), which is harmless: the Publisher is
+	// effectively dead after surfacing a non-retryable error anyway.
 	stream := &fakeStream{sendErr: gstatus.Error(gcodes.InvalidArgument, "bad message")}
 	pub, _ := newPublisher(t, stream)
 
 	err := pub.Send(completedOp(t))
 	require.Error(t, err)
 	assert.Equal(t, gcodes.InvalidArgument, gstatus.Code(err))
-	assert.Empty(t, pub.retryStream.republishMessages, "rejected messages must not be buffered")
 }
 
 func TestRetryingClient_Send_ReconnectsAndDeliversCompletedExactlyOnce(t *testing.T) {

--- a/enterprise/server/remote_execution/operation/operation_test.go
+++ b/enterprise/server/remote_execution/operation/operation_test.go
@@ -1,0 +1,277 @@
+package operation
+
+import (
+	"context"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"cloud.google.com/go/longrunning/autogen/longrunningpb"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	gcodes "google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
+)
+
+var (
+	testDigest = &repb.Digest{Hash: strings.Repeat("a", 64), SizeBytes: 1}
+	testTaskID = digest.NewCASResourceName(testDigest, "test-instance", repb.DigestFunction_SHA256).NewUploadString()
+)
+
+// fakeStream is a minimal grpc.ClientStreamingClient that records sent
+// operations and lets the test program Send / CloseAndRecv outcomes. The
+// embedded grpc.ClientStream is nil; calls to its methods will panic, which
+// is fine because retryingClient only uses Send and CloseAndRecv.
+type fakeStream struct {
+	grpc.ClientStream
+
+	mu       sync.Mutex
+	received []*longrunningpb.Operation
+
+	// sendErr, if non-nil, is returned by every Send call (and the message
+	// is not recorded).
+	sendErr error
+	// closeErr, if non-nil, is returned by CloseAndRecv.
+	closeErr error
+}
+
+func (s *fakeStream) Send(op *longrunningpb.Operation) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.received = append(s.received, op)
+	return nil
+}
+
+func (s *fakeStream) CloseAndRecv() (*repb.PublishOperationResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closeErr != nil {
+		return nil, s.closeErr
+	}
+	return &repb.PublishOperationResponse{}, nil
+}
+
+func (s *fakeStream) recordedOps() []*longrunningpb.Operation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.received)
+}
+
+// fakeExecutionClient implements just enough of repb.ExecutionClient to drive
+// retryingClient. PublishOperation pops the next stream from the streams
+// slice; the test sets up streams in the order it expects them to be opened.
+type fakeExecutionClient struct {
+	repb.ExecutionClient
+
+	mu      sync.Mutex
+	streams []*fakeStream
+	dialed  int
+}
+
+func (c *fakeExecutionClient) PublishOperation(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[longrunningpb.Operation, repb.PublishOperationResponse], error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.dialed >= len(c.streams) {
+		return nil, gstatus.Error(gcodes.Internal, "fakeExecutionClient: no more streams configured")
+	}
+	s := c.streams[c.dialed]
+	c.dialed++
+	return s, nil
+}
+
+// newPublisher returns a Publisher backed by a fake ExecutionClient whose
+// PublishOperation hands out the given streams in order. The first stream
+// becomes the initial PublishOperation stream; subsequent streams are used by
+// reconnect, in order.
+func newPublisher(t *testing.T, streams ...*fakeStream) (*Publisher, *fakeExecutionClient) {
+	t.Helper()
+	require.NotEmpty(t, streams, "must configure at least one stream")
+	client := &fakeExecutionClient{streams: streams}
+	pub, err := Publish(t.Context(), client, testTaskID)
+	require.NoError(t, err)
+	return pub, client
+}
+
+func completedOp(t *testing.T) *longrunningpb.Operation {
+	t.Helper()
+	op, err := Assemble(testTaskID, Metadata(repb.ExecutionStage_COMPLETED, testDigest), nil)
+	require.NoError(t, err)
+	return op
+}
+
+func progressOp(t *testing.T) *longrunningpb.Operation {
+	t.Helper()
+	op, err := Assemble(testTaskID, Metadata(repb.ExecutionStage_EXECUTING, testDigest), nil)
+	require.NoError(t, err)
+	return op
+}
+
+func TestRetryingClient_Send_BuffersCompletedAfterSuccess(t *testing.T) {
+	stream := &fakeStream{}
+	pub, _ := newPublisher(t, stream)
+
+	op := completedOp(t)
+	require.NoError(t, pub.Send(op))
+
+	// Stream received the op, and the buffer contains it for future replay.
+	assert.Equal(t, 1, len(stream.recordedOps()))
+	assert.Equal(t, 1, len(pub.retryStream.previousCompletedMessages))
+}
+
+func TestRetryingClient_Send_DoesNotBufferNonCompleted(t *testing.T) {
+	stream := &fakeStream{}
+	pub, _ := newPublisher(t, stream)
+
+	require.NoError(t, pub.Send(progressOp(t)))
+
+	assert.Equal(t, 1, len(stream.recordedOps()))
+	assert.Empty(t, pub.retryStream.previousCompletedMessages, "non-COMPLETED messages must not be buffered")
+}
+
+func TestRetryingClient_Send_NonRetryableError_NotBuffered(t *testing.T) {
+	// The server rejects the message with a non-retryable error code. The
+	// send returns the error and we must NOT buffer the message — replaying
+	// it on a future reconnect would just fail the same way and poison the
+	// reconnect path for the rest of the Publisher's lifetime.
+	stream := &fakeStream{sendErr: gstatus.Error(gcodes.InvalidArgument, "bad message")}
+	pub, _ := newPublisher(t, stream)
+
+	err := pub.Send(completedOp(t))
+	require.Error(t, err)
+	assert.Equal(t, gcodes.InvalidArgument, gstatus.Code(err))
+	assert.Empty(t, pub.retryStream.previousCompletedMessages, "rejected messages must not be buffered")
+}
+
+func TestRetryingClient_Send_ReconnectsAndDeliversCompletedExactlyOnce(t *testing.T) {
+	// First stream's Send fails with a retryable error. retryingClient
+	// should reconnect, replay the (still-empty) buffer on stream 2, and
+	// retry the send on stream 2. Stream 2 must receive the message exactly
+	// once — not once from the replay loop AND once from the retry.
+	stream1 := &fakeStream{sendErr: io.EOF}
+	stream2 := &fakeStream{}
+	pub, _ := newPublisher(t, stream1, stream2)
+
+	op := completedOp(t)
+	require.NoError(t, pub.Send(op))
+
+	assert.Empty(t, stream1.recordedOps(), "stream 1's Send was rigged to fail")
+	assert.Equal(t, 1, len(stream2.recordedOps()), "stream 2 must receive the COMPLETED exactly once")
+	assert.Equal(t, 1, len(pub.retryStream.previousCompletedMessages))
+}
+
+func TestRetryingClient_Send_ReconnectsAndDeliversNonCompletedExactlyOnce(t *testing.T) {
+	// A non-COMPLETED Send that fails with a retryable error should still
+	// be retried on the new stream by sendWithRetry — the "don't buffer
+	// non-COMPLETED" rule means it won't be replayed by future reconnects,
+	// but the in-flight send itself must succeed.
+	stream1 := &fakeStream{sendErr: io.EOF}
+	stream2 := &fakeStream{}
+	pub, _ := newPublisher(t, stream1, stream2)
+
+	op := progressOp(t)
+	require.NoError(t, pub.Send(op))
+
+	assert.Empty(t, stream1.recordedOps(), "stream 1's Send was rigged to fail")
+	got := stream2.recordedOps()
+	require.Equal(t, 1, len(got), "stream 2 must receive the progress update exactly once")
+	assert.Equal(t, op, got[0])
+	assert.Empty(t, pub.retryStream.previousCompletedMessages, "non-COMPLETED messages must not be buffered even after a reconnect")
+}
+
+func TestRetryingClient_Send_ReplaysBufferedCompletedOnNewStream(t *testing.T) {
+	// COMPLETED #1 succeeds on stream 1 (and is buffered). Then stream 1
+	// breaks. COMPLETED #2's send triggers reconnect, which replays #1 on
+	// stream 2, then sendWithRetry sends #2 on stream 2. Stream 2 should
+	// observe [#1, #2].
+	stream1 := &fakeStream{}
+	stream2 := &fakeStream{}
+	pub, _ := newPublisher(t, stream1, stream2)
+
+	op1 := completedOp(t)
+	op2 := completedOp(t)
+
+	require.NoError(t, pub.Send(op1))
+	assert.Equal(t, 1, len(stream1.recordedOps()))
+
+	stream1.mu.Lock()
+	stream1.sendErr = io.EOF
+	stream1.mu.Unlock()
+
+	require.NoError(t, pub.Send(op2))
+
+	got := stream2.recordedOps()
+	require.Equal(t, 2, len(got), "stream 2 should see both COMPLETED messages")
+	assert.Equal(t, op1, got[0], "buffered COMPLETED replayed first")
+	assert.Equal(t, op2, got[1], "new COMPLETED sent after replay")
+	assert.Equal(t, 2, len(pub.retryStream.previousCompletedMessages))
+}
+
+func TestRetryingClient_Send_DoesNotReplayNonCompleted(t *testing.T) {
+	// A non-COMPLETED progress update goes through on stream 1 but is not
+	// buffered. After stream 1 breaks, a COMPLETED send triggers reconnect.
+	// The replay loop should send nothing (buffer is empty), then the
+	// COMPLETED is sent on stream 2. Stream 2 must NOT see the dropped
+	// progress update.
+	stream1 := &fakeStream{}
+	stream2 := &fakeStream{}
+	pub, _ := newPublisher(t, stream1, stream2)
+
+	progress := progressOp(t)
+	require.NoError(t, pub.Send(progress))
+	assert.Equal(t, 1, len(stream1.recordedOps()))
+
+	stream1.mu.Lock()
+	stream1.sendErr = io.EOF
+	stream1.mu.Unlock()
+
+	op := completedOp(t)
+	require.NoError(t, pub.Send(op))
+
+	got := stream2.recordedOps()
+	require.Equal(t, 1, len(got), "stream 2 should see only the COMPLETED")
+	assert.Equal(t, op, got[0])
+}
+
+func TestRetryingClient_CloseAndRecv_ReconnectsAndReplaysCompleted(t *testing.T) {
+	// COMPLETED is sent successfully on stream 1 (and buffered). Stream 1's
+	// CloseAndRecv then returns a retryable error. closeAndRecv should
+	// reconnect, replay [COMPLETED] on stream 2, and close stream 2
+	// cleanly. Server sees the COMPLETED once on each stream — duplicate
+	// COMPLETED on the wire is the documented tradeoff for resilience.
+	stream1 := &fakeStream{closeErr: gstatus.Error(gcodes.Unavailable, "broken")}
+	stream2 := &fakeStream{}
+	pub, _ := newPublisher(t, stream1, stream2)
+
+	op := completedOp(t)
+	require.NoError(t, pub.Send(op))
+	assert.Equal(t, 1, len(stream1.recordedOps()))
+
+	res, err := pub.CloseAndRecv()
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+
+	got := stream2.recordedOps()
+	require.Equal(t, 1, len(got), "stream 2 should receive the replayed COMPLETED")
+	assert.Equal(t, op, got[0])
+}
+
+func TestRetryingClient_CloseAndRecv_NonRetryableError_Surfaces(t *testing.T) {
+	// CloseAndRecv returning a non-retryable error is surfaced to the
+	// caller without any reconnect attempt.
+	stream1 := &fakeStream{closeErr: gstatus.Error(gcodes.InvalidArgument, "nope")}
+	pub, client := newPublisher(t, stream1)
+
+	_, err := pub.CloseAndRecv()
+	require.Error(t, err)
+	assert.Equal(t, gcodes.InvalidArgument, gstatus.Code(err))
+	assert.Equal(t, 1, client.dialed, "no reconnect attempted on non-retryable error")
+}

--- a/enterprise/server/remote_execution/operation/operation_test.go
+++ b/enterprise/server/remote_execution/operation/operation_test.go
@@ -124,17 +124,39 @@ func TestRetryingClient_Send_BuffersCompletedAfterSuccess(t *testing.T) {
 
 	// Stream received the op, and the buffer contains it for future replay.
 	assert.Equal(t, 1, len(stream.recordedOps()))
-	assert.Equal(t, 1, len(pub.retryStream.previousCompletedMessages))
+	assert.Equal(t, 1, len(pub.retryStream.republishMessages))
 }
 
-func TestRetryingClient_Send_DoesNotBufferNonCompleted(t *testing.T) {
+func TestRetryingClient_Send_BuffersOneMessagePerNonCompletedStage(t *testing.T) {
+	// Non-COMPLETED progress updates are also saved for replay, but at most
+	// one entry per stage — a second update with the same stage replaces
+	// the first in place so the buffer always holds the latest known
+	// progress state for each stage.
 	stream := &fakeStream{}
 	pub, _ := newPublisher(t, stream)
 
-	require.NoError(t, pub.Send(progressOp(t)))
+	first := progressOp(t)
+	require.NoError(t, pub.Send(first))
+	assert.Equal(t, 1, len(pub.retryStream.republishMessages))
 
-	assert.Equal(t, 1, len(stream.recordedOps()))
-	assert.Empty(t, pub.retryStream.previousCompletedMessages, "non-COMPLETED messages must not be buffered")
+	second := progressOp(t)
+	require.NoError(t, pub.Send(second))
+	require.Equal(t, 1, len(pub.retryStream.republishMessages), "same-stage updates collapse")
+	assert.Same(t, second, pub.retryStream.republishMessages[0].msg, "buffer holds the most recent")
+}
+
+func TestRetryingClient_Send_BuffersDifferentNonCompletedStagesSeparately(t *testing.T) {
+	stream := &fakeStream{}
+	pub, _ := newPublisher(t, stream)
+
+	queued, err := Assemble(testTaskID, Metadata(repb.ExecutionStage_QUEUED, testDigest), nil)
+	require.NoError(t, err)
+	executing := progressOp(t) // EXECUTING stage
+
+	require.NoError(t, pub.Send(queued))
+	require.NoError(t, pub.Send(executing))
+
+	assert.Equal(t, 2, len(pub.retryStream.republishMessages), "different stages get separate buffer entries")
 }
 
 func TestRetryingClient_Send_NonRetryableError_NotBuffered(t *testing.T) {
@@ -148,7 +170,7 @@ func TestRetryingClient_Send_NonRetryableError_NotBuffered(t *testing.T) {
 	err := pub.Send(completedOp(t))
 	require.Error(t, err)
 	assert.Equal(t, gcodes.InvalidArgument, gstatus.Code(err))
-	assert.Empty(t, pub.retryStream.previousCompletedMessages, "rejected messages must not be buffered")
+	assert.Empty(t, pub.retryStream.republishMessages, "rejected messages must not be buffered")
 }
 
 func TestRetryingClient_Send_ReconnectsAndDeliversCompletedExactlyOnce(t *testing.T) {
@@ -165,14 +187,14 @@ func TestRetryingClient_Send_ReconnectsAndDeliversCompletedExactlyOnce(t *testin
 
 	assert.Empty(t, stream1.recordedOps(), "stream 1's Send was rigged to fail")
 	assert.Equal(t, 1, len(stream2.recordedOps()), "stream 2 must receive the COMPLETED exactly once")
-	assert.Equal(t, 1, len(pub.retryStream.previousCompletedMessages))
+	assert.Equal(t, 1, len(pub.retryStream.republishMessages))
 }
 
 func TestRetryingClient_Send_ReconnectsAndDeliversNonCompletedExactlyOnce(t *testing.T) {
-	// A non-COMPLETED Send that fails with a retryable error should still
-	// be retried on the new stream by sendWithRetry — the "don't buffer
-	// non-COMPLETED" rule means it won't be replayed by future reconnects,
-	// but the in-flight send itself must succeed.
+	// A non-COMPLETED Send that fails with a retryable error should be
+	// retried on the new stream by sendWithRetry and delivered exactly
+	// once — not duplicated by the replay loop + retry — and then saved
+	// to the buffer for future reconnects.
 	stream1 := &fakeStream{sendErr: io.EOF}
 	stream2 := &fakeStream{}
 	pub, _ := newPublisher(t, stream1, stream2)
@@ -184,7 +206,7 @@ func TestRetryingClient_Send_ReconnectsAndDeliversNonCompletedExactlyOnce(t *tes
 	got := stream2.recordedOps()
 	require.Equal(t, 1, len(got), "stream 2 must receive the progress update exactly once")
 	assert.Equal(t, op, got[0])
-	assert.Empty(t, pub.retryStream.previousCompletedMessages, "non-COMPLETED messages must not be buffered even after a reconnect")
+	assert.Equal(t, 1, len(pub.retryStream.republishMessages))
 }
 
 func TestRetryingClient_Send_ReplaysBufferedCompletedOnNewStream(t *testing.T) {
@@ -212,15 +234,14 @@ func TestRetryingClient_Send_ReplaysBufferedCompletedOnNewStream(t *testing.T) {
 	require.Equal(t, 2, len(got), "stream 2 should see both COMPLETED messages")
 	assert.Equal(t, op1, got[0], "buffered COMPLETED replayed first")
 	assert.Equal(t, op2, got[1], "new COMPLETED sent after replay")
-	assert.Equal(t, 2, len(pub.retryStream.previousCompletedMessages))
+	assert.Equal(t, 2, len(pub.retryStream.republishMessages))
 }
 
-func TestRetryingClient_Send_DoesNotReplayNonCompleted(t *testing.T) {
-	// A non-COMPLETED progress update goes through on stream 1 but is not
-	// buffered. After stream 1 breaks, a COMPLETED send triggers reconnect.
-	// The replay loop should send nothing (buffer is empty), then the
-	// COMPLETED is sent on stream 2. Stream 2 must NOT see the dropped
-	// progress update.
+func TestRetryingClient_Send_ReplaysNonCompletedOnNewStream(t *testing.T) {
+	// A non-COMPLETED progress update goes through on stream 1 and is
+	// buffered. After stream 1 breaks, a COMPLETED send triggers reconnect:
+	// the replay loop sends the buffered progress update on stream 2 first,
+	// then sendWithRetry sends the COMPLETED.
 	stream1 := &fakeStream{}
 	stream2 := &fakeStream{}
 	pub, _ := newPublisher(t, stream1, stream2)
@@ -237,8 +258,9 @@ func TestRetryingClient_Send_DoesNotReplayNonCompleted(t *testing.T) {
 	require.NoError(t, pub.Send(op))
 
 	got := stream2.recordedOps()
-	require.Equal(t, 1, len(got), "stream 2 should see only the COMPLETED")
-	assert.Equal(t, op, got[0])
+	require.Equal(t, 2, len(got), "stream 2 should see the replayed progress update and the COMPLETED")
+	assert.Same(t, progress, got[0], "buffered progress update replayed first")
+	assert.Same(t, op, got[1])
 }
 
 func TestRetryingClient_Reconnect_RetryableReplayFailure_RedialsAndSucceeds(t *testing.T) {
@@ -271,7 +293,7 @@ func TestRetryingClient_Reconnect_RetryableReplayFailure_RedialsAndSucceeds(t *t
 	require.Equal(t, 2, len(got), "stream 3 must receive op1 (replayed) then op2 (retried)")
 	assert.Equal(t, op1, got[0], "buffered COMPLETED replayed first")
 	assert.Equal(t, op2, got[1], "new COMPLETED sent after replay")
-	assert.Equal(t, 2, len(pub.retryStream.previousCompletedMessages))
+	assert.Equal(t, 2, len(pub.retryStream.republishMessages))
 }
 
 func TestRetryingClient_Reconnect_NonRetryableReplayFailure_Surfaces(t *testing.T) {
@@ -292,9 +314,11 @@ func TestRetryingClient_Reconnect_NonRetryableReplayFailure_Surfaces(t *testing.
 
 	err := pub.Send(completedOp(t))
 	require.Error(t, err, "the rejected replay must surface to the caller")
-	// op2's send aborted before the append, so the buffer should only
-	// contain the originally-acked op1.
-	assert.Equal(t, 1, len(pub.retryStream.previousCompletedMessages))
+	// op2 was saved before reconnect (so reconnect's replay would deliver
+	// it) and stays in the buffer when reconnect fails. The Publisher is
+	// effectively dead after surfacing a non-retryable error anyway, so
+	// leaving op2 buffered is harmless.
+	assert.Equal(t, 2, len(pub.retryStream.republishMessages))
 }
 
 func TestRetryingClient_CloseAndRecv_ReplaysMultipleBufferedCompleted(t *testing.T) {

--- a/enterprise/server/remote_execution/operation/operation_test.go
+++ b/enterprise/server/remote_execution/operation/operation_test.go
@@ -127,11 +127,9 @@ func TestRetryingClient_Send_BuffersCompletedAfterSuccess(t *testing.T) {
 	assert.Equal(t, 1, len(pub.retryStream.republishMessages))
 }
 
-func TestRetryingClient_Send_BuffersOneMessagePerNonCompletedStage(t *testing.T) {
-	// Non-COMPLETED progress updates are also saved for replay, but at most
-	// one entry per stage — a second update with the same stage replaces
-	// the first in place so the buffer always holds the latest known
-	// progress state for each stage.
+func TestRetryingClient_Send_KeepsOnlyMostRecentBeforeCompleted(t *testing.T) {
+	// Before any COMPLETED has been sent, the buffer holds only the most
+	// recent message — a newly-saved message drops whatever was there.
 	stream := &fakeStream{}
 	pub, _ := newPublisher(t, stream)
 
@@ -141,22 +139,24 @@ func TestRetryingClient_Send_BuffersOneMessagePerNonCompletedStage(t *testing.T)
 
 	second := progressOp(t)
 	require.NoError(t, pub.Send(second))
-	require.Equal(t, 1, len(pub.retryStream.republishMessages), "same-stage updates collapse")
+	require.Equal(t, 1, len(pub.retryStream.republishMessages), "older buffered message is dropped")
 	assert.Same(t, second, pub.retryStream.republishMessages[0].msg, "buffer holds the most recent")
 }
 
-func TestRetryingClient_Send_BuffersDifferentNonCompletedStagesSeparately(t *testing.T) {
+func TestRetryingClient_Send_AccumulatesMessagesAfterCompleted(t *testing.T) {
+	// Once a COMPLETED is in the buffer, every subsequent message stays —
+	// the execution server needs to see every completion-stage update
+	// (e.g. post-completion stats) to build the final execution record.
 	stream := &fakeStream{}
 	pub, _ := newPublisher(t, stream)
 
-	queued, err := Assemble(testTaskID, Metadata(repb.ExecutionStage_QUEUED, testDigest), nil)
-	require.NoError(t, err)
-	executing := progressOp(t) // EXECUTING stage
+	completed := completedOp(t)
+	require.NoError(t, pub.Send(completed))
+	require.Equal(t, 1, len(pub.retryStream.republishMessages))
 
-	require.NoError(t, pub.Send(queued))
-	require.NoError(t, pub.Send(executing))
-
-	assert.Equal(t, 2, len(pub.retryStream.republishMessages), "different stages get separate buffer entries")
+	progress := progressOp(t)
+	require.NoError(t, pub.Send(progress))
+	assert.Equal(t, 2, len(pub.retryStream.republishMessages), "messages after COMPLETED accumulate")
 }
 
 func TestRetryingClient_Send_NonRetryableError_Surfaces(t *testing.T) {
@@ -173,10 +173,9 @@ func TestRetryingClient_Send_NonRetryableError_Surfaces(t *testing.T) {
 }
 
 func TestRetryingClient_Send_ReconnectsAndDeliversCompletedExactlyOnce(t *testing.T) {
-	// First stream's Send fails with a retryable error. retryingClient
-	// should reconnect, replay the (still-empty) buffer on stream 2, and
-	// retry the send on stream 2. Stream 2 must receive the message exactly
-	// once — not once from the replay loop AND once from the retry.
+	// First stream's Send fails with a retryable error. send saves msg
+	// before failing, then reconnect's replay loop delivers it on stream 2.
+	// Stream 2 must receive the message exactly once.
 	stream1 := &fakeStream{sendErr: io.EOF}
 	stream2 := &fakeStream{}
 	pub, _ := newPublisher(t, stream1, stream2)
@@ -190,10 +189,8 @@ func TestRetryingClient_Send_ReconnectsAndDeliversCompletedExactlyOnce(t *testin
 }
 
 func TestRetryingClient_Send_ReconnectsAndDeliversNonCompletedExactlyOnce(t *testing.T) {
-	// A non-COMPLETED Send that fails with a retryable error should be
-	// retried on the new stream by sendWithRetry and delivered exactly
-	// once — not duplicated by the replay loop + retry — and then saved
-	// to the buffer for future reconnects.
+	// A non-COMPLETED Send that fails with a retryable error must also be
+	// delivered exactly once on the new stream, via reconnect's replay.
 	stream1 := &fakeStream{sendErr: io.EOF}
 	stream2 := &fakeStream{}
 	pub, _ := newPublisher(t, stream1, stream2)
@@ -210,9 +207,9 @@ func TestRetryingClient_Send_ReconnectsAndDeliversNonCompletedExactlyOnce(t *tes
 
 func TestRetryingClient_Send_ReplaysBufferedCompletedOnNewStream(t *testing.T) {
 	// COMPLETED #1 succeeds on stream 1 (and is buffered). Then stream 1
-	// breaks. COMPLETED #2's send triggers reconnect, which replays #1 on
-	// stream 2, then sendWithRetry sends #2 on stream 2. Stream 2 should
-	// observe [#1, #2].
+	// breaks. COMPLETED #2 is saved (appended after #1, since the buffer
+	// head is COMPLETED) and its Send fails, triggering reconnect, which
+	// replays [#1, #2] on stream 2.
 	stream1 := &fakeStream{}
 	stream2 := &fakeStream{}
 	pub, _ := newPublisher(t, stream1, stream2)
@@ -236,11 +233,12 @@ func TestRetryingClient_Send_ReplaysBufferedCompletedOnNewStream(t *testing.T) {
 	assert.Equal(t, 2, len(pub.retryStream.republishMessages))
 }
 
-func TestRetryingClient_Send_ReplaysNonCompletedOnNewStream(t *testing.T) {
+func TestRetryingClient_Send_DropsBufferedNonCompletedWhenSavingNext(t *testing.T) {
 	// A non-COMPLETED progress update goes through on stream 1 and is
-	// buffered. After stream 1 breaks, a COMPLETED send triggers reconnect:
-	// the replay loop sends the buffered progress update on stream 2 first,
-	// then sendWithRetry sends the COMPLETED.
+	// buffered. When stream 1 breaks and a COMPLETED is sent, saveMessage
+	// drops the buffered progress (the head isn't COMPLETED yet) before
+	// appending the COMPLETED. Stream 2's replay therefore sees only the
+	// COMPLETED — the earlier progress update is gone.
 	stream1 := &fakeStream{}
 	stream2 := &fakeStream{}
 	pub, _ := newPublisher(t, stream1, stream2)
@@ -257,9 +255,8 @@ func TestRetryingClient_Send_ReplaysNonCompletedOnNewStream(t *testing.T) {
 	require.NoError(t, pub.Send(op))
 
 	got := stream2.recordedOps()
-	require.Equal(t, 2, len(got), "stream 2 should see the replayed progress update and the COMPLETED")
-	assert.Same(t, progress, got[0], "buffered progress update replayed first")
-	assert.Same(t, op, got[1])
+	require.Equal(t, 1, len(got), "stream 2 should see only the COMPLETED — progress was dropped on save")
+	assert.Same(t, op, got[0])
 }
 
 func TestRetryingClient_Reconnect_RetryableReplayFailure_RedialsAndSucceeds(t *testing.T) {
@@ -366,6 +363,26 @@ func TestRetryingClient_CloseAndRecv_ReconnectsAndReplaysCompleted(t *testing.T)
 	got := stream2.recordedOps()
 	require.Equal(t, 1, len(got), "stream 2 should receive the replayed COMPLETED")
 	assert.Equal(t, op, got[0])
+}
+
+func TestRetryingClient_CloseAndRecv_ReplaysBufferedNonCompleted(t *testing.T) {
+	// A buffered non-COMPLETED stays in the buffer until another saveMessage
+	// call drops it. closeAndRecv doesn't go through saveMessage, so when
+	// its reconnect triggers, the buffered progress update is replayed on
+	// the new stream.
+	stream1 := &fakeStream{closeErr: gstatus.Error(gcodes.Unavailable, "broken")}
+	stream2 := &fakeStream{}
+	pub, _ := newPublisher(t, stream1, stream2)
+
+	progress := progressOp(t)
+	require.NoError(t, pub.Send(progress))
+
+	_, err := pub.CloseAndRecv()
+	require.NoError(t, err)
+
+	got := stream2.recordedOps()
+	require.Equal(t, 1, len(got), "stream 2 should receive the replayed progress update")
+	assert.Same(t, progress, got[0])
 }
 
 func TestRetryingClient_CloseAndRecv_NonRetryableError_Surfaces(t *testing.T) {

--- a/enterprise/server/remote_execution/operation/operation_test.go
+++ b/enterprise/server/remote_execution/operation/operation_test.go
@@ -241,6 +241,87 @@ func TestRetryingClient_Send_DoesNotReplayNonCompleted(t *testing.T) {
 	assert.Equal(t, op, got[0])
 }
 
+func TestRetryingClient_Reconnect_RetryableReplayFailure_RedialsAndSucceeds(t *testing.T) {
+	// Stream 1: first send succeeds, then it breaks.
+	// Stream 2: every send fails with a retryable error — exercises
+	// reconnect's `continue outer`, where a successful redial but failing
+	// replay triggers another redial.
+	// Stream 3: works. The buffered COMPLETED is replayed here, then the
+	// new COMPLETED is sent.
+	stream1 := &fakeStream{}
+	stream2 := &fakeStream{sendErr: io.EOF}
+	stream3 := &fakeStream{}
+	pub, client := newPublisher(t, stream1, stream2, stream3)
+
+	op1 := completedOp(t)
+	op2 := completedOp(t)
+
+	require.NoError(t, pub.Send(op1))
+	assert.Equal(t, 1, len(stream1.recordedOps()))
+
+	stream1.mu.Lock()
+	stream1.sendErr = io.EOF
+	stream1.mu.Unlock()
+
+	require.NoError(t, pub.Send(op2))
+
+	assert.Equal(t, 3, client.dialed, "reconnect should have redialed after stream 2's replay failure")
+	assert.Empty(t, stream2.recordedOps(), "stream 2's replay was rigged to fail")
+	got := stream3.recordedOps()
+	require.Equal(t, 2, len(got), "stream 3 must receive op1 (replayed) then op2 (retried)")
+	assert.Equal(t, op1, got[0], "buffered COMPLETED replayed first")
+	assert.Equal(t, op2, got[1], "new COMPLETED sent after replay")
+	assert.Equal(t, 2, len(pub.retryStream.previousCompletedMessages))
+}
+
+func TestRetryingClient_Reconnect_NonRetryableReplayFailure_Surfaces(t *testing.T) {
+	// Stream 1: first send succeeds, then breaks.
+	// Stream 2: replay fails with a non-retryable error — reconnect must
+	// return the wrapped error immediately rather than redialing or
+	// silently swallowing the rejection.
+	stream1 := &fakeStream{}
+	stream2 := &fakeStream{sendErr: gstatus.Error(gcodes.InvalidArgument, "rejected")}
+	pub, _ := newPublisher(t, stream1, stream2)
+
+	op1 := completedOp(t)
+	require.NoError(t, pub.Send(op1))
+
+	stream1.mu.Lock()
+	stream1.sendErr = io.EOF
+	stream1.mu.Unlock()
+
+	err := pub.Send(completedOp(t))
+	require.Error(t, err, "the rejected replay must surface to the caller")
+	// op2's send aborted before the append, so the buffer should only
+	// contain the originally-acked op1.
+	assert.Equal(t, 1, len(pub.retryStream.previousCompletedMessages))
+}
+
+func TestRetryingClient_CloseAndRecv_ReplaysMultipleBufferedCompleted(t *testing.T) {
+	// Two COMPLETED messages get buffered on stream 1. Stream 1's
+	// CloseAndRecv returns a retryable error, so reconnect runs and must
+	// replay BOTH buffered messages on stream 2 before closeAndRecv loops
+	// back to close it.
+	stream1 := &fakeStream{closeErr: gstatus.Error(gcodes.Unavailable, "broken")}
+	stream2 := &fakeStream{}
+	pub, _ := newPublisher(t, stream1, stream2)
+
+	op1 := completedOp(t)
+	op2 := completedOp(t)
+
+	require.NoError(t, pub.Send(op1))
+	require.NoError(t, pub.Send(op2))
+	assert.Equal(t, 2, len(stream1.recordedOps()))
+
+	_, err := pub.CloseAndRecv()
+	require.NoError(t, err)
+
+	got := stream2.recordedOps()
+	require.Equal(t, 2, len(got), "stream 2 should receive both buffered COMPLETED messages")
+	assert.Equal(t, op1, got[0])
+	assert.Equal(t, op2, got[1])
+}
+
 func TestRetryingClient_CloseAndRecv_ReconnectsAndReplaysCompleted(t *testing.T) {
 	// COMPLETED is sent successfully on stream 1 (and buffered). Stream 1's
 	// CloseAndRecv then returns a retryable error. closeAndRecv should


### PR DESCRIPTION
This will allow the executor to send multiple COMPLETED events and make sure that they are processed in order by execution_server.go