### PR TITLE
api_keys: refresh created key value

### DIFF
--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -795,7 +795,7 @@ const ApiKeyFieldDefaultState: ApiKeyFieldState = {
 };
 
 class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
-  state = ApiKeyFieldDefaultState;
+  state = { ...ApiKeyFieldDefaultState };
 
   private copyTimeout: number | undefined;
   private value: string | undefined;
@@ -804,6 +804,20 @@ class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
     if (this.props.apiKey.value) {
       this.value = this.props.apiKey.value;
     }
+  }
+
+  componentDidUpdate(prevProps: ApiKeyFieldProps) {
+    if (prevProps.apiKey.id === this.props.apiKey.id && prevProps.apiKey.value === this.props.apiKey.value) {
+      return;
+    }
+    this.value = this.props.apiKey.value || undefined;
+    clearTimeout(this.copyTimeout);
+    this.copyTimeout = undefined;
+    this.setState({ ...ApiKeyFieldDefaultState });
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.copyTimeout);
   }
 
   private async retrieveValue() {


### PR DESCRIPTION
Creating two API keys in a row can leave the success banner's
ApiKeyField instance caching the first key's secret. This is wrong
because copying or revealing the second key can surface the previous
value.

Refresh the cached value whenever the API key ID or value changes,
clear any pending copy timer, and reset the field to its hidden
state. Keep this bookkeeping inside ApiKeyField so callers cannot
omit a required React key.

Also clear the timer on unmount. Leave out the previous lifecycle
test because it bypassed React's real update path and offered limited
regression protection.
