### PR TITLE
oci fetcher: do not make HEAD requests for blobs

### DIFF
--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -357,6 +357,15 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 		return err
 	}
+	if contentLength < 0 {
+		// The leader streamed successfully without cache metadata, which means
+		// it intentionally skipped write-through caching. Waiters cannot replay
+		// that streamed response from cache, so they must fetch from the
+		// registry themselves.
+		err = s.fetchBlobFromRemoteToResponse(ctx, digestRef, creds, stream)
+		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
+		return err
+	}
 	err = ocicache.FetchBlobFromCache(ctx, &grpcStreamWriter{stream: stream}, s.bsClient, hash, contentLength)
 	recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 	return err
@@ -380,7 +389,7 @@ func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
 // fetchBlobFromRemoteWriteToCacheAndResponse fetches a blob from the upstream
 // registry, streams it to the response, and writes it to the cache
 // simultaneously using read-through caching.
-// It returns the content length of the blob (0 if metadata was unavailable).
+// It returns the content length of the blob (-1 if metadata was unavailable).
 func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx context.Context, digestRef ctrname.Digest, repo ctrname.Repository, hash ctr.Hash, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer, size int64, mediaType string) (int64, error) {
 	// The blob GET is the only registry request here, and it proves repo
 	// access as a side effect. We deliberately avoid a metadata blob HEAD:
@@ -407,7 +416,7 @@ func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx contex
 
 	// Skip caching when the caller didn't provide metadata.
 	if mediaType == "" || size == 0 {
-		return 0, streamAndClose(rc)
+		return -1, streamAndClose(rc)
 	}
 
 	// cachedRC wraps rc and takes ownership (closes it).
@@ -417,6 +426,25 @@ func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx contex
 		return size, streamAndClose(rc)
 	}
 	return size, streamAndClose(cachedRC)
+}
+
+func (s *ociFetcherServer) fetchBlobFromRemoteToResponse(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	rc, err := withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (io.ReadCloser, error) {
+		layer, err := puller.Layer(ctx, digestRef)
+		if err != nil {
+			return nil, err
+		}
+		return layer.Compressed()
+	})
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	if err := s.streamBlob(rc, stream); err != nil {
+		return err
+	}
+	s.accessProofCache.Add(repoAccessKey(digestRef.Context(), creds), struct{}{})
+	return nil
 }
 
 // streamBlob reads from rc and streams the data to the gRPC stream in chunks.

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -167,7 +167,7 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 		}
 		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
 	}
-	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, req.GetCredentials())
+	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, req.GetCredentials(), req.GetManifestRef(), req.GetSize(), req.GetMediaType())
 }
 
 // FetchBlobMetadata returns OCI blob metadata (size, media type).
@@ -299,7 +299,7 @@ func (s *ociFetcherServer) streamBlobFromCache(ctx context.Context, stream ofpb.
 	return ocicache.FetchBlobFromCache(ctx, &grpcStreamWriter{stream: stream}, s.bsClient, hash, metadata.GetContentLength())
 }
 
-func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef ctrname.Digest, hash ctr.Hash, creds *rgpb.Credentials) error {
+func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef ctrname.Digest, hash ctr.Hash, creds *rgpb.Credentials, manifestRef string, size int64, mediaType string) error {
 	start := time.Now()
 	repo := digestRef.Context()
 	key := ocicache.NewBlobFetchKey(repo, hash, creds)
@@ -307,32 +307,42 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 	contentLength, _, err := s.blobFetchGroup.Do(ctx, key, func(ctx context.Context) (int64, error) {
 		isLeader = true
 
-		// Cached metadata proves the content-addressed blob exists; we only need
-		// to prove the caller may access the repo before serving it from cache.
-		metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
-		if err == nil {
-			if err := s.proveBlobAccess(ctx, digestRef, creds); err != nil {
-				return 0, err
-			}
-			contentLength := metadata.GetContentLength()
-			cacheWriter := &grpcStreamWriter{stream: stream}
-			err := ocicache.FetchBlobFromCache(ctx, cacheWriter, s.bsClient, hash, contentLength)
+		// The cache fast-path requires proving the caller may access the repo
+		// without fetching the blob. We do that with a manifest HEAD, so it is
+		// only available when the caller supplies the manifest ref. Without one
+		// (older clients), we fall through to the registry, where the blob GET
+		// proves access as a side effect.
+		if manifestRef != "" {
+			// Cached metadata proves the content-addressed blob exists; we only
+			// need to prove repo access before serving it from cache.
+			metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
 			if err == nil {
-				return contentLength, nil
+				if err := s.proveBlobAccess(ctx, digestRef, creds, manifestRef); err != nil {
+					return 0, err
+				}
+				contentLength := metadata.GetContentLength()
+				cacheWriter := &grpcStreamWriter{stream: stream}
+				err := ocicache.FetchBlobFromCache(ctx, cacheWriter, s.bsClient, hash, contentLength)
+				if err == nil {
+					return contentLength, nil
+				}
+				// Only recover if no bytes were streamed. Once bytes have been
+				// sent, falling back would corrupt the response by replaying
+				// from offset 0.
+				if cacheWriter.bytesWritten > 0 {
+					return 0, err
+				}
+				log.CtxWarningf(ctx, "Blob metadata was cached but reading blob %q from cache failed before streaming bytes; falling back to registry: %s", digestRef, err)
+			} else if !status.IsNotFoundError(err) {
+				log.CtxWarningf(ctx, "Error looking up blob metadata in cache; falling back to registry: %s", err)
 			}
-			// Only recover if no bytes were streamed. Once bytes have been sent,
-			// falling back would corrupt the response by replaying from offset 0.
-			if cacheWriter.bytesWritten > 0 {
-				return 0, err
-			}
-			log.CtxWarningf(ctx, "Blob metadata was cached but reading blob %q from cache failed before streaming bytes; falling back to registry: %s", digestRef, err)
-		} else if !status.IsNotFoundError(err) {
-			log.CtxWarningf(ctx, "Error looking up blob metadata in cache; falling back to registry: %s", err)
+		} else {
+			log.CtxInfof(ctx, "FetchBlob request for %q has no manifest ref; fetching from registry to prove access", digestRef)
 		}
 
-		// Cache miss: fetch from the registry, which proves access and writes
-		// the blob through to the cache.
-		size, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, digestRef, repo, hash, creds, stream)
+		// Cache miss, no manifest ref, or cache read failure: fetch from the
+		// registry, which proves access and writes the blob through to the cache.
+		size, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, digestRef, repo, hash, creds, stream, size, mediaType)
 		if err == nil {
 			s.accessProofCache.Add(repoAccessKey(repo, creds), struct{}{})
 		}
@@ -371,33 +381,17 @@ func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
 // registry, streams it to the response, and writes it to the cache
 // simultaneously using read-through caching.
 // It returns the content length of the blob (0 if metadata was unavailable).
-func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx context.Context, digestRef ctrname.Digest, repo ctrname.Repository, hash ctr.Hash, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) (int64, error) {
-	// All HTTP-triggering calls (Compressed, MediaType, Size) must be
-	// inside the retry scope so that token refresh covers them, not just
-	// the lazy Layer() reference creation.
-	//
-	// MediaType and Size are fetched before Compressed so that there is
-	// no open ReadCloser to leak if they fail and trigger a retry.
-	// They are best-effort: failures are logged but don't prevent
-	// streaming the blob data. Caching is skipped when metadata is
-	// unavailable.
-	var mediaType string
-	var size int64
+func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx context.Context, digestRef ctrname.Digest, repo ctrname.Repository, hash ctr.Hash, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer, size int64, mediaType string) (int64, error) {
+	// The blob GET is the only registry request here, and it proves repo
+	// access as a side effect. We deliberately avoid a metadata blob HEAD:
+	// some registries (notably public.ecr.aws) reject blob HEADs even when the
+	// GET is authorized. Size and media type are supplied by the caller (from
+	// the manifest descriptor); when absent (older clients) we stream without
+	// caching rather than fall back to a blob HEAD.
 	rc, err := withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (io.ReadCloser, error) {
 		layer, err := puller.Layer(ctx, digestRef)
 		if err != nil {
 			return nil, err
-		}
-		// Best-effort metadata for read-through caching.
-		if mt, err := layer.MediaType(); err != nil {
-			log.CtxWarningf(ctx, "Could not get media type for layer: %s", err)
-		} else {
-			mediaType = string(mt)
-		}
-		if sz, err := layer.Size(); err != nil {
-			log.CtxWarningf(ctx, "Could not get size for layer: %s", err)
-		} else {
-			size = sz
 		}
 		return layer.Compressed()
 	})
@@ -411,7 +405,7 @@ func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx contex
 		return s.streamBlob(r, stream)
 	}
 
