### PR TITLE
Rename a few SKUs to match documented convention

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1792,7 +1792,7 @@ func incrementOLAPExecutionUsage(ctx context.Context, ut interfaces.UsageTracker
 		sku.RemoteExecutionExecuteWorkerCPUNanos:      cpuNanos,
 		sku.RemoteExecutionExecuteWorkerDurationNanos: duration.Nanoseconds(),
 		sku.RemoteExecutionExecuteWorkerMemoryGBNanos: memoryGBNanos,
-		sku.RemoteExecutionExecuteComputeNanos:        duration.Nanoseconds(),
+		sku.RemoteExecutionExecuteFixedComputeNanos:   duration.Nanoseconds(),
 	}
 	return ut.IncrementOLAP(ctx, executionLabels, executionCounts)
 }

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -1069,7 +1069,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		if _, ok := u.Counts[sku.RemoteExecutionExecuteWorkerDurationNanos]; ok {
 			foundOLAPExecutorUsage = &u
 		}
-		if _, ok := u.Counts[sku.RemoteExecutionExecuteComputeNanos]; ok {
+		if _, ok := u.Counts[sku.RemoteExecutionExecuteFixedComputeNanos]; ok {
 			foundOLAPComputeUsage = &u
 		}
 	}
@@ -1093,7 +1093,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		sku.SelfHosted: sku.GetSelfHostedLabel(test.expectedSelfHosted),
 	}
 	assert.Equal(t, expectedComputeOLAPLabels, foundOLAPComputeUsage.Labels)
-	assert.Equal(t, expectedDurationNanos, foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteComputeNanos])
+	assert.Equal(t, expectedDurationNanos, foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFixedComputeNanos])
 
 	collectedExecutions, err := env.GetExecutionCollector().GetExecutions(ctx, invocationID, 0, -1)
 	require.NoError(t, err)

--- a/server/usage/sku/sku.go
+++ b/server/usage/sku/sku.go
@@ -16,27 +16,39 @@ func (s SKU) String() string {
 
 // SKU constants - enumerated explicitly to ensure low cardinality.
 //
-// The format is roughly "<service>.<category>.<metric>". This hierarchical
-// convention allows easily querying subsets of usage data using prefix
-// matching, and when sorting by SKU, the usage data is naturally grouped by
-// service and type.
+// The format is roughly "<product-area>.<category>.<metric>", organized mostly
+// according to the originating RPC. This hierarchical convention allows easily
+// querying subsets of usage data using prefix matching, and when sorting by
+// SKU, the usage data is naturally grouped by service and type.
 const (
-	BuildEventsBESCount SKU = "build_events.build_event_stream.count"
+	// SKUs related to build event handling/processing (PublishBuildToolEventStream RPC)
+	categoryBES = "build_events.build_event_stream."
 
-	RemoteCacheCASHits                   SKU = "remote_cache.content_addressable_storage.hits"
-	RemoteCacheCASDownloadedBytes        SKU = "remote_cache.content_addressable_storage.downloaded_bytes"
-	RemoteCacheCASUploadedBytes          SKU = "remote_cache.content_addressable_storage.uploaded_bytes"
-	RemoteCacheACHits                    SKU = "remote_cache.action_cache_hits.hits"
-	RemoteCacheACCachedExecDurationNanos SKU = "remote_cache.action_cache.cached_execution_duration_nanos"
+	BuildEventsBESCount SKU = categoryBES + "count"
 
-	RemoteExecutionExecuteWorkerDurationNanos   SKU = "remote_execution.execute.worker_duration_nanos"
-	RemoteExecutionExecuteWorkerCPUNanos        SKU = "remote_execution.execute.worker_cpu_nanos"
-	RemoteExecutionExecuteWorkerMemoryGBNanos   SKU = "remote_execution.execute.worker_memory_gb_nanos"
-	RemoteExecutionExecuteComputeNanos          SKU = "remote_execution.execute.compute_nanos"
-	RemoteExecutionExecuteBurstableComputeNanos SKU = "remote_execution.execute.burstable_compute_nanos"
+	// SKUs related to remote cache (Content Addressable Storage / CAS RPCs)
+	categoryCAS = "remote_cache.content_addressable_storage."
 
-	LocalSnapshotSavedBytes  SKU = "remote_execution.local_snapshot_saved_bytes"
-	RemoteSnapshotSavedBytes SKU = "remote_execution.remote_snapshot_saved_bytes"
+	RemoteCacheCASHits            SKU = categoryCAS + "hits"
+	RemoteCacheCASDownloadedBytes SKU = categoryCAS + "downloaded_bytes"
+	RemoteCacheCASUploadedBytes   SKU = categoryCAS + "uploaded_bytes"
+
+	// SKUs related to remote cache (Action Cache / AC RPCs)
+	categoryAC = "remote_cache.action_cache."
+
+	RemoteCacheACHits                    SKU = categoryAC + "hits"
+	RemoteCacheACCachedExecDurationNanos SKU = categoryAC + "cached_execution_duration_nanos"
+
+	// SKUs related to remote execution action processing (Execute RPC)
+	categoryRBE = "remote_execution.execute."
+
+	RemoteExecutionExecuteWorkerDurationNanos      SKU = categoryRBE + "worker_duration_nanos"
+	RemoteExecutionExecuteWorkerCPUNanos           SKU = categoryRBE + "worker_cpu_nanos"
+	RemoteExecutionExecuteWorkerMemoryGBNanos      SKU = categoryRBE + "worker_memory_gb_nanos"
+	RemoteExecutionExecuteFixedComputeNanos        SKU = categoryRBE + "fixed_compute_nanos"
+	RemoteExecutionExecuteFlexibleComputeNanos     SKU = categoryRBE + "flexible_compute_nanos"
+	RemoteExecutionExecuteLocalSnapshotSavedBytes  SKU = categoryRBE + "local_snapshot_saved_bytes"
+	RemoteExecutionExecuteRemoteSnapshotSavedBytes SKU = categoryRBE + "remote_snapshot_saved_bytes"
 )
 
 // LabelName is a usage counter label, which further qualifies the SKU.


### PR DESCRIPTION
- New snapshot metrics were missing the "category" part (I missed this in the PR that added those SKUs). This PR categorizes those under "execute" since snapshot saving is directly triggered by Execute.
- I realized there was a typo in one of the AC SKUs (`action_cache_hits.hits` instead of `action_cache.hits`) - I will do a manual migration for this rename, which should be fine since nothing cares about this SKU yet. (I will probably just drop all partitions again and then run the backfill script, which was pretty fast.)
- Rename `compute_nanos` => `fixed_compute_nanos` and `burstable_compute_nanos` => `flexible_compute_nanos` to match new naming conventions.