### PR TITLE
Optimize pebble_cache.FindMissing

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -815,8 +815,7 @@ func keyRange(key []byte) ([]byte, []byte) {
 	return keyPrefix(key, keys.MinByte), keyPrefix(key, keys.MaxByte)
 }
 
-func olderThanThreshold(t time.Time, threshold time.Duration) bool {
-	age := time.Since(t)
+func olderThanThreshold(age time.Duration, threshold time.Duration) bool {
 	return age >= threshold
 }
 
@@ -935,12 +934,11 @@ func (p *PebbleCache) updateAtime(update *accessTimeUpdate) error {
 	}
 
 	atime := time.UnixMicro(md.GetLastAccessUsec())
+	newAtime := p.clock.Now()
 
-	if !olderThanThreshold(atime, p.atimeUpdateThreshold) {
+	if !olderThanThreshold(newAtime.Sub(atime), p.atimeUpdateThreshold) {
 		return nil
 	}
-
-	newAtime := p.clock.Now()
 
 	if atime.After(newAtime) {
 		// Atime updates are queued -- if an object was overwritten
@@ -1837,11 +1835,11 @@ func (p *PebbleCache) sendSizeUpdate(partID string, cacheType rspb.CacheType, op
 }
 
 func (p *PebbleCache) sendAtimeUpdate(ctx context.Context, key filestore.PebbleKey, lastAccessUsec int64) {
-	atime := time.UnixMicro(lastAccessUsec)
+	age := time.Since(time.UnixMicro(lastAccessUsec))
 
-	p.metrics.atimeDeltaWhenRead.Observe(float64(time.Since(atime).Milliseconds()))
+	p.metrics.atimeDeltaWhenRead.Observe(float64(age.Milliseconds()))
 
-	if !olderThanThreshold(atime, p.atimeUpdateThreshold) {
+	if !olderThanThreshold(age, p.atimeUpdateThreshold) {
 		return
 	}
 

--- a/enterprise/server/filestore/filestore.go
+++ b/enterprise/server/filestore/filestore.go
@@ -160,7 +160,7 @@ func (pmk PebbleKey) LockID() string {
 		}
 		return string(fmk)
 	}
-	return filepath.Join(pmk.isolation, pmk.hash)
+	return pmk.isolation + "/" + pmk.hash
 }
 
 func (pmk PebbleKey) CacheType() rspb.CacheType {
@@ -298,9 +298,7 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 			}
 		}
 		filePath := filepath.Join(hashStr, strconv.Itoa(int(pmk.digestFunction)), pmk.isolation, pmk.encryptionKeyID)
-		partDir := PartitionDirectoryPrefix + pmk.partID
-		filePath = filepath.Join(partDir, filePath, "v5")
-		return []byte(filePath), nil
+		return []byte(PartitionDirectoryPrefix + pmk.partID + "/" + filePath + "/v5"), nil
 	case Version6:
 		hashStr := ""
 		if pmk.syntheticHash != "" {
@@ -317,9 +315,7 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 			}
 		}
 		filePath := filepath.Join(hashStr, strconv.Itoa(int(pmk.digestFunction)), pmk.isolation, pmk.encryptionKeyID)
-		partDir := PartitionDirectoryPrefix + pmk.partID
-		filePath = filepath.Join(partDir, filePath, "v6")
-		return []byte(filePath), nil
+		return []byte(PartitionDirectoryPrefix + pmk.partID + "/" + filePath + "/v6"), nil
 	default:
 		return nil, status.FailedPreconditionErrorf("Unknown key version: %v", version)
 	}


### PR DESCRIPTION
This was motivated by a trace span where FindMissing for 1073 resources took 1.54s. (1.42ms/resource)

<img width="2378" height="119" alt="image" src="https://github.com/user-attachments/assets/740e2c9b-c5d3-4438-a8df-d1d6863c1087" />

There's 2 optimizations:
1. Avoid a duplicate time.Now call in `sendAtimeUpdate`
2. Avoid filepath.Join when it's not necessary.

Benchmark results:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                                │  /tmp/base  │             /tmp/after              │
                                │   sec/op    │   sec/op     vs base                │
FindMissing/LocalPebble10-24      146.1µ ± 2%   122.6µ ± 3%  -16.06% (p=0.000 n=11)
FindMissing/LocalPebble100-24     142.8µ ± 3%   120.0µ ± 1%  -15.96% (p=0.000 n=11)
FindMissing/LocalPebble1000-24    149.7µ ± 2%   125.4µ ± 2%  -16.21% (p=0.000 n=11)
FindMissing/LocalPebble10000-24   140.5µ ± 1%   116.9µ ± 1%  -16.80% (p=0.000 n=11)
geomean                           144.7µ        121.2µ       -16.26%

                                │   /tmp/base   │             /tmp/after              │
                                │     B/op      │     B/op      vs base               │
FindMissing/LocalPebble10-24      107.77Ki ± 0%   98.36Ki ± 0%  -8.73% (p=0.000 n=11)
FindMissing/LocalPebble100-24      112.7Ki ± 0%   103.3Ki ± 0%  -8.35% (p=0.000 n=11)
FindMissing/LocalPebble1000-24     143.8Ki ± 0%   134.4Ki ± 0%  -6.54% (p=0.000 n=11)
FindMissing/LocalPebble10000-24    113.9Ki ± 0%   104.5Ki ± 0%  -8.24% (p=0.000 n=11)
geomean                            118.8Ki        109.3Ki       -7.97%

                                │  /tmp/base  │             /tmp/after             │
                                │  allocs/op  │  allocs/op   vs base               │
FindMissing/LocalPebble10-24      1.810k ± 0%   1.710k ± 0%  -5.52% (p=0.000 n=11)
FindMissing/LocalPebble100-24     1.810k ± 0%   1.710k ± 0%  -5.52% (p=0.000 n=11)
FindMissing/LocalPebble1000-24    1.810k ± 0%   1.710k ± 0%  -5.52% (p=0.000 n=11)
FindMissing/LocalPebble10000-24   1.810k ± 0%   1.710k ± 0%  -5.52% (p=0.000 n=11)
geomean                           1.810k        1.710k       -5.52%
```