### PR TITLE
Attest the original client IP when forwarding unknown RPCs through grpc_forward (relands #12375)

### DIFF
--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -45,12 +45,19 @@ type headerCache struct {
 	entries map[interfaces.ClientIdentity]cachedHeader
 }
 
-func newHeaderCache(clock clockwork.Clock, sign func(*interfaces.ClientIdentity) (string, error)) *headerCache {
+func newHeaderCache(clock clockwork.Clock, expiration time.Duration, sign func(*interfaces.ClientIdentity) (string, error)) (*headerCache, error) {
+	// A cached header is reused for up to cachedHeaderExpiration, so if the
+	// signed JWT's own lifetime doesn't exceed that window we could hand out a
+	// token that has already expired. Require expiration > cachedHeaderExpiration
+	// rather than silently serving stale identities.
+	if expiration <= cachedHeaderExpiration {
+		return nil, status.InvalidArgumentErrorf("app.client_identity.expiration (%s) must be greater than the header cache expiration (%s)", expiration, cachedHeaderExpiration)
+	}
 	return &headerCache{
 		clock:   clock,
 		sign:    sign,
 		entries: make(map[interfaces.ClientIdentity]cachedHeader),
-	}
+	}, nil
 }
 
 // Get returns the cached header for si, signing and caching a fresh one when the
@@ -94,9 +101,13 @@ func New(clock clockwork.Clock) (*Service, error) {
 		signingKey: []byte(*signingKey),
 		clock:      clock,
 	}
-	s.headerCache = newHeaderCache(clock, func(si *interfaces.ClientIdentity) (string, error) {
+	headerCache, err := newHeaderCache(clock, *expiration, func(si *interfaces.ClientIdentity) (string, error) {
 		return s.NewIdentityHeader(si, *expiration)
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.headerCache = headerCache
 	return s, nil
 }
 

--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -30,24 +30,74 @@ var (
 	required   = flag.Bool("app.client_identity.required", false, "If set, a client identity is required.")
 )
 
+type cachedHeader struct {
+	header   string
+	cachedAt time.Time
+}
+
+// headerCache caches a signed identity header per client identity, re-signing
+// each at most once per cachedHeaderExpiration.
+type headerCache struct {
+	clock clockwork.Clock
+	sign  func(si *interfaces.ClientIdentity) (string, error)
+
+	mu      sync.RWMutex
+	entries map[interfaces.ClientIdentity]cachedHeader
+}
+
+func newHeaderCache(clock clockwork.Clock, sign func(*interfaces.ClientIdentity) (string, error)) *headerCache {
+	return &headerCache{
+		clock:   clock,
+		sign:    sign,
+		entries: make(map[interfaces.ClientIdentity]cachedHeader),
+	}
+}
+
+// Get returns the cached header for si, signing and caching a fresh one when the
+// cached value is missing or older than cachedHeaderExpiration.
+func (c *headerCache) Get(si *interfaces.ClientIdentity) (string, error) {
+	key := *si
+	c.mu.RLock()
+	e, ok := c.entries[key]
+	c.mu.RUnlock()
+	if ok && c.clock.Since(e.cachedAt) < cachedHeaderExpiration {
+		return e.header, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Check again in case it was updated while we were waiting for the lock.
+	if e, ok := c.entries[key]; ok && c.clock.Since(e.cachedAt) < cachedHeaderExpiration {
+		return e.header, nil
+	}
+	header, err := c.sign(si)
+	if err != nil {
+		return "", err
+	}
+	c.entries[key] = cachedHeader{header: header, cachedAt: c.clock.Now()}
+	return header, nil
+}
+
 type Service struct {
 	signingKey []byte
 
 	clock clockwork.Clock
 
-	mu               sync.RWMutex
-	cachedHeader     string
-	cachedHeaderTime time.Time
+	headerCache *headerCache
 }
 
 func New(clock clockwork.Clock) (*Service, error) {
 	if *signingKey == "" {
 		return nil, status.InvalidArgumentError("ClientIdentityService requires a signing key")
 	}
-	return &Service{
+	s := &Service{
 		signingKey: []byte(*signingKey),
 		clock:      clock,
-	}, nil
+	}
+	s.headerCache = newHeaderCache(clock, func(si *interfaces.ClientIdentity) (string, error) {
+		return s.NewIdentityHeader(si, *expiration)
+	})
+	return s, nil
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -79,7 +129,7 @@ func ClearIdentity(ctx context.Context) context.Context {
 	return ctx
 }
 
-func (s *Service) IdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+func (s *Service) NewIdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
 	expirationTime := s.clock.Now().Add(expiration)
 	t := jwt.NewWithClaims(jwt.SigningMethodHS256, &claims{
 		StandardClaims: jwt.StandardClaims{ExpiresAt: expirationTime.Unix()},
@@ -88,30 +138,10 @@ func (s *Service) IdentityHeader(si *interfaces.ClientIdentity, expiration time.
 	return t.SignedString(s.signingKey)
 }
 
-func (s *Service) getCachedHeader() (string, error) {
-	s.mu.RLock()
-	headerTime := s.cachedHeaderTime
-	header := s.cachedHeader
-	s.mu.RUnlock()
-	if s.clock.Since(headerTime) < cachedHeaderExpiration {
-		return header, nil
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// Check again in case it was updated while we were waiting for the lock.
-	if s.clock.Since(s.cachedHeaderTime) < cachedHeaderExpiration {
-		return s.cachedHeader, nil
-	}
-	header, err := s.IdentityHeader(&interfaces.ClientIdentity{
-		Origin: *origin,
-		Client: *client,
-	}, *expiration)
-	if err != nil {
-		return "", err
-	}
-	s.cachedHeader = header
-	s.cachedHeaderTime = s.clock.Now()
-	return header, nil
+// CachedIdentityHeader returns a signed identity header for the given identity,
+// re-signing it at most once per cachedHeaderExpiration.
+func (s *Service) CachedIdentityHeader(si *interfaces.ClientIdentity) (string, error) {
+	return s.headerCache.Get(si)
 }
 
 func (s *Service) AddIdentityToContext(ctx context.Context) (context.Context, error) {
@@ -120,7 +150,10 @@ func (s *Service) AddIdentityToContext(ctx context.Context) (context.Context, er
 			return ctx, nil
 		}
 	}
-	header, err := s.getCachedHeader()
+	header, err := s.CachedIdentityHeader(&interfaces.ClientIdentity{
+		Origin: *origin,
+		Client: *client,
+	})
 	if err != nil {
 		return ctx, err
 	}

--- a/enterprise/server/clientidentity/clientidentity_test.go
+++ b/enterprise/server/clientidentity/clientidentity_test.go
@@ -31,7 +31,7 @@ func TestIdentity(t *testing.T) {
 
 	origin := "space"
 	client := "aliens"
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: origin,
 		Client: client,
 	}, clientidentity.DefaultExpiration)
@@ -53,7 +53,7 @@ func TestDuplicateHeaders(t *testing.T) {
 
 	origin := "space"
 	client := "aliens"
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: origin,
 		Client: client,
 	}, clientidentity.DefaultExpiration)
@@ -97,7 +97,7 @@ func TestStaleIdentity(t *testing.T) {
 
 	origin := "space"
 	client := "aliens"
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: origin,
 		Client: client,
 	}, clientidentity.DefaultExpiration)
@@ -118,7 +118,7 @@ func TestRequired(t *testing.T) {
 
 	origin := "space"
 	client := "aliens"
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: origin,
 		Client: client,
 	}, clientidentity.DefaultExpiration)
@@ -139,7 +139,7 @@ func TestClearIdentity(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sis := newService(t, clock)
 
-	headerValue, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: "origin",
 		Client: "client",
 	}, clientidentity.DefaultExpiration)
@@ -160,7 +160,7 @@ func TestAddIdentityToContext_PreservesExisting(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	sis := newService(t, clock)
 
-	existingHeader, err := sis.IdentityHeader(&interfaces.ClientIdentity{
+	existingHeader, err := sis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Origin: "upstream-origin",
 		Client: "upstream",
 	}, clientidentity.DefaultExpiration)
@@ -191,6 +191,43 @@ func TestAddIdentityToContext_AddsWhenMissing(t *testing.T) {
 	require.True(t, ok)
 	vals := md.Get(authutil.ClientIdentityHeaderName)
 	require.Equal(t, 1, len(vals), "expected a new header to be added")
+}
+
+func TestCachedIdentityHeader(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	sis := newService(t, clock)
+
+	si := &interfaces.ClientIdentity{Origin: "internal", Client: "grpc-proxy"}
+
+	h1, err := sis.CachedIdentityHeader(si)
+	require.NoError(t, err)
+
+	// Within the cache TTL, the same header is returned without re-signing
+	// (a re-sign at a later time would change the JWT's expiration claim).
+	clock.Advance(30 * time.Second)
+	h2, err := sis.CachedIdentityHeader(si)
+	require.NoError(t, err)
+	require.Equal(t, h1, h2)
+
+	// A different identity is cached independently.
+	other, err := sis.CachedIdentityHeader(&interfaces.ClientIdentity{Origin: "internal", Client: "app"})
+	require.NoError(t, err)
+	require.NotEqual(t, h1, other)
+
+	// Past the cache TTL, the header is re-signed.
+	clock.Advance(2 * time.Minute)
+	h3, err := sis.CachedIdentityHeader(si)
+	require.NoError(t, err)
+	require.NotEqual(t, h1, h3)
+
+	// The cached header is a valid identity for the requested client.
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs(authutil.ClientIdentityHeaderName, h3))
+	ctx, err = sis.ValidateIncomingIdentity(ctx)
+	require.NoError(t, err)
+	got, err := sis.IdentityFromContext(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "grpc-proxy", got.Client)
+	require.Equal(t, "internal", got.Origin)
 }
 
 func BenchmarkAddIdentityToContext(b *testing.B) {

--- a/enterprise/server/clientidentity/clientidentity_test.go
+++ b/enterprise/server/clientidentity/clientidentity_test.go
@@ -230,6 +230,19 @@ func TestCachedIdentityHeader(t *testing.T) {
 	require.Equal(t, "internal", got.Origin)
 }
 
+func TestNew_RejectsExpirationBelowCacheWindow(t *testing.T) {
+	key, err := random.RandomString(16)
+	require.NoError(t, err)
+	flags.Set(t, "app.client_identity.key", string(key))
+
+	// A JWT lifetime shorter than the header cache window would let the cache
+	// serve an already-expired token, so New must reject it.
+	flags.Set(t, "app.client_identity.expiration", 30*time.Second)
+	_, err = clientidentity.New(clockwork.NewFakeClock())
+	require.Error(t, err)
+	require.True(t, status.IsInvalidArgumentError(err), "expected InvalidArgument, got %v", err)
+}
+
 func BenchmarkAddIdentityToContext(b *testing.B) {
 	sis := newService(b, clockwork.NewRealClock())
 

--- a/enterprise/server/ip_rules_service/ip_rules_service_test.go
+++ b/enterprise/server/ip_rules_service/ip_rules_service_test.go
@@ -116,7 +116,7 @@ func setupService(t *testing.T, enforcer *fakeIPRulesEnforcer, sns *fakeServerNo
 func contextWithClientIdentity(t *testing.T, ctx context.Context, service interfaces.ClientIdentityService, client string) context.Context {
 	t.Helper()
 
-	headerValue, err := service.IdentityHeader(&interfaces.ClientIdentity{
+	headerValue, err := service.NewIdentityHeader(&interfaces.ClientIdentity{
 		Client: client,
 		Origin: "test",
 	}, time.Minute)

--- a/enterprise/server/remote_execution/executorplatform/executorplatform.go
+++ b/enterprise/server/remote_execution/executorplatform/executorplatform.go
@@ -339,7 +339,7 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 		})
 
 		if cis := env.GetClientIdentityService(); cis != nil {
-			h, err := cis.IdentityHeader(&interfaces.ClientIdentity{
+			h, err := cis.NewIdentityHeader(&interfaces.ClientIdentity{
 				Origin: interfaces.ClientIdentityInternalOrigin,
 				Client: interfaces.ClientIdentityWorkflow,
 			}, workflowClientIdentityTokenLifetime)

--- a/enterprise/server/test/integration/cache_proxy/cache_proxy_test.go
+++ b/enterprise/server/test/integration/cache_proxy/cache_proxy_test.go
@@ -436,7 +436,7 @@ func TestIPRulesRBE(t *testing.T) {
 	require.NoError(t, err)
 
 	// RBE Requests from a blockedIP + allowed client identity should succeed.
-	allowedIdentity, err := cis.IdentityHeader(&interfaces.ClientIdentity{
+	allowedIdentity, err := cis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Client: interfaces.ClientIdentityExecutor,
 		Origin: "test",
 	}, time.Minute)
@@ -453,7 +453,7 @@ func TestIPRulesRBE(t *testing.T) {
 
 	// RBE Requests from a blockedIP + blocked client identity should fail.
 	// Sign some other client-identity using the shared signing key.
-	blockedIdentity, err := cis.IdentityHeader(&interfaces.ClientIdentity{
+	blockedIdentity, err := cis.NewIdentityHeader(&interfaces.ClientIdentity{
 		Client: "foo",
 		Origin: "test",
 	}, time.Minute)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1717,9 +1717,14 @@ type ClientIdentityService interface {
 	// outgoing context.
 	AddIdentityToContext(ctx context.Context) (context.Context, error)
 
-	// IdentityHeader generates a signed header value for the specified
+	// NewIdentityHeader generates a new signed header value for the specified
 	// identity.
-	IdentityHeader(si *ClientIdentity, expiration time.Duration) (string, error)
+	NewIdentityHeader(si *ClientIdentity, expiration time.Duration) (string, error)
+
+	// CachedIdentityHeader returns a signed header value for the specified
+	// identity, reusing a cached value that is periodically refreshed instead of
+	// signing a new JWT on every call.
+	CachedIdentityHeader(si *ClientIdentity) (string, error)
 
 	// ValidateIncomingIdentity validates the incoming identity and adds the
 	// authenticated identity information to the context. This function is

--- a/server/remote_cache/hit_tracker/hit_tracker_test.go
+++ b/server/remote_cache/hit_tracker/hit_tracker_test.go
@@ -139,7 +139,7 @@ func TestHitTracker_RecordsUsageAndMetrics(t *testing.T) {
 		env.SetClientIdentityService(&fakeIdentityService{})
 		incomingContextMetadata := make(map[string][]string)
 		if test.clientIdentity != "" {
-			hv, err := env.GetClientIdentityService().IdentityHeader(&interfaces.ClientIdentity{
+			hv, err := env.GetClientIdentityService().NewIdentityHeader(&interfaces.ClientIdentity{
 				Origin: "whocares",
 				Client: test.clientIdentity,
 			}, time.Minute)
@@ -407,8 +407,12 @@ func (f *fakeIdentityService) IdentityFromContext(ctx context.Context) (*interfa
 	}, nil
 }
 
-// IdentityHeader implements interfaces.ClientIdentityService.
-func (f *fakeIdentityService) IdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+// NewIdentityHeader implements interfaces.ClientIdentityService.
+func (f *fakeIdentityService) NewIdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+	return si.Client + "|" + si.Origin, nil
+}
+
+func (f *fakeIdentityService) CachedIdentityHeader(si *interfaces.ClientIdentity) (string, error) {
 	return si.Client + "|" + si.Origin, nil
 }
 

--- a/server/rpc/interceptors/interceptors_test.go
+++ b/server/rpc/interceptors/interceptors_test.go
@@ -261,7 +261,11 @@ func (f *fakeClientIdentityService) AddIdentityToContext(ctx context.Context) (c
 	return ctx, nil
 }
 
-func (f *fakeClientIdentityService) IdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+func (f *fakeClientIdentityService) NewIdentityHeader(si *interfaces.ClientIdentity, expiration time.Duration) (string, error) {
+	return "", nil
+}
+
+func (f *fakeClientIdentityService) CachedIdentityHeader(si *interfaces.ClientIdentity) (string, error) {
 	return "", nil
 }
 

--- a/server/util/authutil/authutil_test.go
+++ b/server/util/authutil/authutil_test.go
@@ -30,7 +30,10 @@ func (m *mockCIS) IdentityFromContext(context.Context) (*interfaces.ClientIdenti
 func (m *mockCIS) AddIdentityToContext(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
-func (m *mockCIS) IdentityHeader(*interfaces.ClientIdentity, time.Duration) (string, error) {
+func (m *mockCIS) NewIdentityHeader(*interfaces.ClientIdentity, time.Duration) (string, error) {
+	return "", nil
+}
+func (m *mockCIS) CachedIdentityHeader(*interfaces.ClientIdentity) (string, error) {
 	return "", nil
 }
 func (m *mockCIS) ValidateIncomingIdentity(ctx context.Context) (context.Context, error) {

--- a/server/util/grpc_forward/BUILD
+++ b/server/util/grpc_forward/BUILD
@@ -6,6 +6,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/grpc_forward",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/environment",
+        "//server/interfaces",
+        "//server/util/authutil",
+        "//server/util/clientip",
         "//server/util/flag",
         "//server/util/grpc_client",
         "//server/util/status",
@@ -20,6 +24,9 @@ go_test(
     srcs = ["grpc_forward_test.go"],
     embed = [":grpc_forward"],
     deps = [
+        "//server/interfaces",
+        "//server/util/authutil",
+        "//server/util/clientip",
         "//server/util/grpc_client",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",

--- a/server/util/grpc_forward/BUILD
+++ b/server/util/grpc_forward/BUILD
@@ -25,6 +25,7 @@ go_test(
     embed = [":grpc_forward"],
     deps = [
         "//server/interfaces",
+        "//server/real_environment",
         "//server/util/authutil",
         "//server/util/clientip",
         "//server/util/grpc_client",

--- a/server/util/grpc_forward/grpc_forward.go
+++ b/server/util/grpc_forward/grpc_forward.go
@@ -81,20 +81,26 @@ func getConnectionPool(dialer dialFn, target string) (*grpc_client.ClientConnPoo
 	return newPool, nil
 }
 
-// ctxWithClientIP overwrites the outgoing client-IP header with the IP this
-// proxy resolved (clientip.Get) and attaches a grpc-proxy identity that attests
-// to it. Any client-supplied client-IP header is stripped first: the proxy is
-// the sole authority for this value, so a caller can't smuggle an allowed IP
-// past the backend's IP-rule checks. The caller's other headers are forwarded by
-// the server's metadata-propagation interceptor (see GetForwardingServerOption).
+// ctxWithClientIP forwards the incoming request metadata to the backend,
+// overwriting the client-IP header with the IP this proxy resolved
+// (clientip.Get) and attaching a grpc-proxy identity that attests to it. Any
+// client-supplied client-IP header is stripped first: the proxy is the sole
+// authority for this value, so a caller can't smuggle an allowed IP past the
+// backend's IP-rule checks. All of the caller's other headers are propagated
+// verbatim.
 //
 // This composes across proxy hops without trusting raw headers: each hop's
 // clientIP interceptor only honors an incoming client-IP header when it carries
 // a verified grpc-proxy identity, so clientip.Get already reflects an upstream
 // proxy's attested IP, and we re-attest it here.
 func ctxWithClientIP(ctx context.Context, cis interfaces.ClientIdentityService) (context.Context, error) {
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
+	// Propagate the caller's incoming metadata to the backend. This is a
+	// blanket copy so that arbitrary headers survive the proxy hop; we then
+	// overwrite only the client-IP and client-identity headers below.
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		md = md.Copy()
+	} else {
 		md = metadata.MD{}
 	}
 

--- a/server/util/grpc_forward/grpc_forward.go
+++ b/server/util/grpc_forward/grpc_forward.go
@@ -83,11 +83,13 @@ func getConnectionPool(dialer dialFn, target string) (*grpc_client.ClientConnPoo
 
 // ctxWithClientIP forwards the incoming request metadata to the backend,
 // overwriting the client-IP header with the IP this proxy resolved
-// (clientip.Get) and attaching a grpc-proxy identity that attests to it. Any
-// client-supplied client-IP header is stripped first: the proxy is the sole
-// authority for this value, so a caller can't smuggle an allowed IP past the
-// backend's IP-rule checks. All of the caller's other headers are propagated
-// verbatim.
+// (clientip.Get). When the caller has no client identity of its own, it also
+// attaches a grpc-proxy identity that attests to that IP; a caller that already
+// carries a signed identity (e.g. a workflow) keeps it so the backend still
+// authorizes on it. Any client-supplied client-IP header is stripped first: the
+// proxy is the sole authority for this value, so a caller can't smuggle an
+// allowed IP past the backend's IP-rule checks. All of the caller's other
+// headers are propagated verbatim.
 //
 // This composes across proxy hops without trusting raw headers: each hop's
 // clientIP interceptor only honors an incoming client-IP header when it carries
@@ -113,10 +115,16 @@ func ctxWithClientIP(ctx context.Context, cis interfaces.ClientIdentityService) 
 	}
 	md.Set(clientip.HeaderName, clientIP)
 
-	// Attach the grpc-proxy identity that attests to the client IP. The signed
-	// header is cached and refreshed by the client identity service. Set (not
-	// append) so a duplicate identity header can't be produced.
-	if cis != nil {
+	// Only attest as grpc-proxy when the caller has no identity of its own.
+	// Internal callers (workflows, executors, the app) forward their own signed
+	// identity, which the backend authorizes on -- e.g. workflows bypass IP
+	// rules by identity. Overwriting it with grpc-proxy would strip that bypass
+	// and get the request checked against the forwarded client IP instead.
+	// External callers have no identity, so we attach the grpc-proxy identity
+	// (cached and refreshed by the client identity service) that attests to the
+	// client IP. Set (not append) so a duplicate identity header can't be
+	// produced.
+	if cis != nil && len(md.Get(authutil.ClientIdentityHeaderName)) == 0 {
 		header, err := cis.CachedIdentityHeader(&interfaces.ClientIdentity{
 			Origin: interfaces.ClientIdentityInternalOrigin,
 			Client: interfaces.ClientIdentityGRPCProxy,

--- a/server/util/grpc_forward/grpc_forward.go
+++ b/server/util/grpc_forward/grpc_forward.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -77,26 +81,74 @@ func getConnectionPool(dialer dialFn, target string) (*grpc_client.ClientConnPoo
 	return newPool, nil
 }
 
-func director(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
-	target, err := lookupProxyTarget(fullMethodName)
-	if err != nil {
-		return nil, nil, err
+// ctxWithClientIP overwrites the outgoing client-IP header with the IP this
+// proxy resolved (clientip.Get) and attaches a grpc-proxy identity that attests
+// to it. Any client-supplied client-IP header is stripped first: the proxy is
+// the sole authority for this value, so a caller can't smuggle an allowed IP
+// past the backend's IP-rule checks. The caller's other headers are forwarded by
+// the server's metadata-propagation interceptor (see GetForwardingServerOption).
+//
+// This composes across proxy hops without trusting raw headers: each hop's
+// clientIP interceptor only honors an incoming client-IP header when it carries
+// a verified grpc-proxy identity, so clientip.Get already reflects an upstream
+// proxy's attested IP, and we re-attest it here.
+func ctxWithClientIP(ctx context.Context, cis interfaces.ClientIdentityService) (context.Context, error) {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.MD{}
 	}
 
-	pool, err := getConnectionPool(dial, target)
-	if err != nil {
-		return nil, nil, err
-	}
+	// Never trust a client-supplied client-IP header; we set it ourselves below.
+	delete(md, clientip.HeaderName)
 
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		ctx = metadata.NewOutgoingContext(ctx, md.Copy())
+	clientIP := clientip.Get(ctx)
+	if clientIP == "" {
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
-	return ctx, pool, nil
+	md.Set(clientip.HeaderName, clientIP)
+
+	// Attach the grpc-proxy identity that attests to the client IP. The signed
+	// header is cached and refreshed by the client identity service. Set (not
+	// append) so a duplicate identity header can't be produced.
+	if cis != nil {
+		header, err := cis.CachedIdentityHeader(&interfaces.ClientIdentity{
+			Origin: interfaces.ClientIdentityInternalOrigin,
+			Client: interfaces.ClientIdentityGRPCProxy,
+		})
+		if err != nil {
+			return nil, err
+		}
+		md.Set(authutil.ClientIdentityHeaderName, header)
+	}
+	return metadata.NewOutgoingContext(ctx, md), nil
 }
 
-func GetForwardingServerOption() grpc.ServerOption {
+func newDirector(env environment.Env) proxy.StreamDirector {
+	cis := env.GetClientIdentityService()
+	return func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
+		target, err := lookupProxyTarget(fullMethodName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		pool, err := getConnectionPool(dial, target)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ctx, err = ctxWithClientIP(ctx, cis)
+		if err != nil {
+			return nil, nil, err
+		}
+		return ctx, pool, nil
+	}
+}
+
+// GetForwardingServerOption returns a gRPC server option that proxies unknown
+// RPCs to the configured app.proxy_targets.
+func GetForwardingServerOption(env environment.Env) grpc.ServerOption {
 	if len(*proxyTargets) == 0 {
 		return nil
 	}
-	return grpc.UnknownServiceHandler(proxy.TransparentHandler(director))
+	return grpc.UnknownServiceHandler(proxy.TransparentHandler(newDirector(env)))
 }

--- a/server/util/grpc_forward/grpc_forward_test.go
+++ b/server/util/grpc_forward/grpc_forward_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
@@ -98,4 +101,108 @@ func TestGetConnectionPool_DedupesConcurrentDialsForSameTarget(t *testing.T) {
 	for _, pool := range pools[1:] {
 		require.Same(t, pools[0], pool)
 	}
+}
+
+// fakeIdentityService records the identity it was asked to sign and returns a
+// canned header.
+type fakeIdentityService struct {
+	mu         sync.Mutex
+	lastClient string
+	header     string
+}
+
+func (f *fakeIdentityService) CachedIdentityHeader(si *interfaces.ClientIdentity) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastClient = si.Client
+	return f.header, nil
+}
+
+func (f *fakeIdentityService) NewIdentityHeader(si *interfaces.ClientIdentity, _ time.Duration) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastClient = si.Client
+	return f.header, nil
+}
+
+func (f *fakeIdentityService) AddIdentityToContext(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+func (f *fakeIdentityService) ValidateIncomingIdentity(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+func (f *fakeIdentityService) IdentityFromContext(context.Context) (*interfaces.ClientIdentity, error) {
+	return nil, nil
+}
+
+func ctxWithResolvedClientIP(ip string) context.Context {
+	return context.WithValue(context.Background(), clientip.ContextKey, ip)
+}
+
+func TestCtxWithClientIP(t *testing.T) {
+	const clientIP = "1.2.3.4"
+	const identity = "signed-grpc-proxy-header"
+
+	t.Run("attaches client IP and identity", func(t *testing.T) {
+		cis := &fakeIdentityService{header: identity}
+		ctx, err := ctxWithClientIP(ctxWithResolvedClientIP(clientIP), cis)
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
+		require.Equal(t, []string{identity}, md.Get(authutil.ClientIdentityHeaderName))
+		// The proxy attests as the grpc-proxy identity.
+		require.Equal(t, interfaces.ClientIdentityGRPCProxy, cis.lastClient)
+	})
+
+	t.Run("no client IP attaches nothing", func(t *testing.T) {
+		cis := &fakeIdentityService{header: identity}
+		ctx, err := ctxWithClientIP(context.Background(), cis)
+		require.NoError(t, err)
+
+		if md, ok := metadata.FromOutgoingContext(ctx); ok {
+			require.Empty(t, md.Get(clientip.HeaderName))
+			require.Empty(t, md.Get(authutil.ClientIdentityHeaderName))
+		}
+	})
+
+	t.Run("client-supplied client IP header is overwritten with the resolved IP", func(t *testing.T) {
+		cis := &fakeIdentityService{header: identity}
+		// Simulate an attacker pre-setting the client-IP header to a spoofed value.
+		ctx := metadata.AppendToOutgoingContext(ctxWithResolvedClientIP(clientIP), clientip.HeaderName, "9.9.9.9")
+		ctx, err := ctxWithClientIP(ctx, cis)
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		// The spoofed value is stripped and replaced with the proxy-resolved IP.
+		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
+		require.Equal(t, []string{identity}, md.Get(authutil.ClientIdentityHeaderName))
+	})
+
+	t.Run("client-supplied client IP is stripped when no IP is resolved", func(t *testing.T) {
+		cis := &fakeIdentityService{header: identity}
+		// Spoofed header present, but the proxy resolved no client IP of its own.
+		ctx := metadata.AppendToOutgoingContext(context.Background(), clientip.HeaderName, "9.9.9.9")
+		ctx, err := ctxWithClientIP(ctx, cis)
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Empty(t, md.Get(clientip.HeaderName))
+		require.Empty(t, md.Get(authutil.ClientIdentityHeaderName))
+	})
+
+	t.Run("nil identity service sets IP without identity", func(t *testing.T) {
+		ctx, err := ctxWithClientIP(ctxWithResolvedClientIP(clientIP), nil)
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
+		require.Empty(t, md.Get(authutil.ClientIdentityHeaderName))
+	})
 }

--- a/server/util/grpc_forward/grpc_forward_test.go
+++ b/server/util/grpc_forward/grpc_forward_test.go
@@ -173,7 +173,7 @@ func TestCtxWithClientIP(t *testing.T) {
 	t.Run("client-supplied client IP header is overwritten with the resolved IP", func(t *testing.T) {
 		cis := &fakeIdentityService{header: identity}
 		// Simulate an attacker pre-setting the client-IP header to a spoofed value.
-		ctx := metadata.AppendToOutgoingContext(ctxWithResolvedClientIP(clientIP), clientip.HeaderName, "9.9.9.9")
+		ctx := metadata.NewIncomingContext(ctxWithResolvedClientIP(clientIP), metadata.Pairs(clientip.HeaderName, "9.9.9.9"))
 		ctx, err := ctxWithClientIP(ctx, cis)
 		require.NoError(t, err)
 
@@ -187,7 +187,7 @@ func TestCtxWithClientIP(t *testing.T) {
 	t.Run("client-supplied client IP is stripped when no IP is resolved", func(t *testing.T) {
 		cis := &fakeIdentityService{header: identity}
 		// Spoofed header present, but the proxy resolved no client IP of its own.
-		ctx := metadata.AppendToOutgoingContext(context.Background(), clientip.HeaderName, "9.9.9.9")
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(clientip.HeaderName, "9.9.9.9"))
 		ctx, err := ctxWithClientIP(ctx, cis)
 		require.NoError(t, err)
 

--- a/server/util/grpc_forward/grpc_forward_test.go
+++ b/server/util/grpc_forward/grpc_forward_test.go
@@ -206,4 +206,22 @@ func TestCtxWithClientIP(t *testing.T) {
 		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
 		require.Empty(t, md.Get(authutil.ClientIdentityHeaderName))
 	})
+
+	t.Run("caller-supplied identity is preserved rather than overwritten", func(t *testing.T) {
+		cis := &fakeIdentityService{header: identity}
+		// A caller that already carries a signed identity (e.g. a workflow) must
+		// keep it so the backend still authorizes on it (e.g. IP-rule bypass);
+		// the proxy must not clobber it with its own grpc-proxy identity.
+		const callerIdentity = "workflow-identity"
+		ctx := metadata.NewIncomingContext(ctxWithResolvedClientIP(clientIP), metadata.Pairs(authutil.ClientIdentityHeaderName, callerIdentity))
+		ctx, err := ctxWithClientIP(ctx, cis)
+		require.NoError(t, err)
+
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, []string{clientIP}, md.Get(clientip.HeaderName))
+		require.Equal(t, []string{callerIdentity}, md.Get(authutil.ClientIdentityHeaderName))
+		// The proxy did not mint a grpc-proxy identity for this request.
+		require.Empty(t, cis.lastClient)
+	})
 }

--- a/server/util/grpc_forward/grpc_forward_test.go
+++ b/server/util/grpc_forward/grpc_forward_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -52,7 +53,7 @@ func TestForwarding_PropagatesClientHeadersToBackend(t *testing.T) {
 	backendTarget := fmt.Sprintf("grpc://localhost:%d", backendLis.Addr().(*net.TCPAddr).Port)
 
 	flags.Set(t, "app.proxy_targets", []proxyPair{{Prefix: "", Target: backendTarget}})
-	fwdOpt := GetForwardingServerOption()
+	fwdOpt := GetForwardingServerOption(real_environment.NewRealEnv(nil))
 	require.NotNil(t, fwdOpt, "forwarding must be enabled when app.proxy_targets is set")
 
 	proxyLis, err := net.Listen("tcp", "localhost:0")

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -116,7 +116,7 @@ func New(env environment.Env, port int, ssl bool, config GRPCServerConfig) (*GRP
 	} else {
 		log.Infof("gRPC listening on %s", b.hostPort)
 	}
-	if fwdingOptions := grpc_forward.GetForwardingServerOption(); fwdingOptions != nil {
+	if fwdingOptions := grpc_forward.GetForwardingServerOption(env); fwdingOptions != nil {
 		grpcOptions = append(grpcOptions, fwdingOptions)
 	}
 	b.server = grpc.NewServer(grpcOptions...)


### PR DESCRIPTION
Relands #12375, which was reverted in #12619, this time preserving both metadata propagation and the caller's client identity through the forwarder.

### Background

#12375 is the forwarding-side counterpart to #12361: when `grpc_forward` proxies an unknown RPC, the backend would otherwise see the proxy's IP instead of the caller's and reject it under IP rules. The director resolves the real client IP, sets it in the `x-buildbuddy-client-ip` header, and attaches a signed `grpc-proxy` client identity that attests to it (minted from the binary's client identity service and cached for a minute so we don't sign a JWT per RPC).

### Why it was reverted

The original change built the forwarded metadata from the **outgoing** context and relied on a "metadata-propagation interceptor" to carry the caller's other headers. No such interceptor runs on the unknown-RPC path (`proxy.TransparentHandler`), so every caller-supplied header was silently dropped on the way to the backend — breaking use cases that depend on propagating metadata through this hop.

### Fix 1: metadata propagation

`ctxWithClientIP` now bases the forwarded metadata on a blanket copy of the **incoming** metadata again (as the pre-#12375 director did), then adjusts only the `x-buildbuddy-client-ip` and client-identity headers. The anti-spoofing behavior is unchanged: any client-supplied client-IP header is stripped and re-set from `clientip.Get`.

A regression test, `TestForwarding_PropagatesClientHeadersToBackend`, stands up a real proxy → backend and asserts an arbitrary caller header survives the hop — it fails on the original approach and passes here.

### Fix 2: preserve the caller's client identity

The original change attached the `grpc-proxy` identity **unconditionally**, overwriting any incoming client identity. That breaks workflows routed through the proxy (via the workflow DNS override): a request carrying the `workflow` identity — which bypasses IP rules ([`bypassIPRules`](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/ip_rules_enforcer/ip_rules_enforcer.go)) — would reach the backend as `grpc-proxy`, which does **not** bypass. It would then be checked against the runner's IP and rejected in any group with IP rules enabled.

The forwarder now attaches the `grpc-proxy` identity only when the caller has no identity of its own. Internal callers (workflows, executors, the app) forward their own signed identity, which the backend continues to authorize on; external callers have none, so they still get the `grpc-proxy` identity attesting the resolved client IP. This is safe: identities are signed JWTs the backend validates, and the proxy ingress rejects invalid ones, so preserving the caller identity can only preserve a legitimately-signed one.

### Reviewing by commit

1. **Reapply "Attest the original client IP…"** — reintroduces #12375 verbatim.
2. **Make newly-added test build** — wires up the regression test / test seam.
3. **grpc_forward: propagate incoming metadata when forwarding unknown RPCs** — Fix 1.
4. **At construction time, reject client-identity signing parameters that will cause problems at runtime** — addresses a latent issue in the client-identity cache (the cached header could outlive the signed JWT if `app.client_identity.expiration` were set below the cache window).
5. **grpc_forward: preserve the caller's client identity when forwarding** — Fix 2.

Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7494
