### PR TITLE
Add a GCS-backed in-process experiment sync plugin

### DIFF
--- a/deps/go_deps.MODULE.bazel
+++ b/deps/go_deps.MODULE.bazel
@@ -273,6 +273,7 @@ use_repo(
     "com_github_mwitkow_grpc_proxy",
     "com_github_ncruces_go_sqlite3",
     "com_github_nishanths_exhaustive",
+    "com_github_open_feature_flagd_core",
     "com_github_open_feature_go_sdk",
     "com_github_open_feature_go_sdk_contrib_providers_flagd",
     "com_github_opencontainers_runtime_spec",

--- a/enterprise/server/experiments/BUILD
+++ b/enterprise/server/experiments/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//server/util/proto",
         "//server/util/region",
         "//server/util/statusz",
+        "@com_github_open_feature_flagd_core//pkg/sync",
         "@com_github_open_feature_go_sdk//openfeature",
         "@com_github_open_feature_go_sdk_contrib_providers_flagd//pkg",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -22,6 +22,7 @@ import (
 
 	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
+	flagdsync "github.com/open-feature/flagd/core/pkg/sync"
 )
 
 var (
@@ -49,7 +50,27 @@ func Register(env *real_environment.RealEnv) error {
 			return err
 		}
 	}
+	return setProvider(env, provider)
+}
 
