### PR TITLE
Add an `--auth.trusted_xforwardedfor_peers` flag restricting which peers' `x-forwarded-for` headers are trusted

### DIFF
--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -343,18 +343,18 @@ func AuthorizeIP(env environment.Env, next http.Handler) http.Handler {
 
 func ClientIP(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerIP := r.RemoteAddr
+		if ip, _, err := net.SplitHostPort(peerIP); err == nil {
+			peerIP = ip
+		}
 		if v := r.Header.Get("X-Forwarded-For"); v != "" {
-			ctx, ok := clientip.SetFromXForwardedForHeader(r.Context(), v)
+			ctx, ok := clientip.SetFromXForwardedForHeader(r.Context(), v, peerIP)
 			if ok {
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
 		}
-		clientIP := r.RemoteAddr
-		if ip, _, err := net.SplitHostPort(clientIP); err == nil {
-			clientIP = ip
-		}
-		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), clientip.ContextKey, clientIP)))
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), clientip.ContextKey, peerIP)))
 	})
 }
 

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -134,13 +134,25 @@ func addClientIPToContext(ctx context.Context, env environment.Env) context.Cont
 		return addPeerIPToContext(ctx)
 	}
 
-	ctx, ok := clientip.SetFromXForwardedForHeader(ctx, hdrs[0])
+	ctx, ok := clientip.SetFromXForwardedForHeader(ctx, hdrs[0], peerIPFromContext(ctx))
 	if ok {
 		return ctx
 	}
 
 	// X-Forwarded-For header is present but not trusted. Fall back to peer.
 	return addPeerIPToContext(ctx)
