### PR TITLE
Add drilldown heatmap color-by-total option

### DIFF
--- a/enterprise/app/trends/common.ts
+++ b/enterprise/app/trends/common.ts
@@ -150,9 +150,13 @@ const SUMMABLE_METRICS = [
   stat_filter.InvocationMetricType.ACTION_CACHE_MISSES_INVOCATION_METRIC,
 ];
 
-export function renderTotalValue(m: stat_filter.Metric, v: number): string | null {
+export function isSummableMetric(m: stat_filter.Metric): boolean {
   const metricType = m.execution ?? m.invocation;
-  if (!metricType || !SUMMABLE_METRICS.includes(metricType)) {
+  return !!metricType && SUMMABLE_METRICS.includes(metricType);
+}
+
+export function renderTotalValue(m: stat_filter.Metric, v: number): string | null {
+  if (!isSummableMetric(m)) {
     return null;
   }
   return renderMetricValue(m, v);

--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -40,6 +40,7 @@ const DD_SELECTED_METRIC_URL_PARAM: string = "ddMetric";
 const DD_SELECTED_AREA_URL_PARAM = "ddSelection";
 const DD_ZOOM_URL_PARAM: string = "ddZoom";
 const DD_SCALE_URL_PARAM: string = "ddScale";
+const DD_COLOR_URL_PARAM: string = "ddColor";
 const EMPTY_LABEL = "(empty)";
 
 function convertMetricUrlParam(param: string): MetricOption | undefined {
@@ -479,19 +480,23 @@ export default class DrilldownPageComponent extends React.Component<Props, State
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (this.props.search != prevProps.search) {
-      const prevSearchWithoutSelection = new URLSearchParams(prevProps.search);
-      prevSearchWithoutSelection.delete(DD_SELECTED_AREA_URL_PARAM);
-      prevSearchWithoutSelection.sort();
+    const prevSearch = new URLSearchParams(prevProps.search);
+    prevSearch.delete(DD_COLOR_URL_PARAM);
+    prevSearch.sort();
 
-      const newSearchWithoutSelection = new URLSearchParams(this.props.search);
-      newSearchWithoutSelection.delete(DD_SELECTED_AREA_URL_PARAM);
-      newSearchWithoutSelection.sort();
+    const newSearch = new URLSearchParams(this.props.search);
+    newSearch.delete(DD_COLOR_URL_PARAM);
+    newSearch.sort();
+
+    if (newSearch.toString() != prevSearch.toString()) {
       this.selectedMetric =
         convertMetricUrlParam(this.props.search.get(DD_SELECTED_METRIC_URL_PARAM) || "") || METRIC_OPTIONS[0];
       this.currentHeatmapSelection = decodeHeatmapSelection(this.props.search.get(DD_SELECTED_AREA_URL_PARAM) || "");
       this.currentZoomFilters = decodeHeatmapSelection(this.props.search.get(DD_ZOOM_URL_PARAM) || "");
-      if (prevSearchWithoutSelection.toString() != newSearchWithoutSelection.toString()) {
+
+      prevSearch.delete(DD_SELECTED_AREA_URL_PARAM);
+      newSearch.delete(DD_SELECTED_AREA_URL_PARAM);
+      if (newSearch.toString() != prevSearch.toString()) {
         this.fetch();
       }
       this.fetchDrilldowns();
@@ -529,6 +534,13 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       ...Object.fromEntries(this.props.search.entries()),
       [DD_SCALE_URL_PARAM]: newScale,
       [DD_SELECTED_AREA_URL_PARAM]: "",
+    });
+  }
+
+  handleColorModeChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    router.updateParams({
+      ...Object.fromEntries(this.props.search.entries()),
+      [DD_COLOR_URL_PARAM]: e.target.value === "total" ? "total" : "",
     });
   }
 
@@ -941,6 +953,13 @@ export default class DrilldownPageComponent extends React.Component<Props, State
               <Option value="linear">Linear scale</Option>
               <Option value="log">Log scale</Option>
             </Select>
+            <Select
+              className="drilldown-page-select"
+              onChange={this.handleColorModeChange.bind(this)}
+              value={this.props.search.get(DD_COLOR_URL_PARAM) === "total" ? "total" : "frequency"}>
+              <Option value="frequency">Color by frequency</Option>
+              <Option value="total">Color by total</Option>
+            </Select>
             {this.renderZoomChip()}
           </div>
         </div>
@@ -956,6 +975,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
                 )}
                 <HeatmapComponent
                   heatmapData={this.state.heatmapData || stats.GetStatHeatmapResponse.create({})}
+                  colorByTotal={this.props.search.get(DD_COLOR_URL_PARAM) === "total"}
                   logScale={this.isLogScale()}
                   metricBucketFormatter={(v) => renderMetricValue(this.selectedMetric.metric, v)}
                   metricBucketName={this.selectedMetric.name}

--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -523,6 +523,14 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     return this.props.search.get(DD_SCALE_URL_PARAM) === "log";
   }
 
