### PR TITLE
Render upgrade prompts on the Cache Proxies page if some Cache Proxies are running old version(s)

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -78,6 +78,7 @@ genrule(
         "//app/components/checkbox:checkbox.css",
         "//app/components/spinner:spinner.css",
         "//app/components/tooltip:tooltip.css",
+        "//app/components/upgrade:upgrade.css",
         "//app/profile:profile.css",
     ],
     outs = ["style.css"],

--- a/app/components/banner/banner.css
+++ b/app/components/banner/banner.css
@@ -28,8 +28,19 @@
   color: var(--color-banner-warning-text);
 }
 
-.banner.banner-warning .icon {
+.banner.banner-warning .icon,
+.banner.banner-warning .lucide {
   stroke: var(--color-banner-warning-icon);
+}
+
+.banner.banner-critical {
+  background: var(--color-banner-critical-bg);
+  color: var(--color-banner-critical-text);
+}
+
+.banner.banner-critical .icon,
+.banner.banner-critical .lucide {
+  stroke: var(--color-banner-critical-icon);
 }
 
 .banner.banner-error {

--- a/app/components/banner/banner.tsx
+++ b/app/components/banner/banner.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, CheckCircle, Info, X, XCircle } from "lucide-react";
+import { AlertCircle, AlertTriangle, CheckCircle, Info, X, XCircle } from "lucide-react";
 import React from "react";
 import { OutlinedButton } from "../button/button";
 
@@ -6,6 +6,7 @@ const ICONS = {
   info: <Info className="blue" />,
   success: <CheckCircle className="green" />,
   warning: <AlertCircle className="orange" />,
+  critical: <AlertTriangle />,
   error: <XCircle className="red" />,
 } as const;
 

--- a/app/components/upgrade/BUILD
+++ b/app/components/upgrade/BUILD
@@ -1,0 +1,16 @@
+load("//rules/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*.css"]))
+
+ts_library(
+    name = "upgrade",
+    srcs = ["upgrade.tsx"],
+    deps = [
+        "//:node_modules/@types/react",
+        "//:node_modules/lucide-react",
+        "//:node_modules/react",
+        "//proto:upgrade_ts_proto",
+    ],
+)

--- a/app/components/upgrade/upgrade.css
+++ b/app/components/upgrade/upgrade.css
@@ -1,0 +1,17 @@
+.upgrade-prompt-banner {
+  margin: 16px 0;
+}
+
+/* The HIGH-urgency prompt is the banner-warning style with a red icon; this
+   needs to out-specialize banner-warning's own icon-color rule. */
+.banner.banner-warning.upgrade-prompt-banner .lucide.red {
+  stroke: var(--color-red-500);
+}
+
+/* The global anchor style removes underlines, which leaves links looking
+   like plain text; make them visibly clickable. */
+.upgrade-prompt-banner .banner-content a {
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}

