### PR TITLE
Inject some concurrency into the CDC chunk check in FindMissing.

### DIFF
--- a/server/remote_cache/chunking/BUILD
+++ b/server/remote_cache/chunking/BUILD
@@ -41,5 +41,6 @@ go_test(
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -664,8 +664,11 @@ func digestsStrings(digests ...*repb.Digest) []string {
 
 // MissingChunkChecker is used to check to make sure all of the chunks that make up a blob
 // are present in the cache, and to de-duplicate excess calls to FindMissing.
+// Safe for concurrent use.
 type MissingChunkChecker struct {
-	cache        interfaces.Cache
+	cache interfaces.Cache
+
+	mu           sync.Mutex
 	chunkPresent map[string]bool
 }
 
@@ -684,25 +687,32 @@ func NewMissingChunkChecker(cache interfaces.Cache) *MissingChunkChecker {
 // update them as missing if they're returned from FindMissing.
 func (c *MissingChunkChecker) AnyChunkMissing(ctx context.Context, manifest *Manifest) (bool, error) {
 	var unknownChunks []*rspb.ResourceName
+	c.mu.Lock()
 	for _, rn := range manifest.ChunkResourceNames() {
 		if present, known := c.chunkPresent[rn.GetDigest().GetHash()]; known {
 			if !present {
+				c.mu.Unlock()
 				return true, nil
 			}
 			continue
 		}
 		unknownChunks = append(unknownChunks, rn)
 	}
+	c.mu.Unlock()
 
 	if len(unknownChunks) == 0 {
 		return false, nil
 	}
 
+	// Issue the FindMissing network call outside the lock so concurrent
+	// callers don't serialize on it.
 	missingDigests, err := c.cache.FindMissing(ctx, unknownChunks)
 	if err != nil {
 		return false, err
 	}
 
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	// To prevent unbounded growth, just clear the chunk
 	// cache if its >1000 entries. Checking the len(map)
 	// is O(1) since Go stores the map length in the map

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
@@ -517,6 +518,62 @@ func TestMissingChunkChecker(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, missing, "expected missing chunk (cached)")
 	assert.Equal(t, 2, trackingCache.findMissingCalls, "expected no additional FindMissing call")
+}
+
+// TestMissingChunkChecker_Concurrent exercises a single shared checker from
+// many goroutines, mirroring how FindMissingBlobs now resolves the
+// chunked-manifest fallback in parallel. Run under -race
+// (--@io_bazel_rules_go//go/config:race) to catch data races on the shared
+// chunkPresent map.
+func TestMissingChunkChecker_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	chunk1RN, chunk1Data := testdigest.RandomCASResourceBuf(t, 100)
+	chunk2RN, chunk2Data := testdigest.RandomCASResourceBuf(t, 150)
+	chunk3RN, _ := testdigest.RandomCASResourceBuf(t, 200) // never stored, so missing
+	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1Data))
+	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2Data))
+
+	blobDigest, err := digest.Compute(bytes.NewReader([]byte("blob")), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	// The two manifests share chunk1 so concurrent calls contend on the same
+	// dedup map entries.
+	manifestAllPresent := &chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk2RN.GetDigest()},
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	manifestWithMissing := &chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk3RN.GetDigest()},
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+
+	checker := chunking.NewMissingChunkChecker(cache)
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(32)
+	for i := 0; i < 200; i++ {
+		manifest, want := manifestAllPresent, false
+		if i%2 == 0 {
+			manifest, want = manifestWithMissing, true
+		}
+		eg.Go(func() error {
+			got, err := checker.AnyChunkMissing(egCtx, manifest)
+			if err != nil {
+				return err
+			}
+			if got != want {
+				return fmt.Errorf("AnyChunkMissing = %v, want %v", got, want)
+			}
+			return nil
+		})
+	}
+	require.NoError(t, eg.Wait())
 }
 
 type findMissingTrackingCache struct {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -48,6 +48,15 @@ import (
 	gstatus "google.golang.org/grpc/status"
 )
 
+const (
+	// defaultFindMissingChunkFallbackConcurrency is the default value of the
+	// cache.find_missing_chunk_fallback_concurrency experiment, which bounds
+	// how many chunked-manifest fallback lookups FindMissingBlobs performs in
+	// parallel. Each lookup issues independent cache reads, so the work is
+	// I/O-bound.
+	defaultFindMissingChunkFallbackConcurrency = 8
+)
+
 var (
 	enableTreeCaching         = flag.Bool("cache.enable_tree_caching", true, "If true, cache GetTree responses (full and partial)")
 	treeCacheSeed             = flag.String("cache.tree_cache_seed", "treecache-09032024", "If set, hash this with digests before caching / reading from tree cache")
@@ -132,25 +141,43 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 		checker := chunking.NewMissingChunkChecker(s.cache)
 		chunkedReadFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
 
-		// https://go.dev/wiki/SliceTricks#filtering-without-allocating
-		stillMissing := missing[:0]
+		var mu sync.Mutex
+		stillMissing := make([]*repb.Digest, 0, len(missing))
+		markMissing := func(d *repb.Digest) {
+			mu.Lock()
+			stillMissing = append(stillMissing, d)
+			mu.Unlock()
+		}
+		concurrency := defaultFindMissingChunkFallbackConcurrency
+		if efp != nil {
+			concurrency = int(efp.Int64(ctx, "cache.find_missing_chunk_fallback_concurrency", defaultFindMissingChunkFallbackConcurrency))
+		}
+		eg, egCtx := errgroup.WithContext(ctx)
+		eg.SetLimit(concurrency)
 		for _, d := range missing {
 			if d.GetSizeBytes() <= chunkedReadFallbackSizeBytes {
-				stillMissing = append(stillMissing, d)
+				markMissing(d)
 				continue
 			}
-			manifest, err := chunking.LoadManifest(ctx, s.cache, d, req.GetInstanceName(), req.GetDigestFunction())
-			if err != nil {
-				stillMissing = append(stillMissing, d)
-				continue
-			}
-			anyMissing, err := checker.AnyChunkMissing(ctx, manifest)
-			if err != nil {
-				return nil, status.WrapErrorf(err, "missing chunks for %s", d.GetHash())
-			}
-			if anyMissing {
-				stillMissing = append(stillMissing, d)
-			}
+			eg.Go(func() error {
+				manifest, err := chunking.LoadManifest(egCtx, s.cache, d, req.GetInstanceName(), req.GetDigestFunction())
+				if err != nil {
+					// Not stored as a chunked manifest, so it's genuinely missing.
+					markMissing(d)
+					return nil
+				}
+				anyMissing, err := checker.AnyChunkMissing(egCtx, manifest)
+				if err != nil {
+					return status.WrapErrorf(err, "missing chunks for %s", d.GetHash())
+				}
+				if anyMissing {
+					markMissing(d)
+				}
+				return nil
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			return nil, err
 		}
 		missing = stillMissing
 	}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -152,6 +152,9 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 		if efp != nil {
 			concurrency = int(efp.Int64(ctx, "cache.find_missing_chunk_fallback_concurrency", defaultFindMissingChunkFallbackConcurrency))
 		}
+		if concurrency <= 0 {
+			concurrency = 1
+		}
 		eg, egCtx := errgroup.WithContext(ctx)
 		eg.SetLimit(concurrency)
 		for _, d := range missing {


### PR DESCRIPTION
The chunk checks are currently done sequentially per-digest which can blow up latency for large FindMissing calls with a lot of digests that are over the chunk threshold.