### PR TITLE
ocifetcher: refactor public methods in terms of common helpers

### DIFF
--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -148,25 +148,11 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return err
 	}
-	digestRef, hash, err := parseBlobDigestRef(req.GetRef(), "blob reference must be a digest reference, got %q")
+	digestRef, hash, err := parseBlobDigestRef(req.GetRef())
 	if err != nil {
 		return err
 	}
 
-	if req.GetBypassRegistry() {
-		err := s.fetchBlobFromCacheWithMetadataLookup(ctx, stream, digestRef, hash)
-		if err == nil {
-			return nil
-		}
-		if !status.IsNotFoundError(err) {
-			// It is possible this error occurred while writing to the stream.
-			// Since we do not know the state of the stream, it is not safe
-			// to write bytes to the stream past this point.
-			log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
-			return err
-		}
-		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
-	}
 	err = s.fetchBlobFromCacheWithMetadataLookup(ctx, stream, digestRef, hash)
 	if err == nil {
 		return nil
@@ -177,6 +163,9 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 		// to write bytes to the stream past this point.
 		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
 		return err
+	}
+	if req.GetBypassRegistry() {
+		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
 	}
 	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, req.GetCredentials())
 }
@@ -192,7 +181,7 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return nil, err
 	}
-	digestRef, hash, err := parseBlobDigestRef(req.GetRef(), "blob reference must be a digest reference (e.g., repo@sha256:...), got %q")
+	digestRef, hash, err := parseBlobDigestRef(req.GetRef())
 	if err != nil {
 		return nil, err
 	}
@@ -270,14 +259,14 @@ func validateBypassRegistry(ctx context.Context, bypassRegistry bool) error {
 	return nil
 }
 
-func parseBlobDigestRef(ref string, digestRequiredMsg string) (gcrname.Digest, gcr.Hash, error) {
+func parseBlobDigestRef(ref string) (gcrname.Digest, gcr.Hash, error) {
 	blobRef, err := gcrname.ParseReference(ref)
 	if err != nil {
 		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
 	}
 	digestRef, ok := blobRef.(gcrname.Digest)
 	if !ok {
-		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf(digestRequiredMsg, ref)
+		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("blob reference must be a digest reference (e.g., repo@sha256:...), got %q", ref)
 	}
 	hash, err := gcr.NewHash(digestRef.DigestStr())
 	if err != nil {

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -71,19 +71,7 @@ type ociFetcherServer struct {
 	// blobFetchGroup deduplicates concurrent blob fetch requests.
 	// Only one request fetches from upstream and writes to cache;
 	// other requests wait and then read from cache.
-	blobFetchGroup singleflight.Group[ocicache.BlobFetchKey, blobFetchResult]
-}
-
-// blobFetchResult holds metadata from the singleflight leader's
-// registry fetch so that waiters can stream from cache without
-// a separate action cache lookup for blob metadata.
-type blobFetchResult struct {
-	contentLength int64
-}
-
-type blobMeta struct {
-	size      int64
-	mediaType string
+	blobFetchGroup singleflight.Group[ocicache.BlobFetchKey, int64]
 }
 
 // NewServer constructs an OCIFetcherServer that
@@ -317,10 +305,9 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 	repo := digestRef.Context()
 	key := ocicache.NewBlobFetchKey(repo, hash, creds)
 	isLeader := false
-	result, _, err := s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (blobFetchResult, error) {
+	contentLength, _, err := s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (int64, error) {
 		isLeader = true
-		contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, digestRef, repo, hash, creds, stream)
-		return blobFetchResult{contentLength: contentLength}, err
+		return s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, digestRef, repo, hash, creds, stream)
 	})
 
 	if isLeader {
@@ -331,7 +318,7 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 		return err
 	}
-	err = s.fetchBlobFromCache(ctx, stream, hash, result.contentLength)
+	err = s.fetchBlobFromCache(ctx, stream, hash, contentLength)
 	recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 	return err
 }
@@ -348,7 +335,7 @@ func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, diges
 }
 
 func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, digestRef gcrname.Digest, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
-	meta, err := withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (*blobMeta, error) {
+	return withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (*ofpb.FetchBlobMetadataResponse, error) {
 		layer, err := puller.Layer(ctx, digestRef)
 		if err != nil {
 			return nil, err
@@ -361,15 +348,11 @@ func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, dige
 		if err != nil {
 			return nil, err
 		}
-		return &blobMeta{size: size, mediaType: string(mediaType)}, nil
+		return &ofpb.FetchBlobMetadataResponse{
+			Size:      size,
+			MediaType: string(mediaType),
+		}, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	return &ofpb.FetchBlobMetadataResponse{
-		Size:      meta.size,
-		MediaType: meta.mediaType,
-	}, nil
 }
 
 func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials, bypassRegistry bool) (gcr.Hash, error) {

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -81,6 +81,27 @@ type blobFetchResult struct {
 	contentLength int64
 }
 
+type validatedBlobRequest struct {
+	blobRef        gcrname.Reference
+	digestRef      gcrname.Digest
+	repo           gcrname.Repository
+	hash           gcr.Hash
+	creds          *rgpb.Credentials
+	bypassRegistry bool
+}
+
+type validatedManifestRequest struct {
+	imageRef       gcrname.Reference
+	repo           gcrname.Repository
+	creds          *rgpb.Credentials
+	bypassRegistry bool
+}
+
+type blobMeta struct {
+	size      int64
+	mediaType string
+}
+
 // NewServer constructs an OCIFetcherServer that
 // fetches OCI blobs and manifests from remote registries.
 //
@@ -152,65 +173,20 @@ func RegisterServer(env *real_environment.RealEnv) error {
 func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
 	ctx := stream.Context()
 
-	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+	blobReq, err := validateFetchBlobRequest(ctx, req)
+	if err != nil {
 		return err
 	}
 
-	blobRef, err := gcrname.ParseReference(req.GetRef())
-	if err != nil {
-		return status.InvalidArgumentErrorf("invalid blob reference %q: %s", req.GetRef(), err)
+	if blobReq.bypassRegistry {
+		return s.fetchBlobFromCacheOnly(ctx, stream, blobReq)
 	}
-
-	digestRef, ok := blobRef.(gcrname.Digest)
-	if !ok {
-		return status.InvalidArgumentErrorf("blob reference must be a digest reference, got %q", req.GetRef())
-	}
-
-	repo := digestRef.Context()
-	hash, err := gcr.NewHash(digestRef.DigestStr())
-	if err != nil {
-		return status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
-	}
-
-	err = s.fetchBlobFromCache(ctx, stream, repo, hash)
-	if err == nil {
+	if err := s.fetchBlobFromCache(ctx, stream, blobReq); err == nil {
 		return nil
-	}
-	if !status.IsNotFoundError(err) {
-		// It is possible this error occurred while writing to the stream.
-		// Since we do not know the state of the stream, it is not safe
-		// to write bytes to the stream past this point.
-		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
+	} else if err := handleBlobCacheStreamError(ctx, err); err != nil {
 		return err
 	}
-
-	if req.GetBypassRegistry() {
-		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", blobRef)
-	}
-
-	start := time.Now()
-	key := ocicache.NewBlobFetchKey(repo, hash, req.GetCredentials())
-	isLeader := false
-	result, _, err := s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (blobFetchResult, error) {
-		isLeader = true
-		contentLength, fetchErr := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, digestRef, repo, hash, req.GetCredentials(), stream)
-		return blobFetchResult{contentLength: contentLength}, fetchErr
-	})
-
-	if isLeader {
-		recordFetchBlobMetrics(metrics.OCIFetcherRoleLeader, err, time.Since(start))
-		return err
-	}
-
-	if err != nil {
-		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
-		return err
-	}
-
-	w := &grpcStreamWriter{stream: stream}
-	err = ocicache.FetchBlobFromCache(ctx, w, s.bsClient, hash, result.contentLength)
-	recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
-	return err
+	return s.fetchBlobWithSingleflight(ctx, stream, blobReq)
 }
 
 func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
@@ -236,47 +212,183 @@ func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
 // Server admins can bypass the registry: the metadata will be served from the action cache
 // if present. If not present, FetchBlobMetadata will not fall back to the remote registry.
 func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.FetchBlobMetadataRequest) (*ofpb.FetchBlobMetadataResponse, error) {
+	blobReq, err := validateFetchBlobMetadataRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp, err := s.fetchBlobMetadataFromCache(ctx, blobReq); err == nil {
+		return resp, nil
+	} else if !status.IsNotFoundError(err) {
+		logCacheReadError(ctx, "blob metadata", err)
+	}
+	if blobReq.bypassRegistry {
+		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", blobReq.blobRef)
+	}
+	return s.fetchBlobMetadataFromRemote(ctx, blobReq)
+}
+
+// FetchManifest returns an OCI manifest from the action cache if present,
+// falling back to the remote registry if not present.
+// FetchManifest will write the manifest contents to the action cache
+// after reading from the remote registry.
+//
+// Requests may have a bypass_registry flag set.
+// Server admins can bypass the registry: the manifest will be served from the action cache
+// if present. If not present, FetchManifest will not fall back to the remote registry.
+func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchManifestRequest) (*ofpb.FetchManifestResponse, error) {
+	manifestReq, err := validateFetchManifestRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return s.fetchManifest(ctx, manifestReq)
+}
+
+// FetchManifestMetadata fetches metadata (digest, size, media type) for an OCI manifest
+// from a remote registry.
+//
+// FetchManifestMetadata does not read from or write to the action cache or byte stream server.
+// Callers may rely on FetchManifestMetadata returning successfully as an indication
+// that the input credentials grant access to the OCI image in the remote registry.
+// Bypassing the registry is not possible. Requests that set the bypass_registry flag
+// will fail with an error.
+func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.FetchManifestMetadataRequest) (*ofpb.FetchManifestMetadataResponse, error) {
+	manifestReq, err := validateFetchManifestMetadataRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return s.fetchManifestMetadataFromRemote(ctx, manifestReq)
+}
+
+func validateFetchBlobRequest(ctx context.Context, req *ofpb.FetchBlobRequest) (*validatedBlobRequest, error) {
 	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return nil, err
 	}
+	return validateBlobRequest(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry(), "blob reference must be a digest reference, got %q")
+}
 
-	blobRef, err := gcrname.ParseReference(req.GetRef())
-	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid blob reference %q: %s", req.GetRef(), err)
+func validateFetchBlobMetadataRequest(ctx context.Context, req *ofpb.FetchBlobMetadataRequest) (*validatedBlobRequest, error) {
+	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
 	}
+	return validateBlobRequest(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry(), "blob reference must be a digest reference (e.g., repo@sha256:...), got %q")
+}
 
