### PR TITLE
Use `multirun` to do releases

### DIFF
--- a/proto/index.proto
+++ b/proto/index.proto
@@ -66,7 +66,6 @@ message RepoStatusResponse {
   string last_indexed_commit_sha = 2;
 }
 
-
 message IncrementalUpdate {
   // The list of commits. The changes from the commits will be applied in order,
   // in a single atomic batch. The commits must be ordered, with each commit

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -40,7 +40,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply.script",
         out = name + ".apply.out",
         content = [
-            "set -x; unset -v PYTHONSAFEPATH; if [ -n \"${1}\" ]; then read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"; fi; shift; %s -m %s cp %s \"${@}\" \"gs://%s/%s${SHA_PREFIX}\"" % (
+            "set -x; unset -v PYTHONSAFEPATH; if [ -n \"${1}\" ]; then read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"; else shift; fi; %s -m %s cp %s \"${@}\" \"gs://%s/%s${SHA_PREFIX}\"" % (
                 gsutil,
                 util_options,
                 copy_options,

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -56,7 +56,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply",
         args = [shell.quote("$(locations %s)" % sha_prefix) if sha_prefix != "" else ""] + [ shell.quote("$(locations %s)" % src) for src in srcs ],
         srcs = [ name + ".apply.script" ],
-        data = srcs + [sha_prefix] if sha_prefix != "" else [],
+        data = srcs + ([sha_prefix] if sha_prefix != "" else []),
         use_bash_launcher = True,
         **kwargs,
     )

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -60,7 +60,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".apply",
-        args = [shell.quote("$(locations %s)" % sha_prefix) if sha_prefix != "" else ""] + [shell.quote("$(locations %s)" % src) for src in srcs],
+        args = ["../$(rlocationpaths %s)" % sha_prefix if sha_prefix != "" else ""] + ["../$(rlocationpaths %s)" % src for src in srcs],
         srcs = [name + ".apply.script"],
         data = srcs + ([sha_prefix] if sha_prefix != "" else []),
         use_bash_launcher = True,
@@ -107,7 +107,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".delete",
-        args = [shell.quote("$(locations %s)" % sha_prefix) if sha_prefix != "" else ""],
+        args = ["../$(rlocationpaths %s)" % sha_prefix if sha_prefix != "" else ""],
         srcs = [name + ".delete.script"],
         data = [sha_prefix] if sha_prefix != "" else [],
         use_bash_launcher = True,

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -1,3 +1,6 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
 # Handles uploading files to GCS.
 #
 # Example usage:
@@ -37,34 +40,70 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         util_options += " -h 'Cache-Control:no-store'"
 
     # Generate an .apply rule for uploading.
-    native.genrule(
+    write_file(
+        name = name + ".apply.script",
+        out = name + ".apply.out",
+        content = [
+            "unset -v PYTHONSAFEPATH; %s -m %s cp %s $(SRCS) gs://%s/%s" % (
+                gsutil,
+                util_options,
+                copy_options,
+                bucket,
+                prefix,
+            ),
+        ],
+        is_executable = True,
+        **kwargs,
+    )
+
+    sh_binary(
         name = name + ".apply",
-        srcs = srcs,
-        outs = [name + ".apply.out"],
-        cmd = "echo \"unset -v PYTHONSAFEPATH; %s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix),
-        local = 1,
-        executable = 1,
-        **kwargs
+        srcs = [
+            name + ".apply.script",
+        ],
+        data = srcs,
+        **kwargs,
     )
 
     # Generate a .diff rule for diffing.
-    native.genrule(
+    write_file(
+        name = name + ".diff.script",
+        out = name + ".diff.out",
+        content = [
+            "echo 'Diff not yet implemented for gcs uploads.'",
+        ],
+        is_executable = True,
+        **kwargs,
+    )
+
+    sh_binary(
         name = name + ".diff",
-        srcs = srcs,
-        outs = [name + ".diff.out"],
-        cmd = "echo \"echo 'Diff not yet implemented for gcs uploads.'\" > $@",
-        local = 1,
-        executable = 1,
-        **kwargs
+        srcs = [
+            name + ".diff.script",
+        ],
+        **kwargs,
     )
 
     # Generate a .delete rule for deleting.
-    native.genrule(
-        name = name + ".delete",
-        srcs = srcs,
-        outs = [name + ".delete.out"],
-        cmd = "echo \"unset -v PYTHONSAFEPATH; %s -m rm -r gs://%s/%s\" > $@" % (gsutil, bucket, prefix),
-        local = 1,
-        executable = 1,
+    write_file(
+        name = name + ".delete.script",
+        out = name + ".delete.out",
+        content = [
+            "unset -v PYTHONSAFEPATH; %s -m rm -r gs://%s/%s" % (
+                gsutil,
+                bucket,
+                prefix,
+            ),
+        ],
+        is_executable = True,
         **kwargs
+    )
+
+    sh_binary(
+        name = name + ".delete",
+        srcs = [
+            name + ".delete.script",
+        ],
+        data = srcs,
+        **kwargs,
     )

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -62,6 +62,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
             name + ".apply.script",
         ],
         data = srcs,
+        use_bash_launcher = True,
         **kwargs,
     )
 
@@ -105,5 +106,6 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
             name + ".delete.script",
         ],
         data = srcs,
+        use_bash_launcher = True,
         **kwargs,
     )

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -1,6 +1,6 @@
-load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 # Handles uploading files to GCS.
 #
@@ -47,24 +47,24 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
             "  shift",
             "fi",
             "{gsutil} {util_options} cp {copy_options} \"${{@}}\" \"gs://{bucket}/{prefix}${{SHA_PREFIX}}\"".format(
-                gsutil=gsutil,
-                util_options=util_options,
-                copy_options=copy_options,
-                bucket=bucket,
-                prefix=prefix,
+                gsutil = gsutil,
+                util_options = util_options,
+                copy_options = copy_options,
+                bucket = bucket,
+                prefix = prefix,
             ),
         ],
         is_executable = True,
-        **kwargs,
+        **kwargs
     )
 
     sh_binary(
         name = name + ".apply",
-        args = [shell.quote("$(locations %s)" % sha_prefix) if sha_prefix != "" else ""] + [ shell.quote("$(locations %s)" % src) for src in srcs ],
-        srcs = [ name + ".apply.script" ],
+        args = [shell.quote("$(locations %s)" % sha_prefix) if sha_prefix != "" else ""] + [shell.quote("$(locations %s)" % src) for src in srcs],
+        srcs = [name + ".apply.script"],
         data = srcs + ([sha_prefix] if sha_prefix != "" else []),
         use_bash_launcher = True,
-        **kwargs,
+        **kwargs
     )
 
     # Generate a .diff rule for diffing.
