### PR TITLE
[RB] Fix duplicate log streaming in CLI

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -8,7 +8,13 @@ package(default_visibility = [
 
 go_library(
     name = "remotebazel",
-    srcs = ["remotebazel.go"],
+    srcs = [
+        "remotebazel.go",
+        "terminal_echo.go",
+        "terminal_echo_darwin.go",
+        "terminal_echo_linux.go",
+        "terminal_echo_unsupported.go",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/remotebazel",
     deps = [
         "//cli/arg",
@@ -56,8 +62,13 @@ go_test(
         "//cli/parser",
         "//cli/parser/test_data",
         "//cli/storage",
+        "//proto:buildbuddy_service_go_proto",
+        "//proto:eventlog_go_proto",
         "//server/testutil/testgit",
         "//server/testutil/testshell",
+        "//server/util/terminal",
+        "@com_github_creack_pty//:pty",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -612,12 +612,13 @@ func generatePatches(baseCommit string) ([][]byte, error) {
 
 func getTermWidth() int {
 	size, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
-	if err != nil {
+	if err != nil || size.Col == 0 {
 		return 80
 	}
 	return int(size.Col)
 }
 
+// splitLogBuffer converts a byte buffer from the log API into terminal rows.
 func splitLogBuffer(buf []byte) []string {
 	var lines []string
 
@@ -632,38 +633,100 @@ func splitLogBuffer(buf []byte) []string {
 	return lines
 }
 
+func commonPrefixLineCount(a, b []string) int {
+	n := min(len(a), len(b))
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}
+
+// liveLogUpdate returns the number of previously printed terminal rows to
+// remove, and the index in the current log buffer to start printing from.
+func liveLogUpdate(previous, current []string) (deleteCount int, printFrom int) {
+	commonPrefixLines := commonPrefixLineCount(previous, current)
+	return len(previous) - commonPrefixLines, commonPrefixLines
+}
+
+type logChunk struct {
+	id       string
+	response *elpb.GetEventLogChunkResponse
+}
+
+func logChunkID(requestedChunkID string, response *elpb.GetEventLogChunkResponse) string {
+	if response.GetLive() {
+		return response.GetNextChunkId()
+	}
+	return requestedChunkID
+}
+
 // streamLogs streams the logs with real-time progress updates. It uses ANSI
 // escape sequences to delete and rewrite outdated progress messages
 func streamLogs(ctx context.Context, bbClient bbspb.BuildBuddyServiceClient, invocationID string) error {
+	// Disable printing input to the terminal, which could corrupt the log stream and break log de-duplication.
 	defer resetTerminalStyles()
+	restoreTerminalEcho, err := disableTerminalEcho(os.Stdin)
+	if err != nil {
+		log.Warnf("Failed to disable terminal echo; typed input may interfere with remote log streaming: %s", err)
+	} else {
+		defer func() {
+			if err := restoreTerminalEcho(); err != nil {
+				log.Warnf("Failed to restore terminal echo: %s", err)
+			}
+		}()
+	}
 
+	// ID of the chunk we're requesting from the server.
 	chunkID := ""
-	moveBack := 0
+	// ID of the live chunk currently drawn on the terminal.
+	liveChunkID := ""
+	// Buffer of lines currently printed to the terminal, kept so redraws do
+	// not reprint log lines that are already on screen.
+	var liveLines []string
 
-	drawChunk := func(chunk *elpb.GetEventLogChunkResponse) {
-		// Are we redrawing the current chunk?
-		if moveBack > 0 {
-			consoleCursorMoveUp(moveBack)
+	drawChunk := func(chunk logChunk) {
+		logLines := splitLogBuffer(chunk.response.GetBuffer())
+		// Index of the log to start printing from. If earlier lines are
+		// already on screen, do not print them again.
+		printFrom := 0
+
+		// Are we redrawing the current live chunk?
+		if liveChunkID == chunk.id {
+			deleteCount := 0
+			deleteCount, printFrom = liveLogUpdate(liveLines, logLines)
+			if deleteCount > 0 {
+				consoleCursorMoveUp(deleteCount)
+				consoleCursorMoveBeginningLine()
+				consoleDeleteLines(deleteCount)
+			}
+		} else if len(liveLines) > 0 {
+			// If we're printing logs from a new chunk, delete volatile log lines
+			// from the previous chunk.
+			consoleCursorMoveUp(len(liveLines))
 			consoleCursorMoveBeginningLine()
-			consoleDeleteLines(moveBack)
+			consoleDeleteLines(len(liveLines))
 		}
 
-		logLines := splitLogBuffer(chunk.GetBuffer())
-		if !chunk.GetLive() {
-			moveBack = 0
+		if !chunk.response.GetLive() {
+			liveChunkID = ""
+			liveLines = nil
 		} else {
-			moveBack = len(logLines)
+			liveChunkID = chunk.id
+			liveLines = logLines
 		}
 
-		for _, l := range logLines {
+		for _, l := range logLines[printFrom:] {
 			_, _ = os.Stdout.Write([]byte(l))
 			_, _ = os.Stdout.Write([]byte("\n"))
 		}
 	}
 
-	var chunks []*elpb.GetEventLogChunkResponse
+	var chunks []logChunk
 	wasLive := false
 	for {
+		requestedChunkID := chunkID
 		l, err := bbClient.GetEventLogChunk(ctx, &elpb.GetEventLogChunkRequest{
 			InvocationId: invocationID,
 			ChunkId:      chunkID,
@@ -673,7 +736,7 @@ func streamLogs(ctx context.Context, bbClient bbspb.BuildBuddyServiceClient, inv
 			return status.WrapError(err, "get event log chunk")
 		}
 
-		chunks = append(chunks, l)
+		chunks = append(chunks, logChunk{id: logChunkID(requestedChunkID, l), response: l})
 		// If the current chunk was live but is no longer then delay redraw
 		// until the next chunk is retrieved. The "volatile" part of the
 		// chunk moves to the next chunk when a chunk is finalized. Without
@@ -696,6 +759,13 @@ func streamLogs(ctx context.Context, bbClient bbspb.BuildBuddyServiceClient, inv
 			time.Sleep(1 * time.Second)
 		}
 		chunkID = l.GetNextChunkId()
+	}
+
+	// The final chunk's redraw may have been delayed (see above) if it
+	// finalized a previously live chunk. Flush anything still pending so the
+	// last lines of the log are not dropped when the stream ends.
+	for _, chunk := range chunks {
+		drawChunk(chunk)
 	}
 	return nil
 }

--- a/cli/remotebazel/remotebazel_test.go
+++ b/cli/remotebazel/remotebazel_test.go
@@ -1,12 +1,17 @@
 package remotebazel
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/login"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
@@ -14,11 +19,64 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testgit"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testshell"
+	"github.com/buildbuddy-io/buildbuddy/server/util/terminal"
+	"github.com/creack/pty"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
+	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
 )
 
 func init() {
 	parser.SetBazelHelpForTesting(test_data.BazelHelpFlagsAsProtoOutput)
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// Used to mock logs streamed from the BuildBuddy server.
+type scriptedBuildBuddyClient struct {
+	bbspb.BuildBuddyServiceClient
+
+	mu        sync.Mutex
+	responses []*elpb.GetEventLogChunkResponse
+	hooks     []func()
+}
+
+func (c *scriptedBuildBuddyClient) GetEventLogChunk(ctx context.Context, req *elpb.GetEventLogChunkRequest, opts ...grpc.CallOption) (*elpb.GetEventLogChunkResponse, error) {
+	c.mu.Lock()
+	if len(c.responses) == 0 {
+		c.mu.Unlock()
+		return &elpb.GetEventLogChunkResponse{}, nil
+	}
+	response := c.responses[0]
+	c.responses = c.responses[1:]
+	var hook func()
+	if len(c.hooks) > 0 {
+		hook = c.hooks[0]
+		c.hooks = c.hooks[1:]
+	}
+	c.mu.Unlock()
+
+	if hook != nil {
+		hook()
+	}
+	return response, nil
 }
 
 func TestParseRemoteCliFlags(t *testing.T) {
@@ -218,6 +276,169 @@ func TestParseRemoteCliFlags(t *testing.T) {
 			require.Equal(t, expectedVal, actualVal.String(), tc.name)
 		}
 	}
+}
+
+func TestLiveLogUpdate(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		previous   []string
+		current    []string
+		wantDelete int
+		wantPrint  int
+	}{
+		{
+			name:      "initial render",
+			current:   []string{"setup", "progress"},
+			wantPrint: 0,
+		},
+		{
+			name:       "append stable lines",
+			previous:   []string{"setup"},
+			current:    []string{"setup", "progress"},
+			wantDelete: 0,
+			wantPrint:  1,
+		},
+		{
+			name:       "redraw changed suffix",
+			previous:   []string{"setup", "progress 1", "fetch 1"},
+			current:    []string{"setup", "progress 2", "fetch 2"},
+			wantDelete: 2,
+			wantPrint:  1,
+		},
+		{
+			name:       "redraw whole chunk if no prefix matches",
+			previous:   []string{"old setup", "old progress"},
+			current:    []string{"new setup", "new progress"},
+			wantDelete: 2,
+			wantPrint:  0,
+		},
+		{
+			name:       "truncate stale live lines",
+			previous:   []string{"setup", "progress", "stale"},
+			current:    []string{"setup", "progress"},
+			wantDelete: 1,
+			wantPrint:  2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deleteCount, printFrom := liveLogUpdate(tc.previous, tc.current)
+			require.Equal(t, tc.wantDelete, deleteCount)
+			require.Equal(t, tc.wantPrint, printFrom)
+		})
+	}
+}
+
+func TestStreamLogs_TerminalClearDoesNotReplayStableLogs(t *testing.T) {
+	clearScreenBeforeSecondResponse := make(chan struct{})
+	continueSecondResponse := make(chan struct{})
+	client := &scriptedBuildBuddyClient{
+		responses: []*elpb.GetEventLogChunkResponse{
+			{
+				Buffer:      []byte("Applied patch cleanly.\nSetup completed.\nAnalyzing: 1\n"),
+				NextChunkId: "0001",
+				Live:        true,
+			},
+			{
+				Buffer:      []byte("Applied patch cleanly.\nSetup completed.\nAnalyzing: 2\n"),
+				NextChunkId: "0001",
+				Live:        true,
+			},
+			{
+				Buffer: []byte("Applied patch cleanly.\nSetup completed.\nAnalyzing: 2\nDone.\n"),
+			},
+		},
+		hooks: []func(){
+			nil,
+			func() {
+				close(clearScreenBeforeSecondResponse)
+				<-continueSecondResponse
+			},
+		},
+	}
+
+	raw, rendered := runStreamLogsWithPTY(t, client, func(ptmx *os.File) {
+		// Clear the terminal before the second log response is streamed.
+		// Duplicate logs should not be reprinted.
+		waitForSignal(t, clearScreenBeforeSecondResponse)
+		_, err := os.Stdout.Write([]byte("\x1b[2J\x1b[H"))
+		require.NoError(t, err)
+		close(continueSecondResponse)
+	})
+
+	// On failure, dump the captured output.
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("rendered logs:\n%s\x1b[0m", rendered)
+		}
+	})
+
+	// Stable logs should not be duplicated.
+	require.Equal(t, 1, strings.Count(rendered, "Analyzing: 2"))
+	require.Equal(t, 1, strings.Count(rendered, "Done."))
+
+	// Stale logs should not be printed.
+	require.NotContains(t, rendered, "Analyzing: 1")
+
+	// After the terminal was cleared, stable logs should not be reprinted.
+	require.NotContains(t, rendered, "Applied patch cleanly.")
+
+	// The raw output should contain the original logs before they were cleared.
+	require.Equal(t, 1, strings.Count(raw, "Applied patch cleanly."))
+
+}
+
+func TestStreamLogs_TypedInputDoesNotCorruptOutput(t *testing.T) {
+	typeInputBeforeSecondResponse := make(chan struct{})
+	continueSecondResponse := make(chan struct{})
+	client := &scriptedBuildBuddyClient{
+		responses: []*elpb.GetEventLogChunkResponse{
+			{
+				Buffer:      []byte("Applied patch cleanly.\nSetup completed.\nAnalyzing: 1\n"),
+				NextChunkId: "0001",
+				Live:        true,
+			},
+			{
+				Buffer:      []byte("Applied patch cleanly.\nSetup completed.\nAnalyzing: 2\n"),
+				NextChunkId: "0001",
+				Live:        true,
+			},
+			{
+				Buffer: []byte("Applied patch cleanly.\nSetup completed.\nAnalyzing: 2\nDone.\n"),
+			},
+		},
+		hooks: []func(){
+			nil,
+			func() {
+				close(typeInputBeforeSecondResponse)
+				<-continueSecondResponse
+			},
+		},
+	}
+
+	_, rendered := runStreamLogsWithPTY(t, client, func(ptmx *os.File) {
+		// Between the first and second log responses, type some input into the terminal.
+		waitForSignal(t, typeInputBeforeSecondResponse)
+		_, err := ptmx.Write([]byte("typed input\n"))
+		require.NoError(t, err)
+		// Close the channel to signal the test to continue.
+		close(continueSecondResponse)
+	})
+
+	// On failure, dump the captured output.
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("rendered logs:\n%s\x1b[0m", rendered)
+		}
+	})
+
+	// Input should not be echoed into the terminal, to prevent corrupting log streaming.
+	require.NotContains(t, rendered, "typed input")
+
+	// No logs should be duplicated.
+	require.Equal(t, 1, strings.Count(rendered, "Applied patch cleanly."))
+	require.Equal(t, 1, strings.Count(rendered, "Setup completed."))
+	require.Equal(t, 1, strings.Count(rendered, "Analyzing: 2"))
+	require.Equal(t, 1, strings.Count(rendered, "Done."))
 }
 
 func TestGitConfig_BranchAndSha(t *testing.T) {
@@ -535,5 +756,68 @@ func TestGetRemoteRunnerTarget(t *testing.T) {
 			actual := getRemoteRunnerTarget(tc.flagArgs)
 			require.Equal(t, tc.wantRunner, actual)
 		})
+	}
+}
+
+// Helper to run the streamLogs function with a test terminal.
+// The first output is the exact output captured from the terminal, including ANSI escape sequences.
+// The second output is the rendered output, with ANSI escape sequences removed.
+func runStreamLogsWithPTY(t *testing.T, client bbspb.BuildBuddyServiceClient, whileRunning func(ptmx *os.File)) (string, string) {
+	// This helper swaps the process-global os.Stdin/os.Stdout, so the test must
+	// not run in parallel. t.Setenv makes the testing package panic if
+	// t.Parallel() is ever called on this test (in either order), enforcing
+	// non-parallel execution at runtime.
+	t.Setenv("BB_REMOTEBAZEL_PTY_TEST", "1")
+
+	ptmx, tty, err := pty.Open()
+	require.NoError(t, err)
+	defer ptmx.Close()
+
+	require.NoError(t, pty.Setsize(ptmx, &pty.Winsize{Rows: 24, Cols: 80}))
+
+	oldStdin := os.Stdin
+	oldStdout := os.Stdout
+	os.Stdin = tty
+	os.Stdout = tty
+	defer func() {
+		os.Stdin = oldStdin
+		os.Stdout = oldStdout
+	}()
+
+	output := &lockedBuffer{}
+	copyDone := make(chan struct{})
+	go func() {
+		defer close(copyDone)
+		_, _ = io.Copy(output, ptmx)
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- streamLogs(context.Background(), client, "test-invocation-id")
+	}()
+	if whileRunning != nil {
+		whileRunning(ptmx)
+	}
+	err = <-errCh
+	require.NoError(t, err)
+
+	_ = tty.Close()
+	<-copyDone
+
+	raw := output.String()
+	screen, err := terminal.NewScreenWriter(math.MaxInt, 0)
+	require.NoError(t, err)
+	_, err = screen.Write([]byte(raw))
+	require.NoError(t, err)
+	rendered := screen.OutputAccumulator.String() + screen.Render()
+
+	return raw, rendered
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}) {
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for streamLogs test signal")
 	}
 }

--- a/cli/remotebazel/terminal_echo.go
+++ b/cli/remotebazel/terminal_echo.go
@@ -1,0 +1,28 @@
+package remotebazel
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// disableTerminalEcho disables writing input to the terminal, but preserves
+// normal terminal signal handling.
+// Returns a function to restore the original settings and flush queued input.
+func disableTerminalEchoWithRequests(f *os.File, getReq, setReq, restoreReq uint) (func() error, error) {
+	fd := int(f.Fd())
+	oldState, err := unix.IoctlGetTermios(fd, getReq)
+	if err != nil {
+		return nil, err
+	}
+
+	newState := *oldState
+	newState.Lflag &^= unix.ECHO | unix.ECHONL
+	if err := unix.IoctlSetTermios(fd, setReq, &newState); err != nil {
+		return nil, err
+	}
+
+	return func() error {
+		return unix.IoctlSetTermios(fd, restoreReq, oldState)
+	}, nil
+}

--- a/cli/remotebazel/terminal_echo_darwin.go
+++ b/cli/remotebazel/terminal_echo_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package remotebazel
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func disableTerminalEcho(f *os.File) (func() error, error) {
+	return disableTerminalEchoWithRequests(f, unix.TIOCGETA, unix.TIOCSETA, unix.TIOCSETAF)
+}

--- a/cli/remotebazel/terminal_echo_linux.go
+++ b/cli/remotebazel/terminal_echo_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package remotebazel
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func disableTerminalEcho(f *os.File) (func() error, error) {
+	return disableTerminalEchoWithRequests(f, unix.TCGETS, unix.TCSETS, unix.TCSETSF)
+}

--- a/cli/remotebazel/terminal_echo_unsupported.go
+++ b/cli/remotebazel/terminal_echo_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux
+
+package remotebazel
+
+import (
+	"fmt"
+	"os"
+)
+
+func disableTerminalEcho(f *os.File) (func() error, error) {
+	return nil, fmt.Errorf("terminal echo control is unsupported on this platform")
+}


### PR DESCRIPTION
Previously streamed logs could be duplicated if:
1. You cleared your terminal with CMD-K
2. You typed random input into the terminal