### PR TITLE
filecache: skip Windows directory sync

### DIFF
--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -135,9 +135,17 @@ jobs:
                    test `
                    --config=untrusted-ci-windows `
                    --test_tag_filters=-performance `
+                   --test_filter=TestFileCacheUncleanShutdownStartupOnWindows `
                    @authArgs `
                    -- `
-                   //enterprise/server/remote_execution/filecache:filecache_test `
+                   //enterprise/server/remote_execution/filecache:filecache_test
+          bazelisk --output_user_root=C:/0 `
+                   --windows_enable_symlinks `
+                   test `
+                   --config=untrusted-ci-windows `
+                   --test_tag_filters=-performance `
+                   @authArgs `
+                   -- `
                    //enterprise/server/remote_execution/workspace:workspace_test `
                    //enterprise/server/util/procstats:procstats_test `
                    //server/util/fastcopy:fastcopy_test

--- a/.github/workflows/build-executor-win.yaml
+++ b/.github/workflows/build-executor-win.yaml
@@ -137,6 +137,7 @@ jobs:
                    --test_tag_filters=-performance `
                    @authArgs `
                    -- `
+                   //enterprise/server/remote_execution/filecache:filecache_test `
                    //enterprise/server/remote_execution/workspace:workspace_test `
                    //enterprise/server/util/procstats:procstats_test `
                    //server/util/fastcopy:fastcopy_test

--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -12,7 +12,7 @@ go_library(
         "filecache.go",
         "filecache_darwin.go",
         "filecache_linux.go",
-        "filecache_other.go",
+        "filecache_unix.go",
         "filecache_windows.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache",
@@ -45,7 +45,10 @@ go_library(
 go_test(
     name = "filecache_test",
     size = "small",
-    srcs = ["filecache_test.go"],
+    srcs = [
+        "filecache_test.go",
+        "filecache_windows_test.go",
+    ],
     deps = [
         ":filecache",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -217,20 +217,6 @@ func (h *directoryHandle) moveToTrash() error {
 	return h.filecache.trash(h.path)
 }
 
-// syncDir fsyncs the directory at path to ensure any pending metadata changes
-// (e.g. file creation or deletion) are durable on disk.
-func syncDir(path string) error {
-	dir, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-	start := time.Now()
-	err = dir.Sync()
-	log.Infof("filecache: syncDir(%q) took %s (err: %v)", path, time.Since(start), err)
-	return err
-}
-
 // NewFileCache constructs an fileCache with maxSize that will cache files
 // in rootDir.
 // If deleteContent is true, the root dir will be deleted and recreated.

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -260,8 +260,8 @@ func NewFileCache(rootDir string, maxSizeBytes int64, deleteContent bool) (*file
 		if err := f.Close(); err != nil {
 			return nil, status.WrapErrorf(err, "failed to close filecache lock file")
 		}
-		if err := syncDir(rootDir); err != nil {
-			return nil, status.WrapErrorf(err, "failed to sync filecache root dir after creating lock file")
+		if err := syncLockFileCreation(rootDir); err != nil {
+			return nil, status.WrapErrorf(err, "failed to sync filecache lock file creation")
 		}
 	}
 	l, err := lru.New[*entry](&lru.Config[*entry]{MaxSize: maxSizeBytes, OnEvict: evictFn(rootDir), SizeFn: sizeFn})

--- a/enterprise/server/remote_execution/filecache/filecache_other.go
+++ b/enterprise/server/remote_execution/filecache/filecache_other.go
@@ -1,7 +1,0 @@
-//go:build !linux && !darwin && !windows
-
-package filecache
-
-func syncFilesystem(path string) error {
-	return nil
-}

--- a/enterprise/server/remote_execution/filecache/filecache_unix.go
+++ b/enterprise/server/remote_execution/filecache/filecache_unix.go
@@ -1,0 +1,24 @@
+//go:build (linux && !android) || (darwin && !ios)
+
+package filecache
+
+import (
+	"os"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+// syncDir fsyncs the directory at path to ensure any pending metadata changes
+// (e.g. file creation or deletion) are durable on disk.
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	start := time.Now()
+	err = dir.Sync()
+	log.Infof("filecache: syncDir(%q) took %s (err: %v)", path, time.Since(start), err)
+	return err
+}

--- a/enterprise/server/remote_execution/filecache/filecache_unix.go
+++ b/enterprise/server/remote_execution/filecache/filecache_unix.go
@@ -22,3 +22,7 @@ func syncDir(path string) error {
 	log.Infof("filecache: syncDir(%q) took %s (err: %v)", path, time.Since(start), err)
 	return err
 }
+
+func syncLockFileCreation(path string) error {
+	return syncDir(path)
+}

--- a/enterprise/server/remote_execution/filecache/filecache_windows.go
+++ b/enterprise/server/remote_execution/filecache/filecache_windows.go
@@ -8,6 +8,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+func syncDir(path string) error {
+	return nil
+}
+
 func syncFilesystem(path string) error {
 	vol := filepath.VolumeName(path)
 	volumePath, err := windows.UTF16PtrFromString(`\\.\` + vol)

--- a/enterprise/server/remote_execution/filecache/filecache_windows.go
+++ b/enterprise/server/remote_execution/filecache/filecache_windows.go
@@ -9,7 +9,31 @@ import (
 )
 
 func syncDir(path string) error {
-	return nil
+	pathp, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	// FILE_FLAG_BACKUP_SEMANTICS is required to open a directory handle.
+	// GENERIC_WRITE avoids the read-only handle that makes FlushFileBuffers
+	// fail with ERROR_ACCESS_DENIED on Windows/ReFS.
+	handle, err := windows.CreateFile(
+		pathp,
+		windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle)
+	return windows.FlushFileBuffers(handle)
+}
+
+func syncLockFileCreation(path string) error {
+	return syncDir(path)
 }
 
 func syncFilesystem(path string) error {

--- a/enterprise/server/remote_execution/filecache/filecache_windows_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package filecache_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+)
+
+const devDrivePath = "E:"
+
+func TestFileCacheUncleanShutdownStartupOnWindows(t *testing.T) {
+	flags.Set(t, "executor.delete_filecache_on_unclean_shutdown", true)
+
+	rootDir := windowsFileCacheRoot(t)
+	require.NoError(t, os.MkdirAll(rootDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "filecache.dirty"), nil, 0644))
+
+	fc, err := filecache.NewFileCache(rootDir, 100_000, false)
+	require.NoError(t, err)
+	require.NotNil(t, fc)
+	t.Cleanup(func() { require.NoError(t, fc.Close()) })
+	fc.WaitForDirectoryScanToComplete()
+}
+
+func windowsFileCacheRoot(t *testing.T) string {
+	rootDir, err := os.MkdirTemp(devDrivePath, "buildbuddy-filecache-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(rootDir)) })
+	return filepath.Join(rootDir, "cache")
+}


### PR DESCRIPTION
A customer hit Windows/ReFS executor startup loops because Go can return
ERROR_ACCESS_DENIED when it calls FlushFileBuffers on a read-only
directory handle after writing the unclean-shutdown marker.

Keep directory fsync on supported Unix platforms, but make the Windows
path a no-op. The clean-shutdown path still flushes the filecache volume
with syncFilesystem before removing the marker.

Add the Windows regression to the existing filecache_test target so the
package keeps a single test target while covering the Dev Drive startup
path in the Windows executor workflow.

