### PR TITLE
cache_proxies: show regional proxies

### DIFF
--- a/enterprise/app/cache_proxies/cache_proxies.tsx
+++ b/enterprise/app/cache_proxies/cache_proxies.tsx
@@ -63,33 +63,52 @@ class CacheProxySetup extends React.Component<CacheProxySetupProps> {
 }
 
 interface CacheProxiesListProps {
-  proxies: RegionalCacheProxy[];
+  regions: RegionalCacheProxyResponse[];
 }
 
 class CacheProxiesList extends React.Component<CacheProxiesListProps> {
   render() {
+    const proxiesByKey = new Map<string, RegionalCacheProxy>();
+    for (const r of this.props.regions) {
+      for (const proxy of r.response.cacheProxy) {
+        if (!proxy.node) {
+          continue;
+        }
+        proxiesByKey.set(`${r.name}-${proxy.node.proxyId}`, {
+          region: r.name,
+          proxy,
+          node: proxy.node as cache_proxy.CacheProxyNode,
+        });
+      }
+    }
+    const keys = Array.from(proxiesByKey.keys()).sort();
+
     return (
       <div className="cache-proxy-cards">
         <div className="cache-proxy-summary">
           <Hash />
           <span>
             <b>
-              {this.props.proxies.length} {this.props.proxies.length === 1 ? "cache proxy" : "cache proxies"}
+              {keys.length} {keys.length === 1 ? "cache proxy" : "cache proxies"}
             </b>
           </span>
         </div>
-        {this.props.proxies.map(
-          ({ region, proxy }) =>
-            proxy.node && (
-              <CacheProxyCardComponent
-                key={`${region}-${proxy.node.proxyId}`}
-                region={region}
-                node={proxy.node as cache_proxy.CacheProxyNode}
-                lastCheckInTime={proxy.lastCheckInTime}
-                statistics={proxy.statistics}
-              />
-            )
-        )}
+        {keys.map((key) => {
+          const regionalProxy = proxiesByKey.get(key);
+          if (!regionalProxy) {
+            return null;
+          }
+          const { region, proxy, node } = regionalProxy;
+          return (
+            <CacheProxyCardComponent
+              key={key}
+              region={region}
+              node={node}
+              lastCheckInTime={proxy.lastCheckInTime}
+              statistics={proxy.statistics}
+            />
+          );
+        })}
       </div>
     );
   }
@@ -105,10 +124,16 @@ interface Props {
 type RegionalCacheProxy = {
   region: string;
   proxy: cache_proxy.GetCacheProxiesResponse.ICacheProxy;
+  node: cache_proxy.CacheProxyNode;
+};
+
+type RegionalCacheProxyResponse = {
+  name: string;
+  response: cache_proxy.GetCacheProxiesResponse;
 };
 
 interface State {
-  regions: { name: string; response: cache_proxy.GetCacheProxiesResponse }[];
+  regions: RegionalCacheProxyResponse[];
   proxyKeys: api_key.IApiKey[];
   loading: FetchType[];
   error: BuildBuddyError | null;
@@ -164,19 +189,27 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
       loading: [...prevState.loading, FetchType.Proxies],
     }));
     try {
-      const regions = rpcService.regionalServices.size
-        ? await Promise.all(
-            Array.from(rpcService.regionalServices).map(([name, service]) =>
-              service.getCacheProxies(cache_proxy.GetCacheProxiesRequest.create({})).then((resp) => {
-                return { name: name, response: resp };
-              })
-            )
+      let regions: RegionalCacheProxyResponse[];
+      if (rpcService.regionalServices.size) {
+        const results = await Promise.allSettled(
+          Array.from(rpcService.regionalServices).map(([name, service]) =>
+            service.getCacheProxies(cache_proxy.GetCacheProxiesRequest.create({})).then((resp) => {
+              return { name: name, response: resp };
+            })
           )
-        : [
-            await rpcService.service.getCacheProxies(cache_proxy.GetCacheProxiesRequest.create({})).then((resp) => {
-              return { name: "", response: resp };
-            }),
-          ];
+        );
+        regions = results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : []));
+        if (regions.length == 0) {
+          const rejected = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+          throw rejected?.reason;
+        }
+      } else {
+        regions = [
+          await rpcService.service.getCacheProxies(cache_proxy.GetCacheProxiesRequest.create({})).then((resp) => {
+            return { name: "", response: resp };
+          }),
+        ];
+      }
       this.setState({ regions });
     } catch (e) {
       this.setState({ error: BuildBuddyError.parse(e) });
@@ -214,10 +247,7 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
   }
 
   render() {
-    const proxies = this.state.regions.flatMap((r) =>
-      r.response.cacheProxy.map((proxy) => ({ region: r.name, proxy }))
-    );
-    const hasProxies = proxies.length > 0;
+    const hasProxies = this.state.regions.some((r) => r.response.cacheProxy.some((proxy) => proxy.node));
     const hasKeys = this.state.proxyKeys.length > 0;
     // When neither proxies nor cache-proxy API keys exist, skip the tab UI
     // and show a single clean empty-state view (matching the executors page
@@ -263,7 +293,7 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
                         <p>Click the "Setup" tab for instructions on self-hosting cache proxies.</p>
                       </div>
                     )}
-                    {hasProxies && <CacheProxiesList proxies={proxies} />}
+                    {hasProxies && <CacheProxiesList regions={this.state.regions} />}
                   </>
                 )}
                 {activeTab === "setup" && <CacheProxySetup user={this.props.user} proxyKeys={this.state.proxyKeys} />}

