### PR TITLE
Add a 'proxy' usage label

### DIFF
--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -49,6 +49,7 @@ go_library(
         "//server/remote_cache/content_addressable_storage_server",
         "//server/rpc/interceptors",
         "//server/ssl",
+        "//server/usage/sku",
         "//server/util/grpc_client",
         "//server/util/grpc_server",
         "//server/util/healthcheck",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -42,6 +42,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
 	"github.com/buildbuddy-io/buildbuddy/server/rpc/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/ssl"
+	"github.com/buildbuddy-io/buildbuddy/server/usage/sku"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
@@ -78,6 +79,8 @@ var (
 	serverType = flag.String("server_type", "cache-proxy", "The server type to match on health checks")
 
 	remoteCache = flag.String("cache_proxy.remote_cache", "grpcs://remote.buildbuddy.dev", "The backing remote cache.")
+
+	proxyType = flag.String("cache_proxy.proxy_type", sku.ProxyExternal, "Whether this is a BuildBuddy-run (\"internal\") or customer-run (\"external\") cache proxy. Used for usage tracking/billing.")
 )
 
 func main() {
@@ -138,6 +141,10 @@ func main() {
 		log.Fatal(err.Error())
 	}
 	usageutil.SetServerName("cache-proxy")
+	if *proxyType != sku.ProxyInternal && *proxyType != sku.ProxyExternal {
+		log.Fatalf("Invalid --cache_proxy.proxy_type %q: must be %q or %q", *proxyType, sku.ProxyInternal, sku.ProxyExternal)
+	}
+	usageutil.SetProxyType(*proxyType)
 
 	env.SetListenAddr(*listen)
 	if err := ssl.Register(env); err != nil {

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -80,7 +80,7 @@ var (
 
 	remoteCache = flag.String("cache_proxy.remote_cache", "grpcs://remote.buildbuddy.dev", "The backing remote cache.")
 
-	proxyType = flag.String("cache_proxy.proxy_type", sku.ProxyExternal, "Whether this is a BuildBuddy-run (\"internal\") or customer-run (\"external\") cache proxy. Used for usage tracking/billing.")
+	proxyType = flag.String("cache_proxy.proxy_type", sku.ProxyCustomer, "Whether this is a BuildBuddy-run (\"buildbuddy\") or customer-run (\"customer\") cache proxy. Used for usage tracking/billing.")
 )
 
 func main() {
@@ -141,8 +141,8 @@ func main() {
 		log.Fatal(err.Error())
 	}
 	usageutil.SetServerName("cache-proxy")
-	if *proxyType != sku.ProxyInternal && *proxyType != sku.ProxyExternal {
-		log.Fatalf("Invalid --cache_proxy.proxy_type %q: must be %q or %q", *proxyType, sku.ProxyInternal, sku.ProxyExternal)
+	if *proxyType != sku.ProxyBuildBuddy && *proxyType != sku.ProxyCustomer && *proxyType != sku.ProxyUnknown {
+		log.Fatalf("Invalid --cache_proxy.proxy_type %q: must be %q, %q, or %q", *proxyType, sku.ProxyBuildBuddy, sku.ProxyCustomer, sku.ProxyUnknown)
 	}
 	usageutil.SetProxyType(*proxyType)
 

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -80,7 +80,7 @@ var (
 
 	remoteCache = flag.String("cache_proxy.remote_cache", "grpcs://remote.buildbuddy.dev", "The backing remote cache.")
 
-	proxyType = flag.String("cache_proxy.proxy_type", sku.ProxyCustomer, "Whether this is a BuildBuddy-run (\"buildbuddy\") or customer-run (\"customer\") cache proxy. Used for usage tracking/billing.")
+	proxyType = flag.String("cache_proxy.proxy_type", sku.ProxyBuildBuddy, "Whether this is a BuildBuddy-run (\"buildbuddy\") or customer-run (\"customer\") cache proxy. Used for usage tracking/billing.")
 )
 
 func main() {

--- a/enterprise/server/hit_tracker_client/hit_tracker_client.go
+++ b/enterprise/server/hit_tracker_client/hit_tracker_client.go
@@ -240,6 +240,9 @@ func (h *HitTrackerFactory) enqueue(ctx context.Context, hit *hitpb.CacheHit) {
 	if h.shouldFlushSynchronously() {
 		log.CtxInfof(ctx, "hit_tracker_client.enqueue after worker shutdown, sending RPC synchronously")
 		// Note: no need to mess with client/origin headers here, they're forwarded along from the incoming ctx.
+		// The proxy label is this proxy's own configured value rather than something
+		// from the incoming ctx, so set it explicitly.
+		ctx = usageutil.AddUsageHeadersToContext(ctx, "", "", usageutil.ProxyType())
 		ctx = ip_rules_enforcer.SetBypassIPRules(ctx)
 		if _, err := h.client.Track(ctx, &hitpb.TrackRequest{Hits: []*hitpb.CacheHit{hit}, Server: usageutil.ServerName()}); err != nil {
 			log.CtxWarningf(ctx, "Error sending HitTrackerService.Track RPC: %v", err)
@@ -419,7 +422,7 @@ func (h *HitTrackerFactory) sendTrackRequest(ctx context.Context) int {
 	if err != nil {
 		log.CtxWarningf(ctx, "Error decoding collection for remote usage tracking key %s: %v", hitsToSend.encodedCollection, err)
 	}
-	ctx = usageutil.AddUsageHeadersToContext(ctx, c.Client, c.Origin)
+	ctx = usageutil.AddUsageHeadersToContext(ctx, c.Client, c.Origin, c.Proxy)
 	ctx = ip_rules_enforcer.SetBypassIPRules(ctx)
 	trackRequest := hitpb.TrackRequest{Hits: hitsToSend.hits, Server: usageutil.ServerName()}
 	groupID := c.GroupID

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -248,6 +248,7 @@ func (ut *tracker) Increment(ctx context.Context, labels *tables.UsageLabels, uc
 		Origin:  labels.Origin,
 		Client:  labels.Client,
 		Server:  labels.Server,
+		Proxy:   labels.Proxy,
 	}
 	// Increment the hash values
 	encodedCollection := usageutil.EncodeCollection(collection)
@@ -611,6 +612,7 @@ func (ut *tracker) flushCountsToPrimaryDB(ctx context.Context, groupID string, p
 				AND origin = ?
 				AND client = ?
 				AND server = ?
+				AND proxy = ?
 			`+dbh.SelectForUpdateModifier(),
 			tu.Region,
 			tu.GroupID,
@@ -618,6 +620,7 @@ func (ut *tracker) flushCountsToPrimaryDB(ctx context.Context, groupID string, p
 			tu.Origin,
 			tu.Client,
 			tu.Server,
+			tu.Proxy,
 		).Take(&tables.Usage{})
 		if err != nil && !db.IsRecordNotFound(err) {
 			return err

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -94,7 +94,7 @@ func queryAllUsages(t *testing.T, te *testenv.TestEnv) []*tables.Usage {
 	dbh := te.GetDBHandle()
 	rq := dbh.NewQuery(ctx, "get_usages").Raw(`
 		SELECT * From "Usages"
-		ORDER BY group_id, period_start_usec, region, client, server, origin ASC;
+		ORDER BY group_id, period_start_usec, region, client, server, origin, proxy ASC;
 	`)
 
 	err := db.ScanEach(rq, func(ctx context.Context, tu *tables.Usage) error {
@@ -877,6 +877,20 @@ func TestUsageTracker_UsageLabels_AllFieldsAreMapped(t *testing.T) {
 			PeriodStartUsec: period1Start.UnixMicro(),
 			UsageCounts:     tables.UsageCounts{Invocations: 1},
 			UsageLabels:     tables.UsageLabels{},
+		},
+		{
+			Region:          "us-west1",
+			GroupID:         "GR1",
+			PeriodStartUsec: period1Start.UnixMicro(),
+			UsageCounts:     tables.UsageCounts{Invocations: 1},
+			UsageLabels:     tables.UsageLabels{Proxy: "Proxy-TestValue1"},
+		},
+		{
+			Region:          "us-west1",
+			GroupID:         "GR1",
+			PeriodStartUsec: period1Start.UnixMicro(),
+			UsageCounts:     tables.UsageCounts{Invocations: 1},
+			UsageLabels:     tables.UsageLabels{Proxy: "Proxy-TestValue2"},
 		},
 		{
 			Region:          "us-west1",

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -834,7 +834,7 @@ type UsageLabels struct {
 	Server string `gorm:"not null;default:''"`
 
 	// Proxy describes whether the usage was reported by a BuildBuddy-run
-	// ("internal") or customer-run ("external") cache proxy. It is empty for
+	// ("buildbuddy") or customer-run ("customer") cache proxy. It is empty for
 	// usage that was not reported by a cache proxy.
 	Proxy string `gorm:"not null;default:''"`
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -832,6 +832,11 @@ type UsageLabels struct {
 	// Server describes the type of server that ultimately handled generating
 	// the response, for example "cache-proxy" or "app".
 	Server string `gorm:"not null;default:''"`
+
+	// Proxy describes whether the usage was reported by a BuildBuddy-run
+	// ("internal") or customer-run ("external") cache proxy. It is empty for
+	// usage that was not reported by a cache proxy.
+	Proxy string `gorm:"not null;default:''"`
 }
 
 // Usage holds usage counter values for a group during a particular time period.

--- a/server/usage/sku/sku.go
+++ b/server/usage/sku/sku.go
@@ -70,6 +70,10 @@ const (
 	Server LabelName = "server"
 	// Origin identifies internal vs. external traffic origin.
 	Origin LabelName = "origin"
+	// Proxy identifies whether usage was reported by a BuildBuddy-run
+	// ("internal") or customer-run ("external") cache proxy. It is unset for
+	// usage that was not reported by a cache proxy.
+	Proxy LabelName = "proxy"
 	// OS identifies the operating system for execution usage.
 	OS LabelName = "os"
 	// Arch identifies the machine architecture for execution usage.
@@ -109,6 +113,9 @@ const (
 	ServerCacheProxy        LabelValue = "cache-proxy"
 	OriginExternal          LabelValue = "external"
 	OriginInternal          LabelValue = "internal"
+	ProxyExternal           LabelValue = "external"
+	ProxyInternal           LabelValue = "internal"
+	ProxyUnknown            LabelValue = "unknown"
 	OSLinux                 LabelValue = "linux"
 	OSMac                   LabelValue = "mac"
 	OSWindows               LabelValue = "windows"

--- a/server/usage/sku/sku.go
+++ b/server/usage/sku/sku.go
@@ -71,7 +71,7 @@ const (
 	// Origin identifies internal vs. external traffic origin.
 	Origin LabelName = "origin"
 	// Proxy identifies whether usage was reported by a BuildBuddy-run
-	// ("internal") or customer-run ("external") cache proxy. It is unset for
+	// ("buildbuddy") or customer-run ("customer") cache proxy. It is unset for
 	// usage that was not reported by a cache proxy.
 	Proxy LabelName = "proxy"
 	// OS identifies the operating system for execution usage.
@@ -113,16 +113,19 @@ const (
 	ServerCacheProxy        LabelValue = "cache-proxy"
 	OriginExternal          LabelValue = "external"
 	OriginInternal          LabelValue = "internal"
-	ProxyExternal           LabelValue = "external"
-	ProxyInternal           LabelValue = "internal"
-	ProxyUnknown            LabelValue = "unknown"
-	OSLinux                 LabelValue = "linux"
-	OSMac                   LabelValue = "mac"
-	OSWindows               LabelValue = "windows"
-	ArchX86_64              LabelValue = "x86_64"
-	ArchArm64               LabelValue = "arm64"
-	SelfHostedFalse         LabelValue = "false"
-	SelfHostedTrue          LabelValue = "true"
+	// ProxyBuildBuddy and ProxyCustomer are the values for the Proxy label,
+	// identifying BuildBuddy-run vs. customer-run cache proxies. ProxyUnknown is
+	// recorded when the proxy type cannot be determined.
+	ProxyBuildBuddy LabelValue = "buildbuddy"
+	ProxyCustomer   LabelValue = "customer"
+	ProxyUnknown    LabelValue = "unknown"
+	OSLinux         LabelValue = "linux"
+	OSMac           LabelValue = "mac"
+	OSWindows       LabelValue = "windows"
+	ArchX86_64      LabelValue = "x86_64"
+	ArchArm64       LabelValue = "arm64"
+	SelfHostedFalse LabelValue = "false"
+	SelfHostedTrue  LabelValue = "true"
 )
 
 // GetOSLabel returns the low-cardinality OS label for an execution platform OS.

--- a/server/util/usageutil/usageutil.go
+++ b/server/util/usageutil/usageutil.go
@@ -39,8 +39,8 @@ var (
 	// and the "server" usage label when a usage-generating request terminates at this server.
 	serverName string
 
-	// The proxy type ("internal" or "external") to record in usage. This is set
-	// on cache proxies and used for the "proxy" usage label so that
+	// The proxy type ("buildbuddy" or "customer") to record in usage. This is
+	// set on cache proxies and used for the "proxy" usage label so that
 	// BuildBuddy-run and customer-run proxy traffic can be billed separately. It
 	// is empty on servers that are not cache proxies.
 	proxyType string
@@ -115,8 +115,8 @@ func ServerName() string {
 	return serverName
 }
 
-// SetProxyType sets the proxy type ("internal" or "external") recorded for the
-// "proxy" usage label on cache proxies.
+// SetProxyType sets the proxy type ("buildbuddy" or "customer") recorded for
+// the "proxy" usage label on cache proxies.
 func SetProxyType(value string) {
 	proxyType = value
 }
@@ -185,7 +185,7 @@ func proxyLabel(ctx context.Context) string {
 	// usage/billing labels, so only let known proxy types through. Record any
 	// other value as "unknown" rather than passing it through.
 	switch vals[0] {
-	case sku.ProxyInternal, sku.ProxyExternal:
+	case sku.ProxyBuildBuddy, sku.ProxyCustomer:
 		return vals[0]
 	default:
 		return sku.ProxyUnknown

--- a/server/util/usageutil/usageutil.go
+++ b/server/util/usageutil/usageutil.go
@@ -22,6 +22,7 @@ const (
 	// gRPC metadata header constants.
 	ClientHeaderName            = "x-buildbuddy-client"
 	OriginHeaderName            = "x-buildbuddy-origin"
+	ProxyHeaderName             = "x-buildbuddy-proxy"
 	SkipUsageTrackingHeaderName = "x-buildbuddy-skip-tracking"
 
 	// Client label constants.
@@ -37,6 +38,12 @@ var (
 	// The server name to record in usage.  This will be used for the "client" usage label when sending RPCS
 	// and the "server" usage label when a usage-generating request terminates at this server.
 	serverName string
+
+	// The proxy type ("internal" or "external") to record in usage. This is set
+	// on cache proxies and used for the "proxy" usage label so that
+	// BuildBuddy-run and customer-run proxy traffic can be billed separately. It
+	// is empty on servers that are not cache proxies.
+	proxyType string
 )
 
 func DisableUsageTracking(ctx context.Context) context.Context {
@@ -50,12 +57,14 @@ func DisableUsageTracking(ctx context.Context) context.Context {
 func LabelsForUsageRecording(ctx context.Context, server string) (*tables.UsageLabels, sku.Labels, error) {
 	origin := originLabel(ctx)
 	client := clientLabel(ctx)
+	proxy := proxyLabel(ctx)
 	primaryDBLabels := &tables.UsageLabels{
 		Origin: origin,
 		Client: client,
 		Server: server,
+		Proxy:  proxy,
 	}
-	olapLabels := make(sku.Labels, 3)
+	olapLabels := make(sku.Labels, 4)
 	if origin != "" {
 		olapLabels[sku.Origin] = sku.LabelValue(origin)
 	}
@@ -64,6 +73,9 @@ func LabelsForUsageRecording(ctx context.Context, server string) (*tables.UsageL
 	}
 	if server != "" {
 		olapLabels[sku.Server] = sku.LabelValue(server)
+	}
+	if proxy != "" {
+		olapLabels[sku.Proxy] = sku.LabelValue(proxy)
 	}
 	return primaryDBLabels, olapLabels, nil
 }
@@ -103,6 +115,19 @@ func ServerName() string {
 	return serverName
 }
 
+// SetProxyType sets the proxy type ("internal" or "external") recorded for the
+// "proxy" usage label on cache proxies.
+func SetProxyType(value string) {
+	proxyType = value
+}
+
+// ProxyType returns the proxy type ("internal" or "external") configured for
+// this server, or "" if it is not a cache proxy. It is recorded for the "proxy"
+// usage label and propagated on outgoing requests via AddUsageHeadersToContext.
+func ProxyType() string {
+	return proxyType
+}
+
 func CollectionFromRPCContext(ctx context.Context) *Collection {
 	groupID := interfaces.AuthAnonymousUser
 	if claims, err := claims.ClaimsFromContext(ctx); err == nil {
@@ -113,16 +138,20 @@ func CollectionFromRPCContext(ctx context.Context) *Collection {
 		Server:  ServerName(),
 		Client:  clientLabel(ctx),
 		Origin:  originLabel(ctx),
+		Proxy:   ProxyType(),
 	}
 	return c
 }
 
-func AddUsageHeadersToContext(ctx context.Context, client string, origin string) context.Context {
+func AddUsageHeadersToContext(ctx context.Context, client string, origin string, proxy string) context.Context {
 	if client != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, ClientHeaderName, client)
 	}
 	if origin != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, OriginHeaderName, origin)
+	}
+	if proxy != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, ProxyHeaderName, proxy)
 	}
 	return ctx
 }
@@ -147,6 +176,22 @@ func clientLabel(ctx context.Context) string {
 	return ""
 }
 
+func proxyLabel(ctx context.Context) string {
+	vals := metadata.ValueFromIncomingContext(ctx, ProxyHeaderName)
+	if len(vals) == 0 {
+		return ""
+	}
+	// The proxy label is read from an untrusted incoming header but feeds into
+	// usage/billing labels, so only let known proxy types through. Record any
+	// other value as "unknown" rather than passing it through.
+	switch vals[0] {
+	case sku.ProxyInternal, sku.ProxyExternal:
+		return vals[0]
+	default:
+		return sku.ProxyUnknown
+	}
+}
+
 // A Collection consists of all of the fields that we currently use to identify
 // different types of usage--these fields are ultimately written out to the
 // `Usages` table as `UsageLabels`, where they determine cost bucketing.
@@ -157,6 +202,7 @@ type Collection struct {
 	Origin  string
 	Server  string
 	Client  string
+	Proxy   string
 }
 
 func (c *Collection) UsageLabels() *tables.UsageLabels {
@@ -164,6 +210,7 @@ func (c *Collection) UsageLabels() *tables.UsageLabels {
 		Origin: c.Origin,
 		Client: c.Client,
 		Server: c.Server,
+		Proxy:  c.Proxy,
 	}
 }
 
@@ -181,6 +228,9 @@ func EncodeCollection(c *Collection) string {
 	if c.Server != "" {
 		s += "&server=" + url.QueryEscape(c.Server)
 	}
+	if c.Proxy != "" {
+		s += "&proxy=" + url.QueryEscape(c.Proxy)
+	}
 	return s
 }
 
@@ -197,6 +247,7 @@ func DecodeCollection(s string) (*Collection, url.Values, error) {
 		Origin:  q.Get("origin"),
 		Client:  q.Get("client"),
 		Server:  q.Get("server"),
+		Proxy:   q.Get("proxy"),
 	}
 	return c, q, nil
 }

--- a/server/util/usageutil/usageutil_test.go
+++ b/server/util/usageutil/usageutil_test.go
@@ -83,23 +83,23 @@ func TestLabels(t *testing.T) {
 			},
 		},
 		{
-			Name:        "ProxyHeaderExternal",
-			ProxyHeader: sku.ProxyExternal,
-			Expected:    &tables.UsageLabels{Proxy: "external"},
+			Name:        "ProxyHeaderCustomer",
+			ProxyHeader: sku.ProxyCustomer,
+			Expected:    &tables.UsageLabels{Proxy: "customer"},
 			ExpectedOLAP: sku.Labels{
-				sku.Proxy: sku.ProxyExternal,
+				sku.Proxy: sku.ProxyCustomer,
 			},
 		},
 		{
-			Name:         "ProxyHeaderInternalWithOriginAndClient",
+			Name:         "ProxyHeaderBuildBuddyWithOriginAndClient",
 			MDHeader:     &repb.RequestMetadata{ToolDetails: &repb.ToolDetails{ToolName: "bazel"}},
 			OriginHeader: "external",
-			ProxyHeader:  sku.ProxyInternal,
-			Expected:     &tables.UsageLabels{Origin: "external", Client: "bazel", Proxy: "internal"},
+			ProxyHeader:  sku.ProxyBuildBuddy,
+			Expected:     &tables.UsageLabels{Origin: "external", Client: "bazel", Proxy: "buildbuddy"},
 			ExpectedOLAP: sku.Labels{
 				sku.Origin: sku.OriginExternal,
 				sku.Client: sku.ClientBazel,
-				sku.Proxy:  sku.ProxyInternal,
+				sku.Proxy:  sku.ProxyBuildBuddy,
 			},
 		},
 		{
@@ -151,7 +151,7 @@ func TestEncodeDecodeCollection(t *testing.T) {
 		},
 		{
 			Name:       "ProxyOnly",
-			Collection: &usageutil.Collection{GroupID: "GR1", Proxy: "external"},
+			Collection: &usageutil.Collection{GroupID: "GR1", Proxy: "customer"},
 		},
 		{
 			Name: "AllFields",
@@ -160,7 +160,7 @@ func TestEncodeDecodeCollection(t *testing.T) {
 				Origin:  "internal",
 				Client:  "bazel",
 				Server:  "cache-proxy",
-				Proxy:   "internal",
+				Proxy:   "buildbuddy",
 			},
 		},
 	} {
@@ -178,13 +178,13 @@ func TestEncodeDecodeCollection(t *testing.T) {
 // (CollectionFromRPCContext), emits it as a header (AddUsageHeadersToContext),
 // and the app reads it back into usage labels (LabelsForUsageRecording).
 func TestProxyHeaderPropagation(t *testing.T) {
-	usageutil.SetProxyType(sku.ProxyExternal)
+	usageutil.SetProxyType(sku.ProxyCustomer)
 	t.Cleanup(func() { usageutil.SetProxyType("") })
 
 	// Proxy side: the collection captured for an incoming request should pick up
 	// the proxy's configured type.
 	c := usageutil.CollectionFromRPCContext(t.Context())
-	require.Equal(t, sku.ProxyExternal, c.Proxy)
+	require.Equal(t, sku.ProxyCustomer, c.Proxy)
 
 	// Proxy side: the proxy type is emitted as an outgoing header.
 	ctx := usageutil.AddUsageHeadersToContext(t.Context(), c.Client, c.Origin, c.Proxy)
@@ -193,8 +193,8 @@ func TestProxyHeaderPropagation(t *testing.T) {
 	// App side: the header is read back into the recorded usage labels.
 	labels, olapLabels, err := usageutil.LabelsForUsageRecording(ctx, "app")
 	require.NoError(t, err)
-	require.Equal(t, sku.ProxyExternal, labels.Proxy)
-	require.Equal(t, sku.ProxyExternal, olapLabels[sku.Proxy])
+	require.Equal(t, sku.ProxyCustomer, labels.Proxy)
+	require.Equal(t, sku.ProxyCustomer, olapLabels[sku.Proxy])
 }
 
 func TestLabelPropagation(t *testing.T) {

--- a/server/util/usageutil/usageutil_test.go
+++ b/server/util/usageutil/usageutil_test.go
@@ -22,6 +22,7 @@ func TestLabels(t *testing.T) {
 		MDHeader     *repb.RequestMetadata
 		ClientHeader string
 		OriginHeader string
+		ProxyHeader  string
 		Expected     *tables.UsageLabels
 		ExpectedOLAP sku.Labels
 	}{
@@ -81,6 +82,36 @@ func TestLabels(t *testing.T) {
 				sku.Client: sku.ClientExecutor,
 			},
 		},
+		{
+			Name:        "ProxyHeaderExternal",
+			ProxyHeader: sku.ProxyExternal,
+			Expected:    &tables.UsageLabels{Proxy: "external"},
+			ExpectedOLAP: sku.Labels{
+				sku.Proxy: sku.ProxyExternal,
+			},
+		},
+		{
+			Name:         "ProxyHeaderInternalWithOriginAndClient",
+			MDHeader:     &repb.RequestMetadata{ToolDetails: &repb.ToolDetails{ToolName: "bazel"}},
+			OriginHeader: "external",
+			ProxyHeader:  sku.ProxyInternal,
+			Expected:     &tables.UsageLabels{Origin: "external", Client: "bazel", Proxy: "internal"},
+			ExpectedOLAP: sku.Labels{
+				sku.Origin: sku.OriginExternal,
+				sku.Client: sku.ClientBazel,
+				sku.Proxy:  sku.ProxyInternal,
+			},
+		},
+		{
+			// An unrecognized proxy header value is recorded as "unknown" so it
+			// can't pollute usage/billing labels with arbitrary values.
+			Name:        "ProxyHeaderInvalidIsUnknown",
+			ProxyHeader: "bogus",
+			Expected:    &tables.UsageLabels{Proxy: "unknown"},
+			ExpectedOLAP: sku.Labels{
+				sku.Proxy: sku.ProxyUnknown,
+			},
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			md := metadata.MD{}
@@ -95,6 +126,9 @@ func TestLabels(t *testing.T) {
 			if test.ClientHeader != "" {
 				md[usageutil.ClientHeaderName] = []string{test.ClientHeader}
 			}
+			if test.ProxyHeader != "" {
+				md[usageutil.ProxyHeaderName] = []string{test.ProxyHeader}
+			}
 			ctx := metadata.NewIncomingContext(t.Context(), md)
 
 			labels, olapLabels, err := usageutil.LabelsForUsageRecording(ctx, "")
@@ -104,6 +138,63 @@ func TestLabels(t *testing.T) {
 			require.Equal(t, test.ExpectedOLAP, olapLabels)
 		})
 	}
+}
+
+func TestEncodeDecodeCollection(t *testing.T) {
+	for _, test := range []struct {
+		Name       string
+		Collection *usageutil.Collection
+	}{
+		{
+			Name:       "Empty",
+			Collection: &usageutil.Collection{GroupID: "GR1"},
+		},
+		{
+			Name:       "ProxyOnly",
+			Collection: &usageutil.Collection{GroupID: "GR1", Proxy: "external"},
+		},
+		{
+			Name: "AllFields",
+			Collection: &usageutil.Collection{
+				GroupID: "GR1",
+				Origin:  "internal",
+				Client:  "bazel",
+				Server:  "cache-proxy",
+				Proxy:   "internal",
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			encoded := usageutil.EncodeCollection(test.Collection)
+			decoded, _, err := usageutil.DecodeCollection(encoded)
+			require.NoError(t, err)
+			require.Equal(t, test.Collection, decoded)
+		})
+	}
+}
+
+// TestProxyHeaderPropagation exercises the path a cache proxy uses to report
+// its configured proxy type: the proxy captures ProxyType() into the collection
+// (CollectionFromRPCContext), emits it as a header (AddUsageHeadersToContext),
+// and the app reads it back into usage labels (LabelsForUsageRecording).
+func TestProxyHeaderPropagation(t *testing.T) {
+	usageutil.SetProxyType(sku.ProxyExternal)
+	t.Cleanup(func() { usageutil.SetProxyType("") })
+
+	// Proxy side: the collection captured for an incoming request should pick up
+	// the proxy's configured type.
+	c := usageutil.CollectionFromRPCContext(t.Context())
+	require.Equal(t, sku.ProxyExternal, c.Proxy)
+
+	// Proxy side: the proxy type is emitted as an outgoing header.
+	ctx := usageutil.AddUsageHeadersToContext(t.Context(), c.Client, c.Origin, c.Proxy)
+	ctx = testgrpc.OutgoingToIncomingContext(t, ctx)
+
+	// App side: the header is read back into the recorded usage labels.
+	labels, olapLabels, err := usageutil.LabelsForUsageRecording(ctx, "app")
+	require.NoError(t, err)
+	require.Equal(t, sku.ProxyExternal, labels.Proxy)
+	require.Equal(t, sku.ProxyExternal, olapLabels[sku.Proxy])
 }
 
 func TestLabelPropagation(t *testing.T) {


### PR DESCRIPTION
Today, we don't have a way to measure cache usage from customer-managed cache proxies versus from BuildBuddy-managed cache proxies. This PR adds a new usage label `proxy` that can be set to `internal`, `external`, or `unknown` to measure this. This is recorded alongside the existing `origin`, `client`, and `server` labels in the primary and OLAP DBs.

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7307