### PR TITLE
Classify container registry HTTP errors by whether people can take action or not

### DIFF
--- a/enterprise/server/oci/ocifetcher/BUILD
+++ b/enterprise/server/oci/ocifetcher/BUILD
@@ -55,6 +55,7 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -5,6 +5,7 @@ package ocifetcher
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -718,13 +719,39 @@ func withPullerRetry[T any](
 	}
 	if err != nil {
 		s.evictPuller(ref, creds)
-		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
-			return zero, status.UnauthenticatedErrorf("not authorized to access resource: %s", err)
-		}
-		return zero, status.UnavailableErrorf("could not fetch from remote registry: %s", err)
+		return zero, remoteRegistryError(err)
 	}
 
 	return result, nil
+}
+
+func remoteRegistryError(err error) error {
+	var transportErr *transport.Error
+	if !errors.As(err, &transportErr) {
+		return status.UnavailableErrorf("could not fetch from remote registry: %s", err)
+	}
+	return ImagePullErrorFromHTTPStatusCode(transportErr.StatusCode, fmt.Sprintf("remote registry returned HTTP %d: %s", transportErr.StatusCode, err))
+}
+
+// ImagePullErrorFromHTTPStatusCode returns a status error for an image pull
+// failure when the registry HTTP status code is known.
+func ImagePullErrorFromHTTPStatusCode(httpStatusCode int, msg string) error {
+	switch httpStatusCode {
+	case http.StatusBadRequest:
+		return status.InvalidArgumentError(msg)
+	case http.StatusUnauthorized:
+		return status.UnauthenticatedError(msg)
+	case http.StatusForbidden:
+		return status.PermissionDeniedError(msg)
+	case http.StatusNotFound:
+		return status.NotFoundError(msg)
+	case http.StatusTooManyRequests:
+		return status.ResourceExhaustedError(msg)
+	}
+	if httpStatusCode >= http.StatusBadRequest && httpStatusCode < http.StatusInternalServerError {
+		return status.InvalidArgumentError(msg)
+	}
+	return status.UnavailableError(msg)
 }
 
 type grpcStreamWriter struct {

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -734,7 +734,10 @@ func RemoteRegistryError(err error, msg string) error {
 	if !errors.As(err, &transportErr) {
 		return status.UnavailableErrorf("%s: %s", msg, err)
 	}
-	return RegistryErrorFromHTTPStatusCode(transportErr.StatusCode, fmt.Sprintf("%s: %s", msg, err))
+	return RegistryErrorFromHTTPStatusCode(
+		transportErr.StatusCode,
+		fmt.Sprintf("%s: remote registry HTTP status %d: %s", msg, transportErr.StatusCode, err),
+	)
 }
 
 // RegistryErrorFromHTTPStatusCode returns a status error for a remote registry

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -719,23 +719,27 @@ func withPullerRetry[T any](
 	}
 	if err != nil {
 		s.evictPuller(ref, creds)
-		return zero, remoteRegistryError(err)
+		return zero, RemoteRegistryError(err, "could not fetch from remote registry")
 	}
 
 	return result, nil
 }
 