+func validateBlobRequest(ref string, creds *rgpb.Credentials, bypassRegistry bool, digestRequiredMsg string) (*validatedBlobRequest, error) {
+	blobRef, err := gcrname.ParseReference(ref)
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
+	}
 	digestRef, ok := blobRef.(gcrname.Digest)
 	if !ok {
-		return nil, status.InvalidArgumentErrorf("blob reference must be a digest reference (e.g., repo@sha256:...), got %q", req.GetRef())
+		return nil, status.InvalidArgumentErrorf(digestRequiredMsg, ref)
 	}
-
-	repo := digestRef.Context()
 	hash, err := gcr.NewHash(digestRef.DigestStr())
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
 	}
+	return &validatedBlobRequest{
+		blobRef:        blobRef,
+		digestRef:      digestRef,
+		repo:           digestRef.Context(),
+		hash:           hash,
+		creds:          creds,
+		bypassRegistry: bypassRegistry,
+	}, nil
+}
 
-	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
-	if err == nil {
-		return &ofpb.FetchBlobMetadataResponse{
-			Size:      metadata.GetContentLength(),
-			MediaType: metadata.GetContentType(),
-		}, nil
+func validateFetchManifestRequest(ctx context.Context, req *ofpb.FetchManifestRequest) (*validatedManifestRequest, error) {
+	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
 	}
-	if !status.IsNotFoundError(err) {
-		log.CtxWarningf(ctx, "Error fetching blob metadata from cache: %s", err)
-	}
+	return validateManifestRequest(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry())
+}
 
-	if req.GetBypassRegistry() {
-		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", blobRef)
+func validateFetchManifestMetadataRequest(ctx context.Context, req *ofpb.FetchManifestMetadataRequest) (*validatedManifestRequest, error) {
+	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
 	}
+	return validateManifestRequest(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry())
+}
 
-	type blobMeta struct {
-		size      int64
-		mediaType string
+func validateManifestRequest(ref string, creds *rgpb.Credentials, bypassRegistry bool) (*validatedManifestRequest, error) {
+	imageRef, err := gcrname.ParseReference(ref)
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", ref, err)
 	}
-	meta, err := withPullerRetry(ctx, s, blobRef, req.GetCredentials(), func(puller *remote.Puller) (*blobMeta, error) {
-		layer, err := puller.Layer(ctx, digestRef)
+	return &validatedManifestRequest{
+		imageRef:       imageRef,
+		repo:           imageRef.Context(),
+		creds:          creds,
+		bypassRegistry: bypassRegistry,
+	}, nil
+}
+
+func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest) error {
+	if err := s.fetchBlobFromCache(ctx, stream, req); err == nil {
+		return nil
+	} else if !status.IsNotFoundError(err) {
+		return handleBlobCacheStreamError(ctx, err)
+	}
+	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", req.blobRef)
+}
+
+func (s *ociFetcherServer) fetchBlobWithSingleflight(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest) error {
+	start := time.Now()
+	key := ocicache.NewBlobFetchKey(req.repo, req.hash, req.creds)
+	isLeader := false
+	result, _, err := s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (blobFetchResult, error) {
+		isLeader = true
+		return s.fetchBlobSingleflightLeader(ctx, stream, req)
+	})
+
+	if isLeader {
+		recordFetchBlobMetrics(metrics.OCIFetcherRoleLeader, err, time.Since(start))
+		return err
+	}
+	return s.fetchBlobSingleflightWaiter(ctx, stream, req, result, err, start)
+}
+
+func (s *ociFetcherServer) fetchBlobSingleflightLeader(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest) (blobFetchResult, error) {
+	contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, req.digestRef, req.repo, req.hash, req.creds, stream)
+	return blobFetchResult{contentLength: contentLength}, err
+}
+
+func (s *ociFetcherServer) fetchBlobSingleflightWaiter(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest, result blobFetchResult, leaderErr error, start time.Time) error {
+	if leaderErr != nil {
+		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, leaderErr, time.Since(start))
+		return leaderErr
+	}
+	w := &grpcStreamWriter{stream: stream}
+	err := ocicache.FetchBlobFromCache(ctx, w, s.bsClient, req.hash, result.contentLength)
+	recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
+	return err
+}
+
+func handleBlobCacheStreamError(ctx context.Context, err error) error {
+	if status.IsNotFoundError(err) {
+		return nil
+	}
+	// It is possible this error occurred while writing to the stream.
+	// Since we do not know the state of the stream, it is not safe
+	// to write bytes to the stream past this point.
+	log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
+	return err
+}
+
+func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, req *validatedBlobRequest) (*ofpb.FetchBlobMetadataResponse, error) {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, req.repo, req.hash)
+	if err != nil {
+		return nil, err
+	}
+	return &ofpb.FetchBlobMetadataResponse{
+		Size:      metadata.GetContentLength(),
+		MediaType: metadata.GetContentType(),
+	}, nil
+}
+
+func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, req *validatedBlobRequest) (*ofpb.FetchBlobMetadataResponse, error) {
+	meta, err := withPullerRetry(ctx, s, req.blobRef, req.creds, func(puller *remote.Puller) (*blobMeta, error) {
+		layer, err := puller.Layer(ctx, req.digestRef)
 		if err != nil {
 			return nil, err
 		}
@@ -299,81 +411,78 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 	}, nil
 }
 
-// FetchManifest returns an OCI manifest from the action cache if present,
-// falling back to the remote registry if not present.
-// FetchManifest will write the manifest contents to the action cache
-// after reading from the remote registry.
-//
-// Requests may have a bypass_registry flag set.
-// Server admins can bypass the registry: the manifest will be served from the action cache
-// if present. If not present, FetchManifest will not fall back to the remote registry.
-func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchManifestRequest) (*ofpb.FetchManifestResponse, error) {
-	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+func (s *ociFetcherServer) fetchManifest(ctx context.Context, req *validatedManifestRequest) (*ofpb.FetchManifestResponse, error) {
+	hash, err := s.resolveManifestDigest(ctx, req)
+	if err != nil {
 		return nil, err
 	}
-
-	imageRef, err := gcrname.ParseReference(req.GetRef())
-	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", req.GetRef(), err)
+	if resp, err := s.fetchManifestFromCache(ctx, req, hash); err == nil {
+		return resp, nil
+	} else if !status.IsNotFoundError(err) {
+		logCacheReadError(ctx, "manifest", err)
 	}
+	if req.bypassRegistry {
+		return nil, status.NotFoundErrorf("bypassing registry, but manifest for %q not found in cache", req.imageRef)
+	}
+	return s.fetchManifestFromRemoteAndCache(ctx, req, hash)
+}
 
-	var hash gcr.Hash
-	if digestRef, ok := imageRef.(gcrname.Digest); ok {
-		hash, err = gcr.NewHash(digestRef.DigestStr())
+func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, req *validatedManifestRequest) (gcr.Hash, error) {
+	if digestRef, ok := req.imageRef.(gcrname.Digest); ok {
+		hash, err := gcr.NewHash(digestRef.DigestStr())
 		if err != nil {
-			return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+			return gcr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
 		}
-		if !req.GetBypassRegistry() {
-			if err := s.proveManifestAccess(ctx, imageRef, req.GetCredentials()); err != nil {
-				return nil, err
+		if !req.bypassRegistry {
+			if err := s.proveManifestAccess(ctx, req.imageRef, req.creds); err != nil {
+				return gcr.Hash{}, err
 			}
 		}
-	} else {
-		if req.GetBypassRegistry() {
-			return nil, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", imageRef)
-		}
-
-		desc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*gcr.Descriptor, error) {
-			return puller.Head(ctx, imageRef)
-		})
-		if err != nil {
-			return nil, err
-		}
-		hash, err = gcr.NewHash(desc.Digest.String())
-		if err != nil {
-			return nil, status.InvalidArgumentErrorf("invalid resolved digest %q: %s", desc.Digest.String(), err)
-		}
+		return hash, nil
 	}
-
-	repo := imageRef.Context()
-	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, repo, hash, imageRef)
-	if err == nil {
-		return &ofpb.FetchManifestResponse{
-			Digest:    hash.String(),
-			Size:      int64(len(cached.GetRaw())),
-			MediaType: cached.GetContentType(),
-			Manifest:  cached.GetRaw(),
-		}, nil
+	if req.bypassRegistry {
+		return gcr.Hash{}, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", req.imageRef)
 	}
-	if !status.IsNotFoundError(err) {
-		log.CtxWarningf(ctx, "Error fetching manifest from cache: %s", err)
-	}
+	return s.resolveTagToDigest(ctx, req)
+}
 
-	if req.GetBypassRegistry() {
-		return nil, status.NotFoundErrorf("bypassing registry, but manifest for %q not found in cache", imageRef)
+func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, req *validatedManifestRequest) (gcr.Hash, error) {
+	desc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+		return puller.Head(ctx, req.imageRef)
+	})
+	if err != nil {
+		return gcr.Hash{}, err
 	}
+	hash, err := gcr.NewHash(desc.Digest.String())
+	if err != nil {
+		return gcr.Hash{}, status.InvalidArgumentErrorf("invalid resolved digest %q: %s", desc.Digest.String(), err)
+	}
+	return hash, nil
+}
 
-	remoteDesc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*remote.Descriptor, error) {
-		return puller.Get(ctx, imageRef)
+func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, req *validatedManifestRequest, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
+	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, req.repo, hash, req.imageRef)
+	if err != nil {
+		return nil, err
+	}
+	return &ofpb.FetchManifestResponse{
+		Digest:    hash.String(),
+		Size:      int64(len(cached.GetRaw())),
+		MediaType: cached.GetContentType(),
+		Manifest:  cached.GetRaw(),
+	}, nil
+}
+
+func (s *ociFetcherServer) fetchManifestFromRemoteAndCache(ctx context.Context, req *validatedManifestRequest, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
+	remoteDesc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
+		return puller.Get(ctx, req.imageRef)
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, repo, hash, string(remoteDesc.MediaType), imageRef); err != nil {
+	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, req.repo, hash, string(remoteDesc.MediaType), req.imageRef); err != nil {
 		log.CtxWarningf(ctx, "Error writing manifest to cache: %s", err)
 	}
-
 	return &ofpb.FetchManifestResponse{
 		Digest:    remoteDesc.Digest.String(),
 		Size:      remoteDesc.Size,
@@ -382,35 +491,22 @@ func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchMan
 	}, nil
 }
 
