### PR TITLE
oci fetcher: skip cache for anonymous requests

### DIFF
--- a/enterprise/server/oci/ocifetcher/BUILD
+++ b/enterprise/server/oci/ocifetcher/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/real_environment",
+        "//server/util/authutil",
         "//server/util/bytebufferpool",
         "//server/util/claims",
         "//server/util/flag",

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bytebufferpool"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
@@ -166,6 +167,10 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 		}
 		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
 	}
+	if isAnonymousUser(ctx) {
+		log.CtxInfof(ctx, "Anonymous user request, skipping blob cache for %q", digestRef)
+		return s.streamBlobFromRemote(ctx, digestRef, req.GetCredentials(), stream)
+	}
 	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, req.GetCredentials())
 }
 
@@ -185,6 +190,10 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 		return nil, err
 	}
 	repo := digestRef.Context()
+	if isAnonymousUser(ctx) {
+		log.CtxInfof(ctx, "Anonymous user request, skipping blob metadata cache for %q", digestRef)
+		return s.fetchBlobMetadataFromRemote(ctx, digestRef, req.GetCredentials())
+	}
 
 	accessKey := repoAccessKey(repo, req.GetCredentials())
 	if req.GetBypassRegistry() || s.accessProofCache.Contains(accessKey) {
@@ -225,6 +234,10 @@ func (s *ociFetcherServer) FetchManifest(ctx context.Context, req *ofpb.FetchMan
 	hash, err := s.resolveManifestDigest(ctx, imageRef, req.GetCredentials(), req.GetBypassRegistry())
 	if err != nil {
 		return nil, err
+	}
+	if isAnonymousUser(ctx) {
+		log.CtxInfof(ctx, "Anonymous user request, skipping manifest cache for %q", imageRef)
+		return s.fetchManifestFromRemote(ctx, imageRef, req.GetCredentials())
 	}
 	if resp, err := s.fetchManifestFromCache(ctx, imageRef, hash); err == nil {
 		return resp, nil
@@ -296,6 +309,21 @@ func (s *ociFetcherServer) streamBlobFromCache(ctx context.Context, stream ofpb.
 		return err
 	}
 	return ocicache.FetchBlobFromCache(ctx, &grpcStreamWriter{stream: stream}, s.bsClient, hash, metadata.GetContentLength())
+}
+
+func (s *ociFetcherServer) streamBlobFromRemote(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	rc, err := withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (io.ReadCloser, error) {
+		layer, err := puller.Layer(ctx, digestRef)
+		if err != nil {
+			return nil, err
+		}
+		return layer.Compressed()
+	})
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	return s.streamBlob(rc, stream)
 }
 
 func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef ctrname.Digest, hash ctr.Hash, creds *rgpb.Credentials) error {
@@ -561,15 +589,12 @@ func (s *ociFetcherServer) fetchManifestFromCache(ctx context.Context, imageRef 
 	}, nil
 }
 
