### PR TITLE
Suppress alerts for negative cached exec duration

### DIFF
--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -709,8 +709,12 @@ func (h *hitTracker) recordCacheUsage(ctx context.Context, d *repb.Digest, actio
 				execStartTime := md.GetExecutionStartTimestamp().AsTime()
 				execEndTime := md.GetExecutionCompletedTimestamp().AsTime()
 				execDuration := execEndTime.Sub(execStartTime)
-				c.TotalCachedActionExecUsec = execDuration.Microseconds()
-				skuCounts[sku.RemoteCacheACCachedExecDurationNanos] = execDuration.Nanoseconds()
+				if execDuration > 0 {
+					c.TotalCachedActionExecUsec = execDuration.Microseconds()
+					skuCounts[sku.RemoteCacheACCachedExecDurationNanos] = execDuration.Nanoseconds()
+				} else if execDuration < 0 {
+					log.CtxInfof(ctx, "Serving ActionResult with negative cached exec duration: executor_id=%q, executor_host_id=%q", md.GetExecutorId(), md.GetWorker())
+				}
 			}
 		} else {
 			c.CASCacheHits = 1


### PR DESCRIPTION
Also log the executor ID and host ID - this should help rule out whether it's an executor issue.