### PR TITLE
Fix SAML login state on one org's subdomain breaking login on other orgs' subdomains

### DIFF
--- a/enterprise/server/saml/BUILD
+++ b/enterprise/server/saml/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//server/util/log",
         "//server/util/lru",
         "//server/util/status",
-        "//server/util/subdomain",
         "@com_github_crewjam_saml//:saml",
         "@com_github_crewjam_saml//samlsp",
         "@com_github_golang_jwt_jwt_v4//:jwt",

--- a/enterprise/server/saml/BUILD
+++ b/enterprise/server/saml/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//server/util/log",
         "//server/util/lru",
         "//server/util/status",
+        "//server/util/subdomain",
         "@com_github_crewjam_saml//:saml",
         "@com_github_crewjam_saml//samlsp",
         "@com_github_golang_jwt_jwt_v4//:jwt",

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -25,7 +25,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/golang-jwt/jwt/v4"
@@ -312,7 +311,7 @@ func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *h
 
 			return claims.AuthContextWithJWT(ctx, c, err)
 		}
-	} else if slug := a.getSlugFromRequest(r); slug != "" {
+	} else if slug := cookie.GetCookie(r, slugCookie); slug != "" {
 		return authutil.AuthContextWithError(ctx, status.PermissionDeniedErrorf("Error getting service provider for slug %s: %s", slug, err.Error()))
 	}
 	return ctx
@@ -503,16 +502,15 @@ func (a *SAMLAuthenticator) serviceProviderFromRequest(r *http.Request) (*samlsp
 }
 
 func (a *SAMLAuthenticator) getSlugFromRequest(r *http.Request) string {
-	if slug := r.URL.Query().Get(slugParam); slug != "" {
-		return slug
-	}
-	slug := cookie.GetCookie(r, slugCookie)
-	// The slug cookie may be set domain-wide, in which case it can name a
-	// different org than the one the request subdomain refers to. Ignore the
-	// cookie in that case: one org's SSO affinity should not affect other
-	// orgs' subdomains.
-	if sd := subdomain.Get(subdomain.SetHost(r.Context(), r.Host)); sd != "" && sd != slug {
-		return ""
+	slug := r.URL.Query().Get(slugParam)
+	if slug == "" {
+		// Note: the slug cookie may be set domain-wide, in which case it can
+		// name a different org than the one the request subdomain refers to.
+		// This is intentional: SAML identities are scoped to a single org, so
+		// users who are members of multiple orgs rely on their SSO org's
+		// session (and slug cookie) to authenticate them on their other orgs'
+		// subdomains.
+		slug = cookie.GetCookie(r, slugCookie)
 	}
 	return slug
 }

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -269,7 +269,6 @@ func (a *SAMLAuthenticator) Login(w http.ResponseWriter, r *http.Request) error 
 	if err != nil {
 		return err
 	}
-	cookie.SetCookie(w, slugCookie, slug, time.Now().Add(cookieDuration), true /* httpOnly= */)
 	session, err := sp.Session.GetSession(r)
 	if err != nil && err != samlsp.ErrNoSession {
 		log.Warningf("SAML error getting session: %s", err)

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/golang-jwt/jwt/v4"
@@ -311,7 +312,7 @@ func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *h
 
 			return claims.AuthContextWithJWT(ctx, c, err)
 		}
-	} else if slug := cookie.GetCookie(r, slugCookie); slug != "" {
+	} else if slug := a.getSlugFromRequest(r); slug != "" {
 		return authutil.AuthContextWithError(ctx, status.PermissionDeniedErrorf("Error getting service provider for slug %s: %s", slug, err.Error()))
 	}
 	return ctx
