### PR TITLE
Fix concurrent UsageStats access

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -129,6 +129,8 @@ type Init struct {
 type UsageStats struct {
 	Clock clockwork.Clock
 
+	mu sync.RWMutex
+
 	// last is the last stats update we observed.
 	last *repb.UsageStats
 	// taskStats is the usage stats relative to when Reset() was last called
@@ -184,6 +186,9 @@ func (s *UsageStats) clock() clockwork.Clock {
 // the new task's resource usage can be accounted for.
 // TODO: make this private - it should only be used by TrackExecution.
 func (s *UsageStats) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.last != nil {
 		s.last.MemoryBytes = 0
 	}
@@ -204,6 +209,9 @@ func (s *UsageStats) Reset() {
 
 // TaskStats returns the usage stats for an executed task.
 func (s *UsageStats) TaskStats() *repb.UsageStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if s.last == nil {
 		return &repb.UsageStats{}
 	}
@@ -243,8 +251,9 @@ func (s *UsageStats) TaskStats() *repb.UsageStats {
 		taskStats.IoPressure.Full.Total -= s.baselineIOPressure.GetFull().GetTotal()
 	}
 
-	// Note: we don't clone the timeline because it's expensive.
-	taskStats.Timeline = s.timeline
+	if s.timeline != nil {
+		taskStats.Timeline = s.timeline.CloneVT()
+	}
 
 	return taskStats
 }
@@ -310,6 +319,9 @@ func (s *UsageStats) updateTimeline(now time.Time) {
 // created).
 // TODO: make this private - it should only be used by TrackExecution.
 func (s *UsageStats) Update(lifetimeStats *repb.UsageStats) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.last = lifetimeStats.CloneVT()
 	if lifetimeStats.GetMemoryBytes() > s.peakMemoryUsageBytes {
 		s.peakMemoryUsageBytes = lifetimeStats.GetMemoryBytes()

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -370,6 +370,37 @@ func TestUsageStats(t *testing.T) {
 	}, s.TaskStats(), protocmp.Transform()))
 }
 
+func TestUsageStats_ConcurrentUpdateAndTaskStats(t *testing.T) {
+	flags.Set(t, "executor.record_usage_timelines", true)
+
+	stats := &container.UsageStats{}
+	stats.Reset()
+
+	// Simulate the stats tracking goroutine updating lifetime usage while a
+	// live stats caller reads task-relative usage.
+	var g errgroup.Group
+	g.Go(func() error {
+		for i := range 1000 {
+			stats.Update(&repb.UsageStats{
+				CpuNanos:      int64(i) * 1e6,
+				MemoryBytes:   int64(i) * 1024,
+				CgroupIoStats: &repb.CgroupIOStats{Rbytes: int64(i), Wbytes: int64(i)},
+			})
+		}
+		return nil
+	})
+	g.Go(func() error {
+		for range 1000 {
+			taskStats := stats.TaskStats()
+			_ = taskStats.GetMemoryBytes()
+			_ = taskStats.GetTimeline().GetTimestamps()
+		}
+		return nil
+	})
+
+	require.NoError(t, g.Wait())
+}
+
 func TestUsageStats_Timeseries(t *testing.T) {
 	flags.Set(t, "executor.record_usage_timelines", true)
 


### PR DESCRIPTION
Makes container UsageStats safe for concurrent Update and TaskStats calls, including cloned timeline snapshots, so live container stats polling can run under the race detector.