### PR TITLE
Fix broken arm64 cache proxy image

### DIFF
--- a/deps/docker.MODULE.bazel
+++ b/deps/docker.MODULE.bazel
@@ -8,6 +8,14 @@ container_pull(
 )
 
 container_pull(
+    name = "buildbuddy_go_image_base_arm64",
+    architecture = "arm64",
+    digest = "sha256:132e45ca8641cb01068ea8c8ca3f7358493e9469b1650fdffcd878c6efa174fe",
+    registry = "gcr.io",
+    repository = "distroless/cc-debian13",
+)
+
+container_pull(
     name = "bazel_image_base",
     digest = "sha256:8bb82ccf73085b71159ce05d2cc6030cbaa927b403c04774f0b22f37ab4fd78a",
     registry = "gcr.io",

--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -80,7 +80,13 @@ container_image(
         "@platforms//cpu:arm64": "arm64",
         "//conditions:default": "amd64",
     }),
-    base = "@buildbuddy_go_image_base//image",
+    # Base layers (libc, dynamic linker, etc.) are architecture-specific, so the
+    # base image must match the target architecture. Setting `architecture`
+    # above only stamps the image config metadata; it does not swap these layers.
+    base = select({
+        "@platforms//cpu:arm64": "@buildbuddy_go_image_base_arm64//image",
+        "//conditions:default": "@buildbuddy_go_image_base//image",
+    }),
     tags = ["manual"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The multi-arch `buildbuddy-proxy-enterprise` image's arm64 variant fails to run with `exec /app/.../cache_proxy: no such file or directory`. The cause: `cache_proxy:base_image` pulls its base from `@buildbuddy_go_image_base`, a `container_pull` that is a repository rule pinned to a single (amd64) digest, so the arm64 release build layers the arm64 binary on top of an amd64 base filesystem — which has no l`d-linux-aarch64.so.1` loader or aarch64 libc. The `architecture = select(...)` already on the rule only stamps the image config metadata; it does not swap the base layers, so the manifest was mislabeled arm64 while shipping amd64 content.

This adds an arm64 `container_pull` of the same distroless image (`buildbuddy_go_image_base_arm64`) and `select()`s it as the base when targeting arm64, leaving the amd64 base untouched. Verified by building the arm64 `base_image` and confirming it now contains `/lib/ld-linux-aarch64.so.1` and the aarch64 libc that were previously missing.