### PR TITLE
[raft] Optimize md server for single key operations

### DIFF
--- a/enterprise/server/raft/metadata/BUILD
+++ b/enterprise/server/raft/metadata/BUILD
@@ -45,7 +45,10 @@ go_library(
 
 go_test(
     name = "metadata_test",
-    srcs = ["metadata_test.go"],
+    srcs = [
+        "metadata_benchmark_test.go",
+        "metadata_test.go",
+    ],
     exec_properties = {
         "test.EstimatedComputeUnits": "8",
         "test.workload-isolation-type": "firecracker",

--- a/enterprise/server/raft/metadata/metadata_benchmark_test.go
+++ b/enterprise/server/raft/metadata/metadata_benchmark_test.go
@@ -1,0 +1,111 @@
+package metadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/metadata"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/stretchr/testify/require"
+
+	mdpb "github.com/buildbuddy-io/buildbuddy/proto/metadata"
+	sgpb "github.com/buildbuddy-io/buildbuddy/proto/storage"
+)
+
+// benchPoolSize is the number of distinct records each benchmark cycles
+// through. Large enough to avoid always hitting warm per-key state, small
+// enough that setup stays quick.
+const benchPoolSize = 512
+
+// setUpBenchmarkCluster starts a 3-node metadata cluster, writes benchPoolSize
+// records owned by group1, and returns a leader Server, a context authenticated
+// as the records' owner, and the file records that were written. The test
+// partitions are configured with NumRanges: 1, so every request below maps to a
+// single range.
+func setUpBenchmarkCluster(b *testing.B) (*metadata.Server, context.Context, []*sgpb.FileRecord) {
+	*log.LogLevel = "error"
+	*log.IncludeShortFileName = true
+	log.Configure()
+
+	b.Helper()
+	configs := getTestConfigs(b, 3)
+	caches := startNodes(b, configs)
+	rc := caches[0]
+
+	ctx, err := configs[0].ta.WithAuthenticatedUser(context.Background(), "user1")
+	require.NoError(b, err)
+
+	records := make([]*sgpb.FileRecord, 0, benchPoolSize)
+	var ops []*mdpb.SetRequest_SetOperation
+	flush := func() {
+		if len(ops) == 0 {
+			return
+		}
+		_, err := rc.Set(ctx, &mdpb.SetRequest{SetOperations: ops})
+		require.NoError(b, err)
+		ops = ops[:0]
+	}
+	for range benchPoolSize {
+		md := randomFileMetadata(b, 100, "group1")
+		records = append(records, md.GetFileRecord())
+		ops = append(ops, &mdpb.SetRequest_SetOperation{FileMetadata: md})
+		// Write in chunks to keep individual raft proposals small.
+		if len(ops) == 64 {
+			flush()
+		}
+	}
+	flush()
+
+	return rc, ctx, records
+}
+
+// BenchmarkGet measures single-key Get, a RANGELEASE read served by the
+// leaseholder (no consensus round trip).
+func BenchmarkGet(b *testing.B) {
+	rc, ctx, records := setUpBenchmarkCluster(b)
+	req := &mdpb.GetRequest{FileRecords: make([]*sgpb.FileRecord, 1)}
+
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		req.FileRecords[0] = records[i%len(records)]
+		i++
+		_, err := rc.Get(ctx, req)
+		require.NoError(b, err)
+	}
+}
+
+// BenchmarkFind measures single-key Find (existence check), also a
+// RANGELEASE read.
+func BenchmarkFind(b *testing.B) {
+	rc, ctx, records := setUpBenchmarkCluster(b)
+	req := &mdpb.FindRequest{FileRecords: make([]*sgpb.FileRecord, 1)}
+
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		req.FileRecords[0] = records[i%len(records)]
+		i++
+		_, err := rc.Find(ctx, req)
+		require.NoError(b, err)
+	}
+}
+
+// BenchmarkGetParallel runs single-key Get from many goroutines at
+// once.
+func BenchmarkGetParallel(b *testing.B) {
+	rc, ctx, records := setUpBenchmarkCluster(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		req := &mdpb.GetRequest{FileRecords: make([]*sgpb.FileRecord, 1)}
+		i := 0
+		for pb.Next() {
+			req.FileRecords[0] = records[i%len(records)]
+			i++
+			_, err := rc.Get(ctx, req)
+			require.NoError(b, err)
+		}
+	})
+}

