### PR TITLE
Add a customer-deployment scope to CMEK key derivation

### DIFF
--- a/enterprise/server/crypter/crypter.go
+++ b/enterprise/server/crypter/crypter.go
@@ -21,8 +21,21 @@ import (
 
 const (
 	// This must be exposed because it is used as an input to the
-	// key-derivation function in crypter_service.
+	// key-derivation function in crypter_service. This must NEVER be 0xFF,
+	// which is reserved for CustomerDeploymentKeyInfoPrefix below (enforced
+	// by a compile-time guard following this const block).
 	EncryptedDataHeaderVersion = 1
+
+	// CustomerDeploymentKeyInfoPrefix domain-separates derived keys scoped to
+	// customer-managed deployments (e.g. cache proxies) from cloud-scoped ones
+	// in the key-derivation function in crypter_service. The cloud HKDF info is
+	// [EncryptedDataHeaderVersion] + groupID; the customer-deployment info is
+	// [CustomerDeploymentKeyInfoPrefix, EncryptedDataHeaderVersion] + groupID.
+	// Since every cloud info begins with the header version byte, which is
+	// never 0xFF, the two derivations can never collide, so keys served to
+	// customer-managed deployments cannot decrypt content stored in the cloud
+	// cache.
+	CustomerDeploymentKeyInfoPrefix = 0xFF
 
 	// The chunk size to use for encrypting plain text data. Encryption is done
 	// in pieces, with data written in chunks up to this size and then flushed
@@ -35,6 +48,13 @@ const (
 	nonceSize                    = chacha20poly1305.NonceSizeX
 	encryptedChunkOverhead       = nonceSize + chacha20poly1305.Overhead
 )
+
+// Compile-time guard that EncryptedDataHeaderVersion never takes the value
+// reserved for CustomerDeploymentKeyInfoPrefix, which would break the domain
+// separation between cloud-scoped and customer-deployment-scoped derived
+// keys. If the two are ever equal, this expression divides by zero and fails
+// to compile.
+const _ = 1 / (CustomerDeploymentKeyInfoPrefix - EncryptedDataHeaderVersion)
 
 // Buffer pool for all the buffers in this package.
 var bufPool = bytebufferpool.VariableSize(PlainTextChunkSize + encryptedChunkOverhead)

--- a/enterprise/server/crypter_key_cache/crypter_key_cache.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache.go
@@ -33,20 +33,36 @@ const (
 	defaultKeyErrCacheTime  = 10 * time.Second
 )
 
+// KeyScope identifies which derivation of a group's encryption key a cache
+// entry holds. Cloud-scoped keys encrypt content stored in the cloud cache;
+// customer-deployment-scoped keys are independently derived and are safe to
+// serve to customer-managed deployments (e.g. cache proxies, and potentially
+// executors in the future).
+type KeyScope int32
+
+const (
+	KeyScopeCloud              KeyScope = 0
+	KeyScopeCustomerDeployment KeyScope = 1
+)
+
 // Note: there are two types of keys in the cache, one with only groupID set
 // (encryption) and one with all values set (decryption).
 type CacheKey struct {
 	GroupID string
 	KeyID   string
 	Version int64
+	Scope   KeyScope
 }
 
 func (ck CacheKey) String() string {
-	if ck.KeyID == "" {
-		return ck.GroupID
-	} else {
-		return fmt.Sprintf("%s/%s/%d", ck.GroupID, ck.KeyID, ck.Version)
+	s := ck.GroupID
+	if ck.KeyID != "" {
+		s = fmt.Sprintf("%s/%s/%d", ck.GroupID, ck.KeyID, ck.Version)
 	}
+	if ck.Scope == KeyScopeCustomerDeployment {
+		s += "/customer-deployment"
+	}
+	return s
 }
 
 type cacheEntry struct {
@@ -217,7 +233,7 @@ func (c *KeyCache) refreshKeyWithRetries(ctx context.Context, ck CacheKey, cache
 	key, err := retry.Do(ctx, opts, func(ctx context.Context) (*crypter.DerivedKey, error) {
 		keyBytes, md, err := c.refreshFn(ctx, ck)
 		// TODO(vadim): figure out if there are other KMS errors we can treat as immediate failures
-		if status.IsNotFoundError(err) {
+		if status.IsNotFoundError(err) || status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err) {
 			return nil, retry.NonRetryableError(err)
 		} else if err != nil {
 			return nil, err
@@ -245,12 +261,14 @@ func (c *KeyCache) refreshKeyWithRetries(ctx context.Context, ck CacheKey, cache
 			expiresAfter: c.clock.Now().Add(c.errCacheTime),
 		})
 	}
-	if status.IsNotFoundError(err) {
+	if status.IsNotFoundError(err) || status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err) {
 		// Preserve the NotFound status so that callers can tell "key does
 		// not exist" apart from transient refresh failures. In particular,
 		// the app returns this error over the GetEncryptionKey RPC, and the
 		// proxy's KeyCache uses the NotFound status to decide that the
-		// refresh should not be retried (see the check above).
+		// refresh should not be retried (see the check above). The same
+		// applies to PermissionDenied/Unauthenticated, which a misconfigured
+		// customer-run proxy can receive from the app.
 		return nil, err
 	}
 	return nil, status.UnavailableErrorf("exhausted attempts to refresh key, last error: %s", err)
@@ -285,7 +303,14 @@ func (c *KeyCache) loadKey(ctx context.Context, em *sgpb.EncryptionMetadata) (*c
 	} else {
 		ck = CacheKey{GroupID: u.GetGroupID()}
 	}
+	return c.LoadKey(ctx, ck)
+}
 
+// LoadKey returns the derived key for the given CacheKey, from the cache if
+// present or via the refresh function otherwise. Unlike EncryptionKey and
+// DecryptionKey, the caller is responsible for constructing (and authorizing)
+// the CacheKey.
+func (c *KeyCache) LoadKey(ctx context.Context, ck CacheKey) (*crypter.DerivedKey, error) {
 	e, ok := c.cacheGet(ck)
 	if ok {
 		e.mu.Lock()

--- a/enterprise/server/crypter_key_cache/crypter_key_cache.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache.go
@@ -59,10 +59,18 @@ func (ck CacheKey) String() string {
 	if ck.KeyID != "" {
 		s = fmt.Sprintf("%s/%s/%d", ck.GroupID, ck.KeyID, ck.Version)
 	}
-	if ck.Scope == KeyScopeCustomerDeployment {
-		s += "/customer-deployment"
+	// This must map every scope to a distinct string: String() keys both the
+	// cache map and the singleflight group, so two scopes rendering
+	// identically could hand one scope's derived key to a caller expecting
+	// the other, defeating the domain separation.
+	switch ck.Scope {
+	case KeyScopeCloud:
+		return s
+	case KeyScopeCustomerDeployment:
+		return s + "/customer-deployment"
+	default:
+		return fmt.Sprintf("%s/scope-%d", s, ck.Scope)
 	}
-	return s
 }
 
 type cacheEntry struct {
@@ -226,6 +234,22 @@ func (c *KeyCache) cacheGet(ck CacheKey) (*cacheEntry, bool) {
 	return e, true
 }
 
+// isNonRetryable returns true for errors that a refresh retry cannot fix:
+// the key doesn't exist, the caller isn't allowed to fetch it, or the request
+// itself is malformed. Auth-class errors are treated as durable (matching
+// standard gRPC retry policies); for CMEK this is also the desired behavior,
+// since a PermissionDenied from the customer's KMS means they revoked our
+// access and we should stop deriving keys promptly rather than retry.
+// Refreshes are singleflighted, so retrying a durable failure would also
+// block all concurrent key loads for the same group while the retry loop
+// runs down the caller's deadline.
+func isNonRetryable(err error) bool {
+	return status.IsNotFoundError(err) ||
+		status.IsPermissionDeniedError(err) ||
+		status.IsUnauthenticatedError(err) ||
+		status.IsInvalidArgumentError(err)
+}
+
 func (c *KeyCache) refreshKeyWithRetries(ctx context.Context, ck CacheKey, cacheError bool) (*crypter.DerivedKey, error) {
 	opts := retry.DefaultOptions()
 	opts.Clock = c.clock
@@ -233,7 +257,7 @@ func (c *KeyCache) refreshKeyWithRetries(ctx context.Context, ck CacheKey, cache
 	key, err := retry.Do(ctx, opts, func(ctx context.Context) (*crypter.DerivedKey, error) {
 		keyBytes, md, err := c.refreshFn(ctx, ck)
 		// TODO(vadim): figure out if there are other KMS errors we can treat as immediate failures
-		if status.IsNotFoundError(err) || status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err) {
+		if isNonRetryable(err) {
 			return nil, retry.NonRetryableError(err)
 		} else if err != nil {
 			return nil, err
@@ -261,14 +285,12 @@ func (c *KeyCache) refreshKeyWithRetries(ctx context.Context, ck CacheKey, cache
 			expiresAfter: c.clock.Now().Add(c.errCacheTime),
 		})
 	}
-	if status.IsNotFoundError(err) || status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err) {
-		// Preserve the NotFound status so that callers can tell "key does
-		// not exist" apart from transient refresh failures. In particular,
-		// the app returns this error over the GetEncryptionKey RPC, and the
-		// proxy's KeyCache uses the NotFound status to decide that the
-		// refresh should not be retried (see the check above). The same
-		// applies to PermissionDenied/Unauthenticated, which a misconfigured
-		// customer-run proxy can receive from the app.
+	if isNonRetryable(err) {
+		// Preserve the status of non-retryable errors so that callers can
+		// tell them apart from transient refresh failures. In particular,
+		// the app returns these errors over the GetEncryptionKey RPC, and
+		// the proxy's KeyCache uses the status to decide that the refresh
+		// should not be retried (see isNonRetryable above).
 		return nil, err
 	}
 	return nil, status.UnavailableErrorf("exhausted attempts to refresh key, last error: %s", err)

--- a/enterprise/server/crypter_key_cache/crypter_key_cache.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache.go
@@ -54,23 +54,16 @@ type CacheKey struct {
 	Scope   KeyScope
 }
 
+// String must map every scope to a distinct string: it keys both the cache
+// map and the singleflight group, so two scopes rendering identically could
+// hand one scope's derived key to a caller expecting the other, defeating
+// the domain separation. The scope is included unconditionally so this holds
+// for any scope value without needing per-scope cases.
 func (ck CacheKey) String() string {
-	s := ck.GroupID
-	if ck.KeyID != "" {
-		s = fmt.Sprintf("%s/%s/%d", ck.GroupID, ck.KeyID, ck.Version)
+	if ck.KeyID == "" {
+		return fmt.Sprintf("%s/scope-%d", ck.GroupID, ck.Scope)
 	}
-	// This must map every scope to a distinct string: String() keys both the
-	// cache map and the singleflight group, so two scopes rendering
-	// identically could hand one scope's derived key to a caller expecting
-	// the other, defeating the domain separation.
-	switch ck.Scope {
-	case KeyScopeCloud:
-		return s
-	case KeyScopeCustomerDeployment:
-		return s + "/customer-deployment"
-	default:
-		return fmt.Sprintf("%s/scope-%d", s, ck.Scope)
-	}
+	return fmt.Sprintf("%s/%s/%d/scope-%d", ck.GroupID, ck.KeyID, ck.Version, ck.Scope)
 }
 
 type cacheEntry struct {

--- a/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
@@ -204,6 +204,108 @@ func TestNotFound(t *testing.T) {
 	require.Equal(t, int32(2), refreshCount.Load())
 }
 
+func TestKeyScopeDistinctness(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	env := testenv.GetTestEnv(t)
+	ctx := setupAuth(t, env)
+
+	backendCK := crypter_key_cache.CacheKey{GroupID: "group1"}
+	customerCK := crypter_key_cache.CacheKey{GroupID: "group1", Scope: crypter_key_cache.KeyScopeCustomerDeployment}
+	versionedBackendCK := crypter_key_cache.CacheKey{GroupID: "group1", KeyID: "key1", Version: 1}
+	versionedCustomerCK := crypter_key_cache.CacheKey{GroupID: "group1", KeyID: "key1", Version: 1, Scope: crypter_key_cache.KeyScopeCustomerDeployment}
+
+	// Keys differing only in scope must never collide in the cache or the
+	// singleflight group, which are both keyed on String().
+	require.NotEqual(t, backendCK.String(), customerCK.String())
+	require.NotEqual(t, versionedBackendCK.String(), versionedCustomerCK.String())
+
+	backendKey := []byte("backend-key")
+	customerKey := []byte("customer-deployment-key")
+	md := &sgpb.EncryptionMetadata{EncryptionKeyId: "key1", Version: 1}
+
+	refreshCount := 0
+	refreshFn := func(ctx context.Context, ck crypter_key_cache.CacheKey) ([]byte, *sgpb.EncryptionMetadata, error) {
+		refreshCount++
+		if ck.Scope == crypter_key_cache.KeyScopeCustomerDeployment {
+			return customerKey, md, nil
+		}
+		return backendKey, md, nil
+	}
+
+	cache := crypter_key_cache.New(env, refreshFn, clock)
+
+	// Loading the same group's key under each scope should trigger separate
+	// refreshes and return separate keys.
+	key, err := cache.LoadKey(ctx, backendCK)
+	require.NoError(t, err)
+	require.Equal(t, backendKey, key.Key)
+	require.Equal(t, 1, refreshCount)
+
+	key, err = cache.LoadKey(ctx, customerCK)
+	require.NoError(t, err)
+	require.Equal(t, customerKey, key.Key)
+	require.Equal(t, 2, refreshCount)
+
+	// Subsequent loads should be served from the cache, each scope keeping
+	// its own entry.
+	key, err = cache.LoadKey(ctx, backendCK)
+	require.NoError(t, err)
+	require.Equal(t, backendKey, key.Key)
+	key, err = cache.LoadKey(ctx, customerCK)
+	require.NoError(t, err)
+	require.Equal(t, customerKey, key.Key)
+	require.Equal(t, 2, refreshCount)
+
+	// EncryptionKey uses the backend scope and should share the backend
+	// entry.
+	key, err = cache.EncryptionKey(ctx)
+	require.NoError(t, err)
+	require.Equal(t, backendKey, key.Key)
+	require.Equal(t, 2, refreshCount)
+}
+
+func TestPermissionDeniedNotRetried(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		err     error
+		checkFn func(error) bool
+	}{
+		{"PermissionDenied", status.PermissionDeniedError("no key for you"), status.IsPermissionDeniedError},
+		{"Unauthenticated", status.UnauthenticatedError("who are you"), status.IsUnauthenticatedError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := clockwork.NewFakeClock()
+			env := testenv.GetTestEnv(t)
+			ctx := setupAuth(t, env)
+
+			refreshCount := atomic.Int32{}
+			refreshFn := func(ctx context.Context, ck crypter_key_cache.CacheKey) ([]byte, *sgpb.EncryptionMetadata, error) {
+				refreshCount.Add(1)
+				return nil, nil, tc.err
+			}
+
+			opts := &crypter_key_cache.Opts{
+				KeyRefreshScanFrequency: time.Hour,
+				KeyErrCacheTime:         5 * time.Second,
+			}
+			cache := crypter_key_cache.NewWithOpts(env, refreshFn, clock, opts)
+
+			// The error should not be retried and its status should be
+			// preserved so that callers (e.g. a misconfigured customer-managed
+			// deployment) can tell it apart from transient refresh failures.
+			_, err := cache.EncryptionKey(ctx)
+			require.True(t, tc.checkFn(err))
+			require.Equal(t, int32(1), refreshCount.Load())
+
+			// A second call within the error cache time should be served from
+			// the error cache without another refresh.
+			_, err = cache.EncryptionKey(ctx)
+			require.True(t, tc.checkFn(err))
+			require.Equal(t, int32(1), refreshCount.Load())
+		})
+	}
+}
+
 func TestCanceledRefreshIsNotCached(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	env := testenv.GetTestEnv(t)

--- a/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
+++ b/enterprise/server/crypter_key_cache/crypter_key_cache_test.go
@@ -215,8 +215,13 @@ func TestKeyScopeDistinctness(t *testing.T) {
 	versionedCustomerCK := crypter_key_cache.CacheKey{GroupID: "group1", KeyID: "key1", Version: 1, Scope: crypter_key_cache.KeyScopeCustomerDeployment}
 
 	// Keys differing only in scope must never collide in the cache or the
-	// singleflight group, which are both keyed on String().
-	require.NotEqual(t, backendCK.String(), customerCK.String())
+	// singleflight group, which are both keyed on String(). This must hold
+	// for scopes that don't exist yet too.
+	unknownScopeCK := crypter_key_cache.CacheKey{GroupID: "group1", Scope: crypter_key_cache.KeyScope(99)}
+	for _, ck := range []crypter_key_cache.CacheKey{customerCK, unknownScopeCK} {
+		require.NotEqual(t, backendCK.String(), ck.String())
+	}
+	require.NotEqual(t, customerCK.String(), unknownScopeCK.String())
 	require.NotEqual(t, versionedBackendCK.String(), versionedCustomerCK.String())
 
 	backendKey := []byte("backend-key")
@@ -264,7 +269,7 @@ func TestKeyScopeDistinctness(t *testing.T) {
 	require.Equal(t, 2, refreshCount)
 }
 
-func TestPermissionDeniedNotRetried(t *testing.T) {
+func TestNonRetryableErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		err     error
@@ -272,6 +277,7 @@ func TestPermissionDeniedNotRetried(t *testing.T) {
 	}{
 		{"PermissionDenied", status.PermissionDeniedError("no key for you"), status.IsPermissionDeniedError},
 		{"Unauthenticated", status.UnauthenticatedError("who are you"), status.IsUnauthenticatedError},
+		{"InvalidArgument", status.InvalidArgumentError("what is this"), status.IsInvalidArgumentError},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			clock := clockwork.NewFakeClock()

--- a/enterprise/server/crypter_service/BUILD
+++ b/enterprise/server/crypter_service/BUILD
@@ -36,6 +36,7 @@ go_test(
     deps = [
         "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/clientidentity",
+        "//enterprise/server/crypter",
         "//enterprise/server/crypter_key_cache",
         "//enterprise/server/testutil/enterprise_testauth",
         "//enterprise/server/testutil/enterprise_testenv",

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -107,7 +107,7 @@ func newWithOpts(env environment.Env, clock clockwork.Clock, opts *crypter_key_c
 	return c, nil
 }
 
-func derivedKey(groupID string, key *tables.EncryptionKeyVersion, kms interfaces.KMS) ([]byte, error) {
+func derivedKey(groupID string, scope crypter_key_cache.KeyScope, key *tables.EncryptionKeyVersion, kms interfaces.KMS) ([]byte, error) {
 	bbmk, err := kms.FetchMasterKey()
 	if err != nil {
 		return nil, err
@@ -131,7 +131,19 @@ func derivedKey(groupID string, key *tables.EncryptionKeyVersion, kms interfaces
 	ckSrc = append(ckSrc, masterKeyPortion...)
 	ckSrc = append(ckSrc, groupKeyPortion...)
 
-	info := append([]byte{crypter.EncryptedDataHeaderVersion}, []byte(groupID)...)
+	var info []byte
+	if scope == crypter_key_cache.KeyScopeCustomerDeployment {
+		// Domain-separate customer-deployment-scoped keys from cloud-scoped
+		// ones so that keys served to customer-managed deployments cannot
+		// decrypt content stored in the cloud cache. See
+		// CustomerDeploymentKeyInfoPrefix.
+		info = []byte{crypter.CustomerDeploymentKeyInfoPrefix, crypter.EncryptedDataHeaderVersion}
+	} else if scope == crypter_key_cache.KeyScopeCloud {
+		info = []byte{crypter.EncryptedDataHeaderVersion}
+	} else {
+		return nil, status.InvalidArgumentErrorf("Invalid key-cache scope: %v", scope)
+	}
+	info = append(info, []byte(groupID)...)
 	derivedKey := make([]byte, 32)
 	r := hkdf.Expand(sha256.New, ckSrc, info)
 	n, err := r.Read(derivedKey)
@@ -171,7 +183,7 @@ func refreshKey(ctx context.Context, ck crypter_key_cache.CacheKey, dbh interfac
 		}
 		return nil, nil, err
 	}
-	key, err := derivedKey(ck.GroupID, ekv, kms)
+	key, err := derivedKey(ck.GroupID, ck.Scope, ekv, kms)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -141,7 +141,7 @@ func derivedKey(groupID string, scope crypter_key_cache.KeyScope, key *tables.En
 	} else if scope == crypter_key_cache.KeyScopeCloud {
 		info = []byte{crypter.EncryptedDataHeaderVersion}
 	} else {
-		return nil, status.InvalidArgumentErrorf("Invalid key-cache scope: %v", scope)
+		return nil, status.InvalidArgumentErrorf("invalid key-cache scope: %v", scope)
 	}
 	info = append(info, []byte(groupID)...)
 	derivedKey := make([]byte, 32)

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/clientidentity"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/crypter"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/crypter_key_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
@@ -348,6 +349,71 @@ func TestDecryptWrongDigest(t *testing.T) {
 	require.NoError(t, err)
 	_, err = io.ReadAll(d)
 	require.ErrorContains(t, err, "authentication failed")
+}
+
+func TestCustomerDeploymentScopedKeyIndependence(t *testing.T) {
+	env, kms := getEnv(t)
+	customerKeyURI := generateKMSKey(t, kms, "customerKey")
+
+	groupID := "GR123"
+	keyID := "EK123"
+	clock := clockwork.NewRealClock()
+	createKey(t, env, clock, keyID, groupID, customerKeyURI)
+
+	ctx := context.Background()
+
+	backendCK := crypter_key_cache.CacheKey{GroupID: groupID}
+	customerCK := crypter_key_cache.CacheKey{GroupID: groupID, Scope: crypter_key_cache.KeyScopeCustomerDeployment}
+
+	backendKey, backendMD, err := refreshKey(ctx, backendCK, env.GetDBHandle(), env.GetKMS())
+	require.NoError(t, err)
+	customerKey, customerMD, err := refreshKey(ctx, customerCK, env.GetDBHandle(), env.GetKMS())
+	require.NoError(t, err)
+
+	// Both scopes are derived from the same key version...
+	require.Equal(t, keyID, backendMD.GetEncryptionKeyId())
+	require.Equal(t, keyID, customerMD.GetEncryptionKeyId())
+	require.EqualValues(t, 1, backendMD.GetVersion())
+	require.EqualValues(t, 1, customerMD.GetVersion())
+	// ...but the derived keys must be independent.
+	require.NotEqual(t, backendKey, customerKey)
+
+	// Looking up a specific key version must respect the scope too.
+	versionedBackendCK := crypter_key_cache.CacheKey{GroupID: groupID, KeyID: keyID, Version: 1}
+	versionedBackendKey, _, err := refreshKey(ctx, versionedBackendCK, env.GetDBHandle(), env.GetKMS())
+	require.NoError(t, err)
+	require.Equal(t, backendKey, versionedBackendKey)
+	versionedCustomerCK := crypter_key_cache.CacheKey{GroupID: groupID, KeyID: keyID, Version: 1, Scope: crypter_key_cache.KeyScopeCustomerDeployment}
+	versionedCustomerKey, _, err := refreshKey(ctx, versionedCustomerCK, env.GetDBHandle(), env.GetKMS())
+	require.NoError(t, err)
+	require.Equal(t, customerKey, versionedCustomerKey)
+
+	testData := make([]byte, 1000)
+	_, err = rand.Read(testData)
+	require.NoError(t, err)
+
+	encryptDecrypt := func(encKey, decKey []byte, md *sgpb.EncryptionMetadata) error {
+		out := bytes.NewBuffer(nil)
+		e, err := crypter.NewEncryptor(ctx, &crypter.DerivedKey{Key: encKey, Metadata: md}, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
+		require.NoError(t, err)
+		testdata.WriteInRandomChunks(t, e, testData)
+		d, err := crypter.NewDecryptor(ctx, &crypter.DerivedKey{Key: decKey, Metadata: md}, dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), groupID, 1024)
+		require.NoError(t, err)
+		decrypted, err := io.ReadAll(d)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, testData, decrypted)
+		return nil
+	}
+
+	// Same-scope decryption succeeds.
+	require.NoError(t, encryptDecrypt(backendKey, backendKey, backendMD))
+	require.NoError(t, encryptDecrypt(customerKey, customerKey, customerMD))
+	// Content encrypted under one scope must not be decryptable under the
+	// other.
+	require.ErrorContains(t, encryptDecrypt(backendKey, customerKey, backendMD), "authentication failed")
+	require.ErrorContains(t, encryptDecrypt(customerKey, backendKey, customerMD), "authentication failed")
 }
 
 func TestKeyLookup(t *testing.T) {


### PR DESCRIPTION
Customer-managed cache proxies currently bypass local caching entirely for CMEK-enabled groups, because the only key that exists is the one that encrypts content in the cloud cache and we don't want to ship that key to customer infrastructure. This PR lays the cryptographic groundwork for fixing that: it adds a KeyScope to the crypter key cache and the key-derivation function, where customer-deployment-scoped keys are derived from the same EncryptionKeyVersions rows as cloud-scoped keys but with a domain-separated HKDF info (prefixed with a reserved 0xFF byte that the ciphertext header version can never take, enforced by a compile-time guard). HKDF outputs with distinct info values are computationally independent, so a key leaked from a customer deployment cannot decrypt cloud-stored content, while KMS revocation, disable, and re-encryption still apply to both scopes automatically since they share the same underlying key material. An alternative was minting a second key-version row per group for customer deployments, but that overloads rotation semantics, doubles the key state to manage, and rests the security boundary on row-filtering discipline instead of the derivation itself. Nothing requests the new scope yet; follow-ups will add an RPC for customer-managed proxies to fetch the customer-deployment key using their API key, and proxy-side support for using it.

This PR also makes PermissionDenied, Unauthenticated, and InvalidArgument errors non-retryable (and status-preserved) in the key cache. This is a deliberate behavior change that affects the cloud path too, not just the upcoming proxy path: auth-class errors are non-retryable in standard gRPC retry policies and are almost always durable in practice — and for CMEK specifically, a PermissionDenied from the customer's KMS means they revoked our access, which we should honor promptly rather than retry against their KMS. Since refreshes are singleflighted, retrying a durable failure also blocks all concurrent key loads for the same group while the retry loop runs down the caller's deadline. The trade-off is that a rare transient auth blip that in-line retries would previously have absorbed now fails fast and is error-cached for ~10s.