-// FetchManifestMetadata fetches metadata (digest, size, media type) for an OCI manifest
-// from a remote registry.
-//
-// FetchManifestMetadata does not read from or write to the action cache or byte stream server.
-// Callers may rely on FetchManifestMetadata returning successfully as an indication
-// that the input credentials grant access to the OCI image in the remote registry.
-// Bypassing the registry is not possible. Requests that set the bypass_registry flag
-// will fail with an error.
-func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.FetchManifestMetadataRequest) (*ofpb.FetchManifestMetadataResponse, error) {
-	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-	imageRef, err := gcrname.ParseReference(req.GetRef())
-	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", req.GetRef(), err)
-	}
-
-	desc, err := withPullerRetry(ctx, s, imageRef, req.GetCredentials(), func(puller *remote.Puller) (*gcr.Descriptor, error) {
-		return puller.Head(ctx, imageRef)
+func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, req *validatedManifestRequest) (*ofpb.FetchManifestMetadataResponse, error) {
+	desc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+		return puller.Head(ctx, req.imageRef)
 	})
 	if err != nil {
 		return nil, err
 	}
-
 	return &ofpb.FetchManifestMetadataResponse{
 		Digest:    desc.Digest.String(),
 		Size:      desc.Size,
 		MediaType: string(desc.MediaType),
 	}, nil
+}
+
+func logCacheReadError(ctx context.Context, what string, err error) {
+	log.CtxWarningf(ctx, "Error fetching %s from cache: %s", what, err)
 }
 
 func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Credentials) []remote.Option {
@@ -480,13 +576,13 @@ func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcr
 
 // fetchBlobFromCache attempts to fetch a blob from the cache and streams it directly to the gRPC response.
 // Returns nil if successful, NotFoundError if not in cache, or another error on failure.
-func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, repo gcrname.Repository, hash gcr.Hash) error {
-	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
+func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest) error {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, req.repo, req.hash)
 	if err != nil {
 		return err
 	}
 	w := &grpcStreamWriter{stream: stream}
-	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, hash, metadata.GetContentLength())
+	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, req.hash, metadata.GetContentLength())
 }
 
 // fetchBlobFromRemoteWriteToCacheAndResponse fetches a blob from the upstream

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -81,20 +81,11 @@ type blobFetchResult struct {
 	contentLength int64
 }
 
-type blobRequest struct {
-	blobRef        gcrname.Reference
-	digestRef      gcrname.Digest
-	repo           gcrname.Repository
-	hash           gcr.Hash
-	creds          *rgpb.Credentials
-	bypassRegistry bool
-}
-
-type manifestRequest struct {
-	imageRef       gcrname.Reference
-	repo           gcrname.Repository
-	creds          *rgpb.Credentials
-	bypassRegistry bool
+type blobDigestRef struct {
+	ref    gcrname.Reference
+	digest gcrname.Digest
+	repo   gcrname.Repository
+	hash   gcr.Hash
 }
 
 type blobMeta struct {
@@ -176,20 +167,26 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return err
 	}
-	blobReq, err := parseBlobDigestRef(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry(), "blob reference must be a digest reference, got %q")
+	blobRef, err := parseBlobDigestRef(req.GetRef(), "blob reference must be a digest reference, got %q")
 	if err != nil {
 		return err
 	}
 
-	if blobReq.bypassRegistry {
-		return s.fetchBlobFromCacheOnly(ctx, stream, blobReq)
+	if req.GetBypassRegistry() {
+		return s.fetchBlobFromCacheOnly(ctx, stream, blobRef)
 	}
-	if err := s.fetchBlobFromCache(ctx, stream, blobReq); err == nil {
+	err = s.fetchBlobFromCache(ctx, stream, blobRef)
+	if err == nil {
 		return nil
-	} else if err := handleBlobCacheStreamError(ctx, err); err != nil {
+	}
+	if !status.IsNotFoundError(err) {
+		// It is possible this error occurred while writing to the stream.
+		// Since we do not know the state of the stream, it is not safe
+		// to write bytes to the stream past this point.
+		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
 		return err
 	}
-	return s.fetchBlobWithSingleflight(ctx, stream, blobReq)
+	return s.fetchBlobWithSingleflight(ctx, stream, blobRef, req.GetCredentials())
 }
 
 func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
@@ -218,19 +215,19 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return nil, err
 	}
-	blobReq, err := parseBlobDigestRef(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry(), "blob reference must be a digest reference (e.g., repo@sha256:...), got %q")
+	blobRef, err := parseBlobDigestRef(req.GetRef(), "blob reference must be a digest reference (e.g., repo@sha256:...), got %q")
 	if err != nil {
 		return nil, err
 	}
-	if resp, err := s.fetchBlobMetadataFromCache(ctx, blobReq); err == nil {
+	if resp, err := s.fetchBlobMetadataFromCache(ctx, blobRef); err == nil {
 		return resp, nil
 	} else if !status.IsNotFoundError(err) {
 		log.CtxWarningf(ctx, "Error fetching blob metadata from cache: %s", err)
 	}
-	if blobReq.bypassRegistry {
-		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", blobReq.blobRef)
+	if req.GetBypassRegistry() {
+		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", blobRef.ref)
 	}
-	return s.fetchBlobMetadataFromRemote(ctx, blobReq)
+	return s.fetchBlobMetadataFromRemote(ctx, blobRef, req.GetCredentials())
 }
 
 // FetchManifest returns an OCI manifest from the action cache if present,
@@ -245,23 +242,23 @@ func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchMan
 	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return nil, err
 	}
-	manifestReq, err := parseManifestRef(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry())
+	imageRef, err := parseManifestRef(req.GetRef())
 	if err != nil {
 		return nil, err
 	}
-	hash, err := s.resolveManifestDigest(ctx, manifestReq)
+	hash, err := s.resolveManifestDigest(ctx, imageRef, req.GetCredentials(), req.GetBypassRegistry())
 	if err != nil {
 		return nil, err
 	}
-	if resp, err := s.fetchManifestFromCache(ctx, manifestReq, hash); err == nil {
+	if resp, err := s.fetchManifestFromCache(ctx, imageRef, hash); err == nil {
 		return resp, nil
 	} else if !status.IsNotFoundError(err) {
 		log.CtxWarningf(ctx, "Error fetching manifest from cache: %s", err)
 	}
-	if manifestReq.bypassRegistry {
-		return nil, status.NotFoundErrorf("bypassing registry, but manifest for %q not found in cache", manifestReq.imageRef)
+	if req.GetBypassRegistry() {
+		return nil, status.NotFoundErrorf("bypassing registry, but manifest for %q not found in cache", imageRef)
 	}
-	return s.fetchManifestFromRemoteAndCache(ctx, manifestReq, hash)
+	return s.fetchManifestFromRemoteWriteToCache(ctx, imageRef, hash, req.GetCredentials())
 }
 
 // FetchManifestMetadata fetches metadata (digest, size, media type) for an OCI manifest
@@ -276,14 +273,14 @@ func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.
 	if err := validateUnsupportedBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return nil, err
 	}
-	manifestReq, err := parseManifestRef(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry())
+	imageRef, err := parseManifestRef(req.GetRef())
 	if err != nil {
 		return nil, err
 	}
-	return s.fetchManifestMetadataFromRemote(ctx, manifestReq)
+	return s.fetchManifestMetadataFromRemote(ctx, imageRef, req.GetCredentials())
 }
 
-func parseBlobDigestRef(ref string, creds *rgpb.Credentials, bypassRegistry bool, digestRequiredMsg string) (*blobRequest, error) {
+func parseBlobDigestRef(ref string, digestRequiredMsg string) (*blobDigestRef, error) {
 	blobRef, err := gcrname.ParseReference(ref)
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
@@ -296,83 +293,71 @@ func parseBlobDigestRef(ref string, creds *rgpb.Credentials, bypassRegistry bool
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
 	}
-	return &blobRequest{
-		blobRef:        blobRef,
-		digestRef:      digestRef,
-		repo:           digestRef.Context(),
-		hash:           hash,
-		creds:          creds,
-		bypassRegistry: bypassRegistry,
+	return &blobDigestRef{
+		ref:    blobRef,
+		digest: digestRef,
+		repo:   digestRef.Context(),
+		hash:   hash,
 	}, nil
 }
 
-func parseManifestRef(ref string, creds *rgpb.Credentials, bypassRegistry bool) (*manifestRequest, error) {
+func parseManifestRef(ref string) (gcrname.Reference, error) {
 	imageRef, err := gcrname.ParseReference(ref)
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", ref, err)
 	}
-	return &manifestRequest{
-		imageRef:       imageRef,
-		repo:           imageRef.Context(),
-		creds:          creds,
-		bypassRegistry: bypassRegistry,
-	}, nil
+	return imageRef, nil
 }
 
-func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest) error {
-	if err := s.fetchBlobFromCache(ctx, stream, req); err == nil {
+func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef) error {
+	err := s.fetchBlobFromCache(ctx, stream, ref)
+	if err == nil {
 		return nil
-	} else if !status.IsNotFoundError(err) {
-		return handleBlobCacheStreamError(ctx, err)
 	}
-	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", req.blobRef)
+	if !status.IsNotFoundError(err) {
+		// It is possible this error occurred while writing to the stream.
+		// Since we do not know the state of the stream, it is not safe
+		// to write bytes to the stream past this point.
+		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
+		return err
+	}
+	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", ref.ref)
 }
 
-func (s *ociFetcherServer) fetchBlobWithSingleflight(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest) error {
+func (s *ociFetcherServer) fetchBlobWithSingleflight(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, creds *rgpb.Credentials) error {
 	start := time.Now()
-	key := ocicache.NewBlobFetchKey(req.repo, req.hash, req.creds)
+	key := ocicache.NewBlobFetchKey(ref.repo, ref.hash, creds)
 	isLeader := false
 	result, _, err := s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (blobFetchResult, error) {
 		isLeader = true
-		return s.fetchBlobSingleflightLeader(ctx, stream, req)
+		return s.fetchBlobSingleflightLeader(ctx, stream, ref, creds)
 	})
 
 	if isLeader {
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleLeader, err, time.Since(start))
 		return err
 	}
-	return s.fetchBlobSingleflightWaiter(ctx, stream, req, result, err, start)
+	return s.fetchBlobSingleflightWaiter(ctx, stream, ref, result, err, start)
 }
 
-func (s *ociFetcherServer) fetchBlobSingleflightLeader(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest) (blobFetchResult, error) {
-	contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, req.digestRef, req.repo, req.hash, req.creds, stream)
+func (s *ociFetcherServer) fetchBlobSingleflightLeader(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, creds *rgpb.Credentials) (blobFetchResult, error) {
+	contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, ref.digest, ref.repo, ref.hash, creds, stream)
 	return blobFetchResult{contentLength: contentLength}, err
 }
 
-func (s *ociFetcherServer) fetchBlobSingleflightWaiter(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest, result blobFetchResult, leaderErr error, start time.Time) error {
+func (s *ociFetcherServer) fetchBlobSingleflightWaiter(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, result blobFetchResult, leaderErr error, start time.Time) error {
 	if leaderErr != nil {
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, leaderErr, time.Since(start))
 		return leaderErr
 	}
 	w := &grpcStreamWriter{stream: stream}
-	err := ocicache.FetchBlobFromCache(ctx, w, s.bsClient, req.hash, result.contentLength)
+	err := ocicache.FetchBlobFromCache(ctx, w, s.bsClient, ref.hash, result.contentLength)
 	recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 	return err
 }
 
