### PR TITLE
[B] Add table to track last successful run time of billing export cron

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -1005,6 +1005,15 @@ func (*IPRule) TableName() string {
 	return "IPRules"
 }
 
+type BillingExportState struct {
+	Model
+	LastSuccessfulPeriodEndUsec int64
+}
+
+func (*BillingExportState) TableName() string {
+	return "BillingExportState"
+}
+
 type PostAutoMigrateLogic func() error
 
 // Manual migration called before auto-migration.
@@ -1519,4 +1528,5 @@ func RegisterTables() {
 	registerTable("UM", &UserListGroup{})
 	registerTable("UR", &UsageAlertingRule{})
 	registerTable("WF", &Workflow{})
+	registerTable("BE", &BillingExportState{})
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -1035,6 +1035,15 @@ func (*IPRule) TableName() string {
 	return "IPRules"
 }
 
+type BillingExportState struct {
+	Model
+	LastSuccessfulPeriodEndUsec int64
+}
+
+func (*BillingExportState) TableName() string {
+	return "BillingExportState"
+}
+
 type PostAutoMigrateLogic func() error
 
 // Manual migration called before auto-migration.
@@ -1549,4 +1558,5 @@ func RegisterTables() {
 	registerTable("UM", &UserListGroup{})
 	registerTable("UR", &UsageAlertingRule{})
 	registerTable("WF", &Workflow{})
+	registerTable("BE", &BillingExportState{})
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -1035,8 +1035,14 @@ func (*IPRule) TableName() string {
 	return "IPRules"
 }
 
+// MetronomeBillingExportDestination is the BillingExportState primary key used
+// by the Metronome usage export cron.
+const MetronomeBillingExportDestination = "metronome"
+
 type BillingExportState struct {
 	Model
+	// Destination is the billing system usage is exported to, e.g. "metronome".
+	Destination                 string `gorm:"primaryKey"`
 	LastSuccessfulPeriodEndUsec int64
 }
 
@@ -1530,6 +1536,7 @@ func RegisterTables() {
 	// Keep these sorted by two-letter prefix (and when adding new tables,
 	// use a unique prefix if possible):
 	registerTable("AK", &APIKey{})
+	registerTable("BE", &BillingExportState{})
 	registerTable("CA", &CacheEntry{})
 	registerTable("CL", &CacheLog{})
 	registerTable("EK", &EncryptionKey{})
@@ -1558,5 +1565,4 @@ func RegisterTables() {
 	registerTable("UM", &UserListGroup{})
 	registerTable("UR", &UsageAlertingRule{})
 	registerTable("WF", &Workflow{})
-	registerTable("BE", &BillingExportState{})
 }


### PR DESCRIPTION
The cron will use this to calculate the next window that should be used for the billing export