### PR TITLE
ocifetcher: prove blob access via a verified manifest ref hint

### DIFF
--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -3,6 +3,7 @@
 package ocifetcher
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -167,7 +168,7 @@ func (s *ociFetcherServer) FetchBlob(req *ofpb.FetchBlobRequest, stream ofpb.OCI
 		}
 		return status.NotFoundErrorf("bypassing registry, but blob %q not found in cache", digestRef)
 	}
-	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, req.GetCredentials())
+	return s.dedupedFetchBlob(ctx, stream, digestRef, hash, req.GetManifestRef(), req.GetCredentials())
 }
 
 // FetchBlobMetadata returns OCI blob metadata (size, media type).
@@ -188,7 +189,24 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 	repo := digestRef.Context()
 
 	accessKey := repoAccessKey(repo, req.GetCredentials())
-	if req.GetBypassRegistry() || s.accessProofCache.Contains(accessKey) {
+	proven := req.GetBypassRegistry() || s.accessProofCache.Contains(accessKey)
+	// A manifest ref hint proves access via a manifest metadata HEAD, and its
+	// descriptor for the blob can serve the metadata itself. Both matter for
+	// registries that reject HEAD requests on blob endpoints (e.g.
+	// public.ecr.aws).
+	var manifestDesc *ctr.Descriptor
+	if !proven && req.GetManifestRef() != "" {
+		desc, err := s.proveBlobAccessViaManifest(ctx, digestRef, hash, req.GetManifestRef(), req.GetCredentials())
+		if err == nil {
+			proven = true
+			manifestDesc = desc
+		} else if status.IsUnauthenticatedError(err) || status.IsPermissionDeniedError(err) {
+			return nil, err
+		} else {
+			log.CtxDebugf(ctx, "Could not prove access to blob %q via manifest ref %q, falling back to blob metadata: %s", digestRef, req.GetManifestRef(), err)
+		}
+	}
+	if proven {
 		if resp, err := s.fetchBlobMetadataFromCache(ctx, digestRef, hash); err == nil {
 			return resp, nil
 		} else if !status.IsNotFoundError(err) {
@@ -196,6 +214,12 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 		}
 		if req.GetBypassRegistry() {
 			return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", digestRef)
+		}
+		if manifestDesc != nil {
+			return &ofpb.FetchBlobMetadataResponse{
+				Size:      manifestDesc.Size,
+				MediaType: string(manifestDesc.MediaType),
+			}, nil
 		}
 	}
 
@@ -299,7 +323,7 @@ func (s *ociFetcherServer) streamBlobFromCache(ctx context.Context, stream ofpb.
 	return ocicache.FetchBlobFromCache(ctx, &grpcStreamWriter{stream: stream}, s.bsClient, hash, metadata.GetContentLength())
 }
 
-func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef ctrname.Digest, hash ctr.Hash, creds *rgpb.Credentials) error {
+func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCIFetcher_FetchBlobServer, digestRef ctrname.Digest, hash ctr.Hash, manifestRef string, creds *rgpb.Credentials) error {
 	start := time.Now()
 	repo := digestRef.Context()
 	key := ocicache.NewBlobFetchKey(repo, hash, creds)
@@ -311,7 +335,7 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 		// to prove the caller may access the repo before serving it from cache.
 		metadata, err := ocicache.FetchBlobMetadataFromCache(ctx, s.bsClient, s.acClient, repo, hash)
 		if err == nil {
-			if err := s.proveBlobAccess(ctx, digestRef, creds); err != nil {
+			if err := s.proveBlobAccessWithManifestHint(ctx, digestRef, hash, manifestRef, creds); err != nil {
 				return 0, err
 			}
 			contentLength := metadata.GetContentLength()
@@ -332,7 +356,7 @@ func (s *ociFetcherServer) dedupedFetchBlob(ctx context.Context, stream ofpb.OCI
 
 		// Cache miss: fetch from the registry, which proves access and writes
 		// the blob through to the cache.
-		size, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, digestRef, repo, hash, creds, stream)
+		size, err := s.fetchBlobFromRemoteWriteToCacheAndResponse(ctx, digestRef, repo, hash, manifestRef, creds, stream)
 		if err == nil {
 			s.accessProofCache.Add(repoAccessKey(repo, creds), struct{}{})
 		}
@@ -371,7 +395,7 @@ func recordFetchBlobMetrics(role string, err error, duration time.Duration) {
 // registry, streams it to the response, and writes it to the cache
 // simultaneously using read-through caching.
 // It returns the content length of the blob (0 if metadata was unavailable).
-func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx context.Context, digestRef ctrname.Digest, repo ctrname.Repository, hash ctr.Hash, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) (int64, error) {
+func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx context.Context, digestRef ctrname.Digest, repo ctrname.Repository, hash ctr.Hash, manifestRef string, creds *rgpb.Credentials, stream ofpb.OCIFetcher_FetchBlobServer) (int64, error) {
 	// All HTTP-triggering calls (Compressed, MediaType, Size) must be
 	// inside the retry scope so that token refresh covers them, not just
 	// the lazy Layer() reference creation.
@@ -394,10 +418,16 @@ func (s *ociFetcherServer) fetchBlobFromRemoteWriteToCacheAndResponse(ctx contex
 		} else {
 			mediaType = string(mt)
 		}
-		if sz, err := layer.Size(); err != nil {
-			log.CtxWarningf(ctx, "Could not get size for layer: %s", err)
-		} else {
+		if sz, err := layer.Size(); err == nil {
 			size = sz
+		} else if _, desc, descErr := s.verifiedBlobDescriptorFromCachedManifest(ctx, digestRef, hash, manifestRef); descErr == nil {
+			// Some registries (e.g. public.ecr.aws) reject the HEAD requests
+			// layer.Size() makes on blob endpoints. The digest-verified cached
+			// manifest is an authoritative source for the blob's descriptor.
+			size = desc.Size
+			mediaType = string(desc.MediaType)
+		} else {
+			log.CtxWarningf(ctx, "Could not get size for layer: HEAD: %s; cached manifest: %s", err, descErr)
 		}
 		return layer.Compressed()
 	})
@@ -532,6 +562,104 @@ func (s *ociFetcherServer) proveBlobAccess(ctx context.Context, digestRef ctrnam
 	}
 	s.accessProofCache.Add(repoAccessKey(repo, creds), struct{}{})
 	return nil
+}
+
+// proveBlobAccessWithManifestHint checks that the caller's credentials allow
+// accessing the blob's repository in the remote registry. When the caller
+// provided a manifest ref hint, access is proven via a manifest metadata HEAD
+// instead of a blob metadata HEAD, which works on registries that reject HEAD
+// requests on blob endpoints (e.g. public.ecr.aws). If the hint is unusable
+// (e.g. the manifest is not cached, or does not reference the blob), access
+// is proven via the blob directly.
+func (s *ociFetcherServer) proveBlobAccessWithManifestHint(ctx context.Context, digestRef ctrname.Digest, hash ctr.Hash, manifestRef string, creds *rgpb.Credentials) error {
+	repo := digestRef.Context()
+	if s.accessProofCache.Contains(repoAccessKey(repo, creds)) {
+		return nil
+	}
+	if manifestRef != "" {
+		_, err := s.proveBlobAccessViaManifest(ctx, digestRef, hash, manifestRef, creds)
+		if err == nil {
+			return nil
+		}
+		// The registry denied the caller access to a manifest in the blob's
+		// repository; a blob metadata request would be denied the same way.
+		if status.IsUnauthenticatedError(err) || status.IsPermissionDeniedError(err) {
+			return err
+		}
+		log.CtxDebugf(ctx, "Could not prove access to blob %q via manifest ref %q, falling back to blob metadata: %s", digestRef, manifestRef, err)
+	}
+	return s.proveBlobAccess(ctx, digestRef, creds)
+}
+
+// proveBlobAccessViaManifest checks that the caller's credentials allow
+// accessing the manifest identified by manifestRef, after verifying that the
+// manifest actually references the blob. Since registry pull authorization is
+// repository-scoped, access to the manifest proves access to the blob.
+// On success it returns the manifest's descriptor for the blob.
+func (s *ociFetcherServer) proveBlobAccessViaManifest(ctx context.Context, digestRef ctrname.Digest, hash ctr.Hash, manifestRef string, creds *rgpb.Credentials) (*ctr.Descriptor, error) {
+	mRef, desc, err := s.verifiedBlobDescriptorFromCachedManifest(ctx, digestRef, hash, manifestRef)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.proveManifestAccess(ctx, mRef, creds); err != nil {
+		return nil, err
+	}
+	return desc, nil
+}
+
+// verifiedBlobDescriptorFromCachedManifest returns the blob's descriptor from
+// the cached manifest identified by manifestRef. The manifest ref is supplied
+// by the caller and cannot be trusted, so it must be a digest reference in
+// the blob's repository, the cached manifest's contents must match that
+// digest, and the manifest must reference the blob as its config or one of
+// its layers. The descriptor of a manifest that passes these checks is
+// authoritative for the blob, but proves nothing about registry access:
+// callers granting access to the blob's contents must still prove access to
+// the manifest against the remote registry.
+func (s *ociFetcherServer) verifiedBlobDescriptorFromCachedManifest(ctx context.Context, digestRef ctrname.Digest, hash ctr.Hash, manifestRef string) (ctrname.Digest, *ctr.Descriptor, error) {
+	if manifestRef == "" {
+		return ctrname.Digest{}, nil, status.NotFoundError("no manifest ref provided")
+	}
+	repo := digestRef.Context()
+	ref, err := ctrname.ParseReference(manifestRef)
+	if err != nil {
+		return ctrname.Digest{}, nil, status.InvalidArgumentErrorf("invalid manifest ref %q: %s", manifestRef, err)
+	}
+	mRef, ok := ref.(ctrname.Digest)
+	if !ok {
+		return ctrname.Digest{}, nil, status.InvalidArgumentErrorf("manifest ref must be a digest reference (e.g., repo@sha256:...), got %q", manifestRef)
+	}
+	if mRef.Context().Name() != repo.Name() {
+		return ctrname.Digest{}, nil, status.InvalidArgumentErrorf("manifest ref %q is not in blob repository %q", manifestRef, repo.Name())
+	}
+	mHash, err := ctr.NewHash(mRef.DigestStr())
+	if err != nil {
+		return ctrname.Digest{}, nil, status.InvalidArgumentErrorf("invalid manifest digest %q: %s", mRef.DigestStr(), err)
+	}
+	cached, err := ocicache.FetchManifestFromAC(ctx, s.acClient, repo, mHash, mRef)
+	if err != nil {
+		return ctrname.Digest{}, nil, err
+	}
+	contentHash, _, err := ctr.SHA256(bytes.NewReader(cached.GetRaw()))
+	if err != nil {
+		return ctrname.Digest{}, nil, err
+	}
+	if mHash.Algorithm != "sha256" || contentHash.Hex != mHash.Hex {
+		return ctrname.Digest{}, nil, status.FailedPreconditionErrorf("cached manifest contents do not match digest %q", mRef.DigestStr())
+	}
+	manifest, err := ctr.ParseManifest(bytes.NewReader(cached.GetRaw()))
+	if err != nil {
+		return ctrname.Digest{}, nil, status.InvalidArgumentErrorf("could not parse cached manifest %q: %s", manifestRef, err)
+	}
+	if manifest.Config.Digest == hash {
+		return mRef, &manifest.Config, nil
+	}
+	for _, desc := range manifest.Layers {
+		if desc.Digest == hash {
+			return mRef, &desc, nil
+		}
+	}
+	return ctrname.Digest{}, nil, status.NotFoundErrorf("manifest %q does not reference blob %q", manifestRef, digestRef)
 }
 
 func (s *ociFetcherServer) resolveTagToDigest(ctx context.Context, imageRef ctrname.Reference, creds *rgpb.Credentials) (ctr.Hash, error) {

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -212,9 +212,6 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 		} else if !status.IsNotFoundError(err) {
 			log.CtxWarningf(ctx, "Error fetching blob metadata from cache: %s", err)
 		}
-		if req.GetBypassRegistry() {
-			return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", digestRef)
-		}
 		if manifestDesc == nil && req.GetManifestRef() != "" {
 			// Access was already proven (e.g. by an earlier FetchManifest on
 			// this repo), so we don't need another manifest HEAD here -- just
@@ -230,6 +227,9 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 				Size:      manifestDesc.Size,
 				MediaType: string(manifestDesc.MediaType),
 			}, nil
+		}
+		if req.GetBypassRegistry() {
+			return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", digestRef)
 		}
 	}
 

