### PR TITLE
Allow configuring plain HTTP registries

### DIFF
--- a/docs/config-rbe.md
+++ b/docs/config-rbe.md
@@ -89,6 +89,23 @@ executor:
         }
 ```
 
+### Using cluster-internal container registries
+
+To use a cluster-internal registry over plain HTTP, configure
+`executor.container_registries`, set `insecure: true` on the internal
+registry, and allow the registry Service's ClusterIP:
+
+```yaml title="config.yaml"
+executor:
+  container_registry_allowed_private_ips:
+    # Replace this with the ClusterIP of the registry Service.
+    - "10.12.34.56/32"
+  container_registries:
+    - hostnames:
+        - "example-image-mirror.example-namespace.svc.cluster.local:5000"
+      insecure: true
+```
+
 ### GPU support
 
 Self-hosted executors can expose GPUs to remotely executed actions. Setup

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -16,9 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oci/ocifetcher"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocicache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ocimanifest"
-	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
-	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
-	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/http/httpclient"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
@@ -31,12 +28,16 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/distribution/reference"
 	"github.com/google/go-containerregistry/pkg/authn"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
+	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	gcrname "github.com/google/go-containerregistry/pkg/name"
+	gcr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -57,6 +58,8 @@ type Registry struct {
 	Hostnames []string `yaml:"hostnames" json:"hostnames"`
 	Username  string   `yaml:"username" json:"username"`
 	Password  string   `yaml:"password" json:"password" config:"secret"`
+	// Insecure allows pulling from the registry over plain HTTP.
+	Insecure bool `yaml:"insecure" json:"insecure"`
 }
 
 type Credentials struct {
@@ -136,7 +139,7 @@ func CredentialsFromProperties(props *platform.Properties) (Credentials, error) 
 func resolveWithDefaultKeychain(ref reference.Named) (Credentials, error) {
 	// TODO: parse the errors below and if they're 403/401 errors then return
 	// Unauthenticated/PermissionDenied
-	ctrRef, err := gcrname.ParseReference(ref.String())
+	ctrRef, err := ParseReference(ref.String())
 	if err != nil {
 		log.Debugf("Failed to parse image ref %q: %s", ref.String(), err)
 		return Credentials{}, nil
@@ -195,6 +198,28 @@ func (c Credentials) Equals(o Credentials) bool {
 	return c.Username == o.Username && c.Password == o.Password
 }
 
+// ParseReference parses an OCI image reference, honoring
+// executor.container_registries[].insecure when selecting the registry scheme.
+func ParseReference(ref string) (gcrname.Reference, error) {
+	imageRef, err := gcrname.ParseReference(ref)
+	if err != nil {
+		return nil, err
+	}
+	if isInsecureRegistryHost(imageRef.Context().RegistryStr()) {
+		return gcrname.ParseReference(ref, gcrname.Insecure)
+	}
+	return imageRef, nil
+}
+
+func isInsecureRegistryHost(hostname string) bool {
+	for _, registry := range *registries {
+		if registry.Insecure && slices.Contains(registry.Hostnames, hostname) {
+			return true
+		}
+	}
+	return false
+}
+
 type Resolver struct {
 	env environment.Env
 
@@ -235,7 +260,7 @@ func (r *Resolver) AuthenticateWithRegistry(ctx context.Context, imageName strin
 
 	log.CtxDebugf(ctx, "Authenticating with registry for %q", imageName)
 
-	imageRef, err := gcrname.ParseReference(imageName)
+	imageRef, err := ParseReference(imageName)
 	if err != nil {
 		return status.InvalidArgumentErrorf("invalid image reference %q: %s", imageName, err)
 	}
@@ -259,28 +284,30 @@ func (r *Resolver) AuthenticateWithRegistry(ctx context.Context, imageName strin
 // ResolveImageDigest keeps an LRU cache that maps between canonical image names with tags
 // to image names with digests, to reduce the number of HEAD requests.
 func (r *Resolver) ResolveImageDigest(ctx context.Context, imageName string, platform *rgpb.Platform, credentials Credentials) (string, error) {
-	if imageRefWithDigest, err := gcrname.NewDigest(imageName); err == nil {
-		return imageRefWithDigest.String(), nil
-	}
-	tagRef, err := gcrname.ParseReference(imageName)
+	// Resolving a tag makes a remote HEAD request, so parse through ParseReference
+	// to honor executor.container_registries[].insecure.
+	imageRef, err := ParseReference(imageName)
 	if err != nil {
 		return "", status.InvalidArgumentErrorf("invalid image name %q", imageName)
 	}
+	if _, ok := imageRef.(gcrname.Digest); ok {
+		return imageRef.String(), nil
+	}
 
-	if nameWithDigest, ok := r.imageTagToDigestLRU.Get(tagRef.String()); ok {
+	if nameWithDigest, ok := r.imageTagToDigestLRU.Get(imageRef.String()); ok {
 		return nameWithDigest, nil
 	}
 
 	remoteOpts := r.getRemoteOpts(ctx, platform, credentials)
-	desc, err := remote.Head(tagRef, remoteOpts...)
+	desc, err := remote.Head(imageRef, remoteOpts...)
 	if err != nil {
 		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
 			return "", status.PermissionDeniedErrorf("not authorized to access image manifest: %s", err)
 		}
 		return "", status.UnavailableErrorf("could not fetch manifest metadata from remote registry: %s", err)
 	}
-	imageNameWithDigest := tagRef.Context().Digest(desc.Digest.String()).String()
-	r.imageTagToDigestLRU.Add(tagRef.String(), imageNameWithDigest)
+	imageNameWithDigest := imageRef.Context().Digest(desc.Digest.String()).String()
+	r.imageTagToDigestLRU.Add(imageRef.String(), imageNameWithDigest)
 	return imageNameWithDigest, nil
 }
 
@@ -288,7 +315,7 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	imageRef, err := gcrname.ParseReference(imageName)
+	imageRef, err := ParseReference(imageName)
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image %q", imageName)
 	}
@@ -312,8 +339,15 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 	}
 	useCache := cacheEnabled && !isAnon
 
-	if useOCIFetcher && r.env.GetOCIFetcherClient() == nil {
-		return nil, status.FailedPreconditionError("OCIFetcherClient is required when useOCIFetcher is true")
+	if useOCIFetcher {
+		if isInsecureRegistryHost(imageRef.Context().RegistryStr()) {
+			// OCIFetcher parses refs on the server side, so keep insecure registry pulls
+			// on the direct path where this resolver has applied the registry config.
+			log.CtxDebugf(ctx, "Skipping OCI fetcher for insecure registry %q", imageRef.Context().RegistryStr())
+			useOCIFetcher = false
+		} else if r.env.GetOCIFetcherClient() == nil {
+			return nil, status.FailedPreconditionError("OCIFetcherClient is required when useOCIFetcher is true")
+		}
 	}
 
 	return fetchImageFromCacheOrRemote(

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -75,6 +75,53 @@ func TestCredentialsFromProto(t *testing.T) {
 	assert.Equal(t, "foo:bar", creds.String())
 }
 
+func TestParseReference_UsesInsecureRegistryConfig(t *testing.T) {
+	for _, testCase := range []struct {
+		name           string
+		registries     []oci.Registry
+		expectedScheme string
+	}{
+		{
+			name: "registry is secure by default",
+			registries: []oci.Registry{
+				{
+					Hostnames: []string{"registry.example.com:5000"},
+				},
+			},
+			expectedScheme: "https",
+		},
+		{
+			name: "insecure registry uses http",
+			registries: []oci.Registry{
+				{
+					Hostnames: []string{"registry.example.com:5000"},
+					Insecure:  true,
+				},
+			},
+			expectedScheme: "http",
+		},
+		{
+			name: "unmatched insecure registry does not affect image",
+			registries: []oci.Registry{
+				{
+					Hostnames: []string{"other.example.com:5000"},
+					Insecure:  true,
+				},
+			},
+			expectedScheme: "https",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags.Set(t, "executor.container_registries", testCase.registries)
+
+			ref, err := oci.ParseReference("registry.example.com:5000/repo/image:tag")
+			require.NoError(t, err)
+
+			require.Equal(t, testCase.expectedScheme, ref.Context().Registry.Scheme())
+		})
+	}
+}
+
 func TestCredentialsFromProperties(t *testing.T) {
 	registries := []oci.Registry{
 		{
@@ -1131,6 +1178,7 @@ func TestResolveImageDigest_AlreadyDigest_NoHTTPRequests(t *testing.T) {
 	require.NoError(t, err)
 	resolvedDigest, err := name.NewDigest(nameWithDigest)
 	require.NoError(t, err)
+	require.Equal(t, nameToResolve, nameWithDigest)
 	require.Equal(t, pushedDigest.String(), resolvedDigest.DigestStr())
 
 	require.Empty(t, counter.Snapshot())
@@ -1326,6 +1374,50 @@ func TestResolveWithOCIFetcher_NoClient(t *testing.T) {
 	)
 	require.True(t, status.IsFailedPreconditionError(err), "expected FailedPreconditionError, got: %v", err)
 	require.Contains(t, err.Error(), "OCIFetcherClient is required")
+}
+
+func TestResolveWithOCIFetcher_InsecureRegistrySkipsFetcher(t *testing.T) {
+	// Use a test env without OCIFetcherClient configured, so this test fails
+	// if insecure registry pulls try to use the fetcher service.
+	te := testenv.GetTestEnv(t)
+	flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
+
+	counter := testhttp.NewRequestCounter()
+	registry := testregistry.Run(t, testregistry.Opts{
+		HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+			counter.Inc(r)
+			return true
+		},
+	})
+	registry.PushNamedImage(t, "test_image", nil)
+	flags.Set(t, "executor.container_registries", []oci.Registry{
+		{
+			Hostnames: []string{registry.Address()},
+			Insecure:  true,
+		},
+	})
+
+	// The registry is configured as insecure, so Resolve should stay on the
+	// direct pull path even though the caller requested the OCI fetcher.
+	counter.Reset()
+	pulledImage, err := newResolver(t, te).Resolve(
+		context.Background(),
+		registry.ImageAddress("test_image"),
+		&rgpb.Platform{
+			Arch: runtime.GOARCH,
+			Os:   runtime.GOOS,
+		},
+		oci.Credentials{},
+		true, /*=useOCIFetcher*/
+	)
+	require.NoError(t, err)
+	require.NotNil(t, pulledImage)
+
+	expectedRequests := map[string]int{
+		http.MethodGet + " /v2/":                            1,
+		http.MethodGet + " /v2/test_image/manifests/latest": 1,
+	}
+	require.Empty(t, cmp.Diff(expectedRequests, counter.Snapshot()))
 }
 
 // TestResolveWithOCIFetcher exercises Resolver.Resolve with useOCIFetcher=true,


### PR DESCRIPTION
Useful for customers using their own in-cluster registry services. This removes a blocker for migrating from `podman` to `oci`, since `podman` supports a registry config with this `insecure` option.