### PR TITLE
Add flag to control gcs atime update separately.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -100,11 +100,12 @@ var (
 	minBytesAutoZstdCompression = flag.Int64("cache.pebble.min_bytes_auto_zstd_compression", DefaultMinBytesAutoZstdCompression, "Blobs larger than this will be zstd compressed before written to disk.")
 
 	// GCS Large File Support
-	gcsBucket      = flag.String("cache.pebble.gcs.bucket", "", "The name of the GCS bucket to store build artifact files in.")
-	gcsTTLDays     = flag.Int64("cache.pebble.gcs.ttl_days", 0, "An object TTL, specified in days, to apply to the GCS bucket (0 means disabled).")
-	gcsCredentials = flag.String("cache.pebble.gcs.credentials", "", "Credentials in JSON format that will be used to authenticate to GCS.", flag.Secret)
-	gcsProjectID   = flag.String("cache.pebble.gcs.project_id", "", "The Google Cloud project ID of the project owning the above credentials and GCS bucket.")
-	gcsAppName     = flag.String("cache.pebble.gcs.app_name", "", "The app name, under which blobstore data will be stored.")
+	gcsBucket               = flag.String("cache.pebble.gcs.bucket", "", "The name of the GCS bucket to store build artifact files in.")
+	gcsTTLDays              = flag.Int64("cache.pebble.gcs.ttl_days", 0, "An object TTL, specified in days, to apply to the GCS bucket (0 means disabled).")
+	gcsCredentials          = flag.String("cache.pebble.gcs.credentials", "", "Credentials in JSON format that will be used to authenticate to GCS.", flag.Secret)
+	gcsProjectID            = flag.String("cache.pebble.gcs.project_id", "", "The Google Cloud project ID of the project owning the above credentials and GCS bucket.")
+	gcsAppName              = flag.String("cache.pebble.gcs.app_name", "", "The app name, under which blobstore data will be stored.")
+	gcsAtimeUpdateThreshold = flag.Duration("cache.pebble.gcs.atime_update_threshold", 0, "Don't update a GCS object's custom time (its atime) if it was updated more recently than this (0 updates on every atime update).")
 )
 
 var (
@@ -207,7 +208,11 @@ type Options struct {
 	GCSAppName          string
 	GCSTTLDays          *int64
 	MinGCSFileSizeBytes *int64
-	FileStorer          filestore.Store
+	// GCSAtimeUpdateThreshold suppresses a GCS object's custom time (atime)
+	// refresh if it was updated more recently than this. 0 updates on every
+	// atime update.
+	GCSAtimeUpdateThreshold *time.Duration
+	FileStorer              filestore.Store
 }
 
 type sizeUpdate struct {
@@ -277,8 +282,9 @@ type PebbleCache struct {
 	oldMetrics       pebble.Metrics
 	metricsCollector *pebble.MetricsCollector
 
-	minGCSFileSizeBytes int64
-	gcsTTLDays          int64
+	minGCSFileSizeBytes     int64
+	gcsTTLDays              int64
+	gcsAtimeUpdateThreshold time.Duration
 
 	metrics struct {
 		compressedBlobSizeWrite   prometheus.Counter
@@ -376,6 +382,7 @@ func Register(env *real_environment.RealEnv) error {
 		GCSAppName:                  *gcsAppName,
 		GCSTTLDays:                  gcsTTLDays,
 		MinGCSFileSizeBytes:         minGCSFileSizeBytesFlag,
+		GCSAtimeUpdateThreshold:     gcsAtimeUpdateThreshold,
 		EnableAutoRatchet:           *enableAutoRatchet,
 	}
 	c, err := NewPebbleCache(env, opts)
@@ -481,6 +488,10 @@ func SetOptionDefaults(opts *Options) {
 	if opts.GCSTTLDays == nil || *opts.GCSTTLDays == 0 {
 		var ttlInDays int64 = 0
 		opts.GCSTTLDays = &ttlInDays
+	}
+	if opts.GCSAtimeUpdateThreshold == nil {
+		var threshold time.Duration = 0
+		opts.GCSAtimeUpdateThreshold = &threshold
 	}
 	if opts.MinBytesAutoZstdCompression == nil {
 		opts.MinBytesAutoZstdCompression = &DefaultMinBytesAutoZstdCompression
@@ -684,6 +695,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		includeMetadataSize:         opts.IncludeMetadataSize,
 		minGCSFileSizeBytes:         *opts.MinGCSFileSizeBytes,
 		gcsTTLDays:                  *opts.GCSTTLDays,
+		gcsAtimeUpdateThreshold:     *opts.GCSAtimeUpdateThreshold,
 		fileStorer:                  fileStorer,
 	}
 	zstdLabels := prometheus.Labels{metrics.CacheNameLabel: pc.name, metrics.CompressionType: "zstd"}
@@ -952,18 +964,25 @@ func (p *PebbleCache) updateAtime(update *accessTimeUpdate) error {
 		metrics.CacheNameLabel: p.name,
 	}
 
-	// If this is a GCS object, update the custom time and record the new
-	// custom time.
+	// If this is a GCS object, refresh the custom time and record the new
+	// custom time. Each refresh is a billed GCS Class A operation and the custom
+	// time is only a defensive TTL backstop, so it does not need to track the
+	// pebble atime closely: skip the refresh unless the recorded custom time is
+	// older than gcsAtimeUpdateThreshold. The pebble atime below is still
+	// updated on every access past the atime threshold.
 	if gcsMetadata := md.GetStorageMetadata().GetGcsMetadata(); gcsMetadata != nil {
 		if gcsutil.ObjectIsPastTTL(p.clock, gcsMetadata, p.gcsTTLDays) {
 			return nil
 		}
-		if err := p.fileStorer.UpdateBlobAtime(p.env.GetServerContext(), gcsMetadata, newAtime); err != nil {
-			metrics.PebbleCacheAtimeUpdateGCSErrorCount.With(lbls).Inc()
-			log.Errorf("Error updating GCS custom time (%q): %s", update.key, err)
-			return err
+		lastCustomTime := time.UnixMicro(gcsMetadata.GetLastCustomTimeUsec())
+		if newAtime.Sub(lastCustomTime) >= p.gcsAtimeUpdateThreshold {
+			if err := p.fileStorer.UpdateBlobAtime(p.env.GetServerContext(), gcsMetadata, newAtime); err != nil {
+				metrics.PebbleCacheAtimeUpdateGCSErrorCount.With(lbls).Inc()
+				log.Errorf("Error updating GCS custom time (%q): %s", update.key, err)
+				return err
+			}
+			md.StorageMetadata.GcsMetadata.LastCustomTimeUsec = newAtime.UnixMicro()
 		}
-		md.StorageMetadata.GcsMetadata.LastCustomTimeUsec = newAtime.UnixMicro()
 	}
 
 	md.LastAccessUsec = newAtime.UnixMicro()

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2792,6 +2792,72 @@ func TestGCSBlobStorageOverwriteObjects(t *testing.T) {
 	}
 }
 
+func TestGCSAtimeUpdateThreshold(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	// sendAtimeUpdate gates on wall-clock time (time.Since), so start the fake
+	// clock well in the past. Otherwise, once an atime update moves the stored
+	// atime to a fake-future timestamp, subsequent accesses would be skipped.
+	clock := clockwork.NewFakeClockAt(time.Now().Add(-30 * 24 * time.Hour))
+	ctx := getAnonContext(t, te)
+
+	var minGCSFileSize int64 = 1
+	var gcsTTLDays int64 = 1
+	atimeThreshold := 10 * time.Hour
+
+	mockGCS := mockgcs.New(clock)
+	require.NoError(t, mockGCS.SetBucketCustomTimeTTL(ctx, gcsTTLDays))
+	fileStorer := filestore.New(filestore.WithGCSBlobstore(mockGCS, "app-name"), filestore.WithClock(clock))
+	options := &pebble_cache.Options{
+		RootDirectory:           testfs.MakeTempDir(t),
+		MaxSizeBytes:            int64(1_000_000), // 1MB
+		Clock:                   clock,
+		FileStorer:              fileStorer,
+		MaxInlineFileSizeBytes:  1,
+		MinGCSFileSizeBytes:     &minGCSFileSize,
+		GCSTTLDays:              &gcsTTLDays,
+		GCSAtimeUpdateThreshold: &atimeThreshold,
+		AtimeUpdateThreshold:    pointer(time.Duration(0)), // update atime on every access
+		AtimeBufferSize:         pointer(0),                // blocking channel of atime updates
+	}
+	pc, err := pebble_cache.NewPebbleCache(te, options)
+	require.NoError(t, err)
+	require.NoError(t, pc.Start())
+	defer pc.Stop()
+
+	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, pc.Set(ctx, rn, buf))
+
+	// Writing the object sets its custom time; it does not call UpdateCustomTime.
+	require.Equal(t, 0, mockGCS.UpdateCustomTimeCallCount())
+
+	// waitForAtime blocks until the object's pebble atime reaches the current
+	// (fake) clock time, i.e. until the queued atime update has been processed.
+	waitForAtime := func() {
+		want := clock.Now().UnixMicro()
+		require.Eventually(t, func() bool {
+			md, err := pc.Metadata(ctx, rn)
+			return err == nil && md.LastAccessTimeUsec == want
+		}, time.Minute, 10*time.Millisecond)
+	}
+
+	// Access the object before the threshold elapses. The pebble atime is
+	// updated, but the GCS custom time is left alone.
+	clock.Advance(1 * time.Hour)
+	_, err = pc.Get(ctx, rn)
+	require.NoError(t, err)
+	waitForAtime()
+	require.Equal(t, 0, mockGCS.UpdateCustomTimeCallCount())
+
+	// Access the object once its custom time is older than the threshold.
+	// Now the GCS custom time is refreshed.
+	clock.Advance(10 * time.Hour)
+	_, err = pc.Get(ctx, rn)
+	require.NoError(t, err)
+	waitForAtime()
+	require.Equal(t, 1, mockGCS.UpdateCustomTimeCallCount())
+}
+
 func pointer[T any](value T) *T {
 	return &value
 }

--- a/server/testutil/mockgcs/mockgcs.go
+++ b/server/testutil/mockgcs/mockgcs.go
@@ -30,10 +30,19 @@ func New(clock clockwork.Clock) *mockGCS {
 // N.B. This implementation only mocks out the bits of GCS needed
 // to implement the pebble.PebbleGCSStorage interface.
 type mockGCS struct {
-	clock     clockwork.Clock
-	ageInDays int64
-	items     map[string]*timestampedBlob
-	mu        sync.Mutex
+	clock                     clockwork.Clock
+	ageInDays                 int64
+	items                     map[string]*timestampedBlob
+	mu                        sync.Mutex
+	updateCustomTimeCallCount int
+}
+
+// UpdateCustomTimeCallCount returns the number of times UpdateCustomTime has
+// been called. It is intended for use by tests.
+func (m *mockGCS) UpdateCustomTimeCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.updateCustomTimeCallCount
 }
 
 func (m *mockGCS) expired(blobName string) bool {
@@ -107,6 +116,7 @@ func (m *mockGCS) DeleteBlob(ctx context.Context, blobName string) error {
 func (m *mockGCS) UpdateCustomTime(ctx context.Context, blobName string, t time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.updateCustomTimeCallCount++
 	blob, ok := m.items[blobName]
 	if !ok {
 		return status.NotFoundError("mock gcs blob not found")


### PR DESCRIPTION
The GCS bucket has a "defensive" TTL to make sure we don't keep any objects around if we fail to properly evict them. The TTL is generally set much higher than the atime threshold.

To that end, there's no need to update the GCS atime as frequently as long as we update it before the bucket TTL.

GCS updates are also charged as "class A" operations which is the same as a "write".