### PR TITLE
WIP: Materialize manifest-only chunks in SpliceBlob

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1074,6 +1074,15 @@ var (
 		ManifestPrefixLabel,
 	})
 
+	ChunkedManifestMaterializedChunksCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "chunked_manifest_materialized_chunks_count",
+		Help:      "Number of SpliceBlob chunks that existed only as chunked manifests and were materialized into whole CAS objects, labeled by outcome.",
+	}, []string{
+		StatusLabel,
+	})
+
 	GetTreeDirectoryLookupCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -339,6 +339,71 @@ func (cm *Manifest) Store(ctx context.Context, cache interfaces.Cache) error {
 	return cm.store(ctx, cache)
 }
 
+// MaterializeMissingChunks converts referenced chunks that exist only as
+// chunked manifests into whole CAS objects. FindMissingBlobs reports
+// manifest-backed blobs as present, so clients (e.g. Bazel) skip uploading
+// such chunks and Store would otherwise fail without any way for the client
+// to recover. Materializing (rather than storing a manifest that references
+// another manifest) keeps stored manifests one level deep. Chunks that cannot
+// be materialized are left missing for Store to report.
+func (cm *Manifest) MaterializeMissingChunks(ctx context.Context, cache interfaces.Cache) error {
+	missing, err := cache.FindMissing(ctx, cm.ChunkResourceNames())
+	if err != nil {
+		return err
+	}
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(4)
+	for _, d := range missing {
+		if d.GetSizeBytes() <= 0 || d.GetSizeBytes() > MaxSupportedChunkSizeBytes() {
+			continue
+		}
+		g.Go(func() error {
+			chunkManifest, err := LoadManifest(gCtx, cache, d, cm.InstanceName, cm.DigestFunction)
+			if status.IsNotFoundError(err) {
+				// Genuinely missing; Store will report it.
+				return nil
+			}
+			if err == nil {
+				err = chunkManifest.materialize(gCtx, cache)
+			}
+			if err != nil {
+				metrics.ChunkedManifestMaterializedChunksCount.WithLabelValues("error").Inc()
+				log.CtxInfof(gCtx, "Failed to materialize manifest-only chunk %s/%d for blob %s: %v", d.GetHash(), d.GetSizeBytes(), cm.BlobDigest.GetHash(), err)
+				return nil
+			}
+			metrics.ChunkedManifestMaterializedChunksCount.WithLabelValues("materialized").Inc()
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+// materialize reconstructs the manifest's blob from its chunks, verifies the
+// combined digest, and writes it to the CAS as a whole object.
+func (cm *Manifest) materialize(ctx context.Context, cache interfaces.Cache) error {
+	buf := make([]byte, 0, cm.BlobDigest.GetSizeBytes())
+	for _, chunkDigest := range cm.ChunkDigests {
+		chunkRN := digest.NewCASResourceName(chunkDigest, cm.InstanceName, cm.DigestFunction)
+		data, err := cache.Get(ctx, chunkRN.ToProto())
+		if err != nil {
+			return err
+		}
+		buf = append(buf, data...)
+		if int64(len(buf)) > cm.BlobDigest.GetSizeBytes() {
+			return status.InvalidArgumentErrorf("manifest chunks exceed expected blob size %d", cm.BlobDigest.GetSizeBytes())
+		}
+	}
+	computed, err := digest.Compute(bytes.NewReader(buf), cm.DigestFunction)
+	if err != nil {
+		return err
+	}
+	if computed.GetHash() != cm.BlobDigest.GetHash() || int64(len(buf)) != cm.BlobDigest.GetSizeBytes() {
+		return status.DataLossErrorf("materialized blob digest mismatch: got %s/%d, want %s/%d", computed.GetHash(), len(buf), cm.BlobDigest.GetHash(), cm.BlobDigest.GetSizeBytes())
+	}
+	rn := digest.NewCASResourceName(cm.BlobDigest, cm.InstanceName, cm.DigestFunction)
+	return cache.Set(ctx, rn.ToProto(), buf)
+}
+
 // StoreWithoutVerification saves the chunked manifest to the cache without
 // checking that all chunks exist or that their combined hash matches the blob
 // digest.

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -1255,7 +1255,24 @@ func (s *ContentAddressableStorageServer) spliceBlob(ctx context.Context, req *r
 	}
 
 	if err := manifest.Store(ctx, s.cache); err != nil {
-		return nil, err
+		// Some referenced chunks may exist only as chunked manifests (e.g.
+		// written before a chunk size increase). FindMissingBlobs reports such
+		// blobs as present, so the client skipped uploading them and can never
+		// satisfy this request on its own. Materialize them into whole CAS
+		// objects and retry once.
+		//
+		// TODO(tfrench): Remove after the chunk size increase has fully rolled
+		// out and ChunkedManifestMaterializedChunksCount has stayed at zero,
+		// i.e. no manifest-only blobs at or below the max chunk size remain.
+		if !status.IsInvalidArgumentError(err) {
+			return nil, err
+		}
+		if merr := manifest.MaterializeMissingChunks(ctx, s.cache); merr != nil {
+			return nil, merr
+		}
+		if err := manifest.Store(ctx, s.cache); err != nil {
+			return nil, err
+		}
 	}
 
 	return &repb.SpliceBlobResponse{

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -1147,6 +1147,122 @@ func TestFindMissingBlobsWithChunkedBlob(t *testing.T) {
 	require.ElementsMatch(t, digestStrings(blobDigest, regularDigest), digestStrings(rsp.MissingBlobDigests...))
 }
 
+// setupChunkingTest returns a CAS client and cache with chunking enabled, plus
+// a "manifest-only" blob: a blob whose sub-chunks are whole CAS objects but
+// which itself exists only as a chunked manifest (as written before a chunk
+// size increase).
+func setupChunkingTest(t *testing.T) (context.Context, repb.ContentAddressableStorageClient, interfaces.Cache, *chunking.Manifest, []byte) {
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.chunking_enabled": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	te.SetExperimentFlagProvider(fp)
+
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, te)
+	casClient := repb.NewContentAddressableStorageClient(clientConn)
+	cache := te.GetCache()
+
+	sub1RN, sub1 := testdigest.RandomCASResourceBuf(t, 512*1024)
+	sub2RN, sub2 := testdigest.RandomCASResourceBuf(t, 512*1024)
+	require.NoError(t, cache.Set(ctx, sub1RN, sub1))
+	require.NoError(t, cache.Set(ctx, sub2RN, sub2))
+
+	manifestOnlyBytes := append(append([]byte{}, sub1...), sub2...)
+	manifestOnlyDigest, err := digest.Compute(bytes.NewReader(manifestOnlyBytes), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	manifestOnly := &chunking.Manifest{
+		BlobDigest:     manifestOnlyDigest,
+		ChunkDigests:   []*repb.Digest{sub1RN.GetDigest(), sub2RN.GetDigest()},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, manifestOnly.Store(ctx, cache))
+
+	manifestOnlyRN := digest.NewCASResourceName(manifestOnlyDigest, "", repb.DigestFunction_SHA256).ToProto()
+	missing, err := cache.FindMissing(ctx, []*rspb.ResourceName{manifestOnlyRN})
+	require.NoError(t, err)
+	require.Len(t, missing, 1, "manifest-only blob must not exist as a whole CAS object")
+
+	return ctx, casClient, cache, manifestOnly, manifestOnlyBytes
+}
+
+func TestSpliceBlobMaterializesManifestOnlyChunks(t *testing.T) {
+	ctx, casClient, cache, manifestOnly, manifestOnlyBytes := setupChunkingTest(t)
+
+	tailRN, tail := testdigest.RandomCASResourceBuf(t, 256*1024)
+	require.NoError(t, cache.Set(ctx, tailRN, tail))
+
+	parentBytes := append(append([]byte{}, manifestOnlyBytes...), tail...)
+	parentDigest, err := digest.Compute(bytes.NewReader(parentBytes), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	// The client skipped uploading the manifest-only chunk because
+	// FindMissingBlobs reported it as present.
+	_, err = casClient.SpliceBlob(ctx, &repb.SpliceBlobRequest{
+		BlobDigest:     parentDigest,
+		ChunkDigests:   []*repb.Digest{manifestOnly.BlobDigest, tailRN.GetDigest()},
+		DigestFunction: repb.DigestFunction_SHA256,
+	})
+	require.NoError(t, err)
+
+	// The manifest-only chunk was materialized into a whole CAS object, so the
+	// stored parent manifest does not reference a nested manifest.
+	manifestOnlyRN := digest.NewCASResourceName(manifestOnly.BlobDigest, "", repb.DigestFunction_SHA256).ToProto()
+	data, err := cache.Get(ctx, manifestOnlyRN)
+	require.NoError(t, err)
+	require.Equal(t, manifestOnlyBytes, data)
+
+	parentManifest, err := chunking.LoadManifest(ctx, cache, parentDigest, "", repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+	missing, err := cache.FindMissing(ctx, parentManifest.ChunkResourceNames())
+	require.NoError(t, err)
+	require.Empty(t, missing)
+}
+
+func TestSpliceBlobFailsWhenManifestOnlyChunkIsUnrecoverable(t *testing.T) {
+	ctx, casClient, cache, manifestOnly, manifestOnlyBytes := setupChunkingTest(t)
+
+	// Losing a sub-chunk makes the manifest-only blob unreconstructable.
+	sub2RN := digest.NewCASResourceName(manifestOnly.ChunkDigests[1], "", repb.DigestFunction_SHA256).ToProto()
+	require.NoError(t, cache.Delete(ctx, sub2RN))
+
+	tailRN, tail := testdigest.RandomCASResourceBuf(t, 256*1024)
+	require.NoError(t, cache.Set(ctx, tailRN, tail))
+
+	parentBytes := append(append([]byte{}, manifestOnlyBytes...), tail...)
+	parentDigest, err := digest.Compute(bytes.NewReader(parentBytes), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	_, err = casClient.SpliceBlob(ctx, &repb.SpliceBlobRequest{
+		BlobDigest:     parentDigest,
+		ChunkDigests:   []*repb.Digest{manifestOnly.BlobDigest, tailRN.GetDigest()},
+		DigestFunction: repb.DigestFunction_SHA256,
+	})
+	require.Error(t, err)
+	require.Equal(t, gcodes.InvalidArgument, gstatus.Code(err), "expected InvalidArgument, got: %v", err)
+
+	manifestOnlyRN := digest.NewCASResourceName(manifestOnly.BlobDigest, "", repb.DigestFunction_SHA256).ToProto()
+	missing, err := cache.FindMissing(ctx, []*rspb.ResourceName{manifestOnlyRN})
+	require.NoError(t, err)
+	require.Len(t, missing, 1, "unrecoverable chunk must not be materialized")
+}
+
 func TestFindMissingBlobsUsesReadFallbackThreshold(t *testing.T) {
 	flags.Set(t, "cache.avg_chunk_size_bytes", 1024*1024)
 	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)


### PR DESCRIPTION
Doubling the chunk size still causes issues. This is because chunks referenced by a SpliceBlob request may exist only as chunked manifests: blobs in the (2MiB, 4MiB] range written before a chunk size increase were chunk-eligible and stored as a manifest plus chunks, with no whole CAS object. 

FindMissingBlobs reports such blobs as present via the chunked-manifest fallback, so clients that do not tag chunk-level calls (e.g. Bazel with --experimental_remote_cache_chunking) skip uploading them, and SpliceBlob then fails validation with 'required chunks not found in CAS' with no way for the client to recover. We can't change FMB to skip these blobs because of this issue: https://github.com/buildbuddy-io/buildbuddy/pull/12269

When Store fails with InvalidArgument, materialize any missing chunks that are stored as chunked manifests into whole CAS objects (verifying the reconstructed digest) and retry once. This keeps stored manifests one level deep, adds no work to the happy path, and lazily heals manifest-only blobs as they are referenced.