### PR TITLE
Use a single encryption key for pebble/metacache writes

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -230,24 +230,34 @@ func (c *Cache) lookupGroupAndPartitionID(ctx context.Context, remoteInstanceNam
 	return groupID, DefaultPartitionID
 }
 
-func (c *Cache) makeFileRecord(ctx context.Context, pr *rspb.ResourceName) (*sgpb.FileRecord, error) {
+// makeFileRecord builds the storage identity for a resource and returns the
+// encryption metadata selected while doing so.
+//
+// For writes, the encryption metadata must be passed through to NewEncryptor,
+// so that encryption uses the same key selected for the FileRecord.
+//
+// For reads, the returned encryption metadata can be ignored, since the stored
+// FileMetadata contains the metadata needed for decryption.
+func (c *Cache) makeFileRecord(ctx context.Context, pr *rspb.ResourceName) (*sgpb.FileRecord, *sgpb.EncryptionMetadata, error) {
 	r := digest.ResourceNameFromProto(pr)
 	if err := r.Validate(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	groupID, partID := c.lookupGroupAndPartitionID(ctx, r.GetInstanceName())
 	encryptionEnabled, err := c.encryptionEnabled(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var encryption *sgpb.Encryption
+	var encryptionMetadata *sgpb.EncryptionMetadata
 	if encryptionEnabled {
 		ak, err := c.env.GetCrypter().ActiveKey(ctx)
 		if err != nil {
-			return nil, status.UnavailableErrorf("encryption key not available: %s", err)
+			return nil, nil, status.UnavailableErrorf("encryption key not available: %s", err)
 		}
+		encryptionMetadata = ak
 		encryption = &sgpb.Encryption{KeyId: ak.GetEncryptionKeyId()}
 	}
 
@@ -262,7 +272,7 @@ func (c *Cache) makeFileRecord(ctx context.Context, pr *rspb.ResourceName) (*sgp
 		DigestFunction: r.GetDigestFunction(),
 		Compressor:     r.GetCompressor(),
 		Encryption:     encryption,
-	}, nil
+	}, encryptionMetadata, nil
 }
 
 // key is a comparable key for uniquely identifying a ResourceName/FileRecord.
@@ -386,13 +396,12 @@ func (c *Cache) writerForRecord(ctx context.Context, fileRecord *sgpb.FileRecord
 	}
 }
 
-func (c *Cache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.FileRecord, sizeHint int64, fn writeMetadataFn) (interfaces.CommittedWriteCloser, error) {
+func (c *Cache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.FileRecord, sizeHint int64, fn writeMetadataFn, encryptionMetadata *sgpb.EncryptionMetadata) (interfaces.CommittedWriteCloser, error) {
 	wcm, err := c.writerForRecord(ctx, fileRecord, sizeHint)
 	if err != nil {
 		return nil, err
 	}
 
-	var encryptionMetadata *sgpb.EncryptionMetadata
 	cwc := ioutil.NewCustomCommitWriteCloser(wcm)
 	cwc.SetCommitFn(func(bytesWritten int64) error {
 		now := c.opts.Clock.Now().UnixMicro()
@@ -412,13 +421,8 @@ func (c *Cache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.FileRecor
 	})
 
 	wc := interfaces.CommittedWriteCloser(cwc)
-	shouldEncrypt, err := c.encryptionEnabled(ctx)
-	if err != nil {
-		_ = wc.Close()
-		return nil, err
-	}
-	if shouldEncrypt {
-		ewc, err := c.env.GetCrypter().NewEncryptor(ctx, fileRecord.GetDigest(), wc)
+	if encryptionMetadata != nil {
+		ewc, err := c.env.GetCrypter().NewEncryptor(ctx, fileRecord.GetDigest(), wc, encryptionMetadata)
 		if err != nil {
 			_ = wc.Close()
 			return nil, status.UnavailableErrorf("encryptor not available: %s", err)
@@ -445,7 +449,7 @@ func (c *Cache) writerWithImmediateCommit(ctx context.Context, r *rspb.ResourceN
 // writer returns an interfaces.CommittedWriteCloser that on Write
 // will:
 // (1) compress the data if shouldCompress is true; and then
-// (2) encrypt the data if encryption is enabled
+// (2) encrypt the data if encryption metadata is provided
 // (3) write the data using input wcm's Write method.
 // On Commit, it will write the metadata for fileRecord using the provided
 // writeMetadataFn.
@@ -472,12 +476,12 @@ func (c *Cache) writer(ctx context.Context, r *rspb.ResourceName, sizeHint int64
 		}
 	}
 
-	fileRecord, err := c.makeFileRecord(ctx, r)
+	fileRecord, encryptionMetadata, err := c.makeFileRecord(ctx, r)
 	if err != nil {
 		return nil, err
 	}
 
-	wc, err := c.newWrappedWriter(ctx, fileRecord, sizeHint, fn)
+	wc, err := c.newWrappedWriter(ctx, fileRecord, sizeHint, fn, encryptionMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -508,7 +512,7 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (cm *interfa
 	start := c.opts.Clock.Now()
 	defer c.recordMetrics("Metadata", resultErr, start)
 
-	fileRecord, err := c.makeFileRecord(ctx, r)
+	fileRecord, _, err := c.makeFileRecord(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +548,7 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 		FileRecords: make([]*sgpb.FileRecord, len(resources)),
 	}
 	for i, r := range resources {
-		fileRecord, err := c.makeFileRecord(ctx, r)
+		fileRecord, _, err := c.makeFileRecord(ctx, r)
 		if err != nil {
 			return nil, err
 		}
@@ -597,7 +601,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 	// Convert resources to fileRecords
 	fileRecords := make([]*sgpb.FileRecord, 0, len(resources))
 	for _, r := range resources {
-		fileRecord, err := c.makeFileRecord(ctx, r)
+		fileRecord, _, err := c.makeFileRecord(ctx, r)
 		if err != nil {
 			return nil, err
 		}
@@ -706,7 +710,7 @@ func (c *Cache) Delete(ctx context.Context, r *rspb.ResourceName) (resultErr err
 	start := c.opts.Clock.Now()
 	defer c.recordMetrics("Delete", resultErr, start)
 
-	fileRecord, err := c.makeFileRecord(ctx, r)
+	fileRecord, _, err := c.makeFileRecord(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -814,7 +818,7 @@ func (c *Cache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOf
 			attribute.Int64("digest_size", r.GetDigest().GetSizeBytes()))
 	}
 
-	fileRecord, err := c.makeFileRecord(ctx, r)
+	fileRecord, _, err := c.makeFileRecord(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -57,6 +57,7 @@ go_test(
         "//enterprise/server/crypter_service",
         "//enterprise/server/filestore",
         "//enterprise/server/raft/keys",
+        "//proto:encryption_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//proto:storage_go_proto",

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1539,25 +1539,35 @@ func (p *PebbleCache) encryptionEnabled(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) (*sgpb.FileRecord, error) {
+// makeFileRecord builds the storage identity for a resource and returns the
+// encryption metadata selected while doing so.
+//
+// For writes, the encryption metadata must be passed through to NewEncryptor,
+// so that encryption uses the same key selected for the FileRecord.
+//
+// For reads, the returned encryption metadata can be ignored, since the stored
+// FileMetadata contains the metadata needed for decryption.
+func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) (*sgpb.FileRecord, *sgpb.EncryptionMetadata, error) {
 	rn := digest.ResourceNameFromProto(r)
 	if err := rn.Validate(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	groupID, partID := p.lookupGroupAndPartitionID(ctx, rn.GetInstanceName())
 
 	encryptionEnabled, err := p.encryptionEnabled(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var encryption *sgpb.Encryption
+	var encryptionMetadata *sgpb.EncryptionMetadata
 	if encryptionEnabled {
 		ak, err := p.env.GetCrypter().ActiveKey(ctx)
 		if err != nil {
-			return nil, status.UnavailableErrorf("encryption key not available: %s", err)
+			return nil, nil, status.UnavailableErrorf("encryption key not available: %s", err)
 		}
+		encryptionMetadata = ak
 		encryption = &sgpb.Encryption{KeyId: ak.GetEncryptionKeyId()}
 	}
 
@@ -1572,7 +1582,7 @@ func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) 
 		DigestFunction: rn.GetDigestFunction(),
 		Compressor:     rn.GetCompressor(),
 		Encryption:     encryption,
-	}, nil
+	}, encryptionMetadata, nil
 }
 
 func (p *PebbleCache) lookupFileMetadataAndVersion(ctx context.Context, db pebble.IPebbleDB, key filestore.PebbleKey, fileMetadata *sgpb.FileMetadata) (filestore.PebbleKeyVersion, error) {
@@ -1630,7 +1640,7 @@ func (p *PebbleCache) Metadata(ctx context.Context, r *rspb.ResourceName) (*inte
 	}
 	defer db.Close()
 
-	fileRecord, err := p.makeFileRecord(ctx, r)
+	fileRecord, _, err := p.makeFileRecord(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -1682,7 +1692,7 @@ func (p *PebbleCache) FindMissing(ctx context.Context, resources []*rspb.Resourc
 }
 
 func (p *PebbleCache) findMissing(ctx context.Context, db pebble.IPebbleDB, r *rspb.ResourceName) error {
-	fileRecord, err := p.makeFileRecord(ctx, r)
+	fileRecord, _, err := p.makeFileRecord(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -1959,7 +1969,7 @@ func getSizeOnLocalDisk(key []byte, md *sgpb.FileMetadata, includeMetadata bool)
 }
 
 func (p *PebbleCache) Delete(ctx context.Context, r *rspb.ResourceName) error {
-	fileRecord, err := p.makeFileRecord(ctx, r)
+	fileRecord, _, err := p.makeFileRecord(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -2043,7 +2053,7 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 		}
 	}
 
-	fileRecord, err := p.makeFileRecord(ctx, r)
+	fileRecord, encryptionMetadata, err := p.makeFileRecord(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -2052,16 +2062,16 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 		return nil, err
 	}
 
-	return p.newWrappedWriter(ctx, fileRecord, key, shouldCompress)
+	return p.newWrappedWriter(ctx, fileRecord, key, shouldCompress, encryptionMetadata)
 }
 
 // newWrappedWriter returns an interfaces.CommittedWriteCloser that on Write
 // will:
 // (1) compress the data if shouldCompress is true; and then
-// (2) encrypt the data if encryption is enabled
+// (2) encrypt the data if encryption metadata is provided
 // (3) write the data using input wcm's Write method.
 // On Commit, it will write the metadata for fileRecord.
-func (p *PebbleCache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.FileRecord, key filestore.PebbleKey, shouldCompress bool) (interfaces.CommittedWriteCloser, error) {
+func (p *PebbleCache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.FileRecord, key filestore.PebbleKey, shouldCompress bool, encryptionMetadata *sgpb.EncryptionMetadata) (interfaces.CommittedWriteCloser, error) {
 	var wcm interfaces.MetadataWriteCloser
 	if fileRecord.GetDigest().GetSizeBytes() < p.maxInlineFileSizeBytes {
 		wcm = p.fileStorer.InlineWriter(ctx, fileRecord.GetDigest().GetSizeBytes())
@@ -2085,7 +2095,6 @@ func (p *PebbleCache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.Fil
 		return nil, err
 	}
 
-	var encryptionMetadata *sgpb.EncryptionMetadata
 	cwc := ioutil.NewCustomCommitWriteCloser(wcm)
 	cwc.SetCloseFn(db.Close)
 	cwc.SetCommitFn(func(bytesWritten int64) error {
@@ -2107,13 +2116,8 @@ func (p *PebbleCache) newWrappedWriter(ctx context.Context, fileRecord *sgpb.Fil
 	})
 
 	wc := interfaces.CommittedWriteCloser(cwc)
-	shouldEncrypt, err := p.encryptionEnabled(ctx)
-	if err != nil {
-		_ = wc.Close()
-		return nil, err
-	}
-	if shouldEncrypt {
-		ewc, err := p.env.GetCrypter().NewEncryptor(ctx, fileRecord.GetDigest(), wc)
+	if encryptionMetadata != nil {
+		ewc, err := p.env.GetCrypter().NewEncryptor(ctx, fileRecord.GetDigest(), wc, encryptionMetadata)
 		if err != nil {
 			_ = wc.Close()
 			return nil, status.UnavailableErrorf("encryptor not available: %s", err)
@@ -2954,7 +2958,7 @@ func (p *PebbleCache) Partition(ctx context.Context, remoteInstanceName string) 
 }
 
 func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.ResourceName, uncompressedOffset int64, uncompressedLimit int64) (io.ReadCloser, error) {
-	fileRecord, err := p.makeFileRecord(ctx, r)
+	fileRecord, _, err := p.makeFileRecord(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	enpb "github.com/buildbuddy-io/buildbuddy/proto/encryption"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	sgpb "github.com/buildbuddy-io/buildbuddy/proto/storage"
@@ -1928,6 +1929,83 @@ func getCrypterEnv(t *testing.T) (*testenv.TestEnv, string) {
 	err = crypter_service.Register(env)
 	require.NoError(t, err)
 	return env, kmsDir
+}
+
+type testCrypter struct {
+	enpb.UnimplementedEncryptionServiceServer
+	activeKeyFunc func(ctx context.Context) (*sgpb.EncryptionMetadata, error)
+}
+
+func (c *testCrypter) SetEncryptionConfig(ctx context.Context, req *enpb.SetEncryptionConfigRequest) (*enpb.SetEncryptionConfigResponse, error) {
+	return &enpb.SetEncryptionConfigResponse{}, nil
+}
+func (c *testCrypter) GetEncryptionConfig(ctx context.Context, req *enpb.GetEncryptionConfigRequest) (*enpb.GetEncryptionConfigResponse, error) {
+	return &enpb.GetEncryptionConfigResponse{Enabled: true}, nil
+}
+
+func (c *testCrypter) ActiveKey(ctx context.Context) (*sgpb.EncryptionMetadata, error) {
+	return c.activeKeyFunc(ctx)
+}
+
+func (c *testCrypter) NewEncryptor(ctx context.Context, d *repb.Digest, w interfaces.CommittedWriteCloser, em *sgpb.EncryptionMetadata) (interfaces.Encryptor, error) {
+	return &metadataOnlyEncryptor{
+		CommittedWriteCloser: w,
+		md:                   em,
+	}, nil
+}
+
+func (c *testCrypter) NewDecryptor(ctx context.Context, d *repb.Digest, r io.ReadCloser, em *sgpb.EncryptionMetadata) (interfaces.Decryptor, error) {
+	return r, nil
+}
+
+type metadataOnlyEncryptor struct {
+	interfaces.CommittedWriteCloser
+
+	md *sgpb.EncryptionMetadata
+}
+
+func (e *metadataOnlyEncryptor) Metadata() *sgpb.EncryptionMetadata {
+	return e.md
+}
+
+func TestEncryptionUsesSameKeyForFileRecordAndEncryptor(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+
+	userID := "US123"
+	groupID := "GR123"
+	user := testauth.User(userID, groupID)
+	user.CacheEncryptionEnabled = true
+	auther := testauth.NewTestAuthenticator(t, map[string]interfaces.UserInfo{userID: user})
+	te.SetAuthenticator(auther)
+	ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+	require.NoError(t, err)
+
+	var nKeysGenerated atomic.Int64
+	crypter := &testCrypter{
+		activeKeyFunc: func(ctx context.Context) (*sgpb.EncryptionMetadata, error) {
+			// Return a new key every time ActiveKey is called.
+			return &sgpb.EncryptionMetadata{
+				EncryptionKeyId: fmt.Sprintf("EK%d", nKeysGenerated.Add(1)),
+			}, nil
+		},
+	}
+	te.SetCrypter(crypter)
+
+	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{
+		RootDirectory: testfs.MakeTempDir(t),
+		Partitions: []disk.Partition{{
+			ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: 1_000_000_000,
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, pc.Start())
+	defer pc.Stop()
+
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, pc.Set(ctx, rn, buf))
+
+	// Make sure the Set operation used only one encryption key.
+	require.Equal(t, int64(1), nKeysGenerated.Load())
 }
 
 func TestEncryption(t *testing.T) {

--- a/enterprise/server/crypter_key_cache/crypter_key_cache.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache.go
@@ -305,11 +305,17 @@ func (c *KeyCache) loadKey(ctx context.Context, em *sgpb.EncryptionMetadata) (*c
 	return loadedKey, nil
 }
 
-func (c *KeyCache) EncryptionKey(ctx context.Context) (*crypter.DerivedKey, error) {
+// ActiveEncryptionKey returns the active encryption key for the caller's group,
+// using the cache when possible and refreshing it if needed.
+func (c *KeyCache) ActiveEncryptionKey(ctx context.Context) (*crypter.DerivedKey, error) {
 	return c.loadKey(ctx, nil)
 }
 
-func (c *KeyCache) DecryptionKey(ctx context.Context, em *sgpb.EncryptionMetadata) (*crypter.DerivedKey, error) {
+// EncryptionKeyForMetadata returns the key for the caller's group using the key
+// ID and version in encryption metadata, using the cache when possible and
+// refreshing it if needed. Use this after metadata has already been selected,
+// so callers do not perform another active key lookup.
+func (c *KeyCache) EncryptionKeyForMetadata(ctx context.Context, em *sgpb.EncryptionMetadata) (*crypter.DerivedKey, error) {
 	if em == nil {
 		return nil, status.FailedPreconditionError("encryption metadata cannot be nil")
 	}

--- a/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
@@ -27,7 +27,7 @@ func setupAuth(t *testing.T, env *real_environment.RealEnv) context.Context {
 	return testauth.WithAuthenticatedUserInfo(t.Context(), user)
 }
 
-func TestEncryptionKey(t *testing.T) {
+func TestActiveEncryptionKey(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	env := testenv.GetTestEnv(t)
 	ctx := setupAuth(t, env)
@@ -50,21 +50,21 @@ func TestEncryptionKey(t *testing.T) {
 	cache := crypter_key_cache.New(env, refreshFn, clock)
 
 	// First call should trigger refresh
-	key, err := cache.EncryptionKey(ctx)
+	key, err := cache.ActiveEncryptionKey(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expectedKey, key.Key)
 	require.Equal(t, expectedMetadata, key.Metadata)
 	require.Equal(t, 1, refreshCount)
 
 	// Second call should use cache
-	key, err = cache.EncryptionKey(ctx)
+	key, err = cache.ActiveEncryptionKey(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expectedKey, key.Key)
 	require.Equal(t, expectedMetadata, key.Metadata)
 	require.Equal(t, 1, refreshCount) // No additional refresh
 }
 
-func TestDecryptionKey(t *testing.T) {
+func TestEncryptionKeyForMetadata(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	env := testenv.GetTestEnv(t)
 	ctx := setupAuth(t, env)
@@ -87,19 +87,19 @@ func TestDecryptionKey(t *testing.T) {
 	cache := crypter_key_cache.New(env, refreshFn, clock)
 
 	// Test nil metadata
-	_, err := cache.DecryptionKey(ctx, nil)
+	_, err := cache.EncryptionKeyForMetadata(ctx, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "encryption metadata cannot be nil")
 
 	// Test valid metadata
-	key, err := cache.DecryptionKey(ctx, inputMetadata)
+	key, err := cache.EncryptionKeyForMetadata(ctx, inputMetadata)
 	require.NoError(t, err)
 	require.Equal(t, expectedKey, key.Key)
 	require.Equal(t, inputMetadata, key.Metadata)
 	require.Equal(t, 1, refreshCount)
 
 	// Second call should use cache
-	key, err = cache.DecryptionKey(ctx, inputMetadata)
+	key, err = cache.EncryptionKeyForMetadata(ctx, inputMetadata)
 	require.NoError(t, err)
 	require.Equal(t, expectedKey, key.Key)
 	require.Equal(t, 1, refreshCount) // No additional refresh
@@ -137,12 +137,12 @@ func TestError(t *testing.T) {
 	}()
 
 	// First call should trigger refresh and cache the error
-	_, err := cache.EncryptionKey(ctx)
+	_, err := cache.ActiveEncryptionKey(ctx)
 	require.True(t, status.IsUnavailableError(err))
 	refreshCount.Store(0)
 
 	// Second call within error cache time should return cached error
-	_, err = cache.EncryptionKey(ctx)
+	_, err = cache.ActiveEncryptionKey(ctx)
 	require.True(t, status.IsUnavailableError(err))
 	require.Equal(t, int32(0), refreshCount.Load())
 }
@@ -160,12 +160,12 @@ func TestInvalidMetadata(t *testing.T) {
 
 	// Test metadata without key ID
 	metadata := &sgpb.EncryptionMetadata{Version: 1}
-	_, err := cache.DecryptionKey(ctx, metadata)
+	_, err := cache.EncryptionKeyForMetadata(ctx, metadata)
 	require.True(t, status.IsFailedPreconditionError(err))
 
 	// Test metadata without version
 	metadata = &sgpb.EncryptionMetadata{EncryptionKeyId: "key123"}
-	_, err = cache.DecryptionKey(ctx, metadata)
+	_, err = cache.EncryptionKeyForMetadata(ctx, metadata)
 	require.True(t, status.IsFailedPreconditionError(err))
 }
 
@@ -187,19 +187,19 @@ func TestNotFound(t *testing.T) {
 	cache := crypter_key_cache.NewWithOpts(env, refreshFn, clock, opts)
 
 	// NotFound errors should not be retried
-	_, err := cache.EncryptionKey(ctx)
+	_, err := cache.ActiveEncryptionKey(ctx)
 	require.True(t, status.IsNotFoundError(err))
 	require.Equal(t, int32(1), refreshCount.Load())
 
 	// A second call within the error cache time should be served from the
 	// error cache without another refresh.
-	_, err = cache.EncryptionKey(ctx)
+	_, err = cache.ActiveEncryptionKey(ctx)
 	require.True(t, status.IsNotFoundError(err))
 	require.Equal(t, int32(1), refreshCount.Load())
 
 	// Once the error cache entry expires, the key should be refreshed again.
 	clock.Advance(6 * time.Second)
-	_, err = cache.EncryptionKey(ctx)
+	_, err = cache.ActiveEncryptionKey(ctx)
 	require.True(t, status.IsNotFoundError(err))
 	require.Equal(t, int32(2), refreshCount.Load())
 }
@@ -236,7 +236,7 @@ func TestCanceledRefreshIsNotCached(t *testing.T) {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := cache.EncryptionKey(cancelCtx)
+		_, err := cache.ActiveEncryptionKey(cancelCtx)
 		errCh <- err
 	}()
 	require.Eventually(t, func() bool { return refreshCount.Load() == 1 }, 5*time.Second, 1*time.Millisecond)
@@ -246,7 +246,7 @@ func TestCanceledRefreshIsNotCached(t *testing.T) {
 	// Now let the refreshFn succeed. A subsequent refresh with a non-canceled
 	// ctx should return a valid key.
 	close(proceed)
-	key, err := cache.EncryptionKey(ctx)
+	key, err := cache.ActiveEncryptionKey(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expectedKey, key.Key)
 	require.Equal(t, expectedMetadata, key.Metadata)
@@ -281,12 +281,12 @@ func TestAlreadyCanceledContextDoesNotPoisonCache(t *testing.T) {
 
 		canceledCtx, cancel := context.WithCancel(ctx)
 		cancel()
-		_, err := cache.EncryptionKey(canceledCtx)
+		_, err := cache.ActiveEncryptionKey(canceledCtx)
 		require.Error(t, err)
 
 		// Make sure the earlier canceled lookup didn't wind up caching the ctx
 		// error or an invalid key.
-		key, err := cache.EncryptionKey(ctx)
+		key, err := cache.ActiveEncryptionKey(ctx)
 		require.NoError(t, err)
 		require.Equal(t, expectedKey, key.Key)
 		require.Equal(t, expectedMetadata, key.Metadata)
@@ -316,7 +316,7 @@ func TestRefreshScan(t *testing.T) {
 	cache.StartRefresher(quitChan)
 
 	// Load a key
-	_, err := cache.EncryptionKey(ctx)
+	_, err := cache.ActiveEncryptionKey(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, refreshCount)
 
@@ -362,7 +362,7 @@ func TestRaciness(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			key, err := cache.EncryptionKey(ctx)
+			key, err := cache.ActiveEncryptionKey(ctx)
 			require.NoError(t, err)
 			require.Equal(t, expectedKey, key.Key)
 		}()
@@ -373,7 +373,7 @@ func TestRaciness(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			key, err := cache.DecryptionKey(ctx, expectedMetadata)
+			key, err := cache.EncryptionKeyForMetadata(ctx, expectedMetadata)
 			require.NoError(t, err)
 			require.Equal(t, expectedKey, key.Key)
 		}()

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -182,8 +182,8 @@ func refreshKey(ctx context.Context, ck crypter_key_cache.CacheKey, dbh interfac
 	return key, md, nil
 }
 
-func (c *Crypter) newEncryptorWithChunkSize(ctx context.Context, digest *repb.Digest, w interfaces.CommittedWriteCloser, groupID string, chunkSize int) (*crypter.Encryptor, error) {
-	loadedKey, err := c.cache.EncryptionKey(ctx)
+func (c *Crypter) newEncryptorWithChunkSize(ctx context.Context, digest *repb.Digest, w interfaces.CommittedWriteCloser, em *sgpb.EncryptionMetadata, groupID string, chunkSize int) (*crypter.Encryptor, error) {
+	loadedKey, err := c.cache.EncryptionKeyForMetadata(ctx, em)
 	if err != nil {
 		return nil, err
 	}
@@ -191,23 +191,24 @@ func (c *Crypter) newEncryptorWithChunkSize(ctx context.Context, digest *repb.Di
 }
 
 func (c *Crypter) ActiveKey(ctx context.Context) (*sgpb.EncryptionMetadata, error) {
-	loadedKey, err := c.cache.EncryptionKey(ctx)
+	loadedKey, err := c.cache.ActiveEncryptionKey(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return loadedKey.Metadata, nil
 }
 
-func (c *Crypter) NewEncryptor(ctx context.Context, digest *repb.Digest, w interfaces.CommittedWriteCloser) (interfaces.Encryptor, error) {
+// NewEncryptor creates an encryptor using the specified key metadata.
+func (c *Crypter) NewEncryptor(ctx context.Context, digest *repb.Digest, w interfaces.CommittedWriteCloser, em *sgpb.EncryptionMetadata) (interfaces.Encryptor, error) {
 	u, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return c.newEncryptorWithChunkSize(ctx, digest, w, u.GetGroupID(), crypter.PlainTextChunkSize)
+	return c.newEncryptorWithChunkSize(ctx, digest, w, em, u.GetGroupID(), crypter.PlainTextChunkSize)
 }
 
 func (c *Crypter) newDecryptorWithChunkSize(ctx context.Context, digest *repb.Digest, r io.ReadCloser, em *sgpb.EncryptionMetadata, groupID string, chunkSize int) (*crypter.Decryptor, error) {
-	loadedKey, err := c.cache.DecryptionKey(ctx, em)
+	loadedKey, err := c.cache.EncryptionKeyForMetadata(ctx, em)
 	if err != nil {
 		return nil, err
 	}
@@ -615,13 +616,13 @@ func (c *Crypter) GetEncryptionKey(ctx context.Context, req *enpb.GetEncryptionK
 
 	var loadedKey *crypter.DerivedKey
 	if req.GetMetadata().GetVersion() == 0 {
-		loadedKey, err = c.cache.EncryptionKey(ctx)
+		loadedKey, err = c.cache.ActiveEncryptionKey(ctx)
 	} else {
 		metadata := sgpb.EncryptionMetadata{
 			EncryptionKeyId: req.GetMetadata().GetId(),
 			Version:         req.GetMetadata().GetVersion(),
 		}
-		loadedKey, err = c.cache.DecryptionKey(ctx, &metadata)
+		loadedKey, err = c.cache.EncryptionKeyForMetadata(ctx, &metadata)
 	}
 	if err != nil {
 		return nil, err

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -236,7 +236,9 @@ func TestEncryptDecrypt(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 	for _, size := range []int64{1, 10, 100, 1000, 1000 * 1000} {
 		t.Run(fmt.Sprint(size), func(t *testing.T) {
-			e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
+			md, err := crypter.ActiveKey(ctx)
+			require.NoError(t, err)
+			e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), md, groupID, 1024)
 			require.NoError(t, err)
 
 			testData := make([]byte, size)
@@ -279,7 +281,9 @@ func TestDecryptWrongGroup(t *testing.T) {
 	require.NoError(t, err)
 	out := bytes.NewBuffer(nil)
 
-	e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
+	md, err := crypter.ActiveKey(ctx)
+	require.NoError(t, err)
+	e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), md, groupID, 1024)
 	require.NoError(t, err)
 
 	testData := make([]byte, 1000)
@@ -322,7 +326,9 @@ func TestDecryptWrongDigest(t *testing.T) {
 	require.NoError(t, err)
 	out := bytes.NewBuffer(nil)
 
-	e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
+	md, err := crypter.ActiveKey(ctx)
+	require.NoError(t, err)
+	e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), md, groupID, 1024)
 	require.NoError(t, err)
 
 	testData := make([]byte, 1000)
@@ -383,7 +389,9 @@ func TestKeyLookup(t *testing.T) {
 		out := bytes.NewBuffer(nil)
 		ctx, err := auther.WithAuthenticatedUser(ctx, userID1)
 		require.NoError(t, err)
-		c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out))
+		md, err := crypter.ActiveKey(ctx)
+		require.NoError(t, err)
+		c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), md)
 		require.NoError(t, err)
 		require.Equal(t, c.Metadata().GetEncryptionKeyId(), group1KeyID)
 		require.EqualValues(t, c.Metadata().GetVersion(), 1)
@@ -403,7 +411,9 @@ func TestKeyLookup(t *testing.T) {
 		out := bytes.NewBuffer(nil)
 		ctx, err := auther.WithAuthenticatedUser(ctx, userID2)
 		require.NoError(t, err)
-		c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out))
+		md, err := crypter.ActiveKey(ctx)
+		require.NoError(t, err)
+		c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), md)
 		require.NoError(t, err)
 		require.Equal(t, c.Metadata().GetEncryptionKeyId(), group2KeyID)
 		require.EqualValues(t, c.Metadata().GetVersion(), 1)
@@ -423,7 +433,9 @@ func TestKeyLookup(t *testing.T) {
 	{
 		ctx, err := auther.WithAuthenticatedUser(ctx, userID1)
 		require.NoError(t, err)
-		c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(bytes.NewBuffer(nil)))
+		md, err := crypter.ActiveKey(ctx)
+		require.NoError(t, err)
+		c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(bytes.NewBuffer(nil)), md)
 		require.NoError(t, err)
 		user1MD := c.Metadata()
 
@@ -437,7 +449,7 @@ func TestKeyLookup(t *testing.T) {
 	{
 		ctx, err := auther.WithAuthenticatedUser(ctx, userID3)
 		require.NoError(t, err)
-		_, err = crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(bytes.NewBuffer(nil)))
+		_, err = crypter.ActiveKey(ctx)
 		require.True(t, status.IsNotFoundError(err))
 
 		ctx, err = auther.WithAuthenticatedUser(ctx, userID2)
@@ -451,7 +463,9 @@ func testEncrypt(ctx context.Context, t *testing.T, auther *testauth.TestAuthent
 	out := bytes.NewBuffer(nil)
 	ctx, err := auther.WithAuthenticatedUser(ctx, userID)
 	require.NoError(t, err)
-	c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out))
+	md, err := crypter.ActiveKey(ctx)
+	require.NoError(t, err)
+	c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), md)
 	require.NoError(t, err)
 	require.Equal(t, c.Metadata().GetEncryptionKeyId(), expectedKeyID)
 	require.EqualValues(t, c.Metadata().GetVersion(), 1)
@@ -480,7 +494,6 @@ func testEncryptDecrypt(ctx context.Context, t *testing.T, auther *testauth.Test
 }
 
 func testKeyError(ctx context.Context, t *testing.T, auther *testauth.TestAuthenticator, crypter *Crypter, userID string, clock *clockwork.FakeClock) error {
-	out := bytes.NewBuffer(nil)
 	ctx, err := auther.WithAuthenticatedUser(ctx, userID)
 	require.NoError(t, err)
 
@@ -498,7 +511,7 @@ func testKeyError(ctx context.Context, t *testing.T, auther *testauth.TestAuthen
 			}
 		}
 	}()
-	_, err = crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out))
+	_, err = crypter.ActiveKey(ctx)
 	require.Error(t, err)
 	return err
 }

--- a/enterprise/server/remote_crypter/remote_crypter.go
+++ b/enterprise/server/remote_crypter/remote_crypter.go
@@ -131,19 +131,20 @@ func (c *RemoteCrypter) GetEncryptionConfig(ctx context.Context, req *enpb.GetEn
 }
 
 func (c *RemoteCrypter) ActiveKey(ctx context.Context) (*sgpb.EncryptionMetadata, error) {
-	loadedKey, err := c.cache.EncryptionKey(ctx)
+	loadedKey, err := c.cache.ActiveEncryptionKey(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return loadedKey.Metadata, nil
 }
 
-func (c *RemoteCrypter) NewEncryptor(ctx context.Context, d *repb.Digest, w interfaces.CommittedWriteCloser) (interfaces.Encryptor, error) {
+// NewEncryptor creates an encryptor using the specified key metadata.
+func (c *RemoteCrypter) NewEncryptor(ctx context.Context, d *repb.Digest, w interfaces.CommittedWriteCloser, em *sgpb.EncryptionMetadata) (interfaces.Encryptor, error) {
 	u, err := c.authenticator.AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	loadedKey, err := c.cache.EncryptionKey(ctx)
+	loadedKey, err := c.cache.EncryptionKeyForMetadata(ctx, em)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func (c *RemoteCrypter) NewDecryptor(ctx context.Context, d *repb.Digest, r io.R
 	if err != nil {
 		return nil, err
 	}
-	loadedKey, err := c.cache.DecryptionKey(ctx, em)
+	loadedKey, err := c.cache.EncryptionKeyForMetadata(ctx, em)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_crypter/remote_crypter_test.go
+++ b/enterprise/server/remote_crypter/remote_crypter_test.go
@@ -199,7 +199,9 @@ func TestEncryptDecrypt(t *testing.T) {
 	for _, size := range []int64{1, 10, 100, 1000, 1000 * 1000} {
 		t.Run(fmt.Sprint(size), func(t *testing.T) {
 			out := bytes.NewBuffer(nil)
-			encryptor, err := crypter.NewEncryptor(ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out))
+			md, err := crypter.ActiveKey(ctx)
+			require.NoError(t, err)
+			encryptor, err := crypter.NewEncryptor(ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out), md)
 			require.NoError(t, err)
 
 			testData := make([]byte, size)
@@ -227,7 +229,9 @@ func TestDecryptWrongDigest(t *testing.T) {
 
 	out := bytes.NewBuffer(nil)
 
-	encryptor, err := crypter.NewEncryptor(ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out))
+	md, err := crypter.ActiveKey(ctx)
+	require.NoError(t, err)
+	encryptor, err := crypter.NewEncryptor(ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out), md)
 	require.NoError(t, err)
 
 	testData := make([]byte, 1000)
@@ -276,7 +280,9 @@ func TestAuth(t *testing.T) {
 
 	// user1 should be able to encrypt and decrypt using their own key
 	{
-		encryptor, err := crypter.NewEncryptor(user1Ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out))
+		md, err := crypter.ActiveKey(user1Ctx)
+		require.NoError(t, err)
+		encryptor, err := crypter.NewEncryptor(user1Ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out), md)
 		require.NoError(t, err)
 		require.Equal(t, group1Key, encryptor.Metadata().GetEncryptionKeyId())
 		require.EqualValues(t, 1, encryptor.Metadata().GetVersion())
@@ -293,7 +299,9 @@ func TestAuth(t *testing.T) {
 
 	// user2 should not be able to decrypt using user1's key
 	{
-		encryptor, err := crypter.NewEncryptor(user2Ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out))
+		md, err := crypter.ActiveKey(user2Ctx)
+		require.NoError(t, err)
+		encryptor, err := crypter.NewEncryptor(user2Ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out), md)
 		require.NoError(t, err)
 		require.Equal(t, group2Key, encryptor.Metadata().GetEncryptionKeyId())
 		require.EqualValues(t, 1, encryptor.Metadata().GetVersion())
@@ -307,7 +315,7 @@ func TestAuth(t *testing.T) {
 
 	// user3 key lookup should fail since they don't have a key setup
 	{
-		_, err = crypter.NewEncryptor(user3Ctx, fooDigest, ioutil.NewCustomCommitWriteCloser(out))
+		_, err = crypter.ActiveKey(user3Ctx)
 		require.True(t, status.IsNotFoundError(err))
 	}
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1595,7 +1595,7 @@ type Crypter interface {
 
 	ActiveKey(ctx context.Context) (*sgpb.EncryptionMetadata, error)
 
-	NewEncryptor(ctx context.Context, d *repb.Digest, w CommittedWriteCloser) (Encryptor, error)
+	NewEncryptor(ctx context.Context, d *repb.Digest, w CommittedWriteCloser, em *sgpb.EncryptionMetadata) (Encryptor, error)
 	NewDecryptor(ctx context.Context, d *repb.Digest, r io.ReadCloser, em *sgpb.EncryptionMetadata) (Decryptor, error)
 
 	enpb.EncryptionServiceServer


### PR DESCRIPTION
Pebble cache (and metacache) encrypted writes previously selected the active key twice:
1. makeFileRecord used ActiveKey to stamp the key ID into the file record and Pebble key
2. newWrappedWriter then called NewEncryptor, which performed another active-key lookup for the actual encryption key 

If those lookups disagreed, the record could be written under one encryption key ID while the stored metadata described another encryption key ID.

The fix is to have Crypter.NewEncryptor accept an EncryptionMetadata arg, so that pebble_cache and metacache can carry the originally looked up key metadata through to the encryption layer, and make sure we encrypt using the same key that is stored in the FileRecord.

Context: https://buildbuddy-corp.slack.com/archives/C06N9AHA4JX/p1781307118962089?thread_ts=1781282730.473909&cid=C06N9AHA4JX