### PR TITLE
fix(CDC): allow growth if unproductive ZSTD exceeds buffer

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -118,7 +118,7 @@ func New(env environment.Env) (*ByteStreamServerProxy, error) {
 		efp:                env.GetExperimentFlagProvider(),
 		localCache:         env.GetCache(),
 		remoteCAS:          env.GetContentAddressableStorageClient(),
-		bufPool:            bytebufferpool.VariableSize(int(compression.ZstdCompressBound(chunking.MaxSupportedChunkSizeBytes()))),
+		bufPool:            bytebufferpool.VariableSize(int(chunking.MaxCompressedChunkReadSizeBytes())),
 	}, nil
 }
 
@@ -533,8 +533,12 @@ func drainChunkReadResults(bufPool *bytebufferpool.VariableSizePool, resultChans
 
 func (s *ByteStreamServerProxy) readChunk(ctx context.Context, rn *digest.CASResourceName, offset int64, remoteOnly bool) chunkReadResult {
 	capacity := rn.GetDigest().GetSizeBytes() - offset
+	allowBufferGrowth := false
 	if rn.GetCompressor() == repb.Compressor_ZSTD {
+		// ZstdCompressBound is not a hard bound for stored zstd streams.
+		// Unproductive multi-frame streams can exceed it.
 		capacity = compression.ZstdCompressBound(capacity)
+		allowBufferGrowth = true
 	}
 	if remoteOnly {
 		data, err := s.readRemoteChunk(ctx, rn, offset, capacity)
@@ -545,7 +549,7 @@ func (s *ByteStreamServerProxy) readChunk(ctx context.Context, rn *digest.CASRes
 	}
 
 	buf := s.bufPool.Get(capacity)
-	stream := newChunkBufferStream(ctx, buf)
+	stream := newChunkBufferStream(ctx, buf, s.bufPool, allowBufferGrowth)
 	localErr := s.local.ReadCASResource(ctx, rn, offset, 0, stream)
 	if localErr == nil {
 		data := stream.Bytes()
@@ -555,7 +559,7 @@ func (s *ByteStreamServerProxy) readChunk(ctx context.Context, rn *digest.CASRes
 			return chunkReadResult{data: data}
 		}
 	}
-	s.bufPool.Put(buf)
+	s.bufPool.Put(stream.Bytes())
 	if !status.IsNotFoundError(localErr) {
 		metrics.ByteStreamProxyChunkedReadFailures.With(prometheus.Labels{
 			metrics.ChunkedFailureReasonLabel: "chunk_local_read_error",
@@ -577,17 +581,17 @@ func (s *ByteStreamServerProxy) readRemoteChunk(ctx context.Context, rn *digest.
 	}
 	data, err := retry.Do(ctx, chunkReadRetryOptions(), func(ctx context.Context) ([]byte, error) {
 		buf := s.bufPool.Get(capacity)
-		stream := newChunkBufferStream(ctx, buf)
+		stream := newChunkBufferStream(ctx, buf, s.bufPool, rn.GetCompressor() == repb.Compressor_ZSTD)
 		err := s.readRemoteOnly(ctx, req, stream)
 		if err == nil {
 			data := stream.Bytes()
 			if rn.GetCompressor() != repb.Compressor_ZSTD && int64(len(data)) != rn.GetDigest().GetSizeBytes()-offset {
-				s.bufPool.Put(buf)
+				s.bufPool.Put(data)
 				return nil, io.ErrUnexpectedEOF
 			}
 			return data, nil
 		}
-		s.bufPool.Put(buf)
+		s.bufPool.Put(stream.Bytes())
 		if err == io.ErrShortBuffer ||
 			status.IsNotFoundError(err) ||
 			status.IsPermissionDeniedError(err) ||
@@ -614,20 +618,37 @@ func (s *ByteStreamServerProxy) readRemoteChunk(ctx context.Context, rn *digest.
 }
 
 type chunkBufferStream struct {
-	ctx  context.Context
-	data []byte
+	ctx               context.Context
+	data              []byte
+	bufPool           *bytebufferpool.VariableSizePool
+	allowBufferGrowth bool
 }
 
-func newChunkBufferStream(ctx context.Context, buf []byte) *chunkBufferStream {
+func newChunkBufferStream(ctx context.Context, buf []byte, bufPool *bytebufferpool.VariableSizePool, allowBufferGrowth bool) *chunkBufferStream {
 	return &chunkBufferStream{
-		ctx:  ctx,
-		data: buf[:0],
+		ctx:               ctx,
+		data:              buf[:0],
+		bufPool:           bufPool,
+		allowBufferGrowth: allowBufferGrowth,
 	}
 }
 
 func (s *chunkBufferStream) Send(message *bspb.ReadResponse) error {
-	if len(s.data)+len(message.GetData()) > cap(s.data) {
-		return io.ErrShortBuffer
+	needed := len(s.data) + len(message.GetData())
+	if needed > cap(s.data) {
+		if !s.allowBufferGrowth {
+			return io.ErrShortBuffer
+		}
+		maxCapacity := chunking.MaxCompressedChunkReadSizeBytes()
+		if int64(needed) > maxCapacity {
+			return status.InternalErrorf("compressed chunk exceeded max read size %d", maxCapacity)
+		}
+		// Grow by doubling. Make room for the current message.
+		buf := s.bufPool.Get(min(max(2*int64(cap(s.data)), int64(needed)), maxCapacity))
+		n := len(s.data)
+		copy(buf, s.data)
+		s.bufPool.Put(s.data)
+		s.data = buf[:n]
 	}
 	s.data = append(s.data, message.GetData()...)
 	return nil

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -79,6 +79,29 @@ type noOpCASClient struct {
 	repb.ContentAddressableStorageClient
 }
 
+type fakeByteStreamClient struct {
+	bspb.ByteStreamClient
+	data []byte
+}
+
+func (c *fakeByteStreamClient) Read(ctx context.Context, req *bspb.ReadRequest, opts ...grpc.CallOption) (bspb.ByteStream_ReadClient, error) {
+	return &fakeByteStreamReadClient{data: c.data}, nil
+}
+
+type fakeByteStreamReadClient struct {
+	grpc.ClientStream
+	data []byte
+	done bool
+}
+
+func (c *fakeByteStreamReadClient) Recv() (*bspb.ReadResponse, error) {
+	if c.done {
+		return nil, io.EOF
+	}
+	c.done = true
+	return &bspb.ReadResponse{Data: c.data}, nil
+}
+
 func (c *noOpCAS) FindMissingBlobs(ctx context.Context, req *repb.FindMissingBlobsRequest) (*repb.FindMissingBlobsResponse, error) {
 	return &repb.FindMissingBlobsResponse{}, nil
 }
@@ -2056,6 +2079,48 @@ func TestReadChunkedCompressedWarmLocal(t *testing.T) {
 	require.Equal(t, float64(len(chunkDigests)), readChunksTotalAfter-readChunksTotalBefore, "total chunks = number of chunks in manifest")
 	require.Equal(t, float64(len(chunkDigests)), readChunksLocalAfter-readChunksLocalBefore, "second read: all chunks served from local cache")
 	require.Equal(t, float64(0), readChunksRemoteAfter-readChunksRemoteBefore, "second read: no remote chunk fetches")
+}
+
+func TestReadChunkZstdLargerThanInitialBuffer(t *testing.T) {
+	chunk := bytes.Repeat([]byte("x"), 646321)
+	chunkDigest, err := digest.Compute(bytes.NewReader(chunk), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	chunkRN := digest.NewCASResourceName(chunkDigest, "", repb.DigestFunction_BLAKE3)
+	chunkRN.SetCompressor(repb.Compressor_ZSTD)
+
+	bufPool := bytebufferpool.VariableSize(int(chunking.MaxCompressedChunkReadSizeBytes()))
+	initialBuf := bufPool.Get(compression.ZstdCompressBound(int64(len(chunk))))
+	initialCap := cap(initialBuf)
+	bufPool.Put(initialBuf)
+
+	compressed := compression.CompressZstd(nil, chunk)
+	payloadSize := initialCap - len(compressed) + 1
+	require.Greater(t, payloadSize, 0)
+	compressed = appendZstdSkippableFrame(compressed, payloadSize)
+	// Old proxy chunk reads failed once the compressed stream exceeded the initial buffer.
+	require.Greater(t, len(compressed), initialCap)
+	require.LessOrEqual(t, len(compressed), int(chunking.MaxCompressedChunkReadSizeBytes()))
+	decompressed, err := compression.DecompressZstd(nil, compressed)
+	require.NoError(t, err)
+	require.Equal(t, chunk, decompressed)
+
+	s := &ByteStreamServerProxy{
+		remote:  &fakeByteStreamClient{data: compressed},
+		bufPool: bufPool,
+	}
+	result := s.readChunk(context.Background(), chunkRN, 0, true)
+	require.NoError(t, result.err)
+	require.True(t, result.remote)
+	// The proxy should return the complete compressed chunk, not a short-buffer error.
+	require.Equal(t, compressed, result.data)
+	bufPool.Put(result.data)
+}
+
+func appendZstdSkippableFrame(dst []byte, payloadSize int) []byte {
+	// Zstd skippable frame magic 0x184D2A50, little-endian.
+	dst = append(dst, 0x50, 0x2a, 0x4d, 0x18)
+	dst = append(dst, byte(payloadSize), byte(payloadSize>>8), byte(payloadSize>>16), byte(payloadSize>>24))
+	return append(dst, make([]byte, payloadSize)...)
 }
 
 type faultyCache struct {

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -96,7 +96,7 @@ func NewByteStreamServer(env environment.Env) (*ByteStreamServer, error) {
 	return &ByteStreamServer{
 		env:        env,
 		cache:      cache,
-		bufferPool: bytebufferpool.VariableSize(max(*remote_cache_config.ReadBufSizeBytes, compressBufSize, int(compression.ZstdCompressBound(chunking.MaxSupportedChunkSizeBytes())))),
+		bufferPool: bytebufferpool.VariableSize(max(*remote_cache_config.ReadBufSizeBytes, compressBufSize, int(chunking.MaxCompressedChunkReadSizeBytes()))),
 		warner:     bazel_deprecation.NewWarner(env),
 	}, nil
 }
@@ -433,13 +433,56 @@ func (r *chunkedBlobReader) readChunk(rn *rspb.ResourceName, offset int64, buf [
 	}
 	defer rc.Close()
 
+	if rn.GetCompressor() == repb.Compressor_ZSTD {
+		// ZstdCompressBound is not a hard bound for stored zstd streams.
+		// Unproductive multi-frame streams can exceed it.
+		buf = buf[:cap(buf)]
+	}
 	n, err := ioutil.ReadTryFillBuffer(rc, buf)
 	if err != nil {
 		return chunkReadResult{data: buf, err: err}
 	}
+	if rn.GetCompressor() == repb.Compressor_ZSTD {
+		return r.finishCompressedChunkRead(rc, buf, n)
+	}
 	readSize := rn.GetDigest().GetSizeBytes() - offset
-	if rn.GetCompressor() != repb.Compressor_ZSTD && int64(n) != readSize {
+	if int64(n) != readSize {
 		return chunkReadResult{data: buf, err: io.ErrUnexpectedEOF}
+	}
+	return chunkReadResult{data: buf[:n]}
+}
+
+func (r *chunkedBlobReader) finishCompressedChunkRead(rc io.Reader, buf []byte, n int) chunkReadResult {
+	// For zstd chunks, the digest size is decompressed. A full buffer means
+	// there may be more compressed bytes, so keep growing until EOF.
+	maxReadSize := chunking.MaxCompressedChunkReadSizeBytes()
+	for n == len(buf) {
+		if int64(len(buf)) >= maxReadSize {
+			// If one more byte exists, the chunk exceeded our cap. We return an
+			// error and discard the buffered data, so the extra byte is not needed.
+			var extra [1]byte
+			_, err := io.ReadFull(rc, extra[:])
+			if err == io.EOF {
+				return chunkReadResult{data: buf[:n]}
+			}
+			if err != nil {
+				return chunkReadResult{data: buf, err: err}
+			}
+			return chunkReadResult{data: buf, err: status.InternalErrorf("compressed chunk exceeded max read size %d", maxReadSize)}
+		}
+		// Grow by doubling. Keep the bytes already read.
+		newBuf := r.bufferPool.Get(min(2*int64(len(buf)), maxReadSize))
+		copy(newBuf, buf[:n])
+		r.bufferPool.Put(buf)
+		buf = newBuf
+		m, err := ioutil.ReadTryFillBuffer(rc, buf[n:])
+		n += m
+		if err == io.EOF {
+			return chunkReadResult{data: buf[:n]}
+		}
+		if err != nil {
+			return chunkReadResult{data: buf, err: err}
+		}
 	}
 	return chunkReadResult{data: buf[:n]}
 }

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"strings"
 	"sync"
 	"testing"
@@ -156,6 +157,13 @@ func (r *closeBlockingReadCloser) Read(_ []byte) (int, error) {
 
 func (r *closeBlockingReadCloser) Close() error {
 	return nil
+}
+
+type zeroReader struct{}
+
+func (r zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }
 
 type readerFuncCache struct {
@@ -765,6 +773,16 @@ func zstdDecompress(t *testing.T, b []byte) []byte {
 	return out
 }
 
+func compressZstdInFrames(data []byte, frameSize int) []byte {
+	var compressed []byte
+	for len(data) > 0 {
+		n := min(frameSize, len(data))
+		compressed = append(compressed, compression.CompressZstd(nil, data[:n])...)
+		data = data[n:]
+	}
+	return compressed
+}
+
 func newUUID(t *testing.T) string {
 	uuid, err := guuid.NewRandom()
 	require.NoError(t, err)
@@ -1032,7 +1050,7 @@ func TestChunkedBlobReaderReadChunk(t *testing.T) {
 		require.ErrorIs(t, result.err, io.ErrUnexpectedEOF)
 	})
 
-	t.Run("zstd allows compression overhead", func(t *testing.T) {
+	t.Run("zstd streams compressed bytes", func(t *testing.T) {
 		data := []byte("abc")
 		compressed := compression.CompressZstd(nil, data)
 		require.Greater(t, len(compressed), len(data))
@@ -1055,6 +1073,28 @@ func TestChunkedBlobReaderReadChunk(t *testing.T) {
 		result := r.readChunk(rn.ToProto(), 0, buf)
 		require.NoError(t, result.err)
 		require.Equal(t, compressed, result.data)
+		r.bufferPool.Put(result.data)
+	})
+
+	t.Run("zstd rejects chunks exceeding compressed read cap", func(t *testing.T) {
+		d := &repb.Digest{Hash: strings.Repeat("a", 64), SizeBytes: chunking.MaxSupportedChunkSizeBytes()}
+		rn := digest.NewCASResourceName(d, "", repb.DigestFunction_BLAKE3)
+		rn.SetCompressor(repb.Compressor_ZSTD)
+		r := &chunkedBlobReader{
+			ctx: context.Background(),
+			cache: &readerFuncCache{
+				reader: func(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+					rc := io.NopCloser(io.LimitReader(zeroReader{}, chunking.MaxCompressedChunkReadSizeBytes()+1))
+					return rc, nil
+				},
+			},
+			bufferPool: bytebufferpool.VariableSize(int(chunking.MaxCompressedChunkReadSizeBytes())),
+		}
+
+		buf := r.bufferPool.Get(compression.ZstdCompressBound(d.GetSizeBytes()))
+		result := r.readChunk(rn.ToProto(), 0, buf)
+		require.True(t, status.IsInternalError(result.err))
+		r.bufferPool.Put(result.data)
 	})
 }
 
@@ -1245,6 +1285,93 @@ func TestReadChunked_ZstdBLAKE3_PassthroughIncompressible(t *testing.T) {
 		require.NoError(t, err)
 		buf.Write(resp.GetData())
 	}
+	require.Equal(t, fullBlob, zstdDecompress(t, buf.Bytes()))
+}
+
+func TestReadChunked_ZstdPassthroughCompressedChunkLargerThanCompressBound(t *testing.T) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+	flags.Set(t, "cache.zstd_transcoding_enabled", true)
+
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	te.SetExperimentFlagProvider(fp)
+	te.SetCache(&casCompressionCache{Cache: te.GetCache()})
+
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runByteStreamServer(ctx, t, te)
+	bsClient := bspb.NewByteStreamClient(clientConn)
+
+	chunk1 := make([]byte, 646321)
+	rng := rand.New(rand.NewSource(12345))
+	for i := range chunk1 {
+		chunk1[i] = byte(rng.Intn(256))
+	}
+	compressedChunk1 := compressZstdInFrames(chunk1, 2616)
+	compressBound := compression.ZstdCompressBound(int64(len(chunk1)))
+	// Old chunked zstd passthrough truncated this chunk at ZstdCompressBound.
+	require.Greater(t, len(compressedChunk1), int(compressBound))
+	require.Equal(t, chunk1, zstdDecompress(t, compressedChunk1))
+
+	chunk2 := make([]byte, 2*1024*1024)
+	for i := range chunk2 {
+		chunk2[i] = byte(rng.Intn(256))
+	}
+	fullBlob := append(append([]byte{}, chunk1...), chunk2...)
+
+	chunk1Digest, err := digest.Compute(bytes.NewReader(chunk1), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	chunk2Digest, err := digest.Compute(bytes.NewReader(chunk2), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+	blobDigest, err := digest.Compute(bytes.NewReader(fullBlob), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+
+	baseCache := te.GetCache().(*casCompressionCache).Cache
+	chunk1RN := digest.NewCASResourceName(chunk1Digest, "", repb.DigestFunction_BLAKE3)
+	chunk2RN := digest.NewCASResourceName(chunk2Digest, "", repb.DigestFunction_BLAKE3)
+	require.NoError(t, baseCache.Set(ctx, chunk1RN.ToProto(), compressedChunk1))
+	require.NoError(t, baseCache.Set(ctx, chunk2RN.ToProto(), chunk2))
+
+	manifest := &chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   []*repb.Digest{chunk1Digest, chunk2Digest},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_BLAKE3,
+	}
+	require.NoError(t, manifest.Store(ctx, te.GetCache()))
+
+	blobRN := digest.NewCASResourceName(blobDigest, "", repb.DigestFunction_BLAKE3)
+	blobRN.SetCompressor(repb.Compressor_ZSTD)
+
+	stream, err := bsClient.Read(ctx, &bspb.ReadRequest{
+		ResourceName: blobRN.DownloadString(),
+	})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		buf.Write(resp.GetData())
+	}
+	// The parent zstd stream should include the full first chunk before chunk2.
 	require.Equal(t, fullBlob, zstdDecompress(t, buf.Bytes()))
 }
 

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -94,6 +94,11 @@ func MaxSupportedChunkSizeBytes() int64 {
 	return 4 * 1024 * 1024
 }
 
+// MaxCompressedChunkReadSizeBytes is the per-chunk compressed read buffer cap.
+func MaxCompressedChunkReadSizeBytes() int64 {
+	return 4 * MaxSupportedChunkSizeBytes()
+}
+
 // MinChunkedReadFallbackSizeBytes can be configured independently from the
 // write threshold so server-side miss fallback paths can still read older
 // chunked blobs that were written with a smaller chunk size, but is clamped to

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -51,6 +51,9 @@ func mustGetZstdEncoder() *zstd.Encoder {
 // the >>8 term) plus the fixed frame header/checksum (bounded by the small-
 // input margin).
 //
+// This is the single-frame worst-case. Many small ZSTD frames can exceed it,
+// so it is not a hard boundary for arbitrary stored zstd streams.
+//
 // Extra headroom examples:
 // 1 KiB -> +67 bytes
 // 1 MiB -> +4 KiB


### PR DESCRIPTION
`ByteStream.Read` can reconstruct a chunked parent blob by concatenating zstd-compressed chunks.

The old code sized each zstd chunk buffer with `compression.ZstdCompressBound(uncompressedChunkSize)` and accepted a full buffer as a complete zstd chunk. That is unsafe since `ZstdCompressBound` is not a hard limit because a chunk can have many zstd frames.

This PR intentonally preserves existing behavior for all cases **except when the buffer fills completely.** This PR fixes the issue, by adding the logic for zstd chunks only:

1. Start with the existing `ZstdCompressBound(uncompressedChunkSize)` buffer.
2. Read into it as before.
3. If the buffer fills, double the buffer and continue reading.
4. Repeat until EOF, with a hard cap of `16MiB` (4x growth, should never happen)
5. Return `ResourceExhausted` if the compressed chunk exceeds that cap instead of truncating it.
I also added some regression tests which fail on master.