--- a/enterprise/server/oci/ocifetcher/ocifetcher.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher.go
@@ -215,6 +215,16 @@ func (s *ociFetcherServer) FetchBlobMetadata(ctx context.Context, req *ofpb.Fetc
 		if req.GetBypassRegistry() {
 			return nil, status.NotFoundErrorf("bypassing registry, but blob metadata for %q not found in cache", digestRef)
 		}
+		if manifestDesc == nil && req.GetManifestRef() != "" {
+			// Access was already proven (e.g. by an earlier FetchManifest on
+			// this repo), so we don't need another manifest HEAD here -- just
+			// the verified descriptor, which requires no registry request.
+			if _, desc, err := s.verifiedBlobDescriptorFromCachedManifest(ctx, digestRef, hash, req.GetManifestRef()); err == nil {
+				manifestDesc = desc
+			} else {
+				log.CtxDebugf(ctx, "Could not get blob metadata from cached manifest ref %q: %s", req.GetManifestRef(), err)
+			}
+		}
 		if manifestDesc != nil {
 			return &ofpb.FetchBlobMetadataResponse{
 				Size:      manifestDesc.Size,

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -1629,6 +1629,233 @@ func TestServerCacheAccessProof(t *testing.T) {
 	})
 }
 
+// blobHeadRejector mimics public.ecr.aws, which responds 401 to every HEAD
+// request on blob endpoints, even with credentials that authorize GETs.
+type blobHeadRejector struct {
+	enabled atomic.Bool
+}
+
+func (b *blobHeadRejector) intercept(w http.ResponseWriter, r *http.Request) bool {
+	if b.enabled.Load() && r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/") {
+		w.WriteHeader(http.StatusUnauthorized)
+		return false
+	}
+	return true
+}
+
+// setupRegistryWithoutBlobHEAD runs a registry that mimics public.ecr.aws by
+// rejecting HEAD requests on blob endpoints, pushes an image to it, and
+// returns the image name and manifest digest along with the digest and data
+// of the image's first layer.
+func setupRegistryWithoutBlobHEAD(t *testing.T) (counter *testhttp.RequestCounter, imageName string, manifestDigest string, blobDigest ctr.Hash, blobData []byte) {
+	rejector := &blobHeadRejector{}
+	reg, counter := setupRegistry(t, nil, rejector.intercept)
+	imageName, img := reg.PushNamedImage(t, "test-image", nil)
+	manifestDigest, _, _ = imageMetadata(t, img)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.NotEmpty(t, layers)
+	layer := layers[0]
+	blobDigest, err = layer.Digest()
+	require.NoError(t, err)
+	blobData = layerData(t, layer)
+	// Pushing the image makes blob HEAD requests, so only start rejecting
+	// them once the image is in place.
+	rejector.enabled.Store(true)
+	return counter, imageName, manifestDigest, blobDigest, blobData
+}
+
+func mustParseHash(t *testing.T, digest string) ctr.Hash {
+	hash, err := ctr.NewHash(digest)
+	require.NoError(t, err)
+	return hash
+}
+
+func TestFetchBlobManifestRefHint(t *testing.T) {
+	t.Run("FetchBlob/CacheHitProvenViaManifestHEAD", func(t *testing.T) {
+		counter, imageName, manifestDigest, blobDigest, blobData := setupRegistryWithoutBlobHEAD(t)
+		_, bsClient, acClient := setupCacheEnv(t)
+		blobRef := imageName + "@" + blobDigest.String()
+		manifestRef := imageName + "@" + manifestDigest
+
+		// Fetching the manifest writes it to the cache, and fetching the blob
+		// (a cache miss) writes the blob and its metadata to the cache.
+		server := newTestServerWithCache(t, bsClient, acClient)
+		_, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: manifestRef})
+		require.NoError(t, err)
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef, ManifestRef: manifestRef}, stream)
+		require.NoError(t, err)
+		require.Equal(t, blobData, stream.collectData())
+
+		// Reuse the cache with a fresh server so access is not proven in
+		// memory. A blob HEAD access proof is impossible on this registry,
+		// but the manifest ref hint proves access with a manifest HEAD.
+		server = newTestServerWithCache(t, bsClient, acClient)
+		counter.Reset()
+		stream = &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef, ManifestRef: manifestRef}, stream)
+		require.NoError(t, err)
+		require.Equal(t, blobData, stream.collectData())
+		manifestPath := "/v2/test-image/manifests/" + manifestDigest
+		assertRequests(t, counter, map[string]int{
+			http.MethodGet + " /v2/":             1,
+			http.MethodHead + " " + manifestPath: 1,
+		})
+
+		// The manifest HEAD proof is repository-scoped, so further blob
+		// requests, even without the hint, are served from cache directly.
+		counter.Reset()
+		stream = &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef}, stream)
+		require.NoError(t, err)
+		require.Equal(t, blobData, stream.collectData())
+		assertRequests(t, counter, map[string]int{})
+	})
+
+	t.Run("FetchBlob/CacheMissUsesManifestDescriptorForCaching", func(t *testing.T) {
+		counter, imageName, manifestDigest, blobDigest, blobData := setupRegistryWithoutBlobHEAD(t)
+		_, bsClient, acClient := setupCacheEnv(t)
+		blobRef := imageName + "@" + blobDigest.String()
+		manifestRef := imageName + "@" + manifestDigest
+
+		server := newTestServerWithCache(t, bsClient, acClient)
+		_, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: manifestRef})
+		require.NoError(t, err)
+
+		// The blob HEAD for layer.Size() fails on this registry, so the size
+		// and media type for read-through caching come from the cached
+		// manifest's descriptor, with no extra registry requests.
+		counter.Reset()
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef, ManifestRef: manifestRef}, stream)
+		require.NoError(t, err)
+		require.Equal(t, blobData, stream.collectData())
+
+		blobPath := "/v2/test-image/blobs/" + blobDigest.String()
+		assertRequests(t, counter, map[string]int{
+			http.MethodHead + " " + blobPath: 1, // layer.Size(), rejected with 401
+			http.MethodGet + " " + blobPath:  1,
+		})
+
+		metadata, err := ocicache.FetchBlobMetadataFromCache(context.Background(), bsClient, acClient, nameRef(t, blobRef).Context(), blobDigest)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(blobData)), metadata.GetContentLength())
+	})
+
+	t.Run("FetchBlob/HintFromDifferentRepositoryDenied", func(t *testing.T) {
+		counter, imageName, manifestDigest, blobDigest, blobData := setupRegistryWithoutBlobHEAD(t)
+		_, bsClient, acClient := setupCacheEnv(t)
+		blobRef := imageName + "@" + blobDigest.String()
+		seedBlobCache(t, bsClient, acClient, blobRef, blobData, "application/vnd.buildbuddy.cached.layer")
+
+		// A manifest ref in a different repository must be rejected without
+		// even consulting the registry: proving access to another repository
+		// proves nothing about the blob's repository. The fallback blob HEAD
+		// is rejected by this registry, so the fetch fails.
+		otherRepoManifestRef := strings.Replace(imageName, "test-image", "other-image", 1) + "@" + manifestDigest
+		server := newTestServerWithCache(t, bsClient, acClient)
+		counter.Reset()
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err := server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef, ManifestRef: otherRepoManifestRef}, stream)
+		require.Error(t, err)
+		require.True(t, status.IsUnauthenticatedError(err), "expected Unauthenticated, got: %v", err)
+		for path := range counter.Snapshot() {
+			require.NotContains(t, path, "/manifests/", "a cross-repository hint must not trigger manifest requests")
+		}
+	})
+
+	t.Run("FetchBlob/HintManifestNotReferencingBlobDenied", func(t *testing.T) {
+		counter, imageName, manifestDigest, _, _ := setupRegistryWithoutBlobHEAD(t)
+		_, bsClient, acClient := setupCacheEnv(t)
+
+		// Request the manifest's own digest as a blob: the cached manifest is
+		// genuine, but does not reference itself, so the hint must be
+		// rejected, and the fallback blob HEAD fails on this registry.
+		blobRef := imageName + "@" + manifestDigest
+		manifestRef := imageName + "@" + manifestDigest
+		server := newTestServerWithCache(t, bsClient, acClient)
+		_, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: manifestRef})
+		require.NoError(t, err)
+		cachedManifest, err := ocicache.FetchManifestFromAC(context.Background(), acClient, nameRef(t, imageName).Context(), mustParseHash(t, manifestDigest), nameRef(t, manifestRef))
+		require.NoError(t, err)
+		seedBlobCache(t, bsClient, acClient, blobRef, cachedManifest.GetRaw(), "application/vnd.buildbuddy.cached.layer")
+
+		server = newTestServerWithCache(t, bsClient, acClient)
+		counter.Reset()
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef, ManifestRef: manifestRef}, stream)
+		require.Error(t, err)
+		require.True(t, status.IsUnauthenticatedError(err), "expected Unauthenticated, got: %v", err)
+		for path := range counter.Snapshot() {
+			require.NotContains(t, path, "/manifests/", "a non-referencing hint must not trigger manifest requests")
+		}
+	})
+
+	t.Run("FetchBlob/HintWithWrongCredentialsDenied", func(t *testing.T) {
+		registryCreds := &testregistry.BasicAuthCreds{Username: "testuser", Password: "testpass"}
+		validCreds := &rgpb.Credentials{Username: "testuser", Password: "testpass"}
+		wrongCreds := &rgpb.Credentials{Username: "testuser", Password: "wrong"}
+
+		reg, counter := setupRegistry(t, registryCreds, nil)
+		imageName, img := reg.PushNamedImage(t, "test-image", registryCreds)
+		manifestDigest, _, _ := imageMetadata(t, img)
+		layers, err := img.Layers()
+		require.NoError(t, err)
+		require.NotEmpty(t, layers)
+		blobDigest, err := layers[0].Digest()
+		require.NoError(t, err)
+		blobRef := imageName + "@" + blobDigest.String()
+		manifestRef := imageName + "@" + manifestDigest
+
+		// Populate the manifest and blob caches with valid credentials.
+		_, bsClient, acClient := setupCacheEnv(t)
+		server := newTestServerWithCache(t, bsClient, acClient)
+		_, err = server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: manifestRef, Credentials: validCreds})
+		require.NoError(t, err)
+		stream := &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef, Credentials: validCreds}, stream)
+		require.NoError(t, err)
+
+		// A genuine hint with wrong credentials is denied by the manifest
+		// HEAD, without wasting a doomed fallback blob request.
+		server = newTestServerWithCache(t, bsClient, acClient)
+		counter.Reset()
+		stream = &mockFetchBlobServer{ctx: context.Background()}
+		err = server.FetchBlob(&ofpb.FetchBlobRequest{Ref: blobRef, ManifestRef: manifestRef, Credentials: wrongCreds}, stream)
+		require.Error(t, err)
+		require.True(t, status.IsUnauthenticatedError(err), "expected Unauthenticated, got: %v", err)
+		for path := range counter.Snapshot() {
+			require.NotContains(t, path, "/blobs/", "denied manifest access must not fall back to blob requests")
+		}
+	})
+
+	t.Run("FetchBlobMetadata/ServedFromManifestDescriptor", func(t *testing.T) {
+		counter, imageName, manifestDigest, blobDigest, blobData := setupRegistryWithoutBlobHEAD(t)
+		_, bsClient, acClient := setupCacheEnv(t)
+		blobRef := imageName + "@" + blobDigest.String()
+		manifestRef := imageName + "@" + manifestDigest
+
+		server := newTestServerWithCache(t, bsClient, acClient)
+		_, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: manifestRef})
+		require.NoError(t, err)
+
+		// Blob metadata is not cached and the registry rejects blob HEADs,
+		// but the verified manifest's descriptor can serve it.
+		server = newTestServerWithCache(t, bsClient, acClient)
+		counter.Reset()
+		resp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{Ref: blobRef, ManifestRef: manifestRef})
+		require.NoError(t, err)
+		require.Equal(t, int64(len(blobData)), resp.GetSize())
+		require.NotEmpty(t, resp.GetMediaType())
+		manifestPath := "/v2/test-image/manifests/" + manifestDigest
+		assertRequests(t, counter, map[string]int{
+			http.MethodGet + " /v2/":             1,
+			http.MethodHead + " " + manifestPath: 1,
+		})
+	})
+}
+
 // runConcurrentFetchBlob runs numRequests concurrent FetchBlob calls and returns results.
 func runConcurrentFetchBlob(
 	t *testing.T,

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -1263,6 +1263,38 @@ func TestServerBypassRegistry(t *testing.T) {
 		assertRequests(t, counter, map[string]int{})
 	})
 