-func handleBlobCacheStreamError(ctx context.Context, err error) error {
-	if status.IsNotFoundError(err) {
-		return nil
-	}
-	// It is possible this error occurred while writing to the stream.
-	// Since we do not know the state of the stream, it is not safe
-	// to write bytes to the stream past this point.
-	log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
-	return err
-}
-
-func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, req *blobRequest) (*ofpb.FetchBlobMetadataResponse, error) {
-	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, req.repo, req.hash)
+func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, ref *blobDigestRef) (*ofpb.FetchBlobMetadataResponse, error) {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, ref.repo, ref.hash)
 	if err != nil {
 		return nil, err
 	}
@@ -382,9 +367,9 @@ func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, req *
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, req *blobRequest) (*ofpb.FetchBlobMetadataResponse, error) {
-	meta, err := withPullerRetry(ctx, s, req.blobRef, req.creds, func(puller *remote.Puller) (*blobMeta, error) {
-		layer, err := puller.Layer(ctx, req.digestRef)
+func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, ref *blobDigestRef, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
+	meta, err := withPullerRetry(ctx, s, ref.ref, creds, func(puller *remote.Puller) (*blobMeta, error) {
+		layer, err := puller.Layer(ctx, ref.digest)
 		if err != nil {
 			return nil, err
 		}
@@ -407,28 +392,28 @@ func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, req 
 	}, nil
 }
 
-func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, req *manifestRequest) (gcr.Hash, error) {
-	if digestRef, ok := req.imageRef.(gcrname.Digest); ok {
+func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials, bypassRegistry bool) (gcr.Hash, error) {
+	if digestRef, ok := imageRef.(gcrname.Digest); ok {
 		hash, err := gcr.NewHash(digestRef.DigestStr())
 		if err != nil {
 			return gcr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
 		}
-		if !req.bypassRegistry {
-			if err := s.proveManifestAccess(ctx, req.imageRef, req.creds); err != nil {
+		if !bypassRegistry {
+			if err := s.proveManifestAccess(ctx, imageRef, creds); err != nil {
 				return gcr.Hash{}, err
 			}
 		}
 		return hash, nil
 	}
-	if req.bypassRegistry {
-		return gcr.Hash{}, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", req.imageRef)
+	if bypassRegistry {
+		return gcr.Hash{}, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", imageRef)
 	}
-	return s.resolveTagToDigest(ctx, req)
+	return s.resolveTagToDigest(ctx, imageRef, creds)
 }
 
-func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, req *manifestRequest) (gcr.Hash, error) {
-	desc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
-		return puller.Head(ctx, req.imageRef)
+func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (gcr.Hash, error) {
+	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+		return puller.Head(ctx, imageRef)
 	})
 	if err != nil {
 		return gcr.Hash{}, err
@@ -440,8 +425,8 @@ func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, req *manifest
 	return hash, nil
 }
 
-func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, req *manifestRequest, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
-	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, req.repo, hash, req.imageRef)
+func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, imageRef gcrname.Reference, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
+	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, imageRef.Context(), hash, imageRef)
 	if err != nil {
 		return nil, err
 	}
@@ -453,14 +438,14 @@ func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, req *mani
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchManifestFromRemoteAndCache(ctx context.Context, req *manifestRequest, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
-	remoteDesc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
-		return puller.Get(ctx, req.imageRef)
+func (s *ociFetcherServer) fetchManifestFromRemoteWriteToCache(ctx context.Context, imageRef gcrname.Reference, hash gcr.Hash, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
+	remoteDesc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
+		return puller.Get(ctx, imageRef)
 	})
 	if err != nil {
 		return nil, err
 	}
-	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, req.repo, hash, string(remoteDesc.MediaType), req.imageRef); err != nil {
+	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, imageRef.Context(), hash, string(remoteDesc.MediaType), imageRef); err != nil {
 		log.CtxWarningf(ctx, "Error writing manifest to cache: %s", err)
 	}
 	return &ofpb.FetchManifestResponse{
@@ -471,9 +456,9 @@ func (s *ociFetcherServer) fetchManifestFromRemoteAndCache(ctx context.Context, 
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, req *manifestRequest) (*ofpb.FetchManifestMetadataResponse, error) {
-	desc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
-		return puller.Head(ctx, req.imageRef)
+func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*ofpb.FetchManifestMetadataResponse, error) {
+	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+		return puller.Head(ctx, imageRef)
 	})
 	if err != nil {
 		return nil, err
@@ -552,13 +537,13 @@ func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcr
 
 // fetchBlobFromCache attempts to fetch a blob from the cache and streams it directly to the gRPC response.
 // Returns nil if successful, NotFoundError if not in cache, or another error on failure.
-func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest) error {
-	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, req.repo, req.hash)
+func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef) error {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, ref.repo, ref.hash)
 	if err != nil {
 		return err
 	}
 	w := &grpcStreamWriter{stream: stream}
-	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, req.hash, metadata.GetContentLength())
+	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, ref.hash, metadata.GetContentLength())
 }
 
 // fetchBlobFromRemoteWriteToCacheAndResponse fetches a blob from the upstream

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -154,9 +154,20 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 	}
 
 	if req.GetBypassRegistry() {
-		return s.fetchBlobFromCacheOnly(ctx, stream, digestRef, hash)
+		err := s.fetchBlobFromCacheWithMetadataLookup(ctx, stream, digestRef, hash)
+		if err == nil {
+			return nil
+		}
+		if !status.IsNotFoundError(err) {
+			// It is possible this error occurred while writing to the stream.
+			// Since we do not know the state of the stream, it is not safe
+			// to write bytes to the stream past this point.
+			log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
+			return err
+		}
+		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
 	}
-	err = s.fetchBlobFromCacheWithMetadata(ctx, stream, digestRef, hash)
+	err = s.fetchBlobFromCacheWithMetadataLookup(ctx, stream, digestRef, hash)
 	if err == nil {
 		return nil
 	}
@@ -275,24 +286,9 @@ func parseBlobDigestRef(ref string, digestRequiredMsg string) (gcrname.Digest, g
 	return digestRef, hash, nil
 }
 
-func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash) error {
-	err := s.fetchBlobFromCacheWithMetadata(ctx, stream, digestRef, hash)
-	if err == nil {
-		return nil
-	}
-	if !status.IsNotFoundError(err) {
-		// It is possible this error occurred while writing to the stream.
-		// Since we do not know the state of the stream, it is not safe
-		// to write bytes to the stream past this point.
-		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
-		return err
-	}
-	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
-}
-
-// fetchBlobFromCacheWithMetadata attempts to fetch a blob from the cache and streams it directly to the gRPC response.
+// fetchBlobFromCacheWithMetadataLookup attempts to fetch a blob from the cache and streams it directly to the gRPC response.
 // Returns nil if successful, NotFoundError if not in cache, or another error on failure.
-func (s *ociFetcherServer) fetchBlobFromCacheWithMetadata(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash) error {
+func (s *ociFetcherServer) fetchBlobFromCacheWithMetadataLookup(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash) error {
 	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, digestRef.Context(), hash)
 	if err != nil {
 		return err

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -175,7 +175,7 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 	if req.GetBypassRegistry() {
 		return s.fetchBlobFromCacheOnly(ctx, stream, blobRef)
 	}
-	err = s.fetchBlobFromCache(ctx, stream, blobRef)
+	err = s.fetchBlobFromCacheWithMetadata(ctx, stream, blobRef)
 	if err == nil {
 		return nil
 	}
@@ -310,7 +310,7 @@ func parseManifestRef(ref string) (gcrname.Reference, error) {
 }
 
 func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef) error {
-	err := s.fetchBlobFromCache(ctx, stream, ref)
+	err := s.fetchBlobFromCacheWithMetadata(ctx, stream, ref)
 	if err == nil {
 		return nil
 	}
@@ -338,16 +338,11 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleLeader, err, time.Since(start))
 		return err
 	}
-	return s.fetchBlobFromCacheAfterDedupedRemoteFetch(ctx, stream, ref, result, err, start)
-}
-
-func (s *ociFetcherServer) fetchBlobFromCacheAfterDedupedRemoteFetch(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, result blobFetchResult, remoteErr error, start time.Time) error {
-	if remoteErr != nil {
-		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, remoteErr, time.Since(start))
-		return remoteErr
+	if err != nil {
+		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
+		return err
 	}
-	w := &grpcStreamWriter{stream: stream}
-	err := ocicache.FetchBlobFromCache(ctx, w, s.bsClient, ref.hash, result.contentLength)
+	err = s.fetchBlobFromCache(ctx, stream, ref, result.contentLength)
 	recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 	return err
 }
@@ -531,15 +526,19 @@ func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcr
 	return nil
 }
 
-// fetchBlobFromCache attempts to fetch a blob from the cache and streams it directly to the gRPC response.
+// fetchBlobFromCacheWithMetadata attempts to fetch a blob from the cache and streams it directly to the gRPC response.
 // Returns nil if successful, NotFoundError if not in cache, or another error on failure.
-func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef) error {
+func (s *ociFetcherServer) fetchBlobFromCacheWithMetadata(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef) error {
 	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, ref.repo, ref.hash)
 	if err != nil {
 		return err
 	}
+	return s.fetchBlobFromCache(ctx, stream, ref, metadata.GetContentLength())
+}
+
+func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, contentLength int64) error {
 	w := &grpcStreamWriter{stream: stream}
-	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, ref.hash, metadata.GetContentLength())
+	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, ref.hash, contentLength)
 }
 
 // fetchBlobFromRemoteWriteToCacheAndResponse fetches a blob from the upstream

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -81,13 +81,6 @@ type blobFetchResult struct {
 	contentLength int64
 }
 
-type blobDigestRef struct {
-	ref    gcrname.Reference
-	digest gcrname.Digest
-	repo   gcrname.Repository
-	hash   gcr.Hash
-}
-
 type blobMeta struct {
 	size      int64
 	mediaType string
@@ -167,15 +160,15 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return err
 	}
-	blobRef, err := parseBlobDigestRef(req.GetRef(), "blob reference must be a digest reference, got %q")
+	digestRef, hash, err := parseBlobDigestRef(req.GetRef(), "blob reference must be a digest reference, got %q")
 	if err != nil {
 		return err
 	}
 
 	if req.GetBypassRegistry() {
-		return s.fetchBlobFromCacheOnly(ctx, stream, blobRef)
+		return s.fetchBlobFromCacheOnly(ctx, stream, digestRef, hash)
 	}
