### PR TITLE
Export new SKUs to clickhouse usage tables

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1537,7 +1537,7 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			if err := s.cacheActionResult(ctx, actionRN, trimmedResponse, action); err != nil {
 				return status.UnavailableErrorf("Error uploading action result: %s", err.Error())
 			}
-			if err := s.markTaskComplete(ctx, actionRN, response, action, cmd, properties, flushExecutionsOnEOF); err != nil {
+			if err := s.markTaskComplete(ctx, actionRN, response, auxMeta, action, cmd, properties, flushExecutionsOnEOF); err != nil {
 				// Errors updating the router or recording usage are non-fatal.
 				log.CtxErrorf(ctx, "Could not update post-completion metadata: %s", err)
 			}
@@ -1640,7 +1640,7 @@ func (s *ExecutionServer) cacheActionResult(ctx context.Context, actionResourceN
 // usage is recorded here from the live ExecuteResponse + platform.Properties.
 // When true, usage is recorded later by flushAndRecordUsage from the merged
 // StoredExecution in Redis.
-func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceName *digest.ACResourceName, executeResponse *repb.ExecuteResponse, action *repb.Action, cmd *repb.Command, properties *platform.Properties, flushExecutionsOnEOF bool) error {
+func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceName *digest.ACResourceName, executeResponse *repb.ExecuteResponse, auxMeta *espb.ExecutionAuxiliaryMetadata, action *repb.Action, cmd *repb.Command, properties *platform.Properties, flushExecutionsOnEOF bool) error {
 	execErr := gstatus.ErrorProto(executeResponse.GetStatus())
 	router := s.env.GetTaskRouter()
 	if router != nil && !executeResponse.GetCachedResult() {
@@ -1666,7 +1666,7 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceNa
 	}
 
 	if !flushExecutionsOnEOF {
-		if err := s.updateUsage(ctx, executeResponse, properties); err != nil {
+		if err := s.updateUsage(ctx, executeResponse, auxMeta, properties); err != nil {
 			// TODO(vanja) should this be done when the executor got a cache hit?
 			log.CtxWarningf(ctx, "Failed to update usage for ExecuteResponse %+v: %s", executeResponse, err)
 		}
@@ -1675,7 +1675,7 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, actionResourceNa
 	return nil
 }
 
-func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb.ExecuteResponse, plat *platform.Properties) error {
+func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb.ExecuteResponse, auxMeta *espb.ExecutionAuxiliaryMetadata, plat *platform.Properties) error {
 	ut := s.env.GetUsageTracker()
 	if ut == nil {
 		return nil
@@ -1700,7 +1700,7 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb
 	}
 
 	counts := &tables.UsageCounts{}
-	setExecutionDuration(counts, dur, pool, plat)
+	setExecutionDuration(counts, dur, pool.IsSelfHosted, plat.OS)
 	usg := executeResponse.GetResult().GetExecutionMetadata().GetUsageStats()
 	if !pool.IsSelfHosted && usg.GetCpuNanos() > 0 {
 		counts.CPUNanos = usg.GetCpuNanos()
@@ -1723,7 +1723,27 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb
 		lastErr = err
 	}
 
-	if err := incrementOLAPExecutionUsage(ctx, ut, olapLabels, plat.OS, plat.Arch, pool.IsSelfHosted, dur, counts.CPUNanos, usg.GetPeakMemoryBytes()); err != nil {
+	// Project the live ExecuteResponse + aux metadata onto a StoredExecution
+	// so we can reuse incrementOLAPExecutionUsage's accounting logic. Only
+	// the fields that function reads are populated; snapshot stats arrive
+	// via a second COMPLETED that this code path doesn't merge.
+	taskSize := auxMeta.GetSchedulingMetadata().GetTaskSize()
+	execution := &repb.StoredExecution{
+		Os:                     plat.OS,
+		Arch:                   plat.Arch,
+		SelfHosted:             pool.IsSelfHosted,
+		EffectiveIsolationType: auxMeta.GetIsolationType(),
+		CpuNanos:               counts.CPUNanos,
+		PeakMemoryBytes:        usg.GetPeakMemoryBytes(),
+		RequestedComputeUnits:  plat.EstimatedComputeUnits,
+		RequestedMilliCpu:      plat.EstimatedMilliCPU,
+		RequestedMemoryBytes:   plat.EstimatedMemoryBytes,
+		RequestedFreeDiskBytes: plat.EstimatedFreeDiskBytes,
+		EstimatedMilliCpu:      taskSize.GetEstimatedMilliCpu(),
+		EstimatedMemoryBytes:   taskSize.GetEstimatedMemoryBytes(),
+		EstimatedFreeDiskBytes: taskSize.GetEstimatedFreeDiskBytes(),
+	}
+	if err := incrementOLAPExecutionUsage(ctx, ut, olapLabels, execution, dur); err != nil {
 		log.CtxWarningf(ctx, "Failed to increment OLAP usage: %s", err)
 		lastErr = err
 	}
@@ -1753,7 +1773,7 @@ func (s *ExecutionServer) updateUsageFromStoredExecution(ctx context.Context, ex
 	}
 
 	counts := &tables.UsageCounts{}
-	setExecutionDurationFromStored(counts, dur, execution)
+	setExecutionDuration(counts, dur, execution.GetSelfHosted(), execution.GetOs())
 	if !execution.GetSelfHosted() && execution.GetCpuNanos() > 0 {
 		counts.CPUNanos = execution.GetCpuNanos()
 
@@ -1774,25 +1794,50 @@ func (s *ExecutionServer) updateUsageFromStoredExecution(ctx context.Context, ex
 		log.CtxWarningf(ctx, "Failed to increment usage: %s", err)
 		lastErr = err
 	}
-	if err := incrementOLAPExecutionUsage(ctx, ut, olapLabels, execution.GetOs(), execution.GetArch(), execution.GetSelfHosted(), dur, counts.CPUNanos, execution.GetPeakMemoryBytes()); err != nil {
+	if err := incrementOLAPExecutionUsage(ctx, ut, olapLabels, execution, dur); err != nil {
 		log.CtxWarningf(ctx, "Failed to increment OLAP usage: %s", err)
 		lastErr = err
 	}
 	return lastErr
 }
 
-func incrementOLAPExecutionUsage(ctx context.Context, ut interfaces.UsageTracker, baseLabels sku.Labels, os, arch string, selfHosted bool, duration time.Duration, cpuNanos, peakMemoryBytes int64) error {
-	executionLabels := make(sku.Labels, len(baseLabels)+3)
+func incrementOLAPExecutionUsage(ctx context.Context, ut interfaces.UsageTracker, baseLabels sku.Labels, execution *repb.StoredExecution, duration time.Duration) error {
+	executionLabels := make(sku.Labels, len(baseLabels)+4)
 	maps.Copy(executionLabels, baseLabels)
-	executionLabels[sku.OS] = sku.GetOSLabel(os)
-	executionLabels[sku.Arch] = sku.GetArchLabel(arch)
-	executionLabels[sku.SelfHosted] = sku.GetSelfHostedLabel(selfHosted)
-	memoryGBNanos := int64(float64(peakMemoryBytes) * float64(duration.Nanoseconds()) / 1e9)
+	executionLabels[sku.OS] = sku.GetOSLabel(execution.GetOs())
+	executionLabels[sku.Arch] = sku.GetArchLabel(execution.GetArch())
+	executionLabels[sku.SelfHosted] = sku.GetSelfHostedLabel(execution.GetSelfHosted())
+	executionLabels[sku.IsolationType] = sku.GetIsolationTypeLabel(execution.GetEffectiveIsolationType())
+	memoryGBNanos := int64(float64(execution.GetPeakMemoryBytes()) * float64(duration.Nanoseconds()) / 1e9)
 	executionCounts := map[sku.SKU]int64{
-		sku.RemoteExecutionExecuteWorkerCPUNanos:      cpuNanos,
+		sku.RemoteExecutionExecuteWorkerCPUNanos:      execution.GetCpuNanos(),
 		sku.RemoteExecutionExecuteWorkerDurationNanos: duration.Nanoseconds(),
 		sku.RemoteExecutionExecuteWorkerMemoryGBNanos: memoryGBNanos,
-		sku.RemoteExecutionExecuteFixedComputeNanos:   duration.Nanoseconds(),
+	}
+	if execution.GetEffectiveIsolationType() == "firecracker" || execution.GetRequestedComputeUnits() > 0 {
+		// Fixed compute
+		computeUnits := max(
+			execution.GetRequestedComputeUnits(),
+			tasksize.CpuComputeUnits(execution.GetRequestedMilliCpu()),
+			tasksize.MemoryComputeUnits(execution.GetRequestedMemoryBytes()),
+			tasksize.DiskComputeUnits(execution.GetRequestedFreeDiskBytes()),
+		)
+		executionCounts[sku.RemoteExecutionExecuteFixedComputeNanos] = int64(computeUnits * float64(duration.Nanoseconds()))
+	} else {
+		// Flexible compute
+		computeUnits := max(
+			tasksize.CpuComputeUnits(execution.GetEstimatedMilliCpu()),
+			tasksize.MemoryComputeUnits(execution.GetEstimatedMemoryBytes()),
+			tasksize.DiskComputeUnits(execution.GetEstimatedFreeDiskBytes()),
+		)
+		executionCounts[sku.RemoteExecutionExecuteFlexibleComputeNanos] = int64(computeUnits * float64(duration.Nanoseconds()))
+	}
+	if execution.GetSnapshotSavedRemotely() {
+		executionCounts[sku.RemoteExecutionExecuteRemoteSnapshotSavedBytes] = execution.SnapshotSavedBytes
+	} else if execution.GetSnapshotSavedLocally() {
+		// Charge for local saves only if the snapshot was saved locally and not
+		// remotely, because remote implies local.
+		executionCounts[sku.RemoteExecutionExecuteLocalSnapshotSavedBytes] = execution.SnapshotSavedBytes
 	}
 	return ut.IncrementOLAP(ctx, executionLabels, executionCounts)
 }
@@ -1887,20 +1932,20 @@ func executionDuration(md *repb.ExecutedActionMetadata) (time.Duration, error) {
 	return dur, nil
 }
 
-func setExecutionDuration(counts *tables.UsageCounts, duration time.Duration, pool *interfaces.PoolInfo, props *platform.Properties) {
+func setExecutionDuration(counts *tables.UsageCounts, duration time.Duration, isSelfHosted bool, os string) {
 	if duration < 0 {
 		return
 	}
-	if pool.IsSelfHosted {
-		if props.OS == platform.LinuxOperatingSystemName {
+	if isSelfHosted {
+		if os == platform.LinuxOperatingSystemName {
 			counts.SelfHostedLinuxExecutionDurationUsec += duration.Microseconds()
-		} else if props.OS == platform.DarwinOperatingSystemName {
+		} else if os == platform.DarwinOperatingSystemName {
 			counts.SelfHostedMacExecutionDurationUsec += duration.Microseconds()
 		}
 	} else {
-		if props.OS == platform.LinuxOperatingSystemName {
+		if os == platform.LinuxOperatingSystemName {
 			counts.LinuxExecutionDurationUsec += duration.Microseconds()
-		} else if props.OS == platform.DarwinOperatingSystemName {
+		} else if os == platform.DarwinOperatingSystemName {
 			counts.MacExecutionDurationUsec += duration.Microseconds()
 		}
 	}
@@ -1917,25 +1962,6 @@ func executionDurationFromStored(execution *repb.StoredExecution) (time.Duration
 		return 0, status.InternalErrorf("Execution duration is <= 0")
 	}
 	return dur, nil
-}
-
-func setExecutionDurationFromStored(counts *tables.UsageCounts, duration time.Duration, execution *repb.StoredExecution) {
-	if duration < 0 {
-		return
-	}
-	if execution.GetSelfHosted() {
-		if execution.GetOs() == platform.LinuxOperatingSystemName {
-			counts.SelfHostedLinuxExecutionDurationUsec += duration.Microseconds()
-		} else if execution.GetOs() == platform.DarwinOperatingSystemName {
-			counts.SelfHostedMacExecutionDurationUsec += duration.Microseconds()
-		}
-	} else {
-		if execution.GetOs() == platform.LinuxOperatingSystemName {
-			counts.LinuxExecutionDurationUsec += duration.Microseconds()
-		} else if execution.GetOs() == platform.DarwinOperatingSystemName {
-			counts.MacExecutionDurationUsec += duration.Microseconds()
-		}
-	}
 }
 
 func (s *ExecutionServer) Cancel(ctx context.Context, invocationID string) error {

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1731,7 +1731,6 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb
 	// stored path uses (via fillExecutionFromActionMetadata, line 107-108).
 	md := executeResponse.GetResult().GetExecutionMetadata()
 	estimatedTaskSize := md.GetEstimatedTaskSize()
-	auxMeta.GetSchedulingMetadata().GetTaskSize()
 	execution := &repb.StoredExecution{
 		Os:                     plat.OS,
 		Arch:                   plat.Arch,

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -479,7 +479,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 			}
 
 			if schedulingMeta := auxMeta.GetSchedulingMetadata(); schedulingMeta != nil {
-				executionProto.EstimatedFreeDiskBytes = schedulingMeta.GetTaskSize().GetEstimatedFreeDiskBytes()
+				executionProto.EstimatedFreeDiskBytes = md.GetEstimatedTaskSize().GetEstimatedFreeDiskBytes()
 				executionProto.PreviousMeasuredMemoryBytes = schedulingMeta.GetMeasuredTaskSize().GetEstimatedMemoryBytes()
 				executionProto.PreviousMeasuredMilliCpu = schedulingMeta.GetMeasuredTaskSize().GetEstimatedMilliCpu()
 				executionProto.PreviousMeasuredFreeDiskBytes = schedulingMeta.GetMeasuredTaskSize().GetEstimatedFreeDiskBytes()
@@ -1726,8 +1726,12 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb
 	// Project the live ExecuteResponse + aux metadata onto a StoredExecution
 	// so we can reuse incrementOLAPExecutionUsage's accounting logic. Only
 	// the fields that function reads are populated; snapshot stats arrive
-	// via a second COMPLETED that this code path doesn't merge.
-	taskSize := auxMeta.GetSchedulingMetadata().GetTaskSize()
+	// via a second COMPLETED that this code path doesn't merge. The
+	// Estimated* fields come from md.EstimatedTaskSize — same source the
+	// stored path uses (via fillExecutionFromActionMetadata, line 107-108).
+	md := executeResponse.GetResult().GetExecutionMetadata()
+	estimatedTaskSize := md.GetEstimatedTaskSize()
+	auxMeta.GetSchedulingMetadata().GetTaskSize()
 	execution := &repb.StoredExecution{
 		Os:                     plat.OS,
 		Arch:                   plat.Arch,
@@ -1739,9 +1743,9 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, executeResponse *repb
 		RequestedMilliCpu:      plat.EstimatedMilliCPU,
 		RequestedMemoryBytes:   plat.EstimatedMemoryBytes,
 		RequestedFreeDiskBytes: plat.EstimatedFreeDiskBytes,
-		EstimatedMilliCpu:      taskSize.GetEstimatedMilliCpu(),
-		EstimatedMemoryBytes:   taskSize.GetEstimatedMemoryBytes(),
-		EstimatedFreeDiskBytes: taskSize.GetEstimatedFreeDiskBytes(),
+		EstimatedMilliCpu:      estimatedTaskSize.GetEstimatedMilliCpu(),
+		EstimatedMemoryBytes:   estimatedTaskSize.GetEstimatedMemoryBytes(),
+		EstimatedFreeDiskBytes: estimatedTaskSize.GetEstimatedFreeDiskBytes(),
 	}
 	if err := incrementOLAPExecutionUsage(ctx, ut, olapLabels, execution, dur); err != nil {
 		log.CtxWarningf(ctx, "Failed to increment OLAP usage: %s", err)
@@ -1804,17 +1808,18 @@ func (s *ExecutionServer) updateUsageFromStoredExecution(ctx context.Context, ex
 func incrementOLAPExecutionUsage(ctx context.Context, ut interfaces.UsageTracker, baseLabels sku.Labels, execution *repb.StoredExecution, duration time.Duration) error {
 	executionLabels := make(sku.Labels, len(baseLabels)+4)
 	maps.Copy(executionLabels, baseLabels)
+	isolationLabel := sku.GetIsolationTypeLabel(execution.GetEffectiveIsolationType())
 	executionLabels[sku.OS] = sku.GetOSLabel(execution.GetOs())
 	executionLabels[sku.Arch] = sku.GetArchLabel(execution.GetArch())
 	executionLabels[sku.SelfHosted] = sku.GetSelfHostedLabel(execution.GetSelfHosted())
-	executionLabels[sku.IsolationType] = sku.GetIsolationTypeLabel(execution.GetEffectiveIsolationType())
+	executionLabels[sku.IsolationType] = isolationLabel
 	memoryGBNanos := int64(float64(execution.GetPeakMemoryBytes()) * float64(duration.Nanoseconds()) / 1e9)
 	executionCounts := map[sku.SKU]int64{
 		sku.RemoteExecutionExecuteWorkerCPUNanos:      execution.GetCpuNanos(),
 		sku.RemoteExecutionExecuteWorkerDurationNanos: duration.Nanoseconds(),
 		sku.RemoteExecutionExecuteWorkerMemoryGBNanos: memoryGBNanos,
 	}
-	if execution.GetEffectiveIsolationType() == "firecracker" || execution.GetRequestedComputeUnits() > 0 {
+	if isolationLabel == string(platform.FirecrackerContainerType) || execution.GetRequestedComputeUnits() > 0 {
 		// Fixed compute
 		computeUnits := max(
 			execution.GetRequestedComputeUnits(),
@@ -1833,11 +1838,11 @@ func incrementOLAPExecutionUsage(ctx context.Context, ut interfaces.UsageTracker
 		executionCounts[sku.RemoteExecutionExecuteFlexibleComputeNanos] = int64(computeUnits * float64(duration.Nanoseconds()))
 	}
 	if execution.GetSnapshotSavedRemotely() {
-		executionCounts[sku.RemoteExecutionExecuteRemoteSnapshotSavedBytes] = execution.SnapshotSavedBytes
+		executionCounts[sku.RemoteExecutionExecuteRemoteSnapshotSavedBytes] = execution.GetSnapshotSavedBytes()
 	} else if execution.GetSnapshotSavedLocally() {
 		// Charge for local saves only if the snapshot was saved locally and not
 		// remotely, because remote implies local.
-		executionCounts[sku.RemoteExecutionExecuteLocalSnapshotSavedBytes] = execution.SnapshotSavedBytes
+		executionCounts[sku.RemoteExecutionExecuteLocalSnapshotSavedBytes] = execution.GetSnapshotSavedBytes()
 	}
 	return ut.IncrementOLAP(ctx, executionLabels, executionCounts)
 }

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -467,7 +467,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 			executionProto.RequestedTimeoutUsec = action.GetTimeout().AsDuration().Microseconds()
 
 			if properties != nil {
-				executionProto.RequestedIsolationType = platform.CoerceContainerType(properties.WorkloadIsolationType)
+				executionProto.RequestedIsolationType, _ = platform.CoerceContainerType(properties.WorkloadIsolationType)
 				executionProto.RequestedComputeUnits = properties.EstimatedComputeUnits
 				executionProto.RequestedMemoryBytes = properties.EstimatedMemoryBytes
 				executionProto.RequestedMilliCpu = properties.EstimatedMilliCPU

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -1075,11 +1075,18 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 	}
 	require.NotNil(t, foundOLAPExecutorUsage, "expected OLAP execution usage to be recorded")
 	assert.Equal(t, "group1", foundOLAPExecutorUsage.GroupID)
+	var expectedIsolationType sku.LabelValue
+	if test.publishMoreMetadata {
+		// aux.IsolationType = "firecracker" propagates into the
+		// StoredExecution and shows up as the lower-cased OLAP label.
+		expectedIsolationType = "firecracker"
+	}
 	expectedOLAPLabels := sku.Labels{
-		sku.Client:     sku.ClientExecutor,
-		sku.OS:         sku.OSLinux,
-		sku.Arch:       sku.ArchX86_64,
-		sku.SelfHosted: sku.GetSelfHostedLabel(test.expectedSelfHosted),
+		sku.Client:        sku.ClientExecutor,
+		sku.OS:            sku.OSLinux,
+		sku.Arch:          sku.ArchX86_64,
+		sku.SelfHosted:    sku.GetSelfHostedLabel(test.expectedSelfHosted),
+		sku.IsolationType: expectedIsolationType,
 	}
 	assert.Equal(t, expectedOLAPLabels, foundOLAPExecutorUsage.Labels)
 	expectedDurationNanos := (5 * time.Second).Nanoseconds()
@@ -1087,13 +1094,21 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 	require.NotNil(t, foundOLAPComputeUsage, "expected OLAP compute duration usage to be recorded")
 	assert.Equal(t, "group1", foundOLAPComputeUsage.GroupID)
 	expectedComputeOLAPLabels := sku.Labels{
-		sku.Client:     sku.ClientExecutor,
-		sku.OS:         sku.OSLinux,
-		sku.Arch:       sku.ArchX86_64,
-		sku.SelfHosted: sku.GetSelfHostedLabel(test.expectedSelfHosted),
+		sku.Client:        sku.ClientExecutor,
+		sku.OS:            sku.OSLinux,
+		sku.Arch:          sku.ArchX86_64,
+		sku.SelfHosted:    sku.GetSelfHostedLabel(test.expectedSelfHosted),
+		sku.IsolationType: expectedIsolationType,
 	}
 	assert.Equal(t, expectedComputeOLAPLabels, foundOLAPComputeUsage.Labels)
-	assert.Equal(t, expectedDurationNanos, foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFixedComputeNanos])
+	// RequestedComputeUnits=2.5 (from EstimatedComputeUnits in the platform)
+	// dominates the max over the cpu/memory/disk dimensions, so the
+	// fixed-compute SKU should be 2.5 * duration.
+	expectedFixedComputeNanos := int64(2.5 * float64(expectedDurationNanos))
+	assert.Equal(t, expectedFixedComputeNanos, foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFixedComputeNanos])
+	// Flexible compute should NOT be recorded when RequestedComputeUnits > 0.
+	_, hasFlexible := foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFlexibleComputeNanos]
+	assert.False(t, hasFlexible, "flexible compute SKU should not be recorded when requested compute units is set")
 
 	collectedExecutions, err := env.GetExecutionCollector().GetExecutions(ctx, invocationID, 0, -1)
 	require.NoError(t, err)
@@ -1753,6 +1768,25 @@ func testPublishOperationSecondCompletedCarriesSnapshotStats(t *testing.T, flush
 	}
 	require.NotNil(t, foundExecutorUsage, "expected executor usage to be recorded")
 	assert.Equal(t, (5 * time.Second).Microseconds(), foundExecutorUsage.Counts.LinuxExecutionDurationUsec)
+
+	// OLAP snapshot bytes are only recorded when the snapshot fields actually
+	// reach the StoredExecution that updateUsageFromStoredExecution reads.
+	// That only happens on the flushAfterCleanup path; on the legacy path
+	// the second COMPLETED is dropped before the OLAP flush runs.
+	var foundRemoteSnapshotBytes, foundLocalSnapshotBytes int64
+	for _, u := range ut.OLAPTotals() {
+		foundRemoteSnapshotBytes += u.Counts[sku.RemoteExecutionExecuteRemoteSnapshotSavedBytes]
+		foundLocalSnapshotBytes += u.Counts[sku.RemoteExecutionExecuteLocalSnapshotSavedBytes]
+	}
+	if flushAfterCleanup {
+		// Both snapshot_saved_locally and snapshot_saved_remotely were sent,
+		// but the remote branch takes precedence in incrementOLAPExecutionUsage.
+		assert.Equal(t, int64(12345), foundRemoteSnapshotBytes, "expected remote snapshot bytes SKU to be recorded")
+		assert.Zero(t, foundLocalSnapshotBytes, "local snapshot bytes SKU should not be recorded when remote takes precedence")
+	} else {
+		assert.Zero(t, foundRemoteSnapshotBytes, "no snapshot SKUs should be recorded on the legacy path")
+		assert.Zero(t, foundLocalSnapshotBytes, "no snapshot SKUs should be recorded on the legacy path")
+	}
 }
 
 // TestPublishOperation_RetryStreamWithOnlyPostCompletionStats simulates the

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -1104,7 +1104,7 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 	}
 	require.NotNil(t, foundOLAPExecutorUsage, "expected OLAP execution usage to be recorded")
 	assert.Equal(t, "group1", foundOLAPExecutorUsage.GroupID)
-	var expectedIsolationType sku.LabelValue
+	expectedIsolationType := sku.UnknownLabelValue
 	if test.publishMoreMetadata {
 		// aux.IsolationType = "firecracker" propagates into the
 		// StoredExecution and shows up as the lower-cased OLAP label.

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -796,6 +796,11 @@ func TestExecuteAndPublishOperation(t *testing.T) {
 			expectedExecutionUsage: tables.UsageCounts{LinuxExecutionDurationUsec: durationUsec},
 			recycleRunner:          true,
 		},
+		{
+			name:                   "FlexibleCompute",
+			expectedExecutionUsage: tables.UsageCounts{LinuxExecutionDurationUsec: durationUsec},
+			flexibleCompute:        true,
+		},
 	} {
 		for _, flushAfterCleanup := range []bool{false, true} {
 			test := test
@@ -825,6 +830,9 @@ type publishTest struct {
 	useDefaultPool           bool
 	recycleRunner            bool
 	flushAfterCleanup        bool
+	// flexibleCompute routes the execution into the flexible-compute branch
+	// of incrementOLAPExecutionUsage.
+	flexibleCompute bool
 }
 
 func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
@@ -859,11 +867,14 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		clientCtx = metadata.AppendToOutgoingContext(clientCtx, "x-buildbuddy-platform."+k, v)
 	}
 	platformProperties := []*repb.Platform_Property{
-		{Name: "EstimatedComputeUnits", Value: "2.5"},
 		{Name: "EstimatedFreeDiskBytes", Value: "1000"},
 		{Name: "EstimatedCPU", Value: "1.5"},
 		{Name: "EstimatedMemory", Value: "2000"},
 		{Name: "workload-isolation-type", Value: "oci"},
+	}
+	if !test.flexibleCompute {
+		// Set EstimatedComputeUnits so we go through the fixed compute path.
+		platformProperties = append(platformProperties, &repb.Platform_Property{Name: "EstimatedComputeUnits", Value: "2.5"})
 	}
 	if !test.useDefaultPool {
 		platformProperties = append(platformProperties, &repb.Platform_Property{Name: "pool", Value: "test-pool"})
@@ -989,6 +1000,14 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 			UsageStats:               usageStats,
 		},
 	}
+	if test.flexibleCompute {
+		// Memory-dominant size: 10 GiB memory => 4 BCU, which beats 1.5 CPU
+		// and tiny disk. Drives the flexible-compute SKU to a non-zero value.
+		actionResult.ExecutionMetadata.EstimatedTaskSize = &scpb.TaskSize{
+			EstimatedMilliCpu:    1500,
+			EstimatedMemoryBytes: 10 * tasksize.GiB,
+		}
+	}
 	expectedExecuteResponse := &repb.ExecuteResponse{
 		CachedResult: test.cachedResult,
 		Result:       actionResult,
@@ -1063,13 +1082,17 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 	// Also check OLAP totals are recorded. Look for the entry that has the
 	// execution duration SKU specifically, since there may be other OLAP
 	// entries from cache operations.
+	expectedComputeSKU := sku.RemoteExecutionExecuteFixedComputeNanos
+	if test.flexibleCompute {
+		expectedComputeSKU = sku.RemoteExecutionExecuteFlexibleComputeNanos
+	}
 	var foundOLAPExecutorUsage *testusage.OLAPTotal
 	var foundOLAPComputeUsage *testusage.OLAPTotal
 	for _, u := range ut.OLAPTotals() {
 		if _, ok := u.Counts[sku.RemoteExecutionExecuteWorkerDurationNanos]; ok {
 			foundOLAPExecutorUsage = &u
 		}
-		if _, ok := u.Counts[sku.RemoteExecutionExecuteFixedComputeNanos]; ok {
+		if _, ok := u.Counts[expectedComputeSKU]; ok {
 			foundOLAPComputeUsage = &u
 		}
 	}
@@ -1101,14 +1124,22 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		sku.IsolationType: expectedIsolationType,
 	}
 	assert.Equal(t, expectedComputeOLAPLabels, foundOLAPComputeUsage.Labels)
-	// RequestedComputeUnits=2.5 (from EstimatedComputeUnits in the platform)
-	// dominates the max over the cpu/memory/disk dimensions, so the
-	// fixed-compute SKU should be 2.5 * duration.
-	expectedFixedComputeNanos := int64(2.5 * float64(expectedDurationNanos))
-	assert.Equal(t, expectedFixedComputeNanos, foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFixedComputeNanos])
-	// Flexible compute should NOT be recorded when RequestedComputeUnits > 0.
-	_, hasFlexible := foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFlexibleComputeNanos]
-	assert.False(t, hasFlexible, "flexible compute SKU should not be recorded when requested compute units is set")
+	if test.flexibleCompute {
+		// 10 GiB / 2.5 GiB/BCU = 4 BCU (memory dimension dominates),
+		// so flexible-compute = 4 * duration.
+		expectedFlexibleComputeNanos := int64(tasksize.MemoryComputeUnits(10*tasksize.GiB) * float64(expectedDurationNanos))
+		assert.Equal(t, expectedFlexibleComputeNanos, foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFlexibleComputeNanos])
+		_, hasFixed := foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFixedComputeNanos]
+		assert.False(t, hasFixed, "fixed compute SKU should not be recorded on the flexible path")
+	} else {
+		// RequestedComputeUnits=2.5 (from EstimatedComputeUnits in the
+		// platform) dominates the max over the cpu/memory/disk dimensions,
+		// so the fixed-compute SKU should be 2.5 * duration.
+		expectedFixedComputeNanos := int64(2.5 * float64(expectedDurationNanos))
+		assert.Equal(t, expectedFixedComputeNanos, foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFixedComputeNanos])
+		_, hasFlexible := foundOLAPComputeUsage.Counts[sku.RemoteExecutionExecuteFlexibleComputeNanos]
+		assert.False(t, hasFlexible, "flexible compute SKU should not be recorded when requested compute units is set")
+	}
 
 	collectedExecutions, err := env.GetExecutionCollector().GetExecutions(ctx, invocationID, 0, -1)
 	require.NoError(t, err)
@@ -1132,7 +1163,6 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		ExitCode:                     test.exitCode,
 		DoNotCache:                   test.doNotCache,
 		CachedResult:                 test.cachedResult,
-		RequestedComputeUnits:        2.5,
 		RequestedFreeDiskBytes:       1000,
 		RequestedMemoryBytes:         2000,
 		RequestedMilliCpu:            1500,
@@ -1150,6 +1180,15 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		QueuedTimestampUsec:          queuedTime.UnixMicro(),
 		WorkerStartTimestampUsec:     workerStartTime.UnixMicro(),
 		WorkerCompletedTimestampUsec: workerEndTime.UnixMicro(),
+	}
+	if !test.flexibleCompute {
+		expectedExecution.RequestedComputeUnits = 2.5
+	} else {
+		// EstimatedTaskSize on the ExecutedActionMetadata flows through
+		// fillExecutionFromActionMetadata -> TableExecToProto into the
+		// StoredExecution proto.
+		expectedExecution.EstimatedMilliCpu = 1500
+		expectedExecution.EstimatedMemoryBytes = 10 * tasksize.GiB
 	}
 	if test.useDefaultPool {
 		expectedExecution.RequestedPool = ""

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -941,7 +941,6 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 			effectivePool = "default-pool"
 		}
 		aux.SchedulingMetadata = &scpb.SchedulingMetadata{
-			TaskSize: &scpb.TaskSize{EstimatedFreeDiskBytes: 1001},
 			MeasuredTaskSize: &scpb.TaskSize{
 				EstimatedMemoryBytes:   2001,
 				EstimatedMilliCpu:      2002,
@@ -1006,6 +1005,13 @@ func testExecuteAndPublishOperation(t *testing.T, test publishTest) {
 		actionResult.ExecutionMetadata.EstimatedTaskSize = &scpb.TaskSize{
 			EstimatedMilliCpu:    1500,
 			EstimatedMemoryBytes: 10 * tasksize.GiB,
+		}
+	}
+	if test.publishMoreMetadata {
+		// md.EstimatedTaskSize is the source for executionProto.EstimatedFreeDiskBytes
+		// (execution_server.go:482) and for the live-path projection in updateUsage.
+		actionResult.ExecutionMetadata.EstimatedTaskSize = &scpb.TaskSize{
+			EstimatedFreeDiskBytes: 1001,
 		}
 	}
 	expectedExecuteResponse := &repb.ExecuteResponse{

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -49,8 +49,10 @@ const (
 
 	// Definitions for BCU ("BuildBuddy Compute Unit")
 
-	ComputeUnitsToMilliCPU = 1000      // 1 BCU = 1000 milli-CPU
-	ComputeUnitsToRAMBytes = 2.5 * 1e9 // 1 BCU = 2.5GB of memory
+	GiB                     = 1024 * 1024 * 1024
+	ComputeUnitsToMilliCPU  = 1000      // 1 BCU = 1000 milli-CPU
+	ComputeUnitsToRAMBytes  = 2.5 * 1e9 // 1 BCU = 2.5GB of memory
+	ComputeUnitsToDiskBytes = 25 * GiB  // 1 BCU = 25GiB of disk
 
 	// Default resource estimates
 
@@ -701,6 +703,24 @@ func CPUMillisToShares(cpuMillis int64) int64 {
 	cpuShares = min(cpuShares, cpuSharesMax)
 	cpuShares = max(cpuShares, cpuSharesMin)
 	return cpuShares
+}
+
+// CpuComputeUnits returns the BCU count equivalent to the given milli-CPU.
+func CpuComputeUnits(milliCpu int64) float64 {
+	return float64(milliCpu) / ComputeUnitsToMilliCPU
+}
+
+// MemoryComputeUnits returns the BCU count equivalent to the given memory size
+// in bytes (1 BCU = 2.5 GiB).
+func MemoryComputeUnits(memoryBytes int64) float64 {
+	// TODO(vanja) make this use ComputeUnitsToRAMBytes once it's using GiB.
+	return float64(memoryBytes) / 1024 / 1024 / 1024 / 2.5
+}
+
+// DiskComputeUnits returns the BCU count equivalent to the given disk size in
+// bytes (1 BCU = 25 GiB).
+func DiskComputeUnits(diskBytes int64) float64 {
+	return float64(diskBytes) / ComputeUnitsToDiskBytes
 }
 
 func String(size *scpb.TaskSize) string {

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -1217,7 +1217,8 @@ message ExecutedActionMetadata {
   // Any compute stats (CPU/memory) that were collected during this execution.
   UsageStats usage_stats = 1002;
 
-  // Estimated task size that was used for scheduling purposes.
+  // Task size that was used for scheduling purposes. Despite the name,
+  // this is the effective task size that the executor used.
   scheduler.TaskSize estimated_task_size = 1003;
 
   // Whether the executed Action was marked with `do_not_cache`.

--- a/server/usage/sku/BUILD
+++ b/server/usage/sku/BUILD
@@ -5,4 +5,5 @@ go_library(
     srcs = ["sku.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/usage/sku",
     visibility = ["//visibility:public"],
+    deps = ["//server/util/platform"],
 )

--- a/server/usage/sku/sku.go
+++ b/server/usage/sku/sku.go
@@ -2,6 +2,8 @@ package sku
 
 import (
 	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 )
 
 // SKU is a unique, human-readable identifier tracking a specific usage count.
@@ -157,7 +159,11 @@ func GetSelfHostedLabel(isSelfHosted bool) LabelValue {
 }
 
 func GetIsolationTypeLabel(isolationType string) LabelValue {
-	return strings.ToLower(isolationType)
+	value, ok := platform.CoerceContainerType(isolationType)
+	if !ok {
+		return UnknownLabelValue
+	}
+	return value
 }
 
 // Labels represents a collection of unique label values.

--- a/server/usage/sku/sku.go
+++ b/server/usage/sku/sku.go
@@ -75,6 +75,9 @@ const (
 	// SelfHosted indicates whether the usage was incurred on a self-hosted
 	// instance of the service.
 	SelfHosted LabelName = "self_hosted"
+	// IsolationType is the effective (lower case) isolation type that ran the
+	// execution (oci, firecracker, etc.).
+	IsolationType LabelName = "isolation_type"
 	// TODO: client region (if known), server region
 )
 
@@ -151,6 +154,10 @@ func GetSelfHostedLabel(isSelfHosted bool) LabelValue {
 		return SelfHostedTrue
 	}
 	return SelfHostedFalse
+}
+
+func GetIsolationTypeLabel(isolationType string) LabelValue {
+	return strings.ToLower(isolationType)
 }
 
 // Labels represents a collection of unique label values.

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -181,15 +181,15 @@ const (
 var KnownContainerTypes []ContainerType = []ContainerType{BareContainerType, PodmanContainerType, DockerContainerType, FirecrackerContainerType, OCIContainerType, SandboxContainerType}
 
 // CoerceContainerType returns t if it's empty or in KnownContainerTypes.
-// Otherwise it returns "Unknown".
-func CoerceContainerType(t string) string {
+// Otherwise it returns "Unknown". It returns true only if t is known.
+func CoerceContainerType(t string) (string, bool) {
 	if t == "" {
-		return ""
+		return "", false
 	}
 	if slices.Contains(KnownContainerTypes, ContainerType(t)) {
-		return t
+		return t, true
 	}
-	return "unknown"
+	return "unknown", false
 }
 
 // PoolType represents the user's requested executor pool type for an executed


### PR DESCRIPTION
Since we're moving to clickhouse, only report the new SKUs in clickhouse.

Reporting them to MySQL would require creating many new fields. One per (os, arch, isolation type, self hosted) tuple.