-func (s *ociFetcherServer) fetchManifestFromRemoteWriteToCache(ctx context.Context, imageRef ctrname.Reference, hash ctr.Hash, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
+func (s *ociFetcherServer) fetchManifestFromRemote(ctx context.Context, imageRef ctrname.Reference, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
 	remoteDesc, err := withPullerRetry(ctx, s, imageRef, creds, func(puller *remote.Puller) (*remote.Descriptor, error) {
 		return puller.Get(ctx, imageRef)
 	})
 	if err != nil {
 		return nil, err
-	}
-	if err := ocicache.WriteManifestToAC(ctx, remoteDesc.Manifest, s.acClient, imageRef.Context(), hash, string(remoteDesc.MediaType), imageRef); err != nil {
-		log.CtxWarningf(ctx, "Error writing manifest to cache: %s", err)
 	}
 	return &ofpb.FetchManifestResponse{
 		Digest:    remoteDesc.Digest.String(),
@@ -577,6 +602,17 @@ func (s *ociFetcherServer) fetchManifestFromRemoteWriteToCache(ctx context.Conte
 		MediaType: string(remoteDesc.MediaType),
 		Manifest:  remoteDesc.Manifest,
 	}, nil
+}
+
+func (s *ociFetcherServer) fetchManifestFromRemoteWriteToCache(ctx context.Context, imageRef ctrname.Reference, hash ctr.Hash, creds *rgpb.Credentials) (*ofpb.FetchManifestResponse, error) {
+	resp, err := s.fetchManifestFromRemote(ctx, imageRef, creds)
+	if err != nil {
+		return nil, err
+	}
+	if err := ocicache.WriteManifestToAC(ctx, resp.GetManifest(), s.acClient, imageRef.Context(), hash, resp.GetMediaType(), imageRef); err != nil {
+		log.CtxWarningf(ctx, "Error writing manifest to cache: %s", err)
+	}
+	return resp, nil
 }
 
 // validateUnsupportedBypassRegistry is used by FetchManifestMetadata which does not support
@@ -662,6 +698,11 @@ func repoAccessKey(repo ctrname.Repository, creds *rgpb.Credentials) string {
 		return hash.Strings(repo.Name(), "", "")
 	}
 	return hash.Strings(repo.Name(), creds.GetUsername(), creds.GetPassword())
+}
+
+func isAnonymousUser(ctx context.Context) bool {
+	_, err := claims.ClaimsFromContext(ctx)
+	return authutil.IsAnonymousUserError(err)
 }
 
 func pullerKey(ref ctrname.Reference, creds *rgpb.Credentials) string {

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -93,6 +93,10 @@ func setupCacheEnv(t *testing.T) (*testenv.TestEnv, bspb.ByteStreamClient, repb.
 	return te, te.GetByteStreamClient(), te.GetActionCacheClient()
 }
 
+func authenticatedContext() context.Context {
+	return testauth.WithAuthenticatedUserInfo(context.Background(), &claims.Claims{UserID: "US123"})
+}
+
 // mockFetchBlobServer implements ofpb.OCIFetcher_FetchBlobServer for testing.
 type mockFetchBlobServer struct {
 	grpc.ServerStream
@@ -417,6 +421,7 @@ func TestServerHappyPath(t *testing.T) {
 		})
 
 		t.Run("FetchBlob/WithCaching/"+ac.name, func(t *testing.T) {
+			ctx := authenticatedContext()
 			reg, counter := setupRegistry(t, ac.registryCreds, nil)
 			imageName, img := reg.PushNamedImage(t, "test-image", ac.registryCreds)
 
@@ -434,7 +439,7 @@ func TestServerHappyPath(t *testing.T) {
 
 			// First fetch - cache miss, should hit registry
 			counter.Reset()
-			stream := &mockFetchBlobServer{ctx: context.Background()}
+			stream := &mockFetchBlobServer{ctx: ctx}
 			err = server.FetchBlob(&ofpb.FetchBlobRequest{
 				Ref:         imageName + "@" + digest.String(),
 				Credentials: ac.requestCreds,
@@ -450,7 +455,7 @@ func TestServerHappyPath(t *testing.T) {
 			// registry access for these credentials, so this is served
 			// from cache without touching the registry.
 			counter.Reset()
-			stream = &mockFetchBlobServer{ctx: context.Background()}
+			stream = &mockFetchBlobServer{ctx: ctx}
 			err = server.FetchBlob(&ofpb.FetchBlobRequest{
 				Ref:         imageName + "@" + digest.String(),
 				Credentials: ac.requestCreds,
@@ -461,6 +466,61 @@ func TestServerHappyPath(t *testing.T) {
 			assertRequests(t, counter, map[string]int{})
 		})
 	}
+}
+
+func TestAnonymousRequestsSkipCache(t *testing.T) {
+	reg, counter := setupRegistry(t, nil, nil)
+	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	expectedDigest, _, _ := imageMetadata(t, img)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layer := layers[0]
+	layerDigest, err := layer.Digest()
+	require.NoError(t, err)
+	expectedData := layerData(t, layer)
+
+	_, bsClient, acClient := setupCacheEnv(t)
+	server := newTestServerWithCache(t, bsClient, acClient)
+
+	for i := 0; i < 2; i++ {
+		counter.Reset()
+		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: imageName})
+		require.NoError(t, err)
+		require.Equal(t, expectedDigest, resp.GetDigest())
+		require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/manifests/latest"], 0)
+	}
+	counter.Reset()
+	resp, err := server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{Ref: imageName})
+	require.NoError(t, err)
+	require.Equal(t, expectedDigest, resp.GetDigest())
+	require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/manifests/latest"], 0)
+
+	for i := 0; i < 2; i++ {
+		counter.Reset()
+		_, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{Ref: imageName + "@" + layerDigest.String()})
+		require.NoError(t, err)
+		require.NotEmpty(t, counter.Snapshot())
+	}
+	counter.Reset()
+	_, err = server.FetchBlobMetadata(authenticatedContext(), &ofpb.FetchBlobMetadataRequest{Ref: imageName + "@" + layerDigest.String()})
+	require.NoError(t, err)
+	require.NotEmpty(t, counter.Snapshot())
+
+	for i := 0; i < 2; i++ {
+		counter.Reset()
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err := server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
+		require.NoError(t, err)
+		require.Equal(t, expectedData, stream.collectData())
+		require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/blobs/"+layerDigest.String()], 0)
+	}
+	counter.Reset()
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
+	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
+	require.NoError(t, err)
+	require.Equal(t, expectedData, stream.collectData())
+	require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/blobs/"+layerDigest.String()], 0)
 }
 
 func TestServerMissingAndInvalidCredentials(t *testing.T) {
@@ -758,7 +818,7 @@ func TestFetchBlobRetryOnCompressedError(t *testing.T) {
 	counter.Reset()
 
 	blobRef := imageName + "@" + layerDigest.String()
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
 	require.NoError(t, err, "FetchBlob should succeed after retrying with a fresh puller")
 	require.Equal(t, expectedLayerData, stream.collectData())
@@ -800,7 +860,7 @@ func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
 	blobRef := imageName + "@" + layerDigest.String()
 	failBlobHead.Store(true)
 
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	counter.Reset()
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
 	require.NoError(t, err, "FetchBlob should fall back to direct streaming when metadata lookups fail")
@@ -819,7 +879,7 @@ func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
 
 	// Metadata lookup failures should skip read-through caching, so a subsequent
 	// fetch still needs to hit the upstream registry.
-	stream = &mockFetchBlobServer{ctx: context.Background()}
+	stream = &mockFetchBlobServer{ctx: authenticatedContext()}
 	counter.Reset()
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
 	require.NoError(t, err)
@@ -868,14 +928,14 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	server := newTestServer(t)
 
 	// FetchManifestMetadata: establish cached Puller
-	resp, err := server.FetchManifestMetadata(context.Background(), &ofpb.FetchManifestMetadataRequest{Ref: imageName})
+	resp, err := server.FetchManifestMetadata(authenticatedContext(), &ofpb.FetchManifestMetadataRequest{Ref: imageName})
 	require.NoError(t, err)
 	require.Equal(t, expectedDigest, resp.GetDigest())
 
 	// FetchManifestMetadata: times out, should NOT retry
 	blockHead.Store(true)
 	headAttempts.Store(0)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(authenticatedContext(), 10*time.Millisecond)
 	_, err = server.FetchManifestMetadata(ctx, &ofpb.FetchManifestMetadataRequest{Ref: imageName})
 	cancel()
 	require.Error(t, err)
@@ -885,7 +945,7 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	// FetchManifestMetadata: Puller should still be cached
 	blockHead.Store(false)
 	counter.Reset()
-	resp, err = server.FetchManifestMetadata(context.Background(), &ofpb.FetchManifestMetadataRequest{Ref: imageName})
+	resp, err = server.FetchManifestMetadata(authenticatedContext(), &ofpb.FetchManifestMetadataRequest{Ref: imageName})
 	require.NoError(t, err)
 	require.Equal(t, expectedDigest, resp.GetDigest())
 	require.Equal(t, expectedSize, resp.GetSize())
@@ -897,7 +957,7 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	// FetchManifest: times out, should NOT retry
 	blockGet.Store(true)
 	getAttempts.Store(0)
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel = context.WithTimeout(authenticatedContext(), 10*time.Millisecond)
 	_, err = server.FetchManifest(ctx, &ofpb.FetchManifestRequest{Ref: imageName})
 	cancel()
 	require.Error(t, err)
@@ -907,7 +967,7 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	// FetchManifest: Puller should still be cached (but HEAD and GET both happen for tag refs)
 	blockGet.Store(false)
 	counter.Reset()
-	manifestResp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: imageName})
+	manifestResp, err := server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{Ref: imageName})
 	require.NoError(t, err)
 	require.Equal(t, expectedDigest, manifestResp.GetDigest())
 	require.Equal(t, expectedSize, manifestResp.GetSize())
@@ -919,14 +979,14 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	})
 
 	// FetchBlobMetadata: establish cached layer access