-	err = s.fetchBlobFromCacheWithMetadata(ctx, stream, blobRef)
+	err = s.fetchBlobFromCacheWithMetadata(ctx, stream, digestRef, hash)
 	if err == nil {
 		return nil
 	}
@@ -186,7 +179,7 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
 		return err
 	}
-	return s.dedupedFetchBlob(ctx, stream, blobRef, req.GetCredentials())
+	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, req.GetCredentials())
 }
 
 func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
@@ -215,19 +208,19 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
 		return nil, err
 	}
-	blobRef, err := parseBlobDigestRef(req.GetRef(), "blob reference must be a digest reference (e.g., repo@sha256:...), got %q")
+	digestRef, hash, err := parseBlobDigestRef(req.GetRef(), "blob reference must be a digest reference (e.g., repo@sha256:...), got %q")
 	if err != nil {
 		return nil, err
 	}
-	if resp, err := s.fetchBlobMetadataFromCache(ctx, blobRef); err == nil {
+	if resp, err := s.fetchBlobMetadataFromCache(ctx, digestRef, hash); err == nil {
 		return resp, nil
 	} else if !status.IsNotFoundError(err) {
 		log.CtxWarningf(ctx, "Error fetching blob metadata from cache: %s", err)
 	}
 	if req.GetBypassRegistry() {
-		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", blobRef.ref)
+		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", digestRef)
 	}
-	return s.fetchBlobMetadataFromRemote(ctx, blobRef, req.GetCredentials())
+	return s.fetchBlobMetadataFromRemote(ctx, digestRef, req.GetCredentials())
 }
 
 // FetchManifest returns an OCI manifest from the action cache if present,
@@ -280,25 +273,20 @@ func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.
 	return s.fetchManifestMetadataFromRemote(ctx, imageRef, req.GetCredentials())
 }
 
-func parseBlobDigestRef(ref string, digestRequiredMsg string) (*blobDigestRef, error) {
+func parseBlobDigestRef(ref string, digestRequiredMsg string) (gcrname.Digest, gcr.Hash, error) {
 	blobRef, err := gcrname.ParseReference(ref)
 	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
+		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
 	}
 	digestRef, ok := blobRef.(gcrname.Digest)
 	if !ok {
-		return nil, status.InvalidArgumentErrorf(digestRequiredMsg, ref)
+		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf(digestRequiredMsg, ref)
 	}
 	hash, err := gcr.NewHash(digestRef.DigestStr())
 	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
 	}
-	return &blobDigestRef{
-		ref:    blobRef,
-		digest: digestRef,
-		repo:   digestRef.Context(),
-		hash:   hash,
-	}, nil
+	return digestRef, hash, nil
 }
 
 func parseManifestRef(ref string) (gcrname.Reference, error) {
@@ -309,8 +297,8 @@ func parseManifestRef(ref string) (gcrname.Reference, error) {
 	return imageRef, nil
 }
 
-func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef) error {
-	err := s.fetchBlobFromCacheWithMetadata(ctx, stream, ref)
+func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash) error {
+	err := s.fetchBlobFromCacheWithMetadata(ctx, stream, digestRef, hash)
 	if err == nil {
 		return nil
 	}
@@ -321,16 +309,17 @@ func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream of
 		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
 		return err
 	}
-	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", ref.ref)
+	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
 }
 
-func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, creds *rgpb.Credentials) error {
+func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash, creds *rgpb.Credentials) error {
 	start := time.Now()
-	key := ocicache.NewBlobFetchKey(ref.repo, ref.hash, creds)
+	repo := digestRef.Context()
+	key := ocicache.NewBlobFetchKey(repo, hash, creds)
 	isLeader := false
 	result, _, err := s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (blobFetchResult, error) {
 		isLeader = true
-		contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, ref.digest, ref.repo, ref.hash, creds, stream)
+		contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, digestRef, repo, hash, creds, stream)
 		return blobFetchResult{contentLength: contentLength}, err
 	})
 
@@ -342,13 +331,13 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 		return err
 	}
-	err = s.fetchBlobFromCache(ctx, stream, ref, result.contentLength)
+	err = s.fetchBlobFromCache(ctx, stream, hash, result.contentLength)
 	recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 	return err
 }
 
-func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, ref *blobDigestRef) (*ofpb.FetchBlobMetadataResponse, error) {
-	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, ref.repo, ref.hash)
+func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, digestRef gcrname.Digest, hash gcr.Hash) (*ofpb.FetchBlobMetadataResponse, error) {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, digestRef.Context(), hash)
 	if err != nil {
 		return nil, err
 	}
@@ -358,9 +347,9 @@ func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, ref *
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, ref *blobDigestRef, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
-	meta, err := withPullerRetry(ctx, s, ref.ref, creds, func(puller *remote.Puller) (*blobMeta, error) {
-		layer, err := puller.Layer(ctx, ref.digest)
+func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, digestRef gcrname.Digest, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
+	meta, err := withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (*blobMeta, error) {
+		layer, err := puller.Layer(ctx, digestRef)
 		if err != nil {
 			return nil, err
 		}
@@ -528,17 +517,17 @@ func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcr
 
 // fetchBlobFromCacheWithMetadata attempts to fetch a blob from the cache and streams it directly to the gRPC response.
 // Returns nil if successful, NotFoundError if not in cache, or another error on failure.
-func (s *ociFetcherServer) fetchBlobFromCacheWithMetadata(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef) error {
-	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, ref.repo, ref.hash)
+func (s *ociFetcherServer) fetchBlobFromCacheWithMetadata(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash) error {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, digestRef.Context(), hash)
 	if err != nil {
 		return err
 	}
-	return s.fetchBlobFromCache(ctx, stream, ref, metadata.GetContentLength())
+	return s.fetchBlobFromCache(ctx, stream, hash, metadata.GetContentLength())
 }
 
-func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, contentLength int64) error {
+func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, hash gcr.Hash, contentLength int64) error {
 	w := &grpcStreamWriter{stream: stream}
-	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, ref.hash, contentLength)
+	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, hash, contentLength)
 }
 
 // fetchBlobFromRemoteWriteToCacheAndResponse fetches a blob from the upstream

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -186,7 +186,7 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 		log.CtxWarningf(ctx, "Error fetching blob from cache: %s", err)
 		return err
 	}
-	return s.fetchBlobWithSingleflight(ctx, stream, blobRef, req.GetCredentials())
+	return s.dedupedFetchBlob(ctx, stream, blobRef, req.GetCredentials())
 }
 
 func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
@@ -324,31 +324,27 @@ func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream of
 	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", ref.ref)
 }
 
-func (s *ociFetcherServer) fetchBlobWithSingleflight(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, creds *rgpb.Credentials) error {
+func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, creds *rgpb.Credentials) error {
 	start := time.Now()
 	key := ocicache.NewBlobFetchKey(ref.repo, ref.hash, creds)
 	isLeader := false
 	result, _, err := s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (blobFetchResult, error) {
 		isLeader = true
-		return s.fetchBlobSingleflightLeader(ctx, stream, ref, creds)
+		contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, ref.digest, ref.repo, ref.hash, creds, stream)
+		return blobFetchResult{contentLength: contentLength}, err
 	})
 
 	if isLeader {
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleLeader, err, time.Since(start))
 		return err
 	}
-	return s.fetchBlobSingleflightWaiter(ctx, stream, ref, result, err, start)
+	return s.fetchBlobFromCacheAfterDedupedRemoteFetch(ctx, stream, ref, result, err, start)
 }
 
-func (s *ociFetcherServer) fetchBlobSingleflightLeader(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, creds *rgpb.Credentials) (blobFetchResult, error) {
-	contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, ref.digest, ref.repo, ref.hash, creds, stream)
-	return blobFetchResult{contentLength: contentLength}, err
-}
-
-func (s *ociFetcherServer) fetchBlobSingleflightWaiter(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, result blobFetchResult, leaderErr error, start time.Time) error {
-	if leaderErr != nil {
-		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, leaderErr, time.Since(start))
-		return leaderErr
+func (s *ociFetcherServer) fetchBlobFromCacheAfterDedupedRemoteFetch(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, ref *blobDigestRef, result blobFetchResult, remoteErr error, start time.Time) error {
+	if remoteErr != nil {
+		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, remoteErr, time.Since(start))
+		return remoteErr
 	}
 	w := &grpcStreamWriter{stream: stream}
 	err := ocicache.FetchBlobFromCache(ctx, w, s.bsClient, ref.hash, result.contentLength)

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -246,19 +246,17 @@ func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.
 	return s.fetchManifestMetadataFromRemote(ctx, imageRef, req.GetCredentials())
 }
 
-func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
-	statusLabel := metrics.OCIFetcherStatusOK
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || status.IsDeadlineExceededError(err) {
-			statusLabel = metrics.OCIFetcherStatusTimeout
-		} else if errors.Is(err, context.Canceled) || status.IsCanceledError(err) {
-			statusLabel = metrics.OCIFetcherStatusCanceled
-		} else {
-			statusLabel = metrics.OCIFetcherStatusError
-		}
+// validateBypassRegistry checks if bypass_registry is enabled and if so,
+// verifies the caller has server admin permissions. Returns an error if
+// bypass_registry is true but the caller is not a server admin.
+func validateBypassRegistry(ctx context.Context, bypassRegistry bool) error {
+	if !bypassRegistry {
+		return nil
 	}
-	metrics.OCIFetcherRequestCount.WithLabelValues(metrics.OCIFetcherMethodFetchBlob, role, statusLabel).Inc()
-	metrics.OCIFetcherRequestDurationUsec.WithLabelValues(metrics.OCIFetcherMethodFetchBlob, role).Observe(float64(duration.Microseconds()))
+	if err := claims.AuthorizeServerAdmin(ctx); err != nil {
+		return status.PermissionDeniedErrorf("not authorized to bypass registry: %s", err)
+	}
+	return nil
 }
 
 func parseBlobDigestRef(ref string, digestRequiredMsg string) (gcrname.Digest, gcr.Hash, error) {
@@ -277,14 +275,6 @@ func parseBlobDigestRef(ref string, digestRequiredMsg string) (gcrname.Digest, g
 	return digestRef, hash, nil
 }
 
-func parseManifestRef(ref string) (gcrname.Reference, error) {
-	imageRef, err := gcrname.ParseReference(ref)
-	if err != nil {
-		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", ref, err)
-	}
-	return imageRef, nil
-}
-
 func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash) error {
 	err := s.fetchBlobFromCacheWithMetadata(ctx, stream, digestRef, hash)
 	if err == nil {
@@ -298,6 +288,21 @@ func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream of
 		return err
 	}
 	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
+}
+
+// fetchBlobFromCacheWithMetadata attempts to fetch a blob from the cache and streams it directly to the gRPC response.
+// Returns nil if successful, NotFoundError if not in cache, or another error on failure.
+func (s *ociFetcherServer) fetchBlobFromCacheWithMetadata(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash) error {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, digestRef.Context(), hash)
+	if err != nil {
+		return err
+	}
+	return s.fetchBlobFromCache(ctx, stream, hash, metadata.GetContentLength())
+}
+
+func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, hash gcr.Hash, contentLength int64) error {
+	w := &grpcStreamWriter{stream: stream}
+	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, hash, contentLength)
 }
 
 func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash, creds *rgpb.Credentials) error {
@@ -323,194 +328,19 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 	return err
 }
 
