### PR TITLE
Reduce allocations in makeFileRecord for both metacache and pebble_cache

### DIFF
--- a/enterprise/server/backends/metacache/metacache.go
+++ b/enterprise/server/backends/metacache/metacache.go
@@ -253,23 +253,24 @@ func (c *Cache) lookupPartitionID(remoteInstanceName, groupID string) string {
 	return DefaultPartitionID
 }
 
-func (c *Cache) makeFileRecord(groupID string, encryption *sgpb.Encryption, pr *rspb.ResourceName) (*sgpb.FileRecord, error) {
-	r := digest.ResourceNameFromProto(pr)
-	if err := r.Validate(); err != nil {
+func (c *Cache) makeFileRecord(groupID string, encryption *sgpb.Encryption, r *rspb.ResourceName) (*sgpb.FileRecord, error) {
+	digestFunction := r.GetDigestFunction()
+	if digestFunction == repb.DigestFunction_UNKNOWN {
+		digestFunction = repb.DigestFunction_SHA256
+	}
+	if err := digest.Validate(r.GetDigest(), digestFunction); err != nil {
 		return nil, err
 	}
-
-	partID := c.lookupPartitionID(r.GetInstanceName(), groupID)
 
 	return &sgpb.FileRecord{
 		Isolation: &sgpb.Isolation{
 			CacheType:          r.GetCacheType(),
 			RemoteInstanceName: r.GetInstanceName(),
-			PartitionId:        partID,
+			PartitionId:        c.lookupPartitionID(r.GetInstanceName(), groupID),
 			GroupId:            groupID,
 		},
 		Digest:         r.GetDigest(),
-		DigestFunction: r.GetDigestFunction(),
+		DigestFunction: digestFunction,
 		Compressor:     r.GetCompressor(),
 		Encryption:     encryption,
 	}, nil

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1543,9 +1543,12 @@ func (p *PebbleCache) activeEncryption(ctx context.Context) (*sgpb.Encryption, e
 	return &sgpb.Encryption{KeyId: ak.GetEncryptionKeyId()}, nil
 }
 
-func (p *PebbleCache) makeFileRecord(groupID string, encryption *sgpb.Encryption, r *rspb.ResourceName) (*sgpb.FileRecord, error) {
-	rn := digest.ResourceNameFromProto(r)
-	if err := rn.Validate(); err != nil {
+func (p *PebbleCache) makeFileRecord(groupID string, encryption *sgpb.Encryption, rn *rspb.ResourceName) (*sgpb.FileRecord, error) {
+	digestFunction := rn.GetDigestFunction()
+	if digestFunction == repb.DigestFunction_UNKNOWN {
+		digestFunction = repb.DigestFunction_SHA256
+	}
+	if err := digest.Validate(rn.GetDigest(), digestFunction); err != nil {
 		return nil, err
 	}
 
@@ -1557,7 +1560,7 @@ func (p *PebbleCache) makeFileRecord(groupID string, encryption *sgpb.Encryption
 			GroupId:            groupID,
 		},
 		Digest:         rn.GetDigest(),
-		DigestFunction: rn.GetDigestFunction(),
+		DigestFunction: digestFunction,
 		Compressor:     rn.GetCompressor(),
 		Encryption:     encryption,
 	}, nil

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -214,7 +214,7 @@ func Validate(d *repb.Digest, digestFunction repb.DigestFunction_Value) error {
 		if IsEmptyHash(d, digestFunction) {
 			return nil
 		}
-		return status.InvalidArgumentError("Invalid (zero-length) SHA256 hash")
+		return status.InvalidArgumentError("Invalid (zero-length) hash")
 	}
 	hash := d.GetHash()
 	if expected := hashLength(digestFunction); len(hash) != expected {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -200,7 +200,10 @@ func isLowerHex(s string) bool {
 }
 
 func (r *ResourceName) Validate() error {
-	d := r.rn.GetDigest()
+	return Validate(r.GetDigest(), r.GetDigestFunction())
+}
+
+func Validate(d *repb.Digest, digestFunction repb.DigestFunction_Value) error {
 	if d == nil {
 		return status.InvalidArgumentError("Invalid (nil) Digest")
 	}
@@ -208,15 +211,15 @@ func (r *ResourceName) Validate() error {
 		return status.InvalidArgumentErrorf("Invalid (negative) digest size")
 	}
 	if d.GetSizeBytes() == int64(0) {
-		if r.IsEmpty() {
+		if IsEmptyHash(d, digestFunction) {
 			return nil
 		}
 		return status.InvalidArgumentError("Invalid (zero-length) SHA256 hash")
 	}
 	hash := d.GetHash()
-	if expected := hashLength(r.GetDigestFunction()); len(hash) != expected {
+	if expected := hashLength(digestFunction); len(hash) != expected {
 		return status.InvalidArgumentErrorf("Invalid length hash. Expected len %v for %s function. Got %v",
-			expected, r.GetDigestFunction().String(), len(hash))
+			expected, digestFunction.String(), len(hash))
 	}
 	if !isLowerHex(hash) {
 		return status.InvalidArgumentError("Hash isn't all lower case hex characters.")


### PR DESCRIPTION
metacache benchmarks:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                      │ /tmp/chunked │       /tmp/optmakefilerecord        │
                      │    sec/op    │    sec/op     vs base               │
GetMulti/Meta10-24       263.1µ ± 3%   257.7µ ±  7%       ~ (p=0.150 n=17)
GetMulti/Meta100-24      262.0µ ± 8%   260.3µ ±  4%       ~ (p=0.708 n=17)
GetMulti/Meta1000-24     298.7µ ± 6%   284.4µ ± 10%       ~ (p=0.413 n=17)
GetMulti/Meta10000-24    10.52m ± 0%   10.56m ±  0%       ~ (p=0.140 n=17)
geomean                  682.2µ        670.0µ        -1.78%

                      │ /tmp/chunked │       /tmp/optmakefilerecord        │
                      │     B/s      │     B/s       vs base               │
GetMulti/Meta10-24      3.624Mi ± 3%   3.700Mi ± 8%       ~ (p=0.152 n=17)
GetMulti/Meta100-24     36.40Mi ± 8%   36.63Mi ± 4%       ~ (p=0.702 n=17)
GetMulti/Meta1000-24    319.3Mi ± 6%   335.4Mi ± 9%       ~ (p=0.413 n=17)
GetMulti/Meta10000-24   90.67Mi ± 0%   90.28Mi ± 0%       ~ (p=0.142 n=17)
geomean                 44.21Mi        45.01Mi       +1.82%

                      │ /tmp/chunked │       /tmp/optmakefilerecord        │
                      │     B/op     │     B/op      vs base               │
GetMulti/Meta10-24      222.8Ki ± 0%   207.8Ki ± 0%  -6.72% (p=0.000 n=17)
GetMulti/Meta100-24     239.6Ki ± 0%   224.5Ki ± 0%  -6.28% (p=0.000 n=17)
GetMulti/Meta1000-24    363.3Ki ± 0%   348.3Ki ± 0%  -4.14% (p=0.000 n=17)
GetMulti/Meta10000-24   1.226Mi ± 0%   1.213Mi ± 0%  -1.05% (p=0.000 n=17)
geomean                 395.0Ki        377.0Ki       -4.57%

                      │ /tmp/chunked │       /tmp/optmakefilerecord       │
                      │  allocs/op   │  allocs/op   vs base               │
GetMulti/Meta10-24       3.309k ± 0%   3.009k ± 0%  -9.07% (p=0.000 n=17)
GetMulti/Meta100-24      3.414k ± 0%   3.114k ± 0%  -8.79% (p=0.000 n=17)
GetMulti/Meta1000-24     3.419k ± 0%   3.119k ± 0%  -8.77% (p=0.000 n=17)
GetMulti/Meta10000-24    3.435k ± 0%   3.136k ± 0%  -8.70% (p=0.000 n=17)
geomean                  3.394k        3.094k       -8.83%
```

pebble_cache benchmarks:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                             │ /tmp/pebblebase │           /tmp/pebbleopt           │
                             │     sec/op      │   sec/op     vs base               │
GetMulti/LocalPebble10-24          147.7µ ± 1%   146.3µ ± 3%       ~ (p=0.085 n=17)
GetMulti/LocalPebble100-24         149.7µ ± 1%   148.1µ ± 3%       ~ (p=0.114 n=17)
GetMulti/LocalPebble1000-24        165.7µ ± 1%   166.0µ ± 2%       ~ (p=0.683 n=17)
GetMulti/LocalPebble10000-24       390.3µ ± 2%   384.8µ ± 1%       ~ (p=0.106 n=17)
geomean                            194.5µ        192.9µ       -0.82%

                             │ /tmp/pebblebase │           /tmp/pebbleopt            │
                             │       B/s       │     B/s       vs base               │
GetMulti/LocalPebble10-24         6.456Mi ± 1%   6.523Mi ± 3%       ~ (p=0.077 n=17)
GetMulti/LocalPebble100-24        63.71Mi ± 1%   64.40Mi ± 3%       ~ (p=0.112 n=17)
GetMulti/LocalPebble1000-24       575.5Mi ± 1%   574.4Mi ± 3%       ~ (p=0.683 n=17)
GetMulti/LocalPebble10000-24      2.386Gi ± 2%   2.420Gi ± 1%       ~ (p=0.106 n=17)
geomean                           155.1Mi        156.4Mi       +0.84%

                             │ /tmp/pebblebase │           /tmp/pebbleopt            │
                             │      B/op       │     B/op      vs base               │
GetMulti/LocalPebble10-24         163.3Ki ± 0%   148.4Ki ± 0%  -9.11% (p=0.000 n=17)
GetMulti/LocalPebble100-24        180.9Ki ± 0%   166.0Ki ± 0%  -8.24% (p=0.000 n=17)
GetMulti/LocalPebble1000-24       301.4Ki ± 0%   286.5Ki ± 0%  -4.95% (p=0.000 n=17)
GetMulti/LocalPebble10000-24      1.183Mi ± 0%   1.168Mi ± 0%  -1.24% (p=0.000 n=17)
geomean                           322.2Ki        303.1Ki       -5.94%

                             │ /tmp/pebblebase │           /tmp/pebbleopt            │
                             │    allocs/op    │  allocs/op   vs base                │
GetMulti/LocalPebble10-24          2.822k ± 0%   2.521k ± 0%  -10.67% (p=0.000 n=17)
GetMulti/LocalPebble100-24         2.922k ± 0%   2.622k ± 0%  -10.27% (p=0.000 n=17)
GetMulti/LocalPebble1000-24        2.923k ± 0%   2.623k ± 0%  -10.26% (p=0.000 n=17)
GetMulti/LocalPebble10000-24       3.128k ± 0%   2.828k ± 0%   -9.59% (p=0.000 n=17)
geomean                            2.947k        2.646k       -10.20%
```