### PR TITLE
Improve cpuset behavior when it's disabled

### DIFF
--- a/buildpatches/com_github_firecracker_microvm_firecracker_go_sdk_cgroup.patch
+++ b/buildpatches/com_github_firecracker_microvm_firecracker_go_sdk_cgroup.patch
@@ -1,5 +1,5 @@
 diff --git a/jailer.go b/jailer.go
-index 208de67..eddd8f1 100644
+index ff3a35a..41a21bc 100644
 --- a/jailer.go
 +++ b/jailer.go
 @@ -85,6 +85,14 @@ type JailerConfig struct {
@@ -26,22 +26,30 @@ index 208de67..eddd8f1 100644
  
  	stdin  io.Reader
  	stdout io.Writer
-@@ -143,6 +153,14 @@ func (b JailerCommandBuilder) Args() []string {
- 		args = append(args, "--cgroup", fmt.Sprintf("cpuset.cpus=%s", cpulist))
- 	}
+@@ -138,9 +148,19 @@ func (b JailerCommandBuilder) Args() []string {
+ 	args = append(args, "--gid", strconv.Itoa(b.gid))
+ 	args = append(args, "--exec-file", b.execFile)
  
+-	if cpulist := getNumaCpuset(b.node); len(cpulist) > 0 {
+-		args = append(args, "--cgroup", fmt.Sprintf("cpuset.mems=%d", b.node))
+-		args = append(args, "--cgroup", fmt.Sprintf("cpuset.cpus=%s", cpulist))
++	if b.node >= 0 {
++		if cpulist := getNumaCpuset(b.node); len(cpulist) > 0 {
++			args = append(args, "--cgroup", fmt.Sprintf("cpuset.mems=%d", b.node))
++			args = append(args, "--cgroup", fmt.Sprintf("cpuset.cpus=%s", cpulist))
++		}
++	}
++
 +	for _, cgroupArg := range b.cgroupArgs {
 +		args = append(args, "--cgroup", cgroupArg)
 +	}
 +
 +	if b.parentCgroup != nil {
 +		args = append(args, "--parent-cgroup", *b.parentCgroup)
-+	}
-+
- 	if len(b.cgroupVersion) > 0 {
- 		args = append(args, "--cgroup-version", b.cgroupVersion)
  	}
-@@ -204,13 +222,38 @@ func (b JailerCommandBuilder) WithExecFile(path string) JailerCommandBuilder {
+ 
+ 	if len(b.cgroupVersion) > 0 {
+@@ -204,13 +224,40 @@ func (b JailerCommandBuilder) WithExecFile(path string) JailerCommandBuilder {
  	return b
  }
  
@@ -52,6 +60,8 @@ index 208de67..eddd8f1 100644
 +// files "cpuset.mems" and "cpuset.cpus".
 +// If those files are also configured using WithCgroupArgs, the values passed to
 +// WithCgroupArgs will take precedence.
++// A negative node means the cpuset files are left unset, so the process is not
++// assigned to any NUMA node or pinned to any CPU.
  func (b JailerCommandBuilder) WithNumaNode(node int) JailerCommandBuilder {
  	b.node = node
  	return b
@@ -81,7 +91,7 @@ index 208de67..eddd8f1 100644
  // WithChrootBaseDir will set the given path as the chroot base directory. This
  // specifies where chroot jails are built and defaults to /srv/jailer.
  func (b JailerCommandBuilder) WithChrootBaseDir(path string) JailerCommandBuilder {
-@@ -348,6 +391,8 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
+@@ -348,6 +395,8 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
  		WithChrootBaseDir(cfg.JailerCfg.ChrootBaseDir).
  		WithDaemonize(cfg.JailerCfg.Daemonize).
  		WithCgroupVersion(cfg.JailerCfg.CgroupVersion).

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -245,11 +245,9 @@ func GetConfiguredEnvironmentOrDie(cacheRoot string, healthChecker *healthcheck.
 	xl := xcode.NewXcodeLocator()
 	realEnv.SetXcodeLocator(xl)
 
-	leaser, err := cpuset.NewLeaser(cpuset.LeaserOpts{})
-	if err != nil {
+	if err := cpuset.Register(realEnv); err != nil {
 		log.Fatal(err.Error())
 	}
-	realEnv.SetCPULeaser(leaser)
 
 	if err := gcs_cache.Register(realEnv); err != nil {
 		log.Fatal(err.Error())

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1829,10 +1829,22 @@ func (c *FirecrackerContainer) getJailerConfig(ctx context.Context, kernelImageP
 		return nil, status.WrapError(err, "get cgroup version")
 	}
 
-	numaNode := 0
+	// We normally apply cpuset config in cgroup.Setup(), but the go
+	// SDK clobbers our setting when applying the NUMA node setting.
+	// Override this manually for now.
+	var cgroupArgs []string
+	// If we don't have a leased NUMA node, pass -1, which tells the
+	// (patched) SDK to skip its default cpuset config. The SDK would
+	// otherwise pin the VM to NUMA node 0.
+	numaNode := -1
 	if c.cgroupSettings.NumaNode != nil {
 		numaNode = int(c.cgroupSettings.GetNumaNode())
+		cgroupArgs = append(cgroupArgs, fmt.Sprintf("cpuset.mems=%d", numaNode))
 	}
+	if cpus := c.cgroupSettings.CpusetCpus; len(cpus) > 0 {
+		cgroupArgs = append(cgroupArgs, fmt.Sprintf("cpuset.cpus=%s", cpuset.Format(cpus...)))
+	}
+
 	return &fcclient.JailerConfig{
 		JailerBinary:   c.executorConfig.JailerBinaryPath,
 		ChrootBaseDir:  c.jailerRoot,
@@ -1845,13 +1857,7 @@ func (c *FirecrackerContainer) getJailerConfig(ctx context.Context, kernelImageP
 		Stdout:         c.vmLogWriter(),
 		Stderr:         c.vmLogWriter(),
 		CgroupVersion:  cgroupVersion,
-		// We normally set cpuset.cpus in cgroup.Setup(), but the go
-		// SDK clobbers our setting when applying the NUMA node setting.
-		// Override this manually for now.
-		CgroupArgs: []string{
-			fmt.Sprintf("cpuset.cpus=%s", cpuset.Format(c.cgroupSettings.GetCpusetCpus()...)),
-			fmt.Sprintf("cpuset.mems=%d", numaNode),
-		},
+		CgroupArgs:     cgroupArgs,
 		// The jailer computes the full cgroup path by appending three path
 		// components:
 		// 1. The cgroup FS root: "/sys/fs/cgroup"
@@ -3386,16 +3392,17 @@ func (c *FirecrackerContainer) cleanupOldSnapshots(ctx context.Context, snapshot
 }
 
 func (c *FirecrackerContainer) setupCgroup(ctx context.Context) error {
-	// Lease CPUs for task execution, and set cleanup function.
-	leaseID := uuid.New()
-	numaNode, leasedCPUs, cleanupFunc := c.env.GetCPULeaser().Acquire(c.vmConfig.NumCpus*1000, leaseID, cpuset.WithNoOverhead())
-	log.CtxInfof(ctx, "Lease %s granted %+v cpus on numa node: %d", leaseID, leasedCPUs, numaNode)
-	c.releaseCPUs = cleanupFunc
-	c.cgroupSettings.CpusetCpus = toInt32s(leasedCPUs)
-	c.cgroupSettings.NumaNode = pointer(int32(numaNode))
-
 	if *debugDisableCgroup {
 		return nil
+	}
+	if c.env.GetCPULeaser() != nil {
+		// Lease CPUs for task execution, and set cleanup function.
+		leaseID := uuid.New()
+		numaNode, leasedCPUs, cleanupFunc := c.env.GetCPULeaser().Acquire(c.vmConfig.NumCpus*1000, leaseID, cpuset.WithNoOverhead())
+		log.CtxInfof(ctx, "Lease %s granted %+v cpus on numa node: %d", leaseID, leasedCPUs, numaNode)
+		c.releaseCPUs = cleanupFunc
+		c.cgroupSettings.CpusetCpus = toInt32s(leasedCPUs)
+		c.cgroupSettings.NumaNode = pointer(int32(numaNode))
 	}
 	if err := os.MkdirAll(c.cgroupPath(), 0755); err != nil {
 		return status.UnavailableErrorf("create cgroup: %s", err)

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -1051,13 +1051,15 @@ func (c *ociContainer) checkPIDLimitExceeded(ctx context.Context, res *interface
 }
 
 func (c *ociContainer) setupCgroup(ctx context.Context) error {
-	// Lease CPUs for task execution, and set cleanup function.
-	leaseID := uuid.New()
-	numaNode, leasedCPUs, cleanupFunc := c.env.GetCPULeaser().Acquire(c.milliCPU, leaseID)
-	log.CtxInfof(ctx, "Lease %s granted %+v cpus on node %d", leaseID, leasedCPUs, numaNode)
-	c.releaseCPUs = cleanupFunc
-	c.cgroupSettings.CpusetCpus = toInt32s(leasedCPUs)
-	c.cgroupSettings.NumaNode = proto.Int32(int32(numaNode))
+	if c.env.GetCPULeaser() != nil {
+		// Lease CPUs for task execution, and set cleanup function.
+		leaseID := uuid.New()
+		numaNode, leasedCPUs, cleanupFunc := c.env.GetCPULeaser().Acquire(c.milliCPU, leaseID)
+		log.CtxInfof(ctx, "Lease %s granted %+v cpus on node %d", leaseID, leasedCPUs, numaNode)
+		c.releaseCPUs = cleanupFunc
+		c.cgroupSettings.CpusetCpus = toInt32s(leasedCPUs)
+		c.cgroupSettings.NumaNode = proto.Int32(int32(numaNode))
+	}
 	if *enableCgroupMemoryLimit && c.memoryBytes > 0 {
 		c.cgroupSettings.MemoryLimitBytes = proto.Int64(c.memoryBytes + int64(float64(c.memoryBytes)*(*cgroupMemoryCushion)))
 	}

--- a/enterprise/server/util/cpuset/BUILD
+++ b/enterprise/server/util/cpuset/BUILD
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/interfaces",
+        "//server/real_environment",
         "//server/util/alert",
         "//server/util/flag",
         "//server/util/log",

--- a/enterprise/server/util/cpuset/cpuset.go
+++ b/enterprise/server/util/cpuset/cpuset.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -30,6 +31,18 @@ const (
 	// leasers forget to close their leases.
 	MaxNumLeases = 1000
 )
+
+func Register(env *real_environment.RealEnv) error {
+	if !*cpuLeaserEnable {
+		return nil
+	}
+	leaser, err := NewLeaser(LeaserOpts{})
+	if err != nil {
+		return err
+	}
+	env.SetCPULeaser(leaser)
+	return nil
+}
 
 // Compile-time check that cpuLeaser implements the interface.
 var _ interfaces.CPULeaser = (*CPULeaser)(nil)
@@ -232,10 +245,6 @@ func (l *CPULeaser) Acquire(milliCPU int64, taskID string, opts ...any) (int, []
 	}
 
 	numCPUs := computeNumCPUs(milliCPU, !options.disableOverhead)
-	// If the CPU leaser is disabled; return all CPUs.
-	if !*cpuLeaserEnable {
-		numCPUs = len(l.cpus)
-	}
 
 	// Put all CPUs in a priority queue.
 	pq := priority_queue.New[CPUInfo]()
@@ -280,31 +289,28 @@ func (l *CPULeaser) Acquire(milliCPU int64, taskID string, opts ...any) (int, []
 		}
 	}
 
-	// If the CPULeaser is enabled, actually track the lease.
-	if *cpuLeaserEnable {
-		if len(l.leases) >= MaxNumLeases {
-			droppedLease := l.leases[0]
-			l.leases = l.leases[1:]
-			for _, processor := range droppedLease.cpus {
-				l.load[processor] -= 1
-			}
-			if *warnAboutLeaks {
-				alert.UnexpectedEvent("cpu_leaser_leak", "Acquire() handle leak at %s!", droppedLease.location)
-			}
-		}
-
-		lease := lease{
-			taskID: taskID,
-			cpus:   leaseSet,
+	if len(l.leases) >= MaxNumLeases {
+		droppedLease := l.leases[0]
+		l.leases = l.leases[1:]
+		for _, processor := range droppedLease.cpus {
+			l.load[processor] -= 1
 		}
 		if *warnAboutLeaks {
-			if _, file, no, ok := runtime.Caller(1); ok {
-				lease.location = fmt.Sprintf("%s:%d", file, no)
-			}
+			alert.UnexpectedEvent("cpu_leaser_leak", "Acquire() handle leak at %s!", droppedLease.location)
 		}
-
-		l.leases = append(l.leases, lease)
 	}
+
+	lease := lease{
+		taskID: taskID,
+		cpus:   leaseSet,
+	}
+	if *warnAboutLeaks {
+		if _, file, no, ok := runtime.Caller(1); ok {
+			lease.location = fmt.Sprintf("%s:%d", file, no)
+		}
+	}
+
+	l.leases = append(l.leases, lease)
 
 	log.Debugf("Leased %s to task: %q (%d milliCPU)", Format(leaseSet...), taskID, milliCPU)
 	return selectedNode, leaseSet, func() {

--- a/enterprise/server/util/cpuset/cpuset_test.go
+++ b/enterprise/server/util/cpuset/cpuset_test.go
@@ -187,53 +187,6 @@ func TestCPUSetOverhead(t *testing.T) {
 	require.Equal(t, 3, len(cpus4))
 }
 
-func TestCPUSetDisabled(t *testing.T) {
-	flags.Set(t, "executor.cpu_leaser.enable", false)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-47")
-
-	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
-	require.NoError(t, err)
-	task1 := uuid.New()
-	numa1, cpus1, cancel1 := cs.Acquire(1100, task1)
-	defer cancel1()
-
-	assert.Equal(t, 0, numa1)
-	assert.Equal(t, 48, len(cpus1))
-}
-
-func TestCPUSetDisabledNumaBalancing(t *testing.T) {
-	flags.Set(t, "executor.cpu_leaser.enable", false)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-3,1:130-133")
-
-	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
-	require.NoError(t, err)
-	nodeFrequency := make(map[int]int, 0)
-	for i := 0; i < 1000; i++ {
-		task := uuid.New()
-		numa, _, cancel := cs.Acquire(1100, task)
-		nodeFrequency[numa]++
-		cancel()
-	}
-	assert.Equal(t, 2, len(nodeFrequency))
-	// TODO: figure out why the node frequencies are sometimes slightly
-	// different, e.g. 498/502 instead of an even 500/500 split.
-	assert.InDelta(t, nodeFrequency[0], nodeFrequency[1], 4)
-}
-
-func TestCPUSetDisabledManualCPUSet(t *testing.T) {
-	flags.Set(t, "executor.cpu_leaser.enable", false)
-	flags.Set(t, "executor.cpu_leaser.cpuset", "0:0-1,3")
-
-	cs, err := cpuset.NewLeaser(cpuset.LeaserOpts{SystemCPUs: getTestCPUs()})
-	require.NoError(t, err)
-	task1 := uuid.New()
-	numa1, cpus1, cancel1 := cs.Acquire(1100, task1)
-	defer cancel1()
-	assert.Equal(t, 0, numa1)
-	// Should return all configured CPUs.
-	assert.Equal(t, []int{0, 1, 3}, cpus1)
-}
-
 func TestNumaNodeFairness(t *testing.T) {
 	flags.Set(t, "executor.cpu_leaser.enable", true)
 	flags.Set(t, "executor.cpu_leaser.overhead", 0)


### PR DESCRIPTION
Instead of setting a "NOP" CPU leaser in env when cpuset is disabled, don't set one in the env at all.

The current code had a few issues:
- (Bug / surprising behavior) The "NOP" CPU leaser would still filter down the granted CPUs to a single NUMA node, which seems like surprising behavior. If we do want NUMA-only task pinning, we probably should add that as an explicit flag option, rather than making it always enabled even if cpuset is explicitly disabled. I'm not aware of anyone relying on this default numa-pinning behavior today (seems very unlikely).
- (Log noise) We would log `Lease granted [0 .. N] cpus` for every task, which adds a lot of log noise during local development / tests (my machine has 32 cores so this list is pretty huge)
- (Portability issue) We would always try to configure the `cpuset` cgroup controller even if the CPU leaser was disabled. Not a big deal, but it means that we have an unnecessary dependency on the `cpuset` controller being enabled, and cgroup controllers can be disabled or unavailable in certain environments (this has come up before in support threads)