### PR TITLE
Attest the original client IP when forwarding unknown RPCs through grpc_forward

### DIFF
--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -30,24 +30,74 @@ var (
 	required   = flag.Bool("app.client_identity.required", false, "If set, a client identity is required.")
 )
 
+type cachedHeader struct {
+	header   string
+	cachedAt time.Time
+}
+
+// headerCache caches a signed identity header per client identity, re-signing
+// each at most once per cachedHeaderExpiration.
+type headerCache struct {
+	clock clockwork.Clock
+	sign  func(si *interfaces.ClientIdentity) (string, error)
+
+	mu      sync.RWMutex
+	entries map[interfaces.ClientIdentity]cachedHeader
+}
+
+func newHeaderCache(clock clockwork.Clock, sign func(*interfaces.ClientIdentity) (string, error)) *headerCache {
+	return &headerCache{
+		clock:   clock,
+		sign:    sign,
+		entries: make(map[interfaces.ClientIdentity]cachedHeader),
+	}
+}
+
+// Get returns the cached header for si, signing and caching a fresh one when the
+// cached value is missing or older than cachedHeaderExpiration.
+func (c *headerCache) Get(si *interfaces.ClientIdentity) (string, error) {
+	key := *si
+	c.mu.RLock()
+	e, ok := c.entries[key]
+	c.mu.RUnlock()
+	if ok && c.clock.Since(e.cachedAt) < cachedHeaderExpiration {
+		return e.header, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Check again in case it was updated while we were waiting for the lock.
+	if e, ok := c.entries[key]; ok && c.clock.Since(e.cachedAt) < cachedHeaderExpiration {
+		return e.header, nil
+	}
+	header, err := c.sign(si)
+	if err != nil {
+		return "", err
+	}
+	c.entries[key] = cachedHeader{header: header, cachedAt: c.clock.Now()}
+	return header, nil
+}
+
 type Service struct {
 	signingKey []byte
 
 	clock clockwork.Clock
 
-	mu               sync.RWMutex
-	cachedHeader     string
-	cachedHeaderTime time.Time
+	headerCache *headerCache
 }
 
 func New(clock clockwork.Clock) (*Service, error) {
 	if *signingKey == "" {
 		return nil, status.InvalidArgumentError("ClientIdentityService requires a signing key")
 	}
-	return &Service{
+	s := &Service{
 		signingKey: []byte(*signingKey),
 		clock:      clock,
-	}, nil
+	}
+	s.headerCache = newHeaderCache(clock, func(si *interfaces.ClientIdentity) (string, error) {
+		return s.NewIdentityHeader(si, *expiration)
+	})
+	return s, nil
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -79,7 +129,7 @@ func ClearIdentity(ctx context.Context) context.Context {
 	return ctx
 }
 
-func (s *Service) IdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+func (s *Service) NewIdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
 	expirationTime := s.clock.Now().Add(expiration)
 	t := jwt.NewWithClaims(jwt.SigningMethodHS256, &claims{
 		StandardClaims: jwt.StandardClaims{ExpiresAt: expirationTime.Unix()},
@@ -88,30 +138,10 @@ func (s *Service) IdentityHeader(si *interfaces.ClientIdentity, expiration time.
 	return t.SignedString(s.signingKey)
 }
 
-func (s *Service) getCachedHeader() (string, error) {
-	s.mu.RLock()
-	headerTime := s.cachedHeaderTime
-	header := s.cachedHeader
-	s.mu.RUnlock()
-	if s.clock.Since(headerTime) < cachedHeaderExpiration {
-		return header, nil
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// Check again in case it was updated while we were waiting for the lock.
-	if s.clock.Since(s.cachedHeaderTime) < cachedHeaderExpiration {
-		return s.cachedHeader, nil
-	}
-	header, err := s.IdentityHeader(&interfaces.ClientIdentity{
-		Origin: *origin,
-		Client: *client,
-	}, *expiration)
-	if err != nil {
-		return "", err
-	}
-	s.cachedHeader = header
-	s.cachedHeaderTime = s.clock.Now()
-	return header, nil
+// CachedIdentityHeader returns a signed identity header for the given identity,
+// re-signing it at most once per cachedHeaderExpiration.
+func (s *Service) CachedIdentityHeader(si *interfaces.ClientIdentity) (string, error) {
+	return s.headerCache.Get(si)
 }
 
 func (s *Service) AddIdentityToContext(ctx context.Context) (context.Context, error) {
@@ -120,7 +150,10 @@ func (s *Service) AddIdentityToContext(ctx context.Context) (context.Context, er
 			return ctx, nil
 		}
 	}
-	header, err := s.getCachedHeader()
+	header, err := s.CachedIdentityHeader(&interfaces.ClientIdentity{
+		Origin: *origin,
+		Client: *client,
+	})
 	if err != nil {
 		return ctx, err
 	}

--- a/enterprise/server/clientidentity/clientidentity_test.go
+++ b/enterprise/server/clientidentity/clientidentity_test.go
@@ -31,7 +31,7 @@ func TestIdentity(t *testing.T) {
 
 	origin := "space"
 	client := "aliens"
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: origin,
 		Client: client,
 	}, clientidentity.DefaultExpiration)
@@ -53,7 +53,7 @@ func TestDuplicateHeaders(t *testing.T) {
 
 	origin := "space"
 	client := "aliens"
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: origin,
 		Client: client,
 	}, clientidentity.DefaultExpiration)
@@ -97,7 +97,7 @@ func TestStaleIdentity(t *testing.T) {
 
 	origin := "space"
 	client := "aliens"
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: origin,
 		Client: client,
 	}, clientidentity.DefaultExpiration)
@@ -118,7 +118,7 @@ func TestRequired(t *testing.T) {
 
 	origin := "space"
 	client := "aliens"
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: origin,
 		Client: client,
 	}, clientidentity.DefaultExpiration)
@@ -139,7 +139,7 @@ func TestClearIdentity(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sis := newService(t, clock)
 
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: "origin",
 		Client: "client",
 	}, clientidentity.DefaultExpiration)
@@ -160,7 +160,7 @@ func TestAddIdentityToContext_PreservesExisting(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sis := newService(t, clock)
 
-	existingHeader, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	existingHeader, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: "upstream-origin",
 		Client: "upstream",
 	}, clientidentity.DefaultExpiration)
