### PR TITLE
Show multiple CPUs for invocation

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -57,7 +57,6 @@ export default class InvocationModel {
   childInvocationsConfigured: build_event_stream.ChildInvocationsConfigured[] = [];
   childInvocationCompletedByInvocationId = new Map<string, build_event_stream.IChildInvocationCompleted>();
   workspaceStatus?: build_event_stream.WorkspaceStatus;
-  configuration?: build_event_stream.Configuration;
   workspaceConfig?: build_event_stream.WorkspaceConfig;
   optionsParsed?: build_event_stream.OptionsParsed;
   unstructuredCommandLine?: build_event_stream.UnstructuredCommandLine;
@@ -81,6 +80,7 @@ export default class InvocationModel {
 
   execLogEntryPromise: Promise<tools.protos.ExecLogEntry[]> | undefined;
 
+  private targetConfigurations: build_event_stream.Configuration[] = [];
   private fileSetIDToFilesMap: Map<string, build_event_stream.File[]> = new Map();
 
   constructor(invocation: invocation.Invocation) {
@@ -155,7 +155,10 @@ export default class InvocationModel {
         );
       }
       if (buildEvent.configuration && buildEvent?.id?.configuration?.id != "none") {
-        this.configuration = buildEvent.configuration as build_event_stream.Configuration;
+        let configuration = buildEvent.configuration as build_event_stream.Configuration;
+        if (!configuration.isTool) {
+          this.targetConfigurations.push(configuration);
+        }
       }
       if (buildEvent.workspaceInfo) {
         this.workspaceConfig = buildEvent.workspaceInfo as build_event_stream.WorkspaceConfig;
@@ -882,7 +885,10 @@ export default class InvocationModel {
         return "darwin_arm64";
       }
     }
-    return this.configuration?.makeVariable.TARGET_CPU || "Unknown CPU";
+    let cpus = Array.from(
+      new Set(this.targetConfigurations.map((configuration) => configuration.makeVariable.TARGET_CPU).filter(Boolean))
+    ).sort();
+    return cpus.join(", ") || "Unknown CPU";
   }
 
   getMode() {

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -155,7 +155,7 @@ export default class InvocationModel {
         );
       }
       if (buildEvent.configuration && buildEvent?.id?.configuration?.id != "none") {
-        let configuration = buildEvent.configuration as build_event_stream.Configuration;
+        const configuration = buildEvent.configuration as build_event_stream.Configuration;
         if (!configuration.isTool) {
           this.targetConfigurations.push(configuration);
         }
@@ -885,7 +885,7 @@ export default class InvocationModel {
         return "darwin_arm64";
       }
     }
-    let cpus = Array.from(
+    const cpus = Array.from(
       new Set(this.targetConfigurations.map((configuration) => configuration.makeVariable.TARGET_CPU).filter(Boolean))
     ).sort();
     return cpus.join(", ") || "Unknown CPU";

--- a/app/invocation/invocation_model_test.ts
+++ b/app/invocation/invocation_model_test.ts
@@ -16,6 +16,24 @@ function newInvocationModelWithBuildMetadata(metadata: Record<string, string>) {
   );
 }
 
+function newInvocationModelWithConfigurations(configurations: { cpu?: string; isTool?: boolean }[]) {
+  return new InvocationModel(
+    new invocation.Invocation({
+      event: configurations.map(
+        (configuration) =>
+          new invocation.InvocationEvent({
+            buildEvent: new build_event_stream.BuildEvent({
+              configuration: new build_event_stream.Configuration({
+                isTool: configuration.isTool,
+                makeVariable: configuration.cpu ? { TARGET_CPU: configuration.cpu } : {},
+              }),
+            }),
+          })
+      ),
+    })
+  );
+}
+
 describe("InvocationModel.getIsRBEEnabled", () => {
   it("uses REMOTE_EXECUTION_ENABLED build metadata from the BES stream", () => {
     const model = newInvocationModelWithBuildMetadata({ REMOTE_EXECUTION_ENABLED: "yes" });
@@ -35,6 +53,24 @@ describe("InvocationModel.getIsRBEEnabled", () => {
     model.optionsMap.set("remote_executor", "grpcs://remote.buildbuddy.io");
 
     expect(model.getIsRBEEnabled()).toBe(true);
+  });
+});
+
+describe("InvocationModel.getCPU", () => {
+  it("returns sorted target configuration CPUs and ignores tool configurations", () => {
+    const model = newInvocationModelWithConfigurations([
+      { cpu: "tool_cpu", isTool: true },
+      { cpu: "target_1_cpu" },
+      { cpu: "target_2_cpu" },
+    ]);
+
+    expect(model.getCPU()).toBe("target_1_cpu, target_2_cpu");
+  });
+
+  it("returns Unknown CPU when there are no target configuration CPUs", () => {
+    const model = newInvocationModelWithConfigurations([{ cpu: "tool_cpu", isTool: true }]);
+
+    expect(model.getCPU()).toBe("Unknown CPU");
   });
 });
 


### PR DESCRIPTION
Previously we were showing the CPU from the last sent configuration,
which could have been an exec configuration and not a target
configuration. Now we show comma separated CPUs from all target
configurations. This can be multiple difference CPUs for multi-platform
builds. This happens if the project has a transition to another platform
in the build. This is very common in the mobile case where builds can
target a mobile platform and the host platform in the same build.

This still isn't perfect since this results in showing something like
`aarch64, x86_64` instead of something more descriptive like
`darwin_arm64, ios_x86_64`, but doing this correctly seems to be quite
difficult with the current BES representation.
