### PR TITLE
Support NS delegation in Density DNS server

### DIFF
--- a/enterprise/dns/server/server.go
+++ b/enterprise/dns/server/server.go
@@ -42,6 +42,12 @@ type handler struct {
 	// instead of re-asking us every time. Nil if the zone file has no SOA.
 	soa dns.RR
 
+	// apex is the canonical zone apex (the SOA owner). NS records here describe
+	// this zone; NS records below it are delegations (zone cuts). Empty if the
+	// zone file has no SOA, in which case we can't tell the two apart and treat
+	// nothing as a delegation.
+	apex string
+
 	env environment.Env
 }
 
@@ -75,6 +81,21 @@ func (h *handler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 
 	qName := dns.CanonicalName(r.Question[0].Name)
 	qType := r.Question[0].Qtype
+
+	// If the name lies at or below a zone cut (an in-zone NS record below the
+	// apex), we are not authoritative for it: return a referral to the child's
+	// nameservers instead of answering from this zone. This is how we hand a
+	// subdomain off to another DNS provider -- e.g. delegating an ACME
+	// _acme-challenge validation name back to a cloud DNS zone.
+	if ns := h.delegation(qName); len(ns) > 0 {
+		m.Authoritative = false
+		m.Ns = append(m.Ns, ns...)
+		m.Extra = append(m.Extra, h.glue(ns)...)
+		if err := w.WriteMsg(m); err != nil {
+			log.Warningf("Failed to write DNS referral for %q: %s", qName, err)
+		}
+		return
+	}
 
 	var negative bool
 	m.Answer, m.Rcode, negative = h.resolve(qName, qType)
@@ -265,6 +286,49 @@ func (h *handler) lookup(name string) ([]dns.RR, bool) {
 	return nil, false
 }
 
+// delegation returns the NS records at the closest zone cut enclosing name, or
+// nil if name is not under a delegation. A zone cut is any owner below the apex
+// that carries NS records; the apex's own NS records describe this zone, not a
+// delegation, so they are never treated as one. Walking up from name, the first
+// such owner is the cut, since a correct parent holds no data below it.
+func (h *handler) delegation(name string) []dns.RR {
+	if h.apex == "" {
+		return nil
+	}
+	for n := name; n != h.apex; {
+		if ns := filterByType(h.records[n], dns.TypeNS); len(ns) > 0 {
+			return ns
+		}
+		off, end := dns.NextLabel(n, 0)
+		if end {
+			break
+		}
+		n = n[off:]
+	}
+	return nil
+}
+
+// glue returns the in-zone (in-bailiwick) address records for the targets of
+// the given NS records, for the additional section of a referral. Out-of-zone
+// targets -- the usual case for our delegations -- contribute no glue and are
+// resolved by the asking resolver itself.
+func (h *handler) glue(nsRecords []dns.RR) []dns.RR {
+	var out []dns.RR
+	for _, rr := range nsRecords {
+		ns, ok := rr.(*dns.NS)
+		if !ok {
+			continue
+		}
+		for _, a := range h.records[dns.CanonicalName(ns.Ns)] {
+			switch a.Header().Rrtype {
+			case dns.TypeA, dns.TypeAAAA:
+				out = append(out, a)
+			}
+		}
+	}
+	return out
+}
+
 // recordTypeLabel maps a query type to a metric label, collapsing unknown
 // types (which the client controls) to "OTHER" so cardinality stays bounded.
 func recordTypeLabel(qType uint16) string {
@@ -361,9 +425,14 @@ func NewHandler(resources []dns.RR, env environment.Env) dns.Handler {
 			soa = rr
 		}
 	}
+	apex := ""
+	if soa != nil {
+		apex = dns.CanonicalName(soa.Header().Name)
+	}
 	return &handler{
 		records: records,
 		soa:     soa,
+		apex:    apex,
 		env:     env,
 	}
 }

