### PR TITLE
Fix disconnected invocation status not getting written to DB

### DIFF
--- a/server/backends/chunkstore/chunkstore.go
+++ b/server/backends/chunkstore/chunkstore.go
@@ -412,7 +412,8 @@ func (w *ChunkstoreWriter) readFromWriteResultChannel() (int, error) {
 			if result != nil && result.Err != nil {
 				return 0, result.Err
 			}
-			return 0, status.UnavailableErrorf("Error accessing %v: Already closed.", w.blobName)
+			// Return a nil error if already closed, but report 0 bytes written.
+			return 0, nil
 		}
 		w.lastChunkIndex = result.LastChunkIndex
 		if result.Timeout {
@@ -454,9 +455,6 @@ func (w *ChunkstoreWriter) Close(ctx context.Context) error {
 	}
 	w.writeChannel <- &WriteRequest{ctx: ctx, Close: true}
 	_, err := w.readFromWriteResultChannel()
-	if status.IsUnavailableError(err) {
-		return nil
-	}
 	return err
 }
 

--- a/server/backends/chunkstore/chunkstore_test.go
+++ b/server/backends/chunkstore/chunkstore_test.go
@@ -2,6 +2,7 @@ package chunkstore
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 	"time"
@@ -467,4 +468,50 @@ func TestWriteInvalidChunk(t *testing.T) {
 	assert.Equal(t, 0, n)
 	assert.Error(t, err)
 	assert.True(t, status.IsResourceExhaustedError(err))
+}
+
+func TestWriteAfterWriteLoopShutsDown(t *testing.T) {
+	m := mockstore.New()
+	c := New(m, &ChunkstoreOptions{})
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Create a writer with a write hook that signals when the write loop
+	// shuts down.
+	shutdown := make(chan struct{})
+	w := c.Writer(ctx, "foo", &ChunkstoreWriterOptions{
+		WriteHook: func(_ context.Context, _ *WriteRequest, result *WriteResult, _, _ []byte) {
+			if result.Close {
+				close(shutdown)
+			}
+		},
+	})
+
+	// Write some data with a volatile tail while the write loop is running.
+	_, err := w.WriteWithTail(ctx, []byte("hello, "), []byte("world"))
+	require.NoError(t, err)
+
+	// Cancel the context. The write loop notices the cancellation on its own,
+	// flushes the buffered data along with the volatile tail, and shuts down.
+	cancel()
+	select {
+	case <-shutdown:
+	case <-time.After(15 * time.Second):
+		require.FailNow(t, "timed out waiting for the write loop to shut down")
+	}
+
+	// A write that discovers the write loop has shut down should report
+	// success with 0 bytes written, just like a write to a writer that is
+	// already known to be closed.
+	n, err := w.Write(t.Context(), []byte("dropped"))
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	// Closing the writer afterwards should succeed.
+	require.NoError(t, w.Close(t.Context()))
+
+	// The data buffered before the cancellation, including the volatile tail,
+	// should have been flushed to storage.
+	blob, err := m.ReadBlob(t.Context(), "foo_0000")
+	require.NoError(t, err)
+	assert.Equal(t, "hello, world", string(blob))
 }

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -867,15 +867,35 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	invocation.Attempt = e.attempt
 	invocation.HasChunkedEventLogs = e.logWriter != nil
 
+	disconnected := invocation.GetInvocationStatus() == inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS
+
+	// Flush/close blobstore writers (raw event protos and build logs).
 	if e.pw != nil {
 		if err := e.pw.Flush(ctx); err != nil {
-			return err
+			// Return the error so that the client can retry sending events,
+			// giving us another chance to write them to blobstore. If the
+			// client disconnected, just log the error since they won't get the
+			// error that we return here. This also ensures that we properly
+			// mark the invocation disconnected below.
+			if disconnected {
+				log.CtxWarningf(ctx, "Failed to flush invocation events to blobstore: %s", err)
+			} else {
+				return err
+			}
 		}
 	}
