### PR TITLE
Prioritize tasks by initial enqueue time

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1024,6 +1024,7 @@ func (s *ExecutionServer) dispatch(ctx context.Context, req *repb.ExecuteRequest
 		ExecutorGroupId:   pool.GroupID,
 		TaskGroupId:       taskGroupID,
 		Priority:          req.GetExecutionPolicy().GetPriority(),
+		QueuedTimestamp:   executionTask.GetQueuedTimestamp(),
 	}
 	serializedTask, err := proto.Marshal(executionTask)
 	if err != nil {

--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -53,5 +53,6 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -201,9 +201,18 @@ func (t *taskQueue) Enqueue(ctx context.Context, req *scpb.EnqueueTaskReservatio
 		EnqueueTaskReservationRequest: req,
 		WorkerQueuedTimestamp:         enqueuedAt,
 	}
+	// Break priority ties using the time at which the task was first enqueued
+	// on the app, so that a task that gets re-enqueued on another executor
+	// keeps its place in line instead of starting over at the back of the
+	// queue. Fall back to the local enqueue time if the app didn't set the
+	// queued timestamp.
+	queuedTimestamp := enqueuedAt
+	if ts := req.GetSchedulingMetadata().GetQueuedTimestamp(); ts != nil {
+		queuedTimestamp = ts.AsTime()
+	}
 	// Using negative priority here, since the remote execution API specifies
 	// that tasks with lower priority values should be scheduled first.
-	pq.Push(qt, -float64(req.GetSchedulingMetadata().GetPriority()))
+	pq.PushWithTime(qt, -float64(req.GetSchedulingMetadata().GetPriority()), queuedTimestamp)
 	t.taskIDs[req.GetTaskId()] = struct{}{}
 	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: taskGroupID}).Set(float64(pq.Len()))
 	if req.GetSchedulingMetadata().GetTrackQueuedTaskSize() {

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
@@ -97,6 +98,47 @@ func TestTaskQueue_MultipleGroups(t *testing.T) {
 	require.Equal(t, "group1Task2", q.Dequeue().GetTaskId())
 	require.Equal(t, "group3Task2", q.Dequeue().GetTaskId())
 	require.Equal(t, "group1Task3", q.Dequeue().GetTaskId())
+	require.Nil(t, q.Dequeue())
+}
+
+func TestTaskQueue_PrioritizesByAppQueuedTimestamp(t *testing.T) {
+	ctx := t.Context()
+	startTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := clockwork.NewFakeClockAt(startTime)
+	q := newTaskQueue(clock)
+
+	// Enqueue a task that was first enqueued on the app just now.
+	fresh := newTaskReservationRequest("fresh", testGroupID1, 0)
+	fresh.SchedulingMetadata.QueuedTimestamp = timestamppb.New(clock.Now())
+	q.Enqueue(ctx, fresh)
+
+	clock.Advance(time.Second)
+
+	// Enqueue a task that was first enqueued on the app a minute before the
+	// other tasks, simulating a task that was retried on this executor after
+	// originally being queued elsewhere. Even though it arrives at this
+	// executor last, it has been waiting the longest overall, so it should be
+	// dequeued before the other same-priority tasks.
+	retried := newTaskReservationRequest("retried", testGroupID1, 0)
+	retried.SchedulingMetadata.QueuedTimestamp = timestamppb.New(startTime.Add(-time.Minute))
+	q.Enqueue(ctx, retried)
+
+	// Enqueue a task with no app queued timestamp, simulating an app that
+	// doesn't set the field yet. It should fall back to the local enqueue
+	// time, placing it after the tasks queued on the app earlier.
+	legacy := newTaskReservationRequest("legacy", testGroupID1, 0)
+	q.Enqueue(ctx, legacy)
+
+	// Enqueue a task with a higher priority; explicit priority should take
+	// precedence over queued timestamps.
+	urgent := newTaskReservationRequest("urgent", testGroupID1, -1000)
+	urgent.SchedulingMetadata.QueuedTimestamp = timestamppb.New(clock.Now())
+	q.Enqueue(ctx, urgent)
+
+	require.Equal(t, "urgent", q.Dequeue().GetTaskId())
+	require.Equal(t, "retried", q.Dequeue().GetTaskId())
+	require.Equal(t, "fresh", q.Dequeue().GetTaskId())
+	require.Equal(t, "legacy", q.Dequeue().GetTaskId())
 	require.Nil(t, q.Dequeue())
 }
 

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -291,7 +291,7 @@ message CgroupSettings {
   optional int32 numa_node = 19;
 }
 
-// Next ID: 9
+// Next ID: 18
 message SchedulingMetadata {
   // DEPRECATED. This field has two different meanings:
   // 1. The execution server sets this to the task size "estimate" which only
@@ -372,6 +372,12 @@ message SchedulingMetadata {
 
   // cgroup2 settings. Will be set only for Linux executions.
   CgroupSettings cgroup_settings = 12;
+
+  // The time at which the task was first enqueued on the app. This value is
+  // preserved when a task is re-enqueued. Executors use it to break priority
+  // ties, so that a task retried on another executor doesn't lose its place
+  // in line.
+  google.protobuf.Timestamp queued_timestamp = 17;
 }
 
 message RoutingConfig {

--- a/server/util/priority_queue/priority_queue.go
+++ b/server/util/priority_queue/priority_queue.go
@@ -108,10 +108,25 @@ func (pq *ThreadSafePriorityQueue[V]) zeroValue() V {
 	return zero
 }
 
+// Push adds a value with the given priority. Ties in priority are broken by
+// insertion time, earliest first, using the current time as the insertion
+// time. Use PushWithTime to specify the insertion time explicitly.
 func (pq *ThreadSafePriorityQueue[V]) Push(v V, priority float64) {
+	pq.PushWithTime(v, priority, time.Now())
+}
+
+// PushWithTime adds a value with the given priority, using the given time
+// instead of the current time to break ties among values with equal priority.
+// Passing an earlier time places the value ahead of equal-priority values
+// that were pushed more recently.
+func (pq *ThreadSafePriorityQueue[V]) PushWithTime(v V, priority float64, insertTime time.Time) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
-	heap.Push(&pq.inner, NewItem(v, priority))
+	heap.Push(&pq.inner, &Item[V]{
+		value:      v,
+		priority:   priority,
+		insertTime: insertTime,
+	})
 }
 
 func (pq *ThreadSafePriorityQueue[V]) Pop() (V, bool) {

--- a/server/util/priority_queue/priority_queue_test.go
+++ b/server/util/priority_queue/priority_queue_test.go
@@ -3,6 +3,7 @@ package priority_queue_test
 import (
 	"container/heap"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/priority_queue"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,26 @@ func TestZeroValue(t *testing.T) {
 	v, ok = q.Pop()
 	assert.Equal(t, 0, v)
 	assert.False(t, ok)
+}
+
+func TestPushWithTime(t *testing.T) {
+	q := priority_queue.New[string]()
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Push A and B with the same priority; A gets an earlier time, so it
+	// should come first.
+	q.PushWithTime("A", 1, baseTime)
+	q.PushWithTime("B", 1, baseTime.Add(time.Second))
+
+	// Push C with the same priority and an even earlier time; it should come
+	// before both A and B despite being pushed last.
+	q.PushWithTime("C", 1, baseTime.Add(-time.Second))
+
+	// Push D with a higher priority and the latest time; priority should take
+	// precedence over time.
+	q.PushWithTime("D", 2, baseTime.Add(time.Hour))
+
+	require.Equal(t, []string{"D", "C", "A", "B"}, q.GetAllOrdered())
 }
 
 func TestRemoveAt(t *testing.T) {


### PR DESCRIPTION
- If an execution has to get internally retried (e.g. because an executor is shutting down) it's unfair to push the task to the end of the queue.
- When work stealing (due to scale up or when the executor is idle) we should prioritize within the sampled task set by their original queue time.

Prioritize re-enqueued tasks using their original enqueue time (i.e. when we got the Execute request).

Note that this change does not affect client-side retries (e.g. task failed with UNAVAILABLE and then bazel does a retry).