### PR TITLE
Remove noisy log in HasReplicaAndIsLeader

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1556,7 +1556,6 @@ func (s *Store) GetReplica(rangeID uint64) (*replica.Replica, error) {
 func (s *Store) HasReplicaAndIsLeader(rangeID uint64) bool {
 	repl, err := s.GetReplica(rangeID)
 	if err != nil {
-		s.log.Debugf("failed to get replica for range %d: %s", rangeID, err)
 		return false
 	}
 	return s.isLeader(rangeID, repl.ReplicaID())


### PR DESCRIPTION
This function is only called in `store.setupPartitions` and `txn.processTxnRecords`. In both cases, it's long running routines that can only run on meta range leaders, so this will long on every pod that doesn't have a meta range replica.