### PR TITLE
Don't eagerly create errors in distributed_client.RemoteWriter

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -2,6 +2,7 @@ package distributed_client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -631,26 +632,27 @@ func (r *distributedCacheReader) Close() error {
 }
 
 type streamWriteCloser struct {
-	cancelFunc        context.CancelFunc
-	sender            rpcutil.Sender[*dcpb.WriteRequest, *dcpb.WriteResponse]
-	r                 *rspb.ResourceName
-	handoffPeer       string
-	sendTimeoutCause  error
-	closeTimeoutCause error
-	alreadyExists     bool
+	cancelFunc    context.CancelFunc
+	sender        rpcutil.Sender[*dcpb.WriteRequest, *dcpb.WriteResponse]
+	r             *rspb.ResourceName
+	peer          string
+	handoffPeer   string
+	alreadyExists bool
 }
 
 func (wc *streamWriteCloser) send(req *dcpb.WriteRequest) error {
-	err := wc.sender.SendWithTimeoutCause(req, *peerWriteTimeout, wc.sendTimeoutCause)
-	if status.IsDeadlineExceededError(err) {
+	err := wc.sender.SendWithTimeoutCause(req, *peerWriteTimeout, context.DeadlineExceeded)
+	if errors.Is(err, context.DeadlineExceeded) {
+		err = status.DeadlineExceededErrorf("timed out sending distributed cache write to peer %q for %s", wc.peer, ResourceIsolationString(wc.r))
 		wc.cancelFunc()
 	}
 	return err
 }
 
 func (wc *streamWriteCloser) closeAndRecv() (*dcpb.WriteResponse, error) {
-	rsp, err := wc.sender.CloseAndRecvWithTimeoutCause(*peerWriteTimeout, wc.closeTimeoutCause)
-	if status.IsDeadlineExceededError(err) {
+	rsp, err := wc.sender.CloseAndRecvWithTimeoutCause(*peerWriteTimeout, context.DeadlineExceeded)
+	if errors.Is(err, context.DeadlineExceeded) {
+		err = status.DeadlineExceededErrorf("timed out finalizing distributed cache write to peer %q for %s", wc.peer, ResourceIsolationString(wc.r))
 		wc.cancelFunc()
 	}
 	return rsp, err
@@ -731,14 +733,12 @@ func (c *Proxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *r
 		return nil, err
 	}
 
-	resourceStr := ResourceIsolationString(r)
 	wc := &streamWriteCloser{
-		cancelFunc:        cancel,
-		sender:            rpcutil.NewSender[*dcpb.WriteRequest, *dcpb.WriteResponse](ctx, stream),
-		handoffPeer:       handoffPeer,
-		r:                 r,
-		sendTimeoutCause:  status.DeadlineExceededErrorf("timed out sending distributed cache write to peer %q for %s", peer, resourceStr),
-		closeTimeoutCause: status.DeadlineExceededErrorf("timed out finalizing distributed cache write to peer %q for %s", peer, resourceStr),
+		cancelFunc:  cancel,
+		sender:      rpcutil.NewSender[*dcpb.WriteRequest, *dcpb.WriteResponse](ctx, stream),
+		peer:        peer,
+		handoffPeer: handoffPeer,
+		r:           r,
 	}
 	return ioutil.NewDoubleBufferWriter(ctx, wc, c.bufPool, digest.SafeBufferSize(r, writeBufSizeBytes), writeBufSizeBytes), nil
 }


### PR DESCRIPTION
Wait until an error actually happens. Benchmarks mostly show an improvement in allocations:

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor
                             │  /tmp/base  │            /tmp/after2             │
                             │   sec/op    │   sec/op     vs base               │
Set/DistPebble10/AC-24         120.2µ ± 1%   116.3µ ± 1%  -3.29% (p=0.000 n=17)
Set/DistPebble10/CAS-24        99.24µ ± 3%   96.65µ ± 1%  -2.61% (p=0.038 n=17)
Set/DistPebble100/AC-24        127.6µ ± 1%   124.3µ ± 1%  -2.59% (p=0.000 n=17)
Set/DistPebble100/CAS-24       93.48µ ± 1%   93.29µ ± 1%       ~ (p=0.259 n=17)
Set/DistPebble1000/AC-24       140.5µ ± 1%   138.7µ ± 0%  -1.32% (p=0.002 n=17)
Set/DistPebble1000/CAS-24      94.77µ ± 1%   94.18µ ± 1%       ~ (p=0.394 n=17)
Set/DistPebble10000/AC-24      257.4µ ± 1%   253.0µ ± 2%  -1.73% (p=0.012 n=17)
Set/DistPebble10000/CAS-24     99.04µ ± 1%   98.53µ ± 0%  -0.51% (p=0.008 n=17)
Set/DistPebble1000000/AC-24    3.746m ± 1%   3.754m ± 1%       ~ (p=0.865 n=17)
Set/DistPebble1000000/CAS-24   549.7µ ± 1%   565.4µ ± 1%  +2.86% (p=0.001 n=17)
geomean                        199.4µ        197.4µ       -1.00%

                             │  /tmp/base   │             /tmp/after2              │
                             │     B/s      │     B/s       vs base                │
Set/DistPebble10/AC-24         78.12Ki ± 0%   87.89Ki ± 0%  +12.50% (p=0.000 n=17)
Set/DistPebble10/CAS-24        97.66Ki ± 0%   97.66Ki ± 0%        ~ (p=0.485 n=17)
Set/DistPebble100/AC-24        761.7Ki ± 1%   781.2Ki ± 1%   +2.56% (p=0.000 n=17)
Set/DistPebble100/CAS-24       1.020Mi ± 1%   1.020Mi ± 1%        ~ (p=0.454 n=17)
Set/DistPebble1000/AC-24       6.790Mi ± 1%   6.876Mi ± 1%   +1.26% (p=0.001 n=17)
Set/DistPebble1000/CAS-24      10.06Mi ± 1%   10.13Mi ± 1%        ~ (p=0.361 n=17)
Set/DistPebble10000/AC-24      37.05Mi ± 1%   37.70Mi ± 2%   +1.75% (p=0.012 n=17)
Set/DistPebble10000/CAS-24     96.29Mi ± 1%   96.79Mi ± 0%   +0.52% (p=0.007 n=17)
Set/DistPebble1000000/AC-24    254.6Mi ± 1%   254.0Mi ± 1%        ~ (p=0.858 n=17)
Set/DistPebble1000000/CAS-24   1.694Gi ± 1%   1.647Gi ± 1%   -2.78% (p=0.001 n=17)
geomean                        7.541Mi        7.658Mi        +1.56%

                             │  /tmp/base   │             /tmp/after2             │
                             │     B/op     │     B/op      vs base               │
Set/DistPebble10/AC-24         38.77Ki ± 0%   38.06Ki ± 0%  -1.83% (p=0.000 n=17)
Set/DistPebble10/CAS-24        33.63Ki ± 0%   33.01Ki ± 0%  -1.85% (p=0.000 n=17)
Set/DistPebble100/AC-24        39.26Ki ± 0%   38.50Ki ± 0%  -1.95% (p=0.000 n=17)
Set/DistPebble100/CAS-24       33.45Ki ± 0%   32.85Ki ± 0%  -1.79% (p=0.000 n=17)
Set/DistPebble1000/AC-24       41.31Ki ± 0%   40.53Ki ± 0%  -1.89% (p=0.000 n=17)
Set/DistPebble1000/CAS-24      34.25Ki ± 0%   33.65Ki ± 0%  -1.76% (p=0.000 n=17)
Set/DistPebble10000/AC-24      51.46Ki ± 0%   50.65Ki ± 0%  -1.58% (p=0.000 n=17)
Set/DistPebble10000/CAS-24     43.15Ki ± 0%   42.54Ki ± 0%  -1.41% (p=0.000 n=17)
Set/DistPebble1000000/AC-24    1.037Mi ± 1%   1.038Mi ± 1%       ~ (p=0.946 n=17)
Set/DistPebble1000000/CAS-24   928.4Ki ± 0%   930.3Ki ± 0%       ~ (p=0.496 n=17)
geomean                        74.55Ki        73.52Ki       -1.38%

                             │ /tmp/base  │            /tmp/after2            │
                             │ allocs/op  │ allocs/op   vs base               │
Set/DistPebble10/AC-24         549.0 ± 0%   537.0 ± 0%  -2.19% (p=0.000 n=17)
Set/DistPebble10/CAS-24        458.0 ± 0%   449.0 ± 0%  -1.97% (p=0.000 n=17)
Set/DistPebble100/AC-24        558.0 ± 0%   546.0 ± 0%  -2.15% (p=0.000 n=17)
Set/DistPebble100/CAS-24       458.0 ± 0%   449.0 ± 0%  -1.97% (p=0.000 n=17)
Set/DistPebble1000/AC-24       553.0 ± 0%   541.0 ± 0%  -2.17% (p=0.000 n=17)
Set/DistPebble1000/CAS-24      453.0 ± 0%   444.0 ± 0%  -1.99% (p=0.000 n=17)
Set/DistPebble10000/AC-24      586.0 ± 0%   574.0 ± 0%  -2.05% (p=0.000 n=17)
Set/DistPebble10000/CAS-24     453.0 ± 0%   444.0 ± 0%  -1.99% (p=0.000 n=17)
Set/DistPebble1000000/AC-24    641.0 ± 0%   650.0 ± 1%  +1.40% (p=0.000 n=17)
Set/DistPebble1000000/CAS-24   567.0 ± 0%   567.0 ± 0%       ~ (p=0.201 n=17)
geomean                        523.7        515.8       -1.51%
```