### PR TITLE
invocation: show CAS-only cacheability

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -143,6 +143,20 @@ export default class InvocationActionCardComponent extends React.Component<Props
   private executionDownloadsContainerRef = React.createRef<HTMLDivElement>();
   private treeShaToChildrenPromiseMap = new Map<string, Promise<TreeNode[]>>();
 
+  private isCasOnlyInvocation() {
+    return this.props.model.hasCASWriteCapability() && !this.props.model.hasActionCacheWriteCapability();
+  }
+
+  private cacheableLabel(action: build.bazel.remote.execution.v2.Action) {
+    if (action.doNotCache) {
+      return "No";
+    }
+    if (this.isCasOnlyInvocation()) {
+      return "No (CAS-only credentials)";
+    }
+    return "Yes";
+  }
+
   componentDidMount() {
     this.fetchAction();
     this.fetchExecuteResponseOrActionResult();
@@ -1716,7 +1730,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
                     </div>
                     <div className="action-section">
                       <div className="action-property-title">Cacheable</div>
-                      <div>{!this.state.action.doNotCache ? "Yes" : "No"}</div>
+                      <div>{this.cacheableLabel(this.state.action)}</div>
                     </div>
                     <div className="action-section">
                       <div className="action-property-title">Timeout</div>

--- a/app/invocation/invocation_spawn_card.tsx
+++ b/app/invocation/invocation_spawn_card.tsx
@@ -45,6 +45,17 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
 
   timeoutRef?: number;
 
+  private isCasOnlyInvocation() {
+    return this.props.model.hasCASWriteCapability() && !this.props.model.hasActionCacheWriteCapability();
+  }
+
+  private cacheableLabel(cacheable?: boolean) {
+    if (cacheable && this.isCasOnlyInvocation()) {
+      return "No (CAS-only credentials)";
+    }
+    return cacheable ? "true" : "false";
+  }
+
   componentDidMount() {
     this.fetchLog();
   }
@@ -343,7 +354,7 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
                           </div>
                         ))}
                         <div>Remotable: {spawn.spawn?.remotable ? "true" : "false"}</div>
-                        <div>Cachable: {spawn.spawn?.cacheable ? "true" : "false"}</div>
+                        <div>Cacheable: {this.cacheableLabel(spawn.spawn?.cacheable)}</div>
                         <div>Exit code: {spawn.spawn?.exitCode || 0}</div>
                         {spawn.spawn?.metrics?.startTime && (
                           <div>Start time: {format.formatTimestamp(spawn.spawn.metrics.startTime)}</div>


### PR DESCRIPTION
Users saw misleading cacheability on CAS-only invocations. CAS-only API keys can upload action outputs to CAS but cannot persist action cache entries. The action detail page reported cacheability only from Action.do_not_cache, so CAS-only invocations still showed "Cacheable: Yes" even though the credential could not populate AC for later reuse.

This changes the action details and execution log spawn rows to show "No (CAS-only credentials)" for cacheable actions and spawns when the invocation has CAS write capability but lacks AC write capability. Real do_not_cache actions still show "No", and fully cache-capable invocations still show "Yes". The spawn row label typo is also fixed from "Cachable" to "Cacheable".