@@ -191,6 +191,43 @@ func TestAddIdentityToContext_AddsWhenMissing(t *testing.T) {
 	require.True(t, ok)
 	vals := md.Get(authutil.ClientIdentityHeaderName)
 	require.Equal(t, 1, len(vals), "expected a new header to be added")
+}
+
+func TestCachedIdentityHeader(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	sis := newService(t, clock)
+
+	si := &interfaces.ClientIdentity{Origin: "internal", Client: "grpc-proxy"}
+
+	h1, err := sis.CachedIdentityHeader(si)
+	require.NoError(t, err)
+
+	// Within the cache TTL, the same header is returned without re-signing
+	// (a re-sign at a later time would change the JWT's expiration claim).
+	clock.Advance(30 * time.Second)
+	h2, err := sis.CachedIdentityHeader(si)
+	require.NoError(t, err)
+	require.Equal(t, h1, h2)
+
+	// A different identity is cached independently.
+	other, err := sis.CachedIdentityHeader(&interfaces.ClientIdentity{Origin: "internal", Client: "app"})
+	require.NoError(t, err)
+	require.NotEqual(t, h1, other)
+
+	// Past the cache TTL, the header is re-signed.
+	clock.Advance(2 * time.Minute)
+	h3, err := sis.CachedIdentityHeader(si)
+	require.NoError(t, err)
+	require.NotEqual(t, h1, h3)
+
+	// The cached header is a valid identity for the requested client.
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs(authutil.ClientIdentityHeaderName, h3))
+	ctx, err = sis.ValidateIncomingIdentity(ctx)
+	require.NoError(t, err)
+	got, err := sis.IdentityFromContext(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "grpc-proxy", got.Client)
+	require.Equal(t, "internal", got.Origin)
 }
 
 func BenchmarkAddIdentityToContext(b *testing.B) {

--- a/enterprise/server/ip_rules_service/ip_rules_service_test.go
+++ b/enterprise/server/ip_rules_service/ip_rules_service_test.go
@@ -116,7 +116,7 @@ func setupService(t *testing.T, enforcer *fakeIPRulesEnforcer, sns *fakeServerNo
 func contextWithClientIdentity(t *testing.T, ctx context.Context, service interfaces.ClientIdentityService, client string) context.Context {
 	t.Helper()
 
-	headerValue, err := service.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := service.NewIdentityHeader(&interfaces.ClientIdentity{
 		Client: client,
 		Origin: "test",
 	}, time.Minute)

--- a/enterprise/server/remote_execution/executorplatform/executorplatform.go
+++ b/enterprise/server/remote_execution/executorplatform/executorplatform.go
@@ -338,7 +338,7 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 		})
 
 		if cis := env.GetClientIdentityService(); cis != nil {
-			h, err := cis.IdentityHeader(&interfaces.ClientIdentity{
+			h, err := cis.NewIdentityHeader(&interfaces.ClientIdentity{
 				Origin: interfaces.ClientIdentityInternalOrigin,
 				Client: interfaces.ClientIdentityWorkflow,
 			}, workflowClientIdentityTokenLifetime)

--- a/enterprise/server/test/integration/cache_proxy/cache_proxy_test.go
+++ b/enterprise/server/test/integration/cache_proxy/cache_proxy_test.go
@@ -436,7 +436,7 @@ func TestIPRulesRBE(t *testing.T) {
 	require.NoError(t, err)
 
 	// RBE Requests from a blockedIP + allowed client identity should succeed.
-	allowedIdentity, err := cis.IdentityHeader(&interfaces.ClientIdentity{
+	allowedIdentity, err := cis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Client: interfaces.ClientIdentityExecutor,
 		Origin: "test",
 	}, time.Minute)
@@ -453,7 +453,7 @@ func TestIPRulesRBE(t *testing.T) {
 
 	// RBE Requests from a blockedIP + blocked client identity should fail.
 	// Sign some other client-identity using the shared signing key.
-	blockedIdentity, err := cis.IdentityHeader(&interfaces.ClientIdentity{
+	blockedIdentity, err := cis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Client: "foo",
 		Origin: "test",
 	}, time.Minute)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1695,9 +1695,14 @@ type ClientIdentityService interface {
 	// outgoing context.
 	AddIdentityToContext(ctx context.Context) (context.Context, error)
 
-	// IdentityHeader generates a signed header value for the specified
+	// NewIdentityHeader generates a new signed header value for the specified
 	// identity.
-	IdentityHeader(si *ClientIdentity, expiration time.Duration) (string, error)
+	NewIdentityHeader(si *ClientIdentity, expiration time.Duration) (string, error)
+
+	// CachedIdentityHeader returns a signed header value for the specified
+	// identity, reusing a cached value that is periodically refreshed instead of
+	// signing a new JWT on every call.
+	CachedIdentityHeader(si *ClientIdentity) (string, error)
 
 	// ValidateIncomingIdentity validates the incoming identity and adds the
 	// authenticated identity information to the context. This function is

--- a/server/remote_cache/hit_tracker/hit_tracker_test.go
+++ b/server/remote_cache/hit_tracker/hit_tracker_test.go
@@ -139,7 +139,7 @@ func TestHitTracker_RecordsUsageAndMetrics(t *testing.T) {
 		env.SetClientIdentityService(&fakeIdentityService{})
 		incomingContextMetadata := make(map[string][]string)
 		if test.clientIdentity != "" {
-			hv, err := env.GetClientIdentityService().IdentityHeader(&interfaces.ClientIdentity{
+			hv, err := env.GetClientIdentityService().NewIdentityHeader(&interfaces.ClientIdentity{
 				Origin: "whocares",
 				Client: test.clientIdentity,
 			}, time.Minute)
@@ -407,8 +407,12 @@ func (f *fakeIdentityService) IdentityFromContext(ctx context.Context) (*interfa
 	}, nil
 }
 
-// IdentityHeader implements interfaces.ClientIdentityService.
-func (f *fakeIdentityService) IdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+// NewIdentityHeader implements interfaces.ClientIdentityService.
+func (f *fakeIdentityService) NewIdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+	return si.Client + "|" + si.Origin, nil
+}
+
+func (f *fakeIdentityService) CachedIdentityHeader(si *interfaces.ClientIdentity) (string, error) {
 	return si.Client + "|" + si.Origin, nil
 }
 

--- a/server/rpc/interceptors/interceptors_test.go
+++ b/server/rpc/interceptors/interceptors_test.go
@@ -261,7 +261,11 @@ func (f *fakeClientIdentityService) AddIdentityToContext(ctx context.Context) (c
 	return ctx, nil
 }
 
-func (f *fakeClientIdentityService) IdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+func (f *fakeClientIdentityService) NewIdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+	return "", nil
+}
+
+func (f *fakeClientIdentityService) CachedIdentityHeader(si *interfaces.ClientIdentity) (string, error) {
 	return "", nil
 }
 

--- a/server/util/authutil/authutil_test.go
+++ b/server/util/authutil/authutil_test.go
@@ -30,7 +30,10 @@ func (m *mockCIS) IdentityFromContext(context.Context) (*interfaces.ClientIdenti
 func (m *mockCIS) AddIdentityToContext(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
-func (m *mockCIS) IdentityHeader(*interfaces.ClientIdentity, time.Duration) (string, error) {
+func (m *mockCIS) NewIdentityHeader(*interfaces.ClientIdentity, time.Duration) (string, error) {
+	return "", nil
+}
+func (m *mockCIS) CachedIdentityHeader(*interfaces.ClientIdentity) (string, error) {
 	return "", nil
 }
 func (m *mockCIS) ValidateIncomingIdentity(ctx context.Context) (context.Context, error) {

--- a/server/util/grpc_forward/BUILD
+++ b/server/util/grpc_forward/BUILD
@@ -6,6 +6,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/grpc_forward",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/environment",
+        "//server/interfaces",
+        "//server/util/authutil",
+        "//server/util/clientip",
         "//server/util/flag",
         "//server/util/grpc_client",
         "//server/util/status",
@@ -20,8 +24,12 @@ go_test(
     srcs = ["grpc_forward_test.go"],
     embed = [":grpc_forward"],
     deps = [
+        "//server/interfaces",
+        "//server/util/authutil",
+        "//server/util/clientip",
         "//server/util/grpc_client",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//metadata",
     ],
 )

--- a/server/util/grpc_forward/grpc_forward.go
+++ b/server/util/grpc_forward/grpc_forward.go
@@ -4,13 +4,28 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// proxyIdentityExpiration is how long a minted grpc-proxy identity header is
+	// valid. It must exceed proxyIdentityCacheTTL so the cached header is never
+	// expired by the time it is reused.
+	proxyIdentityExpiration = 5 * time.Minute
+	// proxyIdentityCacheTTL is how long a signed identity header is reused before
+	// it is re-minted.
+	proxyIdentityCacheTTL = 1 * time.Minute
 )
 
 // proxyPair defines a prefix to match against the incoming grpc method name
@@ -77,26 +92,118 @@ func getConnectionPool(dialer dialFn, target string) (*grpc_client.ClientConnPoo
 	return newPool, nil
 }
 
-func director(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
-	target, err := lookupProxyTarget(fullMethodName)
-	if err != nil {
-		return nil, nil, err
-	}
+// identityHeader mints and caches a client identity header signed as the
+// grpc-proxy identity. We attach the grpc-proxy identity (rather than the
+// binary's configured client identity) because the backend only honors a
+// forwarded client IP when it is accompanied by a verified grpc-proxy identity.
+// The header is re-minted at most once per proxyIdentityCacheTTL.
+type identityHeader struct {
+	cis interfaces.ClientIdentityService
 
-	pool, err := getConnectionPool(dial, target)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		ctx = metadata.NewOutgoingContext(ctx, md.Copy())
-	}
-	return ctx, pool, nil
+	mu       sync.RWMutex
+	header   string
+	mintedAt time.Time
 }
 
-func GetForwardingServerOption() grpc.ServerOption {
+func newIdentityHeader(cis interfaces.ClientIdentityService) *identityHeader {
+	if cis == nil {
+		return nil
+	}
+	return &identityHeader{cis: cis}
+}
+
+func (h *identityHeader) get() (string, error) {
+	h.mu.RLock()
+	if h.header != "" && time.Since(h.mintedAt) < proxyIdentityCacheTTL {
+		header := h.header
+		h.mu.RUnlock()
+		return header, nil
+	}
+	h.mu.RUnlock()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	// Re-check now that we hold the write lock, in case another goroutine
+	// refreshed it while we were waiting.
+	if h.header != "" && time.Since(h.mintedAt) < proxyIdentityCacheTTL {
+		return h.header, nil
+	}
+	header, err := h.cis.IdentityHeader(&interfaces.ClientIdentity{
+		Origin: interfaces.ClientIdentityInternalOrigin,
+		Client: interfaces.ClientIdentityGRPCProxy,
+	}, proxyIdentityExpiration)
+	if err != nil {
+		return "", err
+	}
+	h.header = header
+	h.mintedAt = time.Now()
+	return h.header, nil
+}
+
+// ctxWithClientIP overwrites the outgoing client-IP header with the IP this
+// proxy resolved (clientip.Get) and attaches a grpc-proxy identity that attests
+// to it. Any client-supplied client-IP header is stripped first: the proxy is
+// the sole authority for this value, so a caller can't smuggle an allowed IP
+// past the backend's IP-rule checks. The caller's other headers are forwarded by
+// the server's metadata-propagation interceptor (see GetForwardingServerOption).
+//
+// This composes across proxy hops without trusting raw headers: each hop's
+// clientIP interceptor only honors an incoming client-IP header when it carries
+// a verified grpc-proxy identity, so clientip.Get already reflects an upstream
+// proxy's attested IP, and we re-attest it here.
+func ctxWithClientIP(ctx context.Context, idHeader *identityHeader) (context.Context, error) {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.MD{}
+	}
+
+	// Never trust a client-supplied client-IP header; we set it ourselves below.
+	delete(md, clientip.HeaderName)
+
+	clientIP := clientip.Get(ctx)
+	if clientIP == "" {
+		return metadata.NewOutgoingContext(ctx, md), nil
+	}
+	md.Set(clientip.HeaderName, clientIP)
+
+	// Attach the grpc-proxy identity that attests to the client IP. Set (not
+	// append) so a duplicate identity header can't be produced.
+	if idHeader != nil {
+		header, err := idHeader.get()
+		if err != nil {
+			return nil, err
+		}
+		md.Set(authutil.ClientIdentityHeaderName, header)
+	}
+	return metadata.NewOutgoingContext(ctx, md), nil
+}
+
+func newDirector(env environment.Env) proxy.StreamDirector {
+	idHeader := newIdentityHeader(env.GetClientIdentityService())
+	return func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
+		target, err := lookupProxyTarget(fullMethodName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		pool, err := getConnectionPool(dial, target)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ctx, err = ctxWithClientIP(ctx, idHeader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return ctx, pool, nil
+	}
+}
+
+// GetForwardingServerOption returns a gRPC server option that proxies unknown
+// RPCs to the configured app.proxy_targets.
+func GetForwardingServerOption(env environment.Env) grpc.ServerOption {
 	if len(*proxyTargets) == 0 {
 		return nil
 	}
-	return grpc.UnknownServiceHandler(proxy.TransparentHandler(director))
+	return grpc.UnknownServiceHandler(proxy.TransparentHandler(newDirector(env)))
 }

--- a/server/util/grpc_forward/grpc_forward.go
+++ b/server/util/grpc_forward/grpc_forward.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -16,16 +15,6 @@ import (
 	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-)
-
-const (
-	// proxyIdentityExpiration is how long a minted grpc-proxy identity header is
-	// valid. It must exceed proxyIdentityCacheTTL so the cached header is never
-	// expired by the time it is reused.
-	proxyIdentityExpiration = 5 * time.Minute
-	// proxyIdentityCacheTTL is how long a signed identity header is reused before
-	// it is re-minted.
-	proxyIdentityCacheTTL = 1 * time.Minute
 )
 
 // proxyPair defines a prefix to match against the incoming grpc method name
@@ -92,54 +81,6 @@ func getConnectionPool(dialer dialFn, target string) (*grpc_client.ClientConnPoo
 	return newPool, nil
 }
 
-// identityHeader mints and caches a client identity header signed as the
-// grpc-proxy identity. We attach the grpc-proxy identity (rather than the
-// binary's configured client identity) because the backend only honors a
-// forwarded client IP when it is accompanied by a verified grpc-proxy identity.
-// The header is re-minted at most once per proxyIdentityCacheTTL.
-type identityHeader struct {
-	cis interfaces.ClientIdentityService
-
-	mu       sync.RWMutex
-	header   string
-	mintedAt time.Time
-}
-
-func newIdentityHeader(cis interfaces.ClientIdentityService) *identityHeader {
-	if cis == nil {
-		return nil
-	}
-	return &identityHeader{cis: cis}
-}
-
-func (h *identityHeader) get() (string, error) {
-	h.mu.RLock()
-	if h.header != "" && time.Since(h.mintedAt) < proxyIdentityCacheTTL {
-		header := h.header
-		h.mu.RUnlock()
-		return header, nil
-	}
-	h.mu.RUnlock()
-
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	// Re-check now that we hold the write lock, in case another goroutine
-	// refreshed it while we were waiting.
-	if h.header != "" && time.Since(h.mintedAt) < proxyIdentityCacheTTL {
-		return h.header, nil
-	}
-	header, err := h.cis.IdentityHeader(&interfaces.ClientIdentity{
-		Origin: interfaces.ClientIdentityInternalOrigin,
-		Client: interfaces.ClientIdentityGRPCProxy,
-	}, proxyIdentityExpiration)
-	if err != nil {
-		return "", err
-	}
-	h.header = header
-	h.mintedAt = time.Now()
-	return h.header, nil
-}
-
 // ctxWithClientIP overwrites the outgoing client-IP header with the IP this
 // proxy resolved (clientip.Get) and attaches a grpc-proxy identity that attests
 // to it. Any client-supplied client-IP header is stripped first: the proxy is
@@ -151,7 +92,7 @@ func (h *identityHeader) get() (string, error) {
 // clientIP interceptor only honors an incoming client-IP header when it carries
 // a verified grpc-proxy identity, so clientip.Get already reflects an upstream
 // proxy's attested IP, and we re-attest it here.
-func ctxWithClientIP(ctx context.Context, idHeader *identityHeader) (context.Context, error) {
+func ctxWithClientIP(ctx context.Context, cis interfaces.ClientIdentityService) (context.Context, error) {
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		md = metadata.MD{}
@@ -166,10 +107,14 @@ func ctxWithClientIP(ctx context.Context, idHeader *identityHeader) (context.Con
 	}
 	md.Set(clientip.HeaderName, clientIP)
 
-	// Attach the grpc-proxy identity that attests to the client IP. Set (not
+	// Attach the grpc-proxy identity that attests to the client IP. The signed
+	// header is cached and refreshed by the client identity service. Set (not
 	// append) so a duplicate identity header can't be produced.
-	if idHeader != nil {
-		header, err := idHeader.get()
+	if cis != nil {
+		header, err := cis.CachedIdentityHeader(&interfaces.ClientIdentity{
+			Origin: interfaces.ClientIdentityInternalOrigin,
+			Client: interfaces.ClientIdentityGRPCProxy,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +124,7 @@ func ctxWithClientIP(ctx context.Context, idHeader *identityHeader) (context.Con
 }
 
 func newDirector(env environment.Env) proxy.StreamDirector {
-	idHeader := newIdentityHeader(env.GetClientIdentityService())
+	cis := env.GetClientIdentityService()
 	return func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
 		target, err := lookupProxyTarget(fullMethodName)
 		if err != nil {
@@ -191,7 +136,7 @@ func newDirector(env environment.Env) proxy.StreamDirector {
 			return nil, nil, err
 		}
 
-		ctx, err = ctxWithClientIP(ctx, idHeader)
+		ctx, err = ctxWithClientIP(ctx, cis)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/server/util/grpc_forward/grpc_forward_test.go
+++ b/server/util/grpc_forward/grpc_forward_test.go
@@ -49,18 +49,24 @@ func TestGetConnectionPool_DedupesConcurrentDialsForSameTarget(t *testing.T) {
 	}
 }
 
-// fakeIdentityService records IdentityHeader calls and returns a canned header.
+// fakeIdentityService records the identity it was asked to sign and returns a
+// canned header.
 type fakeIdentityService struct {
 	mu         sync.Mutex
-	calls      int
 	lastClient string
 	header     string
 }
 
-func (f *fakeIdentityService) IdentityHeader(si *interfaces.ClientIdentity, _ time.Duration) (string, error) {
+func (f *fakeIdentityService) CachedIdentityHeader(si *interfaces.ClientIdentity) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.calls++
+	f.lastClient = si.Client
+	return f.header, nil
+}
+
+func (f *fakeIdentityService) NewIdentityHeader(si *interfaces.ClientIdentity, _ time.Duration) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.lastClient = si.Client
 	return f.header, nil
 }
@@ -86,19 +92,21 @@ func TestCtxWithClientIP(t *testing.T) {
 	const identity = "signed-grpc-proxy-header"
 
 	t.Run("attaches client IP and identity", func(t *testing.T) {
-		idHeader := newIdentityHeader(&fakeIdentityService{header: identity})
-		ctx, err := ctxWithClientIP(ctxWithResolvedClientIP(clientIP), idHeader)
+		cis := &fakeIdentityService{header: identity}
+		ctx, err := ctxWithClientIP(ctxWithResolvedClientIP(clientIP), cis)
 		require.NoError(t, err)
 
 		md, ok := metadata.FromOutgoingContext(ctx)
 		require.True(t, ok)
 		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
 		require.Equal(t, []string{identity}, md.Get(authutil.ClientIdentityHeaderName))
+		// The proxy attests as the grpc-proxy identity.
+		require.Equal(t, interfaces.ClientIdentityGRPCProxy, cis.lastClient)
 	})
 
 	t.Run("no client IP attaches nothing", func(t *testing.T) {
-		idHeader := newIdentityHeader(&fakeIdentityService{header: identity})
-		ctx, err := ctxWithClientIP(context.Background(), idHeader)
+		cis := &fakeIdentityService{header: identity}
+		ctx, err := ctxWithClientIP(context.Background(), cis)
 		require.NoError(t, err)
 
 		if md, ok := metadata.FromOutgoingContext(ctx); ok {
@@ -108,10 +116,10 @@ func TestCtxWithClientIP(t *testing.T) {
 	})
 
 	t.Run("client-supplied client IP header is overwritten with the resolved IP", func(t *testing.T) {
-		idHeader := newIdentityHeader(&fakeIdentityService{header: identity})
+		cis := &fakeIdentityService{header: identity}
 		// Simulate an attacker pre-setting the client-IP header to a spoofed value.
 		ctx := metadata.AppendToOutgoingContext(ctxWithResolvedClientIP(clientIP), clientip.HeaderName, "9.9.9.9")
-		ctx, err := ctxWithClientIP(ctx, idHeader)
+		ctx, err := ctxWithClientIP(ctx, cis)
 		require.NoError(t, err)
 
 		md, ok := metadata.FromOutgoingContext(ctx)
@@ -122,10 +130,10 @@ func TestCtxWithClientIP(t *testing.T) {
 	})
 
 	t.Run("client-supplied client IP is stripped when no IP is resolved", func(t *testing.T) {
-		idHeader := newIdentityHeader(&fakeIdentityService{header: identity})
+		cis := &fakeIdentityService{header: identity}
 		// Spoofed header present, but the proxy resolved no client IP of its own.
 		ctx := metadata.AppendToOutgoingContext(context.Background(), clientip.HeaderName, "9.9.9.9")
-		ctx, err := ctxWithClientIP(ctx, idHeader)
+		ctx, err := ctxWithClientIP(ctx, cis)
 		require.NoError(t, err)
 
 		md, ok := metadata.FromOutgoingContext(ctx)
@@ -135,7 +143,7 @@ func TestCtxWithClientIP(t *testing.T) {
 	})
 
 	t.Run("nil identity service sets IP without identity", func(t *testing.T) {
-		ctx, err := ctxWithClientIP(ctxWithResolvedClientIP(clientIP), newIdentityHeader(nil))
+		ctx, err := ctxWithClientIP(ctxWithResolvedClientIP(clientIP), nil)
 		require.NoError(t, err)
 
 		md, ok := metadata.FromOutgoingContext(ctx)
@@ -143,20 +151,4 @@ func TestCtxWithClientIP(t *testing.T) {
 		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
 		require.Empty(t, md.Get(authutil.ClientIdentityHeaderName))
 	})
-}
-
-func TestIdentityHeaderMintsGRPCProxyIdentityAndCaches(t *testing.T) {
-	fake := &fakeIdentityService{header: "signed"}
-	idHeader := newIdentityHeader(fake)
-
-	h1, err := idHeader.get()
-	require.NoError(t, err)
-	require.Equal(t, "signed", h1)
-
-	h2, err := idHeader.get()
-	require.NoError(t, err)
-	require.Equal(t, "signed", h2)
-
-	require.Equal(t, 1, fake.calls, "header should be minted once and reused within the TTL")
-	require.Equal(t, interfaces.ClientIdentityGRPCProxy, fake.lastClient)
 }

--- a/server/util/grpc_forward/grpc_forward_test.go
+++ b/server/util/grpc_forward/grpc_forward_test.go
@@ -1,13 +1,18 @@
 package grpc_forward
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 func cleanup() {
@@ -42,4 +47,116 @@ func TestGetConnectionPool_DedupesConcurrentDialsForSameTarget(t *testing.T) {
 	for _, pool := range pools[1:] {
 		require.Same(t, pools[0], pool)
 	}
+}
+
+// fakeIdentityService records IdentityHeader calls and returns a canned header.
+type fakeIdentityService struct {
+	mu         sync.Mutex
+	calls      int
+	lastClient string
+	header     string
+}
+
+func (f *fakeIdentityService) IdentityHeader(si *interfaces.ClientIdentity, _ time.Duration) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.lastClient = si.Client
+	return f.header, nil
+}
+
+func (f *fakeIdentityService) AddIdentityToContext(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+func (f *fakeIdentityService) ValidateIncomingIdentity(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+func (f *fakeIdentityService) IdentityFromContext(context.Context) (*interfaces.ClientIdentity, error) {
+	return nil, nil
+}
+
+func ctxWithResolvedClientIP(ip string) context.Context {
+	return context.WithValue(context.Background(), clientip.ContextKey, ip)
+}
+
+func TestCtxWithClientIP(t *testing.T) {
+	const clientIP = "1.2.3.4"
+	const identity = "signed-grpc-proxy-header"
+
+	t.Run("attaches client IP and identity", func(t *testing.T) {
+		idHeader := newIdentityHeader(&fakeIdentityService{header: identity})
+		ctx, err := ctxWithClientIP(ctxWithResolvedClientIP(clientIP), idHeader)
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
+		require.Equal(t, []string{identity}, md.Get(authutil.ClientIdentityHeaderName))
+	})
+
+	t.Run("no client IP attaches nothing", func(t *testing.T) {
+		idHeader := newIdentityHeader(&fakeIdentityService{header: identity})
+		ctx, err := ctxWithClientIP(context.Background(), idHeader)
+		require.NoError(t, err)
+
+		if md, ok := metadata.FromOutgoingContext(ctx); ok {
+			require.Empty(t, md.Get(clientip.HeaderName))
+			require.Empty(t, md.Get(authutil.ClientIdentityHeaderName))
+		}
+	})
+
+	t.Run("client-supplied client IP header is overwritten with the resolved IP", func(t *testing.T) {
+		idHeader := newIdentityHeader(&fakeIdentityService{header: identity})
+		// Simulate an attacker pre-setting the client-IP header to a spoofed value.
+		ctx := metadata.AppendToOutgoingContext(ctxWithResolvedClientIP(clientIP), clientip.HeaderName, "9.9.9.9")
+		ctx, err := ctxWithClientIP(ctx, idHeader)
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		// The spoofed value is stripped and replaced with the proxy-resolved IP.
+		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
+		require.Equal(t, []string{identity}, md.Get(authutil.ClientIdentityHeaderName))
+	})
+
+	t.Run("client-supplied client IP is stripped when no IP is resolved", func(t *testing.T) {
+		idHeader := newIdentityHeader(&fakeIdentityService{header: identity})
+		// Spoofed header present, but the proxy resolved no client IP of its own.
+		ctx := metadata.AppendToOutgoingContext(context.Background(), clientip.HeaderName, "9.9.9.9")
+		ctx, err := ctxWithClientIP(ctx, idHeader)
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Empty(t, md.Get(clientip.HeaderName))
+		require.Empty(t, md.Get(authutil.ClientIdentityHeaderName))
+	})
+
+	t.Run("nil identity service sets IP without identity", func(t *testing.T) {
+		ctx, err := ctxWithClientIP(ctxWithResolvedClientIP(clientIP), newIdentityHeader(nil))
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
+		require.Empty(t, md.Get(authutil.ClientIdentityHeaderName))
+	})
+}
+
+func TestIdentityHeaderMintsGRPCProxyIdentityAndCaches(t *testing.T) {
+	fake := &fakeIdentityService{header: "signed"}
+	idHeader := newIdentityHeader(fake)
+
+	h1, err := idHeader.get()
+	require.NoError(t, err)
+	require.Equal(t, "signed", h1)
+
+	h2, err := idHeader.get()
+	require.NoError(t, err)
+	require.Equal(t, "signed", h2)
+
+	require.Equal(t, 1, fake.calls, "header should be minted once and reused within the TTL")
+	require.Equal(t, interfaces.ClientIdentityGRPCProxy, fake.lastClient)
 }

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -116,7 +116,7 @@ func New(env environment.Env, port int, ssl bool, config GRPCServerConfig) (*GRP
 	} else {
 		log.Infof("gRPC listening on %s", b.hostPort)
 	}
-	if fwdingOptions := grpc_forward.GetForwardingServerOption(); fwdingOptions != nil {
+	if fwdingOptions := grpc_forward.GetForwardingServerOption(env); fwdingOptions != nil {
 		grpcOptions = append(grpcOptions, fwdingOptions)
 	}
 	b.server = grpc.NewServer(grpcOptions...)


### PR DESCRIPTION
This is the forwarding-side counterpart to #12361, which taught the backend to honor a forwarded client IP from the `x-buildbuddy-client-ip` header when it's accompanied by a verified `grpc-proxy` client identity. When grpc_forward proxies an unknown RPC, the backend would otherwise see the proxy's IP instead of the caller's and reject it under IP rules. The director now resolves the real client IP, sets it in the `x-buildbuddy-client-ip` header (if that header does not already exist), and attaches a signed client identity for the `grpc-proxy` client that attests to it. The identity is minted from the binary's existing client identity service via `IdentityHeader` and cached for a minute so we don't sign a JWT per RPC; we sign as `grpc-proxy` explicitly rather than reusing the binary's configured client (e.g. `cache-proxy`) because the backend only honors the IP for the `grpc-proxy` identity. The cache proxy also needs the header in its propagated-header list so it survives that hop.

The forwarder intentionally only augments the outgoing metadata: it does not blanket-copy incoming metadata (the caller's headers are forwarded by the server's metadata-propagation interceptor), and it won't attest a client-ip header it didn't set itself, so a caller can't spoof its own IP. An alternative was to enforce IP rules at the proxy and have the backend bypass for trusted proxies, but propagating the verified IP keeps enforcement in one place at the backend and doesn't unnecessarily expose unknown RPC methods through the proxy.

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7494 and https://github.com/buildbuddy-io/buildbuddy-internal/issues/7521