-func remoteRegistryError(err error) error {
+// RemoteRegistryError converts an error from a remote registry request into a
+// status error classified by HTTP status code when one is available, falling
+// back to Unavailable otherwise. msg is a human-readable prefix describing the
+// operation that failed.
+func RemoteRegistryError(err error, msg string) error {
 	var transportErr *transport.Error
 	if !errors.As(err, &transportErr) {
-		return status.UnavailableErrorf("could not fetch from remote registry: %s", err)
+		return status.UnavailableErrorf("%s: %s", msg, err)
 	}
-	return ImagePullErrorFromHTTPStatusCode(transportErr.StatusCode, fmt.Sprintf("remote registry returned HTTP %d: %s", transportErr.StatusCode, err))
+	return RegistryErrorFromHTTPStatusCode(transportErr.StatusCode, fmt.Sprintf("%s: %s", msg, err))
 }
 
-// ImagePullErrorFromHTTPStatusCode returns a status error for an image pull
-// failure when the registry HTTP status code is known.
-func ImagePullErrorFromHTTPStatusCode(httpStatusCode int, msg string) error {
+// RegistryErrorFromHTTPStatusCode returns a status error for a remote registry
+// request failure when the HTTP status code is known.
+func RegistryErrorFromHTTPStatusCode(httpStatusCode int, msg string) error {
 	switch httpStatusCode {
 	case http.StatusBadRequest:
 		return status.InvalidArgumentError(msg)

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -75,6 +76,21 @@ func setupRegistry(t *testing.T, creds *testregistry.BasicAuthCreds, interceptor
 func newTestServer(t *testing.T) ofpb.OCIFetcherServer {
 	_, bsClient, acClient := setupCacheEnv(t)
 	return newTestServerWithCache(t, bsClient, acClient)
+}
+
+func TestRemoteRegistryErrorPreservesHTTPStatusAndRegistryMessage(t *testing.T) {
+	err := ocifetcher.RemoteRegistryError(&transport.Error{
+		StatusCode: http.StatusUnauthorized,
+		Errors: []transport.Diagnostic{{
+			Code:    transport.UnauthorizedErrorCode,
+			Message: "authentication required",
+		}},
+	}, "could not fetch manifest metadata from remote registry")
+
+	require.True(t, status.IsUnauthenticatedError(err), "error: %s", err)
+	msg := status.Message(err)
+	require.Contains(t, msg, "HTTP status 401")
+	require.Contains(t, msg, "UNAUTHORIZED: authentication required")
 }
 
 func newTestServerWithCache(t *testing.T, bsClient bspb.ByteStreamClient, acClient repb.ActionCacheClient) ofpb.OCIFetcherServer {

--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -31,6 +31,8 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
@@ -45,6 +47,7 @@ go_test(
         "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
+        "//server/metrics",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/status",

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -31,6 +31,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
@@ -498,20 +500,10 @@ type VM interface {
 // RecordImageFetchMetrics records the image fetch duration histogram.
 // Counts are available via the histogram's _count suffix.
 func RecordImageFetchMetrics(isolation, registry, trigger string, onDisk, hasCreds, useOCIFetcher bool, err error, duration time.Duration) {
-	statusLabel := metrics.OCIFetcherStatusOK
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || status.IsDeadlineExceededError(err) {
-			statusLabel = metrics.OCIFetcherStatusTimeout
-		} else if errors.Is(err, context.Canceled) || status.IsCanceledError(err) {
-			statusLabel = metrics.OCIFetcherStatusCanceled
-		} else {
-			statusLabel = metrics.OCIFetcherStatusError
-		}
-	}
 	labels := prometheus.Labels{
 		metrics.IsolationTypeLabel:           isolation,
 		metrics.ImageFetchRegistryLabel:      registry,
-		metrics.StatusLabel:                  statusLabel,
+		metrics.StatusLabel:                  ImagePullMetricStatus(err),
 		metrics.ImageFetchOnDiskLabel:        strconv.FormatBool(onDisk),
 		metrics.ImageFetchHasCredsLabel:      strconv.FormatBool(hasCreds),
 		metrics.ImageFetchTriggerLabel:       trigger,
@@ -521,12 +513,44 @@ func RecordImageFetchMetrics(isolation, registry, trigger string, onDisk, hasCre
 }
 
 func LogImagePullError(ctx context.Context, imageRef, isolation, trigger string, useOCIFetcher bool, err error, duration time.Duration) {
-	if err == nil {
+	if !ShouldCountImagePullError(err) {
 		return
 	}
 	log.CtxWarningf(ctx,
 		"image_pull_error: image=%q registry=%s isolation=%s trigger=%s use_oci_fetcher=%v duration=%s err=%s",
 		imageRef, oci.RegistryETLDPlusOne(imageRef), isolation, trigger, useOCIFetcher, duration, err)
+}
+
+// ImagePullMetricStatus returns the metrics status label for an image pull result.
+func ImagePullMetricStatus(err error) string {
+	if err == nil {
+		return metrics.OCIFetcherStatusOK
+	}
+	if errors.Is(err, context.DeadlineExceeded) || status.IsDeadlineExceededError(err) {
+		return metrics.OCIFetcherStatusTimeout
+	}
+	if errors.Is(err, context.Canceled) || status.IsCanceledError(err) {
+		return metrics.OCIFetcherStatusCanceled
+	}
+	if !ShouldCountImagePullError(err) {
+		return metrics.OCIFetcherStatusUserError
+	}
+	return metrics.OCIFetcherStatusError
+}
+
+// ShouldCountImagePullError reports whether a failed image pull should count as
+// an image pull error in metrics and logs. This is based on the gRPC status code
+// intentionally constructed at the call site, not the error message text.
+func ShouldCountImagePullError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch gstatus.Code(err) {
+	case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.PermissionDenied, codes.Unauthenticated, codes.FailedPrecondition, codes.OutOfRange:
+		return false
+	default:
+		return true
+	}
 }
 
 // PullImageIfNecessary pulls the image configured for the container if it

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -2,6 +2,7 @@ package container_test
 
 import (
 	"context"
+	"fmt"
 	"syscall"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -28,6 +30,7 @@ import (
 type FakeContainer struct {
 	RequiredPullCredentials oci.Credentials
 	PullCount               int
+	PullErr                 error
 	pullDelay               time.Duration
 }
 
@@ -43,6 +46,9 @@ func (c *FakeContainer) IsImageCached(context.Context) (bool, error) {
 func (c *FakeContainer) PullImage(ctx context.Context, creds oci.Credentials) error {
 	if c.pullDelay > 0*time.Second {
 		time.Sleep(c.pullDelay)
+	}
+	if c.PullErr != nil {
+		return c.PullErr
 	}
 	if creds != c.RequiredPullCredentials {
 		return status.PermissionDeniedError("Permission denied: wrong pull credentials")
@@ -135,6 +141,106 @@ func TestPullImageIfNecessary_InvalidCredentials_PermissionDenied(t *testing.T) 
 	err = container.PullImageIfNecessary(ctx, env, c, goodCreds, imageRef, false)
 
 	require.NoError(t, err, "good creds should still work after previous incorrect attempts")
+}
+
+func TestPullImageIfNecessary_NonOCIFetcherPullErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		pullErr     error
+		wantStatus  string
+		wantCounted bool
+	}{
+		{
+			name:        "resource exhausted",
+			pullErr:     status.ResourceExhaustedError("remote registry rate limited"),
+			wantStatus:  metrics.OCIFetcherStatusError,
+			wantCounted: true,
+		},
+		{
+			name:        "permission denied",
+			pullErr:     status.PermissionDeniedError("wrong pull credentials"),
+			wantStatus:  metrics.OCIFetcherStatusUserError,
+			wantCounted: false,
+		},
+		{
+			name:        "not found",
+			pullErr:     status.NotFoundError("image not found"),
+			wantStatus:  metrics.OCIFetcherStatusUserError,
+			wantCounted: false,
+		},
+		{
+			name:        "unavailable",
+			pullErr:     status.UnavailableError("remote registry unavailable"),
+			wantStatus:  metrics.OCIFetcherStatusError,
+			wantCounted: true,
+		},
+	} {
+		for _, useOCIFetcher := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/use_oci_fetcher_%t", tc.name, useOCIFetcher), func(t *testing.T) {
+				env := testenv.GetTestEnv(t)
+				imageRef := "docker.io/some-org/some-image:v1.0.0"
+				ctx := context.Background()
+				c := &FakeContainer{PullErr: tc.pullErr}
+
+				err := container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, imageRef, useOCIFetcher)
+
+				require.Error(t, err)
+				require.Equal(t, tc.wantStatus, container.ImagePullMetricStatus(err))
+				require.Equal(t, tc.wantCounted, container.ShouldCountImagePullError(err))
+			})
+		}
+	}
+}
+
+func TestImagePullMetricStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		err         error
+		wantStatus  string
+		wantCounted bool
+	}{
+		{
+			name:        "nil",
+			err:         nil,
+			wantStatus:  metrics.OCIFetcherStatusOK,
+			wantCounted: false,
+		},
+		{
+			name:        "unknown error",
+			err:         status.UnknownError("network unavailable"),
+			wantStatus:  metrics.OCIFetcherStatusError,
+			wantCounted: true,
+		},
+		{
+			name:        "resource exhausted",
+			err:         status.ResourceExhaustedError("remote registry rate limited"),
+			wantStatus:  metrics.OCIFetcherStatusError,
+			wantCounted: true,
+		},
+		{
+			name:        "permission denied",
+			err:         status.PermissionDeniedError("wrong pull credentials"),
+			wantStatus:  metrics.OCIFetcherStatusUserError,
+			wantCounted: false,
+		},
+		{
+			name:        "not found",
+			err:         status.NotFoundError("image not found"),
+			wantStatus:  metrics.OCIFetcherStatusUserError,
+			wantCounted: false,
+		},
+		{
+			name:        "unavailable",
+			err:         status.UnavailableError("remote registry unavailable"),
+			wantStatus:  metrics.OCIFetcherStatusError,
+			wantCounted: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.wantStatus, container.ImagePullMetricStatus(tc.err))
+			require.Equal(t, tc.wantCounted, container.ShouldCountImagePullError(tc.err))
+		})
+	}
 }
 
 func TestPullImageIfNecessary_ParallelCallsSerialized(t *testing.T) {

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -179,7 +179,8 @@ func TestPullImageIfNecessaryReauthenticatesCachedOCIImage(t *testing.T) {
 		Password: "wrong-password",
 	}, imageRef, false)
 
-	require.True(t, status.IsPermissionDeniedError(err), "cached private OCI image must still be re-authenticated for a different group; got %v", err)
+	require.Error(t, err)
+	require.True(t, status.IsUnauthenticatedError(err) || status.IsPermissionDeniedError(err), "cached private OCI image must still be re-authenticated for a different group; got %v", err)
 }
 
 func TestRun(t *testing.T) {

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -29,7 +29,6 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/partial",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
-        "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
         "@com_github_google_go_containerregistry//pkg/v1/types",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
     ],

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -3,11 +3,11 @@ package oci
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
 	"net"
-	"net/http"
 	"runtime"
 	"slices"
 	"sync"
@@ -243,10 +243,7 @@ func (r *Resolver) AuthenticateWithRegistry(ctx context.Context, imageName strin
 	remoteOpts := r.getRemoteOpts(ctx, platform, credentials)
 	_, err = remote.Head(imageRef, remoteOpts...)
 	if err != nil {
-		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
-			return status.PermissionDeniedErrorf("not authorized to access image manifest: %s", err)
-		}
-		return status.UnavailableErrorf("could not fetch manifest metadata from remote registry: %s", err)
+		return remoteRegistryError(err, "could not fetch manifest metadata from remote registry")
 	}
 
 	return nil
@@ -274,10 +271,7 @@ func (r *Resolver) ResolveImageDigest(ctx context.Context, imageName string, pla
 	remoteOpts := r.getRemoteOpts(ctx, platform, credentials)
 	desc, err := remote.Head(tagRef, remoteOpts...)
 	if err != nil {
-		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
-			return "", status.PermissionDeniedErrorf("not authorized to access image manifest: %s", err)
-		}
-		return "", status.UnavailableErrorf("could not fetch manifest metadata from remote registry: %s", err)
+		return "", remoteRegistryError(err, "could not fetch manifest metadata from remote registry")
 	}
 	imageNameWithDigest := tagRef.Context().Digest(desc.Digest.String()).String()
 	r.imageTagToDigestLRU.Add(tagRef.String(), imageNameWithDigest)
@@ -440,16 +434,21 @@ func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef ctrname.Ref
 	)
 }
 
