### PR TITLE
Don't steal tasks still in reconnect grace period

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -162,8 +162,10 @@ var (
 		-- the lease is still in its reconnection grace period.
 		local isNewAttempt = true
 		if ARGV[1] == "true" then
-			local periodEnd = redis.call("hget", KEYS[1], "reconnectPeriodEnd")
-			if periodEnd ~= nil and periodEnd ~= "" and periodEnd > tonumber(ARGV[3]) then
+			-- Redis hget returns false if the field is missing, and
+			-- tonumber(false) returns nil.
+			local periodEndNanos = tonumber(redis.call("hget", KEYS[1], "reconnectPeriodEnd"))
+			if periodEndNanos ~= nil and periodEndNanos > tonumber(ARGV[3]) then
 				local validToken = false
 
 				-- Temporarily accept either reconnectToken or leaseId.
@@ -1699,11 +1701,15 @@ func (s *SchedulerServer) deleteClaimedTask(ctx context.Context, taskID string) 
 }
 
 func (s *SchedulerServer) unclaimTask(ctx context.Context, taskID, leaseID, reconnectToken string) error {
+	reconnectPeriodEnd := time.Now()
+	if reconnectToken != "" {
+		reconnectPeriodEnd = reconnectPeriodEnd.Add(*leaseReconnectGracePeriod)
+	}
 	// The script will return 1 if the task is claimed & claim has been released.
 	r, err := redisReleaseClaim.Run(
 		ctx, s.rdb,
 		[]string{s.redisKeyForTask(taskID)},
-		reconnectToken, time.Now().UnixNano(), leaseID,
+		reconnectToken, reconnectPeriodEnd.UnixNano(), leaseID,
 	).Result()
 	if err != nil {
 		return err
@@ -1728,7 +1734,7 @@ func (s *SchedulerServer) claimTask(ctx context.Context, taskID, reconnectToken 
 	r, err := redisAcquireClaim.Run(
 		ctx, s.rdb,
 		[]string{s.redisKeyForTask(taskID)},
-		checkTaskReconnectToken, reconnectToken, time.Now().UnixNano(), leaseId,
+		strconv.FormatBool(checkTaskReconnectToken), reconnectToken, time.Now().UnixNano(), leaseId,
 	).Result()
 	if err != nil {
 		log.CtxErrorf(ctx, "claimTask error: redis script failed: %s", err)
@@ -1972,10 +1978,17 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 		if !claimed {
 			return
 		}
-		log.CtxWarningf(ctx, "LeaseTask stream closed with task still claimed (shutting_down=%t). Re-enqueueing task.", s.isShuttingDown())
+		shuttingDown := s.isShuttingDown()
+		log.CtxWarningf(ctx, "LeaseTask stream closed with task still claimed (shutting_down=%t). Re-enqueueing task.", shuttingDown)
 		ctx, cancel := background.ExtendContextForFinalization(ctx, 3*time.Second)
 		defer cancel()
 		reEnqueueReason := "stream closed with task still claimed"
+		if !shuttingDown {
+			// TODO: detect whether the executor gave up on the lease due to
+			// shutdown vs hit a transient disconnect. Transient disconnects should
+			// get a reconnect grace period here.
+			reconnectToken = ""
+		}
 		if err := s.reEnqueueTask(ctx, taskID, leaseID, reconnectToken, probesPerTask, reEnqueueReason); err != nil {
 			log.CtxErrorf(ctx, "LeaseTask %q tried to re-enqueue task but failed with err: %s", taskID, err.Error())
 		} // Success case will be logged by ReEnqueueTask flow.

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -660,14 +660,36 @@ func (tl *taskLease) Finalize() error {
 }
 
 func (e *fakeExecutor) Claim(taskID string) *taskLease {
+	lease, err := e.leaseTask(taskID, "" /*=reconnectToken*/)
+	require.NoError(e.t, err)
+	return lease
+}
+
+// Reconnect claims a task using a reconnect token from a previous claim.
+func (e *fakeExecutor) Reconnect(taskID, reconnectToken string) (*taskLease, error) {
+	require.NotEmpty(e.t, reconnectToken)
+	return e.leaseTask(taskID, reconnectToken)
+}
+
+func (e *fakeExecutor) leaseTask(taskID, reconnectToken string) (*taskLease, error) {
 	stream, err := e.schedulerClient.LeaseTask(e.ctx)
-	require.NoError(e.t, err)
+	if err != nil {
+		return nil, err
+	}
 	err = stream.Send(&scpb.LeaseTaskRequest{
-		TaskId: taskID,
+		TaskId:            taskID,
+		ExecutorId:        e.id,
+		ExecutorHostname:  e.node.GetHost(),
+		SupportsReconnect: true,
+		ReconnectToken:    reconnectToken,
 	})
-	require.NoError(e.t, err)
+	if err != nil {
+		return nil, err
+	}
 	rsp, err := stream.Recv()
-	require.NoError(e.t, err)
+	if err != nil {
+		return nil, err
+	}
 	require.NotZero(e.t, rsp.GetLeaseDurationSeconds())
 
 	var task *repb.ExecutionTask
@@ -684,7 +706,7 @@ func (e *fakeExecutor) Claim(taskID string) *taskLease {
 		task:    task,
 		leaseID: rsp.GetLeaseId(),
 	}
-	return lease
+	return lease, nil
 }
 
 type scheduleOpts struct {
@@ -865,13 +887,51 @@ func TestLeaseExpiration(t *testing.T) {
 	fakeClock.Advance(20 * time.Second)
 	fe.EnsureTaskNotReceived(taskID)
 
-	// Move past the grace period. Task should be re-enqueued.
+	// Move past the grace period. Task should be re-enqueued immediately.
 	fakeClock.Advance(2 * time.Second)
 	fe.WaitForTask(taskID)
 
 	// Lease renewal should fail as the stream should be broken.
 	err = lease.Renew()
 	require.ErrorIs(t, io.EOF, err)
+}
+
+func TestLeaseReconnectGrace_AskForMoreWorkCannotStealTask(t *testing.T) {
+	flags.Set(t, "remote_execution.lease_reconnect_grace_period", 10*time.Second)
+	flags.Set(t, "remote_execution.unclaimed_tasks_cache_ttl", 0*time.Second)
+	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
+
+	holder := newFakeExecutorWithId(ctx, t, "holder", env.GetSchedulerClient())
+	holder.Register()
+
+	// The holder claims a task so that a scheduler shutdown can leave the
+	// task reserved for the original lease holder.
+	taskID := scheduleTask(ctx, t, env, map[string]string{})
+	holder.WaitForTask(taskID)
+	lease := holder.Claim(taskID)
+
+	// Simulate a scheduler shutdown path that re-enqueues the task while
+	// allowing the holder to re-establish its lease.
+	s := env.GetSchedulerService().(*SchedulerServer)
+	reconnectToken := "reconnect-token"
+	err := s.reEnqueueTask(ctx, taskID, lease.leaseID, reconnectToken, 1 /*=numReplicas*/, "server shutting down")
+	require.NoError(t, err)
+
+	// A newly registered executor asks for work and samples the unclaimed task.
+	// It may receive a reservation, but it must not be allowed to claim the
+	// task before the reconnect grace period expires.
+	thief := newFakeExecutorWithId(ctx, t, "thief", env.GetSchedulerClient())
+	thief.Register()
+	thief.WaitForTask(taskID)
+	_, err = thief.leaseTask(taskID, "" /*=reconnectToken*/)
+	require.True(t, status.IsNotFoundError(err), "unexpected claim error: %s", err)
+
+	// The original holder can still reconnect using the token it received
+	// before the scheduler shutdown.
+	reconnectedLease, err := holder.Reconnect(taskID, reconnectToken)
+	require.NoError(t, err)
+	require.NotEmpty(t, reconnectedLease.leaseID)
+	require.NoError(t, reconnectedLease.Finalize())
 }
 
 func TestLeaseTask_RefreshToken_FailureDoesNotFailLease(t *testing.T) {


### PR DESCRIPTION
We had two separate bugs which allowed tasks to be incorrectly leased by new executors even though they were still in their lease reconnect grace period (which begins when the scheduler re-enqueues a task that is still claimed during app shutdown)

1. When the lease stream closes with the task still claimed, the lease stream handler calls `reEnqueueTask`, which calls `unclaimTask` to release the claim and set the reconnect token on the task in Redis. But `unclaimTask` stored `reconnectPeriodEnd` as `time.Now()` instead of `time.Now() + leaseReconnectGracePeriod`, so the reconnect grace period was effectively expired as soon as the task was re-enqueued.

2. The `claimTask` Lua script invocation had a bug which prevented the reconnect validation branch from working (we passed a `true` value but checked for the string `"true"`). The reconnect branch also had a bug where it wasn't properly handling `reconnectPeriodEnd`.

This PR also makes some small logging improvements. While debugging this issue, I didn't have sufficient evidence to conclude that the `sampleUnclaimedTasks` path was 100% at play, but these logs should help in the future.
