### PR TITLE
[raft] Remove canary.Start from Replica.Lookup

### DIFF
--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//proto:raft_go_proto",
         "//proto:storage_go_proto",
         "//server/metrics",
-        "//server/util/canary",
         "//server/util/lib/set",
         "//server/util/log",
         "//server/util/proto",

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -19,7 +19,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
-	"github.com/buildbuddy-io/buildbuddy/server/util/canary"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lib/set"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -1715,7 +1714,6 @@ func (sm *Replica) Update(entries []dbsm.Entry) ([]dbsm.Entry, error) {
 // The Lookup method is a read only method, it should never change the state
 // of IOnDiskStateMachine.
 func (sm *Replica) Lookup(key interface{}) (interface{}, error) {
-	defer canary.Start("replica.Lookup", time.Second)()
 	reqBuf, ok := key.([]byte)
 	if !ok {
 		return nil, status.FailedPreconditionError("Cannot convert key to []byte")


### PR DESCRIPTION
I don't think this is useful any more,  and it removes some allocations. Benchmark results:
```
               │ /tmp/base2  │           /tmp/nocanary           │
               │   sec/op    │   sec/op     vs base              │
Get-24           112.0µ ± 4%   110.5µ ± 3%       ~ (p=0.620 n=7)
Find-24          113.5µ ± 7%   109.9µ ± 8%       ~ (p=0.128 n=7)
GetParallel-24   10.57µ ± 4%   10.25µ ± 7%       ~ (p=0.073 n=7)
geomean          51.20µ        49.94µ       -2.47%

               │  /tmp/base2  │           /tmp/nocanary            │
               │     B/op     │     B/op      vs base              │
Get-24           38.17Ki ± 0%   37.02Ki ± 0%  -3.01% (p=0.001 n=7)
Find-24          36.14Ki ± 0%   35.01Ki ± 0%  -3.13% (p=0.001 n=7)
GetParallel-24   37.48Ki ± 0%   36.36Ki ± 0%  -3.00% (p=0.001 n=7)
geomean          37.25Ki        36.12Ki       -3.04%

               │ /tmp/base2 │          /tmp/nocanary           │
               │ allocs/op  │ allocs/op   vs base              │
Get-24           538.0 ± 0%   521.0 ± 0%  -3.16% (p=0.001 n=7)
Find-24          519.0 ± 0%   502.0 ± 0%  -3.28% (p=0.001 n=7)
GetParallel-24   533.0 ± 0%   516.0 ± 0%  -3.19% (p=0.001 n=7)
geomean          529.9        512.9       -3.21%
```