### PR TITLE
explain: Attribute stamping changes to a synthetic workspace status action

### DIFF
--- a/cli/explain/compactgraph/BUILD.bazel
+++ b/cli/explain/compactgraph/BUILD.bazel
@@ -33,8 +33,10 @@ go_test(
     deps = [
         "//proto:spawn_diff_go_proto",
         "//proto:spawn_go_proto",
+        "@com_github_klauspost_compress//zstd",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_bazel_rules_go//go/runfiles",
+        "@org_golang_google_protobuf//encoding/protodelim",
     ],
 )

--- a/cli/explain/compactgraph/compactgraph.go
+++ b/cli/explain/compactgraph/compactgraph.go
@@ -80,6 +80,10 @@ func ReadCompactLog(in io.Reader) (*CompactGraph, error) {
 		interner := newInterner()
 		previousInputs := make(map[uint32]Input)
 		previousInputs[0] = emptyInputSet
+		// The workspace status files (produced by Bazel's workspace status action when stamping is enabled) are not
+		// emitted as a spawn in the execution log even though other spawns consume them. They are collected here so
+		// that a synthetic spawn producing them can be added once the log has been fully read.
+		var stableStatusFile, volatileStatusFile *File
 		for entry := range entries {
 			switch entry.Type.(type) {
 			case *spawnproto.ExecLogEntry_Invocation_:
@@ -92,6 +96,12 @@ func ReadCompactLog(in io.Reader) (*CompactGraph, error) {
 			case *spawnproto.ExecLogEntry_File_:
 				file := protoToFile(entry.GetFile(), cg.settings.hashFunction)
 				previousInputs[entry.Id] = file
+				switch file.Path() {
+				case stableStatusFilePath:
+					stableStatusFile = file
+				case volatileStatusFilePath:
+					volatileStatusFile = file
+				}
 			case *spawnproto.ExecLogEntry_UnresolvedSymlink_:
 				symlink := protoToSymlink(entry.GetUnresolvedSymlink())
 				previousInputs[entry.Id] = symlink
@@ -134,6 +144,7 @@ func ReadCompactLog(in io.Reader) (*CompactGraph, error) {
 				log.Fatalf("unexpected entry type: %T", entry.Type)
 			}
 		}
+		addWorkspaceStatusActionSpawn(cg, stableStatusFile, volatileStatusFile)
 		return nil
 	})
 
@@ -182,6 +193,45 @@ func addRunfilesTreeSpawn(cg *CompactGraph, tree *RunfilesTree) Input {
 	}
 	cg.spawns[tree.Path()] = s
 	return output
+}
+
+// Exec-root-relative paths of the files produced by Bazel's workspace status action when stamping is enabled.
+const (
+	stableStatusFilePath   = "bazel-out/stable-status.txt"
+	volatileStatusFilePath = "bazel-out/volatile-status.txt"
+)
+
+// Bazel's real mnemonic for the workspace status action. It is unique to that action, which is never emitted to the
+// execution log, so it is safe to reuse for the synthetic spawn without conflicting with any logged spawn.
+const workspaceStatusActionMnemonic = "BazelWorkspaceStatusAction"
+
+// addWorkspaceStatusActionSpawn injects a synthetic spawn that produces the workspace status files (stable-status.txt
+// and volatile-status.txt) collected while reading the log. Bazel populates these files via its workspace status
+// action when stamping is enabled (e.g. --stamp), but doesn't emit that action to the execution log even though stamped
+// spawns consume the files. Without this synthetic producer, changes to the status files - in particular the volatile
+// build timestamp, which changes on every build - would be reported on each consuming spawn instead of being
+// attributed to a single non-hermetic root cause.
+func addWorkspaceStatusActionSpawn(cg *CompactGraph, stableStatusFile, volatileStatusFile *File) {
+	var outputs []Input
+	if stableStatusFile != nil {
+		outputs = append(outputs, stableStatusFile)
+	}
+	if volatileStatusFile != nil {
+		outputs = append(outputs, volatileStatusFile)
+	}
+	if len(outputs) == 0 {
+		return
+	}
+	s := &Spawn{
+		Mnemonic:   workspaceStatusActionMnemonic,
+		Inputs:     emptyInputSet,
+		Tools:      emptyInputSet,
+		ParamFiles: emptyInputSet,
+		Outputs:    outputs,
+	}
+	for _, output := range outputs {
+		cg.spawns[output.Path()] = s
+	}
 }
 
 func Diff(old, new *CompactGraph) (*spawn_diff.DiffResult, error) {

--- a/cli/explain/compactgraph/compactgraph.go
+++ b/cli/explain/compactgraph/compactgraph.go
@@ -719,6 +719,18 @@ func diffSpawns(old, new *Spawn, oldResolveSymlinks, newResolveSymlinks func(str
 		if new.Mnemonic == "TestRunner" {
 			// Test action outputs are usually non-reproducible due to timestamps in the test.log and test.xml files.
 			m.Expected = true
+		} else if new.Mnemonic == workspaceStatusActionMnemonic {
+			// The volatile status file (e.g. the build timestamp) changes on essentially every build, so a diff
+			// limited to it is expected noise. A change to the stable status file is meaningful, so don't mark the
+			// diff as expected in that case.
+			stableChanged := false
+			for _, fileDiff := range outputContentsDiffs {
+				if fileDiff.LogicalPath == stableStatusFilePath {
+					stableChanged = true
+					break
+				}
+			}
+			m.Expected = !stableChanged
 		}
 		m.Diffs = append(m.Diffs, &spawn_diff.Diff{Diff: &spawn_diff.Diff_OutputContents{
 			OutputContents: &spawn_diff.FileSetDiff{FileDiffs: outputContentsDiffs},

--- a/cli/explain/compactgraph/compactgraph_test.go
+++ b/cli/explain/compactgraph/compactgraph_test.go
@@ -1,6 +1,7 @@
 package compactgraph_test
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -11,8 +12,10 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/explain/compactgraph"
 	"github.com/buildbuddy-io/buildbuddy/proto/spawn"
 	"github.com/buildbuddy-io/buildbuddy/proto/spawn_diff"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protodelim"
 )
 
 func TestJavaNoopImplChange_7_3_1(t *testing.T) {
@@ -871,4 +874,74 @@ func digest(content string) *spawn.Digest {
 		SizeBytes:        int64(len(content)),
 		HashFunctionName: "SHA-256",
 	}
+}
+
+func writeCompactLog(t *testing.T, entries []*spawn.ExecLogEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w, err := zstd.NewWriter(&buf)
+	require.NoError(t, err)
+	var marshalOpts protodelim.MarshalOptions
+	for _, e := range entries {
+		_, err := marshalOpts.MarshalTo(w, e)
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+// statusLog builds a minimal compact log that contains only the two workspace
+// status files (as a stamped build would), from which ReadCompactLog
+// synthesizes the workspace status action that produces them.
+func statusLog(t *testing.T, stableHash, volatileHash string) *compactgraph.CompactGraph {
+	t.Helper()
+	entries := []*spawn.ExecLogEntry{
+		{Type: &spawn.ExecLogEntry_Invocation_{Invocation: &spawn.ExecLogEntry_Invocation{HashFunctionName: "SHA-256"}}},
+		{Id: 1, Type: &spawn.ExecLogEntry_File_{File: &spawn.ExecLogEntry_File{
+			Path: "bazel-out/stable-status.txt", Digest: &spawn.Digest{Hash: stableHash},
+		}}},
+		{Id: 2, Type: &spawn.ExecLogEntry_File_{File: &spawn.ExecLogEntry_File{
+			Path: "bazel-out/volatile-status.txt", Digest: &spawn.Digest{Hash: volatileHash},
+		}}},
+	}
+	g, err := compactgraph.ReadCompactLog(bytes.NewReader(writeCompactLog(t, entries)))
+	require.NoError(t, err)
+	return g
+}
+
+func TestWorkspaceStatusActionVolatileOnlyChangeIsExpected(t *testing.T) {
+	// Only the volatile status file (e.g. the build timestamp) changed: this is
+	// expected noise that should be hidden unless --verbose is passed.
+	result, err := compactgraph.Diff(
+		statusLog(t, "stable-aaa", "volatile-111"),
+		statusLog(t, "stable-aaa", "volatile-222"),
+	)
+	require.NoError(t, err)
+	require.Len(t, result.GetSpawnDiffs(), 1)
+	sd := result.GetSpawnDiffs()[0]
+	assert.Equal(t, "BazelWorkspaceStatusAction", sd.GetMnemonic())
+	m := sd.GetModified()
+	require.NotNil(t, m)
+	assert.True(t, m.GetExpected(), "a volatile-only status change should be expected")
+	require.Len(t, m.GetDiffs(), 1)
+	oc := m.GetDiffs()[0].GetOutputContents()
+	require.NotNil(t, oc)
+	require.Len(t, oc.GetFileDiffs(), 1)
+	assert.Equal(t, "bazel-out/volatile-status.txt", oc.GetFileDiffs()[0].GetLogicalPath())
+}
+
+func TestWorkspaceStatusActionStableChangeIsNotExpected(t *testing.T) {
+	// The stable status file changed, which is a meaningful change and should be
+	// reported by default.
+	result, err := compactgraph.Diff(
+		statusLog(t, "stable-aaa", "volatile-111"),
+		statusLog(t, "stable-bbb", "volatile-222"),
+	)
+	require.NoError(t, err)
+	require.Len(t, result.GetSpawnDiffs(), 1)
+	m := result.GetSpawnDiffs()[0].GetModified()
+	require.NotNil(t, m)
+	assert.False(t, m.GetExpected(), "a stable status change should not be expected")
+	require.Len(t, m.GetDiffs(), 1)
+	assert.Len(t, m.GetDiffs()[0].GetOutputContents().GetFileDiffs(), 2)
 }

--- a/cli/test/integration/explain/explain_test.go
+++ b/cli/test/integration/explain/explain_test.go
@@ -25,22 +25,33 @@ func runfilePath(t *testing.T, rlocationPath string) string {
 	return p
 }
 
-// The two compact execution logs are for builds of the same two genrule
-// targets but with different output contents, so we expect bb explain to
-// report both spawns as modified.
+// The two compact execution logs are for builds of the same two stamped genrule
+// targets (//server/version:populate_commit and :populate_version) but with
+// different stable-status.txt and volatile-status.txt contents. Both status
+// files are produced by Bazel's workspace status action, which isn't emitted to
+// the execution log; bb explain injects a synthetic spawn for it. We therefore
+// expect that action to be reported as the single non-hermetic root cause, with
+// the two stamped genrules that consume the status files attributed to it as
+// transitively invalidated.
 func assertExpectedDiff(t *testing.T, result *spawn_diff.DiffResult) {
-	require.Len(t, result.GetSpawnDiffs(), 2)
-	var labels []string
-	for _, sd := range result.GetSpawnDiffs() {
-		labels = append(labels, sd.GetTargetLabel())
-		assert.Equal(t, "Genrule", sd.GetMnemonic())
-		assert.NotNil(t, sd.GetModified(), "expected spawn %q to be modified", sd.GetTargetLabel())
-		assert.NotEmpty(t, sd.GetModified().GetDiffs(), "expected spawn %q to have at least one diff", sd.GetTargetLabel())
+	require.Len(t, result.GetSpawnDiffs(), 1)
+	sd := result.GetSpawnDiffs()[0]
+	assert.Equal(t, "BazelWorkspaceStatusAction", sd.GetMnemonic())
+	assert.Equal(t, "bazel-out/stable-status.txt", sd.GetPrimaryOutput())
+	m := sd.GetModified()
+	require.NotNil(t, m, "expected the workspace status action to be modified")
+	require.Len(t, m.GetDiffs(), 1)
+	oc := m.GetDiffs()[0].GetOutputContents()
+	require.NotNil(t, oc, "expected an output contents diff (the status files changed)")
+	var changedPaths []string
+	for _, fd := range oc.GetFileDiffs() {
+		changedPaths = append(changedPaths, fd.GetLogicalPath())
 	}
 	assert.ElementsMatch(t, []string{
-		"//server/version:populate_commit",
-		"//server/version:populate_version",
-	}, labels)
+		"bazel-out/stable-status.txt",
+		"bazel-out/volatile-status.txt",
+	}, changedPaths)
+	assert.Equal(t, map[string]uint32{"Genrule": 2}, m.GetTransitivelyInvalidated())
 }
 
 func TestExplainJsonOutputIsClean(t *testing.T) {
@@ -81,4 +92,31 @@ func TestExplainProtoOutputIsClean(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(stdout, &result),
 		"stdout should be valid proto binary with no extra output from the CLI stack; stdout len: %d", len(stdout))
 	assertExpectedDiff(t, &result)
+}
+
+// Verifies how the non-hermeticity introduced by stamping is surfaced in the
+// default human-readable text output: the synthetic workspace status action is
+// reported as a non-hermetic action whose stable-status.txt and
+// volatile-status.txt outputs changed, and the stamped genrules consuming them
+// are listed as transitively invalidated rather than as separate root causes.
+func TestExplainStampingNonHermeticityText(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	old := runfilePath(t, oldCompactLogRunfilePath)
+	new := runfilePath(t, newCompactLogRunfilePath)
+
+	stdout, stderr, err := testcli.SplitOutput(
+		testcli.Command(t, ws, "explain",
+			"--old="+old,
+			"--new="+new,
+		),
+	)
+	require.NoError(t, err, "bb explain failed; stderr: %s", stderr)
+
+	out := string(stdout)
+	assert.Contains(t, out, "BazelWorkspaceStatusAction")
+	assert.Contains(t, out, "outputs changed (action is non-hermetic)")
+	assert.Contains(t, out, "bazel-out/stable-status.txt")
+	assert.Contains(t, out, "bazel-out/volatile-status.txt")
+	assert.Contains(t, out, "transitively invalidated")
+	assert.Contains(t, out, "Genrule")
 }

--- a/cli/test/integration/explain/explain_test.go
+++ b/cli/test/integration/explain/explain_test.go
@@ -40,6 +40,9 @@ func assertExpectedDiff(t *testing.T, result *spawn_diff.DiffResult) {
 	assert.Equal(t, "bazel-out/stable-status.txt", sd.GetPrimaryOutput())
 	m := sd.GetModified()
 	require.NotNil(t, m, "expected the workspace status action to be modified")
+	// stable-status.txt changed (not just the volatile file), so this is a
+	// meaningful change that is reported rather than treated as expected noise.
+	assert.False(t, m.GetExpected())
 	require.Len(t, m.GetDiffs(), 1)
 	oc := m.GetDiffs()[0].GetOutputContents()
 	require.NotNil(t, oc, "expected an output contents diff (the status files changed)")


### PR DESCRIPTION
## Problem

Bazel's workspace status action produces `bazel-out/stable-status.txt` and `bazel-out/volatile-status.txt` when stamping is enabled (e.g. `--stamp`), and stamped spawns consume them as inputs. But that action is **not emitted to the compact execution log**, so `bb explain` had no spawn producing those files.

Consequences:
- A change in the status files (most importantly the volatile **build timestamp**, which changes on every build) was reported on *each* consuming spawn as an unexplained input-content change.
- There was no single root cause to attribute the churn to, and the consumers showed up as independent "modified" spawns.

## Change

Inject a **synthetic spawn** for the workspace status action, reusing Bazel's real mnemonic `BazelWorkspaceStatusAction` (which is unique to that action and never appears as a logged spawn, so there's no collision). It produces whichever of `stable-status.txt` / `volatile-status.txt` are seen while reading the log.

Now:
- Status-file changes are attributed to this one action.
- It surfaces as a single **non-hermetic root cause** (its outputs changed), with the stamped consumers reported as **transitively invalidated** rather than as separate root causes.
- When **only** `volatile-status.txt` changed (pure timestamp noise), the action's diff is marked **`Expected`**, so it's hidden unless `--verbose`. A `stable-status.txt` change is meaningful and stays reported by default.

This mirrors the existing synthetic-spawn pattern used for runfiles trees (`addRunfilesTreeSpawn`).

## Tests

The existing integration logs (`cli/test/integration/compact/testdata/{1,2}.binpb.zst`) are builds of two stamped genrules (`//server/version:populate_commit`, `:populate_version`) whose `stable-status.txt` and `volatile-status.txt` inputs differ — exactly this scenario.

- Updated `assertExpectedDiff` (used by the JSON and proto output tests): now expects the single `BazelWorkspaceStatusAction` with an `OutputContents` diff for both status files, `TransitivelyInvalidated = {Genrule: 2}`, and `Expected = false` (stable changed).
- `TestExplainStampingNonHermeticityText`: runs `bb explain` in the default text format and asserts the workspace status action is reported as non-hermetic with the stamped genrules listed as transitively invalidated.
- `TestWorkspaceStatusActionVolatileOnlyChangeIsExpected` / `TestWorkspaceStatusActionStableChangeIsNotExpected`: unit tests over crafted minimal logs covering the `Expected` flag for the volatile-only vs stable-changed cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
