### PR TITLE
invocation: fix GitHub repo links

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -493,6 +493,7 @@ ts_library(
         "//app/service:rpc_service",
         "//app/util:cache",
         "//app/util:exit_codes",
+        "//app/util:git",
         "//app/util:proto",
         "//app/util:shlex",
         "//proto:build_event_stream_ts_proto",
@@ -518,6 +519,7 @@ ts_jasmine_node_test(
         ":invocation_model",
         "//:node_modules/tslib",
         "//proto:build_event_stream_ts_proto",
+        "//proto:command_line_ts_proto",
         "//proto:invocation_ts_proto",
     ],
 )

--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -37,6 +37,10 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
 
   render() {
     const isBazelInvocation = this.props.model.isBazelInvocation();
+    const githubRepo = this.props.model.getGithubRepo();
+    const githubActionsRepo = this.props.model.getGithubActionsRepo();
+    const githubActionsUrl = this.props.model.getGithubActionsUrl();
+    const showSeparateGithubActionsRepo = Boolean(githubActionsRepo && githubActionsRepo !== githubRepo);
 
     const cumulativeMetrics = this.props.model.buildMetrics?.cumulativeMetrics;
     const numAnalyses = cumulativeMetrics?.numAnalyses ?? 0;
@@ -186,11 +190,22 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
               </div>
             )}
 
-            {this.props.model.getGithubRepo() && (
+            {githubRepo && (
+              <div className="invocation-section">
+                <div className="invocation-section-title">
+                  {showSeparateGithubActionsRepo ? "Bazel workspace" : "GitHub repo"}
+                </div>
+                <div>
+                  <Link href={`${githubRepo}`}>{githubRepo}</Link>
+                </div>
+              </div>
+            )}
+
+            {showSeparateGithubActionsRepo && (
               <div className="invocation-section">
                 <div className="invocation-section-title">GitHub repo</div>
                 <div>
-                  <Link href={`${this.props.model.getGithubRepo()}`}>{this.props.model.getGithubRepo()}</Link>
+                  <Link href={`${githubActionsRepo}`}>{githubActionsRepo}</Link>
                 </div>
               </div>
             )}
@@ -220,13 +235,11 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
               </div>
             )}
 
-            {this.props.model.getGithubRun() && (
+            {githubActionsUrl && (
               <div className="invocation-section">
                 <div className="invocation-section-title">GitHub run</div>
                 <div>
-                  <Link href={`${this.props.model.getGithubRepo()}/actions/runs/${this.props.model.getGithubRun()}`}>
-                    {this.props.model.getGithubRun()}
-                  </Link>
+                  <Link href={`${githubActionsUrl}`}>{this.props.model.getGithubRun()}</Link>
                 </div>
               </div>
             )}

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -22,6 +22,7 @@ import format, { formatDate } from "../format/format";
 import rpcService from "../service/rpc_service";
 import { resourceNameToString } from "../util/cache";
 import { exitCode } from "../util/exit_codes";
+import { normalizeRepoURL } from "../util/git";
 import { durationToMillisWithFallback, timestampToDateWithFallback } from "../util/proto";
 import { quote } from "../util/shlex";
 
@@ -587,11 +588,40 @@ export default class InvocationModel {
 
   // https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
   getGithubActionsUrl() {
-    if (this.getGithubRepo() && this.clientEnvMap.get("GITHUB_RUN_ID")) {
-      return `${this.getGithubRepo()}/actions/runs/${this.clientEnvMap.get("GITHUB_RUN_ID")}`;
+    if (this.getGithubActionsRepo() && this.clientEnvMap.get("GITHUB_RUN_ID")) {
+      return `${this.getGithubActionsRepo()}/actions/runs/${this.clientEnvMap.get("GITHUB_RUN_ID")}`;
     }
 
     return undefined;
+  }
+
+  getGithubActionsRepo(): string {
+    const repository = this.clientEnvMap.get("GITHUB_REPOSITORY");
+    if (!repository) {
+      return this.getGithubRepo();
+    }
+    if (this.githubRepositoryHasHost(repository)) {
+      return normalizeRepoURL(repository);
+    }
+    return normalizeRepoURL(`${this.getGithubServerUrl()}/${repository.replace(/^\//, "")}`);
+  }
+
+  private getGithubServerUrl(): string {
+    const serverUrl = this.clientEnvMap.get("GITHUB_SERVER_URL");
+    if (serverUrl) {
+      return serverUrl.replace(/\/$/, "");
+    }
+    try {
+      const repoUrl = new URL(this.getGithubRepo());
+      return `${repoUrl.protocol}//${repoUrl.host}`;
+    } catch (e) {
+      return "https://github.com";
+    }
+  }
+
+  private githubRepositoryHasHost(repository: string): boolean {
+    const firstSegment = repository.split("/", 1)[0] || "";
+    return repository.includes("://") || repository.includes("@") || /[.:]/.test(firstSegment);
   }
 
   getGithubRepo(): string {

--- a/app/invocation/invocation_model_test.ts
+++ b/app/invocation/invocation_model_test.ts
@@ -1,4 +1,5 @@
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
+import { command_line } from "../../proto/command_line_ts_proto";
 import { invocation } from "../../proto/invocation_ts_proto";
 import InvocationModel from "./invocation_model";
 
@@ -30,6 +31,32 @@ function newInvocationModelWithConfigurations(configurations: { cpu?: string; is
             }),
           })
       ),
+    })
+  );
+}
+
+function newInvocationModelWithClientEnv(repoUrl: string, env: Record<string, string>) {
+  return new InvocationModel(
+    new invocation.Invocation({
+      repoUrl,
+      structuredCommandLine: [
+        new command_line.CommandLine({
+          commandLineLabel: "canonical",
+          sections: [
+            new command_line.CommandLineSection({
+              optionList: new command_line.OptionList({
+                option: Object.entries(env).map(
+                  ([key, value]) =>
+                    new command_line.Option({
+                      optionName: "client_env",
+                      optionValue: `${key}=${value}`,
+                    })
+                ),
+              }),
+            }),
+          ],
+        }),
+      ],
     })
   );
 }
