### PR TITLE
[FC] Handle partial faults in UFFD handler

### DIFF
--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -114,10 +114,12 @@ type setupMessage struct {
 
 type faultResolver interface {
 	// copy performs a UFFDIO_COPY ioctl. On return, c.Copy holds the number of
-	// bytes copied, or a non-zero errno if no bytes were copied.
+	// bytes copied, or a negative errno if no bytes were copied. The returned
+	// errno can be EAGAIN even if c.Copy reports partial progress.
 	copy(uffd uintptr, c *uffdioCopy) syscall.Errno
 	// zeropage performs a UFFDIO_ZEROPAGE ioctl. On return, z.Zeropage holds the
-	// number of bytes zeroed, or a non-zero errno if no bytes were zeroed.
+	// number of bytes zeroed, or a negative errno if no bytes were zeroed. The
+	// returned errno can be EAGAIN even if z.Zeropage reports partial progress.
 	zeropage(uffd uintptr, z *uffdIoZeropage) syscall.Errno
 }
 
@@ -520,17 +522,20 @@ func (h *Handler) copyZeroes(uffd uintptr, faultingAddress uintptr, mapping *Gue
 		},
 	}
 	errno := h.faultResolver.zeropage(uffd, &zeroIO)
+	// If there's no progress, Zeropage can be a negative errno.
+	zeroed := max(zeroIO.Zeropage, 0)
+	if zeroed > int64(zeroIO.Range.Len) || zeroed%int64(pageSize) != 0 {
+		return status.InternalErrorf("UFFDIO_ZEROPAGE reported invalid progress: zeroed %d of %d bytes", zeroed, zeroIO.Range.Len)
+	}
 
 	// The Zeropage field contains the number of bytes actually zeroed. Only
 	// unmark the pages that were actually zeroed.
 	addr := faultingAddress
