### PR TITLE
Fix task lease reconnect grace period

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -98,11 +98,12 @@ const (
 	taskTTL = 24 * time.Hour
 
 	// Names of task fields in Redis task hash.
-	redisTaskProtoField       = "taskProto"
-	redisTaskMetadataField    = "schedulingMetadataProto"
-	redisTaskQueuedAtUsec     = "queuedAtUsec"
-	redisTaskAttempCountField = "attemptCount"
-	redisTaskClaimedField     = "claimed"
+	redisTaskProtoField              = "taskProto"
+	redisTaskMetadataField           = "schedulingMetadataProto"
+	redisTaskQueuedAtUsec            = "queuedAtUsec"
+	redisTaskAttempCountField        = "attemptCount"
+	redisTaskClaimedField            = "claimed"
+	redisTaskReconnectPeriodEndField = "reconnectPeriodEnd"
 
 	// Maximum number of unclaimed task IDs we track per pool.
 	maxUnclaimedTasksTracked = 10_000
@@ -162,8 +163,10 @@ var (
 		-- the lease is still in its reconnection grace period.
 		local isNewAttempt = true
 		if ARGV[1] == "true" then
-			local periodEnd = redis.call("hget", KEYS[1], "reconnectPeriodEnd")
-			if periodEnd ~= nil and periodEnd ~= "" and periodEnd > tonumber(ARGV[3]) then
+			-- Redis hget returns false if the field is missing, and
+			-- tonumber(false) returns nil.
+			local periodEndNanos = tonumber(redis.call("hget", KEYS[1], "reconnectPeriodEnd"))
+			if periodEndNanos ~= nil and periodEndNanos > tonumber(ARGV[3]) then
 				local validToken = false
 
 				-- Temporarily accept either reconnectToken or leaseId.
@@ -1091,6 +1094,9 @@ type persistedTask struct {
 	serializedTask  []byte
 	queuedTimestamp time.Time
 	attemptCount    int64
+	// reconnectPeriodEnd is the time until which the task is reserved for the
+	// previous lease holder to reconnect. Zero if the task is not reserved.
+	reconnectPeriodEnd time.Time
 }
 
 type schedulerClient struct {
@@ -1699,11 +1705,15 @@ func (s *SchedulerServer) deleteClaimedTask(ctx context.Context, taskID string) 
 }
 
 func (s *SchedulerServer) unclaimTask(ctx context.Context, taskID, leaseID, reconnectToken string) error {
+	var reconnectPeriodEnd time.Time
+	if reconnectToken != "" {
+		reconnectPeriodEnd = time.Now().Add(*leaseReconnectGracePeriod)
+	}
 	// The script will return 1 if the task is claimed & claim has been released.
 	r, err := redisReleaseClaim.Run(
 		ctx, s.rdb,
 		[]string{s.redisKeyForTask(taskID)},
-		reconnectToken, time.Now().UnixNano(), leaseID,
+		reconnectToken, reconnectPeriodEnd.UnixNano(), leaseID,
 	).Result()
 	if err != nil {
 		return err
@@ -1728,7 +1738,7 @@ func (s *SchedulerServer) claimTask(ctx context.Context, taskID, reconnectToken 
 	r, err := redisAcquireClaim.Run(
 		ctx, s.rdb,
 		[]string{s.redisKeyForTask(taskID)},
-		checkTaskReconnectToken, reconnectToken, time.Now().UnixNano(), leaseId,
+		strconv.FormatBool(checkTaskReconnectToken), reconnectToken, time.Now().UnixNano(), leaseId,
 	).Result()
 	if err != nil {
 		log.CtxErrorf(ctx, "claimTask error: redis script failed: %s", err)
@@ -1823,7 +1833,15 @@ func (s *SchedulerServer) sampleUnclaimedTasks(ctx context.Context, count int, n
 	// do this filtering, which means that even if there are `count` tasks that
 	// can fit, we might wind up returning an empty list here.
 	tasksThatFit := make([]*persistedTask, 0, len(tasks))
+	now := time.Now()
 	for _, task := range tasks {
+		// Skip tasks still within their reconnect grace period: they're
+		// reserved for the previous lease holder to reconnect, so any claim by
+		// another executor would be rejected. Assigning the task now would only
+		// produce a doomed lease attempt.
+		if task.reconnectPeriodEnd.After(now) {
+			continue
+		}
 		// Filter to tasks which can fit on the node.
 		if !nodeCanFitTask(node, task.metadata.GetTaskSize()) {
 			continue
@@ -1877,6 +1895,7 @@ func (s *SchedulerServer) readTask(ctx context.Context, taskID string) (*persist
 		redisTaskMetadataField,
 		redisTaskQueuedAtUsec,
 		redisTaskAttempCountField,
+		redisTaskReconnectPeriodEndField,
 	}
 	key := s.redisKeyForTask(taskID)
 	vals, err := s.rdb.HMGet(ctx, key, fields...).Result()
@@ -1928,12 +1947,24 @@ func (s *SchedulerServer) readTask(ctx context.Context, taskID string) (*persist
 		return nil, status.InvalidArgumentErrorf("could not parse attempt count %q: %v", attemptCountStr, attemptCount)
 	}
 
+	// Reconnect period end field. Absent for tasks that are not reserved for a
+	// previous lease holder to reconnect, in which case it's left as zero.
+	var reconnectPeriodEnd time.Time
+	if str, ok := vals[4].(string); ok && str != "" {
+		if nanos, err := strconv.ParseInt(str, 10, 64); err != nil {
+			log.CtxWarningf(ctx, "could not parse reconnect period end %q for task %q: %s", str, taskID, err)
+		} else {
+			reconnectPeriodEnd = time.Unix(0, nanos)
+		}
+	}
+
 	return &persistedTask{
-		taskID:          taskID,
-		metadata:        metadata,
-		serializedTask:  serializedTask,
-		queuedTimestamp: time.UnixMicro(queuedAtUsec),
-		attemptCount:    attemptCount,
+		taskID:             taskID,
+		metadata:           metadata,
+		serializedTask:     serializedTask,
+		queuedTimestamp:    time.UnixMicro(queuedAtUsec),
+		attemptCount:       attemptCount,
+		reconnectPeriodEnd: reconnectPeriodEnd,
 	}, nil
 }
 
@@ -1972,10 +2003,19 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 		if !claimed {
 			return
 		}
-		log.CtxWarningf(ctx, "LeaseTask stream closed with task still claimed (shutting_down=%t). Re-enqueueing task.", s.isShuttingDown())
+		schedulerShuttingDown := s.isShuttingDown()
+		log.CtxWarningf(ctx, "LeaseTask stream closed with task still claimed (shutting_down=%t). Re-enqueueing task.", schedulerShuttingDown)
 		ctx, cancel := background.ExtendContextForFinalization(ctx, 3*time.Second)
 		defer cancel()
 		reEnqueueReason := "stream closed with task still claimed"
+		if !schedulerShuttingDown {
+			// TODO: figure out if we can reliably detect whether the executor
+			// gave up on the lease due to an executor shutdown vs. a transient
+			// issue with the lease stream. Transient disconnects should also
+			// get a reconnect grace period, since the executor should quickly
+			// retry them.
+			reconnectToken = ""
+		}
 		if err := s.reEnqueueTask(ctx, taskID, leaseID, reconnectToken, probesPerTask, reEnqueueReason); err != nil {
 			log.CtxErrorf(ctx, "LeaseTask %q tried to re-enqueue task but failed with err: %s", taskID, err.Error())
 		} // Success case will be logged by ReEnqueueTask flow.

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -187,12 +187,23 @@ var (
 					return 12
 				end
 				isNewAttempt = false
+
+				-- Clear the grace period timer now that the client has
+				-- successfully reconnected within the grace period.
+				--
+				-- If we don't do this, then if the client shuts down and
+				-- re-enqueues the task just after reconnecting, other
+				-- clients would have to unnecessarily wait until the reconnect
+				-- grace period ends, rather than being able to immediately
+				-- retry the task.
+
+				redis.call("hdel", KEYS[1], "reconnectPeriodEnd")
 			end
 		end
 		if isNewAttempt then
 			redis.call("hincrby", KEYS[1], "attemptCount", 1)
 		end
-		redis.call("hset", KEYS[1], "leaseId", ARGV[4])	
+		redis.call("hset", KEYS[1], "leaseId", ARGV[4])
 
 		return redis.call("hset", KEYS[1], "claimed", "1")
 		`)

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -659,6 +659,21 @@ func (tl *taskLease) Finalize() error {
 	return nil
 }
 
+func (tl *taskLease) ReEnqueue() error {
+	err := tl.stream.Send(&scpb.LeaseTaskRequest{
+		TaskId:    tl.taskID,
+		ReEnqueue: true,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = tl.stream.Recv()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (e *fakeExecutor) Claim(taskID string) *taskLease {
 	lease, err := e.leaseTask(taskID, "" /*=reconnectToken*/)
 	require.NoError(e.t, err)
@@ -897,7 +912,10 @@ func TestLeaseExpiration(t *testing.T) {
 }
 
 func TestLeaseReconnectGrace_OtherExecutorsCannotStealTask(t *testing.T) {
-	flags.Set(t, "remote_execution.lease_reconnect_grace_period", 10*time.Second)
+	// Set a high grace period since we use real time in the test.
+	// TODO: use fake time.
+	flags.Set(t, "remote_execution.lease_reconnect_grace_period", 24*time.Hour)
+	// Disable unclaimed tasks cache so we test immediate work stealing.
 	flags.Set(t, "remote_execution.unclaimed_tasks_cache_ttl", 0*time.Second)
 	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
 
@@ -934,7 +952,18 @@ func TestLeaseReconnectGrace_OtherExecutorsCannotStealTask(t *testing.T) {
 	reconnectedLease, err := holder.Reconnect(taskID, reconnectToken)
 	require.NoError(t, err)
 	require.NotEmpty(t, reconnectedLease.leaseID)
-	require.NoError(t, reconnectedLease.Finalize())
+
+	// Simulate the executor shutting down by canceling the newly reconnected
+	// lease. Since the reconnect was successful, this should re-enqueue the
+	// task without preserving the stale reconnect grace period.
+	require.NoError(t, reconnectedLease.ReEnqueue())
+
+	// Because the lease is canceled, another client should be able to get
+	// the lease now without waiting for the old reconnect grace period.
+	normalClient := newFakeExecutorWithId(ctx, t, "norm", env.GetSchedulerClient())
+	normalLease := normalClient.Claim(taskID)
+	require.NotEmpty(t, normalLease.leaseID)
+	require.NoError(t, normalLease.Finalize())
 }
 
 func TestLeaseTask_RefreshToken_FailureDoesNotFailLease(t *testing.T) {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -660,14 +660,36 @@ func (tl *taskLease) Finalize() error {
 }
 
 func (e *fakeExecutor) Claim(taskID string) *taskLease {
+	lease, err := e.leaseTask(taskID, "" /*=reconnectToken*/)
+	require.NoError(e.t, err)
+	return lease
+}
+
+// Reconnect claims a task using a reconnect token from a previous claim.
+func (e *fakeExecutor) Reconnect(taskID, reconnectToken string) (*taskLease, error) {
+	require.NotEmpty(e.t, reconnectToken)
+	return e.leaseTask(taskID, reconnectToken)
+}
+
+func (e *fakeExecutor) leaseTask(taskID, reconnectToken string) (*taskLease, error) {
 	stream, err := e.schedulerClient.LeaseTask(e.ctx)
-	require.NoError(e.t, err)
+	if err != nil {
+		return nil, err
+	}
 	err = stream.Send(&scpb.LeaseTaskRequest{
-		TaskId: taskID,
+		TaskId:            taskID,
+		ExecutorId:        e.id,
+		ExecutorHostname:  e.node.GetHost(),
+		SupportsReconnect: true,
+		ReconnectToken:    reconnectToken,
 	})
-	require.NoError(e.t, err)
+	if err != nil {
+		return nil, err
+	}
 	rsp, err := stream.Recv()
-	require.NoError(e.t, err)
+	if err != nil {
+		return nil, err
+	}
 	require.NotZero(e.t, rsp.GetLeaseDurationSeconds())
 
 	var task *repb.ExecutionTask
@@ -684,7 +706,7 @@ func (e *fakeExecutor) Claim(taskID string) *taskLease {
 		task:    task,
 		leaseID: rsp.GetLeaseId(),
 	}
-	return lease
+	return lease, nil
 }
 
 type scheduleOpts struct {
@@ -872,6 +894,47 @@ func TestLeaseExpiration(t *testing.T) {
 	// Lease renewal should fail as the stream should be broken.
 	err = lease.Renew()
 	require.ErrorIs(t, io.EOF, err)
+}
+
+func TestLeaseReconnectGrace_OtherExecutorsCannotStealTask(t *testing.T) {
+	flags.Set(t, "remote_execution.lease_reconnect_grace_period", 10*time.Second)
+	flags.Set(t, "remote_execution.unclaimed_tasks_cache_ttl", 0*time.Second)
+	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
+
+	holder := newFakeExecutorWithId(ctx, t, "holder", env.GetSchedulerClient())
+	holder.Register()
+
+	// The holder claims a task so that a scheduler shutdown can leave the
+	// task reserved for the original lease holder.
+	taskID := scheduleTask(ctx, t, env, map[string]string{})
+	holder.WaitForTask(taskID)
+	lease := holder.Claim(taskID)
+
+	// Simulate a scheduler shutdown path that re-enqueues the task while
+	// allowing the holder to re-establish its lease.
+	s := env.GetSchedulerService().(*SchedulerServer)
+	reconnectToken := lease.leaseID
+	err := s.reEnqueueTask(ctx, taskID, lease.leaseID, reconnectToken, 1 /*=numReplicas*/, "server shutting down")
+	require.NoError(t, err)
+
+	// A newly registered executor asks for work and samples unclaimed tasks.
+	// While the task is reserved for the holder to reconnect, it must not be
+	// handed out, so the thief should not receive a reservation for it.
+	thief := newFakeExecutorWithId(ctx, t, "thief", env.GetSchedulerClient())
+	thief.Register()
+	thief.EnsureTaskNotReceived(taskID)
+
+	// Even if the thief attempts a lease directly (e.g. acting on a stale
+	// reservation), the claim must be rejected until the grace period expires.
+	_, err = thief.leaseTask(taskID, "" /*=reconnectToken*/)
+	require.True(t, status.IsNotFoundError(err), "unexpected claim error: %s", err)
+
+	// The original holder can still reconnect using the token it received
+	// before the scheduler shutdown.
+	reconnectedLease, err := holder.Reconnect(taskID, reconnectToken)
+	require.NoError(t, err)
+	require.NotEmpty(t, reconnectedLease.leaseID)
+	require.NoError(t, reconnectedLease.Finalize())
 }
 
 func TestLeaseTask_RefreshToken_FailureDoesNotFailLease(t *testing.T) {

--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -141,6 +141,7 @@ func (t *TaskLease) pingServer(ctx context.Context) (b []byte, err error) {
 			return nil, status.WrapError(err, "reconnect lease")
 		}
 		t.stream = stream
+		t.supportsReconnect = false
 		if r == nil {
 			ctx, cancel := context.WithTimeout(ctx, reconnectTimeout)
 			defer cancel()
@@ -150,7 +151,11 @@ func (t *TaskLease) pingServer(ctx context.Context) (b []byte, err error) {
 			return nil, originalErr
 		}
 	}
-	t.supportsReconnect = rsp.GetSupportsReconnect() || rsp.GetReconnectToken() != ""
+	// Lease renewals don't repeat reconnect support fields, so keep reconnect
+	// support enabled once the scheduler advertises it on this stream.
+	if rsp.GetSupportsReconnect() || rsp.GetReconnectToken() != "" {
+		t.supportsReconnect = true
+	}
 	if rsp.GetLeaseId() != "" {
 		t.leaseID = rsp.GetLeaseId()
 	}
@@ -194,6 +199,7 @@ func (t *TaskLease) claim(ctx context.Context) (context.Context, []byte, error) 
 		return nil, nil, err
 	}
 	t.stream = stream
+	t.supportsReconnect = false
 	serializedTask, err := t.pingServer(ctx)
 	if err == nil {
 		defer t.keepLease(ctx)

--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -77,15 +77,15 @@ type TaskLease struct {
 	executorHostname string
 	taskID           string
 
-	ctx               context.Context
-	execTask          *repb.ExecutionTask
-	leaseID           string
-	supportsReconnect bool
-	quit              chan struct{}
-	mu                sync.Mutex // protects stream
-	stream            scpb.Scheduler_LeaseTaskClient
-	ttl               time.Duration
-	cancelFunc        context.CancelFunc
+	ctx            context.Context
+	execTask       *repb.ExecutionTask
+	leaseID        string
+	reconnectToken string
+	quit           chan struct{}
+	mu             sync.Mutex // protects stream
+	stream         scpb.Scheduler_LeaseTaskClient
+	ttl            time.Duration
+	cancelFunc     context.CancelFunc
 }
 
 func (t *TaskLease) Context() context.Context {
@@ -117,9 +117,7 @@ func (t *TaskLease) pingServer(ctx context.Context) (b []byte, err error) {
 		ExecutorHostname:  t.executorHostname,
 		TaskId:            t.taskID,
 		SupportsReconnect: *enableReconnect,
-	}
-	if t.supportsReconnect {
-		req.ReconnectToken = t.leaseID
+		ReconnectToken:    t.reconnectToken,
 	}
 	var rsp *scpb.LeaseTaskResponse
 	var r *retry.Retry
@@ -141,7 +139,6 @@ func (t *TaskLease) pingServer(ctx context.Context) (b []byte, err error) {
 			return nil, status.WrapError(err, "reconnect lease")
 		}
 		t.stream = stream
-		t.supportsReconnect = false
 		if r == nil {
 			ctx, cancel := context.WithTimeout(ctx, reconnectTimeout)
 			defer cancel()
@@ -151,10 +148,8 @@ func (t *TaskLease) pingServer(ctx context.Context) (b []byte, err error) {
 			return nil, originalErr
 		}
 	}
-	// Lease renewals don't repeat reconnect support fields, so keep reconnect
-	// support enabled once the scheduler advertises it on this stream.
-	if rsp.GetSupportsReconnect() || rsp.GetReconnectToken() != "" {
-		t.supportsReconnect = true
+	if rsp.GetReconnectToken() != "" {
+		t.reconnectToken = rsp.GetReconnectToken()
 	}
 	if rsp.GetLeaseId() != "" {
 		t.leaseID = rsp.GetLeaseId()
@@ -199,7 +194,6 @@ func (t *TaskLease) claim(ctx context.Context) (context.Context, []byte, error) 
 		return nil, nil, err
 	}
 	t.stream = stream
-	t.supportsReconnect = false
 	serializedTask, err := t.pingServer(ctx)
 	if err == nil {
 		defer t.keepLease(ctx)


### PR DESCRIPTION
This PR fixes some issues with the "reconnect grace period" logic. Context: https://buildbuddy-corp.slack.com/archives/C07SND71EDC/p1782246097521369?thread_ts=1782151034.068199&cid=C07SND71EDC

The reconnect grace period was intended to allow executors to quickly re-establish a lease that was temporarily broken due to a scheduler shutdown, keeping the lease alive so the task does not have to be retried. However, this logic was not working due to some issues:

- `unclaimTask` always passed the current time as the reconnect period end, instead of actually applying the grace period duration by adding it to the current time.
- The `claimTask` redis script was checking for `checkTaskReconnectToken == "true"`, but the value of that variable was effectively always either `"0"` or `"1"` due to how go-redis serializes Go `bool` values when executing scripts. So the reconnect token check was never running.
  - Even if that check had run, the script would have compared the stored `reconnectPeriodEnd` (a string returned by `hget`) directly against the current time (a number), which raises an error in Lua.
  - The missing-field case was also mishandled, because `hget` returns `false` (not `nil`) when the field is absent. Fixed by converting the field with `tonumber` up front and treating a `nil` result as "not reserved".

Fixing the above issues was enough to get the reconnect behavior mostly working as expected, except for a few other issues which are also addressed in this PR:

- Executors treated the scheduler's `supports_reconnect` response bit as the condition for sending reconnect tokens. Renewal responses do not repeat reconnect fields, so after the first lease renewal the executor would stop sending its already-issued reconnect token and get rejected while the task was still in its reconnect grace period. The client now stores the issued reconnect token directly and sends it on subsequent lease requests.
- The deferred re-enqueue in `LeaseTask` applied the reconnect grace to every stream close, including ordinary executor disconnects. The grace period was originally intended only to run on scheduler shutdown, so that the executor can reconnect to another app replica. An executor that simply dies should have its task re-enqueued promptly (other executors should not have to wait for the grace period to elapse). Fixed by clearing the reconnect token unless the scheduler is shutting down.
  - Note: there are other cases where a grace period makes sense too, for example a transient network error. However I think it is worth being careful about checking for the right error codes, so that we properly distinguish a normal executor shutdown from other errors. I left a TODO for now to handle these in a later PR.
- The re-enqueue delay only applies to the reservation pushed by `reEnqueueTask`, not to tasks pulled from the unclaimed list when an executor asks for work. The other executor would receive the reservation and then (with a high chance) fail to claim the task because it is still in its reconnect grace period. This is not really a correctness issue, but it is wasted work. `sampleUnclaimedTasks` now reads `reconnectPeriodEnd` and skips tasks that are still reserved, so the doomed reservation and lease attempt are avoided.
- We never cleared the reconnect grace period after the task was successfully claimed. There is an edge case here in which an executor reconnects a lease then immediately shuts down - when the executor shuts down, it will re-enqueue the task on another executor. If that executor then tries to lease the task, it will fail because the task is still in its reconnect grace period. In the worst case (no other executors have this task in their queue), the task just sits in the unclaimedTasks list and we're relying only on work stealing / executor registration to assign work. This means that if executors are busy and no new executor registrations are happening, the task can potentially sit in the unclaimedTasks list, unfairly extending its wait time.

This PR also adds a regression test - the lease reconnect behavior was previously only tested through `TestAppShutdownDuringExecution_LeaseTaskRetried` (in `remote_execution_test.go`) which only tested using a single executor. The bug is only observable when there are multiple running executors, which the new test exercises.