@@ -75,13 +75,13 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
             "echo 'Diff not yet implemented for gcs uploads.'",
         ],
         is_executable = True,
-        **kwargs,
+        **kwargs
     )
 
     sh_binary(
         name = name + ".diff",
-        srcs = [ name + ".diff.script" ],
-        **kwargs,
+        srcs = [name + ".diff.script"],
+        **kwargs
     )
 
     # Generate a .delete rule for deleting.
@@ -96,9 +96,9 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
             "  shift",
             "fi",
             "{gsutil} -m rm -r gs://{bucket}/{prefix}${{SHA_PREFIX}}".format(
-                gsutil=gsutil,
-                bucket=bucket,
-                prefix=prefix,
+                gsutil = gsutil,
+                bucket = bucket,
+                prefix = prefix,
             ),
         ],
         is_executable = True,
@@ -108,8 +108,8 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
     sh_binary(
         name = name + ".delete",
         args = [shell.quote("$(locations %s)" % sha_prefix) if sha_prefix != "" else ""],
-        srcs = [ name + ".delete.script" ],
+        srcs = [name + ".delete.script"],
         data = [sha_prefix] if sha_prefix != "" else [],
         use_bash_launcher = True,
-        **kwargs,
+        **kwargs
     )

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -26,9 +26,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
     if prefix != "" and not prefix.endswith("/"):
         prefix += "/"
 
-    # Add the given sha to the prefix if provided.
     if sha_prefix:
-        prefix += "$$(cat $(location %s))/" % sha_prefix
         srcs = srcs + [sha_prefix]
 
     # Zip the files if requested.
