### PR TITLE
shortcut span creation

### DIFF
--- a/server/util/tracing/BUILD
+++ b/server/util/tracing/BUILD
@@ -25,6 +25,7 @@ go_library(
         "@io_opentelemetry_go_otel_sdk//resource",
         "@io_opentelemetry_go_otel_sdk//trace",
         "@io_opentelemetry_go_otel_trace//:trace",
+        "@io_opentelemetry_go_otel_trace//embedded",
         "@org_golang_google_grpc//metadata",
     ],
 )
@@ -38,5 +39,7 @@ go_test(
         "//server/util/log",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel_trace//:trace",
+        "@org_golang_google_grpc//metadata",
     ],
 )

--- a/server/util/tracing/tracing.go
+++ b/server/util/tracing/tracing.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
 	"google.golang.org/grpc/metadata"
 
 	tpb "github.com/buildbuddy-io/buildbuddy/proto/trace"
@@ -49,6 +50,7 @@ var (
 	traceFraction             = flag.Float64("app.trace_fraction", 0, "Fraction of requests to sample for tracing.")
 	traceFractionOverrides    = flag.Slice("app.trace_fraction_overrides", []string{}, "Tracing fraction override based on name in format name=fraction.")
 	ignoreForcedTracingHeader = flag.Bool("app.ignore_forced_tracing_header", false, "If set, we will not honor the forced tracing header.")
+	traceSamplingShortcut     = flag.Bool("app.trace_sampling_shortcut", true, "If set, skip span creation for child spans whose local parent was not sampled (a performance optimization). Disable to always run the sampler.")
 )
 
 // Re-initialized in Configure. Set here so tests that don't call Configure
@@ -95,12 +97,17 @@ func newFractionSampler(fraction float64, fractionOverrides map[string]float64, 
 }
 
 func (s *fractionSampler) checkForcedTrace(parameters sdktrace.SamplingParameters) bool {
+	return s.forcedFromContext(parameters.ParentContext)
+}
+
+// forcedFromContext reports whether tracing is being forced via the
+// x-buildbuddy-trace header on the incoming request metadata.
+func (s *fractionSampler) forcedFromContext(ctx context.Context) bool {
 	if s.ignoreForcedTracingHeader {
 		return false
 	}
-	hdrs := metadata.ValueFromIncomingContext(parameters.ParentContext, traceHeader)
-	forced := len(hdrs) > 0 && hdrs[0] == forceTraceHeaderValue
-	return forced
+	hdrs := metadata.ValueFromIncomingContext(ctx, traceHeader)
+	return len(hdrs) > 0 && hdrs[0] == forceTraceHeaderValue
 }
 
 func (s *fractionSampler) ShouldSample(parameters sdktrace.SamplingParameters) sdktrace.SamplingResult {
@@ -134,6 +141,45 @@ func (s *fractionSampler) ShouldSample(parameters sdktrace.SamplingParameters) s
 
 func (s *fractionSampler) Description() string {
 	return s.description
+}
+
+// shortcutTracerProvider wraps the real TracerProvider so a child of an
+// unsampled local parent skips span creation + the sampler (ParentBased
+// leaves local-not-sampled at AlwaysOff, so the child is dropped anyway).
+// Installed globally, so it covers both StartNamedSpan and the otelgrpc
+// handlers. Remote parents and forced traces are excluded (see Start);
+// breaks if the sampler stops dropping local-not-sampled children (see
+// Configure).
+type shortcutTracerProvider struct {
+	embedded.TracerProvider
+	delegate trace.TracerProvider
+	sampler  *fractionSampler
+}
+
+func newShortcutTracerProvider(delegate trace.TracerProvider, sampler *fractionSampler) *shortcutTracerProvider {
+	return &shortcutTracerProvider{delegate: delegate, sampler: sampler}
+}
+
+func (p *shortcutTracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	return &shortcutTracer{delegate: p.delegate.Tracer(name, opts...), sampler: p.sampler}
+}
+
+type shortcutTracer struct {
+	embedded.Tracer
+	delegate trace.Tracer
+	sampler  *fractionSampler
+}
+
+func (t *shortcutTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	parent := trace.SpanFromContext(ctx)
+	psc := parent.SpanContext()
+	// Return the parent for a child that ParentBased would drop anyway (valid,
+	// local, not sampled, not recording). Remote parents are re-sampled and
+	// forced traces can override, so those go through the real tracer.
+	if psc.IsValid() && !psc.IsRemote() && !psc.IsSampled() && !parent.IsRecording() && !t.sampler.forcedFromContext(ctx) {
+		return ctx, parent
+	}
+	return t.delegate.Start(ctx, spanName, opts...)
 }
 
 // noopExporter is a span exporter that does nothing, used for testing/benchmarking.
@@ -283,11 +329,17 @@ func setupTracingWithExporter(env environment.Env, traceExporter sdktrace.SpanEx
 		res = resource.NewSchemaless(resourceAttrs...)
 	}
 
+	// Leaves local-not-sampled at the ParentBased default (AlwaysOff), which
+	// shortcutTracer.Start relies on; revisit it if that's ever overridden.
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(bsp),
 		sdktrace.WithSampler(sdktrace.ParentBased(sampler, sdktrace.WithRemoteParentNotSampled(sampler))),
 		sdktrace.WithResource(res))