-	blobMetaResp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{Ref: imageName + "@" + layerDigest.String()})
+	blobMetaResp, err := server.FetchBlobMetadata(authenticatedContext(), &ofpb.FetchBlobMetadataRequest{Ref: imageName + "@" + layerDigest.String()})
 	require.NoError(t, err)
 	require.Equal(t, expectedLayerSize, blobMetaResp.GetSize())
 
 	// FetchBlobMetadata: times out, should NOT retry
 	blockBlob.Store(true)
 	blobAttempts.Store(0)
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel = context.WithTimeout(authenticatedContext(), 10*time.Millisecond)
 	_, err = server.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{Ref: imageName + "@" + layerDigest.String()})
 	cancel()
 	require.Error(t, err)
@@ -936,13 +996,13 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	// FetchBlobMetadata: Puller should still be cached
 	blockBlob.Store(false)
 	counter.Reset()
-	blobMetaResp, err = server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{Ref: imageName + "@" + layerDigest.String()})
+	blobMetaResp, err = server.FetchBlobMetadata(authenticatedContext(), &ofpb.FetchBlobMetadataRequest{Ref: imageName + "@" + layerDigest.String()})
 	require.NoError(t, err)
 	require.Equal(t, expectedLayerSize, blobMetaResp.GetSize())
 	require.Equal(t, expectedLayerMediaType, blobMetaResp.GetMediaType())
 
 	// FetchBlob: first fetch caches the blob
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
 	require.NoError(t, err)
 	require.Equal(t, expectedLayerData, stream.collectData())
