### PR TITLE
Parse compilation_mode flag directly

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -886,7 +886,7 @@ export default class InvocationModel {
   }
 
   getMode() {
-    return this.configuration?.makeVariable.COMPILATION_MODE || "Unknown mode";
+    return this.stringCommandLineOption("compilation_mode") || "fastbuild";
   }
 
   getDuration(completionTime: any, beginTime: any) {

--- a/app/invocation/invocation_model_test.ts
+++ b/app/invocation/invocation_model_test.ts
@@ -37,3 +37,15 @@ describe("InvocationModel.getIsRBEEnabled", () => {
     expect(model.getIsRBEEnabled()).toBe(true);
   });
 });
+
+describe("InvocationModel.getMode", () => {
+  it("uses compilation_mode when present, otherwise defaults to fastbuild", () => {
+    const model = new InvocationModel(new invocation.Invocation());
+
+    expect(model.getMode()).toBe("fastbuild");
+
+    model.optionsMap.set("compilation_mode", "opt");
+
+    expect(model.getMode()).toBe("opt");
+  });
+});


### PR DESCRIPTION
Previously this fetched from the configuration, which might have been
the exec configuration. This means it might have shown opt even if the
top level build was for something else.
