### PR TITLE
pebble cache (backed by GCS): test read operations w/ and w/o faults

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -71,6 +71,7 @@ go_test(
         "//server/testutil/testfs",
         "//server/util/compression",
         "//server/util/disk",
+        "//server/util/ioutil",
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/proto",

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3048,83 +3048,26 @@ func TestAtimeUpdater(t *testing.T) {
 	require.Eventually(t, calledFunc, time.Minute, 100*time.Millisecond)
 }
 
-type recordingGCS struct {
-	mu        sync.Mutex
-	storage   filestore.PebbleGCSStorage
-	blobNames []string
+type faultyGCS struct {
+	filestore.PebbleGCSStorage
+	mu      sync.Mutex
+	readErr error
 }
 
-func (g *recordingGCS) SetStorage(storage filestore.PebbleGCSStorage) {
-	g.mu.Lock()
-	g.storage = storage
-	g.mu.Unlock()
-}
-
-func (g *recordingGCS) Storage() filestore.PebbleGCSStorage {
+func (g *faultyGCS) SetReadError(err error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.storage
+	g.readErr = err
 }
 
-func (g *recordingGCS) SetBucketCustomTimeTTL(ctx context.Context, ageInDays int64) error {
-	return g.Storage().SetBucketCustomTimeTTL(ctx, ageInDays)
-}
-
-func (g *recordingGCS) Reader(ctx context.Context, blobName string, offset, limit int64) (io.ReadCloser, error) {
-	return g.Storage().Reader(ctx, blobName, offset, limit)
-}
-
-func (g *recordingGCS) ConditionalWriter(ctx context.Context, blobName string, overwriteExisting bool, customTime time.Time, estimatedSize int64) (interfaces.CommittedWriteCloser, error) {
-	w, err := g.Storage().ConditionalWriter(ctx, blobName, overwriteExisting, customTime, estimatedSize)
+func (g *faultyGCS) Reader(ctx context.Context, blobName string, offset, limit int64) (io.ReadCloser, error) {
+	g.mu.Lock()
+	err := g.readErr
+	g.mu.Unlock()
 	if err != nil {
 		return nil, err
 	}
-	return &recordingGCSWriter{CommittedWriteCloser: w, gcs: g, blobName: blobName}, nil
-}
-
-func (g *recordingGCS) DeleteBlob(ctx context.Context, blobName string) error {
-	return g.Storage().DeleteBlob(ctx, blobName)
-}
-
-func (g *recordingGCS) UpdateCustomTime(ctx context.Context, blobName string, t time.Time) error {
-	return g.Storage().UpdateCustomTime(ctx, blobName, t)
-}
-
-func (g *recordingGCS) DeleteRecordedBlobs(ctx context.Context) error {
-	g.mu.Lock()
-	names := append([]string(nil), g.blobNames...)
-	g.mu.Unlock()
-	for _, name := range names {
-		if err := g.DeleteBlob(ctx, name); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type recordingGCSWriter struct {
-	interfaces.CommittedWriteCloser
-	gcs      *recordingGCS
-	blobName string
-}
-
-func (w *recordingGCSWriter) Commit() error {
-	if err := w.CommittedWriteCloser.Commit(); err != nil {
-		return err
-	}
-	w.gcs.mu.Lock()
-	w.gcs.blobNames = append(w.gcs.blobNames, w.blobName)
-	w.gcs.mu.Unlock()
-	return nil
-}
-
-type readFailingGCS struct {
-	filestore.PebbleGCSStorage
-	err error
-}
-
-func (g *readFailingGCS) Reader(ctx context.Context, blobName string, offset, limit int64) (io.ReadCloser, error) {
-	return nil, g.err
+	return g.PebbleGCSStorage.Reader(ctx, blobName, offset, limit)
 }
 
 type commitFailingGCS struct {
@@ -3319,14 +3262,17 @@ func TestPebbleGCSBlobMissingAfterDelete(t *testing.T) {
 
 func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	gcs := &recordingGCS{storage: mockgcs.New(clock)}
+	gcs := mockgcs.New(clock)
 	te, c := newGCSBackedContractCache(t, clock, gcs)
 	ctx := getAnonContext(t, te)
 	rn, data := testdigest.RandomCASResourceBuf(t, 100)
 
 	require.NoError(t, c.Set(ctx, rn, data))
-	require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
+	require.NoError(t, gcs.DeleteAllBlobs(ctx))
 
+	// Metadata reads are answered from the local index, which still has the
+	// entry even though the backing blob is gone.
+	expectMetadataPresent(t, ctx, c, rn)
 	// The first content miss repairs the local index, so metadata reads miss after it.
 	expectContentNotFound(t, ctx, c, rn)
 	expectMetadataMissing(t, ctx, c, rn)
@@ -3334,16 +3280,13 @@ func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
 
 func TestPebbleGCSBackingReadUnavailable(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	gcs := &recordingGCS{storage: mockgcs.New(clock)}
+	gcs := &faultyGCS{PebbleGCSStorage: mockgcs.New(clock)}
 	te, c := newGCSBackedContractCache(t, clock, gcs)
 	ctx := getAnonContext(t, te)
 	rn, data := testdigest.RandomCASResourceBuf(t, 100)
 
 	require.NoError(t, c.Set(ctx, rn, data))
-	gcs.SetStorage(&readFailingGCS{
-		PebbleGCSStorage: gcs.Storage(),
-		err:              status.UnavailableError("gcs read unavailable"),
-	})
+	gcs.SetReadError(status.UnavailableError("gcs read unavailable"))
 
 	expectMetadataPresent(t, ctx, c, rn)
 	expectContentError(t, ctx, c, rn, "gcs read unavailable")

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3302,20 +3302,58 @@ func TestPebbleGCSReadContractMissingAfterDelete(t *testing.T) {
 }
 
 func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-	gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
-	te, c := newGCSBackedContractCache(t, clock, gcs)
-	ctx := getAnonContext(t, te)
-	rn, data := testdigest.RandomCASResourceBuf(t, 100)
+	for _, tc := range []struct {
+		name string
+		read func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName)
+	}{
+		{
+			name: "get",
+			read: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
+				_, err := c.Get(ctx, rn)
+				require.True(t, status.IsNotFoundError(err), "Get: %v", err)
+			},
+		},
+		{
+			name: "get_with_metadata",
+			read: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
+				_, _, err := c.GetWithMetadata(ctx, rn)
+				require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
+			},
+		},
+		{
+			name: "get_multi",
+			read: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
+				multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
+				require.NoError(t, err, "GetMulti")
+				require.Nil(t, multi[rn.GetDigest()], "GetMulti")
+			},
+		},
+		{
+			name: "reader",
+			read: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
+				rc, err := c.Reader(ctx, rn, 0, 0)
+				require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
+				require.Nil(t, rc, "Reader")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := clockwork.NewFakeClock()
+			gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
+			te, c := newGCSBackedContractCache(t, clock, gcs)
+			ctx := getAnonContext(t, te)
+			rn, data := testdigest.RandomCASResourceBuf(t, 100)
 
-	require.NoError(t, c.Set(ctx, rn, data))
-	require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
+			require.NoError(t, c.Set(ctx, rn, data))
+			require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
 
-	// The metadata methods still report the resource as present because
-	// PebbleCache does not consult backing storage for them, but reading the
-	// content surfaces the now-missing backing blob.
-	expectMetadataPresent(t, ctx, c, rn)
-	expectContentNotFound(t, ctx, c, rn)
+			// The metadata methods still report the resource as present because
+			// PebbleCache does not consult backing storage for them, but reading the
+			// content surfaces the now-missing backing blob.
+			expectMetadataPresent(t, ctx, c, rn)
+			tc.read(t, ctx, c, rn)
+		})
+	}
 }
 
 func TestPebbleGCSBackingObjectDeletedMetadataMethodsShouldReportMissing(t *testing.T) {

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3245,7 +3245,7 @@ func expectContentError(t *testing.T, ctx context.Context, c interfaces.Cache, r
 	require.Nil(t, rc, "Reader")
 }
 
-func TestPebbleGCSReadContractPresent(t *testing.T) {
+func TestPebbleGCSBlobPresent(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		setup func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte)
@@ -3288,7 +3288,7 @@ func TestPebbleGCSReadContractPresent(t *testing.T) {
 	}
 }
 
-func TestPebbleGCSReadContractMissingAfterDelete(t *testing.T) {
+func TestPebbleGCSBlobMissingAfterDelete(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	te, c := newGCSBackedContractCache(t, clock, mockgcs.New(clock))
 	ctx := getAnonContext(t, te)
@@ -3347,10 +3347,7 @@ func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
 			require.NoError(t, c.Set(ctx, rn, data))
 			require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
 
-			// The metadata methods still report the resource as present because
-			// PebbleCache does not consult backing storage for them, but reading the
-			// content surfaces the now-missing backing blob.
-			expectMetadataPresent(t, ctx, c, rn)
+			expectMetadataMissing(t, ctx, c, rn)
 			tc.read(t, ctx, c, rn)
 		})
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3046,3 +3046,412 @@ func TestAtimeUpdater(t *testing.T) {
 	}
 	require.Eventually(t, calledFunc, time.Minute, 100*time.Millisecond)
 }
+
+type recordingGCS struct {
+	filestore.PebbleGCSStorage
+
+	mu        sync.Mutex
+	blobNames []string
+}
+
+func (g *recordingGCS) ConditionalWriter(ctx context.Context, blobName string, overwriteExisting bool, customTime time.Time, estimatedSize int64) (interfaces.CommittedWriteCloser, error) {
+	w, err := g.PebbleGCSStorage.ConditionalWriter(ctx, blobName, overwriteExisting, customTime, estimatedSize)
+	if err != nil {
+		return nil, err
+	}
+	return &recordingGCSWriter{CommittedWriteCloser: w, gcs: g, blobName: blobName}, nil
+}
+
+func (g *recordingGCS) DeleteRecordedBlobs(ctx context.Context) error {
+	g.mu.Lock()
+	names := append([]string(nil), g.blobNames...)
+	g.mu.Unlock()
+	for _, name := range names {
+		if err := g.DeleteBlob(ctx, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type recordingGCSWriter struct {
+	interfaces.CommittedWriteCloser
+	gcs      *recordingGCS
+	blobName string
+}
+
+func (w *recordingGCSWriter) Commit() error {
+	if err := w.CommittedWriteCloser.Commit(); err != nil {
+		return err
+	}
+	w.gcs.mu.Lock()
+	w.gcs.blobNames = append(w.gcs.blobNames, w.blobName)
+	w.gcs.mu.Unlock()
+	return nil
+}
+
+type readFailingGCS struct {
+	filestore.PebbleGCSStorage
+	err error
+}
+
+func (g *readFailingGCS) Reader(ctx context.Context, blobName string, offset, limit int64) (io.ReadCloser, error) {
+	return nil, g.err
+}
+
+type commitFailingGCS struct {
+	filestore.PebbleGCSStorage
+	err error
+}
+
+func (g *commitFailingGCS) ConditionalWriter(ctx context.Context, blobName string, overwriteExisting bool, customTime time.Time, estimatedSize int64) (interfaces.CommittedWriteCloser, error) {
+	return &commitFailingWriter{err: g.err}, nil
+}
+
+type commitFailingWriter struct {
+	err error
+}
+
+func (w *commitFailingWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (w *commitFailingWriter) Close() error {
+	return nil
+}
+
+func (w *commitFailingWriter) Commit() error {
+	return w.err
+}
+
+func newGCSBackedContractCache(t *testing.T, clock clockwork.Clock, gcs filestore.PebbleGCSStorage) (*testenv.TestEnv, interfaces.Cache) {
+	t.Helper()
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	var minGCSFileSize int64 = 1
+	var gcsTTLDays int64 = 30
+	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{
+		RootDirectory:          testfs.MakeTempDir(t),
+		MaxSizeBytes:           1_000_000,
+		Clock:                  clock,
+		FileStorer:             filestore.New(filestore.WithGCSBlobstore(gcs, "app-name")),
+		MaxInlineFileSizeBytes: 1,
+		MinGCSFileSizeBytes:    &minGCSFileSize,
+		GCSTTLDays:             &gcsTTLDays,
+	})
+	require.NoError(t, err)
+	require.NoError(t, pc.Start())
+	t.Cleanup(func() { pc.Stop() })
+	return te, pc
+}
+
+func TestPebbleGCSReadContractPresent(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte)
+	}{
+		{
+			name: "set",
+			setup: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte) {
+				require.NoError(t, c.Set(ctx, rn, data))
+			},
+		},
+		{
+			name: "set_multi",
+			setup: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte) {
+				require.NoError(t, c.SetMulti(ctx, map[*rspb.ResourceName][]byte{rn: data}))
+			},
+		},
+		{
+			name: "writer",
+			setup: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte) {
+				w, err := c.Writer(ctx, rn)
+				require.NoError(t, err)
+				defer w.Close()
+				_, err = w.Write(data)
+				require.NoError(t, err)
+				require.NoError(t, w.Commit())
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := clockwork.NewFakeClock()
+			te, c := newGCSBackedContractCache(t, clock, mockgcs.New(clock))
+			ctx := getAnonContext(t, te)
+			rn, data := testdigest.RandomCASResourceBuf(t, 100)
+
+			tc.setup(t, ctx, c, rn, data)
+
+			t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
+				contains, err := c.Contains(ctx, rn)
+				require.NoError(t, err, "Contains")
+				require.True(t, contains, "Contains")
+
+				_, err = c.Metadata(ctx, rn)
+				require.NoError(t, err, "Metadata")
+
+				missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
+				require.NoError(t, err, "FindMissing")
+				require.Empty(t, missing, "FindMissing")
+			})
+
+			t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
+				got, err := c.Get(ctx, rn)
+				require.NoError(t, err, "Get")
+				require.Equal(t, data, got, "Get")
+
+				got, _, err = c.GetWithMetadata(ctx, rn)
+				require.NoError(t, err, "GetWithMetadata")
+				require.Equal(t, data, got, "GetWithMetadata")
+
+				multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
+				require.NoError(t, err, "GetMulti")
+				require.Equal(t, data, multi[rn.GetDigest()], "GetMulti")
+
+				rc, err := c.Reader(ctx, rn, 0, 0)
+				require.NoError(t, err, "Reader")
+				got, err = io.ReadAll(rc)
+				require.NoError(t, err, "Reader.ReadAll")
+				require.NoError(t, rc.Close(), "Reader.Close")
+				require.Equal(t, data, got, "Reader")
+			})
+		})
+	}
+}
+
+func TestPebbleGCSReadContractMissingAfterDelete(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	te, c := newGCSBackedContractCache(t, clock, mockgcs.New(clock))
+	ctx := getAnonContext(t, te)
+	rn, data := testdigest.RandomCASResourceBuf(t, 100)
+
+	require.NoError(t, c.Set(ctx, rn, data))
+	require.NoError(t, c.Delete(ctx, rn))
+
+	t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
+		contains, err := c.Contains(ctx, rn)
+		require.NoError(t, err, "Contains")
+		require.False(t, contains, "Contains")
+
+		_, err = c.Metadata(ctx, rn)
+		require.True(t, status.IsNotFoundError(err), "Metadata: %v", err)
+
+		missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
+		require.NoError(t, err, "FindMissing")
+		require.Len(t, missing, 1, "FindMissing")
+		require.Equal(t, rn.GetDigest().GetHash(), missing[0].GetHash(), "FindMissing")
+	})
+
+	t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
+		_, err := c.Get(ctx, rn)
+		require.True(t, status.IsNotFoundError(err), "Get: %v", err)
+
+		_, _, err = c.GetWithMetadata(ctx, rn)
+		require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
+
+		multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
+		require.NoError(t, err, "GetMulti")
+		require.Nil(t, multi[rn.GetDigest()], "GetMulti")
+
+		rc, err := c.Reader(ctx, rn, 0, 0)
+		require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
+		require.Nil(t, rc, "Reader")
+	})
+}
+
+func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
+	te, c := newGCSBackedContractCache(t, clock, gcs)
+	ctx := getAnonContext(t, te)
+	rn, data := testdigest.RandomCASResourceBuf(t, 100)
+
+	require.NoError(t, c.Set(ctx, rn, data))
+	require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
+
+	t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
+		contains, err := c.Contains(ctx, rn)
+		require.NoError(t, err, "Contains")
+		require.True(t, contains, "Contains")
+
+		_, err = c.Metadata(ctx, rn)
+		require.NoError(t, err, "Metadata")
+
+		missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
+		require.NoError(t, err, "FindMissing")
+		require.Empty(t, missing, "FindMissing")
+	})
+
+	t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
+		_, err := c.Get(ctx, rn)
+		require.True(t, status.IsNotFoundError(err), "Get: %v", err)
+
+		_, _, err = c.GetWithMetadata(ctx, rn)
+		require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
+
+		multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
+		require.NoError(t, err, "GetMulti")
+		require.Nil(t, multi[rn.GetDigest()], "GetMulti")
+
+		rc, err := c.Reader(ctx, rn, 0, 0)
+		require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
+		require.Nil(t, rc, "Reader")
+	})
+}
+
+func TestPebbleGCSBackingObjectDeletedMetadataMethodsShouldReportMissing(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
+	te, c := newGCSBackedContractCache(t, clock, gcs)
+	ctx := getAnonContext(t, te)
+	rn, data := testdigest.RandomCASResourceBuf(t, 100)
+
+	require.NoError(t, c.Set(ctx, rn, data))
+	require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
+
+	t.Run("Contains", func(t *testing.T) {
+		t.Skip("PebbleCache does not consult backing storage for Contains.")
+
+		contains, err := c.Contains(ctx, rn)
+		require.NoError(t, err)
+		require.False(t, contains)
+	})
+
+	t.Run("Metadata", func(t *testing.T) {
+		t.Skip("PebbleCache does not consult backing storage for Metadata.")
+
+		_, err := c.Metadata(ctx, rn)
+		require.True(t, status.IsNotFoundError(err), "Metadata: %v", err)
+	})
+
+	t.Run("FindMissing", func(t *testing.T) {
+		t.Skip("PebbleCache does not consult backing storage for FindMissing.")
+
+		missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
+		require.NoError(t, err)
+		require.Len(t, missing, 1)
+		require.Equal(t, rn.GetDigest().GetHash(), missing[0].GetHash())
+	})
+}
+
+func TestPebbleGCSBackingReadUnavailable(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
+	te, c := newGCSBackedContractCache(t, clock, gcs)
+	ctx := getAnonContext(t, te)
+	rn, data := testdigest.RandomCASResourceBuf(t, 100)
+
+	require.NoError(t, c.Set(ctx, rn, data))
+	gcs.PebbleGCSStorage = &readFailingGCS{
+		PebbleGCSStorage: gcs.PebbleGCSStorage,
+		err:              status.UnavailableError("gcs read unavailable"),
+	}
+
+	t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
+		contains, err := c.Contains(ctx, rn)
+		require.NoError(t, err, "Contains")
+		require.True(t, contains, "Contains")
+
+		_, err = c.Metadata(ctx, rn)
+		require.NoError(t, err, "Metadata")
+
+		missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
+		require.NoError(t, err, "FindMissing")
+		require.Empty(t, missing, "FindMissing")
+	})
+
+	t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
+		_, err := c.Get(ctx, rn)
+		require.ErrorContains(t, err, "gcs read unavailable", "Get")
+		require.False(t, status.IsNotFoundError(err), "Get: %v", err)
+
+		_, _, err = c.GetWithMetadata(ctx, rn)
+		require.ErrorContains(t, err, "gcs read unavailable", "GetWithMetadata")
+		require.False(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
+
+		_, err = c.GetMulti(ctx, []*rspb.ResourceName{rn})
+		require.ErrorContains(t, err, "gcs read unavailable", "GetMulti")
+		require.False(t, status.IsNotFoundError(err), "GetMulti: %v", err)
+
+		rc, err := c.Reader(ctx, rn, 0, 0)
+		require.ErrorContains(t, err, "gcs read unavailable", "Reader")
+		require.False(t, status.IsNotFoundError(err), "Reader: %v", err)
+		require.Nil(t, rc, "Reader")
+	})
+}
+
+func TestPebbleGCSWriteFaults(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte)
+	}{
+		{
+			name: "set",
+			setup: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte) {
+				err := c.Set(ctx, rn, data)
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "set_multi",
+			setup: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte) {
+				err := c.SetMulti(ctx, map[*rspb.ResourceName][]byte{rn: data})
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "writer",
+			setup: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte) {
+				w, err := c.Writer(ctx, rn)
+				require.NoError(t, err)
+				defer w.Close()
+				_, err = w.Write(data)
+				require.NoError(t, err)
+				require.Error(t, w.Commit())
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := clockwork.NewFakeClock()
+			gcs := &commitFailingGCS{
+				PebbleGCSStorage: mockgcs.New(clock),
+				err:              status.ResourceExhaustedError("too many concurrent writes"),
+			}
+			te, c := newGCSBackedContractCache(t, clock, gcs)
+			ctx := getAnonContext(t, te)
+			rn, data := testdigest.RandomCASResourceBuf(t, 100)
+
+			tc.setup(t, ctx, c, rn, data)
+
+			t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
+				contains, err := c.Contains(ctx, rn)
+				require.NoError(t, err, "Contains")
+				require.False(t, contains, "Contains")
+
+				_, err = c.Metadata(ctx, rn)
+				require.True(t, status.IsNotFoundError(err), "Metadata: %v", err)
+
+				missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
+				require.NoError(t, err, "FindMissing")
+				require.Len(t, missing, 1, "FindMissing")
+				require.Equal(t, rn.GetDigest().GetHash(), missing[0].GetHash(), "FindMissing")
+			})
+
+			t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
+				_, err := c.Get(ctx, rn)
+				require.True(t, status.IsNotFoundError(err), "Get: %v", err)
+
+				_, _, err = c.GetWithMetadata(ctx, rn)
+				require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
+
+				multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
+				require.NoError(t, err, "GetMulti")
+				require.Nil(t, multi[rn.GetDigest()], "GetMulti")
+
+				rc, err := c.Reader(ctx, rn, 0, 0)
+				require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
+				require.Nil(t, rc, "Reader")
+			})
+		})
+	}
+}

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -3048,18 +3049,45 @@ func TestAtimeUpdater(t *testing.T) {
 }
 
 type recordingGCS struct {
-	filestore.PebbleGCSStorage
-
 	mu        sync.Mutex
+	storage   filestore.PebbleGCSStorage
 	blobNames []string
 }
 
