### PR TITLE
Add a small debug menu for quick preference toggling

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -544,7 +544,7 @@
           "REPO_MAPPING:,com_github_buildbuddy_io_buildbuddy ",
           "REPO_MAPPING:aspect_rules_ts+,aspect_rules_ts aspect_rules_ts+",
           "REPO_MAPPING:aspect_rules_ts+,bazel_tools bazel_tools",
-          "FILE:@@//package.json 66abbb7063856b6cd1d7c47ad4a391d729daf07a4c1ceb7c04c7c7c0476bb953"
+          "FILE:@@//package.json 314b6392a6320046015a24a5f5af8d1e84abe01a00b3f40b40c2bd3d26c2b4b7"
         ],
         "generatedRepoSpecs": {
           "npm_typescript": {

--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -47,6 +47,7 @@ genrule(
         "//app/root:root.css",
         "//app/alert:alert.css",
         "//app/picker:picker.css",
+        "//app/debug:debug.css",
         "//app/components/search_bar:search_bar.css",
         "//app/compare:compare.css",
         "//app/invocation:invocation.css",

--- a/app/debug/BUILD
+++ b/app/debug/BUILD
@@ -1,0 +1,17 @@
+load("//rules/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["debug.css"])
+
+ts_library(
+    name = "debug",
+    srcs = ["debug.tsx"],
+    deps = [
+        "//:node_modules/@types/react",
+        "//:node_modules/lucide-react",
+        "//:node_modules/react",
+        "//app/components/button",
+        "//app/preferences",
+    ],
+)

--- a/app/debug/debug.css
+++ b/app/debug/debug.css
@@ -1,0 +1,61 @@
+.debug-panel {
+  position: fixed;
+  right: 16px;
+  bottom: 8px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.5;
+  transition: opacity 120ms ease;
+}
+
+.debug-panel:hover,
+.debug-panel:focus-within {
+  opacity: 1;
+}
+
+.debug-panel .debug-panel-button {
+  width: 32px;
+  height: 32px;
+  min-height: 32px;
+  border-radius: 6px;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-1);
+}
+
+.debug-panel .debug-panel-button:hover {
+  background: var(--color-bg-hover);
+}
+
+.debug-panel .debug-panel-button .icon {
+  width: 16px;
+  height: 16px;
+  stroke: var(--color-text-primary);
+}
+
+.debug-panel-terminal-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+}
+
+.debug-panel .debug-panel-button .debug-panel-terminal-base-icon {
+  width: 17px;
+  height: 17px;
+}
+
+.debug-panel .debug-panel-button .debug-panel-terminal-theme-icon {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 9px;
+  height: 9px;
+  padding: 1px;
+  border-radius: 50%;
+  background: var(--color-bg-primary);
+}

--- a/app/debug/debug.tsx
+++ b/app/debug/debug.tsx
@@ -1,0 +1,103 @@
+import { Moon, Rows2, Rows3, Sun, Terminal } from "lucide-react";
+import React from "react";
+import Button from "../components/button/button";
+import UserPreferences from "../preferences/preferences";
+
+console.log("TIP: run toggleDebugMenu() to show quick preference toggles.");
+
+const DEBUG_MENU_ENABLED_LOCALSTORAGE_KEY = "show-debug-menu";
+const ENABLED_CHANGE_EVENT_NAME = "buildbuddy-debug-menu-preference-changed";
+
+export interface DebugMenuProps {
+  preferences: UserPreferences;
+}
+
+interface State {
+  enabled: boolean;
+}
+
+/**
+ * Renders preference toggles at the bottom-right corner of the screen. This is
+ * useful for quickly testing how a page looks with different preferences
+ * enabled/disabled.
+ */
+export default class DebugMenu extends React.Component<DebugMenuProps, State> {
+  state: State = {
+    enabled: isDebugMenuEnabled(),
+  };
+
+  componentDidMount() {
+    window.addEventListener("storage", this.handleStorage);
+    window.addEventListener(ENABLED_CHANGE_EVENT_NAME, this.handleDebugPanelPreferenceChanged);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("storage", this.handleStorage);
+    window.removeEventListener(ENABLED_CHANGE_EVENT_NAME, this.handleDebugPanelPreferenceChanged);
+  }
+
+  private handleStorage = (e: StorageEvent) => {
+    if (e.key === null || e.key === DEBUG_MENU_ENABLED_LOCALSTORAGE_KEY) {
+      this.updateEnabledStateFromLocalStorage();
+    }
+  };
+
+  private handleDebugPanelPreferenceChanged = () => {
+    this.updateEnabledStateFromLocalStorage();
+  };
+
+  private updateEnabledStateFromLocalStorage() {
+    const showing = isDebugMenuEnabled();
+    if (showing !== this.state.enabled) {
+      this.setState({ enabled: showing });
+    }
+  }
+
+  render() {
+    if (!this.state.enabled) {
+      return null;
+    }
+
+    return (
+      <div className="debug-panel" aria-label="Debug panel">
+        <Button
+          className="debug-panel-button icon-button"
+          title={this.props.preferences.denseModeEnabled ? "Disable dense mode" : "Enable dense mode"}
+          aria-label={this.props.preferences.denseModeEnabled ? "Disable dense mode" : "Enable dense mode"}
+          onClick={() => this.props.preferences.toggleDenseMode()}>
+          {this.props.preferences.denseModeEnabled ? <Rows2 className="icon" /> : <Rows3 className="icon" />}
+        </Button>
+        <Button
+          className="debug-panel-button icon-button"
+          title={this.props.preferences.darkModeEnabled ? "Enable light mode" : "Enable dark mode"}
+          aria-label={this.props.preferences.darkModeEnabled ? "Enable light mode" : "Enable dark mode"}
+          onClick={() => this.props.preferences.setTheme(this.props.preferences.darkModeEnabled ? "light" : "dark")}>
+          {this.props.preferences.darkModeEnabled ? <Sun className="icon" /> : <Moon className="icon" />}
+        </Button>
+        <Button
+          className="debug-panel-button icon-button"
+          title={this.props.preferences.lightTerminalEnabled ? "Enable dark terminal" : "Enable light terminal"}
+          aria-label={this.props.preferences.lightTerminalEnabled ? "Enable dark terminal" : "Enable light terminal"}
+          onClick={() => this.props.preferences.toggleLightTerminal()}>
+          <span className="debug-panel-terminal-icon">
+            <Terminal className="icon debug-panel-terminal-base-icon" />
+            {this.props.preferences.lightTerminalEnabled ? (
+              <Moon className="icon debug-panel-terminal-theme-icon" />
+            ) : (
+              <Sun className="icon debug-panel-terminal-theme-icon" />
+            )}
+          </span>
+        </Button>
+      </div>
+    );
+  }
+}
+
+function isDebugMenuEnabled() {
+  return window.localStorage.getItem(DEBUG_MENU_ENABLED_LOCALSTORAGE_KEY) === String(true);
+}
+
+(window as any).toggleDebugMenu = () => {
+  window.localStorage.setItem(DEBUG_MENU_ENABLED_LOCALSTORAGE_KEY, String(!isDebugMenuEnabled()));
+  window.dispatchEvent(new Event(ENABLED_CHANGE_EVENT_NAME));
+};

--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -530,7 +530,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
         )}
         {this.isCompressedSizeColumnVisible() && (
           <div className={`compressed-size-column ${!result.compressor ? "uncompressed" : ""}`}>
-            {(console.log(result), result.compressor) ? (
+            {result.compressor ? (
               <>
                 <span>{renderCompressionSavings(result)}</span>
               </>

--- a/app/root/BUILD.bazel
+++ b/app/root/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
         "//app/auth:auth_service",
         "//app/capabilities",
         "//app/compare:compare_invocations",
+        "//app/debug",
         "//app/docs:setup",
         "//app/errors:error_service",
         "//app/favicon",

--- a/app/root/root.tsx
+++ b/app/root/root.tsx
@@ -3,6 +3,7 @@ import AlertComponent from "../alert/alert";
 import authService, { User } from "../auth/auth_service";
 import capabilities from "../capabilities/capabilities";
 import CompareInvocationsComponent from "../compare/compare_invocations";
+import DebugMenu from "../debug/debug";
 import SetupComponent from "../docs/setup";
 import errorService from "../errors/error_service";
 import faviconService from "../favicon/favicon";
@@ -104,6 +105,7 @@ export default class RootComponent extends React.Component {
           <FooterComponent />
           <AlertComponent />
         </div>
+        <DebugMenu preferences={this.state.preferences} />
       </div>
     );
   }

--- a/app/target/action_card.tsx
+++ b/app/target/action_card.tsx
@@ -29,7 +29,6 @@ export default class ActionCardComponent extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    console.log(this.props.buildEvent);
     this.fetchStdErr();
     this.fetchStdOut();
   }

--- a/enterprise/app/root/BUILD.bazel
+++ b/enterprise/app/root/BUILD.bazel
@@ -19,6 +19,7 @@ ts_library(
         "//app/compare:compare_actions",
         "//app/compare:compare_invocations",
         "//app/components/button",
+        "//app/debug",
         "//app/docs:setup",
         "//app/errors:error_service",
         "//app/favicon",

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -6,6 +6,7 @@ import capabilities from "../../../app/capabilities/capabilities";
 import CompareActionsComponent from "../../../app/compare/compare_actions";
 import CompareInvocationsComponent from "../../../app/compare/compare_invocations";
 import { OutlinedButton } from "../../../app/components/button/button";
+import DebugMenu from "../../../app/debug/debug";
 import SetupComponent from "../../../app/docs/setup";
 import errorService from "../../../app/errors/error_service";
 import faviconService from "../../../app/favicon/favicon";
@@ -495,6 +496,7 @@ export default class EnterpriseRootComponent extends React.Component {
           <AlertComponent />
           <PickerComponent />
           <ShortcutsComponent preferences={this.state.preferences} />
+          <DebugMenu preferences={this.state.preferences} />
         </div>
       </>
     );

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jasmine-reporters": "^2.5.2",
     "libsodium-wrappers": "^0.7.15",
     "long": "^4.0.0",
-    "lucide-react": "^0.241.0",
+    "lucide-react": "^0.545.0",
     "memoize-one": "^6.0.0",
     "moment": "^2.30.1",
     "monaco-editor": "0.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       lucide-react:
-        specifier: ^0.241.0
-        version: 0.241.0(react@18.3.1)
+        specifier: ^0.545.0
+        version: 0.545.0(react@18.3.1)
       memoize-one:
         specifier: ^6.0.0
         version: 6.0.0
@@ -465,10 +465,10 @@ packages:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
-  lucide-react@0.241.0:
-    resolution: {integrity: sha512-g22ci6iHuNc2hUwjiFz0D3jQQfQYrZBZesXG6+AX5rOV68Epttkt/nF6dMdz6reKJjtpoNzu+LKeKHGu/qjOgQ==}
+  lucide-react@0.545.0:
+    resolution: {integrity: sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -907,7 +907,7 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
-  lucide-react@0.241.0(react@18.3.1):
+  lucide-react@0.545.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
Shows a little debug menu at the bottom-right corner. Disabled by default; can be enabled by running `toggleDebugMenu()` in the devtools console, which sets a `localStorage` preference.

This is useful for making CSS changes and quickly verifying that they look good for dense+normal mode, dark+light mode, and light+dark terminal theme.

[Screencast from 2026-06-14 19-47-11.webm](https://github.com/user-attachments/assets/c746f558-f26b-4e81-a033-ce859cc32a77)
