### PR TITLE
Show allocated CPU and memory for cache proxy nodes

### DIFF
--- a/enterprise/app/cache_proxies/cache_proxy_card.tsx
+++ b/enterprise/app/cache_proxies/cache_proxy_card.tsx
@@ -100,6 +100,18 @@ export default class CacheProxyCardComponent extends React.Component<Props> {
                 <div>{this.props.node.arch}</div>
               </div>
             )}
+            {toNumber(this.props.node.allocatedMemoryBytes) > 0 && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Allocated Memory:</div>
+                <div>{format.bytes(toNumber(this.props.node.allocatedMemoryBytes))}</div>
+              </div>
+            )}
+            {toNumber(this.props.node.allocatedCpuMillis) > 0 && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Allocated Milli CPU:</div>
+                <div>{toNumber(this.props.node.allocatedCpuMillis)}</div>
+              </div>
+            )}
             {this.props.node.labels && Object.keys(this.props.node.labels).length > 0 && (
               <div className="cache-proxy-section">
                 <div className="cache-proxy-section-title">Labels:</div>

--- a/enterprise/server/cache_proxy_registration/BUILD
+++ b/enterprise/server/cache_proxy_registration/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/hostid",
         "//server/metrics",
         "//server/real_environment",
+        "//server/resources",
         "//server/util/authutil",
         "//server/util/disk",
         "//server/util/flag",

--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
@@ -24,6 +24,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/hostid"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
@@ -111,13 +112,15 @@ func Register(env *real_environment.RealEnv) error {
 	}
 	log.Infof("Registering Cache Proxy %s on host %q", proxyID, hostname)
 	node := &cppb.CacheProxyNode{
-		Host:      hostname,
-		ProxyId:   proxyID,
-		OsFamily:  runtime.GOOS,
-		Arch:      runtime.GOARCH,
-		Version:   version.Tag(),
-		StartTime: timestamppb.Now(),
-		Labels:    trimmedLabels,
+		Host:                 hostname,
+		ProxyId:              proxyID,
+		OsFamily:             runtime.GOOS,
+		Arch:                 runtime.GOARCH,
+		Version:              version.Tag(),
+		StartTime:            timestamppb.Now(),
+		Labels:               trimmedLabels,
+		AllocatedCpuMillis:   resources.GetAllocatedCPUMillis(),
+		AllocatedMemoryBytes: resources.GetAllocatedRAMBytes(),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/proto/cache_proxy.proto
+++ b/proto/cache_proxy.proto
@@ -42,6 +42,12 @@ message CacheProxyNode {
   // operationally (e.g. region, canary, environment) and surfaced on the
   // deployment view.
   map<string, string> labels = 8;
+
+  // CPU allocated to this cache proxy node, in milliCPU (1000 == 1 core).
+  int64 allocated_cpu_millis = 9;
+
+  // Memory allocated to this cache proxy node, in bytes.
+  int64 allocated_memory_bytes = 10;
 }
 
 // Statistics about this cache proxy's performance. Cumulative over the


### PR DESCRIPTION
Cache proxies now report their allocated CPU (milliCPU) and memory (bytes) at registration, sourced from the existing resources package, and the cache proxy deployment card surfaces them. The display mirrors the executor card's "Assignable Memory"/"Assignable Milli CPU" rows for consistency, using "Allocated" wording since that matches the underlying resources accessors. The rows are hidden when a proxy doesn't report a value, so cache proxies predating these proto fields don't render a misleading zero.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7702