### PR TITLE
codesearch: Add tree-sitter annotations library

### DIFF
--- a/codesearch/annotations/BUILD
+++ b/codesearch/annotations/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "annotations",
+    srcs = [
+        "golang.go",
+        "annotations.go",
+        "java.go",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/annotations",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//codesearch/indexprofile",
+        "@com_github_smacker_go_tree_sitter//:go-tree-sitter",
+        "@com_github_smacker_go_tree_sitter//golang",
+        "@com_github_smacker_go_tree_sitter//java",
+        "@org_golang_x_mod//modfile",
+    ],
+)
+
+go_test(
+    name = "annotations_test",
+    srcs = ["annotations_test.go"],
+    deps = [
+        ":annotations",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/codesearch/annotations/BUILD
+++ b/codesearch/annotations/BUILD
@@ -3,8 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "annotations",
     srcs = [
-        "golang.go",
         "annotations.go",
+        "golang.go",
         "java.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/annotations",

--- a/codesearch/annotations/annotations.go
+++ b/codesearch/annotations/annotations.go
@@ -1,0 +1,180 @@
+// Package annotations derives indexable facts about source files using
+// tree-sitter. For each file it produces:
+//
+//   - the identity terms it imports (the `imports` field) and the terms by
+//     which other files import it (the `import_id` field). The index's
+//     posting lists over these keyword fields act as the repo's
+//     reverse-import graph: the cardinality of the posting list for an
+//     identity term is the number of files importing it.
+//   - the names it declares (the `symbols` field), for ranking and, in
+//     future, code navigation.
+//
+// Identity terms have the form `<family>:<scope-qualified identity>` (e.g.
+// `go:github.com/buildbuddy-io/buildbuddy/codesearch/index`). Terms are
+// lowercased to match the whitespace keyword tokenizer's normalization, so
+// stored `import_id` values can be looked up directly against indexed
+// `imports` terms.
+package annotations
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/codesearch/indexprofile"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	gomodfile "golang.org/x/mod/modfile"
+)
+
+// RepoContext carries the repo-level inputs needed to resolve import strings
+// to identity terms. It is constructed once per indexed repo.
+type RepoContext struct {
+	rootDir      string
+	goModulePath string
+}
+
+// NewRepoContext returns a RepoContext for the repo rooted at rootDir,
+// reading repo-level metadata (currently just go.mod at the repo root) from
+// disk. Missing or unparsable metadata disables import-identity extraction
+// for the affected language rather than erroring; symbols are unaffected.
+// Callers without a checkout on disk (e.g. incremental updates from a git
+// diff) must use NewRepoContextWithGoModule instead.
+func NewRepoContext(rootDir string) *RepoContext {
+	rc := &RepoContext{rootDir: rootDir}
+	if data, err := os.ReadFile(filepath.Join(rootDir, "go.mod")); err == nil {
+		rc.goModulePath = gomodfile.ModulePath(data)
+	}
+	return rc
+}
+
+// NewRepoContextWithGoModule returns a RepoContext with an explicit Go module
+// path (e.g. read from the repo metadata doc), for callers that don't have a
+// checkout on disk.
+func NewRepoContextWithGoModule(rootDir, goModulePath string) *RepoContext {
+	return &RepoContext{rootDir: rootDir, goModulePath: goModulePath}
+}
+
+func (rc *RepoContext) GoModulePath() string {
+	return rc.goModulePath
+}
+
+// Result holds the annotations extracted from a single file.
+type Result struct {
+	// Imports are the identity terms of in-repo packages/files this file
+	// imports, deduped, with self-edges and external imports dropped. E.g. a
+	// Go file importing two in-repo packages:
+	//   ["go:github.com/example/repo/util/log", "go:github.com/example/repo/db"]
+	Imports []string
+
+	// ImportID are the identity terms by which other files import this file —
+	// today always zero terms (e.g. test files, or files with no module
+	// context) or one, e.g.:
+	//   ["go:github.com/example/repo/util/log"]   // a Go package
+	//   ["java:com.example.build"]                // a Java package
+	// It is a slice for symmetry with Imports (both populate a
+	// space-separated keyword field) and to admit languages where a file has
+	// several import identities, e.g. a C header reachable via multiple
+	// include paths.
+	ImportID []string
+
+	// Symbols are the names this file declares (functions, methods, types,
+	// and package-level consts/vars), in source order, lowercased. Local
+	// variables, parameters, usages, comments, and string literals
+	// contribute nothing: defining a name is strong evidence the file is
+	// about it; merely containing it is not. E.g. for a Go file declaring
+	// `type Greeter struct{…}` and `func (g *Greeter) Greet()`:
+	//   ["greeter", "greet"]
+	// Repeated when a name is declared more than once (e.g. overloaded Java
+	// methods), so posting-list frequency reflects declaration count.
+	Symbols []string
+}
+
+// Extract parses the file with tree-sitter and returns its annotations. lang
+// is the lowercase enry-detected language name. Symbols are extracted for any
+// supported language; import identities additionally require module context
+// (go.mod) and an in-repo path.
+//
+// A nil result means there is nothing to extract — an unsupported language or
+// a missing repo context — and is not an error. A file of a supported
+// language always parses (tree-sitter is error-tolerant, marking unparseable
+// regions with ERROR nodes rather than failing), so it returns non-nil
+// annotations that may simply be empty. A non-nil error is reserved for the
+// genuinely unexpected: a parse interrupted by context cancellation. Callers
+// should not fail indexing on that error, but they should surface it rather
+// than silently dropping the file.
+func Extract(lang, filename string, content []byte, rctx *RepoContext) (*Result, error) {
+	defer indexprofile.Timer(indexprofile.PhaseExtractAnnotations)()
+	if rctx == nil {
+		return nil, nil
+	}
+	switch lang {
+	case "go":
+		return extractGo(filename, content, rctx)
+	case "java":
+		return extractJava(filename, content, rctx)
+	default:
+		return nil, nil
+	}
+}
+
+// mustCompileQuery compiles a tree-sitter query at package init; the pattern
+// is a compile-time constant, so failure is a programming error.
+func mustCompileQuery(pattern string, lang *sitter.Language) *sitter.Query {
+	q, err := sitter.NewQuery([]byte(pattern), lang)
+	if err != nil {
+		panic(fmt.Sprintf("compiling tree-sitter query: %s", err))
+	}
+	return q
+}
+
+// captureAllRaw returns the text of every capture of q in the parsed tree,
+// in source order, case preserved.
+func captureAllRaw(q *sitter.Query, tree *sitter.Tree, content []byte) []string {
+	qc := sitter.NewQueryCursor()
+	defer qc.Close()
+	qc.Exec(q, tree.RootNode())
+
+	var out []string
+	for {
+		m, ok := qc.NextMatch()
+		if !ok {
+			break
+		}
+		for _, c := range m.Captures {
+			if text := c.Node.Content(content); text != "" {
+				out = append(out, text)
+			}
+		}
+	}
+	return out
+}
+
+// captureAll is captureAllRaw lowercased, matching the keyword tokenizer's
+// normalization.
+func captureAll(q *sitter.Query, tree *sitter.Tree, content []byte) []string {
+	out := captureAllRaw(q, tree, content)
+	for i, s := range out {
+		out[i] = strings.ToLower(s)
+	}
+	return out
+}
+
+// relPath returns filename slash-separated and relative to the repo root, or
+// "" if it isn't under it.
+func (rc *RepoContext) relPath(filename string) string {
+	rel := filename
+	if rc.rootDir != "" {
+		r, err := filepath.Rel(rc.rootDir, filename)
+		if err != nil {
+			return ""
+		}
+		rel = r
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return ""
+	}
+	return rel
+}

--- a/codesearch/annotations/annotations.go
+++ b/codesearch/annotations/annotations.go
@@ -17,6 +17,7 @@
 package annotations
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -93,27 +94,28 @@ type Result struct {
 
 // Extract parses the file with tree-sitter and returns its annotations. lang
 // is the lowercase enry-detected language name. Symbols are extracted for any
-// supported language; import identities additionally require module context
-// (go.mod) and an in-repo path.
+// supported, parseable file. Import identities additionally require an in-repo
+// path (the file must live under the repo root) plus, for Go, module context
+// (go.mod); Java identity is taken from the file's own package declaration.
 //
 // A nil result means there is nothing to extract — an unsupported language or
 // a missing repo context — and is not an error. A file of a supported
 // language always parses (tree-sitter is error-tolerant, marking unparseable
 // regions with ERROR nodes rather than failing), so it returns non-nil
 // annotations that may simply be empty. A non-nil error is reserved for the
-// genuinely unexpected: a parse interrupted by context cancellation. Callers
+// genuinely unexpected: a parse interrupted via ctx cancellation. Callers
 // should not fail indexing on that error, but they should surface it rather
 // than silently dropping the file.
-func Extract(lang, filename string, content []byte, rctx *RepoContext) (*Result, error) {
+func Extract(ctx context.Context, lang, filename string, content []byte, rctx *RepoContext) (*Result, error) {
 	defer indexprofile.Timer(indexprofile.PhaseExtractAnnotations)()
 	if rctx == nil {
 		return nil, nil
 	}
 	switch lang {
 	case "go":
-		return extractGo(filename, content, rctx)
+		return extractGo(ctx, filename, content, rctx)
 	case "java":
-		return extractJava(filename, content, rctx)
+		return extractJava(ctx, filename, content, rctx)
 	default:
 		return nil, nil
 	}

--- a/codesearch/annotations/annotations_test.go
+++ b/codesearch/annotations/annotations_test.go
@@ -1,0 +1,277 @@
+package annotations_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/codesearch/annotations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testModule = "github.com/example/Repo"
+
+func testRepoContext(t *testing.T) (*annotations.RepoContext, string) {
+	t.Helper()
+	dir := t.TempDir()
+	gomod := "module " + testModule + "\n\ngo 1.24\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0644))
+	return annotations.NewRepoContext(dir), dir
+}
+
+func extract(t *testing.T, rctx *annotations.RepoContext, rootDir, relPath, content string) *annotations.Result {
+	t.Helper()
+	ann, err := annotations.Extract("go", filepath.Join(rootDir, relPath), []byte(content), rctx)
+	require.NoError(t, err)
+	return ann
+}
+
+func TestGoModulePathFromGoMod(t *testing.T) {
+	rctx, _ := testRepoContext(t)
+	assert.Equal(t, testModule, rctx.GoModulePath())
+}
+
+func TestGoSingleImport(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann := extract(t, rctx, dir, "server/main.go", `package main
+
+import "github.com/example/Repo/util/log"
+
+func main() {}
+`)
+	require.NotNil(t, ann)
+	assert.Equal(t, []string{"go:github.com/example/repo/util/log"}, ann.Imports)
+	assert.Equal(t, []string{"go:github.com/example/repo/server"}, ann.ImportID)
+}
+
+func TestGoFactoredImportsWithAliasBlankAndDot(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann := extract(t, rctx, dir, "server/main.go", `package main
+
+import (
+	"fmt"
+	xlog "github.com/example/Repo/util/log"
+	_ "github.com/example/Repo/util/sideeffect"
+	. "github.com/example/Repo/util/dot"
+	"github.com/other/module/pkg"
+)
+`)
+	require.NotNil(t, ann)
+	assert.Equal(t, []string{
+		"go:github.com/example/repo/util/log",
+		"go:github.com/example/repo/util/sideeffect",
+		"go:github.com/example/repo/util/dot",
+	}, ann.Imports, "stdlib and external imports are dropped; aliased/blank/dot imports kept")
+}
+
+func TestGoImportsDeduped(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann := extract(t, rctx, dir, "a/a.go", `package a
+
+import (
+	l1 "github.com/example/Repo/util/log"
+	l2 "github.com/example/Repo/util/log"
+)
+`)
+	require.NotNil(t, ann)
+	assert.Equal(t, []string{"go:github.com/example/repo/util/log"}, ann.Imports)
+}
+
+func TestGoSelfEdgeDropped(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann := extract(t, rctx, dir, "util/log/log_helpers.go", `package log
+
+import "github.com/example/Repo/util/log"
+`)
+	require.NotNil(t, ann)
+	assert.Empty(t, ann.Imports)
+	assert.Equal(t, []string{"go:github.com/example/repo/util/log"}, ann.ImportID)
+}
+
+func TestGoTestFileGetsNoImportID(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann := extract(t, rctx, dir, "util/log/log_test.go", `package log_test
+
+import (
+	"testing"
+
+	"github.com/example/Repo/util/log"
+	"github.com/example/Repo/testutil"
+)
+`)
+	require.NotNil(t, ann)
+	assert.Equal(t, []string{
+		// The test file's own package is a self-edge even for external
+		// test packages.
+		"go:github.com/example/repo/testutil",
+	}, ann.Imports)
+	assert.Empty(t, ann.ImportID, "test files should not receive import-rank boost")
+}
+
+func TestGoRepoRootPackage(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann := extract(t, rctx, dir, "main.go", `package main
+
+import "github.com/example/Repo/sub"
+`)
+	require.NotNil(t, ann)
+	assert.Equal(t, []string{"go:github.com/example/repo/sub"}, ann.Imports)
+	assert.Equal(t, []string{"go:github.com/example/repo"}, ann.ImportID)
+}
+
+func TestGoParseErrorTolerated(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	// Tree-sitter is error-tolerant; garbage before/after the import should
+	// not lose the parseable import declaration, and must never panic.
+	ann := extract(t, rctx, dir, "a/a.go", `package a
+
+import "github.com/example/Repo/util/log"
+
+func { this is not valid go at all ((
+`)
+	require.NotNil(t, ann)
+	assert.Equal(t, []string{"go:github.com/example/repo/util/log"}, ann.Imports)
+}
+
+func TestUnsupportedLanguageReturnsNil(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann, err := annotations.Extract("python", filepath.Join(dir, "a.py"), []byte("import os\n"), rctx)
+	require.NoError(t, err)
+	assert.Nil(t, ann)
+}
+
+func TestNoGoModDisablesGoImports(t *testing.T) {
+	dir := t.TempDir()
+	rctx := annotations.NewRepoContext(dir)
+	ann := extract(t, rctx, dir, "a/a.go", `package a
+
+import "github.com/example/Repo/util/log"
+
+func DoThing() {}
+`)
+	// Symbols don't need module context; import identities do.
+	require.NotNil(t, ann)
+	assert.Empty(t, ann.Imports)
+	assert.Empty(t, ann.ImportID)
+	assert.Equal(t, []string{"dothing"}, ann.Symbols)
+}
+
+func TestFileOutsideRepoRootGetsNoImports(t *testing.T) {
+	rctx, _ := testRepoContext(t)
+	ann, err := annotations.Extract("go", filepath.Join(t.TempDir(), "b.go"), []byte("package b\n\nfunc Helper() {}\n"), rctx)
+	require.NoError(t, err)
+	require.NotNil(t, ann)
+	assert.Empty(t, ann.Imports)
+	assert.Empty(t, ann.ImportID)
+	assert.Equal(t, []string{"helper"}, ann.Symbols)
+}
+
+func TestGoSymbols(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann := extract(t, rctx, dir, "greet/greet.go", `package greet
+
+import "fmt"
+
+// Greeter says hello. Comment words like Banana must not be indexed.
+type Greeter struct{ Name string }
+
+type Salutation = string
+
+const DefaultName = "World"
+
+var GreetCount int
+
+func (g *Greeter) Greet(loudly bool) {
+	count := GreetCount
+	var local int
+	fmt.Println(g.Name, count, local, "string literals are not symbols")
+}
+
+func NewGreeter() *Greeter { return &Greeter{} }
+`)
+	require.NotNil(t, ann)
+	// Declarations only, source order, lowercased: no package name, no
+	// receivers/params/locals (including var-declared locals), no usages,
+	// no field names, nothing from comments or strings.
+	assert.Equal(t, []string{
+		"greeter",     // type Greeter
+		"salutation",  // type alias
+		"defaultname", // package-level const
+		"greetcount",  // package-level var
+		"greet",       // method
+		"newgreeter",  // function
+	}, ann.Symbols)
+}
+
+func TestJavaSymbolsAndImports(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	ann, err := annotations.Extract("java", filepath.Join(dir, "src/main/java/com/example/build/RuleHelper.java"), []byte(`
+package com.example.build;
+
+import com.example.build.util.Label;
+import com.example.build.util.*;
+import static com.example.other.Constants.MAX_DEPTH;
+import java.util.List;
+
+// Comment words like Banana must not be indexed.
+public class RuleHelper {
+	public static final int DEFAULT_DEPTH = 3;
+	private Label label;
+
+	public RuleHelper(Label label) {
+		this.label = label;
+	}
+
+	public List<String> expandRule(String name) {
+		int localVar = MAX_DEPTH;
+		return List.of(name, "string literals are not symbols");
+	}
+
+	interface Expander {
+		void expand();
+	}
+
+	enum Mode { STRICT, LENIENT }
+}
+`), rctx)
+	require.NoError(t, err)
+	require.NotNil(t, ann)
+	assert.Equal(t, []string{
+		"rulehelper",        // class
+		"default_depth",     // field (constant)
+		"label",             // field
+		"rulehelper",        // constructor
+		"expandrule",        // method
+		"expander",          // nested interface
+		"expand",            // interface method
+		"mode",              // nested enum
+		"strict", "lenient", // enum constants
+	}, ann.Symbols)
+	// Class import, wildcard import, and static import all resolve to their
+	// packages; java.util is external but indexed (it never matches any
+	// import_id, so it adds no in-degree); self-package edges are dropped.
+	assert.Equal(t, []string{
+		"java:com.example.build.util",
+		"java:com.example.other",
+		"java:java.util",
+	}, ann.Imports)
+	assert.Equal(t, []string{"java:com.example.build"}, ann.ImportID)
+}
+
+func TestJavaTestFileGetsNoImportID(t *testing.T) {
+	rctx, dir := testRepoContext(t)
+	for _, name := range []string{
+		"src/test/java/com/example/RuleHelperTest.java",
+		"javatests/com/example/Helpers.java",
+	} {
+		ann, err := annotations.Extract("java", filepath.Join(dir, name), []byte(`
+package com.example;
+public class X {}
+`), rctx)
+		require.NoError(t, err, name)
+		require.NotNil(t, ann, name)
+		assert.Empty(t, ann.ImportID, name)
+		assert.Equal(t, []string{"x"}, ann.Symbols, name)
+	}
+}

--- a/codesearch/annotations/annotations_test.go
+++ b/codesearch/annotations/annotations_test.go
@@ -1,6 +1,7 @@
 package annotations_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +23,7 @@ func testRepoContext(t *testing.T) (*annotations.RepoContext, string) {
 
 func extract(t *testing.T, rctx *annotations.RepoContext, rootDir, relPath, content string) *annotations.Result {
 	t.Helper()
-	ann, err := annotations.Extract("go", filepath.Join(rootDir, relPath), []byte(content), rctx)
+	ann, err := annotations.Extract(context.Background(), "go", filepath.Join(rootDir, relPath), []byte(content), rctx)
 	require.NoError(t, err)
 	return ann
 }
@@ -136,7 +137,7 @@ func { this is not valid go at all ((
 
 func TestUnsupportedLanguageReturnsNil(t *testing.T) {
 	rctx, dir := testRepoContext(t)
-	ann, err := annotations.Extract("python", filepath.Join(dir, "a.py"), []byte("import os\n"), rctx)
+	ann, err := annotations.Extract(context.Background(), "python", filepath.Join(dir, "a.py"), []byte("import os\n"), rctx)
 	require.NoError(t, err)
 	assert.Nil(t, ann)
 }
@@ -159,7 +160,7 @@ func DoThing() {}
 
 func TestFileOutsideRepoRootGetsNoImports(t *testing.T) {
 	rctx, _ := testRepoContext(t)
-	ann, err := annotations.Extract("go", filepath.Join(t.TempDir(), "b.go"), []byte("package b\n\nfunc Helper() {}\n"), rctx)
+	ann, err := annotations.Extract(context.Background(), "go", filepath.Join(t.TempDir(), "b.go"), []byte("package b\n\nfunc Helper() {}\n"), rctx)
 	require.NoError(t, err)
 	require.NotNil(t, ann)
 	assert.Empty(t, ann.Imports)
@@ -206,7 +207,7 @@ func NewGreeter() *Greeter { return &Greeter{} }
 
 func TestJavaSymbolsAndImports(t *testing.T) {
 	rctx, dir := testRepoContext(t)
-	ann, err := annotations.Extract("java", filepath.Join(dir, "src/main/java/com/example/build/RuleHelper.java"), []byte(`
+	ann, err := annotations.Extract(context.Background(), "java", filepath.Join(dir, "src/main/java/com/example/build/RuleHelper.java"), []byte(`
 package com.example.build;
 
 import com.example.build.util.Label;
@@ -265,7 +266,7 @@ func TestJavaTestFileGetsNoImportID(t *testing.T) {
 		"src/test/java/com/example/RuleHelperTest.java",
 		"javatests/com/example/Helpers.java",
 	} {
-		ann, err := annotations.Extract("java", filepath.Join(dir, name), []byte(`
+		ann, err := annotations.Extract(context.Background(), "java", filepath.Join(dir, name), []byte(`
 package com.example;
 public class X {}
 `), rctx)
@@ -274,4 +275,37 @@ public class X {}
 		assert.Empty(t, ann.ImportID, name)
 		assert.Equal(t, []string{"x"}, ann.Symbols, name)
 	}
+}
+
+func TestJavaImportIDSurvivesTestInRepoPath(t *testing.T) {
+	// Test-file detection must run on the repo-relative path, not the
+	// absolute one: a checkout under a directory named "tests" must not
+	// strip identity from every Java file under it.
+	root := filepath.Join(t.TempDir(), "tests", "myrepo")
+	require.NoError(t, os.MkdirAll(root, 0755))
+	rctx := annotations.NewRepoContext(root)
+
+	ann, err := annotations.Extract(context.Background(), "java",
+		filepath.Join(root, "src/main/java/com/example/Foo.java"), []byte(`
+package com.example;
+public class Foo {}
+`), rctx)
+	require.NoError(t, err)
+	require.NotNil(t, ann)
+	assert.Equal(t, []string{"java:com.example"}, ann.ImportID)
+}
+
+func TestJavaFileOutsideRepoRootGetsNoImportID(t *testing.T) {
+	rctx, _ := testRepoContext(t)
+	// A file outside the repo root has no in-repo identity, mirroring Go.
+	ann, err := annotations.Extract(context.Background(), "java",
+		filepath.Join(t.TempDir(), "Stray.java"), []byte(`
+package com.example;
+public class Stray {}
+`), rctx)
+	require.NoError(t, err)
+	require.NotNil(t, ann)
+	assert.Empty(t, ann.Imports)
+	assert.Empty(t, ann.ImportID)
+	assert.Equal(t, []string{"stray"}, ann.Symbols)
 }

--- a/codesearch/annotations/golang.go
+++ b/codesearch/annotations/golang.go
@@ -29,7 +29,14 @@ func goPackageImportPath(modulePath, relPath string) string {
 }
 
 func extractGo(ctx context.Context, filename string, content []byte, rctx *RepoContext) (*Result, error) {
-	tree, err := parseGo(ctx, content)
+	parser := sitter.NewParser()
+	// Close the parser only after the tree: the binding keeps the parser
+	// alive for the tree's lifetime, so freeing it first is a use-after-free.
+	// Defers run LIFO, so registering parser.Close before tree.Close gives
+	// the right order.
+	defer parser.Close()
+	parser.SetLanguage(golang.GetLanguage())
+	tree, err := parser.ParseCtx(ctx, nil, content)
 	if err != nil {
 		return nil, err
 	}
@@ -93,13 +100,6 @@ func extractGo(ctx context.Context, filename string, content []byte, rctx *RepoC
 		ann.ImportID = []string{goTerm(selfPath)}
 	}
 	return ann, nil
-}
-
-func parseGo(ctx context.Context, content []byte) (*sitter.Tree, error) {
-	parser := sitter.NewParser()
-	defer parser.Close() // the returned tree owns its data and outlives the parser
-	parser.SetLanguage(golang.GetLanguage())
-	return parser.ParseCtx(ctx, nil, content)
 }
 
 // goSymbolQuery captures declaration names: functions, methods, types

--- a/codesearch/annotations/golang.go
+++ b/codesearch/annotations/golang.go
@@ -28,8 +28,8 @@ func goPackageImportPath(modulePath, relPath string) string {
 	return modulePath + "/" + dir
 }
 
-func extractGo(filename string, content []byte, rctx *RepoContext) (*Result, error) {
-	tree, err := parseGo(content)
+func extractGo(ctx context.Context, filename string, content []byte, rctx *RepoContext) (*Result, error) {
+	tree, err := parseGo(ctx, content)
 	if err != nil {
 		return nil, err
 	}
@@ -95,10 +95,11 @@ func extractGo(filename string, content []byte, rctx *RepoContext) (*Result, err
 	return ann, nil
 }
 
-func parseGo(content []byte) (*sitter.Tree, error) {
+func parseGo(ctx context.Context, content []byte) (*sitter.Tree, error) {
 	parser := sitter.NewParser()
+	defer parser.Close() // the returned tree owns its data and outlives the parser
 	parser.SetLanguage(golang.GetLanguage())
-	return parser.ParseCtx(context.Background(), nil, content)
+	return parser.ParseCtx(ctx, nil, content)
 }
 
 // goSymbolQuery captures declaration names: functions, methods, types

--- a/codesearch/annotations/golang.go
+++ b/codesearch/annotations/golang.go
@@ -1,0 +1,152 @@
+// Go extraction.
+
+package annotations
+
+import (
+	"context"
+	"path"
+	"strconv"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/golang"
+)
+
+// goTerm formats a Go import path as an identity term. Terms are lowercased
+// to match the keyword tokenizer's normalization.
+func goTerm(importPath string) string {
+	return "go:" + strings.ToLower(importPath)
+}
+
+// goPackageImportPath returns the import path of the package containing the
+// repo-relative file path.
+func goPackageImportPath(modulePath, relPath string) string {
+	dir := path.Dir(relPath)
+	if dir == "." {
+		return modulePath
+	}
+	return modulePath + "/" + dir
+}
+
+func extractGo(filename string, content []byte, rctx *RepoContext) (*Result, error) {
+	tree, err := parseGo(content)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Close()
+
+	ann := &Result{Symbols: goSymbols(tree, content)}
+
+	// Import-identity terms additionally need a module path to resolve
+	// against, and a path within the module.
+	modPath := rctx.goModulePath
+	if modPath == "" {
+		return ann, nil
+	}
+	rel := rctx.relPath(filename)
+	if rel == "" {
+		return ann, nil
+	}
+
+	importPaths := goImportPaths(tree, content)
+
+	// Module "std" (the Go project itself) is special: its packages import
+	// each other by bare path ("fmt", "cmd/internal/obj") with no module
+	// prefix, and everything importable inside it is in-repo.
+	std := modPath == "std"
+
+	selfPath := goPackageImportPath(modPath, rel)
+	if std {
+		if dir := path.Dir(rel); dir == "." {
+			selfPath = modPath
+		} else {
+			selfPath = dir
+		}
+	}
+	// A vendored package is imported by its original path, not its on-disk
+	// path: src/vendor/golang.org/x/net identifies as golang.org/x/net.
+	if i := strings.LastIndex("/"+selfPath, "/vendor/"); i >= 0 {
+		selfPath = ("/" + selfPath)[i+len("/vendor/"):]
+	}
+
+	seen := make(map[string]struct{}, len(importPaths))
+	imports := make([]string, 0, len(importPaths))
+	for _, p := range importPaths {
+		// Keep only in-repo imports, and drop edges to the importing
+		// file's own package. In std every import is in-repo.
+		if !std && p != modPath && !strings.HasPrefix(p, modPath+"/") {
+			continue
+		}
+		if p == selfPath {
+			continue
+		}
+		term := goTerm(p)
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		imports = append(imports, term)
+	}
+
+	ann.Imports = imports
+	if !strings.HasSuffix(rel, "_test.go") {
+		ann.ImportID = []string{goTerm(selfPath)}
+	}
+	return ann, nil
+}
+
+func parseGo(content []byte) (*sitter.Tree, error) {
+	parser := sitter.NewParser()
+	parser.SetLanguage(golang.GetLanguage())
+	return parser.ParseCtx(context.Background(), nil, content)
+}
+
+// goSymbolQuery captures declaration names: functions, methods, types
+// (including aliases), and package-level consts/vars. Const/var captures are
+// anchored to source_file so function-local declarations are excluded.
+var goSymbolQuery = mustCompileQuery(`
+	(function_declaration name: (identifier) @sym)
+	(method_declaration name: (field_identifier) @sym)
+	(type_spec name: (type_identifier) @sym)
+	(type_alias name: (type_identifier) @sym)
+	(source_file (const_declaration (const_spec name: (identifier) @sym)))
+	(source_file (var_declaration (var_spec name: (identifier) @sym)))
+`, golang.GetLanguage())
+
+// goSymbols returns the declared names in the parsed file, in source order,
+// lowercased to match the keyword tokenizer's normalization.
+func goSymbols(tree *sitter.Tree, content []byte) []string {
+	return captureAll(goSymbolQuery, tree, content)
+}
+
+// goImportPaths returns the unquoted import paths of the parsed file, in
+// source order.
+func goImportPaths(tree *sitter.Tree, content []byte) []string {
+	var paths []string
+	var collectSpecs func(n *sitter.Node)
+	collectSpecs = func(n *sitter.Node) {
+		if n.Type() == "import_spec" {
+			pathNode := n.ChildByFieldName("path")
+			if pathNode != nil {
+				if p, err := strconv.Unquote(pathNode.Content(content)); err == nil && p != "" {
+					paths = append(paths, p)
+				}
+			}
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			collectSpecs(n.NamedChild(i))
+		}
+	}
+
+	// Import declarations only appear at the top level of a source file, so
+	// only their subtrees need to be walked.
+	root := tree.RootNode()
+	for i := 0; i < int(root.NamedChildCount()); i++ {
+		child := root.NamedChild(i)
+		if child.Type() == "import_declaration" {
+			collectSpecs(child)
+		}
+	}
+	return paths
+}

--- a/codesearch/annotations/java.go
+++ b/codesearch/annotations/java.go
@@ -85,7 +85,11 @@ func isJavaTestFile(relPath string) bool {
 
 func extractJava(ctx context.Context, filename string, content []byte, rctx *RepoContext) (*Result, error) {
 	parser := sitter.NewParser()
-	defer parser.Close() // the tree owns its data and outlives the parser
+	// Close the parser only after the tree: the binding keeps the parser
+	// alive for the tree's lifetime, so freeing it first is a use-after-free.
+	// Defers run LIFO, so registering parser.Close before tree.Close gives
+	// the right order.
+	defer parser.Close()
 	parser.SetLanguage(java.GetLanguage())
 	tree, err := parser.ParseCtx(ctx, nil, content)
 	if err != nil {

--- a/codesearch/annotations/java.go
+++ b/codesearch/annotations/java.go
@@ -2,7 +2,6 @@ package annotations
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -67,26 +66,41 @@ func javaPackageOf(dotted string) string {
 	return strings.Join(segs[:n], ".")
 }
 
-// isJavaTestFile reports whether the file should be excluded from import-rank
-// identity (mirroring Go's _test.go exclusion).
-func isJavaTestFile(path string) bool {
-	return strings.Contains(path, "/test/") ||
-		strings.Contains(path, "/tests/") ||
-		strings.Contains(path, "/javatests/") ||
-		strings.HasSuffix(path, "Test.java") ||
-		strings.HasSuffix(path, "Tests.java")
+// isJavaTestFile reports whether the repo-relative path is a test file and so
+// should be excluded from import-rank identity (mirroring Go's _test.go
+// exclusion). The check is segment-based on the relative path: a conventional
+// test directory anywhere in the path, or a Test/Tests-suffixed name. This is
+// a heuristic — it misfires on a package legitimately named "test"
+// (com/example/test/Foo.java) — which is acceptable for a fuzzy ranking
+// signal. It must be passed the repo-relative path, not the absolute one, or
+// a checkout under e.g. /work/tests/... would misclassify every file.
+func isJavaTestFile(relPath string) bool {
+	for seg := range strings.SplitSeq(relPath, "/") {
+		if seg == "test" || seg == "tests" || seg == "javatests" {
+			return true
+		}
+	}
+	return strings.HasSuffix(relPath, "Test.java") || strings.HasSuffix(relPath, "Tests.java")
 }
 
-func extractJava(filename string, content []byte, rctx *RepoContext) (*Result, error) {
+func extractJava(ctx context.Context, filename string, content []byte, rctx *RepoContext) (*Result, error) {
 	parser := sitter.NewParser()
+	defer parser.Close() // the tree owns its data and outlives the parser
 	parser.SetLanguage(java.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	tree, err := parser.ParseCtx(ctx, nil, content)
 	if err != nil {
 		return nil, err
 	}
 	defer tree.Close()
 
 	ann := &Result{Symbols: captureAll(javaSymbolQuery, tree, content)}
+
+	// Identity (imports/import_id) is only meaningful for files inside the
+	// repo; symbols are extracted regardless.
+	rel := rctx.relPath(filename)
+	if rel == "" {
+		return ann, nil
+	}
 
 	// Package and import names must keep their case: javaPackageOf depends
 	// on the lowercase-package / Capitalized-class convention to find the
@@ -112,7 +126,7 @@ func extractJava(filename string, content []byte, rctx *RepoContext) (*Result, e
 	}
 	ann.Imports = imports
 
-	if selfPkg != "" && !isJavaTestFile(filepath.ToSlash(filename)) {
+	if selfPkg != "" && !isJavaTestFile(rel) {
 		ann.ImportID = []string{javaTerm(selfPkg)}
 	}
 	return ann, nil

--- a/codesearch/annotations/java.go
+++ b/codesearch/annotations/java.go
@@ -1,0 +1,119 @@
+package annotations
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/java"
+)
+
+// Java support.
+//
+// Identity terms are package-scoped: a file's ImportID is `java:<package>`
+// from its package declaration, and each import contributes the identity of
+// the package it names. Class imports are mapped to their package by Java's
+// naming convention (package segments are lowercase, type names are
+// capitalized), so `import com.foo.Bar` and `import com.foo.*` both yield
+// `java:com.foo`. External-package imports are indexed too; they simply never
+// match any document's import_id, so they contribute nothing to in-degree.
+
+// javaSymbolQuery captures declaration names: types (class/interface/enum/
+// record/annotation), methods, constructors, fields, and enum constants.
+// Local variables are a distinct node type (local_variable_declaration) and
+// are excluded by construction.
+var javaSymbolQuery = mustCompileQuery(`
+	(class_declaration name: (identifier) @sym)
+	(interface_declaration name: (identifier) @sym)
+	(enum_declaration name: (identifier) @sym)
+	(record_declaration name: (identifier) @sym)
+	(annotation_type_declaration name: (identifier) @sym)
+	(method_declaration name: (identifier) @sym)
+	(constructor_declaration name: (identifier) @sym)
+	(field_declaration declarator: (variable_declarator name: (identifier) @sym))
+	(enum_constant name: (identifier) @sym)
+`, java.GetLanguage())
+
+// The (scoped_)identifier must be an immediate child, so nested
+// scoped_identifiers inside a dotted name don't also match.
+var javaPackageQuery = mustCompileQuery(`
+	(package_declaration [(identifier) (scoped_identifier)] @pkg)
+`, java.GetLanguage())
+
+var javaImportQuery = mustCompileQuery(`
+	(import_declaration [(identifier) (scoped_identifier)] @imp)
+`, java.GetLanguage())
+
+// javaTerm formats a Java package as an identity term.
+func javaTerm(pkg string) string {
+	return "java:" + strings.ToLower(pkg)
+}
+
+// javaPackageOf maps a dotted name from an import declaration to the package
+// it names, using Java naming convention: the package is the longest leading
+// run of lowercase-initial segments. `com.foo.Bar` -> `com.foo`,
+// `com.foo.Bar.CONST` (static import) -> `com.foo`, `com.foo` (wildcard
+// import's scoped_identifier) -> `com.foo`.
+func javaPackageOf(dotted string) string {
+	segs := strings.Split(dotted, ".")
+	n := 0
+	for _, s := range segs {
+		if s == "" || !(s[0] >= 'a' && s[0] <= 'z' || s[0] == '_') {
+			break
+		}
+		n++
+	}
+	return strings.Join(segs[:n], ".")
+}
+
+// isJavaTestFile reports whether the file should be excluded from import-rank
+// identity (mirroring Go's _test.go exclusion).
+func isJavaTestFile(path string) bool {
+	return strings.Contains(path, "/test/") ||
+		strings.Contains(path, "/tests/") ||
+		strings.Contains(path, "/javatests/") ||
+		strings.HasSuffix(path, "Test.java") ||
+		strings.HasSuffix(path, "Tests.java")
+}
+
+func extractJava(filename string, content []byte, rctx *RepoContext) (*Result, error) {
+	parser := sitter.NewParser()
+	parser.SetLanguage(java.GetLanguage())
+	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Close()
+
+	ann := &Result{Symbols: captureAll(javaSymbolQuery, tree, content)}
+
+	// Package and import names must keep their case: javaPackageOf depends
+	// on the lowercase-package / Capitalized-class convention to find the
+	// package boundary. javaTerm lowercases at the end.
+	selfPkg := ""
+	if pkgs := captureAllRaw(javaPackageQuery, tree, content); len(pkgs) > 0 {
+		selfPkg = pkgs[0]
+	}
+
+	seen := make(map[string]struct{})
+	var imports []string
+	for _, imp := range captureAllRaw(javaImportQuery, tree, content) {
+		pkg := javaPackageOf(imp)
+		if pkg == "" || pkg == selfPkg {
+			continue
+		}
+		term := javaTerm(pkg)
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		imports = append(imports, term)
+	}
+	ann.Imports = imports
+
+	if selfPkg != "" && !isJavaTestFile(filepath.ToSlash(filename)) {
+		ann.ImportID = []string{javaTerm(selfPkg)}
+	}
+	return ann, nil
+}

--- a/codesearch/indexprofile/indexprofile.go
+++ b/codesearch/indexprofile/indexprofile.go
@@ -37,6 +37,11 @@ const (
 	PhasePebbleBatchCommit  Phase = "pebble_batch_commit"
 )
 
+// Phases recorded by the annotations package.
+const (
+	PhaseExtractAnnotations Phase = "extract_annotations"
+)
+
 type Counter string
 
 const (


### PR DESCRIPTION
using this to improve search quality by adding ranking signals around # of importers (think pagerank) and definitions