### PR TITLE
Allow the UI to read usage data from clickhouse

### DIFF
--- a/enterprise/server/usage_service/BUILD
+++ b/enterprise/server/usage_service/BUILD
@@ -24,6 +24,10 @@ go_library(
     ],
 )
 
+# Tell gazelle to make each file a separate test target,
+# so the ClickHouse-backed usage service test can keep separate runner properties.
+# gazelle:go_test file
+
 go_test(
     name = "usage_service_test",
     srcs = ["usage_service_test.go"],
@@ -38,11 +42,41 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//testing/protocmp",
         "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
+)
+
+go_test(
+    name = "usage_service_olap_test",
+    srcs = ["usage_service_olap_test.go"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.init-dockerd": "true",
+        "test.recycle-runner": "true",
+        "test.runner-recycling-key": "clickhouse25.3",
+        "test.EstimatedComputeUnits": "4",
+    },
+    tags = ["docker"],
+    deps = [
+        ":usage_service",
+        "//proto:context_go_proto",
+        "//proto:usage_go_proto",
+        "//server/tables",
+        "//server/testutil/testenv",
+        "//server/usage/sku",
+        "//server/util/clickhouse/schema",
+        "//server/util/testing/flags",
+        "@com_github_clickhouse_clickhouse_go_v2//lib/column/orderedmap",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/enterprise/server/usage_service/usage_service.go
+++ b/enterprise/server/usage_service/usage_service.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	usageStartDate = flag.String("app.usage_start_date", "", "If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z")
-	alertsEnabled  = flag.Bool("app.usage_alerts_enabled", false, "If set, usage alerts will be enabled in the UI.")
+	usageStartDate      = flag.String("app.usage_start_date", "", "If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z")
+	alertsEnabled       = flag.Bool("app.usage_alerts_enabled", false, "If set, usage alerts will be enabled in the UI.")
+	readUsageFromOLAPDB = flag.Bool("app.read_usage_from_olap_db", false, "If enabled, read Usage page data from OLAP DB.")
 )
 
 const (
@@ -262,8 +263,10 @@ func quotedRawUsageLabelValues(values ...sku.LabelValue) string {
 }
 
 type usageService struct {
-	env   environment.Env
-	clock clockwork.Clock
+	env            environment.Env
+	clock          clockwork.Clock
+	olapdbh        interfaces.OLAPDBHandle
+	readFromOLAPDB bool
 
 	// start is the earliest moment in time at which we're able to return usage
 	// data to the user. We return usage data from the start of the month
@@ -271,20 +274,32 @@ type usageService struct {
 	start time.Time
 }
 
-// Registers the usage service if usage tracking is enabled
+// Register registers the usage service if usage tracking is enabled.
 func Register(env *real_environment.RealEnv) error {
 	if usage_config.UsageTrackingEnabled() {
-		env.SetUsageService(New(env, clockwork.NewRealClock()))
+		service, err := New(env, env.GetClock())
+		if err != nil {
+			return err
+		}
+		env.SetUsageService(service)
 	}
 	return nil
 }
 
-func New(env environment.Env, clock clockwork.Clock) *usageService {
-	return &usageService{
-		env:   env,
-		clock: clock,
-		start: configuredUsageStartDate(),
+// New returns a usage service configured with the provided env and clock.
+func New(env environment.Env, clock clockwork.Clock) (*usageService, error) {
+	olapdbh := env.GetOLAPDBHandle()
+	readFromOLAPDB := *readUsageFromOLAPDB
+	if readFromOLAPDB && olapdbh == nil {
+		return nil, status.FailedPreconditionError("OLAP DB handle must be configured when app.read_usage_from_olap_db is true")
 	}
+	return &usageService{
+		env:            env,
+		clock:          clock,
+		olapdbh:        olapdbh,
+		readFromOLAPDB: readFromOLAPDB,
+		start:          configuredUsageStartDate(),
+	}, nil
 }
 
 // GetAlertsEnabled returns whether usage alerting should be exposed to the frontend.
@@ -505,6 +520,13 @@ func (s *usageService) countUsageAlertingRules(ctx context.Context, dbh interfac
 }
 
 func (s *usageService) scanUsages(ctx context.Context, groupID string, start, end time.Time) ([]*usagepb.Usage, error) {
+	if s.readFromOLAPDB {
+		return s.scanOLAPUsages(ctx, groupID, start, end)
+	}
+	return s.scanPrimaryDBUsages(ctx, groupID, start, end)
+}
+
+func (s *usageService) scanPrimaryDBUsages(ctx context.Context, groupID string, start, end time.Time) ([]*usagepb.Usage, error) {
 	dbh := s.env.GetDBHandle()
 	selectExpressions := []string{dbh.DateFromUsecTimestamp("period_start_usec", 0) + ` AS period`}
 	for _, field := range UsageFields {
@@ -518,6 +540,23 @@ func (s *usageService) scanUsages(ctx context.Context, groupID string, start, en
 		GROUP BY period
 		ORDER BY period ASC
 	`, start.UnixMicro(), end.UnixMicro(), groupID)
+	return db.ScanAll(rq, &usagepb.Usage{})
+}
+
+func (s *usageService) scanOLAPUsages(ctx context.Context, groupID string, start, end time.Time) ([]*usagepb.Usage, error) {
+	dbh := s.olapdbh
+	selectExpressions := []string{"formatDateTime(period_start, '%F') AS period"}
+	for _, field := range UsageFields {
+		selectExpressions = append(selectExpressions, fmt.Sprintf("%s AS %s", field.OLAPExpression, field.Name))
+	}
+	rq := dbh.NewQuery(ctx, "usage_service_scan_olap").Raw(`
+		SELECT `+strings.Join(selectExpressions, ",\n\t\t")+`
+		FROM Usage
+		WHERE period_start >= ? AND period_start < ?
+		AND group_id = ?
+		GROUP BY period
+		ORDER BY period ASC
+	`, start, end, groupID)
 	return db.ScanAll(rq, &usagepb.Usage{})
 }
 

--- a/enterprise/server/usage_service/usage_service_olap_test.go
+++ b/enterprise/server/usage_service/usage_service_olap_test.go
@@ -1,0 +1,290 @@
+package usage_service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/usage_service"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+	usagepb "github.com/buildbuddy-io/buildbuddy/proto/usage"
+)
+
+func TestGetUsage_ReadsFromOLAPDB(t *testing.T) {
+	flags.Set(t, "testenv.use_clickhouse", true)
+	flags.Set(t, "testenv.reuse_server", true)
+	flags.Set(t, "app.read_usage_from_olap_db", true)
+
+	group := &tables.Group{
+		GroupID: "GR1",
+		Model: tables.Model{
+			CreatedAtUsec: time.Date(2023, 7, 9, 0, 0, 0, 0, time.UTC).UnixMicro(),
+		},
+	}
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	now := time.Date(2024, 2, 22, 12, 0, 0, 0, time.UTC)
+	service, err := usage_service.New(env, clockwork.NewFakeClockAt(now))
+	require.NoError(t, err)
+
+	// Seed primary DB usage that would be visible if the OLAP flag were ignored.
+	err = env.GetDBHandle().NewQuery(ctx, "test_create_primary_db_usage").Create(&tables.Usage{
+		UsageID:         "UG1",
+		GroupID:         "GR1",
+		PeriodStartUsec: time.Date(2024, 2, 3, 0, 0, 0, 0, time.UTC).UnixMicro(),
+		UsageCounts:     tables.UsageCounts{Invocations: 999, CASCacheHits: 999},
+	})
+	require.NoError(t, err)
+
+	// Seed raw OLAP usage across multiple minute buckets. The Usage view
+	// aggregates these rows by SKU and labels, and the Usage page query then
+	// groups them into daily usage protos.
+	require.NoError(t, env.GetOLAPDBHandle().FlushUsages(ctx, []*schema.RawUsage{
+		{
+			GroupID:     "GR1",
+			SKU:         sku.BuildEventsBESCount,
+			Labels:      orderedmap.FromMap(map[sku.LabelName]sku.LabelValue(nil)),
+			PeriodStart: time.Date(2024, 2, 3, 0, 1, 0, 0, time.UTC),
+			Count:       13,
+		},
+		{
+			GroupID:     "GR1",
+			SKU:         sku.RemoteCacheCASHits,
+			Labels:      orderedmap.FromMap(map[sku.LabelName]sku.LabelValue(nil)),
+			PeriodStart: time.Date(2024, 2, 3, 0, 2, 0, 0, time.UTC),
+			Count:       10_000,
+		},
+		{
+			GroupID:     "GR1",
+			SKU:         sku.RemoteCacheACCachedExecDurationNanos,
+			Labels:      orderedmap.FromMap(map[sku.LabelName]sku.LabelValue(nil)),
+			PeriodStart: time.Date(2024, 2, 3, 0, 3, 0, 0, time.UTC),
+			Count:       9_000,
+		},
+		// External origin rows should be included in total and external
+		// download counts, but excluded from internal and workflow counts.
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteCacheCASDownloadedBytes,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin: sku.OriginExternal,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 4, 0, 0, time.UTC),
+			Count:       101,
+		},
+		// Internal cache usage from executors should be counted as cloud RBE
+		// usage, not workflow usage.
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteCacheCASDownloadedBytes,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin: sku.OriginInternal,
+				sku.Client: sku.ClientExecutor,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 5, 0, 0, time.UTC),
+			Count:       202,
+		},
+		// Internal cache usage from bazel should be counted as workflow usage,
+		// since BuildBuddy workflows use bazel as a client.
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteCacheCASDownloadedBytes,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin: sku.OriginInternal,
+				sku.Client: sku.ClientBazel,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 6, 0, 0, time.UTC),
+			Count:       303,
+		},
+		// External origin rows should be included in total and external upload
+		// counts, but excluded from internal and workflow upload counts.
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteCacheCASUploadedBytes,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin: sku.OriginExternal,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 6, 30, 0, time.UTC),
+			Count:       404,
+		},
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteCacheCASUploadedBytes,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin: sku.OriginInternal,
+				sku.Client: sku.ClientExecutor,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 6, 40, 0, time.UTC),
+			Count:       505,
+		},
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteCacheCASUploadedBytes,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin: sku.OriginInternal,
+				sku.Client: sku.ClientBazel,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 6, 50, 0, time.UTC),
+			Count:       606,
+		},
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteExecutionExecuteWorkerDurationNanos,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin:     sku.OriginInternal,
+				sku.Client:     sku.ClientExecutor,
+				sku.OS:         sku.OSLinux,
+				sku.SelfHosted: sku.SelfHostedFalse,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 7, 0, 0, time.UTC),
+			Count:       7_000,
+		},
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteExecutionExecuteWorkerDurationNanos,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin:     sku.OriginInternal,
+				sku.Client:     sku.ClientBazel,
+				sku.OS:         sku.OSLinux,
+				sku.SelfHosted: sku.SelfHostedFalse,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 7, 30, 0, time.UTC),
+			Count:       17_000,
+		},
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteExecutionExecuteWorkerCPUNanos,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin:     sku.OriginInternal,
+				sku.Client:     sku.ClientExecutor,
+				sku.OS:         sku.OSLinux,
+				sku.SelfHosted: sku.SelfHostedFalse,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 8, 0, 0, time.UTC),
+			Count:       11_000,
+		},
+		// Workflow CPU should be counted in total cloud CPU and workflow CPU,
+		// but excluded from cloud RBE CPU.
+		{
+			GroupID: "GR1",
+			SKU:     sku.RemoteExecutionExecuteWorkerCPUNanos,
+			Labels: orderedmap.FromMap(map[sku.LabelName]sku.LabelValue{
+				sku.Origin:     sku.OriginInternal,
+				sku.Client:     sku.ClientBazel,
+				sku.OS:         sku.OSLinux,
+				sku.SelfHosted: sku.SelfHostedFalse,
+			}),
+			PeriodStart: time.Date(2024, 2, 3, 0, 9, 0, 0, time.UTC),
+			Count:       13_000,
+		},
+		{
+			GroupID:     "GR1",
+			SKU:         sku.BuildEventsBESCount,
+			Labels:      orderedmap.FromMap(map[sku.LabelName]sku.LabelValue(nil)),
+			PeriodStart: time.Date(2024, 2, 4, 0, 1, 0, 0, time.UTC),
+			Count:       15,
+		},
+		{
+			GroupID:     "GR1",
+			SKU:         sku.RemoteCacheCASHits,
+			Labels:      orderedmap.FromMap(map[sku.LabelName]sku.LabelValue(nil)),
+			PeriodStart: time.Date(2024, 2, 4, 0, 2, 0, 0, time.UTC),
+			Count:       12_000,
+		},
+		// Usage outside the requested month should not be returned.
+		{
+			GroupID:     "GR1",
+			SKU:         sku.BuildEventsBESCount,
+			Labels:      orderedmap.FromMap(map[sku.LabelName]sku.LabelValue(nil)),
+			PeriodStart: time.Date(2024, 1, 3, 0, 1, 0, 0, time.UTC),
+			Count:       77,
+		},
+		// Usage for a different group should not be returned.
+		{
+			GroupID:     "GR2",
+			SKU:         sku.BuildEventsBESCount,
+			Labels:      orderedmap.FromMap(map[sku.LabelName]sku.LabelValue(nil)),
+			PeriodStart: time.Date(2024, 2, 3, 0, 1, 0, 0, time.UTC),
+			Count:       107,
+		},
+	}))
+
+	rsp, err := service.GetUsageInternal(ctx, group, &usagepb.GetUsageRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: "GR1"},
+		UsagePeriod:    "2024-02",
+	})
+	require.NoError(t, err)
+
+	expectedResponse := &usagepb.GetUsageResponse{
+		Usage: &usagepb.Usage{
+			Period:                                  "2024-02",
+			Invocations:                             28,
+			CasCacheHits:                            22_000,
+			TotalCachedActionExecUsec:               9,
+			TotalDownloadSizeBytes:                  606,
+			TotalExternalDownloadSizeBytes:          101,
+			TotalInternalDownloadSizeBytes:          202,
+			TotalWorkflowDownloadSizeBytes:          303,
+			TotalUploadSizeBytes:                    1515,
+			TotalExternalUploadSizeBytes:            404,
+			TotalInternalUploadSizeBytes:            505,
+			TotalWorkflowUploadSizeBytes:            606,
+			LinuxExecutionDurationUsec:              24,
+			CloudRbeLinuxExecutionDurationUsec:      7,
+			CloudWorkflowLinuxExecutionDurationUsec: 17,
+			CloudCpuNanos:                           24_000,
+			CloudRbeCpuNanos:                        11_000,
+			CloudWorkflowCpuNanos:                   13_000,
+		},
+		DailyUsage: []*usagepb.Usage{
+			{
+				Period:                                  "2024-02-03",
+				Invocations:                             13,
+				CasCacheHits:                            10_000,
+				TotalCachedActionExecUsec:               9,
+				TotalDownloadSizeBytes:                  606,
+				TotalExternalDownloadSizeBytes:          101,
+				TotalInternalDownloadSizeBytes:          202,
+				TotalWorkflowDownloadSizeBytes:          303,
+				TotalUploadSizeBytes:                    1515,
+				TotalExternalUploadSizeBytes:            404,
+				TotalInternalUploadSizeBytes:            505,
+				TotalWorkflowUploadSizeBytes:            606,
+				LinuxExecutionDurationUsec:              24,
+				CloudRbeLinuxExecutionDurationUsec:      7,
+				CloudWorkflowLinuxExecutionDurationUsec: 17,
+				CloudCpuNanos:                           24_000,
+				CloudRbeCpuNanos:                        11_000,
+				CloudWorkflowCpuNanos:                   13_000,
+			},
+			{
+				Period:       "2024-02-04",
+				Invocations:  15,
+				CasCacheHits: 12_000,
+			},
+		},
+		AvailableUsagePeriods: []string{
+			"2024-02",
+			"2024-01",
+			"2023-12",
+			"2023-11",
+			"2023-10",
+			"2023-09",
+			"2023-08",
+			"2023-07",
+		},
+	}
+	assert.Empty(t, cmp.Diff(expectedResponse, rsp, protocmp.Transform()))
+}

--- a/enterprise/server/usage_service/usage_service_test.go
+++ b/enterprise/server/usage_service/usage_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -56,7 +57,8 @@ func TestGetUsage(t *testing.T) {
 	// Current time for test: 2024-02-22, noon UTC
 	now := time.Date(2024, 2, 22, 12, 0, 0, 0, time.UTC)
 	clock := clockwork.NewFakeClockAt(now)
-	service := usage_service.New(env, clock)
+	service, err := usage_service.New(env, clock)
+	require.NoError(t, err)
 	// Insert some usage data:
 	for _, row := range []*tables.Usage{
 		// GR1, current usage period
@@ -172,6 +174,18 @@ func TestUsageFields_CoverEveryUsageFieldAndAlertingMetric(t *testing.T) {
 	assert.Equal(t, alertingMetrics, seenAlertingMetrics)
 }
 
+func TestNew_ReadUsageFromOLAPDBRequiresOLAPDB(t *testing.T) {
+	flags.Set(t, "app.read_usage_from_olap_db", true)
+	env := testenv.GetTestEnv(t)
+
+	// Enabling OLAP reads without configuring an OLAP DB should fail during
+	// service setup instead of falling back to primary DB reads later.
+	service, err := usage_service.New(env, clockwork.NewFakeClock())
+
+	require.Nil(t, service)
+	assert.True(t, status.IsFailedPreconditionError(err))
+}
+
 func TestUsageAlertingRules_CreateListDelete(t *testing.T) {
 	ctx := context.Background()
 	env := testenv.GetTestEnv(t)
@@ -186,7 +200,8 @@ func TestUsageAlertingRules_CreateListDelete(t *testing.T) {
 	now := time.Date(2024, 2, 22, 12, 0, 0, 0, time.UTC)
 	clock := clockwork.NewFakeClockAt(now)
 	env.GetDBHandle().SetNowFunc(clock.Now)
-	service := usage_service.New(env, clock)
+	service, err := usage_service.New(env, clock)
+	require.NoError(t, err)
 
 	// Create a usage alerting rule for the authenticated org.
 	createRsp, err := service.CreateUsageAlertingRule(ctx1, &usagepb.CreateUsageAlertingRuleRequest{
@@ -271,7 +286,8 @@ func TestUsageAlertingRules_AreScopedToAuthenticatedGroup(t *testing.T) {
 	now := time.Date(2024, 2, 22, 12, 0, 0, 0, time.UTC)
 	clock := clockwork.NewFakeClockAt(now)
 	env.GetDBHandle().SetNowFunc(clock.Now)
-	service := usage_service.New(env, clock)
+	service, err := usage_service.New(env, clock)
+	require.NoError(t, err)
 	createRsp, err := service.CreateUsageAlertingRule(ctx1, &usagepb.CreateUsageAlertingRuleRequest{
 		Configuration: &usagepb.UsageAlertingRuleConfiguration{
 			Metric:            usagepb.UsageAlertingMetric_TOTAL_WORKFLOW_DOWNLOAD_SIZE_BYTES,
@@ -305,7 +321,8 @@ func TestUsageAlertingRules_RequiresOrgAdmin(t *testing.T) {
 	env.SetAuthenticator(ta)
 	ctx1, err := ta.WithAuthenticatedUser(ctx, "US1")
 	require.NoError(t, err)
-	service := usage_service.New(env, clockwork.NewFakeClock())
+	service, err := usage_service.New(env, clockwork.NewFakeClock())
+	require.NoError(t, err)
 
 	// A group member without ORG_ADMIN cannot list usage alerting rules.
 	_, err = service.GetUsageAlertingRules(ctx1, &usagepb.GetUsageAlertingRulesRequest{})
@@ -337,7 +354,8 @@ func TestUsageAlertingRules_ValidateConfiguration(t *testing.T) {
 	env.SetAuthenticator(ta)
 	ctx1, err := ta.WithAuthenticatedUser(ctx, "US1")
 	require.NoError(t, err)
-	service := usage_service.New(env, clockwork.NewFakeClock())
+	service, err := usage_service.New(env, clockwork.NewFakeClock())
+	require.NoError(t, err)
 
 	for _, testCase := range []struct {
 		name   string
@@ -409,7 +427,8 @@ func TestUsageAlertingRules_DuplicateConfigurationRejected(t *testing.T) {
 	env.SetAuthenticator(ta)
 	ctx1, err := ta.WithAuthenticatedUser(ctx, "US1")
 	require.NoError(t, err)
-	service := usage_service.New(env, clockwork.NewFakeClock())
+	service, err := usage_service.New(env, clockwork.NewFakeClock())
+	require.NoError(t, err)
 
 	configuration := &usagepb.UsageAlertingRuleConfiguration{
 		Metric:            usagepb.UsageAlertingMetric_TOTAL_DOWNLOAD_SIZE_BYTES,
@@ -449,7 +468,8 @@ func TestUsageAlertingRules_MaxRulesPerGroup(t *testing.T) {
 	env.SetAuthenticator(ta)
 	ctx1, err := ta.WithAuthenticatedUser(ctx, "US1")
 	require.NoError(t, err)
-	service := usage_service.New(env, clockwork.NewFakeClock())
+	service, err := usage_service.New(env, clockwork.NewFakeClock())
+	require.NoError(t, err)
 
 	// Rules up to the per-group cap are accepted.
 	for i := range usage_service.MaxUsageAlertingRulesPerGroup {


### PR DESCRIPTION
Allow the UI to read usage data from ClickHouse if `app.read_usage_from_olap_db` is enabled.

I'm planning to wait to turn this on until we've tested using ClickHouse for our billing/invoicing.