### PR TITLE
Make UsageStats safe to access concurrently

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -129,6 +129,8 @@ type Init struct {
 type UsageStats struct {
 	Clock clockwork.Clock
 
+	mu sync.RWMutex
+
 	// last is the last stats update we observed.
 	last *repb.UsageStats
 	// taskStats is the usage stats relative to when Reset() was last called
@@ -184,6 +186,9 @@ func (s *UsageStats) clock() clockwork.Clock {
 // the new task's resource usage can be accounted for.
 // TODO: make this private - it should only be used by TrackExecution.
 func (s *UsageStats) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.last != nil {
 		s.last.MemoryBytes = 0
 	}
@@ -202,8 +207,28 @@ func (s *UsageStats) Reset() {
 	}
 }
 
-// TaskStats returns the usage stats for an executed task.
+// TaskStats returns the usage stats for an executed task, including the usage
+// timeline if one was recorded. The returned timeline is not cloned, so callers
+// that need to read stats while they are being updated should use
+// BasicTaskStats.
 func (s *UsageStats) TaskStats() *repb.UsageStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.taskStatsLocked(true /*=includeTimeline*/)
+}
+
+// BasicTaskStats returns the usage stats for an executed task without the
+// usage timeline. This is intended for live stats polling while usage stats are
+// being updated.
+func (s *UsageStats) BasicTaskStats() *repb.UsageStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.taskStatsLocked(false /*=includeTimeline*/)
+}
+
+func (s *UsageStats) taskStatsLocked(includeTimeline bool) *repb.UsageStats {
 	if s.last == nil {
 		return &repb.UsageStats{}
 	}
@@ -243,8 +268,12 @@ func (s *UsageStats) TaskStats() *repb.UsageStats {
 		taskStats.IoPressure.Full.Total -= s.baselineIOPressure.GetFull().GetTotal()
 	}
 
-	// Note: we don't clone the timeline because it's expensive.
-	taskStats.Timeline = s.timeline
+	if includeTimeline {
+		// Note: we don't clone the timeline because it's expensive. Callers
+		// that need to access stats while they are being updated should use
+		// BasicTaskStats instead.
+		taskStats.Timeline = s.timeline
+	}
 
 	return taskStats
 }
@@ -310,6 +339,9 @@ func (s *UsageStats) updateTimeline(now time.Time) {
 // created).
 // TODO: make this private - it should only be used by TrackExecution.
 func (s *UsageStats) Update(lifetimeStats *repb.UsageStats) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.last = lifetimeStats.CloneVT()
 	if lifetimeStats.GetMemoryBytes() > s.peakMemoryUsageBytes {
 		s.peakMemoryUsageBytes = lifetimeStats.GetMemoryBytes()

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -370,6 +370,52 @@ func TestUsageStats(t *testing.T) {
 	}, s.TaskStats(), protocmp.Transform()))
 }
 
+func TestUsageStats_ConcurrentUpdateAndBasicTaskStats(t *testing.T) {
+	flags.Set(t, "executor.record_usage_timelines", true)
+
+	stats := &container.UsageStats{}
+	stats.Reset()
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		for i := range 1000 {
+			stats.Update(&repb.UsageStats{
+				CpuNanos:      int64(i) * 1e6,
+				MemoryBytes:   int64(i) * 1024,
+				CgroupIoStats: &repb.CgroupIOStats{Rbytes: int64(i), Wbytes: int64(i)},
+			})
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		for range 1000 {
+			taskStats := stats.BasicTaskStats()
+			_ = taskStats.GetMemoryBytes()
+			_ = taskStats.GetCpuNanos()
+		}
+		return nil
+	})
+
+	require.NoError(t, eg.Wait())
+}
+
+func TestUsageStats_BasicTaskStatsOmitsTimeline(t *testing.T) {
+	flags.Set(t, "executor.record_usage_timelines", true)
+
+	stats := &container.UsageStats{}
+	stats.Reset()
+	stats.Update(&repb.UsageStats{
+		CpuNanos:      1e6,
+		MemoryBytes:   1024,
+		CgroupIoStats: &repb.CgroupIOStats{},
+	})
+
+	// Full execution stats should include the timeline, but live stats polling
+	// should skip it to avoid returning a pointer to mutable timeline state.
+	require.NotNil(t, stats.TaskStats().GetTimeline())
+	require.Nil(t, stats.BasicTaskStats().GetTimeline())
+}
+
 func TestUsageStats_Timeseries(t *testing.T) {
 	flags.Set(t, "executor.record_usage_timelines", true)
 

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -959,7 +959,7 @@ func (c *ociContainer) cleanupNetwork(ctx context.Context) error {
 }
 
 func (c *ociContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
-	return c.stats.TaskStats(), nil
+	return c.stats.BasicTaskStats(), nil
 }
 
 // Instruments an OCI runtime call with monitor() to ensure that resource usage

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -689,7 +689,7 @@ func (c *podmanCommandContainer) Unpause(ctx context.Context) error {
 }
 
 func (c *podmanCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
-	return c.stats.TaskStats(), nil
+	return c.stats.BasicTaskStats(), nil
 }
 
 func (c *podmanCommandContainer) runPodman(ctx context.Context, subCommand string, stdio *interfaces.Stdio, args ...string) *interfaces.CommandResult {


### PR DESCRIPTION
This is required by the OOM killer, which will call `Stats()` while the container is executing and the stats are concurrently being updated.

Split off from https://github.com/buildbuddy-io/buildbuddy/pull/12525

Related: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7649