### PR TITLE
Run the code review workflow only when a PR is ready for review

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -130,6 +130,9 @@ actions:
       pull_request:
         branches:
           - "*"
+        types:
+          - opened
+          - ready_for_review
     user: buildbuddy
     steps:
       - run: |

--- a/enterprise/tools/agent_review/main.go
+++ b/enterprise/tools/agent_review/main.go
@@ -162,9 +162,16 @@ func main() {
 	}
 	log.Infof("PR #%d on %s/%s  (head: %s, base: %s)", pr.GetNumber(), owner, repoName, headShort, pr.GetBase().GetRef())
 
-	// To prevent spamming the PR with reviews, we only post a review if the PR doesn't already have a bot review.
-	// Set AGENT_REVIEW_FORCE=1 to override and post a new review.
+	// We review a PR once, when it's ready for review. The workflow triggers on
+	// the "opened" and "ready_for_review" pull_request actions, but "opened" also
+	// fires for PRs opened directly as drafts, so skip drafts here. We also skip
+	// if the PR already has a bot review, to avoid spamming it with reviews.
+	// Set AGENT_REVIEW_FORCE=1 to override both checks and post a new review.
 	if os.Getenv("AGENT_REVIEW_FORCE") != "1" {
+		if pr.GetDraft() {
+			log.Infof("PR #%d is a draft — skipping (set AGENT_REVIEW_FORCE=1 to override).", pr.GetNumber())
+			os.Exit(0)
+		}
 		log.Info("Checking for existing reviews...")
 		reviews, _, err := gh.PullRequests.ListReviews(ctx, owner, repoName, pr.GetNumber(), nil)
 		if err != nil {
@@ -172,7 +179,7 @@ func main() {
 		}
 		for _, r := range reviews {
 			if r.GetUser().GetType() == "Bot" {
-				log.Infof("PR #%d already has a bot review — skipping (set FORCE=1 to override).", pr.GetNumber())
+				log.Infof("PR #%d already has a bot review — skipping (set AGENT_REVIEW_FORCE=1 to override).", pr.GetNumber())
 				os.Exit(0)
 			}
 		}


### PR DESCRIPTION
Depends on: https://github.com/buildbuddy-io/buildbuddy/pull/12478 rolling out

Now that the pull_request trigger supports filtering by action type, scope the Code review action to the "ready_for_review" action so the agent review runs once when a PR is marked ready for review, rather than on every push (including while the PR is still a draft).