### PR TITLE
Add support for sharding pebble blob writes into multiple buckets.

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["pebble_cache.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache",
     deps = [
+        "//enterprise/server/experiments",
         "//enterprise/server/filestore",
         "//enterprise/server/raft/keys",
         "//enterprise/server/util/gcsutil",

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/experiments"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/filestore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/gcsutil"
@@ -106,7 +107,14 @@ var (
 	gcsProjectID            = flag.String("cache.pebble.gcs.project_id", "", "The Google Cloud project ID of the project owning the above credentials and GCS bucket.")
 	gcsAppName              = flag.String("cache.pebble.gcs.app_name", "", "The app name, under which blobstore data will be stored.")
 	gcsAtimeUpdateThreshold = flag.Duration("cache.pebble.gcs.atime_update_threshold", 0, "Don't update a GCS object's custom time (its atime) if it was updated more recently than this (0 updates on every atime update).")
+	shardedGCSBuckets       = flag.Slice("cache.pebble.gcs.sharded_buckets", []string{}, "An optional list of additional GCS buckets to shard writes across (by digest hash). Sharding is gated by the sharded_buckets_enabled experiment; empty disables it.", flag.Internal)
 )
+
+// shardedBucketsExperimentName gates whether a pebble GCS write is sharded
+// across cache.pebble.gcs.sharded_buckets instead of going to the default
+// bucket. The rollout percentage is controlled in flagd, keyed on the digest
+// hash, so it can be ramped up gradually (0 -> 1% -> 10% -> ...).
+const shardedBucketsExperimentName = "cache.pebble.gcs.sharded_buckets_enabled"
 
 var (
 	// Default values for Options
@@ -208,6 +216,10 @@ type Options struct {
 	GCSAppName          string
 	GCSTTLDays          *int64
 	MinGCSFileSizeBytes *int64
+	// GCSShardedBuckets is an optional list of additional GCS buckets that
+	// writes may be sharded across (by digest hash), gated by the
+	// sharded_buckets_enabled experiment. Empty disables sharding.
+	GCSShardedBuckets []string
 	// GCSAtimeUpdateThreshold suppresses a GCS object's custom time (atime)
 	// refresh if it was updated more recently than this. 0 updates on every
 	// atime update.
@@ -382,6 +394,7 @@ func Register(env *real_environment.RealEnv) error {
 		GCSAppName:                  *gcsAppName,
 		GCSTTLDays:                  gcsTTLDays,
 		MinGCSFileSizeBytes:         minGCSFileSizeBytesFlag,
+		GCSShardedBuckets:           *shardedGCSBuckets,
 		GCSAtimeUpdateThreshold:     gcsAtimeUpdateThreshold,
 		EnableAutoRatchet:           *enableAutoRatchet,
 	}
@@ -581,6 +594,20 @@ func defaultPebbleOptions(mc *pebble.MetricsCollector, pcOpts *Options) *pebble.
 }
 
 // NewPebbleCache creates a new cache from the provided env and opts.
+// gcsShardDecider returns a filestore.ShardDeciderFunc backed by the given
+// experiment flag provider. A write is opted into the sharded GCS buckets based
+// on the sharded_buckets_enabled experiment, keyed on the digest hash so the
+// rollout is deterministic per digest. Returns nil (sharding disabled) when no
+// experiment provider is configured.
+func gcsShardDecider(efp interfaces.ExperimentFlagProvider) filestore.ShardDeciderFunc {
+	if efp == nil {
+		return nil
+	}
+	return func(ctx context.Context, digestHash string) bool {
+		return efp.Boolean(ctx, shardedBucketsExperimentName, false, experiments.WithContext("digest_hash", digestHash))
+	}
+}
+
 func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 	SetOptionDefaults(opts)
 	if err := validateOpts(opts); err != nil {
@@ -645,6 +672,27 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 			filestoreOpts = append(filestoreOpts, filestore.WithGCSBlobstore(gcsBlobstore, opts.GCSAppName))
 			log.Infof("Pebble Cache: storing files larger than %d bytes in GCS (bucket: %q)", *opts.MinGCSFileSizeBytes, opts.GCSBucket)
 			log.Infof("Pebble Cache: GCS TTL is set to %d days", *opts.GCSTTLDays)
+
+			// Optionally, shard writes across additional buckets. This is gated
+			// per-digest by the sharded_buckets_enabled experiment so it can be
+			// ramped up gradually. Each object records which bucket it landed
+			// in (see filestore), so reads stay correct at any rollout %.
+			if len(opts.GCSShardedBuckets) > 0 {
+				shardedBlobstores := make([]filestore.PebbleGCSStorage, 0, len(opts.GCSShardedBuckets))
+				for _, bucket := range opts.GCSShardedBuckets {
+					shardedBlobstore, err := gcs.NewGCSBlobStore(ctx, bucket, "", opts.GCSCredentials, opts.GCSProjectID, false /*=enableCompression*/)
+					if err != nil {
+						return nil, err
+					}
+					if err := shardedBlobstore.SetBucketCustomTimeTTL(ctx, *opts.GCSTTLDays); err != nil {
+						return nil, err
+					}
+					shardedBlobstores = append(shardedBlobstores, shardedBlobstore)
+				}
+				shardDecider := gcsShardDecider(env.GetExperimentFlagProvider())
+				filestoreOpts = append(filestoreOpts, filestore.WithShardedGCSBlobstores(shardedBlobstores, shardDecider))
+				log.Infof("Pebble Cache: sharding GCS writes across buckets: %v", opts.GCSShardedBuckets)
+			}
 		}
 
 		// For temporary files stored on disk, write them to a dedicated

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2858,6 +2858,87 @@ func TestGCSAtimeUpdateThreshold(t *testing.T) {
 	require.Equal(t, 1, mockGCS.UpdateCustomTimeCallCount())
 }
 
+func TestGCSBlobStorageSharding(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(t, emptyUserMap))
+	clock := clockwork.NewFakeClock()
+	ctx := getAnonContext(t, te)
+
+	var minGCSFileSize int64 = 1
+	var gcsTTLDays int64 = 1
+
+	// A default bucket plus two sharded buckets.
+	defaultGCS := mockgcs.NewWithBucket(clock, "default-bucket")
+	shard0 := mockgcs.NewWithBucket(clock, "shard-0")
+	shard1 := mockgcs.NewWithBucket(clock, "shard-1")
+	shardedStores := []filestore.PebbleGCSStorage{shard0, shard1}
+	for _, s := range shardedStores {
+		require.NoError(t, s.SetBucketCustomTimeTTL(ctx, gcsTTLDays))
+	}
+	require.NoError(t, defaultGCS.SetBucketCustomTimeTTL(ctx, gcsTTLDays))
+
+	// Shard roughly half of the writes (by digest hash parity), leaving the
+	// rest in the default bucket. This mirrors a partial rollout: reads must
+	// resolve correctly whether an object landed in the default or a shard.
+	shardDecider := func(ctx context.Context, digestHash string) bool {
+		return digestHash[len(digestHash)-1]%2 == 0
+	}
+
+	fileStorer := filestore.New(
+		filestore.WithGCSBlobstore(defaultGCS, "app-name"),
+		filestore.WithShardedGCSBlobstores(shardedStores, shardDecider),
+	)
+	options := &pebble_cache.Options{
+		RootDirectory:          testfs.MakeTempDir(t),
+		MaxSizeBytes:           int64(1_000_000), // 1MB
+		Clock:                  clock,
+		FileStorer:             fileStorer,
+		MaxInlineFileSizeBytes: 1,
+		MinGCSFileSizeBytes:    &minGCSFileSize,
+		GCSTTLDays:             &gcsTTLDays,
+	}
+	pc, err := pebble_cache.NewPebbleCache(te, options)
+	require.NoError(t, err)
+	require.NoError(t, pc.Start())
+	defer pc.Stop()
+
+	sampleData := make(map[*rspb.ResourceName][]byte)
+	for i := 0; i < 20; i++ {
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		sampleData[rn] = buf
+	}
+
+	var written []*rspb.ResourceName
+	for rn, buf := range sampleData {
+		require.NoError(t, pc.Set(ctx, rn, buf))
+		written = append(written, rn)
+	}
+
+	// Every object should be stored exactly once, split across the default and
+	// the sharded buckets. With 20 random digests both sides are populated.
+	total := defaultGCS.BlobCount() + shard0.BlobCount() + shard1.BlobCount()
+	require.Equal(t, len(sampleData), total)
+	require.NotZero(t, defaultGCS.BlobCount(), "expected some objects in the default bucket")
+	require.NotZero(t, shard0.BlobCount()+shard1.BlobCount(), "expected some objects in the sharded buckets")
+
+	// Reads must resolve to the recorded bucket regardless of where an object
+	// landed.
+	for rn, buf := range sampleData {
+		got, err := pc.Get(ctx, rn)
+		require.NoError(t, err, rn)
+		require.Equal(t, buf, got)
+	}
+
+	// The custom-time TTL applies to sharded buckets too: everything expires
+	// once the TTL passes.
+	clock.Advance(25 * time.Hour)
+	for _, rn := range written {
+		exists, err := pc.Contains(ctx, rn)
+		require.NoError(t, err)
+		assert.False(t, exists, rn)
+	}
+}
+
 func pointer[T any](value T) *T {
 	return &value
 }

--- a/enterprise/server/filestore/filestore.go
+++ b/enterprise/server/filestore/filestore.go
@@ -582,6 +582,8 @@ type Store interface {
 }
 
 type PebbleGCSStorage interface {
+	// Bucket returns the name of the GCS bucket this store writes to.
+	Bucket() string
 	SetBucketCustomTimeTTL(ctx context.Context, ageInDays int64) error
 	Reader(ctx context.Context, blobName string, offset, limit int64) (io.ReadCloser, error)
 	ConditionalWriter(ctx context.Context, blobName string, overwriteExisting bool, customTime time.Time, estimatedSize int64) (interfaces.CommittedWriteCloser, error)
@@ -589,11 +591,18 @@ type PebbleGCSStorage interface {
 	UpdateCustomTime(ctx context.Context, blobName string, t time.Time) error
 }
 
+// ShardDeciderFunc reports whether a blob with the given digest hash should be
+// written to the sharded GCS buckets instead of the default bucket. It is how
+// the caller plugs in an experiment-gated, gradually-ramped rollout.
+type ShardDeciderFunc func(ctx context.Context, digestHash string) bool
+
 type Options struct {
-	tmpDir  string
-	gcs     PebbleGCSStorage
-	appName string
-	clock   clockwork.Clock
+	tmpDir       string
+	gcs          PebbleGCSStorage
+	shardedGCS   []PebbleGCSStorage
+	shardDecider ShardDeciderFunc
+	appName      string
+	clock        clockwork.Clock
 }
 
 type Option func(*Options)
@@ -602,6 +611,18 @@ func WithGCSBlobstore(gcs PebbleGCSStorage, appName string) Option {
 	return func(o *Options) {
 		o.gcs = gcs
 		o.appName = appName
+	}
+}
+
+// WithShardedGCSBlobstores configures a set of sharded GCS buckets that writes
+// may be distributed across (in addition to the default bucket configured via
+// WithGCSBlobstore). A write is sharded when shardDecider returns true for its
+// digest; the chosen shard is picked by hashing the digest, and the shard's
+// bucket name is recorded in the blob metadata so reads target it directly.
+func WithShardedGCSBlobstores(sharded []PebbleGCSStorage, shardDecider ShardDeciderFunc) Option {
+	return func(o *Options) {
+		o.shardedGCS = sharded
+		o.shardDecider = shardDecider
 	}
 }
 
@@ -618,10 +639,18 @@ func WithTmpDir(tmpDir string) Option {
 }
 
 type fileStorer struct {
-	tmpDir  string
-	gcs     PebbleGCSStorage
-	appName string
-	clock   clockwork.Clock
+	tmpDir string
+	gcs    PebbleGCSStorage
+	// shardedGCS holds the sharded buckets that writes may be distributed
+	// across; it is empty when sharding is not configured.
+	shardedGCS []PebbleGCSStorage
+	// gcsByBucket maps a (non-empty) bucket name to the store that owns it, so
+	// reads/deletes/atime updates can be routed to the bucket recorded in the
+	// blob metadata.
+	gcsByBucket  map[string]PebbleGCSStorage
+	shardDecider ShardDeciderFunc
+	appName      string
+	clock        clockwork.Clock
 }
 
 // New creates a new filestorer interface.
@@ -633,12 +662,50 @@ func New(opts ...Option) Store {
 	if options.clock == nil {
 		options.clock = clockwork.NewRealClock()
 	}
-	return &fileStorer{
-		tmpDir:  options.tmpDir,
-		gcs:     options.gcs,
-		appName: options.appName,
-		clock:   options.clock,
+	gcsByBucket := make(map[string]PebbleGCSStorage, len(options.shardedGCS))
+	for _, s := range options.shardedGCS {
+		gcsByBucket[s.Bucket()] = s
 	}
+	return &fileStorer{
+		tmpDir:       options.tmpDir,
+		gcs:          options.gcs,
+		shardedGCS:   options.shardedGCS,
+		gcsByBucket:  gcsByBucket,
+		shardDecider: options.shardDecider,
+		appName:      options.appName,
+		clock:        options.clock,
+	}
+}
+
+// gcsForBucket returns the GCS store that holds objects recorded with the given
+// bucket name. An empty bucket name (legacy objects and non-sharded writes)
+// maps to the default store.
+func (fs *fileStorer) gcsForBucket(bucket string) (PebbleGCSStorage, error) {
+	if bucket == "" {
+		return fs.gcs, nil
+	}
+	store, ok := fs.gcsByBucket[bucket]
+	if !ok {
+		return nil, status.NotFoundErrorf("no GCS blobstore configured for bucket %q", bucket)
+	}
+	return store, nil
+}
+
+// gcsWriteStore selects the GCS store a new blob should be written to. When
+// sharded buckets are configured and the shard decider opts this digest in, the
+// blob is sharded (by digest hash) across the sharded buckets; otherwise it goes
+// to the default bucket. The returned bucket name is recorded in the blob
+// metadata (empty for the default bucket).
+func (fs *fileStorer) gcsWriteStore(ctx context.Context, d *repb.Digest) (PebbleGCSStorage, string) {
+	if len(fs.shardedGCS) == 0 || fs.shardDecider == nil {
+		return fs.gcs, ""
+	}
+	if !fs.shardDecider(ctx, d.GetHash()) {
+		return fs.gcs, ""
+	}
+	shard := int(crc32.ChecksumIEEE([]byte(d.GetHash())) % uint32(len(fs.shardedGCS)))
+	store := fs.shardedGCS[shard]
+	return store, store.Bucket()
 }
 
 func (fs *fileStorer) FilePath(fileDir string, f *sgpb.StorageMetadata_FileMetadata) string {
@@ -813,13 +880,18 @@ func (fs *fileStorer) BlobReader(ctx context.Context, b *sgpb.StorageMetadata_GC
 	if fs.gcs == nil || fs.appName == "" {
 		return nil, status.FailedPreconditionError("gcs blobstore or appName not configured")
 	}
-	return fs.gcs.Reader(ctx, b.GetBlobName(), offset, limit)
+	store, err := fs.gcsForBucket(b.GetBucket())
+	if err != nil {
+		return nil, err
+	}
+	return store.Reader(ctx, b.GetBlobName(), offset, limit)
 }
 
 type gcsMetadataWriter struct {
 	interfaces.CommittedWriteCloser
 	ctx        context.Context
 	blobName   string
+	bucket     string
 	customTime time.Time
 	digest     *repb.Digest
 }
@@ -851,6 +923,7 @@ func (g *gcsMetadataWriter) Metadata() *sgpb.StorageMetadata {
 	return &sgpb.StorageMetadata{
 		GcsMetadata: &sgpb.StorageMetadata_GCSMetadata{
 			BlobName:           g.blobName,
+			Bucket:             g.bucket,
 			LastCustomTimeUsec: g.customTime.UnixMicro(),
 		},
 	}
@@ -879,8 +952,9 @@ func (fs *fileStorer) BlobWriter(ctx context.Context, fileRecord *sgpb.FileRecor
 		// underestimate.
 		estimatedSize /= 5
 	}
+	store, bucket := fs.gcsWriteStore(ctx, fileRecord.GetDigest())
 	customTime := fs.clock.Now()
-	wc, err := fs.gcs.ConditionalWriter(ctx, blobName, true /*=overwriteExisting*/, customTime, estimatedSize)
+	wc, err := store.ConditionalWriter(ctx, blobName, true /*=overwriteExisting*/, customTime, estimatedSize)
 	if err != nil {
 		return nil, err
 	}
@@ -888,6 +962,7 @@ func (fs *fileStorer) BlobWriter(ctx context.Context, fileRecord *sgpb.FileRecor
 		ctx:                  ctx,
 		CommittedWriteCloser: wc,
 		blobName:             string(blobName),
+		bucket:               bucket,
 		customTime:           customTime,
 		digest:               fileRecord.GetDigest(),
 	}, nil
@@ -897,7 +972,11 @@ func (fs *fileStorer) DeleteStoredBlob(ctx context.Context, b *sgpb.StorageMetad
 	if fs.gcs == nil || fs.appName == "" {
 		return status.FailedPreconditionError("gcs blobstore or appName not configured")
 	}
-	err := fs.gcs.DeleteBlob(ctx, b.GetBlobName())
+	store, err := fs.gcsForBucket(b.GetBucket())
+	if err != nil {
+		return err
+	}
+	err = store.DeleteBlob(ctx, b.GetBlobName())
 	log.Debugf("Deleted gcs blob: %q with err: %s", b.GetBlobName(), err)
 	return err
 }
@@ -906,7 +985,11 @@ func (fs *fileStorer) UpdateBlobAtime(ctx context.Context, b *sgpb.StorageMetada
 	if fs.gcs == nil || fs.appName == "" {
 		return status.FailedPreconditionError("gcs blobstore or appName not configured")
 	}
-	err := fs.gcs.UpdateCustomTime(ctx, b.GetBlobName(), t)
+	store, err := fs.gcsForBucket(b.GetBucket())
+	if err != nil {
+		return err
+	}
+	err = store.UpdateCustomTime(ctx, b.GetBlobName(), t)
 	log.Debugf("Updated gcs blob: %q atime to %d with err: %s", b.GetBlobName(), t.UnixMicro(), err)
 	return err
 }

--- a/proto/storage.proto
+++ b/proto/storage.proto
@@ -47,6 +47,13 @@ message StorageMetadata {
     // This is used in conjunction with a bucket LifecycleCondition that
     // deletes objects after DaysSinceCustomTime is exceeded.
     int64 last_custom_time_usec = 2;
+
+    // The GCS bucket the blob was written to. An empty value means the default
+    // bucket (cache.pebble.gcs.bucket); a non-empty value is one of the sharded
+    // buckets (cache.pebble.gcs.sharded_buckets). This is recorded at write
+    // time so that reads, deletes, and custom time updates target the right
+    // bucket regardless of the current sharding rollout percentage.
+    string bucket = 3;
   }
   GCSMetadata gcs_metadata = 5;
 

--- a/server/backends/blobstore/gcs/gcs.go
+++ b/server/backends/blobstore/gcs/gcs.go
@@ -42,9 +42,15 @@ var (
 type GCSBlobStore struct {
 	gcsClient    *storage.Client
 	bucketHandle *storage.BucketHandle
+	bucket       string
 	projectID    string
 	compress     bool
 	metricLabel  string
+}
+
+// Bucket returns the name of the GCS bucket this store writes to.
+func (g *GCSBlobStore) Bucket() string {
+	return g.bucket
 }
 
 func UseGCSBlobStore() bool {
@@ -88,6 +94,7 @@ func NewGCSBlobStore(ctx context.Context, bucket, credsFile, creds, projectID st
 	}
 	g := &GCSBlobStore{
 		gcsClient:   gcsClient,
+		bucket:      bucket,
 		projectID:   projectID,
 		compress:    enableCompression,
 		metricLabel: "gcs/" + bucket,

--- a/server/testutil/mockgcs/mockgcs.go
+++ b/server/testutil/mockgcs/mockgcs.go
@@ -19,8 +19,15 @@ type timestampedBlob struct {
 }
 
 func New(clock clockwork.Clock) *mockGCS {
+	return NewWithBucket(clock, "")
+}
+
+// NewWithBucket returns a mockGCS that reports the given bucket name from
+// Bucket(). Use this when testing bucket sharding across multiple stores.
+func NewWithBucket(clock clockwork.Clock, bucket string) *mockGCS {
 	return &mockGCS{
 		clock:     clock,
+		bucket:    bucket,
 		ageInDays: 0,
 		items:     make(map[string]*timestampedBlob),
 		mu:        sync.Mutex{},
@@ -31,10 +38,23 @@ func New(clock clockwork.Clock) *mockGCS {
 // to implement the pebble.PebbleGCSStorage interface.
 type mockGCS struct {
 	clock                     clockwork.Clock
+	bucket                    string
 	ageInDays                 int64
 	items                     map[string]*timestampedBlob
 	mu                        sync.Mutex
 	updateCustomTimeCallCount int
+}
+
+// Bucket returns the name of the bucket this mock represents.
+func (m *mockGCS) Bucket() string {
+	return m.bucket
+}
+
+// BlobCount returns the number of blobs currently stored. Intended for tests.
+func (m *mockGCS) BlobCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.items)
 }
 
 // UpdateCustomTimeCallCount returns the number of times UpdateCustomTime has


### PR DESCRIPTION
The use of the sharded buckets is gated behind an experiment so that we can ramp up the writes per the GCS recommendations.