### PR TITLE
codesearch: Add signal resolution mechanism for import rank

### DIFF
--- a/codesearch/github/BUILD
+++ b/codesearch/github/BUILD
@@ -28,6 +28,7 @@ go_test(
         "//codesearch/annotations",
         "//codesearch/index",
         "//codesearch/schema",
+        "//codesearch/types",
         "//proto:index_go_proto",
         "//server/testutil/testfs",
         "//server/util/git",

--- a/codesearch/github/github_test.go
+++ b/codesearch/github/github_test.go
@@ -654,9 +654,10 @@ func TestRepoMetadataRoundTrip(t *testing.T) {
 	assert.Empty(t, modulePath)
 }
 
-// importSignalsByFilename resolves the import in-degree signal for every
-// document and keys it by base filename for easy assertions.
-func importSignalsByFilename(t *testing.T, r *index.Reader) map[string]float64 {
+// importSignalsByPath resolves the import in-degree signal for every document
+// and keys it by repo-relative path, so files that share a base name (e.g.
+// app1/main.go and app2/main.go) stay distinct.
+func importSignalsByPath(t *testing.T, r *index.Reader, repoDir string) map[string]float64 {
 	t.Helper()
 	matches, err := r.RawQuery("(:all)")
 	require.NoError(t, err)
@@ -665,11 +666,9 @@ func importSignalsByFilename(t *testing.T, r *index.Reader) map[string]float64 {
 	signals := make(map[string]float64, len(matches))
 	for _, m := range matches {
 		doc := r.GetStoredDocument(m.Docid())
-		name := filepath.Base(string(doc.Field(schema.FilenameField).Contents()))
-		if name == "" {
-			continue
-		}
-		signals[name] = m.Signal(types.SignalImportInDegree)
+		rel, err := filepath.Rel(repoDir, string(doc.Field(schema.FilenameField).Contents()))
+		require.NoError(t, err)
+		signals[rel] = m.Signal(types.SignalImportInDegree)
 	}
 	return signals
 }
@@ -703,9 +702,10 @@ func main() { log.Print() }
 	// by reading each doc's stored import_id field and counting the imports
 	// posting list for its terms.
 	r := index.NewReader(ctx, db, "testing-namespace", schema.GitHubFileSchema())
-	signals := importSignalsByFilename(t, r)
-	assert.Equal(t, 2.0, signals["log.go"])
-	assert.Equal(t, 0.0, signals["main.go"])
+	signals := importSignalsByPath(t, r, repoDir)
+	assert.Equal(t, 2.0, signals["util/log/log.go"])
+	assert.Equal(t, 0.0, signals["app1/main.go"])
+	assert.Equal(t, 0.0, signals["app2/main.go"])
 
 	// Incremental update: app2 stops importing util/log. The stale posting
 	// counts toward in-degree until CompactDeletes runs (documented inflation).
@@ -716,8 +716,8 @@ func main() { log.Print() }
 	require.NoError(t, w.Flush())
 
 	r = index.NewReader(ctx, db, "testing-namespace", schema.GitHubFileSchema())
-	signals = importSignalsByFilename(t, r)
-	assert.Equal(t, 2.0, signals["log.go"], "deleted doc inflates in-degree until compaction")
+	signals = importSignalsByPath(t, r, repoDir)
+	assert.Equal(t, 2.0, signals["util/log/log.go"], "deleted doc inflates in-degree until compaction")
 
 	// Compaction brings in-degree down to the single live importer.
 	w, err = index.NewWriter(db, "testing-namespace")
@@ -726,6 +726,6 @@ func main() { log.Print() }
 	require.NoError(t, w.Flush())
 
 	r = index.NewReader(ctx, db, "testing-namespace", schema.GitHubFileSchema())
-	signals = importSignalsByFilename(t, r)
-	assert.Equal(t, 1.0, signals["log.go"])
+	signals = importSignalsByPath(t, r, repoDir)
+	assert.Equal(t, 1.0, signals["util/log/log.go"])
 }

--- a/codesearch/github/github_test.go
+++ b/codesearch/github/github_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/codesearch/annotations"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/index"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/schema"
+	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -651,4 +652,80 @@ func TestRepoMetadataRoundTrip(t *testing.T) {
 	modulePath, err = GetRepoModulePath(r, altRepoURL)
 	require.NoError(t, err)
 	assert.Empty(t, modulePath)
+}
+
+// importSignalsByFilename resolves the import in-degree signal for every
+// document and keys it by base filename for easy assertions.
+func importSignalsByFilename(t *testing.T, r *index.Reader) map[string]float64 {
+	t.Helper()
+	matches, err := r.RawQuery("(:all)")
+	require.NoError(t, err)
+	require.NoError(t, r.ResolveSignals(matches, types.SignalImportInDegree))
+
+	signals := make(map[string]float64, len(matches))
+	for _, m := range matches {
+		doc := r.GetStoredDocument(m.Docid())
+		name := filepath.Base(string(doc.Field(schema.FilenameField).Contents()))
+		if name == "" {
+			continue
+		}
+		signals[name] = m.Signal(types.SignalImportInDegree)
+	}
+	return signals
+}
+
+func TestImportInDegreeSignal(t *testing.T) {
+	ctx := t.Context()
+	db := mustOpenDB(t, testfs.MakeTempDir(t))
+	repoDir := testfs.MakeTempDir(t)
+
+	writeRepoFile(t, repoDir, "go.mod", "module github.com/example/repo\n\ngo 1.24\n")
+	writeRepoFile(t, repoDir, "util/log/log.go", "package log\n\nfunc Print() {}\n")
+	app := `package main
+
+import "github.com/example/repo/util/log"
+
+func main() { log.Print() }
+`
+	writeRepoFile(t, repoDir, "app1/main.go", app)
+	writeRepoFile(t, repoDir, "app2/main.go", app)
+
+	rctx := annotations.NewRepoContext(repoDir, "github.com/example/repo")
+	w, err := index.NewWriter(db, "testing-namespace")
+	require.NoError(t, err)
+	for _, f := range []string{"go.mod", "util/log/log.go", "app1/main.go", "app2/main.go"} {
+		indexRepoFile(t, w, rctx, repoDir, f)
+	}
+	require.NoError(t, w.Flush())
+
+	// In-degree = number of documents importing a doc's identity. util/log is
+	// imported by both apps; nothing imports the apps. The signal is resolved
+	// by reading each doc's stored import_id field and counting the imports
+	// posting list for its terms.
+	r := index.NewReader(ctx, db, "testing-namespace", schema.GitHubFileSchema())
+	signals := importSignalsByFilename(t, r)
+	assert.Equal(t, 2.0, signals["log.go"])
+	assert.Equal(t, 0.0, signals["main.go"])
+
+	// Incremental update: app2 stops importing util/log. The stale posting
+	// counts toward in-degree until CompactDeletes runs (documented inflation).
+	writeRepoFile(t, repoDir, "app2/main.go", "package main\n\nfunc main() {}\n")
+	w, err = index.NewWriter(db, "testing-namespace")
+	require.NoError(t, err)
+	indexRepoFile(t, w, rctx, repoDir, "app2/main.go")
+	require.NoError(t, w.Flush())
+
+	r = index.NewReader(ctx, db, "testing-namespace", schema.GitHubFileSchema())
+	signals = importSignalsByFilename(t, r)
+	assert.Equal(t, 2.0, signals["log.go"], "deleted doc inflates in-degree until compaction")
+
+	// Compaction brings in-degree down to the single live importer.
+	w, err = index.NewWriter(db, "testing-namespace")
+	require.NoError(t, err)
+	require.NoError(t, w.CompactDeletes())
+	require.NoError(t, w.Flush())
+
+	r = index.NewReader(ctx, db, "testing-namespace", schema.GitHubFileSchema())
+	signals = importSignalsByFilename(t, r)
+	assert.Equal(t, 1.0, signals["log.go"])
 }

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -901,6 +902,82 @@ func (r *Reader) populateFieldLengths(docMatches map[uint64]*docMatch) error {
 	return nil
 }
 
+// ResolveSignals computes the named per-document scoring signals and attaches
+// them to the matches, where scorers read them via DocumentMatch.Signal.
+// Implements types.SignalResolver. Resolution is requested explicitly (and
+// typically over a bounded rerank window) so queries that don't score on
+// signals pay nothing.
+//
+// SignalImportInDegree is a document's import in-degree: the number of
+// documents whose imports field references one of this document's import_id
+// terms, summed over those terms. import_id is read from the stored field (a
+// single key per doc) and the count is the cardinality of each term's posting
+// list in the imports field, memoized per call. Counts include not-yet-
+// compacted deleted docs, acceptable for a fuzzy ranking signal.
+func (r *Reader) ResolveSignals(matches []types.DocumentMatch, names ...string) error {
+	for _, name := range names {
+		if name != types.SignalImportInDegree {
+			return status.InvalidArgumentErrorf("unknown scoring signal %q", name)
+		}
+	}
+	if len(names) == 0 || len(matches) == 0 {
+		return nil
+	}
+
+	start := time.Now()
+	defer func() {
+		if tracker := performance.TrackerFromContext(r.ctx); tracker != nil {
+			tracker.Add(performance.SIGNAL_RESOLVE_DURATION, int64(time.Since(start)))
+		}
+	}()
+
+	// The in-degree of an import_id term is the number of docs that import it,
+	// i.e. the cardinality of its posting list in the imports field. Memoized
+	// because popular terms recur across the match set.
+	inDegrees := make(map[string]float64)
+	importInDegree := func(importID string) (float64, error) {
+		var total float64
+		for term := range strings.FieldsSeq(importID) {
+			d, ok := inDegrees[term]
+			if !ok {
+				pl, closer, err := getPostingListReadOnly(r.db, r.namespace, term, types.ImportsField)
+				if err != nil {
+					return 0, err
+				}
+				d = float64(pl.GetCardinality())
+				closer.Close()
+				inDegrees[term] = d
+			}
+			total += d
+		}
+		return total, nil
+	}
+
+	for _, m := range matches {
+		dm, ok := m.(*docMatch)
+		if !ok {
+			continue
+		}
+		fields, err := r.getStoredFields(dm.docid, types.ImportIDField)
+		if err != nil {
+			return err
+		}
+		f, ok := fields[types.ImportIDField]
+		if !ok {
+			continue // no import_id for this doc (e.g. non-Go, test file, deleted)
+		}
+		total, err := importInDegree(string(f.Contents()))
+		if err != nil {
+			return err
+		}
+		if dm.signals == nil {
+			dm.signals = make(map[string]float64, 1)
+		}
+		dm.signals[types.SignalImportInDegree] = total
+	}
+	return nil
+}
+
 // TODO(jdelfino): We can't know if the document exists or not until we fetch the fields, but we
 // also want to fetch lazily, to avoid unnecessary fetches. This results in missing document
 // errors surfacing way downstream, in code that probably doesn't expect the document to be able to
@@ -1074,6 +1151,7 @@ type docMatch struct {
 	docid           uint64
 	matchedPostings map[string]types.Posting
 	fieldLengths    map[string]uint32
+	signals         map[string]float64
 }
 
 type matchPosting struct {
@@ -1101,6 +1179,10 @@ func (dm *docMatch) Posting(fieldName string) types.Posting {
 
 func (dm *docMatch) FieldLength(fieldName string) uint32 {
 	return dm.fieldLengths[fieldName]
+}
+
+func (dm *docMatch) Signal(name string) float64 {
+	return dm.signals[name]
 }
 
 type lazyDoc struct {

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -802,10 +802,17 @@ func (r *Reader) getStoredFields(docID uint64, fieldNames ...string) (map[string
 		return nil, err
 	}
 	defer iter.Close()
-	defer func() {
-		r.recordIterStats(iter, docField)
-	}()
+	defer r.recordIterStats(iter, docField)
+	return r.getStoredFieldsWithIter(iter, docID, fieldNames...)
+}
 
+// getStoredFieldsWithIter reads stored fields for a single doc using the
+// provided iterator, letting callers reuse one iterator across many docs. The
+// iterator must cover the doc's key range; when fieldNames are given each is
+// looked up with an exact SeekGE (so any iterator spanning the keys works),
+// but the no-fieldNames full-scan branch requires the iterator to be bounded
+// to this doc. The caller owns the iterator, including recording its stats.
+func (r *Reader) getStoredFieldsWithIter(iter *pebble.Iterator, docID uint64, fieldNames ...string) (map[string]types.Field, error) {
 	if len(fieldNames) > 0 {
 		fieldNames = slices.Clone(fieldNames)
 		slices.Sort(fieldNames)
@@ -914,6 +921,12 @@ func (r *Reader) populateFieldLengths(docMatches map[uint64]*docMatch) error {
 // single key per doc) and the count is the cardinality of each term's posting
 // list in the imports field, memoized per call. Counts include not-yet-
 // compacted deleted docs, acceptable for a fuzzy ranking signal.
+//
+// The per-term sum equals the true distinct-importer count only because a doc
+// today has a single import_id term (golang.go, java.go). If multi-identity
+// docs ever appear, an importer referencing two of a doc's terms would be
+// counted once per term; correctly de-duplicating it means unioning the
+// terms' posting lists and taking the union's cardinality instead of summing.
 func (r *Reader) ResolveSignals(matches []types.DocumentMatch, names ...string) error {
 	for _, name := range names {
 		if name != types.SignalImportInDegree {
@@ -935,9 +948,11 @@ func (r *Reader) ResolveSignals(matches []types.DocumentMatch, names ...string) 
 	// i.e. the cardinality of its posting list in the imports field. Memoized
 	// because popular terms recur across the match set.
 	inDegrees := make(map[string]float64)
-	importInDegree := func(importID string) (float64, error) {
+	importInDegree := func(docID uint64, importID string) (float64, error) {
 		var total float64
+		terms := 0
 		for term := range strings.FieldsSeq(importID) {
+			terms++
 			d, ok := inDegrees[term]
 			if !ok {
 				pl, closer, err := getPostingListReadOnly(r.db, r.namespace, term, types.ImportsField)
@@ -950,15 +965,35 @@ func (r *Reader) ResolveSignals(matches []types.DocumentMatch, names ...string) 
 			}
 			total += d
 		}
+		if terms > 1 {
+			// Tripwire for the single-identity assumption above: summing per
+			// term over-counts an importer that references more than one of a
+			// doc's terms. If this ever fires, switch to unioning the terms'
+			// posting lists and counting the union (see the doc comment).
+			log.Warningf("import in-degree: doc %d has %d import_id terms; count may over-count importers", docID, terms)
+		}
 		return total, nil
 	}
+
+	// One iterator reused across every match's import_id lookup, bounded to
+	// this namespace's stored-doc keyspace. Stats are recorded once here (not
+	// per call) because iter.Stats() is cumulative over the iterator's life.
+	iter, err := r.db.NewIter(&pebble.IterOptions{
+		LowerBound: r.storedFieldKey(0, ""),
+		UpperBound: fmt.Appendf(nil, "%s:doc:\xff", r.namespace),
+	})
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+	defer r.recordIterStats(iter, docField)
 
 	for _, m := range matches {
 		dm, ok := m.(*docMatch)
 		if !ok {
 			continue
 		}
-		fields, err := r.getStoredFields(dm.docid, types.ImportIDField)
+		fields, err := r.getStoredFieldsWithIter(iter, dm.docid, types.ImportIDField)
 		if err != nil {
 			return err
 		}
@@ -966,7 +1001,7 @@ func (r *Reader) ResolveSignals(matches []types.DocumentMatch, names ...string) 
 		if !ok {
 			continue // no import_id for this doc (e.g. non-Go, test file, deleted)
 		}
-		total, err := importInDegree(string(f.Contents()))
+		total, err := importInDegree(dm.docid, string(f.Contents()))
 		if err != nil {
 			return err
 		}

--- a/codesearch/performance/performance.go
+++ b/codesearch/performance/performance.go
@@ -36,6 +36,8 @@ const (
 	TOTAL_DOCS_SCORED_COUNT
 
 	TOTAL_SEARCH_DURATION
+
+	SIGNAL_RESOLVE_DURATION
 )
 
 func (l label) String() string {
@@ -72,6 +74,8 @@ func (l label) String() string {
 		return "TOTAL_DOCS_SCORED_COUNT"
 	case TOTAL_SEARCH_DURATION:
 		return "TOTAL_SEARCH_DURATION"
+	case SIGNAL_RESOLVE_DURATION:
+		return "SIGNAL_RESOLVE_DURATION"
 	default:
 		return "UNKNOWN_PERFORMANCE_LABEL"
 	}
@@ -154,6 +158,9 @@ func (t *Tracker) PrettyPrint() {
 	}
 	if t.Get(REMOVE_DELETED_DOCS_COUNT) > 0 {
 		log.Printf("Filtered %d deleted docs in %s", t.Get(REMOVE_DELETED_DOCS_COUNT), time.Duration(t.Get(REMOVE_DELETED_DOCS_DURATION)))
+	}
+	if t.Get(SIGNAL_RESOLVE_DURATION) > 0 {
+		log.Printf("Resolved scoring signals in %s", time.Duration(t.Get(SIGNAL_RESOLVE_DURATION)))
 	}
 	log.Printf("Scored %d docs in %s", t.Get(TOTAL_DOCS_SCORED_COUNT), time.Duration(t.Get(TOTAL_SCORING_DURATION)))
 	log.Printf("Completed search in %s", time.Duration(t.Get(TOTAL_SEARCH_DURATION)))

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -48,6 +48,10 @@ func (m testDocumentMatch) FieldLength(fieldName string) uint32 {
 	return m.fieldLengths[fieldName]
 }
 
+func (m testDocumentMatch) Signal(name string) float64 {
+	return 0
+}
+
 func matchWithFrequencies(freqs map[string]uint32) types.DocumentMatch {
 	return matchWithFrequenciesAndLengths(freqs, freqs)
 }

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -14,8 +14,10 @@ const (
 	DocIDField   = "_id"
 	DeletesField = "_del"
 
-	// ImportsField holds the import-identity terms a document imports;
-	// ImportIDField holds the document's own import-identity terms.
+	// ImportsField holds the import-identity terms a document imports.
+	// ImportIDField holds the document's own import-identity terms; it is
+	// known to the index so its value can be carried in the per-doc stats
+	// record and resolved into scoring signals at query time.
 	ImportsField  = "imports"
 	ImportIDField = "import_id"
 
@@ -23,6 +25,10 @@ const (
 	// extracted, lowercased), so symbol-definition matches can be scored
 	// above usage and substring matches.
 	SymbolsField = "symbols"
+
+	// SignalImportInDegree is the number of documents whose ImportsField
+	// contains one of this document's ImportIDField terms.
+	SignalImportInDegree = "import_indegree"
 )
 
 func (ft FieldType) String() string {
@@ -77,6 +83,18 @@ type DocumentMatch interface {
 	FieldNames() []string
 	Posting(fieldName string) Posting
 	FieldLength(fieldName string) uint32
+	// Signal returns the named per-document scoring signal, or 0 if the
+	// signal is absent or has not been resolved. Signals are attached to
+	// matches by a SignalResolver before scoring.
+	Signal(name string) float64
+}
+
+// SignalResolver computes per-document scoring signals for a set of matches
+// and attaches them so scorers can read them via DocumentMatch.Signal.
+// Resolution is requested explicitly so queries that don't score on signals
+// pay nothing. Implemented by index.Reader.
+type SignalResolver interface {
+	ResolveSignals(matches []DocumentMatch, names ...string) error
 }
 
 type Tokenizer interface {


### PR DESCRIPTION
Followup CL will use this to re-rank based on number of importers.