### PR TITLE
Update macOS env var logic

### DIFF
--- a/enterprise/server/remote_execution/executorplatform/executorplatform.go
+++ b/enterprise/server/remote_execution/executorplatform/executorplatform.go
@@ -4,7 +4,6 @@ package executorplatform
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"runtime"
 	"slices"
@@ -273,32 +272,34 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 	}
 
 	if strings.EqualFold(platformProps.OS, platform.DarwinOperatingSystemName) {
-		appleSDKVersion := ""
-		appleSDKPlatform := "MacOSX"
-		xcodeVersion := executorProps.DefaultXcodeVersion
+		appleSDKPlatform := ""
+		xcodeVersion := ""
+		hasAppleSDKPlatform := false
+		hasXcodeVersionOverride := false
 
 		for _, v := range command.EnvironmentVariables {
-			// Environment variables from: https://github.com/bazelbuild/bazel/blob/4ed65b05637cd37f0a6c5e79fdc4dfe0ece3fa68/src/main/java/com/google/devtools/build/lib/rules/apple/AppleConfiguration.java#L43
+			// Environment variables from: https://github.com/bazelbuild/bazel/blob/0878dd724149b73a731ab83859a55a65e9b438ed/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java#L86-L107
 			switch v.Name {
-			case "APPLE_SDK_VERSION_OVERRIDE":
-				appleSDKVersion = v.Value
 			case "APPLE_SDK_PLATFORM":
 				appleSDKPlatform = v.Value
+				hasAppleSDKPlatform = true
 			case "XCODE_VERSION_OVERRIDE":
 				xcodeVersion = v.Value
+				hasXcodeVersionOverride = true
 			}
 		}
 
-		sdk := fmt.Sprintf("%s%s", appleSDKPlatform, appleSDKVersion)
-		developerDir, sdkRoot, err := env.GetXcodeLocator().PathsForVersionAndSDK(xcodeVersion, sdk)
-		if err != nil {
-			return err
-		}
+		if hasAppleSDKPlatform && hasXcodeVersionOverride {
+			developerDir, sdkRoot, err := env.GetXcodeLocator().PathsForVersionAndSDK(xcodeVersion, appleSDKPlatform)
+			if err != nil {
+				return err
+			}
 
-		command.EnvironmentVariables = append(command.EnvironmentVariables, []*repb.Command_EnvironmentVariable{
-			{Name: "DEVELOPER_DIR", Value: developerDir},
-			{Name: "SDKROOT", Value: sdkRoot},
-		}...)
+			command.EnvironmentVariables = append(command.EnvironmentVariables, []*repb.Command_EnvironmentVariable{
+				{Name: "DEVELOPER_DIR", Value: developerDir},
+				{Name: "SDKROOT", Value: sdkRoot},
+			}...)
+		}
 	}
 
 	command.Arguments = append(command.Arguments, platformProps.ExtraArgs...)

--- a/enterprise/server/remote_execution/executorplatform/executorplatform_test.go
+++ b/enterprise/server/remote_execution/executorplatform/executorplatform_test.go
@@ -97,37 +97,37 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		errorExpected       bool
 		defaultXcodeVersion string
 	}{
-		// Default darwin platform
+		// Darwin with xcode override but no sdk platform
 		{[]*repb.Platform_Property{
 			{Name: "osfamily", Value: "darwin"},
 		}, []*repb.Command_EnvironmentVariable{
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
-		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
-			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
-		},
+		}, []*repb.Command_EnvironmentVariable{},
 			false,
 			"12.2",
 		},
-		// Case insensitive darwin platform
+		// Case insensitive darwin with xcode override but no sdk platform
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
 		}, []*repb.Command_EnvironmentVariable{
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
-		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
-			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
-		},
+		}, []*repb.Command_EnvironmentVariable{},
 			false,
 			"12.2",
 		},
 		// Darwin with no overrides
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
-		}, []*repb.Command_EnvironmentVariable{}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
-			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.2.app/Contents/Developer"},
+		}, []*repb.Command_EnvironmentVariable{}, []*repb.Command_EnvironmentVariable{},
+			false,
+			"12.2",
 		},
+		// Darwin with sdk platform but no xcode override
+		{[]*repb.Platform_Property{
+			{Name: "OSFamily", Value: "Darwin"},
+		}, []*repb.Command_EnvironmentVariable{
+			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
+		}, []*repb.Command_EnvironmentVariable{},
 			false,
 			"12.2",
 		},
@@ -135,8 +135,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.1"},
-			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
+			{Name: "APPLE_SDK_PLATFORM", Value: "iPhoneSimulator"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{},
 			true,
@@ -146,11 +145,10 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.3"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone14.3.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			false,
@@ -170,7 +168,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			false,
 			"12.2",
 		},
-		// Darwin with xcode override but invalid sdk version
+		// Darwin ignores sdk version override
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
 			{Name: "enablexcodeoverride", Value: "true"},
@@ -178,19 +176,21 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.2"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
-		}, []*repb.Command_EnvironmentVariable{},
-			true,
+		}, []*repb.Command_EnvironmentVariable{
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
+			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
+		},
+			false,
 			"12.2",
 		},
 		// Case insensitive darwin with xcode override
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.3"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone14.3.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			false,
@@ -209,7 +209,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			false,
 			"",
 		},
-		// Case insensitive darwin with no default xcode version and existing sdk
+		// Case insensitive darwin with no default xcode version and ignored sdk version override
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
 		}, []*repb.Command_EnvironmentVariable{
@@ -217,7 +217,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone14.3.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			false,


### PR DESCRIPTION
- Ignore `APPLE_SDK_VERSION_OVERRIDE` which bazel stopped setting in
  7.x, but also doesn't really matter since Xcode only supports a single
  SDK version per SDK per Xcode
- Don't always set DEVELOPER_DIR / SDKROOT. This replicates what bazel
  is doing which is only setting these env vars when these other
  variables are passed. Some tools like clang respond to these when they
  are set so we want to make sure we do the same thing that is being
  done for local execution. Because of this the default executor version
  also doesn't matter for this case, since it will always be set
  explicitly by bazel