--- a/enterprise/server/raft/metadata/metadata_test.go
+++ b/enterprise/server/raft/metadata/metadata_test.go
@@ -50,7 +50,7 @@ type testConfig struct {
 	config *config.ServerConfig
 }
 
-func getTestConfigs(t *testing.T, n int) []testConfig {
+func getTestConfigs(t testing.TB, n int) []testConfig {
 	res := make([]testConfig, 0, n)
 	for i := 0; i < n; i++ {
 		c := testConfig{
@@ -64,11 +64,11 @@ func getTestConfigs(t *testing.T, n int) []testConfig {
 	return res
 }
 
-func localAddr(t *testing.T) string {
+func localAddr(t testing.TB) string {
 	return fmt.Sprintf("127.0.0.1:%d", testport.FindFree(t))
 }
 
-func getCacheConfig(t *testing.T) *config.ServerConfig {
+func getCacheConfig(t testing.TB) *config.ServerConfig {
 	id, err := guuid.NewRandom()
 	require.NoError(t, err)
 	httpPort := testport.FindFree(t)
@@ -115,7 +115,7 @@ func parallelShutdown(caches ...*metadata.Server) {
 	eg.Wait()
 }
 
-func waitForHealthy(t *testing.T, caches ...*metadata.Server) {
+func waitForHealthy(t testing.TB, caches ...*metadata.Server) {
 	log.Infof("wait for healthy")
 	start := time.Now()
 	timeout := 30 * time.Second
@@ -138,7 +138,7 @@ func waitForHealthy(t *testing.T, caches ...*metadata.Server) {
 	}
 }
 
-func waitForShutdown(t *testing.T, caches ...*metadata.Server) {
+func waitForShutdown(t testing.TB, caches ...*metadata.Server) {
 	timeout := 30 * time.Second
 	done := make(chan struct{})
 	go func() {
@@ -154,7 +154,7 @@ func waitForShutdown(t *testing.T, caches ...*metadata.Server) {
 	}
 }
 
-func startNodes(t *testing.T, configs []testConfig) []*metadata.Server {
+func startNodes(t testing.TB, configs []testConfig) []*metadata.Server {
 	eg := errgroup.Group{}
 	n := len(configs)
 	caches := make([]*metadata.Server, n)

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -667,6 +667,35 @@ func (s *Sender) RunMultiKey(ctx context.Context, keys []*KeyMeta, fn runMultiKe
 	var rsps []any
 	remainingKeys := keys
 	var lastError error
+	runForRange := func(ctx context.Context, rk *rangeKeys) error {
+		var rangeRsp any
+		i, err := s.tryReplicas(ctx, rk.rd, func(ctx context.Context, c rfspb.ApiClient, h *rfpb.Header) error {
+			rsp, err := fn(ctx, c, h, rk.keys)
+			if err != nil {
+				return err
+			}
+			rangeRsp = rsp
+			return nil
+		}, opts.ConsistencyMode)
+		if err != nil {
+			if !status.IsOutOfRangeError(err) {
+				return err
+			}
+			mu.Lock()
+			remainingKeys = append(remainingKeys, rk.keys...)
+			lastError = err
+			mu.Unlock()
+		} else {
+			if i != 0 {
+				replica := rk.rd.GetReplicas()[i]
+				s.rangeCache.SetPreferredReplica(ctx, replica, rk.rd)
+			}
+			mu.Lock()
+			rsps = append(rsps, rangeRsp)
+			mu.Unlock()
+		}
+		return nil
+	}
 	for retrier.Next() {
 		keysByRange, err := s.partitionKeysByRange(ctx, remainingKeys, skipRangeCache)
 		if err != nil {
@@ -676,42 +705,27 @@ func (s *Sender) RunMultiKey(ctx context.Context, keys []*KeyMeta, fn runMultiKe
 		// We'll repopulate remaining keys below.
 		remainingKeys = nil
 
-		eg, egCtx := errgroup.WithContext(ctx)
-		eg.SetLimit(100)
-		for _, rk := range keysByRange {
-			eg.Go(func() error {
-				var rangeRsp any
-				i, err := s.tryReplicas(egCtx, rk.rd, func(ctx context.Context, c rfspb.ApiClient, h *rfpb.Header) error {
-					rsp, err := fn(ctx, c, h, rk.keys)
-					if err != nil {
-						return err
-					}
-					rangeRsp = rsp
-					return nil
-				}, opts.ConsistencyMode)
-				if err != nil {
-					if !status.IsOutOfRangeError(err) {
-						return err
-					}
-					mu.Lock()
-					remainingKeys = append(remainingKeys, rk.keys...)
-					lastError = err
-					mu.Unlock()
-				} else {
-					if i != 0 {
-						replica := rk.rd.GetReplicas()[i]
-						s.rangeCache.SetPreferredReplica(ctx, replica, rk.rd)
-					}
-					mu.Lock()
-					rsps = append(rsps, rangeRsp)
-					mu.Unlock()
+		if len(keysByRange) == 1 {
+			// In the common case where we're operating on a single range (and
+			// usually single key), don't add the overhead of starting
+			// goroutines and growing their stack.
+			// This optimization can probably be removed if
+			// https://github.com/golang/go/issues/77893 is fixed.
+			for _, rk := range keysByRange {
+				if err := runForRange(ctx, rk); err != nil {
+					return nil, err
 				}
-				return nil
-			})
-		}
-
-		if err := eg.Wait(); err != nil {
-			return nil, err
+				return rsps, nil
+			}
+		} else {
+			eg, egCtx := errgroup.WithContext(ctx)
+			eg.SetLimit(100)
+			for _, rk := range keysByRange {
+				eg.Go(func() error { return runForRange(egCtx, rk) })
+			}
+			if err := eg.Wait(); err != nil {
+				return nil, err
+			}
 		}
 
 		if len(remainingKeys) == 0 {

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -715,7 +715,6 @@ func (s *Sender) RunMultiKey(ctx context.Context, keys []*KeyMeta, fn runMultiKe
 				if err := runForRange(ctx, rk); err != nil {
 					return nil, err
 				}
-				return rsps, nil
 			}
 		} else {
 			eg, egCtx := errgroup.WithContext(ctx)


### PR DESCRIPTION
RunMultiKey creates new goroutines with a small stack which then needs to grow. For now, just optimize the simple case when we only have one key/range.

Added new benchmarks. Results:
```
               │  /tmp/base  │            /tmp/after             │
               │   sec/op    │   sec/op     vs base              │
Get-24           120.5µ ± 4%   112.4µ ± 2%  -6.67% (p=0.001 n=7)
Find-24          121.6µ ± 4%   110.8µ ± 3%  -8.87% (p=0.001 n=7)
GetParallel-24   10.73µ ± 7%   10.24µ ± 4%  -4.57% (p=0.004 n=7)
geomean          53.96µ        50.34µ       -6.72%

               │  /tmp/base   │             /tmp/after             │
               │     B/op     │     B/op      vs base              │
Get-24           40.09Ki ± 0%   39.33Ki ± 0%  -1.90% (p=0.001 n=7)
Find-24          38.08Ki ± 0%   37.30Ki ± 0%  -2.04% (p=0.001 n=7)
GetParallel-24   39.35Ki ± 0%   38.64Ki ± 0%  -1.79% (p=0.001 n=7)
geomean          39.16Ki        38.41Ki       -1.91%

               │ /tmp/base  │            /tmp/after            │
               │ allocs/op  │ allocs/op   vs base              │
Get-24           562.0 ± 0%   553.0 ± 0%  -1.60% (p=0.001 n=7)
Find-24          543.0 ± 0%   534.0 ± 0%  -1.66% (p=0.001 n=7)
GetParallel-24   557.0 ± 0%   548.0 ± 0%  -1.62% (p=0.001 n=7)
geomean          553.9        544.9       -1.62%
```