### PR TITLE
Reorder Cache Proxy and Executor properties in the UI for consistency with each other

### DIFF
--- a/enterprise/app/cache_proxies/cache_proxy_card.tsx
+++ b/enterprise/app/cache_proxies/cache_proxy_card.tsx
@@ -81,6 +81,22 @@ export default class CacheProxyCardComponent extends React.Component<Props> {
                 <div>{this.props.node.proxyHostId}</div>
               </div>
             )}
+            <div className="cache-proxy-section">
+              <div className="cache-proxy-section-title">Version:</div>
+              <div>{this.props.node.version}</div>
+            </div>
+            {this.props.node.startTime && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Uptime:</div>
+                <div>{format.durationSince(this.props.node.startTime)}</div>
+              </div>
+            )}
+            {this.props.lastCheckInTime && (
+              <div className="cache-proxy-section">
+                <div className="cache-proxy-section-title">Last Check-in:</div>
+                <div>{format.relativeTimeSeconds(this.props.lastCheckInTime)}</div>
+              </div>
+            )}
             {toNumber(this.props.node.allocatedMemoryBytes) > 0 && (
               <div className="cache-proxy-section">
                 <div className="cache-proxy-section-title">Allocated Memory:</div>
@@ -105,24 +121,6 @@ export default class CacheProxyCardComponent extends React.Component<Props> {
                       </div>
                     ))}
                 </div>
-              </div>
-            )}
-            {this.props.node.startTime && (
-              <div className="cache-proxy-section">
-                <div className="cache-proxy-section-title">Uptime:</div>
-                <div>{format.durationSince(this.props.node.startTime)}</div>
-              </div>
-            )}
-            {this.props.node.version && (
-              <div className="cache-proxy-section">
-                <div className="cache-proxy-section-title">Version:</div>
-                <div>{this.props.node.version}</div>
-              </div>
-            )}
-            {this.props.lastCheckInTime && (
-              <div className="cache-proxy-section">
-                <div className="cache-proxy-section-title">Last Check-in:</div>
-                <div>{format.relativeTimeSeconds(this.props.lastCheckInTime)}</div>
               </div>
             )}
             {this.props.statistics && this.renderStatistics(this.props.statistics)}

--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -32,30 +32,20 @@ export default class ExecutorCardComponent extends React.Component<Props> {
               <div className="executor-section-title">Executor Host ID:</div>
               <div>{this.props.node.executorHostId}</div>
             </div>
-            {this.props.node.osDisplayName && (
-              <div className="executor-section">
-                <div className="executor-section-title">Operating System:</div>
-                <div>{this.props.node.osDisplayName}</div>
-              </div>
-            )}
-            {this.props.node.labels && Object.keys(this.props.node.labels).length > 0 && (
-              <div className="executor-section">
-                <div className="executor-section-title">Labels:</div>
-                <div>
-                  {Object.entries(this.props.node.labels)
-                    .sort(([a], [b]) => a.localeCompare(b))
-                    .map(([k, v]) => (
-                      <div key={k}>
-                        <b>{k}</b>: {v}
-                      </div>
-                    ))}
-                </div>
-              </div>
-            )}
+            <div className="executor-section">
+              <div className="executor-section-title">Version:</div>
+              <div>{this.props.node.version}</div>
+            </div>
             {this.props.node.startTime && (
               <div className="executor-section">
                 <div className="executor-section-title">Uptime:</div>
                 <div>{format.durationSince(this.props.node.startTime)}</div>
+              </div>
+            )}
+            {this.props.lastCheckInTime && (
+              <div className="executor-section">
+                <div className="executor-section-title">Last Check-in:</div>
+                <div>{format.relativeTimeSeconds(this.props.lastCheckInTime)}</div>
               </div>
             )}
             <div className="executor-section">
@@ -74,6 +64,12 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                   : "unknown"}
               </div>
             </div>
+            {this.props.node.osDisplayName && (
+              <div className="executor-section">
+                <div className="executor-section-title">Operating System:</div>
+                <div>{this.props.node.osDisplayName}</div>
+              </div>
+            )}
             {this.props.node.assignableCustomResources && this.props.node.assignableCustomResources.length > 0 && (
               <div className="executor-section">
                 <div className="executor-section-title">Assignable Resources:</div>
@@ -125,20 +121,12 @@ export default class ExecutorCardComponent extends React.Component<Props> {
               </div>
             </div>
             <div className="executor-section">
-              <div className="executor-section-title">Version:</div>
-              <div>{this.props.node.version}</div>
-            </div>
-            <div className="executor-section">
               <div className="executor-section-title">Default:</div>
               <div>{this.props.isDefault ? "True" : "False"}</div>
             </div>
 
             {this.props.lastCheckInTime && (
               <>
-                <div className="executor-section">
-                  <div className="executor-section-title">Last Check-in:</div>
-                  <div>{format.relativeTimeSeconds(this.props.lastCheckInTime)}</div>
-                </div>
                 <div className="executor-section">
                   <div className="executor-section-title">Queue Length:</div>
                   <div>{this.props.node.currentQueueLength || 0}</div>
@@ -148,6 +136,21 @@ export default class ExecutorCardComponent extends React.Component<Props> {
                   <div>{this.props.node.activeActionCount || 0}</div>
                 </div>
               </>
+            )}
+
+            {this.props.node.labels && Object.keys(this.props.node.labels).length > 0 && (
+              <div className="executor-section">
+                <div className="executor-section-title">Labels:</div>
+                <div>
+                  {Object.entries(this.props.node.labels)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([k, v]) => (
+                      <div key={k}>
+                        <b>{k}</b>: {v}
+                      </div>
+                    ))}
+                </div>
+              </div>
             )}
 
             <div className="executor-section">


### PR DESCRIPTION
This change makes it so that any properties common between Cache Proxies and Executors (e.g. host name or uptime) are rendered in the same order on the cards rendered on the Cache Proxies / Executors pages.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7702