### PR TITLE
Create an experiment for whether the executor should publish PostExecutionStats

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -915,7 +915,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		executionTask.Experiments = append(executionTask.Experiments, "executor.download_inputs_chunked")
 	}
 
-	if efp != nil && chunking.Enabled(ctx, efp) && efp.Boolean(ctx, "remote_execution.publish_post_completion_stats", false) {
+	if efp != nil && efp.Boolean(ctx, "remote_execution.publish_post_completion_stats", false) {
 		executionTask.Experiments = append(executionTask.Experiments, "remote_execution.publish_post_completion_stats")
 	}
 

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -915,6 +915,10 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		executionTask.Experiments = append(executionTask.Experiments, "executor.download_inputs_chunked")
 	}
 
+	if efp != nil && chunking.Enabled(ctx, efp) && efp.Boolean(ctx, "remote_execution.publish_post_completion_stats", false) {
+		executionTask.Experiments = append(executionTask.Experiments, "remote_execution.publish_post_completion_stats")
+	}
+
 	// Add in secrets for any action explicitly requesting secrets, and all workflows.
 	secretService := s.env.GetSecretService()
 	if props.IncludeSecrets || len(props.EnvSecrets) > 0 {


### PR DESCRIPTION
This makes sure that PublishOperation only gets a second COMPLETED message if it's ready to process it.