+func remoteRegistryError(err error, msg string) error {
+	var transportErr *transport.Error
+	if errors.As(err, &transportErr) {
+		return ocifetcher.ImagePullErrorFromHTTPStatusCode(transportErr.StatusCode, fmt.Sprintf("%s: %s", msg, err))
+	}
+	return status.UnavailableErrorf("%s: %s", msg, err)
+}
+
 // fetchManifestMetadata makes a HEAD request for the manifest metadata using the puller.
 // This is only used when useOCIFetcher=false; when useOCIFetcher=true, we skip the
 // metadata request and fetch the full manifest directly via fetchManifest.
 func fetchManifestMetadata(ctx context.Context, digestOrTagRef ctrname.Reference, puller *remote.Puller) (*ctr.Descriptor, error) {
 	desc, err := puller.Head(ctx, digestOrTagRef)
 	if err != nil {
-		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
-			return nil, status.PermissionDeniedErrorf("cannot access image manifest: %s", err)
-		}
-		return nil, status.UnavailableErrorf("cannot retrieve manifest metadata from remote: %s", err)
+		return nil, remoteRegistryError(err, "cannot retrieve manifest metadata from remote")
 	}
 	return desc, nil
 }
@@ -482,10 +481,7 @@ func fetchManifest(ctx context.Context, digestOrTagRef ctrname.Reference, puller
 
 	remoteDesc, err := puller.Get(ctx, digestOrTagRef)
 	if err != nil {
-		if t, ok := err.(*transport.Error); ok && t.StatusCode == http.StatusUnauthorized {
-			return nil, nil, status.PermissionDeniedErrorf("not authorized to retrieve image manifest: %s", err)
-		}
-		return nil, nil, status.UnavailableErrorf("could not retrieve manifest from remote: %s", err)
+		return nil, nil, remoteRegistryError(err, "could not retrieve manifest from remote")
 	}
 	return &remoteDesc.Descriptor, remoteDesc.Manifest, nil
 }
