### PR TITLE
Make lockmap.go generic

### DIFF
--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -87,7 +87,7 @@ func New(env environment.Env, rootDirectory, scratchDirectory string) (*codesear
 		env:              env,
 		db:               db,
 		scratchDirectory: scratchDirectory,
-		repoLocks:        lockmap.New(),
+		repoLocks:        lockmap.New[string](),
 
 		kdb: kdb,
 		xs:  xs,
@@ -102,7 +102,7 @@ type codesearchServer struct {
 	db               *pebble.DB
 	scratchDirectory string
 
-	repoLocks lockmap.Locker
+	repoLocks lockmap.Locker[string]
 
 	// Kythe services.
 	kdb keyvalue.DB

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -253,7 +253,7 @@ type PebbleCache struct {
 	env    environment.Env
 	db     pebble.IPebbleDB
 	leaser pebble.Leaser
-	locker lockmap.Locker
+	locker lockmap.Locker[string]
 	clock  clockwork.Clock
 
 	edits    chan *sizeUpdate
@@ -668,7 +668,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		env:                         env,
 		db:                          db,
 		leaser:                      pebble.NewDBLeaser(db),
-		locker:                      lockmap.New(),
+		locker:                      lockmap.New[string](),
 		clock:                       clock,
 		brokenFilesDone:             make(chan struct{}),
 		orphanedFilesDone:           make(chan struct{}),
@@ -2251,7 +2251,7 @@ type partitionEvictor struct {
 	cacheName     string
 	blobDir       string
 	dbGetter      pebble.Leaser
-	locker        lockmap.Locker
+	locker        lockmap.Locker[string]
 	versionGetter versionGetter
 	samples       chan *approxlru.Sample[*evictionKey]
 	deletes       chan *approxlru.Sample[*evictionKey]
@@ -2287,7 +2287,7 @@ type versionGetter interface {
 	minDatabaseVersion() filestore.PebbleKeyVersion
 }
 
-func newPartitionEvictor(ctx context.Context, part disk.Partition, fileStorer filestore.Store, blobDir string, dbg pebble.Leaser, locker lockmap.Locker, vg versionGetter, clock clockwork.Clock, minEvictionAge time.Duration, cacheName string, includeMetadataSize bool, sampleBufferSize int, samplesPerBatch int, samplerIterRefreshPeriod time.Duration, deleteBufferSize int, numDeleteWorkers int) (*partitionEvictor, error) {
+func newPartitionEvictor(ctx context.Context, part disk.Partition, fileStorer filestore.Store, blobDir string, dbg pebble.Leaser, locker lockmap.Locker[string], vg versionGetter, clock clockwork.Clock, minEvictionAge time.Duration, cacheName string, includeMetadataSize bool, sampleBufferSize int, samplesPerBatch int, samplerIterRefreshPeriod time.Duration, deleteBufferSize int, numDeleteWorkers int) (*partitionEvictor, error) {
 	pe := &partitionEvictor{
 		ctx:                      ctx,
 		mu:                       &sync.Mutex{},

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -279,7 +279,7 @@ type Session struct {
 	refreshAt time.Time
 	mu        sync.Mutex
 
-	locker lockmap.Locker
+	locker lockmap.Locker[uint64]
 
 	maxSingleOpTimeout time.Duration
 }
@@ -304,7 +304,7 @@ func NewSessionWithClock(clock clockwork.Clock) *Session {
 		clock:              clock,
 		createdAt:          now,
 		refreshAt:          now.Add(*sessionLifetime),
-		locker:             lockmap.New(),
+		locker:             lockmap.New[uint64](),
 		maxSingleOpTimeout: config.SingleRaftOpTimeout(),
 	}
 }
@@ -341,7 +341,7 @@ func (s *Session) SyncProposeLocal(ctx context.Context, nodehost NodeHost, range
 		}
 		// At most one SyncProposeLocal can be run for the same replica per session.
 		start := s.clock.Now()
-		unlockFn := s.locker.Lock(strconv.Itoa(int(rangeID)))
+		unlockFn := s.locker.Lock(rangeID)
 		spn.End()
 		defer func() {
 			unlockFn()

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -50,7 +50,7 @@ type Sender struct {
 	// collide. proposeLocker still serializes proposes per range so that
 	// indices arrive in order on each range.
 	proposeSession *client.Session
-	proposeLocker  lockmap.Locker
+	proposeLocker  lockmap.Locker[uint64]
 }
 
 func New(rangeCache *rangecache.RangeCache, apiClient *client.APIClient) *Sender {
@@ -58,7 +58,7 @@ func New(rangeCache *rangecache.RangeCache, apiClient *client.APIClient) *Sender
 		rangeCache:     rangeCache,
 		apiClient:      apiClient,
 		proposeSession: client.NewSession(),
-		proposeLocker:  lockmap.New(),
+		proposeLocker:  lockmap.New[uint64](),
 	}
 }
 
@@ -491,7 +491,7 @@ func (s *Sender) setupProposeSessionForRange(rangeID uint64, batchCmd *rfpb.Batc
 	var lockStart time.Time
 	if batchCmd.GetSession() == nil {
 		lockStart = time.Now()
-		unlockFn = s.proposeLocker.Lock(strconv.FormatUint(rangeID, 10))
+		unlockFn = s.proposeLocker.Lock(rangeID)
 		batchCmd.Session = s.proposeSession.NextRequestSession()
 	}
 	// Stamp range ID once, on the first range lookup, and never

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -110,7 +110,7 @@ type COWStore struct {
 	// chunkLock can be used to lock a single chunk, to synchronize simultaneous
 	// access on that chunk (i.e. two goroutines trying to initialize and copy a chunk
 	// at the same time).
-	chunkLock lockmap.Locker
+	chunkLock lockmap.Locker[int64]
 
 	// chunks is a mapping of chunk offset to the backing data store
 	chunks map[int64]*Mmap
@@ -222,7 +222,7 @@ func NewCOWStore(ctx context.Context, env environment.Env, name string, chunks [
 		env:                env,
 		remoteInstanceName: opts.RemoteInstanceName,
 		remoteEnabled:      opts.RemoteEnabled,
-		chunkLock:          lockmap.New(),
+		chunkLock:          lockmap.New[int64](),
 		chunks:             chunkMap,
 		dirty:              make(map[int64]bool, 0),
 		partiallyMapped:    make(map[int64]bool, 0),
@@ -308,7 +308,7 @@ func (c *COWStore) GetPageAddress(offset uintptr, write bool) (uintptr, error) {
 		}
 	}
 
-	chunkUnlockFn := c.chunkLock.RLock(fmt.Sprintf("%d", chunkStartOffset))
+	chunkUnlockFn := c.chunkLock.RLock(chunkStartOffset)
 	defer chunkUnlockFn()
 
 	c.storeLock.RLock()
@@ -381,7 +381,7 @@ func (c *COWStore) ReadAt(p []byte, off int64) (int, error) {
 }
 
 func (c *COWStore) readChunk(p []byte, readRelativeOffset int64, chunkStartOffset int64, readSize int) error {
-	chunkUnlockFn := c.chunkLock.RLock(fmt.Sprintf("%d", chunkStartOffset))
+	chunkUnlockFn := c.chunkLock.RLock(chunkStartOffset)
 	defer chunkUnlockFn()
 
 	c.storeLock.RLock()
@@ -484,7 +484,7 @@ func (c *COWStore) writeToChunk(p []byte, writeRelativeOffset int64, chunkStartO
 		c.updateUsageSummary("WriteToChunk", startTime)
 	}()
 
-	chunkUnlockFn := c.chunkLock.Lock(fmt.Sprintf("%d", chunkStartOffset))
+	chunkUnlockFn := c.chunkLock.Lock(chunkStartOffset)
 	defer chunkUnlockFn()
 
 	c.storeLock.RLock()
@@ -654,7 +654,7 @@ func (s *COWStore) calculateChunkSize(startOffset int64) int64 {
 }
 
 func (s *COWStore) copyChunkIfNotDirty(chunkStartOffset int64) (err error) {
-	chunkUnlockFn := s.chunkLock.Lock(fmt.Sprintf("%d", chunkStartOffset))
+	chunkUnlockFn := s.chunkLock.Lock(chunkStartOffset)
 	defer chunkUnlockFn()
 
 	s.storeLock.RLock()
@@ -806,7 +806,7 @@ func (s *COWStore) eagerFetchChunksInBackground() {
 }
 
 func (s *COWStore) fetchChunk(offset int64) error {
-	chunkUnlockFn := s.chunkLock.Lock(fmt.Sprintf("%d", offset))
+	chunkUnlockFn := s.chunkLock.Lock(offset)
 	defer chunkUnlockFn()
 
 	s.storeLock.RLock()

--- a/server/util/lockmap/lockmap.go
+++ b/server/util/lockmap/lockmap.go
@@ -17,41 +17,41 @@ type collectableMutex struct {
 //
 // Ex.
 //
-//	l := lockmap.New()          <- this returns a Locker
+//	l := lockmap.New[string]()  <- this returns a Locker keyed by string
 //	unlockFn := l.Lock("key-1") <- this is like Lock()ing a RWMutex
 //	defer unlockFn()            <- this is like Unlock()ing a RWMutex
 //	// do work here.
 //
 // Ex 2.
 //
-//	l := lockmap.New()          <- this returns a Locker
-//	unlockFn := l.Lock("key-1") <- this is like RLock()ing a RWMutex
-//	defer unlockFn()            <- this is like RUnlock()ing a RWMutex
+//	l := lockmap.New[int64]() <- this returns a Locker keyed by int64
+//	unlockFn := l.RLock(42)   <- this is like RLock()ing a RWMutex
+//	defer unlockFn()          <- this is like RUnlock()ing a RWMutex
 //	// do work here.
 //
-// Locks are uniquely identified by string, so the same resource can be both
+// Locks are uniquely identified by key, so the same resource can be both
 // RLock()ed and Lock()ed by different threads, they will share the same
 // RWMutex. The lockmap will cull unused locks periodically to save memory.
-type Locker interface {
-	Lock(key string) func()
-	RLock(key string) func()
+type Locker[K comparable] interface {
+	Lock(key K) func()
+	RLock(key K) func()
 	Close() error
 }
 
-type perKeyMutex struct {
+type perKeyMutex[K comparable] struct {
 	mutexes sync.Map
 	closed  chan struct{}
 }
 
-// New returns a new lock map.
+// New returns a new lock map keyed by K.
 // The caller must call Close() when the map is no longer needed.
-func New() *perKeyMutex {
-	pkm := &perKeyMutex{closed: make(chan struct{})}
+func New[K comparable]() *perKeyMutex[K] {
+	pkm := &perKeyMutex[K]{closed: make(chan struct{})}
 	go pkm.gc()
 	return pkm
 }
 
-func (p *perKeyMutex) gc() {
+func (p *perKeyMutex[K]) gc() {
 	t := time.NewTicker(100 * time.Millisecond)
 	defer t.Stop()
 	for {
@@ -85,7 +85,7 @@ func (p *perKeyMutex) gc() {
 	}
 }
 
-func (p *perKeyMutex) Lock(key string) func() {
+func (p *perKeyMutex[K]) Lock(key K) func() {
 	var rcm *collectableMutex
 	for {
 		val, _ := p.mutexes.LoadOrStore(key, &collectableMutex{})
@@ -101,7 +101,7 @@ func (p *perKeyMutex) Lock(key string) func() {
 	return func() { rcm.Unlock() }
 }
 
-func (p *perKeyMutex) RLock(key string) func() {
+func (p *perKeyMutex[K]) RLock(key K) func() {
 	var rcm *collectableMutex
 	for {
 		val, _ := p.mutexes.LoadOrStore(key, &collectableMutex{})
@@ -116,13 +116,13 @@ func (p *perKeyMutex) RLock(key string) func() {
 	return func() { rcm.RUnlock() }
 }
 
-func (p *perKeyMutex) Close() error {
+func (p *perKeyMutex[K]) Close() error {
 	close(p.closed)
 	return nil
 }
 
 // For testing only.
-func (p *perKeyMutex) count() int {
+func (p *perKeyMutex[K]) count() int {
 	count := 0
 	p.mutexes.Range(func(key, value any) bool {
 		count++

--- a/server/util/lockmap/lockmap_test.go
+++ b/server/util/lockmap/lockmap_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestLock(t *testing.T) {
-	l := New()
+	l := New[string]()
 	defer l.Close()
 
 	m := make(map[string]int, 0)
@@ -39,7 +39,7 @@ func TestLock(t *testing.T) {
 }
 
 func TestRLock(t *testing.T) {
-	l := New()
+	l := New[string]()
 	defer l.Close()
 
 	m := make(map[string]int, 0)
@@ -75,7 +75,7 @@ func TestRLock(t *testing.T) {
 }
 
 func benchmarkLock(b *testing.B, keyCount int) {
-	l := New()
+	l := New[string]()
 	defer l.Close()
 
 	keys := make([]string, keyCount)
@@ -105,7 +105,7 @@ func BenchmarkLockQPS(b *testing.B) {
 }
 
 func BenchmarkRLockQPS(b *testing.B) {
-	l := New()
+	l := New[string]()
 	defer l.Close()
 
 	b.ReportAllocs()


### PR DESCRIPTION
It already stores values in a sync.Map, which supports any comparable type. This avoids a bunch of conversions from ints to strings.