### PR TITLE
Add basic prometheus metrics to DNS server

### DIFF
--- a/enterprise/dns/server/BUILD
+++ b/enterprise/dns/server/BUILD
@@ -8,8 +8,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/dns/server",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/metrics",
         "//server/util/log",
         "@com_github_miekg_dns//:dns",
+        "@com_github_prometheus_client_golang//prometheus",
     ],
 )
 

--- a/enterprise/dns/server/server.go
+++ b/enterprise/dns/server/server.go
@@ -32,7 +32,7 @@ func (h *handler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	m.SetReply(r)
 	m.Authoritative = true
 
-	recordType := "NONE"
+	recordType := "NO_QUESTION"
 	if len(r.Question) >= 1 {
 		recordType = recordTypeLabel(r.Question[0].Qtype)
 	}

--- a/enterprise/dns/server/server.go
+++ b/enterprise/dns/server/server.go
@@ -3,10 +3,13 @@ package server
 import (
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // maxCNAMEDepth bounds how many CNAME hops we follow before giving up
@@ -24,9 +27,24 @@ type handler struct {
 }
 
 func (h *handler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
+	start := time.Now()
 	m := new(dns.Msg)
 	m.SetReply(r)
 	m.Authoritative = true
+
+	recordType := "NONE"
+	if len(r.Question) >= 1 {
+		recordType = recordTypeLabel(r.Question[0].Qtype)
+	}
+	defer func() {
+		metrics.DNSServerRequestCount.With(prometheus.Labels{
+			metrics.DNSRecordTypeLabel:   recordType,
+			metrics.DNSResponseCodeLabel: rcodeLabel(m.Rcode),
+		}).Inc()
+		metrics.DNSServerHandlerDurationUsec.With(prometheus.Labels{
+			metrics.DNSRecordTypeLabel: recordType,
+		}).Observe(float64(time.Since(start).Microseconds()))
+	}()
 
 	if len(r.Question) != 1 {
 		m.Rcode = dns.RcodeFormatError
@@ -125,6 +143,23 @@ func (h *handler) lookup(name string) ([]dns.RR, bool) {
 		}
 	}
 	return nil, false
+}
+
+// recordTypeLabel maps a query type to a metric label, collapsing unknown
+// types (which the client controls) to "OTHER" so cardinality stays bounded.
+func recordTypeLabel(qType uint16) string {
+	if s, ok := dns.TypeToString[qType]; ok {
+		return s
+	}
+	return "OTHER"
+}
+
+// rcodeLabel maps a response code to a metric label, with the same bounding.
+func rcodeLabel(rcode int) string {
+	if s, ok := dns.RcodeToString[rcode]; ok {
+		return s
+	}
+	return "OTHER"
 }
 
 func filterByType(records []dns.RR, qType uint16) []dns.RR {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -404,6 +404,14 @@ const (
 
 	// Signing algorithm used (JWT alg), such as "HS256" or "ES256".
 	SigningMethodLabel = "method"
+
+	// The DNS query (record) type, such as "A", "AAAA", "CNAME", or "MX".
+	// Unrecognized types are bucketed as "OTHER" to bound cardinality, since
+	// the type is client-controlled.
+	DNSRecordTypeLabel = "record_type"
+
+	// The DNS response code, such as "NOERROR", "NXDOMAIN", or "FORMERR".
+	DNSResponseCodeLabel = "rcode"
 )
 
 // Label value constants
@@ -4257,6 +4265,50 @@ var (
 		DestinationProviderLabel,
 		DestinationRegionLabel,
 	})
+
+	// ## DNS server metrics
+
+	DNSServerRequestCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "dns",
+		Name:      "server_request_count",
+		Help:      "The total number of DNS queries handled, by record type and response code.",
+	}, []string{
+		DNSRecordTypeLabel,
+		DNSResponseCodeLabel,
+	})
+
+	// #### Examples
+	//
+	// ```promql
+	// # DNS queries per second by record type
+	// sum by (record_type) (rate(buildbuddy_dns_server_request_count[5m]))
+	//
+	// # NXDOMAIN rate
+	// sum(rate(buildbuddy_dns_server_request_count{rcode="NXDOMAIN"}[5m]))
+	//   /
+	// sum(rate(buildbuddy_dns_server_request_count[5m]))
+	// ```
+
+	DNSServerHandlerDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "dns",
+		Name:      "server_handler_duration_usec",
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*time.Second, 2),
+		Help:      "Time to handle a DNS query, in **microseconds**, by record type.",
+	}, []string{
+		DNSRecordTypeLabel,
+	})
+
+	// #### Examples
+	//
+	// ```promql
+	// # Median DNS handler latency in the past 5 minutes
+	// histogram_quantile(
+	//   0.5,
+	//   sum(rate(buildbuddy_dns_server_handler_duration_usec_bucket[5m])) by (le)
+	// )
+	// ```
 )
 
 // exponentialBucketRange returns prometheus.ExponentialBuckets specified in


### PR DESCRIPTION
Add some basic metrics so we can look at DNS lookup QPS and latency, by response code. Bound cardinality.