### PR TITLE
Limit merge with base behavior in certain CI workflows

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -40,6 +40,7 @@ actions:
       pull_request:
         branches:
           - "*"
+        merge_with_base_interval: 3h
     # TODO: Fix the tests below on Mac, and re-enable.
     steps:
       - run: >-
@@ -67,6 +68,7 @@ actions:
       pull_request:
         branches:
           - "*"
+        merge_with_base_interval: 3h
     # TODO: Fix the tests below on Mac, and re-enable.
     steps:
       - run: >-
@@ -99,6 +101,7 @@ actions:
       pull_request:
         branches:
           - "*"
+        merge_with_base_interval: 3h
     steps:
       - run: "bazel test //... --config=linux-workflows --config=race --test_tag_filters=+bare --build_tag_filters=+bare"
     allow_concurrent_runs: false


### PR DESCRIPTION
Now, we will merge with base at most once every 3 hours, instead of every run. This should make CI run faster, as there will be fewer cache invalidations if the PR branch is unchanged but master has advanced

Supported added [here](https://github.com/buildbuddy-io/buildbuddy/pull/12426/changes)