--- a/app/components/upgrade/upgrade.tsx
+++ b/app/components/upgrade/upgrade.tsx
@@ -1,0 +1,62 @@
+import { AlertCircle, Info } from "lucide-react";
+import React from "react";
+import { upgrade } from "../../../proto/upgrade_ts_proto";
+
+export interface UpgradePromptProps {
+  // The upgrade prompt from the server, if any. Nothing is rendered when
+  // this is unset.
+  prompt?: upgrade.IPrompt | null;
+  // Plural, lowercase name of the outdated components, e.g. "cache proxies".
+  componentName: string;
+  // Optional link to upgrade instructions.
+  docsHref?: string;
+}
+
+// Per-urgency banner styling, all from the shared Banner component's
+// stylesheet. HIGH is the yellow banner-warning style like MEDIUM, but with
+// a red icon; CRITICAL is the red banner-error style with an
+// exclamation-mark icon rather than banner-error's usual XCircle.
+function appearance(urgency: upgrade.Prompt.Urgency | null | undefined): { className: string; icon: JSX.Element } {
+  switch (urgency) {
+    case upgrade.Prompt.Urgency.CRITICAL:
+      return { className: "banner-error", icon: <AlertCircle className="red" /> };
+    case upgrade.Prompt.Urgency.HIGH:
+      return { className: "banner-warning", icon: <AlertCircle className="red" /> };
+    case upgrade.Prompt.Urgency.MEDIUM:
+      return { className: "banner-warning", icon: <AlertCircle /> };
+    default:
+      return { className: "banner-info", icon: <Info className="blue" /> };
+  }
+}
+
+/**
+ * A banner prompting the user to upgrade out-of-date components, styled
+ * according to the urgency the server assigned.
+ */
+export default class UpgradePrompt extends React.Component<UpgradePromptProps> {
+  render() {
+    const prompt = this.props.prompt;
+    if (!prompt?.newestAvailableVersion) {
+      return null;
+    }
+    const { className, icon } = appearance(prompt.urgency);
+    return (
+      <div className={`banner upgrade-prompt-banner ${className}`}>
+        {icon}
+        <div className="banner-content">
+          Some of your {this.props.componentName} are running an outdated version. The newest available version is{" "}
+          <b>{prompt.newestAvailableVersion}</b>.
+          {this.props.docsHref && (
+            <>
+              {" "}
+              <a href={this.props.docsHref} target="_blank">
+                See the docs
+              </a>{" "}
+              for upgrade instructions.
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/root/colors.css
+++ b/app/root/colors.css
@@ -155,6 +155,9 @@
   --color-auditlog-entry-bg: var(--color-white);
   --color-auditlog-header-bg: var(--color-gray-50);
   --color-badge-workflow-text: var(--color-white);
+  --color-banner-critical-bg: var(--color-orange-100);
+  --color-banner-critical-icon: var(--color-deep-orange-800);
+  --color-banner-critical-text: var(--color-black);
   --color-banner-error-bg: var(--color-red-100);
   --color-banner-error-text: var(--color-black);
   --color-banner-info-bg: var(--color-light-blue-50);
@@ -162,8 +165,8 @@
   --color-banner-success-bg: var(--color-green-100);
   --color-banner-success-text: var(--color-black);
   --color-banner-impersonation-bg: var(--color-amber-500);
-  --color-banner-warning-bg: var(--color-orange-50);
-  --color-banner-warning-icon: var(--color-amber-900);
+  --color-banner-warning-bg: var(--color-amber-100);
+  --color-banner-warning-icon: var(--color-yellow-800);
   --color-banner-warning-text: var(--color-black);
   --color-bg-card: var(--color-white);
   --color-bg-code: var(--color-gray-200);
@@ -383,6 +386,9 @@
   --color-auditlog-entry-bg: var(--color-bg-card);
   --color-auditlog-header-bg: var(--color-gray-800);
   --color-badge-workflow-text: var(--color-black);
+  --color-banner-critical-bg: var(--color-deep-orange-800);
+  --color-banner-critical-icon: var(--color-white);
+  --color-banner-critical-text: var(--color-white);
   --color-banner-error-bg: var(--color-red-900);
   --color-banner-error-text: var(--color-white);
   --color-banner-info-bg: var(--color-indigo-900);
@@ -390,9 +396,9 @@
   --color-banner-success-bg: var(--color-green-900);
   --color-banner-success-text: var(--color-white);
   --color-banner-impersonation-bg: var(--color-yellow-800);
-  --color-banner-warning-bg: var(--color-brown-800);
-  --color-banner-warning-icon: var(--color-amber-200);
-  --color-banner-warning-text: var(--color-white);
+  --color-banner-warning-bg: var(--color-yellow-800);
+  --color-banner-warning-icon: var(--color-black);
+  --color-banner-warning-text: var(--color-black);
   --color-bg-card: var(--color-gray-900-alt4);
   --color-bg-code: var(--color-gray-900-alt5);
   --color-bg-hover: var(--color-gray-900-alt);

--- a/enterprise/app/cache_proxies/BUILD
+++ b/enterprise/app/cache_proxies/BUILD
@@ -16,6 +16,7 @@ ts_library(
         "//app/auth:auth_service",
         "//app/components/breadcrumbs",
         "//app/components/button:link_button",
+        "//app/components/upgrade",
         "//app/router",
         "//app/service:rpc_service",
         "//app/util:errors",
@@ -23,6 +24,7 @@ ts_library(
         "//proto:api_key_ts_proto",
         "//proto:cache_proxy_ts_proto",
         "//proto:capability_ts_proto",
+        "//proto:upgrade_ts_proto",
     ],
 )
 

--- a/enterprise/app/cache_proxies/cache_proxies.tsx
+++ b/enterprise/app/cache_proxies/cache_proxies.tsx
@@ -4,12 +4,14 @@ import { Subscription } from "rxjs";
 import { User } from "../../../app/auth/auth_service";
 import Breadcrumbs from "../../../app/components/breadcrumbs/breadcrumbs";
 import LinkButton from "../../../app/components/button/link_button";
+import UpgradePrompt from "../../../app/components/upgrade/upgrade";
 import router from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
 import { BuildBuddyError } from "../../../app/util/errors";
 import { api_key } from "../../../proto/api_key_ts_proto";
 import { cache_proxy } from "../../../proto/cache_proxy_ts_proto";
 import { capability } from "../../../proto/capability_ts_proto";
+import { upgrade } from "../../../proto/upgrade_ts_proto";
 import CacheProxyCardComponent from "./cache_proxy_card";
 
 enum FetchType {
@@ -127,6 +129,37 @@ class CacheProxiesList extends React.Component<CacheProxiesListProps> {
       </div>
     );
   }
+}
+
+// The server only populates upgradePrompt when at least one of the group's
+// proxies is far enough behind the newest registered version to warrant an
+// upgrade prompt. With multiple regions, show the most urgent prompt,
+// tie-breaking on the newest version.
+function upgradePrompt(regions: RegionalCacheProxyResponse[]): upgrade.IPrompt | null {
+  let best: upgrade.IPrompt | null = null;
+  for (const region of regions) {
+    const prompt = region.response.upgradePrompt;
+    if (!prompt?.newestAvailableVersion) continue;
+    if (
+      !best ||
+      (prompt.urgency ?? 0) > (best.urgency ?? 0) ||
+      ((prompt.urgency ?? 0) === (best.urgency ?? 0) &&
+        compareVersions(prompt.newestAvailableVersion, best.newestAvailableVersion ?? "") > 0)
+    ) {
+      best = prompt;
+    }
+  }
+  return best;
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.replace(/^v/, "").split(".").map(Number);
+  const pb = b.replace(/^v/, "").split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d) return d;
+  }
+  return 0;
 }
 
 function CacheProxyDetail({ Icon, label, children }: { Icon: LucideIcon; label: string; children: React.ReactNode }) {
@@ -284,6 +317,7 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
   render() {
     const hasProxies = this.state.regions.some((r) => r.response.cacheProxy.some((proxy) => proxy.node));
     const hasKeys = this.state.proxyKeys.length > 0;
+    const prompt = upgradePrompt(this.state.regions);
     // When neither proxies nor cache-proxy API keys exist, skip the tab UI
     // and show a single clean empty-state view (matching the executors page
     // pattern when nothing has been set up).
@@ -336,6 +370,11 @@ export default class CacheProxiesComponent extends React.Component<Props, State>
                 </div>
                 {activeTab === "status" && (
                   <>
+                    <UpgradePrompt
+                      prompt={prompt}
+                      componentName="cache proxies"
+                      docsHref="https://www.buildbuddy.io/docs/enterprise-proxy"
+                    />
                     {!hasProxies && (
                       <div className="empty-state">
                         <h1>No cache proxies are registered.</h1>

--- a/enterprise/server/cache_proxy_registry_server/BUILD
+++ b/enterprise/server/cache_proxy_registry_server/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//proto:cache_proxy_go_proto",
         "//proto:capability_go_proto",
+        "//proto:upgrade_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/real_environment",
@@ -19,8 +20,10 @@ go_library(
         "//server/util/perms",
         "//server/util/proto",
         "//server/util/status",
+        "//server/util/upgrade",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_masterminds_semver_v3//:semver",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
@@ -35,6 +38,7 @@ go_test(
         "//proto:cache_proxy_go_proto",
         "//proto:capability_go_proto",
         "//proto:context_go_proto",
+        "//proto:upgrade_go_proto",
         "//server/interfaces",
         "//server/testutil/testauth",
         "//server/testutil/testenv",

--- a/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server.go
+++ b/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server.go
@@ -19,8 +19,10 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
@@ -28,12 +30,14 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/upgrade"
 	"github.com/go-redis/redis/v8"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cppb "github.com/buildbuddy-io/buildbuddy/proto/cache_proxy"
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
+	uppb "github.com/buildbuddy-io/buildbuddy/proto/upgrade"
 )
 
 const (
@@ -44,6 +48,10 @@ const (
 	// How often we revalidate credentials for an open registration stream. We
 	// need to regularly revlidate credentials to handle revoked API keys.
 	checkRegistrationCredentialsInterval = 5 * time.Minute
+
+	// How long a computed newest-registered-version value is served from the
+	// in-process cache before the Redis registry is scanned again.
+	newestVersionCacheTTL = 5 * time.Minute
 )
 
 type CacheProxyRegistryServer struct {
@@ -51,6 +59,10 @@ type CacheProxyRegistryServer struct {
 	clock         clockwork.Clock
 	rdb           redis.UniversalClient
 	quit          chan struct{}
+
+	mu                  sync.Mutex
+	newestVersion       *semver.Version
+	newestVersionExpiry time.Time
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -213,6 +225,57 @@ func (s *CacheProxyRegistryServer) removeProxy(ctx context.Context, groupID, pro
 	return s.rdb.HDel(ctx, redisKeyForCacheProxies(groupID), proxyID).Err()
 }
 
+func (s *CacheProxyRegistryServer) getNewestVersion(ctx context.Context) *semver.Version {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.clock.Now().Before(s.newestVersionExpiry) {
+		return s.newestVersion
+	}
+
+	var newest *semver.Version
+	var cursor uint64
+	for {
+		keys, next, err := s.rdb.Scan(ctx, cursor, redisKeyForCacheProxies("*"), 100).Result()
+		if err != nil {
+			log.CtxWarningf(ctx, "could not scan cache proxy registrations for newest version: %s", err)
+			// Don't cache the (possibly partial) result of a failed scan.
+			return nil
+		}
+		for _, key := range keys {
+			entries, err := s.rdb.HGetAll(ctx, key).Result()
+			if err != nil {
+				log.CtxWarningf(ctx, "could not read cache proxy registrations at %q: %s", key, err)
+				return nil
+			}
+			for _, data := range entries {
+				reg := &cppb.RegisteredCacheProxy{}
+				if err := proto.Unmarshal([]byte(data), reg); err != nil {
+					continue
+				}
+				if s.clock.Since(reg.GetLastPingTime().AsTime()) > maxRegistrationStaleness {
+					continue
+				}
+				// Skip "unknown" and other unparseable versions.
+				v, err := semver.NewVersion(reg.GetRegistration().GetVersion())
+				if err != nil {
+					continue
+				}
+				if newest == nil || v.GreaterThan(newest) {
+					newest = v
+				}
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+
+	s.newestVersion = newest
+	s.newestVersionExpiry = s.clock.Now().Add(newestVersionCacheTTL)
+	return newest
+}
+
 func (s *CacheProxyRegistryServer) GetCacheProxies(ctx context.Context, req *cppb.GetCacheProxiesRequest) (*cppb.GetCacheProxiesResponse, error) {
 	// The group ID comes from the request context (the UI's "selected
 	// group") rather than the authenticated user, because a user can
@@ -271,6 +334,18 @@ func (s *CacheProxyRegistryServer) GetCacheProxies(ctx context.Context, req *cpp
 	})
 
 	return &cppb.GetCacheProxiesResponse{
-		CacheProxy: proxies,
+		CacheProxy:    proxies,
+		UpgradePrompt: s.upgradePrompt(ctx, proxies),
 	}, nil
+}
+
+func (s *CacheProxyRegistryServer) upgradePrompt(ctx context.Context, proxies []*cppb.GetCacheProxiesResponse_CacheProxy) *uppb.Prompt {
+	if len(proxies) == 0 {
+		return nil
+	}
+	versions := make([]string, 0, len(proxies))
+	for _, p := range proxies {
+		versions = append(versions, p.GetNode().GetVersion())
+	}
+	return upgrade.ForVersions(s.getNewestVersion(ctx), versions)
 }

--- a/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server_test.go
+++ b/enterprise/server/cache_proxy_registry_server/cache_proxy_registry_server_test.go
@@ -25,6 +25,7 @@ import (
 	cppb "github.com/buildbuddy-io/buildbuddy/proto/cache_proxy"
 	cappb "github.com/buildbuddy-io/buildbuddy/proto/capability"
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+	uppb "github.com/buildbuddy-io/buildbuddy/proto/upgrade"
 )
 
 const (
@@ -123,6 +124,95 @@ func TestGetCacheProxies(t *testing.T) {
 	require.Len(t, resp.GetCacheProxy(), 2)
 	assert.Equal(t, "host-a", resp.GetCacheProxy()[0].GetNode().GetHost())
 	assert.Equal(t, "host-b", resp.GetCacheProxy()[1].GetNode().GetHost())
+}
+
+func TestGetCacheProxies_UpgradePrompt(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, _ := newServer(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	// The newest version is registered under a *different* group; the prompt
+	// compares against the newest version across the whole installation.
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), "GR-OTHER", &cppb.CacheProxyNode{
+		Host: "host-new", ProxyId: "id-new", Version: "v2.153.0",
+	}, nil))
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), testGroupID, &cppb.CacheProxyNode{
+		Host: "host-old", ProxyId: "id-old", Version: "v2.140.0",
+	}, nil))
+
+	ctx := claims.AuthContextWithJWT(context.Background(), user.(*claims.Claims), nil)
+	resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetCacheProxy(), 1)
+	require.NotNil(t, resp.GetUpgradePrompt())
+	assert.Equal(t, "v2.153.0", resp.GetUpgradePrompt().GetNewestAvailableVersion())
+	assert.Equal(t, uppb.Prompt_LOW, resp.GetUpgradePrompt().GetUrgency())
+}
+
+func TestGetCacheProxies_UpgradePrompt_WithinThreshold(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, _ := newServer(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), "GR-OTHER", &cppb.CacheProxyNode{
+		Host: "host-new", ProxyId: "id-new", Version: "v2.153.0",
+	}, nil))
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), testGroupID, &cppb.CacheProxyNode{
+		Host: "host-old", ProxyId: "id-old", Version: "v2.152.0",
+	}, nil))
+
+	ctx := claims.AuthContextWithJWT(context.Background(), user.(*claims.Claims), nil)
+	resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, resp.GetUpgradePrompt())
+}
+
+func TestGetCacheProxies_UpgradePrompt_SkipsUnparseableVersions(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, _ := newServer(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	// Dev builds report "unknown"; they should neither count as the newest
+	// version nor trigger the prompt themselves.
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), "GR-OTHER", &cppb.CacheProxyNode{
+		Host: "host-dev", ProxyId: "id-dev", Version: "unknown",
+	}, nil))
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), testGroupID, &cppb.CacheProxyNode{
+		Host: "host-old", ProxyId: "id-old", Version: "unknown",
+	}, nil))
+
+	ctx := claims.AuthContextWithJWT(context.Background(), user.(*claims.Claims), nil)
+	resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, resp.GetUpgradePrompt())
+}
+
+func TestGetCacheProxies_UpgradePrompt_IgnoresStaleRegistrations(t *testing.T) {
+	user := userWithCapabilities("U1", testGroupID, cappb.Capability_REGISTER_CACHE_PROXY)
+	s, _ := newServer(t, map[string]interfaces.UserInfo{"CP_KEY": user})
+
+	// A long-gone proxy with a very new version shouldn't set the bar.
+	stale := &cppb.RegisteredCacheProxy{
+		Registration: &cppb.CacheProxyNode{Host: "host-new", ProxyId: "id-new", Version: "v2.199.0"},
+		GroupId:      "GR-OTHER",
+		LastPingTime: timestamppb.New(time.Now().Add(-2 * maxRegistrationStaleness)),
+	}
+	b, err := proto.Marshal(stale)
+	require.NoError(t, err)
+	require.NoError(t, s.rdb.HSet(context.Background(), redisKeyForCacheProxies("GR-OTHER"), "id-new", b).Err())
+	require.NoError(t, s.insertOrUpdateProxy(context.Background(), testGroupID, &cppb.CacheProxyNode{
+		Host: "host-old", ProxyId: "id-old", Version: "v2.150.0",
+	}, nil))
+
+	ctx := claims.AuthContextWithJWT(context.Background(), user.(*claims.Claims), nil)
+	resp, err := s.GetCacheProxies(ctx, &cppb.GetCacheProxiesRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: testGroupID},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, resp.GetUpgradePrompt())
 }
 
 func TestGetCacheProxies_Isolation(t *testing.T) {

--- a/server/util/upgrade/BUILD
+++ b/server/util/upgrade/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "upgrade",
+    srcs = ["upgrade.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/upgrade",
+    deps = [
+        "//proto:upgrade_go_proto",
+        "//server/util/log",
+        "@com_github_masterminds_semver_v3//:semver",
+    ],
+)
+
+go_test(
+    name = "upgrade_test",
+    srcs = ["upgrade_test.go"],
+    embed = [":upgrade"],
+    deps = [
+        "//proto:upgrade_go_proto",
+        "//server/util/testing/flags",
+        "@com_github_masterminds_semver_v3//:semver",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/upgrade/upgrade.go
+++ b/server/util/upgrade/upgrade.go
@@ -1,0 +1,125 @@
+// Package upgrade computes upgrade nudges: prompts telling the user that some
+// component of their installation (e.g. a self-hosted cache proxy) is out of
+// date, with an urgency proportional to how far behind it is.
+package upgrade
+
+import (
+	"flag"
+	"sync"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+
+	uppb "github.com/buildbuddy-io/buildbuddy/proto/upgrade"
+)
+
+var (
+	criticalMaxLag     = flag.String("upgrade.critical.max_lag", "", "Prompt with CRITICAL urgency when a component is further behind the newest available version than this semver-shaped diff. Empty disables this criterion.")
+	criticalMinVersion = flag.String("upgrade.critical.min_version", "", "Prompt with CRITICAL urgency when a component's version is below this semver. Empty disables this criterion.")
+	highMaxLag         = flag.String("upgrade.high.max_lag", "0.40.0", "Prompt with HIGH urgency when a component is further behind the newest available version than this semver-shaped diff. Empty disables this criterion.")
+	highMinVersion     = flag.String("upgrade.high.min_version", "", "Prompt with HIGH urgency when a component's version is below this semver. Empty disables this criterion.")
+	mediumMaxLag       = flag.String("upgrade.medium.max_lag", "0.20.0", "Prompt with MEDIUM urgency when a component is further behind the newest available version than this semver-shaped diff. Empty disables this criterion.")
+	mediumMinVersion   = flag.String("upgrade.medium.min_version", "", "Prompt with MEDIUM urgency when a component's version is below this semver. Empty disables this criterion.")
+	lowMaxLag          = flag.String("upgrade.low.max_lag", "0.10.0", "Prompt with LOW urgency when a component is further behind the newest available version than this semver-shaped diff. Empty disables this criterion.")
+	lowMinVersion      = flag.String("upgrade.low.min_version", "", "Prompt with LOW urgency when a component's version is below this semver. Empty disables this criterion.")
+)
+
+// One "tier" of an upgrade prompt.
+type prompt struct {
+	urgency    uppb.Prompt_Urgency
+	maxLag     *semver.Version
+	minVersion *semver.Version
+}
+
+var (
+	promptsOnce sync.Once
+	prompts     []prompt
+)
+
+// Parses CLI flags into a list of prompts that can be checked against.
+func getPrompts() []prompt {
+	promptsOnce.Do(func() {
+		for _, t := range []struct {
+			urgency                 uppb.Prompt_Urgency
+			name                    string
+			maxLagFlag, minVersFlag string
+		}{
+			{uppb.Prompt_CRITICAL, "critical", *criticalMaxLag, *criticalMinVersion},
+			{uppb.Prompt_HIGH, "high", *highMaxLag, *highMinVersion},
+			{uppb.Prompt_MEDIUM, "medium", *mediumMaxLag, *mediumMinVersion},
+			{uppb.Prompt_LOW, "low", *lowMaxLag, *lowMinVersion},
+		} {
+			prompts = append(prompts, prompt{
+				urgency:    t.urgency,
+				maxLag:     parseVersionFlag("upgrade."+t.name+".max_lag", t.maxLagFlag),
+				minVersion: parseVersionFlag("upgrade."+t.name+".min_version", t.minVersFlag),
+			})
+		}
+	})
+	return prompts
+}
+
+func parseVersionFlag(name, value string) *semver.Version {
+	if value == "" {
+		return nil
+	}
+	v, err := semver.NewVersion(value)
+	if err != nil {
+		log.Warningf("Ignoring unparseable --%s flag value %q: %s", name, value, err)
+		return nil
+	}
+	return v
+}
+
+func resetForTesting() {
+	promptsOnce = sync.Once{}
+	prompts = nil
+}
+
+// ForVersions returns a Prompt if any of the provided versions meet the
+// desired upgrade criteria. If multiple provided versions meet it, the
+// highest urgency prompt among them is returned.
+func ForVersions(newest *semver.Version, versions []string) *uppb.Prompt {
+	if newest == nil {
+		return nil
+	}
+	urgency := uppb.Prompt_UNKNOWN_URGENCY
+	for _, rawVersion := range versions {
+		version, err := semver.NewVersion(rawVersion)
+		if err != nil {
+			continue
+		}
+		if u := getUrgency(newest, version); u > urgency {
+			urgency = u
+		}
+	}
+	if urgency == uppb.Prompt_UNKNOWN_URGENCY {
+		return nil
+	}
+	return &uppb.Prompt{
+		NewestAvailableVersion: newest.Original(),
+		Urgency:                urgency,
+	}
+}
+
+func getUrgency(newest, v *semver.Version) uppb.Prompt_Urgency {
+	for _, t := range getPrompts() {
+		if (t.minVersion != nil && v.LessThan(t.minVersion)) || lagExceeds(newest, v, t.maxLag) {
+			return t.urgency
+		}
+	}
+	return uppb.Prompt_UNKNOWN_URGENCY
+}
+
+func lagExceeds(newest, current, maxLag *semver.Version) bool {
+	if maxLag == nil || !current.LessThan(newest) {
+		return false
+	}
+	if d := int64(newest.Major()) - int64(current.Major()); d != int64(maxLag.Major()) {
+		return d > int64(maxLag.Major())
+	}
+	if d := int64(newest.Minor()) - int64(current.Minor()); d != int64(maxLag.Minor()) {
+		return d > int64(maxLag.Minor())
+	}
+	return int64(newest.Patch())-int64(current.Patch()) > int64(maxLag.Patch())
+}

--- a/server/util/upgrade/upgrade_test.go
+++ b/server/util/upgrade/upgrade_test.go
@@ -1,0 +1,123 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	uppb "github.com/buildbuddy-io/buildbuddy/proto/upgrade"
+)
+
+// setFlag changes an upgrade flag and clears the parsed-flag cache, both for
+// this test and (via cleanup) for whichever test runs next.
+func setFlag(t *testing.T, name, value string) {
+	flags.Set(t, name, value)
+	resetForTesting()
+	t.Cleanup(resetForTesting)
+}
+
+func TestUrgency_MaxLagDefaults(t *testing.T) {
+	for _, tc := range []struct {
+		newest, v string
+		want      uppb.Prompt_Urgency
+	}{
+		{"v2.153.0", "v2.153.0", uppb.Prompt_UNKNOWN_URGENCY},
+		// Exactly at the low tier's "0.10.0" allowance: no prompt.
+		{"v2.153.0", "v2.143.0", uppb.Prompt_UNKNOWN_URGENCY},
+		// One patch version beyond the "0.10.0" allowance: prompt.
+		{"v2.153.1", "v2.143.0", uppb.Prompt_LOW},
+		{"v2.153.0", "v2.142.0", uppb.Prompt_LOW},
+		// Exactly at the medium tier's "0.20.0" allowance: still LOW.
+		{"v2.153.0", "v2.133.0", uppb.Prompt_LOW},
+		{"v2.153.0", "v2.132.0", uppb.Prompt_MEDIUM},
+		{"v2.153.0", "v2.113.0", uppb.Prompt_MEDIUM},
+		{"v2.153.0", "v2.112.0", uppb.Prompt_HIGH},
+		// Any major-version lag exceeds all the default "0.x.0" allowances,
+		// and the critical tier is disabled by default, so HIGH is the
+		// default ceiling.
+		{"v3.0.0", "v2.153.0", uppb.Prompt_HIGH},
+		// A component newer than "newest" (stale data) never prompts.
+		{"v2.153.0", "v2.154.0", uppb.Prompt_UNKNOWN_URGENCY},
+		{"v2.153.0", "v3.0.0", uppb.Prompt_UNKNOWN_URGENCY},
+	} {
+		newest := semver.MustParse(tc.newest)
+		v := semver.MustParse(tc.v)
+		assert.Equal(t, tc.want, getUrgency(newest, v), "newest=%s v=%s", tc.newest, tc.v)
+	}
+}
+
+func TestUrgency_MaxLagConfigured(t *testing.T) {
+	setFlag(t, "upgrade.low.max_lag", "0.2.0")
+	setFlag(t, "upgrade.medium.max_lag", "0.6.0")
+	setFlag(t, "upgrade.high.max_lag", "1.0.0")
+	setFlag(t, "upgrade.critical.max_lag", "2.0.0")
+
+	newest := semver.MustParse("v3.10.0")
+	for _, tc := range []struct {
+		v    string
+		want uppb.Prompt_Urgency
+	}{
+		{"v3.8.0", uppb.Prompt_UNKNOWN_URGENCY},
+		{"v3.7.0", uppb.Prompt_LOW},
+		{"v3.3.0", uppb.Prompt_MEDIUM},
+		// With a "1.0.0" high allowance, minor-version lag alone never
+		// reaches HIGH; being more than a full major version behind does.
+		{"v3.0.0", uppb.Prompt_MEDIUM},
+		{"v2.10.0", uppb.Prompt_MEDIUM},
+		{"v2.9.0", uppb.Prompt_HIGH},
+		{"v1.0.0", uppb.Prompt_CRITICAL},
+	} {
+		assert.Equal(t, tc.want, getUrgency(newest, semver.MustParse(tc.v)), "v=%s", tc.v)
+	}
+}
+
+func TestUrgency_MinVersion(t *testing.T) {
+	setFlag(t, "upgrade.critical.min_version", "2.150.0")
+	setFlag(t, "upgrade.low.min_version", "2.153.0")
+
+	newest := semver.MustParse("v2.153.0")
+	// Below the critical minimum: CRITICAL even though the lag alone
+	// wouldn't prompt at all.
+	assert.Equal(t, uppb.Prompt_CRITICAL, getUrgency(newest, semver.MustParse("v2.149.5")))
+	// Below the low minimum but within every lag allowance.
+	assert.Equal(t, uppb.Prompt_LOW, getUrgency(newest, semver.MustParse("v2.152.9")))
+	// At the low minimum: no prompt.
+	assert.Equal(t, uppb.Prompt_UNKNOWN_URGENCY, getUrgency(newest, semver.MustParse("v2.153.0")))
+}
+
+func TestUrgency_DisabledTiers(t *testing.T) {
+	// With every criterion disabled, nothing nudges.
+	for _, name := range []string{
+		"upgrade.low.max_lag",
+		"upgrade.medium.max_lag",
+		"upgrade.high.max_lag",
+		"upgrade.critical.max_lag",
+	} {
+		setFlag(t, name, "")
+	}
+	newest := semver.MustParse("v3.0.0")
+	assert.Equal(t, uppb.Prompt_UNKNOWN_URGENCY, getUrgency(newest, semver.MustParse("v1.0.0")))
+}
+
+func TestForVersions(t *testing.T) {
+	newest := semver.MustParse("v2.153.0")
+
+	// The most-outdated version sets the urgency; unparseable versions are
+	// skipped.
+	n := ForVersions(newest, []string{"v2.153.0", "unknown", "v2.132.0"})
+	require.NotNil(t, n)
+	assert.Equal(t, "v2.153.0", n.GetNewestAvailableVersion())
+	assert.Equal(t, uppb.Prompt_MEDIUM, n.GetUrgency())
+
+	// Everything within the allowances: no prompt.
+	assert.Nil(t, ForVersions(newest, []string{"v2.153.0", "v2.152.0"}))
+
+	// Only unparseable versions: no prompt.
+	assert.Nil(t, ForVersions(newest, []string{"unknown"}))
+
+	// No newest version known: no prompt.
+	assert.Nil(t, ForVersions(nil, []string{"v2.100.0"}))
+}


### PR DESCRIPTION
I tried to do this in such a way that it'll be easy to reuse for the executors page, with a shareable proto message, a server-side component that detects out-of-date versions, and a client-side component that renders the warning. Feel free to let me know if this is too much, though. Also, if you'd prefer I break this into four PRs: protocol buffer, server library, server-side implementation, client-side implementation, LMK and I can do that too.

Here's what the four different upgrade prompts look like:

Low:
<img width="1165" height="212" alt="Screenshot 2026-07-08 at 5 17 01 PM" src="https://github.com/user-attachments/assets/a7190533-5945-424f-baac-e5fdec8ee047" />

Medium:
<img width="1165" height="210" alt="Screenshot 2026-07-08 at 5 17 11 PM" src="https://github.com/user-attachments/assets/3e419411-5228-4782-944b-d673505266a1" />

High:
<img width="1160" height="213" alt="Screenshot 2026-07-08 at 5 17 22 PM" src="https://github.com/user-attachments/assets/b59bd39a-5c1c-4eef-9557-bf379353a479" />

Critical:
<img width="1156" height="211" alt="Screenshot 2026-07-08 at 5 17 37 PM" src="https://github.com/user-attachments/assets/730e704d-f09c-4e50-8732-fa4053641c83" />


Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7759