### PR TITLE
[raft] parallelize metacache GetMulti 

### DIFF
--- a/enterprise/server/backends/cache_config/cache_config.go
+++ b/enterprise/server/backends/cache_config/cache_config.go
@@ -75,6 +75,7 @@ type MetaCacheConfig struct {
 	MaxInlineFileSizeBytes      int64                   `yaml:"max_inline_file_size_bytes" usage:"Files smaller than this may be inlined directly into metadata storage."`
 	MinBytesAutoZstdCompression int64                   `yaml:"min_bytes_auto_zstd_compression" usage:"Blobs larger than this will be zstd compressed before written to disk."`
 	MaxWriteGoroutines          int                     `yaml:"max_write_goroutines" usage:"The maximum number of goroutines to write data in SetMulti."`
+	MaxReadGoroutines           int                     `yaml:"max_read_goroutines" usage:"The maximum number of goroutines to read data in GetMulti."`
 	GCSConfig                   GCSConfig               `yaml:"gcs" usage:"GCS configuration for storing large files."`
 }
 

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"math"
 	"os"
 	"slices"
 	"strings"
@@ -62,6 +61,7 @@ const (
 	defaultMaxInlineFileSizeBytes      = int64(1024)
 	defaultMinBytesAutoZstdCompression = int64(100)
 	defaultMaxWriteGoroutines          = 10
+	defaultMaxReadGoroutines           = 10
 )
 
 type Options struct {
@@ -76,6 +76,7 @@ type Options struct {
 	MaxInlineFileSizeBytes      int64
 
 	MaxWriteGoroutines int
+	MaxReadGoroutines  int
 
 	MetadataBackend string
 
@@ -154,6 +155,9 @@ func setOptionDefaults(opts *Options) {
 	}
 	if opts.MaxWriteGoroutines == 0 {
 		opts.MaxWriteGoroutines = defaultMaxWriteGoroutines
+	}
+	if opts.MaxReadGoroutines == 0 {
+		opts.MaxReadGoroutines = defaultMaxReadGoroutines
 	}
 	if opts.Clock == nil {
 		opts.Clock = clockwork.NewRealClock()
@@ -615,6 +619,10 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 	start := c.opts.Clock.Now()
 	defer c.recordMetrics("GetMulti", resultErr, start)
 
+	if len(resources) == 0 {
+		return map[*repb.Digest][]byte{}, nil
+	}
+
 	encryption, err := c.activeEncryption(ctx)
 	if err != nil {
 		return nil, err
@@ -648,8 +656,8 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 	var foundMu sync.Mutex
 	foundMap := make(map[*repb.Digest][]byte, len(keyToMetadata))
 	eg, ctx := errgroup.WithContext(ctx)
-	// split into 10 chunks
-	chunkSize := math.Ceil(float64(len(resources)) / 10)
+	numChunks := c.opts.MaxReadGoroutines
+	chunkSize := (len(resources) + numChunks - 1) / numChunks
 	for chunk := range slices.Chunk(resources, int(chunkSize)) {
 		eg.Go(func() error {
 			for _, r := range chunk {

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -375,35 +375,10 @@ func (c *Cache) readerForStorage(ctx context.Context, storage *sgpb.StorageMetad
 	case storage.GetInlineMetadata() != nil:
 		return c.opts.FileStorer.InlineReader(storage.GetInlineMetadata(), offset, limit)
 	case storage.GetGcsMetadata() != nil:
-		// return &asyncReader{
-		// 	rf: sync.OnceValues(func() (io.ReadCloser, error) {
-		// 		return c.opts.FileStorer.BlobReader(ctx, storage.GetGcsMetadata(), offset, limit)
-		// 	}),
-		// }, nil
 		return c.opts.FileStorer.BlobReader(ctx, storage.GetGcsMetadata(), offset, limit)
 	default:
 		return nil, status.InvalidArgumentErrorf("Unsupported storage metadata: %+v", storage)
 	}
-}
-
-type asyncReader struct {
-	rf func() (io.ReadCloser, error)
-}
-
-func (ar *asyncReader) Read(buf []byte) (int, error) {
-	r, err := ar.rf()
-	if err != nil {
-		return 0, err
-	}
-	return r.Read(buf)
-}
-
-func (ar *asyncReader) Close() error {
-	r, err := ar.rf()
-	if err != nil {
-		return err
-	}
-	return r.Close()
 }
 
 func (c *Cache) writerForRecord(ctx context.Context, fileRecord *sgpb.FileRecord, sizeHint int64) (interfaces.MetadataWriteCloser, error) {
@@ -671,8 +646,9 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 	}
 
 	var foundMu sync.Mutex
-	foundMap := make(map[*repb.Digest][]byte, len(resources))
+	foundMap := make(map[*repb.Digest][]byte, len(keyToMetadata))
 	eg, ctx := errgroup.WithContext(ctx)
+	// split into 10 chunks
 	chunkSize := math.Ceil(float64(len(resources)) / 10)
 	for chunk := range slices.Chunk(resources, int(chunkSize)) {
 		eg.Go(func() error {
@@ -682,9 +658,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 				if !ok {
 					continue
 				}
-				// start := time.Now()
 				rc, err := c.reader(ctx, md, r, 0, 0, encryption)
-				// fmt.Println("reader took:", time.Since(start))
 				if err != nil {
 					if status.IsNotFoundError(err) || os.IsNotExist(err) {
 						continue
@@ -692,9 +666,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 					return err
 				}
 				buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(r, maxReadBufferSize)))
-				// start = time.Now()
 				_, copyErr := io.Copy(buf, rc)
-				// fmt.Println("read took:", time.Since(start))
 				closeErr := rc.Close()
 				if copyErr != nil {
 					log.Warningf("[%s] GetMulti encountered error when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), copyErr)

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -373,10 +373,35 @@ func (c *Cache) readerForStorage(ctx context.Context, storage *sgpb.StorageMetad
 	case storage.GetInlineMetadata() != nil:
 		return c.opts.FileStorer.InlineReader(storage.GetInlineMetadata(), offset, limit)
 	case storage.GetGcsMetadata() != nil:
+		// return &asyncReader{
+		// 	rf: sync.OnceValues(func() (io.ReadCloser, error) {
+		// 		return c.opts.FileStorer.BlobReader(ctx, storage.GetGcsMetadata(), offset, limit)
+		// 	}),
+		// }, nil
 		return c.opts.FileStorer.BlobReader(ctx, storage.GetGcsMetadata(), offset, limit)
 	default:
 		return nil, status.InvalidArgumentErrorf("Unsupported storage metadata: %+v", storage)
 	}
+}
+
+type asyncReader struct {
+	rf func() (io.ReadCloser, error)
+}
+
+func (ar *asyncReader) Read(buf []byte) (int, error) {
+	r, err := ar.rf()
+	if err != nil {
+		return 0, err
+	}
+	return r.Read(buf)
+}
+
+func (ar *asyncReader) Close() error {
+	r, err := ar.rf()
+	if err != nil {
+		return err
+	}
+	return r.Close()
 }
 
 func (c *Cache) writerForRecord(ctx context.Context, fileRecord *sgpb.FileRecord, sizeHint int64) (interfaces.MetadataWriteCloser, error) {
@@ -643,32 +668,44 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 		keyToMetadata[k] = md
 	}
 
+	var foundMu sync.Mutex
 	foundMap := make(map[*repb.Digest][]byte, len(resources))
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(10)
 	for _, r := range resources {
 		k := keyFromResourceName(r)
 		md, ok := keyToMetadata[k]
 		if !ok {
 			continue
 		}
-		rc, err := c.reader(ctx, md, r, 0, 0, encryption)
-		if err != nil {
-			if status.IsNotFoundError(err) || os.IsNotExist(err) {
-				continue
+		eg.Go(func() error {
+			// start := time.Now()
+			rc, err := c.reader(ctx, md, r, 0, 0, encryption)
+			// fmt.Println("reader took:", time.Since(start))
+			if err != nil {
+				if status.IsNotFoundError(err) || os.IsNotExist(err) {
+					return nil
+				}
+				return err
 			}
-			return nil, err
-		}
-		buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(r, maxReadBufferSize)))
-		_, copyErr := io.Copy(buf, rc)
-		closeErr := rc.Close()
-		if copyErr != nil {
-			log.Warningf("[%s] GetMulti encountered error when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), copyErr)
-			continue
-		}
-		if closeErr != nil {
-			log.Warningf("[%s] GetMulti cannot close reader when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), closeErr)
-			continue
-		}
-		foundMap[r.GetDigest()] = buf.Bytes()
+			buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(r, maxReadBufferSize)))
+			// start = time.Now()
+			_, copyErr := io.Copy(buf, rc)
+			// fmt.Println("read took:", time.Since(start))
+			closeErr := rc.Close()
+			if copyErr != nil {
+				log.Warningf("[%s] GetMulti encountered error when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), copyErr)
+				return nil
+			}
+			if closeErr != nil {
+				log.Warningf("[%s] GetMulti cannot close reader when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), closeErr)
+				return nil
+			}
+			foundMu.Lock()
+			foundMap[r.GetDigest()] = buf.Bytes()
+			foundMu.Unlock()
+			return nil
+		})
 	}
 	return foundMap, nil
 }

--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"math"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -671,41 +673,46 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 	var foundMu sync.Mutex
 	foundMap := make(map[*repb.Digest][]byte, len(resources))
 	eg, ctx := errgroup.WithContext(ctx)
-	eg.SetLimit(10)
-	for _, r := range resources {
-		k := keyFromResourceName(r)
-		md, ok := keyToMetadata[k]
-		if !ok {
-			continue
-		}
+	chunkSize := math.Ceil(float64(len(resources)) / 10)
+	for chunk := range slices.Chunk(resources, int(chunkSize)) {
 		eg.Go(func() error {
-			// start := time.Now()
-			rc, err := c.reader(ctx, md, r, 0, 0, encryption)
-			// fmt.Println("reader took:", time.Since(start))
-			if err != nil {
-				if status.IsNotFoundError(err) || os.IsNotExist(err) {
-					return nil
+			for _, r := range chunk {
+				k := keyFromResourceName(r)
+				md, ok := keyToMetadata[k]
+				if !ok {
+					continue
 				}
-				return err
+				// start := time.Now()
+				rc, err := c.reader(ctx, md, r, 0, 0, encryption)
+				// fmt.Println("reader took:", time.Since(start))
+				if err != nil {
+					if status.IsNotFoundError(err) || os.IsNotExist(err) {
+						continue
+					}
+					return err
+				}
+				buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(r, maxReadBufferSize)))
+				// start = time.Now()
+				_, copyErr := io.Copy(buf, rc)
+				// fmt.Println("read took:", time.Since(start))
+				closeErr := rc.Close()
+				if copyErr != nil {
+					log.Warningf("[%s] GetMulti encountered error when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), copyErr)
+					continue
+				}
+				if closeErr != nil {
+					log.Warningf("[%s] GetMulti cannot close reader when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), closeErr)
+					continue
+				}
+				foundMu.Lock()
+				foundMap[r.GetDigest()] = buf.Bytes()
+				foundMu.Unlock()
 			}
-			buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(r, maxReadBufferSize)))
-			// start = time.Now()
-			_, copyErr := io.Copy(buf, rc)
-			// fmt.Println("read took:", time.Since(start))
-			closeErr := rc.Close()
-			if copyErr != nil {
-				log.Warningf("[%s] GetMulti encountered error when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), copyErr)
-				return nil
-			}
-			if closeErr != nil {
-				log.Warningf("[%s] GetMulti cannot close reader when copying %s: %s", c.opts.Name, r.GetDigest().GetHash(), closeErr)
-				return nil
-			}
-			foundMu.Lock()
-			foundMap[r.GetDigest()] = buf.Bytes()
-			foundMu.Unlock()
 			return nil
 		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return foundMap, nil
 }

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -163,6 +163,25 @@ func getDistributedCache(t testing.TB, te environment.Env, c interfaces.Cache, l
 	return dc
 }
 
+type slowGcs struct {
+	filestore.PebbleGCSStorage
+}
+
+// time.Sleep can't reliably sleep for less than 1ms, so use a busy loop
+// instead.
+func busyLoop(dur time.Duration) {
+	start := time.Now()
+	for time.Since(start) < dur {
+	}
+}
+
+func (slow *slowGcs) Reader(ctx context.Context, blobName string, offset, limit int64) (io.ReadCloser, error) {
+	// GCS takes 30-40ms to open a reader. We don't have to wait that long to
+	// reproduce slowness in benchmarks
+	busyLoop(time.Millisecond)
+	return slow.PebbleGCSStorage.Reader(ctx, blobName, offset, limit)
+}
+
 func getMetaCache(t testing.TB, te environment.Env) interfaces.Cache {
 	clock := clockwork.NewRealClock()
 
@@ -170,7 +189,7 @@ func getMetaCache(t testing.TB, te environment.Env) interfaces.Cache {
 	if err := mockGCS.SetBucketCustomTimeTTL(context.Background(), 1); err != nil {
 		t.Fatal(err)
 	}
-	fs := filestore.New(filestore.WithGCSBlobstore(mockGCS, "one-bucket"))
+	fs := filestore.New(filestore.WithGCSBlobstore(&slowGcs{mockGCS}, "one-bucket"))
 
 	mm, err := mockmetadata.NewServer(maxSizeBytes, fs)
 	require.NoError(t, err)


### PR DESCRIPTION
This speeds up GetMulti when reading GCS blobs. It slows down reading tiny blobs in benchmarks, but I don't think this will be visible with a real setup where we make RPCs to a read metadata service.

Benchmark result:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                      │  /tmp/base   │             /tmp/chunked              │
                      │    sec/op    │   sec/op     vs base                  │
GetMulti/Meta10-24       211.7µ ± 9%   263.1µ ± 3%  +24.28% (p=0.000 n=7+17)
GetMulti/Meta100-24      251.0µ ± 1%   262.0µ ± 8%        ~ (p=0.288 n=7+17)
GetMulti/Meta1000-24     364.7µ ± 1%   298.7µ ± 6%  -18.10% (p=0.000 n=7+17)
GetMulti/Meta10000-24   101.29m ± 0%   10.52m ± 0%  -89.62% (p=0.000 n=7+17)
geomean                  1.184m        682.2µ       -42.37%

                      │   /tmp/base   │               /tmp/chunked               │
                      │      B/s      │      B/s       vs base                   │
GetMulti/Meta10-24      4.501Mi ± 10%    3.624Mi ± 3%   -19.49% (p=0.000 n=7+17)
GetMulti/Meta100-24     37.98Mi ±  1%    36.40Mi ± 8%         ~ (p=0.280 n=7+17)
GetMulti/Meta1000-24    261.5Mi ±  1%    319.3Mi ± 6%   +22.11% (p=0.000 n=7+17)
GetMulti/Meta10000-24   9.413Mi ±  0%   90.666Mi ± 0%  +863.22% (p=0.000 n=7+17)
geomean                 25.47Mi          44.21Mi        +73.56%

                      │  /tmp/base   │             /tmp/chunked              │
                      │     B/op     │     B/op      vs base                 │
GetMulti/Meta10-24      221.0Ki ± 0%   222.8Ki ± 0%  +0.81% (p=0.000 n=7+17)
GetMulti/Meta100-24     237.4Ki ± 0%   239.6Ki ± 0%  +0.90% (p=0.000 n=7+17)
GetMulti/Meta1000-24    359.5Ki ± 0%   363.3Ki ± 0%  +1.06% (p=0.000 n=7+17)
GetMulti/Meta10000-24   1.224Mi ± 5%   1.226Mi ± 0%       ~ (p=0.804 n=7+17)
geomean                 392.2Ki        395.0Ki       +0.73%

                      │  /tmp/base   │             /tmp/chunked             │
                      │  allocs/op   │  allocs/op   vs base                 │
GetMulti/Meta10-24      3.283k ±  0%   3.309k ± 0%  +0.79% (p=0.000 n=7+17)
GetMulti/Meta100-24     3.387k ±  0%   3.414k ± 0%  +0.80% (p=0.000 n=7+17)
GetMulti/Meta1000-24    3.392k ±  0%   3.419k ± 0%  +0.80% (p=0.000 n=7+17)
GetMulti/Meta10000-24   3.535k ± 30%   3.435k ± 0%  -2.83% (p=0.000 n=7+17)
geomean                 3.398k         3.394k       -0.12%
```