### PR TITLE
Couple more Grafana fixes for zonal proxy deployments

### DIFF
--- a/tools/metrics/grafana/dashboards/cache-proxy.json
+++ b/tools/metrics/grafana/dashboards/cache-proxy.json
@@ -149,10 +149,10 @@
                 "type": "prometheus",
                 "uid": "vm"
               },
-              "expr": "sum(up{region=\"${region}\", job=~\"cache-proxy.*\"})",
+              "expr": "sum by (job) (up{region=\"${region}\", job=~\"cache-proxy.*\"})",
               "hide": false,
               "interval": "",
-              "legendFormat": "Up",
+              "legendFormat": "{{job}} up",
               "queryType": "randomWalk",
               "refId": "A"
             },
@@ -173,10 +173,10 @@
                 "uid": "vm"
               },
               "editorMode": "code",
-              "expr": "sum(kube_horizontalpodautoscaler_status_desired_replicas{region=\"${region}\", horizontalpodautoscaler=~\"cache-proxy.*autoscaler\"})",
+              "expr": "sum by (horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_desired_replicas{region=\"${region}\", horizontalpodautoscaler=~\"cache-proxy.*autoscaler\"})",
               "hide": false,
               "instant": false,
-              "legendFormat": "Autoscaler target",
+              "legendFormat": "{{horizontalpodautoscaler}} target",
               "range": true,
               "refId": "C"
             }

--- a/tools/metrics/grafana/dashboards/globalstatus.json
+++ b/tools/metrics/grafana/dashboards/globalstatus.json
@@ -1897,7 +1897,7 @@
             "uid": "vm"
           },
           "editorMode": "code",
-          "expr": "sum by (region) (up{job=\"cache-proxy\"})",
+          "expr": "sum by (region) (up{job=~\"cache-proxy.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1910,7 +1910,7 @@
             "uid": "vm"
           },
           "editorMode": "code",
-          "expr": "sum(kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler=\"cache-proxy-autoscaler\"}) + sum(up{region=\"us-sjc\", job=\"cache-proxy\"}) + sum(up{region=~\"^aws-.*\", job=\"cache-proxy\"})",
+          "expr": "sum(kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler=~\"cache-proxy-autoscaler.*\"}) + sum(up{region=\"us-sjc\", job=\"cache-proxy.*\"}) + sum(up{region=\"us-nuq\", job=\"cache-proxy.*\"}) + sum(up{region=~\"^aws-.*\", job=\"cache-proxy.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "Autoscaler target",


### PR DESCRIPTION
1. Make the "up" and "autoscaler targets" per-zone
2. Make globalstatus zonal-deployment-aware
3. Add NUQ proxies to global autoscaler target