-	// Skip caching when metadata is unavailable.
+	// Skip caching when the caller didn't provide metadata.
 	if mediaType == "" || size == 0 {
 		return 0, streamAndClose(rc)
 	}
@@ -521,17 +515,30 @@ func (s *ociFetcherServer) proveManifestAccess(ctx context.Context, imageRef ctr
 }
 
 // proveBlobAccess checks that the caller's credentials allow accessing the
-// blob's repository in the remote registry (via a metadata HEAD).
-func (s *ociFetcherServer) proveBlobAccess(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials) error {
+// blob's repository in the remote registry, so a cached blob may be served.
+//
+// Access is proven with a HEAD of the manifest the blob belongs to (a 200),
+// rather than a blob HEAD: some registries (notably public.ecr.aws) return 401
+// for blob HEAD requests even when the corresponding GET is authorized, which
+// would make already-cached blobs unservable. The manifest endpoint is
+// authorized at repository scope, so this is an equivalent access check.
+//
+// manifestRef must be non-empty; callers that lack it fetch the blob from the
+// registry instead, where the GET proves access.
+func (s *ociFetcherServer) proveBlobAccess(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials, manifestRef string) error {
 	repo := digestRef.Context()
 	if s.accessProofCache.Contains(repoAccessKey(repo, creds)) {
 		return nil
 	}
-	if _, err := s.fetchBlobMetadataFromRemote(ctx, digestRef, creds); err != nil {
+	imageRef, err := parseManifestRef(manifestRef)
+	if err != nil {
 		return err
 	}
-	s.accessProofCache.Add(repoAccessKey(repo, creds), struct{}{})
-	return nil
+	if imageRef.Context().Name() != repo.Name() {
+		return status.InvalidArgumentErrorf("manifest ref %q is not in the same repository as blob %q", manifestRef, digestRef)
+	}
+	// proveManifestAccess records the repo+creds proof in the access cache.
+	return s.proveManifestAccess(ctx, imageRef, creds)
 }
 
 func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, imageRef ctrname.Reference, creds *rgpb.Credentials) (ctr.Hash, error) {

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -363,6 +363,9 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 		// that streamed response from cache, so they must fetch from the
 		// registry themselves.
 		err = s.fetchBlobFromRemoteToResponse(ctx, digestRef, creds, stream)
+		if err == nil {
+			s.accessProofCache.Add(repoAccessKey(repo, creds), struct{}{})
+		}
 		recordFetchBlobMetrics(metrics.OCIFetcherRoleWaiter, err, time.Since(start))
 		return err
 	}
@@ -397,13 +400,7 @@ func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx contex
 	// GET is authorized. Size and media type are supplied by the caller (from
 	// the manifest descriptor); when absent (older clients) we stream without
 	// caching rather than fall back to a blob HEAD.
-	rc, err := withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (io.ReadCloser, error) {
-		layer, err := puller.Layer(ctx, digestRef)
-		if err != nil {
-			return nil, err
-		}
-		return layer.Compressed()
-	})
+	rc, err := s.openBlobReader(ctx, digestRef, creds)
 	if err != nil {
 		return 0, err
 	}
@@ -414,8 +411,10 @@ func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx contex
 		return s.streamBlob(r, stream)
 	}
 
-	// Skip caching when the caller didn't provide metadata.
-	if mediaType == "" || size == 0 {
+	// Skip caching when the caller didn't provide metadata. Media type comes
+	// from the manifest descriptor and is always set when metadata is supplied,
+	// so it (not size, which may legitimately be 0) is the presence signal.
+	if mediaType == "" {
 		return -1, streamAndClose(rc)
 	}
 
@@ -428,23 +427,30 @@ func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx contex
 	return size, streamAndClose(cachedRC)
 }
 
