### PR TITLE
[raft] Sleep a bit when there are no eviction samples for a partition

### DIFF
--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -480,9 +480,13 @@ func TestLRU(t *testing.T) {
 	// and (2) stale-atime samples making recently-Find()'d records appear
 	// old enough to evict.
 	flags.Set(t, "cache.raft.min_eviction_age", 18*time.Minute)
-	// Force the sampler to refresh its pebble iterator on
-	// every read so that samples have up-to-date atimes.
-	flags.Set(t, "cache.raft.samples_per_batch", 0)
+	// Read a small batch forward per random seek instead of refreshing the
+	// iterator on every single read. The records this test evicts (18-24) are
+	// never Find()'d, so their atimes are set once and never change -- a short
+	// batch keeps them fresh while avoiding the per-record db.NewIter churn
+	// that, under the race detector, starves the evictor and makes the sampler
+	// take far too long to randomly land on the last few eligible records.
+	flags.Set(t, "cache.raft.samples_per_batch", 10)
 	// Disable the sampler's idle sleep. In production the sampler sleeps when
 	// it can't find an eligible entry (e.g. a random key landing past the end
 	// of a small partition) to avoid wasting CPU. That sleep uses the fake

--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -483,6 +483,12 @@ func TestLRU(t *testing.T) {
 	// Force the sampler to refresh its pebble iterator on
 	// every read so that samples have up-to-date atimes.
 	flags.Set(t, "cache.raft.samples_per_batch", 0)
+	// Disable the sampler's idle sleep. In production the sampler sleeps when
+	// it can't find an eligible entry (e.g. a random key landing past the end
+	// of a small partition) to avoid wasting CPU. That sleep uses the fake
+	// clock here, which the test doesn't advance during the GC wait below, so
+	// it would stall the sampler and time out eviction.
+	flags.Set(t, "cache.raft.sampler_sleep_duration", time.Duration(0))
 	// Make the sample channel unbuffered so it can't hold stale samples
 	// produced before atime updates from the test's Find() calls were
 	// applied to pebble. Without this, the eviction consumer reads stale

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -389,8 +389,7 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 		iter.Close()
 	}()
 
-	totalCount := 0
-	shouldCreateNewIter := false
+	leftInBatch := pu.samplesPerBatch
 	fileMetadata := sgpb.FileMetadataFromVTPool()
 	defer fileMetadata.ReturnToVTPool()
 
@@ -401,10 +400,8 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 	// instead of doing a new seek for every random sample we will seek once
 	// and just read forward, yielding digests until we've found enough.
 	for {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return nil
-		default:
 		}
 
 		// When we started to populate a cache, we cannot find any eligible
@@ -420,34 +417,40 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 			}
 		}
 
-		if totalCount > pu.samplesPerBatch || time.Since(iterCreatedAt) > pu.samplerIterRefreshPeriod {
-			// Going to refresh the iterator in the next iteration.
-			shouldCreateNewIter = true
-		}
-
 		// Refresh the iterator once a while
-		if shouldCreateNewIter {
-			shouldCreateNewIter = false
-			totalCount = 0
+		if leftInBatch <= 0 || time.Since(iterCreatedAt) > pu.samplerIterRefreshPeriod {
+			leftInBatch = pu.samplesPerBatch
 			iterCreatedAt = time.Now()
+			// This iterator won't be positioned (Valid() will return false),
+			// so we will position it below.
 			newIter, err := db.NewIter(&pebble.IterOptions{
 				LowerBound: start,
 				UpperBound: end,
 			})
+			log.Debugf("Creating new eviction iterator for partition %v; %+v", pu.part.ID, pu.part)
 			if err != nil {
 				return err
 			}
 			iter.Close()
 			iter = newIter
 		}
-		totalCount += 1
+		leftInBatch--
 		if !iter.Valid() {
-			// This should happen once every totalCount times or when
-			// we exausted the iter.
+			// This happens when we create a new iterator or exhaust the
+			// existing one.
 			randomKey := pu.randomKey(64)
-			valid := iter.SeekGE(randomKey)
-			if !valid {
-				shouldCreateNewIter = true
+			if valid := iter.SeekGE(randomKey); !valid {
+				// This is a probabilistic sleep. A partition with no rows on
+				// this node will always sleep. A partition with many rows is
+				// very unlikely to sleep. This ensures that we don't waste CPU
+				// cycles trying to find samples for partition with no (or few)
+				// rows.
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-pu.clock.After(SamplerSleepDuration):
+				}
+				leftInBatch = 0 // Force creating a new iterator
 				continue
 			}
 		}
@@ -457,7 +460,8 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 			continue
 		}
 