@@ -45,11 +43,12 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply.script",
         out = name + ".apply.out",
         content = [
-            "unset -v PYTHONSAFEPATH; %s -m %s cp %s ${@:1:$#-1} gs://%s/${!#}" % (
+            "set -x; unset -v PYTHONSAFEPATH; pwd; [ -n \"${!#}\" ] && read SHA_PREFIX < ${!#} && export SHA_PREFIX=${SHA_PREFIX}/; %s -m %s cp %s ${@:1:$#-1} gs://%s/%s${SHA_PREFIX}" % (
                 gsutil,
                 util_options,
                 copy_options,
                 bucket,
+                prefix,
             ),
         ],
         is_executable = True,
@@ -58,7 +57,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".apply",
-        args = [ "$(rlocationpaths %s)" % src for src in srcs ] + [ prefix ],
+        args = [ shell.quote("$(locations %s)" % src) for src in srcs ] + ([""] if sha_prefix == "" else []),
         srcs = [ name + ".apply.script" ],
         data = srcs,
         use_bash_launcher = True,

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -41,7 +41,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply",
         srcs = srcs,
         outs = [name + ".apply.out"],
-        cmd = "echo \"%s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix),
+        cmd = "echo \"PYTHONSAFEPATH=0 %s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix),
         local = 1,
         executable = 1,
         **kwargs
@@ -63,7 +63,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".delete",
         srcs = srcs,
         outs = [name + ".delete.out"],
-        cmd = "echo \"%s -m rm -r gs://%s/%s\" > $@" % (gsutil, bucket, prefix),
+        cmd = "echo \"PYTHONSAFEPATH=0 %s -m rm -r gs://%s/%s\" > $@" % (gsutil, bucket, prefix),
         local = 1,
         executable = 1,
         **kwargs

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -26,9 +26,6 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
     if prefix != "" and not prefix.endswith("/"):
         prefix += "/"
 
-    if sha_prefix:
-        srcs = srcs + [sha_prefix]
-
     # Zip the files if requested.
     copy_options = "-r"
     if zip:
@@ -43,7 +40,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply.script",
         out = name + ".apply.out",
         content = [
-            "set -x; unset -v PYTHONSAFEPATH; pwd; [ -n \"${!#}\" ] && read SHA_PREFIX < ${!#} && export SHA_PREFIX=${SHA_PREFIX}/; %s -m %s cp %s ${@:1:$#-1} gs://%s/%s${SHA_PREFIX}" % (
+            "unset -v PYTHONSAFEPATH; if [ -n \"${1}\" ]; then read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"; fi; shift; %s -m %s cp %s \"${@}\" \"gs://%s/%s${SHA_PREFIX}\"" % (
                 gsutil,
                 util_options,
                 copy_options,
@@ -57,9 +54,9 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".apply",
-        args = [ shell.quote("$(locations %s)" % src) for src in srcs ] + ([""] if sha_prefix == "" else []),
+        args = [ shell.quote("$(locations %s)" % src) for src in ([sha_prefix] if sha_prefix != "" else [""]) + srcs ],
         srcs = [ name + ".apply.script" ],
-        data = srcs,
+        data = srcs + [sha_prefix] if sha_prefix != "" else [],
         use_bash_launcher = True,
         **kwargs,
     )

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -31,7 +31,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
     if zip:
         copy_options += " -Z"
 
-    util_options = ""
+    util_options = "-m"
     if disable_caching:
         util_options += " -h 'Cache-Control:no-store'"
 
@@ -40,12 +40,18 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply.script",
         out = name + ".apply.out",
         content = [
-            "set -x; unset -v PYTHONSAFEPATH; if [ -n \"${1}\" ]; then read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"; else shift; fi; %s -m %s cp %s \"${@}\" \"gs://%s/%s${SHA_PREFIX}\"" % (
-                gsutil,
-                util_options,
-                copy_options,
-                bucket,
-                prefix,
+            "unset -v PYTHONSAFEPATH",
+            "if [ -n \"${1}\" ]; then",
+            "  read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"",
+            "else",
+            "  shift",
+            "fi",
+            "{gsutil} {util_options} cp {copy_options} \"${{@}}\" \"gs://{bucket}/{prefix}${{SHA_PREFIX}}\"".format(
+                gsutil=gsutil,
+                util_options=util_options,
+                copy_options=copy_options,
+                bucket=bucket,
+                prefix=prefix,
             ),
         ],
         is_executable = True,
@@ -83,10 +89,16 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".delete.script",
         out = name + ".delete.out",
         content = [
-            "unset -v PYTHONSAFEPATH; %s -m rm -r gs://%s/%s" % (
-                gsutil,
-                bucket,
-                prefix,
+            "unset -v PYTHONSAFEPATH",
+            "if [ -n \"${1}\" ]; then",
+            "  read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"",
+            "else",
+            "  shift",
+            "fi",
+            "{gsutil} -m rm -r gs://{bucket}/{prefix}${{SHA_PREFIX}}".format(
+                gsutil=gsutil,
+                bucket=bucket,
+                prefix=prefix,
             ),
         ],
         is_executable = True,
@@ -95,8 +107,9 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".delete",
+        args = [shell.quote("$(locations %s)" % sha_prefix) if sha_prefix != "" else ""],
         srcs = [ name + ".delete.script" ],
-        data = srcs,
+        data = [sha_prefix] if sha_prefix != "" else [],
         use_bash_launcher = True,
         **kwargs,
     )

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -40,7 +40,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply.script",
         out = name + ".apply.out",
         content = [
-            "unset -v PYTHONSAFEPATH; if [ -n \"${1}\" ]; then read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"; fi; shift; %s -m %s cp %s \"${@}\" \"gs://%s/%s${SHA_PREFIX}\"" % (
+            "set -x; unset -v PYTHONSAFEPATH; if [ -n \"${1}\" ]; then read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"; fi; shift; %s -m %s cp %s \"${@}\" \"gs://%s/%s${SHA_PREFIX}\"" % (
                 gsutil,
                 util_options,
                 copy_options,

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -54,7 +54,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".apply",
-        args = [ shell.quote("$(locations %s)" % src) for src in ([sha_prefix] if sha_prefix != "" else [""]) + srcs ],
+        args = [shell.quote("$(locations %s)" % sha_prefix) if sha_prefix != "" else ""] + [ shell.quote("$(locations %s)" % src) for src in srcs ],
         srcs = [ name + ".apply.script" ],
         data = srcs + [sha_prefix] if sha_prefix != "" else [],
         use_bash_launcher = True,

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -1,5 +1,6 @@
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@bazel_skylib//lib:shell.bzl", "shell")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 # Handles uploading files to GCS.
 #
@@ -44,12 +45,11 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply.script",
         out = name + ".apply.out",
         content = [
-            "unset -v PYTHONSAFEPATH; %s -m %s cp %s $(SRCS) gs://%s/%s" % (
+            "unset -v PYTHONSAFEPATH; %s -m %s cp %s ${@:1:$#-1} gs://%s/${!#}" % (
                 gsutil,
                 util_options,
                 copy_options,
                 bucket,
-                prefix,
             ),
         ],
         is_executable = True,
@@ -58,9 +58,8 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".apply",
-        srcs = [
-            name + ".apply.script",
-        ],
+        args = [ "$(rlocationpaths %s)" % src for src in srcs ] + [ prefix ],
+        srcs = [ name + ".apply.script" ],
         data = srcs,
         use_bash_launcher = True,
         **kwargs,
@@ -79,9 +78,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".diff",
-        srcs = [
-            name + ".diff.script",
-        ],
+        srcs = [ name + ".diff.script" ],
         **kwargs,
     )
 
@@ -102,9 +99,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
 
     sh_binary(
         name = name + ".delete",
-        srcs = [
-            name + ".delete.script",
-        ],
+        srcs = [ name + ".delete.script" ],
         data = srcs,
         use_bash_launcher = True,
         **kwargs,

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -41,7 +41,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".apply",
         srcs = srcs,
         outs = [name + ".apply.out"],
-        cmd = "echo \"PYTHONSAFEPATH=0 %s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix),
+        cmd = "echo \"unset -v PYTHONSAFEPATH; %s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix),
         local = 1,
         executable = 1,
         **kwargs
@@ -63,7 +63,7 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
         name = name + ".delete",
         srcs = srcs,
         outs = [name + ".delete.out"],
-        cmd = "echo \"PYTHONSAFEPATH=0 %s -m rm -r gs://%s/%s\" > $@" % (gsutil, bucket, prefix),
+        cmd = "echo \"unset -v PYTHONSAFEPATH; %s -m rm -r gs://%s/%s\" > $@" % (gsutil, bucket, prefix),
         local = 1,
         executable = 1,
         **kwargs

--- a/rules/gcs/index.bzl
+++ b/rules/gcs/index.bzl
@@ -1,3 +1,6 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
 # Handles uploading files to GCS.
 #
 # Example usage:
@@ -22,73 +25,121 @@ def gcs(name, srcs, bucket, gsutil = "gsutil", prefix = "", sha_prefix = "", zip
     if prefix != "" and not prefix.endswith("/"):
         prefix += "/"
 
-    # Add the given sha to the prefix if provided.
-    if sha_prefix:
-        prefix += "$$(cat $(location %s))/" % sha_prefix
-        srcs = srcs + [sha_prefix]
-
     # Zip the files if requested.
     copy_options = "-r"
     if zip:
         copy_options += " -Z"
 
-    util_options = ""
+    util_options = "-m"
     if disable_caching:
         util_options += " -h 'Cache-Control:no-store'"
 
-    upload_cmd = "echo \"%s -m %s cp %s $(SRCS) gs://%s/%s\" > $@" % (gsutil, util_options, copy_options, bucket, prefix)
-
-    # Generate an .apply rule for uploading.
-    native.genrule(
-        name = name + ".apply",
-        srcs = srcs,
-        outs = [name + ".apply.out"],
-        cmd = upload_cmd,
-        local = 1,
-        executable = 1,
+    # Generate a .push_only rule for uploading.
+    write_file(
+        name = name + ".push_only.script",
+        out = name + ".push_only.out",
+        content = [
+            "set -x",
+            "unset -v PYTHONSAFEPATH",
+            "if [ -n \"${1}\" ]; then",
+            "  read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"",
+            "else",
+            "  shift",
+            "fi",
+            "{gsutil} {util_options} cp {copy_options} \"${{@}}\" \"gs://{bucket}/{prefix}${{SHA_PREFIX}}\"".format(
+                gsutil = gsutil,
+                util_options = util_options,
+                copy_options = copy_options,
+                bucket = bucket,
+                prefix = prefix,
+            ),
+        ],
+        is_executable = True,
         **kwargs
     )
 
-    # Generate a .push_only rule for uploading to GCS.
-    native.genrule(
+    sh_binary(
+        name = name + ".apply",
+        args = ["../$(rlocationpaths %s)" % sha_prefix if sha_prefix != "" else ""] + ["../$(rlocationpaths %s)" % src for src in srcs],
+        srcs = [":" + name + ".push_only.script"],
+        data = srcs + ([sha_prefix] if sha_prefix != "" else []),
+        use_bash_launcher = True,
+        **kwargs
+    )
+
+    sh_binary(
         name = name + ".push_only",
-        srcs = srcs,
-        outs = [name + ".push_only.out"],
-        cmd = upload_cmd,
-        local = 1,
-        executable = 1,
+        args = ["../$(rlocationpaths %s)" % sha_prefix if sha_prefix != "" else ""] + ["../$(rlocationpaths %s)" % src for src in srcs],
+        srcs = [":" + name + ".push_only.script"],
+        data = srcs + ([sha_prefix] if sha_prefix != "" else []),
+        use_bash_launcher = True,
         **kwargs
     )
 
     # Uploading is the only deployment operation for a GCS bundle, so there
     # is nothing left to do during the apply-only phase.
-    native.genrule(
+    write_file(
+        name = name + ".apply_only.script",
+        out = name + ".apply_only.out",
+        content = [
+            "true",
+        ],
+        is_executable = True,
+        **kwargs
+    )
+
+    sh_binary(
         name = name + ".apply_only",
-        outs = [name + ".apply_only.out"],
-        cmd = "echo \"true\" > $@",
-        local = 1,
-        executable = 1,
+        srcs = [
+            ":" + name + ".apply_only.script",
+        ],
+        use_bash_launcher = True,
         **kwargs
     )
 
     # Generate a .diff rule for diffing.
-    native.genrule(
+    write_file(
+        name = name + ".diff.script",
+        out = name + ".diff.out",
+        content = [
+            "echo 'Diff not yet implemented for gcs uploads.'",
+        ],
+        is_executable = True,
+        **kwargs
+    )
+
+    sh_binary(
         name = name + ".diff",
-        srcs = srcs,
-        outs = [name + ".diff.out"],
-        cmd = "echo \"echo 'Diff not yet implemented for gcs uploads.'\" > $@",
-        local = 1,
-        executable = 1,
+        srcs = [":" + name + ".diff.script"],
         **kwargs
     )
 
     # Generate a .delete rule for deleting.
-    native.genrule(
+    write_file(
+        name = name + ".delete.script",
+        out = name + ".delete.out",
+        content = [
+            "unset -v PYTHONSAFEPATH",
+            "if [ -n \"${1}\" ]; then",
+            "  read SHA_PREFIX < \"${1}\" && export SHA_PREFIX=\"${SHA_PREFIX}/\"",
+            "else",
+            "  shift",
+            "fi",
+            "{gsutil} -m rm -r gs://{bucket}/{prefix}${{SHA_PREFIX}}".format(
+                gsutil = gsutil,
+                bucket = bucket,
+                prefix = prefix,
+            ),
+        ],
+        is_executable = True,
+        **kwargs
+    )
+
+    sh_binary(
         name = name + ".delete",
-        srcs = srcs,
-        outs = [name + ".delete.out"],
-        cmd = "echo \"%s -m rm -r gs://%s/%s\" > $@" % (gsutil, bucket, prefix),
-        local = 1,
-        executable = 1,
+        args = ["../$(rlocationpaths %s)" % sha_prefix if sha_prefix != "" else ""],
+        srcs = [":" + name + ".delete.script"],
+        data = [sha_prefix] if sha_prefix != "" else [],
+        use_bash_launcher = True,
         **kwargs
     )

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -23,7 +23,9 @@ load("@rules_multirun//:defs.bzl", "command", "multirun")
 # To delete a release, run:
 #   `bazel run :dev.delete`
 #
-def release(name, srcs, run, after, enable_actions = True, **kwargs):
+def release(name, run, after, data = None, enable_actions = True, **kwargs):
+    if data == None:
+        data = []
     actions = [""]
     if enable_actions:
         actions = [".apply", ".diff", ".delete"]
@@ -33,12 +35,12 @@ def release(name, srcs, run, after, enable_actions = True, **kwargs):
         run_action_command = name + action + ".run"
         command(
             name = after_action_command,
-            srcs = srcs,
+            data = [] if action == ".delete" else data,
             command = after + action,
         )
         command(
             name = run_action_command,
-            srcs = srcs,
+            data = [] if action == ".delete" else data,
             command = run + action,
         )
         multirun(

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -29,20 +29,21 @@ def release(name, run, after, enable_actions = True, **kwargs):
         actions = [".apply", ".diff", ".delete"]
 
     for action in actions:
-        run_action_command = name + action + ".run"
         after_action_command = name + action + ".after"
-        command(
-            name = run_action_command,
-            command = run + action,
-        )
+        run_action_command = name + action + ".run"
         command(
             name = after_action_command,
             command = after + action,
         )
+        command(
+            name = run_action_command,
+            command = run + action,
+        )
         multirun(
             name = name + action,
             commands = [
-                run_action_command,
                 after_action_command,
+                run_action_command,
             ],
+            **kwargs,
         )

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -23,7 +23,7 @@ load("@rules_multirun//:defs.bzl", "command", "multirun")
 # To delete a release, run:
 #   `bazel run :dev.delete`
 #
-def release(name, run, after, enable_actions = True, **kwargs):
+def release(name, run, after, enable_actions = True, srcs, **kwargs):
     actions = [""]
     if enable_actions:
         actions = [".apply", ".diff", ".delete"]
@@ -34,10 +34,12 @@ def release(name, run, after, enable_actions = True, **kwargs):
         command(
             name = after_action_command,
             command = after + action,
+            srcs = srcs,
         )
         command(
             name = run_action_command,
             command = run + action,
+            srcs = srcs,
         )
         multirun(
             name = name + action,
@@ -45,5 +47,5 @@ def release(name, run, after, enable_actions = True, **kwargs):
                 after_action_command,
                 run_action_command,
             ],
-            **kwargs
+            **kwargs,
         )

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -23,9 +23,7 @@ load("@rules_multirun//:defs.bzl", "command", "multirun")
 # To delete a release, run:
 #   `bazel run :dev.delete`
 #
-def release(name, run, after, data = None, enable_actions = True, **kwargs):
-    if data == None:
-        data = []
+def release(name, run, after, enable_actions = True, **kwargs):
     actions = [""]
     if enable_actions:
         actions = [".apply", ".diff", ".delete"]
@@ -35,12 +33,10 @@ def release(name, run, after, data = None, enable_actions = True, **kwargs):
         run_action_command = name + action + ".run"
         command(
             name = after_action_command,
-            data = [] if action == ".delete" else data,
             command = after + action,
         )
         command(
             name = run_action_command,
-            data = [] if action == ".delete" else data,
             command = run + action,
         )
         multirun(

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -45,5 +45,5 @@ def release(name, run, after, enable_actions = True, **kwargs):
                 after_action_command,
                 run_action_command,
             ],
-            **kwargs,
+            **kwargs
         )

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -1,3 +1,5 @@
+load("@rules_multirun//:defs.bzl", "command", "multirun")
+
 # Creates a release step that depends on another release step.
 #
 # When run, it will run the target specified by the `run` argument
@@ -27,12 +29,20 @@ def release(name, run, after, enable_actions = True, **kwargs):
         actions = [".apply", ".diff", ".delete"]
 
     for action in actions:
-        native.genrule(
+        run_action_command = name + action + ".run"
+        after_action_command = name + action + ".after"
+        command(
+            name = run_action_command,
+            command = run + action,
+        )
+        command(
+            name = after_action_command,
+            command = after + action,
+        )
+        multirun(
             name = name + action,
-            tools = [run + action, after + action],
-            outs = [name + action + ".out"],
-            cmd = "echo \"bash $(location %s) && bash $(location %s);\" > $@" % (after + action, run + action),
-            local = 1,
-            executable = 1,
-            **kwargs
+            commands = [
+                run_action_command,
+                after_action_command,
+            ],
         )

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -23,7 +23,7 @@ load("@rules_multirun//:defs.bzl", "command", "multirun")
 # To delete a release, run:
 #   `bazel run :dev.delete`
 #
-def release(name, run, after, enable_actions = True, srcs, **kwargs):
+def release(name, srcs, run, after, enable_actions = True, **kwargs):
     actions = [""]
     if enable_actions:
         actions = [".apply", ".diff", ".delete"]
@@ -33,13 +33,13 @@ def release(name, run, after, enable_actions = True, srcs, **kwargs):
         run_action_command = name + action + ".run"
         command(
             name = after_action_command,
-            command = after + action,
             srcs = srcs,
+            command = after + action,
         )
         command(
             name = run_action_command,
-            command = run + action,
             srcs = srcs,
+            command = run + action,
         )
         multirun(
             name = name + action,

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -1,4 +1,4 @@
-load("@rules_multirun//:defs.bzl", "command", "multirun")
+load("@rules_multirun//:defs.bzl", "multirun")
 
 # Creates a release step that depends on another release step.
 #

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -35,5 +35,5 @@ def release(name, run, after, enable_actions = True, **kwargs):
                 after + action,
                 run + action,
             ],
-            **kwargs,
+            **kwargs
         )

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -29,21 +29,11 @@ def release(name, run, after, enable_actions = True, **kwargs):
         actions = [".apply", ".diff", ".delete"]
 
     for action in actions:
-        after_action_command = name + action + ".after"
-        run_action_command = name + action + ".run"
-        command(
-            name = after_action_command,
-            command = after + action,
-        )
-        command(
-            name = run_action_command,
-            command = run + action,
-        )
         multirun(
             name = name + action,
             commands = [
-                after_action_command,
-                run_action_command,
+                after + action,
+                run + action,
             ],
             **kwargs,
         )

--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -1,3 +1,5 @@
+load("@rules_multirun//:defs.bzl", "multirun")
+
 # Creates a release step that depends on another release step.
 #
 # When run, it will run the target specified by the `run` argument
@@ -27,12 +29,11 @@ def release(name, run, after, enable_actions = True, **kwargs):
         actions = [".apply", ".diff", ".delete", ".push_only", ".apply_only"]
 
     for action in actions:
-        native.genrule(
+        multirun(
             name = name + action,
-            tools = [run + action, after + action],
-            outs = [name + action + ".out"],
-            cmd = "echo \"bash $(location %s) && bash $(location %s);\" > $@" % (after + action, run + action),
-            local = 1,
-            executable = 1,
+            commands = [
+                after + action,
+                run + action,
+            ],
             **kwargs
         )


### PR DESCRIPTION
We want the sub-targets in the release to be built with the taarget config, but they are currently built via the `tools` arg of `genrule`, which means they are built with the exec config. This can cause problems with sha mismatches in the app bundle during release. This PR intends to use Keith's `multirun` rules to fix that.
