### PR TITLE
FIx two bugs with distribute cache backfill

### DIFF
--- a/enterprise/server/backends/distributed/BUILD
+++ b/enterprise/server/backends/distributed/BUILD
@@ -64,6 +64,7 @@ go_test(
         "//server/util/grpc_client",
         "//server/util/kubediscovery",
         "//server/util/log",
+        "//server/util/peerset",
         "//server/util/prefix",
         "//server/util/proto",
         "//server/util/status",

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1082,21 +1082,7 @@ func (c *Cache) copyFile(ctx context.Context, rn *rspb.ResourceName, source stri
 type backfillOrder struct {
 	r      *rspb.ResourceName
 	source string
-	dest   string
-}
-
-func dedupeBackfills(backfills []*backfillOrder) []*backfillOrder {
-	deduped := make([]*backfillOrder, 0, len(backfills))
-	seen := make(map[string]struct{}, len(backfills))
-	for _, bf := range backfills {
-		d := bf.r.GetDigest()
-		if _, ok := seen[d.GetHash()]; ok {
-			continue
-		}
-		seen[d.GetHash()] = struct{}{}
-		deduped = append(deduped, bf)
-	}
-	return deduped
+	dests  []string
 }
 
 func groupID(ctx context.Context) string {
@@ -1106,32 +1092,34 @@ func groupID(ctx context.Context) string {
 	return interfaces.AuthAnonymousUser
 }
 
-func (c *Cache) backfillPeers(ctx context.Context, backfills []*backfillOrder) (err error) {
+func (c *Cache) backfillPeers(ctx context.Context, backfills []*backfillOrder) {
 	if len(backfills) == 0 {
-		return nil
+		return
 	}
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 	start := time.Now()
 	defer func() {
-		c.log.CtxDebugf(ctx, "backfill took %s err: %v", time.Since(start), err)
+		c.log.CtxDebugf(ctx, "backfill took %s", time.Since(start))
 	}()
-	backfills = dedupeBackfills(backfills)
 	groupID := groupID(ctx)
-	eg, gCtx := errgroup.WithContext(ctx)
+	var wg sync.WaitGroup
 	for _, bf := range backfills {
-		bf := bf
-		eg.Go(func() error {
-			start := time.Now()
-			err := c.copyFile(gCtx, bf.r, bf.source, bf.dest)
-			metrics.DistributedCacheBackfillLatencyUsec.WithLabelValues(
-				groupID,
-				gstatus.Code(err).String(),
-			).Observe(float64(time.Since(start).Microseconds()))
-			return err
-		})
+		for _, dest := range bf.dests {
+			wg.Go(func() {
+				start := time.Now()
+				err := c.copyFile(ctx, bf.r, bf.source, dest)
+				metrics.DistributedCacheBackfillLatencyUsec.WithLabelValues(
+					groupID,
+					gstatus.Code(err).String(),
+				).Observe(float64(time.Since(start).Microseconds()))
+				if err != nil {
+					c.log.CtxDebugf(ctx, "Error backfilling %s to peer %s: %s", bf.r.GetDigest().GetHash(), dest, err)
+				}
+			})
+		}
 	}
-	return eg.Wait()
+	wg.Wait()
 }
 
 func (c *Cache) getBackfillOrders(r *rspb.ResourceName, ps *peerset.PeerSet) []*backfillOrder {
@@ -1142,16 +1130,11 @@ func (c *Cache) getBackfillOrders(r *rspb.ResourceName, ps *peerset.PeerSet) []*
 	if len(targets) == 0 {
 		return nil
 	}
-
-	orders := make([]*backfillOrder, 0, len(targets))
-	for _, target := range targets {
-		orders = append(orders, &backfillOrder{
-			source: source,
-			dest:   target,
-			r:      r,
-		})
-	}
-	return orders
+	return []*backfillOrder{{
+		r:      r,
+		source: source,
+		dests:  targets,
+	}}
 }
 
 // The first contains result that finds the digest will be returned. If all
@@ -1165,18 +1148,12 @@ func (c *Cache) Contains(ctx context.Context, r *rspb.ResourceName) (bool, error
 		return true, nil
 	}
 	ps := c.readPeers(r)
-	backfill := func() {
-		if err := c.backfillPeers(ctx, c.getBackfillOrders(r, ps)); err != nil {
-			c.log.CtxDebugf(ctx, "Error backfilling peers: %s", err)
-		}
-	}
-
 	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
 		exists, err := c.remoteContains(ctx, peer, r)
 		if err == nil {
 			if exists {
 				c.log.CtxDebugf(ctx, "Contains(%q) found on peer %q", r.GetDigest(), peer)
-				backfill()
+				c.backfillPeers(ctx, c.getBackfillOrders(r, ps))
 				return exists, err
 			}
 			c.log.CtxDebugf(ctx, "Contains(%q) not found on peer %q (err: %+v)", r.GetDigest(), peer, err)
@@ -1343,9 +1320,7 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 		ps := peerMap[h]
 		backfills = append(backfills, c.getBackfillOrders(r, ps)...)
 	}
-	if err := c.backfillPeers(ctx, backfills); err != nil {
-		c.log.CtxDebugf(ctx, "Error backfilling peers: %s", err)
-	}
+	c.backfillPeers(ctx, backfills)
 
 	var missing []*repb.Digest
 	for _, r := range resources {
@@ -1377,18 +1352,12 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 // Values found on a non-primary replica will be backfilled to the primary.
 func (c *Cache) distributedReader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64, metricsLabel string) (io.ReadCloser, error) {
 	ps := c.readPeers(rn)
-	backfill := func() {
-		if err := c.backfillPeers(ctx, c.getBackfillOrders(rn, ps)); err != nil {
-			c.log.CtxDebugf(ctx, "Error backfilling peers: %s", err)
-		}
-	}
-
 	lookups := 0
 	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
 		lookups++
 		r, err := c.remoteReader(ctx, peer, rn, offset, limit)
 		if err == nil {
-			backfill()
+			c.backfillPeers(ctx, c.getBackfillOrders(rn, ps))
 			metrics.DistributedCachePeerLookups.WithLabelValues(
 				metricsLabel,
 				metrics.HitStatusLabel,
@@ -1519,9 +1488,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (m
 			backfills = append(backfills, c.getBackfillOrders(r, ps)...)
 		}
 	}
-	if err := c.backfillPeers(ctx, backfills); err != nil {
-		c.log.CtxDebugf(ctx, "Error backfilling peers: %s", err)
-	}
+	c.backfillPeers(ctx, backfills)
 
 	rsp := make(map[*repb.Digest][]byte, len(resources))
 	for _, r := range resources {

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1099,14 +1099,16 @@ func (c *Cache) backfillPeers(ctx context.Context, backfills []*backfillOrder) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 	start := time.Now()
+	var err error
 	defer func() {
-		c.log.CtxDebugf(ctx, "backfill took %s", time.Since(start))
+		c.log.CtxDebugf(ctx, "backfill took %s; err: %v", time.Since(start), err)
 	}()
 	groupID := groupID(ctx)
-	var wg sync.WaitGroup
+	var eg errgroup.Group
+	eg.SetLimit(10)
 	for _, bf := range backfills {
 		for _, dest := range bf.dests {
-			wg.Go(func() {
+			eg.Go(func() error {
 				start := time.Now()
 				err := c.copyFile(ctx, bf.r, bf.source, dest)
 				metrics.DistributedCacheBackfillLatencyUsec.WithLabelValues(
@@ -1116,10 +1118,11 @@ func (c *Cache) backfillPeers(ctx context.Context, backfills []*backfillOrder) {
 				if err != nil {
 					c.log.CtxDebugf(ctx, "Error backfilling %s to peer %s: %s", bf.r.GetDigest().GetHash(), dest, err)
 				}
+				return nil
 			})
 		}
 	}
-	wg.Wait()
+	err = eg.Wait()
 }
 
 func (c *Cache) getBackfillOrders(r *rspb.ResourceName, ps *peerset.PeerSet) []*backfillOrder {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/kubediscovery"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/peerset"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -728,6 +729,129 @@ func TestBackfill(t *testing.T) {
 			readAndCompareDigest(t, ctx, baseCache, r)
 		}
 	}
+}
+
+// writeFailingCache wraps a Cache whose writes always fail, simulating a
+// backfill destination peer that is unwritable.
+type writeFailingCache struct {
+	interfaces.Cache
+}
+
+func (w *writeFailingCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {
+	return nil, status.UnavailableError("induced write failure")
+}
+
+// TestBackfillCopiesToAllMissingPeers verifies that when a digest is missing
+// from more than one preferred peer, the backfill copies it to *every* missing
+// peer, not just the first.
+func TestBackfillCopiesToAllMissingPeers(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer3 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := Options{
+		ReplicationFactor:    3,
+		Nodes:                []string{peer1, peer2, peer3},
+		DisableLocalLookup:   true,
+		RPCHeartbeatInterval: 100 * time.Millisecond,
+	}
+
+	// peer1 holds the blob; peer2 and peer3 are missing it.
+	memoryCache1 := newMemoryCache(t, singleCacheSizeBytes)
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := newMemoryCache(t, singleCacheSizeBytes)
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	_ = startNewDCache(t, env, config2, memoryCache2)
+
+	memoryCache3 := newMemoryCache(t, singleCacheSizeBytes)
+	config3 := baseConfig
+	config3.ListenAddr = peer3
+	_ = startNewDCache(t, env, config3, memoryCache3)
+
+	waitForReady(t, peer1)
+	waitForReady(t, peer2)
+	waitForReady(t, peer3)
+
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, memoryCache1.Set(ctx, rn, buf))
+
+	// Build a peer set whose last-used peer is peer1 (the source), leaving
+	// peer2 and peer3 as backfill targets.
+	ps := peerset.New([]string{peer2, peer3, peer1}, nil)
+	for p := ps.GetNextPeer(); p != ""; p = ps.GetNextPeer() {
+	}
+	dc1.backfillPeers(ctx, dc1.getBackfillOrders(rn, ps))
+
+	for i, baseCache := range []interfaces.Cache{memoryCache2, memoryCache3} {
+		exists, err := baseCache.Contains(ctx, rn)
+		require.NoError(t, err)
+		require.True(t, exists, "blob was not backfilled to destination %d", i)
+		readAndCompareDigest(t, ctx, baseCache, rn)
+	}
+}
+
+// TestBackfillContinuesWhenOnePeerFails verifies that a failed copy to one
+// backfill destination does not prevent the copy to a healthy destination.
+func TestBackfillContinuesWhenOnePeerFails(t *testing.T) {
+	env, _, ctx := getEnvAuthAndCtx(t)
+	singleCacheSizeBytes := int64(1000000)
+	peer1 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer2 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	peer3 := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	baseConfig := Options{
+		ReplicationFactor:    3,
+		Nodes:                []string{peer1, peer2, peer3},
+		DisableLocalLookup:   true,
+		RPCHeartbeatInterval: 100 * time.Millisecond,
+	}
+
+	// peer1 holds the blob, peer2 is a healthy target, and peer3 always fails
+	// writes.
+	memoryCache1 := newMemoryCache(t, singleCacheSizeBytes)
+	config1 := baseConfig
+	config1.ListenAddr = peer1
+	dc1 := startNewDCache(t, env, config1, memoryCache1)
+
+	memoryCache2 := newMemoryCache(t, singleCacheSizeBytes)
+	config2 := baseConfig
+	config2.ListenAddr = peer2
+	_ = startNewDCache(t, env, config2, memoryCache2)
+
+	memoryCache3 := newMemoryCache(t, singleCacheSizeBytes)
+	config3 := baseConfig
+	config3.ListenAddr = peer3
+	_ = startNewDCache(t, env, config3, &writeFailingCache{Cache: memoryCache3})
+
+	waitForReady(t, peer1)
+	waitForReady(t, peer2)
+	waitForReady(t, peer3)
+
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, memoryCache1.Set(ctx, rn, buf))
+
+	ps := peerset.New([]string{peer2, peer3, peer1}, nil)
+	for p := ps.GetNextPeer(); p != ""; p = ps.GetNextPeer() {
+	}
+	// The copy to peer3 fails, but that failure is swallowed (logged) and must
+	// not prevent the copy to the healthy peer2. backfillPeers blocks until
+	// both copies finish, so the assertions below are deterministic.
+	dc1.backfillPeers(ctx, dc1.getBackfillOrders(rn, ps))
+
+	exists, err := memoryCache2.Contains(ctx, rn)
+	require.NoError(t, err)
+	require.True(t, exists, "healthy peer was not backfilled despite a sibling failure")
+	readAndCompareDigest(t, ctx, memoryCache2, rn)
+
+	// Confirm the induced failure actually took effect (otherwise the test
+	// above would pass vacuously).
+	exists, err = memoryCache3.Contains(ctx, rn)
+	require.NoError(t, err)
+	require.False(t, exists, "blob should not have been written to the failing peer")
 }
 
 func TestCopyFileDoesNotMutateResourceNameCompressor(t *testing.T) {


### PR DESCRIPTION
1. dedupeBackfills only deduped by digest, so if a resource was supposed to be sent to two peers, only one of them would be kept.
2. If a single backfill failed, it would return an error from eg.Go, which would cancel the errgroup context, which would cause all other backfills to fail.