-		err = proto.Unmarshal(iter.Value(), fileMetadata)
+		fileMetadata.ResetVT() // UnmarshalVT doesn't reset, unlike proto.Unmarshal.
+		err = fileMetadata.UnmarshalVT(iter.Value())
 		if err != nil {
 			log.Warningf("cannot generate sample for eviction, skipping: failed to read proto: %s", err)
 			continue
@@ -466,7 +470,6 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 		pu.maybeAddToSampleChan(ctx, iter, fileMetadata, timer)
 
 		iter.Next()
-		fileMetadata.ResetVT()
 	}
 }
 

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -427,7 +427,6 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 				LowerBound: start,
 				UpperBound: end,
 			})
-			log.Debugf("Creating new eviction iterator for partition %v; %+v", pu.part.ID, pu.part)
 			if err != nil {
 				return err
 			}

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -51,6 +51,7 @@ var (
 	deleteBufferSize                   = flag.Int("cache.raft.delete_buffer_size", 20, "Buffer up to this many samples for eviction eviction")
 	minEvictionAge                     = flag.Duration("cache.raft.min_eviction_age", 6*time.Hour, "Don't evict anything unless it's been idle for at least this long")
 	samplerIterRefreshPeriod           = flag.Duration("cache.raft.sampler_iter_refresh_peroid", 5*time.Minute, "How often we refresh iterator in sampler")
+	samplerSleepDuration               = flag.Duration("cache.raft.sampler_sleep_duration", 1*time.Second, "How long the eviction sampler sleeps when it cannot find eligible entries to evict. Set to 0 to disable sleeping (intended for tests).")
 	evictionBatchSize                  = flag.Int("cache.raft.eviction_batch_size", 100, "Buffer this many writes before delete")
 	numDeleteWorkers                   = flag.Int("cache.raft.num_delete_worker", 4, "Number of deletes in parallel")
 	gcsDeleteBufferSize                = flag.Int("cache.raft.gcs_delete_buffer_size", 1000, "Buffer up to this many GCS deletion requests")
@@ -70,12 +71,9 @@ const (
 	// based on data changes.
 	storePartitionUsageMaxAge = 5 * time.Minute
 
-	SamplerSleepThreshold = float64(0.2)
-	SamplerSleepDuration  = 1 * time.Second
-
-	SamplerIterRefreshPeriod = 5 * time.Minute
-	evictFlushPeriod         = 10 * time.Second
-	metricsRefreshPeriod     = 30 * time.Second
+	samplerSleepThreshold = float64(0.2)
+	evictFlushPeriod      = 10 * time.Second
+	metricsRefreshPeriod  = 30 * time.Second
 )
 
 type Tracker struct {
@@ -150,6 +148,7 @@ type partitionUsage struct {
 
 	samplesPerBatch          int
 	samplerIterRefreshPeriod time.Duration
+	samplerSleepDuration     time.Duration
 	minEvictionAge           time.Duration
 	localSizeUpdatePeriod    time.Duration
 	evictionBatchSize        int
@@ -367,6 +366,21 @@ func (pu *partitionUsage) randomKey(n int) []byte {
 	return []byte(randKey.String())
 }
 
+// samplerSleep pauses the sampler for the configured sleep duration to avoid
+// busy-looping when there is nothing useful to sample. It returns false if the
+// context was cancelled.
+func (pu *partitionUsage) samplerSleep(ctx context.Context) bool {
+	if pu.samplerSleepDuration <= 0 {
+		return ctx.Err() == nil
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-pu.clock.After(pu.samplerSleepDuration):
+		return true
+	}
+}
+
 func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error {
 	db, err := pu.dbGetter.DB()
 	if err != nil {
@@ -376,10 +390,7 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 	defer db.Close()
 	start, end := keys.Range([]byte(pu.partitionKeyPrefix() + "/"))
 	iterCreatedAt := time.Now()
-	iter, err := db.NewIter(&pebble.IterOptions{
-		LowerBound: start,
-		UpperBound: end,
-	})
+	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: start, UpperBound: end})
 	if err != nil {
 		return err
 	}
@@ -408,12 +419,10 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 		// entries to evict. We will sleep for some time to prevent from
 		// constantly generating samples in vain.
 		globalSize := pu.GlobalSizeBytes()
-		shouldSleep := globalSize <= int64(SamplerSleepThreshold*float64(pu.part.MaxSizeBytes))
+		shouldSleep := globalSize <= int64(samplerSleepThreshold*float64(pu.part.MaxSizeBytes))
 		if shouldSleep {
-			select {
-			case <-ctx.Done():
+			if !pu.samplerSleep(ctx) {
 				return nil
-			case <-pu.clock.After(SamplerSleepDuration):
 			}
 		}
 
@@ -423,10 +432,7 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 			iterCreatedAt = time.Now()
 			// This iterator won't be positioned (Valid() will return false),
 			// so we will position it below.
-			newIter, err := db.NewIter(&pebble.IterOptions{
-				LowerBound: start,
-				UpperBound: end,
-			})
+			newIter, err := db.NewIter(&pebble.IterOptions{LowerBound: start, UpperBound: end})
 			if err != nil {
 				return err
 			}
@@ -442,12 +448,10 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 				// This is a probabilistic sleep. A partition with no rows on
 				// this node will always sleep. A partition with many rows is
 				// very unlikely to sleep. This ensures that we don't waste CPU
-				// cycles trying to find samples for partition with no (or few)
-				// rows.
-				select {
-				case <-ctx.Done():
+				// cycles trying to find samples for a partition with no (or
+				// few) rows.
+				if !pu.samplerSleep(ctx) {
 					return nil
-				case <-pu.clock.After(SamplerSleepDuration):
 				}
 				leftInBatch = 0 // Force creating a new iterator
 				continue
@@ -458,7 +462,6 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 			log.Warningf("cannot generate sample for eviction, skipping: failed to read key: %s", err)
 			continue
 		}
-
 		fileMetadata.ResetVT() // UnmarshalVT doesn't reset, unlike proto.Unmarshal.
 		err = fileMetadata.UnmarshalVT(iter.Value())
 		if err != nil {
@@ -467,7 +470,6 @@ func (pu *partitionUsage) generateSamplesForEviction(ctx context.Context) error 
 		}
 
 		pu.maybeAddToSampleChan(ctx, iter, fileMetadata, timer)
-
 		iter.Next()
 	}
 }
@@ -490,7 +492,7 @@ func (pu *partitionUsage) maybeAddToSampleChan(ctx context.Context, iter pebble.
 		SizeBytes: sizeBytes,
 		Timestamp: atime,
 	}
-	timer.Reset(SamplerSleepDuration)
+	timer.Reset(pu.samplerSleepDuration)
 	select {
 	case pu.samples <- sample:
 	case <-ctx.Done():
@@ -595,6 +597,7 @@ func New(sender *sender.Sender, dbGetter pebble.Leaser, gossipManager interfaces
 			gcsDeletes:               make(chan *sgpb.StorageMetadata_GCSMetadata, *gcsDeleteBufferSize),
 			samplesPerBatch:          *samplesPerBatch,
 			samplerIterRefreshPeriod: *samplerIterRefreshPeriod,
+			samplerSleepDuration:     *samplerSleepDuration,
 			minEvictionAge:           *minEvictionAge,
 			localSizeUpdatePeriod:    *localSizeUpdatePeriod,
 			evictionBatchSize:        *evictionBatchSize,


### PR DESCRIPTION
This fixes the issue where metadata-server-5 was using more CPU than the rest. It doesn't have any ranges for the `anon` partition, so the iterator was always invalid, so it kept creating new iterators.

The increase in this image is from me adding a logline for every new iterator. The decrease is after I added the sleep.

<img width="2553" height="1131" alt="image" src="https://github.com/user-attachments/assets/505bdb1c-7c96-436c-89d5-1ee346c96375" />

Also simplified `generateSamplesForEviction` a bit, similar to https://github.com/buildbuddy-io/buildbuddy/pull/9855.