### PR TITLE
Add grpc client flag to prefer least-loaded conns instead round robin.

### DIFF
--- a/server/util/grpc_client/BUILD
+++ b/server/util/grpc_client/BUILD
@@ -28,14 +28,18 @@ go_library(
 go_test(
     name = "grpc_client_test",
     size = "small",
-    srcs = ["grpc_client_test.go"],
+    srcs = [
+        "grpc_client_internal_test.go",
+        "grpc_client_test.go",
+    ],
+    embed = [":grpc_client"],
     deps = [
-        ":grpc_client",
         "//proto:ping_service_go_proto",
         "//server/environment",
         "//server/testutil/testenv",
         "//server/testutil/testport",
         "//server/util/grpc_server",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -41,6 +41,8 @@ const (
 var (
 	poolSize = flag.Int("grpc_client.pool_size", 15, "Number of connections to create to each target.")
 
+	loadAwareConnSelection = flag.Bool("grpc_client.load_aware_conn_selection", false, "If true, pick a pool connection for each RPC using the power of two random choices over in-flight RPC counts, instead of round-robin. Steers load away from connections that are backed up.")
+
 	idsMu sync.Mutex
 	ids   = map[string]int{}
 )
@@ -49,6 +51,10 @@ type clientConn struct {
 	*grpc.ClientConn
 	index        string
 	wasEverReady atomic.Bool
+	// pending is the number of in-flight RPCs issued on this connection via
+	// the pool's Invoke and NewStream methods. getConn uses it to steer new
+	// RPCs toward less-loaded connections.
+	pending atomic.Int64
 }
 
 type ClientConnPool struct {
@@ -97,7 +103,28 @@ func (p *ClientConnPool) Close() error {
 	return nil
 }
 
+// getConn returns a connection from the pool.
+//
+// When load-aware connection selection is enabled it uses the power of two
+// random choices: it samples two distinct connections and returns whichever
+// has fewer in-flight RPCs. This steers new RPCs away from connections that are
+// backed up (for example, one stalled behind the load balancer's HTTP/2
+// flow-control or max-concurrent-stream limits) and toward idle ones.
 func (p *ClientConnPool) getConn() *clientConn {
+	n := len(p.conns)
+	if *loadAwareConnSelection && n > 1 {
+		// Sample two distinct connections and take the less-loaded one.
+		i := rand.IntN(n)
+		j := rand.IntN(n - 1)
+		if j >= i {
+			j++
+		}
+		a, b := p.conns[i], p.conns[j]
+		if b.pending.Load() < a.pending.Load() {
+			return b
+		}
+		return a
+	}
 	idx := p.idx.Add(1)
 	return p.conns[idx%uint64(len(p.conns))]
 }
@@ -139,7 +166,11 @@ func (p *ClientConnPool) Invoke(ctx context.Context, method string, args any, re
 	conn := p.getConn()
 	gauge := metrics.PendingClientRPCsPerConnection.WithLabelValues(p.targetForLogging, p.id, method, conn.index)
 	gauge.Inc()
-	defer gauge.Dec()
+	conn.pending.Add(1)
+	defer func() {
+		gauge.Dec()
+		conn.pending.Add(-1)
+	}()
 	return conn.Invoke(ctx, method, args, reply, opts...)
 }
 
@@ -156,9 +187,13 @@ func (p *ClientConnPool) NewStream(ctx context.Context, desc *grpc.StreamDesc, m
 	defer cancel()
 	conn := p.getConn()
 	gauge := metrics.PendingClientRPCsPerConnection.WithLabelValues(p.targetForLogging, p.id, method, conn.index)
-	decFn := sync.OnceFunc(func() { gauge.Dec() })
+	decFn := sync.OnceFunc(func() {
+		gauge.Dec()
+		conn.pending.Add(-1)
+	})
 	opts = append(opts, grpc.OnFinish(func(_ error) { decFn() }))
 	gauge.Inc()
+	conn.pending.Add(1)
 	stream, err := conn.NewStream(ctx, desc, method, opts...)
 	if err != nil {
 		decFn()

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -38,10 +38,19 @@ const (
 	defaultProtocol = "grpcs://"
 )
 
+const (
+	// connPickRoundRobin cycles through pool connections in order.
+	connPickRoundRobin = "round-robin"
+	// connPickLeastPendingRPCs picks a connection using the power of two random
+	// choices over in-flight RPC counts, steering load away from connections
+	// that are backed up.
+	connPickLeastPendingRPCs = "least-pending-rpcs"
+)
+
 var (
 	poolSize = flag.Int("grpc_client.pool_size", 15, "Number of connections to create to each target.")
 
-	loadAwareConnSelection = flag.Bool("grpc_client.load_aware_conn_selection", false, "If true, pick a pool connection for each RPC using the power of two random choices over in-flight RPC counts, instead of round-robin. Steers load away from connections that are backed up.")
+	connPickPolicy = flag.String("grpc_client.conn_pick_policy", connPickRoundRobin, "How to pick a pool connection for each RPC. \""+connPickRoundRobin+"\" cycles through connections in order. \""+connPickLeastPendingRPCs+"\" uses the power of two random choices over in-flight RPC counts to steer load away from connections that are backed up (e.g. stalled behind a load balancer's flow-control or max-concurrent-stream limits).")
 
 	idsMu sync.Mutex
 	ids   = map[string]int{}
@@ -105,14 +114,15 @@ func (p *ClientConnPool) Close() error {
 
 // getConn returns a connection from the pool.
 //
-// When load-aware connection selection is enabled it uses the power of two
-// random choices: it samples two distinct connections and returns whichever
-// has fewer in-flight RPCs. This steers new RPCs away from connections that are
-// backed up (for example, one stalled behind the load balancer's HTTP/2
-// flow-control or max-concurrent-stream limits) and toward idle ones.
+// Under the "least-pending-rpcs" policy it uses the power of two random
+// choices: it samples two distinct connections and returns whichever has fewer
+// in-flight RPCs. This steers new RPCs away from connections that are backed up
+// (for example, one stalled behind the load balancer's HTTP/2 flow-control or
+// max-concurrent-stream limits) and toward idle ones. Otherwise it falls back
+// to round-robin, cycling through connections in order.
 func (p *ClientConnPool) getConn() *clientConn {
 	n := len(p.conns)
-	if *loadAwareConnSelection && n > 1 {
+	if *connPickPolicy == connPickLeastPendingRPCs && n > 1 {
 		// Sample two distinct connections and take the less-loaded one.
 		i := rand.IntN(n)
 		j := rand.IntN(n - 1)

--- a/server/util/grpc_client/grpc_client_internal_test.go
+++ b/server/util/grpc_client/grpc_client_internal_test.go
@@ -1,0 +1,72 @@
+package grpc_client
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+)
+
+// testPool builds a pool of connections with the given in-flight counts. The
+// connections have no underlying grpc.ClientConn, which is fine because getConn
+// only reads the pending counter and index.
+func testPool(pending ...int64) *ClientConnPool {
+	conns := make([]*clientConn, len(pending))
+	for i, n := range pending {
+		c := &clientConn{index: strconv.Itoa(i)}
+		c.pending.Store(n)
+		conns[i] = c
+	}
+	return &ClientConnPool{conns: conns}
+}
+
+func TestGetConn_LoadAware_PicksLessLoadedOfTwo(t *testing.T) {
+	flags.Set(t, "grpc_client.load_aware_conn_selection", true)
+	p := testPool(10, 3)
+	for i := 0; i < 100; i++ {
+		require.Same(t, p.conns[1], p.getConn())
+	}
+}
+
+func TestGetConn_LoadAware_AvoidsBackedUpConnection(t *testing.T) {
+	flags.Set(t, "grpc_client.load_aware_conn_selection", true)
+	// Connection 2 is badly backed up; the rest are idle.
+	p := testPool(0, 0, 1000, 0, 0)
+	counts := make([]int, len(p.conns))
+	for i := 0; i < 10_000; i++ {
+		idx, err := strconv.Atoi(p.getConn().index)
+		require.NoError(t, err)
+		counts[idx]++
+	}
+	// Power of two choices samples two distinct connections and takes the
+	// less-loaded one, so the uniquely most-loaded connection is never picked.
+	require.Zero(t, counts[2], "backed-up connection should never be selected")
+	// Every other connection should still receive traffic.
+	for i, c := range counts {
+		if i == 2 {
+			continue
+		}
+		require.NotZero(t, c, "connection %d should receive traffic", i)
+	}
+}
+
+func TestGetConn_RoundRobinByDefault(t *testing.T) {
+	// With load-aware selection off, selection is round-robin and ignores the
+	// pending counts entirely (connection 1 is heavily loaded but still gets
+	// its turn).
+	flags.Set(t, "grpc_client.load_aware_conn_selection", false)
+	p := testPool(0, 100, 0, 0)
+	want := []int{1, 2, 3, 0, 1, 2, 3, 0}
+	for _, w := range want {
+		require.Equal(t, strconv.Itoa(w), p.getConn().index)
+	}
+}
+
+func TestGetConn_SingleConnection(t *testing.T) {
+	for _, loadAware := range []bool{false, true} {
+		flags.Set(t, "grpc_client.load_aware_conn_selection", loadAware)
+		p := testPool(5)
+		require.Same(t, p.conns[0], p.getConn())
+	}
+}

--- a/server/util/grpc_client/grpc_client_internal_test.go
+++ b/server/util/grpc_client/grpc_client_internal_test.go
@@ -21,16 +21,16 @@ func testPool(pending ...int64) *ClientConnPool {
 	return &ClientConnPool{conns: conns}
 }
 
-func TestGetConn_LoadAware_PicksLessLoadedOfTwo(t *testing.T) {
-	flags.Set(t, "grpc_client.load_aware_conn_selection", true)
+func TestGetConn_LeastPending_PicksLessLoadedOfTwo(t *testing.T) {
+	flags.Set(t, "grpc_client.conn_pick_policy", connPickLeastPendingRPCs)
 	p := testPool(10, 3)
 	for i := 0; i < 100; i++ {
 		require.Same(t, p.conns[1], p.getConn())
 	}
 }
 
-func TestGetConn_LoadAware_AvoidsBackedUpConnection(t *testing.T) {
-	flags.Set(t, "grpc_client.load_aware_conn_selection", true)
+func TestGetConn_LeastPending_AvoidsBackedUpConnection(t *testing.T) {
+	flags.Set(t, "grpc_client.conn_pick_policy", connPickLeastPendingRPCs)
 	// Connection 2 is badly backed up; the rest are idle.
 	p := testPool(0, 0, 1000, 0, 0)
 	counts := make([]int, len(p.conns))
@@ -52,10 +52,10 @@ func TestGetConn_LoadAware_AvoidsBackedUpConnection(t *testing.T) {
 }
 
 func TestGetConn_RoundRobinByDefault(t *testing.T) {
-	// With load-aware selection off, selection is round-robin and ignores the
-	// pending counts entirely (connection 1 is heavily loaded but still gets
-	// its turn).
-	flags.Set(t, "grpc_client.load_aware_conn_selection", false)
+	// Under the round-robin policy, selection cycles through connections in
+	// order and ignores the pending counts entirely (connection 1 is heavily
+	// loaded but still gets its turn).
+	flags.Set(t, "grpc_client.conn_pick_policy", connPickRoundRobin)
 	p := testPool(0, 100, 0, 0)
 	want := []int{1, 2, 3, 0, 1, 2, 3, 0}
 	for _, w := range want {
@@ -64,8 +64,8 @@ func TestGetConn_RoundRobinByDefault(t *testing.T) {
 }
 
 func TestGetConn_SingleConnection(t *testing.T) {
-	for _, loadAware := range []bool{false, true} {
-		flags.Set(t, "grpc_client.load_aware_conn_selection", loadAware)
+	for _, policy := range []string{connPickRoundRobin, connPickLeastPendingRPCs} {
+		flags.Set(t, "grpc_client.conn_pick_policy", policy)
 		p := testPool(5)
 		require.Same(t, p.conns[0], p.getConn())
 	}


### PR DESCRIPTION
With round-robin an already saturated connection can keep piling up more RPCs when there are underutilized connections still available in the pool.