+	// Test that FetchBlobMetadata with bypass_registry for admin still serves
+	// the manifest hint's verified descriptor when blob metadata is uncached
+	// but a matching manifest is cached. That descriptor lookup requires no
+	// registry request, so bypass_registry must not preempt it with a
+	// NotFound.
+	t.Run("FetchBlobMetadata/CacheMiss/Admin/ServedFromCachedManifestDescriptor", func(t *testing.T) {
+		flags.Set(t, "auth.admin_group_id", adminGroupID)
+
+		counter, imageName, manifestDigest, blobDigest, blobData := setupRegistryWithoutBlobHEAD(t)
+		_, bsClient, acClient := setupCacheEnv(t)
+		blobRef := imageName + "@" + blobDigest.String()
+		manifestRef := imageName + "@" + manifestDigest
+
+		server := newTestServerWithCache(t, bsClient, acClient)
+		_, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: manifestRef})
+		require.NoError(t, err)
+
+		ctx := testauth.WithAuthenticatedUserInfo(context.Background(), adminUser)
+		counter.Reset()
+		resp, err := server.FetchBlobMetadata(ctx, &ofpb.FetchBlobMetadataRequest{
+			Ref:            blobRef,
+			ManifestRef:    manifestRef,
+			BypassRegistry: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(len(blobData)), resp.GetSize())
+		require.NotEmpty(t, resp.GetMediaType())
+
+		// Verify no registry requests were made.
+		assertRequests(t, counter, map[string]int{})
+	})
+
 	// Test that FetchManifest returns cached manifest when available (digest ref)
 	t.Run("FetchManifest/WithCaching/DigestRef", func(t *testing.T) {
 		reg, counter := setupRegistry(t, nil, nil)

--- a/enterprise/server/oci/ocifetcher/ocifetcher_test.go
+++ b/enterprise/server/oci/ocifetcher/ocifetcher_test.go
@@ -1854,6 +1854,29 @@ func TestFetchBlobManifestRefHint(t *testing.T) {
 			http.MethodHead + " " + manifestPath: 1,
 		})
 	})
