### PR TITLE
Add 'Today' and 'Last 2 days' as date picker options

### DIFF
--- a/enterprise/app/filter/date_picker_button.tsx
+++ b/enterprise/app/filter/date_picker_button.tsx
@@ -14,7 +14,7 @@ import {
   getDateRangeForPicker,
 } from "./filter_util";
 
-const LAST_N_DAYS_OPTIONS = [7, 30, 90, 180, 365];
+const LAST_N_DAYS_OPTIONS = [1, 2, 7, 30, 90, 180, 365];
 
 type PresetRange = {
   label: string;


### PR DESCRIPTION
Keeps "Last 7 days" as the default, but adds a few more options for convenience

<img width="619" height="420" alt="image" src="https://github.com/user-attachments/assets/b360febc-bddc-46c6-9ae7-99afffa7a546" />
