### PR TITLE
Add nhid, partition ID, and zone fields to a few more metric labels

### DIFF
--- a/enterprise/server/raft/keys/BUILD
+++ b/enterprise/server/raft/keys/BUILD
@@ -6,7 +6,12 @@ go_library(
     name = "keys",
     srcs = ["keys.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys",
-    deps = ["//enterprise/server/filestore"],
+    deps = [
+        "//enterprise/server/filestore",
+        "//proto:raft_go_proto",
+        "//server/metrics",
+        "@com_github_prometheus_client_golang//prometheus",
+    ],
 )
 
 go_test(

--- a/enterprise/server/raft/keys/keys.go
+++ b/enterprise/server/raft/keys/keys.go
@@ -3,8 +3,13 @@ package keys
 import (
 	"bytes"
 	"math"
+	"strconv"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 )
 
 type Key []byte
@@ -59,4 +64,28 @@ func PartitionIDFromRangeStart(key []byte) string {
 		return ""
 	}
 	return string(before)
+}
+
+// RangeMetricLabels builds the standard per-range label set used by raft
+// metrics (e.g. RaftRangeReplica, RaftBytes, RaftLeases, RaftLeaders,
+// RaftProposals), so they can all be sliced by the same dimensions: range,
+// nodehost, partition, and zone.
+func RangeMetricLabels(rd *rfpb.RangeDescriptor, nhid, zone string) prometheus.Labels {
+	partitionID := rd.GetPartitionId()
+	if partitionID == "" {
+		partitionID = PartitionIDFromRangeStart(rd.GetStart())
+	}
+	if partitionID == "" {
+		if rd.GetRangeId() == 1 {
+			partitionID = "meta"
+		} else {
+			partitionID = "unknown"
+		}
+	}
+	return prometheus.Labels{
+		metrics.RaftRangeIDLabel:    strconv.FormatUint(rd.GetRangeId(), 10),
+		metrics.RaftNodeHostIDLabel: nhid,
+		metrics.PartitionID:         partitionID,
+		metrics.ZoneLabel:           zone,
+	}
 }

--- a/enterprise/server/raft/leasekeeper/BUILD
+++ b/enterprise/server/raft/leasekeeper/BUILD
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/events",
+        "//enterprise/server/raft/keys",
         "//enterprise/server/raft/listener",
         "//enterprise/server/raft/nodeliveness",
         "//enterprise/server/raft/rangelease",

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -211,7 +211,7 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 			return
 		}
 		la.log.Debugf("Acquired lease [%s] %s after callback (%s)", la.l.Desc(ctx), dur, instruction)
-		metrics.RaftLeases.With(la.labels).Inc()
+		metrics.RaftLeases.With(la.labels).Set(1.0)
 		metrics.RaftLeaseActionDurationMsec.With(prometheus.Labels{
 			metrics.RaftLeaseActionLabel: leaseAction,
 		}).Observe(float64(dur.Milliseconds()))
@@ -235,7 +235,7 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 			return
 		}
 		la.log.Debugf("Dropped lease [%s] %s after callback (%s)", la.l.Desc(ctx), dur, instruction)
-		metrics.RaftLeases.With(la.labels).Dec()
+		metrics.RaftLeases.With(la.labels).Set(0.0)
 		metrics.RaftLeaseActionDurationMsec.With(prometheus.Labels{
 			metrics.RaftLeaseActionLabel: leaseAction,
 		}).Observe(float64(dur.Milliseconds()))
