### PR TITLE
Cluster cache proxy nodes in the UI by region, OS, and architecture

### DIFF
--- a/enterprise/app/cache_proxies/cache_proxies.css
+++ b/enterprise/app/cache_proxies/cache_proxies.css
@@ -27,7 +27,14 @@
   margin-top: 16px;
 }
 
-.cache-proxies-page .cache-proxy-summary {
+.cache-proxies-page .cache-proxy-details {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.cache-proxies-page .cache-proxy-detail {
   display: flex;
   align-items: center;
   gap: 8px;

--- a/enterprise/app/cache_proxies/cache_proxies.tsx
+++ b/enterprise/app/cache_proxies/cache_proxies.tsx
@@ -1,4 +1,4 @@
-import { Hash } from "lucide-react";
+import { Cpu, Globe, Hash, Laptop, LucideIcon } from "lucide-react";
 import React from "react";
 import { Subscription } from "rxjs";
 import { User } from "../../../app/auth/auth_service";
@@ -68,50 +68,75 @@ interface CacheProxiesListProps {
 
 class CacheProxiesList extends React.Component<CacheProxiesListProps> {
   render() {
-    const proxiesByKey = new Map<string, RegionalCacheProxy>();
-    for (const r of this.props.regions) {
-      for (const proxy of r.response.cacheProxy) {
+    // Cluster proxies by region + OS + architecture.
+    const proxiesByCluster = new Map<string, RegionalCacheProxy[]>();
+    for (const region of this.props.regions) {
+      for (const proxy of region.response.cacheProxy) {
         if (!proxy.node) {
           continue;
         }
-        proxiesByKey.set(`${r.name}-${proxy.node.proxyId}`, {
-          region: r.name,
-          proxy,
-          node: proxy.node as cache_proxy.CacheProxyNode,
-        });
+        const node = proxy.node as cache_proxy.CacheProxyNode;
+        const key = `${region.name}-${node.osFamily || ""}-${node.arch || ""}`;
+        if (!proxiesByCluster.has(key)) {
+          proxiesByCluster.set(key, []);
+        }
+        proxiesByCluster.get(key)!.push({ region: region.name, proxy, node });
       }
     }
-    const keys = Array.from(proxiesByKey.keys()).sort();
+    const keys = Array.from(proxiesByCluster.keys()).sort();
 
     return (
       <div className="cache-proxy-cards">
-        <div className="cache-proxy-summary">
-          <Hash />
-          <span>
-            <b>
-              {keys.length} {keys.length === 1 ? "cache proxy" : "cache proxies"}
-            </b>
-          </span>
-        </div>
         {keys.map((key) => {
-          const regionalProxy = proxiesByKey.get(key);
-          if (!regionalProxy) {
+          const proxies = proxiesByCluster.get(key);
+          if (!proxies || proxies.length === 0) {
             return null;
           }
-          const { region, proxy, node } = regionalProxy;
+          const { region, node } = proxies[0];
           return (
-            <CacheProxyCardComponent
-              key={key}
-              region={region}
-              node={node}
-              lastCheckInTime={proxy.lastCheckInTime}
-              statistics={proxy.statistics}
-            />
+            <React.Fragment key={key}>
+              <div className="cache-proxy-details">
+                {region && (
+                  <CacheProxyDetail Icon={Globe} label="">
+                    {region}
+                  </CacheProxyDetail>
+                )}
+                <CacheProxyDetail Icon={Hash} label="">
+                  {proxies.length} {proxies.length === 1 ? "cache proxy" : "cache proxies"}
+                </CacheProxyDetail>
+                <CacheProxyDetail Icon={Laptop} label="OS">
+                  {node.osFamily || "unknown"}
+                </CacheProxyDetail>
+                <CacheProxyDetail Icon={Cpu} label="Arch">
+                  {node.arch || "unknown"}
+                </CacheProxyDetail>
+              </div>
+              {proxies.map((p) => (
+                <CacheProxyCardComponent
+                  key={`${p.region}-${p.node.proxyId}`}
+                  node={p.node}
+                  lastCheckInTime={p.proxy.lastCheckInTime}
+                  statistics={p.proxy.statistics}
+                />
+              ))}
+            </React.Fragment>
           );
         })}
       </div>
     );
   }
+}
+
+function CacheProxyDetail({ Icon, label, children }: { Icon: LucideIcon; label: string; children: React.ReactNode }) {
+  return (
+    <span className="cache-proxy-detail">
+      <Icon />
+      <span>
+        {label && <>{label}: </>}
+        <b>{children}</b>
+      </span>
+    </span>
+  );
 }
 
 type TabId = "status" | "setup";

--- a/enterprise/app/cache_proxies/cache_proxy_card.tsx
+++ b/enterprise/app/cache_proxies/cache_proxy_card.tsx
@@ -25,7 +25,6 @@ const WRITE_COLOR = cssColor("--color-indigo-500", "#3f51b5");
 const EMPTY_COLOR = "#eee";
 
 interface Props {
-  region?: string;
   node: cache_proxy.CacheProxyNode;
   lastCheckInTime?: google_timestamp.protobuf.Timestamp | null;
   statistics?: cache_proxy.IStatistics | null;
@@ -76,28 +75,10 @@ export default class CacheProxyCardComponent extends React.Component<Props> {
               <div className="cache-proxy-section-title">Proxy Instance ID:</div>
               <div>{this.props.node.proxyId}</div>
             </div>
-            {this.props.region && (
-              <div className="cache-proxy-section">
-                <div className="cache-proxy-section-title">Region:</div>
-                <div>{this.props.region}</div>
-              </div>
-            )}
             {this.props.node.proxyHostId && (
               <div className="cache-proxy-section">
                 <div className="cache-proxy-section-title">Proxy Host ID:</div>
                 <div>{this.props.node.proxyHostId}</div>
-              </div>
-            )}
-            {this.props.node.osFamily && (
-              <div className="cache-proxy-section">
-                <div className="cache-proxy-section-title">Operating System:</div>
-                <div>{this.props.node.osFamily}</div>
-              </div>
-            )}
-            {this.props.node.arch && (
-              <div className="cache-proxy-section">
-                <div className="cache-proxy-section-title">Architecture:</div>
-                <div>{this.props.node.arch}</div>
               </div>
             )}
             {toNumber(this.props.node.allocatedMemoryBytes) > 0 && (


### PR DESCRIPTION
The cache proxies status page now groups proxies into clusters keyed by region, OS family, and architecture, the same way the executors page groups execution nodes. Each cluster gets a header row showing the region, proxy count, OS, and arch, and those three shared properties are no longer repeated on every individual proxy card. This declutters the cards and makes it easy to see at a glance how proxies are distributed across regions and platforms. The previous single total-count summary at the top is replaced by the per-cluster counts, again matching the executors page. Unlike executors there's no pool dimension to cluster on, so the grouping is just region/OS/arch and the cluster header has no pool name heading.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7702