### PR TITLE
DialInternal instead of DialSimple in grpc_forward.go

### DIFF
--- a/server/util/grpc_forward/BUILD
+++ b/server/util/grpc_forward/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/grpc_forward",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/environment",
         "//server/util/flag",
         "//server/util/grpc_client",
         "//server/util/status",

--- a/server/util/grpc_forward/grpc_forward.go
+++ b/server/util/grpc_forward/grpc_forward.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -39,14 +40,16 @@ func lookupProxyTarget(fullMethodName string) (string, error) {
 
 type dialFn = func(string, ...grpc.DialOption) (*grpc_client.ClientConnPool, error)
 
-func dial(target string, opts ...grpc.DialOption) (*grpc_client.ClientConnPool, error) {
-	if *poolSize < 0 {
-		return nil, status.InvalidArgumentErrorf("Invalid pool size: %d", *poolSize)
+func newDialer(env environment.Env) dialFn {
+	return func(target string, opts ...grpc.DialOption) (*grpc_client.ClientConnPool, error) {
+		if *poolSize < 0 {
+			return nil, status.InvalidArgumentErrorf("Invalid pool size: %d", *poolSize)
+		}
+		if *poolSize == 0 {
+			return grpc_client.DialInternal(env, target, opts...)
+		}
+		return grpc_client.DialInternalWithPoolSize(env, target, *poolSize, opts...)
 	}
-	if *poolSize == 0 {
-		return grpc_client.DialSimple(target, opts...)
-	}
-	return grpc_client.DialSimpleWithPoolSize(target, *poolSize, opts...)
 }
 
 func getConnectionPool(dialer dialFn, target string) (*grpc_client.ClientConnPool, error) {
@@ -77,26 +80,29 @@ func getConnectionPool(dialer dialFn, target string) (*grpc_client.ClientConnPoo
 	return newPool, nil
 }
 
-func director(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
-	target, err := lookupProxyTarget(fullMethodName)
-	if err != nil {
-		return nil, nil, err
-	}
+func newDirector(env environment.Env) proxy.StreamDirector {
+	dialer := newDialer(env)
+	return func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
+		target, err := lookupProxyTarget(fullMethodName)
+		if err != nil {
+			return nil, nil, err
+		}
 
-	pool, err := getConnectionPool(dial, target)
-	if err != nil {
-		return nil, nil, err
-	}
+		pool, err := getConnectionPool(dialer, target)
+		if err != nil {
+			return nil, nil, err
+		}
 
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		ctx = metadata.NewOutgoingContext(ctx, md.Copy())
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			ctx = metadata.NewOutgoingContext(ctx, md.Copy())
+		}
+		return ctx, pool, nil
 	}
-	return ctx, pool, nil
 }
 
-func GetForwardingServerOption() grpc.ServerOption {
+func GetForwardingServerOption(env environment.Env) grpc.ServerOption {
 	if len(*proxyTargets) == 0 {
 		return nil
 	}
-	return grpc.UnknownServiceHandler(proxy.TransparentHandler(director))
+	return grpc.UnknownServiceHandler(proxy.TransparentHandler(newDirector(env)))
 }

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -113,7 +113,7 @@ func New(env environment.Env, port int, ssl bool, config GRPCServerConfig) (*GRP
 	} else {
 		log.Infof("gRPC listening on %s", b.hostPort)
 	}
-	if fwdingOptions := grpc_forward.GetForwardingServerOption(); fwdingOptions != nil {
+	if fwdingOptions := grpc_forward.GetForwardingServerOption(env); fwdingOptions != nil {
 		grpcOptions = append(grpcOptions, fwdingOptions)
 	}
 	b.server = grpc.NewServer(grpcOptions...)


### PR DESCRIPTION
I think this fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/7494 because:
1. The IP-Rule-enforcing interceptor should be running for these proxied RPCs and
2. By `DialInternal`-ing instead of `DialSimple`-ing, the server's client-identity is sent along, meaning the app will accept the remotely enforced IP rules.

I need to test this to confirm, though.

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7494