### PR TITLE
Run codesearch indexing (when enabled) on repos even without bb.yaml

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1403,6 +1403,10 @@ func (ws *workflowService) checkStartWorkflowPreconditions(ctx context.Context) 
 
 // fetchWorkflowConfig returns the BuildBuddyConfig from the repo, or the
 // default BuildBuddyConfig if that setting is enabled.
+//
+// It returns nil (the "do nothing" signal) when there are no actions to run:
+// the repo has no buildbuddy.yaml, isn't using the default config, and
+// no additional settings (like codesearch) contribute actions.
 func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider interfaces.GitProvider, workflow *tables.Workflow, webhookData *interfaces.WebhookData) (*config.BuildBuddyConfig, error) {
 	workflowRef := webhookData.SHA
 	if workflowRef == "" {
@@ -1427,10 +1431,14 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider 
 	} else {
 		if status.IsNotFoundError(err) {
 			if workflow.GitRepository != nil && !workflow.GitRepository.UseDefaultWorkflowConfig {
-				return nil, nil
+				// The repo has no buildbuddy.yaml and isn't using the default
+				// config, so the user has no actions of their own. Start from an
+				// empty config rather than bailing out, so that codesearch
+				// indexing actions can still be appended below if enabled.
+				c = &config.BuildBuddyConfig{}
+			} else {
+				c = config.GetDefault(webhookData.TargetRepoDefaultBranch)
 			}
-
-			c = config.GetDefault(webhookData.TargetRepoDefaultBranch)
 		} else {
 			return nil, err
 		}
@@ -1438,6 +1446,13 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider 
 
 	if err := ws.addCodesearchActionsIfEnabled(ctx, c, workflow, webhookData); err != nil {
 		return nil, err
+	}
+
+	// If there are no actions to run, return nil to signal "do nothing", which
+	// callers distinguish from a config with actions (e.g. to clean up orphaned
+	// scheduled runs).
+	if len(c.Actions) == 0 {
+		return nil, nil
 	}
 	return c, nil
 }

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -872,6 +872,56 @@ func TestWebhook_NoWorkflowConfig_NOP(t *testing.T) {
 	require.Zero(t, len(execClient.executeRequests))
 }
 
+func TestWebhook_NoWorkflowConfig_CodesearchEnabled_StartsIndexing(t *testing.T) {
+	ctx := context.Background()
+	u, lis := testhttp.NewServer(t)
+	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "remote_execution.enable_remote_exec", true)
+	flags.Set(t, "remote_execution.enable_codesearch_indexing", true)
+	te := newTestEnv(t)
+	ctx, _, gid := authenticate(t, ctx, te)
+	execClient := te.GetRemoteExecutionClient().(*fakeExecutionClient)
+	te.SetRemoteExecutionClient(execClient)
+	go http.Serve(lis, te.GetWorkflowService())
+	provider := setupFakeGitProvider(t, te)
+	repoURL := makeTempRepo(t)
+	runBBServer(ctx, t, te)
+
+	// Enable codesearch indexing for the group.
+	g, err := te.GetUserDB().GetGroupByID(ctx, gid)
+	require.NoError(t, err)
+	g.URLIdentifier = "mustbeset"
+	g.CodeSearchEnabled = true
+	_, err = te.GetUserDB().UpdateGroup(ctx, g)
+	require.NoError(t, err)
+
+	// `useDefaultWorkflowConfig` is false and the repo has no buildbuddy.yaml, so
+	// the user has no workflow actions of their own. But codesearch indexing is
+	// enabled, so a push should still trigger the codesearch indexing action.
+	repo := createWorkflow(t, te, repoURL, gid, false /*useDefaultWorkflowConfig*/)
+
+	provider.TrustedUsers = []string{"acme-inc-user-1"}
+	provider.WebhookData = &interfaces.WebhookData{
+		EventName:               "push",
+		TargetRepoURL:           "https://github.com/acme-inc/acme",
+		TargetBranch:            "main",
+		TargetRepoDefaultBranch: "main",
+		PushedRepoURL:           "https://github.com/acme-inc/acme",
+		PushedBranch:            "main",
+		SHA:                     "c04d68571cb519e095772c865847007ed3e7fea9",
+		IsTargetRepoPublic:      true,
+	}
+	// Do not return a buildbuddy.yaml config file in the repo contents.
+	provider.FileContents = map[string]string{}
+
+	err = te.GetWorkflowService().HandleRepositoryEvent(ctx, repo, provider.WebhookData, "faketoken")
+	require.NoError(t, err)
+
+	// Expect exactly the codesearch indexing action to be dispatched.
+	execReq := execClient.NextExecuteRequest()
+	require.Equal(t, config.CSIncrementalUpdateName, getExecutedActionName(t, ctx, te, execReq.Payload))
+}
+
 func TestWebhook_FailedToStart_PublishesStatus(t *testing.T) {
 	ctx := context.Background()
 	u, lis := testhttp.NewServer(t)


### PR DESCRIPTION
Currently, the enable-codesearch setting can be enabled but it will not apply to repos that do not have a `buildbuddy.yaml` file. I discussed this with @maggie-lou and we agreed we should fix it.

This change fixes and adds a test.