### PR TITLE
dns: Delegate all ACME checks to a flag-specified delegate

### DIFF
--- a/enterprise/dns/cmd/density/density.go
+++ b/enterprise/dns/cmd/density/density.go
@@ -33,6 +33,8 @@ var (
 	dnsPort    = flag.Int("dns.port", 53, "The port to listen for DNS traffic on")
 	zoneFile   = flag.String("dns.zone_file", "", "Path to a zone file containing the DNS records to serve")
 	zoneOrigin = flag.String("dns.zone_origin", "", "Origin domain to qualify relative names in the zone file against. If empty, names must be fully qualified.")
+
+	acmeChallengeNameservers = flag.Slice[string]("dns.acme_challenge_nameservers", []string{}, "Nameservers to which any in-zone _acme-challenge.* query is referred, delegating ACME DNS-01 validation to a dynamic provider (e.g. Cloud DNS). Empty disables.")
 )
 
 func main() {
@@ -114,7 +116,7 @@ func startDNSServer(env *real_environment.RealEnv) error {
 	if err != nil {
 		return status.WrapErrorf(err, "parse zone file %q", *zoneFile)
 	}
-	handler := server.NewHandler(records, env)
+	handler := server.NewHandler(env, records, *acmeChallengeNameservers)
 
 	addr := fmt.Sprintf("%s:%d", *listen, *dnsPort)
 

--- a/enterprise/dns/server/server.go
+++ b/enterprise/dns/server/server.go
@@ -33,9 +33,9 @@ const (
 	// short so routing decisions can change quickly.
 	asnRoutingTTL = 60
 
-	// acmeChallengeLabel is the leftmost label of an ACME DNS-01 validation
-	// name (the record is always _acme-challenge.<domain being validated>).
-	acmeChallengeLabel = "_acme-challenge"
+	// acmeChallengePrefix matches the leftmost label of an ACME DNS-01
+	// validation name, which is always _acme-challenge.<domain being validated>.
+	acmeChallengePrefix = "_acme-challenge."
 
 	// acmeReferralTTL is the TTL on the NS records of an _acme-challenge
 	// referral. Short, since challenges are transient.
@@ -97,24 +97,15 @@ func (h *handler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	qName := dns.CanonicalName(r.Question[0].Name)
 	qType := r.Question[0].Qtype
 
-	// Dynamic ACME delegation: refer any in-zone _acme-challenge.* name to the
-	// configured nameservers, so DNS-01 validation for every cert in the zone
-	// (current and future) is handled by a dynamic provider with no per-name
-	// record here.
-	if ns := h.acmeChallengeReferral(qName); len(ns) > 0 {
-		m.Authoritative = false
-		m.Ns = append(m.Ns, ns...)
-		if err := w.WriteMsg(m); err != nil {
-			log.Warningf("Failed to write ACME challenge referral for %q: %s", qName, err)
-		}
-		return
-	}
-
 	// If the name lies at or below a zone cut (an in-zone NS record below the
 	// apex), we are not authoritative for it: return a referral to the child's
 	// nameservers instead of answering from this zone. This is how we hand a
 	// subdomain off to another DNS provider -- e.g. delegating an ACME
 	// _acme-challenge validation name back to a cloud DNS zone.
+	//
+	// This runs before the ACME referral below so that a name under a delegation
+	// (including the child's own _acme-challenge names) goes to the child that
+	// owns it, rather than being hijacked to our ACME provider.
 	//
 	// TODO(tylerw): A DS query AT a zone cut is the exception: the DS RRset is
 	// parent-owned authoritative data and must be answered here (or NODATA+SOA),
@@ -128,6 +119,19 @@ func (h *handler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		m.Extra = append(m.Extra, h.glue(ns)...)
 		if err := w.WriteMsg(m); err != nil {
 			log.Warningf("Failed to write DNS referral for %q: %s", qName, err)
+		}
+		return
+	}
+
+	// Dynamic ACME delegation: refer any in-zone _acme-challenge.* name that is
+	// not already under a delegation (handled above) to the configured
+	// nameservers, so DNS-01 validation for every cert in the zone -- current and
+	// future -- is handled by a dynamic provider with no per-name record here.
+	if ns := h.acmeChallengeReferral(qName); len(ns) > 0 {
+		m.Authoritative = false
+		m.Ns = append(m.Ns, ns...)
+		if err := w.WriteMsg(m); err != nil {
+			log.Warningf("Failed to write ACME challenge referral for %q: %s", qName, err)
 		}
 		return
 	}
@@ -347,15 +351,16 @@ func (h *handler) delegation(name string) []dns.RR {
 // ACME nameservers, or nil if ACME delegation is unconfigured or name is not an
 // in-zone _acme-challenge.* name. The referral is synthesized per query (owned
 // by name) so a single config covers every _acme-challenge name in the zone.
+// Callers must check delegation() first: a name under a zone cut belongs to the
+// child, so this does not re-check for one.
 func (h *handler) acmeChallengeReferral(name string) []dns.RR {
 	if len(h.acmeChallengeNS) == 0 || h.apex == "" {
 		return nil
 	}
-	if !dns.IsSubDomain(h.apex, name) {
-		return nil
-	}
-	labels := dns.SplitDomainName(name)
-	if len(labels) == 0 || !strings.EqualFold(labels[0], acmeChallengeLabel) {
+	// name is canonicalized (lowercase, fqdn) by ServeDNS, and acmeChallengePrefix
+	// is lowercase, so a prefix check identifies the _acme-challenge leftmost
+	// label without allocating.
+	if !strings.HasPrefix(name, acmeChallengePrefix) || !dns.IsSubDomain(h.apex, name) {
 		return nil
 	}
 	out := make([]dns.RR, 0, len(h.acmeChallengeNS))

--- a/enterprise/dns/server/server.go
+++ b/enterprise/dns/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
@@ -31,6 +32,14 @@ const (
 	// asnRoutingTTL is the TTL applied to experiment-routed A answers. It is
 	// short so routing decisions can change quickly.
 	asnRoutingTTL = 60
+
+	// acmeChallengeLabel is the leftmost label of an ACME DNS-01 validation
+	// name (the record is always _acme-challenge.<domain being validated>).
+	acmeChallengeLabel = "_acme-challenge"
+
+	// acmeReferralTTL is the TTL on the NS records of an _acme-challenge
+	// referral. Short, since challenges are transient.
+	acmeReferralTTL = 300
 )
 
 type handler struct {
@@ -47,6 +56,12 @@ type handler struct {
 	// zone file has no SOA, in which case we can't tell the two apart and treat
 	// nothing as a delegation.
 	apex string
+
+	// acmeChallengeNS, when non-empty, are the nameservers to which any in-zone
+	// _acme-challenge.* query is referred. This delegates ACME DNS-01 validation
+	// to a dynamic DNS provider (e.g. Cloud DNS) for every name in the zone
+	// without a per-name record -- the leftmost label is always _acme-challenge.
+	acmeChallengeNS []string
 
 	env environment.Env
 }
@@ -81,6 +96,19 @@ func (h *handler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 
 	qName := dns.CanonicalName(r.Question[0].Name)
 	qType := r.Question[0].Qtype
+
+	// Dynamic ACME delegation: refer any in-zone _acme-challenge.* name to the
+	// configured nameservers, so DNS-01 validation for every cert in the zone
+	// (current and future) is handled by a dynamic provider with no per-name
+	// record here.
+	if ns := h.acmeChallengeReferral(qName); len(ns) > 0 {
+		m.Authoritative = false
+		m.Ns = append(m.Ns, ns...)
+		if err := w.WriteMsg(m); err != nil {
+			log.Warningf("Failed to write ACME challenge referral for %q: %s", qName, err)
+		}
+		return
+	}
 
 	// If the name lies at or below a zone cut (an in-zone NS record below the
 	// apex), we are not authoritative for it: return a referral to the child's
@@ -315,6 +343,31 @@ func (h *handler) delegation(name string) []dns.RR {
 	return nil
 }
 
+// acmeChallengeReferral returns NS records delegating name to the configured
+// ACME nameservers, or nil if ACME delegation is unconfigured or name is not an
+// in-zone _acme-challenge.* name. The referral is synthesized per query (owned
+// by name) so a single config covers every _acme-challenge name in the zone.
+func (h *handler) acmeChallengeReferral(name string) []dns.RR {
+	if len(h.acmeChallengeNS) == 0 || h.apex == "" {
+		return nil
+	}
+	if !dns.IsSubDomain(h.apex, name) {
+		return nil
+	}
+	labels := dns.SplitDomainName(name)
+	if len(labels) == 0 || !strings.EqualFold(labels[0], acmeChallengeLabel) {
+		return nil
+	}
+	out := make([]dns.RR, 0, len(h.acmeChallengeNS))
+	for _, ns := range h.acmeChallengeNS {
+		out = append(out, &dns.NS{
+			Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: acmeReferralTTL},
+			Ns:  ns,
+		})
+	}
+	return out
+}
+
 // glue returns the in-zone (in-bailiwick) address records for the targets of
 // the given NS records, for the additional section of a referral. Out-of-zone
 // targets -- the usual case for our delegations -- contribute no glue and are
@@ -422,7 +475,10 @@ func addrFromNetAddr(a net.Addr) netip.Addr {
 	return netip.Addr{}
 }
 
-func NewHandler(resources []dns.RR, env environment.Env) dns.Handler {
+// NewHandler builds a DNS handler serving resources. acmeChallengeNameservers,
+// if non-empty, are the nameservers to which any in-zone _acme-challenge.* query
+// is referred (delegating ACME DNS-01 validation to a dynamic provider).
+func NewHandler(env environment.Env, resources []dns.RR, acmeChallengeNameservers []string) dns.Handler {
 	records := make(map[string][]dns.RR, len(resources))
 	var soa dns.RR
 	for _, rr := range resources {
@@ -436,11 +492,18 @@ func NewHandler(resources []dns.RR, env environment.Env) dns.Handler {
 	if soa != nil {
 		apex = dns.CanonicalName(soa.Header().Name)
 	}
+	var acmeNS []string
+	for _, ns := range acmeChallengeNameservers {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			acmeNS = append(acmeNS, dns.Fqdn(ns))
+		}
+	}
 	return &handler{
-		records: records,
-		soa:     soa,
-		apex:    apex,
-		env:     env,
+		records:         records,
+		soa:             soa,
+		apex:            apex,
+		acmeChallengeNS: acmeNS,
+		env:             env,
 	}
 }
 

--- a/enterprise/dns/server/server_test.go
+++ b/enterprise/dns/server/server_test.go
@@ -566,6 +566,20 @@ func TestACMEChallengeReferral(t *testing.T) {
 	assert.Equal(t, dns.RcodeNameError, m.Rcode)
 	assert.Empty(t, nsTargets(m.Ns))
 
+	// A delegated subdomain owns its own _acme-challenge names: the zone-cut
+	// referral is checked first, so it points at the child's nameservers, not our
+	// ACME provider -- even with the ACME flag set.
+	m = query(t, h, "_acme-challenge.acme.buildbuddy.io.", dns.TypeTXT)
+	assert.False(t, m.Authoritative)
+	assert.ElementsMatch(t,
+		[]string{"ns1.otherns.example.", "ns2.otherns.example."}, nsTargets(m.Ns))
+
+	// ...including in-bailiwick glue for a glued delegation (not the ACME NS).
+	m = query(t, h, "_acme-challenge.glued.buildbuddy.io.", dns.TypeTXT)
+	assert.False(t, m.Authoritative)
+	assert.Equal(t, []string{"ns1.glued.buildbuddy.io."}, nsTargets(m.Ns))
+	assert.Equal(t, []answer{{"ns1.glued.buildbuddy.io.", "A", "5.6.7.8"}}, answers(m.Extra))
+
 	// With no ACME nameservers configured, the rule is off: _acme-challenge
 	// names get ordinary handling (here, the *.buildbuddy.io wildcard), staying
 	// authoritative rather than becoming a referral.

--- a/enterprise/dns/server/server_test.go
+++ b/enterprise/dns/server/server_test.go
@@ -60,7 +60,7 @@ func mustRecords(tb testing.TB) []dns.RR {
 }
 
 func newTestHandler(t *testing.T) dns.Handler {
-	return server.NewHandler(mustRecords(t), testenv.GetTestEnv(t))
+	return server.NewHandler(testenv.GetTestEnv(t), mustRecords(t), nil)
 }
 
 // fakeResponseWriter captures the message written by the handler and reports a
@@ -160,7 +160,7 @@ func handlerWithProvider(t *testing.T, fp *experiments.FlagProvider) dns.Handler
 	t.Helper()
 	te := testenv.GetTestEnv(t)
 	te.SetExperimentFlagProvider(fp)
-	return server.NewHandler(mustRecords(t), te)
+	return server.NewHandler(te, mustRecords(t), nil)
 }
 
 func TestASNRoutingExperiment(t *testing.T) {
@@ -411,7 +411,7 @@ func TestASNRoutingRollout(t *testing.T) {
 // server: it binds the handler to a loopback UDP socket and exchanges queries
 // over concurrent reused connections.
 func BenchmarkServeUDP(b *testing.B) {
-	h := server.NewHandler(mustRecords(b), testenv.GetTestEnv(b))
+	h := server.NewHandler(testenv.GetTestEnv(b), mustRecords(b), nil)
 
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	require.NoError(b, err)
@@ -533,6 +533,46 @@ func TestApexNSIsAuthoritative(t *testing.T) {
 	assert.True(t, m.Authoritative)
 	require.NotEmpty(t, m.Answer)
 	assert.Empty(t, m.Ns)
+}
+
+func TestACMEChallengeReferral(t *testing.T) {
+	acmeNS := []string{"ns-cloud-e1.googledomains.com.", "ns-cloud-e2.googledomains.com."}
+	h := server.NewHandler(testenv.GetTestEnv(t), mustRecords(t), acmeNS)
+
+	// Any in-zone _acme-challenge.* name, at any depth, is referred to the
+	// configured nameservers with no per-name record: NOERROR, not
+	// authoritative, NS in the authority section, no answer.
+	for _, name := range []string{
+		"_acme-challenge.buildbuddy.io.",
+		"_acme-challenge.cache.buildbuddy.io.",
+		"_acme-challenge.a.b.c.buildbuddy.io.",
+	} {
+		m := query(t, h, name, dns.TypeTXT)
+		assert.Equal(t, dns.RcodeSuccess, m.Rcode, name)
+		assert.False(t, m.Authoritative, "%s should be a referral", name)
+		assert.Empty(t, m.Answer, name)
+		assert.ElementsMatch(t,
+			[]string{"ns-cloud-e1.googledomains.com.", "ns-cloud-e2.googledomains.com."},
+			nsTargets(m.Ns), name)
+	}
+
+	// A normal name is answered authoritatively, unaffected by the ACME rule.
+	m := query(t, h, "cache.buildbuddy.io.", dns.TypeA)
+	assert.True(t, m.Authoritative)
+	assert.Equal(t, []answer{{"cache.buildbuddy.io.", "A", "1.2.3.4"}}, answers(m.Answer))
+
+	// An out-of-zone _acme-challenge name is not ours to refer: normal NXDOMAIN.
+	m = query(t, h, "_acme-challenge.example.com.", dns.TypeTXT)
+	assert.Equal(t, dns.RcodeNameError, m.Rcode)
+	assert.Empty(t, nsTargets(m.Ns))
+
+	// With no ACME nameservers configured, the rule is off: _acme-challenge
+	// names get ordinary handling (here, the *.buildbuddy.io wildcard), staying
+	// authoritative rather than becoming a referral.
+	def := newTestHandler(t)
+	m = query(t, def, "_acme-challenge.cache.buildbuddy.io.", dns.TypeA)
+	assert.True(t, m.Authoritative)
+	assert.Equal(t, []answer{{"_acme-challenge.cache.buildbuddy.io.", "A", "9.9.9.9"}}, answers(m.Answer))
 }
 
 func TestExactMatch(t *testing.T) {


### PR DESCRIPTION
This allows us to run density with a flag like `--dns.acme_challenge_nameservers=ns1.goog.com,...,ns4.goog.com` and keep cert-manager pointed at google, and ACME validation will work as it does today without requiring us to manually add any NS records to zone file.