### PR TITLE
Add a `types` filter to the pull_request workflow trigger

### DIFF
--- a/docs/workflows-config.md
+++ b/docs/workflows-config.md
@@ -552,6 +552,13 @@ pushed.
   wants to merge a branch _into_ the `main` branch or any branch prefixed with
   `release/`. Branch patterns are matched using the rules described in
   [Ref pattern matching](#ref-pattern-matching)
+- **`types`** (`string` list): The pull request actions that trigger the
+  workflow. The supported values are `opened`, `synchronize`, `reopened`,
+  `edited` (base-branch changes only), and `ready_for_review`. If unset, the
+  trigger fires on `opened`, `synchronize`, `reopened`, and base-branch edits.
+  Set this to scope the workflow to specific pull_request actions — for example
+  `[ "ready_for_review" ]` to run only when a draft PR is marked ready for
+  review.
 - **`merge_with_base`** (`boolean`, default: `true`): Whether to merge the
   base branch into the PR branch before running the workflow action. This
   can help ensure that the changes in the PR branch do not conflict with

--- a/enterprise/server/webhooks/github/BUILD
+++ b/enterprise/server/webhooks/github/BUILD
@@ -27,6 +27,7 @@ go_test(
         "//enterprise/server/webhooks/github/test_data",
         "//server/interfaces",
         "//server/testutil/testenv",
+        "@com_github_google_go_github_v59//github",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -151,10 +151,13 @@ func ParseWebhookData(event interface{}) (*interfaces.WebhookData, error) {
 
 	case *gh.PullRequestEvent:
 		// Run workflows when the PR is opened, pushed to, or reopened, to match
-		// GitHub the behavior of GitHub actions. Also run workflows when the base
-		// branch changes, to accommodate stacked changes.
-		baseBranchChanged := event.GetAction() == "edited" && event.GetChanges().GetBase() != nil
-		if !(baseBranchChanged || event.GetAction() == "opened" || event.GetAction() == "synchronize" || event.GetAction() == "reopened") {
+		// the behavior of GitHub actions. Also run workflows when the base
+		// branch changes, to accommodate stacked changes, and when a PR is
+		// marked ready for review. The action is recorded on the WebhookData so
+		// triggers can filter by type (e.g. only "ready_for_review").
+		action := event.GetAction()
+		baseBranchChanged := action == "edited" && event.GetChanges().GetBase() != nil
+		if !(baseBranchChanged || action == "opened" || action == "synchronize" || action == "reopened" || action == "ready_for_review") {
 			return nil, nil
 		}
 		wd, err := parsePullRequestOrReview(event)
@@ -162,6 +165,7 @@ func ParseWebhookData(event interface{}) (*interfaces.WebhookData, error) {
 			return nil, err
 		}
 		wd.PullRequestNumber = int64(event.GetPullRequest().GetNumber())
+		wd.PullRequestAction = action
 		return wd, nil
 
 	case *gh.PullRequestReviewEvent:

--- a/enterprise/server/webhooks/github/github_test.go
+++ b/enterprise/server/webhooks/github/github_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/stretchr/testify/assert"
+
+	gh "github.com/google/go-github/v59/github"
 )
 
 func webhookRequest(t *testing.T, eventType string, payload []byte) *http.Request {
@@ -85,6 +87,7 @@ func TestParseRequest_ValidPullRequestEvent_Success(t *testing.T) {
 		TargetBranch:            "main",
 		PullRequestAuthor:       "test",
 		PullRequestNumber:       37,
+		PullRequestAction:       "opened",
 	}, data)
 }
 
@@ -118,4 +121,55 @@ func TestParseRequest_InvalidEvent_Error(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, data)
+}
+
+func pullRequestEvent(action string) *gh.PullRequestEvent {
+	repo := &gh.Repository{
+		CloneURL:      gh.String("https://github.com/test/repo.git"),
+		DefaultBranch: gh.String("main"),
+		Private:       gh.Bool(false),
+	}
+	return &gh.PullRequestEvent{
+		Action: gh.String(action),
+		PullRequest: &gh.PullRequest{
+			Number: gh.Int(7),
+			User:   &gh.User{Login: gh.String("author")},
+			Head: &gh.PullRequestBranch{
+				Ref:  gh.String("feature"),
+				SHA:  gh.String("deadbeef"),
+				Repo: repo,
+			},
+			Base: &gh.PullRequestBranch{
+				Ref:  gh.String("main"),
+				Repo: repo,
+			},
+		},
+	}
+}
+
+func TestParseWebhookData_ReadyForReview_IsPullRequestEventWithAction(t *testing.T) {
+	data, err := github.ParseWebhookData(pullRequestEvent("ready_for_review"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, &interfaces.WebhookData{
+		EventName:               "pull_request",
+		PushedRepoURL:           "https://github.com/test/repo.git",
+		PushedBranch:            "feature",
+		SHA:                     "deadbeef",
+		TargetRepoURL:           "https://github.com/test/repo.git",
+		TargetRepoDefaultBranch: "main",
+		IsTargetRepoPublic:      true,
+		TargetBranch:            "main",
+		PullRequestAuthor:       "author",
+		PullRequestNumber:       7,
+		PullRequestAction:       "ready_for_review",
+	}, data)
+}
+
+func TestParseWebhookData_PullRequestOpened_RecordsAction(t *testing.T) {
+	data, err := github.ParseWebhookData(pullRequestEvent("opened"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "pull_request", data.EventName)
+	assert.Equal(t, "opened", data.PullRequestAction)
 }

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -109,8 +109,18 @@ type PushTrigger struct {
 	Tags     []string `yaml:"tags"`
 }
 
+// defaultPullRequestTypes are the pull_request actions that trigger a
+// pull_request trigger when "types" is not specified. This matches the default
+// behavior of GitHub Actions' pull_request trigger ("edited" is included
+// because the webhook only emits it for base-branch changes).
+var defaultPullRequestTypes = []string{"opened", "synchronize", "reopened", "edited"}
+
 type PullRequestTrigger struct {
 	Branches []string `yaml:"branches"`
+	// Types optionally restricts the trigger to specific pull_request actions
+	// (e.g. "ready_for_review"). If empty, the default set of actions is used:
+	// opened, synchronize, reopened, and base-branch edits.
+	Types []string `yaml:"types"`
 	// NOTE: If nil, defaults to true.
 	MergeWithBase *bool `yaml:"merge_with_base"`
 	// If MergeWithBase is enabled, determines whether the CI runner should manually
@@ -127,6 +137,16 @@ func (t *PullRequestTrigger) GetMergeWithBase() bool {
 
 func (t *PullRequestTrigger) GetForceManualMerge() bool {
 	return t.GetMergeWithBase() && (t.ForceManualMergeWithBase == nil || *t.ForceManualMergeWithBase)
+}
+
+// matchesAction returns whether the trigger should fire for the given
+// pull_request action. An empty action (e.g. a pull_request_review re-run that
+// carries no action) only matches triggers using the default type set.
+func (t *PullRequestTrigger) matchesAction(action string) bool {
+	if len(t.Types) > 0 {
+		return slices.Contains(t.Types, action)
+	}
+	return action == "" || slices.Contains(defaultPullRequestTypes, action)
 }
 
 type ScheduleTrigger struct {
@@ -438,8 +458,10 @@ func GetDefault(targetRepoDefaultBranch string) *BuildBuddyConfig {
 }
 
 // MatchesAnyTrigger returns whether the action is triggered by the event
-// published to the given branch or tag.
-func MatchesAnyTrigger(action *Action, event, branch, tag string) bool {
+// published to the given branch or tag. prAction is the pull_request action
+// (e.g. "opened", "ready_for_review") for pull_request events, and is empty for
+// other events.
+func MatchesAnyTrigger(action *Action, event, branch, tag, prAction string) bool {
 	// If action was manually or automatically (via schedule) dispatched, always run it
 	if event == webhook_data.EventName.ManualDispatch || event == webhook_data.EventName.ScheduledDispatch {
 		return true
@@ -457,7 +479,7 @@ func MatchesAnyTrigger(action *Action, event, branch, tag string) bool {
 	}
 
 	if prCfg := action.Triggers.PullRequest; prCfg != nil && event == webhook_data.EventName.PullRequest {
-		return matchesAnyPattern(prCfg.Branches, branch)
+		return matchesAnyPattern(prCfg.Branches, branch) && prCfg.matchesAction(prAction)
 	}
 	return false
 }

--- a/enterprise/server/workflow/config/config_test.go
+++ b/enterprise/server/workflow/config/config_test.go
@@ -115,7 +115,7 @@ func TestMatchesAnyTrigger_SupportsBasicWildcard(t *testing.T) {
 		}
 		event := "push"
 
-		match := config.MatchesAnyTrigger(action, event, testCase.branchName, "" /*=tag*/)
+		match := config.MatchesAnyTrigger(action, event, testCase.branchName, "" /*=tag*/, "")
 
 		assert.Equal(t, testCase.shouldMatch, match, "expected match(%q, %q) => %v", testCase.branchName, testCase.pattern, testCase.shouldMatch)
 	}
@@ -156,11 +156,11 @@ func TestMatchesAndTrigger_NegationPatterns(t *testing.T) {
 			}
 			event := "push"
 			for _, branch := range tc.shouldMatch {
-				m := config.MatchesAnyTrigger(action, event, branch, "")
+				m := config.MatchesAnyTrigger(action, event, branch, "", "")
 				assert.True(t, m, "MatchesAnyTrigger(%v, %q) should be true", branch, tc.patterns)
 			}
 			for _, branch := range tc.shouldNotMatch {
-				m := config.MatchesAnyTrigger(action, event, branch, "")
+				m := config.MatchesAnyTrigger(action, event, branch, "", "")
 				assert.False(t, m, "MatchesAnyTrigger(%v, %q) should be false", branch, tc.patterns)
 			}
 		})
@@ -187,7 +187,7 @@ func TestMatchesAnyTrigger_TagPushMatchesTagPattern(t *testing.T) {
 				Push: &config.PushTrigger{Tags: []string{tc.pattern}},
 			},
 		}
-		match := config.MatchesAnyTrigger(action, "push", "", tc.tag)
+		match := config.MatchesAnyTrigger(action, "push", "", tc.tag, "")
 		assert.Equal(t, tc.shouldMatch, match, "expected match(tag=%q, pattern=%q) => %v", tc.tag, tc.pattern, tc.shouldMatch)
 	}
 }
@@ -198,7 +198,7 @@ func TestMatchesAnyTrigger_TagPushDoesNotMatchBranchOnlyTrigger(t *testing.T) {
 			Push: &config.PushTrigger{Branches: []string{"*"}},
 		},
 	}
-	match := config.MatchesAnyTrigger(action, "push", "", "v1.0.0")
+	match := config.MatchesAnyTrigger(action, "push", "", "v1.0.0", "")
 	assert.False(t, match, "tag push should not match branch-only trigger")
 }
 
