### PR TITLE
Add partition_id field to RangeDescriptor

### DIFF
--- a/enterprise/server/raft/bringup/BUILD
+++ b/enterprise/server/raft/bringup/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -26,5 +26,16 @@ go_library(
         "@com_github_lni_dragonboat_v4//:dragonboat",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "bringup_test",
+    srcs = ["bringup_test.go"],
+    embed = [":bringup"],
+    deps = [
+        "//server/util/disk",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -382,17 +382,19 @@ func evenlyDividePartitionIntoRanges(partition disk.Partition) ([]*rfpb.RangeDes
 	for i := 0; i < numRanges-1; i++ {
 		r := new(big.Int).Add(l, interval)
 		ranges = append(ranges, &rfpb.RangeDescriptor{
-			Start:      []byte(filestore.PartitionDirectoryPrefix + partition.ID + "/" + hex.EncodeToString(l.Bytes())),
-			End:        []byte(filestore.PartitionDirectoryPrefix + partition.ID + "/" + hex.EncodeToString(r.Bytes())),
-			Generation: 1,
+			Start:       []byte(filestore.PartitionDirectoryPrefix + partition.ID + "/" + hex.EncodeToString(l.Bytes())),
+			End:         []byte(filestore.PartitionDirectoryPrefix + partition.ID + "/" + hex.EncodeToString(r.Bytes())),
+			Generation:  1,
+			PartitionId: partition.ID,
 		})
 		l = r
 	}
 	// Append a final range from nth split --> end.
 	ranges = append(ranges, &rfpb.RangeDescriptor{
-		Start:      []byte(filestore.PartitionDirectoryPrefix + partition.ID + "/" + hex.EncodeToString(l.Bytes())),
-		End:        keys.MakeKey([]byte(filestore.PartitionDirectoryPrefix+partition.ID+"/"+hex.EncodeToString(maxHashAsBigInt.Bytes())), keys.MaxByte),
-		Generation: 1,
+		Start:       []byte(filestore.PartitionDirectoryPrefix + partition.ID + "/" + hex.EncodeToString(l.Bytes())),
+		End:         keys.MakeKey([]byte(filestore.PartitionDirectoryPrefix+partition.ID+"/"+hex.EncodeToString(maxHashAsBigInt.Bytes())), keys.MaxByte),
+		Generation:  1,
+		PartitionId: partition.ID,
 	})
 	return ranges, nil
 }

--- a/enterprise/server/raft/bringup/bringup_test.go
+++ b/enterprise/server/raft/bringup/bringup_test.go
@@ -1,0 +1,21 @@
+package bringup
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvenlyDividePartitionIntoRanges_SetsPartitionID(t *testing.T) {
+	ranges, err := evenlyDividePartitionIntoRanges(disk.Partition{
+		ID:        "PART1",
+		NumRanges: 4,
+	})
+	require.NoError(t, err)
+	require.Len(t, ranges, 4)
+	for i, r := range ranges {
+		assert.Equal(t, "PART1", r.GetPartitionId(), "range %d", i)
+	}
+}

--- a/enterprise/server/raft/events/events.go
+++ b/enterprise/server/raft/events/events.go
@@ -36,7 +36,8 @@ func (t EventType) String() string {
 }
 
 type RangeEvent struct {
-	Type EventType
+	Type    EventType
+	RangeID uint64
 }
 
 func (r RangeEvent) EventType() EventType {
@@ -46,7 +47,7 @@ func (r RangeEvent) EventType() EventType {
 func (r RangeEvent) String() string {
 	switch r.Type {
 	case EventRangeLeaseAcquired, EventRangeLeaseDropped:
-		return r.Type.String()
+		return fmt.Sprintf("%s for range ID %d", r.Type, r.RangeID)
 	default:
 		return fmt.Sprintf("unknown event type: %s", r.Type)
 	}

--- a/enterprise/server/raft/keys/BUILD
+++ b/enterprise/server/raft/keys/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -6,4 +6,18 @@ go_library(
     name = "keys",
     srcs = ["keys.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys",
+    deps = [
+        "//enterprise/server/filestore",
+        "//proto:raft_go_proto",
+    ],
+)
+
+go_test(
+    name = "keys_test",
+    srcs = ["keys_test.go"],
+    deps = [
+        ":keys",
+        "//proto:raft_go_proto",
+        "@com_github_stretchr_testify//assert",
+    ],
 )

--- a/enterprise/server/raft/keys/keys.go
+++ b/enterprise/server/raft/keys/keys.go
@@ -3,6 +3,10 @@ package keys
 import (
 	"bytes"
 	"math"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
+
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 )
 
 type Key []byte
@@ -42,4 +46,33 @@ func IsLocalKey(key Key) bool {
 // range identified by the given key prefix.
 func Range(key []byte) ([]byte, []byte) {
 	return MakeKey(key, MinByte), MakeKey(key, MaxByte)
+}
+
+// PartitionIDFromRangeStart parses the partition ID out of a range descriptor's
+// start key. Range data is keyed under "PT<partition_id>/..."; returns "" for
+// keys without that prefix (e.g., the meta range).
+func PartitionIDFromRangeStart(key []byte) string {
+	rest, found := bytes.CutPrefix(key, []byte(filestore.PartitionDirectoryPrefix))
+	if !found {
+		return ""
+	}
+	before, _, ok := bytes.Cut(rest, []byte{'/'})
+	if !ok {
+		return ""
+	}
+	return string(before)
+}
+
+// EnsurePartitionID backfills rd.PartitionId from its start key if empty.
+// Returns true if the descriptor was modified.
+func EnsurePartitionID(rd *rfpb.RangeDescriptor) bool {
+	if rd.GetPartitionId() != "" {
+		return false
+	}
+	id := PartitionIDFromRangeStart(rd.GetStart())
+	if id == "" {
+		return false
+	}
+	rd.PartitionId = id
+	return true
 }

--- a/enterprise/server/raft/keys/keys_test.go
+++ b/enterprise/server/raft/keys/keys_test.go
@@ -1,0 +1,52 @@
+package keys_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
+	"github.com/stretchr/testify/assert"
+
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+)
+
+func TestPartitionIDFromRangeStart(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{"with_partition", "PTfoo/abc123", "foo"},
+		{"empty_partition_segment", "PT/abc", ""},
+		{"no_slash_after_prefix", "PTfoo", ""},
+		{"missing_prefix", "abc/def", ""},
+		{"meta_range_prefix", "\x02somekey", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := keys.PartitionIDFromRangeStart([]byte(tc.key))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEnsurePartitionID(t *testing.T) {
+	t.Run("backfills_empty", func(t *testing.T) {
+		rd := &rfpb.RangeDescriptor{Start: []byte("PTfoo/abc")}
+		mutated := keys.EnsurePartitionID(rd)
+		assert.True(t, mutated)
+		assert.Equal(t, "foo", rd.GetPartitionId())
+	})
+	t.Run("leaves_set_value_alone", func(t *testing.T) {
+		rd := &rfpb.RangeDescriptor{Start: []byte("PTfoo/abc"), PartitionId: "preset"}
+		mutated := keys.EnsurePartitionID(rd)
+		assert.False(t, mutated)
+		assert.Equal(t, "preset", rd.GetPartitionId())
+	})
+	t.Run("meta_range_unchanged", func(t *testing.T) {
+		rd := &rfpb.RangeDescriptor{Start: []byte("\x02meta")}
+		mutated := keys.EnsurePartitionID(rd)
+		assert.False(t, mutated)
+		assert.Equal(t, "", rd.GetPartitionId())
+	})
+}

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -154,7 +154,8 @@ func (la *leaseAgent) isStopped() bool {
 
 func (la *leaseAgent) sendRangeEvent(eventType events.EventType) {
 	ev := events.RangeEvent{
-		Type: eventType,
+		Type:    eventType,
+		RangeID: la.l.GetRangeID(),
 	}
 	select {
 	case la.broadcast <- ev:

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -250,6 +250,7 @@ func (sm *Replica) setRange(val []byte) error {
 	if err := proto.Unmarshal(val, rangeDescriptor); err != nil {
 		return err
 	}
+	keys.EnsurePartitionID(rangeDescriptor)
 
 	sm.rangeMu.Lock()
 	sm.log.Infof("Range descriptor is changing from %s to %s", rdString(sm.rangeDescriptor), rdString(rangeDescriptor))

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -250,7 +250,10 @@ func (sm *Replica) setRange(val []byte) error {
 	if err := proto.Unmarshal(val, rangeDescriptor); err != nil {
 		return err
 	}
-	keys.EnsurePartitionID(rangeDescriptor)
+	if keys.EnsurePartitionID(rangeDescriptor) {
+		// TODO(go/b/7513): remove backfill once this no longer fires.
+		sm.log.Infof("range %d descriptor missing partition_id; backfilling in-memory to %q", rangeDescriptor.GetRangeId(), rangeDescriptor.GetPartitionId())
+	}
 
 	sm.rangeMu.Lock()
 	sm.log.Infof("Range descriptor is changing from %s to %s", rdString(sm.rangeDescriptor), rdString(rangeDescriptor))

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -569,7 +569,6 @@ func (s *Store) setMetaRangeBuf(buf []byte) {
 		s.log.Errorf("Error unmarshaling new metarange data: %s", err)
 		return
 	}
-	keys.EnsurePartitionID(new)
 	if len(s.metaRangeData) > 0 {
 		// Compare existing to new -- only update if generation is greater.
 		existing := &rfpb.RangeDescriptor{}
@@ -4048,7 +4047,11 @@ func (s *Store) rangeReplicaLabels(rd *rfpb.RangeDescriptor) prometheus.Labels {
 		partitionID = keys.PartitionIDFromRangeStart(rd.GetStart())
 	}
 	if partitionID == "" {
-		partitionID = "meta"
+		if rd.GetRangeId() == 1 {
+			partitionID = "meta"
+		} else {
+			partitionID = "unknown"
+		}
 	}
 	return prometheus.Labels{
 		metrics.RaftRangeIDLabel:    strconv.FormatUint(rd.GetRangeId(), 10),

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -569,6 +569,7 @@ func (s *Store) setMetaRangeBuf(buf []byte) {
 		s.log.Errorf("Error unmarshaling new metarange data: %s", err)
 		return
 	}
+	keys.EnsurePartitionID(new)
 	if len(s.metaRangeData) > 0 {
 		// Compare existing to new -- only update if generation is greater.
 		existing := &rfpb.RangeDescriptor{}
@@ -923,6 +924,10 @@ func (s *Store) Start() error {
 	}
 	s.eg.Go(func() error {
 		s.updateStoreUsageTag(s.egCtx)
+		return nil
+	})
+	s.eg.Go(func() error {
+		s.backfillPartitionIDs(s.egCtx)
 		return nil
 	})
 	s.eg.Go(func() error {
@@ -2585,6 +2590,44 @@ func (s *Store) updateStoreUsageTag(ctx context.Context) {
 	}
 }
 
+// backfillPartitionIDs listens for range-lease-acquired events and persists
+// RangeDescriptor.PartitionId for the leased range if it is missing (e.g. for
+// ranges created before the field existed). Only the lease holder may propose
+// the descriptor update, which is why the work is triggered here.
+func (s *Store) backfillPartitionIDs(ctx context.Context) {
+	eventsCh := s.AddEventListener("backfillPartitionIDs")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-eventsCh:
+			if e.EventType() != events.EventRangeLeaseAcquired {
+				continue
+			}
+			rangeEvent, ok := e.(events.RangeEvent)
+			if !ok {
+				continue
+			}
+			old := s.lookupRange(rangeEvent.RangeID)
+			if old == nil || old.GetPartitionId() != "" {
+				continue
+			}
+			partitionID := keys.PartitionIDFromRangeStart(old.GetStart())
+			if partitionID == "" {
+				continue
+			}
+			new := proto.Clone(old).(*rfpb.RangeDescriptor)
+			new.PartitionId = partitionID
+			new.Generation = old.GetGeneration() + 1
+			if err := s.UpdateRangeDescriptor(ctx, old, new); err != nil {
+				s.log.Warningf("backfill partition_id for range %d failed: %s", old.GetRangeId(), err)
+				continue
+			}
+			s.log.Infof("backfilled partition_id=%q on range %d", partitionID, old.GetRangeId())
+		}
+	}
+}
+
 func (s *Store) Usage() *rfpb.StoreUsage {
 	su := &rfpb.StoreUsage{
 		Node: s.NodeDescriptor(),
@@ -4000,27 +4043,19 @@ func (s *Store) getFileSystemUsage() (gosigar.FileSystemUsage, error) {
 
 // rangeReplicaLabels builds the labelset for the RaftRangeReplica gauge.
 func (s *Store) rangeReplicaLabels(rd *rfpb.RangeDescriptor) prometheus.Labels {
+	partitionID := rd.GetPartitionId()
+	if partitionID == "" {
+		partitionID = keys.PartitionIDFromRangeStart(rd.GetStart())
+	}
+	if partitionID == "" {
+		partitionID = "meta"
+	}
 	return prometheus.Labels{
 		metrics.RaftRangeIDLabel:    strconv.FormatUint(rd.GetRangeId(), 10),
 		metrics.RaftNodeHostIDLabel: s.nodeHost.ID(),
-		metrics.PartitionID:         partitionIDFromRangeStart(rd.GetStart()),
+		metrics.PartitionID:         partitionID,
 		metrics.ZoneLabel:           s.zone,
 	}
-}
-
-// partitionIDFromRangeStart parses the partition_id out of a range descriptor's
-// start key. Range data is keyed under "PT<partition_id>/..."; returns "" for
-// ranges with no partition prefix (e.g., the meta range).
-// TODO(go/b/7513): remove after we add partition to RangeDescriptor.
-func partitionIDFromRangeStart(key []byte) string {
-	rest, found := bytes.CutPrefix(key, []byte(filestore.PartitionDirectoryPrefix))
-	if !found {
-		return "unknown"
-	}
-	if before, _, ok := bytes.Cut(rest, []byte{'/'}); ok {
-		return string(before)
-	}
-	return "unknown"
 }
 
 func (s *Store) setupPartitions(ctx context.Context) {

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -519,6 +519,7 @@ message RangeDescriptor {
   bytes start = 1;
   bytes end = 2;
 
+  string partition_id = 11;
   uint64 range_id = 3;
   repeated ReplicaDescriptor replicas = 4;
 


### PR DESCRIPTION
Also backfill it when it is missing and we get the lease on a range.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/7513