+
+	t.Run("FetchBlobMetadata/ServedFromManifestDescriptorWhenAlreadyProven", func(t *testing.T) {
+		counter, imageName, manifestDigest, blobDigest, blobData := setupRegistryWithoutBlobHEAD(t)
+		_, bsClient, acClient := setupCacheEnv(t)
+		blobRef := imageName + "@" + blobDigest.String()
+		manifestRef := imageName + "@" + manifestDigest
+
+		// Reuse the same server so that the repo's access proof, established
+		// by FetchManifest, is already in the LRU when FetchBlobMetadata
+		// runs. Blob metadata is still uncached, and the registry rejects
+		// blob HEADs, so the verified manifest's descriptor must be
+		// consulted even though no new access proof is needed.
+		server := newTestServerWithCache(t, bsClient, acClient)
+		_, err := server.FetchManifest(context.Background(), &ofpb.FetchManifestRequest{Ref: manifestRef})
+		require.NoError(t, err)
+
+		counter.Reset()
+		resp, err := server.FetchBlobMetadata(context.Background(), &ofpb.FetchBlobMetadataRequest{Ref: blobRef, ManifestRef: manifestRef})
+		require.NoError(t, err)
+		require.Equal(t, int64(len(blobData)), resp.GetSize())
+		require.NotEmpty(t, resp.GetMediaType())
+		assertRequests(t, counter, map[string]int{})
+	})
 }
 
 // runConcurrentFetchBlob runs numRequests concurrent FetchBlob calls and returns results.