-
 	if e.logWriter != nil {
 		if err := e.logWriter.Close(ctx); err != nil {
-			return err
+			// Return the error so that the client can retry sending events,
+			// giving us another chance to write them to blobstore. If the
+			// client disconnected, just log the error since they won't get the
+			// error that we return here. This also ensures that we properly
+			// mark the invocation disconnected in the DB below.
+			if disconnected {
+				log.CtxWarningf(ctx, "Failed to flush invocation logs to blobstore: %s", err)
+			} else {
+				return err
+			}
 		}
 		invocation.LastChunkId = e.logWriter.GetLastChunkId(ctx)
 	}
@@ -900,7 +920,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	// Report a disconnect only if we successfully updated the invocation.
 	// This reduces the likelihood that the disconnected invocation's status
 	// will overwrite any statuses written by a more recent attempt.
-	if invocation.GetInvocationStatus() == inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS {
+	if disconnected {
 		log.CtxWarning(ctx, "Reporting disconnected status for invocation")
 		e.statusReporter.ReportDisconnect(ctx)
 	}

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -978,6 +979,100 @@ func TestUnfinishedFinalizeWithCanceledContext(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "abc123", invocation.CommitSha)
 	assert.Equal(t, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS, invocation.InvocationStatus)
+}
+
+// failingBlobstore wraps a Blobstore and fails all blob writes when
+// failWrites is set.
+type failingBlobstore struct {
+	interfaces.Blobstore
+	failWrites atomic.Bool
+}
+
+func (b *failingBlobstore) WriteBlob(ctx context.Context, blobName string, data []byte) (int, error) {
+	if b.failWrites.Load() {
+		return 0, fmt.Errorf("blobstore write failed")
+	}
+	return b.Blobstore.WriteBlob(ctx, blobName, data)
+}
+
+func TestUnfinishedFinalizeWithBlobstoreWriteFailure(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(t, testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	bs := &failingBlobstore{Blobstore: te.GetBlobstore()}
+	te.SetBlobstore(bs)
+	ctx := t.Context()
+	testUUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+	testInvocationID := testUUID.String()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel, err := handler.OpenChannel(ctx, testInvocationID)
+	require.NoError(t, err)
+	defer channel.Close()
+
+	// Send started event with api key. The event is buffered in the
+	// invocation event stream and not yet flushed to blobstore.
+	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
+	err = channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Make blobstore writes fail, then finalize the invocation without a
+	// finished event, as happens when the client disconnects. Flushing the
+	// buffered events fails, but there is no connected client left to receive
+	// an error and retry, so finalization should proceed anyway.
+	bs.failWrites.Store(true)
+	err = channel.FinalizeInvocation(testInvocationID)
+	require.NoError(t, err)
+
+	// Make sure the invocation was marked disconnected in the DB so that
+	// bazel may retry it.
+	authCtx := auth.AuthContextFromAPIKey(t.Context(), "USER1")
+	ti, err := te.GetInvocationDB().LookupInvocation(authCtx, testInvocationID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS), ti.InvocationStatus)
+}
+
+func TestFinishedFinalizeWithBlobstoreWriteFailure(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(t, testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	bs := &failingBlobstore{Blobstore: te.GetBlobstore()}
+	te.SetBlobstore(bs)
+	ctx := t.Context()
+	testUUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+	testInvocationID := testUUID.String()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel, err := handler.OpenChannel(ctx, testInvocationID)
+	require.NoError(t, err)
+	defer channel.Close()
+
+	// Send started event with api key. The event is buffered in the
+	// invocation event stream and not yet flushed to blobstore.
+	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
+	err = channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Send finished event, so that the invocation finalizes as complete
+	// rather than disconnected.
+	request = streamRequest(finishedEvent(), testInvocationID, 2)
+	err = channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Make blobstore writes fail, then finalize the invocation. The client is
+	// still connected, so the error from flushing the buffered events should
+	// be returned, which lets the client retry sending the events.
+	bs.failWrites.Store(true)
+	err = channel.FinalizeInvocation(testInvocationID)
+	require.Error(t, err)
+
+	// Make sure the invocation was not finalized in the DB.
+	authCtx := auth.AuthContextFromAPIKey(t.Context(), "USER1")
+	ti, err := te.GetInvocationDB().LookupInvocation(authCtx, testInvocationID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(inspb.InvocationStatus_PARTIAL_INVOCATION_STATUS), ti.InvocationStatus)
 }
 
 func TestUnfinishedFinalize(t *testing.T) {

--- a/server/eventlog/eventlog_test.go
+++ b/server/eventlog/eventlog_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/backends/chunkstore"
 	"github.com/buildbuddy-io/buildbuddy/server/eventlog"
@@ -267,4 +268,43 @@ func TestGetEventLogChunk_RunLogs(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "Chunk 0\nChunk 1\n", string(rsp.Buffer))
+}
+
+func TestANSICursorBufferWriterCloseAfterWriteLoopShutsDown(t *testing.T) {
+	m := mockstore.New()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Create a chunkstore writer with a write hook that signals when the
+	// write loop shuts down.
+	shutdown := make(chan struct{})
+	cw := chunkstore.New(m, &chunkstore.ChunkstoreOptions{}).Writer(ctx, "eventlog", &chunkstore.ChunkstoreWriterOptions{
+		WriteHook: func(_ context.Context, _ *chunkstore.WriteRequest, result *chunkstore.WriteResult, _, _ []byte) {
+			if result.Close {
+				close(shutdown)
+			}
+		},
+	})
+	screen, err := terminal.NewScreenWriter(math.MaxInt, 4)
+	require.NoError(t, err)
+	w := eventlog.NewANSICursorBufferWriter(cw, screen)
+
+	// Write log output containing a carriage return, like the progress output
+	// bazel writes when curses are enabled. This makes Close write the final
+	// screen contents before closing the underlying writer.
+	_, err = w.Write(ctx, []byte("Analyzing: //foo:foo\r"))
+	require.NoError(t, err)
+
+	// Cancel the context, simulating an abrupt client disconnect. The write
+	// loop notices the cancellation on its own, flushes the log contents, and
+	// shuts down.
+	cancel()
+	select {
+	case <-shutdown:
+	case <-time.After(15 * time.Second):
+		require.FailNow(t, "timed out waiting for the write loop to shut down")
+	}
+
+	// Closing the writer should succeed even though the write loop already
+	// flushed the log contents and shut down.
+	require.NoError(t, w.Close(t.Context()))
 }


### PR DESCRIPTION
Since f8b1db3dc, finalizing a disconnected invocation fails whenever its build log contains cursor control characters (e.g. `\r`, which bazel writes whenever `curses` is enabled).

When the stream is disconnected (i.e. the stream context is canceled), the chunkstore write loop goroutine shuts down on its own after flushing any buffered log data. The `ChunkstoreWriter` doesn't know this happened, so the next write to it fails with "Already closed". Since f8b1db3dc, `ANSICursorBufferWriter.Close` hits this case, because it writes the trimmed terminal tail just before closing. Previously `Close` went straight to `ChunkstoreWriter.Close`, which swallows this error.

Even though this is a new error as of f8b1db3dc, the error handling in `FinalizeInvocation` is also problematic (and arguably the root issue). When `FinalizeInvocation` fails to close the log writer, it treats the error as fatal and returns the error before it gets to update the DB, so the invocation is never marked DISCONNECTED and its `updated_at_usec` is never refreshed. This is a problem for long-running invocations - retries are only allowed if the row was updated within the last 4 hours, so for builds that ran longer than that, bazel's next attempt gets voided and the invocation appears to be in progress forever.

Changes:

- In `ChunkstoreWriter`, make sure we don't return an error if the stream is closed when we try to write the trimmed terminal tail. This fixes a bug where `Close()` returns an error even though we've successfully finalized the log writer (even though the client cancels their end of the stream, there's no reason we can't still successfully finalize logs - "finalize" here just means "clean up" which is all we should really be on the hook for, since for a DISCONNECTED invocation we're expecting the logs to get re-sent on the next attempt, and shouldn't care too much about what happens to the current log stream).
- In BE handler, during `FinalizeInvocation` - ensure that we always try to write a DISCONNECTED status, even if the log flush fails (including this error regression case). This behavior only applies to DISCONNECTED and not to COMPLETED invocations, because for COMPLETED invocations we want the client to retry sending BES events, giving the log flush another chance to succeed - we don't want to mark the invocation COMPLETED until the invocation is retried and we handle everything successfully, including the log flush.
