### PR TITLE
task_router: select affinity key

### DIFF
--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -48,7 +48,11 @@ const (
 	// Preferred node limit for tasks using [persistentWorkerRouter].
 	persistentWorkerRouterPreferredNodeLimit = 128
 
-	affinityRouterUseTargetPackageExperiment = "remote_execution.affinity_router_use_target_package"
+	affinityRouterKeyExperiment = "remote_execution.affinity_router_key"
+
+	affinityRouterKeyFirstOutput = "first_output"
+	affinityRouterKeyPackage     = "package"
+	affinityRouterKeyTarget      = "target"
 )
 
 type taskRouter struct {
@@ -318,12 +322,23 @@ func (tr *taskRouter) MarkFailed(ctx context.Context, action *repb.Action, cmd *
 
 // Contains the parameters required to make a routing decision.
 type routingParams struct {
-	cmd                                *repb.Command
-	platform                           *repb.Platform
-	remoteInstanceName                 string
-	groupID                            string
-	targetPackageLabel                 string
-	useTargetPackageForAffinityRouting bool
+	cmd                *repb.Command
+	platform           *repb.Platform
+	remoteInstanceName string
+	groupID            string
+	targetLabel        string
+	targetPackageLabel string
+	affinityRouterKey  string
+}
+
+func normalizeAffinityRouterKey(ctx context.Context, key string) string {
+	switch key {
+	case affinityRouterKeyFirstOutput, affinityRouterKeyPackage, affinityRouterKeyTarget:
+		return key
+	default:
+		log.CtxWarningf(ctx, "Ignoring unsupported %s experiment value %q", affinityRouterKeyExperiment, key)
+		return affinityRouterKeyFirstOutput
+	}
 }
 
 func getTargetPackageLabel(targetLabel string) string {
@@ -338,18 +353,21 @@ func getRoutingParams(ctx context.Context, env environment.Env, action *repb.Act
 	if u, err := env.GetAuthenticator().AuthenticatedUser(ctx); err == nil {
 		groupID = u.GetGroupID()
 	}
-	useTargetPackageForAffinityRouting := false
+	affinityRouterKey := affinityRouterKeyFirstOutput
 	if fp := env.GetExperimentFlagProvider(); fp != nil {
-		useTargetPackageForAffinityRouting = fp.Boolean(ctx, affinityRouterUseTargetPackageExperiment, false)
+		affinityRouterKey = fp.String(ctx, affinityRouterKeyExperiment, affinityRouterKeyFirstOutput)
 	}
+	affinityRouterKey = normalizeAffinityRouterKey(ctx, affinityRouterKey)
 	rmd := bazel_request.GetRequestMetadata(ctx)
+	targetLabel := rmd.GetTargetId()
 	return routingParams{
-		cmd:                                cmd,
-		platform:                           platform.GetProto(action, cmd),
-		remoteInstanceName:                 remoteInstanceName,
-		groupID:                            groupID,
-		targetPackageLabel:                 getTargetPackageLabel(rmd.GetTargetId()),
-		useTargetPackageForAffinityRouting: useTargetPackageForAffinityRouting,
+		cmd:                cmd,
+		platform:           platform.GetProto(action, cmd),
+		remoteInstanceName: remoteInstanceName,
+		groupID:            groupID,
+		targetLabel:        targetLabel,
+		targetPackageLabel: getTargetPackageLabel(targetLabel),
+		affinityRouterKey:  affinityRouterKey,
 	}
 }
 
@@ -481,15 +499,12 @@ func (s *ciRunnerRouter) RoutingInfo(params routingParams) (int, []string, error
 //   - remoteInstanceName
 //   - groupID
 //   - platform properties
-//   - and an affinity hint derived from either the first action output
-//     (default) or the request metadata target package (for experiment-enabled
-//     orgs)
+//   - and an affinity hint selected by the affinity-router-key experiment
 //
 // The first-output hint is stable even if an action's inputs change, which can
 // route successive executions of the same Bazel action back to a warmer
-// executor. The target-package experiment deliberately broadens that affinity so
-// related actions for the same package can share warmed executors and reduce
-// routing spray.
+// executor. The affinity-router-key experiment can instead group by Bazel
+// package or by full Bazel target label.
 type affinityRouter struct {
 	rdb redis.UniversalClient
 }
@@ -503,8 +518,15 @@ func (*affinityRouter) preferredNodeLimit(_ routingParams) int {
 }
 
 func getAffinityRoutingHint(params routingParams) string {
-	if params.useTargetPackageForAffinityRouting && params.targetPackageLabel != "" {
-		return params.targetPackageLabel
+	switch params.affinityRouterKey {
+	case affinityRouterKeyTarget:
+		if params.targetLabel != "" {
+			return params.targetLabel
+		}
+	case affinityRouterKeyPackage:
+		if params.targetPackageLabel != "" {
+			return params.targetPackageLabel
+		}
 	}
 	return getFirstOutput(params.cmd)
 }
@@ -522,10 +544,7 @@ func (*affinityRouter) routingKey(params routingParams) (string, error) {
 	}
 	parts = append(parts, hash.Bytes(b))
 
-	// Add the selected affinity hint as the final part of the routing key. By
-	// default this is the first declared output, but a per-org experiment can
-	// switch this to the target package to reduce routing spray across related
-	// actions belonging to the same package.
+	// Add the selected affinity hint as the final part of the routing key.
 	hint := getAffinityRoutingHint(params)
 	if hint == "" {
 		return "", status.InternalError("routing key requested for action with no affinity hint")

--- a/enterprise/server/scheduling/task_router/task_router_test.go
+++ b/enterprise/server/scheduling/task_router/task_router_test.go
@@ -217,24 +217,31 @@ func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
 	requireNotAlwaysRanked(0, executorHostID2, t, router, ctx, thirdCmd, instanceName)
 }
 
-func TestTaskRouter_RankNodes_AffinityRouting_UsesTargetPackageForSelectedGroups(t *testing.T) {
+func TestTaskRouter_RankNodes_AffinityRouting_UsesExperimentSelectedKey(t *testing.T) {
 	env := newTestEnv(t)
 
 	const testFlags = `{
 	  "$schema": "https://flagd.dev/schema/v0/flags.json",
 	  "flags": {
-	    "remote_execution.affinity_router_use_target_package": {
+	    "remote_execution.affinity_router_key": {
 	      "state": "ENABLED",
 	      "variants": {
-	        "enabled": true,
-	        "disabled": false
+	        "first_output": "first_output",
+	        "package": "package",
+	        "target": "target"
 	      },
-	      "defaultVariant": "disabled",
+	      "defaultVariant": "first_output",
 	      "targeting": {
 	        "if": [
 	          { "==": [{ "var": "group_id" }, "GR1"] },
-	          "enabled",
-	          "disabled"
+	          "target",
+	          {
+	            "if": [
+	              { "==": [{ "var": "group_id" }, "GR2"] },
+	              "package",
+	              "first_output"
+	            ]
+	          }
 	        ]
 	      }
 	    }
@@ -261,35 +268,47 @@ func TestTaskRouter_RankNodes_AffinityRouting_UsesTargetPackageForSelectedGroups
 	}
 
 	selectedOrgCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US1"), "//foo/bar:foo_lib", "GoLink")
+	selectedOrgSameTargetCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US1"), "//foo/bar:foo_lib", "TestRunner")
 	selectedOrgOtherTargetCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US1"), "//foo/bar:foo_test", "TestRunner")
 	selectedOrgPackageCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US1"), "//foo/bar", "TestRunner")
 	selectedOrgOtherPackageCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US1"), "//foo/baz:foo_test", "TestRunner")
 	router.MarkSucceeded(selectedOrgCtx, nil, firstCmd, instanceName, executorHostID1)
 
-	ranked := router.RankNodes(selectedOrgOtherTargetCtx, nil, secondCmd, instanceName, nodes)
+	ranked := router.RankNodes(selectedOrgSameTargetCtx, nil, secondCmd, instanceName, nodes)
 	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
-	ranked = router.RankNodes(selectedOrgPackageCtx, nil, secondCmd, instanceName, nodes)
-	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+	requireNotAlwaysRanked(0, executorHostID1, t, router, selectedOrgOtherTargetCtx, secondCmd, instanceName)
+	requireNotAlwaysRanked(0, executorHostID1, t, router, selectedOrgPackageCtx, secondCmd, instanceName)
 	requireNotAlwaysRanked(0, executorHostID1, t, router, selectedOrgOtherPackageCtx, secondCmd, instanceName)
 
-	controlOrgCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US2"), "//foo/bar:foo_lib", "GoLink")
-	controlOrgOtherTargetCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US2"), "//foo/bar:foo_test", "TestRunner")
+	packageOrgCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US2"), "//foo/bar:foo_lib", "GoLink")
+	packageOrgOtherTargetCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US2"), "//foo/bar:foo_test", "TestRunner")
+	packageOrgPackageCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US2"), "//foo/bar", "TestRunner")
+	packageOrgOtherPackageCtx := withRequestMetadata(withAuthUser(t, context.Background(), env, "US2"), "//foo/baz:foo_test", "TestRunner")
+	router.MarkSucceeded(packageOrgCtx, nil, firstCmd, instanceName, executorHostID1)
+
+	ranked = router.RankNodes(packageOrgOtherTargetCtx, nil, secondCmd, instanceName, nodes)
+	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+	ranked = router.RankNodes(packageOrgPackageCtx, nil, secondCmd, instanceName, nodes)
+	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+	requireNotAlwaysRanked(0, executorHostID1, t, router, packageOrgOtherPackageCtx, secondCmd, instanceName)
+
+	controlOrgCtx := withRequestMetadata(context.Background(), "//foo/bar:foo_lib", "GoLink")
+	controlOrgOtherTargetCtx := withRequestMetadata(context.Background(), "//foo/bar:foo_test", "TestRunner")
 	router.MarkSucceeded(controlOrgCtx, nil, firstCmd, instanceName, executorHostID1)
 
 	requireNotAlwaysRanked(0, executorHostID1, t, router, controlOrgOtherTargetCtx, secondCmd, instanceName)
 }
 
-func TestTaskRouter_RankNodes_AffinityRouting_TargetLabelExperimentFallsBackToFirstOutput(t *testing.T) {
+func TestTaskRouter_RankNodes_AffinityRouting_TargetKeyFallsBackToFirstOutput(t *testing.T) {
 	env := newTestEnv(t)
 
 	testProvider := openfeatureTesting.NewTestProvider()
 	testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
-		"remote_execution.affinity_router_use_target_package": {
+		"remote_execution.affinity_router_key": {
 			State:          memprovider.Enabled,
-			DefaultVariant: "enabled",
+			DefaultVariant: "target",
 			Variants: map[string]any{
-				"enabled":  true,
-				"disabled": false,
+				"target": "target",
 			},
 		},
 	})
@@ -306,12 +325,18 @@ func TestTaskRouter_RankNodes_AffinityRouting_TargetLabelExperimentFallsBackToFi
 		OutputPaths: []string{"/bazel-out/k8-fastbuild/bin/foo/libfoo.a"},
 	}
 	secondCmd := &repb.Command{
+		OutputPaths: []string{"/bazel-out/k8-fastbuild/bin/foo/libfoo.a"},
+	}
+	thirdCmd := &repb.Command{
 		OutputPaths: []string{"/bazel-out/k8-fastbuild/testlogs/foo/foo_test/test.outputs"},
 	}
 
 	router.MarkSucceeded(ctx, nil, firstCmd, instanceName, executorHostID1)
 
-	requireNotAlwaysRanked(0, executorHostID1, t, router, ctx, secondCmd, instanceName)
+	nodes := sequentiallyNumberedNodes(100)
+	ranked := router.RankNodes(ctx, nil, secondCmd, instanceName, nodes)
+	require.Equal(t, executorHostID1, ranked[0].GetExecutionNode().GetExecutorHostId())
+	requireNotAlwaysRanked(0, executorHostID1, t, router, ctx, thirdCmd, instanceName)
 }
 
 func TestTaskRouter_RankNodes_WeightedByCPU(t *testing.T) {


### PR DESCRIPTION
This addresses Vanja's review feedback because the old boolean
target-label experiment would have required another code change to test
package, target, and first-output routing per group. Use one
string-valued routing key instead.

Introduce `remote_execution.affinity_router_key` with `first_output` as the
default. The router accepts `target` and `package` values, falls back to
first-output affinity when target metadata is absent, and keeps package
available for groups that still need broader affinity.

Update the routing tests to cover target, package, and default
first-output selection from the same experiment.

Validated with:

- `bazel test --config=remote-minimal //enterprise/server/scheduling/task_router:task_router_test --test_output=errors`
