### PR TITLE
Rename pq GetAll to GetAllUnordered; add GetAllOrdered

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -156,7 +156,7 @@ func (t *taskQueue) GetAll(ctx context.Context) []*scpb.EnqueueTaskReservationRe
 			log.CtxError(ctx, "not a *groupPriorityQueue!??!")
 			continue
 		}
-		for _, t := range pq.GetAll() {
+		for _, t := range pq.GetAllUnordered() {
 			reservations = append(reservations, t.EnqueueTaskReservationRequest)
 		}
 	}

--- a/enterprise/server/util/cpuset/cpuset.go
+++ b/enterprise/server/util/cpuset/cpuset.go
@@ -247,7 +247,9 @@ func (l *CPULeaser) Acquire(milliCPU int64, taskID string, opts ...any) (int, []
 	}
 
 	// Get the set of CPUs, in order of load (incr).
-	leastLoaded := pq.GetAll()
+	// TODO: use GetAllOrdered here instead - GetAllUnordered does not
+	// return CPUs in order of load.
+	leastLoaded := pq.GetAllUnordered()
 
 	// Find the numa node with the largest number of cores in the first
 	// numCPUs CPUs.

--- a/server/util/priority_queue/priority_queue.go
+++ b/server/util/priority_queue/priority_queue.go
@@ -160,12 +160,41 @@ func (pq *ThreadSafePriorityQueue[V]) RemoveAt(index int) (V, bool) {
 	return item.(*Item[V]).value, true
 }
 