+// RegisterInProcessSync adds an interfaces.ExperimentFlagProvider to the env
+// that evaluates flags in-process, sourcing the flag configuration from the
+// provided flagd sync implementation (for example, a GCS-backed sync from the
+// gcsflagsync package). This is an alternative to Register's flagd-backend mode for
+// binaries that pull flags directly from a source rather than talking to a
+// separate flagd process. It will not return until the provider is ready.
+func RegisterInProcessSync(env *real_environment.RealEnv, syncProvider flagdsync.ISync) error {
+	provider, err := flagd.NewProvider(flagd.WithInProcessResolver(), flagd.WithCustomSyncProvider(syncProvider))
+	if err != nil {
+		return err
+	}
+	return setProvider(env, provider)
+}
+
+// setProvider installs the given OpenFeature provider as the global provider
+// and wires the resulting FlagProvider into env. It blocks until the provider
+// is ready.
+func setProvider(env *real_environment.RealEnv, provider openfeature.FeatureProvider) error {
 	if err := openfeature.SetProviderAndWait(provider); err != nil {
 		return err
 	}

--- a/enterprise/server/experiments/experiments.go
+++ b/enterprise/server/experiments/experiments.go
@@ -21,8 +21,8 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
-	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
 	flagdsync "github.com/open-feature/flagd/core/pkg/sync"
+	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
 )
 
 var (

--- a/enterprise/server/experiments/gcsflagsync/BUILD
+++ b/enterprise/server/experiments/gcsflagsync/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "gcsflagsync",
+    srcs = ["gcsflagsync.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments/gcsflagsync",
+    deps = [
+        "//server/backends/blobstore/gcs",
+        "//server/interfaces",
+        "//server/util/flag",
+        "//server/util/log",
+        "//server/util/status",
+        "@com_github_open_feature_flagd_core//pkg/sync",
+    ],
+)

--- a/enterprise/server/experiments/gcsflagsync/BUILD
+++ b/enterprise/server/experiments/gcsflagsync/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -13,5 +13,18 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "@com_github_open_feature_flagd_core//pkg/sync",
+    ],
+)
+
+go_test(
+    name = "gcsflagsync_test",
+    srcs = ["gcsflagsync_test.go"],
+    embed = [":gcsflagsync"],
+    deps = [
+        "//server/interfaces",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "@com_github_open_feature_flagd_core//pkg/sync",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/experiments/gcsflagsync/gcsflagsync.go
+++ b/enterprise/server/experiments/gcsflagsync/gcsflagsync.go
@@ -39,6 +39,9 @@ func New(ctx context.Context) (flagdsync.ISync, error) {
 	if *object == "" {
 		return nil, status.FailedPreconditionError("experiments.gcs.object must be set when experiments.gcs.bucket is set")
 	}
+	if *pollInterval <= 0 {
+		return nil, status.InvalidArgumentErrorf("experiments.gcs.poll_interval must be positive, got %s", *pollInterval)
+	}
 
 	bs, err := gcs.NewGCSBlobStore(ctx, *bucket, *credentialsFile, *credentials, *projectID, false /*=enableCompression*/)
 	if err != nil {
@@ -78,7 +81,10 @@ func (s *syncer) IsReady() bool {
 // polls for changes until ctx is cancelled. A failed initial fetch is fatal so
 // the provider doesn't come up serving an empty flag set.
 func (s *syncer) Sync(ctx context.Context, dataSync chan<- flagdsync.DataSync) error {
-	if err := s.fetch(ctx, dataSync); err != nil {
+	// Force the initial push so the resolver is always seeded, even in the edge
+	// case where the first object read happens to equal the zero-valued
+	// lastData (e.g. it slipped past the non-empty check above).
+	if err := s.fetch(ctx, dataSync, true /*=force*/); err != nil {
 		return status.WrapError(err, "initial GCS flag sync")
 	}
 	s.mu.Lock()
@@ -92,7 +98,7 @@ func (s *syncer) Sync(ctx context.Context, dataSync chan<- flagdsync.DataSync) e
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := s.fetch(ctx, dataSync); err != nil {
+			if err := s.fetch(ctx, dataSync, false /*=force*/); err != nil {
 				// A transient read failure just means we keep serving the last
 				// known flags until the next tick succeeds.
 				log.Warningf("experiments: GCS flag sync failed: %s", err)
@@ -102,18 +108,26 @@ func (s *syncer) Sync(ctx context.Context, dataSync chan<- flagdsync.DataSync) e
 }
 
 // ReSync re-pushes the current flag configuration. flagd calls this to recover
-// the full config; we force a fresh fetch.
+// the full config, so we push unconditionally even if the object is unchanged
+// since our last push.
 func (s *syncer) ReSync(ctx context.Context, dataSync chan<- flagdsync.DataSync) error {
-	return s.fetch(ctx, dataSync)
+	return s.fetch(ctx, dataSync, true /*=force*/)
 }
 
-// fetch reads the flag object and, if it changed since the last push, sends it
-// to dataSync. Unchanged objects are skipped so flagd doesn't re-parse and emit
-// change events on every poll.
-func (s *syncer) fetch(ctx context.Context, dataSync chan<- flagdsync.DataSync) error {
+// fetch reads the flag object and sends it to dataSync. When force is false an
+// unchanged object is skipped, so periodic polls don't make flagd re-parse and
+// emit change events on every tick; when force is true the object is pushed
+// regardless (used for the initial sync and for ReSync, which must re-seed the
+// resolver's store). An empty object is treated as an error rather than pushed,
+// so a truncated/empty config can never replace the last known good flags (and
+// can never bring the provider up "ready" with no flags).
+func (s *syncer) fetch(ctx context.Context, dataSync chan<- flagdsync.DataSync, force bool) error {
 	data, err := s.blobstore.ReadBlob(ctx, s.object)
 	if err != nil {
 		return err
+	}
+	if len(data) == 0 {
+		return status.FailedPreconditionErrorf("flag config object %q is empty", s.object)
 	}
 	s.mu.Lock()
 	changed := !bytes.Equal(data, s.lastData)
@@ -121,7 +135,7 @@ func (s *syncer) fetch(ctx context.Context, dataSync chan<- flagdsync.DataSync) 
 		s.lastData = data
 	}
 	s.mu.Unlock()
-	if !changed {
+	if !changed && !force {
 		return nil
 	}
 	select {

--- a/enterprise/server/experiments/gcsflagsync/gcsflagsync.go
+++ b/enterprise/server/experiments/gcsflagsync/gcsflagsync.go
@@ -1,0 +1,132 @@
+// Package gcsflagsync provides a flagd sync.ISync implementation that sources
+// the flag configuration from a GCS object, polling for changes at a fixed
+// interval. It is meant to be passed to experiments.RegisterInProcessSync so a
+// binary can evaluate experiment flags in-process without running a separate
+// flagd backend.
+package gcsflagsync
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/gcs"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	flagdsync "github.com/open-feature/flagd/core/pkg/sync"
+)
+
+var (
+	bucket          = flag.String("experiments.gcs.bucket", "", "If set, sync the flagd flag configuration in-process from this GCS bucket instead of connecting to a flagd backend.")
+	object          = flag.String("experiments.gcs.object", "", "Path to the flagd JSON config object within --experiments.gcs.bucket.")
+	credentialsFile = flag.String("experiments.gcs.credentials_file", "", "Path to a JSON credentials file used to authenticate to GCS.")
+	credentials     = flag.String("experiments.gcs.credentials", "", "JSON credentials used to authenticate to GCS.", flag.Secret)
+	projectID       = flag.String("experiments.gcs.project_id", "", "GCP project ID owning the GCS bucket.")
+	pollInterval    = flag.Duration("experiments.gcs.poll_interval", 10*time.Second, "How often to poll GCS for flag configuration changes.")
+)
+
+// New constructs a flagd sync.ISync that polls the configured GCS object for
+// flag configuration changes. It returns an error if no bucket/object is
+// configured.
+func New(ctx context.Context) (flagdsync.ISync, error) {
+	if *bucket == "" {
+		return nil, status.FailedPreconditionError("experiments.gcs.bucket must be set")
+	}
+	if *object == "" {
+		return nil, status.FailedPreconditionError("experiments.gcs.object must be set when experiments.gcs.bucket is set")
+	}
+
+	bs, err := gcs.NewGCSBlobStore(ctx, *bucket, *credentialsFile, *credentials, *projectID, false /*=enableCompression*/)
+	if err != nil {
+		return nil, err
+	}
+	return &syncer{
+		blobstore: bs,
+		object:    *object,
+		interval:  *pollInterval,
+	}, nil
+}
+
+// syncer implements flagd's sync.ISync by polling a flag configuration object
+// from GCS at a fixed interval, pushing the latest contents to the in-process
+// flagd resolver whenever they change. It is a lightweight alternative to
+// running a separate flagd backend: the only "backend" is a JSON object in a
+// bucket.
+type syncer struct {
+	blobstore interfaces.Blobstore
+	object    string
+	interval  time.Duration
+
+	mu       sync.Mutex
+	ready    bool
+	lastData []byte
+}
+
+func (s *syncer) Init(ctx context.Context) error { return nil }
+
+func (s *syncer) IsReady() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ready
+}
+
+// Sync performs an initial fetch (so the resolver starts with flags) and then
+// polls for changes until ctx is cancelled. A failed initial fetch is fatal so
+// the provider doesn't come up serving an empty flag set.
+func (s *syncer) Sync(ctx context.Context, dataSync chan<- flagdsync.DataSync) error {
+	if err := s.fetch(ctx, dataSync); err != nil {
+		return status.WrapError(err, "initial GCS flag sync")
+	}
+	s.mu.Lock()
+	s.ready = true
+	s.mu.Unlock()
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := s.fetch(ctx, dataSync); err != nil {
+				// A transient read failure just means we keep serving the last
+				// known flags until the next tick succeeds.
+				log.Warningf("experiments: GCS flag sync failed: %s", err)
+			}
+		}
+	}
+}
+
+// ReSync re-pushes the current flag configuration. flagd calls this to recover
+// the full config; we force a fresh fetch.
+func (s *syncer) ReSync(ctx context.Context, dataSync chan<- flagdsync.DataSync) error {
+	return s.fetch(ctx, dataSync)
+}
+
+// fetch reads the flag object and, if it changed since the last push, sends it
+// to dataSync. Unchanged objects are skipped so flagd doesn't re-parse and emit
+// change events on every poll.
+func (s *syncer) fetch(ctx context.Context, dataSync chan<- flagdsync.DataSync) error {
+	data, err := s.blobstore.ReadBlob(ctx, s.object)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	changed := !bytes.Equal(data, s.lastData)
+	if changed {
+		s.lastData = data
+	}
+	s.mu.Unlock()
+	if !changed {
+		return nil
+	}
+	select {
+	case dataSync <- flagdsync.DataSync{FlagData: string(data), Source: s.object}:
+	case <-ctx.Done():
+	}
+	return nil
+}

--- a/enterprise/server/experiments/gcsflagsync/gcsflagsync_test.go
+++ b/enterprise/server/experiments/gcsflagsync/gcsflagsync_test.go
@@ -1,0 +1,168 @@
+package gcsflagsync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+
+	flagdsync "github.com/open-feature/flagd/core/pkg/sync"
+)
+
+// fakeBlobstore is a minimal interfaces.Blobstore whose ReadBlob returns
+// caller-controlled data/error. Only ReadBlob is exercised by gcsflagsync.
+type fakeBlobstore struct {
+	mu   sync.Mutex
+	data []byte
+	err  error
+}
+
+func (f *fakeBlobstore) setData(b []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data = b
+}
+
+func (f *fakeBlobstore) ReadBlob(ctx context.Context, blobName string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.data, f.err
+}
+
+func (f *fakeBlobstore) BlobExists(ctx context.Context, blobName string) (bool, error) {
+	panic("not implemented")
+}
+func (f *fakeBlobstore) WriteBlob(ctx context.Context, blobName string, data []byte) (int, error) {
+	panic("not implemented")
+}
+func (f *fakeBlobstore) DeleteBlob(ctx context.Context, blobName string) error {
+	panic("not implemented")
+}
+func (f *fakeBlobstore) Writer(ctx context.Context, blobName string) (interfaces.CommittedWriteCloser, error) {
+	panic("not implemented")
+}
+
+func newSyncer(bs interfaces.Blobstore) *syncer {
+	return &syncer{blobstore: bs, object: "flags.json", interval: time.Minute}
+}
+
+// fetch pushes on the first read and skips unchanged objects, but pushes again
+// once the object changes.
+func TestFetch_PushesOnChangeAndDedups(t *testing.T) {
+	ctx := context.Background()
+	bs := &fakeBlobstore{data: []byte(`{"flags":{}}`)}
+	s := newSyncer(bs)
+	ch := make(chan flagdsync.DataSync, 8)
+
+	require.NoError(t, s.fetch(ctx, ch, false /*=force*/))
+	require.Len(t, ch, 1)
+	got := <-ch
+	require.Equal(t, `{"flags":{}}`, got.FlagData)
+	require.Equal(t, "flags.json", got.Source)
+
+	// Same bytes: no push.
+	require.NoError(t, s.fetch(ctx, ch, false /*=force*/))
+	require.Empty(t, ch)
+
+	// Changed bytes: push.
+	bs.setData([]byte(`{"flags":{"x":true}}`))
+	require.NoError(t, s.fetch(ctx, ch, false /*=force*/))
+	require.Len(t, ch, 1)
+	require.Equal(t, `{"flags":{"x":true}}`, (<-ch).FlagData)
+}
+
+// ReSync re-pushes the current config even when the object is unchanged since
+// the last push (regression test: ReSync must re-seed flagd's store).
+func TestReSync_PushesEvenWhenUnchanged(t *testing.T) {
+	ctx := context.Background()
+	bs := &fakeBlobstore{data: []byte(`{"flags":{}}`)}
+	s := newSyncer(bs)
+	ch := make(chan flagdsync.DataSync, 8)
+
+	require.NoError(t, s.fetch(ctx, ch, false /*=force*/))
+	require.Len(t, ch, 1)
+	<-ch
+
+	// A normal poll of the unchanged object pushes nothing...
+	require.NoError(t, s.fetch(ctx, ch, false /*=force*/))
+	require.Empty(t, ch)
+
+	// ...but ReSync pushes regardless.
+	require.NoError(t, s.ReSync(ctx, ch))
+	require.Len(t, ch, 1)
+	require.Equal(t, `{"flags":{}}`, (<-ch).FlagData)
+}
+
+// An empty object is an error and is never pushed, so it can't replace the last
+// known good config.
+func TestFetch_EmptyObjectIsError(t *testing.T) {
+	ctx := context.Background()
+	bs := &fakeBlobstore{data: []byte{}}
+	s := newSyncer(bs)
+	ch := make(chan flagdsync.DataSync, 1)
+
+	err := s.fetch(ctx, ch, true /*=force*/)
+	require.True(t, status.IsFailedPreconditionError(err), "got: %v", err)
+	require.Empty(t, ch)
+}
+
+// Sync fails (and does not report ready) when the initial object is empty.
+func TestSync_EmptyInitialObjectIsFatalAndNotReady(t *testing.T) {
+	ctx := context.Background()
+	bs := &fakeBlobstore{data: []byte{}}
+	s := newSyncer(bs)
+	ch := make(chan flagdsync.DataSync, 1)
+
+	require.Error(t, s.Sync(ctx, ch))
+	require.False(t, s.IsReady())
+	require.Empty(t, ch)
+}
+
+// Sync seeds the resolver on startup, reports ready, and returns cleanly when
+// the context is cancelled.
+func TestSync_SeedsAndBecomesReady(t *testing.T) {
+	bs := &fakeBlobstore{data: []byte(`{"flags":{}}`)}
+	s := newSyncer(bs)
+	ch := make(chan flagdsync.DataSync, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- s.Sync(ctx, ch) }()
+
+	// Initial config is pushed before ready is reported.
+	require.Equal(t, `{"flags":{}}`, (<-ch).FlagData)
+	require.Eventually(t, s.IsReady, time.Second, time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestNew_Validation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("requires bucket", func(t *testing.T) {
+		// bucket defaults to "".
+		_, err := New(ctx)
+		require.True(t, status.IsFailedPreconditionError(err), "got: %v", err)
+	})
+
+	t.Run("requires object", func(t *testing.T) {
+		flags.Set(t, "experiments.gcs.bucket", "my-bucket")
+		_, err := New(ctx)
+		require.True(t, status.IsFailedPreconditionError(err), "got: %v", err)
+	})
+
+	t.Run("rejects non-positive interval", func(t *testing.T) {
+		flags.Set(t, "experiments.gcs.bucket", "my-bucket")
+		flags.Set(t, "experiments.gcs.object", "flags.json")
+		flags.Set(t, "experiments.gcs.poll_interval", time.Duration(0))
+		_, err := New(ctx)
+		require.True(t, status.IsInvalidArgumentError(err), "got: %v", err)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -413,7 +413,7 @@ require (
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/open-feature/flagd-schemas v0.2.13 // indirect
-	github.com/open-feature/flagd/core v0.13.2 // indirect
+	github.com/open-feature/flagd/core v0.13.2
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-tools v0.9.1-0.20251114084447-edf4cb3d2116 // indirect


### PR DESCRIPTION
This plugin will allow the DNS server to sync experiments with only a GCS dependency.