### PR TITLE
Allow clients to opt in to caching AC results in the proxy via a platform property

### DIFF
--- a/enterprise/server/action_cache_server_proxy/BUILD
+++ b/enterprise/server/action_cache_server_proxy/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//server/util/capabilities",
         "//server/util/flag",
         "//server/util/log",
+        "//server/util/platform",
         "//server/util/prefix",
         "//server/util/proto",
         "//server/util/status",

--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_crypter"
@@ -20,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -158,14 +160,30 @@ func (s *ActionCacheServerProxy) cacheActionResultToLocalCAS(ctx context.Context
 
 func (s *ActionCacheServerProxy) actionCacheTTL(ctx context.Context) time.Duration {
 	efp := s.env.GetExperimentFlagProvider()
-	if efp == nil {
-		return 0
+	if efp != nil {
+		ttlSeconds := efp.Int64(ctx, "cache_proxy.action_cache_ttl_seconds", 0)
+		if ttlSeconds > 0 {
+			return time.Duration(ttlSeconds) * time.Second
+		}
 	}
-	ttlSeconds := efp.Int64(ctx, "cache_proxy.action_cache_ttl_seconds", 0)
-	if ttlSeconds <= 0 {
-		return 0
+
+	// Clients may opt into this caching via a platform property as well, whose
+	// value is the duration to serve locally cached results for.
+	for _, prop := range platform.RemoteHeaderOverrides(ctx) {
+		if strings.EqualFold(prop.GetName(), platform.CacheProxyActionCacheTTLPropertyName) {
+			ttl, err := time.ParseDuration(prop.GetValue())
+			if err != nil {
+				log.CtxWarningf(ctx, "Ignoring invalid %q platform property value %q: %s", platform.CacheProxyActionCacheTTLPropertyName, prop.GetValue(), err)
+				return 0
+			}
+			if ttl > 0 {
+				return ttl
+			}
+			return 0
+		}
 	}
-	return time.Duration(ttlSeconds) * time.Second
+
+	return 0
 }
 
 func (s *ActionCacheServerProxy) isLocalActionResultFresh(md *interfaces.CacheMetadata, ttl time.Duration) bool {
@@ -377,11 +395,14 @@ func (s *ActionCacheServerProxy) UpdateActionResult(ctx context.Context, req *re
 		return resp, err
 	}
 
-	// If we have a proxy AC TTL, then we can store this AC entry as valid for that TTL.
-	// This ensures the REv2 guarantee that GetActionResult serves the most recent UpdateActionResult
-	// for all requests to the same endpoint (this proxy).
-	ttl := s.actionCacheTTL(ctx)
-	if *cacheActionResults && ttl > 0 && s.shouldCacheUpdatedActionResult(ctx) {
+	// Always refresh the local AC entry on write, even if this request didn't opt
+	// into local caching. The TTL fast-path in GetActionResult is a per-request
+	// signal, so a read that opts in must observe the most recent write regardless
+	// of whether the writer opted in. Refreshing unconditionally preserves the
+	// REv2 guarantee that GetActionResult serves the most recent UpdateActionResult
+	// for all requests to the same endpoint (this proxy). Entries written while no
+	// client uses the TTL fast-path are simply never read back.
+	if *cacheActionResults && s.shouldCacheUpdatedActionResult(ctx) {
 		cacheCtx, prefixErr := prefix.AttachUserPrefixToContext(ctx, s.env.GetAuthenticator())
 		if prefixErr == nil {
 			getReq := &repb.GetActionResultRequest{

--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy_test.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy_test.go
@@ -360,26 +360,26 @@ func TestActionCacheProxy_CachingEnabled(t *testing.T) {
 	require.True(t, status.IsNotFoundError(err))
 
 	// Write it through the proxy and confirm it's readable from the proxy and
-	// backing cache.
+	// backing cache. Writing through the proxy also populates the local cache,
+	// so reading it back from the proxy is already a cache hit.
 	update(ctx, proxy, digestA, 1, t)
 	require.Equal(t, int32(1), get(ctx, ac, digestA, t).GetExitCode())
 	require.Equal(t, int32(1), get(ctx, proxy, digestA, t).GetExitCode())
-	require.Equal(t, 0, countingClient.cacheHitCount)
-
-	// This extra read should actually be a cached hit.
-	require.Equal(t, int32(1), get(ctx, proxy, digestA, t).GetExitCode())
 	require.Equal(t, 1, countingClient.cacheHitCount)
 
-	// Change the action result, write it, and confirm the new result is
-	// readable from the proxy and backing cache.
+	// Another read is also a cache hit.
+	require.Equal(t, int32(1), get(ctx, proxy, digestA, t).GetExitCode())
+	require.Equal(t, 2, countingClient.cacheHitCount)
+
+	// Change the action result through the proxy. This refreshes the local
+	// entry, so the new result is readable and reads remain cache hits.
 	update(ctx, proxy, digestA, 2, t)
 	require.Equal(t, int32(2), get(ctx, ac, digestA, t).GetExitCode())
 	require.Equal(t, int32(2), get(ctx, proxy, digestA, t).GetExitCode())
-	// That should _not_ be a cache hit.
-	require.Equal(t, 1, countingClient.cacheHitCount)
-	// But reading from the proxy again _should_ be a cache hit.
+	require.Equal(t, 3, countingClient.cacheHitCount)
+	// Reading from the proxy again is also a cache hit.
 	require.Equal(t, int32(2), get(ctx, proxy, digestA, t).GetExitCode())
-	require.Equal(t, 2, countingClient.cacheHitCount)
+	require.Equal(t, 4, countingClient.cacheHitCount)
 
 	countingClient.cacheHitCount = 0
 	// DigestB shouldn't be present initially,

--- a/enterprise/server/util/proxy_util/BUILD
+++ b/enterprise/server/util/proxy_util/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/util/authutil",
         "//server/util/bazel_request",
         "//server/util/cdc",
+        "//server/util/platform",
         "//server/util/usageutil",
         "@org_golang_google_grpc//metadata",
     ],

--- a/enterprise/server/util/proxy_util/proxy_util.go
+++ b/enterprise/server/util/proxy_util/proxy_util.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/cdc"
+	"github.com/buildbuddy-io/buildbuddy/server/util/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/usageutil"
 	"google.golang.org/grpc/metadata"
 )
@@ -27,6 +28,9 @@ var (
 		usageutil.OriginHeaderName,
 		bazel_request.RequestMetadataKey,
 		cdc.ChunkedHeaderName,
+		// Forward the client's opt-in for local AC caching so it survives
+		// proxy-to-proxy hops and every proxy in the chain honors it.
+		platform.OverrideHeaderPrefix + platform.CacheProxyActionCacheTTLPropertyName,
 	}
 )
 

--- a/server/util/platform/platform.go
+++ b/server/util/platform/platform.go
@@ -108,6 +108,15 @@ const (
 	RetryPropertyName                        = "retry"
 	PersistentVolumesPropertyName            = "persistent-volumes"
 	execrootPathPropertyName                 = "execroot-path"
+
+	// CacheProxyActionCacheTTLPropertyName lets clients opt into caching
+	// action results in the cache proxy, rather than always revalidating them
+	// with the authoritative remote cache. The value is the duration to serve
+	// locally cached results for before revalidating, formatted as a Go
+	// duration string (e.g. "15m" or "1h"). A non-positive or unparseable value
+	// disables local caching.
+	CacheProxyActionCacheTTLPropertyName = "cache-proxy-action-cache-ttl"
+
 	// RunUnderPropertyName specifies a wrapper command to run the action
 	// under. The value is shell-tokenized and the resulting tokens are
 	// prepended to the command arguments, so the original executable becomes


### PR DESCRIPTION
Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7611