### PR TITLE
cli: stop logging detect argv

### DIFF
--- a/cli/detect/nondeterminism.go
+++ b/cli/detect/nondeterminism.go
@@ -74,7 +74,6 @@ type explainer interface {
 type osCommandRunner struct{}
 
 func (r osCommandRunner) Run(ctx context.Context, name string, args ...string) error {
-	log.Printf("Running %s", shlex.Quote(append([]string{name}, args...)...))
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
The nondeterminism detector added in b16c237 (cli-v5.0.381)
logs the full Bazel argv before starting each uncached build. When
login.ConfigureAPIKey finds BUILDBUDDY_API_KEY or repo config, it can
inject --remote_header=x-buildbuddy-api-key=<key>, so that local
"Running bazel ..." line can disclose the key in terminal or CI logs.

Server-side BEP redaction already strips remote headers from invocation
metadata, but it cannot protect this client-side log because the line is
printed before Bazel runs or streams events. Remove the command echo
instead of maintaining a second redaction policy in the CLI.

The command already streams BuildBuddy invocation URLs, so users can
inspect the sanitized command line in the invocation UI when they need
it. This also avoids keeping a CLI-only list of sensitive flags in sync
with the server redactor.