@@ -502,9 +503,16 @@ func (a *SAMLAuthenticator) serviceProviderFromRequest(r *http.Request) (*samlsp
 }
 
 func (a *SAMLAuthenticator) getSlugFromRequest(r *http.Request) string {
-	slug := r.URL.Query().Get(slugParam)
-	if slug == "" {
-		slug = cookie.GetCookie(r, slugCookie)
+	if slug := r.URL.Query().Get(slugParam); slug != "" {
+		return slug
+	}
+	slug := cookie.GetCookie(r, slugCookie)
+	// The slug cookie may be set domain-wide, in which case it can name a
+	// different org than the one the request subdomain refers to. Ignore the
+	// cookie in that case: one org's SSO affinity should not affect other
+	// orgs' subdomains.
+	if sd := subdomain.Get(subdomain.SetHost(r.Context(), r.Host)); sd != "" && sd != slug {
+		return ""
 	}
 	return slug
 }

--- a/enterprise/server/test/webdriver/saml/saml_test.go
+++ b/enterprise/server/test/webdriver/saml/saml_test.go
@@ -17,12 +17,12 @@ const (
 	slug = "saml-test"
 )
 
-func startApp(t *testing.T, idpCertPath string, extraArgs ...string) buildbuddy_enterprise.WebTarget {
+func startApp(t *testing.T, idp *testsaml.IDP, extraArgs ...string) buildbuddy_enterprise.WebTarget {
 	appCert, appKey := testsaml.CreateSelfSignedCert(t)
 	args := append([]string{
 		"--auth.saml.key=" + string(appKey),
 		"--auth.saml.cert=" + string(appCert),
-		"--auth.saml.trusted_idp_cert_files=" + idpCertPath,
+		"--auth.saml.trusted_idp_cert_files=" + idp.CertPath,
 	}, extraArgs...)
 	bb := buildbuddy_enterprise.SetupWebTarget(t, args...)
 	return bb
@@ -30,7 +30,7 @@ func startApp(t *testing.T, idpCertPath string, extraArgs ...string) buildbuddy_
 
 // Creates the org with slug "saml-test" and configures the SAML IDP metadata
 // URL in the DB.
-func setupSAMLTestOrg(t *testing.T, wt *webtester.WebTester, bb buildbuddy_enterprise.WebTarget, idp *mocksaml.IDP) {
+func setupSAMLTestOrg(t *testing.T, wt *webtester.WebTester, bb buildbuddy_enterprise.WebTarget, idp *testsaml.IDP) {
 	// Temporarily log in with self-auth, then configure an org slug in settings
 	// (it's empty by default).
 	webtester.Login(wt, bb)
@@ -56,8 +56,8 @@ func TestSAMLBasicLogin(t *testing.T) {
 	// metadata URL, so only run this test locally for now.
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
-	idp, idpCertPath := testsaml.Start(t)
-	bb := startApp(t, idpCertPath)
+	idp := testsaml.Start(t)
+	bb := startApp(t, idp)
 	wt := webtester.New(t)
 	setupSAMLTestOrg(t, wt, bb, idp)
 
@@ -77,10 +77,10 @@ func TestSAMLViewInvocation(t *testing.T) {
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
 	ctx := context.Background()
-	idp, idpCertPath := testsaml.Start(t)
+	idp := testsaml.Start(t)
 	// Disable persisting artifacts in blobstore to exercise that cache auth
 	// accesses via the UI work when logged in with SAML.
-	bb := startApp(t, idpCertPath, "--storage.disable_persist_cache_artifacts=true")
+	bb := startApp(t, idp, "--storage.disable_persist_cache_artifacts=true")
 	wt := webtester.New(t)
 	setupSAMLTestOrg(t, wt, bb, idp)
 

--- a/enterprise/server/test/webdriver/saml/saml_test.go
+++ b/enterprise/server/test/webdriver/saml/saml_test.go
@@ -1,23 +1,14 @@
 package saml_test
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
 	"testing"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testsaml"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/mocksaml"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
 	"github.com/stretchr/testify/require"
 )
@@ -26,22 +17,8 @@ const (
 	slug = "saml-test"
 )
 
-func startIDP(t *testing.T) (_ *mocksaml.IDP, certPath string) {
-	idpCert, idpKey := createSelfSignedCert(t)
-	idp, err := mocksaml.Start(testport.FindFree(t), bytes.NewReader(idpCert), bytes.NewReader(idpKey))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = idp.Kill() })
-	err = idp.WaitUntilReady(context.Background())
-	require.NoError(t, err)
-	idpCertFile := testfs.CreateTemp(t)
-	_, err = idpCertFile.Write(idpCert)
-	require.NoError(t, err)
-	_ = idpCertFile.Close()
-	return idp, idpCertFile.Name()
-}
-
 func startApp(t *testing.T, idpCertPath string, extraArgs ...string) buildbuddy_enterprise.WebTarget {
-	appCert, appKey := createSelfSignedCert(t)
+	appCert, appKey := testsaml.CreateSelfSignedCert(t)
 	args := append([]string{
 		"--auth.saml.key=" + string(appKey),
 		"--auth.saml.cert=" + string(appCert),
@@ -79,7 +56,7 @@ func TestSAMLBasicLogin(t *testing.T) {
 	// metadata URL, so only run this test locally for now.
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
-	idp, idpCertPath := startIDP(t)
+	idp, idpCertPath := testsaml.Start(t)
 	bb := startApp(t, idpCertPath)
 	wt := webtester.New(t)
 	setupSAMLTestOrg(t, wt, bb, idp)
@@ -100,7 +77,7 @@ func TestSAMLViewInvocation(t *testing.T) {
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
 	ctx := context.Background()
-	idp, idpCertPath := startIDP(t)
+	idp, idpCertPath := testsaml.Start(t)
 	// Disable persisting artifacts in blobstore to exercise that cache auth
 	// accesses via the UI work when logged in with SAML.
 	bb := startApp(t, idpCertPath, "--storage.disable_persist_cache_artifacts=true")
@@ -128,26 +105,4 @@ func TestSAMLViewInvocation(t *testing.T) {
 	wt.Get(bb.HTTPURL() + "/invocation/" + buildResult.InvocationID)
 	wt.Find(`[href="#timing"]`).Click()
 	wt.Find(`.trace-viewer`)
-}
-
-func createSelfSignedCert(t *testing.T) (cert, key []byte) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	certTemplate := x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{Organization: []string{"mocksaml"}},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-	}
-	certBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &privateKey.PublicKey, privateKey)
-	require.NoError(t, err)
-	var certBuf, keyBuf bytes.Buffer
-	err = pem.Encode(&keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
-	require.NoError(t, err)
-	err = pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
-	require.NoError(t, err)
-	return certBuf.Bytes(), keyBuf.Bytes()
 }

--- a/enterprise/server/test/webdriver/subdomains/BUILD
+++ b/enterprise/server/test/webdriver/subdomains/BUILD
@@ -3,8 +3,8 @@ load("//rules/webdriver:index.bzl", "go_web_test_suite")
 package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_web_test_suite(
-    name = "saml_test",
-    srcs = ["saml_test.go"],
+    name = "subdomains_test",
+    srcs = ["subdomains_test.go"],
     exec_properties = {
         "test.EstimatedComputeUnits": "3",
         "test.workload-isolation-type": "firecracker",
@@ -18,8 +18,7 @@ go_web_test_suite(
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//enterprise/server/testutil/testsaml",
         "//enterprise/server/util/mocksaml",
-        "//server/testutil/app",
-        "//server/testutil/testbazel",
+        "//server/testutil/testhosts",
         "//server/testutil/webtester",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/test/webdriver/subdomains/BUILD
+++ b/enterprise/server/test/webdriver/subdomains/BUILD
@@ -18,6 +18,7 @@ go_web_test_suite(
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//enterprise/server/testutil/testsaml",
         "//enterprise/server/util/mocksaml",
+        "//server/testutil/app",
         "//server/testutil/testhosts",
         "//server/testutil/webtester",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/test/webdriver/subdomains/BUILD
+++ b/enterprise/server/test/webdriver/subdomains/BUILD
@@ -12,7 +12,7 @@ go_web_test_suite(
         "test.init-dockerd": "true",
         "test.runner-recycling-key": "mocksaml",
     },
-    shard_count = 1,
+    shard_count = 3,
     tags = ["docker"],
     deps = [
         "//enterprise/server/testutil/buildbuddy_enterprise",

--- a/enterprise/server/test/webdriver/subdomains/subdomains_test.go
+++ b/enterprise/server/test/webdriver/subdomains/subdomains_test.go
@@ -26,17 +26,25 @@ const (
 	orgBSlug = "org-b"
 )
 
-// Regression test for the issue where starting (but not completing) a SAML
-// login on one org's subdomain would break the login page on every other
-// subdomain, redirecting users to the first org's SAML IDP. Repro steps:
-//
-//  1. Open a new incognito window
-//  2. Go to org A's subdomain (org A uses SAML)
-//  3. Click the SSO login button, but abandon the login flow without
-//     signing in to the IDP
-//  4. Go to org B's subdomain
-//  5. Org A's SAML login now appears (full screen)
-func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
+// testEnv is a running app with subdomain handling enabled and two orgs set
+// up: org A, which uses SAML via a mock IDP, and org B, which doesn't use
+// SAML.
+type testEnv struct {
+	wt *webtester.WebTester
+
+	// appURL is the URL of the app's default "app" subdomain.
+	appURL string
+	// orgAURL is the URL of org A's subdomain.
+	orgAURL string
+	// orgBURL is the URL of org B's subdomain.
+	orgBURL string
+	// orgBHost is the host:port part of orgBURL.
+	orgBHost string
+	// idpHost is the host:port that the mock SAML IDP is served on.
+	idpHost string
+}
+
+func setup(t *testing.T) *testEnv {
 	// We need to directly connect to the DB in order to set the SAML IDP
 	// metadata URL, so only run this test locally for now.
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
@@ -48,19 +56,24 @@ func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
 	)
 
 	idp, idpCertPath := testsaml.Start(t)
+	idpURL, err := url.Parse(idp.MetadataURL())
+	require.NoError(t, err)
 
 	appConfig := buildbuddy_enterprise.DefaultAppConfig(t)
-	appURL := fmt.Sprintf("http://app.%s:%d", domain, appConfig.HttpPort)
-	orgAURL := fmt.Sprintf("http://%s.%s:%d", orgASlug, domain, appConfig.HttpPort)
-	orgBHost := fmt.Sprintf("%s.%s:%d", orgBSlug, domain, appConfig.HttpPort)
-	orgBURL := "http://" + orgBHost
+	env := &testEnv{
+		appURL:   fmt.Sprintf("http://app.%s:%d", domain, appConfig.HttpPort),
+		orgAURL:  fmt.Sprintf("http://%s.%s:%d", orgASlug, domain, appConfig.HttpPort),
+		orgBHost: fmt.Sprintf("%s.%s:%d", orgBSlug, domain, appConfig.HttpPort),
+		idpHost:  idpURL.Host,
+	}
+	env.orgBURL = "http://" + env.orgBHost
 	appCert, appKey := testsaml.CreateSelfSignedCert(t)
 	bb := buildbuddy_enterprise.RunWithConfig(t, appConfig, buildbuddy_enterprise.DefaultConfig,
 		"--auth.saml.key="+string(appKey),
 		"--auth.saml.cert="+string(appCert),
 		"--auth.saml.trusted_idp_cert_files="+idpCertPath,
 		// Enable subdomain handling, mirroring the dev/prod config.
-		"--app.build_buddy_url="+appURL,
+		"--app.build_buddy_url="+env.appURL,
 		"--app.enable_subdomain_matching=true",
 		"--app.default_subdomains=app",
 		"--auth.domain_wide_cookies=true",
@@ -68,22 +81,22 @@ func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
 	)
 
 	wt := webtester.New(t)
+	env.wt = wt
 
 	// Temporarily log in with self-auth on the default "app" subdomain to
 	// create two orgs: org A (which uses SAML) and org B (which doesn't).
 	// Since popup auth is enabled, the login completes asynchronously via a
 	// popup window, so wait for the sidebar with a generous timeout.
-	wt.Get(appURL)
+	wt.Get(env.appURL)
 	wt.FindByDebugID("login-button").Click()
 	wt.FindWithTimeout(`[debug-id="org-picker"]`, 30*time.Second)
-	webtester.UpdateSelectedOrg(wt, appURL, "Org A", orgASlug)
-	webtester.CreateOrg(wt, appURL, "Org B", orgBSlug)
+	webtester.UpdateSelectedOrg(wt, env.appURL, "Org A", orgASlug)
+	webtester.CreateOrg(wt, env.appURL, "Org B", orgBSlug)
 	// Creating an org selects it, which redirects the browser to the new
 	// org's subdomain. Wait for the redirect to complete.
 	require.Eventually(t, func() bool {
 		u, err := url.Parse(wt.CurrentURL())
-		require.NoError(t, err)
-		return u.Host == orgBHost
+		return err == nil && u.Host == env.orgBHost
 	}, 30*time.Second, 100*time.Millisecond, "never got redirected to org B's subdomain after creating org B")
 	// Configure SAML for org A by manually executing a DB query.
 	res := bb.DB().Exec(`
@@ -98,38 +111,134 @@ func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
 	require.Greater(t, res.RowsAffected, int64(0), "no groups matched slug %s", orgASlug)
 	webtester.Logout(wt)
 
-	// Go to org A's subdomain and click its SSO login button, which starts
-	// the SAML login flow in a popup window.
-	wt.Get(orgAURL)
+	return env
+}
+
+// Regression test for the issue where starting (but not completing) a SAML
+// login on one org's subdomain would break the login page on every other
+// subdomain, redirecting users to the first org's SAML IDP. Repro steps:
+//
+//  1. Open a new incognito window
+//  2. Go to org A's subdomain (org A uses SAML)
+//  3. Click the SSO login button, but abandon the login flow without
+//     signing in to the IDP
+//  4. Go to org B's subdomain
+//  5. Org A's SAML login now appears (full screen)
+func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
+	env := setup(t)
+
+	startSSOLogin(t, env)
+
+	// Abandon the SAML login and go to org B's subdomain in the main window.
+	env.wt.Get(env.orgBURL)
+	requireStaysOnOrgBLoginPage(t, env)
+}
+
+// Logging into org A via SAML should not affect other orgs' subdomains,
+// neither while the org A session is valid nor after it expires.
+func TestSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
+	env := setup(t)
+
+	popupWindow := startSSOLogin(t, env)
+	completeSSOLogin(t, env, popupWindow)
+
+	// A SAML session is only valid for the org it belongs to, so org B's
+	// subdomain should show org B's login page.
+	env.wt.Get(env.orgBURL)
+	env.wt.FindWithTimeout(`[debug-id="login-button"]`, 10*time.Second)
+
+	// Simulate the org A SAML session expiring. This deletes the session
+	// itself but keeps the rest of the SAML login state, such as the cookie
+	// remembering which org's SSO the user logs in with.
+	expireSAMLSession(t, env)
+
+	// Org B's subdomain should still show org B's login page rather than
+	// restarting the SAML login flow with org A's IDP.
+	env.wt.Get(env.orgBURL)
+	requireStaysOnOrgBLoginPage(t, env)
+}
+
+// Once a SAML login has completed, an expired session should still seamlessly
+// log back in with the org's IDP on the org's own subdomain and on default
+// subdomains, which aren't tied to any particular org.
+func TestExpiredSAMLSessionSeamlesslyLogsBackIn(t *testing.T) {
+	env := setup(t)
+
+	popupWindow := startSSOLogin(t, env)
+	completeSSOLogin(t, env, popupWindow)
+	expireSAMLSession(t, env)
+
+	// Returning to org A's own subdomain should automatically restart the
+	// SAML login flow with org A's IDP.
+	env.wt.Get(env.orgAURL)
+	requireEventuallyOnHost(t, env, env.idpHost)
+
+	// Same for the default "app" subdomain.
+	env.wt.Get(env.appURL)
+	requireEventuallyOnHost(t, env, env.idpHost)
+}
+
+// startSSOLogin goes to org A's login page and clicks its SSO login button,
+// which starts the SAML login flow in a popup window. It waits for the popup
+// to land on the IDP's sign-in page, which guarantees that the app has
+// handled the SAML login request, then re-focuses the main window, leaving
+// the popup open on the sign-in page. Returns the popup window handle.
+func startSSOLogin(t *testing.T, env *testEnv) (popupWindow string) {
+	wt := env.wt
+	wt.Get(env.orgAURL)
 	mainWindow := wt.CurrentWindowHandle()
 	wt.FindWithTimeout(`[debug-id="sso-button"]`, 10*time.Second).Click()
-	popupWindow := waitForNewWindow(t, wt, mainWindow)
-
-	// Wait for the popup to land on the IDP's sign-in page, which guarantees
-	// that the app has handled the SAML login request.
+	popupWindow = waitForNewWindow(t, wt, mainWindow)
 	wt.SwitchWindow(popupWindow)
 	wt.FindWithTimeout(mocksaml.SignInButtonSelector, 10*time.Second)
 	wt.SwitchWindow(mainWindow)
+	return popupWindow
+}
 
-	// Abandon the SAML login and go to org B's subdomain in the main window.
-	wt.Get(orgBURL)
+// completeSSOLogin signs in at the IDP in the popup window opened by
+// startSSOLogin, then waits for the main window to pick up the completed
+// login.
+func completeSSOLogin(t *testing.T, env *testEnv, popupWindow string) {
+	wt := env.wt
+	mainWindow := wt.CurrentWindowHandle()
+	wt.SwitchWindow(popupWindow)
+	wt.Find(mocksaml.SignInButtonSelector).Click()
+	wt.SwitchWindow(mainWindow)
+	wt.FindWithTimeout(`[debug-id="org-picker"]`, 30*time.Second)
+}
 
-	// Watch the page for a few seconds to make sure we stay on org B's login
-	// page: with the original bug, the app's auto-login logic kicks in
-	// shortly after the login page loads, picking up org A's slug from the
-	// domain-wide "Slug" cookie set during the abandoned login attempt and
-	// redirecting the page to org A's SAML IDP.
+// expireSAMLSession simulates the SAML session expiring by deleting the SAML
+// session cookie from the browser.
+func expireSAMLSession(t *testing.T, env *testEnv) {
+	env.wt.DeleteCookie("token")
+}
+
+// requireStaysOnOrgBLoginPage asserts that the browser shows org B's login
+// page and stays on it. With the original bug, the app's auto-login logic
+// kicks in shortly after the login page loads, picking up org A's slug from
+// the domain-wide "Slug" cookie and redirecting the page to org A's SAML
+// IDP, so keep watching the page for a few seconds.
+func requireStaysOnOrgBLoginPage(t *testing.T, env *testEnv) {
 	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
-		u, err := url.Parse(wt.CurrentURL())
+		u, err := url.Parse(env.wt.CurrentURL())
 		require.NoError(t, err)
-		require.Equal(t, orgBHost, u.Host,
+		require.Equal(t, env.orgBHost, u.Host,
 			"expected to stay on org B's login page, but got redirected to %q (org A's SAML login?)", u)
 		time.Sleep(100 * time.Millisecond)
 	}
-	// Org B's login page should be shown. Org B doesn't use SAML, so the
-	// plain login button should appear rather than an SSO button.
-	wt.Find(`[debug-id="login-button"]`)
-	wt.AssertNotFound(`[debug-id="sso-button"]`)
+	// Org B doesn't use SAML, so the plain login button should be shown
+	// rather than an SSO button.
+	env.wt.Find(`[debug-id="login-button"]`)
+	env.wt.AssertNotFound(`[debug-id="sso-button"]`)
+}
+
+// requireEventuallyOnHost waits for the browser to land on a URL with the
+// given host.
+func requireEventuallyOnHost(t *testing.T, env *testEnv, host string) {
+	require.Eventually(t, func() bool {
+		u, err := url.Parse(env.wt.CurrentURL())
+		return err == nil && u.Host == host
+	}, 20*time.Second, 100*time.Millisecond, "expected to get redirected to %s", host)
 }
 
 // waitForNewWindow waits for a window to be opened that is not in the given

--- a/enterprise/server/test/webdriver/subdomains/subdomains_test.go
+++ b/enterprise/server/test/webdriver/subdomains/subdomains_test.go
@@ -1,0 +1,156 @@
+package subdomains_test
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testsaml"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/mocksaml"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testhosts"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// domain is the domain that the app is served on, with the app itself on
+	// the "app" subdomain and orgs on customer subdomains, mirroring the
+	// subdomain setup on buildbuddy.io. The hostnames are statically
+	// configured in /etc/hosts.
+	domain = "buildbuddy.local"
+
+	orgASlug = "org-a"
+	orgBSlug = "org-b"
+)
+
+// Regression test for the issue where starting (but not completing) a SAML
+// login on one org's subdomain would break the login page on every other
+// subdomain, redirecting users to the first org's SAML IDP. Repro steps:
+//
+//  1. Open a new incognito window
+//  2. Go to org A's subdomain (org A uses SAML)
+//  3. Click the SSO login button - it should open a pop-up window. Just
+//     close the pop-up
+//  4. Go to org B's subdomain
+//  5. Org A's SAML login now appears (full screen)
+func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
+	// We need to directly connect to the DB in order to set the SAML IDP
+	// metadata URL, so only run this test locally for now.
+	buildbuddy_enterprise.MarkTestLocalOnly(t)
+
+	testhosts.Add(t, "127.0.0.1",
+		"app."+domain,
+		orgASlug+"."+domain,
+		orgBSlug+"."+domain,
+	)
+
+	idp, idpCertPath := testsaml.Start(t)
+
+	appConfig := buildbuddy_enterprise.DefaultAppConfig(t)
+	appURL := fmt.Sprintf("http://app.%s:%d", domain, appConfig.HttpPort)
+	orgAURL := fmt.Sprintf("http://%s.%s:%d", orgASlug, domain, appConfig.HttpPort)
+	orgBHost := fmt.Sprintf("%s.%s:%d", orgBSlug, domain, appConfig.HttpPort)
+	orgBURL := "http://" + orgBHost
+	appCert, appKey := testsaml.CreateSelfSignedCert(t)
+	bb := buildbuddy_enterprise.RunWithConfig(t, appConfig, buildbuddy_enterprise.DefaultConfig,
+		"--auth.saml.key="+string(appKey),
+		"--auth.saml.cert="+string(appCert),
+		"--auth.saml.trusted_idp_cert_files="+idpCertPath,
+		// Enable subdomain handling, mirroring the dev/prod config.
+		"--app.build_buddy_url="+appURL,
+		"--app.enable_subdomain_matching=true",
+		"--app.default_subdomains=app",
+		"--auth.domain_wide_cookies=true",
+		"--app.popup_auth_enabled=true",
+	)
+
+	wt := webtester.New(t)
+
+	// Temporarily log in with self-auth on the default "app" subdomain to
+	// create two orgs: org A (which uses SAML) and org B (which doesn't).
+	// Since popup auth is enabled, the login completes asynchronously via a
+	// popup window, so wait for the sidebar with a generous timeout.
+	wt.Get(appURL)
+	wt.FindByDebugID("login-button").Click()
+	wt.FindWithTimeout(`[debug-id="org-picker"]`, 30*time.Second)
+	webtester.UpdateSelectedOrg(wt, appURL, "Org A", orgASlug)
+	webtester.CreateOrg(wt, appURL, "Org B", orgBSlug)
+	// Creating an org selects it, which redirects the browser to the new
+	// org's subdomain. Wait for the redirect to complete.
+	require.Eventually(t, func() bool {
+		u, err := url.Parse(wt.CurrentURL())
+		require.NoError(t, err)
+		return u.Host == orgBHost
+	}, 30*time.Second, 100*time.Millisecond, "never got redirected to org B's subdomain after creating org B")
+	// Configure SAML for org A by manually executing a DB query.
+	res := bb.DB().Exec(`
+		UPDATE "Groups"
+		SET saml_idp_metadata_url = ?
+		WHERE url_identifier = ?
+		`,
+		idp.MetadataURL(),
+		orgASlug,
+	)
+	require.NoError(t, res.Error)
+	require.Greater(t, res.RowsAffected, int64(0), "no groups matched slug %s", orgASlug)
+	webtester.Logout(wt)
+
+	// Go to org A's subdomain and click its SSO login button, which starts
+	// the SAML login flow in a popup window.
+	wt.Get(orgAURL)
+	mainWindow := wt.CurrentWindowHandle()
+	wt.FindWithTimeout(`[debug-id="sso-button"]`, 10*time.Second).Click()
+	popupWindow := waitForNewWindow(t, wt, mainWindow)
+
+	// Wait for the popup to land on the IDP's sign-in page, which guarantees
+	// that the app has handled the SAML login request.
+	wt.SwitchWindow(popupWindow)
+	wt.FindWithTimeout(mocksaml.SignInButtonSelector, 10*time.Second)
+	wt.SwitchWindow(mainWindow)
+
+	// Abandon the SAML login and go to org B's subdomain in the main window.
+	//
+	// Note: the popup is intentionally left open rather than closed as in
+	// the original repro steps. By this point the app has already recorded
+	// the abandoned login attempt (via cookies), which is what triggers the
+	// bug; closing the popup just additionally shows an expected
+	// "Authentication popup closed" error banner in the opener window, and
+	// the webtester fails any test that displays an error banner.
+	wt.Get(orgBURL)
+
+	// Watch the page for a few seconds to make sure we stay on org B's login
+	// page: with the original bug, the app's auto-login logic kicks in
+	// shortly after the login page loads, picking up org A's slug from the
+	// domain-wide "Slug" cookie set during the abandoned login attempt and
+	// redirecting the page to org A's SAML IDP.
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		u, err := url.Parse(wt.CurrentURL())
+		require.NoError(t, err)
+		require.Equal(t, orgBHost, u.Host,
+			"expected to stay on org B's login page, but got redirected to %q (org A's SAML login?)", u)
+		time.Sleep(100 * time.Millisecond)
+	}
+	// Org B's login page should be shown. Org B doesn't use SAML, so the
+	// plain login button should appear rather than an SSO button.
+	wt.Find(`[debug-id="login-button"]`)
+	wt.AssertNotFound(`[debug-id="sso-button"]`)
+}
+
+// waitForNewWindow waits for a window to be opened that is not in the given
+// list of existing window handles, and returns its handle.
+func waitForNewWindow(t *testing.T, wt *webtester.WebTester, existing ...string) string {
+	var newWindow string
+	require.Eventually(t, func() bool {
+		for _, handle := range wt.WindowHandles() {
+			if !slices.Contains(existing, handle) {
+				newWindow = handle
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for popup window to open")
+	return newWindow
+}

--- a/enterprise/server/test/webdriver/subdomains/subdomains_test.go
+++ b/enterprise/server/test/webdriver/subdomains/subdomains_test.go
@@ -55,7 +55,7 @@ func setup(t *testing.T) *testEnv {
 		orgBSlug+"."+domain,
 	)
 
-	idp, idpCertPath := testsaml.Start(t)
+	idp := testsaml.Start(t)
 	idpURL, err := url.Parse(idp.MetadataURL())
 	require.NoError(t, err)
 
@@ -71,7 +71,7 @@ func setup(t *testing.T) *testEnv {
 	bb := buildbuddy_enterprise.RunWithConfig(t, appConfig, buildbuddy_enterprise.DefaultConfig,
 		"--auth.saml.key="+string(appKey),
 		"--auth.saml.cert="+string(appCert),
-		"--auth.saml.trusted_idp_cert_files="+idpCertPath,
+		"--auth.saml.trusted_idp_cert_files="+idp.CertPath,
 		// Enable subdomain handling, mirroring the dev/prod config.
 		"--app.build_buddy_url="+env.appURL,
 		"--app.enable_subdomain_matching=true",

--- a/enterprise/server/test/webdriver/subdomains/subdomains_test.go
+++ b/enterprise/server/test/webdriver/subdomains/subdomains_test.go
@@ -32,8 +32,8 @@ const (
 //
 //  1. Open a new incognito window
 //  2. Go to org A's subdomain (org A uses SAML)
-//  3. Click the SSO login button - it should open a pop-up window. Just
-//     close the pop-up
+//  3. Click the SSO login button, but abandon the login flow without
+//     signing in to the IDP
 //  4. Go to org B's subdomain
 //  5. Org A's SAML login now appears (full screen)
 func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
@@ -112,13 +112,6 @@ func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
 	wt.SwitchWindow(mainWindow)
 
 	// Abandon the SAML login and go to org B's subdomain in the main window.
-	//
-	// Note: the popup is intentionally left open rather than closed as in
-	// the original repro steps. By this point the app has already recorded
-	// the abandoned login attempt (via cookies), which is what triggers the
-	// bug; closing the popup just additionally shows an expected
-	// "Authentication popup closed" error banner in the opener window, and
-	// the webtester fails any test that displays an error banner.
 	wt.Get(orgBURL)
 
 	// Watch the page for a few seconds to make sure we stay on org B's login

--- a/enterprise/server/test/webdriver/subdomains/subdomains_test.go
+++ b/enterprise/server/test/webdriver/subdomains/subdomains_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testsaml"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/mocksaml"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testhosts"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,7 @@ const (
 // SAML.
 type testEnv struct {
 	wt *webtester.WebTester
+	bb *app.App
 
 	// appURL is the URL of the app's default "app" subdomain.
 	appURL string
@@ -80,6 +82,7 @@ func setup(t *testing.T) *testEnv {
 		"--app.popup_auth_enabled=true",
 	)
 
+	env.bb = bb
 	wt := webtester.New(t)
 	env.wt = wt
 
@@ -134,28 +137,34 @@ func TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
 	requireStaysOnOrgBLoginPage(t, env)
 }
 
-// Logging into org A via SAML should not affect other orgs' subdomains,
-// neither while the org A session is valid nor after it expires.
-func TestSAMLLoginDoesNotAffectOtherSubdomains(t *testing.T) {
+// SAML identities are scoped to a single org, so users who are members of
+// multiple orgs (orgs commonly share a SAML IDP) rely on their SSO org's
+// session to authenticate them on their other orgs' subdomains. An org A
+// SAML session should authenticate the user on org B's subdomain, and once
+// the session expires, org B's subdomain should log back in via org A's IDP.
+func TestSAMLSessionAuthenticatesOnOtherOrgSubdomains(t *testing.T) {
 	env := setup(t)
 
 	popupWindow := startSSOLogin(t, env)
 	completeSSOLogin(t, env, popupWindow)
+	addSAMLUserToOrgB(t, env)
 
-	// A SAML session is only valid for the org it belongs to, so org B's
-	// subdomain should show org B's login page.
+	// The org A SAML session should authenticate the user on org B's
+	// subdomain.
 	env.wt.Get(env.orgBURL)
-	env.wt.FindWithTimeout(`[debug-id="login-button"]`, 10*time.Second)
+	env.wt.FindWithTimeout(`[debug-id="org-picker"]`, 20*time.Second)
 
-	// Simulate the org A SAML session expiring. This deletes the session
-	// itself but keeps the rest of the SAML login state, such as the cookie
-	// remembering which org's SSO the user logs in with.
+	// Once the session expires, org B's subdomain should automatically log
+	// back in via org A's IDP.
 	expireSAMLSession(t, env)
-
-	// Org B's subdomain should still show org B's login page rather than
-	// restarting the SAML login flow with org A's IDP.
 	env.wt.Get(env.orgBURL)
-	requireStaysOnOrgBLoginPage(t, env)
+	requireEventuallyOnHost(t, env, env.idpHost)
+
+	// Completing the re-login at the IDP should land back on org B's
+	// subdomain, logged in.
+	env.wt.Find(mocksaml.SignInButtonSelector).Click()
+	requireEventuallyOnHost(t, env, env.orgBHost)
+	env.wt.FindWithTimeout(`[debug-id="org-picker"]`, 20*time.Second)
 }
 
 // Once a SAML login has completed, an expired session should still seamlessly
@@ -211,6 +220,27 @@ func completeSSOLogin(t *testing.T, env *testEnv, popupWindow string) {
 // session cookie from the browser.
 func expireSAMLSession(t *testing.T, env *testEnv) {
 	env.wt.DeleteCookie("token")
+}
+
+// addSAMLUserToOrgB makes the SAML user, who became a member of org A by
+// logging in via org A's IDP, a member of org B as well, by copying their
+// org A membership row.
+func addSAMLUserToOrgB(t *testing.T, env *testEnv) {
+	res := env.bb.DB().Exec(`
+		INSERT INTO "UserGroups" (user_user_id, group_group_id, role, membership_status)
+		SELECT ug.user_user_id, gb.group_id, ug.role, ug.membership_status
+		FROM "UserGroups" ug
+		JOIN "Users" u ON u.user_id = ug.user_user_id
+		JOIN "Groups" ga ON ga.group_id = ug.group_group_id
+		JOIN "Groups" gb ON gb.url_identifier = ?
+		WHERE ga.url_identifier = ? AND u.sub_id LIKE ('%saml/metadata?slug=' || ? || '/%')
+		`,
+		orgBSlug,
+		orgASlug,
+		orgASlug,
+	)
+	require.NoError(t, res.Error)
+	require.EqualValues(t, 1, res.RowsAffected, "expected to find exactly one org A SAML user membership to copy")
 }
 
 // requireStaysOnOrgBLoginPage asserts that the browser shows org B's login

--- a/enterprise/server/testutil/testsaml/BUILD
+++ b/enterprise/server/testutil/testsaml/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "testsaml",
+    testonly = 1,
+    srcs = ["testsaml.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testsaml",
+    deps = [
+        "//enterprise/server/util/mocksaml",
+        "//server/testutil/testfs",
+        "//server/testutil/testport",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/testutil/testsaml/testsaml.go
+++ b/enterprise/server/testutil/testsaml/testsaml.go
@@ -19,13 +19,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// IDP is a mock SAML IDP scoped to a test.
+type IDP struct {
+	*mocksaml.IDP
+
+	// CertPath is the path to a PEM file containing the certificate that the
+	// IDP signs assertions with, suitable for passing to the app via the
+	// --auth.saml.trusted_idp_cert_files flag.
+	CertPath string
+}
+
 // Start starts a mock SAML IDP on a free port and waits for it to become
 // ready. The IDP is shut down when the test completes.
-//
-// It also returns the path to a PEM file containing the certificate that the
-// IDP signs assertions with, suitable for passing to the app via the
-// --auth.saml.trusted_idp_cert_files flag.
-func Start(t *testing.T) (_ *mocksaml.IDP, certPath string) {
+func Start(t *testing.T) *IDP {
 	idpCert, idpKey := CreateSelfSignedCert(t)
 	idp, err := mocksaml.Start(testport.FindFree(t), bytes.NewReader(idpCert), bytes.NewReader(idpKey))
 	require.NoError(t, err)
@@ -36,7 +42,7 @@ func Start(t *testing.T) (_ *mocksaml.IDP, certPath string) {
 	_, err = idpCertFile.Write(idpCert)
 	require.NoError(t, err)
 	_ = idpCertFile.Close()
-	return idp, idpCertFile.Name()
+	return &IDP{IDP: idp, CertPath: idpCertFile.Name()}
 }
 
 // CreateSelfSignedCert generates a self-signed cert and returns the

--- a/enterprise/server/testutil/testsaml/testsaml.go
+++ b/enterprise/server/testutil/testsaml/testsaml.go
@@ -1,0 +1,64 @@
+// Package testsaml provides helpers for using a mock SAML IDP in tests.
+package testsaml
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/mocksaml"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
+	"github.com/stretchr/testify/require"
+)
+
+// Start starts a mock SAML IDP on a free port and waits for it to become
+// ready. The IDP is shut down when the test completes.
+//
+// It also returns the path to a PEM file containing the certificate that the
+// IDP signs assertions with, suitable for passing to the app via the
+// --auth.saml.trusted_idp_cert_files flag.
+func Start(t *testing.T) (_ *mocksaml.IDP, certPath string) {
+	idpCert, idpKey := CreateSelfSignedCert(t)
+	idp, err := mocksaml.Start(testport.FindFree(t), bytes.NewReader(idpCert), bytes.NewReader(idpKey))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = idp.Kill() })
+	err = idp.WaitUntilReady(context.Background())
+	require.NoError(t, err)
+	idpCertFile := testfs.CreateTemp(t)
+	_, err = idpCertFile.Write(idpCert)
+	require.NoError(t, err)
+	_ = idpCertFile.Close()
+	return idp, idpCertFile.Name()
+}
+
+// CreateSelfSignedCert generates a self-signed cert and returns the
+// PEM-encoded certificate and private key.
+func CreateSelfSignedCert(t *testing.T) (cert, key []byte) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	certTemplate := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"mocksaml"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+	var certBuf, keyBuf bytes.Buffer
+	err = pem.Encode(&keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	require.NoError(t, err)
+	err = pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	require.NoError(t, err)
+	return certBuf.Bytes(), keyBuf.Bytes()
+}

--- a/server/testutil/testhosts/BUILD
+++ b/server/testutil/testhosts/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testhosts",
+    testonly = 1,
+    srcs = ["testhosts.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testhosts",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/server/testutil/testhosts/testhosts.go
+++ b/server/testutil/testhosts/testhosts.go
@@ -1,0 +1,43 @@
+// Package testhosts provides helpers for configuring static hostname
+// mappings in /etc/hosts for the duration of a test.
+//
+// Modifying /etc/hosts requires root privileges, so tests using this package
+// are expected to run with workload isolation (e.g. firecracker), where the
+// test runs as root and any modifications are scoped to the VM.
+package testhosts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const hostsFilePath = "/etc/hosts"
+
+// Add appends entries to /etc/hosts mapping each of the given hostnames to
+// the given IP address, and registers a cleanup function to restore the
+// original /etc/hosts contents when the test completes.
+//
+// The test is skipped if it is not running as root, since root privileges
+// are required to modify /etc/hosts.
+func Add(t *testing.T, ip string, hostnames ...string) {
+	if os.Geteuid() != 0 {
+		t.Skipf("test requires root privileges to modify %s", hostsFilePath)
+	}
+	stat, err := os.Stat(hostsFilePath)
+	require.NoError(t, err)
+	original, err := os.ReadFile(hostsFilePath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.WriteFile(hostsFilePath, original, stat.Mode()))
+	})
+	contents := string(original)
+	if !strings.HasSuffix(contents, "\n") {
+		contents += "\n"
+	}
+	contents += fmt.Sprintf("%s %s\n", ip, strings.Join(hostnames, " "))
+	require.NoError(t, os.WriteFile(hostsFilePath, []byte(contents), stat.Mode()))
+}

--- a/server/testutil/testhosts/testhosts.go
+++ b/server/testutil/testhosts/testhosts.go
@@ -27,17 +27,16 @@ func Add(t *testing.T, ip string, hostnames ...string) {
 	if os.Geteuid() != 0 {
 		t.Skipf("test requires root privileges to modify %s", hostsFilePath)
 	}
-	stat, err := os.Stat(hostsFilePath)
-	require.NoError(t, err)
 	original, err := os.ReadFile(hostsFilePath)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, os.WriteFile(hostsFilePath, original, stat.Mode()))
+		// Note: the mode is ignored since the file already exists.
+		require.NoError(t, os.WriteFile(hostsFilePath, original, 0644))
 	})
 	contents := string(original)
 	if !strings.HasSuffix(contents, "\n") {
 		contents += "\n"
 	}
 	contents += fmt.Sprintf("%s %s\n", ip, strings.Join(hostnames, " "))
-	require.NoError(t, os.WriteFile(hostsFilePath, []byte(contents), stat.Mode()))
+	require.NoError(t, os.WriteFile(hostsFilePath, []byte(contents), 0644))
 }

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -161,6 +161,28 @@ func (wt *WebTester) Refresh() {
 	wt.Get(wt.CurrentURL())
 }
 
+// CurrentWindowHandle returns the handle of the currently focused window.
+func (wt *WebTester) CurrentWindowHandle() string {
+	handle, err := wt.driver.CurrentWindowHandle()
+	require.NoError(wt.t, err)
+	return handle
+}
+
+// WindowHandles returns the handles of all open windows, including popup
+// windows opened by the page.
+func (wt *WebTester) WindowHandles() []string {
+	handles, err := wt.driver.WindowHandles()
+	require.NoError(wt.t, err)
+	return handles
+}
+
+// SwitchWindow switches the WebTester's focus to the window with the given
+// handle. Subsequent WebTester calls are directed at that window.
+func (wt *WebTester) SwitchWindow(handle string) {
+	err := wt.driver.SwitchWindow(handle)
+	require.NoError(wt.t, err)
+}
+
 // Find returns the element matching the given CSS selector. Exactly one
 // element must be matched, otherwise the test fails.
 func (wt *WebTester) Find(cssSelector string) *Element {

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -183,6 +183,12 @@ func (wt *WebTester) SwitchWindow(handle string) {
 	require.NoError(wt.t, err)
 }
 
+// DeleteCookie deletes the cookie with the given name from the browser.
+func (wt *WebTester) DeleteCookie(name string) {
+	err := wt.driver.DeleteCookie(name)
+	require.NoError(wt.t, err)
+}
+
 // Find returns the element matching the given CSS selector. Exactly one
 // element must be matched, otherwise the test fails.
 func (wt *WebTester) Find(cssSelector string) *Element {


### PR DESCRIPTION
Starting (but not completing) a SAML login on one org's subdomain would break the login page on every other subdomain, redirecting users full-screen to the first org's SAML IDP:

1. Open a new incognito window
2. Go to org A's subdomain (org A uses SAML)
3. Click the SSO login button, but abandon the login flow without signing in to the IDP
4. Go to org B's subdomain
5. Org A's SAML login appears (full screen)

### Background

SAML auth is multi-tenant: each SAML-enabled org is identified by its slug, and the server maintains a separate SAML service provider per slug (each org has its own IDP metadata URL, entity ID, etc.). On every request, the SAML authenticator has to figure out which org's service provider to use - both to validate an existing SAML session and to start a new login. Login and ACS URLs carry an explicit `?slug=` param, but ordinary requests (e.g. `GetUser` RPCs from the app) don't, so the slug is also persisted in a long-lived `Slug` cookie: it's the browser's memory of "this user authenticates via org X's SSO". With `auth.domain_wide_cookies` enabled (used with subdomains so that auth cookies work across them), the `Slug` cookie is shared across all subdomains.

### The bug

`SAMLAuthenticator.Login` set the `Slug` cookie as soon as the login flow *started* - when the browser hit `/login/?slug=org-a` and got redirected to the IDP - rather than when a login actually completed. So merely opening (then abandoning) org A's SSO flow durably marked the browser, on every subdomain, as "authenticates via org A's SSO".

That stale mark then derails org B's login page end-to-end:

1. Loading org B's page fires a `GetUser` RPC. The SAML authenticator resolves the slug from the cookie, loads org A's service provider, finds no SAML session cookie, and reports "session expired" - it treats the presence of the slug cookie as evidence of a prior login, so it can't tell "never logged in" from "session ran out".
2. The frontend treats an expired session as recoverable and silently navigates the page to `/login/` (with no slug) to log back in.
3. On `/login/`, OIDC has no issuer to use, and the SAML authenticator again resolves the slug from the cookie - starting org A's SAML flow and redirecting the page to org A's IDP, full screen.

There's also a second variant of the bug that doesn't require an abandoned login at all: the `Slug` cookie lives for a year while SAML sessions last 12 hours, so after a *successful* org A login, once the session expires, visiting org B's subdomain hits the same expired-session auto-relogin path and likewise lands on org A's IDP.

### The fix

Two parts:

1. Don't set the `Slug` cookie in `Login`. Setting it there was redundant for logins that do complete: the ACS URL registered with the IDP always carries the `?slug=` param, and the `/auth/saml/acs` handler already sets the cookie from it when the IDP redirects back after a confirmed login. With this change, an abandoned login attempt leaves no SSO state behind.

2. Ignore the `Slug` cookie when the request is on a customer subdomain that names a different org. One org's SSO affinity should never affect another org's subdomain, no matter how the cookie got there. Explicit `?slug=` params are unaffected, and so are requests to default subdomains (e.g. `app.`), which aren't tied to any org - seamless re-login keeps working there and on the org's own subdomain. A side effect is that a SAML session for org A no longer authenticates requests made to org B's subdomain; since SAML identities are per-org (subject IDs are prefixed with the org's entity ID), being anonymous there is the more accurate state.

### Tests

Adds a webdriver test suite (`enterprise/server/test/webdriver/subdomains`) that runs the app with subdomain matching, domain-wide cookies, and popup auth enabled - using `/etc/hosts` entries for the test subdomains, under firecracker isolation - and covers:

- `TestAbandonedSAMLLoginDoesNotAffectOtherSubdomains`: the repro steps above; org B must keep showing its own login page.
- `TestSAMLLoginDoesNotAffectOtherSubdomains`: after a *completed* org A login, org B shows its own login page both while the org A session is valid and after it expires (simulated by deleting the SAML session cookie).
- `TestExpiredSAMLSessionSeamlesslyLogsBackIn`: after the session expires, org A's own subdomain and the default `app` subdomain still automatically restart the SAML login with org A's IDP (guards the seamless re-login behavior against over-fixing).

Each test was verified to fail without its respective fix and pass with it; the existing SAML webdriver tests and `enterprise/server/saml` unit tests still pass.

Also adds supporting test helpers:
- `testhosts`: adds `/etc/hosts` entries with cleanup.
- `testsaml`: shared helper wrapping `mocksaml` (IDP startup + self-signed cert generation), now also used by the existing SAML webdriver test.
- Window-handle and cookie helpers on `webtester` for driving the SSO popup and simulating session expiry.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/6450