@@ -951,7 +1011,7 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	// was already proven (by the earlier FetchManifest), so no registry calls
 	// are made even with a short timeout.
 	counter.Reset()
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel = context.WithTimeout(authenticatedContext(), 10*time.Millisecond)
 	stream = &mockFetchBlobServer{ctx: ctx}
 	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
 	cancel()
@@ -1073,7 +1133,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 
 		// First fetch - populate cache
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
 			Ref: imageName + "@" + digest.String(),
 		}, stream)
@@ -1150,7 +1210,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 
 		// First, fetch the blob to populate the cache (FetchBlob writes metadata to AC)
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
 			Ref: imageName + "@" + digest.String(),
 		}, stream)
@@ -1160,7 +1220,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		// access for these credentials, so this is served from cache without
 		// contacting the registry.
 		counter.Reset()
-		resp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{
+		resp, err := server.FetchBlobMetadata(authenticatedContext(), &ofpb.FetchBlobMetadataRequest{
 			Ref: imageName + "@" + digest.String(),
 		})
 		require.NoError(t, err)
@@ -1190,7 +1250,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 
 		// First fetch - populate cache via FetchBlob
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
 			Ref: imageName + "@" + digest.String(),
 		}, stream)
@@ -1260,7 +1320,7 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// First fetch by digest - cache miss, should fetch from registry and cache
 		counter.Reset()
