### PR TITLE
Pool buffers in crypter.go

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -774,6 +774,7 @@ func (c *Cache) reader(ctx context.Context, md *sgpb.FileMetadata, r *rspb.Resou
 		if shouldDecrypt {
 			d, err := c.env.GetCrypter().NewDecryptor(ctx, md.GetFileRecord().GetDigest(), reader, md.GetEncryptionMetadata())
 			if err != nil {
+				_ = reader.Close()
 				return nil, status.UnavailableErrorf("decryptor not available: %s", err)
 			}
 			reader = d
@@ -781,6 +782,7 @@ func (c *Cache) reader(ctx context.Context, md *sgpb.FileMetadata, r *rspb.Resou
 		if shouldDecompress {
 			dr, err := compression.NewZstdDecompressingReader(reader)
 			if err != nil {
+				_ = reader.Close()
 				return nil, err
 			}
 			reader = dr

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3035,6 +3035,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 		if shouldDecrypt {
 			d, err := p.env.GetCrypter().NewDecryptor(ctx, fileMetadata.GetFileRecord().GetDigest(), reader, fileMetadata.GetEncryptionMetadata())
 			if err != nil {
+				_ = reader.Close()
 				return nil, status.UnavailableErrorf("decryptor not available: %s", err)
 			}
 			reader = d
@@ -3042,6 +3043,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 		if shouldDecompress {
 			dr, err := compression.NewZstdDecompressingReader(reader)
 			if err != nil {
+				_ = reader.Close()
 				return nil, err
 			}
 			reader = dr

--- a/enterprise/server/crypter/BUILD
+++ b/enterprise/server/crypter/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
+        "//server/util/bytebufferpool",
         "//server/util/status",
         "@org_golang_x_crypto//chacha20poly1305",
     ],

--- a/enterprise/server/crypter/crypter.go
+++ b/enterprise/server/crypter/crypter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bytebufferpool"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"golang.org/x/crypto/chacha20poly1305"
 
@@ -34,6 +35,23 @@ const (
 	nonceSize                    = chacha20poly1305.NonceSizeX
 	encryptedChunkOverhead       = nonceSize + chacha20poly1305.Overhead
 )
+
+// Don't use directly. Call getBuf and putBuf
+var bufPool = bytebufferpool.VariableSize(2 * (PlainTextChunkSize + encryptedChunkOverhead))
+
+func getBuf(size int) []byte {
+	buf := bufPool.Get(int64(size))
+	if len(buf) < size {
+		putBuf(buf)
+		return make([]byte, size)
+	}
+	clear(buf)
+	return buf
+}
+
+func putBuf(buf []byte) {
+	bufPool.Put(buf)
+}
 
 // An encryption key. Note that this is the "derived" key as described in
 // http://go/customer-managed-encryption.
@@ -89,10 +107,10 @@ func NewEncryptor(ctx context.Context, key *DerivedKey, digest *repb.Digest, w i
 		digest:   digest,
 		groupID:  groupID,
 		w:        w,
-		nonceBuf: make([]byte, nonceSize),
+		nonceBuf: getBuf(nonceSize),
 		// We allocate enough space to store an encrypted chunk so that we can
 		// do the encryption in place.
-		buf:    make([]byte, chunkSize+encryptedChunkOverhead),
+		buf:    getBuf(chunkSize + encryptedChunkOverhead),
 		bufCap: chunkSize,
 	}, nil
 }
@@ -159,7 +177,10 @@ func (e *Encryptor) Commit() error {
 }
 
 func (e *Encryptor) Close() error {
-	return e.w.Close()
+	err := e.w.Close()
+	putBuf(e.nonceBuf)
+	putBuf(e.buf)
+	return err
 }
 
 type Decryptor struct {
@@ -189,7 +210,7 @@ func NewDecryptor(ctx context.Context, key *DerivedKey, digest *repb.Digest, r i
 		digest:  digest,
 		groupID: groupID,
 		r:       r,
-		buf:     make([]byte, chunkSize+encryptedChunkOverhead),
+		buf:     getBuf(chunkSize + encryptedChunkOverhead),
 	}, nil
 }
 
@@ -258,5 +279,7 @@ func (d *Decryptor) Read(p []byte) (n int, err error) {
 }
 
 func (d *Decryptor) Close() error {
-	return d.r.Close()
+	err := d.r.Close()
+	putBuf(d.buf)
+	return err
 }

--- a/enterprise/server/crypter/crypter.go
+++ b/enterprise/server/crypter/crypter.go
@@ -36,9 +36,8 @@ const (
 	encryptedChunkOverhead       = nonceSize + chacha20poly1305.Overhead
 )
 
-// Buffer pool for all the buffers in this package. Double the expected max
-// size, just to give some slack. Don't use directly. Call getBuf and putBuf.
-var bufPool = bytebufferpool.VariableSize(2 * (PlainTextChunkSize + encryptedChunkOverhead))
+// Buffer pool for all the buffers in this package.
+var bufPool = bytebufferpool.VariableSize(PlainTextChunkSize + encryptedChunkOverhead)
 
 func getBuf(size int) []byte {
 	buf := bufPool.Get(int64(size))
@@ -100,6 +99,9 @@ type Encryptor struct {
 }
 
 func NewEncryptor(ctx context.Context, key *DerivedKey, digest *repb.Digest, w interfaces.CommittedWriteCloser, groupID string, chunkSize int) (*Encryptor, error) {
+	if chunkSize > PlainTextChunkSize {
+		return nil, status.InvalidArgumentErrorf("chunkSize must be < %v. Was %v", PlainTextChunkSize, chunkSize)
+	}
 	ciph, err := getCipher(key.Key)
 	if err != nil {
 		return nil, err
@@ -207,6 +209,9 @@ type Decryptor struct {
 }
 
 func NewDecryptor(ctx context.Context, key *DerivedKey, digest *repb.Digest, r io.ReadCloser, groupID string, chunkSize int) (*Decryptor, error) {
+	if chunkSize > PlainTextChunkSize {
+		return nil, status.InvalidArgumentErrorf("chunkSize must be < %v. Was %v", PlainTextChunkSize, chunkSize)
+	}
 	ciph, err := getCipher(key.Key)
 	if err != nil {
 		return nil, err

--- a/enterprise/server/crypter/crypter.go
+++ b/enterprise/server/crypter/crypter.go
@@ -36,7 +36,8 @@ const (
 	encryptedChunkOverhead       = nonceSize + chacha20poly1305.Overhead
 )
 
-// Don't use directly. Call getBuf and putBuf
+// Buffer pool for all the buffers in this package. Double the expected max
+// size, just to give some slack. Don't use directly. Call getBuf and putBuf.
 var bufPool = bytebufferpool.VariableSize(2 * (PlainTextChunkSize + encryptedChunkOverhead))
 
 func getBuf(size int) []byte {
@@ -45,6 +46,8 @@ func getBuf(size int) []byte {
 		putBuf(buf)
 		return make([]byte, size)
 	}
+	// clear adds some cost, but guarantees that we don't reuse data between
+	// (de)crypters.
 	clear(buf)
 	return buf
 }
@@ -178,8 +181,11 @@ func (e *Encryptor) Commit() error {
 
 func (e *Encryptor) Close() error {
 	err := e.w.Close()
-	putBuf(e.nonceBuf)
-	putBuf(e.buf)
+	if e.buf != nil {
+		putBuf(e.nonceBuf)
+		putBuf(e.buf)
+		e.buf, e.nonceBuf = nil, nil
+	}
 	return err
 }
 
@@ -280,6 +286,9 @@ func (d *Decryptor) Read(p []byte) (n int, err error) {
 
 func (d *Decryptor) Close() error {
 	err := d.r.Close()
-	putBuf(d.buf)
+	if d.buf != nil {
+		putBuf(d.buf)
+		d.buf = nil
+	}
 	return err
 }

--- a/enterprise/server/crypter/crypter_test.go
+++ b/enterprise/server/crypter/crypter_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/crypter"
@@ -43,12 +44,14 @@ func TestEncryptDecrypt(t *testing.T) {
 				// Write the test data in random chunk sizes. The input chunk sizes should
 				// not affect the final result.
 				testdata.WriteInRandomChunks(t, e, testData)
+				require.NoError(t, e.Close())
 
 				d, err := crypter.NewDecryptor(t.Context(), key, digest, io.NopCloser(out), groupID, 1024)
 				require.NoError(t, err)
 				decrypted, err := io.ReadAll(d)
 
 				require.NoError(t, err)
+				require.NoError(t, d.Close())
 
 				if !bytes.Equal(decrypted, testData) {
 					require.FailNow(t, "original plaintext and decrypted plaintext do not match")
@@ -74,6 +77,7 @@ func TestDecryptWrongKey(t *testing.T) {
 	// Write the test data in random chunk sizes. The input chunk sizes should
 	// not affect the final result.
 	testdata.WriteInRandomChunks(t, e, testData)
+	require.NoError(t, e.Close())
 
 	// Decrypting using a different key should not work.
 	secondKey := &crypter.DerivedKey{Key: []byte(strings.Repeat("f", 32))}
@@ -82,6 +86,7 @@ func TestDecryptWrongKey(t *testing.T) {
 	_, err = io.ReadAll(d)
 
 	require.Error(t, err)
+	require.NoError(t, d.Close())
 }
 
 func TestDecryptWrongDigest(t *testing.T) {
@@ -100,22 +105,102 @@ func TestDecryptWrongDigest(t *testing.T) {
 	// Write the test data in random chunk sizes. The input chunk sizes should
 	// not affect the final result.
 	testdata.WriteInRandomChunks(t, e, testData)
+	require.NoError(t, e.Close())
 
 	d, err := crypter.NewDecryptor(t.Context(), key, digest, io.NopCloser(bytes.NewReader(out.Bytes())), groupID, 1024)
 	require.NoError(t, err)
 	decrypted, err := io.ReadAll(d)
 	require.NoError(t, err)
 	require.Equal(t, decrypted, testData)
+	require.NoError(t, d.Close())
 
 	wrongHashDigest := &repb.Digest{Hash: "badhash", SizeBytes: digest.SizeBytes}
 	d, err = crypter.NewDecryptor(t.Context(), key, wrongHashDigest, io.NopCloser(bytes.NewReader(out.Bytes())), groupID, 1024)
 	require.NoError(t, err)
 	_, err = io.ReadAll(d)
 	require.ErrorContains(t, err, "authentication failed")
+	require.NoError(t, d.Close())
 
 	wrongSizeDigest := &repb.Digest{Hash: digest.Hash, SizeBytes: 9999999999999999}
 	d, err = crypter.NewDecryptor(t.Context(), key, wrongSizeDigest, io.NopCloser(bytes.NewReader(out.Bytes())), groupID, 1024)
 	require.NoError(t, err)
 	_, err = io.ReadAll(d)
 	require.ErrorContains(t, err, "authentication failed")
+	require.NoError(t, d.Close())
+}
+
+// TestEncryptDecryptConcurrentClose exercises the buffer pool by running many
+// concurrent encrypt/decrypt round-trips, each of which closes the
+// (de)crypter. Run under `-race` to detect buffer aliasing from incorrect pool
+// reuse or double-return.
+func TestEncryptDecryptConcurrentClose(t *testing.T) {
+	groupID := "GR123"
+	digest := &repb.Digest{Hash: "foo", SizeBytes: 123}
+	key := &crypter.DerivedKey{Key: []byte(strings.Repeat("a", 32))}
+
+	const goroutines = 8
+	const iterations = 50
+	// Vary the size to hit different power-of-2 buckets in the variable-size
+	// pool. Include sizes that span multiple chunks so the encryptor exercises
+	// the encrypt-in-place buf across flushes.
+	sizes := []int{1, 100, 1023, 1024, 4096, 32 * 1024}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				size := sizes[(g+i)%len(sizes)]
+				testData := make([]byte, size)
+				_, err := rand.Read(testData)
+				require.NoError(t, err)
+
+				out := bytes.NewBuffer(nil)
+				e, err := crypter.NewEncryptor(t.Context(), key, digest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
+				require.NoError(t, err)
+				_, err = e.Write(testData)
+				require.NoError(t, err)
+				require.NoError(t, e.Commit())
+				require.NoError(t, e.Close())
+
+				d, err := crypter.NewDecryptor(t.Context(), key, digest, io.NopCloser(out), groupID, 1024)
+				require.NoError(t, err)
+				decrypted, err := io.ReadAll(d)
+				require.NoError(t, err)
+				require.NoError(t, d.Close())
+
+				if !bytes.Equal(decrypted, testData) {
+					require.FailNowf(t, "mismatch", "goroutine=%d iter=%d size=%d", g, i, size)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestDoubleClose verifies that calling Close twice is safe and does not
+// double-return buffers to the pool.
+func TestDoubleClose(t *testing.T) {
+	groupID := "GR123"
+	digest := &repb.Digest{Hash: "foo", SizeBytes: 123}
+	key := &crypter.DerivedKey{Key: []byte(strings.Repeat("a", 32))}
+
+	out := bytes.NewBuffer(nil)
+	e, err := crypter.NewEncryptor(t.Context(), key, digest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
+	require.NoError(t, err)
+	_, err = e.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.NoError(t, e.Commit())
+	require.NoError(t, e.Close())
+	// Second Close must not panic or re-Put the buffer.
+	require.NoError(t, e.Close())
+
+	d, err := crypter.NewDecryptor(t.Context(), key, digest, io.NopCloser(out), groupID, 1024)
+	require.NoError(t, err)
+	_, err = io.ReadAll(d)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+	// Second Close must not panic or re-Put the buffer.
+	require.NoError(t, d.Close())
 }


### PR DESCRIPTION
There are cases where most of our CPU goes to allocating decryption buffers