### PR TITLE
Add `app.auto_login_enabled` config option

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -270,15 +270,16 @@ export class AuthService {
     window.location.href = url.toString();
   }
 
-  login(slug?: string) {
+  login(slug?: string, options: { forceRedirect?: boolean } = {}) {
     const search = new URLSearchParams(window.location.search);
+    const usePopup = capabilities.config.popupAuthEnabled && !options.forceRedirect;
     if (slug) {
       let url = `/login/?${new URLSearchParams({
         redirect_url: search.get("redirect_url") || window.location.href,
-        show_picker: capabilities.config.popupAuthEnabled ? "true" : "false",
+        show_picker: usePopup ? "true" : "false",
         slug,
       })}`;
-      if (capabilities.config.popupAuthEnabled) {
+      if (usePopup) {
         popup
           .open(url)
           .then(() => this.refreshUser())
@@ -291,10 +292,10 @@ export class AuthService {
 
     let url = `/login/?${new URLSearchParams({
       redirect_url: search.get("redirect_url") || window.location.href,
-      show_picker: capabilities.config.popupAuthEnabled ? "true" : "false",
+      show_picker: usePopup ? "true" : "false",
       issuer_url: capabilities.auth,
     })}`;
-    if (capabilities.config.popupAuthEnabled) {
+    if (usePopup) {
       popup
         .open(url)
         .then(() => this.refreshUser())

--- a/docs/config-app.md
+++ b/docs/config-app.md
@@ -24,6 +24,8 @@ sidebar_label: App
 
 - `default_to_dense_mode` Enables Dense UI mode by default.
 
+- `auto_login_enabled` Automatically starts the default login flow from the login page when there is a single public OIDC provider.
+
 ## Example section
 
 ```yaml title="config.yaml"

--- a/enterprise/app/login/login.tsx
+++ b/enterprise/app/login/login.tsx
@@ -38,6 +38,10 @@ export default class LoginComponent extends React.Component<Props, State> {
   componentDidMount() {
     if (this.isOrgSpecific()) {
       this.fetchOrgName();
+      return;
+    }
+    if (capabilities.config.autoLoginEnabled && capabilities.config.configuredIssuers.length === 1) {
+      authService.login(undefined, { forceRedirect: true });
     }
   }
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -216,6 +216,9 @@ message FrontendConfig {
 
   // Whether cache proxy keys can be created.
   bool cache_proxy_key_creation_enabled = 70;
+
+  // Whether the login page should automatically start the default OIDC login flow.
+  bool auto_login_enabled = 71;
 }
 
 message Region {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -75,6 +75,7 @@ var (
 	userListsUIEnabled                     = flag.Bool("app.user_lists_ui_enabled", false, "If set, show show user list management options in the UI.")
 	darkModeEnabled                        = flag.Bool("app.dark_mode_enabled", false, "If set, show dark mode option in user preferences.")
 	defaultLoginSlug                       = flag.String("app.default_login_slug", "", "If set, the login page will default to using this slug.")
+	autoLoginEnabled                       = flag.Bool("app.auto_login_enabled", false, "If true, the login page will automatically start the default OIDC login flow.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -236,6 +237,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		CspNonce:                               nonce,
 		CommunityLinksEnabled:                  *communityLinksEnabled,
 		DefaultLoginSlug:                       *defaultLoginSlug,
+		AutoLoginEnabled:                       *autoLoginEnabled,
 		ReadOnlyGithubAppEnabled:               env.GetGitHubAppService() != nil && env.GetGitHubAppService().IsReadOnlyAppEnabled(),
 		TargetsPageEnabled:                     *targetsPageEnabled && env.GetOLAPDBHandle() != nil,
 		UserListsUiEnabled:                     *userListsUIEnabled,


### PR DESCRIPTION
If the installation has one OIDC provider configured and this config option is set - the login flow will automatically get kicked off.