### PR TITLE
invocation: speed up compact exec log analysis

### DIFF
--- a/app/invocation/invocation_file_card.tsx
+++ b/app/invocation/invocation_file_card.tsx
@@ -28,6 +28,16 @@ interface State {
   directoryToFileLimit: Map<string, number>;
 }
 
+interface DirectorySummary {
+  entry: tools.protos.ExecLogEntry;
+  sizeBytes: Long;
+}
+
+interface DirectoryMetadata {
+  sizeBytes: Long;
+  hash?: string;
+}
+
 const pageSize = 100;
 export default class InvocationFileCardComponent extends React.Component<Props, State> {
   state: State = {
@@ -42,6 +52,7 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
   };
 
   timeoutRef?: number;
+  directoryMetadataCache = new Map<string, DirectoryMetadata>();
 
   componentDidMount() {
     this.fetchLog();
@@ -99,15 +110,15 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
     }
   }
 
-  compareDirectories(a: tools.protos.ExecLogEntry, b: tools.protos.ExecLogEntry): number {
+  compareDirectories(a: DirectorySummary, b: DirectorySummary): number {
     let first = this.state.direction == "asc" ? a : b;
     let second = this.state.direction == "asc" ? b : a;
 
     switch (this.state.sort) {
       case "size":
-        return +this.sumFileSizes(first?.directory?.files) - +this.sumFileSizes(second?.directory?.files);
+        return first.sizeBytes.compare(second.sizeBytes);
       default:
-        return (first.directory?.path || "").localeCompare(second.directory?.path || "");
+        return (first.entry.directory?.path || "").localeCompare(second.entry.directory?.path || "");
     }
   }
 
@@ -119,9 +130,7 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
   }
 
   sumFileSizes(files: Array<tools.protos.ExecLogEntry.File> | undefined) {
-    return (
-      (files || []).map((f) => f.digest?.sizeBytes || 0).reduce((a, b) => new Long(+a + +b), Long.ZERO) || Long.ZERO
-    );
+    return (files || []).reduce((sum, f) => sum.add(f.digest?.sizeBytes || 0), Long.ZERO);
   }
 
   hashFileHashes(files: Array<tools.protos.ExecLogEntry.File> | undefined) {
@@ -136,6 +145,35 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
         }
         return hash;
       }, "");
+  }
+
+  summarizeDirectory(entry: tools.protos.ExecLogEntry): DirectorySummary {
+    return {
+      entry,
+      sizeBytes: this.directoryMetadata(entry).sizeBytes,
+    };
+  }
+
+  directoryKey(entry: tools.protos.ExecLogEntry): string {
+    return entry.id + ":" + (entry.directory?.path || "");
+  }
+
+  directoryMetadata(entry: tools.protos.ExecLogEntry): DirectoryMetadata {
+    const key = this.directoryKey(entry);
+    let metadata = this.directoryMetadataCache.get(key);
+    if (!metadata) {
+      metadata = { sizeBytes: this.sumFileSizes(entry.directory?.files) };
+      this.directoryMetadataCache.set(key, metadata);
+    }
+    return metadata;
+  }
+
+  directoryHash(entry: tools.protos.ExecLogEntry): string {
+    let metadata = this.directoryMetadata(entry);
+    if (metadata.hash === undefined) {
+      metadata.hash = this.hashFileHashes(entry.directory?.files);
+    }
+    return metadata.hash;
   }
 
   handleSortDirectionChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -231,6 +269,7 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
 
         return true;
       })
+      .map((entry) => this.summarizeDirectory(entry))
       .sort(this.compareDirectories.bind(this));
 
     const symlinks = this.state.log
@@ -361,7 +400,7 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
             </div>
             <div>
               <div className="invocation-execution-table">
-                {directories.slice(0, this.state.directoryLimit).map((entry) => {
+                {directories.slice(0, this.state.directoryLimit).map(({ entry, sizeBytes }) => {
                   let path = entry.directory?.path || "";
                   let fileLimit = this.state.directoryToFileLimit.get(path) || 0;
                   return (
@@ -380,8 +419,8 @@ export default class InvocationFileCardComponent extends React.Component<Props, 
                             <div>
                               <DigestComponent
                                 digest={{
-                                  sizeBytes: this.sumFileSizes(entry.directory?.files),
-                                  hash: this.hashFileHashes(entry.directory?.files),
+                                  sizeBytes,
+                                  hash: this.directoryHash(entry),
                                 }}
                                 expanded={true}
                               />

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -1151,7 +1151,12 @@ export default class InvocationModel {
           entries.push(tools.protos.ExecLogEntry.decode(byteArray.subarray(offset, offset + length)));
           offset += length;
         }
-        console.log(entries);
+        if (rpcService.debuggingEnabled()) {
+          console.debug("Decoded execution log", {
+            bytes: body.byteLength,
+            entries: entries.length,
+          });
+        }
         return entries;
       });
 


### PR DESCRIPTION
A user-reported 6-hour invocation showed the Files tab freezing while the rest
of the invocation UI remained usable. The tab was spending most of its time
unpacking and analyzing the compact execution log on the main thread.

The browser-side instrumentation and local benchmark for the reported invocation
looked like this:

| Area | Time before -> after | Scale / detail | Why it matters |
| --- | ---: | --- | --- |
| Read compact log body | 12,081 ms -> unchanged | 268,453,271 decoded bytes / 256 MiB | Large input, but not the main avoidable cost in this PR |
| Debug log event | not safely measured -> 0 ms by default | 190,207 decoded entries -> byte and entry counts only under `?debug=1` | The old code handed the full decoded array to DevTools; the diagnostic suppressed it rather than measuring that cost |
| File-row sort | 159 ms observed -> unchanged | 174,363 file rows | Not the freeze source |
| Directory-row analysis | 7,101 ms -> 0.6 ms | 2,277 directory rows containing 1,614,729 nested file records | The old comparator repeatedly rescanned directory contents while sorting |
| Files-tab processing benchmark | 9,504 ms -> 1,879 ms | Median of 7 local JS runs against the reported `execution_log.binpb.zst` | Measures the same `protobufjs`, `varint`, and `long` decode path as the UI |

This change caches per-directory metadata by `entry.id:path`, computes each
directory size once, and reuses the cached hash when rendering directory
digests. It also keeps the execution-log debug breadcrumb behind `?debug=1`,
but logs only byte and entry counts instead of retaining the full decoded entry
array in DevTools.

The benchmark intentionally does not include the old full-array console dump,
so the measured before number is conservative. The remaining cost is mostly the
unavoidable first-pass decode, the 174k file-entry sort, and digest rendering
for the first visible directory rows.