-func (s *ociFetcherServer) fetchBlobFromRemoteToResponse(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) error {
-	rc, err := withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (io.ReadCloser, error) {
+// openBlobReader opens a streaming reader for the blob from the upstream
+// registry. The blob GET proves repo access as a side effect; callers record
+// that proof in the access cache on success.
+func (s *ociFetcherServer) openBlobReader(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials) (io.ReadCloser, error) {
+	return withPullerRetry(ctx, s, digestRef, creds, func(puller *remote.Puller) (io.ReadCloser, error) {
 		layer, err := puller.Layer(ctx, digestRef)
 		if err != nil {
 			return nil, err
 		}
 		return layer.Compressed()
 	})
+}
+
+// fetchBlobFromRemoteToResponse streams the blob from the upstream registry to
+// the response without write-through caching. It is used by waiters when the
+// leader streamed without caching (no metadata), so they cannot replay it from
+// cache.
+func (s *ociFetcherServer) fetchBlobFromRemoteToResponse(ctx context.Context, digestRef ctrname.Digest, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	rc, err := s.openBlobReader(ctx, digestRef, creds)
 	if err != nil {
 		return err
 	}
 	defer rc.Close()
-	if err := s.streamBlob(rc, stream); err != nil {
-		return err
-	}
-	s.accessProofCache.Add(repoAccessKey(digestRef.Context(), creds), struct{}{})
-	return nil
+	return s.streamBlob(rc, stream)
 }
 
 // streamBlob reads from rc and streams the data to the gRPC stream in chunks.

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -1835,6 +1835,56 @@ func TestFetchBlobSingleflightHappyPath(t *testing.T) {
 	}
 }
 
+func TestFetchBlobSingleflightWithoutMetadataWaitersFetchFromRegistry(t *testing.T) {
+	const numRequests = 10
+
+	blocker := newBlockingInterceptor()
+	reg, counter := setupRegistry(t, nil, blocker.intercept)
+	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+
+	layer := layers[0]
+	digest, err := layer.Digest()
+	require.NoError(t, err)
+	expectedData := layerData(t, layer)
+
+	_, bsClient, acClient := setupCacheEnv(t)
+	server := newTestServerWithCache(t, bsClient, acClient)
+
+	req := &ofpb.FetchBlobRequest{
+		Ref: imageName + "@" + digest.String(),
+	}
+
+	counter.Reset()
+	blocker.enable()
+	go func() {
+		require.Eventually(t, func() bool {
+			return blocker.requestCount.Load() >= 1
+		}, 5*time.Second, 10*time.Millisecond, "expected at least 1 HTTP request to arrive")
+		time.Sleep(50 * time.Millisecond)
+		blocker.release()
+	}()
+
+	results := runConcurrentFetchBlob(t, server, req, numRequests,
+		func(idx int) *concurrentMockFetchBlobServer {
+			return &concurrentMockFetchBlobServer{ctx: context.Background()}
+		},
+	)
+
+	blobPath := "/v2/test-image/blobs/" + digest.String()
+	snap := counter.Snapshot()
+	require.Greater(t, snap[http.MethodGet+" "+blobPath], 1, "metadata-less waiters should fetch from registry because the leader does not cache")
+	require.Zero(t, snap[http.MethodHead+" "+blobPath], "must not issue a blob HEAD")
+
+	for i, r := range results {
+		require.NoError(t, r.err, "request %d should succeed", i)
+		require.Equal(t, expectedData, r.data, "request %d should have correct data", i)
+	}
+}
+
 // TestFetchBlobSingleflightCacheHit ensures concurrent callers serve from the
 // blob cache without contacting the registry once access has been proven.
 func TestFetchBlobSingleflightCacheHit(t *testing.T) {
@@ -1950,13 +2000,16 @@ func TestFetchBlobSingleflightLeaderSendFails(t *testing.T) {
 	layer := layers[0]
 	digest, err := layer.Digest()
 	require.NoError(t, err)
+	layerSize, layerMediaType := layerMetadata(t, layer)
 	expectedData := layerData(t, layer)
 
 	_, bsClient, acClient := setupCacheEnv(t)
 	server := newTestServerWithCache(t, bsClient, acClient)
 
 	req := &ofpb.FetchBlobRequest{
-		Ref: imageName + "@" + digest.String(),
+		Ref:       imageName + "@" + digest.String(),
+		Size:      ptr(layerSize),
+		MediaType: ptr(layerMediaType),
 	}
 
 	var firstSenderFlag atomic.Bool
@@ -2011,6 +2064,7 @@ func TestFetchBlobSingleflightCacheSetupFailure(t *testing.T) {
 	layer := layers[0]
 	digest, err := layer.Digest()
 	require.NoError(t, err)
+	layerSize, layerMediaType := layerMetadata(t, layer)
 	expectedData := layerData(t, layer)
 
 	bsClient := failingByteStreamClient{}
@@ -2018,7 +2072,9 @@ func TestFetchBlobSingleflightCacheSetupFailure(t *testing.T) {
 	server := newTestServerWithCache(t, bsClient, acClient)
 
 	req := &ofpb.FetchBlobRequest{
-		Ref: imageName + "@" + digest.String(),
+		Ref:       imageName + "@" + digest.String(),
+		Size:      ptr(layerSize),
+		MediaType: ptr(layerMediaType),
 	}
 
 	const numRequests = 4

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -296,6 +296,10 @@ func layerMetadata(t *testing.T, layer ctr.Layer) (size int64, mediaType string)
 	return s, string(mt)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func layerData(t *testing.T, layer ctr.Layer) []byte {
 	rc, err := layer.Compressed()
 	require.NoError(t, err)
@@ -435,6 +439,7 @@ func TestServerHappyPath(t *testing.T) {
 		t.Run("FetchBlob/WithCaching/"+ac.name, func(t *testing.T) {
 			reg, counter := setupRegistry(t, ac.registryCreds, nil)
 			imageName, img := reg.PushNamedImage(t, "test-image", ac.registryCreds)
+			manifestDigest, _, _ := imageMetadata(t, img)
 
 			layers, err := img.Layers()
 			require.NoError(t, err)
@@ -443,17 +448,25 @@ func TestServerHappyPath(t *testing.T) {
 			layer := layers[0]
 			digest, err := layer.Digest()
 			require.NoError(t, err)
+			layerSize, layerMediaType := layerMetadata(t, layer)
 			expectedData := layerData(t, layer)
+
+			blobRef := imageName + "@" + digest.String()
+			manifestRef := imageName + "@" + manifestDigest
 
 			_, bsClient, acClient := setupCacheEnv(t)
 			server := newTestServerWithCache(t, bsClient, acClient)
 
-			// First fetch - cache miss, should hit registry
+			// First fetch - cache miss, should hit registry. Providing the
+			// manifest ref, size, and media type lets the server cache the blob.
 			counter.Reset()
 			stream := &mockFetchBlobServer{ctx: context.Background()}
 			err = server.FetchBlob(&ofpb.FetchBlobRequest{
-				Ref:         imageName + "@" + digest.String(),
+				Ref:         blobRef,
 				Credentials: ac.requestCreds,
+				ManifestRef: manifestRef,
+				Size:        ptr(layerSize),
+				MediaType:   ptr(layerMediaType),
 			}, stream)
 			require.NoError(t, err)
 			require.Equal(t, expectedData, stream.collectData())
@@ -464,12 +477,15 @@ func TestServerHappyPath(t *testing.T) {
 
 			// Second fetch - cache hit. The first fetch already proved
 			// registry access for these credentials, so this is served
-			// from cache without touching the registry.
+			// from cache after proving access via a manifest HEAD.
 			counter.Reset()
 			stream = &mockFetchBlobServer{ctx: context.Background()}
 			err = server.FetchBlob(&ofpb.FetchBlobRequest{
-				Ref:         imageName + "@" + digest.String(),
+				Ref:         blobRef,
 				Credentials: ac.requestCreds,
+				ManifestRef: manifestRef,
+				Size:        ptr(layerSize),
+				MediaType:   ptr(layerMediaType),
 			}, stream)
 			require.NoError(t, err)
 			require.Equal(t, expectedData, stream.collectData())
@@ -787,64 +803,99 @@ func TestFetchBlobRetryOnCompressedError(t *testing.T) {
 		// Two blob GETs: first fails with 401 (simulating expired token),
 		// second succeeds after puller eviction and retry.
 		http.MethodGet + " " + blobPath: 2,
-		// Two blob HEADs for layer.Size(): one per attempt (Size is
-		// fetched before Compressed to avoid leaking the reader on
-		// retry).
-		http.MethodHead + " " + blobPath: 2,
+		// No blob HEADs: the server no longer issues blob HEAD requests.
 	})
 }
 
-func TestFetchBlobStreamsDirectlyWhenBlobMetadataLookupFails(t *testing.T) {
+// TestFetchBlobCacheHitProvesAccessViaManifestRef covers the public.ecr.aws
+// regression: that registry returns 401 for blob HEADs even when the blob GET
+// is authorized. With a manifest ref, the server proves repo access via a
+// manifest HEAD, so an already-cached blob is still servable.
+func TestFetchBlobCacheHitProvesAccessViaManifestRef(t *testing.T) {
 	var failBlobHead atomic.Bool
 	reg, counter := setupRegistry(t, nil, func(w http.ResponseWriter, r *http.Request) bool {
 		if failBlobHead.Load() && r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/") {
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusUnauthorized)
 			return false
 		}
 		return true
 	})
-	imageName, img := reg.PushNamedImage(t, "test-metadata-fallback", nil)
+	imageName, img := reg.PushNamedImage(t, "test-manifest-ref-proof", nil)
+	manifestDigest, _, _ := imageMetadata(t, img)
 	layers, err := img.Layers()
 	require.NoError(t, err)
 	require.NotEmpty(t, layers)
 	layer := layers[0]
 	layerDigest, err := layer.Digest()
 	require.NoError(t, err)
+	mediaType, err := layer.MediaType()
+	require.NoError(t, err)
 	expectedLayerData := layerData(t, layer)
 
-	server := newTestServer(t)
 	blobRef := imageName + "@" + layerDigest.String()
+	manifestRef := imageName + "@" + manifestDigest
+
+	// Seed the cache as if another replica already fetched the blob; this
+	// server's access-proof cache starts cold.
+	_, bsClient, acClient := setupCacheEnv(t)
+	seedBlobCache(t, bsClient, acClient, blobRef, expectedLayerData, string(mediaType))
+	server := newTestServerWithCache(t, bsClient, acClient)
+
 	failBlobHead.Store(true)
-
+	counter.Reset()
 	stream := &mockFetchBlobServer{ctx: context.Background()}
-	counter.Reset()
-	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
-	require.NoError(t, err, "FetchBlob should fall back to direct streaming when metadata lookups fail")
+	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef, ManifestRef: manifestRef}, stream)
+	require.NoError(t, err, "FetchBlob should serve the cached blob by proving access with a manifest HEAD")
 	require.Equal(t, expectedLayerData, stream.collectData())
 
-	blobPath := "/v2/test-metadata-fallback/blobs/" + layerDigest.String()
-	assertRequests(t, counter, map[string]int{
-		http.MethodGet + " /v2/": 1,
-		// Blob data is streamed despite metadata failures.
-		http.MethodGet + " " + blobPath: 1,
-		// Three blob HEADs: MediaType() HEAD (500), Size() HEAD (500),
-		// plus one internal HEAD from go-containerregistry during
-		// Compressed() to determine content length.
-		http.MethodHead + " " + blobPath: 3,
-	})
+	snap := counter.Snapshot()
+	require.Zero(t, snap[http.MethodHead+" /v2/test-manifest-ref-proof/blobs/"+layerDigest.String()], "must not issue a blob HEAD")
+	require.Positive(t, snap[http.MethodHead+" /v2/test-manifest-ref-proof/manifests/"+manifestDigest], "should prove access via a manifest HEAD")
+}
 
-	// Metadata lookup failures should skip read-through caching, so a subsequent
-	// fetch still needs to hit the upstream registry.
-	stream = &mockFetchBlobServer{ctx: context.Background()}
-	counter.Reset()
-	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
+// TestFetchBlobWithoutManifestRefFetchesFromRegistry confirms that without a
+// manifest ref the server does not attempt a blob HEAD to prove access. Even
+// when the blob is already cached, the server re-fetches it from the registry
+// (the blob GET proves access as a side effect), so a registry that rejects
+// blob HEADs (e.g. public.ecr.aws) does not break the fetch.
+func TestFetchBlobWithoutManifestRefFetchesFromRegistry(t *testing.T) {
+	var failBlobHead atomic.Bool
+	reg, counter := setupRegistry(t, nil, func(w http.ResponseWriter, r *http.Request) bool {
+		if failBlobHead.Load() && r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return false
+		}
+		return true
+	})
+	imageName, img := reg.PushNamedImage(t, "test-no-manifest-ref", nil)
+	layers, err := img.Layers()
 	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layer := layers[0]
+	layerDigest, err := layer.Digest()
+	require.NoError(t, err)
+	mediaType, err := layer.MediaType()
+	require.NoError(t, err)
+	expectedLayerData := layerData(t, layer)
+	blobRef := imageName + "@" + layerDigest.String()
+	blobPath := "/v2/test-no-manifest-ref/blobs/" + layerDigest.String()
+
+	_, bsClient, acClient := setupCacheEnv(t)
+	seedBlobCache(t, bsClient, acClient, blobRef, expectedLayerData, string(mediaType))
+
+	// Reject blob HEADs (public.ecr.aws). Without a manifest ref the server must
+	// not issue any blob HEAD; it fetches the blob from the registry instead.
+	server := newTestServerWithCache(t, bsClient, acClient)
+	failBlobHead.Store(true)
+	counter.Reset()
+	stream := &mockFetchBlobServer{ctx: context.Background()}
+	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
+	require.NoError(t, err, "without a manifest ref, the blob should be fetched from the registry")
 	require.Equal(t, expectedLayerData, stream.collectData())
-	assertRequests(t, counter, map[string]int{
-		// No /v2/ ping: puller stays cached across metadata failures.
-		http.MethodGet + " " + blobPath:  1,
-		http.MethodHead + " " + blobPath: 3,
-	})
+
+	snap := counter.Snapshot()
+	require.Positive(t, snap[http.MethodGet+" "+blobPath], "should fetch the blob via GET")
+	require.Zero(t, snap[http.MethodHead+" "+blobPath], "must not issue a blob HEAD")
 }
 
 func TestServerNoRetryOnContextErrors(t *testing.T) {
@@ -957,9 +1008,17 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	require.Equal(t, expectedLayerSize, blobMetaResp.GetSize())
 	require.Equal(t, expectedLayerMediaType, blobMetaResp.GetMediaType())
 
-	// FetchBlob: first fetch caches the blob
+	// FetchBlob: first fetch caches the blob. Providing the manifest ref, size,
+	// and media type lets the server cache the blob on this miss.
+	blobRef := imageName + "@" + layerDigest.String()
+	manifestRef := imageName + "@" + expectedDigest
 	stream := &mockFetchBlobServer{ctx: context.Background()}
-	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
+	err = server.FetchBlob(&ofpb.FetchBlobRequest{
+		Ref:         blobRef,
+		ManifestRef: manifestRef,
+		Size:        ptr(expectedLayerSize),
+		MediaType:   ptr(expectedLayerMediaType),
+	}, stream)
 	require.NoError(t, err)
 	require.Equal(t, expectedLayerData, stream.collectData())
 
@@ -969,7 +1028,12 @@ func TestServerNoRetryOnContextErrors(t *testing.T) {
 	counter.Reset()
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
 	stream = &mockFetchBlobServer{ctx: ctx}
-	err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: imageName + "@" + layerDigest.String()}, stream)
+	err = server.FetchBlob(&ofpb.FetchBlobRequest{
+		Ref:         blobRef,
+		ManifestRef: manifestRef,
+		Size:        ptr(expectedLayerSize),
+		MediaType:   ptr(expectedLayerMediaType),
+	}, stream)
 	cancel()
 	require.NoError(t, err, "cached blob should serve without network calls")
 	require.Equal(t, expectedLayerData, stream.collectData())
@@ -1075,6 +1139,7 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		reg, counter := setupRegistry(t, nil, nil)
 		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		manifestDigest, _, _ := imageMetadata(t, img)
 
 		layers, err := img.Layers()
 		require.NoError(t, err)
@@ -1083,15 +1148,20 @@ func TestServerBypassRegistry(t *testing.T) {
 		layer := layers[0]
 		digest, err := layer.Digest()
 		require.NoError(t, err)
+		layerSize, layerMediaType := layerMetadata(t, layer)
 		expectedData := layerData(t, layer)
 
 		_, bsClient, acClient := setupCacheEnv(t)
 		server := newTestServerWithCache(t, bsClient, acClient)
 
-		// First fetch - populate cache
+		// First fetch - populate cache. Providing the manifest ref, size, and
+		// media type lets the server cache the blob on this miss.
 		stream := &mockFetchBlobServer{ctx: context.Background()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
-			Ref: imageName + "@" + digest.String(),
+			Ref:         imageName + "@" + digest.String(),
+			ManifestRef: imageName + "@" + manifestDigest,
+			Size:        ptr(layerSize),
+			MediaType:   ptr(layerMediaType),
 		}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
@@ -1152,6 +1222,7 @@ func TestServerBypassRegistry(t *testing.T) {
 	t.Run("FetchBlobMetadata/WithCaching", func(t *testing.T) {
 		reg, counter := setupRegistry(t, nil, nil)
 		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		manifestDigest, _, _ := imageMetadata(t, img)
 
 		layers, err := img.Layers()
 		require.NoError(t, err)
@@ -1165,10 +1236,15 @@ func TestServerBypassRegistry(t *testing.T) {
 		_, bsClient, acClient := setupCacheEnv(t)
 		server := newTestServerWithCache(t, bsClient, acClient)
 
-		// First, fetch the blob to populate the cache (FetchBlob writes metadata to AC)
+		// First, fetch the blob to populate the cache (FetchBlob writes metadata
+		// to AC). Providing the manifest ref, size, and media type lets the
+		// server cache the blob (and its metadata) on this miss.
 		stream := &mockFetchBlobServer{ctx: context.Background()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
-			Ref: imageName + "@" + digest.String(),
+			Ref:         imageName + "@" + digest.String(),
+			ManifestRef: imageName + "@" + manifestDigest,
+			Size:        ptr(expectedSize),
+			MediaType:   ptr(expectedMediaType),
 		}, stream)
 		require.NoError(t, err)
 
@@ -1192,6 +1268,7 @@ func TestServerBypassRegistry(t *testing.T) {
 
 		reg, counter := setupRegistry(t, nil, nil)
 		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		manifestDigest, _, _ := imageMetadata(t, img)
 
 		layers, err := img.Layers()
 		require.NoError(t, err)
@@ -1205,10 +1282,14 @@ func TestServerBypassRegistry(t *testing.T) {
 		_, bsClient, acClient := setupCacheEnv(t)
 		server := newTestServerWithCache(t, bsClient, acClient)
 
-		// First fetch - populate cache via FetchBlob
+		// First fetch - populate cache via FetchBlob. Providing the manifest ref,
+		// size, and media type lets the server cache the blob (and its metadata).
 		stream := &mockFetchBlobServer{ctx: context.Background()}
 		err = server.FetchBlob(&ofpb.FetchBlobRequest{
-			Ref: imageName + "@" + digest.String(),
+			Ref:         imageName + "@" + digest.String(),
+			ManifestRef: imageName + "@" + manifestDigest,
+			Size:        ptr(expectedSize),
+			MediaType:   ptr(expectedMediaType),
 		}, stream)
 		require.NoError(t, err)
 
@@ -1521,6 +1602,7 @@ func TestServerCacheAccessProof(t *testing.T) {
 	t.Run("FetchManifestMetadata/ProvesAccessForBlobCacheHit", func(t *testing.T) {
 		reg, counter := setupRegistry(t, nil, nil)
 		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		manifestDigest, _, _ := imageMetadata(t, img)
 
 		layers, err := img.Layers()
 		require.NoError(t, err)
@@ -1529,14 +1611,23 @@ func TestServerCacheAccessProof(t *testing.T) {
 		layer := layers[0]
 		digest, err := layer.Digest()
 		require.NoError(t, err)
+		layerSize, layerMediaType := layerMetadata(t, layer)
 		expectedData := layerData(t, layer)
 
 		_, bsClient, acClient := setupCacheEnv(t)
 		server := newTestServerWithCache(t, bsClient, acClient)
 		blobRef := imageName + "@" + digest.String()
+		manifestRef := imageName + "@" + manifestDigest
 
+		// Providing the manifest ref, size, and media type lets the server cache
+		// the blob on this miss.
 		stream := &mockFetchBlobServer{ctx: context.Background()}
-		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref:         blobRef,
+			ManifestRef: manifestRef,
+			Size:        ptr(layerSize),
+			MediaType:   ptr(layerMediaType),
+		}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
 
@@ -1549,9 +1640,17 @@ func TestServerCacheAccessProof(t *testing.T) {
 			http.MethodHead + " /v2/test-image/manifests/latest": 1,
 		})
 
+		// FetchManifestMetadata above proved repo access, so this blob fetch is
+		// served from cache (access proven via the manifest ref) without any
+		// further registry requests.
 		counter.Reset()
 		stream = &mockFetchBlobServer{ctx: context.Background()}
-		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref:         blobRef,
+			ManifestRef: manifestRef,
+			Size:        ptr(layerSize),
+			MediaType:   ptr(layerMediaType),
+		}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
 		assertRequests(t, counter, map[string]int{})
@@ -1581,16 +1680,18 @@ func TestServerCacheAccessProof(t *testing.T) {
 		require.Equal(t, expectedData, stream.collectData())
 
 		blobPath := "/v2/test-image/blobs/" + digest.String()
+		// No blob HEAD: with no manifest ref the server fetches via blob GET,
+		// which proves access as a side effect.
 		assertRequests(t, counter, map[string]int{
-			http.MethodGet + " /v2/":         1,
-			http.MethodHead + " " + blobPath: 1,
-			http.MethodGet + " " + blobPath:  1,
+			http.MethodGet + " /v2/":        1,
+			http.MethodGet + " " + blobPath: 1,
 		})
 	})
 
 	t.Run("FetchBlob/MetadataCacheHitBlobCacheMissFallsBackToRegistry", func(t *testing.T) {
 		reg, counter := setupRegistry(t, nil, nil)
 		imageName, img := reg.PushNamedImage(t, "test-image", nil)
+		manifestDigest, _, _ := imageMetadata(t, img)
 
 		layers, err := img.Layers()
 		require.NoError(t, err)
@@ -1599,14 +1700,23 @@ func TestServerCacheAccessProof(t *testing.T) {
 		layer := layers[0]
 		digest, err := layer.Digest()
 		require.NoError(t, err)
+		layerSize, layerMediaType := layerMetadata(t, layer)
 		expectedData := layerData(t, layer)
 
 		_, bsClient, acClient := setupCacheEnv(t)
 		server := newTestServerWithCache(t, bsClient, acClient)
 		ref := imageName + "@" + digest.String()
+		manifestRef := imageName + "@" + manifestDigest
 
+		// Providing the manifest ref, size, and media type lets the server cache
+		// the blob (and its metadata) on this miss.
 		stream := &mockFetchBlobServer{ctx: context.Background()}
-		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: ref}, stream)
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref:         ref,
+			ManifestRef: manifestRef,
+			Size:        ptr(layerSize),
+			MediaType:   ptr(layerMediaType),
+		}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
 
@@ -1616,15 +1726,24 @@ func TestServerCacheAccessProof(t *testing.T) {
 		}, acClient)
 		counter.Reset()
 		stream = &mockFetchBlobServer{ctx: context.Background()}
-		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: ref}, stream)
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{
+			Ref:         ref,
+			ManifestRef: manifestRef,
+			Size:        ptr(layerSize),
+			MediaType:   ptr(layerMediaType),
+		}, stream)
 		require.NoError(t, err)
 		require.Equal(t, expectedData, stream.collectData())
 
 		blobPath := "/v2/test-image/blobs/" + digest.String()
+		manifestPath := "/v2/test-image/manifests/" + manifestDigest
+		// The metadata cache hit proves access via a manifest HEAD, then the blob
+		// cache read misses (bytes evicted), so the blob is fetched via GET. No
+		// blob HEADs are issued.
 		assertRequests(t, counter, map[string]int{
-			http.MethodGet + " /v2/":         1,
-			http.MethodHead + " " + blobPath: 2,
-			http.MethodGet + " " + blobPath:  1,
+			http.MethodGet + " /v2/":             1,
+			http.MethodHead + " " + manifestPath: 1,
+			http.MethodGet + " " + blobPath:      1,
 		})
 	})
 }
@@ -1668,6 +1787,7 @@ func TestFetchBlobSingleflightHappyPath(t *testing.T) {
 	blocker := newBlockingInterceptor()
 	reg, counter := setupRegistry(t, nil, blocker.intercept)
 	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	manifestDigest, _, _ := imageMetadata(t, img)
 
 	layers, err := img.Layers()
 	require.NoError(t, err)
@@ -1676,13 +1796,19 @@ func TestFetchBlobSingleflightHappyPath(t *testing.T) {
 	layer := layers[0]
 	digest, err := layer.Digest()
 	require.NoError(t, err)
+	layerSize, layerMediaType := layerMetadata(t, layer)
 	expectedData := layerData(t, layer)
 
 	_, bsClient, acClient := setupCacheEnv(t)
 	server := newTestServerWithCache(t, bsClient, acClient)
 
+	// Provide the manifest ref, size, and media type so the leader caches the
+	// blob and waiters can read it from cache.
 	req := &ofpb.FetchBlobRequest{
-		Ref: imageName + "@" + digest.String(),
+		Ref:         imageName + "@" + digest.String(),
+		ManifestRef: imageName + "@" + manifestDigest,
+		Size:        ptr(layerSize),
+		MediaType:   ptr(layerMediaType),
 	}
 
 	blocker.enable()
@@ -1716,6 +1842,7 @@ func TestFetchBlobSingleflightCacheHit(t *testing.T) {
 
 	reg, counter := setupRegistry(t, nil, nil)
 	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	manifestDigest, _, _ := imageMetadata(t, img)
 
 	layers, err := img.Layers()
 	require.NoError(t, err)
@@ -1724,13 +1851,20 @@ func TestFetchBlobSingleflightCacheHit(t *testing.T) {
 	layer := layers[0]
 	digest, err := layer.Digest()
 	require.NoError(t, err)
+	layerSize, layerMediaType := layerMetadata(t, layer)
 	expectedData := layerData(t, layer)
 
 	_, bsClient, acClient := setupCacheEnv(t)
 	server := newTestServerWithCache(t, bsClient, acClient)
 
+	// Provide the manifest ref, size, and media type so the blob is cached on
+	// the first fetch and concurrent fetches can be served from cache (access is
+	// proven via the manifest ref).
 	req := &ofpb.FetchBlobRequest{
-		Ref: imageName + "@" + digest.String(),
+		Ref:         imageName + "@" + digest.String(),
+		ManifestRef: imageName + "@" + manifestDigest,
+		Size:        ptr(layerSize),
+		MediaType:   ptr(layerMediaType),
 	}
 
 	stream := &mockFetchBlobServer{ctx: context.Background()}
@@ -1980,10 +2114,7 @@ func TestFetchBlobSingleflightDifferentCredentials(t *testing.T) {
 		// Three blob GETs: one for creds1 (succeeds), two for creds2
 		// (first attempt 401, retry 401).
 		http.MethodGet + " " + blobPath: 3,
-		// Three blob HEADs for layer.Size(): one for creds1 (succeeds),
-		// two for creds2 (Size is fetched before Compressed, so each
-		// attempt calls it before the blob GET fails).
-		http.MethodHead + " " + blobPath: 3,
+		// No blob HEADs: the server no longer issues blob HEAD requests.
 	})
 }
 

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
@@ -81,10 +81,11 @@ func (s *OCIFetcherServerProxy) FetchBlob(req *ofpb.FetchBlobRequest, stream ofp
 		return err
 	}
 
-	size, err := s.fetchBlobMetadataSize(ctx, req)
-	if err != nil {
-		return err
+	if req.Size == nil {
+		log.CtxInfof(ctx, "FetchBlob request for %q has no size; streaming through without local proxy caching", req.GetRef())
+		return s.fetchBlobFromUpstreamToResponse(ctx, req, stream)
 	}
+	size := req.GetSize()
 
 	// Also check FailedPrecondition: cachetools.GetBlob wraps NotFound cache
 	// misses as FailedPrecondition via MissingDigestError.
@@ -113,18 +114,6 @@ func parseBlobDigestRef(ref string) (ctrname.Digest, ctr.Hash, error) {
 	return digestRef, hash, nil
 }
 
-func (s *OCIFetcherServerProxy) fetchBlobMetadataSize(ctx context.Context, req *ofpb.FetchBlobRequest) (int64, error) {
-	metaResp, err := s.remote.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{
-		Ref:            req.GetRef(),
-		Credentials:    req.GetCredentials(),
-		BypassRegistry: req.GetBypassRegistry(),
-	})
-	if err != nil {
-		return 0, err
-	}
-	return metaResp.GetSize(), nil
-}
-
 func (s *OCIFetcherServerProxy) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef ctrname.Digest, hash ctr.Hash, size int64, req *ofpb.FetchBlobRequest) error {
 	// Deduplicate concurrent upstream fetches for the same blob+creds.
 	// The leader fetches from upstream and writes to local BSS.
@@ -147,6 +136,25 @@ func (s *OCIFetcherServerProxy) dedupedFetchBlob(ctx context.Context, stream ofp
 
 	// Stream the blob from local BSS to the caller.
 	return fetchBlobFromLocalBS(ctx, s.localBSClient, hash, size, &grpcStreamWriter{stream: stream})
+}
+
+func (s *OCIFetcherServerProxy) fetchBlobFromUpstreamToResponse(ctx context.Context, req *ofpb.FetchBlobRequest, stream ofpb.OCIFetcher_FetchBlobServer) error {
+	remoteStream, err := s.remote.FetchBlob(ctx, req)
+	if err != nil {
+		return err
+	}
+	for {
+		resp, err := remoteStream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
 }
 
 // fetchBlobFromUpstreamToLocalBS fetches a blob from the upstream OCIFetcher

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -206,9 +207,9 @@ func TestFetchBlob_ForwardsRequestUnchanged(t *testing.T) {
 		mediaType *string
 	}{
 		{name: "NoSizeOrMediaType"},
-		{name: "SizeOnly", size: gproto.Int64(12345)},
+		{name: "SizeOnly", size: gproto.Int64(int64(len(blobData)))},
 		{name: "MediaTypeOnly", mediaType: gproto.String("application/vnd.example.layer.v1.tar+gzip")},
-		{name: "SizeAndMediaType", size: gproto.Int64(12345), mediaType: gproto.String("application/vnd.example.layer.v1.tar+gzip")},
+		{name: "SizeAndMediaType", size: gproto.Int64(int64(len(blobData))), mediaType: gproto.String("application/vnd.example.layer.v1.tar+gzip")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -227,6 +228,7 @@ func TestFetchBlob_ForwardsRequestUnchanged(t *testing.T) {
 			require.Equal(t, blobData, collectBlobData(t, stream))
 			require.NotNil(t, remoteClient.fetchBlobRequest)
 			require.Empty(t, cmp.Diff(req, remoteClient.fetchBlobRequest, protocmp.Transform()))
+			require.Zero(t, remoteClient.fetchBlobMetadataCount, "FetchBlob should not call FetchBlobMetadata")
 		})
 	}
 }
@@ -285,6 +287,45 @@ func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
 	require.NoError(t, err)
 	data2 := collectBlobData(t, stream2)
 	require.Equal(t, expectedData, data2)
+}
+
+func TestFetchBlobWithoutSizeDoesNotFetchBlobMetadata(t *testing.T) {
+	ctx := context.Background()
+	counter := testhttp.NewRequestCounter()
+	var failBlobHead atomic.Bool
+	reg := testregistry.Run(t, testregistry.Opts{
+		HttpInterceptor: func(w http.ResponseWriter, r *http.Request) bool {
+			counter.Inc(r)
+			if failBlobHead.Load() && r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/") {
+				w.WriteHeader(http.StatusUnauthorized)
+				return false
+			}
+			return true
+		},
+	})
+	imageName, img := reg.PushNamedImage(t, "test-no-size", nil)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layer := layers[0]
+	digest, err := layer.Digest()
+	require.NoError(t, err)
+	expectedData := layerData(t, layer)
+	blobRef := imageName + "@" + digest.String()
+
+	_, bsClient, acClient := setupCacheEnv(t)
+	ociFetcherClient := runOCIFetcherServer(ctx, t, bsClient, acClient)
+	proxyClient := runOCIFetcherProxy(ctx, t, ociFetcherClient)
+
+	failBlobHead.Store(true)
+	counter.Reset()
+	stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: blobRef})
+	require.NoError(t, err)
+	require.Equal(t, expectedData, collectBlobData(t, stream))
+
+	snap := counter.Snapshot()
+	require.Positive(t, snap[http.MethodGet+" /v2/test-no-size/blobs/"+digest.String()], "should fetch the blob via GET")
+	require.Zero(t, snap[http.MethodHead+" /v2/test-no-size/blobs/"+digest.String()], "must not issue a blob HEAD")
 }
 
 // TestBypassRegistry tests the bypass_registry flag crossed with server admin claims
@@ -727,6 +768,7 @@ func TestFetchBlob_Singleflight(t *testing.T) {
 	layer := layers[0]
 	digest, err := layer.Digest()
 	require.NoError(t, err)
+	layerSize, _ := layerMetadata(t, layer)
 	expectedData := layerData(t, layer)
 
 	_, bsClient, acClient := setupCacheEnv(t)
@@ -745,7 +787,10 @@ func TestFetchBlob_Singleflight(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: ref})
+			stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{
+				Ref:  ref,
+				Size: gproto.Int64(layerSize),
+			})
 			if err != nil {
 				errs[idx] = err
 				return
@@ -904,7 +949,8 @@ func (c *countingOCIFetcherClient) FetchBlobMetadata(ctx context.Context, req *o
 }
 
 type recordingOCIFetcherClient struct {
-	fetchBlobRequest *ofpb.FetchBlobRequest
+	fetchBlobRequest       *ofpb.FetchBlobRequest
+	fetchBlobMetadataCount int
 }
 
 func (c *recordingOCIFetcherClient) FetchManifest(ctx context.Context, req *ofpb.FetchManifestRequest, opts ...grpc.CallOption) (*ofpb.FetchManifestResponse, error) {
@@ -921,6 +967,7 @@ func (c *recordingOCIFetcherClient) FetchBlob(ctx context.Context, req *ofpb.Fet
 }
 
 func (c *recordingOCIFetcherClient) FetchBlobMetadata(ctx context.Context, req *ofpb.FetchBlobMetadataRequest, opts ...grpc.CallOption) (*ofpb.FetchBlobMetadataResponse, error) {
+	c.fetchBlobMetadataCount++
 	return &ofpb.FetchBlobMetadataResponse{Size: 5}, nil
 }
 

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy_test.go
@@ -239,6 +239,7 @@ func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
 
 	reg := setupTestRegistry(t, nil)
 	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	manifestDigest, _, _ := imageMetadata(t, img)
 
 	layers, err := img.Layers()
 	require.NoError(t, err)
@@ -246,6 +247,7 @@ func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
 	layer := layers[0]
 	digest, err := layer.Digest()
 	require.NoError(t, err)
+	layerSize, layerMediaType := layerMetadata(t, layer)
 	expectedData := layerData(t, layer)
 
 	_, bsClient, acClient := setupCacheEnv(t)
@@ -254,9 +256,16 @@ func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
 	proxyClient := runOCIFetcherProxy(ctx, t, ociFetcherClient)
 
 	ref := imageName + "@" + digest.String()
+	manifestRef := imageName + "@" + manifestDigest
 
-	// First fetch: should go to upstream and write to local cache.
-	stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: ref})
+	// First fetch: should go to upstream and write to local cache. Providing
+	// the manifest ref, size, and media type lets the server cache the blob.
+	stream, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{
+		Ref:         ref,
+		ManifestRef: manifestRef,
+		Size:        gproto.Int64(layerSize),
+		MediaType:   gproto.String(layerMediaType),
+	})
 	require.NoError(t, err)
 	data := collectBlobData(t, stream)
 	require.Equal(t, expectedData, data)
