### PR TITLE
[codex] Raise Pebble zstd compression threshold

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1045,9 +1045,9 @@ func (c *Cache) copyFile(ctx context.Context, rn *rspb.ResourceName, source stri
 	if exists, err := c.remoteContains(ctx, dest, rn); err == nil && exists {
 		return nil
 	}
-	if rn.GetDigest().GetSizeBytes() > 100 && c.SupportsCompressor(repb.Compressor_ZSTD) {
+	if rn.GetDigest().GetSizeBytes() > 16*1024 && c.SupportsCompressor(repb.Compressor_ZSTD) {
 		// If the file is large enough and we support ZSTD, then the source will
-		// have it compressed, and we want to store it compressed. 100 is the
+		// have it compressed, and we want to store it compressed. 16 KiB is the
 		// default value of --cache.pebble.min_bytes_auto_zstd_compression.
 		rn = rn.CloneVT()
 		rn.Compressor = repb.Compressor_ZSTD

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -121,7 +121,7 @@ var (
 	DefaultDeleteBufferSize            = 20
 	DefaultNumDeleteWorkers            = 16
 	DefaultMinEvictionAge              = 6 * time.Hour
-	DefaultMinBytesAutoZstdCompression = int64(100)
+	DefaultMinBytesAutoZstdCompression = int64(16 * 1024)
 
 	DefaultName         = "pebble_cache"
 	DefaultMaxSizeBytes = cache_config.MaxSizeBytes()

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1048,9 +1048,10 @@ func TestCompression_NoEarlyEviction(t *testing.T) {
 				(1 / pebble_cache.JanitorCutoffThreshold))) // account for .9 evictor cutoff
 
 	opts := &pebble_cache.Options{
-		RootDirectory:  testfs.MakeTempDir(t),
-		MaxSizeBytes:   maxSizeBytes,
-		MinEvictionAge: &minEvictionAge,
+		RootDirectory:               testfs.MakeTempDir(t),
+		MaxSizeBytes:                maxSizeBytes,
+		MinEvictionAge:              &minEvictionAge,
+		MinBytesAutoZstdCompression: proto.Int64(100),
 	}
 	pc, err := pebble_cache.NewPebbleCache(te, opts)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Raises the default Pebble auto-zstd compression threshold from 100 bytes to 16 KiB, and updates distributed cache backfill's hard-coded compression cutoff to match.

## Why

The production CPU and heap profiles showed substantial CPU and live heap in zstd encode/decode buffers. Compressing very small blobs is unlikely to pay for itself and increases compressor history/buffer pressure.

## Impact

Small blobs below 16 KiB will be stored without automatic zstd compression unless callers explicitly request compressed storage. Larger blobs continue to use the existing automatic compression path.

## Validation

- `bazel test //enterprise/server/backends/pebble_cache:pebble_cache_test //enterprise/server/backends/distributed:distributed_test`