### PR TITLE
Add metric for running task progress

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -422,6 +422,14 @@ func main() {
 	if err := taskScheduler.Start(); err != nil {
 		log.Fatalf("Error starting task scheduler: %v", err)
 	}
+	prometheus.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: "buildbuddy",
+		Subsystem: "remote_execution",
+		Name:      "running_task_progress_seconds",
+		Help:      "Total time, in seconds, that the tasks currently running on this executor have spent executing so far. This approximates the execution progress that would be lost if the executor were shut down, since killed tasks are re-enqueued and restart from scratch.",
+	}, func() float64 {
+		return taskScheduler.TotalRunningTaskExecutionDuration().Seconds()
+	}))
 
 	monitoring.StartMonitoringHandler(env, fmt.Sprintf("%s:%d", *listen, *monitoringPort))
 

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -370,6 +370,10 @@ type PriorityTaskScheduler struct {
 	resourceCapacity        *resourceCounts
 	resourcesUsed           *resourceCounts
 	exclusiveTaskScheduling bool
+
+	// activeTaskStartTimes contains, for each currently running task, the
+	// time at which the task started executing.
+	activeTaskStartTimes map[string]time.Time
 }
 
 func NewPriorityTaskScheduler(env environment.Env, exec IExecutor, runnerPool interfaces.RunnerPool, taskLeaser interfaces.TaskLeaser, options *Options) (*PriorityTaskScheduler, error) {
@@ -414,6 +418,7 @@ func NewPriorityTaskScheduler(env environment.Env, exec IExecutor, runnerPool in
 			Custom:    customResourcesUsed,
 		},
 		exclusiveTaskScheduling: *exclusiveTaskScheduling,
+		activeTaskStartTimes:    make(map[string]time.Time),
 	}
 	qes.rootContext = qes.enrichContext(qes.rootContext)
 
@@ -643,6 +648,7 @@ func (q *PriorityTaskScheduler) runTask(ctx context.Context, st *repb.ScheduledT
 
 func (q *PriorityTaskScheduler) trackTask(res *scpb.EnqueueTaskReservationRequest, cancel *context.CancelFunc) {
 	q.activeCancelFuncsCount.Add(1)
+	q.activeTaskStartTimes[res.GetTaskId()] = q.clock.Now()
 	if size := res.GetTaskSize(); size != nil {
 		q.resourcesUsed.RAMBytes += size.GetEstimatedMemoryBytes()
 		q.resourcesUsed.CPUMillis += size.GetEstimatedMilliCpu()
@@ -664,6 +670,7 @@ func (q *PriorityTaskScheduler) trackTask(res *scpb.EnqueueTaskReservationReques
 
 func (q *PriorityTaskScheduler) untrackTask(res *scpb.EnqueueTaskReservationRequest, cancel *context.CancelFunc) {
 	q.activeCancelFuncsCount.Add(-1)
+	delete(q.activeTaskStartTimes, res.GetTaskId())
 	if size := res.GetTaskSize(); size != nil {
 		q.resourcesUsed.RAMBytes -= size.GetEstimatedMemoryBytes()
 		q.resourcesUsed.CPUMillis -= size.GetEstimatedMilliCpu()
@@ -681,6 +688,21 @@ func (q *PriorityTaskScheduler) untrackTask(res *scpb.EnqueueTaskReservationRequ
 		}
 		log.CtxDebugf(q.rootContext, "Released task resources. Queue stats: %s", q.stats())
 	}
+}
+
+// TotalRunningTaskExecutionDuration returns the total time that currently
+// running tasks have collectively spent executing. This approximates the
+// execution progress that would be lost if this executor were shut down,
+// since tasks that get killed are re-enqueued and restart from scratch.
+func (q *PriorityTaskScheduler) TotalRunningTaskExecutionDuration() time.Duration {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	now := q.clock.Now()
+	var total time.Duration
+	for _, startedAt := range q.activeTaskStartTimes {
+		total += now.Sub(startedAt)
+	}
+	return total
 }
 
 func (q *PriorityTaskScheduler) stats() string {

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
@@ -409,6 +409,67 @@ func TestLocalEnqueueTimestamp(t *testing.T) {
 	require.Equal(t, startTime, task.ScheduledTask.GetWorkerQueuedTimestamp().AsTime())
 }
 
+func TestTotalRunningTaskExecutionDuration(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	startTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := clockwork.NewFakeClockAt(startTime)
+	env.SetClock(clock)
+	env.SetRemoteExecutionClient(&FakeExecutionClient{})
+	executor := NewFakeExecutor()
+	runnerPool := &FakeRunnerPool{}
+	leaser := NewFakeTaskLeaser()
+
+	scheduler, err := NewPriorityTaskScheduler(env, executor, runnerPool, leaser, &Options{})
+	require.NoError(t, err)
+	scheduler.Start()
+	t.Cleanup(func() {
+		err := scheduler.Stop()
+		require.NoError(t, err)
+		assert.NoError(t, scheduler.Shutdown(ctx))
+	})
+
+	// With no tasks running, the total execution duration should be zero.
+	require.Equal(t, time.Duration(0), scheduler.TotalRunningTaskExecutionDuration())
+
+	// Start a task. It just started executing, so the total should still be
+	// zero.
+	task1ID := fakeTaskID("task1")
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{TaskId: task1ID})
+	require.NoError(t, err)
+	execution1 := <-executor.StartedExecutions
+	require.Equal(t, time.Duration(0), scheduler.TotalRunningTaskExecutionDuration())
+
+	// After 10 seconds, the running task has 10 seconds of execution
+	// progress.
+	clock.Advance(10 * time.Second)
+	require.Equal(t, 10*time.Second, scheduler.TotalRunningTaskExecutionDuration())
+
+	// Start a second task, then let 20 more seconds pass. The first task has
+	// now been executing for 30 seconds and the second for 20 seconds, so
+	// the total should be 50 seconds.
+	task2ID := fakeTaskID("task2")
+	_, err = scheduler.EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{TaskId: task2ID})
+	require.NoError(t, err)
+	execution2 := <-executor.StartedExecutions
+	clock.Advance(20 * time.Second)
+	require.Equal(t, 50*time.Second, scheduler.TotalRunningTaskExecutionDuration())
+
+	// Complete the first task. Only the second task's 20 seconds of
+	// execution progress should remain. Task completion is asynchronous, so
+	// poll for the expected value.
+	execution1.Complete()
+	require.Eventually(t, func() bool {
+		return scheduler.TotalRunningTaskExecutionDuration() == 20*time.Second
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Complete the second task; the total should drop back to zero.
+	execution2.Complete()
+	require.Eventually(t, func() bool {
+		return scheduler.TotalRunningTaskExecutionDuration() == 0
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
 func TestRemoveTaskFromQueue(t *testing.T) {
 	ctx := t.Context()
 	// Try a few runs where we enqueue several tasks, cancel a few tasks, then


### PR DESCRIPTION
I am thinking about experimenting with `pod-deletion-cost` as a way to prioritize deleting the pods that would lose the least work when we scale down. This PR adds a prometheus metric so that we can get a rough idea of how effective this would be. If we see that every pod has a similar cost, then `pod-deletion-cost` probably won't be very effective.