### PR TITLE
`gcr[name]` ⏩ `ctr[name]`

### DIFF
--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -32,8 +32,8 @@ import (
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
+	ctrname "github.com/google/go-containerregistry/pkg/name"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -274,23 +274,23 @@ func validateBypassRegistry(ctx context.Context, bypassRegistry bool) error {
 	return nil
 }
 
-func parseBlobDigestRef(ref string) (gcrname.Digest, gcr.Hash, error) {
-	blobRef, err := gcrname.ParseReference(ref)
+func parseBlobDigestRef(ref string) (ctrname.Digest, ctr.Hash, error) {
+	blobRef, err := ctrname.ParseReference(ref)
 	if err != nil {
-		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
+		return ctrname.Digest{}, ctr.Hash{}, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
 	}
-	digestRef, ok := blobRef.(gcrname.Digest)
+	digestRef, ok := blobRef.(ctrname.Digest)
 	if !ok {
-		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("blob reference must be a digest reference (e.g., repo@sha256:...), got %q", ref)
+		return ctrname.Digest{}, ctr.Hash{}, status.InvalidArgumentErrorf("blob reference must be a digest reference (e.g., repo@sha256:...), got %q", ref)
 	}
-	hash, err := gcr.NewHash(digestRef.DigestStr())
+	hash, err := ctr.NewHash(digestRef.DigestStr())
 	if err != nil {
-		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+		return ctrname.Digest{}, ctr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
 	}
 	return digestRef, hash, nil
 }
 
-func (s *ociFetcherServer) streamBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, repo gcrname.Repository, hash gcr.Hash) error {
+func (s *ociFetcherServer) streamBlobFromCache(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, repo ctrname.Repository, hash ctr.Hash) error {
 	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
 	if err != nil {
 		return err
@@ -298,7 +298,7 @@ func (s *ociFetcherServer) streamBlobFromCache(ctx context.Context, stream ofpb.
 	return ocicache.FetchBlobFromCache(ctx, &grpcStreamWriter{stream: stream}, s.bsClient, hash, metadata.GetContentLength())
 }
 
-func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash, creds *rgpb.Credentials) error {
+func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef ctrname.Digest, hash ctr.Hash, creds *rgpb.Credentials) error {
 	start := time.Now()
 	repo := digestRef.Context()
 	key := ocicache.NewBlobFetchKey(repo, hash, creds)
@@ -370,7 +370,7 @@ func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
 // registry, streams it to the response, and writes it to the cache
 // simultaneously using read-through caching.
 // It returns the content length of the blob (0 if metadata was unavailable).
-func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx context.Context, digestRef gcrname.Digest, repo gcrname.Repository, hash gcr.Hash, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) (int64, error) {
+func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx context.Context, digestRef ctrname.Digest, repo ctrname.Repository, hash ctr.Hash, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) (int64, error) {
 	// All HTTP-triggering calls (Compressed, MediaType, Size) must be
 	// inside the retry scope so that token refresh covers them, not just
 	// the lazy Layer() reference creation.
@@ -444,7 +444,7 @@ func (s *ociFetcherServer) streamBlob(rc io.Reader, stream ofpb.OCIFetcher_Fetch
 	}
 }
 
-func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, digestRef gcrname.Digest, hash gcr.Hash) (*ofpb.FetchBlobMetadataResponse, error) {
+func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, digestRef ctrname.Digest, hash ctr.Hash) (*ofpb.FetchBlobMetadataResponse, error) {
 	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, digestRef.Context(), hash)
 	if err != nil {
 		return nil, err
@@ -455,7 +455,7 @@ func (s *ociFetcherServer) fetchBlobMetadataFromCache(ctx context.Context, diges
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, digestRef gcrname.Digest, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
+func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials) (*ofpb.FetchBlobMetadataResponse, error) {
 	return withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (*ofpb.FetchBlobMetadataResponse, error) {
 		layer, err := puller.Layer(ctx, digestRef)
 		if err != nil {
@@ -476,41 +476,41 @@ func (s *ociFetcherServer) fetchBlobMetadataFromRemote(ctx context.Context, dige
 	})
 }
 
-func parseManifestRef(ref string) (gcrname.Reference, error) {
-	imageRef, err := gcrname.ParseReference(ref)
+func parseManifestRef(ref string) (ctrname.Reference, error) {
+	imageRef, err := ctrname.ParseReference(ref)
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image reference %q: %s", ref, err)
 	}
 	return imageRef, nil
 }
 
-func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials, bypassRegistry bool) (gcr.Hash, error) {
-	if digestRef, ok := imageRef.(gcrname.Digest); ok {
-		hash, err := gcr.NewHash(digestRef.DigestStr())
+func (s *ociFetcherServer) resolveManifestDigest(ctx context.Context, imageRef ctrname.Reference, creds *rgpb.Credentials, bypassRegistry bool) (ctr.Hash, error) {
+	if digestRef, ok := imageRef.(ctrname.Digest); ok {
+		hash, err := ctr.NewHash(digestRef.DigestStr())
 		if err != nil {
-			return gcr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
+			return ctr.Hash{}, status.InvalidArgumentErrorf("invalid digest format %q: %s", digestRef.DigestStr(), err)
 		}
 		if !bypassRegistry {
 			if err := s.proveManifestAccess(ctx, imageRef, creds); err != nil {
-				return gcr.Hash{}, err
+				return ctr.Hash{}, err
 			}
 		}
 		return hash, nil
 	}
 	if bypassRegistry {
-		return gcr.Hash{}, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", imageRef)
+		return ctr.Hash{}, status.NotFoundErrorf("bypassing registry, but cannot resolve tag ref %q from cache", imageRef)
 	}
 	return s.resolveTagToDigest(ctx, imageRef, creds)
 }
 
 // proveManifestAccess checks that the caller's credentials allow accessing
 // the given manifest ref in the remote registry.
-func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) error {
+func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef ctrname.Reference, creds *rgpb.Credentials) error {
 	repo := imageRef.Context()
 	if s.accessProofCache.Contains(repoAccessKey(repo, creds)) {
 		return nil
 	}
-	if _, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+	if _, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*ctr.Descriptor, error) {
 		return puller.Head(ctx, imageRef)
 	}); err != nil {
 		return err
@@ -521,7 +521,7 @@ func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef gcr
 
 // proveBlobAccess checks that the caller's credentials allow accessing the
 // blob's repository in the remote registry (via a metadata HEAD).
-func (s *ociFetcherServer) proveBlobAccess(ctx context.Context, digestRef gcrname.Digest, creds *rgpb.Credentials) error {
+func (s *ociFetcherServer) proveBlobAccess(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials) error {
 	repo := digestRef.Context()
 	if s.accessProofCache.Contains(repoAccessKey(repo, creds)) {
 		return nil
@@ -533,22 +533,22 @@ func (s *ociFetcherServer) proveBlobAccess(ctx context.Context, digestRef gcrnam
 	return nil
 }
 
-func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (gcr.Hash, error) {
-	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, imageRef ctrname.Reference, creds *rgpb.Credentials) (ctr.Hash, error) {
+	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*ctr.Descriptor, error) {
 		return puller.Head(ctx, imageRef)
 	})
 	if err != nil {
-		return gcr.Hash{}, err
+		return ctr.Hash{}, err
 	}
 	s.accessProofCache.Add(repoAccessKey(imageRef.Context(), creds), struct{}{})
-	hash, err := gcr.NewHash(desc.Digest.String())
+	hash, err := ctr.NewHash(desc.Digest.String())
 	if err != nil {
-		return gcr.Hash{}, status.InvalidArgumentErrorf("invalid resolved digest %q: %s", desc.Digest.String(), err)
+		return ctr.Hash{}, status.InvalidArgumentErrorf("invalid resolved digest %q: %s", desc.Digest.String(), err)
 	}
 	return hash, nil
 }
 
-func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, imageRef gcrname.Reference, hash gcr.Hash) (*ofpb.FetchManifestResponse, error) {
+func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, imageRef ctrname.Reference, hash ctr.Hash) (*ofpb.FetchManifestResponse, error) {
 	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, imageRef.Context(), hash, imageRef)
 	if err != nil {
 		return nil, err
@@ -561,7 +561,7 @@ func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, imageRef 
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchManifestFromRemoteWriteToCache(ctx context.Context, imageRef gcrname.Reference, hash gcr.Hash, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
+func (s *ociFetcherServer) fetchManifestFromRemoteWriteToCache(ctx context.Context, imageRef ctrname.Reference, hash ctr.Hash, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
 	remoteDesc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
 		return puller.Get(ctx, imageRef)
 	})
@@ -591,8 +591,8 @@ func validateUnsupportedBypassRegistry(ctx context.Context, bypassRegistry bool)
 	return status.NotFoundError("bypass_registry is not yet supported")
 }
 
-func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*ofpb.FetchManifestMetadataResponse, error) {
-	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*gcr.Descriptor, error) {
+func (s *ociFetcherServer) fetchManifestMetadataFromRemote(ctx context.Context, imageRef ctrname.Reference, creds *rgpb.Credentials) (*ofpb.FetchManifestMetadataResponse, error) {
+	desc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*ctr.Descriptor, error) {
 		return puller.Head(ctx, imageRef)
 	})
 	if err != nil {
@@ -626,7 +626,7 @@ func (s *ociFetcherServer) getRemoteOpts(ctx context.Context, creds *rgpb.Creden
 	return opts
 }
 
-func (s *ociFetcherServer) getOrCreatePuller(ctx context.Context, imageRef gcrname.Reference, creds *rgpb.Credentials) (*remote.Puller, error) {
+func (s *ociFetcherServer) getOrCreatePuller(ctx context.Context, imageRef ctrname.Reference, creds *rgpb.Credentials) (*remote.Puller, error) {
 	key := pullerKey(imageRef, creds)
 
 	s.mu.Lock()
@@ -647,7 +647,7 @@ func (s *ociFetcherServer) getOrCreatePuller(ctx context.Context, imageRef gcrna
 	return puller, nil
 }
 
-func (s *ociFetcherServer) evictPuller(imageRef gcrname.Reference, creds *rgpb.Credentials) {
+func (s *ociFetcherServer) evictPuller(imageRef ctrname.Reference, creds *rgpb.Credentials) {
 	key := pullerKey(imageRef, creds)
 	s.mu.Lock()
 	s.pullerLRU.Remove(key)
@@ -657,14 +657,14 @@ func (s *ociFetcherServer) evictPuller(imageRef gcrname.Reference, creds *rgpb.C
 // repoAccessKey returns the access-proof cache key for the given repository and
 // credentials. Registry pull authorization is repository-scoped, so the key is
 // deliberately not specific to any one manifest or blob digest.
-func repoAccessKey(repo gcrname.Repository, creds *rgpb.Credentials) string {
+func repoAccessKey(repo ctrname.Repository, creds *rgpb.Credentials) string {
 	if creds == nil {
 		return hash.Strings(repo.Name(), "", "")
 	}
 	return hash.Strings(repo.Name(), creds.GetUsername(), creds.GetPassword())
 }
 
-func pullerKey(ref gcrname.Reference, creds *rgpb.Credentials) string {
+func pullerKey(ref ctrname.Reference, creds *rgpb.Credentials) string {
 	if creds == nil {
 		return hash.Strings(
 			ref.Context().RegistryStr(),
@@ -686,7 +686,7 @@ func pullerKey(ref gcrname.Reference, creds *rgpb.Credentials) string {
 func withPullerRetry[T any](
 	ctx context.Context,
 	s *ociFetcherServer,
-	ref gcrname.Reference,
+	ref ctrname.Reference,
 	creds *rgpb.Credentials,
 	op func(puller *remote.Puller) (T, error),
 ) (T, error) {

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -34,10 +32,12 @@ import (
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	ctrname "github.com/google/go-containerregistry/pkg/name"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
-func imageMetadata(t *testing.T, img v1.Image) (digest string, size int64, mediaType string) {
+func imageMetadata(t *testing.T, img ctr.Image) (digest string, size int64, mediaType string) {
 	d, err := img.Digest()
 	require.NoError(t, err)
 	s, err := img.Size()
@@ -272,7 +272,7 @@ type fetchResult struct {
 	err  error
 }
 
-func layerMetadata(t *testing.T, layer v1.Layer) (size int64, mediaType string) {
+func layerMetadata(t *testing.T, layer ctr.Layer) (size int64, mediaType string) {
 	s, err := layer.Size()
 	require.NoError(t, err)
 	mt, err := layer.MediaType()
@@ -280,7 +280,7 @@ func layerMetadata(t *testing.T, layer v1.Layer) (size int64, mediaType string) 
 	return s, string(mt)
 }
 
-func layerData(t *testing.T, layer v1.Layer) []byte {
+func layerData(t *testing.T, layer ctr.Layer) []byte {
 	rc, err := layer.Compressed()
 	require.NoError(t, err)
 	defer rc.Close()
@@ -290,9 +290,9 @@ func layerData(t *testing.T, layer v1.Layer) []byte {
 }
 
 func seedBlobCache(t *testing.T, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, ref string, data []byte, mediaType string) {
-	digestRef, ok := nameRef(t, ref).(gcrname.Digest)
+	digestRef, ok := nameRef(t, ref).(ctrname.Digest)
 	require.True(t, ok, "expected digest ref")
-	hash, err := v1.NewHash(digestRef.DigestStr())
+	hash, err := ctr.NewHash(digestRef.DigestStr())
 	require.NoError(t, err)
 	require.NoError(t, ocicache.WriteBlobToCache(
 		context.Background(),
@@ -306,8 +306,8 @@ func seedBlobCache(t *testing.T, bsClient bspb.ByteStreamClient, acClient repb.A
 	))
 }
 
-func nameRef(t *testing.T, ref string) gcrname.Reference {
-	nameRef, err := gcrname.ParseReference(ref)
+func nameRef(t *testing.T, ref string) ctrname.Reference {
+	nameRef, err := ctrname.ParseReference(ref)
 	require.NoError(t, err)
 	return nameRef
 }

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
@@ -22,8 +22,8 @@ import (
 
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
+	ctrname "github.com/google/go-containerregistry/pkg/name"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -97,18 +97,18 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, size, req)
 }
 
-func parseBlobDigestRef(ref string) (gcrname.Digest, gcr.Hash, error) {
-	blobRef, err := gcrname.ParseReference(ref)
+func parseBlobDigestRef(ref string) (ctrname.Digest, ctr.Hash, error) {
+	blobRef, err := ctrname.ParseReference(ref)
 	if err != nil {
-		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
+		return ctrname.Digest{}, ctr.Hash{}, status.InvalidArgumentErrorf("invalid blob reference %q: %s", ref, err)
 	}
-	digestRef, ok := blobRef.(gcrname.Digest)
+	digestRef, ok := blobRef.(ctrname.Digest)
 	if !ok {
-		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("blob reference must be a digest reference, got %q", ref)
+		return ctrname.Digest{}, ctr.Hash{}, status.InvalidArgumentErrorf("blob reference must be a digest reference, got %q", ref)
 	}
-	hash, err := gcr.NewHash(digestRef.DigestStr())
+	hash, err := ctr.NewHash(digestRef.DigestStr())
 	if err != nil {
-		return gcrname.Digest{}, gcr.Hash{}, status.InvalidArgumentErrorf("invalid blob digest in reference %q: %s", ref, err)
+		return ctrname.Digest{}, ctr.Hash{}, status.InvalidArgumentErrorf("invalid blob digest in reference %q: %s", ref, err)
 	}
 	return digestRef, hash, nil
 }
@@ -125,7 +125,7 @@ func (s *OCIFetcherServerProxy) fetchBlobMetadataSize(ctx context.Context, req *
 	return metaResp.GetSize(), nil
 }
 
-func (s *OCIFetcherServerProxy) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef gcrname.Digest, hash gcr.Hash, size int64, req *ofpb.FetchBlobRequest) error {
+func (s *OCIFetcherServerProxy) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef ctrname.Digest, hash ctr.Hash, size int64, req *ofpb.FetchBlobRequest) error {
 	// Deduplicate concurrent upstream fetches for the same blob+creds.
 	// The leader fetches from upstream and writes to local BSS.
 	// After the singleflight completes, all callers stream from local BSS.
@@ -152,7 +152,7 @@ func (s *OCIFetcherServerProxy) dedupedFetchBlob(ctx context.Context, stream ofp
 // fetchBlobFromUpstreamToLocalBS fetches a blob from the upstream OCIFetcher
 // and writes it to the local byte stream cache. It does not stream to any
 // caller; callers read from local BSS after this completes.
-func (s *OCIFetcherServerProxy) fetchBlobFromUpstreamToLocalBS(ctx context.Context, req *ofpb.FetchBlobRequest, hash gcr.Hash, size int64) error {
+func (s *OCIFetcherServerProxy) fetchBlobFromUpstreamToLocalBS(ctx context.Context, req *ofpb.FetchBlobRequest, hash ctr.Hash, size int64) error {
 	remoteStream, err := s.remote.FetchBlob(ctx, req)
 	if err != nil {
 		return err
@@ -185,7 +185,7 @@ func (s *OCIFetcherServerProxy) fetchBlobFromUpstreamToLocalBS(ctx context.Conte
 }
 
 // fetchBlobFromLocalBS reads a blob from the local byte stream cache.
-func fetchBlobFromLocalBS(ctx context.Context, bsClient bspb.ByteStreamClient, hash gcr.Hash, size int64, w io.Writer) error {
+func fetchBlobFromLocalBS(ctx context.Context, bsClient bspb.ByteStreamClient, hash ctr.Hash, size int64, w io.Writer) error {
 	blobDigest := &repb.Digest{
 		Hash:      hash.Hex,
 		SizeBytes: size,
@@ -196,7 +196,7 @@ func fetchBlobFromLocalBS(ctx context.Context, bsClient bspb.ByteStreamClient, h
 }
 
 // newLocalBSWriter creates a cache writer for writing a blob to local BS.
-func newLocalBSWriter(ctx context.Context, bsClient bspb.ByteStreamClient, hash gcr.Hash, size int64) (*cachetools.UploadWriter, error) {
+func newLocalBSWriter(ctx context.Context, bsClient bspb.ByteStreamClient, hash ctr.Hash, size int64) (*cachetools.UploadWriter, error) {
 	blobDigest := &repb.Digest{
 		Hash:      hash.Hex,
 		SizeBytes: size,

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -29,6 +28,7 @@ import (
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gproto "google.golang.org/protobuf/proto"
 )
@@ -774,7 +774,7 @@ func setupTestRegistry(t *testing.T, creds *testregistry.BasicAuthCreds) *testre
 }
 
 // imageMetadata extracts digest, size, and media type from an image.
-func imageMetadata(t *testing.T, img v1.Image) (digest string, size int64, mediaType string) {
+func imageMetadata(t *testing.T, img ctr.Image) (digest string, size int64, mediaType string) {
 	d, err := img.Digest()
 	require.NoError(t, err)
 	s, err := img.Size()
@@ -848,7 +848,7 @@ func runOCIFetcherProxy(ctx context.Context, t *testing.T, remoteClient ofpb.OCI
 }
 
 // layerMetadata extracts size and media type from an image layer.
-func layerMetadata(t *testing.T, layer v1.Layer) (size int64, mediaType string) {
+func layerMetadata(t *testing.T, layer ctr.Layer) (size int64, mediaType string) {
 	s, err := layer.Size()
 	require.NoError(t, err)
 	mt, err := layer.MediaType()
@@ -857,7 +857,7 @@ func layerMetadata(t *testing.T, layer v1.Layer) (size int64, mediaType string) 
 }
 
 // layerData reads the compressed data from an image layer.
-func layerData(t *testing.T, layer v1.Layer) []byte {
+func layerData(t *testing.T, layer ctr.Layer) []byte {
 	rc, err := layer.Compressed()
 	require.NoError(t, err)
 	defer rc.Close()

--- a/enterprise/server/ociregistry/ociregistry.go
+++ b/enterprise/server/ociregistry/ociregistry.go
@@ -32,8 +32,8 @@ import (
 
 	ocipb "github.com/buildbuddy-io/buildbuddy/proto/ociregistry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
+	ctrname "github.com/google/go-containerregistry/pkg/name"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -82,7 +82,7 @@ var (
 // manifestResolveResult holds the outcome of a tag->digest resolution so it can be
 // shared across concurrent requests via singleflight.
 type manifestResolveResult struct {
-	hash          *gcr.Hash
+	hash          *ctr.Hash
 	exists        bool
 	contentLength string
 	contentType   string
@@ -265,7 +265,7 @@ func (r *registry) determineUpstreamRepository(ctx context.Context, req *http.Re
 	registrySubdomain, ok := isRegistryDomainRequest(req)
 	if !ok {
 		if repository == "" {
-			return gcrname.DefaultRegistry, nil
+			return ctrname.DefaultRegistry, nil
 		}
 		return repository, nil
 	}
@@ -301,7 +301,7 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 	// If the request is not for the DockerHub mirror, for now just return
 	// an OK response which tells the client that no auth is required. For now,
 	// we are only mirroring repositories that don't require auth.
-	if remoteRegistry != gcrname.DefaultRegistry {
+	if remoteRegistry != ctrname.DefaultRegistry {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("{}"))
 		return
@@ -337,7 +337,7 @@ func (r *registry) handleV2Request(ctx context.Context, w http.ResponseWriter, i
 	}
 }
 
-func (r *registry) makeUpstreamRequest(ctx context.Context, method string, acceptHeaders []string, authorizationHeader string, ociResourceType ocipb.OCIResourceType, ref gcrname.Reference) (*http.Response, error) {
+func (r *registry) makeUpstreamRequest(ctx context.Context, method string, acceptHeaders []string, authorizationHeader string, ociResourceType ocipb.OCIResourceType, ref ctrname.Reference) (*http.Response, error) {
 	var path string
 	switch ociResourceType {
 	case ocipb.OCIResourceType_BLOB:
@@ -366,18 +366,18 @@ func (r *registry) makeUpstreamRequest(ctx context.Context, method string, accep
 	return r.client.Do(upreq.WithContext(ctx))
 }
 
-func parseDockerContentDigestHeader(value string) (*gcr.Hash, error) {
+func parseDockerContentDigestHeader(value string) (*ctr.Hash, error) {
 	if value == "" {
 		return nil, nil
 	}
-	hash, err := gcr.NewHash(value)
+	hash, err := ctr.NewHash(value)
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("could not parse %s header: %s", headerDockerContentDigest, err)
 	}
 	return &hash, nil
 }
 
-func (r *registry) resolveManifestDigest(ctx context.Context, acceptHeaders []string, authorizationHeader string, ociResourceType ocipb.OCIResourceType, ref gcrname.Reference) (manifestResolveResult, error) {
+func (r *registry) resolveManifestDigest(ctx context.Context, acceptHeaders []string, authorizationHeader string, ociResourceType ocipb.OCIResourceType, ref ctrname.Reference) (manifestResolveResult, error) {
 	headresp, err := r.makeUpstreamRequest(ctx, http.MethodHead, acceptHeaders, authorizationHeader, ociResourceType, ref)
 	if err != nil {
 		return manifestResolveResult{}, status.UnavailableErrorf("error making %s request to upstream registry: %s", http.MethodHead, err)
@@ -466,7 +466,7 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 	acClient := r.env.GetActionCacheClient()
 
 	writeBody := inreq.Method == http.MethodGet
-	hash, err := gcr.NewHash(resolvedRef.Identifier())
+	hash, err := ctr.NewHash(resolvedRef.Identifier())
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error parsing resolved digest in %q: %s", resolvedRef.Context(), err), http.StatusInternalServerError)
 		return
@@ -511,7 +511,7 @@ func (r *registry) handleBlobsOrManifestsRequest(ctx context.Context, w http.Res
 
 // fetchAndCache fetches a blob or manifest from the upstream registry and
 // writes it to the cache. The response body is not written to any client.
-func (r *registry) fetchAndCache(ctx context.Context, inreq *http.Request, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, ociResourceType ocipb.OCIResourceType, resolvedRef gcrname.Reference, hash gcr.Hash, originalRef gcrname.Reference) error {
+func (r *registry) fetchAndCache(ctx context.Context, inreq *http.Request, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, ociResourceType ocipb.OCIResourceType, resolvedRef ctrname.Reference, hash ctr.Hash, originalRef ctrname.Reference) error {
 	upresp, err := r.makeUpstreamRequest(ctx, http.MethodGet, inreq.Header.Values(headerAccept), inreq.Header.Get(headerAuthorization), ociResourceType, resolvedRef)
 	if err != nil {
 		return status.UnavailableErrorf("error making GET request to upstream registry: %s", err)
@@ -537,19 +537,19 @@ func (r *registry) fetchAndCache(ctx context.Context, inreq *http.Request, bsCli
 	return ocicache.WriteBlobOrManifestToCacheAndWriter(ctx, upresp.Body, io.Discard, bsClient, acClient, resolvedRef.Context(), ociResourceType, hash, contentType, contentLength, originalRef)
 }
 
-func writeManifestMetadataToResponse(ctx context.Context, w http.ResponseWriter, hash gcr.Hash, mc *ocipb.OCIManifestContent) {
+func writeManifestMetadataToResponse(ctx context.Context, w http.ResponseWriter, hash ctr.Hash, mc *ocipb.OCIManifestContent) {
 	w.Header().Add(headerDockerContentDigest, hash.String())
 	w.Header().Add(headerContentLength, strconv.Itoa(len(mc.GetRaw())))
 	w.Header().Add(headerContentType, mc.GetContentType())
 }
 
-func writeBlobMetadataToResponse(ctx context.Context, w http.ResponseWriter, hash gcr.Hash, blobMetadata *ocipb.OCIBlobMetadata) {
+func writeBlobMetadataToResponse(ctx context.Context, w http.ResponseWriter, hash ctr.Hash, blobMetadata *ocipb.OCIBlobMetadata) {
 	w.Header().Add(headerDockerContentDigest, hash.String())
 	w.Header().Add(headerContentLength, strconv.FormatInt(blobMetadata.GetContentLength(), 10))
 	w.Header().Add(headerContentType, blobMetadata.GetContentType())
 }
 
-func fetchFromCacheWriteToResponse(ctx context.Context, w http.ResponseWriter, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, ociResourceType ocipb.OCIResourceType, writeBody bool, originalRef gcrname.Reference) error {
+func fetchFromCacheWriteToResponse(ctx context.Context, w http.ResponseWriter, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo ctrname.Repository, hash ctr.Hash, ociResourceType ocipb.OCIResourceType, writeBody bool, originalRef ctrname.Reference) error {
 	if ociResourceType == ocipb.OCIResourceType_MANIFEST {
 		mc, err := ocicache.FetchManifestFromAC(ctx, acClient, repo, hash, originalRef)
 		if err != nil {
@@ -584,7 +584,7 @@ func fetchFromCacheWriteToResponse(ctx context.Context, w http.ResponseWriter, b
 // The returned result also includes Content-Length and Content-Type from the
 // upstream HEAD response, which can be used to serve HEAD requests without a
 // second round-trip.
-func (r *registry) resolveTagToDigest(ctx context.Context, inreq *http.Request, ociResourceType ocipb.OCIResourceType, ref gcrname.Reference) (manifestResolveResult, error) {
+func (r *registry) resolveTagToDigest(ctx context.Context, inreq *http.Request, ociResourceType ocipb.OCIResourceType, ref ctrname.Reference) (manifestResolveResult, error) {
 	// Only use the tag->digest cache for unauthenticated requests, since
 	// different auth tokens may have different access to manifests.
 	useTagDigestCache := inreq.Header.Get(headerAuthorization) == ""
@@ -626,7 +626,7 @@ func (r *registry) resolveTagToDigest(ctx context.Context, inreq *http.Request, 
 // tagDigestCacheKey builds a cache key for the tag->digest cache.
 // The key includes the full reference (repo + tag) and sorted accept headers,
 // since content negotiation can affect which manifest digest is returned.
-func tagDigestCacheKey(ref gcrname.Reference, acceptHeaders []string) string {
+func tagDigestCacheKey(ref ctrname.Reference, acceptHeaders []string) string {
 	sorted := make([]string, len(acceptHeaders))
 	copy(sorted, acceptHeaders)
 	sort.Strings(sorted)
@@ -639,16 +639,16 @@ func tagDigestCacheKey(ref gcrname.Reference, acceptHeaders []string) string {
 }
 
 func isDigest(identifier string) bool {
-	_, err := gcr.NewHash(identifier)
+	_, err := ctr.NewHash(identifier)
 	return err == nil
 }
 
-func parseReference(repository, identifier string) (gcrname.Reference, error) {
+func parseReference(repository, identifier string) (ctrname.Reference, error) {
 	joiner := ":"
 	if isDigest(identifier) {
 		joiner = "@"
 	}
-	ref, err := gcrname.ParseReference(repository + joiner + identifier)
+	ref, err := ctrname.ParseReference(repository + joiner + identifier)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -51,7 +51,7 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	wkpb "github.com/buildbuddy-io/buildbuddy/proto/worker"
-	containerregistry "github.com/google/go-containerregistry/pkg/v1"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -1382,7 +1382,7 @@ func TestHighLayerCount(t *testing.T) {
 		t.Run(fmt.Sprintf("1And%dLayers", tc.layerCount), func(t *testing.T) {
 			// Create new layers on top of busybox
 			var lastContent string
-			var layers []containerregistry.Layer
+			var layers []ctr.Layer
 			for i := range tc.layerCount {
 				lastContent = fmt.Sprintf("layer %d", i)
 				content := []byte(lastContent)
@@ -1621,7 +1621,7 @@ func newImageStoreForTest(t *testing.T, layerDir string) *ociruntime.ImageStore 
 	return imageStore
 }
 
-func pushSingleLayerImage(t *testing.T, name string, layer containerregistry.Layer) string {
+func pushSingleLayerImage(t *testing.T, name string, layer ctr.Layer) string {
 	img, err := mutate.AppendLayers(empty.Image, layer)
 	require.NoError(t, err)
 	reg := testregistry.Run(t, testregistry.Opts{})

--- a/enterprise/server/testutil/testregistry/testregistry.go
+++ b/enterprise/server/testutil/testregistry/testregistry.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/require"
 
-	gcr "github.com/google/go-containerregistry/pkg/v1"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 )
 
 const headerDockerContentDigest = "Docker-Content-Digest"
@@ -126,7 +126,7 @@ func remoteOpts(creds *BasicAuthCreds) []remote.Option {
 	}
 }
 
-func (r *Registry) Push(t *testing.T, image gcr.Image, imageName string, creds *BasicAuthCreds) string {
+func (r *Registry) Push(t *testing.T, image ctr.Image, imageName string, creds *BasicAuthCreds) string {
 	fullImageName := r.ImageAddress(imageName)
 	ref, err := name.ParseReference(fullImageName)
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func (r *Registry) Push(t *testing.T, image gcr.Image, imageName string, creds *
 	return fullImageName
 }
 
-func (r *Registry) PushIndex(t *testing.T, idx gcr.ImageIndex, imageName string, creds *BasicAuthCreds) string {
+func (r *Registry) PushIndex(t *testing.T, idx ctr.ImageIndex, imageName string, creds *BasicAuthCreds) string {
 	fullImageName := r.ImageAddress(imageName)
 	ref, err := name.ParseReference(fullImageName)
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func (r *Registry) PushIndex(t *testing.T, idx gcr.ImageIndex, imageName string,
 	return fullImageName
 }
 
-func (r *Registry) PushRandomImage(t *testing.T, creds *BasicAuthCreds) (string, gcr.Image) {
+func (r *Registry) PushRandomImage(t *testing.T, creds *BasicAuthCreds) (string, ctr.Image) {
 	files := map[string][]byte{}
 	buffer := bytes.Buffer{}
 	buffer.Grow(1024)
@@ -160,7 +160,7 @@ func (r *Registry) PushRandomImage(t *testing.T, creds *BasicAuthCreds) (string,
 	return r.Push(t, image, "test", creds), image
 }
 
-func (r *Registry) PushNamedImage(t *testing.T, imageName string, creds *BasicAuthCreds) (string, gcr.Image) {
+func (r *Registry) PushNamedImage(t *testing.T, imageName string, creds *BasicAuthCreds) (string, ctr.Image) {
 	files := map[string][]byte{
 		"/tmp/" + imageName: []byte(imageName),
 	}
@@ -169,7 +169,7 @@ func (r *Registry) PushNamedImage(t *testing.T, imageName string, creds *BasicAu
 	return r.Push(t, image, imageName, creds), image
 }
 
-func (r *Registry) PushNamedImageWithFiles(t *testing.T, imageName string, files map[string][]byte, creds *BasicAuthCreds) (string, gcr.Image) {
+func (r *Registry) PushNamedImageWithFiles(t *testing.T, imageName string, files map[string][]byte, creds *BasicAuthCreds) (string, ctr.Image) {
 	image, err := imageFromFiles(files)
 	require.NoError(t, err)
 	return r.Push(t, image, imageName, creds), image
@@ -177,7 +177,7 @@ func (r *Registry) PushNamedImageWithFiles(t *testing.T, imageName string, files
 
 // imageFromFiles reimplements crane.Image() but with proper permission added to each tar.Header.
 // This allows us to unpack the tarball locally without priviledged permission (i.e. sudo).
-func imageFromFiles(files map[string][]byte) (gcr.Image, error) {
+func imageFromFiles(files map[string][]byte) (ctr.Image, error) {
 	buf := bytes.Buffer{}
 	tw := tar.NewWriter(&buf)
 
@@ -218,9 +218,9 @@ func imageFromFiles(files map[string][]byte) (gcr.Image, error) {
 	return mutate.AppendLayers(empty.Image, layer)
 }
 
-func (r *Registry) PushNamedImageWithMultipleLayers(t *testing.T, imageName string, creds *BasicAuthCreds) (string, gcr.Image) {
+func (r *Registry) PushNamedImageWithMultipleLayers(t *testing.T, imageName string, creds *BasicAuthCreds) (string, ctr.Image) {
 	base := empty.Image
-	layers := make([]gcr.Layer, 0, 9)
+	layers := make([]ctr.Layer, 0, 9)
 	for i := 0; i < 9; i++ {
 		rn, buf := testdigest.RandomCASResourceBuf(t, 128)
 		layer, err := crane.Layer(map[string][]byte{
@@ -244,7 +244,7 @@ func (r *Registry) Shutdown() error {
 // ImageFromRlocationpath returns an Image from an rlocationpath.
 // The rlocationpath should be set via x_defs in the BUILD file, and the
 // rlocationpath target should be an OCI image target (e.g. oci.pull)
-func ImageFromRlocationpath(t *testing.T, rlocationpath string) gcr.Image {
+func ImageFromRlocationpath(t *testing.T, rlocationpath string) ctr.Image {
 	indexPath, err := runfiles.Rlocation(rlocationpath)
 	require.NoError(t, err)
 	idx, err := layout.ImageIndexFromPath(indexPath)
@@ -261,18 +261,18 @@ func ImageFromRlocationpath(t *testing.T, rlocationpath string) gcr.Image {
 // bytesLayer implements partial.UncompressedLayer from raw bytes.
 type bytesLayer struct {
 	content   []byte
-	diffID    gcr.Hash
+	diffID    ctr.Hash
 	mediaType types.MediaType
 }
 
 // NewBytesLayer returns an image layer representing the given bytes.
 //
 // testtar.EntryBytes may be useful for constructing tarball contents.
-func NewBytesLayer(t *testing.T, b []byte) gcr.Layer {
+func NewBytesLayer(t *testing.T, b []byte) ctr.Layer {
 	sha := sha256.Sum256(b)
 	layer, err := partial.UncompressedToLayer(&bytesLayer{
 		mediaType: types.OCILayer,
-		diffID: gcr.Hash{
+		diffID: ctr.Hash{
 			Algorithm: "sha256",
 			Hex:       hex.EncodeToString(sha[:]),
 		},
@@ -283,7 +283,7 @@ func NewBytesLayer(t *testing.T, b []byte) gcr.Layer {
 }
 
 // DiffID implements partial.UncompressedLayer
-func (ul *bytesLayer) DiffID() (gcr.Hash, error) {
+func (ul *bytesLayer) DiffID() (ctr.Hash, error) {
 	return ul.diffID, nil
 }
 

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -31,8 +31,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/distribution/reference"
 	"github.com/google/go-containerregistry/pkg/authn"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
+	ctrname "github.com/google/go-containerregistry/pkg/name"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
@@ -136,7 +136,7 @@ func CredentialsFromProperties(props *platform.Properties) (Credentials, error) 
 func resolveWithDefaultKeychain(ref reference.Named) (Credentials, error) {
 	// TODO: parse the errors below and if they're 403/401 errors then return
 	// Unauthenticated/PermissionDenied
-	ctrRef, err := gcrname.ParseReference(ref.String())
+	ctrRef, err := ctrname.ParseReference(ref.String())
 	if err != nil {
 		log.Debugf("Failed to parse image ref %q: %s", ref.String(), err)
 		return Credentials{}, nil
@@ -235,7 +235,7 @@ func (r *Resolver) AuthenticateWithRegistry(ctx context.Context, imageName strin
 
 	log.CtxDebugf(ctx, "Authenticating with registry for %q", imageName)
 
-	imageRef, err := gcrname.ParseReference(imageName)
+	imageRef, err := ctrname.ParseReference(imageName)
 	if err != nil {
 		return status.InvalidArgumentErrorf("invalid image reference %q: %s", imageName, err)
 	}
@@ -259,10 +259,10 @@ func (r *Resolver) AuthenticateWithRegistry(ctx context.Context, imageName strin
 // ResolveImageDigest keeps an LRU cache that maps between canonical image names with tags
 // to image names with digests, to reduce the number of HEAD requests.
 func (r *Resolver) ResolveImageDigest(ctx context.Context, imageName string, platform *rgpb.Platform, credentials Credentials) (string, error) {
-	if imageRefWithDigest, err := gcrname.NewDigest(imageName); err == nil {
+	if imageRefWithDigest, err := ctrname.NewDigest(imageName); err == nil {
 		return imageRefWithDigest.String(), nil
 	}
-	tagRef, err := gcrname.ParseReference(imageName)
+	tagRef, err := ctrname.ParseReference(imageName)
 	if err != nil {
 		return "", status.InvalidArgumentErrorf("invalid image name %q", imageName)
 	}
@@ -284,11 +284,11 @@ func (r *Resolver) ResolveImageDigest(ctx context.Context, imageName string, pla
 	return imageNameWithDigest, nil
 }
 
-func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb.Platform, credentials Credentials, useOCIFetcher bool) (gcr.Image, error) {
+func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb.Platform, credentials Credentials, useOCIFetcher bool) (ctr.Image, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	imageRef, err := gcrname.ParseReference(imageName)
+	imageRef, err := ctrname.ParseReference(imageName)
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("invalid image %q", imageName)
 	}
@@ -319,7 +319,7 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 	return fetchImageFromCacheOrRemote(
 		ctx,
 		imageRef,
-		gcr.Platform{
+		ctr.Platform{
 			Architecture: platform.GetArch(),
 			OS:           platform.GetOs(),
 			Variant:      platform.GetVariant(),
@@ -338,12 +338,12 @@ func (r *Resolver) Resolve(ctx context.Context, imageName string, platform *rgpb
 // then falls back to fetching from the upstream remote registry.
 // If the referenced manifest is actually an image index, fetchImageFromCacheOrRemote will recur at most once
 // to fetch a child image matching the given platform.
-func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef gcrname.Reference, platform gcr.Platform, acClient repb.ActionCacheClient, bsClient bspb.ByteStreamClient, puller *remote.Puller, ociFetcherClient ofpb.OCIFetcherClient, credentials Credentials, useCache bool, useOCIFetcher bool) (gcr.Image, error) {
+func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef ctrname.Reference, platform ctr.Platform, acClient repb.ActionCacheClient, bsClient bspb.ByteStreamClient, puller *remote.Puller, ociFetcherClient ofpb.OCIFetcherClient, credentials Credentials, useCache bool, useOCIFetcher bool) (ctr.Image, error) {
 	// When using OCIFetcher, skip the separate metadata request and just fetch
 	// the full manifest. The OCIFetcher server caches manifests, so this avoids
 	// an extra round trip.
 	if useCache && !useOCIFetcher {
-		var desc *gcr.Descriptor
+		var desc *ctr.Descriptor
 		digest, hasDigest := getDigest(digestOrTagRef)
 		// For now, we cannot bypass the registry for tag references,
 		// since cached manifest AC entries need the resolved digest as part of
@@ -381,7 +381,7 @@ func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef gcrname.Ref
 			// represent a complete manifest descriptor (the implementation of
 			// [puller.Head] only sets these fields as well).
 			if desc == nil {
-				desc = &gcr.Descriptor{
+				desc = &ctr.Descriptor{
 					Digest:    digest,
 					Size:      int64(len(mc.GetRaw())),
 					MediaType: types.MediaType(mc.GetContentType()),
@@ -443,7 +443,7 @@ func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef gcrname.Ref
 // fetchManifestMetadata makes a HEAD request for the manifest metadata using the puller.
 // This is only used when useOCIFetcher=false; when useOCIFetcher=true, we skip the
 // metadata request and fetch the full manifest directly via fetchManifest.
-func fetchManifestMetadata(ctx context.Context, digestOrTagRef gcrname.Reference, puller *remote.Puller) (*gcr.Descriptor, error) {
+func fetchManifestMetadata(ctx context.Context, digestOrTagRef ctrname.Reference, puller *remote.Puller) (*ctr.Descriptor, error) {
 	desc, err := puller.Head(ctx, digestOrTagRef)
 	if err != nil {
 		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
@@ -456,7 +456,7 @@ func fetchManifestMetadata(ctx context.Context, digestOrTagRef gcrname.Reference
 
 // fetchManifest fetches the manifest for the given image reference.
 // ociFetcherClient must be non-nil when useOCIFetcher is true.
-func fetchManifest(ctx context.Context, digestOrTagRef gcrname.Reference, puller *remote.Puller, ociFetcherClient ofpb.OCIFetcherClient, credentials Credentials, useOCIFetcher bool) (*gcr.Descriptor, []byte, error) {
+func fetchManifest(ctx context.Context, digestOrTagRef ctrname.Reference, puller *remote.Puller, ociFetcherClient ofpb.OCIFetcherClient, credentials Credentials, useOCIFetcher bool) (*ctr.Descriptor, []byte, error) {
 	if useOCIFetcher && ociFetcherClient == nil {
 		return nil, nil, status.FailedPreconditionError("OCIFetcherClient is required when useOCIFetcher is true")
 	}
@@ -469,11 +469,11 @@ func fetchManifest(ctx context.Context, digestOrTagRef gcrname.Reference, puller
 		if err != nil {
 			return nil, nil, err
 		}
-		digest, err := gcr.NewHash(resp.GetDigest())
+		digest, err := ctr.NewHash(resp.GetDigest())
 		if err != nil {
 			return nil, nil, status.InternalErrorf("invalid digest %q from OCI fetcher: %s", resp.GetDigest(), err)
 		}
-		return &gcr.Descriptor{
+		return &ctr.Descriptor{
 			Digest:    digest,
 			Size:      resp.GetSize(),
 			MediaType: types.MediaType(resp.GetMediaType()),
@@ -494,7 +494,7 @@ func fetchManifest(ctx context.Context, digestOrTagRef gcrname.Reference, puller
 // finds a child image matching the given platform (and fetches a manifest for it) if the given manifest is an index,
 // and otherwise returns an error.
 // ociFetcherClient must be non-nil when useOCIFetcher is true.
-func imageFromDescriptorAndManifest(ctx context.Context, repo gcrname.Repository, desc gcr.Descriptor, rawManifest []byte, platform gcr.Platform, acClient repb.ActionCacheClient, bsClient bspb.ByteStreamClient, puller *remote.Puller, ociFetcherClient ofpb.OCIFetcherClient, credentials Credentials, useCache bool, useOCIFetcher bool) (gcr.Image, error) {
+func imageFromDescriptorAndManifest(ctx context.Context, repo ctrname.Repository, desc ctr.Descriptor, rawManifest []byte, platform ctr.Platform, acClient repb.ActionCacheClient, bsClient bspb.ByteStreamClient, puller *remote.Puller, ociFetcherClient ofpb.OCIFetcherClient, credentials Credentials, useCache bool, useOCIFetcher bool) (ctr.Image, error) {
 	if useOCIFetcher && ociFetcherClient == nil {
 		return nil, status.FailedPreconditionError("OCIFetcherClient is required when useOCIFetcher is true")
 	}
@@ -503,7 +503,7 @@ func imageFromDescriptorAndManifest(ctx context.Context, repo gcrname.Repository
 	}
 
 	if desc.MediaType.IsIndex() {
-		indexManifest, err := gcr.ParseIndexManifest(bytes.NewReader(rawManifest))
+		indexManifest, err := ctr.ParseIndexManifest(bytes.NewReader(rawManifest))
 		if err != nil {
 			return nil, status.UnknownErrorf("error parsing index manifest: %s", err)
 		}
@@ -546,7 +546,7 @@ func (r *Resolver) getRemoteOpts(ctx context.Context, platform *rgpb.Platform, c
 	remoteOpts := []remote.Option{
 		remote.WithContext(ctx),
 		remote.WithPlatform(
-			gcr.Platform{
+			ctr.Platform{
 				Architecture: platform.GetArch(),
 				OS:           platform.GetOs(),
 				Variant:      platform.GetVariant(),
@@ -581,19 +581,19 @@ func RuntimePlatform() *rgpb.Platform {
 
 // getDigest returns the digest from the given reference, if it contains one.
 // Otherwise, it returns (nil, false).
-func getDigest(ref gcrname.Reference) (gcr.Hash, bool) {
-	d, ok := ref.(gcrname.Digest)
+func getDigest(ref ctrname.Reference) (ctr.Hash, bool) {
+	d, ok := ref.(ctrname.Digest)
 	if !ok {
-		return gcr.Hash{}, false
+		return ctr.Hash{}, false
 	}
-	hash, err := gcr.NewHash(d.DigestStr())
+	hash, err := ctr.NewHash(d.DigestStr())
 	if err != nil {
-		return gcr.Hash{}, false
+		return ctr.Hash{}, false
 	}
 	return hash, true
 }
 
-func newImageFromRawManifest(ctx context.Context, repo gcrname.Repository, desc gcr.Descriptor, rawManifest []byte, acClient repb.ActionCacheClient, bsClient bspb.ByteStreamClient, puller *remote.Puller, ociFetcherClient ofpb.OCIFetcherClient, credentials Credentials, useCache bool, useOCIFetcher bool) *imageFromRawManifest {
+func newImageFromRawManifest(ctx context.Context, repo ctrname.Repository, desc ctr.Descriptor, rawManifest []byte, acClient repb.ActionCacheClient, bsClient bspb.ByteStreamClient, puller *remote.Puller, ociFetcherClient ofpb.OCIFetcherClient, credentials Credentials, useCache bool, useOCIFetcher bool) *imageFromRawManifest {
 	i := &imageFromRawManifest{
 		repo:             repo,
 		desc:             desc,
@@ -633,15 +633,15 @@ func newImageFromRawManifest(ctx context.Context, repo gcrname.Repository, desc 
 	return i
 }
 
-var _ gcr.Image = (*imageFromRawManifest)(nil)
+var _ ctr.Image = (*imageFromRawManifest)(nil)
 
 // imageFromRawManifest implements the go-containerregistry Image interface.
 // It allows us to construct an Image from a raw manifest from either the cache
 // or an upstream remote registry.
 // It also allows us to read layers from and write layers to the cache.
 type imageFromRawManifest struct {
-	repo        gcrname.Repository
-	desc        gcr.Descriptor
+	repo        ctrname.Repository
+	desc        ctr.Descriptor
 	rawManifest []byte
 
 	ctx              context.Context
@@ -656,7 +656,7 @@ type imageFromRawManifest struct {
 	fetchRawConfigOnce func() ([]byte, error)
 }
 
-func (i *imageFromRawManifest) Digest() (gcr.Hash, error) {
+func (i *imageFromRawManifest) Digest() (ctr.Hash, error) {
 	return i.desc.Digest, nil
 }
 
@@ -664,12 +664,12 @@ func (i *imageFromRawManifest) RawManifest() ([]byte, error) {
 	return i.rawManifest, nil
 }
 
-func (i *imageFromRawManifest) Manifest() (*gcr.Manifest, error) {
+func (i *imageFromRawManifest) Manifest() (*ctr.Manifest, error) {
 	rawManifest, err := i.RawManifest()
 	if err != nil {
 		return nil, err
 	}
-	manifest, err := gcr.ParseManifest(bytes.NewReader(rawManifest))
+	manifest, err := ctr.ParseManifest(bytes.NewReader(rawManifest))
 	if err != nil {
 		return nil, err
 	}
@@ -691,28 +691,28 @@ func (i *imageFromRawManifest) RawConfigFile() ([]byte, error) {
 	return i.fetchRawConfigOnce()
 }
 
-func (i *imageFromRawManifest) ConfigFile() (*gcr.ConfigFile, error) {
+func (i *imageFromRawManifest) ConfigFile() (*ctr.ConfigFile, error) {
 	rawConfigFile, err := i.RawConfigFile()
 	if err != nil {
 		return nil, err
 	}
-	return gcr.ParseConfigFile(bytes.NewReader(rawConfigFile))
+	return ctr.ParseConfigFile(bytes.NewReader(rawConfigFile))
 }
 
-func (i *imageFromRawManifest) ConfigName() (gcr.Hash, error) {
+func (i *imageFromRawManifest) ConfigName() (ctr.Hash, error) {
 	manifest, err := i.Manifest()
 	if err != nil {
-		return gcr.Hash{}, err
+		return ctr.Hash{}, err
 	}
 	return manifest.Config.Digest, nil
 }
 
-func (i *imageFromRawManifest) Layers() ([]gcr.Layer, error) {
+func (i *imageFromRawManifest) Layers() ([]ctr.Layer, error) {
 	m, err := i.Manifest()
 	if err != nil {
 		return nil, err
 	}
-	layers := make([]gcr.Layer, 0, len(m.Layers))
+	layers := make([]ctr.Layer, 0, len(m.Layers))
 	for _, layerDesc := range m.Layers {
 		layer := newLayerFromDigest(
 			i.repo,
@@ -727,7 +727,7 @@ func (i *imageFromRawManifest) Layers() ([]gcr.Layer, error) {
 	return layers, nil
 }
 
-func (i *imageFromRawManifest) LayerByDigest(digest gcr.Hash) (gcr.Layer, error) {
+func (i *imageFromRawManifest) LayerByDigest(digest ctr.Hash) (ctr.Layer, error) {
 	return newLayerFromDigest(
 		i.repo,
 		digest,
@@ -737,7 +737,7 @@ func (i *imageFromRawManifest) LayerByDigest(digest gcr.Hash) (gcr.Layer, error)
 	), nil
 }
 
-func (i *imageFromRawManifest) LayerByDiffID(diffID gcr.Hash) (gcr.Layer, error) {
+func (i *imageFromRawManifest) LayerByDiffID(diffID ctr.Hash) (ctr.Layer, error) {
 	digest, err := partial.DiffIDToBlob(i, diffID)
 	if err != nil {
 		return nil, err
@@ -751,40 +751,40 @@ func (i *imageFromRawManifest) LayerByDiffID(diffID gcr.Hash) (gcr.Layer, error)
 	), nil
 }
 
-func newLayerFromDigest(repo gcrname.Repository, digest gcr.Hash, image *imageFromRawManifest, puller *remote.Puller, desc *gcr.Descriptor) *layerFromDigest {
+func newLayerFromDigest(repo ctrname.Repository, digest ctr.Hash, image *imageFromRawManifest, puller *remote.Puller, desc *ctr.Descriptor) *layerFromDigest {
 	return &layerFromDigest{
 		repo:   repo,
 		digest: digest,
 		image:  image,
 		puller: puller,
 		desc:   desc,
-		createRemoteLayer: sync.OnceValues(func() (gcr.Layer, error) {
+		createRemoteLayer: sync.OnceValues(func() (ctr.Layer, error) {
 			ref := repo.Digest(digest.String())
 			return puller.Layer(image.ctx, ref)
 		}),
 	}
 }
 
-var _ gcr.Layer = (*layerFromDigest)(nil)
+var _ ctr.Layer = (*layerFromDigest)(nil)
 
 // layerFromDigest implements the go-containerregistry Layer interface.
 // It allows us to read layers from and write layers to the cache.
 type layerFromDigest struct {
-	repo   gcrname.Repository
-	digest gcr.Hash
+	repo   ctrname.Repository
+	digest ctr.Hash
 	image  *imageFromRawManifest
 
 	puller *remote.Puller
-	desc   *gcr.Descriptor
+	desc   *ctr.Descriptor
 
-	createRemoteLayer func() (gcr.Layer, error)
+	createRemoteLayer func() (ctr.Layer, error)
 }
 
-func (l *layerFromDigest) Digest() (gcr.Hash, error) {
+func (l *layerFromDigest) Digest() (ctr.Hash, error) {
 	return l.digest, nil
 }
 
-func (l *layerFromDigest) DiffID() (gcr.Hash, error) {
+func (l *layerFromDigest) DiffID() (ctr.Hash, error) {
 	return partial.BlobToDiffID(l.image, l.digest)
 }
 
@@ -963,7 +963,7 @@ func isAnonymousUser(ctx context.Context) bool {
 // ports. For IP-address registries, it returns the raw IP. Returns
 // "[UNKNOWN]" if the reference cannot be parsed.
 func RegistryETLDPlusOne(imageRef string) string {
-	ref, err := gcrname.ParseReference(imageRef)
+	ref, err := ctrname.ParseReference(imageRef)
 	if err != nil {
 		return "[UNKNOWN]"
 	}

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -43,7 +43,7 @@ import (
 
 	ofpb "github.com/buildbuddy-io/buildbuddy/proto/oci_fetcher"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 )
 
 func TestCredentialsFromProto(t *testing.T) {
@@ -239,7 +239,7 @@ type resolveTestCase struct {
 
 	imageName     string
 	imageFiles    map[string][]byte
-	imagePlatform v1.Platform
+	imagePlatform ctr.Platform
 
 	args       resolveArgs
 	checkError func(error) bool
@@ -255,7 +255,7 @@ func TestResolve(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an existing image without credentials succeeds"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -275,7 +275,7 @@ func TestResolve(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an invalid image name fails with invalid argument error"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -296,7 +296,7 @@ func TestResolve(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an existing image without authorization fails"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -331,7 +331,7 @@ func TestResolve(t *testing.T) {
 				"/name":    []byte("resolving a platform-specific image without including the variant succeeds"),
 				"/variant": []byte("v8"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: "arm64",
 				OS:           "linux",
 				Variant:      "v8",
@@ -356,7 +356,7 @@ func TestResolve(t *testing.T) {
 
 				index := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
 					Add: pushedImage,
-					Descriptor: v1.Descriptor{
+					Descriptor: ctr.Descriptor{
 						Platform: &tc.imagePlatform,
 					},
 				})
@@ -403,7 +403,7 @@ func TestResolve_Layers_DiffIDs(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an existing image without credentials succeeds"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -424,7 +424,7 @@ func TestResolve_Layers_DiffIDs(t *testing.T) {
 				"/name":    []byte("resolving a platform-specific image without including the variant succeeds"),
 				"/variant": []byte("v8"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: "arm64",
 				OS:           "linux",
 				Variant:      "v8",
@@ -456,7 +456,7 @@ func TestResolve_Layers_DiffIDs(t *testing.T) {
 
 				index := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
 					Add: pushedImage,
-					Descriptor: v1.Descriptor{
+					Descriptor: ctr.Descriptor{
 						Platform: &tc.imagePlatform,
 					},
 				})
@@ -504,7 +504,7 @@ func TestResolve_Layers_DiffIDs(t *testing.T) {
 	}
 }
 
-func layerFiles(t *testing.T, layer v1.Layer) map[string][]byte {
+func layerFiles(t *testing.T, layer ctr.Layer) map[string][]byte {
 	rc, err := layer.Uncompressed()
 	require.NoError(t, err)
 	defer func() { err := rc.Close(); require.NoError(t, err) }()
@@ -661,7 +661,7 @@ func TestResolve_WithCache(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an existing image without credentials succeeds"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -682,7 +682,7 @@ func TestResolve_WithCache(t *testing.T) {
 				"/name":    []byte("resolving a platform-specific image without including the variant succeeds"),
 				"/variant": []byte("v8"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: "arm64",
 				OS:           "linux",
 				Variant:      "v8",
@@ -712,7 +712,7 @@ func TestResolve_WithCache(t *testing.T) {
 
 			index := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
 				Add: pushedImage,
-				Descriptor: v1.Descriptor{
+				Descriptor: ctr.Descriptor{
 					Platform: &tc.imagePlatform,
 				},
 			})
@@ -909,8 +909,8 @@ func TestResolve_Concurrency(t *testing.T) {
 	_, pushedImage := registry.PushNamedImageWithMultipleLayers(t, imageName+"_image", nil)
 	pushedLayers, err := pushedImage.Layers()
 	require.NoError(t, err)
-	pushedDigestToFiles := make(map[v1.Hash]map[string][]byte, len(pushedLayers))
-	pushedDigestToDiffID := make(map[v1.Hash]v1.Hash, len(pushedLayers))
+	pushedDigestToFiles := make(map[ctr.Hash]map[string][]byte, len(pushedLayers))
+	pushedDigestToDiffID := make(map[ctr.Hash]ctr.Hash, len(pushedLayers))
 	for _, pushedLayer := range pushedLayers {
 		digest, err := pushedLayer.Digest()
 		require.NoError(t, err)
@@ -958,7 +958,7 @@ func TestResolve_Concurrency(t *testing.T) {
 	layerChan := make(chan layerResult, len(layers))
 	for _, layer := range layers {
 		layerWG.Add(1)
-		go func(layer v1.Layer) {
+		go func(layer ctr.Layer) {
 			defer layerWG.Done()
 			digest, digestErr := layer.Digest()
 			diffID, diffIDErr := layer.DiffID()
@@ -999,9 +999,9 @@ func TestResolve_Concurrency(t *testing.T) {
 }
 
 type layerResult struct {
-	digest        v1.Hash
+	digest        ctr.Hash
 	digestErr     error
-	diffID        v1.Hash
+	diffID        ctr.Hash
 	diffIDErr     error
 	compressed    []byte
 	compressedErr error
@@ -1350,7 +1350,7 @@ func TestResolveWithOCIFetcher(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an existing image without credentials succeeds"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -1370,7 +1370,7 @@ func TestResolveWithOCIFetcher(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an invalid image name fails with invalid argument error"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -1391,7 +1391,7 @@ func TestResolveWithOCIFetcher(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an existing image without authorization fails"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -1426,7 +1426,7 @@ func TestResolveWithOCIFetcher(t *testing.T) {
 				"/name":    []byte("resolving a platform-specific image without including the variant succeeds"),
 				"/variant": []byte("v8"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: "arm64",
 				OS:           "linux",
 				Variant:      "v8",
@@ -1449,7 +1449,7 @@ func TestResolveWithOCIFetcher(t *testing.T) {
 
 			index := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
 				Add: pushedImage,
-				Descriptor: v1.Descriptor{
+				Descriptor: ctr.Descriptor{
 					Platform: &tc.imagePlatform,
 				},
 			})
@@ -1498,7 +1498,7 @@ func TestResolveWithOCIFetcher_Layers_DiffIDs(t *testing.T) {
 			imageFiles: map[string][]byte{
 				"/name": []byte("resolving an existing image without credentials succeeds"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
 			},
@@ -1519,7 +1519,7 @@ func TestResolveWithOCIFetcher_Layers_DiffIDs(t *testing.T) {
 				"/name":    []byte("resolving a platform-specific image without including the variant succeeds"),
 				"/variant": []byte("v8"),
 			},
-			imagePlatform: v1.Platform{
+			imagePlatform: ctr.Platform{
 				Architecture: "arm64",
 				OS:           "linux",
 				Variant:      "v8",
@@ -1549,7 +1549,7 @@ func TestResolveWithOCIFetcher_Layers_DiffIDs(t *testing.T) {
 
 			index := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
 				Add: pushedImage,
-				Descriptor: v1.Descriptor{
+				Descriptor: ctr.Descriptor{
 					Platform: &tc.imagePlatform,
 				},
 			})
@@ -1624,8 +1624,8 @@ func TestResolveWithOCIFetcher_Concurrency(t *testing.T) {
 	_, pushedImage := registry.PushNamedImageWithMultipleLayers(t, imageName+"_image", nil)
 	pushedLayers, err := pushedImage.Layers()
 	require.NoError(t, err)
-	pushedDigestToFiles := make(map[v1.Hash]map[string][]byte, len(pushedLayers))
-	pushedDigestToDiffID := make(map[v1.Hash]v1.Hash, len(pushedLayers))
+	pushedDigestToFiles := make(map[ctr.Hash]map[string][]byte, len(pushedLayers))
+	pushedDigestToDiffID := make(map[ctr.Hash]ctr.Hash, len(pushedLayers))
 	for _, pushedLayer := range pushedLayers {
 		digest, err := pushedLayer.Digest()
 		require.NoError(t, err)
@@ -1681,7 +1681,7 @@ func TestResolveWithOCIFetcher_Concurrency(t *testing.T) {
 	layerChan := make(chan layerResult, len(layers))
 	for _, layer := range layers {
 		layerWG.Add(1)
-		go func(layer v1.Layer) {
+		go func(layer ctr.Layer) {
 			defer layerWG.Done()
 			digest, digestErr := layer.Digest()
 			diffID, diffIDErr := layer.DiffID()

--- a/enterprise/server/util/ocicache/ocicache.go
+++ b/enterprise/server/util/ocicache/ocicache.go
@@ -22,8 +22,8 @@ import (
 	ocipb "github.com/buildbuddy-io/buildbuddy/proto/ociregistry"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
+	ctrname "github.com/google/go-containerregistry/pkg/name"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -42,7 +42,7 @@ const (
 	cacheDigestFunction = repb.DigestFunction_SHA256
 )
 
-func WriteManifestToAC(ctx context.Context, raw []byte, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, originalRef gcrname.Reference) error {
+func WriteManifestToAC(ctx context.Context, raw []byte, acClient repb.ActionCacheClient, repo ctrname.Repository, hash ctr.Hash, contentType string, originalRef ctrname.Reference) error {
 	arRN, err := manifestACKey(repo, hash)
 	if err != nil {
 		return err
@@ -76,19 +76,19 @@ func updateCacheEventMetric(ociResourceTypeLabel, cacheEventType string) {
 	}).Inc()
 }
 
-func manifestMiss(ctx context.Context, repo gcrname.Repository, hash gcr.Hash, originalRef gcrname.Reference) {
+func manifestMiss(ctx context.Context, repo ctrname.Repository, hash ctr.Hash, originalRef ctrname.Reference) {
 	log.CtxDebugf(ctx, "OCI cache manifest miss %s@%s (original ref %q)", repo, hash, originalRef)
 	updateCacheEventMetric(metrics.OCIManifestResourceTypeLabel, metrics.MissStatusLabel)
 }
 
-func manifestHit(ctx context.Context, repo gcrname.Repository, hash gcr.Hash, originalRef gcrname.Reference) {
+func manifestHit(ctx context.Context, repo ctrname.Repository, hash ctr.Hash, originalRef ctrname.Reference) {
 	log.CtxDebugf(ctx, "OCI cache manifest hit %s@%s (original ref %q)", repo, hash, originalRef)
 	updateCacheEventMetric(metrics.OCIManifestResourceTypeLabel, metrics.HitStatusLabel)
 }
 
 // FetchManifestFromAC fetches the given manifest from the AC if present.
 // TODO(dan) remote originalRef argument once we've debugged frequency of manifest cache misses.
-func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, originalRef gcrname.Reference) (*ocipb.OCIManifestContent, error) {
+func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, repo ctrname.Repository, hash ctr.Hash, originalRef ctrname.Reference) (*ocipb.OCIManifestContent, error) {
 	arRN, err := manifestACKey(repo, hash)
 	if err != nil {
 		manifestMiss(ctx, repo, hash, originalRef)
@@ -118,7 +118,7 @@ func FetchManifestFromAC(ctx context.Context, acClient repb.ActionCacheClient, r
 	return mc, nil
 }
 
-func manifestACKey(repo gcrname.Repository, refhash gcr.Hash) (*digest.ACResourceName, error) {
+func manifestACKey(repo ctrname.Repository, refhash ctr.Hash) (*digest.ACResourceName, error) {
 	s := hash.Strings(
 		repo.RegistryStr(),
 		repo.RepositoryStr(),
@@ -148,7 +148,7 @@ func blobMetadataHit(ctx context.Context) {
 	updateCacheEventMetric(metrics.OCIBlobMetadataResourceTypeLabel, metrics.HitStatusLabel)
 }
 
-func FetchBlobMetadataFromCache(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash) (*ocipb.OCIBlobMetadata, error) {
+func FetchBlobMetadataFromCache(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo ctrname.Repository, hash ctr.Hash) (*ocipb.OCIBlobMetadata, error) {
 	arKey := &ocipb.OCIActionResultKey{
 		Registry:      repo.RegistryStr(),
 		Repository:    repo.RepositoryStr(),
@@ -218,7 +218,7 @@ func blobHit(ctx context.Context) {
 	updateCacheEventMetric(metrics.OCIBlobResourceTypeLabel, metrics.HitStatusLabel)
 }
 
-func FetchBlobFromCache(ctx context.Context, w io.Writer, bsClient bspb.ByteStreamClient, hash gcr.Hash, contentLength int64) error {
+func FetchBlobFromCache(ctx context.Context, w io.Writer, bsClient bspb.ByteStreamClient, hash ctr.Hash, contentLength int64) error {
 	blobCASDigest := &repb.Digest{
 		Hash:      hash.Hex,
 		SizeBytes: contentLength,
@@ -244,7 +244,7 @@ func FetchBlobFromCache(ctx context.Context, w io.Writer, bsClient bspb.ByteStre
 	return nil
 }
 
-func writeBlobMetadataToCache(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) error {
+func writeBlobMetadataToCache(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo ctrname.Repository, hash ctr.Hash, contentType string, contentLength int64) error {
 	blobMetadata := &ocipb.OCIBlobMetadata{
 		ContentLength: contentLength,
 		ContentType:   contentType,
@@ -293,7 +293,7 @@ func writeBlobMetadataToCache(ctx context.Context, bsClient bspb.ByteStreamClien
 	return cachetools.UploadActionResult(ctx, acClient, arRN, ar)
 }
 
-func WriteBlobToCache(ctx context.Context, r io.Reader, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) error {
+func WriteBlobToCache(ctx context.Context, r io.Reader, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo ctrname.Repository, hash ctr.Hash, contentType string, contentLength int64) error {
 	blobCASDigest := &repb.Digest{
 		Hash:      hash.Hex,
 		SizeBytes: contentLength,
@@ -315,7 +315,7 @@ func WriteBlobToCache(ctx context.Context, r io.Reader, bsClient bspb.ByteStream
 //
 // Once contentLength bytes have been written, the blobUploader will commit the blob.
 // It is an error to attempt to Write after commit, and to write more than contentLength bytes.
-func NewBlobUploader(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) (interfaces.CommittedWriteCloser, error) {
+func NewBlobUploader(ctx context.Context, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo ctrname.Repository, hash ctr.Hash, contentType string, contentLength int64) (interfaces.CommittedWriteCloser, error) {
 	blobCASDigest := &repb.Digest{
 		Hash:      hash.Hex,
 		SizeBytes: contentLength,
@@ -350,8 +350,8 @@ type blobUploader struct {
 	bsClient bspb.ByteStreamClient
 	acClient repb.ActionCacheClient
 
-	repo          gcrname.Repository
-	hash          gcr.Hash
+	repo          ctrname.Repository
+	hash          ctr.Hash
 	contentType   string
 	contentLength int64
 
@@ -392,7 +392,7 @@ func (b *blobUploader) Close() error {
 // Any errors writing to the CAS will be logged and ignored.
 //
 // Closing the ReadThroughCacher closes the input ReadCloser and the underlying BlobUploader.
-func NewBlobReadThroughCacher(ctx context.Context, rc io.ReadCloser, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, hash gcr.Hash, contentType string, contentLength int64) (io.ReadCloser, error) {
+func NewBlobReadThroughCacher(ctx context.Context, rc io.ReadCloser, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo ctrname.Repository, hash ctr.Hash, contentType string, contentLength int64) (io.ReadCloser, error) {
 	cache, err := NewBlobUploader(ctx, bsClient, acClient, repo, hash, contentType, contentLength)
 	if err != nil {
 		return nil, err
@@ -449,7 +449,7 @@ func (r *readThroughCacher) Close() error {
 	return err
 }
 
-func WriteBlobOrManifestToCacheAndWriter(ctx context.Context, upstream io.Reader, w io.Writer, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo gcrname.Repository, ociResourceType ocipb.OCIResourceType, hash gcr.Hash, contentType string, contentLength int64, originalRef gcrname.Reference) error {
+func WriteBlobOrManifestToCacheAndWriter(ctx context.Context, upstream io.Reader, w io.Writer, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient, repo ctrname.Repository, ociResourceType ocipb.OCIResourceType, hash ctr.Hash, contentType string, contentLength int64, originalRef ctrname.Reference) error {
 	if ociResourceType == ocipb.OCIResourceType_MANIFEST {
 		if contentLength > maxManifestSize {
 			return status.FailedPreconditionErrorf("manifest too large (%d bytes) to write to cache (limit %d bytes)", contentLength, maxManifestSize)
@@ -473,10 +473,10 @@ func WriteBlobOrManifestToCacheAndWriter(ctx context.Context, upstream io.Reader
 // deduplication. Two requests that resolve to the same BlobFetchKey
 // are safe to coalesce: one fetches from upstream while the others wait.
 type BlobFetchKey struct {
-	// repo is the string form of the gcrname.Repository
+	// repo is the string form of the ctrname.Repository
 	// (e.g. "index.docker.io/library/alpine").
 	repo string
-	// digest is the string form of the gcr.Hash
+	// digest is the string form of the ctr.Hash
 	// (e.g. "sha256:abc123").
 	digest string
 	// credsHash is a hash of the credentials used to fetch the blob.
@@ -487,7 +487,7 @@ type BlobFetchKey struct {
 
 // NewBlobFetchKey creates a BlobFetchKey from strongly-typed
 // go-containerregistry values and optional proto credentials.
-func NewBlobFetchKey(repo gcrname.Repository, digest gcr.Hash, creds *rgpb.Credentials) BlobFetchKey {
+func NewBlobFetchKey(repo ctrname.Repository, digest ctr.Hash, creds *rgpb.Credentials) BlobFetchKey {
 	var credsHash string
 	if creds == nil {
 		credsHash = hash.Strings("", "")

--- a/enterprise/server/util/ocicache/ocicache_test.go
+++ b/enterprise/server/util/ocicache/ocicache_test.go
@@ -22,8 +22,8 @@ import (
 	ocipb "github.com/buildbuddy-io/buildbuddy/proto/ociregistry"
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
+	ctrname "github.com/google/go-containerregistry/pkg/name"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 )
 
 func TestCacheSecret(t *testing.T) {
@@ -67,7 +67,7 @@ func TestCacheSecret(t *testing.T) {
 			require.NoError(t, err)
 
 			acClient := te.GetActionCacheClient()
-			ref, err := gcrname.ParseReference("buildbuddy.io/" + tc.imageName)
+			ref, err := ctrname.ParseReference("buildbuddy.io/" + tc.imageName)
 			require.NoError(t, err)
 
 			flags.Set(t, "oci.cache.secret", tc.writeSecret)
@@ -132,7 +132,7 @@ func TestManifestWithRecordActionResultOrigin(t *testing.T) {
 	require.NoError(t, err)
 
 	acClient := te.GetActionCacheClient()
-	ref, err := gcrname.ParseReference("buildbuddy.io/" + imageName)
+	ref, err := ctrname.ParseReference("buildbuddy.io/" + imageName)
 	require.NoError(t, err)
 
 	err = ocicache.WriteManifestToAC(ctx, raw, acClient, ref.Context(), hash, contentType, ref)
@@ -165,7 +165,7 @@ func TestManifestWrittenOnlyToAC(t *testing.T) {
 	require.NoError(t, err)
 
 	acClient := te.GetActionCacheClient()
-	ref, err := gcrname.ParseReference("buildbuddy.io/" + imageName)
+	ref, err := ctrname.ParseReference("buildbuddy.io/" + imageName)
 	require.NoError(t, err)
 
 	var out bytes.Buffer
@@ -270,7 +270,7 @@ func TestBlobUploader_PartialWriteFails(t *testing.T) {
 	blobDoesNotExist(t, ctx, te, repo, hash, contentLength)
 }
 
-func blobDoesNotExist(t *testing.T, ctx context.Context, te *testenv.TestEnv, repo gcrname.Repository, hash gcr.Hash, contentLength int64) {
+func blobDoesNotExist(t *testing.T, ctx context.Context, te *testenv.TestEnv, repo ctrname.Repository, hash ctr.Hash, contentLength int64) {
 	bsClient := te.GetByteStreamClient()
 	acClient := te.GetActionCacheClient()
 	metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, bsClient, acClient, repo, hash)
@@ -397,7 +397,7 @@ func TestReadThroughCacher_ReturnsEOF(t *testing.T) {
 	fetchAndCheckBlob(t, te, layerBuf, repo, hash, contentType)
 }
 
-func createLayer(t *testing.T, imageName string, filesize int64) ([]byte, gcrname.Repository, gcr.Hash, string) {
+func createLayer(t *testing.T, imageName string, filesize int64) ([]byte, ctrname.Repository, ctr.Hash, string) {
 	_, filebuf := testdigest.RandomCASResourceBuf(t, filesize)
 	filename, err := random.RandomString(32)
 	require.NoError(t, err)
@@ -405,7 +405,7 @@ func createLayer(t *testing.T, imageName string, filesize int64) ([]byte, gcrnam
 		"/tmp/" + filename: filebuf,
 	})
 	require.NoError(t, err)
-	imageRef, err := gcrname.ParseReference("buildbuddy.io/" + imageName)
+	imageRef, err := ctrname.ParseReference("buildbuddy.io/" + imageName)
 	require.NoError(t, err)
 	layers, err := image.Layers()
 	require.NoError(t, err)
@@ -425,7 +425,7 @@ func createLayer(t *testing.T, imageName string, filesize int64) ([]byte, gcrnam
 	return layerBuf, layerRef.Context(), hash, contentType
 }
 
-func fetchAndCheckBlob(t *testing.T, te *testenv.TestEnv, layerBuf []byte, repo gcrname.Repository, hash gcr.Hash, contentType string) {
+func fetchAndCheckBlob(t *testing.T, te *testenv.TestEnv, layerBuf []byte, repo ctrname.Repository, hash ctr.Hash, contentType string) {
 	contentLength := int64(len(layerBuf))
 	ctx := context.Background()
 	bsClient := te.GetByteStreamClient()
@@ -442,16 +442,16 @@ func fetchAndCheckBlob(t *testing.T, te *testenv.TestEnv, layerBuf []byte, repo 
 	require.Empty(t, cmp.Diff(layerBuf, out.Bytes()))
 }
 
-func mustRepo(t *testing.T, name string) gcrname.Repository {
+func mustRepo(t *testing.T, name string) ctrname.Repository {
 	t.Helper()
-	repo, err := gcrname.NewRepository(name)
+	repo, err := ctrname.NewRepository(name)
 	require.NoError(t, err)
 	return repo
 }
 
-func mustHash(t *testing.T, s string) gcr.Hash {
+func mustHash(t *testing.T, s string) ctr.Hash {
 	t.Helper()
-	h, err := gcr.NewHash(s)
+	h, err := ctr.NewHash(s)
 	require.NoError(t, err)
 	return h
 }

--- a/enterprise/server/util/ocimanifest/ocimanifest.go
+++ b/enterprise/server/util/ocimanifest/ocimanifest.go
@@ -2,7 +2,7 @@ package ocimanifest
 
 import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // FindFirstImageManifest returns the first image descriptor in the index
@@ -13,7 +13,7 @@ import (
 //   - OS version and variant are identical if provided.
 //   - features and OS features of the required platform are subsets of those of
 //     the given platform.
-func FindFirstImageManifest(indexManifest gcr.IndexManifest, platform gcr.Platform) (*gcr.Descriptor, error) {
+func FindFirstImageManifest(indexManifest ctr.IndexManifest, platform ctr.Platform) (*ctr.Descriptor, error) {
 	matcher := platformMatcher(platform)
 	for _, manifest := range indexManifest.Manifests {
 		if !manifest.MediaType.IsImage() {
@@ -29,8 +29,8 @@ func FindFirstImageManifest(indexManifest gcr.IndexManifest, platform gcr.Platfo
 // platformMatcher creates Matcher that checks if the given descriptors' platform matches the required platforms.
 //
 // Adapted from matchesPlatform in https://github.com/google/go-containerregistry/blob/v0.20.3/pkg/v1/remote/index.go
-func platformMatcher(required gcr.Platform) func(gcr.Descriptor) bool {
-	return func(desc gcr.Descriptor) bool {
+func platformMatcher(required ctr.Platform) func(ctr.Descriptor) bool {
+	return func(desc ctr.Descriptor) bool {
 		given := desc.Platform
 		// Required fields that must be identical.
 		if given.Architecture != required.Architecture || given.OS != required.OS {

--- a/enterprise/tools/replay_action/replay_action.go
+++ b/enterprise/tools/replay_action/replay_action.go
@@ -54,9 +54,9 @@ import (
 	clpb "github.com/buildbuddy-io/buildbuddy/proto/command_line"
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	gcrname "github.com/google/go-containerregistry/pkg/name"
-	gcr "github.com/google/go-containerregistry/pkg/v1"
-	gcrtypes "github.com/google/go-containerregistry/pkg/v1/types"
+	ctrname "github.com/google/go-containerregistry/pkg/name"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
+	ctrtypes "github.com/google/go-containerregistry/pkg/v1/types"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gstatus "google.golang.org/grpc/status"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
@@ -894,16 +894,16 @@ func (r *Replayer) copyCachedContainerImage(ctx, srcCtx, targetCtx context.Conte
 	}
 	// Parse image
 	imageRefStr := strings.TrimPrefix(imageProp, "docker://")
-	imageRef, err := gcrname.ParseReference(imageRefStr)
+	imageRef, err := ctrname.ParseReference(imageRefStr)
 	if err != nil {
 		return status.WrapError(err, "parse image")
 	}
-	digestRef, ok := imageRef.(gcrname.Digest)
+	digestRef, ok := imageRef.(ctrname.Digest)
 	if !ok {
 		log.CtxWarningf(ctx, "Image %q does not include a digest - must be resolved via the remote registry. This will fail if the image is private and credentials aren't set.", imageProp)
 		return nil
 	}
-	hash, err := gcr.NewHash(digestRef.DigestStr())
+	hash, err := ctr.NewHash(digestRef.DigestStr())
 	if err != nil {
 		return fmt.Errorf("invalid digest %q: %s", digestRef.DigestStr(), err)
 	}
@@ -928,9 +928,9 @@ func (r *Replayer) copyCachedContainerImage(ctx, srcCtx, targetCtx context.Conte
 	// target platform, and copy that manifest to cache, since it's what the
 	// executor will use. Then proceed to use that manifest for copying layers.
 	var rawImageManifest []byte
-	mediaType := gcrtypes.MediaType(cachedManifest.GetContentType())
+	mediaType := ctrtypes.MediaType(cachedManifest.GetContentType())
 	if mediaType.IsIndex() {
-		indexManifest, err := gcr.ParseIndexManifest(bytes.NewReader(cachedManifest.GetRaw()))
+		indexManifest, err := ctr.ParseIndexManifest(bytes.NewReader(cachedManifest.GetRaw()))
 		if err != nil {
 			return fmt.Errorf("parse index manifest: %s", err)
 		}
@@ -959,13 +959,13 @@ func (r *Replayer) copyCachedContainerImage(ctx, srcCtx, targetCtx context.Conte
 	} else {
 		return fmt.Errorf("unexpected manifest type: %s", mediaType)
 	}
-	imageManifest, err := gcr.ParseManifest(bytes.NewReader(rawImageManifest))
+	imageManifest, err := ctr.ParseManifest(bytes.NewReader(rawImageManifest))
 	if err != nil {
 		return fmt.Errorf("parse image manifest: %s", err)
 	}
 
 	// Now that we've copied manifests, copy blobs.
-	copyBlob := func(hash gcr.Hash, contentLength int64, contentType string, label string) error {
+	copyBlob := func(hash ctr.Hash, contentLength int64, contentType string, label string) error {
 		pr, pw := io.Pipe()
 		defer pr.Close()
 		go func() {
@@ -983,7 +983,7 @@ func (r *Replayer) copyCachedContainerImage(ctx, srcCtx, targetCtx context.Conte
 
 	// Copy the config blob (if it's not inlined)
 	if len(imageManifest.Config.Data) == 0 && imageManifest.Config.Size > 0 {
-		configHash, err := gcr.NewHash(imageManifest.Config.Digest.String())
+		configHash, err := ctr.NewHash(imageManifest.Config.Digest.String())
 		if err != nil {
 			return fmt.Errorf("parse config digest: %s", err)
 		}
@@ -997,7 +997,7 @@ func (r *Replayer) copyCachedContainerImage(ctx, srcCtx, targetCtx context.Conte
 		if layer.Size <= 0 {
 			continue
 		}
-		layerHash, err := gcr.NewHash(layer.Digest.String())
+		layerHash, err := ctr.NewHash(layer.Digest.String())
 		if err != nil {
 			return fmt.Errorf("parse layer digest %q: %s", layer.Digest.String(), err)
 		}
@@ -1009,13 +1009,13 @@ func (r *Replayer) copyCachedContainerImage(ctx, srcCtx, targetCtx context.Conte
 	return eg.Wait()
 }
 
-func getImagePlatform(action *repb.Action) (gcr.Platform, error) {
+func getImagePlatform(action *repb.Action) (ctr.Platform, error) {
 	partialTask := &repb.ExecutionTask{Action: action}
 	props, err := platform.ParseProperties(partialTask)
 	if err != nil {
-		return gcr.Platform{}, err
+		return ctr.Platform{}, err
 	}
-	return gcr.Platform{
+	return ctr.Platform{
 		OS:           props.OS,
 		Architecture: props.Arch,
 	}, nil


### PR DESCRIPTION
* Someone (Iain?) gave `go-containerregistry` imports the `ctr` alias.
* Someone else (Brandon?) mentioned `gcr` makes them think of Google Container Registry.
* Me too.
* Let's use `ctr` as the alias.
* Is this necessary? No.
* Has it been lurking in the back of mind and is today the day I do something about it? Yes.