### PR TITLE
execution_server: Wait for flush cleanup

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -1546,8 +1546,10 @@ func TestPublishOperation_PeriodicFlushDoesNotClobberCompletedRow(t *testing.T) 
 	}, 5*time.Second, 10*time.Millisecond, "main loop's COMPLETED write never landed in the per-invocation list")
 
 	// Sanity check: in-progress data was cleaned up by flushExecutionToOLAP.
-	_, err = env.GetExecutionCollector().GetInProgressExecution(ctx, taskID)
-	require.Truef(t, status.IsNotFoundError(err), "expected in-progress data to be cleaned up after flush, got err=%v", err)
+	require.Eventually(t, func() bool {
+		_, err := env.GetExecutionCollector().GetInProgressExecution(ctx, taskID)
+		return status.IsNotFoundError(err)
+	}, 5*time.Second, 10*time.Millisecond, "expected in-progress data to be cleaned up after flush")
 
 	// Advance past the 5s flush threshold to let the periodic goroutine wake up
 	fakeClock.Advance(6 * time.Second)


### PR DESCRIPTION
Fix execution-server flakes because a completed execution could become
visible before the async flush removed the matching in-progress row.

Wait for cleanup to observe the eventual not-found result before
advancing the fake clock again, so that the test checks the intended
race without depending on a fixed ordering between the main write and
flush goroutine.

Flake-View: https://buildbuddy.buildbuddy.io/tests/?target=%2F%2Fenterprise%2Fserver%2Fremote_execution%2Fexecution_server%3Aexecution_server_test&repo=https%3A%2F%2Fgithub.com%2Fbuildbuddy-io%2Fbuildbuddy&branch=master#flakes