### PR TITLE
[SS] Add a memory snapshot export monitor

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -2,11 +2,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
+# Tell gazelle to make each file a separate test target,
+# so that tests that don't need firecracker don't have to be run on the special pool.
+# gazelle:go_test file
+
 go_library(
     name = "firecracker",
     srcs = [
         "containeropts.go",
         "firecracker.go",
+        "memory_snapshot_export_monitor.go",
+        "sequential_chunk_write_monitor.go",
     ],
     data = select({
         "//platforms/configs:linux_x86_64": [
@@ -193,5 +199,26 @@ go_test(
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_protobuf//testing/protocmp",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "sequential_chunk_write_monitor_test",
+    srcs = ["sequential_chunk_write_monitor_test.go"],
+    embed = [":firecracker"],
+    deps = [
+        "//enterprise/server/remote_execution/copy_on_write",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
+go_test(
+    name = "memory_snapshot_export_monitor_test",
+    srcs = ["memory_snapshot_export_monitor_test.go"],
+    embed = [":firecracker"],
+    deps = [
+        "//enterprise/server/remote_execution/copy_on_write",
+        "//proto:remote_execution_go_proto",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/remote_execution/containers/firecracker/memory_snapshot_export_monitor.go
+++ b/enterprise/server/remote_execution/containers/firecracker/memory_snapshot_export_monitor.go
@@ -111,6 +111,13 @@ func (m *memorySnapshotExportMonitor) run() error {
 			return m.egCtx.Err()
 		case event, ok := <-m.events:
 			if !ok {
+				// If the chan is closed, all writes have completed and we can safely
+				// finalize the tracker, which should only be called after all writes have
+				// been sequentially observed.
+				if err := m.tracker.Finish(); err != nil {
+					log.CtxWarningf(m.egCtx, "Failed to finalize sequential chunk write tracker: %s", err)
+					return err
+				}
 				return nil
 			}
 			if err := m.tracker.Observe(event); err != nil {
@@ -123,12 +130,8 @@ func (m *memorySnapshotExportMonitor) run() error {
 // Finish signals that no more write events will arrive and waits for queued
 // uploads to finish.
 func (m *memorySnapshotExportMonitor) Finish() error {
-	if err := m.tracker.Finish(); err != nil {
-		log.CtxWarningf(m.egCtx, "Failed to finalize sequential chunk write tracker: %s", err)
-		// All chunks must be cached for a snapshot to be valid, so if the final cache write fails,
-		// abort writing other chunks.
-		m.cancel()
-	}
+	// Don't finalize the tracker here, because events are added to the tracker in the background,
+	// and finalizing the tracker should only happen after all events have been observed
 	close(m.events)
 	err := m.eg.Wait()
 

--- a/enterprise/server/remote_execution/containers/firecracker/memory_snapshot_export_monitor.go
+++ b/enterprise/server/remote_execution/containers/firecracker/memory_snapshot_export_monitor.go
@@ -1,0 +1,150 @@
+package firecracker
+
+import (
+	"context"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"golang.org/x/sync/errgroup"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+// memorySnapshotExportMonitor observes writes while firecracker exports a memory snapshot.
+// Since Firecracker writes the snapshot sequentially, the monitor can cache each completed
+// chunk as soon as writes move on to a later chunk, while the snapshot data is still in the page cache.
+// This removes the need for another pass through the COWStore to cache chunks after the snapshot is generated,
+// reducing memory and IO from processing the large snapshots twice.
+type memorySnapshotExportMonitor struct {
+	cancel context.CancelFunc
+
+	env                environment.Env
+	cow                *copy_on_write.COWStore
+	remoteInstanceName string
+	cacheRemotely      bool
+	cacheLocally       bool
+	allZerosDigest     *repb.Digest
+
+	// The write callback from COWStore adds write events to this channel.
+	// The monitor can then queue finalized chunks to be cached.
+	events chan copy_on_write.WriteEvent
+
+	// chunkUploads is a channel of chunk offsets that are ready to be cached.
+	chunkUploads chan int64
+	eg           *errgroup.Group
+	egCtx        context.Context
+
+	tracker      sequentialChunkWriteTracker
+	cacheChunkFn func(context.Context, int64) error
+
+	compressedBytesWrittenRemotely int64
+}
+
+func newMemorySnapshotExportMonitor(ctx context.Context, env environment.Env, cow *copy_on_write.COWStore, remoteInstanceName string, cacheRemotely, cacheLocally bool, uploadConcurrency int, allZerosDigest *repb.Digest) *memorySnapshotExportMonitor {
+	if uploadConcurrency <= 0 {
+		uploadConcurrency = 1
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	eg, egCtx := errgroup.WithContext(ctx)
+	m := &memorySnapshotExportMonitor{
+		cancel:             cancel,
+		env:                env,
+		cow:                cow,
+		remoteInstanceName: remoteInstanceName,
+		cacheRemotely:      cacheRemotely,
+		cacheLocally:       cacheLocally,
+		allZerosDigest:     allZerosDigest,
+		events:             make(chan copy_on_write.WriteEvent, 1024),
+		chunkUploads:       make(chan int64, uploadConcurrency),
+		eg:                 eg,
+		egCtx:              egCtx,
+	}
+	// TODO(Maggie): Extract logic to cache a chunk from snaploader and set
+	// m.cacheChunkFn.
+	m.tracker = sequentialChunkWriteTracker{
+		chunkSizeBytes: cow.ChunkSizeBytes(),
+		finalizeChunk:  m.queueChunkUpload,
+	}
+	m.startUploadWorkers(uploadConcurrency)
+	m.eg.Go(func() error {
+		defer close(m.chunkUploads)
+		return m.run()
+	})
+	return m
+}
+
+func (m *memorySnapshotExportMonitor) startUploadWorkers(uploadConcurrency int) {
+	for i := 0; i < uploadConcurrency; i++ {
+		m.eg.Go(func() error {
+			for {
+				select {
+				case <-m.egCtx.Done():
+					return nil
+				case chunkOffset, ok := <-m.chunkUploads:
+					if !ok {
+						return nil
+					}
+					if err := m.cacheChunkFn(m.egCtx, chunkOffset); err != nil {
+						return err
+					}
+				}
+			}
+		})
+	}
+}
+
+// A write callback to be registered with the COWStore. The caller must not call
+// OnWrite after Finish.
+func (m *memorySnapshotExportMonitor) OnWrite(event copy_on_write.WriteEvent) {
+	select {
+	case <-m.egCtx.Done():
+	case m.events <- event:
+	}
+}
+
+func (m *memorySnapshotExportMonitor) run() error {
+	for {
+		select {
+		case <-m.egCtx.Done():
+			return m.egCtx.Err()
+		case event, ok := <-m.events:
+			if !ok {
+				return nil
+			}
+			if err := m.tracker.Observe(event); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// Finish signals that no more write events will arrive and waits for queued
+// uploads to finish.
+func (m *memorySnapshotExportMonitor) Finish() error {
+	if err := m.tracker.Finish(); err != nil {
+		log.CtxWarningf(m.egCtx, "Failed to finalize sequential chunk write tracker: %s", err)
+		// All chunks must be cached for a snapshot to be valid, so if the final cache write fails,
+		// abort writing other chunks.
+		m.cancel()
+	}
+	close(m.events)
+	err := m.eg.Wait()
+
+	if m.compressedBytesWrittenRemotely > 0 {
+		log.CtxDebugf(m.egCtx, "Cached %d compressed MB remotely during memory snapshot export", m.compressedBytesWrittenRemotely/(1024*1024))
+	}
+
+	return err
+}
+
+// queueChunkUpload schedules caching for a chunk that the sequential tracker has
+// finalized.
+func (m *memorySnapshotExportMonitor) queueChunkUpload(chunkOffset int64) error {
+	select {
+	case <-m.egCtx.Done():
+	case m.chunkUploads <- chunkOffset:
+	}
+	return nil
+}

--- a/enterprise/server/remote_execution/containers/firecracker/memory_snapshot_export_monitor_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/memory_snapshot_export_monitor_test.go
@@ -1,0 +1,43 @@
+package firecracker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestMemorySnapshotExportMonitor(t *testing.T) {
+	started := make(chan int64, 2)
+	m := newMonitor(t)
+	m.cacheChunkFn = func(ctx context.Context, chunkOffset int64) error {
+		started <- chunkOffset
+		return nil
+	}
+	m.startUploadWorkers(2)
+
+	// Queue chunks to be cached.
+	m.chunkUploads <- 0
+	m.chunkUploads <- 1
+
+	require.Eventually(t, func() bool {
+		return len(started) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, m.Finish())
+}
+
+func newMonitor(t *testing.T) *memorySnapshotExportMonitor {
+	ctx := t.Context()
+
+	allZerosDigest := &repb.Digest{
+		Hash:      "0000000000000000000000000000000000000000000000000000000000000000",
+		SizeBytes: 1024,
+	}
+	m := newMemorySnapshotExportMonitor(ctx, nil, &copy_on_write.COWStore{}, "", false, false, 2, allZerosDigest)
+	return m
+}

--- a/enterprise/server/remote_execution/containers/firecracker/memory_snapshot_export_monitor_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/memory_snapshot_export_monitor_test.go
@@ -2,33 +2,35 @@ package firecracker
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/stretchr/testify/require"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 func TestMemorySnapshotExportMonitor(t *testing.T) {
-	started := make(chan int64, 2)
+	cached := make(chan int64, 2)
 	m := newMonitor(t)
+	m.tracker.chunkSizeBytes = 1
 	m.cacheChunkFn = func(ctx context.Context, chunkOffset int64) error {
-		started <- chunkOffset
+		cached <- chunkOffset
 		return nil
 	}
-	m.startUploadWorkers(2)
 
-	// Queue chunks to be cached.
-	m.chunkUploads <- 0
-	m.chunkUploads <- 1
-
-	require.Eventually(t, func() bool {
-		return len(started) == 2
-	}, time.Second, 10*time.Millisecond)
+	m.OnWrite(copy_on_write.WriteEvent{Offset: 0, Length: 1, ChunkIndex: 0})
+	m.OnWrite(copy_on_write.WriteEvent{Offset: 1, Length: 1, ChunkIndex: 1})
 
 	require.NoError(t, m.Finish())
+
+	require.Eventually(t, func() bool {
+		cachedElements := []int64{<-cached, <-cached}
+		slices.Sort(cachedElements)
+		return slices.Equal([]int64{0, 1}, cachedElements)
+	}, 1*time.Second, 100*time.Millisecond)
 }
 
 func newMonitor(t *testing.T) *memorySnapshotExportMonitor {

--- a/enterprise/server/remote_execution/containers/firecracker/sequential_chunk_write_monitor.go
+++ b/enterprise/server/remote_execution/containers/firecracker/sequential_chunk_write_monitor.go
@@ -1,0 +1,85 @@
+package firecracker
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+// sequentialChunkWriteTracker watches sequential chunk writes.
+// When writes advance from one chunk to a later chunk, the previous chunk is
+// finalized under the invariant that writes are observed in non-decreasing
+// order.
+type sequentialChunkWriteTracker struct {
+	// chunkSizeBytes converts COWStore chunk indexes to chunk start offsets.
+	chunkSizeBytes int64
+
+	// finalizeChunk is called when no more writes are expected for the given chunk.
+	finalizeChunk func(chunkOffset int64) error
+
+	// currentChunkIndex is the chunk currently receiving writes.
+	currentChunkIndex int64
+	// haveCurrentChunk distinguishes "no writes observed yet" from chunk 0.
+	haveCurrentChunk bool
+}
+
+// Observe records a chunk write and finalizes the previous chunk when the write
+// stream advances to a later chunk.
+func (t *sequentialChunkWriteTracker) Observe(event copy_on_write.WriteEvent) error {
+	err := validateSequentialWriteEvent(event, t.currentChunkIndex, t.chunkSizeBytes)
+	if err != nil {
+		return err
+	}
+
+	if !t.haveCurrentChunk {
+		t.currentChunkIndex = event.ChunkIndex
+		t.haveCurrentChunk = true
+		return nil
+	}
+
+	// If the write is to the same chunk, do nothing.
+	if event.ChunkIndex == t.currentChunkIndex {
+		return nil
+	}
+
+	// In a sequential write, if the write has moved to a new chunk, finalize the previous chunk.
+	if err := t.finalizeChunk(t.currentChunkOffset()); err != nil {
+		return err
+	}
+	t.currentChunkIndex = event.ChunkIndex
+	return nil
+}
+
+func validateSequentialWriteEvent(event copy_on_write.WriteEvent, currentChunkIndex, chunkSizeBytes int64) error {
+	if chunkSizeBytes <= 0 {
+		return status.FailedPreconditionErrorf("chunk size must be positive: %d", chunkSizeBytes)
+	}
+	if event.Offset < 0 {
+		return status.InvalidArgumentErrorf("write offset must be non-negative: %d", event.Offset)
+	}
+	if event.Length <= 0 {
+		return status.InvalidArgumentErrorf("write length must be positive: %d", event.Length)
+	}
+	if event.ChunkIndex < 0 {
+		return status.InvalidArgumentErrorf("chunk offset must be non-negative: %d", event.ChunkIndex)
+	}
+	if event.ChunkIndex < currentChunkIndex {
+		return status.FailedPreconditionErrorf("memory snapshot write moved backwards from chunk %d to chunk %d", currentChunkIndex, event.ChunkIndex)
+	}
+	return nil
+}
+
+// After there are no more writes to observe, Finish() ensures final bookkeeping of all written chunks.
+func (t *sequentialChunkWriteTracker) Finish() error {
+	if !t.haveCurrentChunk {
+		return nil
+	}
+	// After the last write, there is no subsequent write to trigger finalization
+	// of the last chunk. Finalize it here.
+	chunkOffset := t.currentChunkOffset()
+	t.haveCurrentChunk = false
+	return t.finalizeChunk(chunkOffset)
+}
+
+func (t *sequentialChunkWriteTracker) currentChunkOffset() int64 {
+	return t.currentChunkIndex * t.chunkSizeBytes
+}

--- a/enterprise/server/remote_execution/containers/firecracker/sequential_chunk_write_monitor.go
+++ b/enterprise/server/remote_execution/containers/firecracker/sequential_chunk_write_monitor.go
@@ -76,8 +76,11 @@ func (t *sequentialChunkWriteTracker) Finish() error {
 	// After the last write, there is no subsequent write to trigger finalization
 	// of the last chunk. Finalize it here.
 	chunkOffset := t.currentChunkOffset()
+	if err := t.finalizeChunk(chunkOffset); err != nil {
+		return err
+	}
 	t.haveCurrentChunk = false
-	return t.finalizeChunk(chunkOffset)
+	return nil
 }
 
 func (t *sequentialChunkWriteTracker) currentChunkOffset() int64 {

--- a/enterprise/server/remote_execution/containers/firecracker/sequential_chunk_write_monitor_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/sequential_chunk_write_monitor_test.go
@@ -1,0 +1,39 @@
+package firecracker
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObserve(t *testing.T) {
+	var finalized []int64
+	tracker := &sequentialChunkWriteTracker{
+		chunkSizeBytes: 1,
+		finalizeChunk: func(chunkOffset int64) error {
+			finalized = append(finalized, chunkOffset)
+			return nil
+		},
+	}
+
+	require.NoError(t, tracker.Observe(copy_on_write.WriteEvent{Offset: 0, Length: 50, ChunkIndex: 0}))
+	require.NoError(t, tracker.Observe(copy_on_write.WriteEvent{Offset: 50, Length: 25, ChunkIndex: 0}))
+	require.NoError(t, tracker.Observe(copy_on_write.WriteEvent{Offset: 100, Length: 20, ChunkIndex: 100}))
+	require.NoError(t, tracker.Observe(copy_on_write.WriteEvent{Offset: 300, Length: 10, ChunkIndex: 300}))
+	require.NoError(t, tracker.Finish())
+
+	require.Equal(t, []int64{0, 100, 300}, finalized)
+}
+
+func TestObserve_RejectsNonMonotonicWrites(t *testing.T) {
+	tracker := &sequentialChunkWriteTracker{
+		chunkSizeBytes: 1,
+		finalizeChunk: func(chunkOffset int64) error {
+			return nil
+		},
+	}
+
+	require.NoError(t, tracker.Observe(copy_on_write.WriteEvent{Offset: 100, Length: 10, ChunkIndex: 100}))
+	require.Error(t, tracker.Observe(copy_on_write.WriteEvent{Offset: 50, Length: 10, ChunkIndex: 0}))
+}


### PR DESCRIPTION
Replacement for [this PR](https://github.com/buildbuddy-io/buildbuddy/pull/12352). Rather than interleaving the logic into copy_on_write store, adds it to the firecracker package