@@ -208,8 +208,46 @@ func TestMatchesAnyTrigger_BranchPushDoesNotMatchTagOnlyTrigger(t *testing.T) {
 			Push: &config.PushTrigger{Tags: []string{"v*"}},
 		},
 	}
-	match := config.MatchesAnyTrigger(action, "push", "main", "")
+	match := config.MatchesAnyTrigger(action, "push", "main", "", "")
 	assert.False(t, match, "branch push should not match tag-only trigger")
+}
+
+func TestMatchesAnyTrigger_PullRequestTypes(t *testing.T) {
+	// An action scoped to "ready_for_review" runs only on that pull_request
+	// action, not on the default push-like actions.
+	readyForReviewOnly := &config.Action{
+		Triggers: &config.Triggers{
+			PullRequest: &config.PullRequestTrigger{Branches: []string{"*"}, Types: []string{"ready_for_review"}},
+		},
+	}
+	assert.True(t, config.MatchesAnyTrigger(readyForReviewOnly, "pull_request", "main", "", "ready_for_review"))
+	assert.False(t, config.MatchesAnyTrigger(readyForReviewOnly, "pull_request", "main", "", "opened"))
+	assert.False(t, config.MatchesAnyTrigger(readyForReviewOnly, "pull_request", "main", "", "synchronize"))
+
+	// A default pull_request trigger (no types) runs on the default actions but
+	// not on "ready_for_review".
+	defaultPR := &config.Action{
+		Triggers: &config.Triggers{
+			PullRequest: &config.PullRequestTrigger{Branches: []string{"*"}},
+		},
+	}
+	assert.True(t, config.MatchesAnyTrigger(defaultPR, "pull_request", "main", "", "opened"))
+	assert.True(t, config.MatchesAnyTrigger(defaultPR, "pull_request", "main", "", "synchronize"))
+	assert.False(t, config.MatchesAnyTrigger(defaultPR, "pull_request", "main", "", "ready_for_review"))
+
+	// An empty action (e.g. a pull_request_review approval re-run) matches a
+	// default trigger but not a types-scoped one.
+	assert.True(t, config.MatchesAnyTrigger(defaultPR, "pull_request", "main", "", ""))
+	assert.False(t, config.MatchesAnyTrigger(readyForReviewOnly, "pull_request", "main", "", ""))
+
+	// Base-branch patterns are still honored alongside the type filter.
+	scoped := &config.Action{
+		Triggers: &config.Triggers{
+			PullRequest: &config.PullRequestTrigger{Branches: []string{"main"}, Types: []string{"ready_for_review"}},
+		},
+	}
+	assert.True(t, config.MatchesAnyTrigger(scoped, "pull_request", "main", "", "ready_for_review"))
+	assert.False(t, config.MatchesAnyTrigger(scoped, "pull_request", "feature", "", "ready_for_review"))
 }
 
 func TestMatchesAnyTrigger_TagNegationPatterns(t *testing.T) {
@@ -218,8 +256,8 @@ func TestMatchesAnyTrigger_TagNegationPatterns(t *testing.T) {
 			Push: &config.PushTrigger{Tags: []string{"v*", "!v0.9.0"}},
 		},
 	}
