### PR TITLE
cli: accept stamped versions in bazelisk test

### DIFF
--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -85,7 +85,7 @@ func TestInvokeViaBazelisk(t *testing.T) {
 		b, err := testcli.CombinedOutput(cmd)
 
 		require.NoError(t, err, "output: %s", string(b))
-		require.Contains(t, string(b), "bb unknown")
+		require.Regexp(t, `(?m)^bb (unknown|\d+\.\d+\.\d+)$`, string(b))
 		require.Contains(t, string(b), "Build label: "+testbazel.Version)
 	}
 	{
@@ -100,7 +100,7 @@ func TestInvokeViaBazelisk(t *testing.T) {
 		b, err := testcli.CombinedOutput(cmd)
 
 		require.NoError(t, err, "output: %s", string(b))
-		require.Contains(t, string(b), "bb unknown")
+		require.Regexp(t, `(?m)^bb (unknown|\d+\.\d+\.\d+)$`, string(b))
 		require.Contains(t, string(b), "Build label: 6.0.0")
 	}
 }


### PR DESCRIPTION
TestInvokeViaBazelisk now fails as "bb 5.0.374" in checkouts with
cli-v* tags. ff0494a90b made the CLI version come from workspace
status stamping, and the test helper binary is built through
testcli:bb_no_cov in opt mode, so it can embed the latest local CLI
tag instead of falling back to unknown.

Because the version line is now tag-dependent, a checkout with cli-v*
tags can fail the test locally while CI can keep passing when tags are
not fetched. Keep the test focused on Bazelisk delegation by accepting
either unknown or a stamped semver CLI version line.
