### PR TITLE
Make firecracker Stats() work during task execution

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -463,9 +463,9 @@ type CommandContainer interface {
 	//
 	// A `nil` value may be returned if the resource usage is unknown.
 	//
-	// Implementations may assume that this will only be called when the
-	// container is paused, for the purposes of computing resources used for
-	// pooled runners.
+	// Live stats are used by the OOM killer to decide which tasks to kill when
+	// the executor is running low on memory. Paused stats are used for pooled
+	// runner accounting.
 	Stats(ctx context.Context) (*repb.UsageStats, error)
 }
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -732,6 +732,10 @@ type FirecrackerContainer struct {
 		err  error
 	}
 
+	// latestGuestStats is the latest UsageStats sample streamed from vmexec.
+	latestGuestStatsMu sync.Mutex
+	latestGuestStats   *repb.UsageStats
+
 	useOCIFetcher bool
 
 	// postCompletionStats accumulates firecracker snapshot save stats
@@ -2311,9 +2315,6 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 	client := vmxpb.NewExecClient(conn)
 	health := hlpb.NewHealthClient(conn)
 
-	var statsMu sync.Mutex
-	var lastGuestStats *repb.UsageStats
-
 	resultCh := make(chan *interfaces.CommandResult, 1)
 	healthCheckErrCh := make(chan error, 1)
 	ctx, cancel := context.WithCancel(ctx)
@@ -2321,9 +2322,7 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 	go func() {
 		log.CtxDebug(ctx, "Starting Execute stream.")
 		statsListener := func(stats *repb.UsageStats) {
-			statsMu.Lock()
-			defer statsMu.Unlock()
-			lastGuestStats = stats
+			c.updateLatestGuestStats(stats)
 		}
 		res := vmexec_client.Execute(ctx, client, cmd, workDir, c.user, statsListener, stdio)
 		resultCh <- res
@@ -2363,10 +2362,8 @@ func (c *FirecrackerContainer) sendExecRequestToGuest(ctx context.Context, conn 
 	case err := <-healthCheckErrCh:
 		cancelCgroupPoll()
 		res := commandutil.ErrorResult(status.UnavailableErrorf("VM health check failed (possibly crashed?): %s", err))
-		statsMu.Lock()
-		res.UsageStats = combineHostAndGuestStats(hostCgroupStats.TaskStats(), lastGuestStats)
+		res.UsageStats = combineHostAndGuestStats(hostCgroupStats.TaskStats(), c.getLatestGuestStats())
 		c.fillNetStats(ctx, res.UsageStats)
-		statsMu.Unlock()
 		return res, false
 	}
 }
@@ -2381,6 +2378,25 @@ func (c *FirecrackerContainer) fillNetStats(ctx context.Context, usageStats *rep
 		return
 	}
 	usageStats.NetworkStats = netStats
+}
+
+func (c *FirecrackerContainer) updateLatestGuestStats(stats *repb.UsageStats) {
+	c.latestGuestStatsMu.Lock()
+	defer c.latestGuestStatsMu.Unlock()
+	if stats == nil {
+		c.latestGuestStats = nil
+		return
+	}
+	c.latestGuestStats = stats.CloneVT()
+}
+
+func (c *FirecrackerContainer) getLatestGuestStats() *repb.UsageStats {
+	c.latestGuestStatsMu.Lock()
+	defer c.latestGuestStatsMu.Unlock()
+	if c.latestGuestStats == nil {
+		return &repb.UsageStats{}
+	}
+	return c.latestGuestStats.CloneVT()
 }
 
 func (c *FirecrackerContainer) vmExecConn(ctx context.Context) (*grpc.ClientConn, error) {
@@ -2904,6 +2920,7 @@ func (c *FirecrackerContainer) stopMachine(ctx context.Context) error {
 	if err := os.Remove(c.cgroupPath()); err != nil && !os.IsNotExist(err) {
 		log.CtxWarningf(ctx, "Failed to remove jailer cgroup: %s", err)
 	}
+	c.updateLatestGuestStats(nil)
 
 	return nil
 }
@@ -3438,10 +3455,9 @@ func (c *FirecrackerContainer) Wait(ctx context.Context) error {
 }
 
 func (c *FirecrackerContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
-	// Note: We return a non-nil value here since paused Firecracker containers
-	// only exist on disk and legitimately consume 0 memory / CPU resources when
-	// paused.
-	return &repb.UsageStats{}, nil
+	// TODO: figure out a clean way of separating the host cgroup stats from the
+	// VM guest stats, which may report different information.
+	return c.getLatestGuestStats(), nil
 }
 
 // parseFatalInitError looks for a fatal error logged by the init binary, and

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -2374,6 +2374,88 @@ func TestFirecrackerComplexFileMapping(t *testing.T) {
 	}
 }
 