+func (g *recordingGCS) SetStorage(storage filestore.PebbleGCSStorage) {
+	g.mu.Lock()
+	g.storage = storage
+	g.mu.Unlock()
+}
+
+func (g *recordingGCS) Storage() filestore.PebbleGCSStorage {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.storage
+}
+
+func (g *recordingGCS) SetBucketCustomTimeTTL(ctx context.Context, ageInDays int64) error {
+	return g.Storage().SetBucketCustomTimeTTL(ctx, ageInDays)
+}
+
+func (g *recordingGCS) Reader(ctx context.Context, blobName string, offset, limit int64) (io.ReadCloser, error) {
+	return g.Storage().Reader(ctx, blobName, offset, limit)
+}
+
 func (g *recordingGCS) ConditionalWriter(ctx context.Context, blobName string, overwriteExisting bool, customTime time.Time, estimatedSize int64) (interfaces.CommittedWriteCloser, error) {
-	w, err := g.PebbleGCSStorage.ConditionalWriter(ctx, blobName, overwriteExisting, customTime, estimatedSize)
+	w, err := g.Storage().ConditionalWriter(ctx, blobName, overwriteExisting, customTime, estimatedSize)
 	if err != nil {
 		return nil, err
 	}
 	return &recordingGCSWriter{CommittedWriteCloser: w, gcs: g, blobName: blobName}, nil
+}
+
+func (g *recordingGCS) DeleteBlob(ctx context.Context, blobName string) error {
+	return g.Storage().DeleteBlob(ctx, blobName)
+}
+
+func (g *recordingGCS) UpdateCustomTime(ctx context.Context, blobName string, t time.Time) error {
+	return g.Storage().UpdateCustomTime(ctx, blobName, t)
 }
 
 func (g *recordingGCS) DeleteRecordedBlobs(ctx context.Context) error {
@@ -3105,23 +3133,11 @@ type commitFailingGCS struct {
 }
 
 func (g *commitFailingGCS) ConditionalWriter(ctx context.Context, blobName string, overwriteExisting bool, customTime time.Time, estimatedSize int64) (interfaces.CommittedWriteCloser, error) {
-	return &commitFailingWriter{err: g.err}, nil
-}
-
-type commitFailingWriter struct {
-	err error
-}
-
-func (w *commitFailingWriter) Write(b []byte) (int, error) {
-	return len(b), nil
-}
-
-func (w *commitFailingWriter) Close() error {
-	return nil
-}
-
-func (w *commitFailingWriter) Commit() error {
-	return w.err
+	w := ioutil.NewCustomCommitWriteCloser(io.Discard)
+	w.SetCommitFn(func(int64) error {
+		return g.err
+	})
+	return w, nil
 }
 
 func newGCSBackedContractCache(t *testing.T, clock clockwork.Clock, gcs filestore.PebbleGCSStorage) (*testenv.TestEnv, interfaces.Cache) {
@@ -3303,7 +3319,7 @@ func TestPebbleGCSBlobMissingAfterDelete(t *testing.T) {
 
 func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
+	gcs := &recordingGCS{storage: mockgcs.New(clock)}
 	te, c := newGCSBackedContractCache(t, clock, gcs)
 	ctx := getAnonContext(t, te)
 	rn, data := testdigest.RandomCASResourceBuf(t, 100)
@@ -3311,22 +3327,23 @@ func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
 	require.NoError(t, c.Set(ctx, rn, data))
 	require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
 
-	// TODO(dan): expectMetadataMissing(t, ctx, c, rn)
+	// The first content miss repairs the local index, so metadata reads miss after it.
 	expectContentNotFound(t, ctx, c, rn)
+	expectMetadataMissing(t, ctx, c, rn)
 }
 
 func TestPebbleGCSBackingReadUnavailable(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
+	gcs := &recordingGCS{storage: mockgcs.New(clock)}
 	te, c := newGCSBackedContractCache(t, clock, gcs)
 	ctx := getAnonContext(t, te)
 	rn, data := testdigest.RandomCASResourceBuf(t, 100)
 
 	require.NoError(t, c.Set(ctx, rn, data))
-	gcs.PebbleGCSStorage = &readFailingGCS{
-		PebbleGCSStorage: gcs.PebbleGCSStorage,
+	gcs.SetStorage(&readFailingGCS{
+		PebbleGCSStorage: gcs.Storage(),
 		err:              status.UnavailableError("gcs read unavailable"),
-	}
+	})
 
 	expectMetadataPresent(t, ctx, c, rn)
 	expectContentError(t, ctx, c, rn, "gcs read unavailable")

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3302,58 +3302,6 @@ func TestPebbleGCSBlobMissingAfterDelete(t *testing.T) {
 }
 
 func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		read func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName)
-	}{
-		{
-			name: "get",
-			read: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
-				_, err := c.Get(ctx, rn)
-				require.True(t, status.IsNotFoundError(err), "Get: %v", err)
-			},
-		},
-		{
-			name: "get_with_metadata",
-			read: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
-				_, _, err := c.GetWithMetadata(ctx, rn)
-				require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
-			},
-		},
-		{
-			name: "get_multi",
-			read: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
-				multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
-				require.NoError(t, err, "GetMulti")
-				require.Nil(t, multi[rn.GetDigest()], "GetMulti")
-			},
-		},
-		{
-			name: "reader",
-			read: func(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
-				rc, err := c.Reader(ctx, rn, 0, 0)
-				require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
-				require.Nil(t, rc, "Reader")
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			clock := clockwork.NewFakeClock()
-			gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
-			te, c := newGCSBackedContractCache(t, clock, gcs)
-			ctx := getAnonContext(t, te)
-			rn, data := testdigest.RandomCASResourceBuf(t, 100)
-
-			require.NoError(t, c.Set(ctx, rn, data))
-			require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
-
-			expectMetadataMissing(t, ctx, c, rn)
-			tc.read(t, ctx, c, rn)
-		})
-	}
-}
-
-func TestPebbleGCSBackingObjectDeletedMetadataMethodsShouldReportMissing(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	gcs := &recordingGCS{PebbleGCSStorage: mockgcs.New(clock)}
 	te, c := newGCSBackedContractCache(t, clock, gcs)
@@ -3363,29 +3311,8 @@ func TestPebbleGCSBackingObjectDeletedMetadataMethodsShouldReportMissing(t *test
 	require.NoError(t, c.Set(ctx, rn, data))
 	require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
 
-	t.Run("Contains", func(t *testing.T) {
-		t.Skip("PebbleCache does not consult backing storage for Contains.")
-
-		contains, err := c.Contains(ctx, rn)
-		require.NoError(t, err)
-		require.False(t, contains)
-	})
-
-	t.Run("Metadata", func(t *testing.T) {
-		t.Skip("PebbleCache does not consult backing storage for Metadata.")
-
-		_, err := c.Metadata(ctx, rn)
-		require.True(t, status.IsNotFoundError(err), "Metadata: %v", err)
-	})
-
-	t.Run("FindMissing", func(t *testing.T) {
-		t.Skip("PebbleCache does not consult backing storage for FindMissing.")
-
-		missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
-		require.NoError(t, err)
-		require.Len(t, missing, 1)
-		require.Equal(t, rn.GetDigest().GetHash(), missing[0].GetHash())
-	})
+	// TODO(dan): expectMetadataMissing(t, ctx, c, rn)
+	expectContentNotFound(t, ctx, c, rn)
 }
 
 func TestPebbleGCSBackingReadUnavailable(t *testing.T) {

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -3145,6 +3145,106 @@ func newGCSBackedContractCache(t *testing.T, clock clockwork.Clock, gcs filestor
 	return te, pc
 }
 
+// expectMetadataPresent asserts that the metadata-only read methods (Contains,
+// Metadata, FindMissing) report rn as present. PebbleCache answers these from
+// its local index without consulting backing storage.
+func expectMetadataPresent(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
+	t.Helper()
+	contains, err := c.Contains(ctx, rn)
+	require.NoError(t, err, "Contains")
+	require.True(t, contains, "Contains")
+
+	_, err = c.Metadata(ctx, rn)
+	require.NoError(t, err, "Metadata")
+
+	missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
+	require.NoError(t, err, "FindMissing")
+	require.Empty(t, missing, "FindMissing")
+}
+
+// expectMetadataMissing asserts that the metadata-only read methods report rn
+// as missing.
+func expectMetadataMissing(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
+	t.Helper()
+	contains, err := c.Contains(ctx, rn)
+	require.NoError(t, err, "Contains")
+	require.False(t, contains, "Contains")
+
+	_, err = c.Metadata(ctx, rn)
+	require.True(t, status.IsNotFoundError(err), "Metadata: %v", err)
+
+	missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
+	require.NoError(t, err, "FindMissing")
+	require.Len(t, missing, 1, "FindMissing")
+	require.Equal(t, rn.GetDigest().GetHash(), missing[0].GetHash(), "FindMissing")
+}
+
+// expectContentPresent asserts that the content-returning read methods (Get,
+// GetWithMetadata, GetMulti, Reader) all return data.
+func expectContentPresent(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, data []byte) {
+	t.Helper()
+	got, err := c.Get(ctx, rn)
+	require.NoError(t, err, "Get")
+	require.Equal(t, data, got, "Get")
+
+	got, _, err = c.GetWithMetadata(ctx, rn)
+	require.NoError(t, err, "GetWithMetadata")
+	require.Equal(t, data, got, "GetWithMetadata")
+
+	multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
+	require.NoError(t, err, "GetMulti")
+	require.Equal(t, data, multi[rn.GetDigest()], "GetMulti")
+
+	rc, err := c.Reader(ctx, rn, 0, 0)
+	require.NoError(t, err, "Reader")
+	got, err = io.ReadAll(rc)
+	require.NoError(t, err, "Reader.ReadAll")
+	require.NoError(t, rc.Close(), "Reader.Close")
+	require.Equal(t, data, got, "Reader")
+}
+
+// expectContentNotFound asserts that the content-returning read methods all
+// report rn as missing.
+func expectContentNotFound(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName) {
+	t.Helper()
+	_, err := c.Get(ctx, rn)
+	require.True(t, status.IsNotFoundError(err), "Get: %v", err)
+
+	_, _, err = c.GetWithMetadata(ctx, rn)
+	require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
+
+	multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
+	require.NoError(t, err, "GetMulti")
+	require.Nil(t, multi[rn.GetDigest()], "GetMulti")
+
+	rc, err := c.Reader(ctx, rn, 0, 0)
+	require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
+	require.Nil(t, rc, "Reader")
+}
+
+// expectContentError asserts that the content-returning read methods all fail
+// with an error containing wantErr that is distinct from a NotFound error (i.e.
+// a transient failure must not be reported as a cache miss).
+func expectContentError(t *testing.T, ctx context.Context, c interfaces.Cache, rn *rspb.ResourceName, wantErr string) {
+	t.Helper()
+	_, err := c.Get(ctx, rn)
+	require.ErrorContains(t, err, wantErr, "Get")
+	require.False(t, status.IsNotFoundError(err), "Get: %v", err)
+
+	_, _, err = c.GetWithMetadata(ctx, rn)
+	require.ErrorContains(t, err, wantErr, "GetWithMetadata")
+	require.False(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
+
+	_, err = c.GetMulti(ctx, []*rspb.ResourceName{rn})
+	require.ErrorContains(t, err, wantErr, "GetMulti")
+	require.False(t, status.IsNotFoundError(err), "GetMulti: %v", err)
+
+	rc, err := c.Reader(ctx, rn, 0, 0)
+	require.ErrorContains(t, err, wantErr, "Reader")
+	require.False(t, status.IsNotFoundError(err), "Reader: %v", err)
+	require.Nil(t, rc, "Reader")
+}
+
 func TestPebbleGCSReadContractPresent(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -3182,39 +3282,8 @@ func TestPebbleGCSReadContractPresent(t *testing.T) {
 
 			tc.setup(t, ctx, c, rn, data)
 
-			t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
-				contains, err := c.Contains(ctx, rn)
-				require.NoError(t, err, "Contains")
-				require.True(t, contains, "Contains")
-
-				_, err = c.Metadata(ctx, rn)
-				require.NoError(t, err, "Metadata")
-
-				missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
-				require.NoError(t, err, "FindMissing")
-				require.Empty(t, missing, "FindMissing")
-			})
-
-			t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
-				got, err := c.Get(ctx, rn)
-				require.NoError(t, err, "Get")
-				require.Equal(t, data, got, "Get")
-
-				got, _, err = c.GetWithMetadata(ctx, rn)
-				require.NoError(t, err, "GetWithMetadata")
-				require.Equal(t, data, got, "GetWithMetadata")
-
-				multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
-				require.NoError(t, err, "GetMulti")
-				require.Equal(t, data, multi[rn.GetDigest()], "GetMulti")
-
-				rc, err := c.Reader(ctx, rn, 0, 0)
-				require.NoError(t, err, "Reader")
-				got, err = io.ReadAll(rc)
-				require.NoError(t, err, "Reader.ReadAll")
-				require.NoError(t, rc.Close(), "Reader.Close")
-				require.Equal(t, data, got, "Reader")
-			})
+			expectMetadataPresent(t, ctx, c, rn)
+			expectContentPresent(t, ctx, c, rn, data)
 		})
 	}
 }
