### PR TITLE
execution server: handle multiple container image rewrite rules

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -86,6 +86,49 @@ const (
 	completedPubSubChanExpiration = 15 * time.Minute
 )
 
+type containerImageRewriteRule struct {
+	prefix      string
+	replacement string
+}
+
+func containerImageRewriteRules(rewriteConfig map[string]any) []containerImageRewriteRule {
+	if rewriteConfig == nil {
+		return nil
+	}
+
+	if rewriteConfig["prefix"] != nil || rewriteConfig["replacement"] != nil {
+		prefix, _ := rewriteConfig["prefix"].(string)
+		replacement, _ := rewriteConfig["replacement"].(string)
+		return []containerImageRewriteRule{{prefix: prefix, replacement: replacement}}
+	}
+
+	rawRewrites, _ := rewriteConfig["rewrites"].([]any)
+	rules := make([]containerImageRewriteRule, 0, len(rawRewrites))
+	for _, rawRewrite := range rawRewrites {
+		rewrite, ok := rawRewrite.(map[string]any)
+		if !ok {
+			continue
+		}
+		prefix, _ := rewrite["prefix"].(string)
+		replacement, _ := rewrite["replacement"].(string)
+		rules = append(rules, containerImageRewriteRule{prefix: prefix, replacement: replacement})
+	}
+	return rules
+}
+
+func rewriteContainerImage(imageName string, rules []containerImageRewriteRule) (string, bool) {
+	imageName = strings.TrimPrefix(imageName, platform.DockerPrefix)
+	for _, rule := range rules {
+		if rule.prefix == "" || rule.replacement == "" {
+			continue
+		}
+		if after, ok := strings.CutPrefix(imageName, rule.prefix); ok {
+			return platform.DockerPrefix + rule.replacement + after, true
+		}
+	}
+	return "", false
+}
+
 var (
 	enableRedisAvailabilityMonitoring = flag.Bool("remote_execution.enable_redis_availability_monitoring", false, "If enabled, the execution server will detect if Redis has lost state and will ask Bazel to retry executions.")
 
@@ -881,18 +924,13 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		const containerImageRewriteExperiment = "remote_execution.container_image_rewrite"
 		rewriteConfig, details := fp.ObjectDetails(ctx, containerImageRewriteExperiment, nil)
 		if rewriteConfig != nil {
-			prefix, _ := rewriteConfig["prefix"].(string)
-			replacement, _ := rewriteConfig["replacement"].(string)
-			imageName := strings.TrimPrefix(props.ContainerImage, platform.DockerPrefix)
-			if prefix != "" && replacement != "" {
-				if after, ok := strings.CutPrefix(imageName, prefix); ok {
-					executionTask.PlatformOverrides.Properties = append(
-						executionTask.PlatformOverrides.Properties,
-						&repb.Platform_Property{
-							Name:  "container-image",
-							Value: "docker://" + replacement + after,
-						})
-				}
+			if imageName, ok := rewriteContainerImage(props.ContainerImage, containerImageRewriteRules(rewriteConfig)); ok {
+				executionTask.PlatformOverrides.Properties = append(
+					executionTask.PlatformOverrides.Properties,
+					&repb.Platform_Property{
+						Name:  "container-image",
+						Value: imageName,
+					})
 			}
 		}
 		if details.Variant() != "" {

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -443,20 +443,43 @@ func TestDispatch_TaskSizeOverridesExperiment(t *testing.T) {
 func TestDispatch_ContainerImageRewriteExperiment(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string
+		rewriteVariant        string
 		containerImage        string
 		wantContainerImage    string
 		wantExperimentVariant string
 	}{
 		{
 			name:                  "matching prefix is rewritten",
+			rewriteVariant:        `"prefix": "gcr.io/flame-public/", "replacement": "buildbuddy.bbcr.io/public/"`,
 			containerImage:        "docker://gcr.io/flame-public/rbe-ubuntu:latest",
 			wantContainerImage:    "docker://buildbuddy.bbcr.io/public/rbe-ubuntu:latest",
 			wantExperimentVariant: "bbcr",
 		},
 		{
 			name:                  "non-matching prefix is not rewritten",
+			rewriteVariant:        `"prefix": "gcr.io/flame-public/", "replacement": "buildbuddy.bbcr.io/public/"`,
 			containerImage:        "docker://us-docker.pkg.dev/other/image:latest",
 			wantContainerImage:    "",
+			wantExperimentVariant: "bbcr",
+		},
+		{
+			name: "matching rewrite from multiple rules is rewritten",
+			rewriteVariant: `"rewrites": [
+            {"prefix": "gcr.io/flame-public/", "replacement": "buildbuddy.bbcr.io/public/"},
+            {"prefix": "public.ecr.aws/", "replacement": "ecr.bbcr.dev/public/"}
+          ]`,
+			containerImage:        "docker://public.ecr.aws/example-org/example-image:latest",
+			wantContainerImage:    "docker://ecr.bbcr.dev/public/example-org/example-image:latest",
+			wantExperimentVariant: "bbcr",
+		},
+		{
+			name: "only first matching rewrite is applied",
+			rewriteVariant: `"rewrites": [
+            {"prefix": "public.ecr.aws/", "replacement": "first.example.com/"},
+            {"prefix": "public.ecr.aws/", "replacement": "second.example.com/"}
+          ]`,
+			containerImage:        "docker://public.ecr.aws/example-org/example-image:latest",
+			wantContainerImage:    "docker://first.example.com/example-org/example-image:latest",
 			wantExperimentVariant: "bbcr",
 		},
 	} {
@@ -472,8 +495,7 @@ func TestDispatch_ContainerImageRewriteExperiment(t *testing.T) {
       "state": "ENABLED",
       "variants": {
         "bbcr": {
-          "prefix": "gcr.io/flame-public/",
-          "replacement": "buildbuddy.bbcr.io/public/"
+          `+tc.rewriteVariant+`
         },
         "default": {}
       },


### PR DESCRIPTION
I would like `bbcr.io` (and `bbcr.dev`) to mirror `public.ecr.aws` as well as `gcr.io/flame-public/` (since `public.ecr.aws` does not support `HEAD` requests on blobs, but `bbcr.io` would and does). That's going to require handling multiple rewrite rules!