### PR TITLE
bazel: fix Bazel 9 target checks

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -246,6 +246,7 @@ go_sdk_tool(
 )
 
 exports_files([
+    ".swcrc",
     "package.json",
 ])
 

--- a/cli/test/integration/compact/BUILD
+++ b/cli/test/integration/compact/BUILD
@@ -2,6 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 package(default_visibility = ["//cli:__subpackages__"])
 
+exports_files(
+    [
+        "testdata/1.binpb.zst",
+        "testdata/2.binpb.zst",
+    ],
+    visibility = ["//cli:__subpackages__"],
+)
+
 go_test(
     name = "compact_test",
     srcs = ["compact_test.go"],

--- a/config/BUILD
+++ b/config/BUILD
@@ -3,6 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 # gazelle:default_visibility //visibility:public
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["buildbuddy.local.yaml"])
+
 filegroup(
     name = "config_files",
     srcs = select({

--- a/rules/typescript/index.bzl
+++ b/rules/typescript/index.bzl
@@ -66,6 +66,7 @@ def ts_jasmine_node_test(name, srcs, deps = [], size = "small", **kwargs):
         src = ":%s_commonjs.js" % name,
         out = ":%s_commonjs.test.js" % name,
         allow_symlink = True,
+        testonly = 1,
     )
 
     jasmine_test(

--- a/rules/typescript/index.bzl
+++ b/rules/typescript/index.bzl
@@ -66,7 +66,7 @@ def ts_jasmine_node_test(name, srcs, deps = [], size = "small", **kwargs):
         src = ":%s_commonjs.js" % name,
         out = ":%s_commonjs.test.js" % name,
         allow_symlink = True,
-        testonly = 1,
+        testonly = True,
     )
 
     jasmine_test(

--- a/server/metrics/BUILD
+++ b/server/metrics/BUILD
@@ -2,6 +2,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["metrics.go"])
+
 go_library(
     name = "metrics",
     srcs = ["metrics.go"],


### PR DESCRIPTION
The Bazel 9 migration fails on two incompatible flags in
bazelisk --migrate test --config=remote-minimal //.... The
--incompatible_no_implicit_file_export flag hides source files that
other packages still reference, and
--incompatible_check_testonly_for_output_files rejects a generated
TypeScript Jasmine entrypoint because its copy target is not test-only.

Export only the referenced files from their owning packages and mark the
copied CommonJS test entrypoint testonly. This also helps Bazel rewrite
attempts use this repository as a benchmark without implementing
soon-to-be-deprecated implicit export or testonly-output behavior.