+}
+
+func peerIPFromContext(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.Addr.Network() == "unix" {
+		return ""
+	}
+	ap, err := netip.ParseAddrPort(p.Addr.String())
+	if err != nil {
+		return ""
+	}
+	return ap.Addr().String()
 }
 
 func addPeerIPToContext(ctx context.Context) context.Context {

--- a/server/util/clientip/BUILD
+++ b/server/util/clientip/BUILD
@@ -5,7 +5,11 @@ go_library(
     srcs = ["clientip.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/clientip",
     visibility = ["//visibility:public"],
-    deps = ["//server/util/flag"],
+    deps = [
+        "//server/util/flag",
+        "//server/util/log",
+        "//server/util/status",
+    ],
 )
 
 go_test(

--- a/server/util/clientip/clientip.go
+++ b/server/util/clientip/clientip.go
@@ -2,9 +2,13 @@ package clientip
 
 import (
 	"context"
+	"net/netip"
 	"strings"
+	"sync/atomic"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
 const ContextKey = "clientIP"
@@ -17,7 +21,8 @@ const ContextKey = "clientIP"
 const HeaderName = "x-buildbuddy-internal-client-ip"
 
 var (
-	trustXForwardedForHeader = flag.Bool("auth.trust_xforwardedfor_header", false, "If true, client IP information will be retrieved from the X-Forwarded-For header. Should only be enabled if the BuildBuddy server is only accessible behind a trusted proxy.")
+	trustXForwardedForHeader  = flag.Bool("auth.trust_xforwardedfor_header", false, "If true, client IP information will be retrieved from the X-Forwarded-For header. Should only be enabled if the BuildBuddy server is only accessible behind a trusted proxy.")
+	trustedXForwardedForPeers = flag.Slice("auth.trusted_xforwardedfor_peers", []string{}, "CIDRs of peers from which the X-Forwarded-For header is trusted. The CIDRs in this flag are ORed with auth.trust_xforwardedfor_header. If that flag is true, all peers are trusted, otherwise, only peers matching CIDRs in this slice are trusted.")
 )
 
 func Get(ctx context.Context) string {
@@ -27,8 +32,48 @@ func Get(ctx context.Context) string {
 	return ""
 }
 
-func SetFromXForwardedForHeader(ctx context.Context, header string) (context.Context, bool) {
-	if !*trustXForwardedForHeader || header == "" {
+var trustedPeerPrefixes atomic.Pointer[[]netip.Prefix]
+
+// Init validates the auth.trusted_xforwardedfor_peers flag. It is safe to
+// call multiple times; each call re-reads the flag.
+func Init() error {
+	prefixes := make([]netip.Prefix, 0, len(*trustedXForwardedForPeers))
+	for _, cidr := range *trustedXForwardedForPeers {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return status.InvalidArgumentErrorf("invalid auth.trusted_xforwardedfor_peers CIDR %q: %s", cidr, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+	trustedPeerPrefixes.Store(&prefixes)
+	return nil
+}
+
+func peerIsTrusted(peerIP string) bool {
+	if *trustXForwardedForHeader {
+		return true
+	}
+
+	prefixes := trustedPeerPrefixes.Load()
+	if prefixes == nil {
+		log.Warningf("--auth.trusted_xforwardedfor_peers is unparsed, did you remember to call clientip.Init()?")
+		return false
+	}
+	addr, err := netip.ParseAddr(peerIP)
+	if err != nil {
+		return false
+	}
+	addr = addr.Unmap()
+	for _, prefix := range *prefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func SetFromXForwardedForHeader(ctx context.Context, header, peerIP string) (context.Context, bool) {
+	if header == "" || (!peerIsTrusted(peerIP)) {
 		return ctx, false
 	}
 

--- a/server/util/clientip/clientip_test.go
+++ b/server/util/clientip/clientip_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestDisabled(t *testing.T) {
-	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4")
+	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4", "10.0.0.1")
 	require.False(t, ok)
 	require.Equal(t, "", clientip.Get(ctx))
 }
 
 func TestNGINXHeader(t *testing.T) {
 	flags.Set(t, "auth.trust_xforwardedfor_header", true)
-	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4")
+	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4", "10.0.0.1")
 	require.True(t, ok)
 	require.Equal(t, "1.2.3.4", clientip.Get(ctx))
 }
@@ -26,12 +26,66 @@ func TestGCPLBHeader(t *testing.T) {
 	flags.Set(t, "auth.trust_xforwardedfor_header", true)
 
 	// If there are exactly two values, we use the second IP from the right.
-	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "4.3.2.1, 1.2.3.4")
+	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "4.3.2.1, 1.2.3.4", "10.0.0.1")
 	require.True(t, ok)
 	require.Equal(t, "4.3.2.1", clientip.Get(ctx))
 
 	// If there are more than two values, we still use the second IP from the right.
-	ctx, ok = clientip.SetFromXForwardedForHeader(context.Background(), "8.8.8.8, 4.3.2.1, 1.2.3.4")
+	ctx, ok = clientip.SetFromXForwardedForHeader(context.Background(), "8.8.8.8, 4.3.2.1, 1.2.3.4", "10.0.0.1")
 	require.True(t, ok)
 	require.Equal(t, "4.3.2.1", clientip.Get(ctx))
+}
+
+func setTrustedPeers(t *testing.T, cidrs []string) {
+	// Registered before flags.Set so that it runs after the flag is restored,
+	// re-parsing the restored value.
+	t.Cleanup(func() { require.NoError(t, clientip.Init()) })
+	flags.Set(t, "auth.trusted_xforwardedfor_peers", cidrs)
+	require.NoError(t, clientip.Init())
+}
+
+func TestTrustedPeers(t *testing.T) {
+	// The header is trusted for matching peers even when
+	// auth.trust_xforwardedfor_header is false.
+	setTrustedPeers(t, []string{"10.0.0.0/8", "2001:db8::/32"})
+
+	// Peer within a trusted CIDR.
+	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4", "10.1.2.3")
+	require.True(t, ok)
+	require.Equal(t, "1.2.3.4", clientip.Get(ctx))
+
+	// IPv6 peer within a trusted CIDR.
+	ctx, ok = clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4", "2001:db8::1")
+	require.True(t, ok)
+	require.Equal(t, "1.2.3.4", clientip.Get(ctx))
+
+	// Peer outside the trusted CIDRs.
+	ctx, ok = clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4", "11.1.2.3")
+	require.False(t, ok)
+	require.Equal(t, "", clientip.Get(ctx))
+
+	// Unknown peer.
+	ctx, ok = clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4", "")
+	require.False(t, ok)
+	require.Equal(t, "", clientip.Get(ctx))
+}
+
+func TestInit(t *testing.T) {
+	t.Cleanup(func() { require.NoError(t, clientip.Init()) })
+
+	flags.Set(t, "auth.trusted_xforwardedfor_peers", []string{"10.0.0.0/8"})
+	require.NoError(t, clientip.Init())
+
+	flags.Set(t, "auth.trusted_xforwardedfor_peers", []string{"10.0.0.0/8", "not-a-cidr"})
+	require.Error(t, clientip.Init())
+}
+
+func TestTrustHeaderOverridesTrustedPeers(t *testing.T) {
+	// If auth.trust_xforwardedfor_header is true, the header is trusted from
+	// every peer, even those outside the trusted CIDRs.
+	flags.Set(t, "auth.trust_xforwardedfor_header", true)
+	setTrustedPeers(t, []string{"10.0.0.0/8"})
+	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4", "11.1.2.3")
+	require.True(t, ok)
+	require.Equal(t, "1.2.3.4", clientip.Get(ctx))
 }

--- a/server/util/grpc_server/BUILD
+++ b/server/util/grpc_server/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/real_environment",
         "//server/rpc/interceptors",
         "//server/util/alert",
+        "//server/util/clientip",
         "//server/util/grpc_forward",
         "//server/util/log",
         "//server/util/rpcutil",

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/rpc/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_forward"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rpcutil"
@@ -94,6 +95,9 @@ func (b *GRPCServer) GetServer() *grpc.Server {
 }
 
 func New(env environment.Env, port int, ssl bool, config GRPCServerConfig) (*GRPCServer, error) {
+	if err := clientip.Init(); err != nil {
+		return nil, err
+	}
 	b := &GRPCServer{env: env}
 	if ssl && !env.GetSSLService().IsEnabled() {
 		return nil, status.InvalidArgumentError("GRPCS requires SSL Service")


### PR DESCRIPTION
Currently, setting `--auth.trust_xforwardedfor_header` trusts the `x-forwarded-for` header from any peer, which is only safe if the server is completely unreachable except through a trusted proxy. This PR adds an `--auth.trusted_xforwardedfor_peers` flag containing a list of CIDRs; the header is now only honored when `--auth.trust_xforwardedfor_header` is enabled and the directly connected peer (the gRPC peer address, or http.Request.RemoteAddr) falls within one of those CIDRs. The default is 0.0.0.0/0 plus ::/0, so existing deployments keep the current trust-everyone behavior until the flag is narrowed. The CIDR list is parsed into netip.Prefixes once per server lifetime via sync.OnceValue, with a reset hook for tests that override the flag.

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7779