### PR TITLE
Render 'uncacheable' digests and bytes in the Cache Proxy UI's performance tracker

### DIFF
--- a/enterprise/app/cache_proxies/cache_proxies.css
+++ b/enterprise/app/cache_proxies/cache_proxies.css
@@ -152,6 +152,10 @@
   background-color: var(--color-status-error);
 }
 
+.cache-proxies-page .cache-uncacheable-color-swatch {
+  background-color: var(--color-amber-500);
+}
+
 .cache-proxies-page .cache-read-color-swatch {
   background-color: var(--color-light-blue-500);
 }

--- a/enterprise/app/cache_proxies/cache_proxy_card.tsx
+++ b/enterprise/app/cache_proxies/cache_proxy_card.tsx
@@ -20,6 +20,7 @@ function cssColor(name: string, fallback: string): string {
 
 const HIT_COLOR = cssColor("--color-green-500", "#4caf50");
 const MISS_COLOR = cssColor("--color-status-error", "#f44336");
+const UNCACHEABLE_COLOR = cssColor("--color-amber-500", "#f59e0b");
 const READ_COLOR = cssColor("--color-light-blue-500", "#03a9f4");
 const WRITE_COLOR = cssColor("--color-indigo-500", "#3f51b5");
 const EMPTY_COLOR = "#eee";
@@ -143,23 +144,31 @@ export default class CacheProxyCardComponent extends React.Component<Props> {
         <div className="cache-proxy-stats-divider"></div>
         <div className="cache-proxy-stats-heading">Statistics</div>
         <div className="cache-proxy-stat-rings">
-          {this.renderReadRing("AC reads (digests)", toNumber(s.acReadHits), toNumber(s.acReadMisses), format.count)}
+          {this.renderReadRing("AC reads (digests)", toNumber(s.acReadHits), toNumber(s.acReadMisses), 0, format.count)}
           {this.renderReadWriteRing("AC reads/writes (digests)", acReads, toNumber(s.acWrites), format.count)}
           {this.renderReadRing(
             "AC reads (bytes)",
             toNumber(s.acReadHitBytes),
             toNumber(s.acReadMissBytes),
+            0,
             format.bytes
           )}
           {this.renderReadWriteRing("AC reads/writes (bytes)", acReadBytes, toNumber(s.acWriteBytes), format.bytes)}
         </div>
         <div className="cache-proxy-stat-rings">
-          {this.renderReadRing("CAS reads (digests)", toNumber(s.casReadHits), toNumber(s.casReadMisses), format.count)}
+          {this.renderReadRing(
+            "CAS reads (digests)",
+            toNumber(s.casReadHits),
+            toNumber(s.casReadMisses),
+            toNumber(s.casReadUncacheable),
+            format.count
+          )}
           {this.renderReadWriteRing("CAS reads/writes (digests)", casReads, toNumber(s.casWrites), format.count)}
           {this.renderReadRing(
             "CAS reads (bytes)",
             toNumber(s.casReadHitBytes),
             toNumber(s.casReadMissBytes),
+            toNumber(s.casReadUncacheableBytes),
             format.bytes
           )}
           {this.renderReadWriteRing("CAS reads/writes (bytes)", casReadBytes, toNumber(s.casWriteBytes), format.bytes)}
@@ -168,12 +177,12 @@ export default class CacheProxyCardComponent extends React.Component<Props> {
     );
   }
 
-  renderReadRing(title: string, hits: number, misses: number, formatValue: (v: number) => string) {
+  renderReadRing(title: string, hits: number, misses: number, uncacheable: number, formatValue: (v: number) => string) {
     return (
       <div className="cache-proxy-stat-ring">
         <div className="cache-proxy-stat-ring-title">{title}</div>
         <div className="cache-proxy-stat-ring-row">
-          {drawReadRing(hits, misses)}
+          {drawReadRing(hits, misses, uncacheable)}
           <div className="cache-proxy-stat-ring-labels">
             <div className="cache-proxy-stat-ring-rate">{hitRate(hits, misses)}</div>
             <div className="cache-chart-label">
@@ -186,6 +195,13 @@ export default class CacheProxyCardComponent extends React.Component<Props> {
               <span className="cache-stat">{formatValue(misses)}</span>
               &nbsp;misses
             </div>
+            {uncacheable > 0 && (
+              <div className="cache-chart-label">
+                <span className="color-swatch cache-uncacheable-color-swatch"></span>
+                <span className="cache-stat">{formatValue(uncacheable)}</span>
+                &nbsp;uncacheable
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -229,12 +245,13 @@ function readWriteRatio(reads: number, writes: number): string {
   return `1:${r < 10 ? r.toFixed(1) : Math.round(r)}`;
 }
 
-function drawReadRing(hits: number, misses: number) {
+function drawReadRing(hits: number, misses: number, uncacheable: number = 0) {
   let colorHit = HIT_COLOR;
   let colorMiss = MISS_COLOR;
+  let colorUncacheable = UNCACHEABLE_COLOR;
   let h = hits;
   let m = misses;
-  if (h === 0 && m === 0) {
+  if (h === 0 && m === 0 && uncacheable === 0) {
     colorHit = EMPTY_COLOR;
     colorMiss = EMPTY_COLOR;
     h = 1;
@@ -242,6 +259,7 @@ function drawReadRing(hits: number, misses: number) {
   return drawPie([
     { value: h, color: colorHit },
     { value: m, color: colorMiss },
+    { value: uncacheable, color: colorUncacheable },
   ]);
 }
 

--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration.go
@@ -216,10 +216,10 @@ func streamHeartbeats(ctx context.Context, shutdownCh <-chan struct{}, client cp
 // meaningful hit/miss distinction on the write side.
 func collectStatistics() *cppb.Statistics {
 	stats := &cppb.Statistics{}
-	stats.AcReadHits, stats.AcReadMisses = sumByHitMiss(metrics.ActionCacheProxiedReadRequests)
-	stats.AcReadHitBytes, stats.AcReadMissBytes = sumByHitMiss(metrics.ActionCacheProxiedReadBytes)
-	stats.CasReadHits, stats.CasReadMisses = sumByHitMiss(metrics.ByteStreamProxiedReadRequests)
-	stats.CasReadHitBytes, stats.CasReadMissBytes = sumByHitMiss(metrics.ByteStreamProxiedReadBytes)
+	stats.AcReadHits, stats.AcReadMisses, stats.AcReadUncacheable = sumByStatus(metrics.ActionCacheProxiedReadRequests)
+	stats.AcReadHitBytes, stats.AcReadMissBytes, stats.AcReadUncacheableBytes = sumByStatus(metrics.ActionCacheProxiedReadBytes)
+	stats.CasReadHits, stats.CasReadMisses, stats.CasReadUncacheable = sumByStatus(metrics.ByteStreamProxiedReadRequests)
+	stats.CasReadHitBytes, stats.CasReadMissBytes, stats.CasReadUncacheableBytes = sumByStatus(metrics.ByteStreamProxiedReadBytes)
 	stats.AcWrites = sumAll(metrics.ActionCacheProxiedWriteRequests)
 	stats.AcWriteBytes = sumAll(metrics.ActionCacheProxiedWriteBytes)
 	stats.CasWrites = sumAll(metrics.ByteStreamProxiedWriteRequests)
@@ -246,36 +246,39 @@ func sumAll(cv *prometheus.CounterVec) int64 {
 	return int64(total)
 }
 
-// sumByHitMiss collects every series from a CounterVec and totals their
-// values into (hits, misses) based on the CacheHitMissStatus label.
-func sumByHitMiss(cv *prometheus.CounterVec) (int64, int64) {
+// sumByStatus collects every series from a CounterVec and totals their values
+// into (hits, misses, uncacheable) based on the CacheHitMissStatus label.
+// Series with any other status value are ignored.
+func sumByStatus(cv *prometheus.CounterVec) (hits int64, misses int64, uncacheable int64) {
 	ch := make(chan prometheus.Metric, 64)
 	go func() {
 		defer close(ch)
 		cv.Collect(ch)
 	}()
-	var hits, misses float64
-	for m := range ch {
+	var h, m, u float64
+	for metric := range ch {
 		dm := &dto.Metric{}
-		if err := m.Write(dm); err != nil {
+		if err := metric.Write(dm); err != nil {
 			continue
 		}
-		var hitMiss string
+		var status string
 		for _, lp := range dm.GetLabel() {
 			if lp.GetName() == metrics.CacheHitMissStatus {
-				hitMiss = lp.GetValue()
+				status = lp.GetValue()
 				break
 			}
 		}
 		v := dm.GetCounter().GetValue()
-		switch hitMiss {
+		switch status {
 		case metrics.HitStatusLabel:
-			hits += v
+			h += v
 		case metrics.MissStatusLabel:
-			misses += v
+			m += v
+		case metrics.UncacheableStatusLabel:
+			u += v
 		}
 	}
-	return int64(hits), int64(misses)
+	return int64(h), int64(m), int64(u)
 }
 
 func openStream(ctx context.Context, client cppb.CacheProxyRegistryClient, node *cppb.CacheProxyNode) (cppb.CacheProxyRegistry_RegisterAndStreamHeartbeatClient, func(), error) {

--- a/enterprise/server/cache_proxy_registration/cache_proxy_registration_test.go
+++ b/enterprise/server/cache_proxy_registration/cache_proxy_registration_test.go
@@ -236,9 +236,9 @@ func TestStreamHeartbeats_UnreachableTarget(t *testing.T) {
 	}
 }
 
-func TestSumByHitMiss(t *testing.T) {
+func TestSumByStatus(t *testing.T) {
 	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "test_sum_by_hit_miss",
+		Name: "test_sum_by_status",
 	}, []string{metrics.CacheHitMissStatus, "other"})
 
 	// Two "hit" series across different "other" labels — these should be
@@ -247,21 +247,25 @@ func TestSumByHitMiss(t *testing.T) {
 	cv.WithLabelValues(metrics.HitStatusLabel, "b").Add(4)
 	// One "miss" series.
 	cv.WithLabelValues(metrics.MissStatusLabel, "a").Add(10)
+	// One "uncacheable" series.
+	cv.WithLabelValues(metrics.UncacheableStatusLabel, "a").Add(5)
 	// A series with a status value the helper doesn't recognize — must be
-	// ignored, not double-counted into either bucket.
+	// ignored, not double-counted into any bucket.
 	cv.WithLabelValues("unknown", "a").Add(99)
 
-	hits, misses := sumByHitMiss(cv)
+	hits, misses, uncacheable := sumByStatus(cv)
 	assert.Equal(t, int64(7), hits)
 	assert.Equal(t, int64(10), misses)
+	assert.Equal(t, int64(5), uncacheable)
 }
 
-func TestSumByHitMiss_Empty(t *testing.T) {
+func TestSumByStatus_Empty(t *testing.T) {
 	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "test_sum_by_hit_miss_empty",
+		Name: "test_sum_by_status_empty",
 	}, []string{metrics.CacheHitMissStatus})
 
-	hits, misses := sumByHitMiss(cv)
+	hits, misses, uncacheable := sumByStatus(cv)
 	assert.Equal(t, int64(0), hits)
 	assert.Equal(t, int64(0), misses)
+	assert.Equal(t, int64(0), uncacheable)
 }

--- a/proto/cache_proxy.proto
+++ b/proto/cache_proxy.proto
@@ -56,12 +56,16 @@ message Statistics {
   // Read statistics — broken out by hit/miss.
   int64 ac_read_hits = 1;
   int64 ac_read_misses = 2;
+  int64 ac_read_uncacheable = 13;
   int64 ac_read_hit_bytes = 3;
   int64 ac_read_miss_bytes = 4;
+  int64 ac_read_uncacheable_bytes = 14;
   int64 cas_read_hits = 5;
   int64 cas_read_misses = 6;
+  int64 cas_read_uncacheable = 15;
   int64 cas_read_hit_bytes = 7;
   int64 cas_read_miss_bytes = 8;
+  int64 cas_read_uncacheable_bytes = 16;
 
   // Write statistics.
   int64 ac_writes = 9;


### PR DESCRIPTION
This should make it easier to diagnose issues like this: https://buildbuddy-corp.slack.com/archives/C08CLEQ5QBA/p1782428488615279

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7702