-		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		resp, err := server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{
 			Ref: imageName + "@" + digest,
 		})
 		require.NoError(t, err)
@@ -1272,7 +1332,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		// Second fetch by digest - auth was already cached from the first fetch,
 		// so no HEAD request is needed; served directly from cache.
 		counter.Reset()
-		resp, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		resp, err = server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{
 			Ref: imageName + "@" + digest,
 		})
 		require.NoError(t, err)
@@ -1294,7 +1354,7 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// First fetch by tag - cache miss, should HEAD then GET from registry
 		counter.Reset()
-		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		resp, err := server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{
 			Ref: imageName,
 		})
 		require.NoError(t, err)
@@ -1307,7 +1367,7 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		// Second fetch by tag - should only HEAD (cache hit avoids GET)
 		counter.Reset()
-		resp, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		resp, err = server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{
 			Ref: imageName,
 		})
 		require.NoError(t, err)
@@ -1332,7 +1392,7 @@ func TestServerBypassRegistry(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 
 		// First fetch - populate cache
-		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{
+		resp, err := server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{
 			Ref: imageName + "@" + digest,
 		})
 		require.NoError(t, err)
@@ -1425,7 +1485,7 @@ func TestServerCacheAccessProof(t *testing.T) {
 
 		server := newTestServerWithCache(t, bsClient, acClient)
 		counter.Reset()
-		resp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{Ref: ref})
+		resp, err := server.FetchBlobMetadata(authenticatedContext(), &ofpb.FetchBlobMetadataRequest{Ref: ref})
 		require.NoError(t, err)
 		require.Equal(t, expectedSize, resp.GetSize())
 		require.Equal(t, expectedMediaType, resp.GetMediaType())
@@ -1458,7 +1518,7 @@ func TestServerCacheAccessProof(t *testing.T) {
 		seedBlobCache(t, bsClient, acClient, ref, expectedData, cachedMediaType)
 
 		counter.Reset()
-		_, err = server.FetchManifestMetadata(context.Background(), &ofpb.FetchManifestMetadataRequest{Ref: imageName})
+		_, err = server.FetchManifestMetadata(authenticatedContext(), &ofpb.FetchManifestMetadataRequest{Ref: imageName})
 		require.NoError(t, err)
 		assertRequests(t, counter, map[string]int{
 			http.MethodGet + " /v2/":                             1,
@@ -1466,7 +1526,7 @@ func TestServerCacheAccessProof(t *testing.T) {
 		})
 
 		counter.Reset()
-		resp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{Ref: ref})
+		resp, err := server.FetchBlobMetadata(authenticatedContext(), &ofpb.FetchBlobMetadataRequest{Ref: ref})
 		require.NoError(t, err)
 		require.Equal(t, int64(len(expectedData)), resp.GetSize())
 		require.Equal(t, cachedMediaType, resp.GetMediaType())
@@ -1484,14 +1544,14 @@ func TestServerCacheAccessProof(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 		ref := imageName + "@" + digest
 
-		resp, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: ref})
+		resp, err := server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{Ref: ref})
 		require.NoError(t, err)
 		require.Equal(t, expectedManifest, resp.GetManifest())
 
 		// Reuse the cache with a fresh server so access is not yet proven in memory.
 		server = newTestServerWithCache(t, bsClient, acClient)
 		counter.Reset()
-		resp, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: ref})
+		resp, err = server.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{Ref: ref})
 		require.NoError(t, err)
 		require.Equal(t, expectedManifest, resp.GetManifest())
 