@@ -83,5 +110,26 @@ describe("InvocationModel.getMode", () => {
     model.optionsMap.set("compilation_mode", "opt");
 
     expect(model.getMode()).toBe("opt");
+  });
+});
+
+describe("InvocationModel.getGithubActionsUrl", () => {
+  it("uses GITHUB_REPOSITORY for the actions run URL", () => {
+    const model = newInvocationModelWithClientEnv("https://github.com/workspace/repo", {
+      GITHUB_REPOSITORY: "actions/repo",
+      GITHUB_RUN_ID: "12345",
+    });
+
+    expect(model.getGithubActionsUrl()).toBe("https://github.com/actions/repo/actions/runs/12345");
+  });
+
+  it("uses GITHUB_SERVER_URL for enterprise actions run URLs", () => {
+    const model = newInvocationModelWithClientEnv("https://ghe.example.com/workspace/repo", {
+      GITHUB_REPOSITORY: "actions/repo",
+      GITHUB_RUN_ID: "12345",
+      GITHUB_SERVER_URL: "https://ghe.example.com",
+    });
+
+    expect(model.getGithubActionsUrl()).toBe("https://ghe.example.com/actions/repo/actions/runs/12345");
   });
 });

--- a/server/backends/github/BUILD
+++ b/server/backends/github/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//server/util/db",
         "//server/util/flag",
         "//server/util/git",
+        "//server/util/githubutil",
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -23,6 +23,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/githubutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -34,7 +35,6 @@ import (
 var (
 	statusNameSuffix = flag.String("github.status_name_suffix", "", "Suffix to be appended to all reported GitHub status names. Useful for differentiating BuildBuddy deployments. For example: '(dev)' ** Enterprise only **")
 	JwtKey           = flag.String("github.jwt_key", "", "The key to use when signing JWT tokens for github auth.", flag.Secret)
-	enterpriseHost   = flag.String("github.enterprise_host", "", "The Github enterprise hostname to use if using GitHub enterprise server, not including https:// and no trailing slash.", flag.Secret)
 
 	accessToken = flag.String("github.access_token", "", "The GitHub access token used to post GitHub commit statuses. This is intended as a convenience option and can be set to a personal access token (PAT) or a shared machine account PAT.", flag.Secret)
 
@@ -802,19 +802,13 @@ func GetUserInfo(token string) (*GithubUserResponse, error) {
 }
 
 func IsEnterpriseConfigured() bool {
-	return *enterpriseHost != ""
+	return githubutil.IsEnterpriseConfigured()
 }
 
 func GithubHost() string {
-	if IsEnterpriseConfigured() {
-		return *enterpriseHost
-	}
-	return "github.com"
+	return githubutil.Host()
 }
 
 func apiEndpoint() string {
-	if IsEnterpriseConfigured() {
-		return *enterpriseHost + "/api/v3"
-	}
-	return "api.github.com"
+	return githubutil.APIEndpoint()
 }

--- a/server/build_event_protocol/event_parser/BUILD
+++ b/server/build_event_protocol/event_parser/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:invocation_go_proto",
         "//server/build_event_protocol/invocation_format",
         "//server/util/git",
+        "//server/util/githubutil",
         "//server/util/timeutil",
     ],
 )

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/proto/command_line"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/invocation_format"
 	"github.com/buildbuddy-io/buildbuddy/server/util/git"
