### PR TITLE
Batch the CDC chunk existence checks in FindMissing.

### DIFF
--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -401,7 +401,12 @@ func loadManifestFrom(ctx context.Context, cache interfaces.Cache, blobDigest *r
 		}
 		return nil, sanitizeManifestError(err, acRNProto.GetDigest().GetHash(), blobDigest.GetHash())
 	}
+	return parseManifest(arBytes, blobDigest, instanceName, digestFunction)
+}
 
+// parseManifest decodes manifest bytes (stored as a marshaled ActionResult)
+// into a Manifest for the given blob.
+func parseManifest(arBytes []byte, blobDigest *repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value) (*Manifest, error) {
 	ar := &repb.ActionResult{}
 	if err := proto.Unmarshal(arBytes, ar); err != nil {
 		return nil, status.InternalErrorf("unmarshal chunked manifest from ActionResult: %w", err)
@@ -728,4 +733,153 @@ func (c *MissingChunkChecker) AnyChunkMissing(ctx context.Context, manifest *Man
 	}
 
 	return len(missingDigests) > 0, nil
+}
+
+// maxFindMissingChunkBatchSize bounds how many chunk resource names are sent in
+// a single FindMissing call. Each manifest expands into multiple chunks, so the
+// combined chunk count can be much larger than the number of candidate blobs.
+const maxFindMissingChunkBatchSize = 4096
+
+// findMissingChunkedWaveSize bounds how many candidate manifests are processed
+// at once. Each wave loads its manifests and expands them into chunk resource
+// names in memory, so capping the wave keeps peak memory (and the per-wave
+// GetMulti/FindMissing request sizes) independent of the overall request size.
+const findMissingChunkedWaveSize = 1024
+
+type chunkedCandidate struct {
+	blob *repb.Digest
+	acRN *rspb.ResourceName
+}
+
+type loadedManifest struct {
+	blob     *repb.Digest
+	manifest *Manifest
+}
+
+// FindMissingChunkedBlobs re-checks blobs that a direct CAS lookup reported as
+// missing, returning the subset that are still missing once chunked storage is
+// taken into account. A blob counts as present only if its chunked manifest
+// exists and all of its chunks are present.
+func FindMissingChunkedBlobs(ctx context.Context, cache interfaces.Cache, blobDigests []*repb.Digest, instanceName string, digestFunction repb.DigestFunction_Value, fallbackSizeThreshold int64) ([]*repb.Digest, error) {
+	var missing []*repb.Digest
+
+	// Blobs at or below the fallback threshold were never chunked. Larger blobs
+	// are candidates whose chunked manifest we look up.
+	candidates := make([]chunkedCandidate, 0, len(blobDigests))
+	for _, d := range blobDigests {
+		if d.GetSizeBytes() <= fallbackSizeThreshold {
+			missing = append(missing, d)
+			continue
+		}
+		acRN, err := acResourceName(d, instanceName, digestFunction)
+		if err != nil {
+			// Can't compute the manifest key, so treat the blob as missing.
+			missing = append(missing, d)
+			continue
+		}
+		candidates = append(candidates, chunkedCandidate{blob: d, acRN: acRN})
+	}
+
+	// Process candidates in bounded waves so peak memory stays independent of the
+	// request size.
+	for start := 0; start < len(candidates); start += findMissingChunkedWaveSize {
+		end := min(start+findMissingChunkedWaveSize, len(candidates))
+		waveMissing, err := findMissingChunkedWave(ctx, cache, candidates[start:end], instanceName, digestFunction)
+		if err != nil {
+			return nil, err
+		}
+		missing = append(missing, waveMissing...)
+	}
+	return missing, nil
+}
+
+// findMissingChunkedWave resolves the chunked-manifest fallback for a single
+// wave of candidates and returns those still missing.
+func findMissingChunkedWave(ctx context.Context, cache interfaces.Cache, candidates []chunkedCandidate, instanceName string, digestFunction repb.DigestFunction_Value) ([]*repb.Digest, error) {
+	manifests, missing, err := loadWaveManifests(ctx, cache, candidates, instanceName, digestFunction)
+	if err != nil {
+		return nil, err
+	}
+	if len(manifests) == 0 {
+		return missing, nil
+	}
+
+	// De-duplicate the chunks across this wave's manifests and check their
+	// existence with batched FindMissing calls.
+	chunkRNs := make([]*rspb.ResourceName, 0)
+	seen := make(map[string]struct{})
+	for _, lm := range manifests {
+		for _, rn := range lm.manifest.ChunkResourceNames() {
+			h := rn.GetDigest().GetHash()
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			chunkRNs = append(chunkRNs, rn)
+		}
+	}
+
+	missingChunks := make(map[string]struct{})
+	for start := 0; start < len(chunkRNs); start += maxFindMissingChunkBatchSize {
+		end := min(start+maxFindMissingChunkBatchSize, len(chunkRNs))
+		missingChunkDigests, err := cache.FindMissing(ctx, chunkRNs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		for _, d := range missingChunkDigests {
+			missingChunks[d.GetHash()] = struct{}{}
+		}
+	}
+
+	// A blob is missing if any of its chunks is missing.
+	for _, lm := range manifests {
+		for _, cd := range lm.manifest.ChunkDigests {
+			if _, ok := missingChunks[cd.GetHash()]; ok {
+				missing = append(missing, lm.blob)
+				break
+			}
+		}
+	}
+	return missing, nil
+}
+
+// loadWaveManifests loads and parses the chunked manifests for a wave of
+// candidates with a single GetMulti. It returns the successfully-parsed
+// manifests and the candidates already known to be missing (no manifest stored,
+// or an unreadable one). The raw manifest bytes are scoped to this call, so they
+// are released before the caller expands chunks.
+func loadWaveManifests(ctx context.Context, cache interfaces.Cache, candidates []chunkedCandidate, instanceName string, digestFunction repb.DigestFunction_Value) ([]loadedManifest, []*repb.Digest, error) {
+	acRNs := make([]*rspb.ResourceName, 0, len(candidates))
+	for _, c := range candidates {
+		acRNs = append(acRNs, c.acRN)
+	}
+	manifestData, err := cache.GetMulti(ctx, acRNs)
+	if err != nil {
+		return nil, nil, err
+	}
+	foundManifests := make(map[string][]byte, len(manifestData))
+	for acDigest, data := range manifestData {
+		foundManifests[digest.String(acDigest)] = data
+	}
+
+	var manifests []loadedManifest
+	var missing []*repb.Digest
+	for _, c := range candidates {
+		data, ok := foundManifests[digest.String(c.acRN.GetDigest())]
+		if !ok {
+			// No chunked manifest stored, so the blob is genuinely missing.
+			missing = append(missing, c.blob)
+			continue
+		}
+		manifest, err := parseManifest(data, c.blob, instanceName, digestFunction)
+		if err != nil {
+			// Unreadable manifest; treat the blob as missing so the client
+			// re-uploads it, matching the per-Get fallback behavior.
+			missing = append(missing, c.blob)
+			continue
+		}
+		metrics.ChunkedManifestLoadCount.WithLabelValues(chunkedManifestPrefix).Inc()
+		manifests = append(manifests, loadedManifest{blob: c.blob, manifest: manifest})
+	}
+	return manifests, missing, nil
 }

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -576,14 +576,113 @@ func TestMissingChunkChecker_Concurrent(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
+func TestFindMissingChunkedBlobs(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	trackingCache := &findMissingTrackingCache{Cache: te.GetCache()}
+
+	// Three present chunks and one that is never stored.
+	chunk1RN, chunk1Data := testdigest.RandomCASResourceBuf(t, 100)
+	chunk2RN, chunk2Data := testdigest.RandomCASResourceBuf(t, 150)
+	chunk3RN, chunk3Data := testdigest.RandomCASResourceBuf(t, 200)
+	absentChunkRN, _ := testdigest.RandomCASResourceBuf(t, 120)
+	require.NoError(t, trackingCache.Set(ctx, chunk1RN, chunk1Data))
+	require.NoError(t, trackingCache.Set(ctx, chunk2RN, chunk2Data))
+	require.NoError(t, trackingCache.Set(ctx, chunk3RN, chunk3Data))
+
+	const threshold = 50
+	storeManifest := func(blob *repb.Digest, chunks ...*repb.Digest) {
+		require.NoError(t, (&chunking.Manifest{
+			BlobDigest:     blob,
+			ChunkDigests:   chunks,
+			DigestFunction: repb.DigestFunction_SHA256,
+		}).StoreWithoutVerification(ctx, trackingCache))
+	}
+
+	// blobPresent: all chunks present. Shares chunk1 with blobMissingChunk to
+	// exercise cross-manifest chunk de-duplication.
+	blobPresentRN, _ := testdigest.RandomCASResourceBuf(t, 1000)
+	blobPresent := blobPresentRN.GetDigest()
+	storeManifest(blobPresent, chunk1RN.GetDigest(), chunk2RN.GetDigest())
+
+	// blobMissingChunk: references an absent chunk, so it's still missing.
+	blobMissingChunkRN, _ := testdigest.RandomCASResourceBuf(t, 1000)
+	blobMissingChunk := blobMissingChunkRN.GetDigest()
+	storeManifest(blobMissingChunk, chunk1RN.GetDigest(), absentChunkRN.GetDigest())
+
+	// blobNoManifest: large enough to be a candidate, but no manifest stored.
+	blobNoManifestRN, _ := testdigest.RandomCASResourceBuf(t, 1000)
+	blobNoManifest := blobNoManifestRN.GetDigest()
+
+	// blobSmall: at/below the fallback threshold, so it was never chunked.
+	blobSmallRN, _ := testdigest.RandomCASResourceBuf(t, 10)
+	blobSmall := blobSmallRN.GetDigest()
+
+	input := []*repb.Digest{blobPresent, blobMissingChunk, blobNoManifest, blobSmall}
+	missing, err := chunking.FindMissingChunkedBlobs(ctx, trackingCache, input, "", repb.DigestFunction_SHA256, threshold)
+	require.NoError(t, err)
+
+	gotHashes := make([]string, 0, len(missing))
+	for _, d := range missing {
+		gotHashes = append(gotHashes, d.GetHash())
+	}
+	assert.ElementsMatch(t,
+		[]string{blobMissingChunk.GetHash(), blobNoManifest.GetHash(), blobSmall.GetHash()},
+		gotHashes, "blobPresent should be the only blob considered present")
+
+	// All candidate manifests are loaded with a single GetMulti, and the
+	// chunk-existence checks for both loadable manifests are batched into a
+	// single FindMissing call.
+	assert.Equal(t, 1, trackingCache.getMultiCalls, "manifests should be loaded with one GetMulti")
+	assert.Equal(t, 1, trackingCache.findMissingCalls, "chunk checks should be one FindMissing")
+}
+
+func TestFindMissingChunkedBlobs_MultipleWaves(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	trackingCache := &findMissingTrackingCache{Cache: te.GetCache()}
+
+	// Use more candidates than the internal wave size (1024) so the wave loop
+	// runs multiple GetMulti waves. None have a stored manifest, so every blob is
+	// reported missing and we exercise accumulating results across waves.
+	const n = 1500
+	input := make([]*repb.Digest, 0, n)
+	want := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		rn, _ := testdigest.RandomCASResourceBuf(t, 1000) // large, no manifest stored
+		input = append(input, rn.GetDigest())
+		want = append(want, rn.GetDigest().GetHash())
+	}
+
+	missing, err := chunking.FindMissingChunkedBlobs(ctx, trackingCache, input, "", repb.DigestFunction_SHA256, 50)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(missing))
+	for _, d := range missing {
+		got = append(got, d.GetHash())
+	}
+	assert.ElementsMatch(t, want, got)
+	assert.Greater(t, trackingCache.getMultiCalls, 1, "candidates should be loaded across multiple GetMulti waves")
+}
+
 type findMissingTrackingCache struct {
 	interfaces.Cache
 	findMissingCalls int
+	getMultiCalls    int
 }
 
 func (c *findMissingTrackingCache) FindMissing(ctx context.Context, resources []*rspb.ResourceName) ([]*repb.Digest, error) {
 	c.findMissingCalls++
 	return c.Cache.FindMissing(ctx, resources)
+}
+
+func (c *findMissingTrackingCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
+	c.getMultiCalls++
+	return c.Cache.GetMulti(ctx, resources)
 }
 
 type booleanFlagProvider struct {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -48,15 +48,6 @@ import (
 	gstatus "google.golang.org/grpc/status"
 )
 
-const (
-	// defaultFindMissingChunkFallbackConcurrency is the default value of the
-	// cache.find_missing_chunk_fallback_concurrency experiment, which bounds
-	// how many chunked-manifest fallback lookups FindMissingBlobs performs in
-	// parallel. Each lookup issues independent cache reads, so the work is
-	// I/O-bound.
-	defaultFindMissingChunkFallbackConcurrency = 8
-)
-
 var (
 	enableTreeCaching         = flag.Bool("cache.enable_tree_caching", true, "If true, cache GetTree responses (full and partial)")
 	treeCacheSeed             = flag.String("cache.tree_cache_seed", "treecache-09032024", "If set, hash this with digests before caching / reading from tree cache")
@@ -138,51 +129,10 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 	// with an older, smaller chunk size still count as present after increasing
 	// the current chunk size.
 	if efp := s.env.GetExperimentFlagProvider(); len(missing) > 0 && !cdc.IsChunked(ctx) && chunking.Enabled(ctx, efp) {
-		checker := chunking.NewMissingChunkChecker(s.cache)
-		chunkedReadFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
-
-		var mu sync.Mutex
-		stillMissing := make([]*repb.Digest, 0, len(missing))
-		markMissing := func(d *repb.Digest) {
-			mu.Lock()
-			stillMissing = append(stillMissing, d)
-			mu.Unlock()
-		}
-		concurrency := defaultFindMissingChunkFallbackConcurrency
-		if efp != nil {
-			concurrency = int(efp.Int64(ctx, "cache.find_missing_chunk_fallback_concurrency", defaultFindMissingChunkFallbackConcurrency))
-		}
-		if concurrency <= 0 {
-			concurrency = 1
-		}
-		eg, egCtx := errgroup.WithContext(ctx)
-		eg.SetLimit(concurrency)
-		for _, d := range missing {
-			if d.GetSizeBytes() <= chunkedReadFallbackSizeBytes {
-				markMissing(d)
-				continue
-			}
-			eg.Go(func() error {
-				manifest, err := chunking.LoadManifest(egCtx, s.cache, d, req.GetInstanceName(), req.GetDigestFunction())
-				if err != nil {
-					// Not stored as a chunked manifest, so it's genuinely missing.
-					markMissing(d)
-					return nil
-				}
-				anyMissing, err := checker.AnyChunkMissing(egCtx, manifest)
-				if err != nil {
-					return status.WrapErrorf(err, "missing chunks for %s", d.GetHash())
-				}
-				if anyMissing {
-					markMissing(d)
-				}
-				return nil
-			})
-		}
-		if err := eg.Wait(); err != nil {
+		missing, err = chunking.FindMissingChunkedBlobs(ctx, s.cache, missing, req.GetInstanceName(), req.GetDigestFunction(), chunking.MinChunkedReadFallbackSizeBytes(ctx, efp))
+		if err != nil {
 			return nil, err
 		}
-		missing = stillMissing
 	}
 
 	rsp.MissingBlobDigests = missing


### PR DESCRIPTION
Batch load the manifest and batch check chunk existence instead of performing the checks serially.

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7673