@@ -1519,14 +1579,14 @@ func TestServerCacheAccessProof(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 		blobRef := imageName + "@" + digest.String()
 
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
 
 		server = newTestServerWithCache(t, bsClient, acClient)
 		counter.Reset()
-		_, err = server.FetchManifestMetadata(context.Background(), &ofpb.FetchManifestMetadataRequest{Ref: imageName})
+		_, err = server.FetchManifestMetadata(authenticatedContext(), &ofpb.FetchManifestMetadataRequest{Ref: imageName})
 		require.NoError(t, err)
 		assertRequests(t, counter, map[string]int{
 			http.MethodGet + " /v2/":                             1,
@@ -1534,7 +1594,7 @@ func TestServerCacheAccessProof(t *testing.T) {
 		})
 
 		counter.Reset()
-		stream = &mockFetchBlobServer{ctx: context.Background()}
+		stream = &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
@@ -1559,7 +1619,7 @@ func TestServerCacheAccessProof(t *testing.T) {
 		ref := imageName + "@" + digest.String()
 
 		counter.Reset()
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: ref}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
@@ -1589,7 +1649,7 @@ func TestServerCacheAccessProof(t *testing.T) {
 		server := newTestServerWithCache(t, bsClient, acClient)
 		ref := imageName + "@" + digest.String()
 
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: ref}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
@@ -1599,7 +1659,7 @@ func TestServerCacheAccessProof(t *testing.T) {
 			missingHash:      digest.Hex,
 		}, acClient)
 		counter.Reset()
-		stream = &mockFetchBlobServer{ctx: context.Background()}
+		stream = &mockFetchBlobServer{ctx: authenticatedContext()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: ref}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
@@ -1680,7 +1740,7 @@ func TestFetchBlobSingleflightHappyPath(t *testing.T) {
 
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
-			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+			return &concurrentMockFetchBlobServer{ctx: authenticatedContext()}
 		},
 	)
 
@@ -1717,14 +1777,14 @@ func TestFetchBlobSingleflightCacheHit(t *testing.T) {
 		Ref: imageName + "@" + digest.String(),
 	}
 
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	err = server.FetchBlob(req, stream)
 	require.NoError(t, err)
 	counter.Reset()
 
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
-			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+			return &concurrentMockFetchBlobServer{ctx: authenticatedContext()}
 		},
 	)
 
@@ -1771,7 +1831,7 @@ func TestFetchBlobSingleflightLeaderFailsUpstream(t *testing.T) {
 
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
-			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+			return &concurrentMockFetchBlobServer{ctx: authenticatedContext()}
 		},
 	)
 
