### PR TITLE
Add open file link to input files browser

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -182,7 +182,10 @@ ts_library(
         "//:node_modules/lucide-react",
         "//:node_modules/react",
         "//app/components/digest",
+        "//app/components/icons:file_icon",
+        "//app/components/link",
         "//app/format",
+        "//app/util:file_types",
         "//proto:remote_execution_ts_proto",
     ],
 )

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -185,7 +185,6 @@ ts_library(
         "//app/components/icons:file_icon",
         "//app/components/link",
         "//app/format",
-        "//app/util:file_types",
         "//proto:remote_execution_ts_proto",
     ],
 )

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -643,6 +643,15 @@ export default class InvocationActionCardComponent extends React.Component<Props
     );
   }
 
+  private getInputFileViewUrl(path: string, digest: IDigest) {
+    const params: Record<string, string> = {
+      bytestream_url: this.props.model.getBytestreamURL(digest),
+      invocation_id: this.props.model.getInvocationId(),
+      filename: path,
+    };
+    return `/code/buildbuddy-io/buildbuddy/?${new URLSearchParams(params).toString()}`;
+  }
+
   private renderTiming(metadata: build.bazel.remote.execution.v2.ExecutedActionMetadata) {
     let timingDescription = null;
     if (metadata.queuedTimestamp && metadata.workerStartTimestamp && metadata.workerCompletedTimestamp) {

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -1418,6 +1418,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
                               treeShaToChildrenMap={this.state.treeShaToChildrenMap}
                               treeShaToTotalSizeMap={this.state.treeShaToTotalSizeMap}
                               handleFileClicked={this.handleFileClicked.bind(this)}
+                              getFileViewUrl={this.getInputFileViewUrl.bind(this)}
                             />
                           ))}
                         </div>

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -1,15 +1,26 @@
-import { ArrowRight, Download, FileSymlink, FolderMinus, FolderPlus } from "lucide-react";
+import {
+  ArrowRight,
+  Download,
+  FileSymlink,
+  FolderMinus,
+  FolderPlus,
+} from "lucide-react";
 import React from "react";
 import { build } from "../../proto/remote_execution_ts_proto";
 import DigestComponent from "../components/digest/digest";
+import { FileIcon } from "../components/icons/file_icon";
+import { TextLink } from "../components/link/link";
 import format from "../format/format";
+import { parseExtension } from "../util/file_types";
 
 interface Props {
   node: TreeNode;
   treeShaToExpanded: Map<string, boolean>;
   treeShaToChildrenMap: Map<string, TreeNode[]>;
   treeShaToTotalSizeMap: Map<string, [Number, Number]>;
-  handleFileClicked: any;
+  path?: string;
+  handleFileClicked: (node: TreeNode) => void;
+  getFileViewUrl?: (path: string, digest: build.bazel.remote.execution.v2.IDigest) => string;
 }
 
 interface State {}
@@ -43,9 +54,12 @@ function getChildCountText(childCount: Number) {
 
 export default class TreeNodeComponent extends React.Component<Props, State> {
   renderFileOrDirectoryNode(node: FileNode | DirectoryNode) {
+    const path = this.props.path ?? node.name;
     const digestString = node.digest?.hash ?? "";
     const sizeInfo = this.props.treeShaToTotalSizeMap.get(digestString);
     const expanded = this.props.treeShaToExpanded.get(digestString);
+    const fileViewUrl =
+      this.props.node.type == "file" && node.digest ? this.props.getFileViewUrl?.(path, node.digest) : undefined;
 
     return (
       <div className="input-tree-node">
@@ -66,6 +80,15 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
             )}
           </span>{" "}
           <span className="input-tree-node-label">{node.name}</span>
+          {fileViewUrl && (
+            <TextLink
+              className="artifact-view"
+              href={fileViewUrl}
+              onClick={(e) => e.stopPropagation()}
+              target="_blank">
+              <FileIcon extension={parseExtension(path)} /> View
+            </TextLink>
+          )}
           {sizeInfo ? (
             <span className="input-tree-node-size">{`${format.bytes(+sizeInfo[0])} (${getChildCountText(
               sizeInfo[1]
@@ -82,10 +105,12 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
               ?.map((child: TreeNode) => (
                 <TreeNodeComponent
                   node={child}
+                  path={joinInputPath(path, child.obj.name)}
                   treeShaToExpanded={this.props.treeShaToExpanded}
                   treeShaToChildrenMap={this.props.treeShaToChildrenMap}
                   treeShaToTotalSizeMap={this.props.treeShaToTotalSizeMap}
                   handleFileClicked={this.props.handleFileClicked}
+                  getFileViewUrl={this.props.getFileViewUrl}
                 />
               ))}
           </div>
@@ -114,4 +139,8 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
       ? this.renderSymlinkNode(this.props.node.obj)
       : this.renderFileOrDirectoryNode(this.props.node.obj);
   }
+}
+
+function joinInputPath(parent: string, child: string): string {
+  return parent ? `${parent}/${child}` : child;
 }

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -1,10 +1,4 @@
-import {
-  ArrowRight,
-  Download,
-  FileSymlink,
-  FolderMinus,
-  FolderPlus,
-} from "lucide-react";
+import { ArrowRight, Download, FileSymlink, FolderMinus, FolderPlus } from "lucide-react";
 import React from "react";
 import { build } from "../../proto/remote_execution_ts_proto";
 import DigestComponent from "../components/digest/digest";
@@ -81,11 +75,7 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
           </span>{" "}
           <span className="input-tree-node-label">{node.name}</span>
           {fileViewUrl && (
-            <TextLink
-              className="artifact-view"
-              href={fileViewUrl}
-              onClick={(e) => e.stopPropagation()}
-              target="_blank">
+            <TextLink className="artifact-view" href={fileViewUrl} onClick={(e) => e.stopPropagation()} target="_blank">
               <FileIcon extension={parseExtension(path)} /> View
             </TextLink>
           )}

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -5,7 +5,6 @@ import DigestComponent from "../components/digest/digest";
 import { FileIcon } from "../components/icons/file_icon";
 import { TextLink } from "../components/link/link";
 import format from "../format/format";
-import { parseExtension } from "../util/file_types";
 
 interface Props {
   node: TreeNode;
@@ -75,8 +74,13 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
           </span>{" "}
           <span className="input-tree-node-label">{node.name}</span>
           {fileViewUrl && (
-            <TextLink className="artifact-view" href={fileViewUrl} onClick={(e) => e.stopPropagation()} target="_blank">
-              <FileIcon extension={parseExtension(path)} /> View
+            <TextLink
+              className="artifact-view"
+              href={fileViewUrl}
+              // Otherwise the file will be downloaded instead
+              onClick={(e) => e.stopPropagation()}
+              target="_blank">
+              <FileIcon extension={node.name} /> View
             </TextLink>
           )}
           {sizeInfo ? (


### PR DESCRIPTION
Previously you could only download files from the input files browser,
now you can also open the file in the browser instead for quicker
viewing.
