### PR TITLE
[codex] backfill short tasks without delaying queued work

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -955,6 +955,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 	defaultTaskSize := tasksize.Default(executionTask)
 	requestedTaskSize := tasksize.Requested(executionTask)
 	taskSize := tasksize.ApplyLimits(ctx, s.env.GetExperimentFlagProvider(), command, props, tasksize.Override(defaultTaskSize, requestedTaskSize))
+	taskSize.EstimatedExecutionDuration = action.GetTimeout()
 	measuredSize := s.taskSizer.Get(ctx, command, props)
 	var predictedSize *scpb.TaskSize
 	if measuredSize == nil {

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -210,6 +210,27 @@ func TestDispatch(t *testing.T) {
 	assert.Equal(t, iid, task.GetRequestMetadata().GetToolInvocationId(), "invocation ID should be passed along")
 }
 
+func TestDispatch_SetsEstimatedExecutionDurationFromActionTimeout(t *testing.T) {
+	env, _, _ := setupEnv(t)
+	ctx := context.Background()
+	s := env.GetRemoteExecutionService()
+
+	ctx, err := env.GetAuthenticator().(*testauth.TestAuthenticator).WithAuthenticatedUser(ctx, "US1")
+	require.NoError(t, err)
+	action := &repb.Action{
+		Timeout: durationpb.New(7 * time.Second),
+	}
+	arn := uploadAction(ctx, t, env, "" /*=instanceName*/, repb.DigestFunction_SHA256, action)
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, env.GetAuthenticator())
+	require.NoError(t, err)
+	err = s.Dispatch(ctx, &repb.ExecuteRequest{ActionDigest: arn.GetDigest()}, action, arn.NewUploadString())
+	require.NoError(t, err)
+
+	sched := env.GetSchedulerService().(*schedulerServerMock)
+	require.Len(t, sched.scheduleReqs, 1)
+	require.Equal(t, 7*time.Second, sched.scheduleReqs[0].GetMetadata().GetTaskSize().GetEstimatedExecutionDuration().AsDuration())
+}
+
 func TestDispatch_UploadOutputsChunkedMaxWriteSize(t *testing.T) {
 	env, _, _ := setupEnv(t)
 

--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -53,5 +53,6 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -56,6 +58,16 @@ type queuedTask struct {
 	// WorkerQueuedTimestamp is the timestamp at which the task was added to
 	// the local queue.
 	WorkerQueuedTimestamp time.Time
+}
+
+type activeTaskResourceUsage struct {
+	resources            *resourceCounts
+	estimatedReleaseTime time.Time
+}
+
+type activeTaskRelease struct {
+	resources *resourceCounts
+	at        time.Time
 }
 
 type groupPriorityQueue struct {
@@ -369,6 +381,7 @@ type PriorityTaskScheduler struct {
 	activeCancelFuncsCount  atomic.Int64
 	resourceCapacity        *resourceCounts
 	resourcesUsed           *resourceCounts
+	resourcesUsedByTask     map[string]*activeTaskResourceUsage
 	customResourceParents   map[string]string
 	customResourceChildren  map[string][]string
 	exclusiveTaskScheduling bool
@@ -423,6 +436,7 @@ func NewPriorityTaskScheduler(env environment.Env, exec IExecutor, runnerPool in
 			CPUMillis: 0,
 			Custom:    customResourcesUsed,
 		},
+		resourcesUsedByTask:     make(map[string]*activeTaskResourceUsage),
 		customResourceParents:   customResourceParents,
 		customResourceChildren:  customResourceChildren,
 		exclusiveTaskScheduling: *exclusiveTaskScheduling,
@@ -656,20 +670,13 @@ func (q *PriorityTaskScheduler) runTask(ctx context.Context, st *repb.ScheduledT
 func (q *PriorityTaskScheduler) trackTask(res *scpb.EnqueueTaskReservationRequest, cancel *context.CancelFunc) {
 	q.activeCancelFuncsCount.Add(1)
 	if size := res.GetTaskSize(); size != nil {
-		q.resourcesUsed.RAMBytes += size.GetEstimatedMemoryBytes()
-		q.resourcesUsed.CPUMillis += size.GetEstimatedMilliCpu()
-		for _, r := range size.GetCustomResources() {
-			if _, ok := q.resourcesUsed.Custom[r.GetName()]; ok {
-				q.resourcesUsed.Custom[r.GetName()] += customResource(r.GetValue())
-			}
+		resources := q.taskResourceCounts(size)
+		q.resourcesUsed.Add(resources)
+		q.resourcesUsedByTask[res.GetTaskId()] = &activeTaskResourceUsage{
+			resources:            resources,
+			estimatedReleaseTime: q.estimatedReleaseTime(size),
 		}
-		metrics.RemoteExecutionAssignedRAMBytes.Set(float64(q.resourcesUsed.RAMBytes))
-		metrics.RemoteExecutionAssignedMilliCPU.Set(float64(q.resourcesUsed.CPUMillis))
-		for name := range q.resourcesUsed.Custom {
-			metrics.RemoteExecutionAssignedCustomResources.With(prometheus.Labels{
-				metrics.CustomResourceNameLabel: name,
-			}).Set(float64(q.customResourceUsed(q.resourcesUsed, name)) / 1e6)
-		}
+		q.updateResourceMetrics()
 		log.CtxDebugf(q.rootContext, "Claimed task resources. Queue stats: %s", q.stats())
 	}
 }
@@ -677,21 +684,25 @@ func (q *PriorityTaskScheduler) trackTask(res *scpb.EnqueueTaskReservationReques
 func (q *PriorityTaskScheduler) untrackTask(res *scpb.EnqueueTaskReservationRequest, cancel *context.CancelFunc) {
 	q.activeCancelFuncsCount.Add(-1)
 	if size := res.GetTaskSize(); size != nil {
-		q.resourcesUsed.RAMBytes -= size.GetEstimatedMemoryBytes()
-		q.resourcesUsed.CPUMillis -= size.GetEstimatedMilliCpu()
-		for _, r := range size.GetCustomResources() {
-			if _, ok := q.resourcesUsed.Custom[r.GetName()]; ok {
-				q.resourcesUsed.Custom[r.GetName()] -= customResource(r.GetValue())
-			}
+		resources, ok := q.resourcesUsedByTask[res.GetTaskId()]
+		if ok {
+			q.resourcesUsed.Sub(resources.resources)
+			delete(q.resourcesUsedByTask, res.GetTaskId())
+		} else {
+			q.resourcesUsed.Sub(q.taskResourceCounts(size))
 		}
-		metrics.RemoteExecutionAssignedRAMBytes.Set(float64(q.resourcesUsed.RAMBytes))
-		metrics.RemoteExecutionAssignedMilliCPU.Set(float64(q.resourcesUsed.CPUMillis))
-		for name := range q.resourcesUsed.Custom {
-			metrics.RemoteExecutionAssignedCustomResources.With(prometheus.Labels{
-				metrics.CustomResourceNameLabel: name,
-			}).Set(float64(q.customResourceUsed(q.resourcesUsed, name)) / 1e6)
-		}
+		q.updateResourceMetrics()
 		log.CtxDebugf(q.rootContext, "Released task resources. Queue stats: %s", q.stats())
+	}
+}
+
+func (q *PriorityTaskScheduler) updateResourceMetrics() {
+	metrics.RemoteExecutionAssignedRAMBytes.Set(float64(q.resourcesUsed.RAMBytes))
+	metrics.RemoteExecutionAssignedMilliCPU.Set(float64(q.resourcesUsed.CPUMillis))
+	for name := range q.resourcesUsed.Custom {
+		metrics.RemoteExecutionAssignedCustomResources.With(prometheus.Labels{
+			metrics.CustomResourceNameLabel: name,
+		}).Set(float64(q.customResourceUsed(q.resourcesUsed, name)) / 1e6)
 	}
 }
 
@@ -713,6 +724,71 @@ func (q *PriorityTaskScheduler) stats() string {
 		q.resourcesUsed.RAMBytes, q.resourceCapacity.RAMBytes, ramBytesRemaining,
 		customResourcesDesc,
 		q.activeCancelFuncsCount.Load(), q.q.Len())
+}
+
+func taskEstimatedExecutionDuration(size *scpb.TaskSize) time.Duration {
+	if size.GetEstimatedExecutionDuration() == nil {
+		return 0
+	}
+	duration := size.GetEstimatedExecutionDuration().AsDuration()
+	if duration <= 0 {
+		return 0
+	}
+	return duration
+}
+
+func (q *PriorityTaskScheduler) estimatedReleaseTime(size *scpb.TaskSize) time.Time {
+	duration := taskEstimatedExecutionDuration(size)
+	if duration <= 0 {
+		return time.Time{}
+	}
+	return q.clock.Now().Add(duration)
+}
+
+func (q *PriorityTaskScheduler) activeTaskReleasesAfter(now time.Time) []activeTaskRelease {
+	releases := make([]activeTaskRelease, 0, len(q.resourcesUsedByTask))
+	for _, usage := range q.resourcesUsedByTask {
+		if usage.estimatedReleaseTime.IsZero() || !usage.estimatedReleaseTime.After(now) {
+			continue
+		}
+		releases = append(releases, activeTaskRelease{
+			resources: usage.resources,
+			at:        usage.estimatedReleaseTime,
+		})
+	}
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].at.Before(releases[j].at)
+	})
+	return releases
+}
+
+func (q *PriorityTaskScheduler) earliestStartTime(task *queuedTask, reservedResources *resourceCounts, now time.Time) (time.Time, bool) {
+	if q.canFitTask(task, reservedResources) {
+		return now, true
+	}
+	reservedResources = reservedResources.Clone()
+	for _, release := range q.activeTaskReleasesAfter(now) {
+		reservedResources.Sub(release.resources)
+		if q.canFitTask(task, reservedResources) {
+			return release.at, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func (q *PriorityTaskScheduler) canBackfillWithoutDelayingSkippedTasks(task *queuedTask, skippedStartTimes []time.Time, now time.Time) bool {
+	if len(skippedStartTimes) == 0 {
+		return false
+	}
+	if !q.canFitTask(task, q.resourcesUsed) {
+		return false
+	}
+	duration := taskEstimatedExecutionDuration(task.GetTaskSize())
+	if duration <= 0 {
+		return false
+	}
+	estimatedFinishTime := now.Add(duration)
+	return !slices.ContainsFunc(skippedStartTimes, estimatedFinishTime.After)
 }
 
 // canFitTask returns whether the task can fit, given the resource capacity and
@@ -867,17 +943,30 @@ func (q *PriorityTaskScheduler) getNextSchedulableTask(ctx context.Context) (*qu
 	// This ensures that when tasks skip ahead in the queue, they don't delay
 	// the start time of other tasks that have been waiting for longer.
 	reservedResources := q.resourcesUsed.Clone()
+	now := q.clock.Now()
+	var skippedStartTimes []time.Time
+	skippedStartTimesKnown := true
 	iterator := q.q.Iterator()
 	for task := iterator.Next(); task != nil; task = iterator.Next() {
 		canFit := q.canFitTask(task, reservedResources)
 		if canFit {
 			return task, iterator.Current()
 		}
+		if skippedStartTimesKnown && q.canBackfillWithoutDelayingSkippedTasks(task, skippedStartTimes, now) {
+			return task, iterator.Current()
+		}
+		startTime, ok := q.earliestStartTime(task, reservedResources, now)
+		if ok {
+			skippedStartTimes = append(skippedStartTimes, startTime)
+		} else {
+			skippedStartTimesKnown = false
+		}
 		reservedResources.Add(q.taskResourceCounts(task.GetTaskSize()))
 
 		// If all resources are reserved, short circuit - none of the remaining
-		// tasks will be able to schedule.
-		if q.resourcesAllGTE(reservedResources, q.resourceCapacity) {
+		// tasks will be able to schedule unless they have a known short enough
+		// duration to finish before the skipped tasks can start.
+		if q.resourcesAllGTE(reservedResources, q.resourceCapacity) && !skippedStartTimesKnown {
 			break
 		}
 	}
@@ -1126,5 +1215,14 @@ func (r *resourceCounts) Add(other *resourceCounts) {
 	r.CPUMillis += other.CPUMillis
 	for k, v := range other.Custom {
 		r.Custom[k] += v
+	}
+}
+
+// Sub mutates the resourceCounts object, subtracting the given counts from it.
+func (r *resourceCounts) Sub(other *resourceCounts) {
+	r.RAMBytes -= other.RAMBytes
+	r.CPUMillis -= other.CPUMillis
+	for k, v := range other.Custom {
+		r.Custom[k] -= v
 	}
 }

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
@@ -304,6 +305,121 @@ func TestPriorityTaskScheduler_QueueSkipping_LargeCustomResourceTasksNotIndefini
 		execution2.ScheduledTask.GetExecutionTask().GetExecutionId(),
 	}
 	require.ElementsMatch(t, []string{gpuSmall1TaskID, gpuLargeTaskID}, startedTaskIDs)
+}
+
+func TestPriorityTaskScheduler_QueueSkipping_KnownShortTaskCanBackfillWithoutDelay(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		duration   time.Duration
+		shouldSkip bool
+	}{
+		{
+			name:       "short task skips",
+			duration:   time.Second,
+			shouldSkip: true,
+		},
+		{
+			name:       "long task waits",
+			duration:   11 * time.Second,
+			shouldSkip: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			env := testenv.GetTestEnv(t)
+			env.SetClock(clockwork.NewFakeClockAt(time.Unix(123, 0)))
+			env.SetRemoteExecutionClient(&FakeExecutionClient{})
+
+			flags.Set(t, "executor.millicpu", 30_000)
+			flags.Set(t, "executor.memory_bytes", 64_000_000_000)
+			flags.Set(t, "executor.custom_resources", []resources.CustomResource{
+				{Name: "gpu", Value: 2.0},
+			})
+			err := resources.Configure(false /*=mmapLRUEnabled*/)
+			require.NoError(t, err)
+
+			executor := NewFakeExecutor()
+			runnerPool := &FakeRunnerPool{}
+			leaser := NewFakeTaskLeaser()
+
+			scheduler, err := NewPriorityTaskScheduler(env, executor, runnerPool, leaser, &Options{})
+			require.NoError(t, err)
+			scheduler.Start()
+			ctx := context.Background()
+			t.Cleanup(func() {
+				err := scheduler.Stop()
+				require.NoError(t, err)
+				assert.NoError(t, scheduler.Shutdown(ctx))
+			})
+
+			gpuSize := func(gpus float32, duration time.Duration) *scpb.TaskSize {
+				return &scpb.TaskSize{
+					EstimatedMilliCpu:          1000,
+					EstimatedMemoryBytes:       1000,
+					CustomResources:            []*scpb.CustomResource{{Name: "gpu", Value: gpus}},
+					EstimatedExecutionDuration: durationpb.New(duration),
+				}
+			}
+			enqueue := func(taskID string, size *scpb.TaskSize) {
+				_, err := scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{
+					TaskId:             taskID,
+					TaskSize:           size,
+					SchedulingMetadata: &scpb.SchedulingMetadata{TaskSize: size},
+				})
+				require.NoError(t, err)
+			}
+			waitForStart := func(taskID string) *FakeExecution {
+				select {
+				case execution := <-executor.StartedExecutions:
+					require.Equal(t, taskID, execution.ScheduledTask.GetExecutionTask().GetExecutionId())
+					return execution
+				case <-time.After(time.Second):
+					require.FailNowf(t, "timed out waiting for task to start", "task %q did not start", taskID)
+					return nil
+				}
+			}
+			requireNoStart := func() {
+				select {
+				case execution := <-executor.StartedExecutions:
+					require.FailNowf(t, "no task should have started", "task %q started", execution.ScheduledTask.GetExecutionTask().GetExecutionId())
+				case <-time.After(100 * time.Millisecond):
+				}
+			}
+
+			gpuSmall1TaskID := fakeTaskID("gpu-small-1")
+			gpuLargeTaskID := fakeTaskID("gpu-large")
+			gpuSmall2TaskID := fakeTaskID("gpu-small-2")
+
+			enqueue(gpuSmall1TaskID, gpuSize(1.0, 10*time.Second))
+			execution1 := waitForStart(gpuSmall1TaskID)
+
+			enqueue(gpuLargeTaskID, gpuSize(2.0, time.Minute))
+			enqueue(gpuSmall2TaskID, gpuSize(1.0, test.duration))
+
+			if test.shouldSkip {
+				execution2 := waitForStart(gpuSmall2TaskID)
+				require.Equal(t, 1, scheduler.q.Len())
+
+				execution2.Complete()
+				requireNoStart()
+
+				execution1.Complete()
+				execution3 := waitForStart(gpuLargeTaskID)
+				execution3.Complete()
+				return
+			}
+
+			requireNoStart()
+			require.Equal(t, 2, scheduler.q.Len())
+
+			execution1.Complete()
+			execution2 := waitForStart(gpuLargeTaskID)
+			require.Equal(t, 1, scheduler.q.Len())
+			execution2.Complete()
+
+			execution3 := waitForStart(gpuSmall2TaskID)
+			execution3.Complete()
+		})
+	}
 }
 
 func TestPriorityTaskScheduler_CustomResourceParentAccountingCeil(t *testing.T) {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -561,6 +561,9 @@ func (h *executorHandle) getMostAccurateTaskSize(req *scpb.EnqueueTaskReservatio
 	requestedSize := req.GetSchedulingMetadata().GetRequestedTaskSize()
 	size.CustomResources = requestedSize.GetCustomResources()
 	size.EstimatedFreeDiskBytes = requestedSize.GetEstimatedFreeDiskBytes()
+	if duration := req.GetSchedulingMetadata().GetTaskSize().GetEstimatedExecutionDuration(); duration != nil {
+		size.EstimatedExecutionDuration = duration
+	}
 
 	return size
 }

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -755,6 +755,32 @@ func enqueueTaskReservation(ctx context.Context, t *testing.T, env environment.E
 	return taskID
 }
 
+func TestGetMostAccurateTaskSize_PreservesEstimatedExecutionDuration(t *testing.T) {
+	duration := durationpb.New(7 * time.Second)
+	handle := &executorHandle{
+		registration: &scpb.ExecutionNode{
+			AssignableMemoryBytes: 10_000,
+			AssignableMilliCpu:    10_000,
+		},
+	}
+	size := handle.getMostAccurateTaskSize(&scpb.EnqueueTaskReservationRequest{
+		SchedulingMetadata: &scpb.SchedulingMetadata{
+			TaskSize: &scpb.TaskSize{
+				EstimatedMemoryBytes:       100,
+				EstimatedMilliCpu:          100,
+				EstimatedExecutionDuration: duration,
+			},
+			MeasuredTaskSize: &scpb.TaskSize{
+				EstimatedMemoryBytes: 200,
+				EstimatedMilliCpu:    200,
+			},
+			RequestedTaskSize: &scpb.TaskSize{},
+		},
+	})
+
+	require.Equal(t, 7*time.Second, size.GetEstimatedExecutionDuration().AsDuration())
+}
+
 func TestExecutorReEnqueue_NoLeaseID(t *testing.T) {
 	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
 

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -148,6 +148,10 @@ message TaskSize {
   // be configured with enough custom resource capacity to satisfy all of the
   // resource requests in this list.
   repeated CustomResource custom_resources = 4;
+
+  // Optional wall-clock execution duration estimate. Executors may use this for
+  // conservative local backfilling; unset means the task duration is unknown.
+  google.protobuf.Duration estimated_execution_duration = 9;
 }
 
 // CgroupSettings defines Linux cgroup2 options for an execution.


### PR DESCRIPTION
## Summary

- Add an optional execution-duration estimate to task sizing metadata.
- Populate it from the action timeout and preserve it when dynamic task sizing swaps in measured or predicted sizes.
- Allow a queued task to backfill only when it fits now and its known duration finishes before older blocked tasks could start.

## Stack

Base branch: `codex/custom-resource-parent-accounting` from draft PR #12474.

## Validation

- `bazel test //enterprise/server/scheduling/priority_task_scheduler:priority_task_scheduler_test //enterprise/server/scheduling/scheduler_server:scheduler_server_test //enterprise/server/remote_execution/execution_server:execution_server_test //server/resources:resources_test`
- `bazel test //enterprise/server/scheduling/scheduler_server:scheduler_server_test`