### PR TITLE
invocation: show compact log action edges

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -149,6 +149,7 @@ ts_library(
         "//app/format",
         "//app/icons:file_icon",
         "//app/invocation:action_compare_button",
+        "//app/invocation:compact_exec_log_action_edges",
         "//app/invocation:execution_status",
         "//app/invocation:invocation_action_tree_node",
         "//app/invocation:invocation_model",
@@ -172,6 +173,25 @@ ts_library(
         "//proto:stored_invocation_ts_proto",
         "//proto:timestamp_ts_proto",
         "//proto:workflow_ts_proto",
+    ],
+)
+
+ts_library(
+    name = "compact_exec_log_action_edges",
+    srcs = ["compact_exec_log_action_edges.ts"],
+    deps = [
+        "//:node_modules/tslib",
+        "//proto:spawn_ts_proto",
+    ],
+)
+
+ts_jasmine_node_test(
+    name = "compact_exec_log_action_edges_test",
+    srcs = ["compact_exec_log_action_edges_test.ts"],
+    deps = [
+        ":compact_exec_log_action_edges",
+        "//:node_modules/tslib",
+        "//proto:spawn_ts_proto",
     ],
 )
 

--- a/app/invocation/compact_exec_log_action_edges.ts
+++ b/app/invocation/compact_exec_log_action_edges.ts
@@ -1,0 +1,888 @@
+import { tools } from "../../proto/spawn_ts_proto";
+
+const CACHE_VERSION = 4;
+const MAX_CACHED_ACTION_EDGE_INDEXES = 5;
+const PERSISTENT_DB_NAME = "buildbuddy-compact-exec-log-action-edges";
+const PERSISTENT_DB_VERSION = 1;
+const PERSISTENT_STORE_NAME = "indexes";
+const PERSISTENT_LAST_ACCESSED_INDEX = "lastAccessedAtMillis";
+const MAX_PERSISTENT_ACTION_EDGE_INDEXES = 20;
+const memoryCache = new Map<string, CompactExecLogActionEdgesIndex>();
+const pendingLoads = new Map<string, Promise<CompactExecLogActionEdgesIndex>>();
+let persistentDBPromise: Promise<IDBDatabase | undefined> | undefined;
+
+interface IDigestLike {
+  hash?: string | null;
+  sizeBytes?: unknown;
+}
+
+export interface CompactExecLogActionSummary {
+  id: string;
+  kind: "spawn" | "symlink";
+  targetLabel: string;
+  label: string;
+  mnemonic: string;
+  cached: boolean;
+  result: "succeeded" | "failed";
+  primaryOutputPath?: string;
+  digestHash?: string;
+  digestSizeBytes?: string;
+  parentIds: string[];
+  childIds: string[];
+  parentEdges: CompactExecLogActionEdge[];
+  childEdges: CompactExecLogActionEdge[];
+}
+
+export interface CompactExecLogActionEdge {
+  actionId: string;
+  artifactId: number;
+  artifactPath: string;
+}
+
+export interface CompactExecLogActionEdgesIndex {
+  actions: CompactExecLogActionSummary[];
+  actionById: Map<string, CompactExecLogActionSummary>;
+}
+
+interface ParsedTargetLabel {
+  workspace: string;
+  packagePath: string;
+  isExternal: boolean;
+  isKnownLabel: boolean;
+}
+
+type ActionKind = CompactExecLogActionSummary["kind"];
+
+interface IndexBuildState {
+  files: Map<number, tools.protos.ExecLogEntry.File>;
+  directories: Map<number, tools.protos.ExecLogEntry.Directory>;
+  symlinks: Map<number, tools.protos.ExecLogEntry.UnresolvedSymlink>;
+  runfilesTrees: Map<number, tools.protos.ExecLogEntry.RunfilesTree>;
+  inputSets: Map<number, tools.protos.ExecLogEntry.InputSet>;
+  symlinkEntrySets: Map<number, tools.protos.ExecLogEntry.SymlinkEntrySet>;
+  spawns: Map<number, tools.protos.ExecLogEntry.Spawn>;
+  symlinkActions: Map<number, tools.protos.ExecLogEntry.SymlinkAction>;
+  actions: Map<string, MutableActionSummary>;
+  pathToArtifactId: Map<string, number>;
+  equivalentPathToArtifactId: Map<string, number>;
+  ambiguousEquivalentPaths: Set<string>;
+  artifactProducers: Map<number, string>;
+  expandedInputSets: Map<number, Set<number>>;
+  expandedSymlinkEntrySets: Map<number, Map<string, number>>;
+}
+
+interface MutableActionSummary {
+  id: string;
+  kind: ActionKind;
+  rawOrder: number;
+  targetLabel: string;
+  label: string;
+  mnemonic: string;
+  cached: boolean;
+  result: "succeeded" | "failed";
+  primaryOutputPath?: string;
+  digestHash?: string;
+  digestSizeBytes?: string;
+  parentIds: Set<string>;
+  childIds: Set<string>;
+  parentEdges: Map<string, CompactExecLogActionEdge>;
+  childEdges: Map<string, CompactExecLogActionEdge>;
+}
+
+interface ActionLabelMeta {
+  actionId: string;
+  mnemonic: string;
+  filename: string;
+  platform: string;
+}
+
+interface PersistentActionEdgesIndexRecord {
+  cacheKey: string;
+  createdAtMillis: number;
+  lastAccessedAtMillis: number;
+  actions: CompactExecLogActionSummary[];
+}
+
+export async function getCompactExecLogActionEdgesIndex(
+  executionLogUri: string,
+  loadEntries: () => Promise<tools.protos.ExecLogEntry[]>
+): Promise<CompactExecLogActionEdgesIndex> {
+  const cacheKey = `v${CACHE_VERSION}:${executionLogUri}`;
+  const cached = getCachedIndex(cacheKey);
+  if (cached) return cached;
+
+  const pending = pendingLoads.get(cacheKey);
+  if (pending) return pending;
+
+  const loadPromise = (async () => {
+    const persistentIndex = await getPersistentCachedIndex(cacheKey);
+    if (persistentIndex) {
+      setCachedIndex(cacheKey, persistentIndex);
+      return persistentIndex;
+    }
+
+    const entries = await loadEntries();
+    const index = buildCompactExecLogActionEdgesIndex(entries);
+    setCachedIndex(cacheKey, index);
+    setPersistentCachedIndex(cacheKey, index);
+    return index;
+  })().finally(() => pendingLoads.delete(cacheKey));
+
+  pendingLoads.set(cacheKey, loadPromise);
+  return loadPromise;
+}
+
+function getCachedIndex(cacheKey: string): CompactExecLogActionEdgesIndex | undefined {
+  const cached = memoryCache.get(cacheKey);
+  if (!cached) return undefined;
+  memoryCache.delete(cacheKey);
+  memoryCache.set(cacheKey, cached);
+  return cached;
+}
+
+function setCachedIndex(cacheKey: string, index: CompactExecLogActionEdgesIndex) {
+  memoryCache.delete(cacheKey);
+  memoryCache.set(cacheKey, index);
+  while (memoryCache.size > MAX_CACHED_ACTION_EDGE_INDEXES) {
+    const oldestKey = memoryCache.keys().next().value;
+    if (!oldestKey) break;
+    memoryCache.delete(oldestKey);
+  }
+}
+
+function getPersistentCacheDB(): Promise<IDBDatabase | undefined> {
+  if (persistentDBPromise) return persistentDBPromise;
+  if (typeof window === "undefined" || !window.indexedDB) {
+    persistentDBPromise = Promise.resolve(undefined);
+    return persistentDBPromise;
+  }
+
+  persistentDBPromise = new Promise((resolve) => {
+    const request = window.indexedDB.open(PERSISTENT_DB_NAME, PERSISTENT_DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      const store = db.objectStoreNames.contains(PERSISTENT_STORE_NAME)
+        ? request.transaction?.objectStore(PERSISTENT_STORE_NAME)
+        : db.createObjectStore(PERSISTENT_STORE_NAME, { keyPath: "cacheKey" });
+      if (store && !store.indexNames.contains(PERSISTENT_LAST_ACCESSED_INDEX)) {
+        store.createIndex(PERSISTENT_LAST_ACCESSED_INDEX, PERSISTENT_LAST_ACCESSED_INDEX);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(undefined);
+    request.onblocked = () => resolve(undefined);
+  });
+  return persistentDBPromise;
+}
+
+async function getPersistentCachedIndex(cacheKey: string): Promise<CompactExecLogActionEdgesIndex | undefined> {
+  const db = await getPersistentCacheDB();
+  if (!db) return undefined;
+
+  const record = await getPersistentCacheRecord(db, cacheKey);
+  if (!record) return undefined;
+
+  updatePersistentCacheLastAccessed(db, cacheKey);
+  return hydrateActionEdgesIndex(record.actions);
+}
+
+function setPersistentCachedIndex(cacheKey: string, index: CompactExecLogActionEdgesIndex) {
+  getPersistentCacheDB().then(async (db) => {
+    if (!db) return;
+    await putPersistentCacheRecord(db, {
+      cacheKey,
+      createdAtMillis: Date.now(),
+      lastAccessedAtMillis: Date.now(),
+      actions: index.actions,
+    });
+    prunePersistentCache(db);
+  });
+}
+
+function hydrateActionEdgesIndex(actions: CompactExecLogActionSummary[]): CompactExecLogActionEdgesIndex {
+  return {
+    actions,
+    actionById: new Map(actions.map((action) => [action.id, action])),
+  };
+}
+
+function getPersistentCacheRecord(
+  db: IDBDatabase,
+  cacheKey: string
+): Promise<PersistentActionEdgesIndexRecord | undefined> {
+  return new Promise((resolve) => {
+    const transaction = db.transaction(PERSISTENT_STORE_NAME, "readonly");
+    const request = transaction.objectStore(PERSISTENT_STORE_NAME).get(cacheKey);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(undefined);
+    transaction.onabort = () => resolve(undefined);
+    transaction.onerror = () => resolve(undefined);
+  });
+}
+
+function putPersistentCacheRecord(db: IDBDatabase, record: PersistentActionEdgesIndexRecord): Promise<void> {
+  return new Promise((resolve) => {
+    const transaction = db.transaction(PERSISTENT_STORE_NAME, "readwrite");
+    transaction.objectStore(PERSISTENT_STORE_NAME).put(record);
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => resolve();
+    transaction.onerror = () => resolve();
+  });
+}
+
+function updatePersistentCacheLastAccessed(db: IDBDatabase, cacheKey: string) {
+  getPersistentCacheRecord(db, cacheKey).then((record) => {
+    if (!record) return;
+    putPersistentCacheRecord(db, { ...record, lastAccessedAtMillis: Date.now() });
+  });
+}
+
+async function prunePersistentCache(db: IDBDatabase) {
+  const cacheKeys = await getPersistentCacheKeysByLastAccess(db);
+  const deleteCount = cacheKeys.length - MAX_PERSISTENT_ACTION_EDGE_INDEXES;
+  if (deleteCount <= 0) return;
+  deletePersistentCacheKeys(db, cacheKeys.slice(0, deleteCount));
+}
+
+function getPersistentCacheKeysByLastAccess(db: IDBDatabase): Promise<string[]> {
+  return new Promise((resolve) => {
+    const cacheKeys: string[] = [];
+    const transaction = db.transaction(PERSISTENT_STORE_NAME, "readonly");
+    const store = transaction.objectStore(PERSISTENT_STORE_NAME);
+    const request = store.index(PERSISTENT_LAST_ACCESSED_INDEX).openKeyCursor();
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (!cursor) return;
+      cacheKeys.push(String(cursor.primaryKey));
+      cursor.continue();
+    };
+    request.onerror = () => resolve([]);
+    transaction.oncomplete = () => resolve(cacheKeys);
+    transaction.onabort = () => resolve([]);
+    transaction.onerror = () => resolve([]);
+  });
+}
+
+function deletePersistentCacheKeys(db: IDBDatabase, cacheKeys: string[]): Promise<void> {
+  return new Promise((resolve) => {
+    const transaction = db.transaction(PERSISTENT_STORE_NAME, "readwrite");
+    const store = transaction.objectStore(PERSISTENT_STORE_NAME);
+    for (const cacheKey of cacheKeys) store.delete(cacheKey);
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => resolve();
+    transaction.onerror = () => resolve();
+  });
+}
+
+export function buildCompactExecLogActionEdgesIndex(
+  entries: tools.protos.ExecLogEntry[]
+): CompactExecLogActionEdgesIndex {
+  const state: IndexBuildState = {
+    files: new Map(),
+    directories: new Map(),
+    symlinks: new Map(),
+    runfilesTrees: new Map(),
+    inputSets: new Map(),
+    symlinkEntrySets: new Map(),
+    spawns: new Map(),
+    symlinkActions: new Map(),
+    actions: new Map(),
+    pathToArtifactId: new Map(),
+    equivalentPathToArtifactId: new Map(),
+    ambiguousEquivalentPaths: new Set(),
+    artifactProducers: new Map(),
+    expandedInputSets: new Map(),
+    expandedSymlinkEntrySets: new Map(),
+  };
+  let nextSpawnId = 1;
+  let nextSymlinkActionId = 1;
+
+  entries.forEach((entry, rawOrder) => {
+    const id = Number(entry.id || 0);
+
+    if (entry.file) {
+      if (id) state.files.set(id, entry.file);
+      if (id && entry.file.path) recordArtifactPath(state, entry.file.path, id);
+      return;
+    }
+    if (entry.directory) {
+      if (id) state.directories.set(id, entry.directory);
+      if (id && entry.directory.path) recordArtifactPath(state, entry.directory.path, id);
+      return;
+    }
+    if (entry.unresolvedSymlink) {
+      if (id) state.symlinks.set(id, entry.unresolvedSymlink);
+      if (id && entry.unresolvedSymlink.path) recordArtifactPath(state, entry.unresolvedSymlink.path, id);
+      return;
+    }
+    if (entry.runfilesTree) {
+      if (id) state.runfilesTrees.set(id, entry.runfilesTree);
+      if (id && entry.runfilesTree.path) recordArtifactPath(state, entry.runfilesTree.path, id);
+      return;
+    }
+    if (entry.inputSet) {
+      if (id) state.inputSets.set(id, entry.inputSet);
+      return;
+    }
+    if (entry.symlinkEntrySet) {
+      if (id) state.symlinkEntrySets.set(id, entry.symlinkEntrySet);
+      return;
+    }
+    if (entry.spawn) {
+      const spawnId = id || nextSpawnId++;
+      const actionId = makeActionId("spawn", spawnId);
+      state.spawns.set(spawnId, entry.spawn);
+      state.actions.set(actionId, createSpawnSummary(actionId, entry.spawn, rawOrder));
+      for (const output of entry.spawn.outputs || []) {
+        const outputId = getOutputId(output);
+        if (outputId) state.artifactProducers.set(outputId, actionId);
+      }
+      return;
+    }
+    if (entry.symlinkAction) {
+      const symlinkActionId = id || nextSymlinkActionId++;
+      const actionId = makeActionId("symlink", symlinkActionId);
+      state.symlinkActions.set(symlinkActionId, entry.symlinkAction);
+      state.actions.set(actionId, createSymlinkSummary(actionId, entry.symlinkAction, rawOrder));
+    }
+  });
+
+  for (const [actionId, action] of state.actions.entries()) {
+    populatePrimaryOutputPath(actionId, action, state);
+  }
+  applyDisambiguatedActionLabels(state);
+
+  for (const [actionId, action] of state.actions.entries()) {
+    if (action.kind !== "symlink") continue;
+    const symlinkArtifactId = resolveSymlinkOutputArtifactId(actionId, state);
+    if (symlinkArtifactId) state.artifactProducers.set(symlinkArtifactId, actionId);
+  }
+
+  for (const [actionId, action] of state.actions.entries()) {
+    const consumedArtifactIds =
+      action.kind === "spawn"
+        ? getConsumedArtifactsForSpawn(actionId, state)
+        : getConsumedArtifactsForSymlinkAction(actionId, state);
+    for (const artifactId of consumedArtifactIds) {
+      const producerActionId = state.artifactProducers.get(artifactId);
+      if (!producerActionId || producerActionId === actionId) continue;
+      const artifactPath = getArtifactPath(artifactId, state) || `artifact ${artifactId}`;
+      action.parentIds.add(producerActionId);
+      action.parentEdges.set(getActionEdgeKey(producerActionId, artifactId), {
+        actionId: producerActionId,
+        artifactId,
+        artifactPath,
+      });
+      const producerAction = state.actions.get(producerActionId);
+      producerAction?.childIds.add(actionId);
+      producerAction?.childEdges.set(getActionEdgeKey(actionId, artifactId), {
+        actionId,
+        artifactId,
+        artifactPath,
+      });
+    }
+  }
+
+  const actions = Array.from(state.actions.values())
+    .sort(compareActions)
+    .map<CompactExecLogActionSummary>((action) => ({
+      id: action.id,
+      kind: action.kind,
+      targetLabel: action.targetLabel,
+      label: action.label,
+      mnemonic: action.mnemonic,
+      cached: action.cached,
+      result: action.result,
+      primaryOutputPath: action.primaryOutputPath,
+      digestHash: action.digestHash,
+      digestSizeBytes: action.digestSizeBytes,
+      parentIds: sortActionIds(action.parentIds, state),
+      childIds: sortActionIds(action.childIds, state),
+      parentEdges: sortActionEdges(action.parentEdges.values(), state),
+      childEdges: sortActionEdges(action.childEdges.values(), state),
+    }));
+
+  return {
+    actions,
+    actionById: new Map(actions.map((action) => [action.id, action])),
+  };
+}
+
+export function findCompactExecLogAction(
+  index: CompactExecLogActionEdgesIndex | undefined,
+  digest: IDigestLike | null | undefined,
+  targetLabel?: string,
+  mnemonic?: string
+): CompactExecLogActionSummary | undefined {
+  if (!index || !digest?.hash) return undefined;
+  const digestSizeBytes = digest.sizeBytes !== undefined && digest.sizeBytes !== null ? String(digest.sizeBytes) : "";
+  let candidates = index.actions.filter((action) => action.digestHash === digest.hash);
+  if (digestSizeBytes) {
+    const exact = candidates.filter((action) => !action.digestSizeBytes || action.digestSizeBytes === digestSizeBytes);
+    if (exact.length) candidates = exact;
+  }
+  if (targetLabel) {
+    const targetMatches = candidates.filter((action) => action.targetLabel === targetLabel);
+    if (targetMatches.length) candidates = targetMatches;
+  }
+  if (mnemonic) {
+    const mnemonicMatches = candidates.filter((action) => action.mnemonic === mnemonic || action.label === mnemonic);
+    if (mnemonicMatches.length) candidates = mnemonicMatches;
+  }
+  return candidates[0];
+}
+
+export function compareTargetLabelsByRelevance(a: string, b: string, referenceTargetLabel: string | undefined): number {
+  const rankA = getTargetLabelRelevanceRank(a, referenceTargetLabel);
+  const rankB = getTargetLabelRelevanceRank(b, referenceTargetLabel);
+  if (rankA !== rankB) return rankA - rankB;
+  return a.localeCompare(b);
+}
+
+function createSpawnSummary(
+  actionId: string,
+  spawn: tools.protos.ExecLogEntry.Spawn,
+  rawOrder: number
+): MutableActionSummary {
+  const mnemonic = getSpawnDisplayMnemonic(spawn);
+  return {
+    id: actionId,
+    kind: "spawn",
+    rawOrder,
+    targetLabel: spawn.targetLabel || "",
+    label: mnemonic,
+    mnemonic,
+    cached: Boolean(spawn.cacheHit),
+    result: isFailedSpawn(spawn) ? "failed" : "succeeded",
+    digestHash: spawn.digest?.hash || undefined,
+    digestSizeBytes: spawn.digest ? String(spawn.digest.sizeBytes || 0) : undefined,
+    parentIds: new Set(),
+    childIds: new Set(),
+    parentEdges: new Map(),
+    childEdges: new Map(),
+  };
+}
+
+function createSymlinkSummary(
+  actionId: string,
+  action: tools.protos.ExecLogEntry.SymlinkAction,
+  rawOrder: number
+): MutableActionSummary {
+  const mnemonic = (action.mnemonic || "Symlink").trim();
+  return {
+    id: actionId,
+    kind: "symlink",
+    rawOrder,
+    targetLabel: action.targetLabel || "",
+    label: mnemonic,
+    mnemonic,
+    cached: false,
+    result: "succeeded",
+    parentIds: new Set(),
+    childIds: new Set(),
+    parentEdges: new Map(),
+    childEdges: new Map(),
+  };
+}
+
+function populatePrimaryOutputPath(actionId: string, action: MutableActionSummary, state: IndexBuildState) {
+  if (action.kind === "spawn") {
+    const spawn = state.spawns.get(parseActionNumericId(actionId));
+    action.primaryOutputPath = spawn ? getSpawnPrimaryOutputPath(spawn, state) : undefined;
+    return;
+  }
+  const symlinkAction = state.symlinkActions.get(parseActionNumericId(actionId));
+  action.primaryOutputPath = symlinkAction?.outputPath || undefined;
+}
+
+function getConsumedArtifactsForSpawn(actionId: string, state: IndexBuildState): Set<number> {
+  const spawn = state.spawns.get(parseActionNumericId(actionId));
+  if (!spawn) return new Set();
+  const result = new Set<number>();
+  mergeInto(result, expandInputSet(spawn.inputSetId, state));
+  mergeInto(result, expandInputSet(spawn.toolSetId, state));
+  return result;
+}
+
+function getConsumedArtifactsForSymlinkAction(actionId: string, state: IndexBuildState): Set<number> {
+  const symlinkAction = state.symlinkActions.get(parseActionNumericId(actionId));
+  if (!symlinkAction?.inputPath) return new Set();
+  const artifactId = findArtifactIdByPath(state, symlinkAction.inputPath);
+  return artifactId ? new Set([artifactId]) : new Set();
+}
+
+function expandInputSet(inputSetId: number | undefined, state: IndexBuildState): Set<number> {
+  if (!inputSetId) return new Set();
+  const cached = state.expandedInputSets.get(inputSetId);
+  if (cached) return cached;
+
+  const inputSet = state.inputSets.get(inputSetId);
+  if (!inputSet) return new Set();
+
+  const result = new Set<number>();
+  for (const transitiveId of inputSet.transitiveSetIds || []) {
+    mergeInto(result, expandInputSet(transitiveId, state));
+  }
+  for (const artifactId of [
+    ...(inputSet.inputIds || []),
+    ...(inputSet.fileIds || []),
+    ...(inputSet.directoryIds || []),
+    ...(inputSet.unresolvedSymlinkIds || []),
+  ]) {
+    collectArtifactDependencies(artifactId, state, result);
+  }
+  state.expandedInputSets.set(inputSetId, result);
+  return result;
+}
+
+function collectArtifactDependencies(artifactId: number, state: IndexBuildState, result: Set<number>) {
+  if (!artifactId || result.has(artifactId)) return;
+  result.add(artifactId);
+
+  const runfilesTree = state.runfilesTrees.get(artifactId);
+  if (!runfilesTree) return;
+
+  mergeInto(result, expandInputSet(runfilesTree.inputSetId, state));
+  for (const entryId of expandSymlinkEntrySet(runfilesTree.symlinksId, state).values()) {
+    collectArtifactDependencies(entryId, state, result);
+  }
+  for (const entryId of expandSymlinkEntrySet(runfilesTree.rootSymlinksId, state).values()) {
+    collectArtifactDependencies(entryId, state, result);
+  }
+}
+
+function expandSymlinkEntrySet(entrySetId: number | undefined, state: IndexBuildState): Map<string, number> {
+  if (!entrySetId) return new Map();
+  const cached = state.expandedSymlinkEntrySets.get(entrySetId);
+  if (cached) return cached;
+
+  const result = new Map<string, number>();
+  const visited = new Set<number>();
+  const visit = (currentId: number) => {
+    if (!currentId || visited.has(currentId)) return;
+    visited.add(currentId);
+    const entrySet = state.symlinkEntrySets.get(currentId);
+    if (!entrySet) return;
+    for (const transitiveId of entrySet.transitiveSetIds || []) {
+      visit(transitiveId);
+    }
+    for (const [relativePath, artifactId] of Object.entries(entrySet.directEntries || {})) {
+      result.set(relativePath, Number(artifactId));
+    }
+  };
+  visit(entrySetId);
+  state.expandedSymlinkEntrySets.set(entrySetId, result);
+  return result;
+}
+
+export function getExecConfiguredPathLookupCandidates(path: string): string[] {
+  const canonicalFallbackPath = path.replace(/-exec-ST-[^/]+\//, "-exec/");
+  return canonicalFallbackPath === path ? [path] : [path, canonicalFallbackPath];
+}
+
+function recordArtifactPath(state: IndexBuildState, path: string, artifactId: number) {
+  state.pathToArtifactId.set(path, artifactId);
+  for (const candidatePath of getExecConfiguredPathLookupCandidates(path)) {
+    if (candidatePath === path) continue;
+    recordEquivalentArtifactPath(state, candidatePath, artifactId);
+  }
+}
+
+function recordEquivalentArtifactPath(state: IndexBuildState, path: string, artifactId: number) {
+  if (state.ambiguousEquivalentPaths.has(path)) return;
+  const existingArtifactId = state.equivalentPathToArtifactId.get(path);
+  if (!existingArtifactId || existingArtifactId === artifactId) {
+    state.equivalentPathToArtifactId.set(path, artifactId);
+    return;
+  }
+
+  state.equivalentPathToArtifactId.delete(path);
+  state.ambiguousEquivalentPaths.add(path);
+}
+
+function findArtifactIdByPath(state: IndexBuildState, path: string): number | undefined {
+  for (const candidatePath of getExecConfiguredPathLookupCandidates(path)) {
+    const exactArtifactId = state.pathToArtifactId.get(candidatePath);
+    if (exactArtifactId) return exactArtifactId;
+
+    if (state.ambiguousEquivalentPaths.has(candidatePath)) continue;
+    const equivalentArtifactId = state.equivalentPathToArtifactId.get(candidatePath);
+    if (equivalentArtifactId) return equivalentArtifactId;
+  }
+  return undefined;
+}
+
+function resolveSymlinkOutputArtifactId(actionId: string, state: IndexBuildState): number | undefined {
+  const symlinkAction = state.symlinkActions.get(parseActionNumericId(actionId));
+  if (!symlinkAction?.outputPath) return undefined;
+
+  return findArtifactIdByPath(state, symlinkAction.outputPath);
+}
+
+function getSpawnPrimaryOutputPath(spawn: tools.protos.ExecLogEntry.Spawn, state: IndexBuildState): string | undefined {
+  let primaryOutputPath: string | undefined;
+  let sawFile = false;
+
+  for (const output of spawn.outputs || []) {
+    const path = resolveOutputPath(output, state);
+    if (!path) continue;
+
+    const outputId = getOutputId(output);
+    if (outputId && state.files.has(outputId)) {
+      if (!primaryOutputPath) primaryOutputPath = path;
+      sawFile = true;
+      continue;
+    }
+
+    if (!sawFile && !primaryOutputPath) primaryOutputPath = path;
+  }
+  return primaryOutputPath;
+}
+
+function resolveOutputPath(output: tools.protos.ExecLogEntry.Output, state: IndexBuildState): string | undefined {
+  if (output.invalidOutputPath) return output.invalidOutputPath;
+  const outputId = getOutputId(output);
+  if (!outputId) return undefined;
+  return getArtifactPath(outputId, state);
+}
+
+function getArtifactPath(artifactId: number, state: IndexBuildState): string | undefined {
+  return (
+    state.files.get(artifactId)?.path ||
+    state.directories.get(artifactId)?.path ||
+    state.symlinks.get(artifactId)?.path ||
+    state.runfilesTrees.get(artifactId)?.path
+  );
+}
+
+function getOutputId(output: tools.protos.ExecLogEntry.Output): number {
+  return (
+    Number(output.outputId || 0) ||
+    Number(output.fileId || 0) ||
+    Number(output.directoryId || 0) ||
+    Number(output.unresolvedSymlinkId || 0)
+  );
+}
+
+function isFailedSpawn(spawn: tools.protos.ExecLogEntry.Spawn): boolean {
+  return Boolean(spawn.status) || Number(spawn.exitCode || 0) !== 0;
+}
+
+function getSpawnDisplayMnemonic(spawn: tools.protos.ExecLogEntry.Spawn): string {
+  const mnemonic = spawn.mnemonic || "Action";
+  const details: string[] = [];
+  const runNumber = getEnvNumber(spawn, "TEST_RUN_NUMBER");
+  if (runNumber && runNumber > 1) details.push(`run ${runNumber}`);
+
+  const shardIndex = getEnvNumber(spawn, "TEST_SHARD_INDEX");
+  const totalShards = getEnvNumber(spawn, "TEST_TOTAL_SHARDS");
+  if (shardIndex !== undefined && totalShards && totalShards > 0) {
+    details.push(`shard ${shardIndex + 1}/${totalShards}`);
+  }
+
+  return details.length ? `${mnemonic} (${details.join(", ")})` : mnemonic;
+}
+
+function getEnvNumber(spawn: tools.protos.ExecLogEntry.Spawn, name: string): number | undefined {
+  const raw = (spawn.envVars || []).find((value) => value.name === name)?.value;
+  if (!raw) return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? Math.floor(value) : undefined;
+}
+
+function applyDisambiguatedActionLabels(state: IndexBuildState) {
+  const actionsByTargetLabel = new Map<string, MutableActionSummary[]>();
+  for (const action of state.actions.values()) {
+    const targetActions = actionsByTargetLabel.get(action.targetLabel) || [];
+    targetActions.push(action);
+    actionsByTargetLabel.set(action.targetLabel, targetActions);
+  }
+
+  for (const actions of actionsByTargetLabel.values()) {
+    const metas = actions
+      .map((action) => getActionLabelMeta(action.id, state))
+      .filter((meta): meta is ActionLabelMeta => Boolean(meta));
+
+    metas.sort(
+      (a, b) =>
+        a.mnemonic.localeCompare(b.mnemonic) ||
+        a.filename.localeCompare(b.filename) ||
+        a.platform.localeCompare(b.platform) ||
+        a.actionId.localeCompare(b.actionId)
+    );
+
+    const byMnemonic = new Map<string, ActionLabelMeta[]>();
+    for (const meta of metas) {
+      const mnemonicActions = byMnemonic.get(meta.mnemonic) || [];
+      mnemonicActions.push(meta);
+      byMnemonic.set(meta.mnemonic, mnemonicActions);
+    }
+
+    for (const [mnemonic, list] of byMnemonic.entries()) {
+      if (list.length === 1) {
+        const action = state.actions.get(list[0].actionId);
+        if (action) action.label = mnemonic;
+        continue;
+      }
+
+      const byFilename = new Map<string, ActionLabelMeta[]>();
+      for (const meta of list) {
+        const filenameActions = byFilename.get(meta.filename) || [];
+        filenameActions.push(meta);
+        byFilename.set(meta.filename, filenameActions);
+      }
+
+      for (const [filename, filenameActions] of byFilename.entries()) {
+        if (filename && filenameActions.length === 1) {
+          const action = state.actions.get(filenameActions[0].actionId);
+          if (action) action.label = `${mnemonic} (${filename})`;
+          continue;
+        }
+
+        for (const meta of filenameActions) {
+          const action = state.actions.get(meta.actionId);
+          if (action) action.label = meta.platform ? `${mnemonic} (${meta.platform})` : mnemonic;
+        }
+      }
+    }
+  }
+}
+
+function getActionLabelMeta(actionId: string, state: IndexBuildState): ActionLabelMeta | undefined {
+  const action = state.actions.get(actionId);
+  if (!action) return undefined;
+
+  if (action.kind === "spawn") {
+    const spawn = state.spawns.get(parseActionNumericId(actionId));
+    if (!spawn) return undefined;
+    const primaryOutputPath = action.primaryOutputPath || getSpawnPrimaryOutputPath(spawn, state);
+    return {
+      actionId,
+      mnemonic: action.mnemonic,
+      filename: extractFilename(primaryOutputPath),
+      platform: extractPlatform(primaryOutputPath) || getSpawnPlatformSummary(spawn),
+    };
+  }
+
+  const symlinkAction = state.symlinkActions.get(parseActionNumericId(actionId));
+  if (!symlinkAction) return undefined;
+  const outputPath = symlinkAction.outputPath || symlinkAction.inputPath;
+  return {
+    actionId,
+    mnemonic: action.mnemonic,
+    filename: extractFilename(outputPath),
+    platform: extractPlatform(outputPath),
+  };
+}
+
+function extractFilename(path: string | undefined): string {
+  if (!path) return "";
+  const parts = path.split("/");
+  return parts[parts.length - 1] || "";
+}
+
+function extractPlatform(path: string | undefined): string {
+  if (!path) return "";
+  const match = path.match(/^bazel-out\/([^/]+)\//);
+  return match?.[1] || "";
+}
+
+function getSpawnPlatformSummary(spawn: tools.protos.ExecLogEntry.Spawn): string {
+  const properties = (spawn.platform?.properties || []).map((property) => [property.name || "", property.value || ""]);
+  const relevant = properties
+    .filter(([name, value]) => name && value)
+    .filter(([name]) => ["OSFamily", "cpu", "container-image", "Pool", "Arch"].includes(name));
+
+  return relevant.map(([name, value]) => `${name}=${value}`).join(", ");
+}
+
+function sortActionIds(ids: Set<string>, state: IndexBuildState): string[] {
+  return Array.from(ids).sort((a, b) => {
+    const actionA = state.actions.get(a);
+    const actionB = state.actions.get(b);
+    if (actionA && actionB) return compareActions(actionA, actionB);
+    return a.localeCompare(b);
+  });
+}
+
+function sortActionEdges(
+  edges: Iterable<CompactExecLogActionEdge>,
+  state: IndexBuildState
+): CompactExecLogActionEdge[] {
+  return Array.from(edges).sort((a, b) => {
+    if (a.artifactPath !== b.artifactPath) return a.artifactPath.localeCompare(b.artifactPath);
+    const actionA = state.actions.get(a.actionId);
+    const actionB = state.actions.get(b.actionId);
+    if (actionA && actionB) return compareActions(actionA, actionB);
+    if (a.actionId !== b.actionId) return a.actionId.localeCompare(b.actionId);
+    return a.artifactId - b.artifactId;
+  });
+}
+
+function compareActions(a: MutableActionSummary, b: MutableActionSummary): number {
+  if (a.targetLabel !== b.targetLabel) return a.targetLabel.localeCompare(b.targetLabel);
+  if (a.rawOrder !== b.rawOrder) return a.rawOrder - b.rawOrder;
+  return a.id.localeCompare(b.id);
+}
+
+function getTargetLabelRelevanceRank(label: string, referenceTargetLabel: string | undefined): number {
+  const parsed = parseTargetLabel(label);
+  const reference = parseTargetLabel(referenceTargetLabel || "");
+
+  if (label && label === referenceTargetLabel) return 0;
+  if (parsed.isKnownLabel && reference.isKnownLabel && parsed.workspace === reference.workspace) {
+    if (parsed.packagePath === reference.packagePath) return 1;
+    return 2;
+  }
+
+  if (parsed.isKnownLabel && !parsed.isExternal) return 3;
+  if (parsed.isKnownLabel && parsed.isExternal) return 4;
+  return 5;
+}
+
+function parseTargetLabel(label: string): ParsedTargetLabel {
+  const trimmed = label.trim();
+  const mainWorkspaceMatch = trimmed.match(/^\/\/([^:]*)(?::(.*))?$/);
+  if (mainWorkspaceMatch) {
+    return {
+      workspace: "",
+      packagePath: mainWorkspaceMatch[1] || "",
+      isExternal: false,
+      isKnownLabel: true,
+    };
+  }
+
+  const externalMatch = trimmed.match(/^(@@?[^/]*)\/\/([^:]*)(?::(.*))?$/);
+  if (externalMatch) {
+    const workspace = externalMatch[1] === "@" || externalMatch[1] === "@@" ? "" : externalMatch[1];
+    return {
+      workspace,
+      packagePath: externalMatch[2] || "",
+      isExternal: Boolean(workspace),
+      isKnownLabel: true,
+    };
+  }
+
+  return {
+    workspace: "",
+    packagePath: "",
+    isExternal: false,
+    isKnownLabel: false,
+  };
+}
+
+function getActionEdgeKey(actionId: string, artifactId: number): string {
+  return `${actionId}:${artifactId}`;
+}
+
+function makeActionId(kind: ActionKind, id: number): string {
+  return `${kind}:${id}`;
+}
+
+function parseActionNumericId(actionId: string): number {
+  return Number(actionId.split(":")[1] || 0);
+}
+
+function mergeInto(destination: Set<number>, source: Set<number>) {
+  source.forEach((value) => destination.add(value));
+}

--- a/app/invocation/compact_exec_log_action_edges_test.ts
+++ b/app/invocation/compact_exec_log_action_edges_test.ts
@@ -1,0 +1,368 @@
+import Long from "long";
+import { tools } from "../../proto/spawn_ts_proto";
+import {
+  buildCompactExecLogActionEdgesIndex,
+  compareTargetLabelsByRelevance,
+  findCompactExecLogAction,
+  getCompactExecLogActionEdgesIndex,
+  getExecConfiguredPathLookupCandidates,
+} from "./compact_exec_log_action_edges";
+
+describe("compact execution log action edges", () => {
+  it("links producer outputs to consumer inputs", () => {
+    const index = buildCompactExecLogActionEdgesIndex([
+      file(1, "src/input.txt"),
+      inputSet(2, [1]),
+      file(3, "bazel-out/bin/pkg/lib.a"),
+      spawn(4, {
+        digest: digest("compile", 1),
+        inputSetId: 2,
+        mnemonic: "CppCompile",
+        outputs: [output(3)],
+        targetLabel: "//pkg:lib",
+      }),
+      inputSet(5, [3]),
+      file(6, "bazel-out/bin/pkg/app"),
+      spawn(7, {
+        digest: digest("link", 1),
+        inputSetId: 5,
+        mnemonic: "CppLink",
+        outputs: [output(6)],
+        targetLabel: "//pkg:app",
+      }),
+    ]);
+
+    const compile = requireDefined(findCompactExecLogAction(index, digest("compile", 1)), "compile action");
+    const link = requireDefined(findCompactExecLogAction(index, digest("link", 1)), "link action");
+
+    expect(compile.childIds).toEqual([link.id]);
+    expect(link.parentIds).toEqual([compile.id]);
+    expect(compile.childEdges).toEqual([
+      {
+        actionId: link.id,
+        artifactId: 3,
+        artifactPath: "bazel-out/bin/pkg/lib.a",
+      },
+    ]);
+    expect(link.parentEdges).toEqual([
+      {
+        actionId: compile.id,
+        artifactId: 3,
+        artifactPath: "bazel-out/bin/pkg/lib.a",
+      },
+    ]);
+  });
+
+  it("keeps the consumed output path when one action has several outputs", () => {
+    const index = buildCompactExecLogActionEdgesIndex([
+      file(1, "bazel-out/bin/pkg/lib.a"),
+      file(2, "bazel-out/bin/pkg/lib.h"),
+      spawn(3, {
+        digest: digest("generate", 1),
+        mnemonic: "Genrule",
+        outputs: [output(1), output(2)],
+        targetLabel: "//pkg:generate",
+      }),
+      inputSet(4, [1]),
+      spawn(5, {
+        digest: digest("archive", 1),
+        mnemonic: "Archive",
+        targetLabel: "//pkg:archive",
+        inputSetId: 4,
+      }),
+      inputSet(6, [2]),
+      spawn(7, {
+        digest: digest("compile", 1),
+        mnemonic: "CppCompile",
+        targetLabel: "//pkg:compile",
+        inputSetId: 6,
+      }),
+    ]);
+
+    const generate = requireDefined(findCompactExecLogAction(index, digest("generate", 1)), "generate action");
+    const archive = requireDefined(findCompactExecLogAction(index, digest("archive", 1)), "archive action");
+    const compile = requireDefined(findCompactExecLogAction(index, digest("compile", 1)), "compile action");
+
+    expect(generate.childIds).toEqual([archive.id, compile.id]);
+    expect(generate.childEdges).toEqual([
+      {
+        actionId: archive.id,
+        artifactId: 1,
+        artifactPath: "bazel-out/bin/pkg/lib.a",
+      },
+      {
+        actionId: compile.id,
+        artifactId: 2,
+        artifactPath: "bazel-out/bin/pkg/lib.h",
+      },
+    ]);
+  });
+
+  it("disambiguates repeated mnemonics within the same target", () => {
+    const index = buildCompactExecLogActionEdgesIndex([
+      file(1, "bazel-out/k8-fastbuild/bin/pkg/lib.a"),
+      spawn(2, {
+        digest: digest("compile-fastbuild", 1),
+        mnemonic: "GoCompilePkg",
+        outputs: [output(1)],
+        targetLabel: "//pkg:lib",
+      }),
+      file(3, "bazel-out/k8-fastbuild/bin/pkg/lib.x"),
+      spawn(4, {
+        digest: digest("compile-x", 1),
+        mnemonic: "GoCompilePkg",
+        outputs: [output(3)],
+        targetLabel: "//pkg:lib",
+      }),
+      file(5, "bazel-out/k8-opt/bin/pkg/lib.a"),
+      spawn(6, {
+        digest: digest("compile-opt", 1),
+        mnemonic: "GoCompilePkg",
+        outputs: [output(5)],
+        targetLabel: "//pkg:lib",
+      }),
+    ]);
+
+    expect(findCompactExecLogAction(index, digest("compile-fastbuild", 1))?.label).toEqual(
+      "GoCompilePkg (k8-fastbuild)"
+    );
+    expect(findCompactExecLogAction(index, digest("compile-x", 1))?.label).toEqual("GoCompilePkg (lib.x)");
+    expect(findCompactExecLogAction(index, digest("compile-opt", 1))?.label).toEqual("GoCompilePkg (k8-opt)");
+  });
+
+  it("links tool inputs and transitive input sets", () => {
+    const index = buildCompactExecLogActionEdgesIndex([
+      file(1, "bazel-out/bin/tools/compiler"),
+      spawn(2, {
+        digest: digest("tool", 1),
+        mnemonic: "GoLink",
+        outputs: [output(1)],
+        targetLabel: "//tools:compiler",
+      }),
+      inputSet(3, [1]),
+      inputSet(4, [], [3]),
+      file(5, "bazel-out/bin/pkg/out"),
+      spawn(6, {
+        digest: digest("compile", 1),
+        mnemonic: "GoCompilePkg",
+        outputs: [output(5)],
+        targetLabel: "//pkg:pkg",
+        toolSetId: 4,
+      }),
+    ]);
+
+    const tool = requireDefined(findCompactExecLogAction(index, digest("tool", 1)), "tool action");
+    const compile = requireDefined(findCompactExecLogAction(index, digest("compile", 1)), "compile action");
+
+    expect(tool.childIds).toEqual([compile.id]);
+    expect(compile.parentIds).toEqual([tool.id]);
+  });
+
+  it("can find actions by digest while preferring target and mnemonic matches", () => {
+    const sharedDigest = digest("same", 1);
+    const index = buildCompactExecLogActionEdgesIndex([
+      spawn(1, {
+        digest: sharedDigest,
+        mnemonic: "Javac",
+        targetLabel: "//pkg:a",
+      }),
+      spawn(2, {
+        digest: sharedDigest,
+        mnemonic: "Javac",
+        targetLabel: "//pkg:b",
+      }),
+    ]);
+
+    expect(findCompactExecLogAction(index, sharedDigest, "//pkg:b")?.targetLabel).toEqual("//pkg:b");
+  });
+
+  it("adds canonical exec path fallback candidates for ST-hashed paths", () => {
+    expect(
+      getExecConfiguredPathLookupCandidates("bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/pkg/foo")
+    ).toEqual([
+      "bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/pkg/foo",
+      "bazel-out/darwin_arm64-opt-exec/bin/pkg/foo",
+    ]);
+  });
+
+  it("sorts target labels by relevance to the current action target", () => {
+    const targetLabels = [
+      "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder",
+      "//server/other:tool",
+      "unlabeled action",
+      "//server/util/shlex:shlex_test",
+      "//server/util/shlex:helper",
+      "//server/util:library",
+      "@repo//server/util/shlex:external_tool",
+    ];
+
+    expect(targetLabels.sort((a, b) => compareTargetLabelsByRelevance(a, b, "//server/util/shlex:shlex_test"))).toEqual(
+      [
+        "//server/util/shlex:shlex_test",
+        "//server/util/shlex:helper",
+        "//server/other:tool",
+        "//server/util:library",
+        "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder",
+        "@repo//server/util/shlex:external_tool",
+        "unlabeled action",
+      ]
+    );
+  });
+
+  it("sorts external labels in the same external workspace before unrelated labels", () => {
+    const targetLabels = [
+      "//server/util/shlex:local_tool",
+      "@@rules_go++go_sdk+main___download_0_linux_amd64//other:tool",
+      "@@other_repo//:tool",
+      "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder_reset",
+      "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder",
+    ];
+
+    expect(
+      targetLabels.sort((a, b) =>
+        compareTargetLabelsByRelevance(a, b, "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder_reset")
+      )
+    ).toEqual([
+      "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder_reset",
+      "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder",
+      "@@rules_go++go_sdk+main___download_0_linux_amd64//other:tool",
+      "//server/util/shlex:local_tool",
+      "@@other_repo//:tool",
+    ]);
+  });
+
+  it("links executable symlinks back to their source action", () => {
+    const builderSourcePath =
+      "bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/" +
+      "rules_go++go_sdk+main___download_0_linux_amd64/builder_reset/builder";
+    const builderCanonicalPath =
+      "bazel-out/k8-opt-exec/bin/external/" + "rules_go++go_sdk+main___download_0_linux_amd64/builder_reset/builder";
+    const builderSymlinkPath =
+      "bazel-out/k8-opt-exec/bin/external/" +
+      "rules_go++go_sdk+main___download_0_linux_amd64/builder_reset/builder_link";
+
+    const index = buildCompactExecLogActionEdgesIndex([
+      file(1, builderSourcePath),
+      spawn(2, {
+        digest: digest("builder", 1),
+        mnemonic: "GoLink",
+        outputs: [output(1)],
+        targetLabel: "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder",
+      }),
+      unresolvedSymlink(3, builderSymlinkPath, builderCanonicalPath),
+      symlinkAction(4, {
+        inputPath: builderCanonicalPath,
+        outputPath: builderSymlinkPath,
+        mnemonic: "ExecutableSymlink",
+        targetLabel: "@@rules_go++go_sdk+main___download_0_linux_amd64//:builder_reset",
+      }),
+      inputSet(5, [3]),
+      spawn(6, {
+        digest: digest("compile", 1),
+        inputSetId: 5,
+        mnemonic: "GoCompilePkg",
+        targetLabel: "//pkg:compile",
+      }),
+    ]);
+
+    const builder = requireDefined(findCompactExecLogAction(index, digest("builder", 1)), "builder action");
+    const compile = requireDefined(findCompactExecLogAction(index, digest("compile", 1)), "compile action");
+    const symlink = requireDefined(
+      index.actions.find((action) => action.kind === "symlink"),
+      "symlink action"
+    );
+
+    expect(symlink.parentIds).toEqual([builder.id]);
+    expect(builder.childIds).toEqual([symlink.id]);
+    expect(symlink.parentEdges).toEqual([
+      {
+        actionId: builder.id,
+        artifactId: 1,
+        artifactPath: builderSourcePath,
+      },
+    ]);
+    expect(symlink.childIds).toEqual([compile.id]);
+    expect(compile.parentIds).toEqual([symlink.id]);
+    expect(compile.parentEdges).toEqual([
+      {
+        actionId: symlink.id,
+        artifactId: 3,
+        artifactPath: builderSymlinkPath,
+      },
+    ]);
+  });
+
+  it("caches the built index by compact execution log URI", async () => {
+    let loadCount = 0;
+    const entries = [
+      spawn(1, {
+        digest: digest("compile", 1),
+        mnemonic: "CppCompile",
+        targetLabel: "//pkg:lib",
+      }),
+    ];
+
+    const first = await getCompactExecLogActionEdgesIndex("test://cache-hit", async () => {
+      loadCount++;
+      return entries;
+    });
+    const second = await getCompactExecLogActionEdgesIndex("test://cache-hit", async () => {
+      loadCount++;
+      return [];
+    });
+
+    expect(loadCount).toEqual(1);
+    expect(second).toBe(first);
+    expect(second.actions.length).toEqual(1);
+  });
+});
+
+function file(id: number, path: string) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    file: new tools.protos.ExecLogEntry.File({ path }),
+  });
+}
+
+function unresolvedSymlink(id: number, path: string, targetPath: string) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    unresolvedSymlink: new tools.protos.ExecLogEntry.UnresolvedSymlink({ path, targetPath }),
+  });
+}
+
+function inputSet(id: number, inputIds: number[], transitiveSetIds: number[] = []) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    inputSet: new tools.protos.ExecLogEntry.InputSet({ inputIds, transitiveSetIds }),
+  });
+}
+
+function output(outputId: number) {
+  return new tools.protos.ExecLogEntry.Output({ outputId });
+}
+
+function spawn(id: number, properties: tools.protos.ExecLogEntry.ISpawn) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    spawn: new tools.protos.ExecLogEntry.Spawn(properties),
+  });
+}
+
+function symlinkAction(id: number, properties: tools.protos.ExecLogEntry.ISymlinkAction) {
+  return new tools.protos.ExecLogEntry({
+    id,
+    symlinkAction: new tools.protos.ExecLogEntry.SymlinkAction(properties),
+  });
+}
+
+function digest(hash: string, sizeBytes: number) {
+  return new tools.protos.Digest({ hash, sizeBytes: Long.fromNumber(sizeBytes) });
+}
+
+function requireDefined<T>(value: T | null | undefined, description: string): T {
+  if (value == null) {
+    throw new Error(`Expected ${description} to be defined`);
+  }
+  return value;
+}

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -696,6 +696,221 @@
   display: block;
 }
 