+func TestStatsReturnsLatestGuestStatsDuringExec(t *testing.T) {
+	ctx := context.Background()
+	env := getTestEnv(ctx, t, envOpts{})
+	workDir := testfs.MakeTempDir(t)
+	opts := firecracker.ContainerOpts{
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		VMConfiguration: &fcpb.VMConfiguration{
+			NumCpus:           1,
+			MemSizeMb:         minMemSizeMB,
+			NetworkMode:       fcpb.NetworkMode_NETWORK_MODE_OFF,
+			ScratchDiskSizeMb: 100,
+		},
+		ExecutorConfig: getExecutorConfig(t),
+	}
+	c, err := firecracker.NewContainer(ctx, env, &repb.ExecutionTask{}, opts)
+	require.NoError(t, err)
+	err = container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, opts.ContainerImage, opts.UseOCIFetcher)
+	require.NoError(t, err)
+	err = c.Create(ctx, workDir)
+	require.NoError(t, err)
+	defer func() {
+		err := c.Remove(ctx)
+		require.NoError(t, err)
+	}()
+
+	// Start a command blocked on stdin so the host can read stats while the
+	// guest vmexec server is still streaming live usage samples.
+	execCtx, cancel := context.WithCancel(ctx)
+	stdinReader, stdinWriter := io.Pipe()
+	done := make(chan struct{})
+	var res *interfaces.CommandResult
+	go func() {
+		defer close(done)
+		res = c.Exec(execCtx, &repb.Command{Arguments: []string{"cat"}}, &interfaces.Stdio{Stdin: stdinReader})
+	}()
+	defer func() {
+		cancel()
+		_ = stdinWriter.Close()
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			t.Error("timed out waiting for firecracker exec to stop")
+		}
+	}()
+
+	// Wait until the guest has reported a nonzero memory sample.
+	require.Eventually(t, func() bool {
+		stats, err := c.Stats(ctx)
+		if err != nil {
+			return false
+		}
+		return stats.GetMemoryBytes() > 0
+	}, 10*time.Second, 50*time.Millisecond)
+	select {
+	case <-done:
+		require.Failf(t, "exec completed before live stats were observed", "result: %v", res)
+	default:
+	}
+
+	// Finish the command and call `Stats` again to make sure it still reports
+	// nonzero memory, since we haven't yet torn down the VM.
+	err = stdinWriter.Close()
+	require.NoError(t, err)
+	<-done
+	require.NotNil(t, res)
+	require.NoError(t, res.Error)
+	require.Equal(t, 0, res.ExitCode)
+
+	stats, err := c.Stats(ctx)
+	require.NoError(t, err)
+	require.Greater(t, stats.GetMemoryBytes(), int64(0))
+
+	// After Pause tears down the VM, the container is no longer consuming live
+	// resources, so Stats should go back to an empty proto.
+	err = c.Pause(ctx)
+	require.NoError(t, err)
+	stats, err = c.Stats(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(&repb.UsageStats{}, stats, protocmp.Transform()))
+}
+
 func TestFirecrackerRunWithNetwork(t *testing.T) {
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})


### PR DESCRIPTION
This is required by the OOM killer since it needs to know the current memory usage.

Also clarify in the Container interface contract that this is a requirement.

As a future improvement, it would probably be better for the OOM killer to look at the cgroup directly, which should both be more accurate and avoid potential issues where the reported Stats() are stale, but this will take a bit of refactoring, and might wind up being a bit more complex since on non-Linux platforms we don't have a cgroup to look at anyway.