### PR TITLE
[raft] Reduce tracing overhead

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -84,11 +84,6 @@ func NewAPIClient(env environment.Env, name string, registry IRegistry) *APIClie
 }
 
 func (c *APIClient) getClient(ctx context.Context, peer string) (returnedClient rfspb.ApiClient, returnedErr error) {
-	ctx, spn := tracing.StartNamedSpan(ctx, "client.APIClient.getClient") // nolint:SA4006
-	defer func() {
-		tracing.RecordErrorToSpan(spn, returnedErr)
-		spn.End()
-	}()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if client, ok := c.clients[peer]; ok {

--- a/enterprise/server/raft/nodeliveness/nodeliveness.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness.go
@@ -149,10 +149,8 @@ func (h *Liveness) BlockingValidateNodeLiveness(ctx context.Context, nl *rfpb.Ra
 }
 
 func (h *Liveness) verifyLease(ctx context.Context, l *rfpb.NodeLivenessRecord) (retErr error) {
-	_, span := tracing.StartNamedSpan(ctx, "nodeliveness.Liveness.verifyLease")
 	defer func() {
-		tracing.RecordErrorToSpan(span, retErr)
-		span.End()
+		tracing.AddErrorEventToCurrentSpan(ctx, "verifyLease", retErr)
 	}()
 	if serf.LamportTime(l.GetEpoch()) != h.clock.Time() {
 		return status.FailedPreconditionErrorf("LeaseInvalid: lease epoch %d != current epoch: %d", l.GetEpoch(), h.clock.Time())
@@ -184,10 +182,8 @@ func (h *Liveness) setLastLivenessRecord(nlr *rfpb.NodeLivenessRecord) {
 }
 
 func (h *Liveness) ensureValidLease(ctx context.Context, forceRenewal bool) (returnedRecord *rfpb.NodeLivenessRecord, returnedErr error) {
-	ctx, span := tracing.StartNamedSpan(ctx, "nodeliveness.Liveness.ensureValidLease")
 	defer func() {
-		tracing.RecordErrorToSpan(span, returnedErr)
-		span.End()
+		tracing.AddErrorEventToCurrentSpan(ctx, "ensureValidLease", returnedErr)
 	}()
 	start := time.Now()
 	h.mu.RLock()

--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -249,14 +249,7 @@ func (s *StaticRegistry) LookupByNHID(nhid string) (*rfpb.ConnectionInfo, error)
 }
 
 // ResolveGRPC returns the gRPC address and the connection key of the specified node.
-func (n *StaticRegistry) ResolveGRPC(ctx context.Context, nhid string) (returnedAddr string, returnedErr error) {
-	ctx, spn := tracing.StartNamedSpan(ctx, "registry.StaticRegistry.ResolveGRPC") // nolint:SA4006
-
-	defer func() {
-		tracing.RecordErrorToSpan(spn, returnedErr)
-		spn.End()
-	}()
-
+func (n *StaticRegistry) ResolveGRPC(ctx context.Context, nhid string) (string, error) {
 	if a, ok := n.targetAddresses.Load(nhid); ok {
 		grpcAddr := a.(addresses).grpc
 		return grpcAddr, nil
@@ -560,12 +553,7 @@ func (d *DynamicNodeRegistry) Lookup(ctx context.Context, rangeID uint64, replic
 }
 
 // ResolveGRPC returns the gRPC address and the connection key of the specified node.
-func (d *DynamicNodeRegistry) ResolveGRPC(ctx context.Context, nhid string) (addr string, returnedErr error) {
-	ctx, spn := tracing.StartNamedSpan(ctx, "registry.DynamicNodeRegistry.ResolveGRPC") // nolint:SA4006
-	defer func() {
-		tracing.RecordErrorToSpan(spn, returnedErr)
-		spn.End()
-	}()
+func (d *DynamicNodeRegistry) ResolveGRPC(ctx context.Context, nhid string) (string, error) {
 	g, err := d.sReg.ResolveGRPC(ctx, nhid)
 	if strings.HasPrefix(status.Message(err), targetAddressUnknownErrorMsg) {
 		req := &rfpb.RegistryQueryRequest{

--- a/server/util/tracing/tracing.go
+++ b/server/util/tracing/tracing.go
@@ -453,6 +453,17 @@ func AddStringAttributeToCurrentSpan(ctx context.Context, key, value string) {
 	span.SetAttributes(attribute.String(key, value))
 }
 
+func AddErrorEventToCurrentSpan(ctx context.Context, name string, err error) {
+	if err == nil {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	span.AddEvent(name, trace.WithAttributes(attribute.String("error", err.Error())))
+}
+
 // RecordErrorToSpan records a non-nil error to the span; and does nothing if
 // span is not recording or err is nil.
 func RecordErrorToSpan(span trace.Span, err error) {


### PR DESCRIPTION
Two types of changes:
1. Don't create a span for fast functions just to record an error, when our caller will already record the error in its span.
2. If we really need to record an error in a fast function, add an event to the existing span instead of creating a new span. Only do this when there actually is an error.

Benchmark results:
```
               │  /tmp/after  │          /tmp/lesstrace2          │
               │    sec/op    │   sec/op     vs base              │
Get-24            112.4µ ± 2%   112.4µ ± 5%       ~ (p=0.620 n=7)
Find-24           110.8µ ± 3%   110.8µ ± 3%       ~ (p=0.805 n=7)
GetParallel-24   10.238µ ± 4%   9.948µ ± 3%       ~ (p=0.097 n=7)
geomean           50.34µ        49.84µ       -0.98%

               │  /tmp/after  │          /tmp/lesstrace2           │
               │     B/op     │     B/op      vs base              │
Get-24           39.33Ki ± 0%   38.15Ki ± 1%  -3.00% (p=0.001 n=7)
Find-24          37.30Ki ± 0%   36.12Ki ± 0%  -3.16% (p=0.001 n=7)
GetParallel-24   38.64Ki ± 0%   37.47Ki ± 0%  -3.03% (p=0.001 n=7)
geomean          38.41Ki        37.24Ki       -3.06%

               │ /tmp/after │         /tmp/lesstrace2          │
               │ allocs/op  │ allocs/op   vs base              │
Get-24           553.0 ± 0%   538.0 ± 0%  -2.71% (p=0.001 n=7)
Find-24          534.0 ± 0%   519.0 ± 0%  -2.81% (p=0.001 n=7)
GetParallel-24   548.0 ± 0%   533.0 ± 0%  -2.74% (p=0.001 n=7)
geomean          544.9        529.9       -2.75%
```