### PR TITLE
Use fewer buckets for gRPC client side metrics

### DIFF
--- a/server/util/rpcutil/rpcutil.go
+++ b/server/util/rpcutil/rpcutil.go
@@ -231,5 +231,32 @@ var MeterProvider = sync.OnceValue(func() metric.MeterProvider {
 		alert.UnexpectedEvent("Error creating prometheus metrics exporter")
 		return noop.NewMeterProvider()
 	}
-	return sdkmetric.NewMeterProvider(sdkmetric.WithReader(exporter))
+	// Override otelgrpc's default 16-bucket histograms for client-side RPC
+	// metrics with coarser bucket sets. The defaults explode cardinality
+	// through the cross product of (rpc_service, rpc_method,
+	// rpc_grpc_status_code, instance) × 16 buckets × 5 histogram families.
+	// The metrics are named `rpc.{client,server}.{duration, request.size, response.size, requests_per_rpc, responses_per_rpc}`
+	durationView := sdkmetric.NewView(
+		sdkmetric.Instrument{Name: "rpc.client.duration"},
+		sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+			Boundaries: []float64{5, 25, 100, 500, 1000, 5000, 10000, 30000}, // in ms
+		}},
+	)
+	sizeView := sdkmetric.NewView(
+		sdkmetric.Instrument{Name: "rpc.client.*.size"},
+		sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+			// 1KiB, 32KiB, 1MiB, 4MiB, 8MiB
+			Boundaries: []float64{1024, 32768, 1048576, 4194304, 8388608},
+		}},
+	)
+	perRPCView := sdkmetric.NewView(
+		sdkmetric.Instrument{Name: "rpc.client.*_per_rpc"},
+		sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+			Boundaries: []float64{1, 10, 100, 1000},
+		}},
+	)
+	return sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(exporter),
+		sdkmetric.WithView(durationView, sizeView, perRPCView),
+	)
 })


### PR DESCRIPTION
These have a huge cardinality. Each SJC executor has over 700 combined buckets, and there are hundreds of executors.

All three currently have the same buckets: 0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000, +Inf

The latency metrics are useful, but we don't need that much precision, especially since we can still compute the average, and we have server side metrics.

The {requests,response}_per_rpc metrics definitely don't need that much precision. We barely use them.

The {request,response}_size_bytes metrics currently have very useless buckets (max at 10KB), and we only use the sum and average.