### PR TITLE
codesearch: add boolean set operations to MergeList and use it in FieldMap

### DIFF
--- a/codesearch/posting/posting.go
+++ b/codesearch/posting/posting.go
@@ -472,10 +472,10 @@ func (f *termFreqs) any() bool {
 	return false
 }
 
-// MergeList is a mutable posting list used by the pebble value merger and by
-// delete compaction. Unlike BuilderList it supports Or (merging another list,
-// summing shared frequencies) and Remove, but not the indexing Add path. It
-// keeps frequencies decoded (termFreqs) so they can be mutated.
+// MergeList is a mutable posting list used by the pebble value merger, delete
+// compaction, and query result combination. Unlike BuilderList it supports
+// boolean set operations, keeping frequencies decoded (termFreqs) so they can
+// be preserved and summed as lists are combined.
 type MergeList struct {
 	docs docIDSet
 
@@ -503,6 +503,39 @@ func (l *MergeList) Clear() {
 	l.docs.reset()
 	l.freqs.clear()
 	l.serialized = nil
+}
+
+func (l *MergeList) Add(id uint64) {
+	if _, ok := l.docs.indexOf(id); ok {
+		return
+	}
+	if l.docs.len() == 0 || id > l.docs.last {
+		l.docs.appendSorted(id)
+		if l.freqs.materialized {
+			l.freqs.dense = append(l.freqs.dense, 1)
+		}
+		l.serialized = nil
+		return
+	}
+
+	oldIDs := l.docs.array()
+	ids := make([]uint64, 0, len(oldIDs)+1)
+	freqs := make([]uint32, 0, len(oldIDs)+1)
+	inserted := false
+	for i, oldID := range oldIDs {
+		if !inserted && id < oldID {
+			ids = append(ids, id)
+			freqs = append(freqs, 1)
+			inserted = true
+		}
+		ids = append(ids, oldID)
+		freqs = append(freqs, l.frequencyAt(i))
+	}
+	if !inserted {
+		ids = append(ids, id)
+		freqs = append(freqs, 1)
+	}
+	l.setFromSorted(ids, freqs)
 }
 
 // setFromSorted resets l to the given ascending doc IDs and parallel
@@ -562,6 +595,40 @@ func (l *MergeList) Or(other ReadOnlyList) {
 		freqs = append(freqs, rFreqs[j])
 	}
 	l.setFromSorted(ids, freqs)
+}
+
+func (l *MergeList) And(other ReadOnlyList) {
+	if l.docs.len() == 0 {
+		return
+	}
+	if other.GetCardinality() == 0 {
+		l.Clear()
+		return
+	}
+	otherBM := readOnlyListToRoaring(other)
+
+	if !l.freqs.materialized {
+		bm := l.docs.roaring()
+		bm.And(otherBM)
+		l.docs.setSorted(bm.ToArray())
+		l.serialized = nil
+		return
+	}
+
+	ids := l.docs.array()
+	keepIDs := make([]uint64, 0, len(ids))
+	keepFreqs := make([]uint32, 0, len(ids))
+	for i, id := range ids {
+		if otherBM.Contains(id) {
+			keepIDs = append(keepIDs, id)
+			keepFreqs = append(keepFreqs, l.freqs.at(i))
+		}
+	}
+	l.setFromSorted(keepIDs, keepFreqs)
+}
+
+func (l *MergeList) AndNot(other ReadOnlyList) {
+	l.RemoveAll(other)
 }
 
 // Remove deletes id from the list, preserving the frequencies of surviving docs.
@@ -908,7 +975,7 @@ func (fm *FieldMap) OrField(fieldName string, pl2 ReadOnlyList) {
 	if pl, ok := (*fm)[fieldName]; ok {
 		pl.Or(pl2)
 	} else {
-		newPl := NewList()
+		newPl := NewMergeList()
 		newPl.Or(pl2)
 		(*fm)[fieldName] = newPl
 	}
@@ -931,7 +998,7 @@ func (fm *FieldMap) And(fm2 FieldMap) {
 	}
 }
 func (fm *FieldMap) ToPosting() List {
-	pl := NewList()
+	pl := NewMergeList()
 	for _, pl2 := range *fm {
 		pl.Or(pl2)
 	}

--- a/codesearch/posting/posting_test.go
+++ b/codesearch/posting/posting_test.go
@@ -299,6 +299,37 @@ func TestMergeListOr(t *testing.T) {
 	assert.Equal(t, []uint64{1, 2, 3}, pl.ToArray())
 }
 
+func TestMergeListAddPreservesFrequencies(t *testing.T) {
+	src := posting.NewBuilderList()
+	src.AddWithFrequency(2, 7)
+	pl := posting.NewMergeList()
+	pl.Or(src)
+
+	pl.Add(1)
+	pl.Add(3)
+
+	assert.Equal(t, []uint64{1, 2, 3}, pl.ToArray())
+	assert.Equal(t, uint32(1), pl.Frequency(1))
+	assert.Equal(t, uint32(7), pl.Frequency(2))
+	assert.Equal(t, uint32(1), pl.Frequency(3))
+}
+
+func TestMergeListAndPreservesFrequencies(t *testing.T) {
+	src := posting.NewBuilderList()
+	src.AddWithFrequency(1, 2)
+	src.AddWithFrequency(2, 3)
+	src.AddWithFrequency(3, 4)
+	pl := posting.NewMergeList()
+	pl.Or(src)
+
+	pl.And(posting.NewList(2, 3, 5))
+
+	assert.Equal(t, []uint64{2, 3}, pl.ToArray())
+	assert.Equal(t, uint32(3), pl.Frequency(2))
+	assert.Equal(t, uint32(4), pl.Frequency(3))
+	assert.Equal(t, uint32(0), pl.Frequency(1))
+}
+
 func TestMergeListRemove(t *testing.T) {
 	pl := posting.NewMergeList()
 	pl.Or(posting.NewBuilderList(1, 2, 3))
@@ -451,6 +482,28 @@ func TestFieldMapAnd(t *testing.T) {
 
 	assert.Equal(t, []uint64{2}, fm["test"].ToArray())
 	assert.Equal(t, []uint64{2}, fm["test2"].ToArray())
+}
+
+func TestFieldMapAndPreservesFieldFrequencies(t *testing.T) {
+	content := posting.NewBuilderList()
+	content.AddWithFrequency(1, 2)
+	content.AddWithFrequency(2, 3)
+
+	filename := posting.NewBuilderList()
+	filename.AddWithFrequency(2, 5)
+	filename.AddWithFrequency(3, 7)
+
+	fm := posting.NewFieldMap()
+	fm.OrField("content", content)
+	fm2 := posting.NewFieldMap()
+	fm2.OrField("filename", filename)
+
+	fm.And(fm2)
+
+	assert.Equal(t, []uint64{2}, fm["content"].ToArray())
+	assert.Equal(t, uint32(3), fm["content"].Frequency(2))
+	assert.Equal(t, []uint64{2}, fm["filename"].ToArray())
+	assert.Equal(t, uint32(5), fm["filename"].Frequency(2))
 }
 
 func BenchmarkListSerializationPosting(b *testing.B) {


### PR DESCRIPTION
Add And, AndNot, and Add to MergeList so it supports the full set of
boolean operations, preserving per-doc frequencies as lists are
combined (And keeps the surviving left-hand frequencies; AndNot reuses
the existing bulk RemoveAll path).

Switch FieldMap.OrField and ToPosting from the plain roaring-backed
NewList to NewMergeList so that query result combination carries term
frequencies through, instead of collapsing every frequency to 1. This
is a prerequisite for frequency-aware scoring.
