### PR TITLE
[metadata server] Fix txn janitor/coordinator race

### DIFF
--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -56,8 +56,9 @@ const (
 )
 
 const (
-	CASErrorMessage    = "CAS expected value did not match"
-	TxnNotFoundMessage = "Transaction not found"
+	CASErrorMessage      = "CAS expected value did not match"
+	TxnNotFoundMessage   = "Transaction not found"
+	TxnRolledBackMessage = "Transaction rolled back"
 )
 
 // Key constants (some of these have to be vars because of how they are made.
@@ -78,10 +79,8 @@ var (
 	// The last rangeID that was generated.
 	LastRangeIDKey = keys.MakeKey(SystemPrefix, []byte("last_range_id-"))
 
-	// A prefix to prepend to transaction records. Transaction Records were written
-	// by the transaction coordinator when the transaction state changes. They
-	// were used to recover stuck transactions. They are different from shard-specific
-	// transaction entries written by replicas when preparing the transactions.
+	// A prefix to prepend to transaction records. These records live in the
+	// meta range and track the global txn decision.
 	TxnRecordPrefix = keys.MakeKey(SystemPrefix, []byte("txn-record-"))
 
 	// A prefix to prepend to session keys
@@ -107,8 +106,14 @@ var (
 	// When this local range was set up.
 	LocalRangeSetupTimeKey = keys.MakeKey(LocalPrefix, []byte("range_initialization_time"))
 
-	// A prefix to prepend to transactions.
+	// A prefix to prepend to participant-local prepared transaction state. The
+	// key is LocalTransactionPrefix + txid, and the value is the marshaled
+	// prepare BatchCmdRequest used to reload prepared state after restart.
 	LocalTransactionPrefix = keys.MakeKey(LocalPrefix, []byte("txn-"))
+
+	// A prefix to prepend to participant-local rollback markers for the
+	// transaction.
+	LocalTxnRollbackMarkerPrefix = keys.MakeKey(LocalPrefix, []byte("rollback-txn-"))
 )
 
 // Error constants -- sender recognizes these errors.

--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -122,6 +122,10 @@ func (bb *BatchBuilder) Add(m proto.Message) *BatchBuilder {
 		req.Value = &rfpb.RequestUnion_DeleteSessions{
 			DeleteSessions: value,
 		}
+	case *rfpb.DeleteTxnRollbackMarkersBeforeRequest:
+		req.Value = &rfpb.RequestUnion_DeleteTxnRollbackMarkersBefore{
+			DeleteTxnRollbackMarkersBefore: value,
+		}
 	case *rfpb.FetchRangesRequest:
 		req.Value = &rfpb.RequestUnion_FetchRanges{
 			FetchRanges: value,

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -541,6 +541,9 @@ func rollbackMarkerFinalizedAtUsec(val []byte) (int64, error) {
 	return int64(bytesToUint64(val)), nil
 }
 
+// HasTxnRollbackMarkersBefore scans this replica's local rollback markers and
+// returns true if any has a positive timestamp at or before cutoffUsec.
+// Non-positive timestamps are skipped (see RollbackTransaction).
 func (sm *Replica) HasTxnRollbackMarkersBefore(cutoffUsec int64) (bool, error) {
 	db, err := sm.leaser.DB()
 	if err != nil {

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -510,7 +510,13 @@ func (sm *Replica) CommitTransaction(txid []byte) error {
 	return nil
 }
 
-func (sm *Replica) RollbackTransaction(wb pebble.Batch, txid []byte, createdAtUsec int64) error {
+// RollbackTransaction releases any prepared state for txid and writes a
+// participant-local rollback marker that fences future PrepareTransaction calls
+// for txid. finalizedAtUsec is the marker's retention timestamp and must be a
+// real (positive) proposer-stamped time: startup GC only deletes markers whose
+// timestamp is positive and at or before its cutoff, so a non-positive value is
+// never collected (safe — fencing is preserved, never prematurely dropped).
+func (sm *Replica) RollbackTransaction(wb pebble.Batch, txid []byte, finalizedAtUsec int64) error {
 	markerKey := keys.MakeKey(constants.LocalTxnRollbackMarkerPrefix, txid)
 	txn, ok := sm.prepared[string(txid)]
 	if ok {
@@ -525,10 +531,10 @@ func (sm *Replica) RollbackTransaction(wb pebble.Batch, txid []byte, createdAtUs
 			return err
 		}
 	}
-	return wb.Set(sm.replicaLocalKey(markerKey), uint64ToBytes(uint64(createdAtUsec)), nil /*ignored write options*/)
+	return wb.Set(sm.replicaLocalKey(markerKey), uint64ToBytes(uint64(finalizedAtUsec)), nil /*ignored write options*/)
 }
 
-func rollbackMarkerCreatedAtUsec(val []byte) (int64, error) {
+func rollbackMarkerFinalizedAtUsec(val []byte) (int64, error) {
 	if len(val) != uint64EncodingSizeBytes {
 		return 0, status.InvalidArgumentErrorf("rollback marker timestamp has length %d, expected %d", len(val), uint64EncodingSizeBytes)
 	}
@@ -542,11 +548,8 @@ func (sm *Replica) HasTxnRollbackMarkersBefore(cutoffUsec int64) (bool, error) {
 	}
 	defer db.Close()
 
-	wb := db.NewIndexedBatch()
-	defer wb.Close()
-
 	start, end := keys.Range(sm.replicaLocalKey(constants.LocalTxnRollbackMarkerPrefix))
-	iter, err := wb.NewIter(&pebble.IterOptions{
+	iter, err := db.NewIter(&pebble.IterOptions{
 		LowerBound: start,
 		UpperBound: end,
 	})
@@ -556,12 +559,14 @@ func (sm *Replica) HasTxnRollbackMarkersBefore(cutoffUsec int64) (bool, error) {
 	defer iter.Close()
 
 	for iter.First(); iter.Valid(); iter.Next() {
-		createdAtUsec, err := rollbackMarkerCreatedAtUsec(iter.Value())
+		finalizedAtUsec, err := rollbackMarkerFinalizedAtUsec(iter.Value())
 		if err != nil {
 			sm.log.Errorf("unable to parse rollback marker %q: %s", iter.Key(), err)
 			continue
 		}
-		if createdAtUsec <= cutoffUsec {
+		// Skip non-positive timestamps so a marker never expires before its real
+		// finalize time; see RollbackTransaction.
+		if finalizedAtUsec > 0 && finalizedAtUsec <= cutoffUsec {
 			return true, nil
 		}
 	}
@@ -581,12 +586,14 @@ func (sm *Replica) deleteTxnRollbackMarkersBefore(wb pebble.Batch, req *rfpb.Del
 
 	cutoffUsec := req.GetCutoffUsec()
 	for iter.First(); iter.Valid(); iter.Next() {
-		createdAtUsec, err := rollbackMarkerCreatedAtUsec(iter.Value())
+		finalizedAtUsec, err := rollbackMarkerFinalizedAtUsec(iter.Value())
 		if err != nil {
 			sm.log.Errorf("unable to parse rollback marker %q: %s", iter.Key(), err)
 			continue
 		}
-		if createdAtUsec <= cutoffUsec {
+		// Skip non-positive timestamps so a marker never expires before its real
+		// finalize time; see RollbackTransaction.
+		if finalizedAtUsec > 0 && finalizedAtUsec <= cutoffUsec {
 			if err := wb.Delete(iter.Key(), nil /* ignore write options */); err != nil {
 				return nil, err
 			}
@@ -1563,7 +1570,7 @@ func (sm *Replica) singleUpdate(db pebble.IPebbleDB, entry dbsm.Entry) (dbsm.Ent
 				batchRsp.Status = statusProto(err)
 			}
 		case rfpb.FinalizeOperation_ROLLBACK:
-			if err := sm.RollbackTransaction(wb, txid, batchReq.GetSession().GetCreatedAtUsec()); err != nil {
+			if err := sm.RollbackTransaction(wb, txid, batchReq.GetTxnFinalizedAtUsec()); err != nil {
 				batchRsp.Status = statusProto(err)
 			}
 		default:

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -513,7 +513,7 @@ func (sm *Replica) CommitTransaction(txid []byte) error {
 // RollbackTransaction releases any prepared state for txid and writes a
 // participant-local rollback marker that fences future PrepareTransaction calls
 // for txid. finalizedAtUsec is the marker's retention timestamp and must be a
-// real (positive) proposer-stamped time: startup GC only deletes markers whose
+// real (positive) proposer-stamped time: GC only deletes markers whose
 // timestamp is positive and at or before its cutoff, so a non-positive value is
 // never collected (safe — fencing is preserved, never prematurely dropped).
 func (sm *Replica) RollbackTransaction(wb pebble.Batch, txid []byte, finalizedAtUsec int64) error {
@@ -541,10 +541,11 @@ func rollbackMarkerFinalizedAtUsec(val []byte) (int64, error) {
 	return int64(bytesToUint64(val)), nil
 }
 
-// HasTxnRollbackMarkersBefore scans this replica's local rollback markers and
-// returns true if any has a positive timestamp at or before cutoffUsec.
-// Non-positive timestamps are skipped (see RollbackTransaction).
-func (sm *Replica) HasTxnRollbackMarkersBefore(cutoffUsec int64) (bool, error) {
+// HasTxnRollbackMarkersBeforeForTest scans this replica's local rollback markers
+// and returns true if any has a positive timestamp at or before cutoffUsec.
+// Non-positive timestamps are skipped (see RollbackTransaction). Exported only
+// for tests, which can't reach the node-local marker keyspace directly.
+func (sm *Replica) HasTxnRollbackMarkersBeforeForTest(cutoffUsec int64) (bool, error) {
 	db, err := sm.leaser.DB()
 	if err != nil {
 		return false, err

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -104,8 +104,10 @@ type Replica struct {
 	bgCancelFn context.CancelFunc
 }
 
+const uint64EncodingSizeBytes = 8
+
 func uint64ToBytes(i uint64) []byte {
-	buf := make([]byte, 8)
+	buf := make([]byte, uint64EncodingSizeBytes)
 	binary.LittleEndian.PutUint64(buf, i)
 	return buf
 }
@@ -460,6 +462,13 @@ func (sm *Replica) loadTxnIntoMemory(txid []byte, batchReq *rfpb.BatchCmdRequest
 // so it can be applied or reverted via CommitTransaction or
 // RollbackTransaction.
 func (sm *Replica) PrepareTransaction(wb pebble.Batch, txid []byte, batchReq *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
+	markerKey := keys.MakeKey(constants.LocalTxnRollbackMarkerPrefix, txid)
+	if _, err := sm.lookup(wb, markerKey); err == nil {
+		return nil, status.FailedPreconditionErrorf("%s: [%s] txid=%q", constants.TxnRolledBackMessage, sm.name(), txid)
+	} else if !status.IsNotFoundError(err) {
+		return nil, err
+	}
+
 	// Save the txn batch in memory and acquire locks.
 	batchRsp, err := sm.loadTxnIntoMemory(txid, batchReq)
 	if err != nil {
@@ -501,25 +510,89 @@ func (sm *Replica) CommitTransaction(txid []byte) error {
 	return nil
 }
 
-func (sm *Replica) RollbackTransaction(txid []byte) error {
+func (sm *Replica) RollbackTransaction(wb pebble.Batch, txid []byte, createdAtUsec int64) error {
+	markerKey := keys.MakeKey(constants.LocalTxnRollbackMarkerPrefix, txid)
 	txn, ok := sm.prepared[string(txid)]
-	if !ok {
-		return status.NotFoundErrorf("%s: [%s] txid=%q", constants.TxnNotFoundMessage, sm.name(), txid)
+	if ok {
+		defer txn.Close()
+		delete(sm.prepared, string(txid))
+
+		sm.releaseLocks(txn, txid)
+		txn.Reset()
+
+		txKey := keys.MakeKey(constants.LocalTransactionPrefix, txid)
+		if err := wb.Delete(sm.replicaLocalKey(txKey), nil /*ignore write options*/); err != nil {
+			return err
+		}
 	}
-	defer txn.Close()
-	delete(sm.prepared, string(txid))
+	return wb.Set(sm.replicaLocalKey(markerKey), uint64ToBytes(uint64(createdAtUsec)), nil /*ignored write options*/)
+}
 
-	sm.releaseLocks(txn, txid)
-
-	txn.Reset()
-	txKey := keys.MakeKey(constants.LocalTransactionPrefix, txid)
-	txn.Delete(sm.replicaLocalKey(txKey), nil /*ignore write options*/)
-
-	if err := txn.Commit(pebble.Sync); err != nil {
-		return err
+func rollbackMarkerCreatedAtUsec(val []byte) (int64, error) {
+	if len(val) != uint64EncodingSizeBytes {
+		return 0, status.InvalidArgumentErrorf("rollback marker timestamp has length %d, expected %d", len(val), uint64EncodingSizeBytes)
 	}
-	sm.updateInMemoryState(txn)
-	return nil
+	return int64(bytesToUint64(val)), nil
+}
+
+func (sm *Replica) HasTxnRollbackMarkersBefore(cutoffUsec int64) (bool, error) {
+	db, err := sm.leaser.DB()
+	if err != nil {
+		return false, err
+	}
+	defer db.Close()
+
+	wb := db.NewIndexedBatch()
+	defer wb.Close()
+
+	start, end := keys.Range(sm.replicaLocalKey(constants.LocalTxnRollbackMarkerPrefix))
+	iter, err := wb.NewIter(&pebble.IterOptions{
+		LowerBound: start,
+		UpperBound: end,
+	})
+	if err != nil {
+		return false, err
+	}
+	defer iter.Close()
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		createdAtUsec, err := rollbackMarkerCreatedAtUsec(iter.Value())
+		if err != nil {
+			sm.log.Errorf("unable to parse rollback marker %q: %s", iter.Key(), err)
+			continue
+		}
+		if createdAtUsec <= cutoffUsec {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (sm *Replica) deleteTxnRollbackMarkersBefore(wb pebble.Batch, req *rfpb.DeleteTxnRollbackMarkersBeforeRequest) (*rfpb.DeleteTxnRollbackMarkersBeforeResponse, error) {
+	start, end := keys.Range(sm.replicaLocalKey(constants.LocalTxnRollbackMarkerPrefix))
+	iter, err := wb.NewIter(&pebble.IterOptions{
+		LowerBound: start,
+		UpperBound: end,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	cutoffUsec := req.GetCutoffUsec()
+	for iter.First(); iter.Valid(); iter.Next() {
+		createdAtUsec, err := rollbackMarkerCreatedAtUsec(iter.Value())
+		if err != nil {
+			sm.log.Errorf("unable to parse rollback marker %q: %s", iter.Key(), err)
+			continue
+		}
+		if createdAtUsec <= cutoffUsec {
+			if err := wb.Delete(iter.Key(), nil /* ignore write options */); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return &rfpb.DeleteTxnRollbackMarkersBeforeResponse{}, nil
 }
 
 func (sm *Replica) loadInflightTransactions(db ReplicaReader) error {
@@ -1238,6 +1311,12 @@ func (sm *Replica) handlePropose(wb pebble.Batch, req *rfpb.RequestUnion) *rfpb.
 			DeleteSessions: r,
 		}
 		rsp.Status = statusProto(err)
+	case *rfpb.RequestUnion_DeleteTxnRollbackMarkersBefore:
+		r, err := sm.deleteTxnRollbackMarkersBefore(wb, value.DeleteTxnRollbackMarkersBefore)
+		rsp.Value = &rfpb.ResponseUnion_DeleteTxnRollbackMarkersBefore{
+			DeleteTxnRollbackMarkersBefore: r,
+		}
+		rsp.Status = statusProto(err)
 	default:
 		rsp.Status = statusProto(status.UnimplementedErrorf("SyncPropose handling for %+v not implemented.", req))
 	}
@@ -1484,7 +1563,7 @@ func (sm *Replica) singleUpdate(db pebble.IPebbleDB, entry dbsm.Entry) (dbsm.Ent
 				batchRsp.Status = statusProto(err)
 			}
 		case rfpb.FinalizeOperation_ROLLBACK:
-			if err := sm.RollbackTransaction(txid); err != nil {
+			if err := sm.RollbackTransaction(wb, txid, batchReq.GetSession().GetCreatedAtUsec()); err != nil {
 				batchRsp.Status = statusProto(err)
 			}
 		default:

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -1097,7 +1097,7 @@ func TestClearStateBeforeApplySnapshot(t *testing.T) {
 		require.NoError(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
 	}
 
-	wb := repl.DB().NewBatch()
+	wb := repl.DB().NewIndexedBatch()
 	txid := []byte("TX1")
 	cmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
@@ -1150,7 +1150,7 @@ func TestClearStateBeforeApplySnapshot(t *testing.T) {
 	}
 
 	// Prepare a transaction before recovering from snapshot
-	wb2 := repl2.DB().NewBatch()
+	wb2 := repl2.DB().NewIndexedBatch()
 	txid2 := []byte("TX2")
 	cmd2, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
@@ -1405,7 +1405,7 @@ func TestTransactionPrepareAndCommit(t *testing.T) {
 	em := newEntryMaker(t)
 	writeDefaultRangeDescriptor(t, em, repl.Replica)
 
-	wb := repl.DB().NewBatch()
+	wb := repl.DB().NewIndexedBatch()
 	txid := []byte("TX1")
 	cmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
@@ -1419,7 +1419,7 @@ func TestTransactionPrepareAndCommit(t *testing.T) {
 	require.NoError(t, wb.Commit(pebble.Sync))
 	require.NoError(t, wb.Close())
 
-	wb = repl.DB().NewBatch()
+	wb = repl.DB().NewIndexedBatch()
 	txid2 := []byte("TX2")
 	badCmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
@@ -1474,7 +1474,7 @@ func TestTransactionLockingMappedRange(t *testing.T) {
 	}
 	writeLocalRangeDescriptor(t, em, repl.Replica, rd)
 
-	wb := repl.DB().NewBatch()
+	wb := repl.DB().NewIndexedBatch()
 	txid := []byte("TX1")
 	rd.End = keys.Key("b")
 	rd.Generation = 2
@@ -1509,7 +1509,7 @@ func TestTransactionLockingMappedRange(t *testing.T) {
 
 	// cannot write to [a, c) in a txn
 	{
-		wb = repl.DB().NewBatch()
+		wb = repl.DB().NewIndexedBatch()
 		txid2 := []byte("TX2")
 		badCmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 			Kv: &rfpb.KV{
@@ -1543,7 +1543,7 @@ func TestTransactionLockingMappedRange(t *testing.T) {
 
 	// should be able to write to [a, c) in a txn
 	{
-		wb = repl.DB().NewBatch()
+		wb = repl.DB().NewIndexedBatch()
 		txid2 := []byte("TX2")
 		badCmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 			Kv: &rfpb.KV{
@@ -1572,7 +1572,7 @@ func TestTransactionPrepareAndRollback(t *testing.T) {
 	em := newEntryMaker(t)
 	writeDefaultRangeDescriptor(t, em, repl.Replica)
 
-	wb := repl.DB().NewBatch()
+	wb := repl.DB().NewIndexedBatch()
 	txid := []byte("TX1")
 	cmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
@@ -1586,12 +1586,110 @@ func TestTransactionPrepareAndRollback(t *testing.T) {
 	require.NoError(t, wb.Commit(pebble.Sync))
 	require.NoError(t, wb.Close())
 
-	err = repl.RollbackTransaction(txid)
+	wb = repl.DB().NewIndexedBatch()
+	err = repl.RollbackTransaction(wb, txid, time.Now().UnixMicro())
 	require.NoError(t, err)
+	require.NoError(t, wb.Commit(pebble.Sync))
+	require.NoError(t, wb.Close())
 
 	buf, _, err := repl.DB().Get([]byte("foo"))
 	require.Error(t, err)
 	require.Nil(t, buf)
+}
+
+func TestRollbackMarkerSurvivesRestartAndRejectsPrepare(t *testing.T) {
+	txid := []byte("TX1")
+	em := newEntryMaker(t)
+	var leaser pebble.Leaser
+
+	{
+		repl := testutil.NewTestingReplica(t, 1, 1)
+		leaser = repl.Leaser()
+		require.NotNil(t, repl)
+
+		stopc := make(chan struct{})
+		_, err := repl.Open(stopc)
+		require.NoError(t, err)
+
+		writeDefaultRangeDescriptor(t, em, repl.Replica)
+
+		wb := repl.DB().NewIndexedBatch()
+		err = repl.RollbackTransaction(wb, txid, time.Now().UnixMicro())
+		require.NoError(t, err)
+		require.NoError(t, wb.Commit(pebble.Sync))
+		require.NoError(t, wb.Close())
+
+		err = repl.Close()
+		require.NoError(t, err)
+	}
+
+	{
+		repl := testutil.NewTestingReplicaWithLeaser(t, 1, 1, leaser)
+		require.NotNil(t, repl)
+		t.Cleanup(func() {
+			err := repl.Close()
+			require.NoError(t, err)
+		})
+
+		stopc := make(chan struct{})
+		_, err := repl.Open(stopc)
+		require.NoError(t, err)
+
+		wb := repl.DB().NewIndexedBatch()
+		cmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+			Kv: &rfpb.KV{
+				Key:   []byte("foo"),
+				Value: []byte("bar"),
+			},
+		}).ToProto()
+		_, err = repl.PrepareTransaction(wb, txid, cmd)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), constants.TxnRolledBackMessage)
+		require.NoError(t, wb.Close())
+	}
+}
+
+func TestRollbackMarkerGCFiltersByTimestamp(t *testing.T) {
+	repl := testutil.NewTestingReplica(t, 1, 1)
+	require.NotNil(t, repl)
+	t.Cleanup(func() {
+		err := repl.Close()
+		require.NoError(t, err)
+	})
+
+	stopc := make(chan struct{})
+	_, err := repl.Open(stopc)
+	require.NoError(t, err)
+
+	em := newEntryMaker(t)
+	writeDefaultRangeDescriptor(t, em, repl.Replica)
+
+	now := time.Now()
+	oldTxid := []byte("old-tx")
+	newTxid := []byte("new-tx")
+	wb := repl.DB().NewIndexedBatch()
+	require.NoError(t, repl.RollbackTransaction(wb, oldTxid, now.Add(-4*24*time.Hour).UnixMicro()))
+	require.NoError(t, repl.RollbackTransaction(wb, newTxid, now.UnixMicro()))
+	require.NoError(t, wb.Commit(pebble.Sync))
+	require.NoError(t, wb.Close())
+
+	hasMarkers, err := repl.HasTxnRollbackMarkersBefore(now.Add(-3 * 24 * time.Hour).UnixMicro())
+	require.NoError(t, err)
+	require.True(t, hasMarkers)
+
+	batch := rbuilder.NewBatchBuilder().Add(&rfpb.DeleteTxnRollbackMarkersBeforeRequest{
+		CutoffUsec: now.Add(-3 * 24 * time.Hour).UnixMicro(),
+	})
+	entry := em.makeEntry(batch)
+	writeRsp, err := repl.Update([]dbsm.Entry{entry})
+	require.NoError(t, err)
+	require.NoError(t, rbuilder.NewBatchResponse(writeRsp[0].Result.Data).AnyError())
+
+	_, err = directRead(t, repl, keys.MakeKey(constants.LocalTxnRollbackMarkerPrefix, oldTxid))
+	require.Error(t, err)
+
+	_, err = directRead(t, repl, keys.MakeKey(constants.LocalTxnRollbackMarkerPrefix, newTxid))
+	require.NoError(t, err)
 }
 
 func TestTransactionsSurviveRestart(t *testing.T) {
@@ -1614,7 +1712,7 @@ func TestTransactionsSurviveRestart(t *testing.T) {
 		em := newEntryMaker(t)
 		writeDefaultRangeDescriptor(t, em, repl.Replica)
 
-		wb := repl.DB().NewBatch()
+		wb := repl.DB().NewIndexedBatch()
 		cmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 			Kv: &rfpb.KV{
 				Key:   []byte("foo"),

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -1673,7 +1673,7 @@ func TestRollbackMarkerGCFiltersByTimestamp(t *testing.T) {
 	require.NoError(t, wb.Commit(pebble.Sync))
 	require.NoError(t, wb.Close())
 
-	hasMarkers, err := repl.HasTxnRollbackMarkersBefore(now.Add(-3 * 24 * time.Hour).UnixMicro())
+	hasMarkers, err := repl.HasTxnRollbackMarkersBeforeForTest(now.Add(-3 * 24 * time.Hour).UnixMicro())
 	require.NoError(t, err)
 	require.True(t, hasMarkers)
 

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2884,6 +2884,10 @@ type txnRollbackMarkerGCWorker struct {
 // gcTxnRollbackMarkersAfterStartup sweeps expired rollback markers once, after
 // replicas finish initializing. Markers created while the process runs are not
 // collected until the next restart, so storage is bounded only across restarts.
+// Sweep-once (rather than periodic) is acceptable because rollback markers are
+// written only on the txn failure path (rare) and are tiny, so the storage they
+// accumulate between restarts is negligible; periodic GC is a possible follow-up
+// if that ever stops holding.
 func (s *Store) gcTxnRollbackMarkersAfterStartup(ctx context.Context, retention time.Duration) {
 	for !s.ReplicasInitDone() {
 		select {
@@ -2914,6 +2918,8 @@ func (s *Store) gcTxnRollbackMarkersAfterStartup(ctx context.Context, retention 
 }
 
 func (w *txnRollbackMarkerGCWorker) gcOnce(ctx context.Context, cutoffUsec int64) error {
+	// gcErr retains only the last failing replica's error (each failure is also
+	// logged below); it exists solely to surface a single startup warning.
 	var gcErr error
 	w.store.replicas.Range(func(key, value any) bool {
 		repl, ok := value.(*replica.Replica)
@@ -2927,6 +2933,15 @@ func (w *txnRollbackMarkerGCWorker) gcOnce(ctx context.Context, cutoffUsec int64
 		if !w.store.HasReplicaAndIsLeader(repl.RangeID()) {
 			return true
 		}
+		// Leadership can change between this check and the propose inside
+		// gcReplica. That is safe: a propose on a non-leader is dropped by raft so
+		// SyncProposeLocal returns ErrShardNotReady (logged as a warning, never a
+		// half-apply), and the delete is idempotent and only removes
+		// already-expired markers. Because GC runs once at startup with no
+		// periodic re-run, a range skipped this way is not collected until the
+		// next process restart of whichever node is then leader — a node that
+		// merely becomes leader later does not trigger GC. Acceptable since
+		// markers are tiny and retention (days) far exceeds restart cadence.
 		if err := w.gcReplica(ctx, repl, cutoffUsec); err != nil {
 			w.store.log.Warningf("txn rollback marker GC failed for range %d: %s", repl.RangeID(), err)
 			gcErr = err
@@ -2936,7 +2951,23 @@ func (w *txnRollbackMarkerGCWorker) gcOnce(ctx context.Context, cutoffUsec int64
 	return gcErr
 }
 
+// GCTxnRollbackMarkersOnceForTest runs a single rollback-marker GC sweep with the
+// given cutoff. Exported only for tests; production GC runs via
+// gcTxnRollbackMarkersAfterStartup.
+func (s *Store) GCTxnRollbackMarkersOnceForTest(ctx context.Context, cutoffUsec int64) error {
+	worker := &txnRollbackMarkerGCWorker{
+		store:   s,
+		session: client.NewSessionWithClock(s.clock),
+	}
+	return worker.gcOnce(ctx, cutoffUsec)
+}
+
 func (w *txnRollbackMarkerGCWorker) gcReplica(ctx context.Context, repl *replica.Replica, cutoffUsec int64) error {
+	// Precheck with a cheap local read before proposing. The delete is a
+	// replicated raft command that applies on every replica, so unconditionally
+	// proposing it on every range at every startup — even when nothing is expired
+	// — would write no-op entries to every log. The precheck avoids that in the
+	// common case; the replicated delete remains the source of truth.
 	hasMarkers, err := repl.HasTxnRollbackMarkersBefore(cutoffUsec)
 	if err != nil {
 		return err

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -79,6 +79,7 @@ var (
 	zombieNodeScanInterval        = flag.Duration("cache.raft.zombie_node_scan_interval", 30*time.Second, "Check if one replica is a zombie every this often. 0 to disable.")
 	replicaScanInterval           = flag.Duration("cache.raft.replica_scan_interval", 1*time.Minute, "The interval we wait to check if the replicas need to be queued for replication")
 	clientSessionTTL              = flag.Duration("cache.raft.client_session_ttl", 24*time.Hour, "The duration we keep the sessions stored.")
+	txnRollbackMarkerRetention    = flag.Duration("cache.raft.txn_rollback_marker_retention", 3*24*time.Hour, "How long participant-local txn rollback markers are retained before startup GC. Must exceed the longest possible coordinator lifetime so no late prepare can arrive after a marker is deleted. 0 disables startup GC.")
 	enableDriver                  = flag.Bool("cache.raft.enable_driver", true, "If true, enable placement driver")
 	enableTxnCleanup              = flag.Bool("cache.raft.enable_txn_cleanup", true, "If true, clean up stuck transactions periodically")
 	enableRegistryPreload         = flag.Bool("cache.raft.enable_registry_preload", false, "If true, preload the registry on start-up")
@@ -937,6 +938,12 @@ func (s *Store) Start() error {
 		s.deleteSessionWorker.Start(s.egCtx)
 		return nil
 	})
+	if *txnRollbackMarkerRetention > 0 {
+		s.eg.Go(func() error {
+			s.gcTxnRollbackMarkersAfterStartup(s.egCtx, *txnRollbackMarkerRetention)
+			return nil
+		})
+	}
 	s.eg.Go(func() error {
 		s.setupPartitions(s.egCtx)
 		return nil
@@ -2867,6 +2874,85 @@ func (w *replicaWorker) Start(ctx context.Context) {
 			}
 		}
 	}
+}
+
+type txnRollbackMarkerGCWorker struct {
+	store   *Store
+	session *client.Session
+}
+
+func (s *Store) gcTxnRollbackMarkersAfterStartup(ctx context.Context, retention time.Duration) {
+	for !s.ReplicasInitDone() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.clock.After(time.Second):
+		}
+	}
+
+	worker := &txnRollbackMarkerGCWorker{
+		store:   s,
+		session: client.NewSessionWithClock(s.clock),
+	}
+	// Safety assumption behind deleting markers: a rollback marker fences late
+	// prepares for its txid, so it is only safe to delete once no coordinator
+	// can still retry a PrepareTransaction for that txid. We approximate that
+	// with `retention` rather than a hard proof. This is safe because a
+	// coordinator's prepares are bounded by request/RPC deadlines (seconds to
+	// minutes), far below the default retention (days). Note the marker's
+	// timestamp is the first rollback-apply time and is not refreshed on deduped
+	// retries, so retention is measured from then. If coordinators could ever
+	// run longer than `retention`, this GC would need a stronger bound (e.g. an
+	// applied-index proof that no older prepare can still apply).
+	cutoffUsec := s.clock.Now().Add(-retention).UnixMicro()
+	if err := worker.gcOnce(ctx, cutoffUsec); err != nil {
+		s.log.Warningf("txn rollback marker startup GC failed: %s", err)
+	}
+}
+
+func (w *txnRollbackMarkerGCWorker) gcOnce(ctx context.Context, cutoffUsec int64) error {
+	var gcErr error
+	w.store.replicas.Range(func(key, value any) bool {
+		repl, ok := value.(*replica.Replica)
+		if !ok {
+			return true
+		}
+		// Only the leader prechecks and proposes the delete, which then applies
+		// on all replicas. The precheck is exact: the leader holds every
+		// committed marker (leader completeness), so a follower can only lag,
+		// never hold a marker the leader is missing.
+		if !w.store.HasReplicaAndIsLeader(repl.RangeID()) {
+			return true
+		}
+		if err := w.gcReplica(ctx, repl, cutoffUsec); err != nil {
+			w.store.log.Warningf("txn rollback marker GC failed for range %d: %s", repl.RangeID(), err)
+			gcErr = err
+		}
+		return true
+	})
+	return gcErr
+}
+
+func (w *txnRollbackMarkerGCWorker) gcReplica(ctx context.Context, repl *replica.Replica, cutoffUsec int64) error {
+	hasMarkers, err := repl.HasTxnRollbackMarkersBefore(cutoffUsec)
+	if err != nil {
+		return err
+	}
+	if !hasMarkers {
+		return nil
+	}
+	batch := rbuilder.NewBatchBuilder().Add(&rfpb.DeleteTxnRollbackMarkersBeforeRequest{
+		CutoffUsec: cutoffUsec,
+	})
+	request, err := batch.ToProto()
+	if err != nil {
+		return err
+	}
+	rsp, err := w.session.SyncProposeLocal(ctx, w.store.NodeHost(), repl.RangeID(), request)
+	if err != nil {
+		return err
+	}
+	return rbuilder.NewBatchResponseFromProto(rsp).AnyError()
 }
 
 type deleteSessionWorker struct {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -79,7 +79,7 @@ var (
 	zombieNodeScanInterval        = flag.Duration("cache.raft.zombie_node_scan_interval", 30*time.Second, "Check if one replica is a zombie every this often. 0 to disable.")
 	replicaScanInterval           = flag.Duration("cache.raft.replica_scan_interval", 1*time.Minute, "The interval we wait to check if the replicas need to be queued for replication")
 	clientSessionTTL              = flag.Duration("cache.raft.client_session_ttl", 24*time.Hour, "The duration we keep the sessions stored.")
-	txnRollbackMarkerRetention    = flag.Duration("cache.raft.txn_rollback_marker_retention", 3*24*time.Hour, "How long participant-local txn rollback markers are retained before startup GC. Must exceed the longest possible coordinator lifetime so no late prepare can arrive after a marker is deleted. 0 disables startup GC.")
+	txnRollbackMarkerRetention    = flag.Duration("cache.raft.txn_rollback_marker_retention", 3*24*time.Hour, "How long participant-local txn rollback markers are retained before GC. Must exceed the longest possible coordinator lifetime so no late prepare can arrive after a marker is deleted. 0 disables marker GC.")
 	enableDriver                  = flag.Bool("cache.raft.enable_driver", true, "If true, enable placement driver")
 	enableTxnCleanup              = flag.Bool("cache.raft.enable_txn_cleanup", true, "If true, clean up stuck transactions periodically")
 	enableRegistryPreload         = flag.Bool("cache.raft.enable_registry_preload", false, "If true, preload the registry on start-up")
@@ -155,9 +155,9 @@ type Store struct {
 	updateTagsWorker *updateTagsWorker
 	txnCoordinator   *txn.Coordinator
 
-	driverQueue         *driver.Queue
-	deleteSessionWorker *deleteSessionWorker
-	replicaJanitor      *replicaJanitor
+	driverQueue    *driver.Queue
+	rangeGCWorker  *rangeGCWorker
+	replicaJanitor *replicaJanitor
 
 	clock clockwork.Clock
 
@@ -408,7 +408,7 @@ func New(env environment.Env, cfg *raftConfig.ServerConfig, opts ...Option) (*St
 	if *enableDriver {
 		s.driverQueue = driver.NewQueue(s, s.sender, cfg.GossipManager, nhLog, apiClient, clock, env.GetExperimentFlagProvider())
 	}
-	s.deleteSessionWorker = newDeleteSessionsWorker(clock, s, *clientSessionTTL)
+	s.rangeGCWorker = newRangeGCWorker(clock, s, *clientSessionTTL, *txnRollbackMarkerRetention)
 	s.replicaJanitor = newReplicaJanitor(clock, s, *zombieNodeScanInterval)
 
 	if err != nil {
@@ -935,15 +935,9 @@ func (s *Store) Start() error {
 		})
 	}
 	s.eg.Go(func() error {
-		s.deleteSessionWorker.Start(s.egCtx)
+		s.rangeGCWorker.Start(s.egCtx)
 		return nil
 	})
-	if *txnRollbackMarkerRetention > 0 {
-		s.eg.Go(func() error {
-			s.gcTxnRollbackMarkersAfterStartup(s.egCtx, *txnRollbackMarkerRetention)
-			return nil
-		})
-	}
 	s.eg.Go(func() error {
 		s.setupPartitions(s.egCtx)
 		return nil
@@ -2876,148 +2870,44 @@ func (w *replicaWorker) Start(ctx context.Context) {
 	}
 }
 
-type txnRollbackMarkerGCWorker struct {
-	store   *Store
-	session *client.Session
-}
-
-// gcTxnRollbackMarkersAfterStartup sweeps expired rollback markers once, after
-// replicas finish initializing. Markers created while the process runs are not
-// collected until the next restart, so storage is bounded only across restarts.
-// Sweep-once (rather than periodic) is acceptable because rollback markers are
-// written only on the txn failure path (rare) and are tiny, so the storage they
-// accumulate between restarts is negligible; periodic GC is a possible follow-up
-// if that ever stops holding.
-func (s *Store) gcTxnRollbackMarkersAfterStartup(ctx context.Context, retention time.Duration) {
-	for !s.ReplicasInitDone() {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.clock.After(time.Second):
-		}
-	}
-
-	worker := &txnRollbackMarkerGCWorker{
-		store:   s,
-		session: client.NewSessionWithClock(s.clock),
-	}
-	// Safety assumption behind deleting markers: a rollback marker fences late
-	// prepares for its txid, so it is only safe to delete once no coordinator
-	// can still retry a PrepareTransaction for that txid. We approximate that
-	// with `retention` rather than a hard proof. This is safe because a
-	// coordinator's prepares are bounded by request/RPC deadlines (seconds to
-	// minutes), far below the default retention (days). Note the marker's
-	// timestamp is the first rollback-apply time and is not refreshed on deduped
-	// retries, so retention is measured from then. If coordinators could ever
-	// run longer than `retention`, this GC would need a stronger bound (e.g. an
-	// applied-index proof that no older prepare can still apply).
-	cutoffUsec := s.clock.Now().Add(-retention).UnixMicro()
-	if err := worker.gcOnce(ctx, cutoffUsec); err != nil {
-		s.log.Warningf("txn rollback marker startup GC failed: %s", err)
-	}
-}
-
-func (w *txnRollbackMarkerGCWorker) gcOnce(ctx context.Context, cutoffUsec int64) error {
-	// gcErr retains only the last failing replica's error (each failure is also
-	// logged below); it exists solely to surface a single startup warning.
-	var gcErr error
-	w.store.replicas.Range(func(key, value any) bool {
-		repl, ok := value.(*replica.Replica)
-		if !ok {
-			return true
-		}
-		// Only the leader prechecks and proposes the delete, which then applies
-		// on all replicas. The precheck is exact: the leader holds every
-		// committed marker (leader completeness), so a follower can only lag,
-		// never hold a marker the leader is missing.
-		if !w.store.HasReplicaAndIsLeader(repl.RangeID()) {
-			return true
-		}
-		// Leadership can change between this check and the propose inside
-		// gcReplica. That is safe: a propose on a non-leader is dropped by raft so
-		// SyncProposeLocal returns ErrShardNotReady (logged as a warning, never a
-		// half-apply), and the delete is idempotent and only removes
-		// already-expired markers. Because GC runs once at startup with no
-		// periodic re-run, a range skipped this way is not collected until the
-		// next process restart of whichever node is then leader — a node that
-		// merely becomes leader later does not trigger GC. Acceptable since
-		// markers are tiny and retention (days) far exceeds restart cadence.
-		if err := w.gcReplica(ctx, repl, cutoffUsec); err != nil {
-			w.store.log.Warningf("txn rollback marker GC failed for range %d: %s", repl.RangeID(), err)
-			gcErr = err
-		}
-		return true
-	})
-	return gcErr
-}
-
-// GCTxnRollbackMarkersOnceForTest runs a single rollback-marker GC sweep with the
-// given cutoff. Exported only for tests; production GC runs via
-// gcTxnRollbackMarkersAfterStartup.
-func (s *Store) GCTxnRollbackMarkersOnceForTest(ctx context.Context, cutoffUsec int64) error {
-	worker := &txnRollbackMarkerGCWorker{
-		store:   s,
-		session: client.NewSessionWithClock(s.clock),
-	}
-	return worker.gcOnce(ctx, cutoffUsec)
-}
-
-func (w *txnRollbackMarkerGCWorker) gcReplica(ctx context.Context, repl *replica.Replica, cutoffUsec int64) error {
-	// Precheck with a cheap local read before proposing. The delete is a
-	// replicated raft command that applies on every replica, so unconditionally
-	// proposing it on every range at every startup — even when nothing is expired
-	// — would write no-op entries to every log. The precheck avoids that in the
-	// common case; the replicated delete remains the source of truth.
-	hasMarkers, err := repl.HasTxnRollbackMarkersBefore(cutoffUsec)
-	if err != nil {
-		return err
-	}
-	if !hasMarkers {
-		return nil
-	}
-	batch := rbuilder.NewBatchBuilder().Add(&rfpb.DeleteTxnRollbackMarkersBeforeRequest{
-		CutoffUsec: cutoffUsec,
-	})
-	request, err := batch.ToProto()
-	if err != nil {
-		return err
-	}
-	rsp, err := w.session.SyncProposeLocal(ctx, w.store.NodeHost(), repl.RangeID(), request)
-	if err != nil {
-		return err
-	}
-	return rbuilder.NewBatchResponseFromProto(rsp).AnyError()
-}
-
-type deleteSessionWorker struct {
+// rangeGCWorker garbage-collects expired per-range state on the leaseholder:
+// expired client sessions and expired txn rollback markers.
+type rangeGCWorker struct {
 	rateLimiter       *rate.Limiter
-	lastExecutionTime sync.Map // map of uint64 rangeID -> the timestamp we last delete sessions
+	lastExecutionTime sync.Map // map of uint64 rangeID -> the timestamp we last ran GC
 	session           *client.Session
 	clock             clockwork.Clock
 	store             *Store
 	clientSessionTTL  time.Duration
+	// txnRollbackMarkerRetention is how long rollback markers are kept before GC.
+	// 0 disables marker GC.
+	txnRollbackMarkerRetention time.Duration
 
 	*replicaWorker
 }
 
-func newDeleteSessionsWorker(clock clockwork.Clock, store *Store, clientSessionTTL time.Duration) *deleteSessionWorker {
-	res := &deleteSessionWorker{
-		rateLimiter:       rate.NewLimiter(rate.Limit(deleteSessionsRateLimit), 1),
-		store:             store,
-		lastExecutionTime: sync.Map{},
-		session:           client.NewSessionWithClock(clock),
-		clock:             clock,
-		clientSessionTTL:  clientSessionTTL,
+func newRangeGCWorker(clock clockwork.Clock, store *Store, clientSessionTTL, txnRollbackMarkerRetention time.Duration) *rangeGCWorker {
+	res := &rangeGCWorker{
+		rateLimiter:                rate.NewLimiter(rate.Limit(deleteSessionsRateLimit), 1),
+		store:                      store,
+		lastExecutionTime:          sync.Map{},
+		session:                    client.NewSessionWithClock(clock),
+		clock:                      clock,
+		clientSessionTTL:           clientSessionTTL,
+		txnRollbackMarkerRetention: txnRollbackMarkerRetention,
 	}
 	res.replicaWorker = &replicaWorker{
-		name:     "deleteSessionWorker",
+		name:     "rangeGCWorker",
 		tasks:    make(chan *replica.Replica, 10000),
-		handleFn: res.deleteSessions,
+		handleFn: res.gcExpiredRangeState,
 	}
 	return res
 }
 
-func (w *deleteSessionWorker) deleteSessions(ctx context.Context, repl *replica.Replica) error {
+// gcExpiredRangeState runs on the leaseholder and deletes expired per-range
+// state in a single raft proposal: expired client sessions and (when enabled)
+// expired txn rollback markers.
+func (w *rangeGCWorker) gcExpiredRangeState(ctx context.Context, repl *replica.Replica) error {
 	if repl.RangeID() == 0 {
 		return nil
 	}
@@ -3027,11 +2917,11 @@ func (w *deleteSessionWorker) deleteSessions(ctx context.Context, repl *replica.
 		lastExecutionTime, ok := lastExecutionTimeI.(time.Time)
 		if ok {
 			if w.clock.Since(lastExecutionTime) <= client.SessionLifetime() {
-				// There are probably no client sessions to delete.
+				// There is probably nothing to GC yet.
 				return nil
 			}
 		} else {
-			return status.InternalErrorf("unable to delete sessions for rangeID=%d: unable to parse lastExecutionTime", rd.GetRangeId())
+			return status.InternalErrorf("unable to GC rangeID=%d: unable to parse lastExecutionTime", rd.GetRangeId())
 		}
 	}
 
@@ -3045,23 +2935,35 @@ func (w *deleteSessionWorker) deleteSessions(ctx context.Context, repl *replica.
 		return err
 	}
 	now := w.clock.Now()
-	request, err := rbuilder.NewBatchBuilder().Add(
-		&rfpb.DeleteSessionsRequest{
-			CreatedAtUsec: now.Add(-w.clientSessionTTL).UnixMicro(),
-		}).ToProto()
+	bb := rbuilder.NewBatchBuilder().Add(&rfpb.DeleteSessionsRequest{
+		CreatedAtUsec: now.Add(-w.clientSessionTTL).UnixMicro(),
+	})
+	// retention <= 0 disables marker GC; a positive retention must outlast any
+	// coordinator so no late prepare can arrive after a marker is deleted.
+	if w.txnRollbackMarkerRetention > 0 {
+		cutoffUsec := now.Add(-w.txnRollbackMarkerRetention).UnixMicro()
+		bb.Add(&rfpb.DeleteTxnRollbackMarkersBeforeRequest{CutoffUsec: cutoffUsec})
+	}
+	request, err := bb.ToProto()
 	if err != nil {
-		return status.WrapErrorf(err, "unable to delete sessions for rangeID=%d: unable to build request", rd.GetRangeId())
+		return status.WrapErrorf(err, "unable to GC rangeID=%d: unable to build request", rd.GetRangeId())
 	}
 	rsp, err := w.session.SyncProposeLocal(ctx, w.store.NodeHost(), repl.RangeID(), request)
 	if err != nil {
-		return status.WrapErrorf(err, "unable to delete sessions for rangeID=%d: SyncProposeLocal fails", rd.GetRangeId())
+		return status.WrapErrorf(err, "unable to GC rangeID=%d: SyncProposeLocal fails", rd.GetRangeId())
 	}
 	w.lastExecutionTime.Store(rd.GetRangeId(), now)
-	_, err = rbuilder.NewBatchResponseFromProto(rsp).DeleteSessionsResponse(0)
-	if err != nil {
-		return status.WrapErrorf(err, "unable to delete sessions for rangeID=%d: deleteSessions fails", rd.GetRangeId())
+	if err := rbuilder.NewBatchResponseFromProto(rsp).AnyError(); err != nil {
+		return status.WrapErrorf(err, "unable to GC rangeID=%d", rd.GetRangeId())
 	}
 	return nil
+}
+
+// GCExpiredRangeStateForTest runs one rangeGCWorker pass (expired sessions + txn
+// rollback markers) for repl. Exported only for tests; production GC runs via
+// scanReplicas enqueueing onto the worker.
+func (s *Store) GCExpiredRangeStateForTest(ctx context.Context, repl *replica.Replica) error {
+	return s.rangeGCWorker.gcExpiredRangeState(ctx, repl)
 }
 
 type SplitRangeTxn struct {
@@ -4030,7 +3932,7 @@ func (store *Store) scanReplicas(ctx context.Context, scanInterval time.Duration
 			if store.driverQueue != nil {
 				store.driverQueue.MaybeAddRangeTask(ctx, repl)
 			}
-			store.deleteSessionWorker.Enqueue(repl)
+			store.rangeGCWorker.Enqueue(repl)
 		}
 	}
 }

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2881,6 +2881,9 @@ type txnRollbackMarkerGCWorker struct {
 	session *client.Session
 }
 
+// gcTxnRollbackMarkersAfterStartup sweeps expired rollback markers once, after
+// replicas finish initializing. Markers created while the process runs are not
+// collected until the next restart, so storage is bounded only across restarts.
 func (s *Store) gcTxnRollbackMarkersAfterStartup(ctx context.Context, retention time.Duration) {
 	for !s.ReplicasInitDone() {
 		select {

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1921,18 +1921,19 @@ func writeRollbackMarker(t *testing.T, ctx context.Context, clock clockwork.Cloc
 	require.NoError(t, rbuilder.NewBatchResponseFromProto(rsp).AnyError())
 }
 
-// TestTxnRollbackMarkerStartupGC exercises the store-level GC sweep
-// (gcOnce/gcReplica + the leader-only precheck), which the replica-level tests do
-// not cover. It writes an expired and a fresh marker, runs one sweep, and asserts
-// the expired marker is collected while the fresh one is retained.
-func TestTxnRollbackMarkerStartupGC(t *testing.T) {
+// TestTxnRollbackMarkerGC exercises the store-level GC path, which the
+// replica-level tests do not cover. It writes an expired and a fresh marker,
+// runs one GC pass on the leaseholder, and asserts the expired marker is
+// collected while the fresh one is retained.
+func TestTxnRollbackMarkerGC(t *testing.T) {
 	flags.Set(t, "cache.raft.enable_driver", false)
 	flags.Set(t, "cache.raft.target_range_size_bytes", 0)
 	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
 	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
-	// Disable the automatic startup sweep so this test owns the only GC call and
-	// stays deterministic.
-	flags.Set(t, "cache.raft.txn_rollback_marker_retention", 0)
+	// Disable the periodic scan so this test owns the only GC call and stays
+	// deterministic; retention defines the worker's cutoff (now - 3d).
+	flags.Set(t, "cache.raft.replica_scan_interval", 0)
+	flags.Set(t, "cache.raft.txn_rollback_marker_retention", 3*24*time.Hour)
 	clock := clockwork.NewFakeClock()
 
 	sf := testutil.NewStoreFactoryWithClock(t, clock)
@@ -1955,18 +1956,18 @@ func TestTxnRollbackMarkerStartupGC(t *testing.T) {
 
 	leaderRepl, err := leader.GetReplica(2)
 	require.NoError(t, err)
-	hasMarkers, err := leaderRepl.HasTxnRollbackMarkersBefore(cutoffUsec)
+	hasMarkers, err := leaderRepl.HasTxnRollbackMarkersBeforeForTest(cutoffUsec)
 	require.NoError(t, err)
 	require.True(t, hasMarkers, "expired marker should be present before GC")
 
-	require.NoError(t, leader.GCTxnRollbackMarkersOnceForTest(ctx, cutoffUsec))
+	require.NoError(t, leader.GCExpiredRangeStateForTest(ctx, leaderRepl))
 
-	hasMarkers, err = leaderRepl.HasTxnRollbackMarkersBefore(cutoffUsec)
+	hasMarkers, err = leaderRepl.HasTxnRollbackMarkersBeforeForTest(cutoffUsec)
 	require.NoError(t, err)
 	require.False(t, hasMarkers, "expired marker should be collected by GC")
 
 	// The fresh marker (stamped now) is newer than the cutoff and must survive.
-	hasMarkers, err = leaderRepl.HasTxnRollbackMarkersBefore(now.Add(time.Minute).UnixMicro())
+	hasMarkers, err = leaderRepl.HasTxnRollbackMarkersBeforeForTest(now.Add(time.Minute).UnixMicro())
 	require.NoError(t, err)
 	require.True(t, hasMarkers, "fresh marker should be retained")
 }

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -1904,6 +1904,73 @@ func TestCleanupExpiredSessions(t *testing.T) {
 
 }
 
+// writeRollbackMarker writes a participant-local rollback marker on rangeID by
+// proposing a replicated ROLLBACK finalize (the no-prepared-batch path), so the
+// marker lands on every replica with finalizedAtUsec as its retention timestamp.
+func writeRollbackMarker(t *testing.T, ctx context.Context, clock clockwork.Clock, ts *testutil.TestingStore, rangeID uint64, txid []byte, finalizedAtUsec int64) {
+	batch, err := rbuilder.NewBatchBuilder().
+		SetTransactionID(txid).
+		SetFinalizeOperation(rfpb.FinalizeOperation_ROLLBACK).
+		ToProto()
+	require.NoError(t, err)
+	batch.TxnFinalizedAtUsec = finalizedAtUsec
+
+	session := client.NewSessionWithClock(clock)
+	rsp, err := session.SyncProposeLocal(ctx, ts.NodeHost(), rangeID, batch)
+	require.NoError(t, err)
+	require.NoError(t, rbuilder.NewBatchResponseFromProto(rsp).AnyError())
+}
+
+// TestTxnRollbackMarkerStartupGC exercises the store-level GC sweep
+// (gcOnce/gcReplica + the leader-only precheck), which the replica-level tests do
+// not cover. It writes an expired and a fresh marker, runs one sweep, and asserts
+// the expired marker is collected while the fresh one is retained.
+func TestTxnRollbackMarkerStartupGC(t *testing.T) {
+	flags.Set(t, "cache.raft.enable_driver", false)
+	flags.Set(t, "cache.raft.target_range_size_bytes", 0)
+	flags.Set(t, "cache.raft.enable_txn_cleanup", false)
+	flags.Set(t, "cache.raft.zombie_node_scan_interval", 0)
+	// Disable the automatic startup sweep so this test owns the only GC call and
+	// stays deterministic.
+	flags.Set(t, "cache.raft.txn_rollback_marker_retention", 0)
+	clock := clockwork.NewFakeClock()
+
+	sf := testutil.NewStoreFactoryWithClock(t, clock)
+	s1 := sf.NewStore(t, testutil.StoreOptions{})
+	s2 := sf.NewStore(t, testutil.StoreOptions{})
+	s3 := sf.NewStore(t, testutil.StoreOptions{})
+	ctx := context.Background()
+
+	stores := []*testutil.TestingStore{s1, s2, s3}
+	sf.StartShard(t, ctx, stores...)
+
+	leader := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
+	now := clock.Now()
+	oldTxid := []byte("old-tx")
+	newTxid := []byte("new-tx")
+	writeRollbackMarker(t, ctx, clock, leader, 2, oldTxid, now.Add(-4*24*time.Hour).UnixMicro())
+	writeRollbackMarker(t, ctx, clock, leader, 2, newTxid, now.UnixMicro())
+
+	cutoffUsec := now.Add(-3 * 24 * time.Hour).UnixMicro()
+
+	leaderRepl, err := leader.GetReplica(2)
+	require.NoError(t, err)
+	hasMarkers, err := leaderRepl.HasTxnRollbackMarkersBefore(cutoffUsec)
+	require.NoError(t, err)
+	require.True(t, hasMarkers, "expired marker should be present before GC")
+
+	require.NoError(t, leader.GCTxnRollbackMarkersOnceForTest(ctx, cutoffUsec))
+
+	hasMarkers, err = leaderRepl.HasTxnRollbackMarkersBefore(cutoffUsec)
+	require.NoError(t, err)
+	require.False(t, hasMarkers, "expired marker should be collected by GC")
+
+	// The fresh marker (stamped now) is newer than the cutoff and must survive.
+	hasMarkers, err = leaderRepl.HasTxnRollbackMarkersBefore(now.Add(time.Minute).UnixMicro())
+	require.NoError(t, err)
+	require.True(t, hasMarkers, "fresh marker should be retained")
+}
+
 func TestSplitAcrossClusters(t *testing.T) {
 	flags.Set(t, "cache.raft.target_range_size_bytes", 0) // disable auto splitting
 	sf := testutil.NewStoreFactory(t)

--- a/enterprise/server/raft/txn/txn.go
+++ b/enterprise/server/raft/txn/txn.go
@@ -71,7 +71,7 @@ func (tc *Coordinator) RunTxnWithProto(ctx context.Context, txnProto *rfpb.TxnRe
 	txnRecord := &rfpb.TxnRecord{
 		TxnRequest:    txnProto,
 		TxnState:      rfpb.TxnRecord_PENDING,
-		CreatedAtUsec: time.Now().UnixMicro(),
+		CreatedAtUsec: tc.clock.Now().UnixMicro(),
 	}
 
 	pendingBytes, err := tc.writeTxnRecord(ctx, txnRecord)
@@ -108,33 +108,49 @@ func (tc *Coordinator) RunTxnWithProto(ctx context.Context, txnProto *rfpb.TxnRe
 		operation = rfpb.FinalizeOperation_COMMIT
 	}
 
+	// Record our decision by CASing the txn record from PENDING to PREPARED.
+	// pendingBytes is the exact value we wrote above, so the CAS only succeeds if
+	// nothing has touched the record since. This is the single linearization
+	// point that decides the txn's outcome; the coordinator's background recovery
+	// routine (recoverTxnRecords) races us for the same record, and exactly one of
+	// us wins.
 	txnRecord.Op = operation
 	txnRecord.TxnState = rfpb.TxnRecord_PREPARED
 	matched, currentRecord, err := tc.casTxnRecord(ctx, pendingBytes, txnRecord)
 	if err != nil {
 		return status.WrapErrorf(err, "failed to write txn decision (txid=%q)", txnID)
 	}
-	if !matched {
-		if currentRecord == nil {
-			return status.FailedPreconditionErrorf("txn record was deleted before decision (txid=%q)", txnID)
-		}
-		if err := tc.finalizeTxnRecord(ctx, currentRecord); err != nil {
+
+	if matched {
+		// We won the decision. Finalize our own record across all participants,
+		// then surface any prepare error to the caller (prepareError is nil on a
+		// successful COMMIT, so this returns nil in the happy path).
+		if err := tc.finalizeTxnRecord(ctx, txnRecord); err != nil {
 			return err
 		}
-		if prepareError != nil {
-			return prepareError
-		}
-		if currentRecord.GetOp() != operation {
-			return status.FailedPreconditionErrorf("txn decision already written (txid=%q, op=%s)", txnID, currentRecord.GetOp())
-		}
-		return nil
+		return prepareError
 	}
 
-	if err := tc.finalizeTxnRecord(ctx, txnRecord); err != nil {
+	// We lost the CAS: another actor (the background recovery routine, or a peer
+	// coordinator retrying the same txn) already wrote the decision. A nil
+	// currentRecord means the record was finalized and deleted out from under us.
+	if currentRecord == nil {
+		return status.FailedPreconditionErrorf("txn record was deleted before decision (txid=%q)", txnID)
+	}
+	// Help drive the winner's decision to completion (finalize is idempotent),
+	// then report.
+	if err := tc.finalizeTxnRecord(ctx, currentRecord); err != nil {
 		return err
 	}
+	// Check prepareError before the op mismatch: a prepare failure means our
+	// intended outcome was ROLLBACK and the caller must learn the txn did not
+	// commit, regardless of who won the CAS; an op mismatch only matters when our
+	// own prepare actually succeeded.
 	if prepareError != nil {
 		return prepareError
+	}
+	if currentRecord.GetOp() != operation {
+		return status.FailedPreconditionErrorf("txn decision already written (txid=%q, op=%s)", txnID, currentRecord.GetOp())
 	}
 	return nil
 }
@@ -191,6 +207,10 @@ func (tc *Coordinator) deleteTxnRecord(ctx context.Context, txnID []byte) error 
 	return rbuilder.NewBatchResponseFromProto(rsp).AnyError()
 }
 
+// writeTxnRecord persists txnRecord (in the PENDING state) and returns the exact
+// marshaled bytes it wrote. The caller passes those bytes back to casTxnRecord as
+// the CAS expected-value, so the PENDING->PREPARED decision only lands if the
+// record is untouched in between — this is the txn's linearization anchor.
 func (tc *Coordinator) writeTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord) ([]byte, error) {
 	key := keys.MakeKey(constants.TxnRecordPrefix, txnRecord.GetTxnRequest().GetTransactionId())
 	buf, err := proto.Marshal(txnRecord)
@@ -221,6 +241,14 @@ func (tc *Coordinator) WriteTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRe
 	return err
 }
 
+// casTxnRecord atomically swaps the txn record from expectedValue to txnRecord's
+// marshaled form. The return tuple (matched, current, err) encodes the outcome:
+//   - (true, nil, nil):     the CAS succeeded.
+//   - (false, current, nil): the CAS failed; current is the record now on disk
+//     (the value the caller should help finalize).
+//   - (false, nil, nil):    the CAS failed and the record is absent/empty (it was
+//     already finalized and deleted).
+//   - (false, nil, err):    an RPC or unmarshal error occurred.
 func (tc *Coordinator) casTxnRecord(ctx context.Context, expectedValue []byte, txnRecord *rfpb.TxnRecord) (bool, *rfpb.TxnRecord, error) {
 	key := keys.MakeKey(constants.TxnRecordPrefix, txnRecord.GetTxnRequest().GetTransactionId())
 	buf, err := proto.Marshal(txnRecord)
@@ -327,12 +355,12 @@ func (tj *Coordinator) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-tj.clock.After(txnCleanupPeriod):
-			tj.processTxnRecords(ctx)
+			tj.recoverTxnRecords(ctx)
 		}
 	}
 }
 
-func (tc *Coordinator) processTxnRecords(ctx context.Context) {
+func (tc *Coordinator) recoverTxnRecords(ctx context.Context) {
 	if !tc.store.HasReplicaAndIsLeader(constants.MetaRangeID) {
 		return
 	}
@@ -344,8 +372,8 @@ func (tc *Coordinator) processTxnRecords(ctx context.Context) {
 	errCount := 0
 	for _, txnRecord := range txnRecords {
 		txnID := txnRecord.record.GetTxnRequest().GetTransactionId()
-		if err := tc.processTxnRecord(ctx, txnRecord.record, txnRecord.raw); err != nil {
-			log.Warningf("Failed to processTxnRecord for txn (%q): %s, statements: %+v", txnID, err, txnRecord.record.GetTxnRequest().GetStatements())
+		if err := tc.recoverTxnRecord(ctx, txnRecord.record, txnRecord.raw); err != nil {
+			log.Warningf("Failed to recoverTxnRecord for txn (%q): %s, statements: %+v", txnID, err, txnRecord.record.GetTxnRequest().GetStatements())
 			errCount++
 		} else {
 			log.Debugf("Successfully processed txn record %q", txnID)
@@ -445,9 +473,14 @@ func (tc *Coordinator) finalizeTxnRecord(ctx context.Context, txnRecord *rfpb.Tx
 	return tc.deleteTxnRecord(ctx, txnID)
 }
 
-func (tc *Coordinator) processTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord, raw []byte) error {
+// recoverTxnRecord drives a single scanned txn record to completion. A record
+// still PENDING means no coordinator recorded a decision, so the recovery routine
+// CASes it to PREPARED{ROLLBACK} — fencing any coordinator still racing it —
+// and rolls it back; a record already PREPARED is finalized directly. raw is the
+// record's exact on-disk value, used as the CAS expected-value.
+func (tc *Coordinator) recoverTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord, raw []byte) error {
 	if txnRecord.GetTxnState() == rfpb.TxnRecord_PENDING {
-		rollbackRecord := proto.Clone(txnRecord).(*rfpb.TxnRecord)
+		rollbackRecord := txnRecord.CloneVT()
 		rollbackRecord.TxnState = rfpb.TxnRecord_PREPARED
 		rollbackRecord.Op = rfpb.FinalizeOperation_ROLLBACK
 
@@ -455,13 +488,17 @@ func (tc *Coordinator) processTxnRecord(ctx context.Context, txnRecord *rfpb.Txn
 		if err != nil {
 			return status.WrapError(err, "failed to write rollback decision")
 		}
-		if !matched {
-			if currentRecord == nil {
-				return nil
-			}
-			return tc.finalizeTxnRecord(ctx, currentRecord)
+		if matched {
+			// We won the decision; roll the txn back.
+			return tc.finalizeTxnRecord(ctx, rollbackRecord)
 		}
-		return tc.finalizeTxnRecord(ctx, rollbackRecord)
+		// We lost the CAS: a coordinator recorded the decision first. A nil
+		// currentRecord means it already finalized and deleted the record, so
+		// there is nothing left to do; otherwise help finalize its decision.
+		if currentRecord == nil {
+			return nil
+		}
+		return tc.finalizeTxnRecord(ctx, currentRecord)
 	}
 	if txnRecord.GetTxnState() == rfpb.TxnRecord_PREPARED {
 		return tc.finalizeTxnRecord(ctx, txnRecord)
@@ -469,14 +506,14 @@ func (tc *Coordinator) processTxnRecord(ctx context.Context, txnRecord *rfpb.Txn
 	return status.InvalidArgumentErrorf("unexpected txnRecord.state %s", txnRecord.GetTxnState())
 }
 
-// ProcessTxnRecordForTest fences the decision CAS on the marshaled bytes of the
-// passed record (the production janitor, processTxnRecords, uses the raw scanned
-// bytes). This lets a test drive a specific, possibly stale janitor view — e.g.
-// processing a PENDING snapshot of a record that is already PREPARED on disk.
-func (tc *Coordinator) ProcessTxnRecordForTest(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
+// RecoverTxnRecordForTest fences the decision CAS on the marshaled bytes of the
+// passed record (the production recovery routine, recoverTxnRecords, uses the raw
+// scanned bytes). This lets a test drive a specific, possibly stale recovery view
+// — e.g. processing a PENDING snapshot of a record that is already PREPARED.
+func (tc *Coordinator) RecoverTxnRecordForTest(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
 	raw, err := proto.Marshal(txnRecord)
 	if err != nil {
 		return err
 	}
-	return tc.processTxnRecord(ctx, txnRecord, raw)
+	return tc.recoverTxnRecord(ctx, txnRecord, raw)
 }

--- a/enterprise/server/raft/txn/txn.go
+++ b/enterprise/server/raft/txn/txn.go
@@ -109,11 +109,9 @@ func (tc *Coordinator) RunTxnWithProto(ctx context.Context, txnProto *rfpb.TxnRe
 	}
 
 	// Record our decision by CASing the txn record from PENDING to PREPARED.
-	// pendingBytes is the exact value we wrote above, so the CAS only succeeds if
-	// nothing has touched the record since. This is the single linearization
-	// point that decides the txn's outcome; the coordinator's background recovery
-	// routine (recoverTxnRecords) races us for the same record, and exactly one of
-	// us wins.
+	// pendingBytes is the exact value written above, so the CAS lands only if the
+	// record is untouched. This is the single linearization point for the txn's
+	// outcome: recoverTxnRecords races us for the same record and exactly one wins.
 	txnRecord.Op = operation
 	txnRecord.TxnState = rfpb.TxnRecord_PREPARED
 	matched, currentRecord, err := tc.casTxnRecord(ctx, pendingBytes, txnRecord)
@@ -122,18 +120,17 @@ func (tc *Coordinator) RunTxnWithProto(ctx context.Context, txnProto *rfpb.TxnRe
 	}
 
 	if matched {
-		// We won the decision. Finalize our own record across all participants,
-		// then surface any prepare error to the caller (prepareError is nil on a
-		// successful COMMIT, so this returns nil in the happy path).
+		// We won the decision. Finalize our record, then surface any prepare error
+		// (nil on a successful COMMIT, so the happy path returns nil).
 		if err := tc.finalizeTxnRecord(ctx, txnRecord); err != nil {
 			return err
 		}
 		return prepareError
 	}
 
-	// We lost the CAS: another actor (the background recovery routine, or a peer
-	// coordinator retrying the same txn) already wrote the decision. A nil
-	// currentRecord means the record was finalized and deleted out from under us.
+	// We lost the CAS: another actor (recoverTxnRecords or a peer coordinator)
+	// already wrote the decision. A nil currentRecord means it was finalized and
+	// deleted out from under us.
 	if currentRecord == nil {
 		return status.FailedPreconditionErrorf("txn record was deleted before decision (txid=%q)", txnID)
 	}
@@ -143,9 +140,9 @@ func (tc *Coordinator) RunTxnWithProto(ctx context.Context, txnProto *rfpb.TxnRe
 		return err
 	}
 	// Check prepareError before the op mismatch: a prepare failure means our
-	// intended outcome was ROLLBACK and the caller must learn the txn did not
-	// commit, regardless of who won the CAS; an op mismatch only matters when our
-	// own prepare actually succeeded.
+	// intended outcome was ROLLBACK, so the caller must learn the txn did not
+	// commit regardless of who won; an op mismatch only matters if our prepare
+	// succeeded.
 	if prepareError != nil {
 		return prepareError
 	}

--- a/enterprise/server/raft/txn/txn.go
+++ b/enterprise/server/raft/txn/txn.go
@@ -74,7 +74,8 @@ func (tc *Coordinator) RunTxnWithProto(ctx context.Context, txnProto *rfpb.TxnRe
 		CreatedAtUsec: time.Now().UnixMicro(),
 	}
 
-	if err := tc.WriteTxnRecord(ctx, txnRecord); err != nil {
+	pendingBytes, err := tc.writeTxnRecord(ctx, txnRecord)
+	if err != nil {
 		return err
 	}
 
@@ -109,23 +110,28 @@ func (tc *Coordinator) RunTxnWithProto(ctx context.Context, txnProto *rfpb.TxnRe
 
 	txnRecord.Op = operation
 	txnRecord.TxnState = rfpb.TxnRecord_PREPARED
-	if err := tc.WriteTxnRecord(ctx, txnRecord); err != nil {
-		return status.WrapErrorf(err, "failed to write txn record (txid=%q)", txnID)
+	matched, currentRecord, err := tc.casTxnRecord(ctx, pendingBytes, txnRecord)
+	if err != nil {
+		return status.WrapErrorf(err, "failed to write txn decision (txid=%q)", txnID)
 	}
-
-	for _, stmt := range txnProto.GetStatements() {
-		// Finalize each statement.
-		if err := tc.finalizeTxn(ctx, txnID, operation, stmt); err != nil {
-			if isTxnNotFoundError(err) && operation == rfpb.FinalizeOperation_ROLLBACK {
-				// if there is error during preparation for this range, then txn not found is expected during rollback.
-				continue
-			}
-			return status.WrapErrorf(err, "failed to finalize statement in txn(%q) for range_id:%d, operation: %s", txnID, stmt.GetRange().GetRangeId(), operation)
+	if !matched {
+		if currentRecord == nil {
+			return status.FailedPreconditionErrorf("txn record was deleted before decision (txid=%q)", txnID)
 		}
+		if err := tc.finalizeTxnRecord(ctx, currentRecord); err != nil {
+			return err
+		}
+		if prepareError != nil {
+			return prepareError
+		}
+		if currentRecord.GetOp() != operation {
+			return status.FailedPreconditionErrorf("txn decision already written (txid=%q, op=%s)", txnID, currentRecord.GetOp())
+		}
+		return nil
 	}
 
-	if err := tc.deleteTxnRecord(ctx, txnID); err != nil {
-		return status.WrapErrorf(err, "failed to delete txn record (txid=%q)", txnID)
+	if err := tc.finalizeTxnRecord(ctx, txnRecord); err != nil {
+		return err
 	}
 	if prepareError != nil {
 		return prepareError
@@ -185,11 +191,11 @@ func (tc *Coordinator) deleteTxnRecord(ctx context.Context, txnID []byte) error 
 	return rbuilder.NewBatchResponseFromProto(rsp).AnyError()
 }
 
-func (tc *Coordinator) WriteTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
+func (tc *Coordinator) writeTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord) ([]byte, error) {
 	key := keys.MakeKey(constants.TxnRecordPrefix, txnRecord.GetTxnRequest().GetTransactionId())
 	buf, err := proto.Marshal(txnRecord)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	batch, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{
@@ -198,13 +204,59 @@ func (tc *Coordinator) WriteTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRe
 		},
 	}).ToProto()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	rsp, err := tc.sender().SyncPropose(ctx, key, batch)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return rbuilder.NewBatchResponseFromProto(rsp).AnyError()
+	if err := rbuilder.NewBatchResponseFromProto(rsp).AnyError(); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (tc *Coordinator) WriteTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
+	_, err := tc.writeTxnRecord(ctx, txnRecord)
+	return err
+}
+
+func (tc *Coordinator) casTxnRecord(ctx context.Context, expectedValue []byte, txnRecord *rfpb.TxnRecord) (bool, *rfpb.TxnRecord, error) {
+	key := keys.MakeKey(constants.TxnRecordPrefix, txnRecord.GetTxnRequest().GetTransactionId())
+	buf, err := proto.Marshal(txnRecord)
+	if err != nil {
+		return false, nil, err
+	}
+	batch, err := rbuilder.NewBatchBuilder().Add(&rfpb.CASRequest{
+		Kv: &rfpb.KV{
+			Key:   key,
+			Value: buf,
+		},
+		ExpectedValue: expectedValue,
+	}).ToProto()
+	if err != nil {
+		return false, nil, err
+	}
+	rsp, err := tc.sender().SyncPropose(ctx, key, batch)
+	if err != nil {
+		return false, nil, err
+	}
+	casRsp, err := rbuilder.NewBatchResponseFromProto(rsp).CASResponse(0)
+	if err == nil {
+		return true, nil, nil
+	}
+	if !status.IsFailedPreconditionError(err) || casRsp == nil {
+		return false, nil, err
+	}
+	kv := casRsp.GetKv()
+	if len(kv.GetValue()) == 0 {
+		return false, nil, nil
+	}
+	currentRecord := &rfpb.TxnRecord{}
+	if unmarshalErr := proto.Unmarshal(kv.GetValue(), currentRecord); unmarshalErr != nil {
+		return false, nil, unmarshalErr
+	}
+	return false, currentRecord, nil
 }
 
 func isConflictKeyError(err error) bool {
@@ -280,16 +332,16 @@ func (tc *Coordinator) processTxnRecords(ctx context.Context) {
 	if !tc.store.HasReplicaAndIsLeader(constants.MetaRangeID) {
 		return
 	}
-	txnRecords, err := tc.FetchTxnRecords(ctx, false /*=includeLive*/)
+	txnRecords, err := tc.fetchTxnRecords(ctx, false /*=includeLive*/)
 	if err != nil {
 		log.Warningf("Failed to fetch txn records: %s", err)
 	}
 
 	errCount := 0
 	for _, txnRecord := range txnRecords {
-		txnID := txnRecord.GetTxnRequest().GetTransactionId()
-		if err := tc.ProcessTxnRecord(ctx, txnRecord); err != nil {
-			log.Warningf("Failed to processTxnRecord for txn (%q): %s, statements: %+v", txnID, err, txnRecord.GetTxnRequest().GetStatements())
+		txnID := txnRecord.record.GetTxnRequest().GetTransactionId()
+		if err := tc.processTxnRecord(ctx, txnRecord.record, txnRecord.raw); err != nil {
+			log.Warningf("Failed to processTxnRecord for txn (%q): %s, statements: %+v", txnID, err, txnRecord.record.GetTxnRequest().GetStatements())
 			errCount++
 		} else {
 			log.Debugf("Successfully processed txn record %q", txnID)
@@ -306,7 +358,12 @@ func (tc *Coordinator) processTxnRecords(ctx context.Context) {
 	}
 }
 
-func (tc *Coordinator) FetchTxnRecords(ctx context.Context, includeLive bool) ([]*rfpb.TxnRecord, error) {
+type fetchedTxnRecord struct {
+	record *rfpb.TxnRecord
+	raw    []byte
+}
+
+func (tc *Coordinator) fetchTxnRecords(ctx context.Context, includeLive bool) ([]*fetchedTxnRecord, error) {
 	start, end := keys.Range(constants.TxnRecordPrefix)
 
 	batchReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.ScanRequest{
@@ -333,7 +390,7 @@ func (tc *Coordinator) FetchTxnRecords(ctx context.Context, includeLive bool) ([
 	if len(scanRsp.GetKvs()) == 0 {
 		return nil, nil
 	}
-	txnRecords := make([]*rfpb.TxnRecord, 0, len(scanRsp.GetKvs()))
+	txnRecords := make([]*fetchedTxnRecord, 0, len(scanRsp.GetKvs()))
 	for _, kv := range scanRsp.GetKvs() {
 		txnRecord := &rfpb.TxnRecord{}
 		if err := proto.Unmarshal(kv.GetValue(), txnRecord); err != nil {
@@ -345,7 +402,22 @@ func (tc *Coordinator) FetchTxnRecords(ctx context.Context, includeLive bool) ([
 			// This txn record is created very recently; skip processing
 			continue
 		}
-		txnRecords = append(txnRecords, txnRecord)
+		txnRecords = append(txnRecords, &fetchedTxnRecord{
+			record: txnRecord,
+			raw:    kv.GetValue(),
+		})
+	}
+	return txnRecords, nil
+}
+
+func (tc *Coordinator) FetchTxnRecords(ctx context.Context, includeLive bool) ([]*rfpb.TxnRecord, error) {
+	fetched, err := tc.fetchTxnRecords(ctx, includeLive)
+	if err != nil {
+		return nil, err
+	}
+	txnRecords := make([]*rfpb.TxnRecord, 0, len(fetched))
+	for _, txnRecord := range fetched {
+		txnRecords = append(txnRecords, txnRecord.record)
 	}
 	return txnRecords, nil
 }
@@ -354,31 +426,49 @@ func isTxnNotFoundError(err error) bool {
 	return status.IsNotFoundError(err) && strings.Contains(err.Error(), constants.TxnNotFoundMessage)
 }
 
-func (tc *Coordinator) ProcessTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
+func (tc *Coordinator) finalizeTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
 	txnID := txnRecord.GetTxnRequest().GetTransactionId()
-	if txnRecord.GetTxnState() == rfpb.TxnRecord_PENDING {
-		// The transaction is not fully prepared. Let's rollback all the statements.
-		for _, statement := range txnRecord.GetTxnRequest().GetStatements() {
-			err := tc.finalizeTxn(ctx, txnID, rfpb.FinalizeOperation_ROLLBACK, statement)
-			if err != nil && !isTxnNotFoundError(err) {
-				// if the statement is not prepared, we will get NotFound Error when we rollback and this is fine.
-				return status.WrapErrorf(err, "failed to rollback pending statement on range %d", statement.GetRange().GetRangeId())
-			}
-		}
-	} else if txnRecord.GetTxnState() == rfpb.TxnRecord_PREPARED {
-		// The transaction is prepared, but not fully finalized. Let's finalize
-		// all the prepared statements.
-		if txnRecord.GetOp() == rfpb.FinalizeOperation_UNKNOWN_OPERATION {
-			return status.InvalidArgumentError("unexpected txnRecord.op")
-		}
+	if txnRecord.GetOp() == rfpb.FinalizeOperation_UNKNOWN_OPERATION {
+		return status.InvalidArgumentError("unexpected txnRecord.op")
+	}
 
-		for _, stmt := range txnRecord.GetTxnRequest().GetStatements() {
-			err := tc.finalizeTxn(ctx, txnID, txnRecord.GetOp(), stmt)
-			if err != nil && !isTxnNotFoundError(err) {
-				// if the statement is already finalized, we will get NotFound Error when we finalize and this is fine.
-				return status.WrapErrorf(err, "failed to finalize prepared statement on range %d, operation=%s", stmt.GetRange().GetRangeId(), txnRecord.GetOp())
-			}
+	for _, stmt := range txnRecord.GetTxnRequest().GetStatements() {
+		err := tc.finalizeTxn(ctx, txnID, txnRecord.GetOp(), stmt)
+		if err != nil && !isTxnNotFoundError(err) {
+			return status.WrapErrorf(err, "failed to finalize statement on range %d, operation=%s", stmt.GetRange().GetRangeId(), txnRecord.GetOp())
 		}
 	}
 	return tc.deleteTxnRecord(ctx, txnID)
+}
+
+func (tc *Coordinator) processTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord, raw []byte) error {
+	if txnRecord.GetTxnState() == rfpb.TxnRecord_PENDING {
+		rollbackRecord := proto.Clone(txnRecord).(*rfpb.TxnRecord)
+		rollbackRecord.TxnState = rfpb.TxnRecord_PREPARED
+		rollbackRecord.Op = rfpb.FinalizeOperation_ROLLBACK
+
+		matched, currentRecord, err := tc.casTxnRecord(ctx, raw, rollbackRecord)
+		if err != nil {
+			return status.WrapError(err, "failed to write rollback decision")
+		}
+		if !matched {
+			if currentRecord == nil {
+				return nil
+			}
+			return tc.finalizeTxnRecord(ctx, currentRecord)
+		}
+		return tc.finalizeTxnRecord(ctx, rollbackRecord)
+	}
+	if txnRecord.GetTxnState() == rfpb.TxnRecord_PREPARED {
+		return tc.finalizeTxnRecord(ctx, txnRecord)
+	}
+	return status.InvalidArgumentErrorf("unexpected txnRecord.state %s", txnRecord.GetTxnState())
+}
+
+func (tc *Coordinator) ProcessTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
+	raw, err := proto.Marshal(txnRecord)
+	if err != nil {
+		return err
+	}
+	return tc.processTxnRecord(ctx, txnRecord, raw)
 }

--- a/enterprise/server/raft/txn/txn.go
+++ b/enterprise/server/raft/txn/txn.go
@@ -302,6 +302,10 @@ func (tc *Coordinator) finalizeTxn(ctx context.Context, txnID []byte, op rfpb.Fi
 		return err
 	}
 	batchProto.Session = tc.txnRequestSession(txnID, "finalize/"+op.String())
+	// Proposer-stamped finalize time. On ROLLBACK the replica records this as the
+	// rollback marker's retention timestamp; kept separate from the session so
+	// marker GC does not depend on session lifetime semantics.
+	batchProto.TxnFinalizedAtUsec = tc.clock.Now().UnixMicro()
 
 	if op == rfpb.FinalizeOperation_COMMIT {
 		for _, hook := range stmt.GetHooks() {
@@ -465,7 +469,11 @@ func (tc *Coordinator) processTxnRecord(ctx context.Context, txnRecord *rfpb.Txn
 	return status.InvalidArgumentErrorf("unexpected txnRecord.state %s", txnRecord.GetTxnState())
 }
 
-func (tc *Coordinator) ProcessTxnRecord(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
+// ProcessTxnRecordForTest fences the decision CAS on the marshaled bytes of the
+// passed record (the production janitor, processTxnRecords, uses the raw scanned
+// bytes). This lets a test drive a specific, possibly stale janitor view — e.g.
+// processing a PENDING snapshot of a record that is already PREPARED on disk.
+func (tc *Coordinator) ProcessTxnRecordForTest(ctx context.Context, txnRecord *rfpb.TxnRecord) error {
 	raw, err := proto.Marshal(txnRecord)
 	if err != nil {
 		return err

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -766,3 +766,143 @@ func TestRecoverRollbackTxnRetryMatrix(t *testing.T) {
 		})
 	}
 }
+
+func TestStalePendingJanitorHelpsCommit(t *testing.T) {
+	sf := testutil.NewStoreFactory(t)
+	s1 := sf.NewStore(t, testutil.StoreOptions{})
+	s2 := sf.NewStore(t, testutil.StoreOptions{})
+	s3 := sf.NewStore(t, testutil.StoreOptions{})
+	stores := []*testutil.TestingStore{s1, s2, s3}
+	ctx := context.Background()
+	sf.StartShard(t, ctx, stores...)
+
+	userKey := []byte("PTdefault/f11")
+	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   userKey,
+			Value: []byte("before"),
+		},
+	}).ToProto()
+	require.NoError(t, err)
+	writeRsp, err := s1.Sender().SyncPropose(ctx, userKey, writeReq)
+	require.NoError(t, err)
+	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+
+	metaKey := keys.MakeKey(constants.SystemPrefix, []byte("stale-pending-commit"))
+	metaStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
+	metaRD := metaStore.GetRange(1)
+	dataStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
+	dataRD := dataStore.GetRange(2)
+
+	dataBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   userKey,
+			Value: []byte("after"),
+		},
+	})
+	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   metaKey,
+			Value: []byte("committed"),
+		},
+	})
+
+	tb := rbuilder.NewTxn()
+	tb.AddStatement().SetRangeDescriptor(dataRD).SetBatch(dataBatch)
+	tb.AddStatement().SetRangeDescriptor(metaRD).SetBatch(metaBatch)
+	txnProto, err := tb.ToProto()
+	require.NoError(t, err)
+
+	clock := clockwork.NewFakeClock()
+	tc := txn.NewCoordinator(s1, s1.APIClient(), clock)
+	for _, stmt := range txnProto.GetStatements() {
+		require.NoError(t, tc.PrepareStatement(ctx, txnProto.GetTransactionId(), stmt))
+	}
+
+	stalePendingRecord := &rfpb.TxnRecord{
+		TxnRequest:    txnProto,
+		TxnState:      rfpb.TxnRecord_PENDING,
+		CreatedAtUsec: clock.Now().UnixMicro(),
+	}
+	require.NoError(t, tc.WriteTxnRecord(ctx, stalePendingRecord))
+
+	commitRecord := proto.Clone(stalePendingRecord).(*rfpb.TxnRecord)
+	commitRecord.TxnState = rfpb.TxnRecord_PREPARED
+	commitRecord.Op = rfpb.FinalizeOperation_COMMIT
+	require.NoError(t, tc.WriteTxnRecord(ctx, commitRecord))
+
+	require.NoError(t, tc.ProcessTxnRecord(ctx, stalePendingRecord))
+
+	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
+	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("after"))
+	verifyDirectReadValue(t, ctx, s1.Sender(), metaKey, []byte("committed"))
+}
+
+func TestRollbackNotFoundPreventsLatePrepare(t *testing.T) {
+	sf := testutil.NewStoreFactory(t)
+	s1 := sf.NewStore(t, testutil.StoreOptions{})
+	s2 := sf.NewStore(t, testutil.StoreOptions{})
+	s3 := sf.NewStore(t, testutil.StoreOptions{})
+	stores := []*testutil.TestingStore{s1, s2, s3}
+	ctx := context.Background()
+	sf.StartShard(t, ctx, stores...)
+
+	userKey := []byte("PTdefault/f11")
+	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   userKey,
+			Value: []byte("before"),
+		},
+	}).ToProto()
+	require.NoError(t, err)
+	writeRsp, err := s1.Sender().SyncPropose(ctx, userKey, writeReq)
+	require.NoError(t, err)
+	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+
+	metaKey := keys.MakeKey(constants.SystemPrefix, []byte("rollback-marker-late-prepare"))
+	metaStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
+	metaRD := metaStore.GetRange(1)
+	dataStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
+	dataRD := dataStore.GetRange(2)
+
+	dataBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   userKey,
+			Value: []byte("after"),
+		},
+	})
+	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   metaKey,
+			Value: []byte("late-prepare"),
+		},
+	})
+
+	tb := rbuilder.NewTxn()
+	tb.AddStatement().SetRangeDescriptor(dataRD).SetBatch(dataBatch)
+	tb.AddStatement().SetRangeDescriptor(metaRD).SetBatch(metaBatch)
+	txnProto, err := tb.ToProto()
+	require.NoError(t, err)
+
+	clock := clockwork.NewFakeClock()
+	coordinator := txn.NewCoordinator(s1, s1.APIClient(), clock)
+	require.NoError(t, coordinator.PrepareStatement(ctx, txnProto.GetTransactionId(), txnProto.GetStatements()[0]))
+
+	txnRecord := &rfpb.TxnRecord{
+		TxnRequest:    txnProto,
+		TxnState:      rfpb.TxnRecord_PENDING,
+		CreatedAtUsec: clock.Now().UnixMicro(),
+	}
+	require.NoError(t, coordinator.WriteTxnRecord(ctx, txnRecord))
+
+	require.NoError(t, coordinator.ProcessTxnRecord(ctx, txnRecord))
+	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
+	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("before"))
+	verifyDirectReadNotFound(t, ctx, s1.Sender(), metaKey)
+
+	// B is a normal write that would prepare successfully if rollback had not
+	// written a participant-local marker for this txid.
+	err = coordinator.PrepareStatement(ctx, txnProto.GetTransactionId(), txnProto.GetStatements()[1])
+	require.Error(t, err)
+	verifyDirectReadNotFound(t, ctx, s1.Sender(), metaKey)
+}

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -89,7 +89,7 @@ func TestCommitPreparedTxn(t *testing.T) {
 		require.NoError(t, readBatch.AnyError())
 	}
 
-	err = tc.ProcessTxnRecord(ctx, txnRecord)
+	err = tc.ProcessTxnRecordForTest(ctx, txnRecord)
 	require.NoError(t, err)
 
 	{ // Do a DirectRead and verify the txn record doesn't exist
@@ -175,7 +175,7 @@ func TestRecoverTxnToUpdateRangeDescriptor(t *testing.T) {
 	require.NoError(t, err)
 
 	// Tries to finalize the txn again.
-	err = tc.ProcessTxnRecord(ctx, txnRecord)
+	err = tc.ProcessTxnRecordForTest(ctx, txnRecord)
 	require.NoError(t, err)
 
 	verifyTxnRecordNotExist(t, ctx, store.Sender(), txnProto.GetTransactionId())
@@ -724,7 +724,7 @@ func TestRecoverSplitTxnRetryMatrix(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, repl.CommitTransaction(txnProto.GetTransactionId()))
 
-			require.NoError(t, coordinator.ProcessTxnRecord(ctx, txnRecord))
+			require.NoError(t, coordinator.ProcessTxnRecordForTest(ctx, txnRecord))
 
 			verifyTxnRecordNotExist(t, ctx, store.Sender(), txnProto.GetTransactionId())
 			verifyRangeDescriptorInMetaRangeEquals(t, ctx, store.Sender(), updatedLeftRange)
@@ -757,7 +757,7 @@ func TestRecoverRollbackTxnRetryMatrix(t *testing.T) {
 			})
 			ctx, store, coordinator, txnProto, txnRecord, userKey, metaKey := setupPendingRollbackTxnForRecovery(t, harness)
 
-			require.NoError(t, coordinator.ProcessTxnRecord(ctx, txnRecord))
+			require.NoError(t, coordinator.ProcessTxnRecordForTest(ctx, txnRecord))
 
 			verifyTxnRecordNotExist(t, ctx, store.Sender(), txnProto.GetTransactionId())
 			verifyDirectReadValue(t, ctx, store.Sender(), userKey, []byte("before"))
@@ -831,7 +831,7 @@ func TestStalePendingJanitorHelpsCommit(t *testing.T) {
 	commitRecord.Op = rfpb.FinalizeOperation_COMMIT
 	require.NoError(t, tc.WriteTxnRecord(ctx, commitRecord))
 
-	require.NoError(t, tc.ProcessTxnRecord(ctx, stalePendingRecord))
+	require.NoError(t, tc.ProcessTxnRecordForTest(ctx, stalePendingRecord))
 
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
 	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("after"))
@@ -895,7 +895,7 @@ func TestRollbackNotFoundPreventsLatePrepare(t *testing.T) {
 	}
 	require.NoError(t, coordinator.WriteTxnRecord(ctx, txnRecord))
 
-	require.NoError(t, coordinator.ProcessTxnRecord(ctx, txnRecord))
+	require.NoError(t, coordinator.ProcessTxnRecordForTest(ctx, txnRecord))
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
 	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("before"))
 	verifyDirectReadNotFound(t, ctx, s1.Sender(), metaKey)
@@ -905,4 +905,82 @@ func TestRollbackNotFoundPreventsLatePrepare(t *testing.T) {
 	err = coordinator.PrepareStatement(ctx, txnProto.GetTransactionId(), txnProto.GetStatements()[1])
 	require.Error(t, err)
 	verifyDirectReadNotFound(t, ctx, s1.Sender(), metaKey)
+}
+
+func TestRollbackMarkerStampedWithFinalizeTime(t *testing.T) {
+	sf := testutil.NewStoreFactory(t)
+	s1 := sf.NewStore(t, testutil.StoreOptions{})
+	s2 := sf.NewStore(t, testutil.StoreOptions{})
+	s3 := sf.NewStore(t, testutil.StoreOptions{})
+	stores := []*testutil.TestingStore{s1, s2, s3}
+	ctx := context.Background()
+	sf.StartShard(t, ctx, stores...)
+
+	userKey := []byte("PTdefault/f11")
+	writeReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{Key: userKey, Value: []byte("before")},
+	}).ToProto()
+	require.NoError(t, err)
+	writeRsp, err := s1.Sender().SyncPropose(ctx, userKey, writeReq)
+	require.NoError(t, err)
+	require.NoError(t, rbuilder.NewBatchResponseFromProto(writeRsp).AnyError())
+
+	dataStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 2)
+	dataRD := dataStore.GetRange(2)
+	metaStore := testutil.GetStoreWithRangeLease(t, ctx, stores, 1)
+	metaRD := metaStore.GetRange(1)
+
+	dataBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{Key: userKey, Value: []byte("after")},
+	})
+	metaKey := keys.MakeKey(constants.SystemPrefix, []byte("rollback-marker-finalize-ts"))
+	metaBatch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{Key: metaKey, Value: []byte("x")},
+	})
+
+	tb := rbuilder.NewTxn()
+	tb.AddStatement().SetRangeDescriptor(dataRD).SetBatch(dataBatch)
+	tb.AddStatement().SetRangeDescriptor(metaRD).SetBatch(metaBatch)
+	txnProto, err := tb.ToProto()
+	require.NoError(t, err)
+
+	clock := clockwork.NewFakeClock()
+	coordinator := txn.NewCoordinator(s1, s1.APIClient(), clock)
+	require.NoError(t, coordinator.PrepareStatement(ctx, txnProto.GetTransactionId(), txnProto.GetStatements()[0]))
+
+	createdAtUsec := clock.Now().UnixMicro()
+	txnRecord := &rfpb.TxnRecord{
+		TxnRequest:    txnProto,
+		TxnState:      rfpb.TxnRecord_PENDING,
+		CreatedAtUsec: createdAtUsec,
+	}
+	require.NoError(t, coordinator.WriteTxnRecord(ctx, txnRecord))
+
+	// Advance the clock so finalize time is distinct from creation time: the
+	// marker must record the finalize time, not the txn creation time.
+	clock.Advance(time.Hour)
+	finalizeAtUsec := clock.Now().UnixMicro()
+
+	// The janitor rolls back the stale PENDING txn, writing a participant-local
+	// rollback marker on each range stamped with the finalize timestamp.
+	require.NoError(t, coordinator.ProcessTxnRecordForTest(ctx, txnRecord))
+	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
+	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("before"))
+
+	repl, err := dataStore.GetReplica(2)
+	require.NoError(t, err)
+
+	// The marker's timestamp is exactly the finalize time: present at a cutoff of
+	// finalizeAt, absent one microsecond earlier. A timestamp of 0 (field not
+	// plumbed) would be skipped by the GC guard and fail the first assertion.
+	has, err := repl.HasTxnRollbackMarkersBefore(finalizeAtUsec)
+	require.NoError(t, err)
+	require.True(t, has)
+	has, err = repl.HasTxnRollbackMarkersBefore(finalizeAtUsec - 1)
+	require.NoError(t, err)
+	require.False(t, has)
+	// In particular it is not stamped with the earlier creation time.
+	has, err = repl.HasTxnRollbackMarkersBefore(createdAtUsec)
+	require.NoError(t, err)
+	require.False(t, has)
 }

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -973,14 +973,14 @@ func TestRollbackMarkerStampedWithFinalizeTime(t *testing.T) {
 	// The marker's timestamp is exactly the finalize time: present at a cutoff of
 	// finalizeAt, absent one microsecond earlier. A timestamp of 0 (field not
 	// plumbed) would be skipped by the GC guard and fail the first assertion.
-	has, err := repl.HasTxnRollbackMarkersBefore(finalizeAtUsec)
+	has, err := repl.HasTxnRollbackMarkersBeforeForTest(finalizeAtUsec)
 	require.NoError(t, err)
 	require.True(t, has)
-	has, err = repl.HasTxnRollbackMarkersBefore(finalizeAtUsec - 1)
+	has, err = repl.HasTxnRollbackMarkersBeforeForTest(finalizeAtUsec - 1)
 	require.NoError(t, err)
 	require.False(t, has)
 	// In particular it is not stamped with the earlier creation time.
-	has, err = repl.HasTxnRollbackMarkersBefore(createdAtUsec)
+	has, err = repl.HasTxnRollbackMarkersBeforeForTest(createdAtUsec)
 	require.NoError(t, err)
 	require.False(t, has)
 }

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -89,7 +89,7 @@ func TestCommitPreparedTxn(t *testing.T) {
 		require.NoError(t, readBatch.AnyError())
 	}
 
-	err = tc.ProcessTxnRecordForTest(ctx, txnRecord)
+	err = tc.RecoverTxnRecordForTest(ctx, txnRecord)
 	require.NoError(t, err)
 
 	{ // Do a DirectRead and verify the txn record doesn't exist
@@ -175,7 +175,7 @@ func TestRecoverTxnToUpdateRangeDescriptor(t *testing.T) {
 	require.NoError(t, err)
 
 	// Tries to finalize the txn again.
-	err = tc.ProcessTxnRecordForTest(ctx, txnRecord)
+	err = tc.RecoverTxnRecordForTest(ctx, txnRecord)
 	require.NoError(t, err)
 
 	verifyTxnRecordNotExist(t, ctx, store.Sender(), txnProto.GetTransactionId())
@@ -724,7 +724,7 @@ func TestRecoverSplitTxnRetryMatrix(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, repl.CommitTransaction(txnProto.GetTransactionId()))
 
-			require.NoError(t, coordinator.ProcessTxnRecordForTest(ctx, txnRecord))
+			require.NoError(t, coordinator.RecoverTxnRecordForTest(ctx, txnRecord))
 
 			verifyTxnRecordNotExist(t, ctx, store.Sender(), txnProto.GetTransactionId())
 			verifyRangeDescriptorInMetaRangeEquals(t, ctx, store.Sender(), updatedLeftRange)
@@ -757,7 +757,7 @@ func TestRecoverRollbackTxnRetryMatrix(t *testing.T) {
 			})
 			ctx, store, coordinator, txnProto, txnRecord, userKey, metaKey := setupPendingRollbackTxnForRecovery(t, harness)
 
-			require.NoError(t, coordinator.ProcessTxnRecordForTest(ctx, txnRecord))
+			require.NoError(t, coordinator.RecoverTxnRecordForTest(ctx, txnRecord))
 
 			verifyTxnRecordNotExist(t, ctx, store.Sender(), txnProto.GetTransactionId())
 			verifyDirectReadValue(t, ctx, store.Sender(), userKey, []byte("before"))
@@ -831,7 +831,7 @@ func TestStalePendingJanitorHelpsCommit(t *testing.T) {
 	commitRecord.Op = rfpb.FinalizeOperation_COMMIT
 	require.NoError(t, tc.WriteTxnRecord(ctx, commitRecord))
 
-	require.NoError(t, tc.ProcessTxnRecordForTest(ctx, stalePendingRecord))
+	require.NoError(t, tc.RecoverTxnRecordForTest(ctx, stalePendingRecord))
 
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
 	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("after"))
@@ -895,7 +895,7 @@ func TestRollbackNotFoundPreventsLatePrepare(t *testing.T) {
 	}
 	require.NoError(t, coordinator.WriteTxnRecord(ctx, txnRecord))
 
-	require.NoError(t, coordinator.ProcessTxnRecordForTest(ctx, txnRecord))
+	require.NoError(t, coordinator.RecoverTxnRecordForTest(ctx, txnRecord))
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
 	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("before"))
 	verifyDirectReadNotFound(t, ctx, s1.Sender(), metaKey)
@@ -963,7 +963,7 @@ func TestRollbackMarkerStampedWithFinalizeTime(t *testing.T) {
 
 	// The janitor rolls back the stale PENDING txn, writing a participant-local
 	// rollback marker on each range stamped with the finalize timestamp.
-	require.NoError(t, coordinator.ProcessTxnRecordForTest(ctx, txnRecord))
+	require.NoError(t, coordinator.RecoverTxnRecordForTest(ctx, txnRecord))
 	verifyTxnRecordNotExist(t, ctx, s1.Sender(), txnProto.GetTransactionId())
 	verifyDirectReadValue(t, ctx, s1.Sender(), userKey, []byte("before"))
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -327,6 +327,14 @@ message BatchCmdRequest {
   // writes will be allowed; it will be unlocked when the transaction is
   // committed or rolled back.
   bool lock_mapped_range = 7;
+
+  // Wall-clock time (micros) at which the coordinator/janitor issued this
+  // finalize, stamped by the proposer so it is deterministic across replicas.
+  // On ROLLBACK it becomes the participant-local rollback marker's retention
+  // timestamp (see RollbackTransaction); startup GC deletes markers this old.
+  // Kept separate from `session` so marker retention does not depend on session
+  // lifetime semantics.
+  int64 txn_finalized_at_usec = 8;
 }
 
 message BatchCmdResponse {

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -115,6 +115,16 @@ message DeleteSessionsRequest {
 
 message DeleteSessionsResponse {}
 
+// State-idempotent (re-sweep finds nothing left to delete) and
+// response-idempotent (empty response). Operates on replica-local rollback
+// marker keys.
+message DeleteTxnRollbackMarkersBeforeRequest {
+  // Delete all txn rollback markers created before or at this timestamp.
+  int64 cutoff_usec = 1;
+}
+
+message DeleteTxnRollbackMarkersBeforeResponse {}
+
 message FetchRangesRequest {
   // The filters are ORed.
 
@@ -142,6 +152,8 @@ message RequestUnion {
     FindSplitPointRequest find_split_point = 14;
     DeleteSessionsRequest delete_sessions = 16;
     FetchRangesRequest fetch_ranges = 17;
+    DeleteTxnRollbackMarkersBeforeRequest delete_txn_rollback_markers_before =
+        18;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetRequest get = 7;
@@ -172,6 +184,8 @@ message ResponseUnion {
     FindSplitPointResponse find_split_point = 15;
     DeleteSessionsResponse delete_sessions = 17;
     FetchRangesResponse fetch_ranges = 18;
+    DeleteTxnRollbackMarkersBeforeResponse delete_txn_rollback_markers_before =
+        19;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetResponse get = 8;


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy-internal/issues/7525

1. use CAS when we write the txn record to change the state from PENDING to PREPARED.
2. When we rollback a transaction, write a local rollback marker for the txid even when the prepared batch is not found. PrepareTransaction(txid) rejects if that marker exists.
  Note: This is necessary. Without it, even when we use CAS, we can still encounter a bug (documented in the comment in the issue)
3. Implement a background gc to delete the marker. Right now, I only
   delete the marker once on start up. Each store issues the delete
   requests for the range where it is the leader.
