### PR TITLE
Only allow 1 `x-buildbuddy-client-ip` header value

### DIFF
--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -119,8 +119,11 @@ func addClientIPToContext(ctx context.Context, env environment.Env) context.Cont
 	// is trusted, as verified by its clientidentity.
 	if cis := env.GetClientIdentityService(); cis != nil {
 		if si, err := cis.IdentityFromContext(ctx); err == nil && si != nil && si.Client == interfaces.ClientIdentityGRPCProxy {
-			if hdrs := metadata.ValueFromIncomingContext(ctx, clientip.HeaderName); len(hdrs) > 0 {
+			// Require exactly one value: a trusted proxy sets a single header.
+			if hdrs := metadata.ValueFromIncomingContext(ctx, clientip.HeaderName); len(hdrs) == 1 {
 				return context.WithValue(ctx, clientip.ContextKey, hdrs[0])
+			} else if len(hdrs) > 1 {
+				log.CtxWarningf(ctx, "Multiple %q headers present in request from trusted proxy; ignoring", clientip.HeaderName)
 			}
 		}
 	}


### PR DESCRIPTION
Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7521