### PR TITLE
explain: Minor cleanups

### DIFF
--- a/cli/explain/compactgraph/input.go
+++ b/cli/explain/compactgraph/input.go
@@ -528,10 +528,10 @@ func protoToRunfilesTree(r *spawn.ExecLogEntry_RunfilesTree, previousInputs map[
 		contentHash.Write(repoMappingManifest.ShallowContentHash())
 	}
 
-	binary.Write(contentHash, binary.LittleEndian, uint64(len(r.EmptyFiles)))
+	_ = binary.Write(contentHash, binary.LittleEndian, uint64(len(r.EmptyFiles)))
 	internedEmptyFiles := make([]string, 0, len(r.EmptyFiles))
 	for _, emptyFilePath := range r.EmptyFiles {
-		binary.Write(contentHash, binary.LittleEndian, uint64(len(emptyFilePath)))
+		_ = binary.Write(contentHash, binary.LittleEndian, uint64(len(emptyFilePath)))
 		contentHash.Write([]byte(emptyFilePath))
 		// Bazel emits an empty file for each parent of a directory with a Python file in it. This typically results in
 		// many duplicated paths across Python runfiles trees. Interning them reduces the retained memory to be roughly

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -181,7 +181,6 @@ func HandleExplain(args []string) (int, error) {
 		if err := pprof.Lookup(profile).WriteTo(f, 0); err != nil {
 			log.Fatalf("Could not write %s profile: %s", profile, err)
 		}
-		f.Close()
 	}
 	return 0, nil
 }
@@ -202,13 +201,11 @@ func Diff(oldPath, newPath string) (*spawn_diff.DiffResult, error) {
 	var oldGraph *compactgraph.CompactGraph
 	readsEG.Go(func() (err error) {
 		oldGraph, err = compactgraph.ReadCompactLog(oldSource)
-		oldSource.Close()
 		return err
 	})
 	var newGraph *compactgraph.CompactGraph
 	readsEG.Go(func() (err error) {
 		newGraph, err = compactgraph.ReadCompactLog(newSource)
-		newSource.Close()
 		return err
 	})
 	if err := readsEG.Wait(); err != nil {
@@ -266,7 +263,7 @@ func openLog(pathOrId string) (io.ReadCloser, error) {
 			out.Close()
 		}
 	}()
-	return in, err
+	return in, nil
 }
 
 func getExecLogResource(ctx context.Context, conn *grpc_client.ClientConnPool, invocationId string) (*digest.CASResourceName, error) {


### PR DESCRIPTION
Small, behavior-preserving cleanups in `bb explain` spotted while reviewing the code.

- **Profiling loop** (`HandleExplain`): dropped the redundant explicit `f.Close()` that followed a `defer f.Close()` (the file was closed twice). Kept the `defer` — the loop is short, so it reads more clearly.
- **`Diff`**: dropped the redundant `oldSource.Close()`/`newSource.Close()` calls inside the `ReadCompactLog` goroutines. The function-level `defer …Close()` already closes both sources on every return path (including the early-error paths), so these were a double close.
- **`openLog`**: returns `in, nil` instead of `in, err` — at that point `err` is always nil.
- **`protoToRunfilesTree`**: use `_ = binary.Write(...)` consistently with the other hash writes in the file.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
