### PR TITLE
Improve color of dark+dense selected tab

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1695,6 +1695,8 @@ code .comment {
 }
 
 .dense .tab {
+  --tab-selected-color: var(--color-gray-700);
+
   margin-top: 0;
   padding: 12px 16px;
   border: 0;
@@ -1703,16 +1705,20 @@ code .comment {
   color: var(--color-text-emphasis);
 }
 
+.dark.dense .tab {
+  --tab-selected-color: var(--color-blue-gray-200);
+}
+
 .dense .tab.selected {
   background-color: transparent;
-  color: var(--color-gray-700);
+  color: var(--tab-selected-color);
   position: relative;
 }
 
 .dense .tab.selected:after {
   display: block;
   content: " ";
-  background-color: var(--color-gray-700);
+  background-color: var(--tab-selected-color);
   height: 4px;
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
Before (looks grayed out/disabled; contrast is a bit low):

<img width="581" height="518" alt="image" src="https://github.com/user-attachments/assets/7e7b30b5-67db-45d7-9d2c-59963dd8edc0" />

After (lighter gray color with a hint of blue, which kinda feels more "selected"):

<img width="581" height="518" alt="image" src="https://github.com/user-attachments/assets/a83356ca-da73-48e7-9b8c-8de0ba8c1301" />