@@ -3228,35 +3297,8 @@ func TestPebbleGCSReadContractMissingAfterDelete(t *testing.T) {
 	require.NoError(t, c.Set(ctx, rn, data))
 	require.NoError(t, c.Delete(ctx, rn))
 
-	t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
-		contains, err := c.Contains(ctx, rn)
-		require.NoError(t, err, "Contains")
-		require.False(t, contains, "Contains")
-
-		_, err = c.Metadata(ctx, rn)
-		require.True(t, status.IsNotFoundError(err), "Metadata: %v", err)
-
-		missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
-		require.NoError(t, err, "FindMissing")
-		require.Len(t, missing, 1, "FindMissing")
-		require.Equal(t, rn.GetDigest().GetHash(), missing[0].GetHash(), "FindMissing")
-	})
-
-	t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
-		_, err := c.Get(ctx, rn)
-		require.True(t, status.IsNotFoundError(err), "Get: %v", err)
-
-		_, _, err = c.GetWithMetadata(ctx, rn)
-		require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
-
-		multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
-		require.NoError(t, err, "GetMulti")
-		require.Nil(t, multi[rn.GetDigest()], "GetMulti")
-
-		rc, err := c.Reader(ctx, rn, 0, 0)
-		require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
-		require.Nil(t, rc, "Reader")
-	})
+	expectMetadataMissing(t, ctx, c, rn)
+	expectContentNotFound(t, ctx, c, rn)
 }
 
 func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
