### PR TITLE
Periodically update invocation row while streaming build events

### DIFF
--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -28,6 +28,12 @@ import (
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 )
 
+// invocationReconnectWindow is how long after an incomplete invocation's
+// last DB update the invocation may still be retried. An incomplete
+// invocation whose row has not been updated within this window is assumed to
+// be abandoned and may not be retried.
+const invocationReconnectWindow = 4 * time.Hour
+
 type InvocationDB struct {
 	env environment.Env
 	h   interfaces.DBHandle
@@ -63,12 +69,12 @@ func (d *InvocationDB) registerInvocationAttempt(ctx context.Context, ti *tables
 				`+d.h.SelectForUpdateModifier(),
 			ti.InvocationID,
 			int64(inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS),
-			tx.NowFunc().Add(time.Hour*-4).UnixMicro(),
+			tx.NowFunc().Add(-invocationReconnectWindow).UnixMicro(),
 		).Take(ti)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				// The invocation either succeeded or is more than 4 hours old. It may
-				// not be re-attempted.
+				// The invocation either succeeded or is past the reconnect
+				// window. It may not be re-attempted.
 				return nil
 			}
 			return err
@@ -306,6 +312,10 @@ func (d *InvocationDB) deleteInvocation(ctx context.Context, tx interfaces.DB, i
 
 func (d *InvocationDB) SetNowFunc(now func() time.Time) {
 	d.h.SetNowFunc(now)
+}
+
+func (d *InvocationDB) GetInvocationReconnectWindow() time.Duration {
+	return invocationReconnectWindow
 }
 
 func TableInvocationToProto(i *tables.Invocation) *inpb.Invocation {

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -88,6 +88,7 @@ go_test(
         "//server/util/testing/flags",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_uuid//:uuid",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//encoding/prototext",

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -843,6 +843,10 @@ type EventChannel struct {
 	// when we're retrying an invocation that is already complete, or is
 	// incomplete but was created too far in the past.
 	isVoid bool
+
+	// lastDBUpdateTime is when the invocation row was last written to the DB.
+	// It is used to periodically update the row while events are streaming.
+	lastDBUpdateTime time.Time
 }
 
 func (e *EventChannel) Context() context.Context {
@@ -1088,10 +1092,11 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 		}
 		if !created {
 			// We failed to retry an existing invocation
-			log.CtxWarningf(e.ctx, "Voiding EventChannel for invocation %s: invocation already exists and is either completed or was last updated over 4 hours ago, so may not be retried.", iid)
+			log.CtxWarningf(e.ctx, "Voiding EventChannel for invocation %s: invocation already exists and is either completed or past its reconnect window, so may not be retried.", iid)
 			e.isVoid = true
 			return nil
 		}
+		e.lastDBUpdateTime = e.env.GetClock().Now()
 		e.attempt = ti.Attempt
 		e.ctx = log.EnrichContext(e.ctx, "invocation_attempt", fmt.Sprintf("%d", e.attempt))
 		log.CtxInfof(e.ctx, "Created invocation %q, attempt %d", ti.InvocationID, ti.Attempt)
@@ -1283,6 +1288,25 @@ func (e *EventChannel) processSingleEvent(event *inpb.InvocationEvent, iid strin
 		e.wroteBuildMetadata = true
 	}
 
+	// While events are still streaming, periodically update the invocation
+	// row. The row is otherwise only updated at creation, when metadata is
+	// loaded, and at finalization, so an invocation that runs longer than the
+	// reconnect window would look abandoned and could never be retried if it
+	// got disconnected.
+	updatePeriod := e.env.GetInvocationDB().GetInvocationReconnectWindow() / 2
+	if e.env.GetClock().Since(e.lastDBUpdateTime) >= updatePeriod {
+		ti := &tables.Invocation{InvocationID: iid, Attempt: e.attempt}
+		if updated, err := e.env.GetInvocationDB().UpdateInvocation(e.ctx, ti); err != nil {
+			log.CtxErrorf(e.ctx, "Error updating invocation row while streaming events: %s", err)
+			return status.UnavailableErrorf("write periodic metadata update: %s", err)
+		} else if !updated {
+			e.isVoid = true
+			return status.CanceledErrorf("Attempt %d of invocation %s pre-empted by more recent attempt.", e.attempt, iid)
+		} else {
+			e.lastDBUpdateTime = e.env.GetClock().Now()
+		}
+	}
+
 	return nil
 }
 
@@ -1383,6 +1407,7 @@ func (e *EventChannel) writeBuildMetadata(ctx context.Context, invocationID stri
 		e.isVoid = true
 		return status.CanceledErrorf("Attempt %d of invocation %s pre-empted by more recent attempt, no build metadata written.", e.attempt, invocationID)
 	}
+	e.lastDBUpdateTime = e.env.GetClock().Now()
 	return nil
 }
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -1021,6 +1022,62 @@ func TestUnfinishedFinalize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "abc123", invocation.CommitSha)
 	assert.Equal(t, inspb.InvocationStatus_DISCONNECTED_INVOCATION_STATUS, invocation.InvocationStatus)
+}
+
+func TestPeriodicInvocationRowUpdateWhileStreaming(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(t, testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	clock := clockwork.NewFakeClock()
+	te.SetClock(clock)
+	ctx := context.Background()
+	testUUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+	testInvocationID := testUUID.String()
+
+	// Make DB writes stamp a fixed time so that we can tell when the
+	// invocation row gets written.
+	t0 := time.Unix(1000, 0)
+	te.GetInvocationDB().SetNowFunc(func() time.Time { return t0 })
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel, err := handler.OpenChannel(ctx, testInvocationID)
+	require.NoError(t, err)
+	defer channel.Close()
+
+	// Send started event with api key, which creates the invocation row.
+	request := streamRequest(startedEvent("--remote_header='"+authutil.APIKeyHeader+"=USER1'", &bspb.BuildEventId_WorkspaceStatus{}), testInvocationID, 1)
+	err = channel.HandleEvent(request)
+	require.NoError(t, err)
+
+	authCtx := auth.AuthContextFromAPIKey(context.Background(), "USER1")
+	ti, err := te.GetInvocationDB().LookupInvocation(authCtx, testInvocationID)
+	require.NoError(t, err)
+	require.Equal(t, t0.UnixMicro(), ti.UpdatedAtUsec)
+
+	// Advance the DB clock. An event that arrives before the periodic update
+	// period has elapsed should not update the invocation row.
+	t1 := time.Unix(2000, 0)
+	te.GetInvocationDB().SetNowFunc(func() time.Time { return t1 })
+	request = streamRequest(progressEventWithOutput("hello", ""), testInvocationID, 2)
+	err = channel.HandleEvent(request)
+	require.NoError(t, err)
+
+	ti, err = te.GetInvocationDB().LookupInvocation(authCtx, testInvocationID)
+	require.NoError(t, err)
+	assert.Equal(t, t0.UnixMicro(), ti.UpdatedAtUsec)
+
+	// Advance the stream's clock past half the reconnect window. The next
+	// event should update the invocation row, keeping the invocation
+	// retryable in case it gets disconnected later.
+	clock.Advance(te.GetInvocationDB().GetInvocationReconnectWindow()/2 + time.Second)
+	request = streamRequest(progressEventWithOutput("world", ""), testInvocationID, 3)
+	err = channel.HandleEvent(request)
+	require.NoError(t, err)
+
+	ti, err = te.GetInvocationDB().LookupInvocation(authCtx, testInvocationID)
+	require.NoError(t, err)
+	assert.Equal(t, t1.UnixMicro(), ti.UpdatedAtUsec)
 }
 
 func TestRetryOnComplete(t *testing.T) {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -458,6 +458,10 @@ type InvocationDB interface {
 	DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *UserInfo, invocationID string) error
 	FillCounts(ctx context.Context, log *telpb.TelemetryStat) error
 	SetNowFunc(now func() time.Time)
+
+	// GetInvocationReconnectWindow returns how long after an incomplete
+	// invocation's last DB update the invocation may still be retried.
+	GetInvocationReconnectWindow() time.Duration
 }
 
 type APIKeyGroup interface {

--- a/server/testutil/mockinvocationdb/mockinvocationdb.go
+++ b/server/testutil/mockinvocationdb/mockinvocationdb.go
@@ -55,3 +55,6 @@ func (m *MockInvocationDB) FillCounts(ctx context.Context, log *telpb.TelemetryS
 }
 func (m *MockInvocationDB) SetNowFunc(now func() time.Time) {
 }
+func (m *MockInvocationDB) GetInvocationReconnectWindow() time.Duration {
+	return 4 * time.Hour
+}


### PR DESCRIPTION
An invocation may only be retried after a disconnect if its DB row was updated within the last 4 hours, but the row is only written at creation, when build metadata is loaded, and at finalization - so a build that ran longer than 4 hours could never be retried, leaving the invocation stuck in a partial state forever.

Expose the reconnect window from InvocationDB and update the row at half that window (2 hours) while build events are streaming, so an active invocation always stays retryable.

An alternative would be to extend or remove this retry window, but I feel like this window is somewhat useful as it provides some protection for older invocations, and extending it just reduces the protection while not really solving the root issue (longer-running invocations will eventually hit this issue again).