### PR TITLE
Update spawn proto for new field

### DIFF
--- a/proto/spawn.proto
+++ b/proto/spawn.proto
@@ -114,6 +114,8 @@ message SpawnMetrics {
   google.protobuf.Duration time_limit = 19;
   // Instant when the spawn started to execute.
   google.protobuf.Timestamp start_time = 20;
+  // Measured peak memory usage in bytes, or 0 if unavailable.
+  int64 measured_memory_peak_bytes = 21;
 }
 
 // Details of an executed spawn.


### PR DESCRIPTION
measured_memory_peak_bytes was added in
https://github.com/bazelbuild/bazel/commit/b3126b539ef6ba4a6ebb67db623e25a15b9adf5b
and is useful for printing
