### PR TITLE
explain: Return errors from HandleExplain instead of log.Fatal

### DIFF
--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -108,30 +108,30 @@ func HandleExplain(args []string) (int, error) {
 	if profilePaths["cpu"] != "" {
 		f, err := os.Create(profilePaths["cpu"])
 		if err != nil {
-			log.Fatal("Could not create CPU profile: ", err)
+			return 1, fmt.Errorf("could not create CPU profile: %v", err)
 		}
 		defer f.Close()
 		if err := pprof.StartCPUProfile(f); err != nil {
-			log.Fatal("Could not start CPU profile: ", err)
+			return 1, fmt.Errorf("could not start CPU profile: %v", err)
 		}
 		defer pprof.StopCPUProfile()
 	}
 	if *newLog == "" {
 		newId, err := flaghistory.GetPreviousFlag(flaghistory.InvocationIDFlagName)
 		if err != nil {
-			log.Fatal("Could not get invocation ID of the last build, please specify --new: ", err)
+			return 1, fmt.Errorf("could not get invocation ID of the last build, please specify --new: %v", err)
 		}
 		if newId == "" {
-			log.Fatal("No previous build to compare against, please specify --new")
+			return 1, fmt.Errorf("no previous build to compare against, please specify --new")
 		}
 		*newLog = newId
 		if *oldLog == "" {
 			oldId, err := flaghistory.GetNthPreviousFlag(flaghistory.InvocationIDFlagName, 2)
 			if err != nil {
-				log.Fatal("Could not get invocation ID of the build before the last, please specify --old: ", err)
+				return 1, fmt.Errorf("could not get invocation ID of the build before the last, please specify --old: %v", err)
 			}
 			if oldId == "" {
-				log.Fatal("No previous build to compare against, please specify --old")
+				return 1, fmt.Errorf("no previous build to compare against, please specify --old")
 			}
 			*oldLog = oldId
 		}
@@ -171,7 +171,7 @@ func HandleExplain(args []string) (int, error) {
 		}
 		f, err := os.Create(p)
 		if err != nil {
-			log.Fatalf("Could not create %s profile: %s", profile, err)
+			return 1, fmt.Errorf("could not create %s profile: %v", profile, err)
 		}
 		defer f.Close()
 		if profile == "heap" || profile == "alloc" {
@@ -179,7 +179,7 @@ func HandleExplain(args []string) (int, error) {
 			runtime.GC()
 		}
 		if err := pprof.Lookup(profile).WriteTo(f, 0); err != nil {
-			log.Fatalf("Could not write %s profile: %s", profile, err)
+			return 1, fmt.Errorf("could not write %s profile: %v", profile, err)
 		}
 		f.Close()
 	}

--- a/cli/explain/explain.go
+++ b/cli/explain/explain.go
@@ -108,30 +108,30 @@ func HandleExplain(args []string) (int, error) {
 	if profilePaths["cpu"] != "" {
 		f, err := os.Create(profilePaths["cpu"])
 		if err != nil {
-			return 1, fmt.Errorf("could not create CPU profile: %v", err)
+			return -1, fmt.Errorf("could not create CPU profile: %v", err)
 		}
 		defer f.Close()
 		if err := pprof.StartCPUProfile(f); err != nil {
-			return 1, fmt.Errorf("could not start CPU profile: %v", err)
+			return -1, fmt.Errorf("could not start CPU profile: %v", err)
 		}
 		defer pprof.StopCPUProfile()
 	}
 	if *newLog == "" {
 		newId, err := flaghistory.GetPreviousFlag(flaghistory.InvocationIDFlagName)
 		if err != nil {
-			return 1, fmt.Errorf("could not get invocation ID of the last build, please specify --new: %v", err)
+			return -1, fmt.Errorf("could not get invocation ID of the last build, please specify --new: %v", err)
 		}
 		if newId == "" {
-			return 1, fmt.Errorf("no previous build to compare against, please specify --new")
+			return -1, fmt.Errorf("no previous build to compare against, please specify --new")
 		}
 		*newLog = newId
 		if *oldLog == "" {
 			oldId, err := flaghistory.GetNthPreviousFlag(flaghistory.InvocationIDFlagName, 2)
 			if err != nil {
-				return 1, fmt.Errorf("could not get invocation ID of the build before the last, please specify --old: %v", err)
+				return -1, fmt.Errorf("could not get invocation ID of the build before the last, please specify --old: %v", err)
 			}
 			if oldId == "" {
-				return 1, fmt.Errorf("no previous build to compare against, please specify --old")
+				return -1, fmt.Errorf("no previous build to compare against, please specify --old")
 			}
 			*oldLog = oldId
 		}
@@ -171,7 +171,7 @@ func HandleExplain(args []string) (int, error) {
 		}
 		f, err := os.Create(p)
 		if err != nil {
-			return 1, fmt.Errorf("could not create %s profile: %v", profile, err)
+			return -1, fmt.Errorf("could not create %s profile: %v", profile, err)
 		}
 		defer f.Close()
 		if profile == "heap" || profile == "alloc" {
@@ -179,7 +179,7 @@ func HandleExplain(args []string) (int, error) {
 			runtime.GC()
 		}
 		if err := pprof.Lookup(profile).WriteTo(f, 0); err != nil {
-			return 1, fmt.Errorf("could not write %s profile: %v", profile, err)
+			return -1, fmt.Errorf("could not write %s profile: %v", profile, err)
 		}
 		f.Close()
 	}


### PR DESCRIPTION
`HandleExplain` returns `(int, error)`, but used `log.Fatal`/`log.Fatalf` for its setup and profile-writing error paths. `log.Fatal` calls `os.Exit`, which skips deferred functions — notably `defer pprof.StopCPUProfile()` and the CPU profile file's `Close`. So with `--profile=cpu`, any fatal after the profile was started (e.g. a `flaghistory` lookup failure, or a failure writing a heap/alloc profile) left the CPU profile file unflushed/incomplete.

This converts every `log.Fatal`/`log.Fatalf` inside `HandleExplain` to `return -1, fmt.Errorf(...)` (exit code 1, matching the existing usage/setup error convention and the file's existing returned-error style), so deferred cleanup runs. No other behavior changes; `log.Fatal` usages elsewhere are untouched.

Follow-up to the review of #12491.

Note: this touches the profiling loop that #12492 also edits, so whichever of the two merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