-func (pq *ThreadSafePriorityQueue[V]) GetAll() []V {
+// GetAllUnordered returns all values in the queue, in an unspecified order
+// that is generally NOT priority order. Use GetAllOrdered if the order
+// matters.
+//
+// It has complexity O(n).
+func (pq *ThreadSafePriorityQueue[V]) GetAllUnordered() []V {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	allValues := make([]V, len(pq.inner))
 	for i, v := range pq.inner {
 		allValues[i] = v.value
+	}
+	return allValues
+}
+
+// GetAllOrdered returns all values in the queue in priority order, highest
+// priority first. Ties in priority are broken by insertion time, earliest
+// first. The queue is left unchanged.
+//
+// It has complexity O(n*log(n)).
+func (pq *ThreadSafePriorityQueue[V]) GetAllOrdered() []V {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	// Pop all items to get them in priority order, then push the items back
+	// to restore the queue. Pushing back the original items (rather than
+	// re-creating them) preserves their insertion times.
+	allValues := make([]V, 0, len(pq.inner))
+	items := make([]*Item[V], 0, len(pq.inner))
+	for len(pq.inner) > 0 {
+		item := heap.Pop(&pq.inner).(*Item[V])
+		allValues = append(allValues, item.value)
+		items = append(items, item)
+	}
+	for _, item := range items {
+		heap.Push(&pq.inner, item)
 	}
 	return allValues
 }

--- a/server/util/priority_queue/priority_queue.go
+++ b/server/util/priority_queue/priority_queue.go
@@ -2,7 +2,6 @@ package priority_queue
 
 import (
 	"container/heap"
-	"slices"
 	"sync"
 	"time"
 )
@@ -92,9 +91,16 @@ func New[V any]() *ThreadSafePriorityQueue[V] {
 func (pq *ThreadSafePriorityQueue[V]) Clone() *ThreadSafePriorityQueue[V] {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	return &ThreadSafePriorityQueue[V]{
-		inner: slices.Clone(pq.inner),
+
+	// Dereference and copy each item, since the priority queue holds a slice of
+	// pointers, and [Item.index] may be concurrently accessed.
+	inner := make([]*Item[V], len(pq.inner))
+	for i := range pq.inner {
+		clone := *pq.inner[i]
+		inner[i] = &clone
 	}
+
+	return &ThreadSafePriorityQueue[V]{inner: inner}
 }
 
 func (pq *ThreadSafePriorityQueue[V]) zeroValue() V {
@@ -181,20 +187,15 @@ func (pq *ThreadSafePriorityQueue[V]) GetAllUnordered() []V {
 //
 // It has complexity O(n*log(n)).
 func (pq *ThreadSafePriorityQueue[V]) GetAllOrdered() []V {
-	pq.mu.Lock()
-	defer pq.mu.Unlock()
-	// Pop all items to get them in priority order, then push the items back
-	// to restore the queue. Pushing back the original items (rather than
-	// re-creating them) preserves their insertion times.
-	allValues := make([]V, 0, len(pq.inner))
-	items := make([]*Item[V], 0, len(pq.inner))
-	for len(pq.inner) > 0 {
-		item := heap.Pop(&pq.inner).(*Item[V])
+	// Create an O(n) clone with the lock held. The loop below is O(n*log(n)) so
+	// this reduces the time spent with the queue locked.
+	tmp := pq.Clone().inner
+
+	// Repeatedly pop and append the highest priority element to a new slice.
+	allValues := make([]V, 0, len(tmp))
+	for len(tmp) > 0 {
+		item := heap.Pop(&tmp).(*Item[V])
 		allValues = append(allValues, item.value)
-		items = append(items, item)
-	}
-	for _, item := range items {
-		heap.Push(&pq.inner, item)
 	}
 	return allValues
 }

--- a/server/util/priority_queue/priority_queue_test.go
+++ b/server/util/priority_queue/priority_queue_test.go
@@ -146,6 +146,63 @@ func TestGetAllOrdered(t *testing.T) {
 	require.Equal(t, []string{"D", "C", "B", "E", "A"}, popped)
 }
 
+func TestCloneIsIndependent(t *testing.T) {
+	// Fill a queue with elements with distinct priorities.
+	q := priority_queue.New[int]()
+	for i := range 100 {
+		q.Push(i, float64(i))
+	}
+
+	// Churn the queue in a background goroutine by repeatedly popping the
+	// highest priority element and pushing it back. Heap operations write
+	// bookkeeping fields (Item.index) on the queue's items, so if clones
+	// shared items with the original queue, draining the clones below would
+	// race with this goroutine and be reported by the race detector.
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			v, ok := q.Pop()
+			if !ok {
+				continue
+			}
+			q.Push(v, float64(v))
+		}
+	}()
+
+	// While the churn is running, repeatedly clone the queue and drain each
+	// clone. Each element's priority equals its value, so each clone should
+	// drain in strictly decreasing value order.
+	for range 100 {
+		clone := q.Clone()
+		prev := 100
+		for {
+			v, ok := clone.Pop()
+			if !ok {
+				break
+			}
+			require.Less(t, v, prev, "clone should drain in priority order")
+			prev = v
+		}
+	}
+	close(stop)
+	<-done
+
+	// Draining the clones should not have affected the original queue: it
+	// should still pop all 100 elements in priority order.
+	for i := 99; i >= 0; i-- {
+		v, ok := q.Pop()
+		require.True(t, ok)
+		require.Equal(t, i, v)
+	}
+}
+
 func TestRemoveItemWithMinPriority(t *testing.T) {
 	pq := &priority_queue.PriorityQueue[string]{}
 	heap.Push(pq, priority_queue.NewItem("A", 1))

--- a/server/util/priority_queue/priority_queue_test.go
+++ b/server/util/priority_queue/priority_queue_test.go
@@ -104,6 +104,48 @@ func TestRemoveAt(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestGetAllUnordered(t *testing.T) {
+	q := priority_queue.New[string]()
+	q.Push("A", 1)
+	q.Push("B", 2)
+	q.Push("C", 3)
+	q.Push("D", 4)
+
+	// GetAllUnordered should return all elements, in any order.
+	require.ElementsMatch(t, []string{"A", "B", "C", "D"}, q.GetAllUnordered())
+
+	// The queue should not be modified.
+	require.Equal(t, 4, q.Len())
+}
+
+func TestGetAllOrdered(t *testing.T) {
+	q := priority_queue.New[string]()
+	// Push elements in increasing priority order, which leaves the heap's
+	// internal array out of priority order.
+	q.Push("A", 1)
+	q.Push("B", 2)
+	q.Push("C", 3)
+	q.Push("D", 4)
+	// Push an element tied with B's priority; the tie should be broken by
+	// insertion time, so B comes first.
+	q.Push("E", 2)
+
+	// GetAllOrdered should return elements in priority order, highest
+	// priority first.
+	require.Equal(t, []string{"D", "C", "B", "E", "A"}, q.GetAllOrdered())
+
+	// The queue should not be modified: it should still contain all elements
+	// and pop them in priority order.
+	require.Equal(t, 5, q.Len())
+	popped := make([]string, 0, 5)
+	for range 5 {
+		v, ok := q.Pop()
+		require.True(t, ok)
+		popped = append(popped, v)
+	}
+	require.Equal(t, []string{"D", "C", "B", "E", "A"}, popped)
+}
+
 func TestRemoveItemWithMinPriority(t *testing.T) {
 	pq := &priority_queue.PriorityQueue[string]{}
 	heap.Push(pq, priority_queue.NewItem("A", 1))


### PR DESCRIPTION
`cpuset.go` has this code:

```
	// Get the set of CPUs, in order of load (incr).
	leastLoaded := pq.GetAll()
```

This code looks correct at a glance - `pq.GetAll` looks like it would plausibly return the elements in priority order. In reality though, it returns the heap elements in the heap array order, which is different. For example, `[1 3 6 5 9 8]` is a valid array representation of a binary heap.

This PR renames `pq.GetAll` to `pq.GetAllUnordered` to make this same mistake less likely in the future, since the above code would be more obviously incorrect. It also adds a `pq.GetAllOrdered` version which does return the elements in priority order, to be used in the follow-up fix.