--- a/enterprise/app/cache_proxies/cache_proxies.tsx
+++ b/enterprise/app/cache_proxies/cache_proxies.tsx
@@ -63,7 +63,7 @@ class CacheProxySetup extends React.Component<CacheProxySetupProps> {
 }
 
 interface CacheProxiesListProps {
-  proxies: cache_proxy.GetCacheProxiesResponse.ICacheProxy[];
+  proxies: RegionalCacheProxy[];
 }
 
 class CacheProxiesList extends React.Component<CacheProxiesListProps> {
@@ -79,10 +79,11 @@ class CacheProxiesList extends React.Component<CacheProxiesListProps> {
           </span>
         </div>
         {this.props.proxies.map(
-          (proxy) =>
+          ({ region, proxy }) =>
             proxy.node && (
               <CacheProxyCardComponent
-                key={proxy.node.proxyId}
+                key={`${region}-${proxy.node.proxyId}`}
+                region={region}
                 node={proxy.node as cache_proxy.CacheProxyNode}
                 lastCheckInTime={proxy.lastCheckInTime}
                 statistics={proxy.statistics}
@@ -101,8 +102,13 @@ interface Props {
   path: string;
 }
 
+type RegionalCacheProxy = {
+  region: string;
+  proxy: cache_proxy.GetCacheProxiesResponse.ICacheProxy;
+};
+
 interface State {
-  proxies: cache_proxy.GetCacheProxiesResponse.ICacheProxy[];
+  regions: { name: string; response: cache_proxy.GetCacheProxiesResponse }[];
   proxyKeys: api_key.IApiKey[];
   loading: FetchType[];
   error: BuildBuddyError | null;
@@ -110,7 +116,7 @@ interface State {
 
 export default class CacheProxiesComponent extends React.Component<Props, State> {
   state: State = {
-    proxies: [],
+    regions: [],
     proxyKeys: [],
     loading: [],
     error: null,
@@ -158,8 +164,20 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
       loading: [...prevState.loading, FetchType.Proxies],
     }));
     try {
-      const response = await rpcService.service.getCacheProxies(cache_proxy.GetCacheProxiesRequest.create({}));
-      this.setState({ proxies: response.cacheProxy });
+      const regions = rpcService.regionalServices.size
+        ? await Promise.all(
+            Array.from(rpcService.regionalServices).map(([name, service]) =>
+              service.getCacheProxies(cache_proxy.GetCacheProxiesRequest.create({})).then((resp) => {
+                return { name: name, response: resp };
+              })
+            )
+          )
+        : [
+            await rpcService.service.getCacheProxies(cache_proxy.GetCacheProxiesRequest.create({})).then((resp) => {
+              return { name: "", response: resp };
+            }),
+          ];
+      this.setState({ regions });
     } catch (e) {
       this.setState({ error: BuildBuddyError.parse(e) });
     } finally {
@@ -196,7 +214,10 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
   }
 
   render() {
-    const hasProxies = this.state.proxies.length > 0;
+    const proxies = this.state.regions.flatMap((r) =>
+      r.response.cacheProxy.map((proxy) => ({ region: r.name, proxy }))
+    );
+    const hasProxies = proxies.length > 0;
     const hasKeys = this.state.proxyKeys.length > 0;
     // When neither proxies nor cache-proxy API keys exist, skip the tab UI
     // and show a single clean empty-state view (matching the executors page
@@ -242,7 +263,7 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
                         <p>Click the "Setup" tab for instructions on self-hosting cache proxies.</p>
                       </div>
                     )}
-                    {hasProxies && <CacheProxiesList proxies={this.state.proxies} />}
+                    {hasProxies && <CacheProxiesList proxies={proxies} />}
                   </>
                 )}
                 {activeTab === "setup" && <CacheProxySetup user={this.props.user} proxyKeys={this.state.proxyKeys} />}

--- a/enterprise/app/cache_proxies/cache_proxy_card.tsx
+++ b/enterprise/app/cache_proxies/cache_proxy_card.tsx
@@ -25,6 +25,7 @@ const WRITE_COLOR = cssColor("--color-indigo-500", "#3f51b5");
 const EMPTY_COLOR = "#eee";
 
 interface Props {
+  region?: string;
   node: cache_proxy.CacheProxyNode;
   lastCheckInTime?: google_timestamp.protobuf.Timestamp | null;
   statistics?: cache_proxy.IStatistics | null;
@@ -75,6 +76,12 @@ export default class CacheProxyCardComponent extends React.Component<Props> {
               <div className="cache-proxy-section-title">Proxy Instance ID:</div>
               <div>{this.props.node.proxyId}</div>
             </div>
+            {this.props.region && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Region:</div>
+                <div>{this.props.region}</div>
+              </div>
+            )}
             {this.props.node.proxyHostId && (
               <div className="cache-proxy-section">
                 <div className="cache-proxy-section-title">Proxy Host ID:</div>


### PR DESCRIPTION
Fix the cache proxy status page hiding proxies that registered
with a regional app instead of the primary app. This matters because
a customer saw no proxies at /cache-proxies/status but the same org
showed a live proxy on europe.buildbuddy.io.

The executors page already handles this deployment shape by querying
each configured regional service. Teach the cache proxies page to do
the same for GetCacheProxies, then flatten the regional responses for
the status view and include the region name on each proxy card.

This keeps cache proxy registration scoped to the regional app that
received the heartbeat, while letting the primary UI show proxies from
all configured regions.