-	assert.True(t, config.MatchesAnyTrigger(action, "push", "", "v1.0.0"))
-	assert.False(t, config.MatchesAnyTrigger(action, "push", "", "v0.9.0"))
+	assert.True(t, config.MatchesAnyTrigger(action, "push", "", "v1.0.0", ""))
+	assert.False(t, config.MatchesAnyTrigger(action, "push", "", "v0.9.0", ""))
 }
 
 func TestMatchesAnyTrigger_BothBranchAndTagTriggers(t *testing.T) {
@@ -233,17 +271,17 @@ func TestMatchesAnyTrigger_BothBranchAndTagTriggers(t *testing.T) {
 	}
 
 	// Tag push matches tag pattern, not branch pattern.
-	assert.True(t, config.MatchesAnyTrigger(action, "push", "", "v1.0.0"))
-	assert.False(t, config.MatchesAnyTrigger(action, "push", "", "nightly-2024"))
+	assert.True(t, config.MatchesAnyTrigger(action, "push", "", "v1.0.0", ""))
+	assert.False(t, config.MatchesAnyTrigger(action, "push", "", "nightly-2024", ""))
 
 	// Branch push matches branch pattern, not tag pattern.
-	assert.True(t, config.MatchesAnyTrigger(action, "push", "main", ""))
-	assert.True(t, config.MatchesAnyTrigger(action, "push", "release-2024", ""))
-	assert.False(t, config.MatchesAnyTrigger(action, "push", "feature-x", ""))
+	assert.True(t, config.MatchesAnyTrigger(action, "push", "main", "", ""))
+	assert.True(t, config.MatchesAnyTrigger(action, "push", "release-2024", "", ""))
+	assert.False(t, config.MatchesAnyTrigger(action, "push", "feature-x", "", ""))
 
 	// Tag named "main" matches tag patterns (not branch patterns),
 	// so it should not match since "main" doesn't match "v*".
-	assert.False(t, config.MatchesAnyTrigger(action, "push", "", "main"))
+	assert.False(t, config.MatchesAnyTrigger(action, "push", "", "main", ""))
 }
 
 func TestGetGitFetchFilters(t *testing.T) {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -567,7 +567,7 @@ func (ws *workflowService) filterActions(ctx context.Context, wf *tables.Workflo
 	filteredActions := make([]*config.Action, 0, len(actions))
 	for _, a := range actions {
 		matchesActionName := len(actionFilter) == 0 || config.MatchesAnyActionName(a, actionFilter)
-		matchesTrigger := config.MatchesAnyTrigger(a, wd.EventName, wd.TargetBranch, wd.PushedTag)
+		matchesTrigger := config.MatchesAnyTrigger(a, wd.EventName, wd.TargetBranch, wd.PushedTag, wd.PullRequestAction)
 		if matchesActionName && matchesTrigger {
 			filteredActions = append(filteredActions, a)
 		}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -919,6 +919,12 @@ type WebhookData struct {
 	// Ex: "acmedev123"
 	PullRequestApprover string
 
+	// PullRequestAction is the action of the pull_request event that produced
+	// this data, if applicable. It is used to filter pull_request triggers by
+	// type (see config.PullRequestTrigger.Types).
+	// Ex: "opened", "synchronize", "ready_for_review"
+	PullRequestAction string
+
 	// ChangedFiles is the list of files changed by branch push events. Only
 	// populated for branch push events.
 	ChangedFiles []string


### PR DESCRIPTION
## What

Adds an optional `types` field to the `pull_request` workflow trigger in `buildbuddy.yaml`, mirroring GitHub Actions. It restricts which pull_request actions fire an action's trigger. For example:

```yaml
triggers:
  pull_request:
    branches: ["*"]
    types: [ready_for_review]
```

runs the action only when a draft PR is marked ready for review. When `types` is unset, the trigger fires on the default set (`opened`, `synchronize`, `reopened`, and base-branch edits) — unchanged from today.

## How

- The GitHub webhook now records the pull_request action on `WebhookData`, and `ready_for_review` events are delivered (previously dropped).
- `PullRequestTrigger` gains a `types` field; `MatchesAnyTrigger` filters on it.

Modeled as a subset of the existing `pull_request` trigger (per review feedback) so existing PR handling (merge-with-base, etc.) is inherited and there's a single PR trigger to reason about.

## Rollout

Server-side only. The `buildbuddy.yaml` change pointing the code review workflow at `types: [ready_for_review]` is intentionally **not** in this PR — it'll land in a follow-up after this deploys, so the code review workflow keeps running in the meantime.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7615