### PR TITLE
One more targets CSS tweak

### DIFF
--- a/enterprise/app/targets/targets.css
+++ b/enterprise/app/targets/targets.css
@@ -85,6 +85,7 @@
 .targets .targets-table-container .results-table {
   border: 1px solid var(--color-border-primary);
   border-radius: 8px;
+  overflow: hidden;
 }
 
 .targets .targets-table-container .row {


### PR DESCRIPTION
Make it so the row hover BG doesn't overflow the card, which looks a bit weird at the corner. Accidentally broke this in the last cleanup PR