-func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, digestRef gcrname.Digest, hash gcr.Hash) (*ofpb.FetchBlobMetadataResponse, error) {
-	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, digestRef.Context(), hash)
+func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
+	statusLabel := metrics.OCIFetcherStatusOK
 	if err != nil {
-		return nil, err
-	}
-	return &ofpb.FetchBlobMetadataResponse{
-		Size:      metadata.GetContentLength(),
-		MediaType: metadata.GetContentType(),
-	}, nil
-}
-
-func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, digestRef gcrname.Digest, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
-	return withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (*ofpb.FetchBlobMetadataResponse, error) {
-		layer, err := puller.Layer(ctx, digestRef)
-		if err != nil {
-			return nil, err
+		if errors.Is(err, context.DeadlineExceeded) || status.IsDeadlineExceededError(err) {
+			statusLabel = metrics.OCIFetcherStatusTimeout
+		} else if errors.Is(err, context.Canceled) || status.IsCanceledError(err) {
+			statusLabel = metrics.OCIFetcherStatusCanceled
+		} else {
+			statusLabel = metrics.OCIFetcherStatusError
 		}
-		size, err := layer.Size()
-		if err != nil {
-			return nil, err
-		}
-		mediaType, err := layer.MediaType()
-		if err != nil {
-			return nil, err
-		}
-		return &ofpb.FetchBlobMetadataResponse{
-			Size:      size,
-			MediaType: string(mediaType),
-		}, nil
-	})
-}
-
-func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials, bypassRegistry bool) (gcr.Hash, error) {
-	if digestRef, ok := imageRef.(gcrname.Digest); ok {
-		hash, err := gcr.NewHash(digestRef.DigestStr())
-		if err != nil {
-			return gcr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
-		}
-		if !bypassRegistry {
-			if err := s.proveManifestAccess(ctx, imageRef, creds); err != nil {
-				return gcr.Hash{}, err
-			}
-		}
-		return hash, nil
 	}
-	if bypassRegistry {
-		return gcr.Hash{}, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", imageRef)
-	}
-	return s.resolveTagToDigest(ctx, imageRef, creds)
-}
-
-func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (gcr.Hash, error) {
-	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
-		return puller.Head(ctx, imageRef)
-	})
-	if err != nil {
-		return gcr.Hash{}, err
-	}
-	hash, err := gcr.NewHash(desc.Digest.String())
-	if err != nil {
-		return gcr.Hash{}, status.InvalidArgumentErrorf("invalid resolved digest %q: %s", desc.Digest.String(), err)
-	}
-	return hash, nil
-}
-
-func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, imageRef gcrname.Reference, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
-	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, imageRef.Context(), hash, imageRef)
-	if err != nil {
-		return nil, err
-	}
-	return &ofpb.FetchManifestResponse{
-		Digest:    hash.String(),
-		Size:      int64(len(cached.GetRaw())),
-		MediaType: cached.GetContentType(),
-		Manifest:  cached.GetRaw(),
-	}, nil
-}
-
-func (s *ociFetcherServer) fetchManifestFromRemoteWriteToCache(ctx context.Context, imageRef gcrname.Reference, hash gcr.Hash, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
-	remoteDesc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
-		return puller.Get(ctx, imageRef)
-	})
-	if err != nil {
-		return nil, err
-	}
-	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, imageRef.Context(), hash, string(remoteDesc.MediaType), imageRef); err != nil {
-		log.CtxWarningf(ctx, "Error writing manifest to cache: %s", err)
-	}
-	return &ofpb.FetchManifestResponse{
-		Digest:    remoteDesc.Digest.String(),
-		Size:      remoteDesc.Size,
-		MediaType: string(remoteDesc.MediaType),
-		Manifest:  remoteDesc.Manifest,
-	}, nil
-}
-
-func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*ofpb.FetchManifestMetadataResponse, error) {
-	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
-		return puller.Head(ctx, imageRef)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &ofpb.FetchManifestMetadataResponse{
-		Digest:    desc.Digest.String(),
-		Size:      desc.Size,
-		MediaType: string(desc.MediaType),
-	}, nil
-}
-
-func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Credentials) []remote.Option {
-	opts := []remote.Option{remote.WithContext(ctx)}
-
-	if creds != nil && creds.GetUsername() != "" && creds.GetPassword() != "" {
-		opts = append(opts, remote.WithAuth(&authn.Basic{
-			Username: creds.GetUsername(),
-			Password: creds.GetPassword(),
-		}))
-	}
-
-	tr := httpclient.New(s.allowedPrivateIPs, "oci_fetcher").Transport
-
-	if len(s.mirrors) > 0 {
-		opts = append(opts, remote.WithTransport(NewMirrorTransport(tr, s.mirrors)))
-	} else {
-		opts = append(opts, remote.WithTransport(tr))
-	}
-
-	return opts
-}
-
-func (s *ociFetcherServer) getOrCreatePuller(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*remote.Puller, error) {
-	key := pullerKey(imageRef, creds)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	entry, ok := s.pullerLRU.Get(key)
-
-	if ok {
-		return entry.puller, nil
-	}
-
-	remoteOpts := s.getRemoteOpts(ctx, creds)
-	puller, err := remote.NewPuller(remoteOpts...)
-	if err != nil {
-		return nil, status.InternalErrorf("error creating puller: %s", err)
-	}
-	s.pullerLRU.Add(key, &pullerLRUEntry{puller: puller})
-
-	return puller, nil
-}
-
-func (s *ociFetcherServer) evictPuller(imageRef gcrname.Reference, creds *rgpb.Credentials) {
-	key := pullerKey(imageRef, creds)
-	s.mu.Lock()
-	s.pullerLRU.Remove(key)
-	s.mu.Unlock()
-}
-
-// proveManifestAccess checks that the caller's credentials allow accessing
-// the given manifest ref in the remote registry.
-func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) error {
-	key := manifestCacheKey(imageRef, creds)
-	if s.manifestCache.Contains(key) {
-		return nil
-	}
-	if _, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
-		return puller.Head(ctx, imageRef)
-	}); err != nil {
-		return err
-	}
-	s.manifestCache.Add(key, struct{}{})
-	return nil
-}
-
-// fetchBlobFromCacheWithMetadata attempts to fetch a blob from the cache and streams it directly to the gRPC response.
-// Returns nil if successful, NotFoundError if not in cache, or another error on failure.
-func (s *ociFetcherServer) fetchBlobFromCacheWithMetadata(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash) error {
-	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, digestRef.Context(), hash)
-	if err != nil {
-		return err
-	}
-	return s.fetchBlobFromCache(ctx, stream, hash, metadata.GetContentLength())
-}
-
-func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, hash gcr.Hash, contentLength int64) error {
-	w := &grpcStreamWriter{stream: stream}
-	return ocicache.FetchBlobFromCache(ctx, w, s.bsClient, hash, contentLength)
+	metrics.OCIFetcherRequestCount.WithLabelValues(metrics.OCIFetcherMethodFetchBlob, role, statusLabel).Inc()
+	metrics.OCIFetcherRequestDurationUsec.WithLabelValues(metrics.OCIFetcherMethodFetchBlob, role).Observe(float64(duration.Microseconds()))
 }
 
 // fetchBlobFromRemoteWriteToCacheAndResponse fetches a blob from the upstream
@@ -591,6 +421,201 @@ func (s *ociFetcherServer) streamBlob(rc io.Reader, stream ofpb.OCIFetcher_Fetch
 	}
 }
 