@@ -1823,7 +1883,7 @@ func TestFetchBlobSingleflightLeaderSendFails(t *testing.T) {
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
 			stream := &concurrentMockFetchBlobServer{
-				ctx:             context.Background(),
+				ctx:             authenticatedContext(),
 				sendErr:         status.InternalError("simulated Send failure"),
 				sendErrAfterN:   0,
 				firstSenderFlag: &firstSenderFlag,
@@ -1841,7 +1901,7 @@ func TestFetchBlobSingleflightLeaderSendFails(t *testing.T) {
 	}
 
 	counter.Reset()
-	stream := &mockFetchBlobServer{ctx: context.Background()}
+	stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 	err = server.FetchBlob(req, stream)
 	require.NoError(t, err, "subsequent fetch should succeed")
 	require.Equal(t, expectedData, stream.collectData())
@@ -1874,7 +1934,7 @@ func TestFetchBlobSingleflightCacheSetupFailure(t *testing.T) {
 	const numRequests = 4
 	results := runConcurrentFetchBlob(t, server, req, numRequests,
 		func(idx int) *concurrentMockFetchBlobServer {
-			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+			return &concurrentMockFetchBlobServer{ctx: authenticatedContext()}
 		},
 	)
 
@@ -1934,13 +1994,13 @@ func TestFetchBlobSingleflightDifferentCredentials(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		result1Err = server.FetchBlob(req1, stream)
 		result1Data = stream.collectData()
 	}()
 	go func() {
 		defer wg.Done()
-		stream := &mockFetchBlobServer{ctx: context.Background()}
+		stream := &mockFetchBlobServer{ctx: authenticatedContext()}
 		result2Err = server.FetchBlob(req2, stream)
 	}()
 

--- a/enterprise/server/ocifetcher_server_proxy/BUILD
+++ b/enterprise/server/ocifetcher_server_proxy/BUILD
@@ -15,6 +15,8 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
+        "//server/util/authutil",
+        "//server/util/claims",
         "//server/util/log",
         "//server/util/status",
         "//third_party/singleflight",

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
@@ -16,6 +16,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/third_party/singleflight"
@@ -76,6 +78,11 @@ func (s *OCIFetcherServerProxy) FetchBlobMetadata(ctx context.Context, req *ofpb
 func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
 	ctx := stream.Context()
 
+	if isAnonymousUser(ctx) {
+		log.CtxInfof(ctx, "Anonymous user request, skipping local OCI blob cache for %q", req.GetRef())
+		return s.streamBlobFromUpstream(ctx, req, stream)
+	}
+
 	digestRef, hash, err := parseBlobDigestRef(req.GetRef())
 	if err != nil {
 		return err
@@ -95,6 +102,25 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 	}
 
 	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, size, req)
+}
+
+func (s *OCIFetcherServerProxy) streamBlobFromUpstream(ctx context.Context, req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	remoteStream, err := s.remote.FetchBlob(ctx, req)
+	if err != nil {
+		return err
+	}
+	for {
+		resp, err := remoteStream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := stream.Send(resp); err != nil {
+			return status.WrapError(err, "send")
+		}
+	}
 }
 
 func parseBlobDigestRef(ref string) (ctrname.Digest, ctr.Hash, error) {
@@ -204,6 +230,11 @@ func newLocalBSWriter(ctx context.Context, bsClient bspb.ByteStreamClient, hash 
 	rn := digest.NewCASResourceName(blobDigest, "", cacheDigestFunction)
 	rn.SetCompressor(repb.Compressor_ZSTD)
 	return cachetools.NewUploadWriter(ctx, bsClient, rn)
+}
+
+func isAnonymousUser(ctx context.Context) bool {
+	_, err := claims.ClaimsFromContext(ctx)
+	return authutil.IsAnonymousUserError(err)
 }
 
 type grpcStreamWriter struct {

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
@@ -53,6 +53,10 @@ func TestNew_MissingLocalBSClient(t *testing.T) {
 	require.True(t, status.IsFailedPreconditionError(err), "expected FailedPrecondition, got: %v", err)
 }
 
+func authenticatedContext() context.Context {
+	return testauth.WithAuthenticatedUserInfo(context.Background(), &claims.Claims{UserID: "US123"})
+}
+
 // TestHappyPath tests successful FetchBlob, FetchBlobMetadata, FetchManifest,
 // FetchManifestMetadata calls with no credentials and with credentials.
 func TestHappyPath(t *testing.T) {
@@ -235,7 +239,7 @@ func TestFetchBlob_ForwardsRequestUnchanged(t *testing.T) {
 // the blob is written to the proxy's local BS cache and can be served from
 // there on a subsequent request.
 func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
-	ctx := context.Background()
+	ctx := authenticatedContext()
 
 	reg := setupTestRegistry(t, nil)
 	imageName, img := reg.PushNamedImage(t, "test-image", nil)
@@ -271,6 +275,79 @@ func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
 	require.NoError(t, err)
 	data2 := collectBlobData(t, stream2)
 	require.Equal(t, expectedData, data2)
+}
+
+func TestAnonymousRequestsSkipCache(t *testing.T) {
+	ctx := context.Background()
+
+	counter := testhttp.NewRequestCounter()
+	reg := testregistry.Run(t, testregistry.Opts{
+		HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+			counter.Inc(r)
+			return true
+		},
+	})
+	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	expectedDigest, _, _ := imageMetadata(t, img)
+
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layer := layers[0]
+	digest, err := layer.Digest()
+	require.NoError(t, err)
+	expectedData := layerData(t, layer)
+
+	_, bsClient, acClient := setupCacheEnv(t)
+	ociFetcherClient := runOCIFetcherServer(ctx, t, bsClient, acClient)
+	proxyClient := runOCIFetcherProxy(ctx, t, ociFetcherClient)
+
+	ref := imageName + "@" + digest.String()
+
+	for i := 0; i < 2; i++ {
+		counter.Reset()
+		resp, err := proxyClient.FetchManifest(ctx, &ofpb.FetchManifestRequest{Ref: imageName})
+		require.NoError(t, err)
+		require.Equal(t, expectedDigest, resp.GetDigest())
+		require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/manifests/latest"], 0)
+	}
+	counter.Reset()
+	resp, err := proxyClient.FetchManifest(authenticatedContext(), &ofpb.FetchManifestRequest{Ref: imageName})
+	require.NoError(t, err)
+	require.Equal(t, expectedDigest, resp.GetDigest())
+	require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/manifests/latest"], 0)
+
+	for i := 0; i < 2; i++ {
+		counter.Reset()
+		_, err := proxyClient.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{Ref: ref})
+		require.NoError(t, err)
+		require.NotEmpty(t, counter.Snapshot())
+	}
+	counter.Reset()
+	_, err = proxyClient.FetchBlobMetadata(authenticatedContext(), &ofpb.FetchBlobMetadataRequest{Ref: ref})
+	require.NoError(t, err)
+	require.NotEmpty(t, counter.Snapshot())
+
+	for i := 0; i < 2; i++ {
+		counter.Reset()
+		stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: ref})
+		require.NoError(t, err)
+		require.Equal(t, expectedData, collectBlobData(t, stream))
+		require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/blobs/"+digest.String()], 0)
+	}
+	counter.Reset()
+	stream, err := proxyClient.FetchBlob(authenticatedContext(), &ofpb.FetchBlobRequest{Ref: ref})
+	require.NoError(t, err)
+	require.Equal(t, expectedData, collectBlobData(t, stream))
+	require.Greater(t, counter.Snapshot()[http.MethodGet+" /v2/test-image/blobs/"+digest.String()], 0)
+
+	err = reg.Shutdown()
+	require.NoError(t, err)
+
+	stream, err = proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: ref})
+	require.NoError(t, err)
+	_, err = stream.Recv()
+	require.Error(t, err)
 }
 
 // TestBypassRegistry tests the bypass_registry flag crossed with server admin claims
