### PR TITLE
Add realistic webdriver auth tests with SAML, subdomains, and auth popup

### DIFF
--- a/enterprise/server/test/webdriver/saml/saml_test.go
+++ b/enterprise/server/test/webdriver/saml/saml_test.go
@@ -1,23 +1,14 @@
 package saml_test
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
 	"testing"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testsaml"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/mocksaml"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
 	"github.com/stretchr/testify/require"
 )
@@ -26,26 +17,12 @@ const (
 	slug = "saml-test"
 )
 
-func startIDP(t *testing.T) (_ *mocksaml.IDP, certPath string) {
-	idpCert, idpKey := createSelfSignedCert(t)
-	idp, err := mocksaml.Start(testport.FindFree(t), bytes.NewReader(idpCert), bytes.NewReader(idpKey))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = idp.Kill() })
-	err = idp.WaitUntilReady(context.Background())
-	require.NoError(t, err)
-	idpCertFile := testfs.CreateTemp(t)
-	_, err = idpCertFile.Write(idpCert)
-	require.NoError(t, err)
-	_ = idpCertFile.Close()
-	return idp, idpCertFile.Name()
-}
-
-func startApp(t *testing.T, idpCertPath string, extraArgs ...string) buildbuddy_enterprise.WebTarget {
-	appCert, appKey := createSelfSignedCert(t)
+func startApp(t *testing.T, idp *testsaml.IDP, extraArgs ...string) buildbuddy_enterprise.WebTarget {
+	appCert, appKey := testsaml.CreateSelfSignedCert(t)
 	args := append([]string{
 		"--auth.saml.key=" + string(appKey),
 		"--auth.saml.cert=" + string(appCert),
-		"--auth.saml.trusted_idp_cert_files=" + idpCertPath,
+		"--auth.saml.trusted_idp_cert_files=" + idp.CertPath,
 	}, extraArgs...)
 	bb := buildbuddy_enterprise.SetupWebTarget(t, args...)
 	return bb
@@ -53,7 +30,7 @@ func startApp(t *testing.T, idpCertPath string, extraArgs ...string) buildbuddy_
 
 // Creates the org with slug "saml-test" and configures the SAML IDP metadata
 // URL in the DB.
-func setupSAMLTestOrg(t *testing.T, wt *webtester.WebTester, bb buildbuddy_enterprise.WebTarget, idp *mocksaml.IDP) {
+func setupSAMLTestOrg(t *testing.T, wt *webtester.WebTester, bb buildbuddy_enterprise.WebTarget, idp *testsaml.IDP) {
 	// Temporarily log in with self-auth, then configure an org slug in settings
 	// (it's empty by default).
 	webtester.Login(wt, bb)
@@ -79,8 +56,8 @@ func TestSAMLBasicLogin(t *testing.T) {
 	// metadata URL, so only run this test locally for now.
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
-	idp, idpCertPath := startIDP(t)
-	bb := startApp(t, idpCertPath)
+	idp := testsaml.Start(t)
+	bb := startApp(t, idp)
 	wt := webtester.New(t)
 	setupSAMLTestOrg(t, wt, bb, idp)
 
@@ -100,10 +77,10 @@ func TestSAMLViewInvocation(t *testing.T) {
 	buildbuddy_enterprise.MarkTestLocalOnly(t)
 
 	ctx := context.Background()
-	idp, idpCertPath := startIDP(t)
+	idp := testsaml.Start(t)
 	// Disable persisting artifacts in blobstore to exercise that cache auth
 	// accesses via the UI work when logged in with SAML.
-	bb := startApp(t, idpCertPath, "--storage.disable_persist_cache_artifacts=true")
+	bb := startApp(t, idp, "--storage.disable_persist_cache_artifacts=true")
 	wt := webtester.New(t)
 	setupSAMLTestOrg(t, wt, bb, idp)
 
@@ -128,26 +105,4 @@ func TestSAMLViewInvocation(t *testing.T) {
 	wt.Get(bb.HTTPURL() + "/invocation/" + buildResult.InvocationID)
 	wt.Find(`[href="#timing"]`).Click()
 	wt.Find(`.trace-viewer`)
-}
-
-func createSelfSignedCert(t *testing.T) (cert, key []byte) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	certTemplate := x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{Organization: []string{"mocksaml"}},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-	}
-	certBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &privateKey.PublicKey, privateKey)
-	require.NoError(t, err)
-	var certBuf, keyBuf bytes.Buffer
-	err = pem.Encode(&keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
-	require.NoError(t, err)
-	err = pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
-	require.NoError(t, err)
-	return certBuf.Bytes(), keyBuf.Bytes()
 }

--- a/enterprise/server/test/webdriver/subdomains/BUILD
+++ b/enterprise/server/test/webdriver/subdomains/BUILD
@@ -3,8 +3,8 @@ load("//rules/webdriver:index.bzl", "go_web_test_suite")
 package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_web_test_suite(
-    name = "saml_test",
-    srcs = ["saml_test.go"],
+    name = "subdomains_test",
+    srcs = ["subdomains_test.go"],
     exec_properties = {
         "test.EstimatedComputeUnits": "3",
         "test.workload-isolation-type": "firecracker",
@@ -12,14 +12,14 @@ go_web_test_suite(
         "test.init-dockerd": "true",
         "test.runner-recycling-key": "mocksaml",
     },
-    shard_count = 1,
+    shard_count = 7,
     tags = ["docker"],
     deps = [
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//enterprise/server/testutil/testsaml",
         "//enterprise/server/util/mocksaml",
         "//server/testutil/app",
-        "//server/testutil/testbazel",
+        "//server/testutil/testhosts",
         "//server/testutil/webtester",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/test/webdriver/subdomains/subdomains_test.go
+++ b/enterprise/server/test/webdriver/subdomains/subdomains_test.go
@@ -1,0 +1,302 @@
+package subdomains_test
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testsaml"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/mocksaml"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testhosts"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
+	"github.com/stretchr/testify/require"
+)
+
+type testEnv struct {
+	wt *webtester.WebTester
+	bb *app.App
+
+	// App HTTP port
+	port int
+	// mocksaml host:port
+	samlIDPHost string
+}
+
+// Does a basic SAML login into org-a (which has SAML enabled).
+func TestBasicSAMLLogin(t *testing.T) {
+	env := setup(t)
+	wt := env.wt
+
+	// Go to org A's subdomain and complete a login via its SAML IDP.
+	wt.Get(fmt.Sprintf("http://org-a.buildbuddy.local:%d", env.port))
+	popupWindow := startSSOLogin(t, wt)
+	completeSSOLogin(wt, popupWindow)
+
+	// We should be logged in to org A, as shown by the org picker in the sidebar.
+	wt.Find(`[debug-id="org-picker"]`)
+}
+
+// Does a basic self-auth (non-SAML) login on the default "app" subdomain.
+func TestBasicSelfAuthLogin(t *testing.T) {
+	env := setup(t)
+	wt := env.wt
+
+	// Click the login button on the app subdomain to log in via self-auth.
+	wt.Get(fmt.Sprintf("http://app.buildbuddy.local:%d", env.port))
+	wt.FindByDebugID("login-button").Click()
+
+	// We should be logged in, as shown by the org picker in the sidebar. The
+	// login completes asynchronously via a popup, so allow a generous timeout.
+	wt.FindWithTimeout(`[debug-id="org-picker"]`, 30*time.Second)
+}
+
+// A SAML-enabled org's login page should offer SSO login, while a non-SAML
+// org's login page should not.
+func TestLoginPageOffersSSOForSAMLOrgOnly(t *testing.T) {
+	env := setup(t)
+	wt := env.wt
+
+	// Org A uses SAML, so its login page should offer SSO login.
+	wt.Get(fmt.Sprintf("http://org-a.buildbuddy.local:%d", env.port))
+	wt.Find(`[debug-id="sso-button"]`)
+
+	// Org B doesn't use SAML, so its login page should show the self-auth login
+	// button and no SSO button.
+	wt.Get(fmt.Sprintf("http://org-b.buildbuddy.local:%d", env.port))
+	wt.Find(`[debug-id="login-button"]`)
+	wt.AssertNotFound(`[debug-id="sso-button"]`)
+}
+
+// Logging out should destroy the session, so revisiting the app afterwards
+// requires logging in again.
+func TestLogoutClearsSession(t *testing.T) {
+	env := setup(t)
+	wt := env.wt
+
+	// Log in via self-auth on the app subdomain.
+	appURL := fmt.Sprintf("http://app.buildbuddy.local:%d", env.port)
+	wt.Get(appURL)
+	wt.FindByDebugID("login-button").Click()
+	wt.FindWithTimeout(`[debug-id="org-picker"]`, 30*time.Second)
+
+	// Log out, then revisit the app subdomain. We should be back on the login
+	// page, with no org picker (i.e. logged out).
+	webtester.Logout(wt)
+	wt.Get(appURL)
+	wt.Find(`[debug-id="login-button"]`)
+	wt.AssertNotFound(`[debug-id="org-picker"]`)
+}
+
+// A logged-out user visiting a subdomain should be shown its login page rather
+// than app content.
+func TestLoggedOutUserSeesLoginPage(t *testing.T) {
+	env := setup(t)
+	wt := env.wt
+
+	// setup leaves the browser logged out. The default "app" subdomain and a
+	// non-SAML org's subdomain should each show a login button and no org picker.
+	for _, subdomain := range []string{"app", "org-b"} {
+		wt.Get(fmt.Sprintf("http://%s.buildbuddy.local:%d", subdomain, env.port))
+		wt.Find(`[debug-id="login-button"]`)
+		wt.AssertNotFound(`[debug-id="org-picker"]`)
+	}
+}
+
+// SAML identities are scoped to a single org, so users who are members of
+// multiple orgs (orgs commonly share a SAML IDP) rely on their SSO org's
+// session to authenticate them on their other orgs' subdomains. An org A
+// SAML session should authenticate the user on org B's subdomain, and once
+// the session expires, org B's subdomain should log back in via org A's IDP.
+func TestSAMLSessionAuthenticatesOnOtherOrgSubdomains(t *testing.T) {
+	env := setup(t)
+	wt := env.wt
+
+	// Log in to org A via its SAML IDP.
+	wt.Get(fmt.Sprintf("http://org-a.buildbuddy.local:%d", env.port))
+	popupWindow := startSSOLogin(t, wt)
+	completeSSOLogin(wt, popupWindow)
+	addSAMLUserToOrgB(t, env)
+
+	// The org A SAML session should authenticate the user on org B's subdomain.
+	wt.Get(fmt.Sprintf("http://org-b.buildbuddy.local:%d", env.port))
+	wt.FindWithTimeout(`[debug-id="org-picker"]`, 20*time.Second)
+
+	// Expire the SAML session.
+	wt.DeleteCookie("token")
+
+	// Org B's subdomain should now automatically log back in via org A's IDP.
+	wt.Get(fmt.Sprintf("http://org-b.buildbuddy.local:%d", env.port))
+	requireEventuallyOnHost(t, wt, env.samlIDPHost)
+
+	// Completing the re-login at the IDP should land back on org B's subdomain,
+	// logged in.
+	wt.Find(mocksaml.SignInButtonSelector).Click()
+	requireEventuallyOnHost(t, wt, fmt.Sprintf("org-b.buildbuddy.local:%d", env.port))
+	wt.FindWithTimeout(`[debug-id="org-picker"]`, 20*time.Second)
+}
+
+// Once a SAML login has completed, an expired session should still seamlessly
+// log back in with the org's IDP on the org's own subdomain and on default
+// subdomains, which aren't tied to any particular org.
+func TestExpiredSAMLSessionSeamlesslyLogsBackIn(t *testing.T) {
+	env := setup(t)
+	wt := env.wt
+
+	// Log in to org A via its SAML IDP.
+	wt.Get(fmt.Sprintf("http://org-a.buildbuddy.local:%d", env.port))
+	popupWindow := startSSOLogin(t, wt)
+	completeSSOLogin(wt, popupWindow)
+
+	// Expire the SAML session.
+	wt.DeleteCookie("token")
+
+	// Returning to org A's own subdomain should automatically restart the
+	// SAML login flow with org A's IDP.
+	wt.Get(fmt.Sprintf("http://org-a.buildbuddy.local:%d", env.port))
+	requireEventuallyOnHost(t, wt, env.samlIDPHost)
+
+	// Same for the default "app" subdomain.
+	wt.Get(fmt.Sprintf("http://app.buildbuddy.local:%d", env.port))
+	requireEventuallyOnHost(t, wt, env.samlIDPHost)
+}
+
+func setup(t *testing.T) *testEnv {
+	// We directly connect to the DB in order to set the SAML IDP metadata URL,
+	// so only run this test locally for now.
+	buildbuddy_enterprise.MarkTestLocalOnly(t)
+
+	// Set up the "app." subdomain and some org-specific subdomains to resolve
+	// to localhost.
+	testhosts.ResolveToLocalhost(t,
+		"app.buildbuddy.local",
+		"org-a.buildbuddy.local",
+		"org-b.buildbuddy.local",
+	)
+
+	idp := testsaml.Start(t)
+	idpURL, err := url.Parse(idp.MetadataURL())
+	require.NoError(t, err)
+
+	appConfig := buildbuddy_enterprise.DefaultAppConfig(t)
+	env := &testEnv{
+		port:        appConfig.HttpPort,
+		samlIDPHost: idpURL.Host,
+	}
+	appURL := fmt.Sprintf("http://app.buildbuddy.local:%d", env.port)
+	appCert, appKey := testsaml.CreateSelfSignedCert(t)
+	bb := buildbuddy_enterprise.RunWithConfig(t, appConfig, buildbuddy_enterprise.DefaultConfig,
+		"--auth.saml.key="+string(appKey),
+		"--auth.saml.cert="+string(appCert),
+		"--auth.saml.trusted_idp_cert_files="+idp.CertPath,
+		// Enable subdomain handling, mirroring the dev/prod config.
+		"--app.build_buddy_url="+appURL,
+		"--app.enable_subdomain_matching=true",
+		"--app.default_subdomains=app",
+		"--auth.domain_wide_cookies=true",
+		// Enable popup auth to match dev/prod.
+		"--app.popup_auth_enabled=true",
+	)
+
+	env.bb = bb
+	wt := webtester.New(t)
+	env.wt = wt
+
+	// Temporarily log in with self-auth on the default "app" subdomain to
+	// create two orgs: org A, which we configure to use SAML below, and org B,
+	// which keeps using self-auth (it never gets a SAML IDP configured).
+	wt.Get(appURL)
+	wt.FindByDebugID("login-button").Click()
+
+	// Since popup auth is enabled, the login completes asynchronously via a
+	// popup window, so wait for the sidebar with a generous timeout.
+	wt.FindWithTimeout(`[debug-id="org-picker"]`, 30*time.Second)
+	webtester.UpdateSelectedOrg(wt, appURL, "Org A", "org-a")
+
+	// Create org B, which should redirect to org B's subdomain. Wait until the
+	// redirect is complete.
+	webtester.CreateOrg(wt, appURL, "Org B", "org-b")
+	require.Eventually(t, func() bool {
+		u, err := url.Parse(wt.CurrentURL())
+		return err == nil && u.Host == fmt.Sprintf("org-b.buildbuddy.local:%d", env.port)
+	}, 30*time.Second, 100*time.Millisecond, "never got redirected to org B's subdomain after creating org B")
+
+	// Configure SAML for org A by manually executing a DB query.
+	res := bb.DB().Exec(`
+		UPDATE "Groups"
+		SET saml_idp_metadata_url = ?
+		WHERE url_identifier = ?
+		`,
+		idp.MetadataURL(),
+		"org-a",
+	)
+	require.NoError(t, res.Error)
+	require.Greater(t, res.RowsAffected, int64(0), "no groups matched slug %s", "org-a")
+	webtester.Logout(wt)
+
+	return env
+}
+
+// startSSOLogin clicks the SSO login button on the current login page, waits
+// for the SAML login page to become visible, then returns a handle on the
+// popup.
+func startSSOLogin(t *testing.T, wt *webtester.WebTester) (popupWindow string) {
+	mainWindow := wt.CurrentWindowHandle()
+	wt.FindWithTimeout(`[debug-id="sso-button"]`, 10*time.Second).Click()
+	require.Eventually(t, func() bool {
+		for _, handle := range wt.WindowHandles() {
+			if handle != mainWindow {
+				popupWindow = handle
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for popup window to open")
+	wt.SwitchWindow(popupWindow)
+	wt.FindWithTimeout(mocksaml.SignInButtonSelector, 10*time.Second)
+	wt.SwitchWindow(mainWindow)
+	return popupWindow
+}
+
+// completeSSOLogin signs in at the IDP in the popup window opened by
+// startSSOLogin, then waits for the main window to pick up the completed
+// login.
+func completeSSOLogin(wt *webtester.WebTester, popupWindow string) {
+	mainWindow := wt.CurrentWindowHandle()
+	wt.SwitchWindow(popupWindow)
+	wt.Find(mocksaml.SignInButtonSelector).Click()
+	wt.SwitchWindow(mainWindow)
+	wt.FindWithTimeout(`[debug-id="org-picker"]`, 30*time.Second)
+}
+
+// addSAMLUserToOrgB makes the SAML user, who became a member of org A by
+// logging in via org A's IDP, a member of org B as well, by copying their
+// org A membership row.
+func addSAMLUserToOrgB(t *testing.T, env *testEnv) {
+	res := env.bb.DB().Exec(`
+		INSERT INTO "UserGroups" (user_user_id, group_group_id, role, membership_status)
+		SELECT ug.user_user_id, gb.group_id, ug.role, ug.membership_status
+		FROM "UserGroups" ug
+		JOIN "Users" u ON u.user_id = ug.user_user_id
+		JOIN "Groups" ga ON ga.group_id = ug.group_group_id
+		JOIN "Groups" gb ON gb.url_identifier = ?
+		WHERE ga.url_identifier = ? AND u.sub_id LIKE ('%saml/metadata?slug=' || ? || '/%')
+		`,
+		"org-b",
+		"org-a",
+		"org-a",
+	)
+	require.NoError(t, res.Error)
+	require.EqualValues(t, 1, res.RowsAffected, "expected to find exactly one org A SAML user membership to copy")
+}
+
+// requireEventuallyOnHost waits for the browser to land on a URL with the
+// given host.
+func requireEventuallyOnHost(t *testing.T, wt *webtester.WebTester, host string) {
+	require.Eventually(t, func() bool {
+		u, err := url.Parse(wt.CurrentURL())
+		return err == nil && u.Host == host
+	}, 20*time.Second, 100*time.Millisecond, "expected to get redirected to %s", host)
+}

--- a/enterprise/server/testutil/testsaml/BUILD
+++ b/enterprise/server/testutil/testsaml/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "testsaml",
+    testonly = 1,
+    srcs = ["testsaml.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testsaml",
+    deps = [
+        "//enterprise/server/util/mocksaml",
+        "//server/testutil/testfs",
+        "//server/testutil/testport",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/testutil/testsaml/testsaml.go
+++ b/enterprise/server/testutil/testsaml/testsaml.go
@@ -1,0 +1,70 @@
+// Package testsaml provides helpers for using a mock SAML IDP in tests.
+package testsaml
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/mocksaml"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
+	"github.com/stretchr/testify/require"
+)
+
+// IDP is a mock SAML IDP scoped to a test.
+type IDP struct {
+	*mocksaml.IDP
+
+	// CertPath is the path to a PEM file containing the certificate that the
+	// IDP signs assertions with, suitable for passing to the app via the
+	// --auth.saml.trusted_idp_cert_files flag.
+	CertPath string
+}
+
+// Start starts a mock SAML IDP on a free port and waits for it to become
+// ready. The IDP is shut down when the test completes.
+func Start(t *testing.T) *IDP {
+	idpCert, idpKey := CreateSelfSignedCert(t)
+	idp, err := mocksaml.Start(testport.FindFree(t), bytes.NewReader(idpCert), bytes.NewReader(idpKey))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = idp.Kill() })
+	err = idp.WaitUntilReady(context.Background())
+	require.NoError(t, err)
+	idpCertFile := testfs.CreateTemp(t)
+	_, err = idpCertFile.Write(idpCert)
+	require.NoError(t, err)
+	_ = idpCertFile.Close()
+	return &IDP{IDP: idp, CertPath: idpCertFile.Name()}
+}
+
+// CreateSelfSignedCert generates a self-signed cert and returns the
+// PEM-encoded certificate and private key.
+func CreateSelfSignedCert(t *testing.T) (cert, key []byte) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	certTemplate := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"mocksaml"}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+	var certBuf, keyBuf bytes.Buffer
+	err = pem.Encode(&keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	require.NoError(t, err)
+	err = pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	require.NoError(t, err)
+	return certBuf.Bytes(), keyBuf.Bytes()
+}

--- a/server/testutil/testhosts/BUILD
+++ b/server/testutil/testhosts/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testhosts",
+    testonly = 1,
+    srcs = ["testhosts.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testhosts",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/server/testutil/testhosts/testhosts.go
+++ b/server/testutil/testhosts/testhosts.go
@@ -1,0 +1,42 @@
+// Package testhosts provides helpers for configuring static hostname
+// mappings in /etc/hosts for the duration of a test.
+//
+// Modifying /etc/hosts requires root privileges, so tests using this package
+// are expected to run with workload isolation (e.g. firecracker), where the
+// test runs as root and any modifications are scoped to the VM.
+package testhosts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const hostsFilePath = "/etc/hosts"
+
+// ResolveToLocalhost appends entries to /etc/hosts mapping each of the given
+// hostnames to 127.0.0.1, and registers a cleanup function to restore the
+// original /etc/hosts contents when the test completes.
+//
+// The test is skipped if it is not running as root, since root privileges are
+// required to modify /etc/hosts.
+func ResolveToLocalhost(t *testing.T, hostnames ...string) {
+	if os.Geteuid() != 0 {
+		t.Skipf("test requires root privileges to modify %s", hostsFilePath)
+	}
+	original, err := os.ReadFile(hostsFilePath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Note: the mode is ignored since the file already exists.
+		require.NoError(t, os.WriteFile(hostsFilePath, original, 0644))
+	})
+	contents := string(original)
+	if !strings.HasSuffix(contents, "\n") {
+		contents += "\n"
+	}
+	contents += fmt.Sprintf("127.0.0.1 %s\n", strings.Join(hostnames, " "))
+	require.NoError(t, os.WriteFile(hostsFilePath, []byte(contents), 0644))
+}

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -161,6 +161,34 @@ func (wt *WebTester) Refresh() {
 	wt.Get(wt.CurrentURL())
 }
 
+// CurrentWindowHandle returns the handle of the currently focused window.
+func (wt *WebTester) CurrentWindowHandle() string {
+	handle, err := wt.driver.CurrentWindowHandle()
+	require.NoError(wt.t, err)
+	return handle
+}
+
+// WindowHandles returns the handles of all open windows, including popup
+// windows opened by the page.
+func (wt *WebTester) WindowHandles() []string {
+	handles, err := wt.driver.WindowHandles()
+	require.NoError(wt.t, err)
+	return handles
+}
+
+// SwitchWindow switches the WebTester's focus to the window with the given
+// handle. Subsequent WebTester calls are directed at that window.
+func (wt *WebTester) SwitchWindow(handle string) {
+	err := wt.driver.SwitchWindow(handle)
+	require.NoError(wt.t, err)
+}
+
+// DeleteCookie deletes the cookie with the given name from the browser.
+func (wt *WebTester) DeleteCookie(name string) {
+	err := wt.driver.DeleteCookie(name)
+	require.NoError(wt.t, err)
+}
+
 // Find returns the element matching the given CSS selector. Exactly one
 // element must be matched, otherwise the test fails.
 func (wt *WebTester) Find(cssSelector string) *Element {


### PR DESCRIPTION
SAML login + subdomains can have some complex interactions (esp. around the `Slug` cookie) and we have a few known bugs around SAML login as well as how it interacts w/ OAuth login.

Add some webdriver tests to lock in some of the current good behaviors before we start making changes.

Misc
- Add webtester utils for interacting with the auth popup, which is nice to test since we have popup auth enabled in prod.
- Extract some SAML test helpers
- Add a test helper for messing with `/etc/hosts` (and restore it after the test). These tests can be safely run within firecracker VMs or OCI containers