+func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, digestRef gcrname.Digest, hash gcr.Hash) (*ofpb.FetchBlobMetadataResponse, error) {
+	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, digestRef.Context(), hash)
+	if err != nil {
+		return nil, err
+	}
+	return &ofpb.FetchBlobMetadataResponse{
+		Size:      metadata.GetContentLength(),
+		MediaType: metadata.GetContentType(),
+	}, nil
+}
+
+func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, digestRef gcrname.Digest, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
+	return withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (*ofpb.FetchBlobMetadataResponse, error) {
+		layer, err := puller.Layer(ctx, digestRef)
+		if err != nil {
+			return nil, err
+		}
+		size, err := layer.Size()
+		if err != nil {
+			return nil, err
+		}
+		mediaType, err := layer.MediaType()
+		if err != nil {
+			return nil, err
+		}
+		return &ofpb.FetchBlobMetadataResponse{
+			Size:      size,
+			MediaType: string(mediaType),
+		}, nil
+	})
+}
+
+func parseManifestRef(ref string) (gcrname.Reference, error) {
+	imageRef, err := gcrname.ParseReference(ref)
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", ref, err)
+	}
+	return imageRef, nil
+}
+
+func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials, bypassRegistry bool) (gcr.Hash, error) {
+	if digestRef, ok := imageRef.(gcrname.Digest); ok {
+		hash, err := gcr.NewHash(digestRef.DigestStr())
+		if err != nil {
+			return gcr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+		}
+		if !bypassRegistry {
+			if err := s.proveManifestAccess(ctx, imageRef, creds); err != nil {
+				return gcr.Hash{}, err
+			}
+		}
+		return hash, nil
+	}
+	if bypassRegistry {
+		return gcr.Hash{}, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", imageRef)
+	}
+	return s.resolveTagToDigest(ctx, imageRef, creds)
+}
+
+// proveManifestAccess checks that the caller's credentials allow accessing
+// the given manifest ref in the remote registry.
+func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) error {
+	key := manifestCacheKey(imageRef, creds)
+	if s.manifestCache.Contains(key) {
+		return nil
+	}
+	if _, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+		return puller.Head(ctx, imageRef)
+	}); err != nil {
+		return err
+	}
+	s.manifestCache.Add(key, struct{}{})
+	return nil
+}
+
+func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (gcr.Hash, error) {
+	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+		return puller.Head(ctx, imageRef)
+	})
+	if err != nil {
+		return gcr.Hash{}, err
+	}
+	hash, err := gcr.NewHash(desc.Digest.String())
+	if err != nil {
+		return gcr.Hash{}, status.InvalidArgumentErrorf("invalid resolved digest %q: %s", desc.Digest.String(), err)
+	}
+	return hash, nil
+}
+
+func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, imageRef gcrname.Reference, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
+	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, imageRef.Context(), hash, imageRef)
+	if err != nil {
+		return nil, err
+	}
+	return &ofpb.FetchManifestResponse{
+		Digest:    hash.String(),
+		Size:      int64(len(cached.GetRaw())),
+		MediaType: cached.GetContentType(),
+		Manifest:  cached.GetRaw(),
+	}, nil
+}
+
+func (s *ociFetcherServer) fetchManifestFromRemoteWriteToCache(ctx context.Context, imageRef gcrname.Reference, hash gcr.Hash, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
+	remoteDesc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
+		return puller.Get(ctx, imageRef)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, imageRef.Context(), hash, string(remoteDesc.MediaType), imageRef); err != nil {
+		log.CtxWarningf(ctx, "Error writing manifest to cache: %s", err)
+	}
+	return &ofpb.FetchManifestResponse{
+		Digest:    remoteDesc.Digest.String(),
+		Size:      remoteDesc.Size,
+		MediaType: string(remoteDesc.MediaType),
+		Manifest:  remoteDesc.Manifest,
+	}, nil
+}
+
+// validateUnsupportedBypassRegistry is used by FetchManifestMetadata which does not support
+// bypass_registry at all (it always needs registry access for credential validation).
+func validateUnsupportedBypassRegistry(ctx context.Context, bypassRegistry bool) error {
+	if !bypassRegistry {
+		return nil
+	}
+	if err := claims.AuthorizeServerAdmin(ctx); err != nil {
+		return status.PermissionDeniedErrorf("authorize bypass_registry: %s", err)
+	}
+	return status.NotFoundError("bypass_registry is not yet supported")
+}
+
+func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*ofpb.FetchManifestMetadataResponse, error) {
+	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+		return puller.Head(ctx, imageRef)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ofpb.FetchManifestMetadataResponse{
+		Digest:    desc.Digest.String(),
+		Size:      desc.Size,
+		MediaType: string(desc.MediaType),
+	}, nil
+}
+
+func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Credentials) []remote.Option {
+	opts := []remote.Option{remote.WithContext(ctx)}
+
+	if creds != nil && creds.GetUsername() != "" && creds.GetPassword() != "" {
+		opts = append(opts, remote.WithAuth(&authn.Basic{
+			Username: creds.GetUsername(),
+			Password: creds.GetPassword(),
+		}))
+	}
+
+	tr := httpclient.New(s.allowedPrivateIPs, "oci_fetcher").Transport
+
+	if len(s.mirrors) > 0 {
+		opts = append(opts, remote.WithTransport(NewMirrorTransport(tr, s.mirrors)))
+	} else {
+		opts = append(opts, remote.WithTransport(tr))
+	}
+
+	return opts
+}
+
+func (s *ociFetcherServer) getOrCreatePuller(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*remote.Puller, error) {
+	key := pullerKey(imageRef, creds)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.pullerLRU.Get(key)
+
+	if ok {
+		return entry.puller, nil
+	}
+
+	remoteOpts := s.getRemoteOpts(ctx, creds)
+	puller, err := remote.NewPuller(remoteOpts...)
+	if err != nil {
+		return nil, status.InternalErrorf("error creating puller: %s", err)
+	}
+	s.pullerLRU.Add(key, &pullerLRUEntry{puller: puller})
+
+	return puller, nil
+}
+
+func (s *ociFetcherServer) evictPuller(imageRef gcrname.Reference, creds *rgpb.Credentials) {
+	key := pullerKey(imageRef, creds)
+	s.mu.Lock()
+	s.pullerLRU.Remove(key)
+	s.mu.Unlock()
+}
+
 func manifestCacheKey(ref gcrname.Reference, creds *rgpb.Credentials) string {
 	if creds == nil {
 		return hash.Strings(ref.String(), "", "")
@@ -659,31 +684,6 @@ func withPullerRetry[T any](
 	}
 
 	return result, nil
-}
-
-// validateBypassRegistry checks if bypass_registry is enabled and if so,
-// verifies the caller has server admin permissions. Returns an error if
-// bypass_registry is true but the caller is not a server admin.
-func validateBypassRegistry(ctx context.Context, bypassRegistry bool) error {
-	if !bypassRegistry {
-		return nil
-	}
-	if err := claims.AuthorizeServerAdmin(ctx); err != nil {
-		return status.PermissionDeniedErrorf("not authorized to bypass registry: %s", err)
-	}
-	return nil
-}
-
-// validateUnsupportedBypassRegistry is used by FetchManifestMetadata which does not support
-// bypass_registry at all (it always needs registry access for credential validation).
-func validateUnsupportedBypassRegistry(ctx context.Context, bypassRegistry bool) error {
-	if !bypassRegistry {
-		return nil
-	}
-	if err := claims.AuthorizeServerAdmin(ctx); err != nil {
-		return status.PermissionDeniedErrorf("authorize bypass_registry: %s", err)
-	}
-	return status.NotFoundError("bypass_registry is not yet supported")
 }
 
 type grpcStreamWriter struct {

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -170,21 +170,6 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, req.GetCredentials())
 }
 
-func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
-	statusLabel := metrics.OCIFetcherStatusOK
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || status.IsDeadlineExceededError(err) {
-			statusLabel = metrics.OCIFetcherStatusTimeout
-		} else if errors.Is(err, context.Canceled) || status.IsCanceledError(err) {
-			statusLabel = metrics.OCIFetcherStatusCanceled
-		} else {
-			statusLabel = metrics.OCIFetcherStatusError
-		}
-	}
-	metrics.OCIFetcherRequestCount.WithLabelValues(metrics.OCIFetcherMethodFetchBlob, role, statusLabel).Inc()
-	metrics.OCIFetcherRequestDurationUsec.WithLabelValues(metrics.OCIFetcherMethodFetchBlob, role).Observe(float64(duration.Microseconds()))
-}
-
 // FetchBlobMetadata returns OCI blob metadata (size, media type).
 // It will first read this metadata from the action cache, falling back
 // to the upstream remote registry.
@@ -259,6 +244,21 @@ func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.
 		return nil, err
 	}
 	return s.fetchManifestMetadataFromRemote(ctx, imageRef, req.GetCredentials())