+.action-edge-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 720px;
+}
+
+.action-edge-group {
+  min-width: 0;
+}
+
+.action-edge-artifact-path {
+  color: var(--color-text-secondary);
+  font-family: var(--monospace-font-family);
+  font-size: 12px;
+  line-height: 1.4;
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action-edge-group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  padding-left: 12px;
+}
+
+.action-edge-row {
+  align-items: baseline;
+  color: var(--color-text-primary);
+  display: inline-flex;
+  font-size: 12px;
+  line-height: 1.4;
+  max-width: 100%;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.action-edge-row:hover {
+  text-decoration: underline;
+}
+
+.action-edge-row-static:hover {
+  text-decoration: none;
+}
+
+.action-edge-action-only .action-edge-action {
+  max-width: 100%;
+}
+
+.action-edge-target,
+.action-edge-action {
+  display: inline-block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action-edge-target {
+  color: var(--color-text-secondary);
+  max-width: min(44ch, 50%);
+}
+
+.action-edge-action {
+  font-weight: 600;
+  max-width: min(44ch, 100%);
+}
+
+.action-edge-separator {
+  color: var(--color-text-tertiary);
+  flex-shrink: 0;
+  height: 1em;
+  margin: 0 4px;
+  transform: translateY(0.15em);
+  width: 1em;
+}
+
+.action-edge-chip {
+  border: 1px solid var(--color-border-primary);
+  border-radius: 4px;
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+  font-size: 11px;
+  margin-left: 6px;
+  padding: 0 4px;
+}
+
+.action-edge-chip.failed {
+  color: var(--color-status-error);
+}
+
+.action-edge-empty {
+  color: var(--color-text-secondary);
+  font-size: 12px;
+}
+
+.action-edge-target-group {
+  min-width: 0;
+}
+
+.action-edge-target-group + .action-edge-target-group {
+  margin-top: 8px;
+}
+
+.action-edge-target-group-label {
+  color: var(--color-text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action-edge-target-group-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-left: 18px;
+  min-width: 0;
+}
+
+.action-edge-target-group-action {
+  min-width: 0;
+}
+
+.action-edge-section-toggle,
+.action-edge-output-toggle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  gap: 2px;
+  line-height: 18px;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.action-edge-section-toggle:hover,
+.action-edge-output-toggle:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+}
+
+.action-edge-section-toggle .icon,
+.action-edge-output-toggle .icon {
+  height: 14px;
+  width: 14px;
+}
+
+.action-edge-section-panel {
+  margin-top: 6px;
+}
+
+.action-output-entry {
+  min-width: 0;
+}
+
+.action-output-entry > .file-name {
+  align-items: center;
+  flex-wrap: nowrap;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.action-output-entry > .file-name > span:first-child,
+.action-output-entry > .file-name .artifact-view,
+.action-output-entry > .file-name .detail,
+.action-output-entry > .file-name .digest-component {
+  flex-shrink: 0;
+}
+
+.action-output-entry > .file-name .prop-link {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action-output-entry + .action-output-entry {
+  margin-top: 4px;
+}
+
+.action-edge-output-consumer-section {
+  min-width: 0;
+}
+
+.action-edge-output-consumer-line {
+  margin: 1px 0 3px 24px;
+}
+
+.action-edge-output-consumer-line:empty {
+  display: none;
+}
+
+.action-edge-output-consumers {
+  border-left: 2px solid var(--color-border-primary);
+  margin: 2px 0 8px 38px;
+  max-width: 720px;
+  padding: 4px 0 4px 10px;
+}
+
+.action-edge-output-consumers .action-edge-group-list {
+  padding-left: 0;
+}
+
 .action-argument-row {
   align-items: center;
   display: flex;

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -54,6 +54,14 @@ import { MessageClass, timestampToDate } from "../util/proto";
 import { getErrorReason } from "../util/rpc";
 import { quote } from "../util/shlex";
 import ActionCompareButtonComponent from "./action_compare_button";
+import {
+  CompactExecLogActionEdge,
+  CompactExecLogActionEdgesIndex,
+  CompactExecLogActionSummary,
+  compareTargetLabelsByRelevance,
+  findCompactExecLogAction,
+  getCompactExecLogActionEdgesIndex,
+} from "./compact_exec_log_action_edges";
 import { ExecuteOperation, executionStatusLabel, waitExecution } from "./execution_status";
 import TreeNodeComponent, { TreeNode } from "./invocation_action_tree_node";
 import InvocationModel from "./invocation_model";
@@ -113,11 +121,26 @@ interface State {
   executionDownloads: cache.ExecutionDownload[];
   executionDownloadsLoading: boolean;
   executionDownloadsNextPageToken: string;
+  actionEdgesIndex?: CompactExecLogActionEdgesIndex;
+  actionEdgesLoading: boolean;
+  actionEdgesError?: string;
+  inputSourcesExpanded: boolean;
+  expandedOutputConsumerPaths: Set<string>;
 }
 
 interface ServerLog {
   name: string;
   text: string;
+}
+
+interface ActionEdgeGroup {
+  artifactPath: string;
+  edges: CompactExecLogActionEdge[];
+}
+
+interface ActionEdgeTargetGroup {
+  targetLabel: string;
+  actions: CompactExecLogActionSummary[];
 }
 
 export default class InvocationActionCardComponent extends React.Component<Props, State> {
@@ -138,15 +161,20 @@ export default class InvocationActionCardComponent extends React.Component<Props
     executionDownloads: [],
     executionDownloadsLoading: false,
     executionDownloadsNextPageToken: "",
+    actionEdgesLoading: false,
+    inputSourcesExpanded: false,
+    expandedOutputConsumerPaths: new Set<string>(),
   };
 
   private executionDownloadsContainerRef = React.createRef<HTMLDivElement>();
   private treeShaToChildrenPromiseMap = new Map<string, Promise<TreeNode[]>>();
+  private actionEdgesRequestId = 0;
 
   componentDidMount() {
     this.fetchAction();
     this.fetchExecuteResponseOrActionResult();
     this.fetchSpawnMetrics();
+    this.fetchActionEdges();
     if (this.getExecutionId()) {
       this.fetchExecutionDownloads("");
     }
@@ -157,11 +185,13 @@ export default class InvocationActionCardComponent extends React.Component<Props
       this.fetchAction();
       this.fetchExecuteResponseOrActionResult();
       this.fetchSpawnMetrics();
+      this.fetchActionEdges();
       this.fetchExecutionDownloads("");
       return;
     }
     if (prevProps.model.getExecutionLogFileUri() !== this.props.model.getExecutionLogFileUri()) {
       this.fetchSpawnMetrics();
+      this.fetchActionEdges();
     }
     if (prevProps.search.get("executeResponseDigest") !== this.props.search.get("executeResponseDigest")) {
       this.fetchExecuteResponseOrActionResult();
@@ -174,6 +204,10 @@ export default class InvocationActionCardComponent extends React.Component<Props
     if (prevExecutionId !== executionId) {
       this.fetchExecutionDownloads("");
     }
+  }
+
+  componentWillUnmount() {
+    this.actionEdgesRequestId++;
   }
 
   fetchSpawnMetrics() {
@@ -207,6 +241,46 @@ export default class InvocationActionCardComponent extends React.Component<Props
         });
       })
       .catch((e) => console.error("Failed to fetch execution log:", e));
+  }
+
+  fetchActionEdges() {
+    const requestId = ++this.actionEdgesRequestId;
+    const actionDigestParam = this.props.search.get("actionDigest");
+    const actionDigest = parseActionDigest(actionDigestParam || "");
+    const model = this.props.model;
+    const executionLogUri = model.getExecutionLogFileUri();
+    if (!actionDigest || !executionLogUri) {
+      this.setState({ actionEdgesIndex: undefined, actionEdgesLoading: false, actionEdgesError: undefined });
+      return;
+    }
+
+    this.setState({
+      actionEdgesLoading: true,
+      actionEdgesError: undefined,
+      inputSourcesExpanded: false,
+      expandedOutputConsumerPaths: new Set<string>(),
+    });
+    getCompactExecLogActionEdgesIndex(executionLogUri, () => model.getExecutionLog())
+      .then((index) => {
+        if (
+          requestId !== this.actionEdgesRequestId ||
+          this.props.model !== model ||
+          this.props.search.get("actionDigest") !== actionDigestParam ||
+          this.props.model.getExecutionLogFileUri() !== executionLogUri
+        ) {
+          return;
+        }
+        this.setState({ actionEdgesIndex: index, actionEdgesLoading: false });
+      })
+      .catch((e) => {
+        if (requestId !== this.actionEdgesRequestId) return;
+        console.error("Failed to fetch compact execution log action edges:", e);
+        this.setState({
+          actionEdgesIndex: undefined,
+          actionEdgesLoading: false,
+          actionEdgesError: "Failed to load compact execution log action dependencies.",
+        });
+      });
   }
 
   fetchAction() {
@@ -1017,6 +1091,329 @@ export default class InvocationActionCardComponent extends React.Component<Props
     );
   }
 
