### PR TITLE
Fix capability filter for SendNotification API

### DIFF
--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -95,6 +95,10 @@ var (
 
 		// Audit logs.
 		buildBuddyServicePrefix + "GetAuditLogs",
+
+		// Sending notifications requires the SEND_NOTIFICATION capability.
+		// It's checked by the RPC handler.
+		buildBuddyServicePrefix + "SendNotification",
 	}
 
 	// groupMemberRPCs can only be called when logged in as a member of
@@ -202,8 +206,6 @@ var (
 		buildBuddyServicePrefix + "GetUsageAlertingRules",
 		buildBuddyServicePrefix + "CreateUsageAlertingRule",
 		buildBuddyServicePrefix + "DeleteUsageAlertingRule",
-		// Notifications.
-		buildBuddyServicePrefix + "SendNotification",
 		// Encryption.
 		buildBuddyServicePrefix + "GetEncryptionConfig",
 		buildBuddyServicePrefix + "SetEncryptionConfig",

--- a/server/capabilities_filter/capabilities_filter_test.go
+++ b/server/capabilities_filter/capabilities_filter_test.go
@@ -185,15 +185,9 @@ func TestAllowedRPCs(t *testing.T) {
 			Allowed:      true,
 		},
 		{
-			Name:         "SendNotification_NonAdmin_NotAllowed",
+			Name:         "SendNotification_Allowed_Unrestricted",
 			RPC:          buildBuddyServicePrefix + "SendNotification",
 			Capabilities: []cappb.Capability{},
-			Allowed:      false,
-		},
-		{
-			Name:         "SendNotification_Admin_Allowed",
-			RPC:          buildBuddyServicePrefix + "SendNotification",
-			Capabilities: []cappb.Capability{cappb.Capability_ORG_ADMIN},
 			Allowed:      true,
 		},
 		{


### PR DESCRIPTION
Using the SendNotification API requires a very narrowly scoped API key. This API key does not have admin permissions, so requests were rejected by the capabilities filter. The notification capability will still be checked [here](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/notification/notification.go#L61)