### PR TITLE
Fix code search icon styling

### DIFF
--- a/enterprise/app/codesearch/codesearch.css
+++ b/enterprise/app/codesearch/codesearch.css
@@ -8,6 +8,10 @@
   align-items: center;
   background: var(--color-search-result-header-bg);
   padding: 2px 32px;
+
+  .icon {
+    --icon-size: 16px;
+  }
 }
 
 .code-search .repo-name {
@@ -97,7 +101,7 @@
   height: 100%;
 }
 
-.code-search .icon {
+.code-search .big-icon {
   --icon-size: 180px;
 }
 

--- a/enterprise/app/codesearch/codesearch.tsx
+++ b/enterprise/app/codesearch/codesearch.tsx
@@ -96,7 +96,7 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
       return (
         <div className="no-results">
           <div className="circle">
-            <Search className="gray" />
+            <Search className="big-icon gray" />
             <h2>Empty Query</h2>
             <p>
               To see results, try entering a query. Here are some examples:
@@ -127,7 +127,7 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
       return (
         <div className="no-results">
           <div className="circle">
-            <XCircle className="gray" />
+            <XCircle className="big-icon gray" />
             <h2>Invalid Search Query</h2>
             <p>{this.state.errorMessage}</p>
           </div>
@@ -143,7 +143,7 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
       return (
         <div className="no-results">
           <div className="circle">
-            <Bird className="gray" />
+            <Bird className="big-icon gray" />
             <h2>No results found</h2>
           </div>
         </div>
@@ -198,7 +198,7 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
         <div>
           {this.state.loading && (
             <div className="spinner-center">
-              <Spinner></Spinner>
+              <Spinner />
             </div>
           )}
           {!this.state.loading && this.renderTheRestOfTheOwl()}

--- a/enterprise/app/codesearch/result.tsx
+++ b/enterprise/app/codesearch/result.tsx
@@ -90,7 +90,7 @@ export default class ResultComponent extends React.Component<ResultProps, Result
     return (
       <div className="result">
         <div className="result-title-bar">
-          <File size={16}></File>
+          <File />
           <div className="repo-name">[{this.props.result.repo}]</div>
           <div className="filename">
             <a href={this.getFileOnlyURL()}>{this.props.result.filename}</a>


### PR DESCRIPTION
The `<File>` icon in the search result rows became huge after https://github.com/buildbuddy-io/buildbuddy/pull/12557, because the `.code-search .icon` style sets the default icon size within the `.code-search` page to 180px, and the `<File>` component was previously not setting `className="icon"`, but now it is.

Fix:
- Don't make the default icon size 180px; just use the default 24px.
  - Without this change, if we want to add more icons/components throughout this UI, the icons will have a huge default appearance that always has to be overridden, making the CSS messy.
- Add a `big-icon` class for the stylized huge icons that display when there are no results etc.
- Define the `<File>` size in css rather than inline (not strictly needed, just a tad more conventional)