@@ -376,11 +376,13 @@ func (lk *LeaseKeeper) watchLeases() {
 			if la != nil {
 				if la.replicaID == nodeInfo.ReplicaID {
 					// This is the terminal teardown for the range's replica
-					// on this node. Remove its RaftLeaders series so a stale
-					// leader=1 value doesn't linger: once the lease agent is
-					// gone, later leader-change callbacks find no agent and
-					// are dropped, so nothing else would reset the gauge.
+					// on this node. Remove its RaftLeaders/RaftLeases series
+					// so a stale leader=1 or lease=1 value doesn't linger:
+					// once the lease agent is gone, later callbacks find no
+					// agent and are dropped, so nothing else would reset the
+					// gauges. (stop() does not process a lease Drop.)
 					metrics.RaftLeaders.Delete(la.labels)
+					metrics.RaftLeases.Delete(la.labels)
 					la.stop()
 				}
 			}

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/events"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/listener"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/nodeliveness"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangelease"
@@ -64,6 +65,7 @@ func (l leaseInstruction) String() string {
 
 type LeaseKeeper struct {
 	nodeHost  *dragonboat.NodeHost
+	zone      string
 	log       log.Logger
 	liveness  *nodeliveness.Liveness
 	session   *client.Session
@@ -86,11 +88,12 @@ type LeaseKeeper struct {
 	nodeLivenessUpdates <-chan *rfpb.NodeLivenessRecord
 }
 
-func New(nodeHost *dragonboat.NodeHost, log log.Logger, liveness *nodeliveness.Liveness, listener *listener.RaftListener, broadcast chan<- events.Event, session *client.Session) *LeaseKeeper {
+func New(nodeHost *dragonboat.NodeHost, zone string, log log.Logger, liveness *nodeliveness.Liveness, listener *listener.RaftListener, broadcast chan<- events.Event, session *client.Session) *LeaseKeeper {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	eg, gctx := errgroup.WithContext(ctx)
 	return &LeaseKeeper{
 		nodeHost:            nodeHost,
+		zone:                zone,
 		log:                 log,
 		liveness:            liveness,
 		session:             session,
@@ -140,6 +143,11 @@ type leaseAgent struct {
 	eg        *errgroup.Group
 	broadcast chan<- events.Event
 
+	// labels is the standard per-range metric labelset (range, nodehost,
+	// partition, zone) for this lease agent's range. Computed once at
+	// creation and immutable thereafter, so it can be read without locking.
+	labels prometheus.Labels
+
 	updates *boundedstack.BoundedStack[*leaseInstruction]
 }
 
@@ -150,6 +158,16 @@ func (la *leaseAgent) isStopped() bool {
 	default:
 		return false
 	}
+}
+
+// setLeaderGauge records whether this node is the raft leader for the agent's
+// range, keyed by the full per-range labelset.
+func (la *leaseAgent) setLeaderGauge(leader bool) {
+	v := 0.0
+	if leader {
+		v = 1.0
+	}
+	metrics.RaftLeaders.With(la.labels).Set(v)
 }
 
 func (la *leaseAgent) sendRangeEvent(eventType events.EventType) {
@@ -193,9 +211,7 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 			return
 		}
 		la.log.Debugf("Acquired lease [%s] %s after callback (%s)", la.l.Desc(ctx), dur, instruction)
-		metrics.RaftLeases.With(prometheus.Labels{
-			metrics.RaftRangeIDLabel: strconv.Itoa(int(la.l.GetRangeID())),
-		}).Inc()
+		metrics.RaftLeases.With(la.labels).Inc()
 		metrics.RaftLeaseActionDurationMsec.With(prometheus.Labels{
 			metrics.RaftLeaseActionLabel: leaseAction,
 		}).Observe(float64(dur.Milliseconds()))
@@ -219,9 +235,7 @@ func (la *leaseAgent) doSingleInstruction(ctx context.Context, instruction *leas
 			return
 		}
 		la.log.Debugf("Dropped lease [%s] %s after callback (%s)", la.l.Desc(ctx), dur, instruction)
-		metrics.RaftLeases.With(prometheus.Labels{
-			metrics.RaftRangeIDLabel: strconv.Itoa(int(rangeID)),
-		}).Dec()
+		metrics.RaftLeases.With(la.labels).Dec()
 		metrics.RaftLeaseActionDurationMsec.With(prometheus.Labels{
 			metrics.RaftLeaseActionLabel: leaseAction,
 		}).Observe(float64(dur.Milliseconds()))
@@ -269,6 +283,7 @@ func (lk *LeaseKeeper) newLeaseAgent(rd *rfpb.RangeDescriptor, r *replica.Replic
 		cancel:    cancel,
 		eg:        eg,
 		broadcast: lk.broadcast,
+		labels:    keys.RangeMetricLabels(rd, lk.nodeHost.ID(), lk.zone),
 		updates:   updates,
 	}
 	la.eg.Go(func() error {
@@ -289,15 +304,6 @@ func (lk *LeaseKeeper) watchLeases() {
 			leader := info.LeaderID == info.ReplicaID && info.Term > 0
 			rangeID := rangeID(info.ShardID)
 
-			rlGauge := metrics.RaftLeaders.With(prometheus.Labels{
-				metrics.RaftRangeIDLabel: strconv.Itoa(int(rangeID)),
-			})
-			if leader {
-				rlGauge.Set(1.0)
-			} else {
-				rlGauge.Set(0.0)
-			}
-
 			lk.mu.Lock()
 			open := lk.open.Contains(rangeID)
 			if leader {
@@ -309,9 +315,14 @@ func (lk *LeaseKeeper) watchLeases() {
 			lk.mu.Unlock()
 
 			if la == nil {
+				// We don't have a lease agent for this range yet, so we
+				// can't build the full RaftLeaders labelset. The gauge is
+				// emitted once the range is added (see setLeaderGauge in
+				// AddRange) and on subsequent leader updates.
 				lk.log.Debugf("Range %d has not been opened yet (ignoring leader update)", rangeID)
 				continue
 			}
+			la.setLeaderGauge(leader)
 			action := Drop
 			if open && leader {
 				action = Acquire
@@ -414,6 +425,8 @@ func (lk *LeaseKeeper) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 	lk.open.Add(rangeID)
 	leader := lk.leaders.Contains(rangeID)
 	lk.mu.Unlock()
+
+	la.setLeaderGauge(leader)
 
 	action := Drop
 	if leader {

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -375,6 +375,12 @@ func (lk *LeaseKeeper) watchLeases() {
 			lk.mu.Unlock()
 			if la != nil {
 				if la.replicaID == nodeInfo.ReplicaID {
+					// This is the terminal teardown for the range's replica
+					// on this node. Remove its RaftLeaders series so a stale
+					// leader=1 value doesn't linger: once the lease agent is
+					// gone, later leader-change callbacks find no agent and
+					// are dropped, so nothing else would reset the gauge.
+					metrics.RaftLeaders.Delete(la.labels)
 					la.stop()
 				}
 			}

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -60,6 +60,7 @@ type IStore interface {
 	SnapshotCluster(ctx context.Context, rangeID uint64) error
 	StartShard(ctx context.Context, req *rfpb.StartShardRequest) (*rfpb.StartShardResponse, error)
 	NHID() string
+	Zone() string
 }
 
 // Replica implements the interface IOnDiskStateMachine. More details of
@@ -268,9 +269,7 @@ func (sm *Replica) setRange(val []byte) error {
 		// channel (which can drop under load). The apply path will refresh
 		// it as data is written; this guarantees presence at replica open
 		// and on every range-descriptor mutation.
-		metrics.RaftBytes.With(prometheus.Labels{
-			metrics.RaftRangeIDLabel: strconv.FormatUint(rangeDescriptor.GetRangeId(), 10),
-		}).Set(float64(usage.GetEstimatedDiskBytesUsed()))
+		metrics.RaftBytes.With(keys.RangeMetricLabels(rangeDescriptor, sm.NHID, sm.store.Zone())).Set(float64(usage.GetEstimatedDiskBytesUsed()))
 		sm.notifyListenersOfUsage(rangeDescriptor, usage)
 	} else {
 		sm.log.Errorf("Error computing usage upon opening replica: %s", err)
@@ -1549,10 +1548,7 @@ func (sm *Replica) singleUpdate(db pebble.IPebbleDB, entry dbsm.Entry) (dbsm.Ent
 	sm.rangeMu.RUnlock()
 
 	// Increment QPS counters.
-	rangeID := rd.GetRangeId()
-	metrics.RaftProposals.With(prometheus.Labels{
-		metrics.RaftRangeIDLabel: strconv.Itoa(int(rangeID)),
-	}).Inc()
+	metrics.RaftProposals.With(keys.RangeMetricLabels(rd, sm.NHID, sm.store.Zone())).Inc()
 	sm.raftProposeQPS.Inc()
 
 	batchRsp := &rfpb.BatchCmdResponse{}
@@ -2120,9 +2116,7 @@ func (sm *Replica) Close() error {
 		sm.store.RemoveRange(rangeDescriptor, sm)
 	}
 	if rangeDescriptor != nil {
-		metrics.RaftBytes.Delete(prometheus.Labels{
-			metrics.RaftRangeIDLabel: strconv.FormatUint(rangeDescriptor.GetRangeId(), 10),
-		})
+		metrics.RaftBytes.Delete(keys.RangeMetricLabels(rangeDescriptor, sm.NHID, sm.store.Zone()))
 	}
 
 	sm.readQPS.Stop()

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -373,7 +373,7 @@ func New(env environment.Env, cfg *raftConfig.ServerConfig, opts ...Option) (*St
 		openRanges: make(map[uint64]*rfpb.RangeDescriptor),
 		rangeMap:   rangemap.New[*rfpb.RangeDescriptor](),
 
-		leaseKeeper: leasekeeper.New(nodeHost, nhLog, nodeLiveness, raftListener, eventsChan, lkSession),
+		leaseKeeper: leasekeeper.New(nodeHost, zone, nhLog, nodeLiveness, raftListener, eventsChan, lkSession),
 		replicas:    sync.Map{},
 
 		eventsMu:       sync.Mutex{},
@@ -1300,7 +1300,7 @@ func (s *Store) UpdateRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 			metrics.RaftNodeHostIDLabel: s.nodeHost.ID(),
 		}).Inc()
 	}
-	metrics.RaftRangeReplica.With(s.rangeReplicaLabels(rd)).Set(1)
+	metrics.RaftRangeReplica.With(s.rangeMetricLabels(rd)).Set(1)
 
 	if len(rd.GetReplicas()) == 0 {
 		s.log.Debugf("range %d has no replicas (yet?)", rd.GetRangeId())
@@ -1350,7 +1350,7 @@ func (s *Store) RemoveRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 	metrics.RaftRanges.With(prometheus.Labels{
 		metrics.RaftNodeHostIDLabel: s.nodeHost.ID(),
 	}).Dec()
-	metrics.RaftRangeReplica.Delete(s.rangeReplicaLabels(rd))
+	metrics.RaftRangeReplica.Delete(s.rangeMetricLabels(rd))
 
 	if len(rd.GetReplicas()) == 0 {
 		s.log.Debugf("range descriptor had no replicas yet")
@@ -1512,6 +1512,10 @@ func (s *Store) NodeHost() *dragonboat.NodeHost {
 
 func (s *Store) NHID() string {
 	return s.nodeHost.ID()
+}
+
+func (s *Store) Zone() string {
+	return s.zone
 }
 
 func (s *Store) NodeDescriptor() *rfpb.NodeDescriptor {
@@ -2531,9 +2535,7 @@ func (s *Store) checkIfReplicasNeedSplitting(ctx context.Context, targetRangeSiz
 				rangeUsageEvent := e.(events.RangeUsageEvent)
 				rangeID := rangeUsageEvent.RangeDescriptor.GetRangeId()
 				estimatedDiskBytes := rangeUsageEvent.ReplicaUsage.GetEstimatedDiskBytesUsed()
-				metrics.RaftBytes.With(prometheus.Labels{
-					metrics.RaftRangeIDLabel: strconv.FormatUint(rangeID, 10),
-				}).Set(float64(estimatedDiskBytes))
+				metrics.RaftBytes.With(s.rangeMetricLabels(rangeUsageEvent.RangeDescriptor)).Set(float64(estimatedDiskBytes))
 				if rangeID == constants.MetaRangeID {
 					continue
 				}
@@ -4015,25 +4017,10 @@ func (s *Store) getFileSystemUsage() (gosigar.FileSystemUsage, error) {
 	return fsu, err
 }
 
-// rangeReplicaLabels builds the labelset for the RaftRangeReplica gauge.
-func (s *Store) rangeReplicaLabels(rd *rfpb.RangeDescriptor) prometheus.Labels {
-	partitionID := rd.GetPartitionId()
-	if partitionID == "" {
-		partitionID = keys.PartitionIDFromRangeStart(rd.GetStart())
-	}
-	if partitionID == "" {
-		if rd.GetRangeId() == 1 {
-			partitionID = "meta"
-		} else {
-			partitionID = "unknown"
-		}
-	}
-	return prometheus.Labels{
-		metrics.RaftRangeIDLabel:    strconv.FormatUint(rd.GetRangeId(), 10),
-		metrics.RaftNodeHostIDLabel: s.nodeHost.ID(),
-		metrics.PartitionID:         partitionID,
-		metrics.ZoneLabel:           s.zone,
-	}
+// rangeMetricLabels builds the standard per-range labelset (range, nodehost,
+// partition, zone) shared by the raft range metrics.
+func (s *Store) rangeMetricLabels(rd *rfpb.RangeDescriptor) prometheus.Labels {
+	return keys.RangeMetricLabels(rd, s.nodeHost.ID(), s.zone)
 }
 
 func (s *Store) setupPartitions(ctx context.Context) {

--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -378,6 +378,9 @@ func (fs *FakeStore) StartShard(ctx context.Context, req *rfpb.StartShardRequest
 func (fs *FakeStore) NHID() string {
 	return ""
 }
+func (fs *FakeStore) Zone() string {
+	return ""
+}
 
 type TestingReplica struct {
 	t testing.TB

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2874,6 +2874,9 @@ var (
 		Help:      "Number of raft leases on each nodehost.",
 	}, []string{
 		RaftRangeIDLabel,
+		RaftNodeHostIDLabel,
+		PartitionID,
+		ZoneLabel,
 	})
 
 	RaftLeaders = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -2883,6 +2886,9 @@ var (
 		Help:      "Number of raft leaders on each nodehost.",
 	}, []string{
 		RaftRangeIDLabel,
+		RaftNodeHostIDLabel,
+		PartitionID,
+		ZoneLabel,
 	})
 
 	RaftBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -2892,6 +2898,9 @@ var (
 		Help:      "Size (in bytes) of each range.",
 	}, []string{
 		RaftRangeIDLabel,
+		RaftNodeHostIDLabel,
+		PartitionID,
+		ZoneLabel,
 	})
 
 	RaftProposals = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2901,6 +2910,9 @@ var (
 		Help:      "The total number of statemachine proposals on each range.",
 	}, []string{
 		RaftRangeIDLabel,
+		RaftNodeHostIDLabel,
+		PartitionID,
+		ZoneLabel,
 	})
 
 	RaftSplits = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Since partition ID is always the same for a range ID, and nhid and zone are always the same for a pod, this doesn't increase cardinality.

It does make it easier to see how many lease holders there are per zone, or to see how many leaser holders each pod has for a specific partition.