### PR TITLE
Enable app.expanded_suggestions_enabled by default

### DIFF
--- a/server/static/static.go
+++ b/server/static/static.go
@@ -44,7 +44,7 @@ var (
 	userManagementEnabled                  = flag.Bool("app.user_management_enabled", true, "If set, the user management page will be enabled in the UI.", flag.Deprecated("This flag has no effect and will be removed in the future."))
 	testGridV2Enabled                      = flag.Bool("app.test_grid_v2_enabled", true, "Whether to enable test grid V2")
 	usageEnabled                           = flag.Bool("app.usage_enabled", false, "If set, the usage page will be enabled in the UI.")
-	expandedSuggestionsEnabled             = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")
+	expandedSuggestionsEnabled             = flag.Bool("app.expanded_suggestions_enabled", true, "If set, enable more build suggestions in the UI.")
 	enableWorkflows                        = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
 	enableExecutorKeyCreation              = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
 	enableCacheProxyKeyCreation            = flag.Bool("cache_proxy.enable_cache_proxy_key_creation", false, "If enabled, UI will allow cache proxy keys to be created.")


### PR DESCRIPTION
Primarily useful for local testing so you don't have to know to set this
flag since this is already true in production