+}
+
+func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
+	statusLabel := metrics.OCIFetcherStatusOK
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || status.IsDeadlineExceededError(err) {
+			statusLabel = metrics.OCIFetcherStatusTimeout
+		} else if errors.Is(err, context.Canceled) || status.IsCanceledError(err) {
+			statusLabel = metrics.OCIFetcherStatusCanceled
+		} else {
+			statusLabel = metrics.OCIFetcherStatusError
+		}
+	}
+	metrics.OCIFetcherRequestCount.WithLabelValues(metrics.OCIFetcherMethodFetchBlob, role, statusLabel).Inc()
+	metrics.OCIFetcherRequestDurationUsec.WithLabelValues(metrics.OCIFetcherMethodFetchBlob, role).Observe(float64(duration.Microseconds()))
 }
 
 func parseBlobDigestRef(ref string, digestRequiredMsg string) (gcrname.Digest, gcr.Hash, error) {

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -70,7 +70,8 @@ type ociFetcherServer struct {
 
 	// blobFetchGroup deduplicates concurrent blob fetch requests.
 	// Only one request fetches from upstream and writes to cache;
-	// other requests wait and then read from cache.
+	// other requests wait and then read from cache using the returned
+	// content length.
 	blobFetchGroup singleflight.Group[ocicache.BlobFetchKey, int64]
 }
 

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -81,7 +81,7 @@ type blobFetchResult struct {
 	contentLength int64
 }
 
-type validatedBlobRequest struct {
+type blobRequest struct {
 	blobRef        gcrname.Reference
 	digestRef      gcrname.Digest
 	repo           gcrname.Repository
@@ -90,7 +90,7 @@ type validatedBlobRequest struct {
 	bypassRegistry bool
 }
 
-type validatedManifestRequest struct {
+type manifestRequest struct {
 	imageRef       gcrname.Reference
 	repo           gcrname.Repository
 	creds          *rgpb.Credentials
@@ -173,7 +173,10 @@ func RegisterServer(env *real_environment.RealEnv) error {
 func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
 	ctx := stream.Context()
 
-	blobReq, err := validateFetchBlobRequest(ctx, req)
+	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return err
+	}
+	blobReq, err := parseBlobDigestRef(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry(), "blob reference must be a digest reference, got %q")
 	if err != nil {
 		return err
 	}
@@ -212,14 +215,17 @@ func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
 // Server admins can bypass the registry: the metadata will be served from the action cache
 // if present. If not present, FetchBlobMetadata will not fall back to the remote registry.
 func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.FetchBlobMetadataRequest) (*ofpb.FetchBlobMetadataResponse, error) {
-	blobReq, err := validateFetchBlobMetadataRequest(ctx, req)
+	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
+	}
+	blobReq, err := parseBlobDigestRef(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry(), "blob reference must be a digest reference (e.g., repo@sha256:...), got %q")
 	if err != nil {
 		return nil, err
 	}
 	if resp, err := s.fetchBlobMetadataFromCache(ctx, blobReq); err == nil {
 		return resp, nil
 	} else if !status.IsNotFoundError(err) {
-		logCacheReadError(ctx, "blob metadata", err)
+		log.CtxWarningf(ctx, "Error fetching blob metadata from cache: %s", err)
 	}
 	if blobReq.bypassRegistry {
 		return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", blobReq.blobRef)
@@ -236,11 +242,26 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 // Server admins can bypass the registry: the manifest will be served from the action cache
 // if present. If not present, FetchManifest will not fall back to the remote registry.
 func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchManifestRequest) (*ofpb.FetchManifestResponse, error) {
-	manifestReq, err := validateFetchManifestRequest(ctx, req)
+	if err := validateBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
+	}
+	manifestReq, err := parseManifestRef(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry())
 	if err != nil {
 		return nil, err
 	}
-	return s.fetchManifest(ctx, manifestReq)
+	hash, err := s.resolveManifestDigest(ctx, manifestReq)
+	if err != nil {
+		return nil, err
+	}
+	if resp, err := s.fetchManifestFromCache(ctx, manifestReq, hash); err == nil {
+		return resp, nil
+	} else if !status.IsNotFoundError(err) {
+		log.CtxWarningf(ctx, "Error fetching manifest from cache: %s", err)
+	}
+	if manifestReq.bypassRegistry {
+		return nil, status.NotFoundErrorf("bypassing registry, but manifest for %q not found in cache", manifestReq.imageRef)
+	}
+	return s.fetchManifestFromRemoteAndCache(ctx, manifestReq, hash)
 }
 
 // FetchManifestMetadata fetches metadata (digest, size, media type) for an OCI manifest
@@ -252,28 +273,17 @@ func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchMan
 // Bypassing the registry is not possible. Requests that set the bypass_registry flag
 // will fail with an error.
 func (s *ociFetcherServer) FetchManifestMetadata(ctx context.Context, req *ofpb.FetchManifestMetadataRequest) (*ofpb.FetchManifestMetadataResponse, error) {
-	manifestReq, err := validateFetchManifestMetadataRequest(ctx, req)
+	if err := validateUnsupportedBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
+		return nil, err
+	}
+	manifestReq, err := parseManifestRef(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry())
 	if err != nil {
 		return nil, err
 	}
 	return s.fetchManifestMetadataFromRemote(ctx, manifestReq)
 }
 
-func validateFetchBlobRequest(ctx context.Context, req *ofpb.FetchBlobRequest) (*validatedBlobRequest, error) {
-	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-	return validateBlobRequest(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry(), "blob reference must be a digest reference, got %q")
-}
-
-func validateFetchBlobMetadataRequest(ctx context.Context, req *ofpb.FetchBlobMetadataRequest) (*validatedBlobRequest, error) {
-	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-	return validateBlobRequest(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry(), "blob reference must be a digest reference (e.g., repo@sha256:...), got %q")
-}
-
-func validateBlobRequest(ref string, creds *rgpb.Credentials, bypassRegistry bool, digestRequiredMsg string) (*validatedBlobRequest, error) {
+func parseBlobDigestRef(ref string, creds *rgpb.Credentials, bypassRegistry bool, digestRequiredMsg string) (*blobRequest, error) {
 	blobRef, err := gcrname.ParseReference(ref)
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
@@ -286,7 +296,7 @@ func validateBlobRequest(ref string, creds *rgpb.Credentials, bypassRegistry boo
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
 	}
-	return &validatedBlobRequest{
+	return &blobRequest{
 		blobRef:        blobRef,
 		digestRef:      digestRef,
 		repo:           digestRef.Context(),
@@ -296,26 +306,12 @@ func validateBlobRequest(ref string, creds *rgpb.Credentials, bypassRegistry boo
 	}, nil
 }
 
-func validateFetchManifestRequest(ctx context.Context, req *ofpb.FetchManifestRequest) (*validatedManifestRequest, error) {
-	if err := authorizeBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-	return validateManifestRequest(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry())
-}
-
-func validateFetchManifestMetadataRequest(ctx context.Context, req *ofpb.FetchManifestMetadataRequest) (*validatedManifestRequest, error) {
-	if err := checkBypassRegistry(ctx, req.GetBypassRegistry()); err != nil {
-		return nil, err
-	}
-	return validateManifestRequest(req.GetRef(), req.GetCredentials(), req.GetBypassRegistry())
-}
-
-func validateManifestRequest(ref string, creds *rgpb.Credentials, bypassRegistry bool) (*validatedManifestRequest, error) {
+func parseManifestRef(ref string, creds *rgpb.Credentials, bypassRegistry bool) (*manifestRequest, error) {
 	imageRef, err := gcrname.ParseReference(ref)
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", ref, err)
 	}
-	return &validatedManifestRequest{
+	return &manifestRequest{
 		imageRef:       imageRef,
 		repo:           imageRef.Context(),
 		creds:          creds,
@@ -323,7 +319,7 @@ func validateManifestRequest(ref string, creds *rgpb.Credentials, bypassRegistry
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest) error {
+func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest) error {
 	if err := s.fetchBlobFromCache(ctx, stream, req); err == nil {
 		return nil
 	} else if !status.IsNotFoundError(err) {
@@ -332,7 +328,7 @@ func (s *ociFetcherServer) fetchBlobFromCacheOnly(ctx context.Context, stream of
 	return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", req.blobRef)
 }
 
-func (s *ociFetcherServer) fetchBlobWithSingleflight(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest) error {
+func (s *ociFetcherServer) fetchBlobWithSingleflight(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest) error {
 	start := time.Now()
 	key := ocicache.NewBlobFetchKey(req.repo, req.hash, req.creds)
 	isLeader := false
@@ -348,12 +344,12 @@ func (s *ociFetcherServer) fetchBlobWithSingleflight(ctx context.Context, stream
 	return s.fetchBlobSingleflightWaiter(ctx, stream, req, result, err, start)
 }
 
-func (s *ociFetcherServer) fetchBlobSingleflightLeader(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest) (blobFetchResult, error) {
+func (s *ociFetcherServer) fetchBlobSingleflightLeader(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest) (blobFetchResult, error) {
 	contentLength, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, req.digestRef, req.repo, req.hash, req.creds, stream)
 	return blobFetchResult{contentLength: contentLength}, err
 }
 
-func (s *ociFetcherServer) fetchBlobSingleflightWaiter(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest, result blobFetchResult, leaderErr error, start time.Time) error {
+func (s *ociFetcherServer) fetchBlobSingleflightWaiter(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest, result blobFetchResult, leaderErr error, start time.Time) error {
 	if leaderErr != nil {
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, leaderErr, time.Since(start))
 		return leaderErr
@@ -375,7 +371,7 @@ func handleBlobCacheStreamError(ctx context.Context, err error) error {
 	return err
 }
 
-func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, req *validatedBlobRequest) (*ofpb.FetchBlobMetadataResponse, error) {
+func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, req *blobRequest) (*ofpb.FetchBlobMetadataResponse, error) {
 	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, req.repo, req.hash)
 	if err != nil {
 		return nil, err
@@ -386,7 +382,7 @@ func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, req *
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, req *validatedBlobRequest) (*ofpb.FetchBlobMetadataResponse, error) {
+func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, req *blobRequest) (*ofpb.FetchBlobMetadataResponse, error) {
 	meta, err := withPullerRetry(ctx, s, req.blobRef, req.creds, func(puller *remote.Puller) (*blobMeta, error) {
 		layer, err := puller.Layer(ctx, req.digestRef)
 		if err != nil {
@@ -411,23 +407,7 @@ func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, req 
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchManifest(ctx context.Context, req *validatedManifestRequest) (*ofpb.FetchManifestResponse, error) {
-	hash, err := s.resolveManifestDigest(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if resp, err := s.fetchManifestFromCache(ctx, req, hash); err == nil {
-		return resp, nil
-	} else if !status.IsNotFoundError(err) {
-		logCacheReadError(ctx, "manifest", err)
-	}
-	if req.bypassRegistry {
-		return nil, status.NotFoundErrorf("bypassing registry, but manifest for %q not found in cache", req.imageRef)
-	}
-	return s.fetchManifestFromRemoteAndCache(ctx, req, hash)
-}
-
-func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, req *validatedManifestRequest) (gcr.Hash, error) {
+func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, req *manifestRequest) (gcr.Hash, error) {
 	if digestRef, ok := req.imageRef.(gcrname.Digest); ok {
 		hash, err := gcr.NewHash(digestRef.DigestStr())
 		if err != nil {
@@ -446,7 +426,7 @@ func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, req *valid
 	return s.resolveTagToDigest(ctx, req)
 }
 
-func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, req *validatedManifestRequest) (gcr.Hash, error) {
+func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, req *manifestRequest) (gcr.Hash, error) {
 	desc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
 		return puller.Head(ctx, req.imageRef)
 	})
@@ -460,7 +440,7 @@ func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, req *validate
 	return hash, nil
 }
 
-func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, req *validatedManifestRequest, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
+func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, req *manifestRequest, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
 	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, req.repo, hash, req.imageRef)
 	if err != nil {
 		return nil, err
@@ -473,7 +453,7 @@ func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, req *vali
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchManifestFromRemoteAndCache(ctx context.Context, req *validatedManifestRequest, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
+func (s *ociFetcherServer) fetchManifestFromRemoteAndCache(ctx context.Context, req *manifestRequest, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
 	remoteDesc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
 		return puller.Get(ctx, req.imageRef)
 	})
@@ -491,7 +471,7 @@ func (s *ociFetcherServer) fetchManifestFromRemoteAndCache(ctx context.Context, 
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, req *validatedManifestRequest) (*ofpb.FetchManifestMetadataResponse, error) {
+func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, req *manifestRequest) (*ofpb.FetchManifestMetadataResponse, error) {
 	desc, err := withPullerRetry(ctx, s, req.imageRef, req.creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
 		return puller.Head(ctx, req.imageRef)
 	})
@@ -503,10 +483,6 @@ func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, 
 		Size:      desc.Size,
 		MediaType: string(desc.MediaType),
 	}, nil
-}
-
-func logCacheReadError(ctx context.Context, what string, err error) {
-	log.CtxWarningf(ctx, "Error fetching %s from cache: %s", what, err)
 }
 
 func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Credentials) []remote.Option {
@@ -576,7 +552,7 @@ func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcr
 
 // fetchBlobFromCache attempts to fetch a blob from the cache and streams it directly to the gRPC response.
 // Returns nil if successful, NotFoundError if not in cache, or another error on failure.
-func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *validatedBlobRequest) error {
+func (s *ociFetcherServer) fetchBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, req *blobRequest) error {
 	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, req.repo, req.hash)
 	if err != nil {
 		return err
@@ -733,10 +709,10 @@ func withPullerRetry[T any](
 	return result, nil
 }
 
-// authorizeBypassRegistry checks if bypass_registry is enabled and if so,
+// validateBypassRegistry checks if bypass_registry is enabled and if so,
 // verifies the caller has server admin permissions. Returns an error if
 // bypass_registry is true but the caller is not a server admin.
-func authorizeBypassRegistry(ctx context.Context, bypassRegistry bool) error {
+func validateBypassRegistry(ctx context.Context, bypassRegistry bool) error {
 	if !bypassRegistry {
 		return nil
 	}
@@ -746,9 +722,9 @@ func authorizeBypassRegistry(ctx context.Context, bypassRegistry bool) error {
 	return nil
 }
 
-// checkBypassRegistry is used by FetchManifestMetadata which does not support
+// validateUnsupportedBypassRegistry is used by FetchManifestMetadata which does not support
 // bypass_registry at all (it always needs registry access for credential validation).
-func checkBypassRegistry(ctx context.Context, bypassRegistry bool) error {
+func validateUnsupportedBypassRegistry(ctx context.Context, bypassRegistry bool) error {
 	if !bypassRegistry {
 		return nil
 	}


### PR DESCRIPTION
Greetings!

This change is meant to be mechanical: rewrite the ~70-line public OCI Fetcher methods in terms of helpers, so a human being can understand the flow.
It may be helpful to just look at `ocifetcher.go` on the `boring-ocifetcher` branch.
If this change is helpful, I will make similar changes to `ocifetcher_server_proxy`.

Follow-on changes that bring access control more in-line with the existing `oci.Resolver.Resolve(...)` path _should_ be smaller and easier to understand after this refactoring.