### PR TITLE
Fix scheduler to extend deletion context

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -2564,8 +2564,10 @@ func (s *SchedulerServer) ScheduleTask(ctx context.Context, req *scpb.ScheduleTa
 		emitRemoteRunnerMetric(ctx, task, metadata, "initial")
 	}
 	if err := s.enqueueTaskReservations(ctx, enqueueRequest, task, opts); err != nil {
-		if _, err := s.deleteTask(ctx, taskID); err != nil {
-			log.CtxWarningf(ctx, "Failed to delete task after scheduling failure: %s", err)
+		deletionContext, deletionCancel := background.ExtendContextForFinalization(ctx, time.Minute)
+		defer deletionCancel()
+		if _, err := s.deleteTask(deletionContext, taskID); err != nil {
+			log.CtxWarningf(deletionContext, "Failed to delete task %q after scheduling failure: %s", taskID, err)
 		}
 		return nil, err
 	}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -2564,7 +2564,7 @@ func (s *SchedulerServer) ScheduleTask(ctx context.Context, req *scpb.ScheduleTa
 		emitRemoteRunnerMetric(ctx, task, metadata, "initial")
 	}
 	if err := s.enqueueTaskReservations(ctx, enqueueRequest, task, opts); err != nil {
-		deletionContext, deletionCancel := background.ExtendContextForFinalization(ctx, time.Minute)
+		deletionContext, deletionCancel := background.ExtendContextForFinalization(ctx, 5*time.Second)
 		defer deletionCancel()
 		if _, err := s.deleteTask(deletionContext, taskID); err != nil {
 			log.CtxWarningf(deletionContext, "Failed to delete task %q after scheduling failure: %s", taskID, err)


### PR DESCRIPTION
`Failed to delete task after scheduling failure: context canceled` errors can happen when a build is canceled while we are in the middle of scheduling an execution. In that case the task may have already been written to Redis, but the cleanup delete also uses the canceled context and can fail, leaving an orphaned task that may be picked up later and reported as having a very long queue time. 

This fix uses an extended finalization context for the cleanup delete so the task is removed even after the original scheduling request is canceled. The finalization timeout is one minute, which should be more than enough for this cleanup path because a Redis `DEL` should complete far faster than a minute under normal conditions.
