### PR TITLE
Improve handling of EOPNOTSUPP when reading PSI

### DIFF
--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -490,24 +490,24 @@ func Stats(ctx context.Context, dir string, blockDevice *block_io.Device) (*repb
 	}
 
 	// Read PSI metrics.
-	// Note that PSI may not be supported in all environments,
-	// so ignore NotExist errors.
+	// Note that PSI may not be supported in all environments. The files may
+	// either be missing, or reads may return EOPNOTSUPP if PSI is disabled.
 
 	cpuPressurePath := filepath.Join(dir, "cpu.pressure")
 	cpuPressure, err := readPSIFile(cpuPressurePath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !isUnsupportedPSIError(err) {
 		return nil, err
 	}
 
 	memPressurePath := filepath.Join(dir, "memory.pressure")
 	memPressure, err := readPSIFile(memPressurePath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !isUnsupportedPSIError(err) {
 		return nil, err
 	}
 
 	ioPressurePath := filepath.Join(dir, "io.pressure")
 	ioPressure, err := readPSIFile(ioPressurePath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !isUnsupportedPSIError(err) {
 		return nil, err
 	}
 
@@ -519,6 +519,10 @@ func Stats(ctx context.Context, dir string, blockDevice *block_io.Device) (*repb
 		MemoryPressure: memPressure,
 		IoPressure:     ioPressure,
 	}, nil
+}
+
+func isUnsupportedPSIError(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, syscall.EOPNOTSUPP)
 }
 
 func (p *Paths) v1Stats(ctx context.Context, cid string) (*repb.UsageStats, error) {

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -38,6 +39,10 @@ const (
 var (
 	// ErrV1NotSupported is returned when a function does not support cgroup V1.
 	ErrV1NotSupported = fmt.Errorf("cgroup v1 is not supported")
+
+	// true if we've ever gotten EOPNOTSUPP when trying to read a PSI file. This
+	// can happen for some cloud platforms which have PSI disabled by default.
+	psiNotSupported atomic.Bool
 )
 
 // GetCurrent returns the cgroup of which the current process is a member.
@@ -494,20 +499,20 @@ func Stats(ctx context.Context, dir string, blockDevice *block_io.Device) (*repb
 	// either be missing, or reads may return EOPNOTSUPP if PSI is disabled.
 
 	cpuPressurePath := filepath.Join(dir, "cpu.pressure")
-	cpuPressure, err := readPSIFile(cpuPressurePath)
-	if err != nil && !isUnsupportedPSIError(err) {
+	cpuPressure, err := readPSIFileIfSupported(cpuPressurePath)
+	if err != nil {
 		return nil, err
 	}
 
 	memPressurePath := filepath.Join(dir, "memory.pressure")
-	memPressure, err := readPSIFile(memPressurePath)
-	if err != nil && !isUnsupportedPSIError(err) {
+	memPressure, err := readPSIFileIfSupported(memPressurePath)
+	if err != nil {
 		return nil, err
 	}
 
 	ioPressurePath := filepath.Join(dir, "io.pressure")
-	ioPressure, err := readPSIFile(ioPressurePath)
-	if err != nil && !isUnsupportedPSIError(err) {
+	ioPressure, err := readPSIFileIfSupported(ioPressurePath)
+	if err != nil {
 		return nil, err
 	}
 
@@ -519,10 +524,6 @@ func Stats(ctx context.Context, dir string, blockDevice *block_io.Device) (*repb
 		MemoryPressure: memPressure,
 		IoPressure:     ioPressure,
 	}, nil
-}
-
-func isUnsupportedPSIError(err error) bool {
-	return os.IsNotExist(err) || errors.Is(err, syscall.EOPNOTSUPP)
 }
 
 func (p *Paths) v1Stats(ctx context.Context, cid string) (*repb.UsageStats, error) {
@@ -672,6 +673,32 @@ func readAllInt64Fields(path string) (map[string]int64, error) {
 		m[fields[0]] = val
 	}
 	return m, nil
+}
+
+func readPSIFileIfSupported(path string) (*repb.PSI, error) {
+	if psiNotSupported.Load() {
+		return nil, nil
+	}
+	psi, err := readPSIFile(path)
+	if err != nil {
+		// TODO: can NotExist happen in cases where PSI is supported (e.g.
+		// occasionally, due to race conditions or other edge cases)? If not,
+		// maybe set psiNotSupported=true to match the EOPNOTSUPP case below.
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		// On some systems, PSI files may exist, but trying to read them
+		// returns EOPNOTSUPP. Detect this case lazily and prevent future PSI
+		// reads.
+		if errors.Is(err, syscall.EOPNOTSUPP) {
+			if psiNotSupported.CompareAndSwap(false, true) {
+				log.Infof("Linux PSI is unavailable: reading cgroup pressure file %q returned EOPNOTSUPP. BuildBuddy will omit PSI metrics; CPU, memory, and IO usage stats are still collected, but task autosizing may be less accurate. To enable PSI, boot executor nodes with kernel parameter psi=1.", path)
+			}
+			return nil, nil
+		}
+		return nil, err
+	}
+	return psi, nil
 }
 
 func readPSIFile(path string) (*repb.PSI, error) {

--- a/enterprise/server/remote_execution/cgroup/cgroup_test.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup_test.go
@@ -1,7 +1,9 @@
 package cgroup
 
 import (
+	"io/fs"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/block_io"
@@ -149,6 +151,18 @@ full avg10=0.01 avg60=0.50 avg300=1.23 total=23456
 			Total:  23456,
 		},
 	}, psi, protocmp.Transform()))
+}
+
+func TestIsUnsupportedPSIError(t *testing.T) {
+	// Kernels with PSI disabled can expose cgroup pressure files but reject
+	// reads with EOPNOTSUPP.
+	require.True(t, isUnsupportedPSIError(&fs.PathError{Op: "read", Path: "/sys/fs/cgroup/cpu.pressure", Err: syscall.EOPNOTSUPP}))
+
+	// Some cgroup environments do not expose PSI files at all.
+	require.True(t, isUnsupportedPSIError(&fs.PathError{Op: "open", Path: "/sys/fs/cgroup/cpu.pressure", Err: fs.ErrNotExist}))
+
+	// Other read failures should still be surfaced.
+	require.False(t, isUnsupportedPSIError(&fs.PathError{Op: "read", Path: "/sys/fs/cgroup/cpu.pressure", Err: syscall.EIO}))
 }
 
 func TestParseIOStats(t *testing.T) {

--- a/enterprise/server/remote_execution/cgroup/cgroup_test.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup_test.go
@@ -1,9 +1,7 @@
 package cgroup
 
 import (
-	"io/fs"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/block_io"
@@ -151,18 +149,6 @@ full avg10=0.01 avg60=0.50 avg300=1.23 total=23456
 			Total:  23456,
 		},
 	}, psi, protocmp.Transform()))
-}
-
-func TestIsUnsupportedPSIError(t *testing.T) {
-	// Kernels with PSI disabled can expose cgroup pressure files but reject
-	// reads with EOPNOTSUPP.
-	require.True(t, isUnsupportedPSIError(&fs.PathError{Op: "read", Path: "/sys/fs/cgroup/cpu.pressure", Err: syscall.EOPNOTSUPP}))
-
-	// Some cgroup environments do not expose PSI files at all.
-	require.True(t, isUnsupportedPSIError(&fs.PathError{Op: "open", Path: "/sys/fs/cgroup/cpu.pressure", Err: fs.ErrNotExist}))
-
-	// Other read failures should still be surfaced.
-	require.False(t, isUnsupportedPSIError(&fs.PathError{Op: "read", Path: "/sys/fs/cgroup/cpu.pressure", Err: syscall.EIO}))
 }
 
 func TestParseIOStats(t *testing.T) {


### PR DESCRIPTION
In some setups, the kernel creates PSI files but reading them returns EOPNOTSUPP.

Handle these cases better by disabling subsequent PSI file reads the first time we see this error, rather than spamming warning logs on every task execution.

Context: https://buildbuddy-corp.slack.com/archives/C07SND71EDC/p1780952849844659?thread_ts=1780937320.797719&cid=C07SND71EDC