### PR TITLE
Discard legacy chunked blobs during chunk-size override

### DIFF
--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -78,7 +78,7 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, instanceName s
 	}
 	checker := chunking.NewMissingChunkChecker(cache)
 	for _, d := range missing {
-		if d.GetSizeBytes() <= chunking.MinChunkedReadFallbackSizeBytes(ctx, efp) {
+		if d.GetSizeBytes() <= chunking.MinChunkedReadFallbackSizeBytes(ctx, efp) || chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, d.GetSizeBytes()) {
 			return status.NotFoundErrorf("ActionResult output file %q not found in cache", digest.String(d))
 		}
 		manifest, err := chunking.LoadManifest(ctx, cache, d, instanceName, digestFunction)

--- a/server/remote_cache/action_cache_server/action_cache_server_test.go
+++ b/server/remote_cache/action_cache_server/action_cache_server_test.go
@@ -692,6 +692,60 @@ func TestValidateActionResult_ChunkedOutputFile(t *testing.T) {
 	assert.True(t, status.IsNotFoundError(err))
 }
 
+func TestValidateActionResult_DiscardsLegacyChunkedOutputFileForAvgChunkSizeOverride(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 512*1024)
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+	cache := te.GetCache()
+
+	chunk1RN, chunk1Data := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	chunk2RN, chunk2Data := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	chunk3RN, chunk3Data := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1Data))
+	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2Data))
+	require.NoError(t, cache.Set(ctx, chunk3RN, chunk3Data))
+
+	allData := append(append(chunk1Data, chunk2Data...), chunk3Data...)
+	blobDigest, err := digest.Compute(bytes.NewReader(allData), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	cm := &chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk2RN.GetDigest(), chunk3RN.GetDigest()},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, cm.Store(ctx, cache))
+
+	ar := &repb.ActionResult{
+		OutputFiles: []*repb.OutputFile{
+			{Path: "output.bin", Digest: blobDigest},
+		},
+	}
+
+	efp := actionCacheFlagProvider{intValues: map[string]int64{"cache.avg_chunk_size_override": 1024 * 1024}}
+	err = action_cache_server.ValidateActionResult(ctx, cache, "", repb.DigestFunction_SHA256, true, efp, ar)
+	require.Error(t, err)
+	assert.True(t, status.IsNotFoundError(err))
+}
+
+type actionCacheFlagProvider struct {
+	interfaces.ExperimentFlagProvider
+	intValues map[string]int64
+}
+
+func (p actionCacheFlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
+	v, ok := p.intValues[flagName]
+	if ok {
+		return v
+	}
+	return defaultValue
+}
+
 func TestRecordOriginScorecard(t *testing.T) {
 	flags.Set(t, "cache.record_action_result_origin", true)
 	flags.Set(t, "cache.detailed_stats_enabled", true)

--- a/server/remote_cache/chunking/chunking.go
+++ b/server/remote_cache/chunking/chunking.go
@@ -102,6 +102,19 @@ func MinChunkedReadFallbackSizeBytes(ctx context.Context, efp interfaces.Experim
 	return min(*minChunkedReadFallbackSizeBytes, MaxChunkSizeBytes(ctx, efp))
 }
 
+// ShouldDiscardLegacyChunkedBlob reports whether a missing whole CAS blob should
+// skip manifest fallback while migrating to a larger avg chunk-size override.
+func ShouldDiscardLegacyChunkedBlob(ctx context.Context, efp interfaces.ExperimentFlagProvider, digestSizeBytes int64) bool {
+	if efp == nil {
+		return false
+	}
+	if AvgChunkSizeBytes(ctx, efp) <= *avgChunkSizeBytes {
+		return false
+	}
+	return digestSizeBytes > MinChunkedReadFallbackSizeBytes(ctx, efp) &&
+		digestSizeBytes <= MaxChunkSizeBytes(ctx, efp)
+}
+
 func MaxWriteSizeBytes(ctx context.Context, efp interfaces.ExperimentFlagProvider) int64 {
 	if efp == nil {
 		return defaultMaxChunkedWriteSizeBytes

--- a/server/remote_cache/chunking/chunking_test.go
+++ b/server/remote_cache/chunking/chunking_test.go
@@ -588,7 +588,8 @@ func (c *findMissingTrackingCache) FindMissing(ctx context.Context, resources []
 
 type booleanFlagProvider struct {
 	interfaces.ExperimentFlagProvider
-	values map[string]bool
+	values    map[string]bool
+	intValues map[string]int64
 }
 
 func (p booleanFlagProvider) Boolean(ctx context.Context, flagName string, defaultValue bool, opts ...any) bool {
@@ -600,7 +601,25 @@ func (p booleanFlagProvider) Boolean(ctx context.Context, flagName string, defau
 }
 
 func (p booleanFlagProvider) Int64(ctx context.Context, flagName string, defaultValue int64, opts ...any) int64 {
+	v, ok := p.intValues[flagName]
+	if ok {
+		return v
+	}
 	return defaultValue
+}
+
+func TestShouldDiscardLegacyChunkedBlob(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 512*1024)
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
+
+	ctx := context.Background()
+	efp := booleanFlagProvider{intValues: map[string]int64{"cache.avg_chunk_size_override": 1024 * 1024}}
+	assert.False(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, nil, 3*1024*1024))
+	assert.False(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, booleanFlagProvider{}, 3*1024*1024))
+	assert.False(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, 2*1024*1024))
+	assert.True(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, 3*1024*1024))
+	assert.True(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, 4*1024*1024))
+	assert.False(t, chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, 4*1024*1024+1))
 }
 
 func TestEnabled_FallsBackToExperimentFlag(t *testing.T) {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -134,9 +134,8 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 
 	// The chunked-manifest fallback lookup is skipped when the caller signals
 	// that these digests are individual content-defined chunks, not whole blobs.
-	// Otherwise, use the same fallback threshold as read paths so blobs chunked
-	// with an older, smaller chunk size still count as present after increasing
-	// the current chunk size.
+	// Otherwise, use the read fallback threshold so old chunked blobs still
+	// count as present, except for the override-only chunk-size migration range.
 	if efp := s.env.GetExperimentFlagProvider(); len(missing) > 0 && !cdc.IsChunked(ctx) && chunking.Enabled(ctx, efp) {
 		checker := chunking.NewMissingChunkChecker(s.cache)
 		chunkedReadFallbackSizeBytes := chunking.MinChunkedReadFallbackSizeBytes(ctx, efp)
@@ -158,7 +157,7 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 		eg, egCtx := errgroup.WithContext(ctx)
 		eg.SetLimit(concurrency)
 		for _, d := range missing {
-			if d.GetSizeBytes() <= chunkedReadFallbackSizeBytes {
+			if d.GetSizeBytes() <= chunkedReadFallbackSizeBytes || chunking.ShouldDiscardLegacyChunkedBlob(ctx, efp, d.GetSizeBytes()) {
 				markMissing(d)
 				continue
 			}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -1212,6 +1212,63 @@ func TestFindMissingBlobsUsesReadFallbackThreshold(t *testing.T) {
 	require.Equal(t, blobDigest.GetHash(), rsp.MissingBlobDigests[0].GetHash())
 }
 
+func TestFindMissingBlobsDiscardsLegacyChunkedBlobForAvgChunkSizeOverride(t *testing.T) {
+	flags.Set(t, "cache.avg_chunk_size_bytes", 512*1024)
+	flags.Set(t, "cache.min_chunked_read_fallback_size_bytes", 2*1024*1024)
+
+	testProvider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"cache.avg_chunk_size_override": {
+			State:          memprovider.Enabled,
+			DefaultVariant: "one_mb",
+			Variants: map[string]any{
+				"one_mb": 1 * 1024 * 1024,
+			},
+		},
+	})
+	require.NoError(t, openfeature.SetNamedProviderAndWait(t.Name(), testProvider))
+
+	fp, err := experiments.NewFlagProvider(t.Name())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	te.SetExperimentFlagProvider(fp)
+
+	ctx, err = prefix.AttachUserPrefixToContext(ctx, te.GetAuthenticator())
+	require.NoError(t, err)
+
+	clientConn := runCASServer(ctx, t, te)
+	casClient := repb.NewContentAddressableStorageClient(clientConn)
+	cache := te.GetCache()
+
+	chunk1RN, chunk1 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	chunk2RN, chunk2 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	chunk3RN, chunk3 := testdigest.RandomCASResourceBuf(t, 1024*1024)
+	fullBlob := append(append(chunk1, chunk2...), chunk3...)
+
+	blobDigest, err := digest.Compute(bytes.NewReader(fullBlob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	require.NoError(t, cache.Set(ctx, chunk1RN, chunk1))
+	require.NoError(t, cache.Set(ctx, chunk2RN, chunk2))
+	require.NoError(t, cache.Set(ctx, chunk3RN, chunk3))
+
+	manifest := &chunking.Manifest{
+		BlobDigest:     blobDigest,
+		ChunkDigests:   []*repb.Digest{chunk1RN.GetDigest(), chunk2RN.GetDigest(), chunk3RN.GetDigest()},
+		InstanceName:   "",
+		DigestFunction: repb.DigestFunction_SHA256,
+	}
+	require.NoError(t, manifest.Store(ctx, cache))
+
+	rsp, err := casClient.FindMissingBlobs(ctx, &repb.FindMissingBlobsRequest{
+		BlobDigests: []*repb.Digest{blobDigest},
+	})
+	require.NoError(t, err)
+	require.Len(t, rsp.MissingBlobDigests, 1)
+	require.Equal(t, blobDigest.GetHash(), rsp.MissingBlobDigests[0].GetHash())
+}
+
 func TestBatchReadBlobsWithChunkedBlob(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string


### PR DESCRIPTION
To safely double the chunk size, we need to discard any legacy chunked blobs in the (2MiB, 4MiB] range.

This does not cause the same issue as https://github.com/buildbuddy-io/buildbuddy/pull/12269 because those "lost" inputs are from valid actions that are reported missing. Here we mark these as both invalid and missing.

Rollout plan:
1. cache_proxy.intercept_and_chunk_large_writes=false.
2. Wait for in-flight old-size writes to drain. Let it sit a little bit for these entries to self evict a little.
3. Enable cache.avg_chunk_size_override=1048576 for the group; this activates the temporary discard behavior for (2MiB, 4MiB].
4. Re-enable BB-controlled CDC writes for the group.
5. Clean up these edge cases and set defaults up to new 1MB value.