@@ -3269,34 +3311,11 @@ func TestPebbleGCSBackingObjectDeleted(t *testing.T) {
 	require.NoError(t, c.Set(ctx, rn, data))
 	require.NoError(t, gcs.DeleteRecordedBlobs(ctx))
 
-	t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
-		contains, err := c.Contains(ctx, rn)
-		require.NoError(t, err, "Contains")
-		require.True(t, contains, "Contains")
-
-		_, err = c.Metadata(ctx, rn)
-		require.NoError(t, err, "Metadata")
-
-		missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
-		require.NoError(t, err, "FindMissing")
-		require.Empty(t, missing, "FindMissing")
-	})
-
-	t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
-		_, err := c.Get(ctx, rn)
-		require.True(t, status.IsNotFoundError(err), "Get: %v", err)
-
-		_, _, err = c.GetWithMetadata(ctx, rn)
-		require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
-
-		multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
-		require.NoError(t, err, "GetMulti")
-		require.Nil(t, multi[rn.GetDigest()], "GetMulti")
-
-		rc, err := c.Reader(ctx, rn, 0, 0)
-		require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
-		require.Nil(t, rc, "Reader")
-	})
+	// The metadata methods still report the resource as present because
+	// PebbleCache does not consult backing storage for them, but reading the
+	// content surfaces the now-missing backing blob.
+	expectMetadataPresent(t, ctx, c, rn)
+	expectContentNotFound(t, ctx, c, rn)
 }
 
 func TestPebbleGCSBackingObjectDeletedMetadataMethodsShouldReportMissing(t *testing.T) {
@@ -3347,37 +3366,8 @@ func TestPebbleGCSBackingReadUnavailable(t *testing.T) {
 		err:              status.UnavailableError("gcs read unavailable"),
 	}
 
-	t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
-		contains, err := c.Contains(ctx, rn)
-		require.NoError(t, err, "Contains")
-		require.True(t, contains, "Contains")
-
-		_, err = c.Metadata(ctx, rn)
-		require.NoError(t, err, "Metadata")
-
-		missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
-		require.NoError(t, err, "FindMissing")
-		require.Empty(t, missing, "FindMissing")
-	})
-
-	t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
-		_, err := c.Get(ctx, rn)
-		require.ErrorContains(t, err, "gcs read unavailable", "Get")
-		require.False(t, status.IsNotFoundError(err), "Get: %v", err)
-
-		_, _, err = c.GetWithMetadata(ctx, rn)
-		require.ErrorContains(t, err, "gcs read unavailable", "GetWithMetadata")
-		require.False(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
-
-		_, err = c.GetMulti(ctx, []*rspb.ResourceName{rn})
-		require.ErrorContains(t, err, "gcs read unavailable", "GetMulti")
-		require.False(t, status.IsNotFoundError(err), "GetMulti: %v", err)
-
-		rc, err := c.Reader(ctx, rn, 0, 0)
-		require.ErrorContains(t, err, "gcs read unavailable", "Reader")
-		require.False(t, status.IsNotFoundError(err), "Reader: %v", err)
-		require.Nil(t, rc, "Reader")
-	})
+	expectMetadataPresent(t, ctx, c, rn)
+	expectContentError(t, ctx, c, rn, "gcs read unavailable")
 }
 
 func TestPebbleGCSWriteFaults(t *testing.T) {
@@ -3423,35 +3413,8 @@ func TestPebbleGCSWriteFaults(t *testing.T) {
 
 			tc.setup(t, ctx, c, rn, data)
 
-			t.Run("Contains_Metadata_FindMissing", func(t *testing.T) {
-				contains, err := c.Contains(ctx, rn)
-				require.NoError(t, err, "Contains")
-				require.False(t, contains, "Contains")
-
-				_, err = c.Metadata(ctx, rn)
-				require.True(t, status.IsNotFoundError(err), "Metadata: %v", err)
-
-				missing, err := c.FindMissing(ctx, []*rspb.ResourceName{rn})
-				require.NoError(t, err, "FindMissing")
-				require.Len(t, missing, 1, "FindMissing")
-				require.Equal(t, rn.GetDigest().GetHash(), missing[0].GetHash(), "FindMissing")
-			})
-
-			t.Run("Get_GetWithMetadata_GetMulti_Reader", func(t *testing.T) {
-				_, err := c.Get(ctx, rn)
-				require.True(t, status.IsNotFoundError(err), "Get: %v", err)
-
-				_, _, err = c.GetWithMetadata(ctx, rn)
-				require.True(t, status.IsNotFoundError(err), "GetWithMetadata: %v", err)
-
-				multi, err := c.GetMulti(ctx, []*rspb.ResourceName{rn})
-				require.NoError(t, err, "GetMulti")
-				require.Nil(t, multi[rn.GetDigest()], "GetMulti")
-
-				rc, err := c.Reader(ctx, rn, 0, 0)
-				require.True(t, status.IsNotFoundError(err), "Reader: %v", err)
-				require.Nil(t, rc, "Reader")
-			})
+			expectMetadataMissing(t, ctx, c, rn)
+			expectContentNotFound(t, ctx, c, rn)
 		})
 	}
 }

