### PR TITLE
Fix pooling bug in distributed_cache.Read.

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -567,7 +567,10 @@ func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceN
 type distributedCacheReader struct {
 	stream dcpb.DistributedCache_ReadClient
 	rsp    *dcpb.ReadResponse
-	err    error
+	// offset into rsp.Data so we don't muck with rsp.Data
+	// advancing rsp.Data prevents vtproto from reusing the backing buffer.
+	off int
+	err error
 }
 
 func newDistributedCacheReader(stream dcpb.DistributedCache_ReadClient, expectEOF bool) (*distributedCacheReader, error) {
@@ -590,18 +593,21 @@ func newDistributedCacheReader(stream dcpb.DistributedCache_ReadClient, expectEO
 // moreData fetches the next batch of data if necessary, and returns true if
 // there is more data.
 func (r *distributedCacheReader) moreData() bool {
-	if r.err == nil && len(r.rsp.GetData()) == 0 {
+	if r.err == nil && r.off == len(r.rsp.GetData()) {
 		r.err = r.stream.RecvMsg(r.rsp)
+		if r.err == nil {
+			r.off = 0
+		}
 	}
-	return r.err == nil || len(r.rsp.GetData()) > 0
+	return r.err == nil || r.off < len(r.rsp.GetData())
 }
 
 func (r *distributedCacheReader) Read(out []byte) (int, error) {
 	if !r.moreData() {
 		return 0, r.err
 	}
-	n := copy(out, r.rsp.GetData())
-	r.rsp.Data = r.rsp.Data[n:]
+	n := copy(out, r.rsp.GetData()[r.off:])
+	r.off += n
 	if !r.moreData() {
 		// If there is no more data, allow returning a possible EOF. This lets
 		// the client skip making another Read call just to get EOF.
@@ -613,12 +619,12 @@ func (r *distributedCacheReader) Read(out []byte) (int, error) {
 func (r *distributedCacheReader) WriteTo(w io.Writer) (int64, error) {
 	var total int64
 	for r.moreData() {
-		n, err := w.Write(r.rsp.GetData())
+		n, err := w.Write(r.rsp.GetData()[r.off:])
 		total += int64(n)
 		if err != nil {
 			return total, err
 		}
-		r.rsp.Data = r.rsp.Data[n:]
+		r.off += n
 	}
 	if r.err == io.EOF {
 		return total, nil


### PR DESCRIPTION
vtproto reuses the underlying byte buffer, but since we keep advancing the slice it forces vtproto to keep allocating more bytes.

BenchmarkRead/digest16MiB goes from 17MB to 214KB per op.

```
                    │ /tmp/before.stat │           /tmp/after.stat            │
                    │      sec/op      │    sec/op     vs base                │
Read/digest128B-32         63.97µ ± 8%   66.88µ ± 13%        ~ (p=0.315 n=10)
Read/digest16KiB-32        80.82µ ± 7%   82.96µ ± 42%        ~ (p=1.000 n=10)
Read/digest16MiB-32        9.375m ± 4%   7.703m ±  2%  -17.83% (p=0.000 n=10)
geomean                    364.6µ        349.6µ         -4.10%

                    │ /tmp/before.stat │            /tmp/after.stat            │
                    │       B/op       │     B/op       vs base                │
Read/digest128B-32        24.96Ki ± 4%   25.10Ki ±  3%        ~ (p=0.853 n=10)
Read/digest16KiB-32       43.67Ki ± 2%   28.16Ki ±  6%  -35.52% (p=0.000 n=10)
Read/digest16MiB-32     16998.1Ki ± 0%   214.4Ki ± 15%  -98.74% (p=0.000 n=10)
geomean                   264.6Ki        53.31Ki        -79.85%

                    │ /tmp/before.stat │          /tmp/after.stat           │
                    │    allocs/op     │  allocs/op   vs base               │
Read/digest128B-32          359.0 ± 0%    358.0 ± 0%  -0.28% (p=0.000 n=10)
Read/digest16KiB-32         355.0 ± 0%    354.0 ± 0%  -0.28% (p=0.000 n=10)
Read/digest16MiB-32        2.467k ± 8%   2.236k ± 4%  -9.36% (p=0.005 n=10)
geomean                     680.0         656.9       -3.40%
```