### PR TITLE
[codex] Tighten distributed lookaside cache values

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -245,8 +245,9 @@ func NewDistributedCache(env environment.Env, c interfaces.Cache, opts Options, 
 				// []byte size + 8 bytes for the int64 timestamp.
 				return int64(len(v.data) + 8)
 			},
-			ThreadSafe: true,
-			TTL:        *lookasideCacheTTL,
+			ThreadSafe:    true,
+			TTL:           *lookasideCacheTTL,
+			UpdateInPlace: true,
 		})
 		if err != nil {
 			return nil, err
@@ -453,14 +454,14 @@ func (c *Cache) addLookasideEntry(ctx context.Context, r *rspb.ResourceName, dat
 }
 
 func (c *Cache) setLookasideEntry(lookasideKey string, data []byte) {
+	ownedData := make([]byte, len(data))
+	copy(ownedData, data)
 	entry := lookasideCacheEntry{
 		createdAtMillis: time.Now().UnixMilli(),
-		data:            data,
+		data:            ownedData,
 	}
 
-	if !c.lookaside.Contains(lookasideKey) {
-		c.lookaside.Add(lookasideKey, entry)
-	}
+	c.lookaside.Add(lookasideKey, entry)
 	c.log.Debugf("Set %q in lookaside cache", lookasideKey)
 }
 

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/kubediscovery"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/peerset"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
@@ -2143,6 +2144,40 @@ func TestAbandonedReadDoesntWriteToLookaside(t *testing.T) {
 	assert.Equal(t, buf, data)
 
 	assert.Equal(t, 4, len(memoryCache.ops), "Ops were %v", memoryCache.ops)
+}
+
+func TestSetLookasideEntryCopiesData(t *testing.T) {
+	lookaside, err := lru.New[lookasideCacheEntry](&lru.Config[lookasideCacheEntry]{
+		MaxSize: 100,
+		SizeFn: func(v lookasideCacheEntry) int64 {
+			return int64(len(v.data) + 8)
+		},
+		UpdateInPlace: true,
+	})
+	require.NoError(t, err)
+
+	c := &Cache{
+		log:       log.NamedSubLogger("test"),
+		lookaside: lookaside,
+	}
+
+	backing := make([]byte, 32)
+	copy(backing, "abc")
+	c.setLookasideEntry("key", backing[:3])
+	backing[0] = 'z'
+
+	entry, ok := c.lookaside.Get("key")
+	require.True(t, ok)
+	require.Equal(t, "abc", string(entry.data))
+	require.Equal(t, len(entry.data), cap(entry.data))
+	require.Equal(t, int64(len("abc")+8), c.lookaside.Size())
+
+	c.setLookasideEntry("key", []byte("abcdef"))
+	entry, ok = c.lookaside.Get("key")
+	require.True(t, ok)
+	require.Equal(t, "abcdef", string(entry.data))
+	require.Equal(t, len(entry.data), cap(entry.data))
+	require.Equal(t, int64(len("abcdef")+8), c.lookaside.Size())
 }
 
 func TestGetMultiLookaside(t *testing.T) {


### PR DESCRIPTION
## Summary

Copies distributed lookaside cache values into exact-sized owned byte slices before inserting them into the LRU, and enables in-place updates for repeated keys.

## Why

The heap profile showed nearly 1 GB live under distributed lookaside paths. One risk is that lookaside entries can retain backing arrays from proto/gRPC or caller buffers that are larger than the byte slice length accounted by the LRU.

## Impact

Lookaside cache accounting better matches retained heap, and cached entries no longer keep caller/proto backing arrays alive. Repeated entries refresh in place instead of going through conflict eviction.

## Validation

- `bazel test //enterprise/server/backends/distributed:distributed_test`