+  private getCurrentCompactLogAction(): CompactExecLogActionSummary | undefined {
+    const digest = parseActionDigest(this.props.search.get("actionDigest") ?? "");
+    return findCompactExecLogAction(
+      this.state.actionEdgesIndex,
+      digest,
+      this.state.execution?.targetLabel,
+      this.state.execution?.actionMnemonic
+    );
+  }
+
+  private getRelatedCompactLogActionEdges(direction: "parents" | "children"): CompactExecLogActionEdge[] {
+    const currentAction = this.getCurrentCompactLogAction();
+    if (!currentAction) return [];
+    return direction === "parents" ? currentAction.parentEdges : currentAction.childEdges;
+  }
+
+  private groupCompactLogActionEdges(edges: CompactExecLogActionEdge[]): ActionEdgeGroup[] {
+    const groups = new Map<string, CompactExecLogActionEdge[]>();
+    for (const edge of edges) {
+      const group = groups.get(edge.artifactPath);
+      if (group) {
+        group.push(edge);
+      } else {
+        groups.set(edge.artifactPath, [edge]);
+      }
+    }
+    return Array.from(groups.entries()).map(([artifactPath, edges]) => ({ artifactPath, edges }));
+  }
+
+  private groupCompactLogActionEdgesByTarget(
+    edges: CompactExecLogActionEdge[],
+    referenceTargetLabel?: string
+  ): ActionEdgeTargetGroup[] {
+    const groups = new Map<string, CompactExecLogActionSummary[]>();
+    const seenActionIdsByTarget = new Map<string, Set<string>>();
+    for (const edge of edges) {
+      const action = this.state.actionEdgesIndex?.actionById.get(edge.actionId);
+      if (!action) continue;
+      const targetLabel = action.targetLabel || "";
+      const seenActionIds = seenActionIdsByTarget.get(targetLabel) || new Set<string>();
+      if (seenActionIds.has(action.id)) continue;
+      seenActionIds.add(action.id);
+      seenActionIdsByTarget.set(targetLabel, seenActionIds);
+      const actions = groups.get(targetLabel) || [];
+      actions.push(action);
+      groups.set(targetLabel, actions);
+    }
+    return Array.from(groups.entries())
+      .map(([targetLabel, actions]) => ({ targetLabel, actions }))
+      .sort((a, b) => compareTargetLabelsByRelevance(a.targetLabel, b.targetLabel, referenceTargetLabel));
+  }
+
+  private getUniqueCompactLogActionCount(edges: CompactExecLogActionEdge[]): number {
+    return new Set(edges.map((edge) => edge.actionId)).size;
+  }
+
+  private getOutputConsumerEdges(outputPath: string): CompactExecLogActionEdge[] {
+    const currentAction = this.getCurrentCompactLogAction();
+    if (!currentAction) return [];
+
+    const exactMatches = currentAction.childEdges.filter((edge) => edge.artifactPath === outputPath);
+    if (exactMatches.length) return exactMatches;
+
+    const outputPathSuffix = this.getBazelOutBinSuffix(outputPath);
+    if (!outputPathSuffix) return [];
+    return currentAction.childEdges.filter((edge) => this.getBazelOutBinSuffix(edge.artifactPath) === outputPathSuffix);
+  }
+
+  private getBazelOutBinSuffix(path: string): string | undefined {
+    const match = path.match(/^bazel-out\/[^/]+\/bin\/(.+)$/);
+    return match?.[1];
+  }
+
+  private isOutputConsumerExpanded(outputPath: string): boolean {
+    return this.state.expandedOutputConsumerPaths.has(outputPath);
+  }
+
+  private toggleOutputConsumerExpansion(outputPath: string) {
+    this.setState((state) => {
+      const expandedOutputConsumerPaths = new Set(state.expandedOutputConsumerPaths);
+      if (expandedOutputConsumerPaths.has(outputPath)) {
+        expandedOutputConsumerPaths.delete(outputPath);
+      } else {
+        expandedOutputConsumerPaths.add(outputPath);
+      }
+      return { expandedOutputConsumerPaths };
+    });
+  }
+
+  private getDigestBackedCompactLogActionHref(action: CompactExecLogActionSummary): string | undefined {
+    if (!action.digestHash) return undefined;
+    const search = new URLSearchParams();
+    search.set("actionDigest", `${action.digestHash}/${action.digestSizeBytes || 0}`);
+    return `/invocation/${this.props.model.getInvocationId()}?${search.toString()}#action`;
+  }
+
+  private getSymlinkSourceAction(
+    action: CompactExecLogActionSummary,
+    visitedActionIds = new Set<string>()
+  ): CompactExecLogActionSummary | undefined {
+    if (visitedActionIds.has(action.id)) return undefined;
+    visitedActionIds.add(action.id);
+
+    for (const parentId of action.parentIds) {
+      const parentAction = this.state.actionEdgesIndex?.actionById.get(parentId);
+      if (!parentAction) continue;
+      if (parentAction.digestHash) return parentAction;
+      if (parentAction.kind === "symlink") {
+        const sourceAction = this.getSymlinkSourceAction(parentAction, visitedActionIds);
+        if (sourceAction) return sourceAction;
+      }
+    }
+    return undefined;
+  }
+
+  private getCompactLogActionHref(action: CompactExecLogActionSummary): string | undefined {
+    const digestBackedHref = this.getDigestBackedCompactLogActionHref(action);
+    if (digestBackedHref) return digestBackedHref;
+
+    const sourceAction = action.kind === "symlink" ? this.getSymlinkSourceAction(action) : undefined;
+    return sourceAction ? this.getDigestBackedCompactLogActionHref(sourceAction) : undefined;
+  }
+
+  private renderCompactLogActionLink(action: CompactExecLogActionSummary, hideTargetLabel: boolean = false) {
+    const actionText = action.cached ? `${action.label} (Cached)` : action.label;
+    const symlinkSourceAction =
+      action.kind === "symlink" && !action.digestHash ? this.getSymlinkSourceAction(action) : undefined;
+    const href = this.getCompactLogActionHref(action);
+    const actionTitle = [
+      actionText,
+      action.primaryOutputPath ? `Primary output: ${action.primaryOutputPath}` : "",
+      symlinkSourceAction
+        ? `Opens source action: ${symlinkSourceAction.targetLabel} > ${symlinkSourceAction.label}`
+        : "",
+      !href && action.kind === "symlink" ? "Symlink action source not found in the compact execution log." : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    const content = (
+      <>
+        {!hideTargetLabel && (
+          <>
+            <span className="action-edge-target" title={action.targetLabel}>
+              {action.targetLabel || "<unknown target>"}
+            </span>
+            <ChevronRight className="action-edge-separator icon" />
+          </>
+        )}
+        <span className="action-edge-action" title={actionTitle}>
+          {actionText}
+        </span>
+        {action.kind === "symlink" && <span className="action-edge-chip">Symlink</span>}
+        {action.result === "failed" && <span className="action-edge-chip failed">Failed</span>}
+      </>
+    );
+    if (!href) {
+      return (
+        <span className={`action-edge-row action-edge-row-static ${hideTargetLabel ? "action-edge-action-only" : ""}`}>
+          {content}
+        </span>
+      );
+    }
+    return (
+      <TextLink className={`action-edge-row ${hideTargetLabel ? "action-edge-action-only" : ""}`} href={href}>
+        {content}
+      </TextLink>
+    );
+  }
+
+  private renderActionEdgeTargetGroups(edges: CompactExecLogActionEdge[]) {
+    const targetGroups = this.groupCompactLogActionEdgesByTarget(edges, this.getCurrentCompactLogAction()?.targetLabel);
+    return targetGroups.map((group) => (
+      <div className="action-edge-target-group" key={group.targetLabel || "<unknown target>"}>
+        <div className="action-edge-target-group-label" title={group.targetLabel}>
+          {group.targetLabel || "<unknown target>"}
+        </div>
+        <div className="action-edge-target-group-actions">
+          {group.actions.map((action) => (
+            <div className="action-edge-target-group-action" key={action.id}>
+              {this.renderCompactLogActionLink(action, true)}
+            </div>
+          ))}
+        </div>
+      </div>
+    ));
+  }
+
+  private renderOutputConsumerDisclosure(outputPath: string) {
+    const edges = this.getOutputConsumerEdges(outputPath);
+    if (!edges.length) return null;
+
+    const expanded = this.isOutputConsumerExpanded(outputPath);
+    const consumerCount = this.groupCompactLogActionEdgesByTarget(
+      edges,
+      this.getCurrentCompactLogAction()?.targetLabel
+    ).reduce((count, group) => count + group.actions.length, 0);
+    const Chevron = expanded ? ChevronDown : ChevronRight;
+    return (
+      <button
+        className="action-edge-output-toggle"
+        onClick={(event) => {
+          event.stopPropagation();
+          this.toggleOutputConsumerExpansion(outputPath);
+        }}
+        type="button">
+        <Chevron className="icon" />
+        Consumed by {consumerCount}
+      </button>
+    );
+  }
+
+  private renderOutputConsumerSection(outputPath: string) {
+    const disclosure = this.renderOutputConsumerDisclosure(outputPath);
+    if (!disclosure) return null;
+    return (
+      <div className="action-edge-output-consumer-section">
+        <div className="action-edge-output-consumer-line">{disclosure}</div>
+        {this.renderOutputConsumerDetails(outputPath)}
+      </div>
+    );
+  }
+
+  private renderOutputConsumerDetails(outputPath: string) {
+    if (!this.isOutputConsumerExpanded(outputPath)) return null;
+    const edges = this.getOutputConsumerEdges(outputPath);
+    if (!edges.length) return null;
+    return <div className="action-edge-output-consumers">{this.renderActionEdgeTargetGroups(edges)}</div>;
+  }
+
+  private renderInputSourcesSection() {
+    if (!this.props.model.hasExecutionLog()) return null;
+
+    if (this.state.actionEdgesLoading) {
+      return (
+        <div className="action-section">
+          <div className="action-property-title">Input sources</div>
+          <div>
+            <div className="action-edge-empty">Loading compact execution log dependencies...</div>
+          </div>
+        </div>
+      );
+    }
+    if (this.state.actionEdgesError) return null;
+
+    const currentAction = this.getCurrentCompactLogAction();
+    if (!currentAction) return null;
+
+    const relatedEdges = this.getRelatedCompactLogActionEdges("parents");
+    const expanded = this.state.inputSourcesExpanded;
+    const sourceCount = this.getUniqueCompactLogActionCount(relatedEdges);
+    return (
+      <div className="action-section">
+        <div className="action-property-title">Input sources</div>
+        <div>
+          {relatedEdges.length ? (
+            <>
+              <button
+                className="action-edge-section-toggle"
+                onClick={() => this.setState({ inputSourcesExpanded: !expanded })}
+                type="button">
+                {expanded ? <ChevronDown className="icon" /> : <ChevronRight className="icon" />}
+                {expanded ? "Hide" : "Show"} {sourceCount} input source{sourceCount === 1 ? "" : "s"}
+              </button>
+              {expanded && this.renderInputSourceDetails(relatedEdges)}
+            </>
+          ) : (
+            <div className="action-edge-empty">No input sources found in the compact execution log.</div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  private renderInputSourceDetails(edges: CompactExecLogActionEdge[]) {
+    const edgeGroups = this.groupCompactLogActionEdges(edges);
+    return (
+      <div className="action-edge-section-panel">
+        <div className="action-edge-list">
+          {edgeGroups.map((group) => (
+            <div className="action-edge-group" key={group.artifactPath}>
+              <div className="action-edge-artifact-path" title={group.artifactPath}>
+                {group.artifactPath}
+              </div>
+              <div className="action-edge-group-list">{this.renderActionEdgeTargetGroups(group.edges)}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  private renderCompactLogActionIdentity() {
+    const action = this.getCurrentCompactLogAction();
+    if (!action) return null;
+
+    const targetLabel = action.targetLabel || "<unknown target>";
+    const actionText = action.cached ? `${action.label} (Cached)` : action.label;
+    return (
+      <>
+        <div className="action-section">
+          <div className="action-property-title">Target label</div>
+          <div>
+            {action.targetLabel ? (
+              <TextLink
+                className="target-label-link"
+                href={`/invocation/${this.props.model.getInvocationId()}?${new URLSearchParams({
+                  target: action.targetLabel,
+                })}`}>
+                {targetLabel}
+              </TextLink>
+            ) : (
+              targetLabel
+            )}
+          </div>
+        </div>
+        <div className="action-section">
+          <div className="action-property-title">Action</div>
+          <div>{actionText}</div>
+        </div>
+      </>
+    );
+  }
+
   /** Build a fully-formed `bb execute` command for this action. */
   private buildBbExecuteCommand(): string {
     const { action, command } = this.state;
@@ -1289,16 +1686,19 @@ export default class InvocationActionCardComponent extends React.Component<Props
         {actionsResult.outputDirectories.length ? (
           <div className="action-list">
             {actionsResult.outputDirectories.map((dir) => (
-              <TreeNodeComponent
-                node={{
-                  obj: new build.bazel.remote.execution.v2.DirectoryNode({ name: dir.path, digest: dir.treeDigest }),
-                  type: "tree",
-                }}
-                treeShaToExpanded={this.state.treeShaToExpanded}
-                treeShaToChildrenMap={this.state.treeShaToChildrenMap}
-                treeShaToTotalSizeMap={this.state.treeShaToTotalSizeMap}
-                handleFileClicked={this.handleFileClicked.bind(this)}
-              />
+              <div className="action-output-entry" key={dir.path}>
+                <TreeNodeComponent
+                  node={{
+                    obj: new build.bazel.remote.execution.v2.DirectoryNode({ name: dir.path, digest: dir.treeDigest }),
+                    type: "tree",
+                  }}
+                  treeShaToExpanded={this.state.treeShaToExpanded}
+                  treeShaToChildrenMap={this.state.treeShaToChildrenMap}
+                  treeShaToTotalSizeMap={this.state.treeShaToTotalSizeMap}
+                  handleFileClicked={this.handleFileClicked.bind(this)}
+                />
+                {this.renderOutputConsumerSection(dir.path)}
+              </div>
             ))}
           </div>
         ) : (
@@ -1319,15 +1719,18 @@ export default class InvocationActionCardComponent extends React.Component<Props
         {symlinks.length ? (
           <div className="action-list">
             {symlinks.map((symlink) => (
-              <div className="tree-node-symlink">
-                <span>
-                  <FileSymlink className="symlink-icon" />
-                </span>{" "}
-                <span>{symlink.path}</span>{" "}
-                <span>
-                  <ArrowRight className="arrow-right-icon" />
-                </span>{" "}
-                <span>{symlink.target}</span>
+              <div className="action-output-entry" key={symlink.path}>
+                <div className="tree-node-symlink">
+                  <span>
+                    <FileSymlink className="symlink-icon" />
+                  </span>{" "}
+                  <span>{symlink.path}</span>{" "}
+                  <span>
+                    <ArrowRight className="arrow-right-icon" />
+                  </span>{" "}
+                  <span>{symlink.target}</span>
+                </div>
+                {this.renderOutputConsumerSection(symlink.path)}
               </div>
             ))}
           </div>
@@ -1683,6 +2086,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
               {this.state.action ? (
                 <div className="details">
                   <div>
+                    {this.renderCompactLogActionIdentity()}
                     <div className="action-section">
                       <div className="action-property-title">Digest</div>
                       <DigestComponent digest={digest} expanded={true} />
@@ -1697,23 +2101,26 @@ export default class InvocationActionCardComponent extends React.Component<Props
                     )}
                     <div className="action-section">
                       <div className="action-property-title">Input files</div>
-                      {this.state.inputNodes.length ? (
-                        <div className="input-tree">
-                          {this.state.inputNodes.map((node) => (
-                            <TreeNodeComponent
-                              node={node}
-                              treeShaToExpanded={this.state.treeShaToExpanded}
-                              treeShaToChildrenMap={this.state.treeShaToChildrenMap}
-                              treeShaToTotalSizeMap={this.state.treeShaToTotalSizeMap}
-                              handleFileClicked={this.handleFileClicked.bind(this)}
-                              getFileViewUrl={this.getFileViewUrl.bind(this)}
-                            />
-                          ))}
-                        </div>
-                      ) : (
-                        <div>None found</div>
-                      )}
+                      <div>
+                        {this.state.inputNodes.length ? (
+                          <div className="input-tree">
+                            {this.state.inputNodes.map((node) => (
+                              <TreeNodeComponent
+                                node={node}
+                                treeShaToExpanded={this.state.treeShaToExpanded}
+                                treeShaToChildrenMap={this.state.treeShaToChildrenMap}
+                                treeShaToTotalSizeMap={this.state.treeShaToTotalSizeMap}
+                                handleFileClicked={this.handleFileClicked.bind(this)}
+                                getFileViewUrl={this.getFileViewUrl.bind(this)}
+                              />
+                            ))}
+                          </div>
+                        ) : (
+                          <div>None found</div>
+                        )}
+                      </div>
                     </div>
+                    {this.renderInputSourcesSection()}
                     <div className="action-section">
                       <div className="action-property-title">Cacheable</div>
                       <div>{!this.state.action.doNotCache ? "Yes" : "No"}</div>
@@ -1969,34 +2376,41 @@ export default class InvocationActionCardComponent extends React.Component<Props
                       </div>
                       <div className="action-section">
                         <div className="action-property-title">Output files</div>
-                        {this.state.actionResult.outputFiles ? (
-                          <div className="action-list">
-                            {this.state.actionResult.outputFiles.map((file) => (
-                              <div
-                                className="file-name clickable"
-                                onClick={this.handleOutputFileClicked.bind(this, file)}>
-                                <span>
-                                  <Download className="file-icon" />
-                                </span>
-                                <span className="prop-link">{file.path}</span>
-                                {file.digest && (
-                                  <TextLink
-                                    className="artifact-view"
-                                    href={this.getFileViewUrl(file.path, file.digest)}
-                                    // Otherwise the file will be downloaded instead
-                                    onClick={(e) => e.stopPropagation()}
-                                    target="_blank">
-                                    <FileIcon extension={file.path} /> View
-                                  </TextLink>
-                                )}
-                                {file.isExecutable && <span className="detail"> (executable)</span>}
-                                {file.digest && <DigestComponent digest={file.digest} />}
-                              </div>
-                            ))}
-                          </div>
-                        ) : (
-                          <div>None found</div>
-                        )}
+                        <div>
+                          {this.state.actionResult.outputFiles ? (
+                            <div className="action-list">
+                              {this.state.actionResult.outputFiles.map((file) => (
+                                <div className="action-output-entry" key={file.path}>
+                                  <div
+                                    className="file-name clickable"
+                                    onClick={this.handleOutputFileClicked.bind(this, file)}>
+                                    <span>
+                                      <Download className="file-icon" />
+                                    </span>
+                                    <span className="prop-link" title={file.path}>
+                                      {file.path}
+                                    </span>
+                                    {file.digest && (
+                                      <TextLink
+                                        className="artifact-view"
+                                        href={this.getFileViewUrl(file.path, file.digest)}
+                                        // Otherwise the file will be downloaded instead
+                                        onClick={(e) => e.stopPropagation()}
+                                        target="_blank">
+                                        <FileIcon extension={file.path} /> View
+                                      </TextLink>
+                                    )}
+                                    {file.isExecutable && <span className="detail"> (executable)</span>}
+                                    {file.digest && <DigestComponent digest={file.digest} />}
+                                  </div>
+                                  {this.renderOutputConsumerSection(file.path)}
+                                </div>
+                              ))}
+                            </div>
+                          ) : (
+                            <div>None found</div>
+                          )}
+                        </div>
                       </div>
                       {this.renderOutputDirectories(this.state.actionResult)}
                       {this.renderOutputSymlinks(this.state.actionResult)}


### PR DESCRIPTION
Action details can fetch compact execution logs, but users could not see which action produced an input or which downstream action consumed each output. This keeps that dependency context beside the existing input and output views because that is where action debugging already happens.

Build an action-edge index from compact execution log spawns and symlink actions, with memory and IndexedDB caches keyed by the log URI. Track artifact-specific parent and child edges so each output row can expose its own consumers, and use the same index to show the compact-log target label and action identity at the top of the details view.

Render input sources below input files as a collapsed section and add collapsed per-output "Consumed by N" rows for files, directories, and symlinks. Symlink actions trace back to their digest-backed source action when possible, repeated mnemonics are disambiguated with output names or platform hints, and related targets are sorted by relevance to the current action before falling back to external labels.

This replaces the target-tab prototype in #11666 and carries forward the useful compact-log indexing and action-labeling lessons from the spawn graph exploration in #10184, while avoiding a separate graph surface.

Collapsed view:

![Collapsed compact action edge view](https://raw.githubusercontent.com/buildbuddy-io/buildbuddy/sluongng/compact-log-action-edge-screenshots/action-edges-collapsed.png)

Expanded view:

![Expanded compact action edge view](https://raw.githubusercontent.com/buildbuddy-io/buildbuddy/sluongng/compact-log-action-edge-screenshots/action-edges-expanded.png)
