### PR TITLE
Implement executor pod deletion cost

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -57,6 +57,7 @@ go_library(
         "//server/util/healthcheck",
         "//server/util/log",
         "//server/util/monitoring",
+        "//server/util/pod_deletion_cost",
         "//server/util/shlex",
         "//server/util/status",
         "//server/util/statusz",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -47,6 +47,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
+	"github.com/buildbuddy-io/buildbuddy/server/util/pod_deletion_cost"
 	"github.com/buildbuddy-io/buildbuddy/server/util/shlex"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
@@ -421,6 +422,12 @@ func main() {
 	}
 	if err := taskScheduler.Start(); err != nil {
 		log.Fatalf("Error starting task scheduler: %v", err)
+	}
+	if err := pod_deletion_cost.Start(rootContext, resources.GetK8sPodName(), resources.GetK8sNamespace(), func() int32 {
+		secs := int64(taskScheduler.TotalRunningTaskExecutionDuration() / time.Second)
+		return int32(min(secs, math.MaxInt32))
+	}); err != nil {
+		log.Fatalf("Error starting pod deletion cost updates: %s", err)
 	}
 
 	monitoring.StartMonitoringHandler(env, fmt.Sprintf("%s:%d", *listen, *monitoringPort))

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -370,6 +370,10 @@ type PriorityTaskScheduler struct {
 	resourceCapacity        *resourceCounts
 	resourcesUsed           *resourceCounts
 	exclusiveTaskScheduling bool
+
+	// activeTaskStartTimes contains, for each currently running task, the
+	// time at which the task started executing.
+	activeTaskStartTimes map[string]time.Time
 }
 
 func NewPriorityTaskScheduler(env environment.Env, exec IExecutor, runnerPool interfaces.RunnerPool, taskLeaser interfaces.TaskLeaser, options *Options) (*PriorityTaskScheduler, error) {
@@ -414,6 +418,7 @@ func NewPriorityTaskScheduler(env environment.Env, exec IExecutor, runnerPool in
 			Custom:    customResourcesUsed,
 		},
 		exclusiveTaskScheduling: *exclusiveTaskScheduling,
+		activeTaskStartTimes:    make(map[string]time.Time),
 	}
 	qes.rootContext = qes.enrichContext(qes.rootContext)
 
@@ -643,6 +648,7 @@ func (q *PriorityTaskScheduler) runTask(ctx context.Context, st *repb.ScheduledT
 
 func (q *PriorityTaskScheduler) trackTask(res *scpb.EnqueueTaskReservationRequest, cancel *context.CancelFunc) {
 	q.activeCancelFuncsCount.Add(1)
+	q.activeTaskStartTimes[res.GetTaskId()] = q.clock.Now()
 	if size := res.GetTaskSize(); size != nil {
 		q.resourcesUsed.RAMBytes += size.GetEstimatedMemoryBytes()
 		q.resourcesUsed.CPUMillis += size.GetEstimatedMilliCpu()
@@ -664,6 +670,7 @@ func (q *PriorityTaskScheduler) trackTask(res *scpb.EnqueueTaskReservationReques
 
 func (q *PriorityTaskScheduler) untrackTask(res *scpb.EnqueueTaskReservationRequest, cancel *context.CancelFunc) {
 	q.activeCancelFuncsCount.Add(-1)
+	delete(q.activeTaskStartTimes, res.GetTaskId())
 	if size := res.GetTaskSize(); size != nil {
 		q.resourcesUsed.RAMBytes -= size.GetEstimatedMemoryBytes()
 		q.resourcesUsed.CPUMillis -= size.GetEstimatedMilliCpu()
@@ -681,6 +688,21 @@ func (q *PriorityTaskScheduler) untrackTask(res *scpb.EnqueueTaskReservationRequ
 		}
 		log.CtxDebugf(q.rootContext, "Released task resources. Queue stats: %s", q.stats())
 	}
+}
+
+// TotalRunningTaskExecutionDuration returns the total time that currently
+// running tasks have collectively spent executing. This approximates the
+// execution progress that would be lost if this executor were shut down,
+// since tasks that get killed are re-enqueued and restart from scratch.
+func (q *PriorityTaskScheduler) TotalRunningTaskExecutionDuration() time.Duration {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	now := q.clock.Now()
+	var total time.Duration
+	for _, startedAt := range q.activeTaskStartTimes {
+		total += now.Sub(startedAt)
+	}
+	return total
 }
 
 func (q *PriorityTaskScheduler) stats() string {

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
@@ -409,6 +409,67 @@ func TestLocalEnqueueTimestamp(t *testing.T) {
 	require.Equal(t, startTime, task.ScheduledTask.GetWorkerQueuedTimestamp().AsTime())
 }
 
+func TestTotalRunningTaskExecutionDuration(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	startTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := clockwork.NewFakeClockAt(startTime)
+	env.SetClock(clock)
+	env.SetRemoteExecutionClient(&FakeExecutionClient{})
+	executor := NewFakeExecutor()
+	runnerPool := &FakeRunnerPool{}
+	leaser := NewFakeTaskLeaser()
+
+	scheduler, err := NewPriorityTaskScheduler(env, executor, runnerPool, leaser, &Options{})
+	require.NoError(t, err)
+	scheduler.Start()
+	t.Cleanup(func() {
+		err := scheduler.Stop()
+		require.NoError(t, err)
+		assert.NoError(t, scheduler.Shutdown(ctx))
+	})
+
+	// With no tasks running, the total execution duration should be zero.
+	require.Equal(t, time.Duration(0), scheduler.TotalRunningTaskExecutionDuration())
+
+	// Start a task. It just started executing, so the total should still be
+	// zero.
+	task1ID := fakeTaskID("task1")
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{TaskId: task1ID})
+	require.NoError(t, err)
+	execution1 := <-executor.StartedExecutions
+	require.Equal(t, time.Duration(0), scheduler.TotalRunningTaskExecutionDuration())
+
+	// After 10 seconds, the running task has 10 seconds of execution
+	// progress.
+	clock.Advance(10 * time.Second)
+	require.Equal(t, 10*time.Second, scheduler.TotalRunningTaskExecutionDuration())
+
+	// Start a second task, then let 20 more seconds pass. The first task has
+	// now been executing for 30 seconds and the second for 20 seconds, so
+	// the total should be 50 seconds.
+	task2ID := fakeTaskID("task2")
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{TaskId: task2ID})
+	require.NoError(t, err)
+	execution2 := <-executor.StartedExecutions
+	clock.Advance(20 * time.Second)
+	require.Equal(t, 50*time.Second, scheduler.TotalRunningTaskExecutionDuration())
+
+	// Complete the first task. Only the second task's 20 seconds of
+	// execution progress should remain. Task completion is asynchronous, so
+	// poll for the expected value.
+	execution1.Complete()
+	require.Eventually(t, func() bool {
+		return scheduler.TotalRunningTaskExecutionDuration() == 20*time.Second
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Complete the second task; the total should drop back to zero.
+	execution2.Complete()
+	require.Eventually(t, func() bool {
+		return scheduler.TotalRunningTaskExecutionDuration() == 0
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
 func TestRemoveTaskFromQueue(t *testing.T) {
 	ctx := t.Context()
 	// Try a few runs where we enqueue several tasks, cancel a few tasks, then

--- a/server/util/pod_deletion_cost/BUILD
+++ b/server/util/pod_deletion_cost/BUILD
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "pod_deletion_cost",
+    srcs = ["pod_deletion_cost.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/pod_deletion_cost",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/log",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_client_go//kubernetes",
+        "@io_k8s_client_go//rest",
+    ],
+)
+
+go_test(
+    name = "pod_deletion_cost_test",
+    srcs = ["pod_deletion_cost_test.go"],
+    embed = [":pod_deletion_cost"],
+    deps = [
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_client_go//kubernetes",
+        "@io_k8s_client_go//kubernetes/fake",
+        "@io_k8s_client_go//testing",
+    ],
+)

--- a/server/util/pod_deletion_cost/pod_deletion_cost.go
+++ b/server/util/pod_deletion_cost/pod_deletion_cost.go
@@ -1,0 +1,129 @@
+// Package pod_deletion_cost keeps the
+// controller.kubernetes.io/pod-deletion-cost annotation on the server's own
+// pod up to date, so that on scale-down, Kubernetes prefers to delete the
+// pods with the lowest deletion cost. For example, executors report the total
+// execution progress of their running tasks as the cost, so that scale-down
+// wastes as little work as possible.
+package pod_deletion_cost
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/jonboulle/clockwork"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	enabled = flag.Bool("pod_deletion_cost.enabled", false, "Whether to periodically update the controller.kubernetes.io/pod-deletion-cost annotation on this server's own pod. On scale-down, Kubernetes prefers to delete the pods with the lowest deletion cost. Requires the MY_POD_NAME and MY_NAMESPACE environment variables (typically set via the downward API) and RBAC permission to patch the pod.")
+
+	// Note: Kubernetes docs discourage frequent updates of this annotation:
+	// https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#pod-deletion-cost
+	updateInterval = flag.Duration("pod_deletion_cost.update_interval", 30*time.Second, "How often to update the pod-deletion-cost annotation.")
+)
+
+// AnnotationKey is the annotation that the ReplicaSet controller reads when
+// deciding which pods to delete first on scale-down. Pods with lower values
+// are deleted first.
+const AnnotationKey = "controller.kubernetes.io/pod-deletion-cost"
+
+const patchTimeout = 10 * time.Second
+
+// An Updater periodically patches the server's own pod, setting the
+// pod-deletion-cost annotation to the value returned by the cost function.
+type Updater struct {
+	client    kubernetes.Interface
+	clock     clockwork.Clock
+	podName   string
+	namespace string
+	cost      func() int32
+
+	lastCost    int32
+	hasLastCost bool
+}
+
+func NewUpdater(client kubernetes.Interface, podName, namespace string, clock clockwork.Clock, cost func() int32) *Updater {
+	return &Updater{
+		client:    client,
+		clock:     clock,
+		podName:   podName,
+		namespace: namespace,
+		cost:      cost,
+	}
+}
+
+// Start begins updating the pod-deletion-cost annotation in the background,
+// if enabled. cost returns the current deletion cost for this pod.
+func Start(ctx context.Context, podName, podNamespace string, cost func() int32) error {
+	if !*enabled {
+		return nil
+	}
+	if podName == "" {
+		return fmt.Errorf("pod deletion cost updates require a pod name; make sure the MY_POD_NAME and MY_NAMESPACE environment variables are set")
+	}
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("get in-cluster k8s config: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("create k8s client: %w", err)
+	}
+	log.Infof("Starting pod deletion cost updates for pod %q in namespace %q", podName, podNamespace)
+	u := NewUpdater(client, podName, podNamespace, clockwork.NewRealClock(), cost)
+	go u.Run(ctx)
+	return nil
+}
+
+// Run updates the annotation immediately and then on every update interval,
+// until ctx is canceled.
+func (u *Updater) Run(ctx context.Context) {
+	ticker := u.clock.NewTicker(*updateInterval)
+	defer ticker.Stop()
+	for {
+		if err := u.Update(ctx); err != nil {
+			log.Warningf("Could not update pod deletion cost: %s", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.Chan():
+		}
+	}
+}
+
+// Update patches the pod-deletion-cost annotation with the current cost. The
+// patch is skipped if the cost is unchanged since the last update.
+func (u *Updater) Update(ctx context.Context) error {
+	cost := u.cost()
+	if u.hasLastCost && cost == u.lastCost {
+		return nil
+	}
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				AnnotationKey: strconv.FormatInt(int64(cost), 10),
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal patch: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, patchTimeout)
+	defer cancel()
+	if _, err := u.client.CoreV1().Pods(u.namespace).Patch(ctx, u.podName, types.StrategicMergePatchType, patch, k8smeta.PatchOptions{}); err != nil {
+		return fmt.Errorf("patch pod %s/%s: %w", u.namespace, u.podName, err)
+	}
+	u.lastCost = cost
+	u.hasLastCost = true
+	return nil
+}

--- a/server/util/pod_deletion_cost/pod_deletion_cost_test.go
+++ b/server/util/pod_deletion_cost/pod_deletion_cost_test.go
@@ -1,0 +1,95 @@
+package pod_deletion_cost
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func newFakePod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: k8smeta.ObjectMeta{
+			Name:      "executor-pod",
+			Namespace: "executor-ns",
+		},
+	}
+}
+
+func getAnnotation(t *testing.T, client kubernetes.Interface) string {
+	pod, err := client.CoreV1().Pods("executor-ns").Get(t.Context(), "executor-pod", k8smeta.GetOptions{})
+	require.NoError(t, err)
+	return pod.GetAnnotations()[AnnotationKey]
+}
+
+func TestUpdateSetsAnnotationToCost(t *testing.T) {
+	ctx := t.Context()
+	client := fake.NewClientset(newFakePod())
+	cost := int32(0)
+	u := NewUpdater(client, "executor-pod", "executor-ns", clockwork.NewFakeClock(), func() int32 { return cost })
+
+	// With a cost of 0, the first update should explicitly set the deletion
+	// cost annotation to 0, marking this pod as the cheapest to delete.
+	require.NoError(t, u.Update(ctx))
+	require.Equal(t, "0", getAnnotation(t, client))
+
+	// Raise the cost; the annotation should be updated to match.
+	cost = 90
+	require.NoError(t, u.Update(ctx))
+	require.Equal(t, "90", getAnnotation(t, client))
+
+	// Drop the cost back to 0; the annotation should follow.
+	cost = 0
+	require.NoError(t, u.Update(ctx))
+	require.Equal(t, "0", getAnnotation(t, client))
+}
+
+func TestUpdateSkipsPatchIfCostUnchanged(t *testing.T) {
+	ctx := t.Context()
+	client := fake.NewClientset(newFakePod())
+	cost := int32(60)
+	u := NewUpdater(client, "executor-pod", "executor-ns", clockwork.NewFakeClock(), func() int32 { return cost })
+
+	countPatches := func() int {
+		n := 0
+		for _, action := range client.Actions() {
+			if _, ok := action.(k8stesting.PatchAction); ok {
+				n++
+			}
+		}
+		return n
+	}
+
+	// The first update should patch the pod.
+	require.NoError(t, u.Update(ctx))
+	require.Equal(t, 1, countPatches())
+
+	// The cost hasn't changed, so the next update should not issue another
+	// patch.
+	require.NoError(t, u.Update(ctx))
+	require.Equal(t, 1, countPatches())
+
+	// Once the cost changes, the next update should patch the pod again.
+	cost = 61
+	require.NoError(t, u.Update(ctx))
+	require.Equal(t, 2, countPatches())
+	require.Equal(t, "61", getAnnotation(t, client))
+}
+
+func TestUpdateAllowsNegativeCost(t *testing.T) {
+	ctx := t.Context()
+	client := fake.NewClientset(newFakePod())
+	// Report a negative cost, which Kubernetes allows; it should be written
+	// to the annotation as-is.
+	cost := int32(math.MinInt32)
+	u := NewUpdater(client, "executor-pod", "executor-ns", clockwork.NewFakeClock(), func() int32 { return cost })
+	require.NoError(t, u.Update(ctx))
+	require.Equal(t, "-2147483648", getAnnotation(t, client))
+}


### PR DESCRIPTION
Have each executor periodically patch its own pod-deletion-cost annotation, so that when scaling down, we can minimize lost execution progress. For now, the cost is calculated as the sum of all active tasks' execution durations. At some point, we might want to consider weighting by compute units as well.

XXX: k8s docs discourage updating this metric frequently. We might want to see if there is a way to only update it right before we're about to scale down. That would probably be more accurate as well.
