### PR TITLE
lru: support updating size after creation

### DIFF
--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -43,8 +43,8 @@ type LRU[V any] interface {
 
 	// SetMaxSize updates the maximum size of the LRU. If the new max is smaller
 	// than the current size, the least recently used entries are evicted (with
-	// SizeEviction) until the current size fits. A negative max is treated as 0.
-	SetMaxSize(maxSize int64)
+	// SizeEviction) until the current size fits. New value must be positive.
+	SetMaxSize(maxSize int64) error
 
 	// Purge removes all entries from the LRU, invoking the eviction callback for
 	// each (with ManualEviction). The LRU remains usable afterwards.
@@ -349,16 +349,15 @@ func (c *lru[V]) removeElement(e *list.Element, reason EvictionReason) {
 	}
 }
 
-func (c *lru[V]) SetMaxSize(maxSize int64) {
-	if maxSize < 0 {
-		maxSize = 0
+func (c *lru[V]) SetMaxSize(maxSize int64) error {
+	if maxSize <= 0 {
+		return errors.New("must provide a positive size")
 	}
 	c.maxSize = maxSize
-	// Evict least-recently-used entries until we fit. The Len check guards
-	// against spinning when maxSize is 0 and the list is already empty.
-	for c.currentSize > c.maxSize && c.evictList.Len() > 0 {
+	for c.currentSize > c.maxSize {
 		c.removeOldest()
 	}
+	return nil
 }
 
 func (c *lru[V]) Purge() {
@@ -413,8 +412,8 @@ func (c *expiringLRU[V]) RemoveOldest() (V, bool) {
 	return entry.value, true
 }
 
-func (c *expiringLRU[V]) SetMaxSize(maxSize int64) {
-	c.inner.SetMaxSize(maxSize)
+func (c *expiringLRU[V]) SetMaxSize(maxSize int64) error {
+	return c.inner.SetMaxSize(maxSize)
 }
 
 func (c *expiringLRU[V]) Purge() {
@@ -485,10 +484,10 @@ func (c *threadSafeLRU[V]) RemoveOldest() (V, bool) {
 	return c.inner.RemoveOldest()
 }
 
-func (c *threadSafeLRU[V]) SetMaxSize(maxSize int64) {
+func (c *threadSafeLRU[V]) SetMaxSize(maxSize int64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.inner.SetMaxSize(maxSize)
+	return c.inner.SetMaxSize(maxSize)
 }
 
 func (c *threadSafeLRU[V]) Purge() {

--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -41,6 +41,15 @@ type LRU[V any] interface {
 	// Remove()s the oldest value in the LRU. (See Remove() above).
 	RemoveOldest() (V, bool)
 
+	// SetMaxSize updates the maximum size of the LRU. If the new max is smaller
+	// than the current size, the least recently used entries are evicted (with
+	// SizeEviction) until the current size fits. A negative max is treated as 0.
+	SetMaxSize(maxSize int64)
+
+	// Purge removes all entries from the LRU, invoking the eviction callback for
+	// each (with ManualEviction). The LRU remains usable afterwards.
+	Purge()
+
 	// Returns all keys in the LRU, ordered from most recently used to least.
 	Keys() []string
 }
@@ -340,6 +349,30 @@ func (c *lru[V]) removeElement(e *list.Element, reason EvictionReason) {
 	}
 }
 
+func (c *lru[V]) SetMaxSize(maxSize int64) {
+	if maxSize < 0 {
+		maxSize = 0
+	}
+	c.maxSize = maxSize
+	// Evict least-recently-used entries until we fit. The Len check guards
+	// against spinning when maxSize is 0 and the list is already empty.
+	for c.currentSize > c.maxSize && c.evictList.Len() > 0 {
+		c.removeOldest()
+	}
+}
+
+func (c *lru[V]) Purge() {
+	if c.onEvict != nil {
+		for e := c.evictList.Front(); e != nil; e = e.Next() {
+			kv := e.Value.(*Entry[V])
+			c.onEvict(kv.key, kv.value, ManualEviction)
+		}
+	}
+	c.evictList.Init()
+	c.items = make(map[string]*list.Element)
+	c.currentSize = 0
+}
+
 func (c *expiringLRU[V]) Add(key string, value V) bool {
 	return c.inner.Add(key, c.wrapValue(value))
 }
@@ -378,6 +411,14 @@ func (c *expiringLRU[V]) RemoveOldest() (V, bool) {
 		return zero, false
 	}
 	return entry.value, true
+}
+
+func (c *expiringLRU[V]) SetMaxSize(maxSize int64) {
+	c.inner.SetMaxSize(maxSize)
+}
+
+func (c *expiringLRU[V]) Purge() {
+	c.inner.Purge()
 }
 
 func (c *expiringLRU[V]) Len() int {
@@ -442,6 +483,18 @@ func (c *threadSafeLRU[V]) RemoveOldest() (V, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.inner.RemoveOldest()
+}
+
+func (c *threadSafeLRU[V]) SetMaxSize(maxSize int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inner.SetMaxSize(maxSize)
+}
+
+func (c *threadSafeLRU[V]) Purge() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.inner.Purge()
 }
 
 func (c *threadSafeLRU[V]) Len() int {

--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -303,3 +303,75 @@ func TestThreadSafeLRU_ConcurrentAccess(t *testing.T) {
 
 	require.LessOrEqual(t, l.Len(), 10)
 }
+
+func TestSetMaxSize(t *testing.T) {
+	testConfigs(t, func(t *testing.T, config *lru.Config[int]) {
+		cfg := *config
+		cfg.MaxSize = 3
+		cfg.SizeFn = func(value int) int64 { return 1 }
+		l, err := lru.New[int](&cfg)
+		require.NoError(t, err)
+
+		require.True(t, l.Add("a", 1))
+		require.True(t, l.Add("b", 2))
+		require.True(t, l.Add("c", 3))
+		require.Equal(t, 3, l.Len())
+
+		// Shrinking evicts least-recently-used entries down to the new max.
+		l.SetMaxSize(1)
+		require.Equal(t, 1, l.Len())
+		require.Equal(t, int64(1), l.Size())
+		require.True(t, l.Contains("c")) // most recently added survives
+		require.False(t, l.Contains("a"))
+		require.False(t, l.Contains("b"))
+
+		// Growing allows more entries again.
+		l.SetMaxSize(3)
+		require.True(t, l.Add("d", 4))
+		require.True(t, l.Add("e", 5))
+		require.Equal(t, 3, l.Len())
+
+		// Max of 0 drops everything and retains nothing added afterwards.
+		l.SetMaxSize(0)
+		require.Equal(t, 0, l.Len())
+		require.True(t, l.Add("f", 6)) // Add reports success...
+		require.Equal(t, 0, l.Len())   // ...but the entry is immediately evicted.
+
+		// Negative is treated as 0 (must not panic or spin).
+		l.SetMaxSize(-5)
+		require.Equal(t, 0, l.Len())
+	})
+}
+
+func TestPurge(t *testing.T) {
+	testConfigs(t, func(t *testing.T, config *lru.Config[int]) {
+		evictions := []eviction{}
+		cfg := *config
+		cfg.MaxSize = 10
+		cfg.SizeFn = func(value int) int64 { return 1 }
+		cfg.OnEvict = func(key string, value int, reason lru.EvictionReason) {
+			evictions = append(evictions, eviction{key, value, reason})
+		}
+		l, err := lru.New[int](&cfg)
+		require.NoError(t, err)
+
+		require.True(t, l.Add("a", 1))
+		require.True(t, l.Add("b", 2))
+
+		l.Purge()
+		require.Equal(t, 0, l.Len())
+		require.Equal(t, int64(0), l.Size())
+		require.False(t, l.Contains("a"))
+		require.False(t, l.Contains("b"))
+		// onEvict is invoked once per entry, with ManualEviction.
+		require.Len(t, evictions, 2)
+		for _, e := range evictions {
+			require.Equal(t, lru.ManualEviction, e.reason)
+		}
+
+		// The LRU remains usable after a purge.
+		require.True(t, l.Add("c", 3))
+		require.True(t, l.Contains("c"))
+		require.Equal(t, 1, l.Len())
+	})
+}

--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -318,7 +318,8 @@ func TestSetMaxSize(t *testing.T) {
 		require.Equal(t, 3, l.Len())
 
 		// Shrinking evicts least-recently-used entries down to the new max.
-		l.SetMaxSize(1)
+		err = l.SetMaxSize(1)
+		require.NoError(t, err)
 		require.Equal(t, 1, l.Len())
 		require.Equal(t, int64(1), l.Size())
 		require.True(t, l.Contains("c")) // most recently added survives
@@ -326,20 +327,25 @@ func TestSetMaxSize(t *testing.T) {
 		require.False(t, l.Contains("b"))
 
 		// Growing allows more entries again.
-		l.SetMaxSize(3)
+		err = l.SetMaxSize(3)
+		require.NoError(t, err)
 		require.True(t, l.Add("d", 4))
 		require.True(t, l.Add("e", 5))
 		require.Equal(t, 3, l.Len())
 
-		// Max of 0 drops everything and retains nothing added afterwards.
-		l.SetMaxSize(0)
-		require.Equal(t, 0, l.Len())
-		require.True(t, l.Add("f", 6)) // Add reports success...
-		require.Equal(t, 0, l.Len())   // ...but the entry is immediately evicted.
+		// Max of 0 rejected, previous size kept.
+		err = l.SetMaxSize(0)
+		require.ErrorContains(t, err, "must provide a positive size")
+		require.Equal(t, 3, l.Len()) // Previous size retained.
+		require.True(t, l.Add("f", 6))
+		require.Equal(t, 3, l.Len())
 
-		// Negative is treated as 0 (must not panic or spin).
-		l.SetMaxSize(-5)
-		require.Equal(t, 0, l.Len())
+		// Negative is treated as 0.
+		err = l.SetMaxSize(0)
+		require.ErrorContains(t, err, "must provide a positive size")
+		require.Equal(t, 3, l.Len()) // Previous size retained.
+		require.True(t, l.Add("f", 6))
+		require.Equal(t, 3, l.Len())
 	})
 }
 


### PR DESCRIPTION
Unblocks the ability to dynamically adjust LRU sizes via experiments.