### PR TITLE
Fix the raft_range_bytes metric

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -270,6 +270,13 @@ func (sm *Replica) setRange(val []byte) error {
 	sm.rangeMu.Unlock()
 
 	if usage, err := sm.Usage(); err == nil {
+		// Set RaftBytes directly here rather than going through the event
+		// channel (which can drop under load). The apply path will refresh
+		// it as data is written; this guarantees presence at replica open
+		// and on every range-descriptor mutation.
+		metrics.RaftBytes.With(prometheus.Labels{
+			metrics.RaftRangeIDLabel: strconv.FormatUint(rangeDescriptor.GetRangeId(), 10),
+		}).Set(float64(usage.GetEstimatedDiskBytesUsed()))
 		sm.notifyListenersOfUsage(rangeDescriptor, usage)
 	} else {
 		sm.log.Errorf("Error computing usage upon opening replica: %s", err)
@@ -2031,6 +2038,11 @@ func (sm *Replica) Close() error {
 
 	if sm.store != nil && rangeDescriptor != nil {
 		sm.store.RemoveRange(rangeDescriptor, sm)
+	}
+	if rangeDescriptor != nil {
+		metrics.RaftBytes.Delete(prometheus.Labels{
+			metrics.RaftRangeIDLabel: strconv.FormatUint(rangeDescriptor.GetRangeId(), 10),
+		})
 	}
 
 	sm.readQPS.Stop()

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1314,15 +1314,6 @@ func (s *Store) UpdateRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 		return
 	}
 
-	// Make sure RaftBytes has a value for this range. The apply path will
-	// refresh it as data is written; this guarantees presence even for idle
-	// ranges that never get to entriesBetweenUsageChecks.
-	if usage, err := r.Usage(); err == nil {
-		metrics.RaftBytes.With(prometheus.Labels{
-			metrics.RaftRangeIDLabel: strconv.FormatUint(rd.GetRangeId(), 10),
-		}).Set(float64(usage.GetEstimatedDiskBytesUsed()))
-	}
-
 	s.mu.Lock()
 	stopped := s.stopped
 	s.mu.Unlock()
@@ -1361,9 +1352,6 @@ func (s *Store) RemoveRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 	metrics.RaftRanges.With(prometheus.Labels{
 		metrics.RaftNodeHostIDLabel: s.nodeHost.ID(),
 	}).Dec()
-	metrics.RaftBytes.Delete(prometheus.Labels{
-		metrics.RaftRangeIDLabel: strconv.FormatUint(rd.GetRangeId(), 10),
-	})
 
 	if len(rd.GetReplicas()) == 0 {
 		s.log.Debugf("range descriptor had no replicas yet")
@@ -2546,7 +2534,7 @@ func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context, targetRangeSiz
 				rangeID := rangeUsageEvent.RangeDescriptor.GetRangeId()
 				estimatedDiskBytes := rangeUsageEvent.ReplicaUsage.GetEstimatedDiskBytesUsed()
 				metrics.RaftBytes.With(prometheus.Labels{
-					metrics.RaftRangeIDLabel: strconv.Itoa(int(rangeID)),
+					metrics.RaftRangeIDLabel: strconv.FormatUint(rangeID, 10),
 				}).Set(float64(estimatedDiskBytes))
 				if rangeID == constants.MetaRangeID {
 					continue

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1314,6 +1314,15 @@ func (s *Store) UpdateRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 		return
 	}
 
+	// Make sure RaftBytes has a value for this range. The apply path will
+	// refresh it as data is written; this guarantees presence even for idle
+	// ranges that never get to entriesBetweenUsageChecks.
+	if usage, err := r.Usage(); err == nil {
+		metrics.RaftBytes.With(prometheus.Labels{
+			metrics.RaftRangeIDLabel: strconv.FormatUint(rd.GetRangeId(), 10),
+		}).Set(float64(usage.GetEstimatedDiskBytesUsed()))
+	}
+
 	s.mu.Lock()
 	stopped := s.stopped
 	s.mu.Unlock()
@@ -1352,6 +1361,9 @@ func (s *Store) RemoveRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 	metrics.RaftRanges.With(prometheus.Labels{
 		metrics.RaftNodeHostIDLabel: s.nodeHost.ID(),
 	}).Dec()
+	metrics.RaftBytes.Delete(prometheus.Labels{
+		metrics.RaftRangeIDLabel: strconv.FormatUint(rd.GetRangeId(), 10),
+	})
 
 	if len(rd.GetReplicas()) == 0 {
 		s.log.Debugf("range descriptor had no replicas yet")


### PR DESCRIPTION
Make sure it's set when a pod starts, even if a range doesn't get any writes.

I also moved `metrics.RaftBytes.Delete` to replica.go, so that the add and remove calls are in the same file.