### PR TITLE
[WF] Support linking already-installed GH app from our UI

### DIFF
--- a/enterprise/app/workflows/BUILD
+++ b/enterprise/app/workflows/BUILD
@@ -72,6 +72,7 @@ ts_library(
         "//:node_modules/@types/react",
         "//:node_modules/lucide-react",
         "//:node_modules/react",
+        "//:node_modules/tslib",
         "//app/alert:alert_service",
         "//app/auth:user",
         "//app/components/banner",

--- a/enterprise/app/workflows/github_app_import.tsx
+++ b/enterprise/app/workflows/github_app_import.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronsDown, ExternalLink } from "lucide-react";
+import { Check, ChevronsDown, Download, ExternalLink, RefreshCw } from "lucide-react";
 import React from "react";
 import alertService from "../../../app/alert/alert_service";
 import { User } from "../../../app/auth/user";
@@ -24,6 +24,8 @@ type GitHubAppImportProps = {
 type State = {
   installationsResponse: github.GetAppInstallationsResponse | null;
   installationsLoading: boolean;
+  installationsFromGitHubResponse: github.GetGithubUserInstallationsResponse | null;
+  installationsFromGitHubLoading: boolean;
 
   accessibleReposResponse: github.GetAccessibleReposResponse | null;
   accessibleReposLoading: boolean;
@@ -37,6 +39,9 @@ type State = {
 
   linkRequest: github.ILinkRepoRequest | null;
   linkLoading: boolean;
+
+  importInstallationRequest: github.UserInstallation | null;
+  importInstallationLoading: boolean;
 };
 
 const SEARCH_DEBOUNCE_DURATION_MS = 250;
@@ -50,6 +55,8 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
   state: State = {
     installationsLoading: false,
     installationsResponse: null,
+    installationsFromGitHubLoading: false,
+    installationsFromGitHubResponse: null,
 
     accessibleReposResponse: null,
     accessibleReposLoading: false,
@@ -63,9 +70,13 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
 
     linkLoading: false,
     linkRequest: null,
+
+    importInstallationLoading: false,
+    importInstallationRequest: null,
   };
 
   private fetchInstallationsRPC?: CancelablePromise;
+  private fetchInstallationsFromGitHubRPC?: CancelablePromise;
   private linkedReposRPC?: CancelablePromise;
   private searchRPC?: CancelablePromise;
 
@@ -81,9 +92,12 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
   /** Fetches installations from GitHub as well as BB-linked repos. */
   private fetch() {
     this.fetchInstallationsRPC?.cancel();
+    this.fetchInstallationsFromGitHubRPC?.cancel();
     this.setState({
       installationsLoading: false,
       installationsResponse: null,
+      installationsFromGitHubLoading: false,
+      installationsFromGitHubResponse: null,
       linkedReposLoading: false,
       linkedReposResponse: null,
     });
@@ -93,16 +107,33 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
     this.fetchInstallationsRPC = rpcService.service
       .getGitHubAppInstallations(new github.GetAppInstallationsRequest())
       .then((response) => {
-        this.setState({
-          installationsResponse: response,
-          selectedInstallation:
-            response.installations.find(
-              (installation) => installation.owner === this.state.selectedInstallation?.owner
-            ) || response.installations[0],
-        });
-        if (response.installations?.length) this.search();
+        const selectedInstallation =
+          response.installations.find(
+            (installation) => installation.owner === this.state.selectedInstallation?.owner
+          ) ||
+          response.installations[0] ||
+          null;
+        this.setState(
+          {
+            installationsResponse: response,
+            selectedInstallation,
+          },
+          () => {
+            if (selectedInstallation) {
+              this.search();
+            } else {
+              // If no app installations have been imported to BuildBuddy,
+              // query GitHub (through a BB API) to fetch installations that the user has installed,
+              // and prompt the user to import them to BuildBuddy.
+              this.fetchInstallationsFromGitHub();
+            }
+          }
+        );
       })
-      .catch((e) => errorService.handleError(e))
+      .catch((e) => {
+        errorService.handleError(e);
+        this.fetchInstallationsFromGitHub();
+      })
       .finally(() => this.setState({ installationsLoading: false }));
 
     this.setState({ linkedReposLoading: true });
@@ -112,6 +143,23 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
       .then((response) => this.setState({ linkedReposResponse: response }))
       .catch((e) => errorService.handleError(e))
       .finally(() => this.setState({ linkedReposLoading: false }));
+  }
+
+  private fetchInstallationsFromGitHub() {
+    this.fetchInstallationsFromGitHubRPC?.cancel();
+    this.setState({
+      installationsFromGitHubLoading: true,
+      installationsFromGitHubResponse: null,
+    });
+    this.fetchInstallationsFromGitHubRPC = rpcService.service
+      .getGithubUserInstallations(new github.GetGithubUserInstallationsRequest())
+      .then((response) => {
+        this.setState({
+          installationsFromGitHubResponse: response,
+        });
+      })
+      .catch((e) => errorService.handleError(e))
+      .finally(() => this.setState({ installationsFromGitHubLoading: false }));
   }
 
   private search() {
@@ -181,6 +229,83 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
         window.location.href = path;
       })
       .catch((e) => errorService.handleError(e));
+  }
+
+  private onClickImportInstallation(installation: github.UserInstallation) {
+    this.setState({ importInstallationRequest: installation, importInstallationLoading: true });
+    rpcService.service
+      .linkGitHubAppInstallation(
+        github.LinkAppInstallationRequest.create({
+          installationId: installation.id,
+          appId: installation.appId,
+        })
+      )
+      .then(() => {
+        alertService.success(`Successfully imported github.com/${installation.login}`);
+        this.fetch();
+      })
+      .catch((e) => errorService.handleError(e))
+      .finally(() => this.setState({ importInstallationRequest: null, importInstallationLoading: false }));
+  }
+
+  private renderImportInstallation() {
+    if (this.state.installationsFromGitHubLoading) {
+      return (
+        <Banner type="info" className="install-app-banner">
+          <div>Checking GitHub for BuildBuddy app installations...</div>
+          <Spinner />
+        </Banner>
+      );
+    }
+
+    const installationsFromGitHub = this.state.installationsFromGitHubResponse?.installations || [];
+    if (!installationsFromGitHub.length) {
+      return (
+        <Banner type="info" className="install-app-banner">
+          <div>To link a repository, install the BuildBuddy app on GitHub.</div>
+          <div className="installation-import-actions">
+            <LinkButton className="big-button" onClick={this.onClickInstallApp.bind(this)}>
+              Install
+            </LinkButton>
+            <OutlinedButton className="big-button" onClick={this.fetchInstallationsFromGitHub.bind(this)}>
+              <RefreshCw className="icon" />
+              Check GitHub
+            </OutlinedButton>
+          </div>
+        </Banner>
+      );
+    }
+
+    return (
+      <Banner type="info" className="install-app-banner">
+        <div>BuildBuddy found GitHub app installations. Import an installation to continue linking a repository.</div>
+        {!this.props.user.canCall("linkGitHubAppInstallation") && (
+          <div>You need admin access to import a GitHub app installation.</div>
+        )}
+        <div className="github-installation-import-list">
+          {installationsFromGitHub.map((installation) => {
+            const isImporting = this.state.importInstallationRequest?.id.toString() === installation.id.toString();
+            return (
+              <div className="github-installation-import-item" key={installation.id.toString()}>
+                <div className="github-installation-import-owner">{installation.login}</div>
+                {isImporting ? (
+                  <Spinner />
+                ) : (
+                  <FilledButton
+                    disabled={
+                      this.state.importInstallationLoading || !this.props.user.canCall("linkGitHubAppInstallation")
+                    }
+                    onClick={this.onClickImportInstallation.bind(this, installation)}>
+                    <Download className="icon" />
+                    Import
+                  </FilledButton>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </Banner>
+    );
   }
 
   private renderRepos() {
@@ -281,14 +406,9 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
               </LinkButton>
             </Banner>
           )}
-          {this.props.user.githubLinked && !this.state.installationsResponse?.installations?.length && (
-            <Banner type="info" className="install-app-banner">
-              <div>To link a repository, install the BuildBuddy app on GitHub.</div>
-              <LinkButton className="big-button" onClick={this.onClickInstallApp.bind(this)}>
-                Install
-              </LinkButton>
-            </Banner>
-          )}
+          {this.props.user.githubLinked &&
+            !this.state.installationsResponse?.installations?.length &&
+            this.renderImportInstallation()}
           {Boolean(this.state.installationsResponse?.installations?.length) && (
             <>
               <div className="repo-search">

--- a/enterprise/app/workflows/workflows.css
+++ b/enterprise/app/workflows/workflows.css
@@ -375,6 +375,41 @@
   align-self: start;
 }
 
+.workflows-github-import .installation-import-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.workflows-github-import .github-installation-import-list {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.workflows-github-import .github-installation-import-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 40px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--color-border-primary);
+}
+
+.workflows-github-import .github-installation-import-item:first-child {
+  border-top: 1px solid var(--color-border-primary);
+}
+
+.workflows-github-import .github-installation-import-owner {
+  min-width: 0;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .workflows-github-import .repo-search {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
When you install the BuildBuddy app in GH, we also need to import the installation into our database. Previously this import only happened in the callback from the GH installation. That callback might fail if the user who installed in GitHub was not logged in to BuildBuddy. This is common for orgs that need GitHub admins to install the app, but those admins don't have BuildBuddy accounts. If this callback did not succeed, there was no recovery mechanism

Add a way in our UI to fetch installations that a user has already installed, so they can continue the repo linking process

<img width="729" height="478" alt="image" src="https://github.com/user-attachments/assets/5a3221db-5808-4ba2-ac8a-0ecc8d21aab0" />

(Note that I removed the labels that say "User" or "Organization") ([Ex](https://buildbuddy-corp.slack.com/archives/C0BEHJ6VDV4/p1783041396308209))
