### PR TITLE
Double the size of the pebble table cache (again)

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -531,7 +531,7 @@ func defaultPebbleOptions(mc *pebble.MetricsCollector, pcOpts *Options) *pebble.
 		L0CompactionThreshold:    2,
 		MaxConcurrentCompactions: func() int { return 18 },
 		MemTableSize:             64 << 20, // 64 MB
-		MaxOpenFiles:             2000,     // double the default
+		MaxOpenFiles:             4000,     // 4x the default
 		EventListener: &pebble.EventListener{
 			BackgroundError: mc.BackgroundError,
 			WriteStallBegin: mc.WriteStallBegin,


### PR DESCRIPTION
When I did this originally in https://github.com/buildbuddy-io/buildbuddy/pull/9818, in improved that table cache hit rate, but it's since regressed to about 94%.

This change only adds 2MB of memory to each server.