--- a/enterprise/dns/server/server.go
+++ b/enterprise/dns/server/server.go
@@ -87,6 +87,13 @@ func (h *handler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	// nameservers instead of answering from this zone. This is how we hand a
 	// subdomain off to another DNS provider -- e.g. delegating an ACME
 	// _acme-challenge validation name back to a cloud DNS zone.
+	//
+	// TODO(tylerw): A DS query AT a zone cut is the exception: the DS RRset is
+	// parent-owned authoritative data and must be answered here (or NODATA+SOA),
+	// not referred down to the child (RFC 4035 sec. 3.1.4.1). DS queries strictly
+	// below the cut still refer, so the guard is "for DS, evaluate the delegation
+	// from qName's parent label", not a blanket skip. Inert until we serve
+	// DNSSEC (no DS/RRSIG today), and a full fix also needs signed DS/RRSIG/NSEC.
 	if ns := h.delegation(qName); len(ns) > 0 {
 		m.Authoritative = false
 		m.Ns = append(m.Ns, ns...)

--- a/enterprise/dns/server/server_test.go
+++ b/enterprise/dns/server/server_test.go
@@ -35,6 +35,17 @@ var zone = []string{
 	"*.aws.buildbuddy.io. 60 IN CNAME elb.amazonaws.example.",
 	"www.buildbuddy.io. 60 IN CNAME external.github.io.",
 	"alias.buildbuddy.io. 60 IN CNAME cache.buildbuddy.io.",
+	// The apex's own NS records describe this zone (not a delegation).
+	"buildbuddy.io. 60 IN NS ns1.example.",
+	// acme.buildbuddy.io is delegated to another provider (out-of-zone NS),
+	// e.g. to hand off ACME DNS-01 validation; queries at or below it (even
+	// ones a wildcard would otherwise cover) are referred, not answered.
+	"acme.buildbuddy.io. 60 IN NS ns1.otherns.example.",
+	"acme.buildbuddy.io. 60 IN NS ns2.otherns.example.",
+	// glued.buildbuddy.io is delegated to an in-bailiwick nameserver, so its
+	// address is glue served in the additional section of the referral.
+	"glued.buildbuddy.io. 60 IN NS ns1.glued.buildbuddy.io.",
+	"ns1.glued.buildbuddy.io. 60 IN A 5.6.7.8",
 }
 
 func mustRecords(tb testing.TB) []dns.RR {
@@ -456,6 +467,72 @@ func answers(rrs []dns.RR) []answer {
 		}
 	}
 	return out
+}
+
+// nsTargets returns the target names of the NS records in rrs.
+func nsTargets(rrs []dns.RR) []string {
+	var out []string
+	for _, rr := range rrs {
+		if ns, ok := rr.(*dns.NS); ok {
+			out = append(out, ns.Ns)
+		}
+	}
+	return out
+}
+
+func TestDelegationReferral(t *testing.T) {
+	h := newTestHandler(t)
+	// A name under the delegated subzone is referred: NOERROR, not
+	// authoritative, NS records in the authority section, no answer, no SOA.
+	m := query(t, h, "_acme-challenge.foo.acme.buildbuddy.io.", dns.TypeTXT)
+	assert.Equal(t, dns.RcodeSuccess, m.Rcode)
+	assert.False(t, m.Authoritative, "a referral must not set the authoritative flag")
+	assert.Empty(t, m.Answer)
+	assert.ElementsMatch(t,
+		[]string{"ns1.otherns.example.", "ns2.otherns.example."}, nsTargets(m.Ns))
+	for _, rr := range m.Ns {
+		assert.NotEqual(t, dns.TypeSOA, rr.Header().Rrtype, "a referral carries NS, not the SOA")
+	}
+}
+
+func TestDelegationAtCut(t *testing.T) {
+	h := newTestHandler(t)
+	// The delegation point itself is referred, regardless of query type.
+	m := query(t, h, "acme.buildbuddy.io.", dns.TypeA)
+	assert.Equal(t, dns.RcodeSuccess, m.Rcode)
+	assert.False(t, m.Authoritative)
+	assert.Empty(t, m.Answer)
+	require.NotEmpty(t, m.Ns)
+}
+
+func TestDelegationBeatsWildcard(t *testing.T) {
+	h := newTestHandler(t)
+	// *.buildbuddy.io would otherwise synthesize an A; the zone cut takes
+	// precedence (RFC 4592) and we refer instead.
+	m := query(t, h, "host.acme.buildbuddy.io.", dns.TypeA)
+	assert.False(t, m.Authoritative)
+	assert.Empty(t, m.Answer)
+	require.NotEmpty(t, m.Ns)
+}
+
+func TestDelegationGlue(t *testing.T) {
+	h := newTestHandler(t)
+	// An in-bailiwick nameserver target contributes a glue A in the additional
+	// section so the resolver can reach the child without a lookup loop.
+	m := query(t, h, "x.glued.buildbuddy.io.", dns.TypeA)
+	assert.False(t, m.Authoritative)
+	assert.Equal(t, []answer{{"ns1.glued.buildbuddy.io.", "A", "5.6.7.8"}}, answers(m.Extra))
+}
+
+func TestApexNSIsAuthoritative(t *testing.T) {
+	h := newTestHandler(t)
+	// The apex's own NS records describe this zone and are answered
+	// authoritatively, not as a referral.
+	m := query(t, h, "buildbuddy.io.", dns.TypeNS)
+	assert.Equal(t, dns.RcodeSuccess, m.Rcode)
+	assert.True(t, m.Authoritative)
+	require.NotEmpty(t, m.Answer)
+	assert.Empty(t, m.Ns)
 }
 
 func TestExactMatch(t *testing.T) {


### PR DESCRIPTION
This is necessary in order to delegate ACME verification elsewhere.