### PR TITLE
Measure buildroot disk usage after remote execution tasks complete (flag-guarded)

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -384,13 +384,14 @@ func (s *ExecutionServer) updateExecutionPostCompletion(ctx context.Context, exe
 		// Stage must be COMPLETED, otherwise mergeExecutionUpdates drops this
 		// event as "execution progress appears to restart" after the first
 		// COMPLETED.
-		Stage:                 int64(repb.ExecutionStage_COMPLETED),
-		UpdatedAtUsec:         time.Now().UnixMicro(),
-		PauseDurationUsec:     stats.GetPauseDurationUsec(),
-		SnapshotSavedLocally:  fcStats.GetSnapshotSavedLocally(),
-		SnapshotSavedRemotely: fcStats.GetSnapshotSavedRemotely(),
-		SnapshotIsDiff:        fcStats.GetSnapshotIsDiff(),
-		SnapshotSavedBytes:    fcStats.GetSnapshotSavedBytes(),
+		Stage:                   int64(repb.ExecutionStage_COMPLETED),
+		UpdatedAtUsec:           time.Now().UnixMicro(),
+		PauseDurationUsec:       stats.GetPauseDurationUsec(),
+		SnapshotSavedLocally:    fcStats.GetSnapshotSavedLocally(),
+		SnapshotSavedRemotely:   fcStats.GetSnapshotSavedRemotely(),
+		SnapshotIsDiff:          fcStats.GetSnapshotIsDiff(),
+		SnapshotSavedBytes:      fcStats.GetSnapshotSavedBytes(),
+		BuildrootDiskUsageBytes: stats.GetBuildrootDiskUsageBytes(),
 	}
 	return s.executionCollector.UpdateInProgressExecution(ctx, execution)
 }

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -82,6 +82,8 @@ var (
 	resolveImageDigests       = flag.Bool("executor.resolve_image_digests", false, "Whether to resolve image names with tags to digests.")
 
 	overlayfsEnabled = flag.Bool("executor.workspace.overlayfs_enabled", false, "Enable overlayfs support for anonymous action workspaces. ** UNSTABLE **")
+
+	measureWorkspaceDiskUsage = flag.Bool("executor.workspace.measure_disk_usage", false, "If set, measure the disk space used by the task's buildroot (workspace) after each task finishes and report it in the task's usage stats. Note: this requires walking the entire workspace tree, which may add CPU/IO overhead for tasks with large workspaces.")
 )
 
 const (
@@ -233,6 +235,11 @@ type taskRunner struct {
 
 	memoryUsageBytes int64
 	diskUsageBytes   int64
+
+	// measuredWorkspaceDiskUsageBytes is the disk usage of the workspace
+	// measured during the recycle/cleanup path (see measureWorkspaceDiskUsage).
+	// Reported via PostCompletionStats.
+	measuredWorkspaceDiskUsageBytes int64
 }
 
 func (r *taskRunner) Metadata() *espb.RunnerMetadata {
@@ -469,6 +476,31 @@ func (r *taskRunner) Run(ctx context.Context, ioStats *repb.IOStats) (res *inter
 	return execResult
 }
 
+// measureWorkspaceDiskUsage measures the disk space used by the task's
+// workspace (buildroot) and stashes it so it can be reported via
+// PostCompletionStats. It is called from the recycle/cleanup path (after the
+// result has been returned to the client and before the workspace is cleaned
+// up), so it doesn't add latency to task completion.
+func (r *taskRunner) measureWorkspaceDiskUsage(ctx context.Context) {
+	if !*measureWorkspaceDiskUsage {
+		return
+	}
+
+	// VM runners report file system usage measured inside the VM. Their host's
+	// workspace only holds the VM disk image, so they are skipped.
+	if _, ok := r.Container.Delegate.(container.VM); ok {
+		return
+	}
+	start := time.Now()
+	usage, err := r.Workspace.DiskUsageBytes()
+	if err != nil {
+		log.CtxWarningf(ctx, "Failed to measure workspace disk usage: %s", err)
+		return
+	}
+	metrics.RemoteExecutionBuildrootDiskUsageMeasurementDurationUsec.Observe(float64(time.Since(start).Microseconds()))
+	r.measuredWorkspaceDiskUsageBytes = usage
+}
+
 func (r *taskRunner) GracefulTerminate(ctx context.Context) error {
 	return r.Container.Signal(ctx, syscall.SIGTERM)
 }
@@ -506,10 +538,17 @@ func (r *taskRunner) GetIsolationType() string {
 	return r.PlatformProperties.WorkloadIsolationType
 }
 
-// PostCompletionStats returns observability data produced by the underlying
-// Container after Exec or Run have completed.
+// PostCompletionStats returns observability data produced after Exec or Run
+// have completed, including data gathered during the recycle/cleanup path.
 func (r *taskRunner) PostCompletionStats() *espb.PostCompletionStats {
-	return r.Container.PostCompletionStats()
+	stats := r.Container.PostCompletionStats()
+	if r.measuredWorkspaceDiskUsageBytes > 0 {
+		if stats == nil {
+			stats = &espb.PostCompletionStats{}
+		}
+		stats.BuildrootDiskUsageBytes = r.measuredWorkspaceDiskUsageBytes
+	}
+	return stats
 }
 
 // shutdown runs any manual cleanup required to clean up processes before
@@ -1508,6 +1547,11 @@ func (p *pool) TryRecycle(ctx context.Context, r interfaces.Runner, finishedClea
 		alert.UnexpectedEvent("unexpected_runner_type", "unexpected runner type %T", r)
 		return
 	}
+
+	// Measure workspace disk usage before the workspace is cleaned up or
+	// removed below. This runs after the result has been returned to the
+	// client, so it doesn't add latency to task completion.
+	cr.measureWorkspaceDiskUsage(ctx)
 
 	recycled := false
 	defer func() {

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -168,6 +168,14 @@ message PostCompletionStats {
 
   // Firecracker-specific post-execution stats. Nil for non-firecracker runners.
   FirecrackerPostExecStats firecracker_post_exec_stats = 2;
+
+  // Disk space used by the task's workspace (buildroot), in bytes, measured
+  // just before the workspace is cleaned up. This is the logical (apparent)
+  // size summed across the workspace tree. Only populated when
+  // executor.workspace.measure_disk_usage is enabled, and not populated for
+  // VM-based runners. Measured off the task's critical path, so it does not add
+  // latency to task completion.
+  int64 buildroot_disk_usage_bytes = 3;
 }
 
 message FirecrackerPostExecStats {

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -3076,4 +3076,8 @@ message StoredExecution {
   int64 snapshot_saved_bytes = 86;
   // Wall-clock duration of Container.Pause.
   int64 pause_duration_usec = 87;
+  // Disk space used by the task's workspace (buildroot), in bytes, measured
+  // after the task finishes. Only populated when
+  // executor.workspace.measure_disk_usage is enabled.
+  int64 buildroot_disk_usage_bytes = 88;
 }

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1251,6 +1251,14 @@ var (
 		StatusHumanReadableLabel,
 	})
 
+	RemoteExecutionBuildrootDiskUsageMeasurementDurationUsec = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "buildroot_disk_usage_measurement_duration_usec",
+		Help:      "Duration of the buildroot (workspace) disk usage measurement performed after a task finishes, in **microseconds**.",
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*time.Minute, 2),
+	})
+
 	RemoteExecutionResourceUsageTimelineMetadataSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -464,6 +464,7 @@ func ExecutionFromProto(in *repb.StoredExecution, inv *sipb.StoredInvocation) (*
 		SnapshotIsDiff:                     in.GetSnapshotIsDiff(),
 		SnapshotSavedBytes:                 in.GetSnapshotSavedBytes(),
 		PauseDurationUsec:                  in.GetPauseDurationUsec(),
+		BuildrootDiskUsageBytes:            in.GetBuildrootDiskUsageBytes(),
 	}
 
 	if err := FillExecutionResourceFieldsFromExecutionID(out, in.GetExecutionId()); err != nil {

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -285,6 +285,11 @@ type Execution struct {
 	SnapshotSavedBytes    int64 `gorm:"codec:T64,ZSTD(1)"`
 	PauseDurationUsec     int64 `gorm:"codec:T64,ZSTD(1)"`
 
+	// Disk usage of the task's workspace (buildroot), measured after the task
+	// finishes. Only populated when executor.workspace.measure_disk_usage is
+	// enabled.
+	BuildrootDiskUsageBytes int64 `gorm:"codec:T64,ZSTD(1)"`
+
 	Experiments []string `gorm:"type:Array(LowCardinality(String))"`
 
 	// Long string fields
@@ -396,6 +401,7 @@ func (e *Execution) AdditionalFields() []string {
 		"SnapshotIsDiff",
 		"SnapshotSavedBytes",
 		"PauseDurationUsec",
+		"BuildrootDiskUsageBytes",
 		"ExecutorHostname",
 		"Experiments",
 		"ClientIP",


### PR DESCRIPTION
My goal here is to enable this in dev to see how long this measurement takes to determine if it's feasible to do this in prod.

One limitation of this approach is that it only measures the buildroot size once, at the end of the action, so if the action deletes things from the buildroot then this measurement won't capture the maximum size of the buildroot. Again, once we have a sense of how long this measurement takes generally, we can explore a polling approach or some other alternative.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7351