@@ -702,7 +779,7 @@ func TestPrivateRegistryCacheHitsRequireValidCredentials(t *testing.T) {
 // the same blob are deduplicated: only one upstream FetchBlob RPC is made and
 // all callers receive the correct data.
 func TestFetchBlob_Singleflight(t *testing.T) {
-	ctx := context.Background()
+	ctx := authenticatedContext()
 
 	reg := setupTestRegistry(t, nil)
 	imageName, img := reg.PushNamedImage(t, "test-image", nil)

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -1457,7 +1457,7 @@ func TestResolveWithOCIFetcher(t *testing.T) {
 
 			for _, nameToResolve := range []string{tc.args.imageName + "_image", tc.args.imageName + "_index"} {
 				pulledImage, err := newResolver(t, te).Resolve(
-					context.Background(),
+					contextWithUnverifiedJWT(&claims.Claims{UserID: "US123"}),
 					registry.ImageAddress(nameToResolve),
 					tc.args.platform,
 					tc.args.credentials,
@@ -1557,7 +1557,7 @@ func TestResolveWithOCIFetcher_Layers_DiffIDs(t *testing.T) {
 
 			for _, nameToResolve := range []string{tc.args.imageName + "_image", tc.args.imageName + "_index"} {
 				pulledImage, err := newResolver(t, te).Resolve(
-					context.Background(),
+					contextWithUnverifiedJWT(&claims.Claims{UserID: "US123"}),
 					registry.ImageAddress(nameToResolve),
 					tc.args.platform,
 					tc.args.credentials,


### PR DESCRIPTION
* Anonymous requests won't be deduped.
* Eventually, would love to have anonymous requests access known-public blobs and manifests.