@@ -760,7 +756,11 @@ func newLayerFromDigest(repo ctrname.Repository, digest ctr.Hash, image *imageFr
 		desc:   desc,
 		createRemoteLayer: sync.OnceValues(func() (ctr.Layer, error) {
 			ref := repo.Digest(digest.String())
-			return puller.Layer(image.ctx, ref)
+			layer, err := puller.Layer(image.ctx, ref)
+			if err != nil {
+				return nil, remoteRegistryError(err, "could not retrieve layer from remote")
+			}
+			return layer, nil
 		}),
 	}
 }

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -3,7 +3,6 @@ package oci
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -35,7 +34,6 @@ import (
 	ctr "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -243,7 +241,7 @@ func (r *Resolver) AuthenticateWithRegistry(ctx context.Context, imageName strin
 	remoteOpts := r.getRemoteOpts(ctx, platform, credentials)
 	_, err = remote.Head(imageRef, remoteOpts...)
 	if err != nil {
-		return remoteRegistryError(err, "could not fetch manifest metadata from remote registry")
+		return ocifetcher.RemoteRegistryError(err, "could not fetch manifest metadata from remote registry")
 	}
 
 	return nil
@@ -271,7 +269,7 @@ func (r *Resolver) ResolveImageDigest(ctx context.Context, imageName string, pla
 	remoteOpts := r.getRemoteOpts(ctx, platform, credentials)
 	desc, err := remote.Head(tagRef, remoteOpts...)
 	if err != nil {
-		return "", remoteRegistryError(err, "could not fetch manifest metadata from remote registry")
+		return "", ocifetcher.RemoteRegistryError(err, "could not fetch manifest metadata from remote registry")
 	}
 	imageNameWithDigest := tagRef.Context().Digest(desc.Digest.String()).String()
 	r.imageTagToDigestLRU.Add(tagRef.String(), imageNameWithDigest)
@@ -434,21 +432,13 @@ func fetchImageFromCacheOrRemote(ctx context.Context, digestOrTagRef ctrname.Ref
 	)
 }
 
-func remoteRegistryError(err error, msg string) error {
-	var transportErr *transport.Error
-	if errors.As(err, &transportErr) {
-		return ocifetcher.ImagePullErrorFromHTTPStatusCode(transportErr.StatusCode, fmt.Sprintf("%s: %s", msg, err))
-	}
-	return status.UnavailableErrorf("%s: %s", msg, err)
-}
-
 // fetchManifestMetadata makes a HEAD request for the manifest metadata using the puller.
 // This is only used when useOCIFetcher=false; when useOCIFetcher=true, we skip the
 // metadata request and fetch the full manifest directly via fetchManifest.
 func fetchManifestMetadata(ctx context.Context, digestOrTagRef ctrname.Reference, puller *remote.Puller) (*ctr.Descriptor, error) {
 	desc, err := puller.Head(ctx, digestOrTagRef)
 	if err != nil {
-		return nil, remoteRegistryError(err, "cannot retrieve manifest metadata from remote")
+		return nil, ocifetcher.RemoteRegistryError(err, "cannot retrieve manifest metadata from remote")
 	}
 	return desc, nil
 }
@@ -481,7 +471,7 @@ func fetchManifest(ctx context.Context, digestOrTagRef ctrname.Reference, puller
 
 	remoteDesc, err := puller.Get(ctx, digestOrTagRef)
 	if err != nil {
-		return nil, nil, remoteRegistryError(err, "could not retrieve manifest from remote")
+		return nil, nil, ocifetcher.RemoteRegistryError(err, "could not retrieve manifest from remote")
 	}
 	return &remoteDesc.Descriptor, remoteDesc.Manifest, nil
 }
@@ -758,7 +748,7 @@ func newLayerFromDigest(repo ctrname.Repository, digest ctr.Hash, image *imageFr
 			ref := repo.Digest(digest.String())
 			layer, err := puller.Layer(image.ctx, ref)
 			if err != nil {
-				return nil, remoteRegistryError(err, "could not retrieve layer from remote")
+				return nil, ocifetcher.RemoteRegistryError(err, "could not retrieve layer from remote")
 			}
 			return layer, nil
 		}),

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -46,6 +46,8 @@ import (
 	ctr "github.com/google/go-containerregistry/pkg/v1"
 )
 