+	"github.com/buildbuddy-io/buildbuddy/server/util/githubutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
@@ -279,7 +280,7 @@ func (sep *StreamingEventParser) fillInvocationFromStructuredCommandLine(command
 		sep.setRepoUrl(url, priority)
 	}
 	if url, ok := envVarMap["GITHUB_REPOSITORY"]; ok && url != "" {
-		sep.setRepoUrl(url, priority)
+		sep.setRepoUrl(githubRepositoryURL(url), priority)
 	}
 	if branch, ok := envVarMap["TRAVIS_BRANCH"]; ok && branch != "" {
 		sep.setBranchName(branch, priority)
@@ -369,6 +370,22 @@ func (sep *StreamingEventParser) fillInvocationFromStructuredCommandLine(command
 	if val, ok := options["remote_upload_local_results"]; ok && val == "1" {
 		sep.invocation.UploadLocalResultsEnabled = true
 	}
+}
+
+func githubRepositoryURL(repository string) string {
+	repository = strings.TrimSpace(repository)
+	if repository == "" {
+		return repository
+	}
+	if githubRepositoryHasHost(repository) {
+		return repository
+	}
+	return "https://" + githubutil.Host() + "/" + strings.TrimPrefix(repository, "/")
+}
+
+func githubRepositoryHasHost(repository string) bool {
+	firstSegment, _, _ := strings.Cut(repository, "/")
+	return strings.Contains(repository, "://") || strings.Contains(repository, "@") || strings.ContainsAny(firstSegment, ".:")
 }
 
 func (sep *StreamingEventParser) fillInvocationFromWorkspaceStatus(workspaceStatus *build_event_stream.WorkspaceStatus) {

--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -415,17 +415,30 @@ func TestTagMerging(t *testing.T) {
 
 func TestEnvVarDiscovery(t *testing.T) {
 	tests := []struct {
-		name      string
-		envVars   map[string]string
-		repoUrl   string
-		branch    string
-		commitSha string
-		role      string
+		name                 string
+		envVars              map[string]string
+		repoUrl              string
+		branch               string
+		commitSha            string
+		role                 string
+		githubEnterpriseHost string
 	}{
 		{
 			name:    "GITHUB_REPOSITORY sets repo URL defaulting to github.com",
 			envVars: map[string]string{"GITHUB_REPOSITORY": "buildbuddy-io/buildbuddy"},
 			repoUrl: "https://github.com/buildbuddy-io/buildbuddy",
+		},
+		{
+			name:                 "GITHUB_REPOSITORY uses configured enterprise GitHub host",
+			envVars:              map[string]string{"GITHUB_REPOSITORY": "example-org/example-repo"},
+			repoUrl:              "https://ghe.example.com/example-org/example-repo",
+			githubEnterpriseHost: "ghe.example.com",
+		},
+		{
+			name:                 "GITHUB_REPOSITORY keeps explicit repo URL host",
+			envVars:              map[string]string{"GITHUB_REPOSITORY": "https://github.example.com/owner/repo"},
+			repoUrl:              "https://github.example.com/owner/repo",
+			githubEnterpriseHost: "ghe.example.com",
 		},
 		{
 			name:    "GITHUB_REF sets branch for heads ref",
@@ -462,6 +475,9 @@ func TestEnvVarDiscovery(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.githubEnterpriseHost != "" {
+				flags.Set(t, "github.enterprise_host", tc.githubEnterpriseHost)
+			}
 			options := make([]*command_line.Option, 0, len(tc.envVars))
 			for k, v := range tc.envVars {
 				options = append(options, &command_line.Option{

--- a/server/util/githubutil/BUILD
+++ b/server/util/githubutil/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "githubutil",
+    srcs = ["githubutil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/githubutil",
+    deps = [
+        "//server/util/flag",
+    ],
+)

--- a/server/util/githubutil/githubutil.go
+++ b/server/util/githubutil/githubutil.go
@@ -1,0 +1,25 @@
+package githubutil
+
+import "github.com/buildbuddy-io/buildbuddy/server/util/flag"
+
+var (
+	enterpriseHost = flag.String("github.enterprise_host", "", "The Github enterprise hostname to use if using GitHub enterprise server, not including https:// and no trailing slash.", flag.Secret)
+)
+
+func IsEnterpriseConfigured() bool {
+	return *enterpriseHost != ""
+}
+
+func Host() string {
+	if IsEnterpriseConfigured() {
+		return *enterpriseHost
+	}
+	return "github.com"
+}
+
+func APIEndpoint() string {
+	if IsEnterpriseConfigured() {
+		return *enterpriseHost + "/api/v3"
+	}
+	return "api.github.com"
+}


### PR DESCRIPTION
GitHub Actions invocations can report two different repositories: the
Bazel workspace being built and the repository that owns the workflow
run. BuildBuddy currently conflates those values in two places. Bare
GITHUB_REPOSITORY values are normalized through github.com even on
GitHub Enterprise deployments, and the details card builds the run link
from the workspace repo instead of the Actions repo.

Share the configured GitHub Enterprise host with invocation parsing so
bare GITHUB_REPOSITORY values expand to the right host. Then derive the
Actions run URL from GITHUB_REPOSITORY and GITHUB_SERVER_URL in the UI,
while keeping the workspace repo for branch and commit links. When the
two repos differ, the details card shows both values explicitly.
