### PR TITLE
oci resolver: test cache path requires valid credentials

### DIFF
--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -825,7 +825,10 @@ func TestResolve_WithCache(t *testing.T) {
 	}
 }
 
-func TestResolveWithCacheWithoutOCIFetcherRequiresValidCredentials(t *testing.T) {
+// TestResolveWithCacheRequiresValidCredentials verifies that the in-executor
+// cache path (use_oci_fetcher=false) does not serve a cached private image to
+// callers with missing or invalid credentials.
+func TestResolveWithCacheRequiresValidCredentials(t *testing.T) {
 	te := setupTestEnvWithCache(t)
 	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 	flags.Set(t, "executor.container_registry.use_cache_percent", 100)
@@ -853,9 +856,6 @@ func TestResolveWithCacheWithoutOCIFetcherRequiresValidCredentials(t *testing.T)
 	require.Len(t, layers, 1)
 	require.Empty(t, cmp.Diff(map[string][]byte{"/private": []byte("private image contents")}, layerFiles(t, layers[0])))
 
-	authError := func(err error) bool {
-		return status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err)
-	}
 	for _, tc := range []struct {
 		name        string
 		credentials oci.Credentials
@@ -878,7 +878,7 @@ func TestResolveWithCacheWithoutOCIFetcherRequiresValidCredentials(t *testing.T)
 				false, /*=useOCIFetcher*/
 			)
 			require.Error(t, err)
-			require.True(t, authError(err), "expected auth error, got: %v", err)
+			require.True(t, status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err), "expected auth error, got: %v", err)
 		})
 	}
 }

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -833,11 +833,10 @@ func TestResolveWithCacheRequiresValidCredentials(t *testing.T) {
 	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
 	flags.Set(t, "executor.container_registry.use_cache_percent", 100)
 
+	imageFiles := map[string][]byte{"/private": []byte("private image contents")}
 	registryCreds := &testregistry.BasicAuthCreds{Username: "testuser", Password: "testpass"}
 	registry := testregistry.Run(t, testregistry.Opts{Creds: registryCreds})
-	imageAddress, pushedImage := registry.PushNamedImageWithFiles(t, "private_image", map[string][]byte{
-		"/private": []byte("private image contents"),
-	}, registryCreds)
+	imageAddress, pushedImage := registry.PushNamedImageWithFiles(t, "private_image", imageFiles, registryCreds)
 	imageDigest, err := pushedImage.Digest()
 	require.NoError(t, err)
 	imageAddressWithDigest := imageAddress + "@" + imageDigest.String()
@@ -854,7 +853,7 @@ func TestResolveWithCacheRequiresValidCredentials(t *testing.T) {
 	layers, err := pulledImage.Layers()
 	require.NoError(t, err)
 	require.Len(t, layers, 1)
-	require.Empty(t, cmp.Diff(map[string][]byte{"/private": []byte("private image contents")}, layerFiles(t, layers[0])))
+	require.Empty(t, cmp.Diff(imageFiles, layerFiles(t, layers[0])))
 
 	for _, tc := range []struct {
 		name        string

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -825,6 +825,64 @@ func TestResolve_WithCache(t *testing.T) {
 	}
 }
 
+func TestResolveWithCacheWithoutOCIFetcherRequiresValidCredentials(t *testing.T) {
+	te := setupTestEnvWithCache(t)
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
+	flags.Set(t, "executor.container_registry.use_cache_percent", 100)
+
+	registryCreds := &testregistry.BasicAuthCreds{Username: "testuser", Password: "testpass"}
+	registry := testregistry.Run(t, testregistry.Opts{Creds: registryCreds})
+	imageAddress, pushedImage := registry.PushNamedImageWithFiles(t, "private_image", map[string][]byte{
+		"/private": []byte("private image contents"),
+	}, registryCreds)
+	imageDigest, err := pushedImage.Digest()
+	require.NoError(t, err)
+	imageAddressWithDigest := imageAddress + "@" + imageDigest.String()
+
+	ctx := contextWithUnverifiedJWT(&claims.Claims{UserID: "US123"})
+	pulledImage, err := newResolver(t, te).Resolve(
+		ctx,
+		imageAddressWithDigest,
+		oci.RuntimePlatform(),
+		creds(registryCreds.Username, registryCreds.Password),
+		false, /*=useOCIFetcher*/
+	)
+	require.NoError(t, err)
+	layers, err := pulledImage.Layers()
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+	require.Empty(t, cmp.Diff(map[string][]byte{"/private": []byte("private image contents")}, layerFiles(t, layers[0])))
+
+	authError := func(err error) bool {
+		return status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err)
+	}
+	for _, tc := range []struct {
+		name        string
+		credentials oci.Credentials
+	}{
+		{
+			name:        "MissingCredentials",
+			credentials: oci.Credentials{},
+		},
+		{
+			name:        "InvalidCredentials",
+			credentials: creds("wrong", "wrong"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := newResolver(t, te).Resolve(
+				ctx,
+				imageAddressWithDigest,
+				oci.RuntimePlatform(),
+				tc.credentials,
+				false, /*=useOCIFetcher*/
+			)
+			require.Error(t, err)
+			require.True(t, authError(err), "expected auth error, got: %v", err)
+		})
+	}
+}
+
 // contextWithUnverifiedJWT creates a JWT with the given claims
 // and attaches it to the returned context.
 // Necessary now that we do not allow anonymous requests to access


### PR DESCRIPTION
Adds a regression test verifying that resolving a private image through the in-executor cache (`useOCIFetcher=false`) does not serve cached layers to callers with **missing or invalid** registry credentials.