### PR TITLE
Allow setting URL param to query clickhouse usage

### DIFF
--- a/enterprise/app/usage/usage.tsx
+++ b/enterprise/app/usage/usage.tsx
@@ -31,9 +31,14 @@ interface State {
 // This is the first month with usage numbers broken down by internal/external,
 // workflows, etc.  Prior months will still show the "old" charts.
 const FIRST_DETAILED_MONTH = "2025-08";
+const OLAP_QUERY_PARAM = "olap";
 
 function shouldShowDetailedView(periodStart: string): boolean {
   return new Date(periodStart) >= new Date(FIRST_DETAILED_MONTH);
+}
+
+function useOLAPFromURL(): boolean {
+  return new URLSearchParams(window.location.search).get(OLAP_QUERY_PARAM) === "1";
 }
 
 /** UsageComponent renders the Usage page shell and active tab. */
@@ -138,7 +143,7 @@ class UsageReport extends React.Component<UsageReportProps, State> {
     this.setState({ loading: true });
 
     rpcService.service
-      .getUsage(new usage.GetUsageRequest({ usagePeriod: period }))
+      .getUsage(new usage.GetUsageRequest({ usagePeriod: period, useOlap: useOLAPFromURL() }))
       .then((response) => {
         console.log(response);
         if (!response.usage) {

--- a/enterprise/server/usage_service/usage_service.go
+++ b/enterprise/server/usage_service/usage_service.go
@@ -332,7 +332,7 @@ func (s *usageService) GetUsageInternal(ctx context.Context, g *tables.Group, re
 		end = addCalendarMonths(start, 1)
 	}
 
-	usages, err := s.scanUsages(ctx, g.GroupID, start, end)
+	usages, err := s.scanUsages(ctx, g.GroupID, start, end, req.GetUseOlap())
 	if err != nil {
 		return nil, err
 	}
@@ -519,8 +519,11 @@ func (s *usageService) countUsageAlertingRules(ctx context.Context, dbh interfac
 	return row.Count, nil
 }
 
-func (s *usageService) scanUsages(ctx context.Context, groupID string, start, end time.Time) ([]*usagepb.Usage, error) {
-	if s.readFromOLAPDB {
+func (s *usageService) scanUsages(ctx context.Context, groupID string, start, end time.Time, useOLAP bool) ([]*usagepb.Usage, error) {
+	if s.readFromOLAPDB || useOLAP {
+		if s.olapdbh == nil {
+			return nil, status.FailedPreconditionError("OLAP DB handle must be configured for usage OLAP reads")
+		}
 		return s.scanOLAPUsages(ctx, groupID, start, end)
 	}
 	return s.scanPrimaryDBUsages(ctx, groupID, start, end)

--- a/proto/usage.proto
+++ b/proto/usage.proto
@@ -13,6 +13,9 @@ message GetUsageRequest {
   // The usage period to be fetched, as a UTC month in "YYYY-MM" format.
   // If empty, the current usage period will be returned.
   string usage_period = 2;
+
+  // If true, query usage data from the OLAP DB for this request.
+  bool use_olap = 3;
 }
 
 message GetUsageResponse {


### PR DESCRIPTION
This will allow some manual E2E testing to build more confidence before switching the UI onto querying clickhouse for usage.

I've already compared the data in the DB and things look good, but would like to compare the usage UI as an extra sanity check.