### PR TITLE
scheduler: allow GRPCS peer dials

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -62,11 +62,15 @@ var (
 	maxSchedulingDelay           = flag.Duration("remote_execution.max_scheduling_delay", 5*time.Second, "Max duration that actions can sit in a non-preferred executor's queue before they are executed.")
 	cgroupSettingsEnabled        = flag.Bool("remote_execution.cgroup_settings_enabled", true, "Apply cgroup2 settings to Linux executions.")
 	proactiveCancellationEnabled = flag.Bool("remote_execution.proactive_cancellation_enabled", false, "If true, the scheduler will proactively cancel task reservations on executors when a task is completed by another executor.")
+	schedulerRPCSchemeFlag       = flag.String("remote_execution.scheduler_rpc_scheme", "grpc", "Protocol scheme to use when this scheduler dials another scheduler to enqueue task reservations. Supported values: grpc, grpcs.")
 	debugExecutorLabelsKey       = flag.String("remote_execution.debug_executor_labels_key", "", "If set, requests using the 'debug-executor-labels' platform property must also set the 'debug-executor-labels-key' platform property to this value, otherwise the requested labels are ignored. If empty, anyone can use 'debug-executor-labels'.", flag.Secret)
 	unclaimedTasksCacheTTL       = flag.Duration("remote_execution.unclaimed_tasks_cache_ttl", 1*time.Second, "If set, cache the unclaimed task list in memory for up to this TTL", flag.Internal)
 )
 
 const (
+	schedulerRPCSchemeGRPC  = "grpc"
+	schedulerRPCSchemeGRPCS = "grpcs"
+
 	// This number controls how many reservations the scheduler will
 	// enqueue (across executor nodes) for each task. Typically this
 	// is 2 -- we've increased it to 3 because each executor will
@@ -1115,16 +1119,18 @@ type schedulerClientCache struct {
 
 	mu      sync.Mutex
 	clients map[string]*schedulerClient
+	scheme  string
 	// Address of this app instance. If the destination address matches the address of this instance, we call into
 	// the local scheduler server instance directly instead of using RPCs.
 	localServerHostPort string
 	localServer         *SchedulerServer
 }
 
-func newSchedulerClientCache(env environment.Env, localServerHostPort string, localServer *SchedulerServer) *schedulerClientCache {
+func newSchedulerClientCache(env environment.Env, localServerHostPort string, localServer *SchedulerServer, scheme string) *schedulerClientCache {
 	cache := &schedulerClientCache{
 		env:                 env,
 		clients:             make(map[string]*schedulerClient),
+		scheme:              scheme,
 		localServerHostPort: localServerHostPort,
 		localServer:         localServer,
 	}
@@ -1161,7 +1167,7 @@ func (c *schedulerClientCache) get(hostPort string) (*schedulerClient, error) {
 			client = &schedulerClient{localServer: c.localServer}
 		} else {
 			// This is non-blocking so it's OK to hold the lock.
-			conn, err := grpc_client.DialInternalWithPoolSize(c.env, "grpc://"+hostPort, 2)
+			conn, err := grpc_client.DialInternalWithPoolSize(c.env, schedulerRPCTarget(c.scheme, hostPort), 2)
 			if err != nil {
 				return nil, status.UnavailableErrorf("could not dial scheduler: %s", err)
 			}
@@ -1171,6 +1177,31 @@ func (c *schedulerClientCache) get(hostPort string) (*schedulerClient, error) {
 	}
 	client.lastAccess = time.Now()
 	return client, nil
+}
+
+func schedulerRPCScheme() (string, error) {
+	scheme := strings.TrimSpace(strings.ToLower(*schedulerRPCSchemeFlag))
+	switch scheme {
+	case schedulerRPCSchemeGRPC, schedulerRPCSchemeGRPCS:
+		return scheme, nil
+	default:
+		return "", status.InvalidArgumentErrorf("remote_execution.scheduler_rpc_scheme must be one of %q or %q, got %q", schedulerRPCSchemeGRPC, schedulerRPCSchemeGRPCS, *schedulerRPCSchemeFlag)
+	}
+}
+
+func schedulerRPCTarget(scheme, hostPort string) string {
+	return fmt.Sprintf("%s://%s", scheme, hostPort)
+}
+
+func schedulerPort(options *Options, scheme string) (int32, error) {
+	if options.LocalPortOverride != 0 {
+		return options.LocalPortOverride, nil
+	}
+	portFlagName := "grpc_port"
+	if scheme == schedulerRPCSchemeGRPCS {
+		portFlagName = "grpcs_port"
+	}
+	return resources.GetMyPortFromEnvOrFlag(portFlagName)
 }
 
 // Options for overriding server behavior needed for testing.
@@ -1246,17 +1277,18 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 	if taskRouter == nil {
 		return nil, status.FailedPreconditionError("Missing task router in env")
 	}
+	schedulerScheme, err := schedulerRPCScheme()
+	if err != nil {
+		return nil, err
+	}
 
 	ownHostname, err := resources.GetMyHostname()
 	if err != nil {
 		return nil, status.UnknownErrorf("Could not determine own hostname: %s", err)
 	}
-	ownPort := options.LocalPortOverride
-	if ownPort == 0 {
-		ownPort, err = resources.GetMyPort()
-		if err != nil {
-			return nil, status.UnknownErrorf("Could not determine own port: %s", err)
-		}
+	ownPort, err := schedulerPort(options, schedulerScheme)
+	if err != nil {
+		return nil, status.UnknownErrorf("Could not determine own port: %s", err)
 	}
 
 	clock := env.GetClock()
@@ -1293,7 +1325,7 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 		leaseDuration:                     options.LeaseDuration,
 		leaseGracePeriod:                  options.LeaseGracePeriod,
 	}
-	s.schedulerClientCache = newSchedulerClientCache(env, s.ownHostPort, s)
+	s.schedulerClientCache = newSchedulerClientCache(env, s.ownHostPort, s, schedulerScheme)
 	return s, nil
 }
 

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -101,6 +101,82 @@ type schedulerOpts struct {
 	preferredExecutors []string
 }
 
+func TestSchedulerRPCScheme(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		scheme      string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "grpc",
+			scheme:   "grpc",
+			expected: schedulerRPCSchemeGRPC,
+		},
+		{
+			name:     "grpcs",
+			scheme:   "grpcs",
+			expected: schedulerRPCSchemeGRPCS,
+		},
+		{
+			name:     "normalizes",
+			scheme:   " GRPCS ",
+			expected: schedulerRPCSchemeGRPCS,
+		},
+		{
+			name:        "rejects invalid scheme",
+			scheme:      "https",
+			expectError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			flags.Set(t, "remote_execution.scheduler_rpc_scheme", test.scheme)
+
+			scheme, err := schedulerRPCScheme()
+			if test.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "remote_execution.scheduler_rpc_scheme")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, scheme)
+		})
+	}
+}
+
+func TestSchedulerRPCTarget(t *testing.T) {
+	require.Equal(t, "grpc://scheduler-0.headless:1985", schedulerRPCTarget(schedulerRPCSchemeGRPC, "scheduler-0.headless:1985"))
+	require.Equal(t, "grpcs://scheduler-0.headless:1986", schedulerRPCTarget(schedulerRPCSchemeGRPCS, "scheduler-0.headless:1986"))
+}
+
+func TestSchedulerPortUsesSchemeDefault(t *testing.T) {
+	flags.Set(t, "grpc_port", 1985)
+	flags.Set(t, "grpcs_port", 1986)
+
+	port, err := schedulerPort(&Options{}, schedulerRPCSchemeGRPC)
+	require.NoError(t, err)
+	require.Equal(t, int32(1985), port)
+
+	port, err = schedulerPort(&Options{}, schedulerRPCSchemeGRPCS)
+	require.NoError(t, err)
+	require.Equal(t, int32(1986), port)
+}
+
+func TestSchedulerPortHonorsOverride(t *testing.T) {
+	port, err := schedulerPort(&Options{LocalPortOverride: 1234}, schedulerRPCSchemeGRPCS)
+	require.NoError(t, err)
+	require.Equal(t, int32(1234), port)
+}
+
+func TestSchedulerPortHonorsMyPort(t *testing.T) {
+	t.Setenv("MY_PORT", "4321")
+	flags.Set(t, "grpcs_port", 1986)
+
+	port, err := schedulerPort(&Options{}, schedulerRPCSchemeGRPCS)
+	require.NoError(t, err)
+	require.Equal(t, int32(4321), port)
+}
+
 func getEnv(t *testing.T, opts *schedulerOpts, user string) (*testenv.TestEnv, context.Context) {
 	redisTarget := testredis.Start(t).Target
 	env := enterprise_testenv.GetCustomTestEnv(t, &enterprise_testenv.Options{

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -259,10 +259,14 @@ func GetMyHostname() (string, error) {
 }
 
 func GetMyPort() (int32, error) {
+	return GetMyPortFromEnvOrFlag("grpc_port")
+}
+
+func GetMyPortFromEnvOrFlag(flagName string) (int32, error) {
 	portStr := ""
 	if v := os.Getenv(portEnvVarName); v != "" {
 		portStr = v
-	} else if p, err := flagutil.GetDereferencedValue[int]("grpc_port"); err == nil {
+	} else if p, err := flagutil.GetDereferencedValue[int](flagName); err == nil {
 		portStr = strconv.Itoa(p)
 	}
 	i, err := strconv.ParseInt(portStr, 10, 32)


### PR DESCRIPTION
A customer wants on-prem deployments to encrypt BuildBuddy backend
traffic end to end. This matters because scheduler-to-scheduler
forwarding still forced grpc:// when one scheduler had to enqueue
work on an executor connected to another app replica. That left the
headless-service path plaintext even if the deployment otherwise
enabled GRPCS.

Add remote_execution.scheduler_rpc_scheme with the existing grpc
behavior as the default. When set to grpcs, schedulers build grpcs://
targets for peer EnqueueTaskReservation RPCs and advertise grpcs_port
as their own port unless MY_PORT or the test override is set.
Invalid schemes are rejected before the scheduler starts.

This intentionally does not configure certificates or Helm service
wiring. Deployments enabling grpcs still need app certificates that
peer app pods trust and that cover the headless or pod DNS names;
chart wiring can make that deployment shape opt-in separately.