--- a/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
+++ b/enterprise/server/ocifetcher_server_proxy/ocifetcher_server_proxy.go
@@ -118,6 +118,7 @@ func (s *OCIFetcherServerProxy) fetchBlobMetadataSize(ctx context.Context, req *
 		Ref:            req.GetRef(),
 		Credentials:    req.GetCredentials(),
 		BypassRegistry: req.GetBypassRegistry(),
+		ManifestRef:    req.GetManifestRef(),
 	})
 	if err != nil {
 		return 0, err

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -841,6 +841,10 @@ func (l *layerFromDigest) fetchFromRemote() (io.ReadCloser, error) {
 			Ref:            ref.String(),
 			Credentials:    l.image.credentials.ToProto(),
 			BypassRegistry: l.image.credentials.bypassRegistry,
+			// The manifest this layer came from lets the server prove
+			// registry access without a blob HEAD request, which some
+			// registries (e.g. public.ecr.aws) reject.
+			ManifestRef: l.repo.Digest(l.image.desc.Digest.String()).String(),
 		})
 		if err != nil {
 			cancel()

--- a/proto/oci_fetcher.proto
+++ b/proto/oci_fetcher.proto
@@ -73,6 +73,16 @@ message FetchBlobRequest {
   bool bypass_registry = 3;
   optional int64 size = 4;
   optional string media_type = 5;
+  // Optional digest reference (e.g. gcr.io/org/repo@sha256:...) of a manifest
+  // in the same repository that references the blob. Implementations may
+  // prove registry access via a HEAD request for this manifest instead of the
+  // blob itself, which allows serving cached blobs from registries that
+  // reject HEAD requests on blob endpoints (e.g. public.ecr.aws).
+  //
+  // The hint cannot be forged to gain access to unrelated cached blobs:
+  // implementations only honor it after confirming that a cached manifest
+  // whose contents match this digest actually references the blob.
+  string manifest_ref = 6;
 }
 
 message FetchBlobResponse {
@@ -83,6 +93,10 @@ message FetchBlobMetadataRequest {
   string ref = 1;
   registry.Credentials credentials = 2;
   bool bypass_registry = 3;
+  // See FetchBlobRequest.manifest_ref. In addition to proving access, the
+  // referenced manifest's descriptor for the blob may be used to serve the
+  // blob's size and media type when the registry rejects blob HEAD requests.
+  string manifest_ref = 4;
 }
 
 message FetchBlobMetadataResponse {


### PR DESCRIPTION
public.ecr.aws responds 401 to every HEAD request on blob endpoints (non-compliant with the OCI distribution spec), which breaks serving its blobs from cache: the blob HEAD access proof before a cache hit fails, and layer.Size() on the miss path fails so blobs are never written to cache in the first place.

Let FetchBlob and FetchBlobMetadata requests carry a manifest_ref hint naming a manifest that references the blob. The hint cannot be forged to gain access to unrelated cached blobs: the server only honors it after checking that a server-cached manifest whose contents match the hinted digest actually references the blob as its config or one of its layers. Proving access to that manifest (a HEAD request, which public.ecr.aws accepts) then proves access to the blob, since registry pull authorization is repository-scoped. The proof feeds the same repository-scoped access-proof LRU used for manifests, so one proof covers subsequent blob and manifest requests for the same repo and credentials.

The verified manifest's descriptor also supplies the blob's size and media type, so the miss path can write blobs to the cache without a blob HEAD (and with the manifest's real media type rather than go-containerregistry's constant), and FetchBlobMetadata can answer without a blob HEAD.

The executor client sends the hint from the image manifest each layer came from, and the executor-side proxy forwards it.