### PR TITLE
Fix OOM killer memory measurement

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -93,6 +93,14 @@ var (
 	maxThreads        = flag.Int("executor.max_threads", 0, "The maximum number of threads to allow before panicking. If unset, the golang default will be used (currently 10,000).")
 )
 
+// Cgroups contains the executor's cgroup paths discovered during setup.
+type Cgroups struct {
+	// StartingCgroup is the cgroup that contained the executor before setup.
+	StartingCgroup string
+	// CgroupParent is the parent under which task cgroups are created.
+	CgroupParent string
+}
+
 func isOldEndpoint(endpoint string) bool {
 	u, err := url.Parse(endpoint)
 	return err == nil && u.Hostname() == "cloud.buildbuddy.io"
@@ -387,14 +395,14 @@ func main() {
 	imageCacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	env.SetImageCacheAuthenticator(imageCacheAuth)
 
-	tasksCgroupParent, err := setupCgroups()
+	cgroups, err := setupCgroups()
 	if err != nil {
 		log.Fatalf("cgroup setup failed: %s", err)
 	}
 
 	var oomKiller oomkiller.Killer
 	if oomkiller.Enabled() {
-		k, err := oomkiller.New(rootContext, oomkiller.NewMemoryMonitor())
+		k, err := oomkiller.New(rootContext, oomkiller.NewMemoryMonitor(cgroups.StartingCgroup))
 		if err != nil {
 			log.Fatalf("Error initializing executor OOM killer: %s", err)
 		}
@@ -402,7 +410,7 @@ func main() {
 	}
 
 	runnerPool, err := runner.NewPool(env, cacheRoot, &runner.PoolOptions{
-		CgroupParent: tasksCgroupParent,
+		CgroupParent: cgroups.CgroupParent,
 		OOMKiller:    oomKiller,
 	})
 	if err != nil {

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -95,7 +95,9 @@ var (
 
 // Cgroups contains the executor's cgroup paths discovered during setup.
 type Cgroups struct {
-	// StartingCgroup is the cgroup that contained the executor before setup.
+	// StartingCgroup is the cgroup that contained the executor before setup,
+	// relative to the cgroupfs root. It is empty if the cgroup could not be
+	// determined or if the executor started in the root cgroup.
 	StartingCgroup string
 	// CgroupParent is the parent under which task cgroups are created.
 	CgroupParent string
@@ -402,7 +404,11 @@ func main() {
 
 	var oomKiller oomkiller.Killer
 	if oomkiller.Enabled() {
-		k, err := oomkiller.New(rootContext, oomkiller.NewMemoryMonitor(cgroups.StartingCgroup))
+		monitor, err := oomkiller.NewMemoryMonitor(cgroups.StartingCgroup)
+		if err != nil {
+			log.Fatalf("Error initializing executor OOM killer memory monitor: %s", err)
+		}
+		k, err := oomkiller.New(rootContext, monitor)
 		if err != nil {
 			log.Fatalf("Error initializing executor OOM killer: %s", err)
 		}

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -94,6 +94,7 @@ var (
 )
 
 // Cgroups contains the executor's cgroup paths discovered during setup.
+// On platforms other than linux, all fields are empty.
 type Cgroups struct {
 	// StartingCgroup is the cgroup that contained the executor before setup,
 	// relative to the cgroupfs root. It is empty if the cgroup could not be

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -51,8 +51,12 @@ const (
 //				...
 //
 // It returns the original executor cgroup and the parent where task cgroups
-// are placed, both relative to the cgroup root.
+// are placed, both relative to the cgroup root. In the above example, these
+// would be "kubepods.slice/pod-abc/container-123" and
+// "kubepods.slice/pod-abc/container-123/buildbuddy.executor.tasks".
 func setupCgroups() (*Cgroups, error) {
+	// Get the cgroup that the executor process was originally started in.
+	// On k8s this will be something like "kubepods.slice/pod-abc/container-123"
 	startingCgroup, err := cgroup.GetCurrent()
 	if err != nil {
 		if errors.Is(err, cgroup.ErrV1NotSupported) {

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -53,7 +53,7 @@ const (
 // It returns the original executor cgroup and the parent where task cgroups
 // are placed, both relative to the cgroup root.
 func setupCgroups() (*Cgroups, error) {
-	cgroups := new(Cgroups)
+	cgroups := &Cgroups{}
 	startingCgroup, err := cgroup.GetCurrent()
 	if err != nil {
 		if errors.Is(err, cgroup.ErrV1NotSupported) {

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,7 +56,11 @@ func setupCgroups() (*Cgroups, error) {
 	cgroups := new(Cgroups)
 	startingCgroup, err := cgroup.GetCurrent()
 	if err != nil {
-		log.Warningf("Could not determine starting cgroup: %s", err)
+		if errors.Is(err, cgroup.ErrV1NotSupported) {
+			log.Warningf("Note: executor is running under cgroup v1, which has limited support. Some functionality may not work as expected.")
+		} else {
+			log.Warningf("Could not determine starting cgroup: %s", err)
+		}
 		return cgroups, nil
 	}
 	cgroups.StartingCgroup = startingCgroup

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -53,7 +53,6 @@ const (
 // It returns the original executor cgroup and the parent where task cgroups
 // are placed, both relative to the cgroup root.
 func setupCgroups() (*Cgroups, error) {
-	cgroups := &Cgroups{}
 	startingCgroup, err := cgroup.GetCurrent()
 	if err != nil {
 		if errors.Is(err, cgroup.ErrV1NotSupported) {
@@ -61,12 +60,11 @@ func setupCgroups() (*Cgroups, error) {
 		} else {
 			log.Warningf("Could not determine starting cgroup: %s", err)
 		}
-		return cgroups, nil
+		return &Cgroups{}, nil
 	}
-	cgroups.StartingCgroup = startingCgroup
 
 	if !*childCgroupsEnabled {
-		return cgroups, nil
+		return &Cgroups{StartingCgroup: startingCgroup}, nil
 	}
 
 	// Create the executor cgroup and move the executor process to it.
@@ -107,8 +105,10 @@ func setupCgroups() (*Cgroups, error) {
 		return nil, fmt.Errorf("inherit subtree control: %w", err)
 	}
 
-	cgroups.CgroupParent = filepath.Join(startingCgroup, taskCgroupName)
-	return cgroups, nil
+	return &Cgroups{
+		StartingCgroup: startingCgroup,
+		CgroupParent:   taskCgroup,
+	}, nil
 }
 
 func moveTiniToExecutorCgroup(executorCgroupPath string) error {

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -58,7 +58,7 @@ func setupCgroups() (*Cgroups, error) {
 		log.Warningf("Could not determine starting cgroup: %s", err)
 		return cgroups, nil
 	}
-	cgroups.StartingCgroup = filepath.Clean(startingCgroup)
+	cgroups.StartingCgroup = startingCgroup
 
 	if !*childCgroupsEnabled {
 		return cgroups, nil

--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,32 +49,29 @@ const (
 //				/def456/
 //				...
 //
-// This function returns the cgroup where tasks are placed, relative to
-// the cgroup root. In the above example, this would be
-// "kubepods.slice/pod-abc/container-123/buildbuddy.executor.tasks"
-func setupCgroups() (string, error) {
-	if !*childCgroupsEnabled {
-		return "", nil
-	}
-
-	// Get the cgroup that the executor process was originally started in.
-	// On k8s this will be something like "kubepods.slice/pod-abc/container-123"
+// It returns the original executor cgroup and the parent where task cgroups
+// are placed, both relative to the cgroup root.
+func setupCgroups() (*Cgroups, error) {
+	cgroups := new(Cgroups)
 	startingCgroup, err := cgroup.GetCurrent()
 	if err != nil {
-		if errors.Is(err, cgroup.ErrV1NotSupported) {
-			log.Warningf("Note: executor is running under cgroup v1, which has limited support. Some functionality may not work as expected.")
-			return "", nil
-		}
+		log.Warningf("Could not determine starting cgroup: %s", err)
+		return cgroups, nil
+	}
+	cgroups.StartingCgroup = filepath.Clean(startingCgroup)
+
+	if !*childCgroupsEnabled {
+		return cgroups, nil
 	}
 
 	// Create the executor cgroup and move the executor process to it.
 	executorCgroup := filepath.Join(startingCgroup, executorCgroupName)
 	executorCgroupPath := filepath.Join(cgroup.RootPath, executorCgroup)
 	if err := os.MkdirAll(executorCgroupPath, 0755); err != nil {
-		return "", fmt.Errorf("create executor cgroup %s: %w", executorCgroupPath, err)
+		return nil, fmt.Errorf("create executor cgroup %s: %w", executorCgroupPath, err)
 	}
 	if err := os.WriteFile(filepath.Join(executorCgroupPath, "cgroup.procs"), []byte(strconv.Itoa(os.Getpid())), 0); err != nil {
-		return "", fmt.Errorf("add executor to cgroup %s: %w", executorCgroupPath, err)
+		return nil, fmt.Errorf("add executor to cgroup %s: %w", executorCgroupPath, err)
 	}
 	log.Infof("Set up executor cgroup at %s", executorCgroupPath)
 
@@ -84,7 +80,7 @@ func setupCgroups() (string, error) {
 		// delegate controllers, otherwise it violates the "no internal
 		// processes constraint".
 		if err := moveTiniToExecutorCgroup(executorCgroupPath); err != nil {
-			return "", fmt.Errorf("move tini to cgroup %s: %w", executorCgroupPath, err)
+			return nil, fmt.Errorf("move tini to cgroup %s: %w", executorCgroupPath, err)
 		}
 	}
 
@@ -92,22 +88,22 @@ func setupCgroups() (string, error) {
 	taskCgroup := filepath.Join(startingCgroup, taskCgroupName)
 	taskCgroupPath := filepath.Join(cgroup.RootPath, taskCgroup)
 	if err := os.MkdirAll(taskCgroupPath, 0755); err != nil {
-		return "", fmt.Errorf("create task cgroup %s: %w", taskCgroupPath, err)
+		return nil, fmt.Errorf("create task cgroup %s: %w", taskCgroupPath, err)
 	}
 	log.Infof("Set up task cgroup at %s", taskCgroupPath)
 
 	if err := prometheus.Register(newCgroupMemCollector(executorCgroup, taskCgroup)); err != nil {
-		return "", fmt.Errorf("register cgroup mem collector: %w", err)
+		return nil, fmt.Errorf("register cgroup mem collector: %w", err)
 	}
 
 	// Enable the same controllers for the child cgroups that were enabled
 	// for the starting cgroup.
 	if err := cgroup.DelegateControllers(filepath.Join(cgroup.RootPath, startingCgroup)); err != nil {
-		return "", fmt.Errorf("inherit subtree control: %w", err)
+		return nil, fmt.Errorf("inherit subtree control: %w", err)
 	}
 
-	taskCgroupRelpath := filepath.Join(startingCgroup, taskCgroupName)
-	return taskCgroupRelpath, nil
+	cgroups.CgroupParent = filepath.Join(startingCgroup, taskCgroupName)
+	return cgroups, nil
 }
 
 func moveTiniToExecutorCgroup(executorCgroupPath string) error {

--- a/enterprise/server/cmd/executor/executor_notlinux.go
+++ b/enterprise/server/cmd/executor/executor_notlinux.go
@@ -9,8 +9,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 )
 
-func setupCgroups() (string, error) {
-	return "", nil
+func setupCgroups() (*Cgroups, error) {
+	return new(Cgroups), nil
 }
 
 func setupNetworking(rootContext context.Context) {

--- a/enterprise/server/cmd/executor/executor_notlinux.go
+++ b/enterprise/server/cmd/executor/executor_notlinux.go
@@ -10,7 +10,7 @@ import (
 )
 
 func setupCgroups() (*Cgroups, error) {
-	return new(Cgroups), nil
+	return &Cgroups{}, nil
 }
 
 func setupNetworking(rootContext context.Context) {

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -450,33 +450,37 @@ func ReadMemoryCurrent(dir string) (int64, error) {
 }
 
 // ReadMemoryMax reads the "memory.max" file under the given cgroup directory
-// and returns the configured memory limit in bytes, or -1 if the limit is
+// and returns the configured memory limit in bytes, or nil if the limit is
 // "max" (unlimited). The directory should be an absolute path, including the
 // /sys/fs/cgroup prefix.
-func ReadMemoryMax(dir string) (int64, error) {
+func ReadMemoryMax(dir string) (*int64, error) {
 	b, err := os.ReadFile(filepath.Join(dir, "memory.max"))
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	s := strings.TrimSpace(string(b))
 	if s == "max" {
-		return -1, nil
+		return nil, nil
 	}
-	return strconv.ParseInt(s, 10, 64)
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
 }
 
 // ReadEffectiveMemoryLimit returns the smallest "memory.max" limit in effect
 // for the cgroup at the given absolute path, taking ancestor cgroup limits
-// into account. It returns -1 if neither the cgroup nor any of its ancestors
+// into account. It returns nil if neither the cgroup nor any of its ancestors
 // sets a limit.
-func ReadEffectiveMemoryLimit(dir string) (int64, error) {
-	limit := int64(-1)
+func ReadEffectiveMemoryLimit(dir string) (*int64, error) {
+	var limit *int64
 	for dir = filepath.Clean(dir); strings.HasPrefix(dir, RootPath+string(os.PathSeparator)); dir = ParentPath(dir) {
 		v, err := ReadMemoryMax(dir)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
-		if v >= 0 && (limit < 0 || v < limit) {
+		if v != nil && (limit == nil || *v < *limit) {
 			limit = v
 		}
 	}

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -472,16 +472,25 @@ func ReadMemoryMax(dir string) (*int64, error) {
 // ReadEffectiveMemoryLimit returns the smallest "memory.max" limit in effect
 // for the cgroup at the given absolute path, taking ancestor cgroup limits
 // into account. It returns nil if neither the cgroup nor any of its ancestors
-// sets a limit.
+// sets a limit. The walk includes the cgroupfs root: the real cgroup v2 root
+// has no memory.max file and is treated as unlimited, but under a cgroup
+// namespace the root directory is a non-root cgroup on the host, and any
+// limit set on it applies.
 func ReadEffectiveMemoryLimit(dir string) (*int64, error) {
 	var limit *int64
-	for dir = filepath.Clean(dir); strings.HasPrefix(dir, RootPath+string(os.PathSeparator)); dir = ParentPath(dir) {
+	for dir = filepath.Clean(dir); dir == RootPath || strings.HasPrefix(dir, RootPath+string(os.PathSeparator)); dir = ParentPath(dir) {
 		v, err := ReadMemoryMax(dir)
 		if err != nil {
+			if dir == RootPath && os.IsNotExist(err) {
+				break
+			}
 			return nil, err
 		}
 		if v != nil && (limit == nil || *v < *limit) {
 			limit = v
+		}
+		if dir == RootPath {
+			break
 		}
 	}
 	return limit, nil

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -487,6 +487,13 @@ func ReadEffectiveMemoryLimit(dir string) (*int64, error) {
 	return limit, nil
 }
 
+// ReadMemoryStatField reads the given field from the "memory.stat" file under
+// the given cgroup directory. The directory should be an absolute path,
+// including the /sys/fs/cgroup prefix.
+func ReadMemoryStatField(dir, field string) (int64, error) {
+	return readCgroupInt64Field(filepath.Join(dir, "memory.stat"), field)
+}
+
 // ReadPidsEvents reads the "pids.events" file under the given cgroup
 // directory and returns the counter values as a map. The directory should be an
 // absolute path, including the /sys/fs/cgroup prefix.

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -449,6 +449,40 @@ func ReadMemoryCurrent(dir string) (int64, error) {
 	return readInt64FromFile(filepath.Join(dir, "memory.current"))
 }
 
+// ReadMemoryMax reads the "memory.max" file under the given cgroup directory
+// and returns the configured memory limit in bytes, or -1 if the limit is
+// "max" (unlimited). The directory should be an absolute path, including the
+// /sys/fs/cgroup prefix.
+func ReadMemoryMax(dir string) (int64, error) {
+	b, err := os.ReadFile(filepath.Join(dir, "memory.max"))
+	if err != nil {
+		return 0, err
+	}
+	s := strings.TrimSpace(string(b))
+	if s == "max" {
+		return -1, nil
+	}
+	return strconv.ParseInt(s, 10, 64)
+}
+
+// ReadEffectiveMemoryLimit returns the smallest "memory.max" limit in effect
+// for the cgroup at the given absolute path, taking ancestor cgroup limits
+// into account. It returns -1 if neither the cgroup nor any of its ancestors
+// sets a limit.
+func ReadEffectiveMemoryLimit(dir string) (int64, error) {
+	limit := int64(-1)
+	for dir = filepath.Clean(dir); strings.HasPrefix(dir, RootPath+string(os.PathSeparator)); dir = ParentPath(dir) {
+		v, err := ReadMemoryMax(dir)
+		if err != nil {
+			return 0, err
+		}
+		if v >= 0 && (limit < 0 || v < limit) {
+			limit = v
+		}
+	}
+	return limit, nil
+}
+
 // ReadPidsEvents reads the "pids.events" file under the given cgroup
 // directory and returns the counter values as a map. The directory should be an
 // absolute path, including the /sys/fs/cgroup prefix.

--- a/enterprise/server/remote_execution/cgroup/cgroup_test.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup_test.go
@@ -138,14 +138,15 @@ func TestReadMemoryMax(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "memory.max"), []byte("1073741824\n"), 0644))
 	limit, err := ReadMemoryMax(dir)
 	require.NoError(t, err)
-	require.Equal(t, int64(1073741824), limit)
+	require.NotNil(t, limit)
+	require.Equal(t, int64(1073741824), *limit)
 
 	// The special value "max" means the cgroup has no memory limit, which is
-	// reported as -1.
+	// reported as nil.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "memory.max"), []byte("max\n"), 0644))
 	limit, err = ReadMemoryMax(dir)
 	require.NoError(t, err)
-	require.Equal(t, int64(-1), limit)
+	require.Nil(t, limit)
 }
 
 func TestParsePSI(t *testing.T) {

--- a/enterprise/server/remote_execution/cgroup/cgroup_test.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup_test.go
@@ -1,6 +1,8 @@
 package cgroup
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -127,6 +129,23 @@ func TestSettingsMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadMemoryMax(t *testing.T) {
+	dir := t.TempDir()
+
+	// A numeric memory.max value should be returned as the limit in bytes.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "memory.max"), []byte("1073741824\n"), 0644))
+	limit, err := ReadMemoryMax(dir)
+	require.NoError(t, err)
+	require.Equal(t, int64(1073741824), limit)
+
+	// The special value "max" means the cgroup has no memory limit, which is
+	// reported as -1.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "memory.max"), []byte("max\n"), 0644))
+	limit, err = ReadMemoryMax(dir)
+	require.NoError(t, err)
+	require.Equal(t, int64(-1), limit)
 }
 
 func TestParsePSI(t *testing.T) {

--- a/enterprise/server/remote_execution/cgroup/cgroup_test.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup_test.go
@@ -149,6 +149,21 @@ func TestReadMemoryMax(t *testing.T) {
 	require.Nil(t, limit)
 }
 
+func TestReadMemoryStatField(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "memory.stat"), []byte("anon 1024\nfile 2048\ninactive_file 512\n"), 0644))
+
+	// The requested field's value should be returned, ignoring other fields.
+	value, err := ReadMemoryStatField(dir, "inactive_file")
+	require.NoError(t, err)
+	require.Equal(t, int64(512), value)
+
+	// Requesting a field that is not present in memory.stat should return an
+	// error.
+	_, err = ReadMemoryStatField(dir, "nonexistent_field")
+	require.Error(t, err)
+}
+
 func TestParsePSI(t *testing.T) {
 	r := strings.NewReader(`some avg10=0.00 avg60=1.00 avg300=4.11 total=123456
 full avg10=0.01 avg60=0.50 avg300=1.23 total=23456

--- a/enterprise/server/remote_execution/executor/oomkiller/BUILD
+++ b/enterprise/server/remote_execution/executor/oomkiller/BUILD
@@ -1,5 +1,8 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# Keep gazelle from merging the VM test into the oomkiller_test target.
+# gazelle:exclude oomkiller_linux_vm_test.go
+
 package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
@@ -44,5 +47,30 @@ go_test(
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
+    ],
+)
+
+# Exercises the OOM killer against real cgroups. Runs in a firecracker microVM
+# so that the test can run as root and manage cgroups without affecting the
+# host.
+go_test(
+    name = "oomkiller_linux_vm_test",
+    srcs = ["oomkiller_linux_vm_test.go"],  # keep
+    embed = [":oomkiller"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.EstimatedMemory": "4GB",
+    },
+    tags = ["docker"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        # keep
+        "//enterprise/server/remote_execution/cgroup",
+        "//enterprise/server/remote_execution/oom",
+        "//proto:remote_execution_go_proto",
+        "//server/util/testing/flags",
+        "//server/util/uuid",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_sys//unix",
     ],
 )

--- a/enterprise/server/remote_execution/executor/oomkiller/BUILD
+++ b/enterprise/server/remote_execution/executor/oomkiller/BUILD
@@ -4,7 +4,11 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "oomkiller",
-    srcs = ["oomkiller.go"],
+    srcs = [
+        "oomkiller.go",
+        "oomkiller_linux.go",
+        "oomkiller_notlinux.go",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor/oomkiller",
     deps = [
         "//enterprise/server/remote_execution/executorplatform",
@@ -17,12 +21,20 @@ go_library(
         "//server/util/log",
         "//server/util/platform",
         "//server/util/status",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//enterprise/server/remote_execution/cgroup",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(
     name = "oomkiller_test",
-    srcs = ["oomkiller_test.go"],
+    srcs = [
+        "oomkiller_linux_test.go",
+        "oomkiller_test.go",
+    ],
     embed = [":oomkiller"],
     # TODO: enable this test on macOS once bare isolation type is supported.
     target_compatible_with = ["@platforms//os:linux"],

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
@@ -111,19 +111,23 @@ type MemoryMonitor interface {
 	Snapshot(ctx context.Context) (*MemorySnapshot, error)
 }
 
-// systemMemoryMonitor measures system-wide memory usage. It is used when
-// cgroup-based measurement is unavailable.
+// systemMemoryMonitor measures system-wide memory usage against total system
+// memory. It is used when cgroup-based measurement is unavailable or when the
+// executor cgroup has no memory limit.
 type systemMemoryMonitor struct{}
 
 func (systemMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
-	limitBytes := resources.GetAllocatedRAMBytes()
+	totalBytes, err := resources.GetSysTotalRAMBytes()
+	if err != nil {
+		return nil, fmt.Errorf("read system total memory: %w", err)
+	}
 	availableBytes, err := resources.GetSysFreeRAMBytes()
 	if err != nil {
 		return nil, fmt.Errorf("read system free memory: %w", err)
 	}
 	return &MemorySnapshot{
-		UsedBytes:      max(int64(0), limitBytes-availableBytes),
-		LimitBytes:     limitBytes,
+		UsedBytes:      totalBytes - availableBytes,
+		LimitBytes:     totalBytes,
 		AvailableBytes: availableBytes,
 	}, nil
 }

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
@@ -25,10 +25,6 @@ package oomkiller
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -115,61 +111,21 @@ type MemoryMonitor interface {
 	Snapshot(ctx context.Context) (*MemorySnapshot, error)
 }
 
-// NewMemoryMonitor returns the default executor memory monitor. cgroupPath is
-// the executor's starting cgroup path relative to the cgroupfs root. If empty,
-// the monitor uses system memory instead.
-func NewMemoryMonitor(cgroupPath string) MemoryMonitor {
-	if cgroupPath == "" {
-		return resourcesMemoryMonitor{}
-	}
-	cgroupPath = filepath.Join("/sys/fs/cgroup", cgroupPath)
-	monitor := &cgroupMemoryMonitor{
-		cgroupPath: cgroupPath,
-		limitBytes: resources.GetAllocatedRAMBytes(),
-	}
-	if _, err := monitor.readMemoryCurrent(); err != nil {
-		log.Warningf("Failed to read executor cgroup memory for OOM monitoring; falling back to system memory: %s", err)
-		return resourcesMemoryMonitor{}
-	}
-	return monitor
-}
+// systemMemoryMonitor measures system-wide memory usage. It is used when
+// cgroup-based measurement is unavailable.
+type systemMemoryMonitor struct{}
 
-type resourcesMemoryMonitor struct{}
-
-func (resourcesMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
+func (systemMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
 	limitBytes := resources.GetAllocatedRAMBytes()
-	availableBytes := resources.GetSysFreeRAMBytes()
+	availableBytes, err := resources.GetSysFreeRAMBytes()
+	if err != nil {
+		return nil, fmt.Errorf("read system free memory: %w", err)
+	}
 	return &MemorySnapshot{
 		UsedBytes:      max(int64(0), limitBytes-availableBytes),
 		LimitBytes:     limitBytes,
 		AvailableBytes: availableBytes,
 	}, nil
-}
-
-type cgroupMemoryMonitor struct {
-	cgroupPath string
-	limitBytes int64
-}
-
-func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
-	usedBytes, err := m.readMemoryCurrent()
-	if err != nil {
-		return nil, fmt.Errorf("read executor cgroup memory: %w", err)
-	}
-	usedBytes = max(int64(0), usedBytes)
-	return &MemorySnapshot{
-		UsedBytes:      usedBytes,
-		LimitBytes:     m.limitBytes,
-		AvailableBytes: max(int64(0), m.limitBytes-usedBytes),
-	}, nil
-}
-
-func (m *cgroupMemoryMonitor) readMemoryCurrent() (int64, error) {
-	b, err := os.ReadFile(filepath.Join(m.cgroupPath, "memory.current"))
-	if err != nil {
-		return 0, err
-	}
-	return strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
 }
 
 type killer struct {

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
@@ -114,20 +114,27 @@ type MemoryMonitor interface {
 // systemMemoryMonitor measures system-wide memory usage against total system
 // memory. It is used when cgroup-based measurement is unavailable or when the
 // executor cgroup has no memory limit.
-type systemMemoryMonitor struct{}
+type systemMemoryMonitor struct {
+	// totalBytes is the total system memory, read once at startup.
+	totalBytes int64
+}
 
-func (systemMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
+func newSystemMemoryMonitor() (*systemMemoryMonitor, error) {
 	totalBytes, err := resources.GetSysTotalRAMBytes()
 	if err != nil {
 		return nil, fmt.Errorf("read system total memory: %w", err)
 	}
+	return &systemMemoryMonitor{totalBytes: totalBytes}, nil
+}
+
+func (m *systemMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
 	availableBytes, err := resources.GetSysFreeRAMBytes()
 	if err != nil {
 		return nil, fmt.Errorf("read system free memory: %w", err)
 	}
 	return &MemorySnapshot{
-		UsedBytes:      totalBytes - availableBytes,
-		LimitBytes:     totalBytes,
+		UsedBytes:      m.totalBytes - availableBytes,
+		LimitBytes:     m.totalBytes,
 		AvailableBytes: availableBytes,
 	}, nil
 }

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller.go
@@ -25,6 +25,10 @@ package oomkiller
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -111,9 +115,23 @@ type MemoryMonitor interface {
 	Snapshot(ctx context.Context) (*MemorySnapshot, error)
 }
 
-// NewMemoryMonitor returns the default executor memory monitor.
-func NewMemoryMonitor() MemoryMonitor {
-	return resourcesMemoryMonitor{}
+// NewMemoryMonitor returns the default executor memory monitor. cgroupPath is
+// the executor's starting cgroup path relative to the cgroupfs root. If empty,
+// the monitor uses system memory instead.
+func NewMemoryMonitor(cgroupPath string) MemoryMonitor {
+	if cgroupPath == "" {
+		return resourcesMemoryMonitor{}
+	}
+	cgroupPath = filepath.Join("/sys/fs/cgroup", cgroupPath)
+	monitor := &cgroupMemoryMonitor{
+		cgroupPath: cgroupPath,
+		limitBytes: resources.GetAllocatedRAMBytes(),
+	}
+	if _, err := monitor.readMemoryCurrent(); err != nil {
+		log.Warningf("Failed to read executor cgroup memory for OOM monitoring; falling back to system memory: %s", err)
+		return resourcesMemoryMonitor{}
+	}
+	return monitor
 }
 
 type resourcesMemoryMonitor struct{}
@@ -126,6 +144,32 @@ func (resourcesMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, erro
 		LimitBytes:     limitBytes,
 		AvailableBytes: availableBytes,
 	}, nil
+}
+
+type cgroupMemoryMonitor struct {
+	cgroupPath string
+	limitBytes int64
+}
+
+func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
+	usedBytes, err := m.readMemoryCurrent()
+	if err != nil {
+		return nil, fmt.Errorf("read executor cgroup memory: %w", err)
+	}
+	usedBytes = max(int64(0), usedBytes)
+	return &MemorySnapshot{
+		UsedBytes:      usedBytes,
+		LimitBytes:     m.limitBytes,
+		AvailableBytes: max(int64(0), m.limitBytes-usedBytes),
+	}, nil
+}
+
+func (m *cgroupMemoryMonitor) readMemoryCurrent() (int64, error) {
+	b, err := os.ReadFile(filepath.Join(m.cgroupPath, "memory.current"))
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
 }
 
 type killer struct {

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -34,14 +34,14 @@ func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read cgroup memory limit: %w", err)
 	}
-	if limitBytes < 0 {
+	if limitBytes == nil {
 		log.Infof("Executor cgroup has no memory limit; the OOM killer will measure system memory usage.")
 		return systemMemoryMonitor{}, nil
 	}
-	log.Infof("Executor OOM killer is measuring memory usage of cgroup %q with effective memory limit %d bytes", cgroupPath, limitBytes)
+	log.Infof("Executor OOM killer is measuring memory usage of cgroup %q with effective memory limit %d bytes", cgroupPath, *limitBytes)
 	return &cgroupMemoryMonitor{
 		dir:        dir,
-		limitBytes: limitBytes,
+		limitBytes: *limitBytes,
 	}, nil
 }
 

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -63,9 +63,10 @@ func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, erro
 	}
 	// Exclude inactive page cache from usage, since the kernel reclaims it
 	// under memory pressure instead of OOM killing. This matches the "working
-	// set" definition that the kubelet uses for eviction decisions. Note that
-	// memory.current and memory.stat are read separately, so the subtraction
-	// can skew slightly negative under concurrent cache growth.
+	// set" definition that the kubelet uses for eviction decisions. See
+	// https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#memory-signals
+	// Note that memory.current and memory.stat are read separately, so the
+	// subtraction can skew slightly negative under concurrent cache growth.
 	inactiveFileBytes, err := cgroup.ReadMemoryStatField(m.dir, "inactive_file")
 	if err != nil {
 		return nil, fmt.Errorf("read executor cgroup memory stats: %w", err)

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -1,0 +1,60 @@
+//go:build linux && !android
+
+package oomkiller
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
+	"github.com/buildbuddy-io/buildbuddy/server/resources"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+// NewMemoryMonitor returns the default executor memory monitor. cgroupPath is
+// the executor's starting cgroup path relative to the cgroupfs root. The
+// monitor measures the cgroup's memory usage if the cgroup memory controller
+// is enabled, and system memory usage otherwise. An empty cgroupPath means the
+// cgroup is unknown or is the root cgroup, which also means system memory
+// usage.
+func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
+	if cgroupPath == "" {
+		return systemMemoryMonitor{}, nil
+	}
+	dir := filepath.Join(cgroup.RootPath, cgroupPath)
+	controllers, err := cgroup.EnabledControllers(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read enabled controllers for %q: %w", dir, err)
+	}
+	if !controllers["memory"] {
+		log.Infof("Executor cgroup does not have the memory controller enabled; the OOM killer will measure system memory usage.")
+		return systemMemoryMonitor{}, nil
+	}
+	log.Infof("Executor OOM killer is measuring memory usage of cgroup %q", cgroupPath)
+	return &cgroupMemoryMonitor{
+		dir:        dir,
+		limitBytes: resources.GetAllocatedRAMBytes(),
+	}, nil
+}
+
+// cgroupMemoryMonitor measures executor memory usage from a cgroup.
+type cgroupMemoryMonitor struct {
+	// dir is the absolute cgroupfs directory of the monitored cgroup.
+	dir string
+	// limitBytes is the executor memory limit.
+	limitBytes int64
+}
+
+func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
+	usedBytes, err := cgroup.ReadMemoryCurrent(m.dir)
+	if err != nil {
+		return nil, fmt.Errorf("read executor cgroup memory: %w", err)
+	}
+	usedBytes = max(int64(0), usedBytes)
+	return &MemorySnapshot{
+		UsedBytes:      usedBytes,
+		LimitBytes:     m.limitBytes,
+		AvailableBytes: max(int64(0), m.limitBytes-usedBytes),
+	}, nil
+}

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -51,7 +51,9 @@ func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, erro
 	if err != nil {
 		return nil, fmt.Errorf("read executor cgroup memory: %w", err)
 	}
-	usedBytes = max(int64(0), usedBytes)
+	if usedBytes < 0 {
+		return nil, fmt.Errorf("cgroup memory.current is negative (%d)", usedBytes)
+	}
 	return &MemorySnapshot{
 		UsedBytes:      usedBytes,
 		LimitBytes:     m.limitBytes,

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -5,6 +5,7 @@ package oomkiller
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
@@ -14,12 +15,24 @@ import (
 // NewMemoryMonitor returns the default executor memory monitor. cgroupPath is
 // the executor's starting cgroup path relative to the cgroupfs root. The
 // monitor measures the cgroup's memory usage against its effective memory
-// limit. If the cgroup is unknown (empty cgroupPath), does not have the memory
-// controller enabled, or has no memory limit, the monitor measures system
-// memory usage instead, since the executor is then bounded by system memory.
+// limit. If cgroup-based accounting is unavailable (cgroup v1, the real
+// cgroup v2 root, no memory controller, or no memory limit), the monitor
+// measures system memory usage instead, since the executor is then bounded by
+// system memory.
 func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 	if cgroupPath == "" {
-		return newSystemMemoryMonitor()
+		// The executor is at the cgroupfs root. Under a cgroup namespace
+		// (e.g. when the executor runs in a container), the root directory is
+		// really a non-root cgroup on the host and can be monitored like any
+		// other cgroup. The real cgroup v2 root (and cgroup v1) has no
+		// memory.current file, and system memory is the right measurement.
+		if _, err := os.Stat(filepath.Join(cgroup.RootPath, "memory.current")); err != nil {
+			if !os.IsNotExist(err) {
+				return nil, err
+			}
+			log.Infof("Executor is in the root cgroup; the OOM killer will measure system memory usage.")
+			return newSystemMemoryMonitor()
+		}
 	}
 	dir := filepath.Join(cgroup.RootPath, cgroupPath)
 	controllers, err := cgroup.EnabledControllers(dir)

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -54,13 +54,23 @@ type cgroupMemoryMonitor struct {
 }
 
 func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
-	usedBytes, err := cgroup.ReadMemoryCurrent(m.dir)
+	currentBytes, err := cgroup.ReadMemoryCurrent(m.dir)
 	if err != nil {
 		return nil, fmt.Errorf("read executor cgroup memory: %w", err)
 	}
-	if usedBytes < 0 {
-		return nil, fmt.Errorf("cgroup memory.current is negative (%d)", usedBytes)
+	if currentBytes < 0 {
+		return nil, fmt.Errorf("cgroup memory.current is negative (%d)", currentBytes)
 	}
+	// Exclude inactive page cache from usage, since the kernel reclaims it
+	// under memory pressure instead of OOM killing. This matches the "working
+	// set" definition that the kubelet uses for eviction decisions. Note that
+	// memory.current and memory.stat are read separately, so the subtraction
+	// can skew slightly negative under concurrent cache growth.
+	inactiveFileBytes, err := cgroup.ReadMemoryStatField(m.dir, "inactive_file")
+	if err != nil {
+		return nil, fmt.Errorf("read executor cgroup memory stats: %w", err)
+	}
+	usedBytes := max(int64(0), currentBytes-inactiveFileBytes)
 	return &MemorySnapshot{
 		UsedBytes:      usedBytes,
 		LimitBytes:     m.limitBytes,

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -8,16 +8,15 @@ import (
 	"path/filepath"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
-	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
 // NewMemoryMonitor returns the default executor memory monitor. cgroupPath is
 // the executor's starting cgroup path relative to the cgroupfs root. The
-// monitor measures the cgroup's memory usage if the cgroup memory controller
-// is enabled, and system memory usage otherwise. An empty cgroupPath means the
-// cgroup is unknown or is the root cgroup, which also means system memory
-// usage.
+// monitor measures the cgroup's memory usage against its effective memory
+// limit. If the cgroup is unknown (empty cgroupPath), does not have the memory
+// controller enabled, or has no memory limit, the monitor measures system
+// memory usage instead, since the executor is then bounded by system memory.
 func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 	if cgroupPath == "" {
 		return systemMemoryMonitor{}, nil
@@ -31,10 +30,18 @@ func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 		log.Infof("Executor cgroup does not have the memory controller enabled; the OOM killer will measure system memory usage.")
 		return systemMemoryMonitor{}, nil
 	}
-	log.Infof("Executor OOM killer is measuring memory usage of cgroup %q", cgroupPath)
+	limitBytes, err := cgroup.ReadEffectiveMemoryLimit(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read cgroup memory limit: %w", err)
+	}
+	if limitBytes < 0 {
+		log.Infof("Executor cgroup has no memory limit; the OOM killer will measure system memory usage.")
+		return systemMemoryMonitor{}, nil
+	}
+	log.Infof("Executor OOM killer is measuring memory usage of cgroup %q with effective memory limit %d bytes", cgroupPath, limitBytes)
 	return &cgroupMemoryMonitor{
 		dir:        dir,
-		limitBytes: resources.GetAllocatedRAMBytes(),
+		limitBytes: limitBytes,
 	}, nil
 }
 
@@ -42,7 +49,7 @@ func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 type cgroupMemoryMonitor struct {
 	// dir is the absolute cgroupfs directory of the monitored cgroup.
 	dir string
-	// limitBytes is the executor memory limit.
+	// limitBytes is the effective memory limit of the monitored cgroup.
 	limitBytes int64
 }
 

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -54,27 +54,35 @@ type cgroupMemoryMonitor struct {
 }
 
 func (m *cgroupMemoryMonitor) Snapshot(_ context.Context) (*MemorySnapshot, error) {
-	currentBytes, err := cgroup.ReadMemoryCurrent(m.dir)
+	usedBytes, err := getCgroupWorkingSetMemoryBytes(m.dir)
 	if err != nil {
 		return nil, fmt.Errorf("read executor cgroup memory: %w", err)
 	}
-	if currentBytes < 0 {
-		return nil, fmt.Errorf("cgroup memory.current is negative (%d)", currentBytes)
-	}
-	// Exclude inactive page cache from usage, since the kernel reclaims it
-	// under memory pressure instead of OOM killing. This matches the "working
-	// set" definition that the kubelet uses for eviction decisions. See
-	// https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#memory-signals
-	// Note that memory.current and memory.stat are read separately, so the
-	// subtraction can skew slightly negative under concurrent cache growth.
-	inactiveFileBytes, err := cgroup.ReadMemoryStatField(m.dir, "inactive_file")
-	if err != nil {
-		return nil, fmt.Errorf("read executor cgroup memory stats: %w", err)
-	}
-	usedBytes := max(int64(0), currentBytes-inactiveFileBytes)
 	return &MemorySnapshot{
 		UsedBytes:      usedBytes,
 		LimitBytes:     m.limitBytes,
 		AvailableBytes: max(int64(0), m.limitBytes-usedBytes),
 	}, nil
+}
+
+// getCgroupWorkingSetMemoryBytes returns the memory usage of the cgroup at the
+// given cgroupfs directory, excluding inactive page cache, which the kernel
+// reclaims under memory pressure instead of OOM killing. This matches the
+// "working set" definition that the kubelet uses for eviction decisions. See
+// https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#memory-signals
+func getCgroupWorkingSetMemoryBytes(dir string) (int64, error) {
+	currentBytes, err := cgroup.ReadMemoryCurrent(dir)
+	if err != nil {
+		return 0, err
+	}
+	if currentBytes < 0 {
+		return 0, fmt.Errorf("cgroup memory.current is negative (%d)", currentBytes)
+	}
+	inactiveFileBytes, err := cgroup.ReadMemoryStatField(dir, "inactive_file")
+	if err != nil {
+		return 0, fmt.Errorf("read memory stats: %w", err)
+	}
+	// memory.current and memory.stat are read separately, so the subtraction
+	// can skew slightly negative under concurrent cache growth.
+	return max(int64(0), currentBytes-inactiveFileBytes), nil
 }

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux.go
@@ -19,7 +19,7 @@ import (
 // memory usage instead, since the executor is then bounded by system memory.
 func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 	if cgroupPath == "" {
-		return systemMemoryMonitor{}, nil
+		return newSystemMemoryMonitor()
 	}
 	dir := filepath.Join(cgroup.RootPath, cgroupPath)
 	controllers, err := cgroup.EnabledControllers(dir)
@@ -28,7 +28,7 @@ func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 	}
 	if !controllers["memory"] {
 		log.Infof("Executor cgroup does not have the memory controller enabled; the OOM killer will measure system memory usage.")
-		return systemMemoryMonitor{}, nil
+		return newSystemMemoryMonitor()
 	}
 	limitBytes, err := cgroup.ReadEffectiveMemoryLimit(dir)
 	if err != nil {
@@ -36,7 +36,7 @@ func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
 	}
 	if limitBytes == nil {
 		log.Infof("Executor cgroup has no memory limit; the OOM killer will measure system memory usage.")
-		return systemMemoryMonitor{}, nil
+		return newSystemMemoryMonitor()
 	}
 	log.Infof("Executor OOM killer is measuring memory usage of cgroup %q with effective memory limit %d bytes", cgroupPath, *limitBytes)
 	return &cgroupMemoryMonitor{

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
@@ -13,13 +13,30 @@ import (
 func TestCgroupMemoryMonitorSnapshot(t *testing.T) {
 	cgroupDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("750"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("anon 500\ninactive_file 200\n"), 0644))
 	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
 
-	// The monitor should report usage from the executor cgroup and calculate
-	// the remaining headroom relative to the cgroup memory limit.
+	// The monitor should report usage from the executor cgroup, excluding
+	// inactive page cache since the kernel reclaims it under memory pressure,
+	// and calculate the remaining headroom relative to the cgroup memory
+	// limit.
 	snapshot, err := monitor.Snapshot(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, &MemorySnapshot{UsedBytes: 750, LimitBytes: 1000, AvailableBytes: 250}, snapshot)
+	require.Equal(t, &MemorySnapshot{UsedBytes: 550, LimitBytes: 1000, AvailableBytes: 450}, snapshot)
+}
+
+func TestCgroupMemoryMonitorSnapshot_InactiveFileAboveCurrent(t *testing.T) {
+	cgroupDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("100"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("inactive_file 150\n"), 0644))
+	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
+
+	// memory.current and memory.stat are read separately, so inactive page
+	// cache can momentarily exceed the earlier memory.current reading. Clamp
+	// the reported usage to zero instead of going negative.
+	snapshot, err := monitor.Snapshot(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, &MemorySnapshot{UsedBytes: 0, LimitBytes: 1000, AvailableBytes: 1000}, snapshot)
 }
 
 func TestCgroupMemoryMonitorSnapshot_NegativeUsage(t *testing.T) {
@@ -37,6 +54,7 @@ func TestCgroupMemoryMonitorSnapshot_NegativeUsage(t *testing.T) {
 func TestCgroupMemoryMonitorSnapshot_UsageAboveLimit(t *testing.T) {
 	cgroupDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("1250"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.stat"), []byte("inactive_file 100\n"), 0644))
 	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
 
 	// If usage somehow exceeds the memory limit, preserve the observed usage
@@ -44,5 +62,5 @@ func TestCgroupMemoryMonitorSnapshot_UsageAboveLimit(t *testing.T) {
 	// zero.
 	snapshot, err := monitor.Snapshot(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, &MemorySnapshot{UsedBytes: 1250, LimitBytes: 1000, AvailableBytes: 0}, snapshot)
+	require.Equal(t, &MemorySnapshot{UsedBytes: 1150, LimitBytes: 1000, AvailableBytes: 0}, snapshot)
 }

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
@@ -1,0 +1,36 @@
+//go:build linux && !android
+
+package oomkiller
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCgroupMemoryMonitorSnapshot(t *testing.T) {
+	cgroupDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("750"), 0644))
+	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
+
+	// The monitor should report usage from the executor cgroup and calculate
+	// the remaining headroom relative to the configured executor limit.
+	snapshot, err := monitor.Snapshot(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, &MemorySnapshot{UsedBytes: 750, LimitBytes: 1000, AvailableBytes: 250}, snapshot)
+}
+
+func TestCgroupMemoryMonitorSnapshot_UsageAboveLimit(t *testing.T) {
+	cgroupDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("1250"), 0644))
+	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
+
+	// Cgroup usage can exceed the executor's assignable memory. Preserve the
+	// observed usage so the killer remains over threshold, but clamp the
+	// reported headroom to zero.
+	snapshot, err := monitor.Snapshot(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, &MemorySnapshot{UsedBytes: 1250, LimitBytes: 1000, AvailableBytes: 0}, snapshot)
+}

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
@@ -16,7 +16,7 @@ func TestCgroupMemoryMonitorSnapshot(t *testing.T) {
 	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
 
 	// The monitor should report usage from the executor cgroup and calculate
-	// the remaining headroom relative to the configured executor limit.
+	// the remaining headroom relative to the cgroup memory limit.
 	snapshot, err := monitor.Snapshot(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, &MemorySnapshot{UsedBytes: 750, LimitBytes: 1000, AvailableBytes: 250}, snapshot)
@@ -39,9 +39,9 @@ func TestCgroupMemoryMonitorSnapshot_UsageAboveLimit(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("1250"), 0644))
 	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
 
-	// Cgroup usage can exceed the executor's assignable memory. Preserve the
-	// observed usage so the killer remains over threshold, but clamp the
-	// reported headroom to zero.
+	// If usage somehow exceeds the memory limit, preserve the observed usage
+	// so the killer remains over threshold, but clamp the reported headroom to
+	// zero.
 	snapshot, err := monitor.Snapshot(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, &MemorySnapshot{UsedBytes: 1250, LimitBytes: 1000, AvailableBytes: 0}, snapshot)

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_test.go
@@ -22,6 +22,18 @@ func TestCgroupMemoryMonitorSnapshot(t *testing.T) {
 	require.Equal(t, &MemorySnapshot{UsedBytes: 750, LimitBytes: 1000, AvailableBytes: 250}, snapshot)
 }
 
+func TestCgroupMemoryMonitorSnapshot_NegativeUsage(t *testing.T) {
+	cgroupDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("-5"), 0644))
+	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1000}
+
+	// The kernel never reports negative memory usage, so a negative value
+	// means the read went wrong somehow. Report an error instead of feeding a
+	// bogus measurement to the killer.
+	_, err := monitor.Snapshot(t.Context())
+	require.ErrorContains(t, err, "negative")
+}
+
 func TestCgroupMemoryMonitorSnapshot_UsageAboveLimit(t *testing.T) {
 	cgroupDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.current"), []byte("1250"), 0644))

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
@@ -149,6 +149,24 @@ func TestVMNewMemoryMonitorUsesEffectiveLimitFromAncestors(t *testing.T) {
 	require.Equal(t, int64(268435456), cgroupMonitor.limitBytes)
 }
 
+func TestVMReadEffectiveMemoryLimitTreatsRealRootAsUnlimited(t *testing.T) {
+	// The real cgroup v2 root has no memory.max file. The effective limit
+	// walk should treat it as unlimited rather than returning an error.
+	limit, err := cgroup.ReadEffectiveMemoryLimit(cgroup.RootPath)
+	require.NoError(t, err)
+	require.Nil(t, limit)
+}
+
+func TestVMNewMemoryMonitorAtRealRootUsesSystemMemory(t *testing.T) {
+	// An empty cgroup path means the executor is at the cgroupfs root. The VM
+	// root cgroup is a real cgroup v2 root with no memory accounting files,
+	// so the monitor should measure system memory.
+	monitor, err := NewMemoryMonitor("")
+	require.NoError(t, err)
+	_, ok := monitor.(*systemMemoryMonitor)
+	require.True(t, ok, "expected a system memory monitor, got %T", monitor)
+}
+
 // setupTestCgroup creates a cgroup with the memory controller enabled and
 // returns its absolute cgroupfs directory. The cgroup and any processes still
 // running in it are cleaned up when the test finishes.

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
@@ -1,0 +1,219 @@
+//go:build linux && !android
+
+package oomkiller
+
+// The tests in this file exercise the OOM killer against real cgroups. They
+// run as root in their own VM via the firecracker workload isolation
+// configured on the oomkiller_linux_vm_test target.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/oom"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestVMCgroupMemoryMonitorCountsTmpfsAsUsed(t *testing.T) {
+	cgroupDir := setupTestCgroup(t)
+
+	// Mount a tmpfs. Files written to it are backed by memory that the kernel
+	// cannot reclaim under memory pressure (there is no swap).
+	mnt := filepath.Join(t.TempDir(), "tmpfs")
+	require.NoError(t, os.Mkdir(mnt, 0755))
+	require.NoError(t, unix.Mount("tmpfs", mnt, "tmpfs", 0, "size=256m"))
+	t.Cleanup(func() { require.NoError(t, unix.Unmount(mnt, 0)) })
+
+	// Write a 100MB file to the tmpfs from inside the cgroup. The tmpfs pages
+	// are charged to the cgroup that allocated them and stay charged after the
+	// writing process exits.
+	cmd, _ := startBashInCgroup(t, cgroupDir, fmt.Sprintf("dd if=/dev/zero of=%s/f bs=1M count=100", mnt))
+	require.NoError(t, cmd.Wait())
+
+	// tmpfs memory is not reclaimable, so the monitor should count the whole
+	// file as used.
+	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1 << 30}
+	snapshot, err := monitor.Snapshot(t.Context())
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, snapshot.UsedBytes, int64(100<<20))
+}
+
+func TestVMCgroupMemoryMonitorExcludesPageCache(t *testing.T) {
+	cgroupDir := setupTestCgroup(t)
+
+	// This test needs a disk-backed scratch directory so that file writes
+	// produce page cache rather than tmpfs memory. Firecracker VMs place the
+	// test scratch dir on a disk-backed workspace filesystem.
+	scratchDir := t.TempDir()
+	var st unix.Statfs_t
+	require.NoError(t, unix.Statfs(scratchDir, &st))
+	require.NotEqual(t, int64(unix.TMPFS_MAGIC), st.Type, "scratch dir %s is on tmpfs; expected a disk-backed filesystem", scratchDir)
+
+	// Write a 100MB file to disk from inside the cgroup, syncing at the end so
+	// that the cached pages are clean. The page cache is charged to the cgroup
+	// and stays charged after the writing process exits.
+	cmd, _ := startBashInCgroup(t, cgroupDir, fmt.Sprintf("dd if=/dev/zero of=%s/f bs=1M count=100 conv=fsync", scratchDir))
+	require.NoError(t, cmd.Wait())
+
+	// Confirm the page cache was actually charged to the cgroup, so that the
+	// working set assertion below can't pass vacuously.
+	currentBytes, err := cgroup.ReadMemoryCurrent(cgroupDir)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, currentBytes, int64(100<<20))
+
+	// Clean page cache is reclaimable under memory pressure, so the monitor
+	// should exclude it from the reported usage.
+	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 1 << 30}
+	snapshot, err := monitor.Snapshot(t.Context())
+	require.NoError(t, err)
+	require.Less(t, snapshot.UsedBytes, int64(50<<20))
+}
+
+func TestVMKillerKillsTaskWhenCgroupMemoryIsExhausted(t *testing.T) {
+	cgroupDir := setupTestCgroup(t)
+	ctx := t.Context()
+
+	flags.Set(t, "executor.oom_killer.enabled", true)
+	flags.Set(t, "executor.oom_killer.poll_interval", 100*time.Millisecond)
+	flags.Set(t, "executor.oom_killer.memory_usage_threshold", 0.9)
+	flags.Set(t, "executor.enable_oci", true)
+
+	// Give the monitor an artificial 100MB limit instead of setting memory.max
+	// on the cgroup. The killer must act before the limit is reached, so this
+	// exercises the same logic without racing the kernel OOM killer.
+	monitor := &cgroupMemoryMonitor{dir: cgroupDir, limitBytes: 100 << 20}
+	oomKiller, err := New(ctx, monitor)
+	require.NoError(t, err)
+
+	task := &vmTestTask{killed: make(chan error, 1)}
+	unregister := oomKiller.Register(ctx, task)
+	defer unregister()
+
+	// Allocate ~95MB of anonymous memory inside the cgroup and hold it by
+	// blocking on stdin, pushing usage over the 90% kill threshold.
+	_, stdin := startBashInCgroup(t, cgroupDir, `data=$(head -c 95000000 /dev/zero | tr '\0' x) && read -r _`)
+	defer stdin.Close()
+
+	// The killer should terminate the registered task with an OOM error.
+	select {
+	case err := <-task.killed:
+		require.True(t, oom.IsError(err), "expected an OOM error, got: %s", err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("task was not killed by the OOM killer")
+	}
+}
+
+func TestVMNewMemoryMonitorReadsCgroupLimit(t *testing.T) {
+	cgroupDir := setupTestCgroup(t)
+
+	// Set a memory limit on the cgroup. NewMemoryMonitor should detect the
+	// enabled memory controller and pick up the limit.
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "memory.max"), []byte("536870912"), 0))
+	monitor, err := NewMemoryMonitor(filepath.Base(cgroupDir))
+	require.NoError(t, err)
+	cgroupMonitor, ok := monitor.(*cgroupMemoryMonitor)
+	require.True(t, ok, "expected a cgroup memory monitor, got %T", monitor)
+	require.Equal(t, int64(536870912), cgroupMonitor.limitBytes)
+}
+
+func TestVMNewMemoryMonitorUsesEffectiveLimitFromAncestors(t *testing.T) {
+	parentDir := setupTestCgroup(t)
+	childDir := filepath.Join(parentDir, "child")
+	require.NoError(t, os.Mkdir(childDir, 0755))
+	t.Cleanup(func() { require.NoError(t, os.Remove(childDir)) })
+	require.NoError(t, cgroup.EnableController(childDir, "memory"))
+
+	// Give the parent cgroup a smaller memory limit than the child. The
+	// kernel enforces the parent limit on the child's memory usage, so the
+	// monitor should use the parent limit as the effective limit.
+	require.NoError(t, os.WriteFile(filepath.Join(parentDir, "memory.max"), []byte("268435456"), 0))
+	require.NoError(t, os.WriteFile(filepath.Join(childDir, "memory.max"), []byte("536870912"), 0))
+
+	monitor, err := NewMemoryMonitor(filepath.Join(filepath.Base(parentDir), "child"))
+	require.NoError(t, err)
+	cgroupMonitor, ok := monitor.(*cgroupMemoryMonitor)
+	require.True(t, ok, "expected a cgroup memory monitor, got %T", monitor)
+	require.Equal(t, int64(268435456), cgroupMonitor.limitBytes)
+}
+
+// setupTestCgroup creates a cgroup with the memory controller enabled and
+// returns its absolute cgroupfs directory. The cgroup and any processes still
+// running in it are cleaned up when the test finishes.
+func setupTestCgroup(t *testing.T) string {
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root to manage cgroups")
+	}
+	dir := filepath.Join(cgroup.RootPath, "oomkiller-test-"+uuid.New())
+	require.NoError(t, os.Mkdir(dir, 0755))
+	t.Cleanup(func() {
+		// Kill anything still running in the cgroup. Removal fails until the
+		// kernel has finished tearing down the cgroup, so retry briefly.
+		_ = os.WriteFile(filepath.Join(dir, "cgroup.kill"), []byte("1"), 0)
+		var err error
+		for range 100 {
+			if err = os.Remove(dir); err == nil {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		t.Errorf("remove test cgroup: %s", err)
+	})
+	require.NoError(t, cgroup.EnableController(dir, "memory"))
+	return dir
+}
+
+// startBashInCgroup starts a bash script in the given cgroup. The script only
+// begins executing after the process has been moved into the cgroup. Closing
+// the returned stdin pipe unblocks any trailing "read" in the script.
+func startBashInCgroup(t *testing.T, cgroupDir, script string) (*exec.Cmd, io.WriteCloser) {
+	// Block on a stdin read first so that we can move the process into the
+	// cgroup before it does any work.
+	cmd := exec.Command("bash", "-c", "read -r _ && "+script)
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = stdin.Close()
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupDir, "cgroup.procs"), []byte(strconv.Itoa(cmd.Process.Pid)), 0))
+	_, err = io.WriteString(stdin, "\n")
+	require.NoError(t, err)
+	return cmd, stdin
+}
+
+type vmTestTask struct {
+	killed chan error
+}
+
+func (f *vmTestTask) State(ctx context.Context) (*TaskState, error) {
+	return &TaskState{
+		EstimatedMemoryBytes: 1,
+		StartedAt:            time.Now(),
+		Active:               true,
+		UsageStats:           &repb.UsageStats{MemoryBytes: 50 << 20},
+	}, nil
+}
+
+func (f *vmTestTask) Kill(ctx context.Context, err error) {
+	select {
+	case f.killed <- err:
+	default:
+	}
+}

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_linux_vm_test.go
@@ -149,14 +149,6 @@ func TestVMNewMemoryMonitorUsesEffectiveLimitFromAncestors(t *testing.T) {
 	require.Equal(t, int64(268435456), cgroupMonitor.limitBytes)
 }
 
-func TestVMReadEffectiveMemoryLimitTreatsRealRootAsUnlimited(t *testing.T) {
-	// The real cgroup v2 root has no memory.max file. The effective limit
-	// walk should treat it as unlimited rather than returning an error.
-	limit, err := cgroup.ReadEffectiveMemoryLimit(cgroup.RootPath)
-	require.NoError(t, err)
-	require.Nil(t, limit)
-}
-
 func TestVMNewMemoryMonitorAtRealRootUsesSystemMemory(t *testing.T) {
 	// An empty cgroup path means the executor is at the cgroupfs root. The VM
 	// root cgroup is a real cgroup v2 root with no memory accounting files,

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_notlinux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_notlinux.go
@@ -5,5 +5,5 @@ package oomkiller
 // NewMemoryMonitor returns the default executor memory monitor. cgroupPath is
 // unused on non-linux platforms; the monitor measures system memory usage.
 func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
-	return systemMemoryMonitor{}, nil
+	return newSystemMemoryMonitor()
 }

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_notlinux.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_notlinux.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package oomkiller
+
+// NewMemoryMonitor returns the default executor memory monitor. cgroupPath is
+// unused on non-linux platforms; the monitor measures system memory usage.
+func NewMemoryMonitor(cgroupPath string) (MemoryMonitor, error) {
+	return systemMemoryMonitor{}, nil
+}

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_test.go
@@ -2,8 +2,6 @@ package oomkiller
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -16,31 +14,6 @@ import (
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
-
-func TestCgroupMemoryMonitorSnapshot(t *testing.T) {
-	cgroupPath := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "memory.current"), []byte("750"), 0644))
-	monitor := &cgroupMemoryMonitor{cgroupPath: cgroupPath, limitBytes: 1000}
-
-	// The monitor should report usage from the executor cgroup and calculate
-	// the remaining headroom relative to the configured executor limit.
-	snapshot, err := monitor.Snapshot(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, &MemorySnapshot{UsedBytes: 750, LimitBytes: 1000, AvailableBytes: 250}, snapshot)
-}
-
-func TestCgroupMemoryMonitorSnapshot_UsageAboveLimit(t *testing.T) {
-	cgroupPath := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "memory.current"), []byte("1250"), 0644))
-	monitor := &cgroupMemoryMonitor{cgroupPath: cgroupPath, limitBytes: 1000}
-
-	// Cgroup usage can exceed the executor's assignable memory. Preserve the
-	// observed usage so the killer remains over threshold, but clamp the
-	// reported headroom to zero.
-	snapshot, err := monitor.Snapshot(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, &MemorySnapshot{UsedBytes: 1250, LimitBytes: 1000, AvailableBytes: 0}, snapshot)
-}
 
 func TestKillerKillsTaskIfOutOfMemory(t *testing.T) {
 	ctx := t.Context()

--- a/enterprise/server/remote_execution/executor/oomkiller/oomkiller_test.go
+++ b/enterprise/server/remote_execution/executor/oomkiller/oomkiller_test.go
@@ -2,6 +2,8 @@ package oomkiller
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -14,6 +16,31 @@ import (
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
+
+func TestCgroupMemoryMonitorSnapshot(t *testing.T) {
+	cgroupPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "memory.current"), []byte("750"), 0644))
+	monitor := &cgroupMemoryMonitor{cgroupPath: cgroupPath, limitBytes: 1000}
+
+	// The monitor should report usage from the executor cgroup and calculate
+	// the remaining headroom relative to the configured executor limit.
+	snapshot, err := monitor.Snapshot(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, &MemorySnapshot{UsedBytes: 750, LimitBytes: 1000, AvailableBytes: 250}, snapshot)
+}
+
+func TestCgroupMemoryMonitorSnapshot_UsageAboveLimit(t *testing.T) {
+	cgroupPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cgroupPath, "memory.current"), []byte("1250"), 0644))
+	monitor := &cgroupMemoryMonitor{cgroupPath: cgroupPath, limitBytes: 1000}
+
+	// Cgroup usage can exceed the executor's assignable memory. Preserve the
+	// observed usage so the killer remains over threshold, but clamp the
+	// reported headroom to zero.
+	snapshot, err := monitor.Snapshot(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, &MemorySnapshot{UsedBytes: 1250, LimitBytes: 1000, AvailableBytes: 0}, snapshot)
+}
 
 func TestKillerKillsTaskIfOutOfMemory(t *testing.T) {
 	ctx := t.Context()

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -173,10 +173,12 @@ func Configure(mmapLRUEnabled bool) error {
 	return nil
 }
 
-func GetSysFreeRAMBytes() int64 {
+func GetSysFreeRAMBytes() (int64, error) {
 	mem := gosigar.Mem{}
-	mem.Get()
-	return int64(mem.ActualFree)
+	if err := mem.Get(); err != nil {
+		return 0, fmt.Errorf("get memory info: %w", err)
+	}
+	return int64(mem.ActualFree), nil
 }
 
 func GetAllocatedRAMBytes() int64 {

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -173,6 +173,16 @@ func Configure(mmapLRUEnabled bool) error {
 	return nil
 }
 
+// GetSysTotalRAMBytes returns the total system memory. Note that in a
+// container this reflects the host, not the container's cgroup.
+func GetSysTotalRAMBytes() (int64, error) {
+	mem := gosigar.Mem{}
+	if err := mem.Get(); err != nil {
+		return 0, fmt.Errorf("get memory info: %w", err)
+	}
+	return int64(mem.Total), nil
+}
+
 // GetSysFreeRAMBytes returns the system memory available to new workloads,
 // including reclaimable page cache (MemAvailable from /proc/meminfo), not
 // strictly free memory. Note that in a container this reflects the host, not

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -173,6 +173,10 @@ func Configure(mmapLRUEnabled bool) error {
 	return nil
 }
 
+// GetSysFreeRAMBytes returns the system memory available to new workloads,
+// including reclaimable page cache (MemAvailable from /proc/meminfo), not
+// strictly free memory. Note that in a container this reflects the host, not
+// the container's cgroup.
 func GetSysFreeRAMBytes() (int64, error) {
 	mem := gosigar.Mem{}
 	if err := mem.Get(); err != nil {


### PR DESCRIPTION
Before, we computed memory usage fraction as `max(0, schedulable_memory - sys_free_memory) / schedulable_memory` which might never quite reach 0.95 (the OOM kill threshold) if the system has enough free memory outside of the executor cgroup.

This PR changes the calculation to:
- If the current cgroup has an effective memory limit (i.e. `memory.max` is set on either the current cgroup or an ancestor cgroup), then use `(cgroup_current_memory - cgroup_inactive_file_memory) / cgroup_effective_memory_limit`
- Otherwise, use `used_memory / total_memory`

This `cgroup_current_memory - cgroup_inactive_file_memory` calculation is inspired by the k8s "working set" memory calculation which is what it uses to determine whether a node is low on memory before it starts evicting pods. Inactive page cache is reclaimable under memory pressure, so it shouldn't count toward usage. We subtract `inactive_file` specifically, rather than the whole `file` stat, because `file` also includes tmpfs/shmem, which can't be reclaimed (tmpfs has no backing file and can only be swapped, and executors run without swap), and because active page cache is the hot set that the kernel keeps under pressure, so it counts as used.

Edge case: on cgroup v1, the executor can't determine its cgroup (only v2 is supported), so it logs a warning and uses the system memory calculation.

This PR also introduces integration tests that run under firecracker. I figure it's worth having these tests because kernel memory management is pretty complex and the cost of getting this behavior wrong is pretty high (we could be over-killing tasks or under-killing tasks)