+  canColorByTotal(): boolean {
+    return renderTotalValue(this.selectedMetric.metric, 0) != null;
+  }
+
+  colorByTotal(): boolean {
+    return this.canColorByTotal() && this.props.search.get(DD_COLOR_URL_PARAM) === "total";
+  }
+
   handleScaleChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const newScale = e.target.value;
     if ((newScale === "log") === this.isLogScale()) {
@@ -956,9 +964,11 @@ export default class DrilldownPageComponent extends React.Component<Props, State
             <Select
               className="drilldown-page-select"
               onChange={this.handleColorModeChange.bind(this)}
-              value={this.props.search.get(DD_COLOR_URL_PARAM) === "total" ? "total" : "frequency"}>
+              value={this.colorByTotal() ? "total" : "frequency"}>
               <Option value="frequency">Color by frequency</Option>
-              <Option value="total">Color by total</Option>
+              <Option value="total" disabled={!this.canColorByTotal()}>
+                Color by total
+              </Option>
             </Select>
             {this.renderZoomChip()}
           </div>
@@ -975,7 +985,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
                 )}
                 <HeatmapComponent
                   heatmapData={this.state.heatmapData || stats.GetStatHeatmapResponse.create({})}
-                  colorByTotal={this.props.search.get(DD_COLOR_URL_PARAM) === "total"}
+                  colorByTotal={this.colorByTotal()}
                   logScale={this.isLogScale()}
                   metricBucketFormatter={(v) => renderMetricValue(this.selectedMetric.metric, v)}
                   metricBucketName={this.selectedMetric.name}

--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -31,6 +31,7 @@ import {
   encodeMetricUrlParam,
   encodeTargetLabelUrlParam,
   encodeWorkerUrlParam,
+  isSummableMetric,
   renderMetricValue,
   renderTotalValue,
 } from "./common";
@@ -524,7 +525,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
   }
 
   canColorByTotal(): boolean {
-    return renderTotalValue(this.selectedMetric.metric, 0) != null;
+    return isSummableMetric(this.selectedMetric.metric);
   }
 
   colorByTotal(): boolean {

--- a/enterprise/app/trends/heatmap.tsx
+++ b/enterprise/app/trends/heatmap.tsx
@@ -10,6 +10,7 @@ import { stats } from "../../../proto/stats_ts_proto";
 interface HeatmapProps {
   heatmapData: stats.GetStatHeatmapResponse;
 
+  colorByTotal: boolean;
   valueFormatter: (value: number) => string;
   metricBucketName: string;
   metricBucketFormatter: (value: number) => string;
@@ -630,9 +631,10 @@ class HeatmapComponentInternal extends React.Component<ResizableHeatmapProps, St
     let min = 0;
     let max = 0;
     this.props.heatmapData.column.forEach((column) => {
-      column.value.forEach((value) => {
-        min = Math.min(+value, min);
-        max = Math.max(+value, max);
+      column.value.forEach((value, yIndex) => {
+        const colorValue = this.props.colorByTotal ? +(column.total[yIndex] ?? 0) : +value;
+        min = Math.min(colorValue, min);
+        max = Math.max(colorValue, max);
       });
     });
 
@@ -664,7 +666,13 @@ class HeatmapComponentInternal extends React.Component<ResizableHeatmapProps, St
                             y={this.yScaleTops[yIndex] ?? 0}
                             width={this.xScaleBand.bandwidth() || 0}
                             height={this.yScaleHeights[yIndex] ?? 0}
-                            fill={this.getCellColor(xIndex, yIndex, +value, interpolator, selection)}></rect>
+                            fill={this.getCellColor(
+                              xIndex,
+                              yIndex,
+                              this.props.colorByTotal ? +(column.total[yIndex] ?? 0) : +value,
+                              interpolator,
+                              selection
+                            )}></rect>
                         )
                       )}
                     </>

--- a/enterprise/app/trends/heatmap.tsx
+++ b/enterprise/app/trends/heatmap.tsx
@@ -639,10 +639,13 @@ class HeatmapComponentInternal extends React.Component<ResizableHeatmapProps, St
     });
 
     const selection = this.computeSelectionData();
-    const interpolator = (v: number, selected: boolean) =>
-      selected
-        ? heatmapGreens[Math.floor(((heatmapGreens.length - 1) * (v - min)) / (max - min))]
-        : heatmapPurples[Math.floor(((heatmapPurples.length - 1) * (v - min)) / (max - min))];
+    const interpolator = (v: number, selected: boolean) => {
+      const colors = selected ? heatmapGreens : heatmapPurples;
+      if (max <= min) {
+        return colors[0];
+      }
+      return colors[Math.floor(((colors.length - 1) * (v - min)) / (max - min))];
+    };
 
     return (
       <div>


### PR DESCRIPTION
Adds a drilldown heatmap color mode dropdown so users can color cells by frequency or by total metric value. The selected color mode is persisted in the URL with `ddColor=total`.