### PR TITLE
go_deps: fix tree-sitter cgo alloc

### DIFF
--- a/buildpatches/com_github_smacker_go_tree_sitter_alloc_cdeps.patch
+++ b/buildpatches/com_github_smacker_go_tree_sitter_alloc_cdeps.patch
@@ -1,0 +1,131 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,9 +1,19 @@
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
+ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+ 
++cc_library(
++    name = "alloc",
++    srcs = ["alloc.c"],
++    hdrs = [
++        "alloc.h",
++        "api.h",
++    ],
++    visibility = ["//visibility:public"],
++)
++
+ go_library(
+     name = "go-tree-sitter",
+     srcs = [
+-        "alloc.c",
+         "alloc.h",
+         "api.h",
+         "array.h",
+@@ -52,6 +62,7 @@ go_library(
+         "wasm_store.c",
+         "wasm_store.h",
+     ],
++    cdeps = [":alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter",
+     visibility = ["//visibility:public"],
+diff --git a/bash/BUILD.bazel b/bash/BUILD.bazel
+--- a/bash/BUILD.bazel
++++ b/bash/BUILD.bazel
+@@ -8,6 +8,7 @@ go_library(
+         "parser.h",
+         "scanner.c",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter/bash",
+     visibility = ["//visibility:public"],
+diff --git a/cpp/BUILD.bazel b/cpp/BUILD.bazel
+--- a/cpp/BUILD.bazel
++++ b/cpp/BUILD.bazel
+@@ -8,6 +8,7 @@ go_library(
+         "parser.h",
+         "scanner.c",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter/cpp",
+     visibility = ["//visibility:public"],
+diff --git a/csharp/BUILD.bazel b/csharp/BUILD.bazel
+--- a/csharp/BUILD.bazel
++++ b/csharp/BUILD.bazel
+@@ -8,6 +8,7 @@ go_library(
+         "parser.h",
+         "scanner.c",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     copts = ["-Wno-trigraphs"],
+     importpath = "github.com/smacker/go-tree-sitter/csharp",
+diff --git a/html/BUILD.bazel b/html/BUILD.bazel
+--- a/html/BUILD.bazel
++++ b/html/BUILD.bazel
+@@ -9,6 +9,7 @@ go_library(
+         "scanner.c",
+         "tag.h",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter/html",
+     visibility = ["//visibility:public"],
+diff --git a/kotlin/BUILD.bazel b/kotlin/BUILD.bazel
+--- a/kotlin/BUILD.bazel
++++ b/kotlin/BUILD.bazel
+@@ -8,6 +8,7 @@ go_library(
+         "parser.h",
+         "scanner.c",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter/kotlin",
+     visibility = ["//visibility:public"],
+diff --git a/python/BUILD.bazel b/python/BUILD.bazel
+--- a/python/BUILD.bazel
++++ b/python/BUILD.bazel
+@@ -8,6 +8,7 @@ go_library(
+         "parser.h",
+         "scanner.c",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter/python",
+     visibility = ["//visibility:public"],
+diff --git a/ruby/BUILD.bazel b/ruby/BUILD.bazel
+--- a/ruby/BUILD.bazel
++++ b/ruby/BUILD.bazel
+@@ -8,6 +8,7 @@ go_library(
+         "parser.h",
+         "scanner.c",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter/ruby",
+     visibility = ["//visibility:public"],
+diff --git a/rust/BUILD.bazel b/rust/BUILD.bazel
+--- a/rust/BUILD.bazel
++++ b/rust/BUILD.bazel
+@@ -8,6 +8,7 @@ go_library(
+         "parser.h",
+         "scanner.c",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter/rust",
+     visibility = ["//visibility:public"],
+diff --git a/scala/BUILD.bazel b/scala/BUILD.bazel
+--- a/scala/BUILD.bazel
++++ b/scala/BUILD.bazel
+@@ -9,6 +9,7 @@ go_library(
+         "scanner.c",
+         "stack.h",
+     ],
++    cdeps = ["//:alloc"],
+     cgo = True,
+     importpath = "github.com/smacker/go-tree-sitter/scala",
+     visibility = ["//visibility:public"],

--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -81,6 +81,13 @@ go_deps.module_override(
     patches = ["@com_github_buildbuddy_io_buildbuddy//buildpatches:go-grpc-channelz.patch"],
     path = "github.com/rantav/go-grpc-channelz",
 )
+go_deps.module_override(
+    patch_strip = 1,
+    patches = [
+        "@com_github_buildbuddy_io_buildbuddy//buildpatches:com_github_smacker_go_tree_sitter_alloc_cdeps.patch",
+    ],
+    path = "github.com/smacker/go-tree-sitter",
+)
 # Go repos with custom directives
 go_deps.gazelle_override(
     directives = [


### PR DESCRIPTION
go_deps: fix tree-sitter cgo alloc

This fixes bazel run :gazelle, which regressed while building
Gazelle's generated github.com/smacker/go-tree-sitter repository. The
failing cgo package was the Python grammar. Its C link step reported
undefined ts_current_malloc, ts_current_realloc, and ts_current_free
symbols.

The scanner includes ../array.h, which includes the root alloc.h header.
That header maps ts_malloc, ts_realloc, and ts_free through tree-sitter
allocator hooks. The storage for those hooks lives in alloc.c.

A Go dependency on //:go-tree-sitter gives grammar packages the Go
package and headers. It does not make the root package's C objects
available while rules_go compiles a separate cgo archive for each
grammar package, so declarations from alloc.h were present without the
matching definitions from alloc.c.

This patch is needed because generated tree-sitter grammar packages
build their C scanner code independently from the root tree-sitter cgo
package. Patch generated go-tree-sitter BUILD files to build alloc.c
once as a cc_library named //:alloc. The root cgo package and each
grammar whose scanner includes ../alloc.h or ../array.h now depend on
that target via cdeps, keeping upstream allocator wiring intact instead
of overriding scanner source.