### PR TITLE
allow us to disable message events instrumentation

### DIFF
--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -380,8 +380,12 @@ func (c *rpcCredentials) RequireTransportSecurity() bool {
 }
 
 func CommonGRPCClientOptions() []grpc.DialOption {
+	otelOpts := []otelgrpc.Option{otelgrpc.WithMeterProvider(rpcutil.MeterProvider())}
+	if rpcutil.OTELMessageEventsEnabled() {
+		otelOpts = append(otelOpts, otelgrpc.WithMessageEvents(otelgrpc.ReceivedEvents, otelgrpc.SentEvents))
+	}
 	return []grpc.DialOption{
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithMeterProvider(rpcutil.MeterProvider()), otelgrpc.WithMessageEvents(otelgrpc.ReceivedEvents, otelgrpc.SentEvents))),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(otelOpts...)),
 		interceptors.GetUnaryClientInterceptor(),
 		interceptors.GetStreamClientInterceptor(),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -381,7 +381,7 @@ func (c *rpcCredentials) RequireTransportSecurity() bool {
 
 func CommonGRPCClientOptions() []grpc.DialOption {
 	otelOpts := []otelgrpc.Option{otelgrpc.WithMeterProvider(rpcutil.MeterProvider())}
-	if rpcutil.OTELMessageEventsEnabled() {
+	if *rpcutil.OTELGRPCMessageEventsEnabled {
 		otelOpts = append(otelOpts, otelgrpc.WithMessageEvents(otelgrpc.ReceivedEvents, otelgrpc.SentEvents))
 	}
 	return []grpc.DialOption{

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -221,8 +221,12 @@ func CommonGRPCServerOptionsWithConfig(env environment.Env, config GRPCServerCon
 			"uint32(grpc_server_worker_multiplier) is too large (%v). Disabling workers", *serverWorkerMultiplier)
 		workerMultiplier = 0
 	}
+	otelOpts := []otelgrpc.Option{otelgrpc.WithMeterProvider(rpcutil.MeterProvider())}
+	if rpcutil.OTELMessageEventsEnabled() {
+		otelOpts = append(otelOpts, otelgrpc.WithMessageEvents(otelgrpc.ReceivedEvents, otelgrpc.SentEvents))
+	}
 	opts := []grpc.ServerOption{
-		grpc.StatsHandler(otelgrpc.NewServerHandler(otelgrpc.WithMeterProvider(rpcutil.MeterProvider()), otelgrpc.WithMessageEvents(otelgrpc.ReceivedEvents, otelgrpc.SentEvents))),
+		grpc.StatsHandler(otelgrpc.NewServerHandler(otelOpts...)),
 		interceptors.GetUnaryInterceptor(env, config.ExtraChainedUnaryInterceptors...),
 		interceptors.GetStreamInterceptor(env, config.ExtraChainedStreamInterceptors...),
 		grpc.ChainUnaryInterceptor(config.PostAuthUnaryInterceptors...),

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -222,7 +222,7 @@ func CommonGRPCServerOptionsWithConfig(env environment.Env, config GRPCServerCon
 		workerMultiplier = 0
 	}
 	otelOpts := []otelgrpc.Option{otelgrpc.WithMeterProvider(rpcutil.MeterProvider())}
-	if rpcutil.OTELMessageEventsEnabled() {
+	if *rpcutil.OTELGRPCMessageEventsEnabled {
 		otelOpts = append(otelOpts, otelgrpc.WithMessageEvents(otelgrpc.ReceivedEvents, otelgrpc.SentEvents))
 	}
 	opts := []grpc.ServerOption{

--- a/server/util/rpcutil/BUILD
+++ b/server/util/rpcutil/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/util/alert",
+        "//server/util/flag",
         "//server/util/proto",
         "//server/util/status",
         "//server/util/vtprotocodec",

--- a/server/util/rpcutil/rpcutil.go
+++ b/server/util/rpcutil/rpcutil.go
@@ -21,12 +21,8 @@ import (
 
 const GRPCMaxSizeBytes = int64(4 * 1000 * 1000)
 
-var otelMessageEventsEnabled = flag.Bool("app.otel_grpc_message_events_enabled", true,
+var OTELGRPCMessageEventsEnabled = flag.Bool("grpc_otel_message_events_enabled", true,
 	"If set, record per-message OpenTelemetry events on gRPC spans. Only useful for streaming RPCs; disable on unary-only servers (e.g. the metadata server) to save per-RPC allocation.")
-
-// OTELMessageEventsEnabled reports whether per-message gRPC span events should
-// be recorded. Backs the app.otel_grpc_message_events_enabled flag.
-func OTELMessageEventsEnabled() bool { return *otelMessageEventsEnabled }
 
 func init() {
 	vtprotocodec.Register()

--- a/server/util/rpcutil/rpcutil.go
+++ b/server/util/rpcutil/rpcutil.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/vtprotocodec"
@@ -19,6 +20,13 @@ import (
 )
 
 const GRPCMaxSizeBytes = int64(4 * 1000 * 1000)
+
+var otelMessageEventsEnabled = flag.Bool("app.otel_grpc_message_events_enabled", true,
+	"If set, record per-message OpenTelemetry events on gRPC spans. Only useful for streaming RPCs; disable on unary-only servers (e.g. the metadata server) to save per-RPC allocation.")
+
+// OTELMessageEventsEnabled reports whether per-message gRPC span events should
+// be recorded. Backs the app.otel_grpc_message_events_enabled flag.
+func OTELMessageEventsEnabled() bool { return *otelMessageEventsEnabled }
 
 func init() {
 	vtprotocodec.Register()


### PR DESCRIPTION
WithMessageEvents are useful for streaming RPCs. metadata server don't have
streaming RPCs. and metadata servers have more RPCs because of metadata-server
internal RPCs. disable the instrumentation to save some CPUs.