+var manifestRequestRegexp = regexp.MustCompile("/v2/.*/manifests/.*")
+
 func TestCredentialsFromProto(t *testing.T) {
 	creds, err := oci.CredentialsFromProto(&rgpb.Credentials{
 		Username: "",
@@ -308,7 +310,7 @@ func TestResolve(t *testing.T) {
 					Os:   runtime.GOOS,
 				},
 			},
-			checkError: status.IsPermissionDeniedError,
+			checkError: status.IsUnauthenticatedError,
 			opts: testregistry.Opts{
 				HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
 					if r.Method == "GET" {
@@ -383,6 +385,100 @@ func TestResolve(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestResolve_RemoteRegistryHTTPStatusCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		statusCode int
+		checkError func(error) bool
+	}{
+		{
+			name:       "bad request",
+			statusCode: http.StatusBadRequest,
+			checkError: status.IsInvalidArgumentError,
+		},
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			checkError: status.IsUnauthenticatedError,
+		},
+		{
+			name:       "forbidden",
+			statusCode: http.StatusForbidden,
+			checkError: status.IsPermissionDeniedError,
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			checkError: status.IsNotFoundError,
+		},
+		{
+			name:       "other client error",
+			statusCode: http.StatusTeapot,
+			checkError: status.IsInvalidArgumentError,
+		},
+		{
+			name:       "too many requests",
+			statusCode: http.StatusTooManyRequests,
+			checkError: status.IsResourceExhaustedError,
+		},
+		{
+			name:       "internal server error",
+			statusCode: http.StatusInternalServerError,
+			checkError: status.IsUnavailableError,
+		},
+		{
+			name:       "service unavailable",
+			statusCode: http.StatusServiceUnavailable,
+			checkError: status.IsUnavailableError,
+		},
+	} {
+		for _, useOCIFetcher := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/use_oci_fetcher_%t", tc.name, useOCIFetcher), func(t *testing.T) {
+				flags.Set(t, "executor.container_registry_allowed_private_ips", []string{"127.0.0.1/32"})
+				flags.Set(t, "executor.container_registry.use_cache_percent", 0)
+				te := testenv.GetTestEnv(t)
+				if useOCIFetcher {
+					te = setupTestEnvWithCache(t)
+				}
+
+				var interceptPulls atomic.Bool
+				registry := testregistry.Run(t, testregistry.Opts{
+					HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+						if interceptPulls.Load() && isManifestRequest(r) {
+							w.WriteHeader(tc.statusCode)
+							return false
+						}
+						return true
+					},
+				})
+				registry.PushNamedImage(t, "remote_registry_status", nil)
+				interceptPulls.Store(true)
+
+				_, err := newResolver(t, te).Resolve(
+					context.Background(),
+					registry.ImageAddress("remote_registry_status"),
+					&rgpb.Platform{
+						Arch: runtime.GOARCH,
+						Os:   runtime.GOOS,
+					},
+					oci.Credentials{},
+					useOCIFetcher,
+				)
+
+				require.Error(t, err)
+				require.True(t, tc.checkError(err), "error: %s", err)
+			})
+		}
+	}
+}
+
+func isManifestRequest(r *http.Request) bool {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return false
+	}
+	return manifestRequestRegexp.MatchString(r.URL.Path)
 }
 
 // TestResolve_Layers_DiffIDs tests for a specific regression that led to an incident:
@@ -1098,7 +1194,7 @@ func TestResolveImageDigest_TagDoesNotExist(t *testing.T) {
 		oci.Credentials{},
 	)
 	require.Error(t, err)
-	require.True(t, status.IsUnavailableError(err), "expected UnavailableError, got: %v", err)
+	require.True(t, status.IsNotFoundError(err), "expected NotFoundError, got: %v", err)
 }
 
 func TestResolveImageDigest_AlreadyDigest_NoHTTPRequests(t *testing.T) {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -433,6 +433,7 @@ const (
 	OCIFetcherRoleWaiter      = "waiter"
 	OCIFetcherStatusOK        = "ok"
 	OCIFetcherStatusError     = "error"
+	OCIFetcherStatusUserError = "user_error"
 	OCIFetcherStatusTimeout   = "timeout"
 	OCIFetcherStatusCanceled  = "canceled"
 


### PR DESCRIPTION
When pulling an OCI image, there are HTTP errors that people can something about (most 4xx) and ones where they're stuck (429, 5xx).

This change maps registry HTTP error codes to gRPC statuses, and only logs (and counts) image pull errors for errors outside users' control.