### PR TITLE
[codex] Cap distributed buffer pool retention

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -51,8 +51,9 @@ const (
 )
 
 var (
-	enableKubeResolver = flag.Bool("cache.distributed_cache.enable_kube_resolver", false, "Enable Kubernetes resolver for resolving peer pod IPs")
-	peerWriteTimeout   = flag.Duration("cache.distributed_cache.peer_write_timeout", time.Minute, "Maximum time to wait for a single distributed cache peer write send or close operation before treating the peer as stalled.")
+	enableKubeResolver      = flag.Bool("cache.distributed_cache.enable_kube_resolver", false, "Enable Kubernetes resolver for resolving peer pod IPs")
+	peerWriteTimeout        = flag.Duration("cache.distributed_cache.peer_write_timeout", time.Minute, "Maximum time to wait for a single distributed cache peer write send or close operation before treating the peer as stalled.")
+	maxRetainedBufSizeBytes = flag.Int("cache.distributed_cache.max_retained_buf_size_bytes", 256*1024, "Maximum distributed cache proxy buffer size retained in the shared buffer pool. Larger buffers can still be allocated, but are dropped when returned.")
 )
 
 type Proxy struct {
@@ -75,7 +76,7 @@ func New(env environment.Env, c interfaces.Cache, listenAddr string) *Proxy {
 		env:        env,
 		cache:      c,
 		log:        log.NamedSubLogger(fmt.Sprintf("Proxy(%s)", listenAddr)),
-		bufPool:    bytebufferpool.VariableSize(max(*config.ReadBufSizeBytes, writeBufSizeBytes)),
+		bufPool:    bytebufferpool.VariableSizeWithMaxRetained(max(*config.ReadBufSizeBytes, writeBufSizeBytes), *maxRetainedBufSizeBytes),
 		listenAddr: listenAddr,
 		mu:         &sync.Mutex{},
 		// server goes here

--- a/server/util/bytebufferpool/bytebufferpool.go
+++ b/server/util/bytebufferpool/bytebufferpool.go
@@ -37,14 +37,30 @@ type VariableSizePool struct {
 	// is indexed by the exponent.
 	// index 0 containing a pool of 2^0 capacity slices, index 1 containing 2^1
 	// capacity slices and so forth.
-	pools []*fixedSizePool
+	pools                 []*fixedSizePool
+	maxRetainedBufferSize int
 }
 
 // VariableSize returns a byte buffer pool that can be used when the buffer
 // size is not fixed. It internally maintains pools of different buffer sizes to
 // accommodate requests of different sizes.
 func VariableSize(maxBufferSize int) *VariableSizePool {
-	bp := &VariableSizePool{}
+	return VariableSizeWithMaxRetained(maxBufferSize, maxBufferSize)
+}
+
+// VariableSizeWithMaxRetained returns a byte buffer pool that can serve buffers
+// up to maxBufferSize, but drops buffers larger than maxRetainedBufferSize when
+// they are returned to the pool.
+func VariableSizeWithMaxRetained(maxBufferSize, maxRetainedBufferSize int) *VariableSizePool {
+	if maxBufferSize < 1 {
+		maxBufferSize = 1
+	}
+	if maxRetainedBufferSize <= 0 || maxRetainedBufferSize > maxBufferSize {
+		maxRetainedBufferSize = maxBufferSize
+	}
+	bp := &VariableSizePool{
+		maxRetainedBufferSize: maxRetainedBufferSize,
+	}
 	for size := 1; ; size *= 2 {
 		size := size
 		bp.pools = append(bp.pools, fixedSize(size))
@@ -75,6 +91,9 @@ func (bp *VariableSizePool) Get(length int64) []byte {
 
 // Put returns a byte slice back into the pool.
 func (bp *VariableSizePool) Put(buf []byte) {
+	if cap(buf) > bp.maxRetainedBufferSize {
+		return
+	}
 	// Calculate the largest power of 2 exponent x where 2^x <= cap
 	idx := bits.Len64(uint64(cap(buf))) - 1
 	if idx < 0 {

--- a/server/util/bytebufferpool/bytebufferpool_test.go
+++ b/server/util/bytebufferpool/bytebufferpool_test.go
@@ -43,3 +43,17 @@ func TestReuse(t *testing.T) {
 		assert.GreaterOrEqual(t, len(buf), i, "buffer for length %d did not have sufficient length", i)
 	}
 }
+
+func TestMaxRetainedBufferSize(t *testing.T) {
+	bp := bytebufferpool.VariableSizeWithMaxRetained(1024, 16)
+
+	small := make([]byte, 16)
+	small[0] = 7
+	bp.Put(small)
+	assert.Equal(t, byte(7), bp.Get(16)[0])
+
+	large := make([]byte, 32)
+	large[0] = 9
+	bp.Put(large)
+	assert.Equal(t, byte(0), bp.Get(32)[0])
+}


### PR DESCRIPTION
## Summary

Adds `bytebufferpool.VariableSizeWithMaxRetained`, which can serve large buffers but drops buffers above a retention cap when returned to the pool. The distributed cache proxy now uses this with a default retained-buffer cap of 256 KiB.

## Why

The heap profile showed hundreds of MB retained in gRPC and BuildBuddy buffer pools after high-concurrency cache traffic. Large buffers are useful while streaming but expensive to keep in `sync.Pool` across many Ps after bursts.

## Impact

Distributed cache reads/writes can still allocate up to the existing maximum buffer size, but buffers larger than `--cache.distributed_cache.max_retained_buf_size_bytes` are not retained for reuse. This trades some burst reallocation for lower steady-state heap retention.

## Validation

- `bazel test //server/util/bytebufferpool:bytebufferpool_test //enterprise/server/util/distributed_client:distributed_client_test`