### PR TITLE
[codex] Stream large remote GetMulti blobs

### DIFF
--- a/enterprise/server/util/distributed_client/distributed_client.go
+++ b/enterprise/server/util/distributed_client/distributed_client.go
@@ -1,6 +1,7 @@
 package distributed_client
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -51,8 +52,10 @@ const (
 )
 
 var (
-	enableKubeResolver = flag.Bool("cache.distributed_cache.enable_kube_resolver", false, "Enable Kubernetes resolver for resolving peer pod IPs")
-	peerWriteTimeout   = flag.Duration("cache.distributed_cache.peer_write_timeout", time.Minute, "Maximum time to wait for a single distributed cache peer write send or close operation before treating the peer as stalled.")
+	enableKubeResolver        = flag.Bool("cache.distributed_cache.enable_kube_resolver", false, "Enable Kubernetes resolver for resolving peer pod IPs")
+	peerWriteTimeout          = flag.Duration("cache.distributed_cache.peer_write_timeout", time.Minute, "Maximum time to wait for a single distributed cache peer write send or close operation before treating the peer as stalled.")
+	maxGetMultiBlobSizeBytes  = flag.Int64("cache.distributed_cache.max_getmulti_blob_size_bytes", 1*1024*1024, "Maximum blob size to read via distributed cache GetMulti. Larger blobs are read through the streaming Read RPC. Set <= 0 to disable this limit.")
+	maxGetMultiBatchSizeBytes = flag.Int64("cache.distributed_cache.max_getmulti_batch_size_bytes", 4*1024*1024, "Maximum total blob size to read in a single distributed cache GetMulti request. Additional blobs are read through the streaming Read RPC. Set <= 0 to disable this limit.")
 )
 
 type Proxy struct {
@@ -497,8 +500,16 @@ func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, resources []*rs
 	req := &dcpb.GetMultiRequest{}
 	hashDigests := make(map[string]*repb.Digest, len(resources))
 	compressedHashes := make(set.Set[string], len(resources))
+	streamedResources := make([]*rspb.ResourceName, 0)
+	var getMultiSizeBytes int64
 	for _, r := range resources {
 		hashDigests[r.GetDigest().GetHash()] = r.GetDigest()
+		sizeBytes := r.GetDigest().GetSizeBytes()
+		if shouldStreamRemoteGetMultiResource(sizeBytes, getMultiSizeBytes) {
+			streamedResources = append(streamedResources, r)
+			continue
+		}
+		getMultiSizeBytes += sizeBytes
 		if c.shouldReadCompressed(r) {
 			r = r.CloneVT()
 			r.Compressor = repb.Compressor_ZSTD
@@ -506,30 +517,66 @@ func (c *Proxy) RemoteGetMulti(ctx context.Context, peer string, resources []*rs
 		}
 		req.Resources = append(req.Resources, r)
 	}
-	client, err := c.getClient(ctx, peer)
-	if err != nil {
-		return nil, err
-	}
-	rsp, err := client.GetMulti(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	resultMap := make(map[*repb.Digest][]byte, len(rsp.GetKeyValue()))
-	for _, keyValue := range rsp.GetKeyValue() {
-		d, ok := hashDigests[keyValue.GetKey().GetKey()]
-		if !ok {
-			continue
+	resultMap := make(map[*repb.Digest][]byte, len(resources))
+	if len(req.GetResources()) > 0 {
+		client, err := c.getClient(ctx, peer)
+		if err != nil {
+			return nil, err
 		}
-		buf := keyValue.GetValue()
-		if compressedHashes.Contains(d.GetHash()) {
-			buf, err = compression.DecompressZstd(make([]byte, d.GetSizeBytes()), buf)
-			if err != nil {
-				return nil, err
+		rsp, err := client.GetMulti(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		for _, keyValue := range rsp.GetKeyValue() {
+			d, ok := hashDigests[keyValue.GetKey().GetKey()]
+			if !ok {
+				continue
 			}
+			buf := keyValue.GetValue()
+			if compressedHashes.Contains(d.GetHash()) {
+				buf, err = compression.DecompressZstd(make([]byte, d.GetSizeBytes()), buf)
+				if err != nil {
+					return nil, err
+				}
+			}
+			resultMap[d] = buf
 		}
-		resultMap[d] = buf
+	}
+	for _, r := range streamedResources {
+		buf, err := c.remoteGetMultiStreamedResource(ctx, peer, r)
+		if err != nil {
+			if status.IsNotFoundError(err) {
+				continue
+			}
+			return nil, err
+		}
+		resultMap[r.GetDigest()] = buf
 	}
 	return resultMap, nil
+}
+
+func shouldStreamRemoteGetMultiResource(sizeBytes, batchSizeBytes int64) bool {
+	if *maxGetMultiBlobSizeBytes > 0 && sizeBytes > *maxGetMultiBlobSizeBytes {
+		return true
+	}
+	return *maxGetMultiBatchSizeBytes > 0 && batchSizeBytes > 0 && batchSizeBytes+sizeBytes > *maxGetMultiBatchSizeBytes
+}
+
+func (c *Proxy) remoteGetMultiStreamedResource(ctx context.Context, peer string, r *rspb.ResourceName) ([]byte, error) {
+	rc, err := c.RemoteReader(ctx, peer, r, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, digest.SafeBufferSize(r, *config.ReadBufSizeBytes)))
+	_, copyErr := io.Copy(buf, rc)
+	closeErr := rc.Close()
+	if copyErr != nil {
+		return nil, copyErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return buf.Bytes(), nil
 }
 
 func (c *Proxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {

--- a/enterprise/server/util/distributed_client/distributed_client_test.go
+++ b/enterprise/server/util/distributed_client/distributed_client_test.go
@@ -872,6 +872,39 @@ func TestGetMulti(t *testing.T) {
 	}
 }
 
+func TestRemoteGetMultiStreamsLargeResources(t *testing.T) {
+	flags.Set(t, "cache.distributed_cache.max_getmulti_blob_size_bytes", int64(50))
+	flags.Set(t, "cache.distributed_cache.max_getmulti_batch_size_bytes", int64(0))
+
+	ctx := context.Background()
+	te := getTestEnv(t, emptyUserMap)
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	peer := fmt.Sprintf("localhost:%d", testport.FindFree(t))
+	spy := &spyCache{Cache: te.GetCache()}
+	c := distributed_client.New(te, spy, peer)
+	require.NoError(t, c.StartListening())
+	waitUntilServerIsAlive(peer)
+
+	smallRN, smallBuf := testdigest.RandomCASResourceBuf(t, 10)
+	largeRN, largeBuf := testdigest.RandomCASResourceBuf(t, 100)
+	require.NoError(t, te.GetCache().Set(ctx, smallRN, smallBuf))
+	require.NoError(t, te.GetCache().Set(ctx, largeRN, largeBuf))
+
+	gotMap, err := c.RemoteGetMulti(ctx, peer, []*rspb.ResourceName{smallRN, largeRN})
+	require.NoError(t, err)
+	require.Equal(t, smallBuf, gotMap[smallRN.GetDigest()])
+	require.Equal(t, largeBuf, gotMap[largeRN.GetDigest()])
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	require.Equal(t, repb.Compressor_IDENTITY, spy.getMultiCompressors[smallRN.GetDigest().GetHash()])
+	require.NotContains(t, spy.getMultiCompressors, largeRN.GetDigest().GetHash())
+	require.Len(t, spy.readerCompressors, 1)
+}
+
 func TestEmptyRead(t *testing.T) {
 	ctx := context.Background()
 	te := getTestEnv(t, emptyUserMap)


### PR DESCRIPTION
## Summary

Adds size gates to distributed cache `RemoteGetMulti`: small blobs still use unary `GetMulti`, while blobs above `--cache.distributed_cache.max_getmulti_blob_size_bytes` or beyond `--cache.distributed_cache.max_getmulti_batch_size_bytes` are read through the streaming `Read` RPC.

## Why

The heap profile showed large allocation volume in `RemoteGetMulti`, `KV.UnmarshalVT`, and `PebbleCache.GetMulti`. Unary `GetMulti` buffers the full response and all values before callers can consume them.

## Impact

Large blobs avoid the giant unary proto response path. The returned API shape remains the same, but the client reads large values through streaming internally. The size gates can be disabled by setting the new flags to `<= 0`.

## Validation

- `bazel test //enterprise/server/util/distributed_client:distributed_client_test`