@@ -267,7 +276,12 @@ func TestFetchBlob_LocalCacheWriteThrough(t *testing.T) {
 
 	// Second fetch: access was proven on the first fetch, so this is served
 	// from the local BS cache without contacting the (now-stopped) registry.
-	stream2, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{Ref: ref})
+	stream2, err := proxyClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{
+		Ref:         ref,
+		ManifestRef: manifestRef,
+		Size:        gproto.Int64(layerSize),
+		MediaType:   gproto.String(layerMediaType),
+	})
 	require.NoError(t, err)
 	data2 := collectBlobData(t, stream2)
 	require.Equal(t, expectedData, data2)

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -606,7 +606,7 @@ func newImageFromRawManifest(ctx context.Context, repo ctrname.Repository, desc 
 			manifest.Config.Digest,
 			i,
 			i.puller,
-			nil,
+			&manifest.Config,
 		)
 
 		rc, err := layer.Uncompressed()
@@ -834,14 +834,28 @@ func (l *layerFromDigest) fetchFromRemote() (io.ReadCloser, error) {
 	}
 	if l.image.useOCIFetcher {
 		ref := l.repo.Digest(l.digest.String())
+		// Pass the manifest this blob belongs to so the server can prove repo
+		// access with a manifest HEAD rather than a blob HEAD (some registries,
+		// e.g. public.ecr.aws, reject blob HEADs even when the GET is allowed).
+		manifestRef := l.repo.Digest(l.image.desc.Digest.String())
+		req := &ofpb.FetchBlobRequest{
+			Ref:            ref.String(),
+			ManifestRef:    manifestRef.String(),
+			Credentials:    l.image.credentials.ToProto(),
+			BypassRegistry: l.image.credentials.bypassRegistry,
+		}
+		// Pass the blob's size and media type (from the manifest descriptor) so
+		// the server can write the blob to cache without a metadata blob HEAD.
+		if l.desc != nil {
+			size := l.desc.Size
+			mediaType := string(l.desc.MediaType)
+			req.Size = &size
+			req.MediaType = &mediaType
+		}
 		// Create a cancellable context so that Close() can abort the stream
 		// if the caller doesn't read to EOF.
 		ctx, cancel := context.WithCancel(l.image.ctx)
-		stream, err := l.image.ociFetcherClient.FetchBlob(ctx, &ofpb.FetchBlobRequest{
-			Ref:            ref.String(),
-			Credentials:    l.image.credentials.ToProto(),
-			BypassRegistry: l.image.credentials.bypassRegistry,
-		})
+		stream, err := l.image.ociFetcherClient.FetchBlob(ctx, req)
 		if err != nil {
 			cancel()
 			return nil, err

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -714,17 +714,7 @@ func (i *imageFromRawManifest) Layers() ([]ctr.Layer, error) {
 }
 
 func (i *imageFromRawManifest) LayerByDigest(digest ctr.Hash) (ctr.Layer, error) {
-	return newLayerFromDigest(
-		i.repo,
-		digest,
-		i,
-		i.puller,
-		nil,
-	), nil
-}
-
-func (i *imageFromRawManifest) LayerByDiffID(diffID ctr.Hash) (ctr.Layer, error) {
-	digest, err := partial.DiffIDToBlob(i, diffID)
+	desc, err := i.descriptorForDigest(digest)
 	if err != nil {
 		return nil, err
 	}
@@ -733,8 +723,47 @@ func (i *imageFromRawManifest) LayerByDiffID(diffID ctr.Hash) (ctr.Layer, error)
 		digest,
 		i,
 		i.puller,
-		nil,
+		desc,
 	), nil
+}
+
+func (i *imageFromRawManifest) LayerByDiffID(diffID ctr.Hash) (ctr.Layer, error) {
+	digest, err := partial.DiffIDToBlob(i, diffID)
+	if err != nil {
+		return nil, err
+	}
+	desc, err := i.descriptorForDigest(digest)
+	if err != nil {
+		return nil, err
+	}
+	return newLayerFromDigest(
+		i.repo,
+		digest,
+		i,
+		i.puller,
+		desc,
+	), nil
+}
+
+// descriptorForDigest returns the manifest descriptor (config or layer) for the
+// given blob digest, so callers can supply the blob's size and media type
+// without a registry round-trip. It returns nil (not an error) when the digest
+// isn't referenced by the manifest; the blob is then fetched without
+// write-through caching.
+func (i *imageFromRawManifest) descriptorForDigest(digest ctr.Hash) (*ctr.Descriptor, error) {
+	manifest, err := i.Manifest()
+	if err != nil {
+		return nil, err
+	}
+	if manifest.Config.Digest == digest {
+		return &manifest.Config, nil
+	}
+	for idx := range manifest.Layers {
+		if manifest.Layers[idx].Digest == digest {
+			return &manifest.Layers[idx], nil
+		}
+	}
+	return nil, nil
 }
 
 func newLayerFromDigest(repo ctrname.Repository, digest ctr.Hash, image *imageFromRawManifest, puller *remote.Puller, desc *ctr.Descriptor) *layerFromDigest {

--- a/enterprise/server/util/oci/oci_test.go
+++ b/enterprise/server/util/oci/oci_test.go
@@ -1023,10 +1023,9 @@ func TestResolve_Concurrency(t *testing.T) {
 	imageAddress := registry.ImageAddress(imageName + "_image")
 	expected := map[string]int{
 		http.MethodGet + " /v2/": 1,
-		http.MethodHead + " /v2/" + imageName + "_image/manifests/latest":               1,
-		http.MethodGet + " /v2/" + imageName + "_image/manifests/latest":                1,
-		http.MethodHead + " /v2/" + imageName + "_image/blobs/" + configDigest.String(): 1,
-		http.MethodGet + " /v2/" + imageName + "_image/blobs/" + configDigest.String():  1,
+		http.MethodHead + " /v2/" + imageName + "_image/manifests/latest":              1,
+		http.MethodGet + " /v2/" + imageName + "_image/manifests/latest":               1,
+		http.MethodGet + " /v2/" + imageName + "_image/blobs/" + configDigest.String(): 1,
 	}
 	for digest := range pushedDigestToFiles {
 		expected[http.MethodGet+" /v2/"+imageName+"_image/blobs/"+digest.String()] = 1
@@ -1673,11 +1672,10 @@ func TestResolveWithOCIFetcher_Layers_DiffIDs(t *testing.T) {
 				require.NoError(t, err)
 				// With OCIFetcher, fetching the config blob uses FetchBlob which:
 				// - Reuses the puller from Resolve() (no additional GET /v2/)
-				// - Makes a HEAD request for the config blob to get size for caching
-				// - Makes a GET request for the config blob data
+				// - Makes a GET request for the config blob data (no blob HEAD;
+				//   the config descriptor carries size/media type)
 				expected = map[string]int{
-					http.MethodHead + " /v2/" + nameToResolve + "/blobs/" + configDigest.String(): 1,
-					http.MethodGet + " /v2/" + nameToResolve + "/blobs/" + configDigest.String():  1,
+					http.MethodGet + " /v2/" + nameToResolve + "/blobs/" + configDigest.String(): 1,
 				}
 
 				// To make the DiffID() request counts always be zero,
@@ -1741,18 +1739,16 @@ func TestResolveWithOCIFetcher_Concurrency(t *testing.T) {
 	// - 1 HEAD manifest: From FetchManifest (which does HEAD before GET)
 	//   Note: We skip the separate FetchManifestMetadata call when using OCIFetcher
 	// - 1 GET manifest
-	// - 1 HEAD + 1 GET for config blob
-	// - 1 HEAD + 1 GET for each layer blob (HEAD is for getting size for caching)
+	// - 1 GET for config blob (no blob HEAD; size/media type come from the descriptor)
+	// - 1 GET for each layer blob (no blob HEAD)
 	expected := map[string]int{
 		http.MethodGet + " /v2/": 1,
-		http.MethodHead + " /v2/" + imageName + "_image/manifests/latest":               1,
-		http.MethodGet + " /v2/" + imageName + "_image/manifests/latest":                1,
-		http.MethodHead + " /v2/" + imageName + "_image/blobs/" + configDigest.String(): 1,
-		http.MethodGet + " /v2/" + imageName + "_image/blobs/" + configDigest.String():  1,
+		http.MethodHead + " /v2/" + imageName + "_image/manifests/latest":              1,
+		http.MethodGet + " /v2/" + imageName + "_image/manifests/latest":               1,
+		http.MethodGet + " /v2/" + imageName + "_image/blobs/" + configDigest.String(): 1,
 	}
 	for digest := range pushedDigestToFiles {
 		expected[http.MethodGet+" /v2/"+imageName+"_image/blobs/"+digest.String()] = 1
-		expected[http.MethodHead+" /v2/"+imageName+"_image/blobs/"+digest.String()] = 1
 	}
 	counter.Reset()
 	c := &claims.Claims{UserID: "US123"}

--- a/proto/oci_fetcher.proto
+++ b/proto/oci_fetcher.proto
@@ -73,6 +73,12 @@ message FetchBlobRequest {
   bool bypass_registry = 3;
   optional int64 size = 4;
   optional string media_type = 5;
+  // The manifest the blob belongs to, e.g. gcr.io/org/repo@sha256:...
+  // (manifest digest reference, same repository as ref). When set, the server
+  // proves repository access with a HEAD of this manifest instead of a blob
+  // HEAD, which some registries (e.g. public.ecr.aws) reject even when the
+  // blob GET is authorized. When unset, the server falls back to a blob HEAD.
+  string manifest_ref = 6;
 }
 
 message FetchBlobResponse {

--- a/proto/oci_fetcher.proto
+++ b/proto/oci_fetcher.proto
@@ -77,7 +77,8 @@ message FetchBlobRequest {
   // (manifest digest reference, same repository as ref). When set, the server
   // proves repository access with a HEAD of this manifest instead of a blob
   // HEAD, which some registries (e.g. public.ecr.aws) reject even when the
-  // blob GET is authorized. When unset, the server falls back to a blob HEAD.
+  // blob GET is authorized. When unset, the server fetches the blob from the
+  // registry, where the blob GET proves access as a side effect.
   string manifest_ref = 6;
 }
 


### PR DESCRIPTION
AWS public ECR always responds HTTP 401 for HEAD requests on blobs.