-	for ; addr < faultingAddress+uintptr(zeroIO.Zeropage); addr += pageSize {
+	for zeroEnd := faultingAddress + uintptr(zeroed); addr < zeroEnd; addr += pageSize {
 		delete(h.removedAddresses, int64(addr))
 	}
 
-	// EEXIST is returned if the last page attempted to be zeroed was already mapped.
-	// This should not happen with the current single-threaded UFFD handler, but this check is defensive.
-	// Remove it from removedAddresses and no further action is needed.
+	// EEXIST means the faulting page is already populated. Treat the fault as resolved.
 	if errno == unix.EEXIST {
 		delete(h.removedAddresses, int64(addr))
 		return nil
@@ -676,6 +681,10 @@ func (h *Handler) resolvePageFault(uffd uintptr, faultingRegion uint64, src uint
 	errno := h.faultResolver.copy(uffd, &copyData)
 	// On failure, Copy contains a negative errno instead of a byte count.
 	copied := max(copyData.Copy, 0)
+	pageSize := int64(os.Getpagesize())
+	if copied > int64(size) || copied%pageSize != 0 {
+		return 0, status.InternalErrorf("UFFDIO_COPY reported invalid progress: copied %d of %d bytes", copied, size)
+	}
 	if errno != 0 {
 		return copied, wrapErrno(errno, "UFFDIO_COPY failed")
 	}

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -524,12 +524,12 @@ func (h *Handler) copyZeroes(uffd uintptr, faultingAddress uintptr, mapping *Gue
 	// The Zeropage field contains the number of bytes actually zeroed. Only
 	// unmark the pages that were actually zeroed.
 	addr := faultingAddress
-	for zeroedBytes := zeroIO.Zeropage; zeroedBytes > 0; zeroedBytes -= int64(pageSize) {
+	for ; addr < faultingAddress+uintptr(zeroIO.Zeropage); addr += pageSize {
 		delete(h.removedAddresses, int64(addr))
-		addr += pageSize
 	}
 
 	// EEXIST is returned if the last page attempted to be zeroed was already mapped.
+	// This should not happen with the current single-threaded UFFD handler, but this check is defensive.
 	// Remove it from removedAddresses and no further action is needed.
 	if errno == unix.EEXIST {
 		delete(h.removedAddresses, int64(addr))
@@ -543,7 +543,7 @@ func (h *Handler) copyZeroes(uffd uintptr, faultingAddress uintptr, mapping *Gue
 		return nil
 	}
 	if errno != 0 {
-		return wrapErrno(errno, fmt.Sprintf("UFFDIO_ZEROPAGE failed with errno(%d)", errno))
+		return wrapErrno(errno, "UFFDIO_ZEROPAGE failed")
 	}
 	if addr == faultingAddress {
 		return status.InternalError("UFFDIO_ZEROPAGE succeeded but zeroed 0 bytes")
@@ -677,7 +677,7 @@ func (h *Handler) resolvePageFault(uffd uintptr, faultingRegion uint64, src uint
 	// On failure, Copy contains a negative errno instead of a byte count.
 	copied := max(copyData.Copy, 0)
 	if errno != 0 {
-		return copied, wrapErrno(errno, fmt.Sprintf("UFFDIO_COPY failed with errno(%d)", errno))
+		return copied, wrapErrno(errno, "UFFDIO_COPY failed")
 	}
 	return copied, nil
 }
@@ -779,5 +779,5 @@ func guestMemoryAddrToMapping(addr uintptr, mappings []GuestRegionUFFDMapping) (
 // status.WrapError only extracts the original error's message as a string, but
 // does not preserve its type.
 func wrapErrno(err syscall.Errno, msg string) error {
-	return fmt.Errorf("%s: %w", msg, err)
+	return fmt.Errorf("%s: %w (%d)", msg, err, err)
 }

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -489,7 +489,7 @@ func (h *Handler) handlePageFault(uffd uintptr, memoryStore *copy_on_write.COWSt
 
 	// If address had been previously removed, zero it.
 	if _, removed := h.removedAddresses[int64(guestPageAddr)]; removed {
-		return h.copyZeroes(uffd, guestPageAddr)
+		return h.copyZeroes(uffd, guestPageAddr, mapping)
 	}
 
 	// Otherwise copy data from the memory snapshot.
@@ -498,34 +498,55 @@ func (h *Handler) handlePageFault(uffd uintptr, memoryStore *copy_on_write.COWSt
 
 // copyZeroes handles a page fault by copying zeroes into the guest. The guest
 // expects zeroes if the faulting page was previously removed by the balloon.
-func (h *Handler) copyZeroes(uffd uintptr, faultingAddress uintptr) error {
-	// If multiple consecutive pages were removed, zero them all.
+func (h *Handler) copyZeroes(uffd uintptr, faultingAddress uintptr, mapping *GuestRegionUFFDMapping) error {
+	pageSize := uintptr(os.Getpagesize())
+
+	// If multiple consecutive pages were removed, eagerly attempt to zero them all. Don't scan
+	// past the end of the mapping - a single UFFDIO_ZEROPAGE call cannot span
+	// multiple memory regions.
+	mappingEndAddr := mapping.BaseHostVirtAddr + mapping.Size
 	end := faultingAddress
-	for {
-		_, removed := h.removedAddresses[int64(end)]
-		if !removed {
+	for end < mappingEndAddr {
+		if _, removed := h.removedAddresses[int64(end)]; !removed {
 			break
 		}
-
-		end += uintptr(os.Getpagesize())
+		end += pageSize
 	}
 
-	sizeToZero := end - faultingAddress
-	if sizeToZero > 0 {
-		zeroIO := uffdIoZeropage{
-			Range: uffdIoRange{
-				Start: uint64(faultingAddress),
-				Len:   uint64(sizeToZero),
-			},
-		}
-		errno := h.faultResolver.zeropage(uffd, &zeroIO)
-		if errno != 0 {
-			return wrapErrno(errno, fmt.Sprintf("UFFDIO_ZEROPAGE failed with errno(%d)", errno))
-		}
+	zeroIO := uffdIoZeropage{
+		Range: uffdIoRange{
+			Start: uint64(faultingAddress),
+			Len:   uint64(end - faultingAddress),
+		},
+	}
+	errno := h.faultResolver.zeropage(uffd, &zeroIO)
+
+	// The Zeropage field contains the number of bytes actually zeroed. Only
+	// unmark the pages that were actually zeroed.
+	addr := faultingAddress
+	for zeroedBytes := zeroIO.Zeropage; zeroedBytes > 0; zeroedBytes -= int64(pageSize) {
+		delete(h.removedAddresses, int64(addr))
+		addr += pageSize
 	}
 
-	for zeroedPage := faultingAddress; zeroedPage < end; zeroedPage += uintptr(os.Getpagesize()) {
-		delete(h.removedAddresses, int64(zeroedPage))
+	// EEXIST is returned if the last page attempted to be zeroed was already mapped.
+	// Remove it from removedAddresses and no further action is needed.
+	if errno == unix.EEXIST {
+		delete(h.removedAddresses, int64(addr))
+		return nil
+	}
+
+	if errno == unix.EAGAIN && addr > faultingAddress {
+		// We try to eagerly zero more pages than what actually faulted.
+		// If the operation is only partially successful, that's okay as long
+		// as the actually faulting page was handled, and the faulting thread in the guest will resume successfully.
+		return nil
+	}
+	if errno != 0 {
+		return wrapErrno(errno, fmt.Sprintf("UFFDIO_ZEROPAGE failed with errno(%d)", errno))
+	}
+	if addr == faultingAddress {
+		return status.InternalError("UFFDIO_ZEROPAGE succeeded but zeroed 0 bytes")
 	}
 	return nil
 }
@@ -581,8 +602,7 @@ func (h *Handler) copyDataFromMemorySnapshot(uffd uintptr, memoryStore *copy_on_
 		copySize -= invalidBytesAtChunkEnd
 	}
 
-	_, err = h.resolvePageFault(uffd, uint64(destAddr), uint64(hostAddr), uint64(copySize))
-	if err != nil {
+	if err := h.copyRange(uffd, destAddr, hostAddr, copySize); err != nil {
 		return err
 	}
 
@@ -594,13 +614,54 @@ func (h *Handler) copyDataFromMemorySnapshot(uffd uintptr, memoryStore *copy_on_
 	return nil
 }
 
+// copyRange resolves page faults by copying memory from the host into the guest.
+func (h *Handler) copyRange(uffd uintptr, destAddr uintptr, hostAddr uintptr, size int64) error {
+	pageSize := int64(os.Getpagesize())
+	for size > 0 {
+		// A single UFFDIO_COPY may stop partway through the range - for example if it
+		// reaches a page that is already mapped, or if the balloon concurrently removes memory.
+		// The kernel only wakes faulting threads if the data was actually copied,
+		// so we still need to try to resolve the rest of the range.
+		copied, err := h.resolvePageFault(uffd, uint64(destAddr), uint64(hostAddr), uint64(size))
+		destAddr += uintptr(copied)
+		hostAddr += uintptr(copied)
+		size -= copied
+
+		if err == nil {
+			if copied == 0 {
+				return status.InternalError("UFFDIO_COPY succeeded but copied 0 bytes")
+			}
+			continue
+		}
+
+		if errors.Is(err, unix.EEXIST) {
+			// EEXIST is returned if the last page attempted to be copied was already mapped
+			// (i.e. by an earlier partial copy of this chunk).
+			// No further action needed for that page, so skip it and continue with the next page.
+			destAddr += uintptr(pageSize)
+			hostAddr += uintptr(pageSize)
+			size -= pageSize
+			continue
+		}
+
+		if errors.Is(err, unix.EAGAIN) && copied > 0 {
+			// Made partial progress - retry the remainder.
+			continue
+		}
+		return err
+	}
+	return nil
+}
+
 // resolvePageFault executes the resolution of a page fault.
 // It copies `size` bytes of memory from a `Src` address to the faulting region `Dst`.
 //
 // When complete, the UFFDIO_COPY call wakes up the process that triggered the page fault (When a process
 // attempts to access unallocated memory, it triggers a page fault and hangs until it has been resolved)
 //
-// Returns the number of bytes copied
+// Returns the number of bytes copied. This may be less than `size` if the copy
+// stopped early - in that case err is non-nil and the threads whose faulting pages
+// were not copied will remain blocked.
 func (h *Handler) resolvePageFault(uffd uintptr, faultingRegion uint64, src uint64, size uint64) (int64, error) {
 	start := time.Now()
 	defer func() {
@@ -613,14 +674,12 @@ func (h *Handler) resolvePageFault(uffd uintptr, faultingRegion uint64, src uint
 		Len: size,
 	}
 	errno := h.faultResolver.copy(uffd, &copyData)
+	// On failure, Copy contains a negative errno instead of a byte count.
+	copied := max(copyData.Copy, 0)
 	if errno != 0 {
-		// If error is due to the page already being mapped, ignore.
-		if errno == unix.EEXIST {
-			return 0, nil
-		}
-		return 0, wrapErrno(errno, fmt.Sprintf("UFFDIO_COPY failed with errno(%d)", errno))
+		return copied, wrapErrno(errno, fmt.Sprintf("UFFDIO_COPY failed with errno(%d)", errno))
 	}
-	return copyData.Copy, nil
+	return copied, nil
 }
 
 // readEvent reads a notification from UFFD.

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -635,7 +635,7 @@ func (h *Handler) copyRange(uffd uintptr, destAddr uintptr, hostAddr uintptr, si
 		}
 
 		if errors.Is(err, unix.EEXIST) {
-			// EEXIST is returned if the last page attempted to be copied was already mapped
+			// EEXIST is returned if the first page attempted to be copied was already mapped
 			// (i.e. by an earlier partial copy of this chunk).
 			// No further action needed for that page, so skip it and continue with the next page.
 			destAddr += uintptr(pageSize)
@@ -660,8 +660,8 @@ func (h *Handler) copyRange(uffd uintptr, destAddr uintptr, hostAddr uintptr, si
 // attempts to access unallocated memory, it triggers a page fault and hangs until it has been resolved)
 //
 // Returns the number of bytes copied. This may be less than `size` if the copy
-// stopped early - in that case err is non-nil and the threads whose faulting pages
-// were not copied will remain blocked.
+// stopped early - in that case the threads whose faulting pages were not copied will remain blocked.
+// The caller should retry resolving the remainder of the range.
 func (h *Handler) resolvePageFault(uffd uintptr, faultingRegion uint64, src uint64, size uint64) (int64, error) {
 	start := time.Now()
 	defer func() {

--- a/enterprise/server/remote_execution/uffd/uffd_test.go
+++ b/enterprise/server/remote_execution/uffd/uffd_test.go
@@ -58,6 +58,7 @@ func TestRemoveEventsAreHandledBeforePageFaults(t *testing.T) {
 
 			// The two consecutive pages that were removed should be zeroed.
 			require.Equal(t, uint64(2*pageSize), z.Range.Len)
+			z.Zeropage = int64(z.Range.Len)
 			zeroCalls++
 			return 0
 		},
@@ -130,6 +131,7 @@ func TestEAGAIN_DefersRemainingPageFaults(t *testing.T) {
 			if z.Range.Start == pageFaults[1].Address {
 				return unix.EAGAIN
 			}
+			z.Zeropage = int64(z.Range.Len)
 			return 0
 		},
 	})
@@ -148,6 +150,102 @@ func TestEAGAIN_DefersRemainingPageFaults(t *testing.T) {
 	require.Equal(t, pageFaults[1:], deferred)
 }
 
+func TestCopyRange_ContinuesAfterPartialEAGAIN(t *testing.T) {
+	pageSize := uint64(os.Getpagesize())
+	uffd := uintptr(10)
+	destAddress := uint64(0x100000)
+	hostAddress := uint64(0x200000)
+
+	copyCalls := 0
+	h := newTestHandler(&fakeResolver{
+		onCopy: func(gotUffd uintptr, c *uffdioCopy) syscall.Errno {
+			require.Equal(t, uffd, gotUffd)
+			copyCalls++
+			switch copyCalls {
+			case 1:
+				// Simulate the first UFFDIO_COPY successfully copying 1 page,
+				// then returning EAGAIN.
+				require.Equal(t, destAddress, c.Dst)
+				require.Equal(t, hostAddress, c.Src)
+				require.Equal(t, 3*pageSize, c.Len)
+				c.Copy = int64(pageSize)
+				return unix.EAGAIN
+			case 2:
+				// Simulate the second UFFDIO_COPY successfully copying the remaining 2 pages.
+				require.Equal(t, destAddress+pageSize, c.Dst)
+				require.Equal(t, hostAddress+pageSize, c.Src)
+				require.Equal(t, 2*pageSize, c.Len)
+				c.Copy = int64(2 * pageSize)
+				return 0
+			default:
+				require.FailNow(t, "unexpected copy call")
+				return 0
+			}
+		},
+	})
+
+	err := h.copyRange(uffd, uintptr(destAddress), uintptr(hostAddress), int64(3*pageSize))
+
+	require.NoError(t, err)
+	require.Equal(t, 2, copyCalls)
+}
+
+func TestCopyRange_ReturnsEAGAINIfNoProgressMade(t *testing.T) {
+	pageSize := uint64(os.Getpagesize())
+	uffd := uintptr(10)
+	destAddress := uint64(0x100000)
+	hostAddress := uint64(0x200000)
+
+	copyCalls := 0
+	h := newTestHandler(&fakeResolver{
+		onCopy: func(gotUffd uintptr, c *uffdioCopy) syscall.Errno {
+			// Simulate a successful copy of the first page.
+			if copyCalls == 0 {
+				c.Copy = int64(pageSize)
+			}
+			copyCalls++
+			return unix.EAGAIN
+		},
+	})
+
+	err := h.copyRange(uffd, uintptr(destAddress), uintptr(hostAddress), int64(3*pageSize))
+
+	require.True(t, errors.Is(err, unix.EAGAIN), "error should wrap EAGAIN, got %v", err)
+	require.Equal(t, 2, copyCalls)
+}
+
+func TestCopyRange_SkipsAlreadyMappedPages(t *testing.T) {
+	pageSize := uint64(os.Getpagesize())
+	uffd := uintptr(10)
+	destAddress := uint64(0x100000)
+	hostAddress := uint64(0x200000)
+
+	copyCalls := 0
+	h := newTestHandler(&fakeResolver{
+		onCopy: func(gotUffd uintptr, c *uffdioCopy) syscall.Errno {
+			// Simulate returning EEXIST after the first page was successfully copied.
+			if copyCalls == 0 {
+				c.Copy = int64(pageSize)
+				return unix.EEXIST
+			}
+
+			copyCalls++
+
+			// On the second copy request, we expect the second page to be skipped, because it
+			// was already mapped.
+			require.Equal(t, destAddress+2*pageSize, c.Dst)
+			require.Equal(t, hostAddress+2*pageSize, c.Src)
+			require.Equal(t, pageSize, c.Len)
+			return 0
+		},
+	})
+
+	err := h.copyRange(uffd, uintptr(destAddress), uintptr(hostAddress), int64(3*pageSize))
+
+	require.NoError(t, err)
+	require.Equal(t, 0, copyCalls)
+}
+
 func TestZero_Error(t *testing.T) {
 	pageSize := uintptr(os.Getpagesize())
 	faultingAddress := uintptr(0x100000)
@@ -159,11 +257,78 @@ func TestZero_Error(t *testing.T) {
 	})
 	h.removedAddresses[int64(faultingAddress)] = struct{}{}
 	h.removedAddresses[int64(faultingAddress+pageSize)] = struct{}{}
+	mapping := &GuestRegionUFFDMapping{
+		BaseHostVirtAddr: faultingAddress,
+		Size:             2 * pageSize,
+	}
 
-	err := h.copyZeroes(0 /*=uffd*/, faultingAddress)
+	err := h.copyZeroes(0 /*=uffd*/, faultingAddress, mapping)
 
 	require.True(t, errors.Is(err, unix.EAGAIN), "error should wrap EAGAIN, got %v", err)
 	// The pages should still be in the map because they were never successfully zeroed.
 	require.Contains(t, h.removedAddresses, int64(faultingAddress))
+	require.Contains(t, h.removedAddresses, int64(faultingAddress+pageSize))
+}
+
+func TestZero_PartialEAGAIN(t *testing.T) {
+	pageSize := uintptr(os.Getpagesize())
+	faultingAddress := uintptr(0x100000)
+
+	zeroCalls := 0
+	h := newTestHandler(&fakeResolver{
+		onZeropage: func(uffd uintptr, z *uffdIoZeropage) syscall.Errno {
+			zeroCalls++
+			// Simulate successfully zeroing the first page, then returning EAGAIN.
+			z.Zeropage = int64(pageSize)
+			return unix.EAGAIN
+		},
+	})
+	// Simulate that all faulting addresses were previously removed by the balloon.
+	for addr := faultingAddress; addr < faultingAddress+3*pageSize; addr += pageSize {
+		h.removedAddresses[int64(addr)] = struct{}{}
+	}
+	mapping := &GuestRegionUFFDMapping{
+		BaseHostVirtAddr: faultingAddress,
+		Size:             3 * pageSize,
+	}
+
+	err := h.copyZeroes(0 /*=uffd*/, faultingAddress, mapping)
+
+	// Even though the entire range was not successfully eagerly zeroed,
+	// as long as mapping the first page succeeded, we should not return an error.
+	require.NoError(t, err)
+	require.Equal(t, 1, zeroCalls)
+	require.NotContains(t, h.removedAddresses, int64(faultingAddress))
+	require.Contains(t, h.removedAddresses, int64(faultingAddress+pageSize))
+	require.Contains(t, h.removedAddresses, int64(faultingAddress+2*pageSize))
+}
+
+func TestZero_EEXIST(t *testing.T) {
+	pageSize := uintptr(os.Getpagesize())
+	faultingAddress := uintptr(0x100000)
+
+	h := newTestHandler(&fakeResolver{
+		onZeropage: func(uffd uintptr, z *uffdIoZeropage) syscall.Errno {
+			return unix.EEXIST
+		},
+	})
+	// Simulate that two pages were previously removed by the balloon.
+	h.removedAddresses[int64(faultingAddress)] = struct{}{}
+	h.removedAddresses[int64(faultingAddress+pageSize)] = struct{}{}
+
+	// Try to zero 2 pages.
+	mapping := &GuestRegionUFFDMapping{
+		BaseHostVirtAddr: faultingAddress,
+		Size:             2 * pageSize,
+	}
+
+	err := h.copyZeroes(0 /*=uffd*/, faultingAddress, mapping)
+
+	// If the EEXIST error was returned by the IOCTL, we should not return an error.
+	require.NoError(t, err)
+	// The first page should be removed from the map because EEXIST indicates that
+	// it's already been handled.
+	require.NotContains(t, h.removedAddresses, int64(faultingAddress))
+	// The second page should still be in the map because it was not successfully zeroed.
 	require.Contains(t, h.removedAddresses, int64(faultingAddress+pageSize))
 }

--- a/enterprise/server/remote_execution/uffd/uffd_test.go
+++ b/enterprise/server/remote_execution/uffd/uffd_test.go
@@ -223,27 +223,31 @@ func TestCopyRange_SkipsAlreadyMappedPages(t *testing.T) {
 	copyCalls := 0
 	h := newTestHandler(&fakeResolver{
 		onCopy: func(gotUffd uintptr, c *uffdioCopy) syscall.Errno {
-			// Simulate returning EEXIST after the first page was successfully copied.
-			if copyCalls == 0 {
-				c.Copy = int64(pageSize)
+			defer func() { copyCalls++ }()
+			switch copyCalls {
+			case 0:
+				// Simulate the first page being already mapped, which returns
+				// EEXIST with 0 bytes copied.
 				return unix.EEXIST
+			case 1:
+				// On the second copy request, we expect the first page to be
+				// skipped, because it was already mapped.
+				require.Equal(t, destAddress+pageSize, c.Dst)
+				require.Equal(t, hostAddress+pageSize, c.Src)
+				require.Equal(t, 2*pageSize, c.Len)
+				c.Copy = int64(2 * pageSize)
+				return 0
+			default:
+				require.FailNow(t, "unexpected copy call")
+				return 0
 			}
-
-			copyCalls++
-
-			// On the second copy request, we expect the second page to be skipped, because it
-			// was already mapped.
-			require.Equal(t, destAddress+2*pageSize, c.Dst)
-			require.Equal(t, hostAddress+2*pageSize, c.Src)
-			require.Equal(t, pageSize, c.Len)
-			return 0
 		},
 	})
 
 	err := h.copyRange(uffd, uintptr(destAddress), uintptr(hostAddress), int64(3*pageSize))
 
 	require.NoError(t, err)
-	require.Equal(t, 0, copyCalls)
+	require.Equal(t, 2, copyCalls)
 }
 
 func TestZero_Error(t *testing.T) {

--- a/enterprise/server/remote_execution/uffd/uffd_test.go
+++ b/enterprise/server/remote_execution/uffd/uffd_test.go
@@ -129,6 +129,7 @@ func TestEAGAIN_DefersRemainingPageFaults(t *testing.T) {
 			zeroedAddresses = append(zeroedAddresses, z.Range.Start)
 			// Simulate an EAGAIN error for the second page fault.
 			if z.Range.Start == pageFaults[1].Address {
+				z.Zeropage = -int64(unix.EAGAIN)
 				return unix.EAGAIN
 			}
 			z.Zeropage = int64(z.Range.Len)
@@ -202,6 +203,8 @@ func TestCopyRange_ReturnsEAGAINIfNoProgressMade(t *testing.T) {
 			// Simulate a successful copy of the first page.
 			if copyCalls == 0 {
 				c.Copy = int64(pageSize)
+			} else {
+				c.Copy = -int64(unix.EAGAIN)
 			}
 			copyCalls++
 			return unix.EAGAIN
@@ -226,16 +229,19 @@ func TestCopyRange_SkipsAlreadyMappedPages(t *testing.T) {
 			defer func() { copyCalls++ }()
 			switch copyCalls {
 			case 0:
-				// Simulate the first page being already mapped, which returns
+				// Simulate the first page was already mapped, which returns
 				// EEXIST with 0 bytes copied.
+				c.Copy = -int64(unix.EEXIST)
 				return unix.EEXIST
 			case 1:
-				// On the second copy request, we expect the first page to be
-				// skipped, because it was already mapped.
-				require.Equal(t, destAddress+pageSize, c.Dst)
-				require.Equal(t, hostAddress+pageSize, c.Src)
-				require.Equal(t, 2*pageSize, c.Len)
-				c.Copy = int64(2 * pageSize)
+				// Simulate the second page was also already mapped,
+				// with returns EEXIST with 0 bytes copied.
+				c.Copy = -int64(unix.EEXIST)
+				return unix.EEXIST
+			case 2:
+				// Simulate the third page was not previously mapped.
+				// and is copied successfully.
+				c.Copy = int64(pageSize)
 				return 0
 			default:
 				require.FailNow(t, "unexpected copy call")
@@ -247,7 +253,21 @@ func TestCopyRange_SkipsAlreadyMappedPages(t *testing.T) {
 	err := h.copyRange(uffd, uintptr(destAddress), uintptr(hostAddress), int64(3*pageSize))
 
 	require.NoError(t, err)
-	require.Equal(t, 2, copyCalls)
+	require.Equal(t, 3, copyCalls)
+}
+
+func TestCopyRange_RejectsInvalidProgress(t *testing.T) {
+	pageSize := uint64(os.Getpagesize())
+	h := newTestHandler(&fakeResolver{
+		onCopy: func(uffd uintptr, c *uffdioCopy) syscall.Errno {
+			// Simulate copying an invalid number of bytes that is not page-aligned
+			c.Copy = int64(pageSize + 1)
+			return 0
+		},
+	})
+
+	err := h.copyRange(0 /*=uffd*/, 0x100000, 0x200000, int64(2*pageSize))
+	require.Error(t, err)
 }
 
 func TestZero_Error(t *testing.T) {
@@ -256,6 +276,7 @@ func TestZero_Error(t *testing.T) {
 
 	h := newTestHandler(&fakeResolver{
 		onZeropage: func(uffd uintptr, z *uffdIoZeropage) syscall.Errno {
+			z.Zeropage = -int64(unix.EAGAIN)
 			return unix.EAGAIN
 		},
 	})
@@ -313,6 +334,7 @@ func TestZero_EEXIST(t *testing.T) {
 
 	h := newTestHandler(&fakeResolver{
 		onZeropage: func(uffd uintptr, z *uffdIoZeropage) syscall.Errno {
+			z.Zeropage = -int64(unix.EEXIST)
 			return unix.EEXIST
 		},
 	})
@@ -335,4 +357,63 @@ func TestZero_EEXIST(t *testing.T) {
 	require.NotContains(t, h.removedAddresses, int64(faultingAddress))
 	// The second page should still be in the map because it was not successfully zeroed.
 	require.Contains(t, h.removedAddresses, int64(faultingAddress+pageSize))
+}
+
+func TestZero_DoesNotCrossMappingBoundary(t *testing.T) {
+	pageSize := uintptr(os.Getpagesize())
+	baseAddress := uintptr(0x100000)
+	mappings := []*GuestRegionUFFDMapping{
+		{BaseHostVirtAddr: baseAddress, Size: 2 * pageSize},
+		{BaseHostVirtAddr: baseAddress + 2*pageSize, Size: 2 * pageSize},
+	}
+
+	zeroCalls := 0
+	h := newTestHandler(&fakeResolver{
+		onZeropage: func(uffd uintptr, z *uffdIoZeropage) syscall.Errno {
+			require.Less(t, zeroCalls, len(mappings))
+			require.Equal(t, uint64(mappings[zeroCalls].BaseHostVirtAddr), z.Range.Start)
+			require.Equal(t, uint64(mappings[zeroCalls].Size), z.Range.Len)
+			z.Zeropage = int64(z.Range.Len)
+			zeroCalls++
+			return 0
+		},
+	})
+	for addr := baseAddress; addr < baseAddress+4*pageSize; addr += pageSize {
+		h.removedAddresses[int64(addr)] = struct{}{}
+	}
+
+	// Zero pages in the first mapping. The 2 pages in that mapping should be zeroed
+	// and removed from removedAddresses. The pages from the other mapping should still be in the map.
+	err := h.copyZeroes(0 /*=uffd*/, mappings[0].BaseHostVirtAddr, mappings[0])
+	require.NoError(t, err)
+	require.NotContains(t, h.removedAddresses, int64(baseAddress))
+	require.NotContains(t, h.removedAddresses, int64(baseAddress+pageSize))
+	require.Contains(t, h.removedAddresses, int64(baseAddress+2*pageSize))
+	require.Contains(t, h.removedAddresses, int64(baseAddress+3*pageSize))
+
+	// Zero pages in the second mapping. All pages should be zeroed and removed from removedAddresses.
+	require.NoError(t, h.copyZeroes(0 /*=uffd*/, mappings[1].BaseHostVirtAddr, mappings[1]))
+	require.Empty(t, h.removedAddresses)
+	require.Equal(t, len(mappings), zeroCalls)
+}
+
+func TestZero_RejectsInvalidProgress(t *testing.T) {
+	pageSize := uintptr(os.Getpagesize())
+	faultingAddress := uintptr(0x100000)
+	h := newTestHandler(&fakeResolver{
+		onZeropage: func(uffd uintptr, z *uffdIoZeropage) syscall.Errno {
+			// Simulate zeroing an invalid number of bytes that is not page-aligned.
+			z.Zeropage = int64(pageSize + 1)
+			return 0
+		},
+	})
+	h.removedAddresses[int64(faultingAddress)] = struct{}{}
+	mapping := &GuestRegionUFFDMapping{
+		BaseHostVirtAddr: faultingAddress,
+		Size:             pageSize,
+	}
+
+	err := h.copyZeroes(0 /*=uffd*/, faultingAddress, mapping)
+	require.Error(t, err)
+	require.Contains(t, h.removedAddresses, int64(faultingAddress))
 }


### PR DESCRIPTION
The kernel can partially handle a UFFDIO call before encountering an error, such as a page that was concurrently mapped. In that case, the ioctl returns EAGAIN and its output field reports the number of bytes successfully resolved

Add support to the UFFD handler for partial progress. Copy operations will now skip pages that were already mapped and retry the remaining range

Also ensure eager zeropage operations do not cross memory-mapping boundaries, which can cause the kernel to reject the range.