### PR TITLE
Revert "[FC] Upgrade firecracker to v1.16.0"

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -34,9 +34,9 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             'package(default_visibility = ["//visibility:public"])',
             'filegroup(name = "firecracker", srcs = ["release-{release}/firecracker-{release}"])',
             'filegroup(name = "jailer", srcs = ["release-{release}/jailer-{release}"])',
-        ]).format(release = "v1.16.0-x86_64"),
-        sha256 = "bd04e26952d4e158085778c6230a0b383d2619c319182e27eaa9d61a212e92d6",
-        urls = ["https://github.com/firecracker-microvm/firecracker/releases/download/v1.16.0/firecracker-v1.16.0-x86_64.tgz"],
+        ]).format(release = "v1.15.1-x86_64"),
+        sha256 = "d4a32ab2322d887ca1bc4a4e7afa9cc35393e6362dfc2b3becb389d362e4275a",
+        urls = ["https://github.com/firecracker-microvm/firecracker/releases/download/v1.15.1/firecracker-v1.15.1-x86_64.tgz"],
     )
     http_archive(
         name = "com_github_firecracker_microvm_firecracker_arm64",


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#12421

[Balloon tests look unhealthy](https://buildbuddy.buildbuddy.dev/history/repo/buildbuddy-io/buildbuddy?role=CI_RUNNER&pattern=Baremetal%20tests) since this was merged. Revert while I investigate