### PR TITLE
Strip `x-buildbuddy-internal-...` gRPC headers when not provided by trusted callers

### DIFF
--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -274,6 +274,81 @@ func identityStreamServerInterceptor(env environment.Env) grpc.StreamServerInter
 	}
 }
 
+// trustedInternalClients are the client identities permitted to set
+// authutil.InternalHeaderPrefix headers. A request from any other caller (most
+// importantly, one with no validated client identity) has those headers
+// stripped.
+var trustedInternalClients = map[string]struct{}{
+	interfaces.ClientIdentityApp:        {},
+	interfaces.ClientIdentityExecutor:   {},
+	interfaces.ClientIdentityCacheProxy: {},
+	interfaces.ClientIdentityGRPCProxy:  {},
+}
+
+func isTrustedInternalClient(env environment.Env, ctx context.Context) bool {
+	cis := env.GetClientIdentityService()
+	if cis == nil {
+		return false
+	}
+	si, err := cis.IdentityFromContext(ctx)
+	if err != nil || si == nil {
+		return false
+	}
+	_, ok := trustedInternalClients[si.Client]
+	return ok
+}
+
+// stripInternalHeadersFromContext removes every incoming metadata header with
+// the authutil.InternalHeaderPrefix prefix unless the request comes from a
+// trusted internal client (verified via its client identity). Those headers
+// carry internal trust signals (e.g. the resolved client IP) that only trusted
+// peers may set, so stripping them from untrusted callers prevents spoofing.
+//
+// This must run after the identity interceptor (which validates the client
+// identity) and before any interceptor that reads an internal header.
+func stripInternalHeadersFromContext(env environment.Env, ctx context.Context) context.Context {
+	if isTrustedInternalClient(env, ctx) {
+		return ctx
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+	// Fast path for the common case (no internal header present): scan keys
+	// without allocating, and only build a filtered copy if there's a match.
+	// Incoming metadata keys are already lowercased by gRPC.
+	hasInternal := false
+	for k := range md {
+		if strings.HasPrefix(k, authutil.InternalHeaderPrefix) {
+			hasInternal = true
+			break
+		}
+	}
+	if !hasInternal {
+		return ctx
+	}
+	filtered := make(metadata.MD, len(md))
+	for k, v := range md {
+		if strings.HasPrefix(k, authutil.InternalHeaderPrefix) {
+			continue
+		}
+		filtered[k] = v
+	}
+	return metadata.NewIncomingContext(ctx, filtered)
+}
+
+func stripInternalHeadersUnaryServerInterceptor(env environment.Env) grpc.UnaryServerInterceptor {
+	return contextReplacingUnaryServerInterceptor(func(ctx context.Context) context.Context {
+		return stripInternalHeadersFromContext(env, ctx)
+	})
+}
+
+func stripInternalHeadersStreamServerInterceptor(env environment.Env) grpc.StreamServerInterceptor {
+	return contextReplacingStreamServerInterceptor(func(ctx context.Context) context.Context {
+		return stripInternalHeadersFromContext(env, ctx)
+	})
+}
+
 // requestIDStreamInterceptor is a server interceptor that inserts a request ID
 // into the context if one is not already present.
 func requestIDStreamServerInterceptor() grpc.StreamServerInterceptor {
@@ -572,9 +647,9 @@ func GetUnaryInterceptor(env environment.Env, extraInterceptors ...grpc.UnarySer
 		unaryRecoveryInterceptor(),
 		copyHeadersUnaryServerInterceptor(),
 		propagateRequestMetadataToSpanUnaryServerInterceptor(),
-		// identity must run before clientIP so that a trusted proxy's asserted
-		// client IP can be honored.
+		// Check client-identity early so it can be used in later interceptors.
 		identityUnaryServerInterceptor(env),
+		stripInternalHeadersUnaryServerInterceptor(env),
 		clientIPUnaryServerInterceptor(env),
 		subdomainUnaryServerInterceptor(),
 		requestIDUnaryServerInterceptor(),
@@ -600,9 +675,9 @@ func GetStreamInterceptor(env environment.Env, extraInterceptors ...grpc.StreamS
 		streamRecoveryInterceptor(),
 		copyHeadersStreamServerInterceptor(),
 		propagateRequestMetadataToSpanStreamServerInterceptor(),
-		// identity must run before clientIP so that a trusted proxy's asserted
-		// client IP can be honored.
+		// Check client-identity early so it can be used in later interceptors.
 		identityStreamServerInterceptor(env),
+		stripInternalHeadersStreamServerInterceptor(env),
 		clientIPStreamServerInterceptor(env),
 		subdomainStreamServerInterceptor(),
 		requestIDStreamServerInterceptor(),

--- a/server/rpc/interceptors/interceptors_test.go
+++ b/server/rpc/interceptors/interceptors_test.go
@@ -26,11 +26,13 @@ import (
 )
 
 type pingServer struct {
-	lastClientIP string
+	lastClientIP   string
+	lastIncomingMD metadata.MD
 }
 
 func (p *pingServer) Ping(ctx context.Context, req *pspb.PingRequest) (*pspb.PingResponse, error) {
 	p.lastClientIP = clientip.Get(ctx)
+	p.lastIncomingMD, _ = metadata.FromIncomingContext(ctx)
 	return &pspb.PingResponse{
 		Tag: req.GetTag(),
 	}, nil
@@ -336,6 +338,70 @@ func TestTrustedClientIPInterceptor(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.wantIP, ps.lastClientIP)
+		})
+	}
+}
+
+func TestStripsInternalHeadersFromUntrustedCallers(t *testing.T) {
+	const internalHeader = authutil.InternalHeaderPrefix + "test"
+
+	for _, tc := range []struct {
+		name           string
+		clientIdentity string // sent in the client-identity header; "" sends none
+		wantStripped   bool
+	}{
+		{
+			name:           "untrusted caller without identity is stripped",
+			clientIdentity: "",
+			wantStripped:   true,
+		},
+		{
+			name:           "untrusted caller with unknown identity is stripped",
+			clientIdentity: "some-untrusted-client",
+			wantStripped:   true,
+		},
+		{
+			name:           "grpc-proxy identity is preserved",
+			clientIdentity: interfaces.ClientIdentityGRPCProxy,
+			wantStripped:   false,
+		},
+		{
+			name:           "app identity is preserved",
+			clientIdentity: interfaces.ClientIdentityApp,
+			wantStripped:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+
+			env := testenv.GetTestEnv(t)
+			env.SetClientIdentityService(&fakeClientIdentityService{})
+
+			grpcServer := grpc.NewServer(grpc_server.CommonGRPCServerOptions(env)...)
+			ps := &pingServer{}
+			pspb.RegisterApiServer(grpcServer, ps)
+
+			lis, err := net.Listen("tcp", listenAddr)
+			require.NoError(t, err)
+			go func() { grpcServer.Serve(lis) }()
+			t.Cleanup(grpcServer.Stop)
+
+			conn, err := grpc.Dial(listenAddr, grpc.WithInsecure())
+			require.NoError(t, err)
+			t.Cleanup(func() { conn.Close() })
+
+			ctx := metadata.AppendToOutgoingContext(context.Background(), internalHeader, "spoofed")
+			if tc.clientIdentity != "" {
+				ctx = metadata.AppendToOutgoingContext(ctx, authutil.ClientIdentityHeaderName, tc.clientIdentity)
+			}
+			_, err = pspb.NewApiClient(conn).Ping(ctx, &pspb.PingRequest{Tag: 123})
+			require.NoError(t, err)
+
+			if tc.wantStripped {
+				assert.Empty(t, ps.lastIncomingMD.Get(internalHeader))
+			} else {
+				assert.Equal(t, []string{"spoofed"}, ps.lastIncomingMD.Get(internalHeader))
+			}
 		})
 	}
 }

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -42,6 +42,14 @@ const (
 	// The context key under which client-identity information is stored.
 	ClientIdentityHeaderName = "x-buildbuddy-client-identity"
 
+	// InternalHeaderPrefix marks gRPC metadata headers that carry internal
+	// trust signals (e.g. the resolved client IP) which only trusted internal
+	// clients may set. The gRPC server strips any incoming header with this
+	// prefix from callers that don't present a trusted client identity, so
+	// external callers can't spoof them. Headers signed/verified on their own
+	// (like the client identity header) don't use this prefix.
+	InternalHeaderPrefix = "x-buildbuddy-internal-"
+
 	// The context key under which auth headers are stored.
 	authHeadersKey = "auth-headers"
 


### PR DESCRIPTION
This change introduces the concept of "internal" gRPC headers which are only accepted when set by a trusted client, as verified using the incoming request's client identity. It adds a new gRPC server interceptor that performs this check and removes these headers if the caller isn't authorized to set them.

I plan to use this for fixing https://github.com/buildbuddy-io/buildbuddy-internal/issues/7494 by making the client-IP header begin with `x-buildbuddy-internal`.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7494