--- a/server/testutil/mockgcs/mockgcs.go
+++ b/server/testutil/mockgcs/mockgcs.go
@@ -104,6 +104,14 @@ func (m *mockGCS) DeleteBlob(ctx context.Context, blobName string) error {
 	return nil
 }
 
+// DeleteAllBlobs removes every blob in the mock bucket.
+func (m *mockGCS) DeleteAllBlobs(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items = make(map[string]*timestampedBlob)
+	return nil
+}
+
 func (m *mockGCS) UpdateCustomTime(ctx context.Context, blobName string, t time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
After cache writes or write faults, all cache read operations should agree on whether a blob is present or missing.

Read operations tested:
- `Contains`
- `Metadata`
- `FindMissing`
- `Get`
- `GetWithMetadata`
- `GetMulti`
- `Reader`

Write operations tested:
- `Set` succeeds.
- `SetMulti` succeeds.
- `Writer` / `Commit` succeeds.
- `Delete` after `Set` succeeds.

Faults tested:
- GCS `Commit()` returns `ResourceExhausted` for `Set`, `SetMulti`, and `Writer` / `Commit`.
- Backing GCS object is deleted out of band.
- Backing GCS reads return `Unavailable`.

TODO: `Contains`, `Metadata`, and `FindMissing` only consult pebble and not the backing store. I _believe_ that is intentional and do not assert missing blobs for those methods.