### PR TITLE
Proto changes to support in-app upgrade prompts

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -160,6 +160,7 @@ proto_library(
     deps = [
         ":acl_proto",
         ":context_proto",
+        ":upgrade_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )
@@ -704,6 +705,11 @@ proto_library(
 )
 
 proto_library(
+    name = "upgrade_proto",
+    srcs = ["upgrade.proto"],
+)
+
+proto_library(
     name = "semver_proto",
     srcs = ["semver.proto"],
 )
@@ -802,6 +808,7 @@ proto_library(
         ":acl_proto",
         ":context_proto",
         ":trace_proto",
+        ":upgrade_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@googleapis//google/rpc:status_proto",
@@ -1536,6 +1543,12 @@ go_proto_library(
 )
 
 go_proto_library(
+    name = "upgrade_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/upgrade",
+    proto = ":upgrade_proto",
+)
+
+go_proto_library(
     name = "semver_go_proto",
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/semver",
     proto = ":semver_proto",
@@ -1617,6 +1630,7 @@ go_proto_library(
     deps = [
         ":acl_go_proto",
         ":context_go_proto",
+        ":upgrade_go_proto",
     ],
 )
 
@@ -1734,6 +1748,7 @@ go_proto_library(
         ":acl_go_proto",
         ":context_go_proto",
         ":trace_go_proto",
+        ":upgrade_go_proto",
         "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
@@ -2076,6 +2091,7 @@ ts_proto_library(
         ":grpc_status_ts_proto",
         ":timestamp_ts_proto",
         ":trace_ts_proto",
+        ":upgrade_ts_proto",
     ],
 )
 
@@ -2247,6 +2263,11 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "upgrade_ts_proto",
+    proto = ":upgrade_proto",
+)
+
+ts_proto_library(
     name = "usage_ts_proto",
     proto = ":usage_proto",
     deps = [
@@ -2398,6 +2419,7 @@ ts_proto_library(
         ":acl_ts_proto",
         ":context_ts_proto",
         ":timestamp_ts_proto",
+        ":upgrade_ts_proto",
     ],
 )
 

--- a/proto/cache_proxy.proto
+++ b/proto/cache_proxy.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "google/protobuf/timestamp.proto";
 import "proto/acl.proto";
 import "proto/context.proto";
+import "proto/upgrade.proto";
 
 package cache_proxy;
 
@@ -109,6 +110,8 @@ message GetCacheProxiesResponse {
     // Statistics about this cache proxy's performance.
     Statistics statistics = 3;
   }
+
+  upgrade.Prompt upgrade_prompt = 3;
 }
 
 // Persisted information about a connected cache proxy.

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -6,6 +6,7 @@ import "google/protobuf/timestamp.proto";
 import "proto/acl.proto";
 import "proto/context.proto";
 import "proto/trace.proto";
+import "proto/upgrade.proto";
 
 package scheduler;
 
@@ -633,6 +634,8 @@ message GetExecutionNodesResponse {
   }
 
   bool user_owned_executors_supported = 3;
+
+  upgrade.Prompt upgrade_prompt = 4;
 }
 
 // Persisted information about connected executors.

--- a/proto/upgrade.proto
+++ b/proto/upgrade.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package upgrade;
+
+// Tells the UI to prompt the user to upgrade an old component.
+message Prompt {
+  enum Urgency {
+    UNKNOWN_URGENCY = 0;
+    LOW = 1;
+    MEDIUM = 2;
+    HIGH = 3;
+    CRITICAL = 4;
+  }
+  Urgency urgency = 1;
+  string newest_available_version = 2;
+}

--- a/proto/upgrade.proto
+++ b/proto/upgrade.proto
@@ -13,4 +13,7 @@ message Prompt {
   }
   Urgency urgency = 1;
   string newest_available_version = 2;
+
+  // The message that should be displayed in the UI upgrade prompt.
+  string message = 3;
 }


### PR DESCRIPTION
This PR adds an upgrade.proto that contains a single message that is embedded in the registration-style RPCs we make between the cache proxy/executor and the app that signals the UI to render an upgrade prompt.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7759