### PR TITLE
enterprise-proxy: document bytestream uri prefix

### DIFF
--- a/docs/enterprise-proxy.md
+++ b/docs/enterprise-proxy.md
@@ -54,3 +54,12 @@ resources:
 ## Usage
 
 Now you can point Bazel hosts and remote executors in the same cluster at your cache proxy deployment, using its cluster IP. The relevant flags are `--remote_cache` for Bazel and `--executor.cache_target` for the BuildBuddy remote executor. If you need to access the proxy from outside of the cluster, you can create and use an ingress.
+
+When Bazel uses a cache proxy as its `--remote_cache`, it also uses that `--remote_cache` target when writing `bytestream://` artifact URIs into the build event stream. If the proxy is only reachable inside your cluster, set `--remote_bytestream_uri_prefix` to the canonical BuildBuddy cache hostname so BuildBuddy can fetch build event artifacts such as Bazel timing profiles:
+
+```bash title=".bazelrc"
+build:buildbuddy_proxy --remote_cache=grpc://cache-proxy.example.com:1985
+build:buildbuddy_proxy --remote_bytestream_uri_prefix=<org-slug>.buildbuddy.io
+```
+
+You can use your org-specific cache hostname, such as `<org-slug>.buildbuddy.io`, or `remote.buildbuddy.io`. Do not include a `grpc://`, `grpcs://`, or `bytestream://` scheme in `--remote_bytestream_uri_prefix`.

--- a/docs/enterprise-proxy.md
+++ b/docs/enterprise-proxy.md
@@ -55,7 +55,7 @@ resources:
 
 Now you can point Bazel hosts and remote executors in the same cluster at your cache proxy deployment, using its cluster IP. The relevant flags are `--remote_cache` for Bazel and `--executor.cache_target` for the BuildBuddy remote executor. If you need to access the proxy from outside of the cluster, you can create and use an ingress.
 
-When Bazel uses a cache proxy as its `--remote_cache`, it also uses that `--remote_cache` target when writing `bytestream://` artifact URIs into the build event stream. If the proxy is only reachable inside your cluster, set `--remote_bytestream_uri_prefix` to the canonical BuildBuddy cache hostname so BuildBuddy can fetch build event artifacts such as Bazel timing profiles:
+When Bazel uses a cache proxy as its `--remote_cache`, it also uses that `--remote_cache` target when writing `bytestream://` artifact URIs into the build event stream. Set `--remote_bytestream_uri_prefix` to the canonical BuildBuddy cache hostname so BuildBuddy can fetch build event artifacts such as Bazel timing profiles:
 
 ```bash title=".bazelrc"
 build:buildbuddy_proxy --remote_cache=grpc://cache-proxy.example.com:1985


### PR DESCRIPTION
We ran into issue where invocation's important artifacts were not being
copied over to object storage for longer term storage. This was caused
by the bytestream uri in BuildEventStream using the self-hosted proxy
domain, as Bazel set that endpoint in the --remote_cache flag.

Document the current known workaround using remote_bytestream_uri_prefix
flag so the longer term persistent of important artifacts (test logs,
timing profiles) continue to work correctly.