-	otel.SetTracerProvider(tp)
+	var provider trace.TracerProvider = tp
+	if *traceSamplingShortcut {
+		provider = newShortcutTracerProvider(tp, sampler)
+	}
+	otel.SetTracerProvider(provider)
 	// Re-enable this if GCS tracing is fixed to not include blob names in span names
 	// Necessary imports: "go.opentelemetry.io/otel/bridge/opencensus"
 	//                    octrace "go.opencensus.io/trace"

--- a/server/util/tracing/tracing_test.go
+++ b/server/util/tracing/tracing_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/metadata"
 )
 
 func init() {
@@ -20,6 +22,141 @@ func init() {
 func setupBench(b *testing.B) {
 	flags.Set(b, "app.trace_fraction", 0.01)
 	require.NoError(b, tracing.ConfigureWithNoopExporter(testenv.GetTestEnv(b)))
+}
+
+// parentContext returns a context carrying a (non-recording) parent span with
+// the given sampled/remote flags. firstByte controls the high bits of the
+// trace ID, which drives the fraction sampler when a span is (re)sampled:
+// 0xff => Drop, 0x00 => Sample (at any non-zero fraction).
+func parentContext(sampled, remote bool, firstByte byte) (context.Context, trace.SpanID) {
+	var tid trace.TraceID
+	for i := 0; i < 8; i++ {
+		tid[i] = firstByte
+	}
+	tid[15] = 1 // keep the trace ID valid (non-zero) even when firstByte is 0.
+	sid := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+	cfg := trace.SpanContextConfig{TraceID: tid, SpanID: sid, Remote: remote}
+	if sampled {
+		cfg.TraceFlags = trace.FlagsSampled
+	}
+	sc := trace.NewSpanContext(cfg)
+	return trace.ContextWithSpanContext(context.Background(), sc), sid
+}
+
+func setupTracing(t *testing.T, fraction float64) {
+	flags.Set(t, "app.trace_fraction", fraction)
+	require.NoError(t, tracing.ConfigureWithNoopExporter(testenv.GetTestEnv(t)))
+}
+
+// An unsampled LOCAL parent: the fast path returns the parent span itself
+// rather than allocating a new (would-be-dropped) child span. The trace ID
+// (0x00) would sample if the fraction sampler ran, proving the child is
+// dropped because of the local-not-sampled parent, not the fraction.
+func TestStartNamedSpan_UnsampledLocalParent_ReturnsParent(t *testing.T) {
+	setupTracing(t, 0.01)
+	ctx, parentSID := parentContext(false /*sampled*/, false /*remote*/, 0x00)
+
+	_, span := tracing.StartNamedSpan(ctx, "child")
+
+	require.False(t, span.IsRecording(), "child of an unsampled local parent should not record")
+	require.Equal(t, parentSID, span.SpanContext().SpanID(),
+		"fast path should return the parent span (no new span created)")
+}
+
+// A sampled parent must still produce a real, recording child span.
+func TestStartNamedSpan_SampledParent_CreatesChild(t *testing.T) {
+	setupTracing(t, 0.01)
+	ctx, parentSID := parentContext(true /*sampled*/, false /*remote*/, 0xff)
+
+	_, span := tracing.StartNamedSpan(ctx, "child")
+
+	require.True(t, span.IsRecording(), "child of a sampled parent should record")
+	require.NotEqual(t, parentSID, span.SpanContext().SpanID(),
+		"a real child span should have its own span ID")
+}
+
+// A REMOTE not-sampled parent must be re-sampled (WithRemoteParentNotSampled),
+// so the fast path must NOT short-circuit it. With a trace ID that samples,
+// the resulting span records.
+func TestStartNamedSpan_RemoteUnsampledParent_Resampled(t *testing.T) {
+	setupTracing(t, 0.01)
+	sampleID, _ := parentContext(false /*sampled*/, true /*remote*/, 0x00)
+	_, span := tracing.StartNamedSpan(sampleID, "child")
+	require.True(t, span.IsRecording(), "remote unsampled parent should be re-sampled, not short-circuited")
+
+	dropID, _ := parentContext(false /*sampled*/, true /*remote*/, 0xff)
+	_, span = tracing.StartNamedSpan(dropID, "child")
+	require.False(t, span.IsRecording(), "remote unsampled parent that fails resampling is dropped")
+}
+
+// The force-trace header overrides sampling where the sampler actually runs
+// (root / remote not-sampled parent), so the fast path must not short-circuit
+// such spans. (A local not-sampled parent is AlwaysOff and never consults the
+// sampler, so force does not apply there -- see TestSamplerAssumption below.)
+func TestStartNamedSpan_ForcedHeader_OverridesRemoteUnsampledParent(t *testing.T) {
+	setupTracing(t, 0.01)
+	base, _ := parentContext(false /*sampled*/, true /*remote*/, 0xff)
+
+	// Without the force header, the (0xff) trace ID fails resampling -> dropped.
+	_, span := tracing.StartNamedSpan(base, "child")
+	require.False(t, span.IsRecording())
+
+	// With the force header it records.
+	forced := metadata.NewIncomingContext(base, metadata.Pairs("x-buildbuddy-trace", "force"))
+	_, span = tracing.StartNamedSpan(forced, "child")
+	require.True(t, span.IsRecording(), "forced trace should record even under an unsampled remote parent")
+}
+
+// Guards the shortcut's invariant on the real sampler (shortcut disabled): a
+// child of an unsampled local parent is always dropped, fraction and force
+// ignored. Fails if a sampler-config change (e.g. WithLocalParentNotSampled)
+// makes it sample-able -- the signal to revisit shortcutTracer.Start.
+func TestSamplerAssumption_LocalUnsampledParentAlwaysDropped(t *testing.T) {
+	flags.Set(t, "app.trace_sampling_shortcut", false) // exercise the real sampler
+	setupTracing(t, 0.01)
+
+	base, _ := parentContext(false /*sampled*/, false /*remote*/, 0x00 /*would sample*/)
+
+	_, span := tracing.StartNamedSpan(base, "child")
+	require.False(t, span.IsRecording(), "local unsampled parent must drop its child (fraction ignored)")
+
+	forced := metadata.NewIncomingContext(base, metadata.Pairs("x-buildbuddy-trace", "force"))
+	_, span = tracing.StartNamedSpan(forced, "child")
+	require.False(t, span.IsRecording(), "force does not apply to a local unsampled parent (AlwaysOff)")
+}
+
+// The kill-switch flag disables the shortcut: a child of an unsampled local
+// parent then goes through the real tracer (a new, non-recording span).
+func TestStartNamedSpan_ShortcutDisabled(t *testing.T) {
+	flags.Set(t, "app.trace_sampling_shortcut", false)
+	setupTracing(t, 0.01)
+	ctx, parentSID := parentContext(false /*sampled*/, false /*remote*/, 0xff)
+
+	_, span := tracing.StartNamedSpan(ctx, "child")
+
+	require.False(t, span.IsRecording())
+	require.NotEqual(t, parentSID, span.SpanContext().SpanID(),
+		"with the shortcut disabled a real (new) child span is created")
+}
+
+// Same workload -- a child span of an unsampled local parent -- with the
+// shortcut on vs off, to isolate the shortcut's effect.
+func benchmarkUnsampledLocalParent(b *testing.B, shortcut bool) {
+	flags.Set(b, "app.trace_fraction", 0.01)
+	flags.Set(b, "app.trace_sampling_shortcut", shortcut)
+	require.NoError(b, tracing.ConfigureWithNoopExporter(testenv.GetTestEnv(b)))
+	ctx, _ := parentContext(false /*sampled*/, false /*remote*/, 0xff)
+	for b.Loop() {
+		tracing.StartNamedSpan(ctx, "bench")
+	}
+}
+
+func BenchmarkUnsampledLocalParent_ShortcutOn(b *testing.B) {
+	benchmarkUnsampledLocalParent(b, true)
+}
+
+func BenchmarkUnsampledLocalParent_ShortcutOff(b *testing.B) {
+	benchmarkUnsampledLocalParent(b, false)
 }
 
 func BenchmarkStartSpan(b *testing.B) {


### PR DESCRIPTION
 CPU profiles of the metadata server show OpenTelemetry creating a span on every gRPC call despite 1% sampling — the largest single cost being the outbound otelgrpc client handler (clientHandler.TagRPC → tracer.Start, ~1.7s of a 30s profile) — yet ~99% of these are child spans of unsampled requests that get dropped anyway.

  This skips span creation for children of unsampled local parents (which ParentBased drops regardless), cutting that path from ~171→20 ns/op and 2 allocs→0.
