### PR TITLE
Delete invocation->execution links when the execution finishes

### DIFF
--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector.go
@@ -231,14 +231,6 @@ func (c *collector) GetInProgressExecution(ctx context.Context, executionID stri
 
 // DeleteInProgressExecution deletes the given in-progress execution.
 func (c *collector) DeleteInProgressExecution(ctx context.Context, executionID string) error {
-	// TODO: maybe also proactively delete the reverse invocation links for this
-	// execution, since reverse links are only used to point back to the
-	// in-progress executions for an invocation. Those links will get cleaned up
-	// when the invocation is complete, but cleaning them up here would reduce
-	// the amount of unnecessary data fetched in the invocation page for
-	// executions that have already been completed. For now, this is probably
-	// not a big enough issue to justify the additional reads from redis and
-	// additional complexity.
 	pipe := c.rdb.Pipeline()
 	pipe.Del(ctx, getExecutionUpdatesKey(executionID)).Err()
 	_, err := pipe.Exec(ctx)
@@ -274,10 +266,6 @@ func (c *collector) GetExecutions(ctx context.Context, iid string, start, stop i
 	return res, nil
 }
 
-func (c *collector) DeleteExecutions(ctx context.Context, iid string) error {
-	return c.rdb.Del(ctx, getExecutionKey(iid)).Err()
-}
-
 // ExpireExecutions sets the TTL of executions data. This can be used to clean
 // up executions data after some delay.
 func (c *collector) ExpireExecutions(ctx context.Context, iid string, ttl time.Duration) error {
@@ -288,8 +276,12 @@ func (c *collector) DeleteExecutionInvocationLinks(ctx context.Context, executio
 	return c.rdb.Del(ctx, getExecutionInvocationLinksKey(executionID)).Err()
 }
 
-func (c *collector) DeleteInvocationExecutionLinks(ctx context.Context, invocationID string) error {
-	return c.rdb.Del(ctx, getInvocationExecutionLinksKey(invocationID)).Err()
+func (c *collector) DeleteInvocationExecutionLink(ctx context.Context, link *sipb.StoredInvocationLink) error {
+	b, err := proto.Marshal(link)
+	if err != nil {
+		return err
+	}
+	return c.rdb.SRem(ctx, getInvocationExecutionLinksKey(link.GetInvocationId()), string(b)).Err()
 }
 
 func unmarshalStoredInvocationLinks(serializedResults []string) ([]*sipb.StoredInvocationLink, error) {

--- a/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
+++ b/enterprise/server/backends/redis_execution_collector/redis_execution_collector_test.go
@@ -103,9 +103,13 @@ func TestCollectExecutionUpdates(t *testing.T) {
 		},
 	}, executions, protocmp.Transform()))
 
-	// Delete reverse invocation links; should no longer be able to look up
+	// Delete reverse invocation link; should no longer be able to look up
 	// in-progress executions by invocation ID.
-	err = collector.DeleteInvocationExecutionLinks(ctx, invocationID)
+	err = collector.DeleteInvocationExecutionLink(ctx, &sipb.StoredInvocationLink{
+		ExecutionId:  executionID,
+		InvocationId: invocationID,
+		Type:         sipb.StoredInvocationLink_NEW,
+	})
 	require.NoError(t, err)
 	executions, err = collector.GetInProgressExecutions(ctx, invocationID)
 	require.NoError(t, err)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -546,9 +546,12 @@ func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionID 
 		return nil, nil
 	}
 
-	// Always clean up invocationLinks and execution updates from the collector.
-	// The execution cannot be retried after this point, so nothing will clean
-	// up this data if we don't do it here.
+	// Always clean up executionInvocationLinks, invocationExecutionLinks, and
+	// execution updates from the collector. The execution cannot be retried
+	// after this point, so nothing will clean up this data if we don't do it
+	// here. This means that even if we fail to AppendExecution or
+	// FlushExecutionStats, we will still remove all links and in-progress
+	// executions.
 	var links []*sipb.StoredInvocationLink
 	defer func() {
 		err := s.executionCollector.DeleteExecutionInvocationLinks(ctx, executionID)
@@ -559,9 +562,6 @@ func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionID 
 		if err != nil {
 			log.CtxErrorf(ctx, "Failed to clean up in-progress execution in collector: %s", err)
 		}
-		// Clean up the reverse invocation => execution links for just this
-		// execution, since they are only needed to list this execution while it
-		// is in-progress, and it has now been flushed.
 		for _, link := range links {
 			if err := s.executionCollector.DeleteInvocationExecutionLink(ctx, link); err != nil {
 				log.CtxErrorf(ctx, "Failed to clean up reverse invocation link for invocation %q: %s", link.GetInvocationId(), err)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -549,6 +549,7 @@ func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionID 
 	// Always clean up invocationLinks and execution updates from the collector.
 	// The execution cannot be retried after this point, so nothing will clean
 	// up this data if we don't do it here.
+	var links []*sipb.StoredInvocationLink
 	defer func() {
 		err := s.executionCollector.DeleteExecutionInvocationLinks(ctx, executionID)
 		if err != nil {
@@ -558,6 +559,14 @@ func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionID 
 		if err != nil {
 			log.CtxErrorf(ctx, "Failed to clean up in-progress execution in collector: %s", err)
 		}
+		// Clean up the reverse invocation => execution links for just this
+		// execution, since they are only needed to list this execution while it
+		// is in-progress, and it has now been flushed.
+		for _, link := range links {
+			if err := s.executionCollector.DeleteInvocationExecutionLink(ctx, link); err != nil {
+				log.CtxErrorf(ctx, "Failed to clean up reverse invocation link for invocation %q: %s", link.GetInvocationId(), err)
+			}
+		}
 	}()
 
 	executionProto, err := s.executionCollector.GetInProgressExecution(ctx, executionID)
@@ -565,7 +574,7 @@ func (s *ExecutionServer) flushExecutionToOLAP(ctx context.Context, executionID 
 		return nil, status.InternalErrorf("failed to get execution %q from redis: %s", executionID, err)
 	}
 
-	links, err := s.executionCollector.GetExecutionInvocationLinks(ctx, executionID)
+	links, err = s.executionCollector.GetExecutionInvocationLinks(ctx, executionID)
 	if err != nil {
 		return nil, status.InternalErrorf("failed to get invocations for execution %q: %s", executionID, err)
 	}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -392,15 +392,6 @@ func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, ij *in
 		log.CtxInfo(ctx, "Successfully wrote invocation to redis")
 	}
 
-	// Once we've flushed execution stats to ClickHouse for this invocation,
-	// clean up the invocation => execution links, since these are only needed
-	// for listing in-progress executions linked to an invocation, and this
-	// listing will now be queryable using ClickHouse.
-	defer func() {
-		if err := r.env.GetExecutionCollector().DeleteInvocationExecutionLinks(ctx, inv.InvocationID); err != nil {
-			log.CtxErrorf(ctx, "Failed to clean up reverse invocation links for invocation %q: %s", inv.InvocationID, err)
-		}
-	}()
 	for {
 		endIndex = startIndex + batchSize - 1
 		executions, err := r.env.GetExecutionCollector().GetExecutions(ctx, inv.InvocationID, int64(startIndex), int64(endIndex))

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1561,9 +1561,9 @@ type ExecutionCollector interface {
 	// behavior, and will not return the deleted execution.
 	DeleteInProgressExecution(ctx context.Context, executionID string) error
 
-	// DeleteInvocationExecutionLinks deletes all invocation => []execution
-	// links for the given invocation ID.
-	DeleteInvocationExecutionLinks(ctx context.Context, invocationID string) error
+	// DeleteInvocationExecutionLink deletes the single invocation => execution
+	// link.
+	DeleteInvocationExecutionLink(ctx context.Context, link *sipb.StoredInvocationLink) error
 
 	AppendExecution(ctx context.Context, iid string, execution *repb.StoredExecution) error
 	// GetExecutions fetches a range of executions for the given invocation ID.
@@ -1571,7 +1571,6 @@ type ExecutionCollector interface {
 	// of range, then the returned slice will contain as many executions are
 	// available starting from the start index.
 	GetExecutions(ctx context.Context, iid string, start, stop int64) ([]*repb.StoredExecution, error)
-	DeleteExecutions(ctx context.Context, iid string) error
 	ExpireExecutions(ctx context.Context, iid string, ttl time.Duration) error
 	AddInvocation(ctx context.Context, inv *sipb.StoredInvocation) error
 	GetInvocation(ctx context.Context, iid string) (*sipb.StoredInvocation, error)


### PR DESCRIPTION
Instead of when the invocation finishes. This handle cases where the execution is still running (or cleaning up) after an invocation finishes.