### PR TITLE
Remove unused ExecutionSummary proto

### DIFF
--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -56,25 +56,6 @@ message Rusage {
   int64 involuntary_context_switches = 13;
 }
 
-// TODO(http://go/b/1451): remove this; stats have been moved to
-// ExecutedActionMetadata. Next tag: 12
-message ExecutionSummary {
-  reserved 1, 3, 4, 5, 6, 7, 9;
-
-  // Any io_stats that were collected during this execution.
-  build.bazel.remote.execution.v2.IOStats io_stats = 2;
-
-  // Any compute stats (CPU/memory) that were collected during this execution.
-  build.bazel.remote.execution.v2.UsageStats usage_stats = 10;
-
-  // Estimated task size that was used for scheduling purposes.
-  scheduler.TaskSize estimated_task_size = 11;
-
-  // Execution stage timings.
-  build.bazel.remote.execution.v2.ExecutedActionMetadata
-      executed_action_metadata = 8;
-}
-
 // Next Tag: 20
 message Execution {
   reserved 4, 10;


### PR DESCRIPTION
Removed the ExecutionSummary message as stats have been moved to ExecutedActionMetadata.